### PR TITLE
test(recording): require a dataset root the test owns, not just a named one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,12 @@ hatch run format            # ruff check --fix, ruff format
     would close the class in one line and would also break the one test that
     legitimately asserts the documented default, which is why the rule lives at
     the call site. `tests_integ/` records real datasets and is out of scope.
+    Naming *a* root is not enough: a fixed absolute path such as `root="/tmp/ds"`
+    is not the shared cache and is shared all the same, with every other test
+    that names it and with every process on the host, so the guard reads the
+    value and refuses a `root` given as a string literal - a shape that cannot
+    be per-test unique. `root=root` with `root` bound from `tmp_path` is the
+    idiomatic form and is accepted.
     Pinned by tests/test_recording_root_is_not_the_shared_cache.py.
 
 16. **An example attests the records it shows, not the whole audit log** -

--- a/changelog.d/2777-recording-root-is-the-tests-own.md
+++ b/changelog.d/2777-recording-root-is-the-tests-own.md
@@ -1,0 +1,36 @@
+### Tests: a recording test's dataset root must be one it owns, not just one it names
+
+`tests/test_recording_root_is_not_the_shared_cache.py` requires every recording
+call that names a `repo_id` to name a `root`, so a unit test cannot resolve its
+dataset directory out of `$HF_LEROBOT_HOME` and inherit whatever the host's cache
+already holds. The rule read the keyword and not the value it carried, and those
+are different claims: `root="/tmp/ds"` is not the shared cache, and it is shared
+all the same - with every other test that names it, and with every process on the
+machine that can write `/tmp`.
+
+That was live rather than theoretical.
+`tests/test_dataset_recorder.py::test_create_passes_vcodec_directly_when_supported`
+named `/tmp/ds`, and `DatasetRecorder.create` resolves and inspects that
+directory through `_prepare_dataset_target` before the injected fake dataset
+class is reached. On a host where `/tmp/ds/meta` existed the test failed with
+`FileExistsError: A LeRobotDataset already exists at /tmp/ds` - a filesystem
+verdict on a test whose subject is codec normalisation and which writes nothing,
+and which passes with no other change once the same call points at a fresh
+directory. The immediately following test in the same file already used
+`root=str(tmp_path / "dataset")`, so the correct shape was one line away.
+
+The rule now reads the value as well as the keyword, and refuses exactly one
+shape: a `root` given as a string literal. That boundary is deliberate. A literal
+cannot be per-test unique, which is decidable from the syntax alone with no false
+positives, whereas `root=root` with `root` bound from `tmp_path` earlier in the
+function is the idiomatic form 101 of the 194 recording calls use - telling that
+apart from a shared local would need dataflow analysis a hygiene sweep has no
+business doing. `root=None` is left alone for a different reason: it asks for the
+shared home, which is a question about the home rather than about the call site,
+and the modules that pass it are the ones whose subject is that resolution.
+
+Three call sites named a literal and now take a `tmp_path` root. Two of them are
+refused before the root is resolved and so were latent; the convention this
+module implements already requires a root of those too, on the grounds that
+exempting them means modelling which guard fires first, which is a fact about the
+implementation rather than about the test.

--- a/tests/simulation/test_recording_preflight_refusals_across_backends.py
+++ b/tests/simulation/test_recording_preflight_refusals_across_backends.py
@@ -255,9 +255,10 @@ class TestARefusedStartTouchesNoDataset:
             pytest.param({"cameras": "wrist"}, id="cameras"),
         ],
     )
-    def test_recording_is_not_marked_active(self, factory: Any, kwargs: Any) -> None:
+    def test_recording_is_not_marked_active(self, factory: Any, kwargs: Any, tmp_path: Path) -> None:
         engine = factory()
-        assert engine.start_recording(repo_id="local/p", root="/tmp/strands-never", **kwargs)["status"] == "error"
+        target = tmp_path / "never"
+        assert engine.start_recording(repo_id="local/p", root=str(target), **kwargs)["status"] == "error"
         state = engine._recording_state()
         assert state is not None
         assert not state.get("recording")

