### PR TITLE
fix(simulation): name an unknown router key by the spelling the caller wrote

### DIFF
--- a/changelog.d/2775-router-unknown-key-names-caller-spelling.md
+++ b/changelog.d/2775-router-unknown-key-names-caller-spelling.md
@@ -1,0 +1,31 @@
+### Fixed: an unknown router key is named by the spelling the caller wrote
+
+`_dispatch_action` rewrites `_FIELD_ALIASES` to method parameter names before validating, so every
+refusal downstream of that rewrite reports the name it validated rather than the field the payload
+carried. `_reported_param_name` exists to undo that for the caller, and four of the five refusal
+sites in `_validate_and_build_kwargs` consult it. The unknown-parameter branch interpolated
+`unknown[0]` -- a key taken straight out of the post-rewrite payload -- so the offending key was
+reported canonically while the `Valid:` list beside it, built through the helper in the same
+statement, was reported in caller spellings.
+
+Every alias reproduces it, because the rewrite is unconditional and the target is a parameter of one
+action rather than all of them: sending `torque_vec` to any action but `apply_force` was answered
+`Unknown parameter 'torque'`, and `checkpoint_name`, `camera_names` and `joint_positions` were
+answered `name`, `cameras` and `positions`. Three of those four canonical names are not published
+properties at all, so a schema-constrained caller was named a field it is not permitted to emit and
+had no route from the message back to the one that works -- the dead-end diagnostic
+`_reported_param_name` was introduced to remove, surviving in the one branch that read its loop
+variable directly.
+
+The branch now routes through the same helper. A key the alias map does not mention still reports
+itself, and a caller who writes the canonical parameter directly is still named by it: the
+substitution is driven by what the payload carries, not by the map, so it cannot answer either
+caller with a field they did not send.
+
+The contract's structural guard is replaced rather than extended. It forbade two literal format
+strings and asserted a minimum count of helper calls, which grades how a slot is written and how
+many there are -- not where a slot's value came from -- so it stayed green for the one raw site it
+had not been told about, and no count could have moved. The replacement asks the dataflow question
+instead: a name assigned from an expression over `remapped` or `received` holds post-rewrite keys,
+and no refusal in the function may interpolate one. The behavioural sweep beside it is derived from
+`_FIELD_ALIASES`, so an alias added later is graded on arrival without a second list to keep true.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5895,13 +5895,22 @@ class MuJoCoSimEngine(
         # 1) Unknown kwargs (skipped for **kwargs methods which legitimately passthrough)
         unknown = [] if method_has_var_keyword else [k for k in remapped if k not in accepted_field_names]
         if unknown:
+            # Name the offending key by the spelling the caller wrote, the same
+            # rule the ``Valid:`` list beside it already uses. ``remapped`` holds
+            # post-rewrite names, so an alias whose target is not a parameter of
+            # THIS action (``torque_vec`` -> ``torque`` on any action but
+            # ``apply_force``) would otherwise be reported under a key the
+            # payload never carried - the canonical-name refusal this helper
+            # exists to prevent, surviving in the one branch that read the loop
+            # variable directly.
+            reported_unknown = _reported_param_name(unknown[0], self._FIELD_ALIASES, received)
             valid_sorted = sorted(
                 _reported_param_name(param, self._FIELD_ALIASES, received) for param in method_param_names - {"action"}
             )
             return None, {
                 "status": "error",
                 "content": [
-                    {"text": (f"Unknown parameter '{unknown[0]}' for action '{action}'. Valid: {valid_sorted}")}
+                    {"text": (f"Unknown parameter '{reported_unknown}' for action '{action}'. Valid: {valid_sorted}")}
                 ],
             }
 

--- a/tests/simulation/mujoco/test_router_refusals_name_a_published_spelling.py
+++ b/tests/simulation/mujoco/test_router_refusals_name_a_published_spelling.py
@@ -28,9 +28,11 @@ alias added later is graded without a second list to keep true.
 
 from __future__ import annotations
 
+import ast
 import inspect
 import json
 import re
+import textwrap
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -132,6 +134,28 @@ def _aliases_by_kind(kind: str) -> list[tuple[str, str]]:
         for wire, param in MuJoCoSimEngine._FIELD_ALIASES.items()
         if _SPEC["properties"].get(wire, {}).get("type") == kind
     )
