### PR TITLE
fix(g1): apply the vendor's per-joint gains on rt/lowcmd, not one scalar

### DIFF
--- a/changelog.d/2780-g1-per-joint-gains.md
+++ b/changelog.d/2780-g1-per-joint-gains.md
@@ -1,0 +1,42 @@
+### Fixed: the G1 low-level write path applies the vendor's per-joint gains, not one scalar
+
+`G1Driver.send_action` builds a `LowCmd_` for `rt/lowcmd`, filling `kp`/`kd` for
+any joint the caller did not give explicit gains for. Those defaults were a
+single pair -- `kp=25.0`, `kd=0.5` -- applied to all 29 joints. The G1's
+low-level position mode is tuned against a per-joint gain table whose `Kp` takes
+three distinct values and `Kd` two, because the joints do not carry comparable
+loads: both knees are the stiffest entries at `kp=100, kd=2`, and they are the
+joints that hold a standing biped up.
+
+Every entry of the scalar pair sat strictly below every entry of the reference
+table, so no joint was even coincidentally correct. The deficit arrived in three
+distinct ratio pairs -- 1.6x stiffness and 2.0x damping on the ankles, waist and
+arms; 2.4x and 2.0x on the hips and waist yaw; 4.0x and 4.0x on both knees --
+which is why no single scalar, chosen anywhere in the table's range, can
+reproduce it.
+
+Nothing surfaced this. The firmware validates `crc`, `mode_machine` and the
+per-motor Enable byte; it does not validate gains. An under-gained frame is
+therefore well formed, accepted, and reported as a successful publish, so the
+only symptom is a robot that tracks its target badly or sags under its own
+weight, with no error for an operator to read. Gains also sit inside the
+checksum payload -- the vendor's `LowCmd_` pack format spends `B3x5fI` per motor
+on mode, padding, `q`/`dq`/`tau`/`kp`/`kd`, and reserve -- so they have to be
+correct before the CRC is stamped rather than corrected in a later frame.
+
+The gain tables are now grouped the way the vendor groups its own lists (two
+legs, a waist, two arms), so the 29-entry width follows from 6 + 6 + 3 + 7 + 7
+and the left/right symmetry is visible rather than asserted. Behaviour a caller
+already relied on is unchanged: a supplied `kp`/`kd` still wins, including when
+only one of the two is supplied, in which case the omitted term falls back to
+that joint's own reference value rather than to a flat default. The zero-torque
+stop frame still zeroes every gain, which is what "soft" means on that wire.
+
+This also strengthens the test that claimed to pin the defaults. Its docstring
+said the wire capture made a change to them "a test-visible event, not a silent
+regression", while the assertion imported the two constants it was comparing
+against -- an expectation read from the constant under test follows any edit to
+that constant, so it stayed green for every value including a wrong one. The
+expected numbers are now literals, and the new regression file grades the whole
+table against a locally stated copy of the reference, slot by slot, without
+needing the vendor SDK installed.

--- a/changelog.d/2780-g1-per-joint-gains.md
+++ b/changelog.d/2780-g1-per-joint-gains.md
@@ -17,9 +17,9 @@ reproduce it.
 
 Nothing surfaced this. The firmware validates `crc`, `mode_machine` and the
 per-motor Enable byte; it does not validate gains. An under-gained frame is