--- a/tests/simulation/test_reserved_camera_name_at_removal.py
+++ b/tests/simulation/test_reserved_camera_name_at_removal.py
@@ -108,7 +108,7 @@ class TestTheFreeViewAliasCannotBeSurrendered:
         assert sim.list_cameras() == ["default"]
         assert _compiled_camera_names(sim) == ["default"]
 
-    def test_the_recordable_alias_survives_the_attempt(self, sim) -> None:
+    def test_the_recordable_alias_survives_the_attempt(self, sim, tmp_path) -> None:
         """The consequence: recording the advertised name stopped working.
 
         ``list_cameras`` kept naming ``'default'`` while ``start_recording``
@@ -119,7 +119,7 @@ class TestTheFreeViewAliasCannotBeSurrendered:
             repo_id="local/reserved_removal",
             task="t",
             fps=30,
-            root="/tmp/strands-reserved-removal",
+            root=str(tmp_path / "dataset"),
             cameras=["default"],
         )
         assert started["status"] == "success", started

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1085,13 +1085,18 @@ class _FakeDatasetCameraEncoderCreate:
         return cls(repo_id, root=root)
 
 
-def test_create_passes_vcodec_directly_when_supported(monkeypatch):
+def test_create_passes_vcodec_directly_when_supported(monkeypatch, tmp_path):
     """When create() takes ``vcodec=``, the recorder forwards it as-is and does
     not synthesize a camera_encoder; backend kwargs absent from the signature
     are not sent."""
     _patch_lerobot_dataset(monkeypatch, _FakeDatasetVcodecCreate)
     recorder = DatasetRecorder.create(
-        "user/data", fps=50, root="/tmp/ds", joint_names=["j1", "j2"], vcodec="libx264", task="pick"
+        "user/data",
+        fps=50,
+        root=str(tmp_path / "dataset"),
+        joint_names=["j1", "j2"],
+        vcodec="libx264",
+        task="pick",
     )
 
     sent = _FakeDatasetVcodecCreate.last_create_kwargs

--- a/tests/test_recording_root_is_not_the_shared_cache.py
+++ b/tests/test_recording_root_is_not_the_shared_cache.py
@@ -62,6 +62,28 @@ instrumentation agrees - no ``resume`` test reached the home.
 
 ``tests_integ/`` deliberately records real datasets and may want the shared
 home, so the scan is scoped to ``tests/``.
+
+Naming a root is necessary and not sufficient. The rule above reads the keyword
+and not the value it carries, so ``root="/tmp/ds"`` satisfies it while
+reproducing verbatim the failure this module exists to prevent: a fixed absolute
+path is shared between every test that names it and with every other process on
+the machine, so the verdict still depends on what the host already holds. That
+is not hypothetical - ``tests/test_dataset_recorder.py`` named ``/tmp/ds`` and
+the test failed on any host where that directory existed, with the same
+``FileExistsError`` from the same ``_prepare_dataset_target`` inspection, for a
+test whose subject is codec normalisation and which writes nothing. Pointing the
+same call at a fresh directory turned it green with no other change.
+
+So the second rule reads the value, and it refuses exactly one shape: a ``root``
+given as a string literal. The boundary is deliberate. A literal cannot be
+per-test unique, which is decidable from the syntax alone with no false
+positives; whereas ``root=root`` with ``root`` bound from ``tmp_path`` earlier in
+the function is the idiomatic form 101 of the 194 recording calls use, and
+telling that apart from a shared local would need dataflow this module has no
+business doing. ``root=None`` is left alone for a different reason: it means
+"resolve the shared home", which is a question about the home rather than about
+the call site, and the modules that pass it are the ones whose subject is that
+resolution.
 """
 
 from __future__ import annotations
@@ -129,6 +151,27 @@ def _names_a_repo_id(call: ast.Call, *, direct: bool) -> bool:
     if direct and call.args:
         return True
     return any(kw.arg == "repo_id" for kw in call.keywords)