+
+
+def _actions_without_param(param: str) -> list[str]:
+    """Published actions whose method takes neither *param* nor ``**kwargs``.
+
+    Sending an alias for *param* to one of these is what makes the offending key
+    differ from what the caller wrote: the dispatcher rewrites the wire name to
+    *param* before validating, and *param* is not a field of this action, so the
+    unknown-key branch is the one that reports it.
+    """
+    out = []
+    for action in _SPEC["properties"]["action"]["enum"]:
+        if action in _VAR_KEYWORD_ACTIONS:
+            continue
+        method = getattr(MuJoCoSimEngine, MuJoCoSimEngine._ACTION_ALIASES.get(action, action), None)
+        if method is None:  # pragma: no cover - every published action resolves today
+            continue
+        names = set(inspect.signature(method).parameters) - {"self"}
+        if param in names or {"name", "robot_name"} & {param} and names & {"name", "robot_name"}:
+            continue
+        out.append(action)
+    return sorted(out)
 
 
 class TestTheAliasMapIsWhatMakesThisReachable:
@@ -373,9 +397,42 @@ class TestOneOwnerForTheReportingRule:
         messages at once.
         """
         source = inspect.getsource(MuJoCoSimEngine._validate_and_build_kwargs)
-        for raw in ("{vparam}", "{param_name}'."):
-            assert raw not in source, f"a refusal still formats the raw name {raw!r}"
-        assert source.count("_reported_param_name(") >= 4, source.count("_reported_param_name(")
+        assert source.count("_reported_param_name(") >= 5, source.count("_reported_param_name(")
+
+        # Derived rather than a list of spellings to forbid: a blocklist of
+        # format strings grades how a slot is written, not where its value came
+        # from, so it stays green for any raw name it was not told about. This
+        # asks the dataflow question instead - a name built out of ``remapped``
+        # or ``received`` carries post-rewrite keys, and a refusal may only
+        # interpolate one that has been through the shared rule.
+        function = ast.parse(textwrap.dedent(source)).body[0]
+        assert isinstance(function, ast.FunctionDef)
+        body = ast.Module(body=function.body, type_ignores=[])
+        resolved: set[str] = set()
+        tainted: set[str] = set()
+        for node in ast.walk(body):
+            if not isinstance(node, ast.Assign):
+                continue
+            value = ast.unparse(node.value)
+            names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            if "_reported_param_name(" in value:
+                resolved |= names
+            elif "remapped" in value or "received" in value:
+                tainted |= names
+        assert "unknown" in tainted, f"premise: the post-rewrite key list is not payload-derived: {sorted(tainted)}"
+        assert resolved, "premise: no name is produced by the shared reporting rule"
+
+        for node in ast.walk(body):
+            if not isinstance(node, ast.Return) or node.value is None:
+                continue
+            for piece in ast.walk(node.value):
+                if not isinstance(piece, ast.FormattedValue):
+                    continue
+                slot = {n.id for n in ast.walk(piece.value) if isinstance(n, ast.Name)}
+                assert not (slot & tainted), (
+                    f"a refusal interpolates {sorted(slot & tainted)}, which holds post-rewrite "
+                    f"names; route it through _reported_param_name as the other sites do"
+                )
 
     def test_the_reported_spelling_prefers_the_payload_then_the_schema(self) -> None:
         """The rule's three branches, stated directly on the helper."""
@@ -387,3 +444,73 @@ class TestOneOwnerForTheReportingRule:
         assert _reported_param_name("torque", aliases, {}) == "torque_vec"
         assert _reported_param_name("force", aliases, {}) == "force"
         assert _reported_param_name("bucket", aliases, {}) == "bucket"
