### PR TITLE
fix(simulation): read the joints a spatial tendon drives, not just its joint wraps

### DIFF
--- a/changelog.d/2784-spatial-tendon-drive-reads-as-driven.md
+++ b/changelog.d/2784-spatial-tendon-drive-reads-as-driven.md
@@ -1,0 +1,31 @@
+### Fixed: a joint driven through a spatial tendon is no longer read as free
+
+MJCF spells a tendon two ways, and only one of them names joints. A `<fixed>` tendon lists joint
+coordinates, so its wrap entries are joint ids. A `<spatial>` tendon lists a route of sites and wrap
+geoms, so its entries come from other id spaces entirely. `tendon_joint_ids` kept only the
+`mjWRAP_JOINT` entries, so every spatial tendon read as driving nothing at all whatever it was wired
+to -- the "reads an actuated joint as free" failure `actuator_driven_joint_ids` names in its own
+docstring, for the tendon kind that the standard cable-driven hand is actuated with throughout.
+
+Three surfaces resolve a tendon through that one rule, and each got a wrong answer from it.
+`send_action` looks up the actuator driving a joint when the action key is a joint name, found none,
+and dropped the value with `joint has no driving actuator` -- the silent gripper drop issue #318 was
+filed to remove. `actuate_robot` saw nothing driven and would add a position servo per joint on top
+of the cable already pulling it, the double-actuation its own refusal exists to prevent.
+`joint_drive_map` placed those joints in neither the servo nor the other-drive map, so a pose write
+treated a cable-driven finger as free. Measured on the shipped `aero_hand` asset (16 joints, 7
+actuators, 6 of them cables) loaded through `load_scene`, six actuators reported no driven joint
+while MuJoCo's own `qfrc_actuator` moves 15 of the hand's 16 joints from their `ctrl`, leaving one
+commandable joint of sixteen.
+
+A spatial tendon's length is the distance along its route, so what it drives is every joint between
+the bodies that route touches -- the path from each of them up to their deepest common ancestor, above
+which they move together and no distance among them changes. Sites are the points the cable is
+anchored to and wrap geoms are obstacles it bends around, and moving either changes the length, so
+both end the span; `mjWRAP_PULLEY` carries a divisor rather than an id and contributes nothing. The
+rule stays in the shared reader so the two directions -- which joints an actuator drives, and which
+actuator drives a joint -- cannot disagree about what a tendon reaches.
+
+Graded against `qfrc_actuator` across the 554 MJCF files in the asset cache: the reading now agrees
+for all 75 tendon-transmission actuators, where it agreed for 57 of 75 before, and the 57 joint-wrap
+readings are byte-identical. Only the three `tetheria_aero_hand_open` files change.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -354,11 +354,13 @@ def actuator_driven_joint_ids(model: Any, act_id: int, mj: Any) -> frozenset[int
     it has one ``ctrl`` slot to seed from one joint's position. It reports
     ``-1`` for a tendon, because a tendon is not a joint.
 
-    A joint can still be driven *through* that tendon, though: a fixed tendon
-    that wraps joints couples them to one ``ctrl``, which is the standard MJCF
-    gripper idiom. So a caller asking "is this joint already driven" - rather
-    than "which joint is this actuator's target" - must resolve the tendon's
-    wrap list too, or it reads an actuated joint as free. That distinction is
+    A joint can still be driven *through* that tendon, though: a tendon couples
+    several joints to one ``ctrl``, which is the standard MJCF gripper and
+    tendon-driven-hand idiom. So a caller asking "is this joint already driven" -
+    rather than "which joint is this actuator's target" - must resolve the
+    tendon's wrap list too, or it reads an actuated joint as free. Which joints
+    that list names is :func:`tendon_joint_ids`' rule, and it covers a spatial
+    tendon's site route as well as a fixed tendon's joint entries. That distinction is
     the whole reason this is a second function and not a flag on the first: the
     two questions have different answers for the same actuator, and collapsing
     them would make one of the two call sites wrong.
@@ -410,10 +412,10 @@ def actuator_target_body_ids(model: Any, act_id: int, mj: Any) -> frozenset[int]
       id is a *reference* frame the force is measured against, not another part
       the actuator moves.
     * ``mjTRN_BODY`` -- that body.
-    * ``mjTRN_TENDON`` -- the bodies of the joints the tendon wraps, via
-      :func:`tendon_joint_ids`, so the tendon rule stays owned in one place. A
-      purely spatial tendon wraps sites rather than joints and so contributes
-      nothing, matching what that function reports.
+    * ``mjTRN_TENDON`` -- the bodies of the joints the tendon drives, via
+      :func:`tendon_joint_ids`, so the tendon rule stays owned in one place.
+      That covers a spatial tendon too: the joints its site route spans are the
+      ones between the links it moves, so their bodies are those links.
 
     Args:
         model: The compiled ``MjModel``.
@@ -453,15 +455,85 @@ def actuator_target_body_ids(model: Any, act_id: int, mj: Any) -> frozenset[int]
     return frozenset()
 
 
+def _joints_spanning(model: Any, bodies: list[int]) -> frozenset[int]:
+    """Return the joints on the kinematic paths ``bodies`` span.
+
+    Moving a joint changes the distance between two bodies exactly when it lies
+    on the path between them, which is the path from each body up to their
+    deepest common ancestor: above that ancestor the two bodies move together,
+    so a joint there leaves every distance among them unchanged. That makes this
+    set the joints a *length*-driven coupling reaches, and no others.
+
+    Args:
+        model: The compiled ``MjModel``.
+        bodies: Body ids the route touches, in any order; duplicates are fine.
+
+    Returns:
+        The spanned joint ids, empty when the route never leaves one body.
+    """
+
+    def walk_to_world(body: int) -> list[int]:
+        """Bodies from ``body`` up to the world, nearest first, world excluded."""
+        walk: list[int] = []
+        while body > 0:
+            walk.append(body)
+            body = int(model.body_parentid[body])
+        return walk
+
+    walks = {body: walk_to_world(body) for body in set(bodies)}
+    if not walks:
+        return frozenset()
+    one = next(iter(walks.values()))
+    shared = set(one)
+    for walk in walks.values():
+        shared &= set(walk)
+    # Every shared body lies on ``one``, which is ordered nearest-first, so the
+    # deepest of them is the one appearing earliest. With no shared ancestor the
+    # bodies hang off the world separately and every joint on both walks counts.
+    deepest = min(shared, key=one.index) if shared else 0
+    spanned: set[int] = set()
+    for walk in walks.values():
+        for body in walk:
+            if body == deepest:
+                break
+            adr = int(model.body_jntadr[body])
+            num = int(model.body_jntnum[body])
+            if adr >= 0:
+                spanned.update(range(adr, adr + num))
+    return frozenset(spanned)
+
+
 def tendon_joint_ids(model: Any, tendon_id: int, mj: Any) -> frozenset[int]:
-    """Return the joint ids wired into tendon ``tendon_id`` by its wrap list.
+    """Return the joint ids tendon ``tendon_id`` drives.
 
     A tendon's wrap entries live in one flat table shared by every tendon, so a
-    reader has to slice its own span (``tendon_adr`` / ``tendon_num``) and keep
-    only the ``mjWRAP_JOINT`` entries - site and pulley wraps carry ids from
-    other spaces. Walking that table is the part both "which actuator drives
-    this joint" and "which joints does this actuator drive" need, so it lives
-    here once rather than in each direction.
+    reader has to slice its own span (``tendon_adr`` / ``tendon_num``). Two kinds
+    of entry there identify a driven joint, and which kind a tendon carries is
+    decided by how MJCF spells it:
+
+    * ``mjWRAP_JOINT`` -- a ``<fixed>`` tendon's length is a weighted sum of the
+      joint coordinates it lists, so it drives each of them directly and the id
+      is already a joint id.
+    * ``mjWRAP_SITE`` and ``mjWRAP_SPHERE`` / ``mjWRAP_CYLINDER`` -- a
+      ``<spatial>`` tendon's length is the distance along a route, so what it
+      drives is every joint BETWEEN the bodies that route touches
+      (:func:`_joints_spanning`). Sites are the points it is anchored to and
+      wrap geoms are obstacles it bends around, but both are carried by a body
+      and moving either changes the length, so both are ends of the span: with a
+      wrap geom on a body outside the sites' own span, MuJoCo moves a joint that
+      the sites alone do not reach. None of those ids is a joint id, so reading
+      the joint wraps alone reports a spatial tendon as driving nothing whatever
+      it is wired to - and the standard tendon-driven hand is actuated entirely
+      this way, one cable per finger routed over sites on the links it closes.
+      ``mjWRAP_PULLEY`` carries a divisor rather than an id and contributes
+      nothing.
+
+    The two rules are unioned rather than selected between, so a tendon carrying
+    both kinds of entry needs no separate case here.
+
+    Walking that table is the part both "which actuator drives this joint" and
+    "which joints does this actuator drive" need, so it lives here once rather
+    than in each direction.
 
     Args:
         model: The compiled ``MjModel``.
@@ -469,14 +541,28 @@ def tendon_joint_ids(model: Any, tendon_id: int, mj: Any) -> frozenset[int]:
         mj: The ``mujoco`` module.
 
     Returns:
-        The wrapped joint ids, empty when the tendon wraps no joint.
+        The driven joint ids, empty when the tendon reaches no joint - a route
+        whose sites all sit on one body, which no joint can lengthen.
     """
     if tendon_id < 0 or tendon_id >= int(model.ntendon):
         return frozenset()
     wrap_joint = int(mj.mjtWrap.mjWRAP_JOINT)
+    wrap_site = int(mj.mjtWrap.mjWRAP_SITE)
+    wrap_geom = {int(mj.mjtWrap.mjWRAP_SPHERE), int(mj.mjtWrap.mjWRAP_CYLINDER)}
     adr = int(model.tendon_adr[tendon_id])
     num = int(model.tendon_num[tendon_id])
-    return frozenset(int(model.wrap_objid[w]) for w in range(adr, adr + num) if int(model.wrap_type[w]) == wrap_joint)
+    wrapped: set[int] = set()
+    route: list[int] = []
+    for w in range(adr, adr + num):
+        kind = int(model.wrap_type[w])
+        objid = int(model.wrap_objid[w])
+        if kind == wrap_joint:
+            wrapped.add(objid)
+        elif kind == wrap_site:
+            route.append(int(model.site_bodyid[objid]))
+        elif kind in wrap_geom:
+            route.append(int(model.geom_bodyid[objid]))
+    return frozenset(wrapped) | _joints_spanning(model, route)
 
 
 def robot_owned_actuator_ids(model: Any, robot: SimRobot, mj: Any) -> list[int]:

--- a/tests/simulation/mujoco/test_spatial_tendon_drive_is_not_read_as_free.py
+++ b/tests/simulation/mujoco/test_spatial_tendon_drive_is_not_read_as_free.py
@@ -1,0 +1,383 @@
+"""A cable routed over sites drives the joints it spans, and is read that way.
+
+MJCF spells a tendon two ways. A ``<fixed>`` tendon lists joint coordinates, so
+its wrap entries name joints outright. A ``<spatial>`` tendon lists a route of
+*sites*, so its wrap entries name sites - and a site id names no joint at all.
+``tendon_joint_ids`` kept only the joint entries, so every spatial tendon read as
+driving nothing whatever it was wired to.
+
+That is the "reads an actuated joint as free" failure
+:func:`~strands_robots.simulation.mujoco.scene_ops.actuator_driven_joint_ids`
+names in its own docstring, and it reached the surfaces a caller drives the robot
+through. Measured on the shipped ``aero_hand`` asset (Tetheria Aero Hand Open,
+16 joints, 7 actuators, 6 of them cables), loaded through ``load_scene``:
+
+* those 6 actuators reported no driven joint, while MuJoCo's own
+  ``qfrc_actuator`` moves 15 of the hand's 16 joints when their ``ctrl`` moves;
+* ``send_action({"<finger joint>": x})`` therefore found no driving actuator for
+  the joint and **dropped the value**, the silent-gripper-drop class issue #318
+  was filed to fix, leaving one commandable joint of sixteen;
+* ``actuate_robot`` saw nothing driven and would add a position servo per joint
+  on top of the cable already pulling it, so the two fight - the double-actuation
+  its own refusal exists to prevent;
+* ``joint_drive_map`` placed those joints in neither the servo nor the
+  other-drive map, so a pose write treats a cable-driven finger as free.
+
+Every model here is inline MJCF loaded through ``add_robot(urdf_path=...)``, so
+none of it downloads an asset, and the reading is graded against MuJoCo rather
+than against the rule under test: ``_physically_driven`` moves one actuator's
+``ctrl`` and reports the joints whose generalized force responds. Across the 554
+MJCF files shipped in the asset cache that oracle agrees with the reading for all
+75 tendon-transmission actuators, where before it agreed for 57 of 75 - the 18 it
+disagreed with being every spatial drive in the corpus.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.scene_ops import (  # noqa: E402
+    actuator_driven_joint_ids,
+    actuator_joint_id,
+    actuator_target_body_ids,
+    joint_drive_map,
+    tendon_joint_ids,
+)
+from tests.simulation.mujoco.test_actuate_robot_sees_a_tendon_drive import (  # noqa: E402
+    SITE_DRIVE_XML,
+    _lone,
+)
+from tests.simulation.mujoco.test_actuator_ownership_by_transmission import GRIPPER_XML  # noqa: E402
+
+# A two-link finger closed by one cable anchored on the palm and routed over a
+# site on each link: the tendon-driven-hand idiom, and the shape all 18 spatial
+# drives in the shipped asset cache take.
+FLEXOR_XML = """
+<mujoco model="flexor">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <body name="palm" pos="0 0 0.3">
+      <geom type="box" size="0.05 0.02 0.02"/>
+      <site name="anchor" pos="-0.04 0 0.02"/>
+      <body name="prox" pos="0.05 0 0">
+        <joint name="mcp" type="hinge" axis="0 1 0" range="-1.6 1.6" damping="0.05"/>
+        <geom type="capsule" fromto="0 0 0 0.08 0 0" size="0.012"/>
+        <site name="mid" pos="0.04 0 0.015"/>
+        <body name="dist" pos="0.08 0 0">
+          <joint name="pip" type="hinge" axis="0 1 0" range="-1.6 1.6" damping="0.05"/>
+          <geom type="capsule" fromto="0 0 0 0.06 0 0" size="0.01"/>
+          <site name="tip" pos="0.03 0 0.012"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <spatial name="flexor" width="0.002">
+      <site site="anchor"/>
+      <site site="mid"/>
+      <site site="tip"/>
+    </spatial>
+  </tendon>
+  <actuator>
+    <position name="flexor_act" tendon="flexor" kp="40" ctrlrange="-0.2 0.2"/>
+  </actuator>
+</mujoco>
+"""
+
+# The same cable routed over a wrap geom that sits on a body carrying no site of
+# its own, so the geom is OUTSIDE the span the sites alone describe. Rotating the
+# wrist swings the anchor around that fixed sphere and so changes the cable's
+# length: MuJoCo drives the wrist here, and a rule reading only the sites would
+# miss it. In all 18 spatial drives shipped in the asset cache the wrap geom
+# happens to sit on a body that already carries one of the route's sites, so the
+# two rules coincide there and only a model like this one separates them.
+WRAP_GEOM_XML = """
+<mujoco model="pulley">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <body name="base">
+      <geom type="box" size="0.04 0.04 0.01"/>
+      <geom name="pulley_geom" type="sphere" size="0.008" pos="0 0 0.1"/>
+      <site name="pulley_side" pos="0 0 0.112"/>
+      <body name="palm" pos="0 0 0.06">
+        <joint name="wrist" type="hinge" axis="0 1 0" range="-1 1" damping="0.05"/>
+        <geom type="box" size="0.05 0.02 0.02"/>
+        <site name="anchor" pos="-0.04 0 0.02"/>
+        <body name="prox" pos="0.05 0 0">
+          <joint name="mcp" type="hinge" axis="0 1 0" range="-1.6 1.6" damping="0.05"/>
+          <geom type="capsule" fromto="0 0 0 0.08 0 0" size="0.012"/>
+          <site name="tip" pos="0.06 0 0.015"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <spatial name="flexor" width="0.002">
+      <site site="anchor"/>
+      <geom geom="pulley_geom" sidesite="pulley_side"/>
+      <site site="tip"/>
+    </spatial>
+  </tendon>
+  <actuator>
+    <position name="flexor_act" tendon="flexor" kp="40" ctrlrange="-0.2 0.2"/>
+  </actuator>
+</mujoco>
+"""
+
+# A route whose sites all sit on one link. Its length cannot change, so it
+# drives nothing - the case a span rule must not over-report.
+SAME_BODY_ROUTE_XML = """
+<mujoco model="taut">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <body name="base">
+      <geom type="box" size="0.04 0.04 0.01"/>
+      <body name="link" pos="0 0 0.06">
+        <joint name="hinge" type="hinge" axis="0 1 0" range="-1 1" damping="0.05"/>
+        <geom type="capsule" fromto="0 0 0 0.1 0 0" size="0.012"/>
+        <site name="near" pos="0.02 0 0.015"/>
+        <site name="far" pos="0.08 0 0.015"/>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <spatial name="taut" width="0.002">
+      <site site="near"/>
+      <site site="far"/>
+    </spatial>
+  </tendon>
+  <actuator>
+    <position name="taut_act" tendon="taut" kp="40" ctrlrange="-0.2 0.2"/>
+  </actuator>
+</mujoco>
+"""
+
+# A cable between two separately floating hulls: the two routes share no
+# ancestor but the world, so every joint on both walks is spanned.
+TETHER_XML = """
+<mujoco model="tether">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <body name="hull_a" pos="0 0 0.5">
+      <freejoint name="base_a"/>
+      <geom type="sphere" size="0.05"/>
+      <site name="sa" pos="0.05 0 0"/>
+    </body>
+    <body name="hull_b" pos="0.4 0 0.5">
+      <freejoint name="base_b"/>
+      <geom type="sphere" size="0.05"/>
+      <site name="sb" pos="-0.05 0 0"/>
+    </body>
+  </worldbody>
+  <tendon>
+    <spatial name="tether" width="0.002">
+      <site site="sa"/>
+      <site site="sb"/>
+    </spatial>
+  </tendon>
+  <actuator>
+    <position name="winch" tendon="tether" kp="40" ctrlrange="-0.2 0.2"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _physically_driven(model, act_id: int) -> frozenset[int]:
+    """Joints whose generalized force responds to this actuator's ``ctrl``.
+
+    MuJoCo's own answer to "what does this actuator move", and independent of
+    every rule under test: the difference in ``qfrc_actuator`` between a scene at
+    rest and the same scene with one ``ctrl`` displaced names the moved dofs, and
+    ``dof_jntid`` maps those back to joints.
+    """
+    rest = mujoco.MjData(model)
+    mujoco.mj_forward(model, rest)
+    moved = mujoco.MjData(model)
+    moved.ctrl[act_id] = 1.0
+    mujoco.mj_forward(model, moved)
+    delta = np.abs(np.asarray(moved.qfrc_actuator) - np.asarray(rest.qfrc_actuator))
+    return frozenset(int(model.dof_jntid[v]) for v in np.nonzero(delta > 1e-9)[0])
+
+
+def _ids(sim, obj, *names: str) -> frozenset[int]:
+    model = sim._world._model
+    out = set()
+    for name in names:
+        ident = mujoco.mj_name2id(model, obj, name)
+        assert ident >= 0, name
+        out.add(int(ident))
+    return frozenset(out)
+
+
+def _joint_value(sim, full_name: str) -> float:
+    model, data = sim._world._model, sim._world._data
+    jnt = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, full_name)
+    assert jnt >= 0, full_name
+    return float(data.qpos[int(model.jnt_qposadr[jnt])])
+
+
+class TestTheReadingIsWhatMujocoMoves:
+    """The reading is graded against ``qfrc_actuator``, not against the rule."""
+
+    def test_a_cable_reports_the_joints_it_actually_drives(self, tmp_path: Path) -> None:
+        sim = _lone(tmp_path, "fing", FLEXOR_XML)
+        try:
+            model = sim._world._model
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "fing/flexor_act")
+            physical = _physically_driven(model, act)
+            assert physical == _ids(sim, mujoco.mjtObj.mjOBJ_JOINT, "fing/mcp", "fing/pip"), (
+                "premise: MuJoCo moves both finger joints from this one ctrl"
+            )
+            assert actuator_driven_joint_ids(model, act, mujoco) == physical
+        finally:
+            sim.cleanup()
+
+    def test_a_wrap_geom_outside_the_sites_span_is_still_part_of_the_route(self, tmp_path: Path) -> None:
+        """The obstacle the cable bends around moves it too, so it ends the span."""
+        sim = _lone(tmp_path, "pul", WRAP_GEOM_XML)
+        try:
+            model = sim._world._model
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "pul/flexor_act")
+            physical = _physically_driven(model, act)
+            both = _ids(sim, mujoco.mjtObj.mjOBJ_JOINT, "pul/wrist", "pul/mcp")
+            assert physical == both, "premise: swinging the wrist past the sphere pulls the cable"
+            assert actuator_driven_joint_ids(model, act, mujoco) == physical
+        finally:
+            sim.cleanup()
+
+    def test_a_route_inside_one_link_drives_nothing(self, tmp_path: Path) -> None:
+        """No joint can lengthen it, and MuJoCo agrees."""
+        sim = _lone(tmp_path, "taut", SAME_BODY_ROUTE_XML)
+        try:
+            model = sim._world._model
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "taut/taut_act")
+            assert _physically_driven(model, act) == frozenset(), "premise: nothing moves"
+            assert actuator_driven_joint_ids(model, act, mujoco) == frozenset()
+        finally:
+            sim.cleanup()
+
+    def test_a_tether_between_two_floating_hulls_reaches_both_bases(self, tmp_path: Path) -> None:
+        """With no shared ancestor but the world, both walks are spanned."""
+        sim = _lone(tmp_path, "teth", TETHER_XML)
+        try:
+            model = sim._world._model
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "teth/winch")
+            physical = _physically_driven(model, act)
+            assert physical == _ids(sim, mujoco.mjtObj.mjOBJ_JOINT, "teth/base_a", "teth/base_b"), (
+                "premise: winching pulls on both floating bases"
+            )
+            assert actuator_driven_joint_ids(model, act, mujoco) == physical
+        finally:
+            sim.cleanup()
+
+
+class TestTheSurfacesThatDriveTheRobot:
+    """What the reading is for: commanding a joint, and refusing to double-drive it."""
+
+    def test_a_cable_driven_joint_is_commandable_by_its_own_name(self, tmp_path: Path) -> None:
+        """The #318 fallback: a joint name resolves to the actuator driving it."""
+        sim = _lone(tmp_path, "fing", FLEXOR_XML)
+        try:
+            result = sim.send_action({"pip": 0.15}, robot_name="fing")
+            assert result["status"] == "success", result["content"][0]["text"]
+            model, data = sim._world._model, sim._world._data
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "fing/flexor_act")
+            assert float(data.ctrl[act]) != 0.0, "the value reached the cable's ctrl"
+        finally:
+            sim.cleanup()
+
+    def test_commanding_the_cable_moves_the_finger(self, tmp_path: Path) -> None:
+        """End to end: the joint the caller named actually flexes."""
+        sim = _lone(tmp_path, "fing", FLEXOR_XML)
+        try:
+            start = _joint_value(sim, "fing/pip")
+            assert sim.send_action({"pip": 0.18}, robot_name="fing")["status"] == "success"
+            assert sim.step(1200)["status"] == "success"
+            assert abs(_joint_value(sim, "fing/pip") - start) > 0.05
+        finally:
+            sim.cleanup()
+
+    def test_actuate_robot_refuses_to_add_a_servo_beside_the_cable(self, tmp_path: Path) -> None:
+        """The double-actuation the guard's own refusal exists to prevent."""
+        sim = _lone(tmp_path, "fing", FLEXOR_XML)
+        try:
+            result = sim.actuate_robot(robot_name="fing")
+            assert result["status"] == "error"
+            text = result["content"][0]["text"]
+            assert "flexor_act" in text
+            assert "pip" in text and "mcp" in text
+        finally:
+            sim.cleanup()
+
+    def test_a_cable_driven_joint_is_not_offered_as_a_pose_target(self, tmp_path: Path) -> None:
+        """A cable's ctrl is in tendon units, so it lands in *other*, not *servos*."""
+        sim = _lone(tmp_path, "fing", FLEXOR_XML)
+        try:
+            model = sim._world._model
+            servos, other = joint_drive_map(model, mujoco)
+            driven = _ids(sim, mujoco.mjtObj.mjOBJ_JOINT, "fing/mcp", "fing/pip")
+            assert set(other) == set(driven)
+            assert not set(servos) & set(driven)
+        finally:
+            sim.cleanup()
+
+    def test_the_bodies_a_cable_moves_are_the_links_it_spans(self, tmp_path: Path) -> None:
+        """The body question resolves through the same rule, so it agrees."""
+        sim = _lone(tmp_path, "fing", FLEXOR_XML)
+        try:
+            model = sim._world._model
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "fing/flexor_act")
+            assert actuator_target_body_ids(model, act, mujoco) == _ids(
+                sim, mujoco.mjtObj.mjOBJ_BODY, "fing/prox", "fing/dist"
+            )
+        finally:
+            sim.cleanup()
+
+
+class TestWhatIsUnchanged:
+    """Every reading the joint-wrap rule already got right is still that reading."""
+
+    def test_a_fixed_tendon_still_reports_the_joints_it_lists(self, tmp_path: Path) -> None:
+        sim = _lone(tmp_path, "grip", GRIPPER_XML)
+        try:
+            model = sim._world._model
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "grip/finger_act")
+            wrapped = _ids(sim, mujoco.mjtObj.mjOBJ_JOINT, "grip/finger1", "grip/finger2")
+            assert actuator_driven_joint_ids(model, act, mujoco) == wrapped
+            assert _physically_driven(model, act) == wrapped
+        finally:
+            sim.cleanup()
+
+    def test_a_site_transmission_still_commands_no_joint(self, tmp_path: Path) -> None:
+        """A frame wrench moves a body without commanding a joint coordinate."""
+        sim = _lone(tmp_path, "thruster", SITE_DRIVE_XML)
+        try:
+            model = sim._world._model
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "thruster/thrust")
+            assert actuator_driven_joint_ids(model, act, mujoco) == frozenset()
+        finally:
+            sim.cleanup()
+
+    def test_the_per_ctrl_question_still_answers_minus_one_for_a_cable(self, tmp_path: Path) -> None:
+        """A tendon is still not a joint, so no joint angle is written into it."""
+        sim = _lone(tmp_path, "fing", FLEXOR_XML)
+        try:
+            model = sim._world._model
+            act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "fing/flexor_act")
+            assert actuator_joint_id(model, act, mujoco) == -1
+        finally:
+            sim.cleanup()
+
+    def test_a_stale_tendon_id_is_still_an_empty_answer(self, tmp_path: Path) -> None:
+        sim = _lone(tmp_path, "fing", FLEXOR_XML)
+        try:
+            model = sim._world._model
+            assert tendon_joint_ids(model, -1, mujoco) == frozenset()
+            assert tendon_joint_ids(model, int(model.ntendon), mujoco) == frozenset()
+        finally:
+            sim.cleanup()


