### PR TITLE
fix(device_connect): defer device_connect_edge import to first use (fixes #2771)

### DIFF
--- a/changelog.d/2771-device-connect-init-lazy-imports.md
+++ b/changelog.d/2771-device-connect-init-lazy-imports.md
@@ -1,0 +1,36 @@
+### Fixed: `strands_robots.device_connect` imports on a stock `pip install strands-robots`
+
+The package's `__init__` opened by doing `from device_connect_edge import DeviceRuntime`
+unconditionally, and `device-connect-edge` lives only in the `[device-connect]` /
+`[all]` extras. Sitting next to it in the same package,
+`strands_robots.device_connect.reachy_transport` is stdlib-only; the native
+Reachy driver imports that leaf on every daemon touch. Importing the leaf
+executes the parent package's `__init__`, so on a default install every
+`ReachyDriver` call reached `_daemon_get` / `_wire_commands` and raised
+`ModuleNotFoundError: No module named 'device_connect_edge'` -- escaping the
+driver's own no-raise refusal contract and breaking three `AGENTS.md`
+conventions at once (`Return error dicts, never raise`, `require_optional()`
+for optional deps, the module-load discipline the driver's docstring makes
+explicit). CI never saw it because the hatch env installs `[all]`.
+
+`__init__` now uses PEP 562 `__getattr__` (documented at
+[python.org](https://docs.python.org/3/reference/datamodel.html#customizing-module-attribute-access))
+to resolve every public name from the export table on first access. Names that
+need the extra (`init_device_connect`, `init_device_connect_sync`,
+`resolve_allow_insecure`, `RobotDeviceDriver`, `SimulationDeviceDriver`,
+`ReachyMiniDriver`) live in a private `_impl` submodule that is imported only
+when a caller reaches for one of them, so a stock install can import
+`strands_robots.device_connect.reachy_transport` and reach the Reachy driver
+without paying the extra. The public surface is unchanged and each name still
+raises a `ModuleNotFoundError` naming `device_connect_edge` if used without the
+extra, so a caller that needs those symbols is still told which extra to
+install -- the failure just no longer arrives as collateral damage on a caller
+that never asked for them.
+
+Two behaviours are preserved on purpose: `dir(strands_robots.device_connect)`
+still advertises every public name (via a `__dir__` override) so IDE completion
+sees the same surface as before, and each resolved name is cached on the
+package so identity assertions like
+`isinstance(x, RobotDeviceDriver)` and `RobotDeviceDriver is
+strands_robots.device_connect.RobotDeviceDriver` hold across calls. Fixes
+#2771.

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -12,23 +12,56 @@ Usage:
     # Now discoverable via Device Connect tools:
     #   discover_devices(device_type="strands_robot")
     #   invoke_device("so100-lab-1", "execute", {"instruction": "pick up cube"})
+
+Module-load discipline
+----------------------
+
+Every symbol this package exports is behind ``__getattr__`` (:pep:`562`). The
+package imports on a stock ``pip install strands-robots`` -- with no extras --
+and only reaches ``device_connect_edge`` when a caller *uses* a name that needs
+it. The four Device Connect drivers, ``DeviceRuntime`` and the two
+``init_device_connect`` entry points all sit behind that gate.
+
+This is required, not a stylistic choice. The sibling module
+``strands_robots.device_connect.reachy_transport`` is stdlib-only and is
+imported by the native Reachy driver (:mod:`strands_robots.drivers.reachy`).
+Importing that leaf executes this ``__init__``, so a package init that eagerly
+imports ``device_connect_edge`` raises ``ModuleNotFoundError`` inside the
+native driver's first daemon touch on any install without ``[device-connect]``
+-- escaping the driver's own no-raise refusal contract and breaking three
+:mod:`AGENTS.md` conventions at once (\"Return error dicts, never raise\",
+``require_optional()`` for optional deps, the module-load discipline the
+driver's docstring makes explicit).
+
+The public names are unchanged: ``from strands_robots.device_connect import
+init_device_connect`` still works, and only fails when the caller reaches for a
+name whose implementation genuinely needs ``device_connect_edge``. Static tools
+(mypy, IDE autocomplete) see the names through the ``TYPE_CHECKING`` guard.
 """
 
-import asyncio
-import logging
-import os
-import threading
-import uuid
-from typing import Any
+from __future__ import annotations
 
-from device_connect_edge import DeviceRuntime
+import importlib
+from typing import TYPE_CHECKING, Any
 
-from strands_robots.device_connect.reachy_mini_driver import ReachyMiniDriver
-from strands_robots.device_connect.robot_driver import RobotDeviceDriver
-from strands_robots.device_connect.sim_driver import SimulationDeviceDriver
-from strands_robots.utils import is_boolean
+if TYPE_CHECKING:  # pragma: no cover - typing-only, never executed
+    from device_connect_edge import DeviceRuntime  # noqa: F401
 
-logger = logging.getLogger(__name__)
+    from strands_robots.device_connect._impl import (  # noqa: F401
+        init_device_connect,
+        init_device_connect_sync,
+        resolve_allow_insecure,
+    )
+    from strands_robots.device_connect.reachy_mini_driver import (  # noqa: F401
+        ReachyMiniDriver,
+    )
+    from strands_robots.device_connect.robot_driver import (  # noqa: F401
+        RobotDeviceDriver,
+    )
+    from strands_robots.device_connect.sim_driver import (  # noqa: F401
+        SimulationDeviceDriver,
+    )
+
 
 __all__ = [
     "init_device_connect",
@@ -39,263 +72,77 @@ __all__ = [
     "ReachyMiniDriver",
 ]
 
-_INSECURE_TRUE = ("true", "1", "yes")
 
-# ``init_device_connect_sync`` bounds the background bring-up: the awaited half
-# constructs a ``DeviceRuntime``, which can block on a broker, so the wrapper
-# must not hang its caller forever. Expiry is a failed bring-up, not a slow one
-# that later succeeds -- the wrapper has already returned by then.
-_INIT_TIMEOUT_S: float = 30.0
+# Map each exported name to the module it lives in. Grouped by whether the
+# module itself needs ``device_connect_edge`` so a reader can see at a glance
+# which names cost the extra and which are pure Python.
+#
+# All three driver modules import ``device_connect_edge`` at module load, and
+# the two ``init_device_connect*`` entry points construct a ``DeviceRuntime``
+# from it. ``resolve_allow_insecure`` is stdlib-only, kept in the same private
+# ``_impl`` module so its behavioural pin does not drag the extra in either.
+_ATTR_TO_MODULE: dict[str, str] = {
+    "init_device_connect": "strands_robots.device_connect._impl",
+    "init_device_connect_sync": "strands_robots.device_connect._impl",
+    "resolve_allow_insecure": "strands_robots.device_connect._impl",
+    "RobotDeviceDriver": "strands_robots.device_connect.robot_driver",
+    "SimulationDeviceDriver": "strands_robots.device_connect.sim_driver",
+    "ReachyMiniDriver": "strands_robots.device_connect.reachy_mini_driver",
+}
 
 
-def resolve_allow_insecure(
-    explicit: bool | None = None,
-    env_value: str | None = None,
-) -> bool:
-    """Resolve the effective ``allow_insecure`` setting (secure by default).
+def __getattr__(name: str) -> Any:
+    """Resolve a public name lazily.
 
-    Precedence: explicit arg > ``DEVICE_CONNECT_ALLOW_INSECURE`` env var >
-    secure default (``False``). Insecure transport is never implicit - it
-    must be opted into via the argument or the env var.
+    Follows :pep:`562`. Called by the Python attribute machinery only when
+    ``name`` is not already in the module's namespace, so first access pays
+    the import cost and every subsequent access is a plain attribute read.
 
-    Extracted as a pure function so the secure-by-default posture is unit
-    testable without standing up a DeviceRuntime.
-
-    The two sources carry the same setting in different shapes, and each is held
-    to its own declared type rather than to the other's. An environment variable
-    is a string by construction, so *env_value* is **parsed**: only
-    ``("true", "1", "yes")`` opt in and every other spelling is secure. The
-    argument is declared ``bool | None``, so it is **checked**: a non-boolean is
-    refused rather than parsed with that same vocabulary.
-
-    Checking the argument is what keeps the two sources from disagreeing about
-    one value. A non-empty string is truthy, so returning the argument as given
-    made ``resolve_allow_insecure("false")`` enable insecure transport while
-    ``DEVICE_CONNECT_ALLOW_INSECURE=false`` disabled it: every falsy spelling
-    inverted, and only on the path documented here as the higher precedence.
-    Parsing the argument with the environment vocabulary instead would move
-    which spellings invert rather than remove the inversion - ``"on"``,
-    ``"enabled"`` and ``"y"`` are absent from that vocabulary, so each would
-    silently resolve to secure while reading as an opt-in.
-
-    Args:
-        explicit: The caller's setting, or ``None`` to fall through to the
-            environment variable. Must be a python or numpy boolean when given.
-        env_value: The raw ``DEVICE_CONNECT_ALLOW_INSECURE`` value, or ``None``
-            when it is unset.
-
-    Returns:
-        Whether insecure transport is enabled, always as a real ``bool`` - so a
-        numpy boolean from a caller's own comparison satisfies the annotation
-        and the identity assertions the runtime's setting is pinned with.
-
-    Raises:
-        ValueError: If *explicit* is neither a boolean nor ``None``, or
-            *env_value* is neither a string nor ``None``.
+    A name that needs ``device_connect_edge`` is not imported by this package
+    on load. Reaching for one on an install without ``[device-connect]``
+    raises the ``ImportError`` from the target module rather than during
+    ``import strands_robots.device_connect``. That is what lets the stdlib-only
+    leaf ``strands_robots.device_connect.reachy_transport`` be imported on a
+    stock install: importing that leaf executes this ``__init__`` first, and
+    with this contract that ``__init__`` succeeds.
     """
-    if explicit is not None:
-        if not is_boolean(explicit):
-            raise ValueError(
-                f"allow_insecure must be a bool or None, got {explicit!r}. A string "
-                "spelling is read only from DEVICE_CONNECT_ALLOW_INSECURE, where "
-                f"{_INSECURE_TRUE} opt in and anything else is secure; passed as this "
-                "argument a non-empty string is truthy, so 'false' would enable insecure "
-                "transport rather than refuse it."
-            )
-        return bool(explicit)
-    if env_value is not None:
-        if not isinstance(env_value, str):
-            raise ValueError(
-                f"env_value must be a str or None, got {env_value!r}. It carries the raw "
-                "DEVICE_CONNECT_ALLOW_INSECURE value, which is a string by construction; a "
-                "caller that has already resolved a boolean should pass it as the explicit "
-                "argument instead, where it is checked rather than parsed."
-            )
-        return env_value.lower() in _INSECURE_TRUE
-    return False
+    # Public name from the export table -- resolve to a symbol its module carries.
+    module_name = _ATTR_TO_MODULE.get(name)
+    if module_name is not None:
+        module = importlib.import_module(module_name)
+        value = getattr(module, name)
+        # Cache on the package so subsequent lookups skip __getattr__ entirely
+        # and ``getattr`` returns bit-identical references across calls.
+        globals()[name] = value
+        return value
 
-
-async def init_device_connect(
-    robot,
-    peer_id: str | None = None,
-    peer_type: str = "robot",
-    messaging_url: str | None = None,
-    messaging_backend: str | None = None,
-    tenant: str = "default",
-    allow_insecure: bool | None = None,
-) -> DeviceRuntime:
-    """Initialize Device Connect for a Robot or Simulation.
-
-    Drop-in replacement for init_mesh(). Creates a DeviceDriver adapter
-    and starts a DeviceRuntime in the background.
-
-    When messaging_backend="zenoh" and messaging_url is None, the runtime
-    enters D2D mode - devices discover each other directly via Zenoh
-    multicast scouting on the LAN. No broker, no Docker, no env vars.
-
-    Args:
-        robot: A Robot or Simulation instance to wrap.
-        peer_id: Device ID for registration (auto-generated if None).
-        peer_type: "robot" or "sim" - selects the appropriate driver.
-        messaging_url: Explicit messaging URL (overrides env vars).
-        messaging_backend: Messaging backend - "zenoh" or "nats".
-            None = auto-detect from MESSAGING_BACKEND env var (default "zenoh").
-        tenant: Device Connect tenant namespace.
-        allow_insecure: Allow insecure (unencrypted, unauthenticated)
-            transport. Must be a boolean or None; a string spelling such as
-            ``"false"`` is refused here rather than read, because the string
-            vocabulary belongs to DEVICE_CONNECT_ALLOW_INSECURE and a non-empty
-            string is truthy as an argument. None = auto-detect: respects the
-            DEVICE_CONNECT_ALLOW_INSECURE env var if set, otherwise defaults
-            to False (secure). Insecure transport must be explicitly opted
-            into; a prominent warning is logged whenever it is active.
-
-    Returns:
-        The running DeviceRuntime instance.
-    """
-    if peer_type == "sim":
-        driver = SimulationDeviceDriver(robot)
-    else:
-        driver = RobotDeviceDriver(robot)
-
-    device_id = peer_id or f"{getattr(robot, 'tool_name_str', 'robot')}-{uuid.uuid4().hex[:4]}"
-
-    urls = [messaging_url] if messaging_url else None
-
-    # Resolve messaging_backend: explicit arg > env var > default "zenoh"
-    if messaging_backend is None:
-        messaging_backend = os.environ.get("MESSAGING_BACKEND", "zenoh")
-
-    # Resolve allow_insecure: explicit arg > env var > secure default.
-    # Security hardening: insecure (unencrypted, unauthenticated) transport is
-    # NO LONGER the default. It must be explicitly opted into - via the
-    # ``allow_insecure=True`` argument or ``DEVICE_CONNECT_ALLOW_INSECURE`` env
-    # var - and we log a prominent warning whenever it is active so an insecure
-    # deployment is never silent.
-    allow_insecure = resolve_allow_insecure(allow_insecure, os.environ.get("DEVICE_CONNECT_ALLOW_INSECURE"))
-
-    if allow_insecure:
-        logger.warning(
-            "Device Connect is running in INSECURE mode (unencrypted, "
-            "unauthenticated transport). Robot commands and state are exposed "
-            "to the local network. Only use this on a trusted, isolated "
-            "network; configure a broker / secure transport for production."
-        )
-
-    runtime = DeviceRuntime(
-        driver=driver,
-        device_id=device_id,
-        messaging_urls=urls,
-        messaging_backend=messaging_backend,
-        tenant=tenant,
-        allow_insecure=allow_insecure,
-    )
-
-    # Provide robot-specific heartbeat data
-    runtime.set_heartbeat_provider(lambda: _build_heartbeat(robot, peer_type))
-
-    # Start runtime in background task; store ref to prevent GC
-    runtime._background_task = asyncio.create_task(runtime.run())
-
-    logger.info(
-        "Device Connect initialized: %s (%s, backend=%s, d2d=%s)", device_id, peer_type, messaging_backend, urls is None
-    )
-    return runtime
-
-
-def init_device_connect_sync(
-    robot,
-    peer_id: str | None = None,
-    peer_type: str = "robot",
-    messaging_url: str | None = None,
-    messaging_backend: str | None = None,
-    tenant: str = "default",
-    allow_insecure: bool | None = None,
-) -> "DeviceRuntime":
-    """Non-blocking sync wrapper around init_device_connect().
-
-    Starts the DeviceRuntime on a dedicated daemon thread so the caller
-    returns immediately - matching the Zenoh mesh ``init_mesh()`` pattern.
-    The runtime stays alive as long as the process (daemon thread).
-
-    Same parameters as :func:`init_device_connect`.
-
-    Raises:
-        Exception: Whatever :func:`init_device_connect` raised on the
-            background thread, re-raised here so a failed bring-up reaches
-            the caller rather than being confined to a thread it cannot see.
-        TimeoutError: If the bring-up does not finish within the wrapper's
-            budget. The runtime is not returned in that case, so the caller
-            is never handed ``None`` in place of a ``DeviceRuntime``.
-    """
-    loop = asyncio.new_event_loop()
-    ready = threading.Event()
-    runtime_holder = [None]
-    error_holder = [None]
-
-    async def _start():
+    # Submodule lookup -- ``getattr(pkg, "reachy_transport")`` and
+    # ``from strands_robots.device_connect import reachy_transport`` are the two
+    # spellings a caller uses to reach the leaves this package ships, and only
+    # the second one is served by Python's own import machinery before
+    # ``__getattr__`` is consulted. Attempting the import here answers the first
+    # spelling with the same module the second returns, without turning the
+    # dispatcher into a wildcard: a non-existent submodule name still raises
+    # ``AttributeError`` below, because ``import_module`` for a name that is
+    # neither a module nor in the export table raises ``ModuleNotFoundError``
+    # here rather than reaching the caller as an attribute miss.
+    if not name.startswith("_"):
         try:
-            rt = await init_device_connect(
-                robot,
-                peer_id=peer_id,
-                peer_type=peer_type,
-                messaging_url=messaging_url,
-                messaging_backend=messaging_backend,
-                tenant=tenant,
-                allow_insecure=allow_insecure,
-            )
-            runtime_holder[0] = rt
-        except Exception as exc:
-            error_holder[0] = exc
-        finally:
-            ready.set()
+            submodule = importlib.import_module(f"{__name__}.{name}")
+        except ModuleNotFoundError:
+            pass
+        else:
+            globals()[name] = submodule
+            return submodule
 
-    def _run():
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(_start())
-        loop.run_forever()
-
-    thread = threading.Thread(target=_run, daemon=True, name="device-connect-runtime")
-    thread.start()
-    started = ready.wait(timeout=_INIT_TIMEOUT_S)
-
-    # The recorded failure first: ``_start``'s ``finally`` sets the event on both
-    # paths, so a bring-up that failed inside the budget arrives with ``started``
-    # true and its own exception, which names the cause better than the budget.
-    if error_holder[0] is not None:
-        raise error_holder[0]
-    if not started:
-        raise TimeoutError(
-            f"init_device_connect_sync: the Device Connect runtime did not come up "
-            f"within {_INIT_TIMEOUT_S:g}s. The bring-up is still running on its "
-            f"background thread; check that the messaging URL / broker is reachable."
-        )
-
-    runtime = runtime_holder[0]
-    if runtime is not None:
-        runtime._loop = loop
-        runtime._thread = thread
-    return runtime
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def _build_heartbeat(robot: Any, peer_type: str) -> dict[str, Any]:
-    """Build heartbeat payload with robot-specific metadata."""
-    data = {
-        "peer_type": peer_type,
-        "tool_name": getattr(robot, "tool_name_str", "unknown"),
-    }
+def __dir__() -> list[str]:
+    """Advertise the lazy names to ``dir()`` and IDE completion.
 
-    if peer_type == "robot":
-        task = getattr(robot, "_task_state", None)
-        if task:
-            data["task_status"] = getattr(task.status, "value", "unknown")
-            data["instruction"] = task.instruction or ""
-            data["step_count"] = task.step_count
-    elif peer_type == "sim":
-        world = getattr(robot, "_world", None)
-        if world:
-            data["sim_time"] = world.sim_time
-            data["step_count"] = world.step_count
-            data["robots"] = list(world.robots.keys())
-
-    return data
+    Without this, ``dir(strands_robots.device_connect)`` reports only the
+    module's own literals, hiding every public symbol from a reader listing
+    the package's contents.
+    """
+    return sorted(set(__all__) | set(globals()))

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -73,9 +73,14 @@ __all__ = [
 ]
 
 
-# Map each exported name to the module it lives in. Grouped by whether the
-# module itself needs ``device_connect_edge`` so a reader can see at a glance
-# which names cost the extra and which are pure Python.
+# Map each name callers reach through the package to the module it lives in.
+# The public :data:`__all__` names are the documented API; the additional
+# ``_PATCH_TARGETS`` names below are module-level symbols the ``_impl`` submodule
+# re-exports (via ``from device_connect_edge import ...``) that existing tests
+# and callers patch through this package. Serving them here keeps
+# ``mock.patch("strands_robots.device_connect.DeviceRuntime", ...)`` working
+# without eagerly importing ``device_connect_edge`` on package load -- the
+# import is deferred until first access, same as every other lazy name.
 #
 # All three driver modules import ``device_connect_edge`` at module load, and
 # the two ``init_device_connect*`` entry points construct a ``DeviceRuntime``
@@ -88,6 +93,30 @@ _ATTR_TO_MODULE: dict[str, str] = {
     "RobotDeviceDriver": "strands_robots.device_connect.robot_driver",
     "SimulationDeviceDriver": "strands_robots.device_connect.sim_driver",
     "ReachyMiniDriver": "strands_robots.device_connect.reachy_mini_driver",
+    # Names re-exported by ``_impl`` from ``device_connect_edge``. Not in
+    # ``__all__`` (not part of the public API), but reachable through the
+    # package because existing tests patch them here -- and because dropping
+    # a name that used to live on the package silently is a worse contract
+    # break than any lazy-import scheme is meant to prevent.
+    "DeviceRuntime": "strands_robots.device_connect._impl",
+    # Private helper the heartbeat regression suite imports through the
+    # package (``from strands_robots.device_connect import _build_heartbeat``).
+    # Leading underscore is a "not public API" signal, not a "not reachable"
+    # signal; it lived here before this PR and existing suites depend on it.
+    "_build_heartbeat": "strands_robots.device_connect._impl",
+    # Module-level budget the sync wrapper reads through the package (see the
+    # comment inside ``init_device_connect_sync``). Reachable here so
+    # ``module._INIT_TIMEOUT_S`` and ``monkeypatch.setattr(module,
+    # "_INIT_TIMEOUT_S", ...)`` -- the shape every wrapper-budget test uses --
+    # find the value on first access without eagerly importing ``_impl``.
+    "_INIT_TIMEOUT_S": "strands_robots.device_connect._impl",
+    # The opt-in vocabulary the insecure-setting refusal quotes. Read through
+    # the package by the ``TestParsingTheArgumentWasRejectedForAMeasuredReason``
+    # suite, which pins the refusal's contract by comparing its message against
+    # this tuple's values (an ``on``/``enabled``/``y`` spelling outside the
+    # vocabulary should read as secure, and the vocabulary itself is what the
+    # refusal quotes).
+    "_INSECURE_TRUE": "strands_robots.device_connect._impl",
 }
 
 

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -73,11 +73,22 @@ __all__ = [
 ]
 
 
+# The bring-up budget ``init_device_connect_sync`` bounds its background thread
+# with. A float literal with no ``device_connect_edge`` dependency, so it is
+# defined here rather than served from ``_impl``: routing it through that module
+# would make reading the shipped budget import the extra, and a deferred import
+# that still fires is not a deferral. ``init_device_connect_sync`` reads it back
+# off this package, which is also what lets a test substitute a millisecond
+# budget for the shipped 30 seconds. Expiry is a failed bring-up, not a slow one
+# that later succeeds -- the wrapper has already returned by then.
+_INIT_TIMEOUT_S: float = 30.0
+
+
 # Map each name callers reach through the package to the module it lives in.
 # The public :data:`__all__` names are the documented API; the additional
-# ``_PATCH_TARGETS`` names below are module-level symbols the ``_impl`` submodule
-# re-exports (via ``from device_connect_edge import ...``) that existing tests
-# and callers patch through this package. Serving them here keeps
+# private names below are module-level symbols ``_impl`` defines or re-exports
+# (via ``from device_connect_edge import ...``) that existing tests and callers
+# reach through this package. Serving them here keeps
 # ``mock.patch("strands_robots.device_connect.DeviceRuntime", ...)`` working
 # without eagerly importing ``device_connect_edge`` on package load -- the
 # import is deferred until first access, same as every other lazy name.
@@ -104,12 +115,6 @@ _ATTR_TO_MODULE: dict[str, str] = {
     # Leading underscore is a "not public API" signal, not a "not reachable"
     # signal; it lived here before this PR and existing suites depend on it.
     "_build_heartbeat": "strands_robots.device_connect._impl",
-    # Module-level budget the sync wrapper reads through the package (see the
-    # comment inside ``init_device_connect_sync``). Reachable here so
-    # ``module._INIT_TIMEOUT_S`` and ``monkeypatch.setattr(module,
-    # "_INIT_TIMEOUT_S", ...)`` -- the shape every wrapper-budget test uses --
-    # find the value on first access without eagerly importing ``_impl``.
-    "_INIT_TIMEOUT_S": "strands_robots.device_connect._impl",
     # The opt-in vocabulary the insecure-setting refusal quotes. Read through
     # the package by the ``TestParsingTheArgumentWasRejectedForAMeasuredReason``
     # suite, which pins the refusal's contract by comparing its message against

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -24,7 +24,7 @@ it. The four Device Connect drivers, ``DeviceRuntime`` and the two
 
 This is required, not a stylistic choice. The sibling module
 ``strands_robots.device_connect.reachy_transport`` is stdlib-only and is
-imported by the native Reachy driver (:mod:`strands_robots.drivers.reachy`).
+imported by the native Reachy driver (``strands_robots.drivers.reachy``, landing in #2762).
 Importing that leaf executes this ``__init__``, so a package init that eagerly
 imports ``device_connect_edge`` raises ``ModuleNotFoundError`` inside the
 native driver's first daemon touch on any install without ``[device-connect]``

--- a/strands_robots/device_connect/_impl.py
+++ b/strands_robots/device_connect/_impl.py
@@ -182,7 +182,15 @@ async def init_device_connect(
             "network; configure a broker / secure transport for production."
         )
 
-    runtime = DeviceRuntime(
+    # ``DeviceRuntime`` is looked up through the package namespace rather than
+    # the module-local import above so that
+    # ``mock.patch("strands_robots.device_connect.DeviceRuntime", ...)`` -- the
+    # patch target every existing test uses -- reaches the constructor this
+    # function invokes. Bind at call time; the module-local ``DeviceRuntime``
+    # kept only for typing / docstrings.
+    import strands_robots.device_connect as _pkg  # noqa: PLC0415 - lazy on purpose
+
+    runtime = _pkg.DeviceRuntime(
         driver=driver,
         device_id=device_id,
         messaging_urls=urls,
@@ -234,8 +242,14 @@ def init_device_connect_sync(
     error_holder = [None]
 
     async def _start():
+        # ``init_device_connect`` is looked up through the package so
+        # ``monkeypatch.setattr(strands_robots.device_connect,
+        # "init_device_connect", bring_up)`` -- the substitution every
+        # sync-wrapper outcome test uses -- reaches this call.
+        import strands_robots.device_connect as _pkg  # noqa: PLC0415 - lazy on purpose
+
         try:
-            rt = await init_device_connect(
+            rt = await _pkg.init_device_connect(
                 robot,
                 peer_id=peer_id,
                 peer_type=peer_type,
@@ -257,7 +271,16 @@ def init_device_connect_sync(
 
     thread = threading.Thread(target=_run, daemon=True, name="device-connect-runtime")
     thread.start()
-    started = ready.wait(timeout=_INIT_TIMEOUT_S)
+    # ``_INIT_TIMEOUT_S`` is read through the package rather than the module-local
+    # binding so that ``monkeypatch.setattr(strands_robots.device_connect,
+    # "_INIT_TIMEOUT_S", budget)`` -- the shape every wrapper-budget test uses
+    # -- reaches this read. The module-local literal above is still the source
+    # of truth on first access; the lookup here just honours a caller that
+    # overrode it through the package.
+    import strands_robots.device_connect as _pkg  # noqa: PLC0415 - lazy on purpose
+
+    _timeout = _pkg._INIT_TIMEOUT_S
+    started = ready.wait(timeout=_timeout)
 
     # The recorded failure first: ``_start``'s ``finally`` sets the event on both
     # paths, so a bring-up that failed inside the budget arrives with ``started``
@@ -267,7 +290,7 @@ def init_device_connect_sync(
     if not started:
         raise TimeoutError(
             f"init_device_connect_sync: the Device Connect runtime did not come up "
-            f"within {_INIT_TIMEOUT_S:g}s. The bring-up is still running on its "
+            f"within {_timeout:g}s. The bring-up is still running on its "
             f"background thread; check that the messaging URL / broker is reachable."
         )
 

--- a/strands_robots/device_connect/_impl.py
+++ b/strands_robots/device_connect/_impl.py
@@ -1,0 +1,301 @@
+"""Private implementation of the ``device_connect_edge``-backed entry points.
+
+Split out of ``strands_robots.device_connect.__init__`` so importing the
+package does not import ``device_connect_edge``. The package's ``__getattr__``
+imports this module the first time a caller asks for one of the three symbols
+it re-exports (``init_device_connect``, ``init_device_connect_sync``,
+``resolve_allow_insecure``), so a stock ``pip install strands-robots`` reaches
+those names only when it also brings the extra that supplies them.
+
+``resolve_allow_insecure`` is pure Python and could live in a stdlib-only
+module. It stays here so the behavioural pin travels with the two entry points
+it guards -- one import path per public name, one place to change the vocabulary
+its refusal quotes. The tests exercise it through
+``strands_robots.device_connect.resolve_allow_insecure`` rather than reaching
+into this private module, so pushing the module load a level deeper does not
+change what the suite grades.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import uuid
+from typing import Any
+
+from device_connect_edge import DeviceRuntime
+
+from strands_robots.device_connect.robot_driver import RobotDeviceDriver
+from strands_robots.device_connect.sim_driver import SimulationDeviceDriver
+from strands_robots.utils import is_boolean
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "init_device_connect",
+    "init_device_connect_sync",
+    "resolve_allow_insecure",
+]
+
+_INSECURE_TRUE = ("true", "1", "yes")
+
+# ``init_device_connect_sync`` bounds the background bring-up: the awaited half
+# constructs a ``DeviceRuntime``, which can block on a broker, so the wrapper
+# must not hang its caller forever. Expiry is a failed bring-up, not a slow one
+# that later succeeds -- the wrapper has already returned by then.
+_INIT_TIMEOUT_S: float = 30.0
+
+
+def resolve_allow_insecure(
+    explicit: bool | None = None,
+    env_value: str | None = None,
+) -> bool:
+    """Resolve the effective ``allow_insecure`` setting (secure by default).
+
+    Precedence: explicit arg > ``DEVICE_CONNECT_ALLOW_INSECURE`` env var >
+    secure default (``False``). Insecure transport is never implicit - it
+    must be opted into via the argument or the env var.
+
+    Extracted as a pure function so the secure-by-default posture is unit
+    testable without standing up a DeviceRuntime.
+
+    The two sources carry the same setting in different shapes, and each is held
+    to its own declared type rather than to the other's. An environment variable
+    is a string by construction, so *env_value* is **parsed**: only
+    ``("true", "1", "yes")`` opt in and every other spelling is secure. The
+    argument is declared ``bool | None``, so it is **checked**: a non-boolean is
+    refused rather than parsed with that same vocabulary.
+
+    Checking the argument is what keeps the two sources from disagreeing about
+    one value. A non-empty string is truthy, so returning the argument as given
+    made ``resolve_allow_insecure("false")`` enable insecure transport while
+    ``DEVICE_CONNECT_ALLOW_INSECURE=false`` disabled it: every falsy spelling
+    inverted, and only on the path documented here as the higher precedence.
+    Parsing the argument with the environment vocabulary instead would move
+    which spellings invert rather than remove the inversion - ``"on"``,
+    ``"enabled"`` and ``"y"`` are absent from that vocabulary, so each would
+    silently resolve to secure while reading as an opt-in.
+
+    Args:
+        explicit: The caller's setting, or ``None`` to fall through to the
+            environment variable. Must be a python or numpy boolean when given.
+        env_value: The raw ``DEVICE_CONNECT_ALLOW_INSECURE`` value, or ``None``
+            when it is unset.
+
+    Returns:
+        Whether insecure transport is enabled, always as a real ``bool`` - so a
+        numpy boolean from a caller's own comparison satisfies the annotation
+        and the identity assertions the runtime's setting is pinned with.
+
+    Raises:
+        ValueError: If *explicit* is neither a boolean nor ``None``, or
+            *env_value* is neither a string nor ``None``.
+    """
+    if explicit is not None:
+        if not is_boolean(explicit):
+            raise ValueError(
+                f"allow_insecure must be a bool or None, got {explicit!r}. A string "
+                "spelling is read only from DEVICE_CONNECT_ALLOW_INSECURE, where "
+                f"{_INSECURE_TRUE} opt in and anything else is secure; passed as this "
+                "argument a non-empty string is truthy, so 'false' would enable insecure "
+                "transport rather than refuse it."
+            )
+        return bool(explicit)
+    if env_value is not None:
+        if not isinstance(env_value, str):
+            raise ValueError(
+                f"env_value must be a str or None, got {env_value!r}. It carries the raw "
+                "DEVICE_CONNECT_ALLOW_INSECURE value, which is a string by construction; a "
+                "caller that has already resolved a boolean should pass it as the explicit "
+                "argument instead, where it is checked rather than parsed."
+            )
+        return env_value.lower() in _INSECURE_TRUE
+    return False
+
+
+async def init_device_connect(
+    robot,
+    peer_id: str | None = None,
+    peer_type: str = "robot",
+    messaging_url: str | None = None,
+    messaging_backend: str | None = None,
+    tenant: str = "default",
+    allow_insecure: bool | None = None,
+) -> DeviceRuntime:
+    """Initialize Device Connect for a Robot or Simulation.
+
+    Drop-in replacement for init_mesh(). Creates a DeviceDriver adapter
+    and starts a DeviceRuntime in the background.
+
+    When messaging_backend="zenoh" and messaging_url is None, the runtime
+    enters D2D mode - devices discover each other directly via Zenoh
+    multicast scouting on the LAN. No broker, no Docker, no env vars.
+
+    Args:
+        robot: A Robot or Simulation instance to wrap.
+        peer_id: Device ID for registration (auto-generated if None).
+        peer_type: "robot" or "sim" - selects the appropriate driver.
+        messaging_url: Explicit messaging URL (overrides env vars).
+        messaging_backend: Messaging backend - "zenoh" or "nats".
+            None = auto-detect from MESSAGING_BACKEND env var (default "zenoh").
+        tenant: Device Connect tenant namespace.
+        allow_insecure: Allow insecure (unencrypted, unauthenticated)
+            transport. Must be a boolean or None; a string spelling such as
+            ``"false"`` is refused here rather than read, because the string
+            vocabulary belongs to DEVICE_CONNECT_ALLOW_INSECURE and a non-empty
+            string is truthy as an argument. None = auto-detect: respects the
+            DEVICE_CONNECT_ALLOW_INSECURE env var if set, otherwise defaults
+            to False (secure). Insecure transport must be explicitly opted
+            into; a prominent warning is logged whenever it is active.
+
+    Returns:
+        The running DeviceRuntime instance.
+    """
+    if peer_type == "sim":
+        driver = SimulationDeviceDriver(robot)
+    else:
+        driver = RobotDeviceDriver(robot)
+
+    device_id = peer_id or f"{getattr(robot, 'tool_name_str', 'robot')}-{uuid.uuid4().hex[:4]}"
+
+    urls = [messaging_url] if messaging_url else None
+
+    # Resolve messaging_backend: explicit arg > env var > default "zenoh"
+    if messaging_backend is None:
+        messaging_backend = os.environ.get("MESSAGING_BACKEND", "zenoh")
+
+    # Resolve allow_insecure: explicit arg > env var > secure default.
+    # Security hardening: insecure (unencrypted, unauthenticated) transport is
+    # NO LONGER the default. It must be explicitly opted into - via the
+    # ``allow_insecure=True`` argument or ``DEVICE_CONNECT_ALLOW_INSECURE`` env
+    # var - and we log a prominent warning whenever it is active so an insecure
+    # deployment is never silent.
+    allow_insecure = resolve_allow_insecure(allow_insecure, os.environ.get("DEVICE_CONNECT_ALLOW_INSECURE"))
+
+    if allow_insecure:
+        logger.warning(
+            "Device Connect is running in INSECURE mode (unencrypted, "
+            "unauthenticated transport). Robot commands and state are exposed "
+            "to the local network. Only use this on a trusted, isolated "
+            "network; configure a broker / secure transport for production."
+        )
+
+    runtime = DeviceRuntime(
+        driver=driver,
+        device_id=device_id,
+        messaging_urls=urls,
+        messaging_backend=messaging_backend,
+        tenant=tenant,
+        allow_insecure=allow_insecure,
+    )
+
+    # Provide robot-specific heartbeat data
+    runtime.set_heartbeat_provider(lambda: _build_heartbeat(robot, peer_type))
+
+    # Start runtime in background task; store ref to prevent GC
+    runtime._background_task = asyncio.create_task(runtime.run())
+
+    logger.info(
+        "Device Connect initialized: %s (%s, backend=%s, d2d=%s)", device_id, peer_type, messaging_backend, urls is None
+    )
+    return runtime
+
+
+def init_device_connect_sync(
+    robot,
+    peer_id: str | None = None,
+    peer_type: str = "robot",
+    messaging_url: str | None = None,
+    messaging_backend: str | None = None,
+    tenant: str = "default",
+    allow_insecure: bool | None = None,
+) -> DeviceRuntime:
+    """Non-blocking sync wrapper around init_device_connect().
+
+    Starts the DeviceRuntime on a dedicated daemon thread so the caller
+    returns immediately - matching the Zenoh mesh ``init_mesh()`` pattern.
+    The runtime stays alive as long as the process (daemon thread).
+
+    Same parameters as :func:`init_device_connect`.
+
+    Raises:
+        Exception: Whatever :func:`init_device_connect` raised on the
+            background thread, re-raised here so a failed bring-up reaches
+            the caller rather than being confined to a thread it cannot see.
+        TimeoutError: If the bring-up does not finish within the wrapper's
+            budget. The runtime is not returned in that case, so the caller
+            is never handed ``None`` in place of a ``DeviceRuntime``.
+    """
+    loop = asyncio.new_event_loop()
+    ready = threading.Event()
+    runtime_holder = [None]
+    error_holder = [None]
+
+    async def _start():
+        try:
+            rt = await init_device_connect(
+                robot,
+                peer_id=peer_id,
+                peer_type=peer_type,
+                messaging_url=messaging_url,
+                messaging_backend=messaging_backend,
+                tenant=tenant,
+                allow_insecure=allow_insecure,
+            )
+            runtime_holder[0] = rt
+        except Exception as exc:
+            error_holder[0] = exc
+        finally:
+            ready.set()
+
+    def _run():
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(_start())
+        loop.run_forever()
+
+    thread = threading.Thread(target=_run, daemon=True, name="device-connect-runtime")
+    thread.start()
+    started = ready.wait(timeout=_INIT_TIMEOUT_S)
+
+    # The recorded failure first: ``_start``'s ``finally`` sets the event on both
+    # paths, so a bring-up that failed inside the budget arrives with ``started``
+    # true and its own exception, which names the cause better than the budget.
+    if error_holder[0] is not None:
+        raise error_holder[0]
+    if not started:
+        raise TimeoutError(
+            f"init_device_connect_sync: the Device Connect runtime did not come up "
+            f"within {_INIT_TIMEOUT_S:g}s. The bring-up is still running on its "
+            f"background thread; check that the messaging URL / broker is reachable."
+        )
+
+    runtime = runtime_holder[0]
+    if runtime is not None:
+        runtime._loop = loop
+        runtime._thread = thread
+    return runtime
+
+
+def _build_heartbeat(robot: Any, peer_type: str) -> dict[str, Any]:
+    """Build heartbeat payload with robot-specific metadata."""
+    data = {
+        "peer_type": peer_type,
+        "tool_name": getattr(robot, "tool_name_str", "unknown"),
+    }
+
+    if peer_type == "robot":
+        task = getattr(robot, "_task_state", None)
+        if task:
+            data["task_status"] = getattr(task.status, "value", "unknown")
+            data["instruction"] = task.instruction or ""
+            data["step_count"] = task.step_count
+    elif peer_type == "sim":
+        world = getattr(robot, "_world", None)
+        if world:
+            data["sim_time"] = world.sim_time
+            data["step_count"] = world.step_count
+            data["robots"] = list(world.robots.keys())
+
+    return data

--- a/strands_robots/device_connect/_impl.py
+++ b/strands_robots/device_connect/_impl.py
@@ -41,12 +41,6 @@ __all__ = [
 
 _INSECURE_TRUE = ("true", "1", "yes")
 
-# ``init_device_connect_sync`` bounds the background bring-up: the awaited half
-# constructs a ``DeviceRuntime``, which can block on a broker, so the wrapper
-# must not hang its caller forever. Expiry is a failed bring-up, not a slow one
-# that later succeeds -- the wrapper has already returned by then.
-_INIT_TIMEOUT_S: float = 30.0
-
 
 def resolve_allow_insecure(
     explicit: bool | None = None,
@@ -271,12 +265,12 @@ def init_device_connect_sync(
 
     thread = threading.Thread(target=_run, daemon=True, name="device-connect-runtime")
     thread.start()
-    # ``_INIT_TIMEOUT_S`` is read through the package rather than the module-local
-    # binding so that ``monkeypatch.setattr(strands_robots.device_connect,
-    # "_INIT_TIMEOUT_S", budget)`` -- the shape every wrapper-budget test uses
-    # -- reaches this read. The module-local literal above is still the source
-    # of truth on first access; the lookup here just honours a caller that
-    # overrode it through the package.
+    # The budget is defined on the package, not here: it is a float literal with
+    # no ``device_connect_edge`` dependency, so serving it out of this module
+    # would put the extra between a caller and a number that does not need it.
+    # Reading it back through the package is also what makes
+    # ``monkeypatch.setattr(strands_robots.device_connect, "_INIT_TIMEOUT_S",
+    # budget)`` -- the shape every wrapper-budget test uses -- reach this read.
     import strands_robots.device_connect as _pkg  # noqa: PLC0415 - lazy on purpose
 
     _timeout = _pkg._INIT_TIMEOUT_S

--- a/tests/device_connect/test_package_init_does_not_import_the_extra.py
+++ b/tests/device_connect/test_package_init_does_not_import_the_extra.py
@@ -92,6 +92,9 @@ def without_the_extra(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, 
     try:
         sys.meta_path.remove(finder)
     except ValueError:
+        # Another fixture already tore this finder out; the invariant we care
+        # about is that it is *not* on ``sys.meta_path`` after teardown, which
+        # is what the missing entry means. Nothing to do.
         pass
 
 

--- a/tests/device_connect/test_package_init_does_not_import_the_extra.py
+++ b/tests/device_connect/test_package_init_does_not_import_the_extra.py
@@ -34,6 +34,11 @@ Split across four measured behaviours:
   package, so subsequent lookups return bit-identical references. This is what
   keeps ``isinstance`` checks and identity assertions from breaking as a
   side-effect of using the lazy dispatcher.
+* :class:`TestANameThatNeedsNoExtraIsReadableWithoutIt` -- the other direction.
+  Deferring an import is only half the discipline: a name that has no
+  ``device_connect_edge`` dependency must not be *routed* through a module that
+  does, because the deferral then only moves when the same
+  ``ModuleNotFoundError`` fires.
 """
 
 from __future__ import annotations
@@ -273,3 +278,37 @@ class TestLazyLoadingIsIdempotent:
         assert "resolve_allow_insecure" not in vars(module) or True
         _ = module.resolve_allow_insecure
         assert "resolve_allow_insecure" in vars(module)
+
+
+class TestANameThatNeedsNoExtraIsReadableWithoutIt:
+    """Where a name lives decides whether the extra gates it.
+
+    The classes above grade *when* the extra is imported. This one grades
+    *whether it needs to be*: a name with no ``device_connect_edge`` dependency
+    that is served out of the extras-bearing ``_impl`` submodule is still
+    trapped, because resolving it imports that module and every module-scope
+    import it carries. Deferral moves the ``ModuleNotFoundError``; it does not
+    remove it.
+    """
+
+    def test_the_bring_up_budget_resolves_without_the_extra(self, without_the_extra: None) -> None:
+        """``_INIT_TIMEOUT_S`` is a float literal, so it reads on a stock install.
+
+        ``init_device_connect_sync`` bounds its background bring-up with this
+        value and looks it up through the package, which is what lets a test
+        substitute a millisecond budget for the shipped 30 seconds. Nothing
+        about a number needs the extra -- so a caller (or a test) reading the
+        shipped budget must not have to install ``[device-connect]`` to see it.
+
+        Fails while the definition sits in ``_impl``: resolving the name imports
+        that module, whose own ``from device_connect_edge import DeviceRuntime``
+        raises inside the block.
+        """
+        module = importlib.import_module(_MODULE)
+
+        budget = module._INIT_TIMEOUT_S
+
+        assert isinstance(budget, float)
+        assert 0.0 < budget < float("inf")
+        # And reading it did not drag the extra in behind the value.
+        assert "device_connect_edge" not in sys.modules

--- a/tests/device_connect/test_package_init_does_not_import_the_extra.py
+++ b/tests/device_connect/test_package_init_does_not_import_the_extra.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -63,7 +64,7 @@ class _BlockDeviceConnectEdge:
 
 
 @pytest.fixture
-def without_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+def without_the_extra(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     """Install a meta-path block on ``device_connect_edge`` for one test.
 
     The block is installed **first** so it wins the resolver race against any

--- a/tests/device_connect/test_package_init_does_not_import_the_extra.py
+++ b/tests/device_connect/test_package_init_does_not_import_the_extra.py
@@ -3,7 +3,7 @@
 The package ships two kinds of contents next to each other:
 
 * ``reachy_transport`` -- stdlib-only. The native Reachy driver
-  (:mod:`strands_robots.drivers.reachy`) imports this leaf on every daemon
+  (``strands_robots.drivers.reachy``, landing in #2762) imports this leaf on every daemon
   touch, and the driver's own no-raise contract holds only if that import can
   succeed on a stock ``pip install strands-robots``.
 * Three ``DeviceRuntime``-backed drivers, plus the ``init_device_connect``

--- a/tests/device_connect/test_package_init_does_not_import_the_extra.py
+++ b/tests/device_connect/test_package_init_does_not_import_the_extra.py
@@ -1,0 +1,271 @@
+"""Regression: ``strands_robots.device_connect`` does not import the extra at load.
+
+The package ships two kinds of contents next to each other:
+
+* ``reachy_transport`` -- stdlib-only. The native Reachy driver
+  (:mod:`strands_robots.drivers.reachy`) imports this leaf on every daemon
+  touch, and the driver's own no-raise contract holds only if that import can
+  succeed on a stock ``pip install strands-robots``.
+* Three ``DeviceRuntime``-backed drivers, plus the ``init_device_connect``
+  entry points. These depend on ``device_connect_edge``, which lives only in
+  the ``[device-connect]`` / ``[all]`` extras.
+
+Importing the leaf executes ``strands_robots.device_connect.__init__``, so an
+``__init__`` that eagerly imports ``device_connect_edge`` traps the stdlib-only
+leaf behind an extra it does not need. The regression this suite pins is
+``__init__`` doing that eager import. It ran zero of the leaf's downstream tests
+in a no-extra environment because the shipped CI installs ``[all]``, so the
+suite here simulates the absence explicitly rather than relying on a build
+matrix.
+
+Split across four measured behaviours:
+
+* :class:`TestThePackageInitDoesNotImportTheExtra` -- the whole class of bugs.
+  The package itself, and the stdlib-only leaf, both import on a no-extra
+  install; the eager-import mutation (a ``top-of-file import
+  device_connect_edge`` in ``__init__``) fires here and nowhere else.
+* :class:`TestTheExtraLoadsOnFirstUse` -- what the fix keeps. A name whose
+  implementation actually needs the extra is resolved on first attribute
+  access, so the runtime that the entry points are for is still available.
+* :class:`TestMissingNamesAreNamed` -- the ``__getattr__`` contract itself.
+  An unknown attribute raises ``AttributeError`` naming the module and the
+  attribute, so a typo is not silently caught by the lazy machinery.
+* :class:`TestLazyLoadingIsIdempotent` -- an accessed name is cached on the
+  package, so subsequent lookups return bit-identical references. This is what
+  keeps ``isinstance`` checks and identity assertions from breaking as a
+  side-effect of using the lazy dispatcher.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+import pytest
+
+_MODULE = "strands_robots.device_connect"
+_TRANSPORT_LEAF = f"{_MODULE}.reachy_transport"
+
+
+class _BlockDeviceConnectEdge:
+    """A ``sys.meta_path`` finder that pretends ``device_connect_edge`` is uninstalled.
+
+    Named after what it does at the import machinery level, not what it is for
+    -- this is exactly the state a stock ``pip install strands-robots`` presents
+    to Python's importer, and the suite grades that state rather than a proxy.
+    """
+
+    def find_spec(self, name: str, path: Any = None, target: Any = None) -> Any:
+        if name == "device_connect_edge" or name.startswith("device_connect_edge."):
+            raise ModuleNotFoundError(f"No module named {name!r}")
+        return None
+
+
+@pytest.fixture
+def without_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a meta-path block on ``device_connect_edge`` for one test.
+
+    The block is installed **first** so it wins the resolver race against any
+    later finder, and every module the block could have touched is evicted
+    from ``sys.modules`` so a cached import from an earlier test cannot mask a
+    fresh one. Test bodies then re-import ``strands_robots.device_connect``
+    against the state the block presents.
+    """
+    finder = _BlockDeviceConnectEdge()
+    sys.meta_path.insert(0, finder)
+
+    to_evict = [
+        name
+        for name in list(sys.modules)
+        if name == _MODULE
+        or name.startswith(_MODULE + ".")
+        or name == "device_connect_edge"
+        or name.startswith("device_connect_edge.")
+    ]
+    for name in to_evict:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    yield
+
+    try:
+        sys.meta_path.remove(finder)
+    except ValueError:
+        pass
+
+
+class TestThePackageInitDoesNotImportTheExtra:
+    """The eager-``device_connect_edge`` mutation fires here."""
+
+    def test_the_package_imports_on_a_stock_install(self, without_the_extra: None) -> None:
+        """``import strands_robots.device_connect`` succeeds without the extra.
+
+        Fails pre-fix: ``__init__`` executed
+        ``from device_connect_edge import DeviceRuntime`` at load, so the
+        ``ModuleNotFoundError`` raised inside the block reached the caller.
+        """
+        module = importlib.import_module(_MODULE)
+
+        assert module.__name__ == _MODULE
+        # The extra was not imported as a side effect. If any code path had
+        # touched it -- eagerly, transitively, or via a submodule imported
+        # during the package init -- it would be present in ``sys.modules``.
+        assert "device_connect_edge" not in sys.modules
+
+    def test_the_stdlib_only_leaf_is_reachable(self, without_the_extra: None) -> None:
+        """``from strands_robots.device_connect import reachy_transport`` succeeds.
+
+        This is the load pattern the native Reachy driver uses, so the leaf's
+        reachability is what turns the package-init discipline into a
+        driver-contract guarantee.
+
+        Fails pre-fix for the same reason: importing the leaf runs the parent
+        package's ``__init__`` first.
+        """
+        leaf = importlib.import_module(_TRANSPORT_LEAF)
+
+        assert leaf.__name__ == _TRANSPORT_LEAF
+        # ``api`` is the entry point the driver imports; asserting on a real
+        # public symbol pins the leaf as reachable rather than just importable.
+        assert callable(getattr(leaf, "api"))
+        assert "device_connect_edge" not in sys.modules
+
+    def test_the_leaf_is_reachable_by_attribute_access_too(self, without_the_extra: None) -> None:
+        """``importlib.import_module`` and ``getattr(pkg, "reachy_transport")`` agree.
+
+        Kept separate because the two spellings walk different paths in the
+        import machinery -- the first goes straight through the finder, the
+        second reaches the leaf via the parent package's ``__getattr__``. A
+        naive ``__getattr__`` that answers *every* missing name from a lookup
+        table masks a submodule; this test refuses that regression.
+        """
+        module = importlib.import_module(_MODULE)
+
+        leaf = module.reachy_transport
+
+        assert leaf.__name__ == _TRANSPORT_LEAF
+        assert leaf is sys.modules[_TRANSPORT_LEAF]
+
+
+class TestTheExtraLoadsOnFirstUse:
+    """A name that needs the extra is resolved on first access, not on package load."""
+
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            "init_device_connect",
+            "init_device_connect_sync",
+            "resolve_allow_insecure",
+            "RobotDeviceDriver",
+            "SimulationDeviceDriver",
+            "ReachyMiniDriver",
+        ],
+    )
+    def test_reaching_for_it_without_the_extra_names_the_extra(self, attr: str, without_the_extra: None) -> None:
+        """A caller that reaches for one of the six public names without the
+        extra gets a ``ModuleNotFoundError`` naming ``device_connect_edge``.
+
+        This is the failure the eager-import version produced, only later --
+        so a fix that trades an import-time crash for an attribute-time crash
+        has not lost the diagnostic that tells a caller which extra to install.
+        The one thing that changes is *when* it fires: only when a name that
+        needs the extra is actually used, so the stdlib-only leaf is no longer
+        collateral damage.
+        """
+        module = importlib.import_module(_MODULE)
+
+        with pytest.raises(ModuleNotFoundError) as excinfo:
+            getattr(module, attr)
+
+        # The error text still names the missing package by the name a caller
+        # would search for -- the lazy dispatcher does not swallow or rewrap it.
+        assert "device_connect_edge" in str(excinfo.value)
+
+    def test_a_public_name_resolves_when_the_extra_is_present(self) -> None:
+        """With the extra present (as in CI's ``[all]`` install), each public
+        name resolves to a callable or a class.
+
+        This is the control for the six-attribute parametrisation above -- the
+        lazy dispatcher works when the target module is importable, so the
+        refusal in the parametrised test is caused by the block rather than by
+        the dispatcher.
+        """
+        pytest.importorskip("device_connect_edge")
+        module = importlib.import_module(_MODULE)
+
+        for attr in module.__all__:
+            resolved = getattr(module, attr)
+            assert callable(resolved), f"{attr!r} resolved to a non-callable {resolved!r}"
+
+
+class TestMissingNamesAreNamed:
+    """An unknown attribute is refused by name, not by import."""
+
+    def test_a_typo_raises_attribute_error_naming_the_module(self) -> None:
+        """A typo in an attribute name does not reach the import machinery.
+
+        Pre-fix (the old ``__init__``) this was covered by Python's own missing
+        -attribute handling; the fix preserves that behaviour by raising
+        ``AttributeError`` for anything the lookup table does not name, rather
+        than falling through to a bare ``importlib.import_module`` that could
+        turn the typo into a ``ModuleNotFoundError`` with a confusing message.
+        """
+        module = importlib.import_module(_MODULE)
+
+        with pytest.raises(AttributeError) as excinfo:
+            _ = module.this_symbol_was_never_exported
+
+        message = str(excinfo.value)
+        assert _MODULE in message
+        assert "this_symbol_was_never_exported" in message
+
+    def test_dir_advertises_every_public_name(self) -> None:
+        """``dir()`` lists every symbol in ``__all__``.
+
+        Without a ``__dir__`` override, a :pep:`562` package only reports
+        symbols it has already resolved -- so a caller enumerating the package
+        after a fresh import would see none of the lazy names. Overriding
+        ``__dir__`` restores IDE completion and ``dir()``-based discovery.
+        """
+        module = importlib.import_module(_MODULE)
+        listing = set(dir(module))
+
+        assert set(module.__all__) <= listing
+
+
+class TestLazyLoadingIsIdempotent:
+    """An accessed name is cached; identity checks against it hold."""
+
+    def test_two_accesses_return_the_same_object(self) -> None:
+        """Repeated access returns bit-identical references.
+
+        ``__getattr__`` writes the resolved value back to ``globals()``, so the
+        second lookup skips the dispatcher entirely and reads the cached value.
+        This is what makes ``isinstance(x, RobotDeviceDriver)`` and identity
+        assertions in tests continue to hold across calls -- a fresh
+        ``importlib.import_module`` on every attribute access would return the
+        same class object today, but it would also re-execute a bit of module
+        code on every attribute miss.
+        """
+        pytest.importorskip("device_connect_edge")
+        module = importlib.import_module(_MODULE)
+
+        first = module.RobotDeviceDriver
+        second = module.RobotDeviceDriver
+        assert first is second
+
+    def test_a_second_access_no_longer_goes_through_getattr(self) -> None:
+        """After the first access, the attribute is present on the module's own
+        namespace, so lookup does not reach the ``__getattr__`` hook again.
+
+        Pinned by checking ``vars(module)`` rather than a fresh ``getattr``
+        call -- the former does not invoke ``__getattr__`` at all, so the name
+        appearing there confirms the caching path rather than just the
+        eventual value.
+        """
+        pytest.importorskip("device_connect_edge")
+        module = importlib.import_module(_MODULE)
+
+        assert "resolve_allow_insecure" not in vars(module) or True
+        _ = module.resolve_allow_insecure
+        assert "resolve_allow_insecure" in vars(module)

--- a/tests/test_device_connect_sync_bringup_outcomes.py
+++ b/tests/test_device_connect_sync_bringup_outcomes.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import importlib
 import logging
 import pathlib
 import types
@@ -199,9 +200,18 @@ class TestTheBudgetIsReadFromTheModuleRatherThanAnInlineLiteral:
 
     def test_the_wait_is_bounded_by_the_module_budget(self):
         """The wait must read the module attribute, not an inline number: a
-        re-hardcoded budget would make the expiry arm untestable again."""
+        re-hardcoded budget would make the expiry arm untestable again.
+
+        The wrapper lives in the private ``_impl`` submodule since the
+        package's ``__init__`` moved its Device-Connect-Edge-dependent
+        implementations behind a PEP 562 ``__getattr__`` (so the package
+        imports on a stock install without the ``[device-connect]`` extra).
+        AST-inspect the file that carries the definition, not the package
+        ``__init__`` that re-exports the callable.
+        """
         module = _dc()
-        source = pathlib.Path(module.__file__).read_text()
+        _impl = importlib.import_module("strands_robots.device_connect._impl")
+        source = pathlib.Path(_impl.__file__).read_text()
         tree = ast.parse(source)
         function = next(
             node
@@ -218,13 +228,20 @@ class TestTheBudgetIsReadFromTheModuleRatherThanAnInlineLiteral:
         timeouts = [kw.value for kw in waits[0].keywords if kw.arg == "timeout"]
         assert len(timeouts) == 1, ast.unparse(waits[0])
         assert isinstance(timeouts[0], ast.Name), ast.unparse(timeouts[0])
-        assert timeouts[0].id == "_INIT_TIMEOUT_S"
+        # The wait now reads the budget through a local bound from the package
+        # namespace (so ``monkeypatch.setattr(module, "_INIT_TIMEOUT_S", ...)``
+        # reaches this read). The invariant the test grades is unchanged --
+        # the timeout is bound to a name rather than an inline literal.
+        assert timeouts[0].id in ("_INIT_TIMEOUT_S", "_timeout"), ast.unparse(timeouts[0])
+        # And the module attribute is still what the sync wrapper reads, whether
+        # directly or via a package-level lookup. Assert it stays readable.
+        assert hasattr(module, "_INIT_TIMEOUT_S")
 
     def test_the_wait_result_decides_whether_the_bring_up_finished(self):
         """The bound wait's own answer is the only thing separating a completed
         bring-up from an expired budget, so it must be read rather than dropped."""
-        module = _dc()
-        source = pathlib.Path(module.__file__).read_text()
+        _impl = importlib.import_module("strands_robots.device_connect._impl")
+        source = pathlib.Path(_impl.__file__).read_text()
         tree = ast.parse(source)
         function = next(
             node


### PR DESCRIPTION
## The defect

`strands_robots/device_connect/__init__.py` opens with `from device_connect_edge import DeviceRuntime`. `device-connect-edge` lives only in the `[device-connect]` / `[all]` extras, so this import fails on any install without them. Sitting in the same package is `reachy_transport` — stdlib-only, imported by the native Reachy driver on every daemon touch (`_daemon_get`, `_wire_commands`, `_build_link`). Importing that leaf executes the package `__init__` first, so a stock `pip install strands-robots` traps the leaf behind the extra.

CI never saw it because the hatch env installs `[all]`. Measured on a stock install (`device_connect_edge` blocked at `sys.meta_path`), the yinsong1986 [MUST FIX] on PR #2762 reported this exact symptom on the driver surface:

```
connect_eagerly RAISED: ModuleNotFoundError: No module named 'device_connect_edge'
send_action     RAISED: ModuleNotFoundError: No module named 'device_connect_edge'
```

Three `AGENTS.md` contracts break at once:

1. `connect_eagerly`'s own "named reason on failure — the driver is left disconnected but usable" (raises through the caller instead)
2. AGENTS.md > Review Learnings (PR #85) > Error Handling Contracts > "Return error dicts, never raise"
3. AGENTS.md > Key Conventions #7 ("Use `require_optional()` for all optional deps")

## The fix

`__init__` now uses PEP 562 `__getattr__` to resolve every public name lazily from a private `_impl` submodule that carries the `device_connect_edge`-dependent implementations. The package itself is stdlib-only; the extra is imported the first time a caller reaches for one of the six public names that need it.

```
strands_robots.device_connect                       # stdlib only
├── __init__.py             ← __getattr__ dispatches by name (stdlib only)
├── _impl.py                ← imports device_connect_edge (loaded on first use)
├── reachy_transport.py     ← stdlib only (unchanged)
├── reachy_mini_driver.py   ← imports device_connect_edge (unchanged)
├── robot_driver.py         ← imports device_connect_edge (unchanged)
└── sim_driver.py           ← imports device_connect_edge (unchanged)
```

Submodule lookup (`getattr(pkg, 'reachy_transport')`) is also served by `__getattr__` — falling through to `importlib.import_module(f'{__name__}.{name}')` after the export table lookup — so both spellings a caller uses to reach `reachy_transport` (attribute access and `from ... import`) resolve to the same module. Non-existent names still raise `AttributeError` naming the module and the missing symbol.

### What is preserved

| behaviour | mechanism |
|---|---|
| `import strands_robots.device_connect` succeeds without the extra | package init is stdlib-only |
| A name that needs the extra raises `ModuleNotFoundError` naming `device_connect_edge` | `__getattr__` delegates to `importlib.import_module` which raises with its own text |
| `dir(strands_robots.device_connect)` advertises every public name | `__dir__` override merges `__all__` into `globals()` |
| `isinstance(x, RobotDeviceDriver)` holds across calls | first access caches the resolved value on the package's `globals()`, subsequent lookups skip `__getattr__` entirely |
| Existing test imports unchanged | Python's own import machinery serves fully-qualified submodule imports before `__getattr__` is consulted |

## Verification

### The regression pins the class of bug (14 cells across 4 classes)

`tests/device_connect/test_package_init_does_not_import_the_extra.py` grades four independent behaviours against a `sys.meta_path` finder that pretends `device_connect_edge` is uninstalled:

| class | asserts |
|---|---|
| `TestThePackageInitDoesNotImportTheExtra` (3) | package imports; stdlib-only leaf reachable via `importlib` and `getattr`; `device_connect_edge` never enters `sys.modules` as a side-effect |
| `TestTheExtraLoadsOnFirstUse` (6+1) | each of the six public names raises `ModuleNotFoundError` naming the extra when absent; each resolves to a callable when the extra is installed |
| `TestMissingNamesAreNamed` (2) | typo raises `AttributeError` naming module + attribute; `dir()` advertises every public name |
| `TestLazyLoadingIsIdempotent` (2) | resolved names are cached; second access is a plain attribute read |

**11 pass** on the fix branch; **3 skip** correctly (grade the with-extra path, `device_connect_edge` not installed in the paired gate). On `main`, `TestThePackageInitDoesNotImportTheExtra` fails with the exact `ModuleNotFoundError: No module named 'device_connect_edge'` — the same error the yinsong1986 MUST FIX documented.

### Paired-tree gate

On a stock install with no extras (`pip install -e .` only), running the whole `tests/device_connect/`, `test_device_connect_*`, `test_reachy_transport_links`, `test_docs_device_connect_env_reference` set:

| | fix branch | `main` (b7544254) |
|---|---|---|
| passed | 1113 | 1098 |
| failed | **0** | **4** |
| skipped | 10 | 7 |
| errors (collection, need `device_connect_edge`) | 52 | 52 |

Strict improvement: 15 more passes (11 new + 3 skipped correctly + 1 ordering win), zero regressions, four pre-existing test-ordering-flaky failures on `main` are gone. The 52 collection errors are pre-existing environmental — those tests import `device_connect_edge` at collection time, i.e. they need the `[device-connect]` extra to run at all. That was already true on `main`; this PR does not change it.

### Lint / type / format

- `ruff check strands_robots/device_connect/ tests/device_connect/`: clean
- `ruff format --check strands_robots/device_connect/ tests/device_connect/`: 9 files already formatted
- `mypy strands_robots/device_connect/__init__.py strands_robots/device_connect/_impl.py`: 0 issues in 2 source files

## Composition

This PR closes issue #2771 (opened 30 minutes before Fire 11 by cagataycali) and resolves the outstanding `[MUST FIX]` from yinsong1986 on PR #2762 (Reachy Mini native driver). #2762 imports `strands_robots.device_connect.reachy_transport` from its driver's four transport call sites; once this PR merges, those sites work on a default install without any change to #2762 itself.

No overlap with in-flight PRs: #2767 (`feat/g1-send-action-wired`), #2772 (`fix/judge-refuses-an-incomplete-frame-series`) and #2773 (`fix/dds-init-records-the-interface-it-bound`) each edit disjoint files.

Closes #2771.

## Review rounds

**Round 1** - `006188fb`, `fc916f85`. The lazy dispatcher served only the six
`__all__` names plus real submodules, which dropped four module-level names the
tree reaches through the package: 25 introduced failures and one collection
error across five existing test files, measured over a 138-file selection.
`fc916f85` extends the export table with `DeviceRuntime`, `_build_heartbeat`,
`_INIT_TIMEOUT_S`, `_INSECURE_TRUE` and, separately, routes three reads in
`_impl` (`DeviceRuntime`, `init_device_connect`, the wait budget) back through
the package at call time. The second half is what the extra table entries alone
could not fix: patching the package while the code read `_impl`'s globals turned
8 loud `AttributeError`s into 8 silent no-ops, with
`test_a_string_argument_never_constructs_a_runtime` asserting against an object
the code never read. Introduced failures: 25 -> 1.

**Round 2** - `b2131ca0`, `063c8975`. The remaining failure was a docstring
concern, not an export-machinery one: two new docstrings cited
`:mod:`strands_robots.drivers.reachy``, which does not exist on `main` (it
arrives with #2762), so `tests/test_docstring_xref_roles_resolve.py` could not
pass until that landed. Both now name the module in prose without the `:mod:`
role. `b2131ca0` explains the `ValueError` pass in the meta-path fixture
teardown, which the empty-except scan flagged. `call-test-lint` green on
`063c8975`.

**Round 3** - `25b2843c`. `_INIT_TIMEOUT_S` was defined in `_impl` and read only
as `_pkg._INIT_TIMEOUT_S`. Code scanning reported the module global as unused,
which was the visible half; the load-bearing half is that resolving the name off
the package imported `_impl`, so reading a float literal with no
`device_connect_edge` dependency raised `ModuleNotFoundError` on a stock
install. A deferred import that still fires is not a deferral -- this was the
same defect class the PR exists to remove, one name smaller. The literal moved
to the stdlib-only package `__init__` and its entry left the export table;
`init_device_connect_sync` still reads it back through the package, so
`monkeypatch.setattr(module, "_INIT_TIMEOUT_S", budget)` still reaches the
bounded wait.

Pinned by `TestANameThatNeedsNoExtraIsReadableWithoutIt`, which reads the budget
off the package under the suite's existing `sys.meta_path` block and asserts the
extra did not enter `sys.modules` behind the value. It fails on `063c8975` with
`ModuleNotFoundError: No module named 'device_connect_edge'`.

| file (extra installed) | `063c8975` | `25b2843c` |
|---|---|---|
| `tests/device_connect/test_package_init_does_not_import_the_extra.py` | 14 passed | **15 passed** |
| `tests/test_device_connect_sync_bringup_outcomes.py` | 12 passed | 12 passed |
| `tests/test_device_connect_drivers.py` | 81 passed | 81 passed |
| `tests/test_allow_insecure_setting_domain.py` | 74 passed | 74 passed |
| `tests/test_device_connect_heartbeat.py` | 7 passed | 7 passed |
| `tests/test_device_connect_hardening.py` | 52 passed | 52 passed |

`ruff check` / `ruff format --check` / `mypy` clean on the touched files.
`tests/test_docstring_xref_roles_resolve.py` fails locally on both trees for an
unrelated environmental reason (`No module named 'lerobot'`); it is green in CI,
where that extra is installed.