+
+
+class TestAnUnknownKeySentUnderAWireNameIsNamedByIt:
+    """The offending key of an ``Unknown parameter`` refusal, not just its ``Valid:`` list.
+
+    The list beside it was already resolved back to published spellings; the key
+    the refusal is *about* was interpolated straight from ``remapped``, which
+    holds post-rewrite names. An alias whose target is a parameter of some other
+    action (every entry in ``_FIELD_ALIASES``) therefore came back named as the
+    canonical parameter - a key the payload never carried, and for
+    ``torque``/``positions``/``cameras`` one the schema does not publish at all,
+    so the caller's only route back was to guess the mapping.
+
+    Derived from ``_FIELD_ALIASES``, so an alias added later is graded here
+    without a second list to keep true.
+    """
+
+    @pytest.mark.parametrize(("wire", "param"), sorted(MuJoCoSimEngine._FIELD_ALIASES.items()))
+    def test_the_refusal_names_the_wire_name_the_caller_wrote(self, sim: Simulation, wire: str, param: str) -> None:
+        """Not the canonical parameter the dispatcher rewrote it to."""
+        action = _actions_without_param(param)[0]
+        method = getattr(MuJoCoSimEngine, MuJoCoSimEngine._ACTION_ALIASES.get(action, action))
+        assert param not in inspect.signature(method).parameters, (
+            f"premise: {action!r} accepts {param!r}, so the rewrite produces no unknown key"
+        )
+        result = sim(**{"action": action, wire: _BAD_BY_TYPE["array"]})
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "Unknown parameter" in text, text
+        assert f"'{wire}'" in text, f"refusal did not name the spelling the caller wrote: {text}"
+        assert f"Unknown parameter '{param}'" not in text, (
+            f"refusal named {param!r}, which the payload never carried: {text}"
+        )
+
+    @pytest.mark.parametrize(("wire", "param"), sorted(MuJoCoSimEngine._FIELD_ALIASES.items()))
+    def test_an_action_that_rejects_the_alias_target_exists(self, wire: str, param: str) -> None:
+        """Premise: the sweep above is not vacuous for any alias.
+
+        If every published action accepted *param*, the rewrite could never
+        produce an unknown key and there would be nothing to misname.
+        """
+        assert _actions_without_param(param), f"no action rejects {param!r}, so {wire!r} is ungraded"
+
+    @pytest.mark.parametrize(("wire", "param"), sorted(MuJoCoSimEngine._FIELD_ALIASES.items()))
+    def test_a_caller_who_writes_the_canonical_name_is_named_by_it(
+        self, sim: Simulation, wire: str, param: str
+    ) -> None:
+        """Over-reach control: the substitution is driven by the payload, not by the map.
+
+        A Python caller may write the canonical parameter directly. Preferring
+        the wire name unconditionally would answer them with a field they did not
+        send, which is the same defect pointed the other way.
+        """
+        action = _actions_without_param(param)[0]
+        result = sim(**{"action": action, param: _BAD_BY_TYPE["array"]})
+        assert result["status"] == "error"
+        text = _text(result)
+        assert f"Unknown parameter '{param}'" in text, f"expected the canonical name back, got: {text}"
+        assert f"'{wire}'" not in text, f"refusal named {wire!r}, which the payload never carried: {text}"
+
+    def test_a_key_with_no_alias_keeps_its_own_name(self, sim: Simulation) -> None:
+        """Over-reach control: resolving the spelling must not rewrite an ordinary typo.
+
+        A misspelling the alias map does not mention has only one name, and the
+        refusal must still report exactly that.
+        """
+        result = sim(action="step", definitely_not_a_field=1)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "Unknown parameter 'definitely_not_a_field'" in text, text


### PR DESCRIPTION
## The defect

`_dispatch_action` rewrites `_FIELD_ALIASES` to method parameter names *before* validating, so a
refusal downstream of that rewrite reports the name it validated rather than the field the payload
carried. `_reported_param_name` is the shared rule that undoes it. Four of the five refusal sites in
`_validate_and_build_kwargs` consult it; the unknown-parameter branch interpolated `unknown[0]`,
taken straight out of the post-rewrite payload.

The result is a message that reports the offending key canonically while the `Valid:` list built
one statement above it, through the helper, reports caller spellings.

## Measured, all four aliases

Each row sends the wire name to an action whose method does not take the alias target, so the
rewrite produces an unknown key:

| caller wrote | rewritten to | refusal before | refusal after |
|---|---|---|---|
| `checkpoint_name` | `name` | `Unknown parameter 'name' for action 'step'` | `Unknown parameter 'checkpoint_name' ...` |
| `torque_vec` | `torque` | `Unknown parameter 'torque' for action 'step'` | `Unknown parameter 'torque_vec' ...` |
| `camera_names` | `cameras` | `Unknown parameter 'cameras' for action 'step'` | `Unknown parameter 'camera_names' ...` |
| `joint_positions` | `positions` | `Unknown parameter 'positions' for action 'step'` | `Unknown parameter 'joint_positions' ...` |

Refusals naming a key the caller never wrote: **4 of 4 before, 0 of 4 after.**