### PR DESCRIPTION
## Problem

MJCF spells a tendon two ways, and only one of them names joints. A `<fixed>` tendon lists joint coordinates, so its wrap entries are joint ids. A `<spatial>` tendon lists a route of **sites** and wrap geoms, so its entries come from other id spaces entirely.

`tendon_joint_ids` kept only the `mjWRAP_JOINT` entries, so every spatial tendon read as driving **nothing at all** whatever it was wired to. That is the failure `actuator_driven_joint_ids` names in its own docstring — *"must resolve the tendon's wrap list too, or it reads an actuated joint as free"* — for the tendon kind the standard cable-driven hand is actuated with throughout.

Three surfaces resolve a tendon through that one rule, and each got a wrong answer:

| surface | what it did with a cable-driven joint |
|---|---|
| `send_action` (joint-name key) | found no driving actuator and **dropped the value** — the silent gripper drop #318 was filed to remove |
| `actuate_robot` | saw nothing driven, so it would add a position servo beside the cable already pulling the joint — the double-actuation its own refusal exists to prevent |
| `joint_drive_map` | listed the joint in **neither** the servo nor the other-drive map, so a pose write treats it as free |

Measured on the shipped `aero_hand` asset (Tetheria Aero Hand Open, 16 joints, 7 actuators, 6 of them cables) loaded through `load_scene`:

```
act 0 'left_index_A_tendon'   reported driven: []   MuJoCo qfrc_actuator moves: [index_mcp_flex, index_pip, index_dip]
act 1 'left_middle_A_tendon'  reported driven: []                              [middle_mcp_flex, middle_pip, middle_dip]
act 2 'left_ring_A_tendon'    reported driven: []                              [ring_mcp_flex, ring_pip, ring_dip]
act 3 'left_pinky_A_tendon'   reported driven: []                              [pinky_mcp_flex, pinky_pip, pinky_dip]
act 4 'left_thumb_A_cmc_abd'  reported driven: [12]                            [thumb_cmc_abd]        <- direct joint drive, correct
act 5 'left_th1_A_tendon'     reported driven: []                              [thumb_cmc_flex]
act 6 'left_th2_A_tendon'     reported driven: []                              [thumb_cmc_flex, thumb_mcp, thumb_ip]

joint_drive_map: servos=1 other=0  -> 15 of 16 joints in NEITHER map
```

One commandable joint of sixteen.

## Change

A spatial tendon's length is the distance along its route, so what it drives is every joint **between the bodies that route touches**: the path from each of them up to their deepest common ancestor, above which they move together and no distance among them changes. Sites are the points the cable is anchored to and wrap geoms are obstacles it bends around — moving either changes the length, so both end the span. `mjWRAP_PULLEY` carries a divisor rather than an id and contributes nothing.