+
+
+def _sole_call(source: str) -> ast.Call:
+    """The one call expression in ``source``, for the exemplars below."""
+    statement = ast.parse(source).body[0]
+    assert isinstance(statement, ast.Expr), source
+    call = statement.value
+    assert isinstance(call, ast.Call), source
+    return call
+
+
+def _literal_root(call: ast.Call) -> str | None:
+    """The ``root`` this call names, if it names one as a string literal.
+
+    Returns the literal so the failure message can quote the path a reader has
+    to go and find, rather than only the line it is on.
+    """
+    for keyword in call.keywords:
+        if keyword.arg == "root" and isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+            return keyword.value.value
+    return None
 
 
 def _recording_calls(path: Path) -> list[tuple[ast.Call, bool, set[str]]]:
@@ -209,3 +252,42 @@ def test_the_scan_still_reads_a_positional_repo_id() -> None:
         "no direct recording call in test_dataset_recorder.py is seen to pass a "
         "positional repo_id, so the rule now rests on the keyword form alone"
     )
+
+
+def test_a_named_root_is_not_a_fixed_absolute_path() -> None:
+    """A unit test's dataset directory is unique to the test, not just non-default.
+
+    The rule above requires a root; this one requires it to be the test's own. A
+    string literal is shared by construction - with every other test naming it and
+    with every process on the host - so it carries the same exposure as the shared
+    cache the module is named for.
+    """
+    offenders = [
+        f"{path.relative_to(_TESTS_ROOT)}:{call.lineno}: root={literal!r}"
+        for path, calls in _scan().items()
+        for call, direct, _keywords in calls
+        if _names_a_repo_id(call, direct=direct) and (literal := _literal_root(call)) is not None
+    ]
+    assert not offenders, (
+        "these recording calls name a root as a fixed absolute path, so it is "
+        "shared with every other test that names it and with every process on "
+        "the host, and the verdict depends on what is already there - pass "
+        "root=str(tmp_path / 'dataset'):\n" + "\n".join(offenders)
+    )
+
+
+def test_the_literal_root_rule_reads_the_value_and_not_the_keyword() -> None:
+    """Non-vacuity, on constructed calls rather than on the corpus.
+
+    With the offenders fixed the corpus can no longer exercise a rejection, so a
+    rule graded only against it would pass by having nothing to look at. These
+    two exemplars are the shapes the rule has to separate, and the accepted one
+    also pins that the rule does not simply refuse every root.
+    """
+    refused = _sole_call('DatasetRecorder.create("user/data", root="/tmp/ds")')
+    accepted = _sole_call('DatasetRecorder.create("user/data", root=str(tmp_path / "ds"))')
+
+    assert _literal_root(refused) == "/tmp/ds"
+    assert _literal_root(accepted) is None
+    # Both are recording calls, so the rule is separating them on the value.
+    assert _is_entry_call(refused) and _is_entry_call(accepted)


### PR DESCRIPTION
## The rule reads the keyword and not the value it carries

`tests/test_recording_root_is_not_the_shared_cache.py` exists because a `repo_id`
with no `root` resolves to `$HF_LEROBOT_HOME/{repo_id}`, and `create` *inspects*
that directory before any injected fake dataset class is reached - so a unit test
that writes nothing to the developer's cache still reads it. Its rule is:

```python
if _names_a_repo_id(call, direct=direct) and "root" not in keywords
```

That reads the presence of the keyword. `root="/tmp/ds"` satisfies it, and is
shared all the same: with every other test that names it, and with every process
on the host that can write `/tmp`. The failure mode the module is named for is
reproduced verbatim by a path that passes it.

## Reproduced, on `main`

`tests/test_dataset_recorder.py::test_create_passes_vcodec_directly_when_supported`
named `/tmp/ds`. Its subject is codec normalisation and it writes nothing; the
dataset class is faked. It fails anyway:

```
FAILED tests/test_dataset_recorder.py::test_create_passes_vcodec_directly_when_supported
  FileExistsError: A LeRobotDataset already exists at /tmp/ds. Pass overwrite=True ...
```

Three measurements isolate it to the root and nothing else:

| | |
|---|---|
| on pristine `main` (`b754425`), `/tmp/ds/meta/info.json` present | fails |
| the same test, sole change `root=` pointed at a fresh directory | **1 passed** |
| after this change, with `/tmp/ds/meta` **still present** | **1 passed** |