Three of those four canonical names (`torque`, `cameras`, `positions`) are not published properties
at all, so a schema-constrained caller was named a field it is not permitted to emit, with no route
from the message back to the one that works. That is the dead-end diagnostic
`_reported_param_name` was introduced to remove; it survived in the branch that read its loop
variable directly.

Reachability needs no unusual input: the rewrite is unconditional, and each alias target is a
parameter of one action rather than all of them, so any other action reproduces it.

## Why the existing guards were silent

This contract has an owner, `tests/simulation/mujoco/test_router_refusals_name_a_published_spelling.py`,
and both of its relevant guards look past this branch.

`test_no_refusal_in_the_validator_formats_a_raw_parameter_name` claims "every site names the field
through the shared rule". It graded that by forbidding two literal format strings and asserting
`count >= 4`:

```python
for raw in ("{vparam}", "{param_name}'."):
    assert raw not in source
assert source.count("_reported_param_name(") >= 4
```

`{unknown[0]}` is not in that list, and `>= 4` was already satisfied by the four compliant sites, so
no count could move. It grades how a slot is written and how many there are, not where a slot's value
came from.

`test_the_valid_list_names_only_fields_the_schema_publishes` reads the same message, but through
`_valid_list(text)`, which parses only the `Valid: [...]` portion. The module docstring records
fixing that half of this very message and left the offending-key half.

## Break table

Run against the contract file (128 cases). `collected` is recorded so a row cannot hide behind a
deselection.

| row | fails | collected | fires |
|---|---|---|---|
| b0 control, no mutation | 0 | 128 | - |
| b1 fix reverted, refusal names `unknown[0]` | 5 | 128 | 4 alias cases + the dataflow guard |
| b2 defect present, **old blocklist guard only** | **0** | 128 | nothing |
| b3 defect present, **new dataflow guard only** | **1** | 128 | the guard |
| b4 helper reads `remapped` instead of `received` | 4 | 128 | the 4 alias cases |
| b5 helper reads neither, reports the schema name always | 4 | 128 | 3 alias cases + the over-reach control |
| b6 the sweep's action picker ignores the signature | 0 | 128 | nothing, see below |

**b2 against b3 is the argument for replacing the guard rather than extending it**: the same defect,
the same isolation, 0 against 1.

b4 is what shows the two halves are complementary. The helper is still called, so the structural
guard passes; only the behavioural sweep fires. Neither half is sufficient alone.

b6 fires 0, and it is a measured no-op rather than a gap: with the signature filter removed the
alphabetically-first candidate is unchanged for all four aliases (`actuate_robot`, `apply_force`,
`actuate_robot`, `actuate_robot`) and still does not accept the target, so there is nothing wrong
with the choice for the premise assertion inside the sweep to catch. That assertion is what grades it
the day the action list makes the filter load-bearing.

Source and test files restored byte-identically after the table (md5 verified).

## Pre-fix split

`5 failed, 123 passed`. The four alias cases plus the dataflow guard. **0 of the premise cases and 0
of the two over-reach controls** fail pre-fix: a key with no alias must keep its own name, and a
caller who writes the canonical parameter directly must be named by it. The substitution is driven by
what the payload carries, not by the alias map, so it cannot answer either caller with a field they
did not send.

## Gate

| check | result |
|---|---|
| paired selection, 518 files identical on both trees, contract file excluded from each | `21 failed, 20275 passed, 80 skipped` on **both**, 20376 collected each |
| failing-id sets | 21 == 21, `comm` empty in **both** directions |
| `ruff check` / `ruff format --check` | clean / 1590 files already formatted |
| `mypy strands_robots tests tests_integ` | 24 == 24, normalized message sets identical, **0** in the changed files |
| contract file | 124 -> 128 cases, all passing |

The 21 shared failures are pre-existing and accounted for: 17 in `tests/mesh/test_iot_*` need
`awsiot`/`awscrt` (absent here, declared in the `[mesh-iot]` extra, confirmed with `tomllib` and
`find_spec`), and 4 in `test_recording_frame_loss_is_not_tolerated.py` are a large-selection module
caching artifact -- that file is `13 passed` in isolation on both trees.

No visual artifact: this changes refusal text in the agent dispatch layer, not a policy, a
simulation behaviour, a render, a recording or an asset. The measured before/after table is the
evidence.