The rule stays in the shared reader, which is what keeps the two directions — *which joints does this actuator drive* and *which actuator drives this joint* — in the agreement `rendering.py` relies on ("this direction and the ... direction cannot disagree about what a tendon reaches").

## Verification against MuJoCo, not against the rule

The oracle is MuJoCo's own `qfrc_actuator`: displace one actuator's `ctrl` and read which dofs' generalized force responds. Over the 554 MJCF files in the asset cache:

| tendon kind | actuators | agreed before | agreed after |
|---|---|---|---|
| `<fixed>` (joint wraps) | 57 | 57 | 57 |
| `<spatial>` (site route) | 18 | **0** | **18** |

0 rows disagree with physics after the change, and the 57 joint-wrap readings are byte-identical — only the three `tetheria_aero_hand_open` files change. All 18 spatial drives carry `mjWRAP_CYLINDER` entries, so the wrap-geom handling is exercised by shipped assets.

## Visual

A two-link finger closed by one cable anchored on the palm and routed over a site on each link. Same scene, same camera (distance 0.3551 m, asserted equal from both captures), same 1200 MuJoCo steps; the only difference is the reading. On `main` the command is dropped and the finger merely sags under gravity.

![spatial tendon drive](https://github.com/cagataycali/robots/releases/download/artifacts/spatial-tendon-drive.png)

## Tests

`tests/simulation/mujoco/test_spatial_tendon_drive_is_not_read_as_free.py`, 13 cases. Every reading is graded against `_physically_driven` (the `qfrc_actuator` oracle above) rather than against the rule under test, and each case asserts its own premise — what MuJoCo moves — before comparing.

Pre-fix split, behavioural revert: **8 failed / 5 passed, 0 of 4 in `TestWhatIsUnchanged`**. The one non-failing regression-class cell is the over-reach boundary (a route inside one link drives nothing — empty both ways).

11 mutations, control clean, 5 distinct firing sets, `sib` = failures in the three pre-existing tendon/ownership suites:

| row | fires | sib | mutation |
|---|---|---|---|
| b0 | 0 | 0 | control |
| b1 | 8 | 0 | the site-route rule removed (joint wraps only) |
| b2 | 1 | **6** | the joint-wrap rule removed (site route only) |
| b3 | 1 | 0 | the span reaches through the deepest shared ancestor too |
| b4 | 1 | 0 | a wrap geom dropped from the route |
| b5 | 1 | 0 | the shallowest shared ancestor taken instead of the deepest |
| b6 | 8 | 0 | the shared set unioned instead of intersected |
| b7 | 8 | 0 | a wrap site id read as a body id (id-space confusion) |
| b8 | 1 | 0 | no shared ancestor answers empty instead of walking to the world |
| b9 | 0 | 0 | the jointless-body guard dropped — **measured no-op** |
| b10 | 0 | 0 | the two rules selected between instead of unioned — **measured no-op** |
| b11 | 8 | 0 | the whole fix reverted |

b1/b6/b7/b11 share one firing set and b3/b5 share another: within each group the mutations are the same failure (the route is not resolved at all; the span reaches one level too high). `sib` is 0 on every row except b2, which trips 6 pre-existing cases — the over-reach evidence that the joint-wrap half is still load-bearing.

The two 0 rows are no-ops for measured reasons rather than gaps. b9: `body_jntnum` is 0 wherever `body_jntadr` is -1 across every model in the cache (0 violations), so the guard's range is empty either way — it is kept to make the sentinel explicit. b10: MJCF spells the two tendon kinds as different elements, so no tendon carries both entry kinds (the cache holds only `('mjWRAP_JOINT',)` and `('mjWRAP_CYLINDER','mjWRAP_SITE')`); the union is written so a mixed tendon needs no separate case.

`b4` initially fired 0 and that was a fixture coincidence worth recording: in all 18 shipped spatial drives the wrap geom happens to sit on a body that already carries one of the route's sites, so sites-only and sites+geoms coincide there. A model where the geom sits outside the sites' own span separates them, and MuJoCo prefers sites+geoms — it drives a joint (`wrist`) the sites alone do not reach. The fixture now uses that model.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1603 files).
- `mypy` **24 == 24** against a worktree of the merge-base, normalized message sets byte-identical in both directions, 0 in the changed files.
- Paired pytest, identical 458-file selection (all of `tests/simulation/mujoco/`, everything naming `scene_ops`/`tendon`/`send_action`/`actuate_robot`/`joint_drive_map`, and every tree-walking or docstring-reading guard), the new file excluded from both trees: **16105 collected, 4 failed, 15878 passed, 223 skipped on each**, failing-ID sets identical and `comm` empty both directions. The 4 are in `test_recording_frame_loss_is_not_tolerated.py` and pass 13/13 in isolation on **both** trees — a large-selection module-caching artifact, unrelated.
- The changed files pass on mujoco 3.12.0 as well as the declared 3.5.0 floor.

## Scope

`actuator_target_body_ids` resolves its tendon branch through the same rule, so a cable's target bodies become the links it spans; that reading is pinned here too. `add_robot`'s spec attach drops most of `aero_hand`'s 20 tendons on the way into a shared world (`ntendon` 20 -> 1), which is a separate matter in the attach path and deliberately untouched — `load_scene` preserves them, and that is the route measured above.
