### PR TITLE
fix(g1): release a DDS endpoint whose construction failed part way

### DIFF
--- a/changelog.d/2783-dds-partial-construction-is-released.md
+++ b/changelog.d/2783-dds-partial-construction-is-released.md
@@ -1,0 +1,44 @@
+### Fixed: a DDS endpoint whose construction failed part way is released, not dropped
+
+`DDSSubscriberSet.subscribe` and `DDSPublisher.get_publisher` build an SDK
+endpoint in two steps - construct, then `Init` - and report a named reason if
+either raises. Neither step is atomic, and the endpoint that failed holds real
+DDS state: `ChannelSubscriber.__init__` creates a live `Channel` before `Init`
+runs, and `unitree_sdk2py` starts the `ch_reader` daemon thread *before* it
+constructs the `DataReader` that can raise. Both handlers returned the reason
+and dropped the endpoint.
+
+That leaks exactly what the engine's `close` methods exist to release, and it
+leaks it where `close` can never reach: the failing call never appended to
+`_subs` or wrote to `_pubs`, so `G1Driver.cleanup()` walks a collection the
+half-built endpoint is not in. Measured against `unitree_sdk2py` 1.0.1 by
+driving `subscribe` with a `DataReader` that raises:
+
+```
+subscribe() reason        failed to subscribe to 'rt/lowstate': DDS resource limit reached
+subscribers recorded      0
+ch_reader threads live    1     <- before this change
+after close()             1     <- close() has nothing to walk
+ch_reader threads live    0     <- after this change
+```
+
+The thread runs for the life of the process, blocked on its queue, keeping the
+channel and its `DataReader` reachable so no finaliser releases them - the same
+reference chain `DDSSubscriberSet.close`'s docstring already describes when it
+explains why dropping a reference is not a release. A driver that retries
+`connect_eagerly()` after a transient DDS failure accumulates one more per
+attempt, four topics at a time.
+
+Both construction sites now pass the half-built endpoint through one release
+helper before returning. `Close()` is safe on a partial init - it routes to
+`Channel.CloseReader`/`CloseWriter`, which skip an entity that was never created
+and still stop and join the reader thread - and a `Close()` that fails is
+reported rather than allowed to replace the construction failure the caller
+needs. A constructor that raised before there was an endpoint releases nothing
+and says nothing about closing one. The reason strings both methods return are
+unchanged, and a construction that succeeded is still recorded, still cached and
+still closed only by `close`.
+
+The write path gets the same rule for the reason its own `close` docstring
+gives: a dropped writer starts no thread and does reach CycloneDDS' finaliser,
+but only "whenever the last reference happens to go", and closing "says when".

--- a/strands_robots/tools/g1/_dds_engine.py
+++ b/strands_robots/tools/g1/_dds_engine.py
@@ -30,6 +30,39 @@ from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK, ensure_dds
 logger = logging.getLogger(__name__)
 
 
+def _release_partial(endpoint: Any | None, what: str) -> None:
+    """Close an endpoint whose construction failed, rather than dropping it.
+
+    ``ChannelSubscriber.__init__`` and ``ChannelPublisher.__init__`` create a
+    live ``Channel`` before ``Init`` runs, and ``Init`` is not atomic either:
+    ``unitree_sdk2py`` starts the ``ch_reader`` daemon thread *before* it
+    constructs the ``DataReader`` that can raise. A construction that fails
+    part way therefore leaves an endpoint holding real DDS state, and for a
+    subscriber that state includes a running thread whose target is a bound
+    method of the channel's reader - the same thread
+    :meth:`DDSSubscriberSet.close` documents, which keeps the channel
+    reachable so no finaliser releases it.
+
+    Such an endpoint is unreachable from :meth:`DDSSubscriberSet.close` and
+    :meth:`DDSPublisher.close`, because the call that failed never recorded
+    it - so releasing it here is the only opportunity. ``Close()`` is safe on
+    a half-built endpoint: it routes to ``Channel.CloseReader`` /
+    ``CloseWriter``, which skip an entity that was never created and still
+    stop and join the reader thread.
+
+    Args:
+        endpoint: The half-built subscriber or publisher, or ``None`` when the
+            constructor itself raised and there is nothing to release.
+        what: How to name the endpoint if closing it also fails.
+    """
+    if endpoint is None:
+        return
+    try:
+        endpoint.Close()
+    except Exception as exc:  # noqa: BLE001 - SDK raises bare Exception
+        logger.warning("failed to close a partially built %s: %s", what, exc)
+
+
 class DDSSubscriberSet:
     """A bag of :class:`unitree_sdk2py.core.channel.ChannelSubscriber` objects.
 
@@ -89,7 +122,10 @@ class DDSSubscriberSet:
 
         Returns:
             ``None`` on success. An error string if the SDK is missing or the
-            subscriber constructor raised; never raises.
+            subscriber constructor raised; never raises. A construction that
+            failed part way is closed before the reason is returned, because
+            an unrecorded subscriber is one :meth:`close` can never reach -
+            see :func:`_release_partial`.
         """
         if not self._started:
             return "DDS not initialised - call start() first"
