### PR TITLE
fix(simulation): stop a backend permuting a parameter it shares with a sibling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,29 @@ hatch run format            # ruff check --fix, ruff format
     tests/mesh/test_ackermann_command_gate.py, whose inventory of bridges owing
     a gate suite is derived from the tree, so the next transport is graded on
     arrival rather than at the review that happens to look.
+19. **A backend may add a parameter but must never permute one it shares** -
+    `create_simulation(backend=...)` makes the same `sim` variable a different
+    class, and nothing in the type system relates two backends' signatures for a
+    method both implement: `add_camera` is on no ABC at all and `randomize` is
+    on `SimEngine` only as a `**kwargs` sink whose docstring hands the signature
+    to the backend. So a permutation is invisible to every gate and to Python.
+    Isaac declared `add_camera(..., width, height, fov, ...)` where MuJoCo and
+    Newton declare `(..., fov, width, height, ...)`, so
+    `add_camera("wrist", pos, target, 100, 200, 90)` asked for a 200x90 view at
+    fov 100 on two backends and a 100x200 view at fov 90 on the third - every
+    value valid under either reading, so nothing refused it and the caller found
+    out from the pixels. Newton's `randomize` had the same shape, listing the
+    three ranges in reverse. Adding a parameter is fine and shifts no shared
+    name's *relative* order (Isaac's `mjcf_path`/`usd_path`, Newton's `source`,
+    MuJoCo's `randomize_positions`); reordering one is what makes a positional
+    call ambiguous. State the shared order where a reader will copy it - the
+    signature line in `docs/simulation/newton.md` and the call in
+    `docs/simulation/domain-randomization.md` are both graded against the
+    signatures - and note that this rule is deliberately weaker than index
+    parity, which a mid-signature insertion still breaks. Pinned by
+    tests/simulation/test_backend_shared_parameter_order.py, whose backend
+    inventory is derived from the table `create_simulation` resolves, so a
+    fourth backend is held to the rule the hour it lands.
 
 ## PR Workflow
 

--- a/changelog.d/2781-backend-shared-parameter-order.md
+++ b/changelog.d/2781-backend-shared-parameter-order.md
@@ -1,0 +1,40 @@
+### Fixed: a backend no longer permutes a parameter it shares with a sibling
+
+`create_simulation(backend=...)` makes the same `sim` variable a different class, and nothing in the
+type system relates two backends' signatures for a method both implement. `add_camera` is on no ABC
+at all -- `SimEngine.__abstractmethods__` does not list it -- and `randomize` is on `SimEngine` only
+as a `**kwargs` sink whose docstring hands the signature to the backend. Two of them had drifted into
+ordering a parameter they share differently, so one positional call meant two different things and
+nothing was in a position to notice.
+
+`IsaacSimulation.add_camera` declared `(name, position, target, width, height, fov, parent_body)`
+where `MuJoCoSimEngine` and `NewtonSimEngine` both declare `(name, position, target, fov, width,
+height, parent_body)`. So `add_camera("wrist", pos, target, 100, 200, 90)` asked for a 200x90 view at
+fov 100 on two backends and a 100x200 view at fov 90 on the third. Every one of those six values is
+inside its own domain under either reading -- `fov=100` and `fov=90` are both in `(0, 180)`, and 100,
+200 and 90 are all positive integers -- so no guard refused the call, nothing warned, and the caller
+found out from the pixels. `docs/simulation/newton.md` states that order as the shared one and calls
+it "matching the MuJoCo signature", so the divergence also contradicted the page a reader copies it
+from.
+
+`NewtonSimEngine.randomize` had the same shape, listing `mass_range`, `friction_range`, `color_range`
+where MuJoCo lists `color_range`, `friction_range`, `mass_range` -- a reversal of three parameters
+that carry the same type, so nothing distinguishes them by value either. Its docstring said "Keyword
+names and defaults mirror the MuJoCo backend so randomization code transfers across backends
+unchanged", a conclusion wider than its premise: names and defaults did mirror, and the missing third
+term was the order. That divergence is caught rather than silent, because MuJoCo declares two axes
+Newton does not (`randomize_positions`, `position_noise`) and a positional call reaches the
+boolean-flag domain first, but the two signatures still could not be read against each other.
+
+Both signatures now declare their shared parameters in the order the documentation already gives, and
+both docstrings' parameter blocks follow the signature. Adding a parameter is still allowed and
+shifts no shared name's relative order, so `IsaacSimulation.add_robot`'s `mjcf_path` / `usd_path`,
+`NewtonSimEngine.add_robot`'s `source` and MuJoCo's two extra randomization axes are untouched, as
+are each backend's own defaults -- Isaac still resolves an omitted `width` from `IsaacConfig` where
+MuJoCo defaults it to 640.
+
+The rule is pinned by `tests/simulation/test_backend_shared_parameter_order.py`, whose backend
+inventory is derived from the table `create_simulation` resolves rather than from a list in the test,
+so a fourth backend is graded when it lands. The rule is deliberately weaker than "a shared parameter
+sits at the same positional index", which a mid-signature insertion still breaks; that boundary is
+measured and pinned in the same module rather than left to be rediscovered.

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -52,6 +52,12 @@ domain, so an axis you can turn off on one is not left on by the other. The
 numeric knobs in the same signature keep their own domain: a `mass_range` is a
 quantity, and it is still refused as a range rather than as a flag.
 