Source restored byte-identically after the middle measurement. The third row is
the one that matters: the directory was not removed, so the test is no longer
reading it. The `FileExistsError` comes from `_prepare_dataset_target`, which is
the same inspection the module's docstring is about - only the shared location is
`/tmp` instead of `$HOME`.

The immediately following test in the same file already used
`root=str(tmp_path / "dataset")`, so the shape this asks for was one line away.

## The rule now reads the value, and refuses exactly one shape

A `root` given as a **string literal**. The boundary is deliberate, and measured:

| root expression | recording calls | decision |
|---|---|---|
| derived from `tmp_path` (`root=root`, `root=str(root)`, ...) | 101 of 194 | accepted |
| a string literal | 3 | refused |
| `root=None` | the remainder | out of scope, see below |

A literal cannot be per-test unique, which is decidable from the syntax alone
with no false positives. Requiring the expression to *mention* `tmp_path` would
instead flag the idiomatic majority form, because `root` is usually a local bound
from `tmp_path` earlier in the function - separating that from a shared local
needs dataflow analysis a hygiene sweep has no business doing.

`root=None` is left alone for a different reason: it asks for the shared home,
which is a question about the home rather than about the call site, and the
modules that pass it are the ones whose subject is that resolution
(`test_recording_dataset_home_across_backends.py`). Naming it here rather than
silently skipping it, because it is the obvious next question.

## The three sites

| site | root was | status before |
|---|---|---|
| `tests/test_dataset_recorder.py:1093` | `/tmp/ds` | **failing** |
| `tests/simulation/test_recording_preflight_refusals_across_backends.py:260` | `/tmp/strands-never` | latent |
| `tests/simulation/test_reserved_camera_name_at_removal.py:118` | `/tmp/strands-reserved-removal` | latent |

Each takes a `tmp_path` root in the shape its own file already uses. The two
latent ones are refused before the root is resolved; the convention already
requires a root of those too, on the stated grounds that exempting them means
modelling which guard fires first, which is a fact about the implementation
rather than about the test.

## Mutation table

Selection: the guard plus the three changed files. `collected` recorded per row;
source restored byte-identically (md5 verified).

| row | fails | collected | firing set |
|---|---|---|---|
| b0 control, no mutation | 0 | 276 | - |
| b1 site 1 reverted | 2 | 276 | the vcodec test + the new rule |
| b2 site 2 reverted | 1 | 276 | the new rule |
| b3 site 3 reverted | 1 | 276 | the new rule |
| b4 all three reverted | 2 | 276 | the vcodec test + the new rule |

b1 fires two because site 1 is the live one - the environmental failure returns
with it. b2 and b3 fire only the rule, which is what "latent" means here.

### Why the existing rule could not see any of it

With all three sites reverted, and no mutation to either rule:

| | |
|---|---|
| the pre-existing rule, `-k also_names_a_root` | **0 failed** |
| the new rule, `-k not_a_fixed_absolute_path` | **1 failed** |

Silence, not a weaker signal. That is the whole argument for reading the value
rather than extending an allowlist of paths.

### Non-vacuity

After this change the corpus has no literal root left, so the rule can no longer
exercise a rejection against it and would pass by inspecting nothing. It is
therefore graded on two constructed calls - one of each shape - and the accepted
one also pins that the rule does not simply refuse every root.

## Gate

| check | result |
|---|---|
| pre-fix split on the guard file | **1 failed / 4 passed**, the failure naming all three offenders |
| the guard file after | 5 passed |
| the three changed test files | 271 passed |
| with the base's own new guards (`parameter_deletes`, `no_host_paths`) | 293 passed |
| `ruff check` / `ruff format --check` | clean, 1593 files already formatted |
| `mypy strands_robots tests tests_integ` | **24 == 24** vs a pristine worktree of the same base, normalised message sets identical, both `comm` directions empty |
| changelog fragments | `OK (801 pending)`, inclusion verified via `--print` |

No visual artifact: this changes a test's dataset root and a hygiene rule, not a
policy, a simulation, a render or a recording format. The measurements above are
the evidence.