@@ -99,10 +135,12 @@ class DDSSubscriberSet:
         except ImportError as exc:  # pragma: no cover - exercised on hardware
             return f"unitree_sdk2py is not installed: {exc}"
         with _DDS_INIT_LOCK:
+            sub: Any | None = None
             try:
                 sub = ChannelSubscriber(topic, message_class)
                 sub.Init(callback, 10)
             except Exception as exc:  # noqa: BLE001 - SDK raises bare Exception
+                _release_partial(sub, f"subscriber for {topic!r}")
                 return f"failed to subscribe to {topic!r}: {exc}"
             self._subs.append(sub)
             logger.debug("subscribed to %s", topic)
@@ -211,7 +249,10 @@ class DDSPublisher:
 
         Returns:
             ``(publisher, None)`` on success. ``(None, reason)`` if the SDK
-            is missing or the publisher constructor raised; never raises.
+            is missing or the publisher constructor raised; never raises. A
+            construction that failed part way is closed before the reason is
+            returned, because an uncached publisher is one :meth:`close` can
+            never reach - see :func:`_release_partial`.
         """
         if not self._started:
             return None, "DDS not initialised - call start() first"
@@ -230,10 +271,12 @@ class DDSPublisher:
             cached = self._pubs.get(key)
             if cached is not None:
                 return cached, None
+            pub: Any | None = None
             try:
                 pub = ChannelPublisher(topic, message_class)
                 pub.Init()
             except Exception as exc:  # noqa: BLE001 - SDK raises bare Exception
+                _release_partial(pub, f"publisher for {topic!r}")
                 return None, f"failed to build publisher for {topic!r}: {exc}"
             self._pubs[key] = pub
             logger.debug("built publisher for %s", topic)

--- a/tests/tools/g1/test_dds_partial_construction_is_released.py
+++ b/tests/tools/g1/test_dds_partial_construction_is_released.py
@@ -1,0 +1,572 @@
+"""A DDS endpoint whose construction failed part way is closed, not dropped.
+
+:meth:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet.subscribe` and
+:meth:`~strands_robots.tools.g1._dds_engine.DDSPublisher.get_publisher` each
+build an SDK endpoint in two steps - construct, then ``Init`` - and report a
+named reason if either step raises. Neither step is atomic, and the endpoint
+that failed holds real DDS state: ``ChannelSubscriber.__init__`` creates a live
+``Channel`` before ``Init`` runs, and ``unitree_sdk2py`` starts the
+``ch_reader`` daemon thread *before* it constructs the ``DataReader`` that can
+raise.
+
+Returning the reason and dropping the endpoint therefore leaks exactly what
+``close`` exists to release, and it leaks it where ``close`` can never reach:
+the failing call never appended to ``_subs`` or wrote to ``_pubs``, so the
+driver's teardown walks a collection the half-built endpoint is not in. The
+engine's own ``close`` docstrings spell out why a dropped reference is not a
+release - the reader thread keeps the channel reachable, so no finaliser runs.
+
+The behavioural cells drive recording stand-ins, so they grade the production
+path on a box with no SDK. The facts a stand-in cannot establish - that a
+partial ``Init`` really leaves a live thread, and that ``Close()`` really
+releases it - are driven against the installed SDK and skip where it is
+absent. They need no DDS bus: the reader is constructed directly and the
+``DataReader`` it would build is the injected fault, so nothing here
+initialises the process-wide channel factory.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import sys
+import threading
+import types
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from strands_robots.tools.g1 import _dds_engine, reset_dds_state
+from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
+
+_ENGINE_LOGGER = "strands_robots.tools.g1._dds_engine"
+
+# The queue length ``subscribe`` asks the SDK for. Stated here rather than read
+# off the engine so a change to either side has to be a deliberate one.
+_QUEUE_LEN = 10
+
+
+# =========================================================================
+# Stand-ins - endpoints that fail the way the SDK's can.                   #
+# =========================================================================
+
+
+class _Endpoint:
+    """Stands in for a ``ChannelSubscriber``/``ChannelPublisher``.
+
+    Counts ``Close()`` calls, because the question this file asks is whether
+    the engine closed an endpoint it is about to stop referring to.
+    """
+
+    def __init__(self, topic: str, message_class: type) -> None:
+        self.topic = topic
+        self.message_class = message_class
+        self.queue_len: int | None = None
+        self.closes = 0
+        self.init_should_raise: Exception | None = None
+        self.close_should_raise: Exception | None = None
+
+    def Init(self, handler: Any = None, queue_len: int | None = None) -> None:  # noqa: N802 - SDK spelling
+        self.queue_len = queue_len
+        if self.init_should_raise is not None:
+            raise self.init_should_raise
+
+    def Close(self) -> None:  # noqa: N802 - SDK spelling
+        self.closes += 1
+        if self.close_should_raise is not None:
+            raise self.close_should_raise
+
+
+class _Factory:
+    """Builds :class:`_Endpoint` objects and records every one it built.
+
+    ``init_raises`` makes the *second* construction step fail, which is the
+    partial init this file is about. ``construct_raises`` makes the *first*
+    step fail, where there is no endpoint to release at all.
+    """
+
+    def __init__(
+        self,
+        init_raises: Exception | None = None,
+        close_raises: Exception | None = None,
+        construct_raises: Exception | None = None,
+    ) -> None:
+        self.built: list[_Endpoint] = []
+        self.init_raises = init_raises
+        self.close_raises = close_raises
+        self.construct_raises = construct_raises
+
+    def __call__(self, topic: str, message_class: type) -> _Endpoint:
+        if self.construct_raises is not None:
+            raise self.construct_raises
+        endpoint = _Endpoint(topic, message_class)
+        endpoint.init_should_raise = self.init_raises
+        endpoint.close_should_raise = self.close_raises
+        self.built.append(endpoint)
+        return endpoint
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, attribute: str, factory: _Factory) -> None:
+    """Make the engine's lazy ``from ... import <attribute>`` resolve to ``factory``.
+
+    ``monkeypatch.setitem`` restores whatever was in ``sys.modules``, so a box
+    that really has the SDK gets it back.
+    """
+    channel = types.ModuleType("unitree_sdk2py.core.channel")
+    setattr(channel, attribute, factory)
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py", types.ModuleType("unitree_sdk2py"))
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py.core", types.ModuleType("unitree_sdk2py.core"))
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py.core.channel", channel)
+
+
+@pytest.fixture
+def dds_ready(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Let ``start()`` succeed without touching a real interface.
+
+    The engine's ``start`` calls ``ensure_dds``, which initialises the
+    process-wide channel factory. Short-circuiting it means these cells drive
+    the real ``start`` success path rather than assigning ``_started``.
+    """
+    monkeypatch.setattr(f"{_ENGINE_LOGGER}.ensure_dds", lambda interface: None)
+    yield
+    reset_dds_state()
+
+
+def _started_subscriber(monkeypatch: pytest.MonkeyPatch, factory: _Factory) -> DDSSubscriberSet:
+    """A subscriber set that really ran ``start()``, with ``factory`` on the bus."""
+    _install(monkeypatch, "ChannelSubscriber", factory)
+    subs = DDSSubscriberSet("eth0")
+    assert subs.start() is None
+    return subs
+
+
+def _started_publisher(monkeypatch: pytest.MonkeyPatch, factory: _Factory) -> DDSPublisher:
+    """A publisher cache that really ran ``start()``, with ``factory`` on the bus."""
+    _install(monkeypatch, "ChannelPublisher", factory)
+    pubs = DDSPublisher("eth0")
+    assert pubs.start() is None
+    return pubs
+
+
+# =========================================================================
+# Premise - the SDK really leaves live state behind a partial init.        #
+# =========================================================================
+
+
+class TestTheSdkLeavesRealStateBehindAPartialInit:
+    """What a recording stand-in cannot establish, asked of the installed SDK.
+
+    A stand-in models ``Init`` raising, but it cannot show that the real
+    ``Init`` has already started a thread by the time it raises - and that is
+    the whole reason a dropped endpoint is a leak rather than an untidy
+    reference. These cells drive the SDK's own reader directly with a raising
+    ``DataReader``, so no DDS bus and no channel factory are involved.
+    """
+
+    @staticmethod
+    def _channel() -> Any:
+        return pytest.importorskip(
+            "unitree_sdk2py.core.channel",
+            reason="needs unitree_sdk2py (office bring-up, not a headless runner)",
+        )
+
+    @staticmethod
+    def _reader_threads() -> list[threading.Thread]:
+        return [thread for thread in threading.enumerate() if thread.name == "ch_reader"]
+
+    def _partially_init(self, monkeypatch: pytest.MonkeyPatch, queue_len: int) -> Any:
+        """Run the SDK reader's ``Init`` with a ``DataReader`` that raises."""
+        channel = self._channel()
+
+        class _Boom:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError("DDS resource limit reached")
+
+        monkeypatch.setattr(channel, "DataReader", _Boom)
+        reader = channel.Channel._Channel__Reader()
+        with pytest.raises(RuntimeError, match="DDS resource limit reached"):
+            reader.Init(object(), object(), None, lambda _msg: None, queue_len)
+        return reader
+
+    def test_a_partial_init_leaves_the_reader_thread_running(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The thread starts before the ``DataReader`` that can raise."""
+        before = len(self._reader_threads())
+        reader = self._partially_init(monkeypatch, _QUEUE_LEN)
+        try:
+            assert len(self._reader_threads()) == before + 1
+        finally:
+            reader.Close()
+
+    def test_closing_a_half_built_reader_stops_the_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``Close()`` is what releases it - and it works on a partial init."""
+        before = len(self._reader_threads())
+        reader = self._partially_init(monkeypatch, _QUEUE_LEN)
+        reader.Close()
+        assert len(self._reader_threads()) == before
+
+    def test_a_zero_queue_length_starts_no_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """So the queue length ``subscribe`` asks for is what makes this a leak."""
+        before = len(self._reader_threads())
+        reader = self._partially_init(monkeypatch, 0)
+        try:
+            assert len(self._reader_threads()) == before
+        finally:
+            reader.Close()
+
+    def test_subscribe_asks_for_the_queue_length_that_starts_one(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        """The engine's own choice, so the two premises above meet."""
+        factory = _Factory()
+        subs = _started_subscriber(monkeypatch, factory)
+        assert subs.subscribe("rt/lowstate", dict, lambda _msg: None) is None
+        assert [endpoint.queue_len for endpoint in factory.built] == [_QUEUE_LEN]
+
+    def test_closing_an_endpoint_whose_init_never_ran_is_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Releasing is safe even when the first step is the one that failed."""
+        channel = self._channel()
+        monkeypatch.setattr(channel, "DataReader", lambda *a, **k: object())
+        reader = channel.Channel._Channel__Reader()
+        reader.Close()
+
+
+# =========================================================================
+# Premise - close() cannot reach a half-built endpoint, either way.        #
+# =========================================================================
+
+
+class TestCloseCannotReachAHalfBuiltEndpoint:
+    """Why the release has to happen where the construction failed.
+
+    Both cells hold before and after the release was added: a failed call
+    records nothing, so the driver's teardown walks a collection the half-built
+    endpoint is not in. That is the argument for closing at the failure site
+    rather than leaving it to ``close``.
+    """
+
+    def test_a_failed_subscribe_records_no_subscriber_for_close_to_find(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory(init_raises=RuntimeError("DDS resource limit reached"))
+        subs = _started_subscriber(monkeypatch, factory)
+        assert subs.subscribe("rt/lowstate", dict, lambda _msg: None) is not None
+        assert subs._subs == []
+        closes_before_teardown = [endpoint.closes for endpoint in factory.built]
+        subs.close()
+        assert [endpoint.closes for endpoint in factory.built] == closes_before_teardown
+
+    def test_a_failed_publisher_build_caches_nothing_for_close_to_find(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory(init_raises=RuntimeError("DDS resource limit reached"))
+        pubs = _started_publisher(monkeypatch, factory)
+        assert pubs.get_publisher("rt/lowcmd", dict)[1] is not None
+        assert pubs._pubs == {}
+        closes_before_teardown = [built.closes for built in factory.built]
+        pubs.close()
+        assert [built.closes for built in factory.built] == closes_before_teardown
+
+
+# =========================================================================
+# Regression - the half-built endpoint is released.                        #
+# =========================================================================
+
+
+class TestAFailedSubscribeReleasesTheHalfBuiltSubscriber:
+    """A subscriber whose ``Init`` raised is closed before the reason returns."""
+
+    def test_the_half_built_subscriber_is_closed(self, monkeypatch: pytest.MonkeyPatch, dds_ready: None) -> None:
+        factory = _Factory(init_raises=RuntimeError("DDS resource limit reached"))
+        subs = _started_subscriber(monkeypatch, factory)
+        assert subs.subscribe("rt/lowstate", dict, lambda _msg: None) is not None
+        assert [endpoint.closes for endpoint in factory.built] == [1]
+
+    def test_each_failure_releases_its_own_subscriber_exactly_once(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        """Two failed subscribes release two subscribers, one close each."""
+        factory = _Factory(init_raises=RuntimeError("DDS resource limit reached"))
+        subs = _started_subscriber(monkeypatch, factory)
+        for topic in ("rt/lowstate", "rt/lf/bmsstate"):
+            assert subs.subscribe(topic, dict, lambda _msg: None) is not None
+        assert [endpoint.closes for endpoint in factory.built] == [1, 1]
+
+
+class TestAFailedPublisherBuildReleasesTheHalfBuiltPublisher:
+    """The write path's half-built publisher gets the same release.
+
+    ``DDSPublisher.close``'s own docstring says a dropped writer reaches
+    CycloneDDS' finaliser only "whenever the last reference happens to go" and
+    that closing "says when" - the same argument, so the same rule.
+    """
+
+    def test_the_half_built_publisher_is_closed(self, monkeypatch: pytest.MonkeyPatch, dds_ready: None) -> None:
+        factory = _Factory(init_raises=RuntimeError("DDS resource limit reached"))
+        pubs = _started_publisher(monkeypatch, factory)
+        endpoint, reason = pubs.get_publisher("rt/lowcmd", dict)
+        assert endpoint is None
+        assert reason is not None
+        assert [built.closes for built in factory.built] == [1]
+
+    def test_each_failure_releases_its_own_publisher_exactly_once(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory(init_raises=RuntimeError("DDS resource limit reached"))
+        pubs = _started_publisher(monkeypatch, factory)
+        for topic in ("rt/lowcmd", "rt/arm_sdk"):
+            assert pubs.get_publisher(topic, dict)[1] is not None
+        assert [built.closes for built in factory.built] == [1, 1]
+
+
+class TestAFailingReleaseIsReported:
+    """A swallowed cleanup failure is a leak nobody can see."""
+
+    def test_the_report_names_the_reason_and_the_endpoint(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        factory = _Factory(
+            init_raises=RuntimeError("DDS resource limit reached"),
+            close_raises=RuntimeError("dds entity already gone"),
+        )
+        subs = _started_subscriber(monkeypatch, factory)
+        with caplog.at_level(logging.WARNING, logger=_ENGINE_LOGGER):
+            subs.subscribe("rt/lowstate", dict, lambda _msg: None)
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("dds entity already gone" in message for message in messages), messages
+        assert any("rt/lowstate" in message for message in messages), messages
+
+
+# =========================================================================
+# Over-reach - what the release must not change.                           #
+# =========================================================================
+
+
+class TestWhatTheReleaseMustNotChange:
+    """Everything asserted here held before the release was added.
+
+    These are the cells that keep the fix from becoming "close every
+    endpoint", and that keep the caller's reason byte-identical.
+    """
+
+    def test_the_subscribe_reason_names_the_topic_and_the_cause(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory(init_raises=RuntimeError("DDS resource limit reached"))
+        subs = _started_subscriber(monkeypatch, factory)
+        assert (
+            subs.subscribe("rt/lowstate", dict, lambda _msg: None)
+            == "failed to subscribe to 'rt/lowstate': DDS resource limit reached"
+        )
+
+    def test_the_publisher_reason_names_the_topic_and_the_cause(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory(init_raises=RuntimeError("DDS resource limit reached"))
+        pubs = _started_publisher(monkeypatch, factory)
+        assert pubs.get_publisher("rt/lowcmd", dict)[1] == (
+            "failed to build publisher for 'rt/lowcmd': DDS resource limit reached"
+        )
+
+    def test_a_release_that_also_fails_does_not_mask_the_reason(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        """The construction failure is what the caller needs, not the cleanup one."""
+        factory = _Factory(
+            init_raises=RuntimeError("DDS resource limit reached"),
+            close_raises=RuntimeError("dds entity already gone"),
+        )
+        subs = _started_subscriber(monkeypatch, factory)
+        assert (
+            subs.subscribe("rt/lowstate", dict, lambda _msg: None)
+            == "failed to subscribe to 'rt/lowstate': DDS resource limit reached"
+        )
+
+    def test_a_subscriber_constructor_that_raised_leaves_nothing_to_release(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        """No endpoint exists yet, so the reason is reported and nothing is closed."""
+        factory = _Factory(construct_raises=RuntimeError("no such topic"))
+        subs = _started_subscriber(monkeypatch, factory)
+        assert subs.subscribe("rt/lowstate", dict, lambda _msg: None) == (
+            "failed to subscribe to 'rt/lowstate': no such topic"
+        )
+        assert factory.built == []
+
+    def test_a_constructor_failure_says_nothing_about_closing(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No endpoint was built, so there is nothing to report about releasing one."""
+        factory = _Factory(construct_raises=RuntimeError("no such topic"))
+        subs = _started_subscriber(monkeypatch, factory)
+        with caplog.at_level(logging.WARNING, logger=_ENGINE_LOGGER):
+            subs.subscribe("rt/lowstate", dict, lambda _msg: None)
+        assert [record.getMessage() for record in caplog.records] == []
+
+    def test_a_publisher_constructor_that_raised_leaves_nothing_to_release(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory(construct_raises=RuntimeError("no such topic"))
+        pubs = _started_publisher(monkeypatch, factory)
+        endpoint, reason = pubs.get_publisher("rt/lowcmd", dict)
+        assert endpoint is None
+        assert reason == "failed to build publisher for 'rt/lowcmd': no such topic"
+        assert factory.built == []
+
+    def test_a_successful_subscribe_closes_nothing(self, monkeypatch: pytest.MonkeyPatch, dds_ready: None) -> None:
+        factory = _Factory()
+        subs = _started_subscriber(monkeypatch, factory)
+        assert subs.subscribe("rt/lowstate", dict, lambda _msg: None) is None
+        assert [endpoint.closes for endpoint in factory.built] == [0]
+
+    def test_a_successful_subscriber_is_still_recorded_and_still_closed(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory()
+        subs = _started_subscriber(monkeypatch, factory)
+        assert subs.subscribe("rt/lowstate", dict, lambda _msg: None) is None
+        assert len(subs._subs) == 1
+        subs.close()
+        assert [endpoint.closes for endpoint in factory.built] == [1]
+
+    def test_a_successful_publisher_build_closes_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory()
+        pubs = _started_publisher(monkeypatch, factory)
+        endpoint, reason = pubs.get_publisher("rt/lowcmd", dict)
+        assert reason is None
+        assert endpoint is not None
+        assert [built.closes for built in factory.built] == [0]
+
+    def test_a_successful_publisher_is_still_cached_and_still_closed(
+        self, monkeypatch: pytest.MonkeyPatch, dds_ready: None
+    ) -> None:
+        factory = _Factory()
+        pubs = _started_publisher(monkeypatch, factory)
+        assert pubs.get_publisher("rt/lowcmd", dict)[1] is None
+        assert len(pubs._pubs) == 1
+        pubs.close()
+        assert [built.closes for built in factory.built] == [1]
+
+    def test_a_refusal_before_the_bus_is_reached_builds_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``start()`` never ran, so there is nothing to construct or release."""
+        factory = _Factory(init_raises=RuntimeError("unreachable"))
+        _install(monkeypatch, "ChannelSubscriber", factory)
+        subs = DDSSubscriberSet("eth0")
+        assert subs.subscribe("rt/lowstate", dict, lambda _msg: None) == "DDS not initialised - call start() first"
+        assert factory.built == []
+
+
+# =========================================================================
+# Structural - one release, reached by every endpoint construction.        #
+# =========================================================================
+
+
+def _endpoint_class_names(module_source: str) -> set[str]:
+    """Names the module lazily imports from the SDK's channel module.
+
+    Derived rather than listed, so an endpoint kind added later is graded on
+    arrival instead of being silently outside the rule.
+    """
+    return {
+        alias.name
+        for node in ast.walk(ast.parse(module_source))
+        if isinstance(node, ast.ImportFrom) and node.module == "unitree_sdk2py.core.channel"
+        for alias in node.names
+    }
+
+
+def _constructions_that_do_not_release(module_source: str) -> list[str]:
+    """``try`` blocks building an SDK endpoint whose handlers do not release it."""
+    endpoint_classes = _endpoint_class_names(module_source)
+    offenders = []
+    for node in ast.walk(ast.parse(module_source)):
+        if not isinstance(node, ast.Try):
+            continue
+        builds = [
+            call
+            for statement in node.body
+            for call in ast.walk(statement)
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id in endpoint_classes
+        ]
+        if not builds:
+            continue
+        releases = any(
+            isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id == "_release_partial"
+            for handler in node.handlers
+            for statement in handler.body
+            for call in ast.walk(statement)
+        )
+        if not releases:
+            offenders.append(ast.unparse(builds[0]))
+    return offenders
+
+
+class TestEveryEndpointConstructionRoutesThroughOneRelease:
+    """A third endpoint kind cannot reintroduce the drop.
+
+    The rule is derived from the SDK classes the module imports, so it covers
+    a construction added later without anyone remembering to list it.
+    """
+
+    def test_no_endpoint_construction_drops_a_half_built_endpoint(self) -> None:
+        source = inspect.getsource(_dds_engine)
+        offenders = _constructions_that_do_not_release(source)
+        assert offenders == [], f"release these through _release_partial(): {offenders}"
+
+    def test_the_rule_has_something_to_grade(self) -> None:
+        """Both endpoint kinds are found, so the check above is not vacuous."""
+        source = inspect.getsource(_dds_engine)
+        assert _endpoint_class_names(source) == {"ChannelSubscriber", "ChannelPublisher"}
+
+    def test_the_release_is_named_once_for_both_paths(self) -> None:
+        """One helper, so the two paths cannot drift apart."""
+        source = inspect.getsource(_dds_engine)
+        assert source.count("def _release_partial(") == 1
+        assert source.count("_release_partial(") == 3
+
+    @pytest.mark.parametrize(
+        ("label", "handler_body", "expected_offenders"),
+        [
+            ("drops-it", "return 'failed'", 1),
+            ("releases-it", "_release_partial(endpoint, 'x')\n            return 'failed'", 0),
+        ],
+    )
+    def test_the_rule_separates_a_dropping_construction_from_a_releasing_one(
+        self, label: str, handler_body: str, expected_offenders: int
+    ) -> None:
+        """Graded on constructed exemplars, since the module itself is now clean."""
+        source = (
+            "def build():\n"
+            "    from unitree_sdk2py.core.channel import ChannelSubscriber\n"
+            "    endpoint = None\n"
+            "    try:\n"
+            "        endpoint = ChannelSubscriber('t', dict)\n"
+            "        endpoint.Init(None, 10)\n"
+            "    except Exception:\n"
+            f"            {handler_body}\n"
+            "    return endpoint\n"
+        )
+        assert len(_constructions_that_do_not_release(source)) == expected_offenders, label
+
+    def test_the_exemplars_reach_both_verdicts(self) -> None:
+        """Neither exemplar row can be passing for the same reason as the other."""
+
+        def _built(handler_body: str) -> str:
+            return (
+                "def build():\n"
+                "    from unitree_sdk2py.core.channel import ChannelSubscriber\n"
+                "    endpoint = None\n"
+                "    try:\n"
+                "        endpoint = ChannelSubscriber('t', dict)\n"
+                "    except Exception:\n"
+                f"            {handler_body}\n"
+            )
+
+        verdicts = {
+            not _constructions_that_do_not_release(_built("return 'failed'")),
+            not _constructions_that_do_not_release(_built("_release_partial(endpoint, 'x')")),
+        }
+        assert verdicts == {True, False}


### PR DESCRIPTION
## A failed `subscribe()` leaves a live thread that `close()` can never reach

`DDSSubscriberSet.subscribe` and `DDSPublisher.get_publisher` build an SDK endpoint in
two steps - construct, then `Init` - and report a named reason if either raises. The
endpoint that failed was dropped. It holds real DDS state, and `unitree_sdk2py` starts
the `ch_reader` daemon thread **before** it constructs the `DataReader` that can raise
(`Channel.__Reader.Init`), so a failure in that constructor is a partial init: thread
live, reader absent.

Measured against `unitree_sdk2py` 1.0.1 by driving the real `subscribe()` with a
`DataReader` that raises:

| | before | after |
|---|---|---|
| `subscribe()` returns | `failed to subscribe to 'rt/lowstate_probe': DDS resource limit reached` | identical |
| subscribers recorded in `_subs` | 0 | 0 |
| live `ch_reader` threads | **1** | **0** |
| live `ch_reader` threads after `close()` | **1** | 0 |

The third row is the leak; the fourth is why it cannot be swept up later. `close()`
walks `_subs`, and the failing call never appended to it - so the half-built subscriber
is unreachable from the driver's only release path. `G1Driver.cleanup()` reports a clean
teardown while the thread keeps looping.

That thread is the same one `DDSSubscriberSet.close`'s docstring already reasons about:
its target is a bound method of the channel's reader, so it keeps the whole channel
reachable and no finaliser releases the `DataReader`. The module argues at length that
dropping a reference is not a substitute for `Close()`, and this error path was doing
exactly that. A driver retrying `connect_eagerly()` after a transient DDS failure
accumulates one more per attempt, four topics at a time.

### The change

Both construction sites pass the half-built endpoint through one `_release_partial`
helper before returning. `Close()` is safe on a partial init - it routes to
`Channel.CloseReader`/`CloseWriter`, which skip an entity that was never created and
still set the stop event, interrupt the queue and join the thread - verified directly:

```
Init raised           : RuntimeError DDS resource limit reached
ch_reader after raise : 1
Close()               : returned cleanly
ch_reader after Close : 0
Close() with no Init at all : clean      # both endpoint classes
```

The write path gets the same rule for the reason its own `close` docstring gives: a
dropped writer starts no thread and does reach CycloneDDS' finaliser, but only
"whenever the last reference happens to go", and closing "says when".

`+45/-2` in `_dds_engine.py`. The reason strings are unchanged, a construction that
succeeded is untouched, and a constructor that raised before there was an endpoint
releases nothing and says nothing about closing one.

### Why nothing caught it

`tests/drivers/test_g1_dds_engine_release.py` is a suite dedicated to this exact
hazard - its `TestSubscribeAsksForAQueuedReader` docstring says "the queue length is the
whole reason a dropped subscriber leaks" - and it grades only the success path. There
was no cell in which a construction fails, so the endpoint that gets dropped was never
built.

### Tests

`tests/tools/g1/test_dds_partial_construction_is_released.py`, 29 cells. Reverting the
source to `main` and keeping the tests:

```
7 failed, 22 passed

  0/5   premise (SDK)        TestTheSdkLeavesRealStateBehindAPartialInit
  0/2   premise              TestCloseCannotReachAHalfBuiltEndpoint
  2/2   REGRESSION           TestAFailedSubscribeReleasesTheHalfBuiltSubscriber
  2/2   REGRESSION           TestAFailedPublisherBuildReleasesTheHalfBuiltPublisher
  1/1   REGRESSION           TestAFailingReleaseIsReported
  0/11  over-reach control   TestWhatTheReleaseMustNotChange
  2/5   structural           TestEveryEndpointConstructionRoutesThroughOneRelease