+They also declare the parameters they share in the order shown above. Newton
+adds no axis of its own and MuJoCo adds two (`randomize_positions`,
+`position_noise`), so the two signatures are not the same length - but neither
+reorders a name the other also carries, so the three ranges cannot be read as
+each other.
+
 **Destructive** - writes into MuJoCo model arrays. To restore: `load_scene(...)` or recreate
 the sim. Every *other* scene mutation restores it too, as a side effect of rebuilding the
 model from the spec: `add_object`, `remove_object`, `add_camera`, `remove_camera`,

--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -90,7 +90,9 @@ no-op until then.
   "png", ...}}`) as MuJoCo, so the shared `PolicyRunner` video pipeline works
   without modification.
 - `add_camera(name, position, target, fov=60, width, height, parent_body=None)`
-  registers named cameras, matching the MuJoCo signature. `render(camera_name=...)`
+  registers named cameras. That order is the same on every backend - Isaac
+  included - so a positional call means one thing whichever
+  `create_simulation(backend=...)` produced the `sim`. `render(camera_name=...)`
   returns the named view; multiple cameras coexist and `get_observation()`
   returns one RGB frame per camera keyed by name. A `parent_body` (a body label
   from `list_bodies`) mounts the camera ON that body so a wrist camera tracks

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -4942,9 +4942,9 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         name: str = "default",
         position: list[float] | None = None,
         target: list[float] | None = None,
+        fov: float = 60.0,
         width: int | None = None,
         height: int | None = None,
-        fov: float = 60.0,
         parent_body: str | None = None,
     ) -> dict[str, Any]:
         """Add an RTX camera to the scene.
@@ -4979,6 +4979,13 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             via ``omni.isaac.core.utils.viewports.set_camera_view``.
             If ``None``, the camera keeps its constructed orientation
             (identity).
+        fov : float
+            Horizontal field of view in degrees. Default 60.0. Declared in the
+            same position as on the MuJoCo and Newton backends, so a positional
+            call is read the same way on all three. Mapped onto
+            ``Camera.set_focal_length`` using the standard pinhole relation
+            ``focal_length = horizontal_aperture / (2 * tan(fov/2))`` with the
+            USD-default 24 mm horizontal aperture.
         width : int, optional
             Image width in pixels; a positive integer. ``None`` (omitted)
             takes ``IsaacConfig.camera_width``.
@@ -4999,11 +5006,6 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             bare ``TypeError`` naming neither the capability nor the
             alternative. Omit it (the default) for a world-fixed camera,
             which this backend does support.
-        fov : float
-            Horizontal field of view in degrees. Default 60.0. Mapped
-            onto ``Camera.set_focal_length`` using the standard pinhole
-            relation ``focal_length = horizontal_aperture / (2 * tan(fov/2))``
-            with the USD-default 24 mm horizontal aperture.
 
         Validation
         ----------

--- a/strands_robots/simulation/newton/randomization.py
+++ b/strands_robots/simulation/newton/randomization.py
@@ -54,9 +54,9 @@ _RANDOMIZE_PARAMS: tuple[str, ...] = (
     "randomize_physics",
     "randomize_positions",
     "position_noise",
-    "mass_range",
-    "friction_range",
     "color_range",
+    "friction_range",
+    "mass_range",
     "seed",
 )
 _OBS_NOISE_PARAMS: tuple[str, ...] = (
@@ -93,17 +93,18 @@ class DomainRandomizationMixin:
         randomize_colors: bool = True,
         randomize_lighting: bool = True,
         randomize_physics: bool = False,
-        mass_range: tuple[float, float] = (0.5, 2.0),
-        friction_range: tuple[float, float] = (0.5, 1.5),
         color_range: tuple[float, float] = (0.1, 1.0),
+        friction_range: tuple[float, float] = (0.5, 1.5),
+        mass_range: tuple[float, float] = (0.5, 2.0),
         seed: int | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Apply domain randomization to the Newton scene.
 
-        Keyword names and defaults mirror the MuJoCo backend so randomization
-        code transfers across backends unchanged - including the shared
-        boolean-flag domain each axis flag is checked on
+        Keyword names, defaults and parameter order all mirror the MuJoCo
+        backend, so randomization code transfers across backends unchanged
+        whether it passes the ranges by keyword or positionally - including the
+        shared boolean-flag domain each axis flag is checked on
         (:func:`~strands_robots.utils.boolean_flag_error`), so an axis is not
         turned off by ``"false"``, ``"no"``, ``"off"`` or ``"0"``. Each axis is
         opt-in:
@@ -132,11 +133,11 @@ class DomainRandomizationMixin:
             randomize_colors: Resample per-shape RGB.
             randomize_lighting: Jitter the directional-light orientation.
             randomize_physics: Scale per-body mass and per-shape friction.
+            color_range: ``(lo, hi)`` for uniform RGB sampling.
+            friction_range: ``(lo, hi)`` multiplicative scale on shape friction.
             mass_range: ``(lo, hi)`` multiplicative scale on body mass. Must
                 be strictly positive: a zero multiplier leaves a massless body
                 that ignores gravity rather than a lighter one.
-            friction_range: ``(lo, hi)`` multiplicative scale on shape friction.
-            color_range: ``(lo, hi)`` for uniform RGB sampling.
             seed: Optional seed for reproducible randomization; a non-negative
                 integer, or None for fresh entropy.
             **kwargs: Tolerated for MuJoCo-signature parity: ``randomize_positions``

--- a/tests/simulation/test_backend_shared_parameter_order.py
+++ b/tests/simulation/test_backend_shared_parameter_order.py
@@ -1,0 +1,420 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: a backend must not permute a parameter it shares with a sibling.
+
+``create_simulation(backend=...)`` is the backend-agnostic entry point, so the
+same ``sim`` variable is a different class depending on one string. A method two
+backends both implement therefore has two signatures, and nothing in the type
+system relates them: ``add_camera`` is not on the :class:`SimEngine` ABC at all
+(``__abstractmethods__`` does not list it), and ``randomize`` is on it only as a
+``**kwargs`` sink whose docstring says "Concrete backends define their own
+parameter signatures".
+
+Two of them had permuted a parameter they share with both siblings, so one
+positional call meant two things. Measured on this tree before the fix::
+
+    add_camera("wrist", [0.1, 0.0, 0.05], [0.3, 0.0, 0.0], 100, 200, 90)
+
+    mujoco   fov=100  width=200  height=90
+    newton   fov=100  width=200  height=90
+    isaac    fov=90   width=100  height=200      <- a 100x200 view at fov 90
+
+Every one of those six values is inside its own domain on both readings, so
+nothing refuses the call and nothing warns: the caller gets a different camera,
+and finds out from the pixels. ``randomize`` had the same shape, with the three
+range parameters in reverse order between MuJoCo (``color_range``,
+``friction_range``, ``mass_range``) and Newton (``mass_range``,
+``friction_range``, ``color_range``).
+
+Both divergences contradicted a parity claim the code and docs already made.
+Newton's ``randomize`` docstring said "Keyword names and defaults mirror the
+MuJoCo backend so randomization code transfers across backends unchanged" - the
+premise (names and defaults) is narrower than the conclusion (code transfers),
+and the missing third term was the order. ``docs/simulation/newton.md`` states
+the camera order as ``add_camera(name, position, target, fov=60, width, height,
+parent_body=None)`` and calls it "matching the MuJoCo signature", and
+``docs/simulation/domain-randomization.md`` lists the three ranges in MuJoCo's
+order. Those two documented orders are what this module grades the backends
+against, so the pages and the signatures cannot drift apart.
+
+The rule is that a backend may *add* parameters but must not *permute* the ones
+it shares. That is deliberately weaker than "a shared parameter sits at the same
+positional index" - see :class:`TestWhatThisDoesNotDecide`, which measures the
+methods where the weaker rule holds and the stronger one does not, and pins the
+distinction rather than leaving it to be rediscovered.
+
+The universe is derived from
+:data:`~strands_robots.simulation.factory._BUILTIN_BACKENDS`, the table
+``create_simulation`` resolves, so a fourth backend is held to the rule the hour
+it lands rather than when someone remembers to extend a list. Nothing here needs
+Isaac Sim, Newton, a GPU or GL: only the signatures are read, and all three
+engine modules import on a host with neither optional runtime installed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import itertools
+import pathlib
+import re
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.factory import _BUILTIN_BACKENDS
+
+#: One positional camera call whose every argument is valid under either reading.
+#: ``fov=100`` and ``fov=90`` are both inside ``(0, 180)`` and ``100``/``200``/``90``
+#: are all positive integers, which is why the permutation was silent rather than
+#: refused.
+_CAMERA_CALL: tuple[Any, ...] = ("wrist", [0.1, 0.0, 0.05], [0.3, 0.0, 0.0], 100, 200, 90)
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _engines() -> dict[str, type]:
+    """Resolve every shipped backend name to its engine class.
+
+    Returns:
+        A mapping of backend name to engine class, derived from the table
+        ``create_simulation`` resolves rather than from a list in this file.
+    """
+    out: dict[str, type] = {}
+    for name, (module_path, class_name) in sorted(_BUILTIN_BACKENDS.items()):
+        out[name] = getattr(importlib.import_module(module_path), class_name)
+    return out
+
+
+def _positional_parameters(method: Callable[..., Any]) -> list[str]:
+    """The parameter names a caller can supply positionally, in order.
+
+    ``self`` is dropped, and keyword-only parameters are excluded because a
+    keyword-only name cannot be reached positionally and so cannot be permuted
+    in the sense this module grades.
+
+    Args:
+        method: The function to read.
+
+    Returns:
+        The positional parameter names, in signature order.
+    """
+    return [
+        p.name
+        for p in inspect.signature(method).parameters.values()
+        if p.name != "self" and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ]
+
+
+def permuted_shared_parameters(left: Callable[..., Any], right: Callable[..., Any]) -> tuple[str, ...]:
+    """The parameters two signatures share but order differently.
+
+    A parameter only one side declares is ignored: a backend adding its own
+    loader or option is allowed, and shifts nothing about the *relative* order
+    of the names both sides carry.
+
+    Args:
+        left: One implementation.
+        right: The other implementation.
+
+    Returns:
+        The shared parameter names whose position within the shared sequence
+        differs between the two, sorted. Empty when the shared parameters are
+        in the same relative order.
+    """
+    left_params = _positional_parameters(left)
+    right_params = _positional_parameters(right)
+    shared = set(left_params) & set(right_params)
+    left_order = [p for p in left_params if p in shared]
+    right_order = [p for p in right_params if p in shared]
+    return tuple(sorted(name for name in shared if left_order.index(name) != right_order.index(name)))
+
+
+def _shared_methods() -> list[tuple[str, str, str]]:
+    """Every ``(method, backend_a, backend_b)`` a rule can be asked about.
+
+    Returns:
+        One row per public method implemented by a pair of backends.
+    """
+    engines = _engines()
+    owners: dict[str, list[str]] = {}
+    for backend, engine in engines.items():
+        for name, _ in inspect.getmembers(engine, inspect.isfunction):
+            if not name.startswith("_"):
+                owners.setdefault(name, []).append(backend)
+    rows: list[tuple[str, str, str]] = []
+    for method, backends in sorted(owners.items()):
+        for left, right in itertools.combinations(sorted(backends), 2):
+            rows.append((method, left, right))
+    return rows
+
+
+def _order_in(window: str, names: tuple[str, ...], pattern: str) -> list[str]:
+    """``names`` sorted by where ``pattern`` first matches each of them in ``window``.
+
+    Args:
+        window: The documentation text to read.
+        names: The parameter names to locate.
+        pattern: A ``str.format`` template producing the regex for one name.
+
+    Returns:
+        ``names`` in the order the window mentions them.
+    """
+    found: list[tuple[int, str]] = []
+    for name in names:
+        match = re.search(pattern.format(re.escape(name)), window)
+        assert match is not None, f"{name} not matched by {pattern!r} in:\n{window}"
+        found.append((match.start(), name))
+    return [name for _, name in sorted(found)]
+
+
+def _documented_signature_order(page: str, marker: str, names: tuple[str, ...]) -> list[str]:
+    """The order ``names`` appear in, in the documented signature line holding ``marker``.
+
+    Reads a single line so a later paragraph naming the same parameters in prose
+    cannot decide the answer.
+
+    Args:
+        page: Path relative to the repository root.
+        marker: A substring selecting the signature line.
+        names: The parameter names to locate.
+
+    Returns:
+        ``names`` in documented order.
+    """
+    for line in (_REPO_ROOT / page).read_text(encoding="utf-8").splitlines():
+        if marker in line:
+            return _order_in(line, names, r"\b{}\b")
+    raise AssertionError(f"{marker!r} not found in {page}")
+
+
+def _documented_call_order(page: str, marker: str, names: tuple[str, ...]) -> list[str]:
+    """The order ``names`` are *assigned* in, in the first documented call after ``marker``.
+
+    Matches ``name=`` rather than a bare mention: the randomization page
+    annotates ``randomize_physics`` with a comment naming ``mass_range`` and
+    ``friction_range`` before either is passed, so a bare-mention scan reads that
+    comment as the documented order.
+
+    Args:
+        page: Path relative to the repository root.
+        marker: A substring selecting the call.
+        names: The parameter names to locate.
+
+    Returns:
+        ``names`` in documented order.
+    """
+    text = (_REPO_ROOT / page).read_text(encoding="utf-8")
+    start = text.index(marker)
+    return _order_in(text[start : start + 900], names, r"\b{}\s*=")
+
+
+_SHARED_METHODS = _shared_methods()
+
+
+class TestThePopulationIsReal:
+    """The premises the derived rule rests on, so a silent empty scan cannot pass."""
+
+    def test_every_shipped_backend_resolves_without_its_runtime(self) -> None:
+        engines = _engines()
+        assert len(engines) >= 3, sorted(engines)
+        for backend, engine in engines.items():
+            assert issubclass(engine, SimEngine), f"{backend}: {engine!r}"
+
+    def test_there_are_methods_two_backends_both_implement(self) -> None:
+        assert len(_SHARED_METHODS) > 20, len(_SHARED_METHODS)
+
+    def test_the_two_methods_this_module_names_are_in_the_population(self) -> None:
+        pairs = {(method, left, right) for method, left, right in _SHARED_METHODS}
+        assert ("add_camera", "isaac", "mujoco") in pairs
+        assert ("randomize", "mujoco", "newton") in pairs
+
+    def test_add_camera_is_related_by_no_declaration_at_all(self) -> None:
+        """Nothing but this rule relates the three ``add_camera`` signatures."""
+        assert not hasattr(SimEngine, "add_camera")
+        assert "add_camera" not in getattr(SimEngine, "__abstractmethods__", frozenset())
+
+    def test_randomize_is_related_only_by_a_kwargs_sink(self) -> None:
+        assert _positional_parameters(SimEngine.randomize) == []
+
+
+class TestNoBackendPermutesASharedParameter:
+    """The rule, over every method a pair of shipped backends both implement."""
+
+    @pytest.mark.parametrize(("method", "left", "right"), _SHARED_METHODS)
+    def test_the_shared_parameters_are_in_one_order(self, method: str, left: str, right: str) -> None:
+        engines = _engines()
+        permuted = permuted_shared_parameters(getattr(engines[left], method), getattr(engines[right], method))
+        assert permuted == (), (
+            f"{method}: {left} and {right} order {list(permuted)} differently.\n"
+            f"  {left}: {_positional_parameters(getattr(engines[left], method))}\n"
+            f"  {right}: {_positional_parameters(getattr(engines[right], method))}"
+        )
+
+
+class TestOnePositionalCallMeansOneThingEverywhere:
+    """The consequence, driven through the signatures rather than asserted about them."""
+
+    def test_the_camera_call_binds_the_same_parameters_on_every_backend(self) -> None:
+        engines = _engines()
+        bound = {}
+        for backend, engine in engines.items():
+            arguments = inspect.signature(engine.add_camera).bind(None, *_CAMERA_CALL).arguments
+            bound[backend] = {k: v for k, v in arguments.items() if k != "self"}
+        reference = bound["mujoco"]
+        for backend, got in bound.items():
+            assert got == reference, f"{backend} read the same call as {got}, mujoco as {reference}"
+
+    def test_the_camera_call_is_the_resolution_and_angle_the_caller_wrote(self) -> None:
+        """Pins which reading is the shared one, not merely that they agree."""
+        engines = _engines()
+        for backend, engine in engines.items():
+            arguments = inspect.signature(engine.add_camera).bind(None, *_CAMERA_CALL).arguments
+            assert arguments["fov"] == 100, backend
+            assert arguments["width"] == 200, backend
+            assert arguments["height"] == 90, backend
+
+
+class TestTheDocumentedOrderIsEveryBackendsOrder:
+    """The two pages that write an order down grade the signatures."""
+
+    def test_the_camera_order_matches_the_newton_page(self) -> None:
+        names = ("fov", "width", "height")
+        documented = _documented_signature_order("docs/simulation/newton.md", "`add_camera(name,", names)
+        assert documented == ["fov", "width", "height"], documented
+        engines = _engines()
+        for backend, engine in engines.items():
+            params = _positional_parameters(engine.add_camera)
+            assert [p for p in params if p in names] == documented, backend
+
+    def test_the_randomization_range_order_matches_the_randomization_page(self) -> None:
+        names = ("color_range", "friction_range", "mass_range")
+        documented = _documented_call_order("docs/simulation/domain-randomization.md", "sim.randomize(", names)
+        assert documented == ["color_range", "friction_range", "mass_range"], documented
+        engines = _engines()
+        graded = 0
+        for backend, engine in engines.items():
+            params = _positional_parameters(engine.randomize)
+            if not set(names) <= set(params):
+                continue
+            graded += 1
+            assert [p for p in params if p in names] == documented, backend
+        assert graded >= 2, "no backend declares all three ranges, so nothing was graded"
+
+
+class TestTheRuleIsNotVacuous:
+    """The shipped set is clean, so the predicate is graded on constructed exemplars.
+
+    Without these the whole module would pass on a tree whose rule had been
+    weakened to accept anything, because after the fix there is no violation
+    left for the derived scan to find.
+    """
+
+    @staticmethod
+    def _permuting() -> tuple[Callable[..., Any], Callable[..., Any]]:
+        def left(self: Any, name: str, fov: float = 60.0, width: int = 640) -> None: ...
+        def right(self: Any, name: str, width: int = 640, fov: float = 60.0) -> None: ...
+
+        return left, right
+
+    @staticmethod
+    def _inserting() -> tuple[Callable[..., Any], Callable[..., Any]]:
+        def left(self: Any, name: str, fov: float = 60.0, width: int = 640) -> None: ...
+        def right(self: Any, name: str, extra: int = 0, fov: float = 60.0, width: int = 640) -> None: ...
+
+        return left, right
+
+    def test_a_permutation_is_reported(self) -> None:
+        left, right = self._permuting()
+        assert permuted_shared_parameters(left, right) == ("fov", "width")
+
+    def test_an_insertion_is_not_reported(self) -> None:
+        left, right = self._inserting()
+        assert permuted_shared_parameters(left, right) == ()
+
+    def test_both_outcomes_are_reachable(self) -> None:
+        outcomes = {
+            permuted_shared_parameters(*self._permuting()) != (),
+            permuted_shared_parameters(*self._inserting()) != (),
+        }
+        assert outcomes == {True, False}, outcomes
+
+    def test_a_keyword_only_parameter_is_out_of_scope(self) -> None:
+        """A name no caller can pass positionally cannot be permuted positionally."""
+
+        def left(self: Any, name: str, *, fov: float = 60.0, width: int = 640) -> None: ...
+        def right(self: Any, name: str, *, width: int = 640, fov: float = 60.0) -> None: ...
+
+        assert permuted_shared_parameters(left, right) == ()
+
+
+class TestABackendMayStillAddItsOwnParameters:
+    """The rule must not have been satisfied by flattening the backends together."""
+
+    def test_isaac_keeps_its_own_loaders(self) -> None:
+        params = _positional_parameters(_engines()["isaac"].add_robot)
+        assert {"mjcf_path", "usd_path"} <= set(params), params
+
+    def test_newton_keeps_its_own_source(self) -> None:
+        assert "source" in _positional_parameters(_engines()["newton"].add_robot)
+
+    def test_mujoco_keeps_the_position_axis_newton_lacks(self) -> None:
+        mujoco = set(_positional_parameters(_engines()["mujoco"].randomize))
+        newton = set(_positional_parameters(_engines()["newton"].randomize))
+        assert {"randomize_positions", "position_noise"} <= mujoco - newton
+
+    def test_each_backend_keeps_its_own_camera_defaults(self) -> None:
+        """Reordering must not have changed what omitting a parameter means."""
+        engines = _engines()
+        for backend, expected in (("mujoco", (640, 480)), ("newton", (640, 480)), ("isaac", (None, None))):
+            params = inspect.signature(engines[backend].add_camera).parameters
+            assert (params["width"].default, params["height"].default) == expected, backend
+
+    def test_the_camera_mount_contract_is_unchanged(self) -> None:
+        """``parent_body`` stays last and world-fixed by default on every backend."""
+        for backend, engine in _engines().items():
+            params = _positional_parameters(engine.add_camera)
+            assert params[-1] == "parent_body", f"{backend}: {params}"
+            assert inspect.signature(engine.add_camera).parameters["parent_body"].default is None
+
+
+class TestWhatThisDoesNotDecide:
+    """The boundary: a shared parameter may still sit at a different *index*.
+
+    A backend that inserts its own parameter mid-signature shifts every shared
+    parameter after it, so a positional call still means two things even with no
+    permutation anywhere. Closing that would move ``IsaacSimulation.add_robot``'s
+    ``mjcf_path`` / ``usd_path`` off the position they have shipped at, which is
+    an API decision about the primary entry point rather than a correction, so
+    it is measured here and left to its own change.
+    """
+
+    @staticmethod
+    def _index_divergences() -> list[tuple[str, str, str, tuple[str, ...]]]:
+        engines = _engines()
+        rows = []
+        for method, left, right in _SHARED_METHODS:
+            left_params = _positional_parameters(getattr(engines[left], method))
+            right_params = _positional_parameters(getattr(engines[right], method))
+            shared = set(left_params) & set(right_params)
+            bad = tuple(sorted(p for p in shared if left_params.index(p) != right_params.index(p)))
+            if bad:
+                rows.append((method, left, right, bad))
+        return rows
+
+    def test_index_parity_is_not_the_rule_and_is_measurably_weaker(self) -> None:
+        rows = self._index_divergences()
+        assert rows, "index parity now holds everywhere - promote it to the rule above"
+        assert {method for method, _, _, _ in rows} >= {"add_robot"}, rows
+
+    def test_every_index_divergence_is_an_insertion_not_a_permutation(self) -> None:
+        """Whatever index parity still allows, the order rule above is satisfied."""
+        engines = _engines()
+        for method, left, right, _ in self._index_divergences():
+            assert permuted_shared_parameters(getattr(engines[left], method), getattr(engines[right], method)) == (), (
+                method,
+                left,
+                right,
+            )

--- a/tests/simulation/test_backend_shared_parameter_order.py
+++ b/tests/simulation/test_backend_shared_parameter_order.py
@@ -75,14 +75,18 @@ _CAMERA_CALL: tuple[Any, ...] = ("wrist", [0.1, 0.0, 0.05], [0.3, 0.0, 0.0], 100
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
-def _engines() -> dict[str, type]:
+def _engines() -> dict[str, Any]:
     """Resolve every shipped backend name to its engine class.
 
     Returns:
         A mapping of backend name to engine class, derived from the table
         ``create_simulation`` resolves rather than from a list in this file.
+        Typed as ``Any`` so tests can drive ``.add_camera`` / ``.add_robot`` /
+        ``.randomize`` off it without mypy losing the shared surface at the
+        ``type`` widening step; every backend declares those bindings and the
+        assertions grade the same call across them.
     """
-    out: dict[str, type] = {}
+    out: dict[str, Any] = {}
     for name, (module_path, class_name) in sorted(_BUILTIN_BACKENDS.items()):
         out[name] = getattr(importlib.import_module(module_path), class_name)
     return out

--- a/tests/simulation/test_backend_shared_parameter_order.py
+++ b/tests/simulation/test_backend_shared_parameter_order.py
@@ -81,10 +81,11 @@ def _engines() -> dict[str, Any]:
     Returns:
         A mapping of backend name to engine class, derived from the table
         ``create_simulation`` resolves rather than from a list in this file.
-        Typed as ``Any`` so tests can drive ``.add_camera`` / ``.add_robot`` /
-        ``.randomize`` off it without mypy losing the shared surface at the
-        ``type`` widening step; every backend declares those bindings and the
-        assertions grade the same call across them.
+    The values are typed ``Any`` rather than ``type`` for the reason this module
+    exists. ``add_camera`` is declared on no base class, so mypy reports
+    ``"type" has no attribute "add_camera"`` against a bare ``type`` and
+    ``"type[SimEngine]" has no attribute "add_camera"`` once ``issubclass``
+    narrows it - the checker cannot see the surface these tests grade either.
     """
     out: dict[str, Any] = {}
     for name, (module_path, class_name) in sorted(_BUILTIN_BACKENDS.items()):


### PR DESCRIPTION
## Problem

`create_simulation(backend=...)` makes the same `sim` variable a different class, and nothing relates two backends' signatures for a method both implement. `add_camera` is on no ABC at all -- `SimEngine.__abstractmethods__` does not list it -- and `randomize` is on `SimEngine` only as a `**kwargs` sink whose docstring says "Concrete backends define their own parameter signatures". Two methods had drifted into ordering a parameter they share differently, so one positional call meant two things.

Measured on `main` (`f5876e0e`), one call, three backends:

```
sim.add_camera("wrist", [0.1, 0.0, 0.05], [0.3, 0.0, 0.0], 100, 200, 90)

mujoco   fov=100  width=200  height=90
newton   fov=100  width=200  height=90
isaac    fov=90   width=100  height=200
```

Every one of those six values is inside its own domain under either reading: `fov=100` and `fov=90` are both in `(0, 180)`, and 100, 200 and 90 are all positive integers. So no guard refuses the call, nothing warns, and the difference arrives in the pixels.

`NewtonSimEngine.randomize` had the same shape, listing `mass_range, friction_range, color_range` where MuJoCo lists `color_range, friction_range, mass_range` -- three parameters of the same type, so nothing distinguishes them by value either.

Both contradicted a parity claim already in the tree. Newton's `randomize` docstring said "Keyword names and defaults mirror the MuJoCo backend so randomization code transfers across backends unchanged" -- a conclusion wider than its premise, with the order as the missing third term. `docs/simulation/newton.md` documents the camera order as `add_camera(name, position, target, fov=60, width, height, parent_body=None)` and calls it "matching the MuJoCo signature", and `docs/simulation/domain-randomization.md` lists the three ranges in MuJoCo's order -- so the pages a reader copies from already stated the order the signatures did not keep.

## Severity, honestly split

The two divergences are not equally dangerous, and the PR does not claim they are.

| | reachable silently? | why |
|---|---|---|
| `add_camera` | yes | all three backends share every parameter, so a positional call binds cleanly under both readings |
| `randomize` | no | MuJoCo declares two axes Newton lacks (`randomize_positions`, `position_noise`), so a positional call hits the boolean-flag domain at index 4 and is refused loudly |

`randomize` is fixed because the rule cannot land with a known violation in it, and because the documented order is the one a reader transfers -- not because a caller is silently losing colour for mass today.

## Change

Reorder the two signatures onto the order the documentation already gives, and make each docstring's parameter block follow its signature. Adding a parameter is still allowed and shifts no shared name's relative order, so `IsaacSimulation.add_robot`'s `mjcf_path`/`usd_path`, `NewtonSimEngine.add_robot`'s `source` and MuJoCo's two extra randomization axes are untouched -- as are each backend's own defaults (Isaac still resolves an omitted `width` from `IsaacConfig` where MuJoCo defaults it to 640).

No in-tree caller is affected: an AST sweep of `strands_robots`, `tests`, `tests_integ`, `examples`, `scripts` and `docs` finds 263 `add_camera` calls and 83 `randomize` calls, of which the largest positional-argument count anywhere is 2 for `add_camera` and 1 for `randomize`.

## Guard

`tests/simulation/test_backend_shared_parameter_order.py` derives its backend inventory from `_BUILTIN_BACKENDS`, the table `create_simulation` resolves, so a fourth backend is graded when it lands rather than when someone extends a list. It needs no Isaac Sim, no Newton, no GPU and no GL: only signatures are read, and all three engine modules import on a host with neither optional runtime installed.

Pre-fix split: **8 failed / 167 passed**, and the three classes that must not move are clean.

| class | failed / total | role |
|---|---|---|
| `TestNoBackendPermutesASharedParameter` | 3 / 66 | the derived rule |
| `TestOnePositionalCallMeansOneThingEverywhere` | 2 / 2 | the consequence, via `signature.bind` |
| `TestTheDocumentedOrderIsEveryBackendsOrder` | 2 / 2 | the two pages that write an order down |
| `TestWhatThisDoesNotDecide` | 1 / 2 | fires because a permutation is not an insertion |
| `TestThePopulationIsReal` | 0 / 5 | premise |
| `TestTheRuleIsNotVacuous` | 0 / 4 | non-vacuity |
| `TestABackendMayStillAddItsOwnParameters` | 0 / 5 | over-reach control |

## Mutation table

Each row mutates the tree, runs the new module (`own`) and the pre-existing neighbouring suites (`sib`), and records `collected`. Source restored md5-identical after every row.

| row | own | sib | coll | mutation |
|---|---|---|---|---|
| b0 | 0 | 0 | 175 | control, no mutation |
| b1 | 6 | 0 | 175 | Isaac `add_camera` order reverted |
| b2 | 3 | 0 | 175 | Newton `randomize` order reverted |
| b3 | 8 | 0 | 175 | both reverted (the behavioural pre-fix state) |
| b4 | 6 | 0 | 175 | rule weakened to a set comparison, plus both reverted |
| b5 | 6 | 0 | 175 | rule disabled outright, plus both reverted |
| b6 | 1 | 0 | 175 | keyword-only parameters folded into the positional list |
| b7 | 7 | 0 | **292** | a fourth permuting backend, inventory **derived** |
| b8 | **0** | 0 | **175** | the same plant, inventory **hardcoded** to today's three |
| b9 | 1 | 0 | 175 | documented order read by bare mention instead of by assignment |
| b10 | 9 | 0 | 175 | report only the first differing name, plus both reverted |

Eight distinct firing sets across the nine non-empty rows. Notes worth reading:

- **b1 and b2 are complementary and exact**: `b1 | b2 == b3` is `True`, and their single-element overlap is `test_every_index_divergence_is_an_insertion_not_a_permutation`, which fires if either half is a permutation. So neither fix rides on the other's tests.
- **b7 against b8 is why the inventory is derived.** The same planted fourth backend fires 7 tests with the inventory derived and **0** with it hardcoded -- and the hardcoded run also collects 117 fewer tests, so a suite that silently stopped grading a backend would still have reported success. A hardcoded list equal to today's derived set fires nothing and looks like a working test; this pair is the only way to show the difference.
- **b4 and b5 share a firing set** for a structural reason: both make the predicate return `()` unconditionally. Their six failures include the two `TestTheRuleIsNotVacuous` exemplars, which is exactly what those exist for -- with the derived scan blinded, the constructed permuting/inserting pair still catches the weakened rule.
- **b9** is the trap this module's own helper had to be fixed for: the randomization page annotates `randomize_physics` with a comment naming `mass_range` and `friction_range` before either is passed, so a bare-mention scan reads that comment as the documented order. The helper matches `name=` instead.
- **`sib` is 0 on all eleven rows** across the pre-existing camera, randomization, mount-capability, reserved-name and Isaac-backend suites. That is the measurement of why nothing caught this: the closest existing guard, `tests/simulation/test_camera_mount_capability_across_backends.py`, reads `inspect.signature(engine.add_camera).parameters` -- but asks only whether `parent_body` is present and defaults to `None`, never where anything sits.

## What this does not decide

The rule is "a backend may add a parameter but must not permute one it shares", which is deliberately weaker than "a shared parameter sits at the same positional index". Index parity is still violated -- measured, by `add_robot` (Isaac inserts `mjcf_path`/`usd_path` mid-signature, shifting `data_config`, `position`, `orientation`, `keyframe`), by `randomize`, and by `start_cameras_recording`. Closing that would move parameters off positions they have shipped at on the primary entry point, which is an API decision rather than a correction. `TestWhatThisDoesNotDecide` measures that set, asserts it is non-empty, and asserts every member of it is an insertion rather than a permutation, so the boundary is pinned instead of left to be rediscovered.

## Visual

![One positional add_camera call, read two ways](https://github.com/cagataycali/robots/releases/download/artifacts/add_camera_order.png)

Both panels are rendered by the MuJoCo engine from the identical scene (SO-101 arm plus a cube) and the identical camera pose, so the only difference between them is which parameter each value bound to. Left is the shared reading (`fov=100`, 200x90) that MuJoCo, Newton and now Isaac all produce; right is the reading Isaac produced before this change (`fov=90`, 100x200). Native render sizes were read back from the frames and asserted against the request before the figure was drawn; panels are nearest-neighbour upscaled 2x for legibility.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1595 files).
- `mypy strands_robots tests tests_integ`: **24 on the branch, 24 on a pristine worktree of the merge-base**, normalized message sets byte-identical in both directions, none in any changed file.
- Paired run over an identical 795-file selection (all of `tests/simulation/`, plus every test that walks the tree, parses source, reads docstrings, reads `docs/`, `README`, `AGENTS.md` or `changelog.d`, or names `add_camera` / `randomize` / `create_simulation` / `_BUILTIN_BACKENDS`), with the new file excluded from **both** trees and every path verified present on both: identical **28917 collected** and **`18 failed, 28613 passed, 286 skipped`** on each, failing-ID sets identical, `comm` empty in both directions. All 18 are pre-existing: 17 `tests/mesh/test_iot_*` needing `awsiot` (absent; declared in the `[mesh-iot]` extra) and 1 `tests/training/test_lerobot_e2e.py`.
- New module: 175 passed on mujoco 3.5.0, the declared floor.
- Neighbouring suites after the change: 2296 passed, 16 skipped.