-therefore well formed, accepted, and reported as a successful publish, so the
-only symptom is a robot that tracks its target badly or sags under its own
-weight, with no error for an operator to read. Gains also sit inside the
+therefore well formed, accepted, and reported as a successful publish. The
+closed-loop stiffness of each joint is whatever was sent, and no status a caller
+can read says otherwise. Gains also sit inside the
 checksum payload -- the vendor's `LowCmd_` pack format spends `B3x5fI` per motor
 on mode, padding, `q`/`dq`/`tau`/`kp`/`kd`, and reserve -- so they have to be
 correct before the CRC is stamped rather than corrected in a later frame.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -131,12 +131,39 @@ _G1_JOINT_INDEX: dict[str, int] = {
 # ``for i in range(G1_NUM_MOTOR)``, where ``G1_NUM_MOTOR = 29``).
 _G1_NAMED_JOINTS: int = max(_G1_JOINT_INDEX.values()) + 1
 
-# PD gain defaults used when a caller does not supply per-joint gains.  These
-# are the gains the neon reference stack uses for a rested-arm hold; they are
-# deliberately conservative and match what the FSM 501 (sitting) hold expects.
-# A caller who cares supplies ``kp``/``kd`` in the action dict.
-_DEFAULT_KP: float = 25.0
-_DEFAULT_KD: float = 0.5
+# Per-joint PD gains applied when a caller does not supply ``kp``/``kd``,
+# indexed by the same slot as :data:`_G1_JOINT_INDEX`.  Transcribed from the
+# vendor's own ``rt/lowcmd`` reference for this robot -- the module-scope
+# ``Kp``/``Kd`` lists in
+# ``unitree_sdk2_python/example/g1/low_level/g1_low_level_example.py`` -- which
+# is the gain set the firmware's low-level position mode is tuned against.
+#
+# These cannot collapse to a single scalar: ``Kp`` takes three distinct values
+# and ``Kd`` two, because the joints do not carry comparable loads.  Both knees
+# (slots 3 and 9) are the stiffest entries at ``kp=100, kd=2`` and they are the
+# joints that hold a standing biped up, so a scalar chosen anywhere in the
+# table's range understiffens something: an arm-sized ``kp=40`` leaves each knee
+# at 40% of its reference stiffness.  The firmware treats gains as advisory --
+# it validates ``crc``, ``mode_machine`` and the Enable byte, not ``kp``/``kd``
+# -- so a mis-gained frame is accepted and reported successful, and the only
+# symptom is that the robot tracks the target badly or sags under its own
+# weight.
+#
+# A caller who wants different gains supplies ``kp``/``kd`` per joint in the
+# action dict; a supplied value always wins over the table.
+# The vendor groups its lists as two legs, a waist and two arms; naming the
+# groups keeps that structure legible (the two legs are identical, as are the two
+# arms) and makes the 29-entry width fall out of 6 + 6 + 3 + 7 + 7 rather than
+# being asserted separately.
+_LEG_KP: tuple[float, ...] = (60.0, 60.0, 60.0, 100.0, 40.0, 40.0)  # hip p/r/y, knee, ankle p/r
+_WAIST_KP: tuple[float, ...] = (60.0, 40.0, 40.0)  # yaw, roll, pitch
+_ARM_KP: tuple[float, ...] = (40.0,) * 7  # shoulder p/r/y, elbow, wrist r/p/y
+_SDK_KP: tuple[float, ...] = _LEG_KP + _LEG_KP + _WAIST_KP + _ARM_KP + _ARM_KP
+
+_LEG_KD: tuple[float, ...] = (1.0, 1.0, 1.0, 2.0, 1.0, 1.0)
+_WAIST_KD: tuple[float, ...] = (1.0, 1.0, 1.0)
+_ARM_KD: tuple[float, ...] = (1.0,) * 7
+_SDK_KD: tuple[float, ...] = _LEG_KD + _LEG_KD + _WAIST_KD + _ARM_KD + _ARM_KD
 
 
 class G1Driver:
@@ -494,8 +521,8 @@ class G1Driver:
         for the exact set).  A caller supplies either
 
         * ``{joint_name: target_position_radians}`` for the common case where
-          every joint uses the driver's default :data:`_DEFAULT_KP` /
-          :data:`_DEFAULT_KD` gains, or
+          the joint takes its reference gains from :data:`_SDK_KP` /
+          :data:`_SDK_KD`, or
         * ``{joint_name: {"q": ..., "kp": ..., "kd": ..., "dq": ..., "tau": ...}}``
           when a caller wants per-joint control.  Any missing key inside the
           inner dict falls back to the default gain (``kp``, ``kd``) or zero