```

All 5 regression cells fail pre-fix and none of the 18 premise or control cells does.

The premise cells drive the SDK's own reader with an injected `DataReader`, so they
establish the partial init and its release against the real thing rather than against a
stand-in that could agree with a bug. They need **no DDS bus**: the reader is
constructed directly and the `DataReader` it would build is the fault, so nothing
initialises the process-wide channel factory. They skip where the SDK is absent, which
is why the behavioural cells use recording stand-ins - with `unitree_sdk2py` shimmed
unimportable the file is `25 passed, 4 skipped`, so every regression cell still runs on
an install without the SDK.

The structural rule derives the endpoint classes from the module's own lazy
`from unitree_sdk2py.core.channel import ...` statements, so a third endpoint kind added
later is graded on arrival rather than being outside a hardcoded list. Since the module
is now clean the rule has nothing to reject, so it is also graded on constructed
exemplars - a dropping construction and a releasing one - with a check that both
verdicts are reached.

### Mutations

11 mutations, `collected` 29 on every row, source restored md5-identical after each.
`mine` counts cells in the new file, `sib` counts failures across the nine pre-existing
g1 and driver suites (284 cells).

| row | mine | sib | mutation |
|---|---|---|---|
| b0 | 0 | 0 | control - no mutation |
| b1 | 5 | 0 | `subscribe` drops the release |
| b2 | 4 | 0 | `get_publisher` drops the release |
| b3 | 7 | 0 | both drop it (== the shipped base) |
| b4 | 5 | 0 | helper returns without closing |
| b5 | 1 | 0 | helper drops its `None` guard |
| b6 | 1 | 0 | helper swallows the close failure |
| b7 | 2 | 0 | the close failure replaces the reason |
| b8 | 4 | 0 | rule re-derived inline in `subscribe` only |
| b9 | 3 | **5** | the endpoint is closed on success too |
| b10 | 2 | 0 | the `None` initialiser is dropped |

11 distinct firing sets, none undetected. `b1 | b2 == b3` and the two behavioural halves
are disjoint - the two cells they share are the structural ones, which correctly fire
for either - so each path is independently pinned. b8 is the row that justifies the
shared helper rather than two inline closes. b9 is the over-reach row: closing on
success trips 5 cells in the pre-existing release suite as well as the controls here.

b5 initially fired nothing, which was a gap in the tests rather than a redundant guard:
without it, a constructor failure logs a spurious "failed to close a partially built
subscriber: 'NoneType' object has no attribute 'Close'". A cell asserting that path
reports nothing about closing closes it.

### Coverage

`tests/tools/g1/ tests/drivers/` reports the same `98 / 8 / 92%` and the same
missing-line list for this module as the full suite, so it is a faithful oracle for it.

| | statements | missing | covered |
|---|---|---|---|
| before | 98 | 8 | 92% |
| after | 109 | 3 | **97%** |

The 3 that remain are outside this change: the subscriber's idempotent-`start()`
re-entry, the publisher's DDS-init-failure branch, and the double-check-under-lock cache
hit in `get_publisher`.

### Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`
  (1598 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the merge
  base, normalised message sets identical in both directions, 0 attributable to either
  changed file.
- Paired run over an identical 488-file selection - every g1 and driver suite plus every
  test that walks the tree, parses source, reads docstrings or reads `changelog.d` - with
  the new file excluded from both sides: **23129 collected** and
  `20 failed, 23009 passed, 100 skipped` on **both** trees, the 20 failing ids identical
  and `comm` empty in both directions. All 20 are already failing in a pristine
  full-suite baseline: 17 need `awsiot` (`awsiotsdk` in the `[mesh-iot]` extra, absent
  here) and 3 are a lerobot-from-source `encode()` drift in `tests/training/`.
- Re-verified after rebasing onto `89fd8a25`: `tests/tools/g1/ tests/drivers/` plus the
  changelog guards, **343 passed**.

No visual artifact: this is a resource-lifecycle fix in a DDS transport helper, with no
policy, simulation, rendering, recording or asset behaviour attached. The thread-count
measurements above are the evidence.