@@ -813,7 +840,7 @@ def _build_lowcmd_from_action(
       silently drop a joint the caller thought was commanded, which is the
       single worst failure mode on a robot.
     * A scalar value is interpreted as the position target ``q``, with
-      :data:`_DEFAULT_KP` / :data:`_DEFAULT_KD` gains and zero ``dq``/``tau``.
+      the slot's :data:`_SDK_KP` / :data:`_SDK_KD` gains and zero ``dq``/``tau``.
     * A dict value must contain ``"q"``; ``"kp"``, ``"kd"``, ``"dq"``, ``"tau"``
       are optional.  An unknown key inside the inner dict is refused for the
       same reason as an unknown joint name: silent drop is worse than a
@@ -871,12 +898,12 @@ def _build_lowcmd_from_action(
             if "q" not in value:
                 return None, f"per-joint dict for {name!r} is missing required key 'q'"
             q = value["q"]
-            kp = value.get("kp", _DEFAULT_KP)
-            kd = value.get("kd", _DEFAULT_KD)
+            kp = value.get("kp", _SDK_KP[slot])
+            kd = value.get("kd", _SDK_KD[slot])
             dq = value.get("dq", 0.0)
             tau = value.get("tau", 0.0)
         else:
-            q, kp, kd, dq, tau = value, _DEFAULT_KP, _DEFAULT_KD, 0.0, 0.0
+            q, kp, kd, dq, tau = value, _SDK_KP[slot], _SDK_KD[slot], 0.0, 0.0
         try:
             q_f = float(q)
             kp_f = float(kp)

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -145,9 +145,9 @@ _G1_NAMED_JOINTS: int = max(_G1_JOINT_INDEX.values()) + 1
 # table's range understiffens something: an arm-sized ``kp=40`` leaves each knee
 # at 40% of its reference stiffness.  The firmware treats gains as advisory --
 # it validates ``crc``, ``mode_machine`` and the Enable byte, not ``kp``/``kd``
-# -- so a mis-gained frame is accepted and reported successful, and the only
-# symptom is that the robot tracks the target badly or sags under its own
-# weight.
+# -- so a mis-gained frame is accepted and the publish reports success.  The
+# closed-loop stiffness of the joint is then whatever was sent, and there is no
+# status for a caller to read that says otherwise.
 #
 # A caller who wants different gains supplies ``kp``/``kd`` per joint in the
 # action dict; a supplied value always wins over the table.

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -975,17 +975,21 @@ def test_send_action_fills_the_named_slot_and_leaves_the_rest_alone() -> None:
 
 @pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
 def test_send_action_applies_default_gains_for_scalar_targets() -> None:
-    """A scalar target lands with :data:`_DEFAULT_KP`/``_DEFAULT_KD``.
+    """A scalar target lands that slot's reference gains on the wire.
 
     The scalar form is the common case (a caller who just wants a hold).
-    The wire capture pins the exact defaults so a change to them is a
-    test-visible event, not a silent regression.
+    ``right_elbow`` is an arm joint, so the vendor's ``rt/lowcmd`` reference
+    gives it ``kp=40, kd=1``.
+
+    The expected numbers are written as literals rather than imported from
+    :data:`~strands_robots.drivers.g1._SDK_KP` / ``_SDK_KD``: an assertion that
+    reads the constant it grades follows any edit to that constant, so it stays
+    green for every value including a wrong one.  Spelled out, this cell is an
+    independent check on the value that reaches the topic.
+    ``tests/drivers/test_g1_per_joint_gains.py`` grades the whole table the same
+    way, slot by slot.
     """
-    from strands_robots.drivers.g1 import (
-        _DEFAULT_KD,
-        _DEFAULT_KP,
-        _G1_JOINT_INDEX,
-    )
+    from strands_robots.drivers.g1 import _G1_JOINT_INDEX
 
     driver, pub = _gated_driver()
     driver.send_action({"right_elbow": -0.2})
@@ -994,8 +998,8 @@ def test_send_action_applies_default_gains_for_scalar_targets() -> None:
     slot = _G1_JOINT_INDEX["right_elbow"]
     m = message.motor_cmd[slot]
     assert m.q == pytest.approx(-0.2)
-    assert m.kp == pytest.approx(_DEFAULT_KP)
-    assert m.kd == pytest.approx(_DEFAULT_KD)
+    assert m.kp == pytest.approx(40.0)
+    assert m.kd == pytest.approx(1.0)
     assert m.dq == pytest.approx(0.0)
     assert m.tau == pytest.approx(0.0)
 

--- a/tests/drivers/test_g1_per_joint_gains.py
+++ b/tests/drivers/test_g1_per_joint_gains.py
@@ -1,0 +1,291 @@
+"""Regression: ``rt/lowcmd`` gains come from the vendor's per-joint table.
+
+``_build_lowcmd_from_action`` fills ``kp``/``kd`` for any joint the caller did
+not give explicit gains for.  Those defaults used to be a single pair applied to
+all 29 joints (``kp=25.0``, ``kd=0.5``), which cannot reproduce the gain set the
+G1's low-level position mode is tuned against: the vendor's own ``rt/lowcmd``
+reference ships 29-entry ``Kp``/``Kd`` lists taking three and two distinct
+values respectively, because the joints do not carry comparable loads.  Both
+knees are the stiffest entries at ``kp=100, kd=2`` and they are the joints that
+hold a standing biped up.
+
+The firmware validates ``crc``, ``mode_machine`` and the Enable byte; it does
+not validate gains.  So an under-gained frame is accepted, the publish reports
+success, and the only symptom is a robot that tracks its target badly -- there
+is no error to read.  That is the class of defect these cells exist to catch.
+
+Layering, and why it is this way:
+
+* The vendor's numbers are stated **locally** below rather than imported from the
+  driver, so the value cells are an independent oracle instead of a tautology.
+  A test that reads the constant it grades follows any edit to that constant and
+  cannot detect a wrong value -- which is exactly how the single-pair default
+  reached the wire past a test whose docstring claimed to pin it.
+* The contract cells need no ``unitree_sdk2py``, so ``call-test-lint`` grades
+  them in CI, where the SDK is not installed.  ``unitree-sdk2`` is not a
+  declared dependency of this project, so a contract asserted only behind
+  ``skipif(not _HAS_SDK)`` is asserted by nothing in CI.
+* The wire cells, which do need the SDK to build a real ``LowCmd_``, confirm the
+  contract cells describe what actually lands on the topic.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.g1 import (
+    _G1_JOINT_INDEX,
+    _G1_NAMED_JOINTS,
+    _SDK_KD,
+    _SDK_KP,
+    _build_lowcmd_from_action,
+    _build_zero_torque_lowcmd,
+)
+
+# The vendor's gain lists for this robot, transcribed from the module scope of
+# ``unitree_sdk2_python/example/g1/low_level/g1_low_level_example.py``.  Stated
+# here so these cells grade the driver against the reference rather than against
+# themselves.
+VENDOR_KP: tuple[float, ...] = (
+    60.0,
+    60.0,
+    60.0,
+    100.0,
+    40.0,
+    40.0,  # left leg: hip p/r/y, knee, ankle p/r
+    60.0,
+    60.0,
+    60.0,
+    100.0,
+    40.0,
+    40.0,  # right leg
+    60.0,
+    40.0,
+    40.0,  # waist: yaw, roll, pitch
+    40.0,
+    40.0,
+    40.0,
+    40.0,
+    40.0,
+    40.0,
+    40.0,  # left arm
+    40.0,
+    40.0,
+    40.0,
+    40.0,
+    40.0,
+    40.0,
+    40.0,  # right arm
+)
+VENDOR_KD: tuple[float, ...] = (
+    1.0,
+    1.0,
+    1.0,
+    2.0,
+    1.0,
+    1.0,  # left leg
+    1.0,
+    1.0,
+    1.0,
+    2.0,
+    1.0,
+    1.0,  # right leg
+    1.0,
+    1.0,
+    1.0,  # waist
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,  # left arm
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,  # right arm
+)
+
+_KNEE_SLOTS = (3, 9)
+_SLOT_NAME = {slot: name for name, slot in _G1_JOINT_INDEX.items()}
+
+try:  # pragma: no cover - environment probe
+    import unitree_sdk2py.idl.default as _sdk_default
+
+    _HAS_SDK = _sdk_default is not None
+except Exception:  # pragma: no cover - environment probe
+    _HAS_SDK = False
+
+
+def _slot_ids() -> list[str]:
+    """Parametrize ids that name the joint, so a failure reads as the joint."""
+    return [f"{slot}-{_SLOT_NAME.get(slot, '?')}" for slot in range(_G1_NAMED_JOINTS)]
+
+
+class TestTheGainTableIsTheVendorReference:
+    """Every slot's default gains equal the vendor's value for that slot."""
+
+    def test_the_table_covers_exactly_the_named_joints(self) -> None:
+        """One entry per commanded joint, aligned with the Enable-byte bound.
+
+        ``_build_lowcmd_from_action`` indexes the table by the slot a joint
+        name resolved to, so a table shorter than the joint map is an
+        ``IndexError`` on the last joints, and a longer one carries entries no
+        joint can reach.  Tying the length to ``_G1_NAMED_JOINTS`` means a
+        joint added to the map later moves the table in the same edit.
+        """
+        assert len(_SDK_KP) == _G1_NAMED_JOINTS
+        assert len(_SDK_KD) == _G1_NAMED_JOINTS
+        assert len(VENDOR_KP) == _G1_NAMED_JOINTS  # the local oracle, same width
+
+    @pytest.mark.parametrize("slot", range(_G1_NAMED_JOINTS), ids=_slot_ids())
+    def test_each_slot_carries_the_vendor_gains(self, slot: int) -> None:
+        """Graded per slot so a wrong entry names the joint it belongs to."""
+        assert _SDK_KP[slot] == pytest.approx(VENDOR_KP[slot])
+        assert _SDK_KD[slot] == pytest.approx(VENDOR_KD[slot])
+
+    def test_both_knees_are_the_stiffest_entries(self) -> None:
+        """The load-bearing joints hold the table maximum.
+
+        Called out on its own because it is the consequence that matters: a
+        knee is what a standing G1 holds itself up with, and it is the slot a
+        scalar default understiffens most.
+        """
+        for slot in _KNEE_SLOTS:
+            assert _SLOT_NAME[slot].endswith("knee")
+            # Strictly greater than the table minimum, not merely equal to the
+            # maximum: on a flattened table every entry ties the maximum, so an
+            # equality-only assertion would pass on exactly the shape this cell
+            # exists to reject.
+            assert _SDK_KP[slot] == max(_SDK_KP) > min(_SDK_KP)
+            assert _SDK_KD[slot] == max(_SDK_KD) > min(_SDK_KD)
+
+
+class TestTheGainsAreGenuinelyPerJoint:
+    """The table cannot be replaced by any single pair of numbers.
+
+    This is the cell that fails if the per-slot table is ever collapsed back
+    into a scalar -- including a scalar chosen from inside the table's own
+    range, which no equality-against-a-constant test would notice.
+    """
+
+    def test_the_table_holds_more_than_one_value(self) -> None:
+        assert len(set(_SDK_KP)) > 1, "a single kp cannot be the vendor's table"
+        assert len(set(_SDK_KD)) > 1, "a single kd cannot be the vendor's table"
+
+    def test_the_distinct_values_are_the_vendor_s(self) -> None:
+        """Three stiffnesses and two dampings, matching the reference."""
+        assert sorted(set(_SDK_KP)) == sorted(set(VENDOR_KP))
+        assert sorted(set(_SDK_KD)) == sorted(set(VENDOR_KD))
+        assert len(set(_SDK_KP)) == 3
+        assert len(set(_SDK_KD)) == 2
+
+    def test_a_knee_is_stiffer_than_an_arm_by_the_reference_ratio(self) -> None:
+        """The spread a scalar erases, stated as the ratio it would erase.
+
+        ``right_elbow`` is an ordinary arm joint; the knee is the extreme. Any
+        scalar makes this ratio 1.0.
+        """
+        knee, arm = _G1_JOINT_INDEX["left_knee"], _G1_JOINT_INDEX["right_elbow"]
+        assert _SDK_KP[knee] / _SDK_KP[arm] == pytest.approx(2.5)
+        assert _SDK_KD[knee] / _SDK_KD[arm] == pytest.approx(2.0)
+
+
+class TestTheBuilderIndexesTheTablePerSlot:
+    """The builder reads the table by slot, not by taking one entry for all.
+
+    A structural cell, because it is reachable without the SDK and it pins the
+    mechanism rather than one sampled value: subscripting the table with the
+    resolved slot is what makes the per-joint values reach the wire at all.
+    """
+
+    def test_both_gain_tables_are_subscripted_in_the_builder(self) -> None:
+        tree = ast.parse(inspect.getsource(_build_lowcmd_from_action))
+        subscripted = {
+            node.value.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name)
+        }
+        assert "_SDK_KP" in subscripted, "kp default is not indexed by slot"
+        assert "_SDK_KD" in subscripted, "kd default is not indexed by slot"
+
+
+@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+class TestTheWireFrameCarriesTheSlotsOwnGains:
+    """The frame that reaches ``rt/lowcmd`` carries each slot's own gains."""
+
+    def test_every_slot_lands_its_vendor_gains(self) -> None:
+        """A scalar target for all 29 joints, checked slot by slot."""
+        action: dict[str, Any] = {name: 0.0 for name in _G1_JOINT_INDEX}
+        cmd, err = _build_lowcmd_from_action(action, mode_machine=9)
+        assert err is None
+        assert cmd is not None
+        for slot in range(_G1_NAMED_JOINTS):
+            motor = cmd.motor_cmd[slot]
+            assert motor.kp == pytest.approx(VENDOR_KP[slot]), _SLOT_NAME[slot]
+            assert motor.kd == pytest.approx(VENDOR_KD[slot]), _SLOT_NAME[slot]
+
+    def test_a_knee_and_an_arm_in_one_frame_differ(self) -> None:
+        """Two joints, one frame, two gain pairs - the scalar's failure mode."""
+        cmd, err = _build_lowcmd_from_action({"left_knee": 0.2, "right_elbow": -0.2}, mode_machine=9)
+        assert err is None
+        assert cmd is not None
+        knee = cmd.motor_cmd[_G1_JOINT_INDEX["left_knee"]]
+        arm = cmd.motor_cmd[_G1_JOINT_INDEX["right_elbow"]]
+        assert knee.kp == pytest.approx(100.0)
+        assert arm.kp == pytest.approx(40.0)
+        assert knee.kp != arm.kp
+
+    def test_a_partially_supplied_gain_falls_back_to_that_slot(self) -> None:
+        """``kp`` supplied, ``kd`` omitted - the omitted one is the slot's own.
+
+        The fallback has to stay per-slot in the partial case too, or a caller
+        tuning one term silently flattens the other.  Graded here rather than
+        among the over-reach guards because it fails on the flat-default shape,
+        so it grades the fix rather than protecting what the fix must not move.
+        """
+        cmd, err = _build_lowcmd_from_action({"left_knee": {"q": 0.1, "kp": 7.0}}, mode_machine=9)
+        assert err is None
+        assert cmd is not None
+        motor = cmd.motor_cmd[_G1_JOINT_INDEX["left_knee"]]
+        assert motor.kp == pytest.approx(7.0)
+        assert motor.kd == pytest.approx(VENDOR_KD[_G1_JOINT_INDEX["left_knee"]])
+
+
+@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+class TestWhatTheTableDoesNotChange:
+    """Over-reach guards: the table is a default, and only a default.
+
+    Both cells hold on the flat-default shape as well as on the table, which is
+    what makes them guards rather than regression cells - they fail only if the
+    change reached somewhere it should not have.
+    """
+
+    def test_a_supplied_gain_still_wins(self) -> None:
+        """An explicit ``kp``/``kd`` overrides the table, as before."""
+        cmd, err = _build_lowcmd_from_action({"left_knee": {"q": 0.1, "kp": 7.0, "kd": 0.25}}, mode_machine=9)
+        assert err is None
+        assert cmd is not None
+        motor = cmd.motor_cmd[_G1_JOINT_INDEX["left_knee"]]
+        assert motor.kp == pytest.approx(7.0)
+        assert motor.kd == pytest.approx(0.25)
+
+    def test_the_zero_torque_frame_stays_soft(self) -> None:
+        """A stop frame zeroes gains; the table must not leak into it.
+
+        ``_build_zero_torque_lowcmd`` is what "soft" looks like on the wire.
+        Its gains are zero by intent, so a table applied there would make a
+        stop stiff.
+        """
+        cmd, err = _build_zero_torque_lowcmd(mode_machine=9)
+        assert err is None
+        assert cmd is not None
+        assert all(motor.kp == 0.0 for motor in cmd.motor_cmd)
+        assert all(motor.kd == 0.0 for motor in cmd.motor_cmd)

--- a/tests/drivers/test_g1_per_joint_gains.py
+++ b/tests/drivers/test_g1_per_joint_gains.py
@@ -10,9 +10,10 @@ knees are the stiffest entries at ``kp=100, kd=2`` and they are the joints that
 hold a standing biped up.
 
 The firmware validates ``crc``, ``mode_machine`` and the Enable byte; it does
-not validate gains.  So an under-gained frame is accepted, the publish reports
-success, and the only symptom is a robot that tracks its target badly -- there
-is no error to read.  That is the class of defect these cells exist to catch.
+not validate gains.  So an under-gained frame is accepted and the publish
+reports success, leaving each joint's closed-loop stiffness at whatever was
+sent with no status that says otherwise.  That is the class of defect these
+cells exist to catch: wrong on the wire, silent at the API.
 
 Layering, and why it is this way:
 


### PR DESCRIPTION
## The defect

`_build_lowcmd_from_action` fills `kp`/`kd` for any joint the caller did not give
explicit gains for. Those defaults were a single pair — `kp=25.0`, `kd=0.5` —
applied to all 29 joints.

The G1's low-level position mode is tuned against a per-joint gain table. The
vendor's own `rt/lowcmd` reference for this robot ships 29-entry `Kp`/`Kd` lists
at module scope, and they are not flat: `Kp` takes three distinct values and `Kd`
two, because the joints do not carry comparable loads. Both knees are the
stiffest entries at `kp=100, kd=2`.

Measured on the frame the shipped builder produces, driving all 29 joints with
scalar targets:

| slots | joints | shipped | reference | under by |
|---|---|---|---|---|
| 3, 9 | both knees | 25.0 / 0.5 | 100 / 2 | **4.0x kp, 4.0x kd** |
| 0-2, 6-8, 12 | hips, waist yaw | 25.0 / 0.5 | 60 / 1 | 2.4x kp, 2.0x kd |
| 4-5, 10-11, 13-14, 15-28 | ankles, waist, arms | 25.0 / 0.5 | 40 / 1 | 1.6x kp, 2.0x kd |

Every shipped value sat strictly below every reference value, so no joint was
even coincidentally right:

```
EVERY shipped kp strictly below EVERY reference kp: True
EVERY shipped kd strictly below EVERY reference kd: True
distinct (kp, kd) under-by pairs: [(1.6, 2.0), (2.4, 2.0), (4.0, 4.0)]
worst kp deficit: 4.00x on ['left_knee', 'right_knee']
```

Three distinct ratio pairs is the reason this cannot be fixed by picking a better
scalar — no single value reproduces the table.

## Why nothing surfaced it

Two independent reasons, and they compound.

**The firmware does not validate gains.** It validates `crc`, `mode_machine` and
the per-motor Enable byte — the three fields whose absence makes a frame get
dropped. An under-gained frame is well formed, accepted, and reported as a
successful publish. Each joint's closed-loop stiffness is then whatever was
sent, and no status a caller can read says otherwise.

**The test that claimed to pin the defaults could not.** Its docstring said the
wire capture made a change to them "a test-visible event, not a silent
regression", while the assertion imported the two constants it compared against:

```python
from strands_robots.drivers.g1 import _DEFAULT_KD, _DEFAULT_KP
...
assert m.kp == pytest.approx(_DEFAULT_KP)
```

An expectation read from the constant under test follows any edit to that
constant, so it stayed green for every value including a wrong one.

Gains also sit **inside the checksum payload** — the vendor's `LowCmd_` pack
format spends `B3x5fI` per motor on mode, padding, `q`/`dq`/`tau`/`kp`/`kd`, and
reserve. Measured, changing one knee's gains moves the frame's CRC from
`3439364746` to `1975534031`. So gains have to be right before the CRC is
stamped; they are not correctable in a later frame.

## The change

`_SDK_KP` / `_SDK_KD` carry the reference table, indexed by the same slot as
`_G1_JOINT_INDEX`, and the builder subscripts them with the slot the joint name
resolved to. The tables are grouped the way the vendor groups its own lists —
two legs, a waist, two arms — so the 29-entry width follows from
`6 + 6 + 3 + 7 + 7` and the left/right symmetry is visible rather than asserted.

The old constants are removed rather than aliased. Behaviour a caller relied on
is unchanged: a supplied `kp`/`kd` still wins, and when only one of the two is
supplied the omitted term falls back to *that joint's* reference value rather
than to a flat default. The zero-torque stop frame still zeroes every gain.

One further correction: the removed constants' comment attributed `25.0 / 0.5` to
a reference stack's "rested-arm hold". That provenance is not locatable — the
vendor SDK's `example/g1/` tree contains no such gains, and its own value for an
arm joint is `40 / 1`.

## Verification

**The regression fails before the change and passes after.** Flattening the
table back to `25.0 / 0.5` and re-running:

| | failed | of |
|---|---|---|
| with the fix | **0** | 112 |
| table flattened to `25.0 / 0.5` | **37** | 112 |

Per class, on the flattened tree:

| class | pre-fix | role |
|---|---|---|
| `TestTheGainTableIsTheVendorReference` | 30/31 | regression |
| `TestTheGainsAreGenuinelyPerJoint` | 3/3 | regression |
| `TestTheWireFrameCarriesTheSlotsOwnGains` | 3/3 | regression |
| `test_g1_driver.py` (the strengthened cell) | 1/72 | regression |
| `TestTheBuilderIndexesTheTablePerSlot` | **0/1** | structural, value-independent |
| `TestWhatTheTableDoesNotChange` | **0/2** | over-reach guard |

Both guard classes are clean pre-fix, which is what makes them guards.

**Mutations.** Ten, each applied to the source with the tests held fixed;
`collected` is stable at 112 in every row, so no row hides behind a deselection:

| mutation | fires |
|---|---|
| control (fix in place) | **0** |
| table flattened to `25.0 / 0.5` | 37 |
| `kp` flattened to `40.0` — a value from *inside* the table's range | **15** |
| knee `kp` 100 -> 40 (one entry) | 7 |
| `kd` flattened to `1.0` (`kp` intact) | 8 |
| waist and second leg groups transposed | 8 |
| `kp` table truncated (one arm group dropped) | 13 |
| builder uses `_SDK_KP[0]` for every slot | 4 |
| zero-torque frame leaks the table (over-reach) | 2 |

Ten distinct firing sets, none undetected. The `40.0` row is the one that
matters: a scalar chosen from inside the table's own range is still caught, which
is exactly what an equality-against-the-constant assertion cannot do.

**The contract is graded without the vendor SDK.** `unitree-sdk2` is not a
declared dependency, so a contract asserted only behind `skipif(not _HAS_SDK)` is
asserted by nothing in CI. 35 of the 40 new cells need no SDK; the 5 wire cells
confirm the rest describes what lands on the topic.

```
no SDK on the path : 35 passed, 5 skipped
SDK available      : 40 passed
tests/drivers/     : 253 passed
```

**Paired gate**, 430 files (all of `tests/drivers/`, every test that walks the
tree or reads source/docstrings/`changelog.d`, and everything naming g1), the new
file excluded from both trees:

| | collected | failed | passed | skipped |
|---|---|---|---|---|
| this branch | 21705 | 12 | 21571 | 122 |
| base | 21705 | 12 | 21571 | 122 |

Failing-ID sets are identical, both `comm` directions empty. All 12 are
environmental and pre-existing: 7 in `tests/mesh/test_mesh_session.py` from a
`STRANDS_MESH_AUTH_MODE=mtls` value in the environment, and 5 that assert `rclpy`
is absent where it resolves.

`ruff check` and `ruff format --check` clean over `strands_robots tests
tests_integ`; `mypy` reports `Success: no issues found in 1591 source files`,
with 0 errors attributable to the changed files.

## No visual artifact

The change is a wire-format default on a hardware driver, so there is no
simulation behaviour, rendering, recording or asset to show. I did attempt to
demonstrate the physical consequence and it is worth recording why it does not
work: the vendor's MuJoCo G1 drives its joints with position servos carrying
their own fixed `kp=500 / kv=43` (`gaintype=FIXED gainprm=500`,
`biastype=AFFINE biasprm=[0, -500, -43.01]`), so `ctrl` is a position target and
the `LowCmd_` gains have no representation in that model at all — with
`ctrl[:] = 0` it holds the keyframe pose at `z=0.7915`. Demonstrating the deficit
would mean rebuilding those actuators as torque motors and adding a balance
controller, which would measure a model I authored rather than the robot. The
measured tables above are the evidence; nothing in the description claims a
physical outcome I did not measure.

## Scope

Issue #2765 lists this as decidable against the SDK without hardware, alongside
several items that are not. This change takes only the gain table. The remaining
items there — in particular whether an `rt/lowcmd` write should consult an FSM
gate at all — need a G1 in the room, so the issue stays open.
