### PR TITLE
test(drivers): repair the two module-identity defects that make main's suite order-dependent

### DIFF
--- a/changelog.d/2785-g1-load-probe-leaves-the-registration-reachable.md
+++ b/changelog.d/2785-g1-load-probe-leaves-the-registration-reachable.md
@@ -1,0 +1,34 @@
+### Fixed: probing the G1 driver's load-time imports no longer orphans its registration
+
+`tests/drivers/test_g1_driver.py` pins that importing
+`strands_robots.drivers.g1` pulls in no `unitree_sdk2py` module, so the driver
+stays importable on Thor and CI without the SDK. Observing that needs a genuine
+re-execution - the module is already imported by the time any test runs - and the
+cell used `importlib.reload`.
+
+`reload` re-executes the source into the *live* module object, rebinding every
+attribute it defines. `strands_robots.drivers.g1.G1Driver` therefore became a
+different class object from the one `strands_robots.drivers` registered from
+`_SHIPPED_DRIVERS` at first import, and nothing put the original back:
+`get_native_driver_class("unitree_g1")` answered with a class no importer could
+reach for the remainder of the session. That is the orphan AGENTS.md > Testing
+Patterns forbids for a `sys.modules` removal, reached through `reload` instead,
+and it carried the same cost the rule records - a double installed on the module
+attribute is not read through the registered class.
+
+It surfaced as a cross-file failure with no local cause. `test_reachy_driver.py`'s
+`test_the_g1_registration_survives_a_second_shipped_driver` compares the
+registered class to the imported one by identity, and read as
+`assert <class 'strands_robots.drivers.g1.G1Driver'> is <class
+'strands_robots.drivers.g1.G1Driver'>` - two identically named classes, on a
+branch touching neither file. Any cell that reads the registration that way would
+have done; this one only failed because `tests/drivers/test_g1_driver.py` sorts
+ahead of it.
+
+The probe now executes the same source into a throwaway module object, which
+observes exactly the same module-scope imports and leaves both the live module and
+the registration untouched. That is safe because the driver imports only absolute
+paths and does not register itself - the registration loop lives in the package
+`__init__` - so a second execution has no side effect to undo. The identity
+assertion that caught the orphan is left as it was, since it was reporting
+correctly.

--- a/changelog.d/2785-reachy-guards-stage-the-absence-at-the-resolver.md
+++ b/changelog.d/2785-reachy-guards-stage-the-absence-at-the-resolver.md
@@ -1,0 +1,29 @@
+### Fixed: the Reachy transport guards stage the absence at the module the resolver imports
+
+`tests/drivers/test_reachy_transport_guards_are_reachable.py` grades the two
+`_resolve_transport` guards that `ReachyDriver.connect_eagerly`'s pre-check
+hides, so a stock install is refused by name rather than crashing. It staged
+that absence by making `device_connect_edge` unimportable and evicting the
+`strands_robots.device_connect` subtree from `sys.modules`, relying on the next
+import to re-execute a package `__init__` that fails.
+
+That `__init__` no longer imports the extra - deferring it is the whole point of
+the lazy export table it now carries - so the eviction re-executes an `__init__`
+that succeeds, the stdlib-only transport leaf imports, and `_resolve_transport`
+hands back the real module. The driver then reaches the daemon: six of the
+file's nine cells failed with `daemon unreachable (localhost:8000): <urlopen
+error [Errno 111] Connection refused>`, a real network call from a unit test.
+
+The eviction had a second cost. Deleting the subtree let the next import build a
+fresh module object for `strands_robots.device_connect.reachy_transport`, so a
+double installed on one object was not read through the other. Run before its
+sibling, this file took `tests/drivers/test_reachy_driver.py` from 109 passed to
+46 passed / 72 failed, and the pair from 0.30s to 21.49s of real connection
+timeouts.
+
+The absence is now staged at the one module `_resolve_transport` imports, and
+nothing else in `sys.modules` is touched. The premise test that should have
+caught the drift asserted `from device_connect_edge import` appeared in
+`__init__.py`, which the `TYPE_CHECKING` block satisfies - a block the source
+itself annotates `never executed`. It now reads the executed module-scope
+imports, so a typing-only import no longer reads as an eager one.

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -1370,6 +1370,54 @@ def test_send_action_echoes_cached_mode_machine_not_fsm_id() -> None:
 # =========================================================================
 
 
+def _sdk_modules_pulled_in_by_executing_the_driver() -> set[str]:
+    """Execute the driver module's source afresh and report the SDK it imports.
+
+    The module is already imported by the time any test runs, so observing its
+    load-time imports needs a genuine re-execution; a plain
+    ``import strands_robots.drivers.g1`` is answered from ``sys.modules`` and
+    observes nothing.
+
+    The re-execution goes into a throwaway module object rather than through
+    ``importlib.reload``. ``reload`` re-executes the source *into the live
+    module*, rebinding every attribute it defines - so
+    ``strands_robots.drivers.g1.G1Driver`` becomes a different class object from
+    the one :mod:`strands_robots.drivers` registered from ``_SHIPPED_DRIVERS`` at
+    first import, and nothing puts the original back. The registry then holds a
+    class no importer can reach for the rest of the session, which is the orphan
+    AGENTS.md > Testing Patterns forbids: any later cell that reads the
+    registration through the module attribute compares two identically named
+    classes and fails on import order rather than on behaviour.
+
+    Executing a fresh module object observes exactly the same module-scope
+    imports and leaves both the live module and the registration untouched. It is
+    safe to do so because the driver module imports only absolute paths and does
+    not register itself - the registration loop lives in the package ``__init__``
+    - so a second execution has no side effect to undo.
+
+    Returns:
+        The ``unitree_sdk2py`` submodules that executing the driver imported,
+        which is empty on a tree that keeps the SDK import lazy.
+    """
+    import importlib
+    import importlib.util
+    import sys
+
+    module = importlib.import_module("strands_robots.drivers.g1")
+    source = getattr(module, "__file__", None)
+    assert source is not None, "the driver module has no source file to execute"
+    spec = importlib.util.spec_from_file_location("_g1_load_probe", source)
+    assert spec is not None and spec.loader is not None, f"no import machinery for {source}"
+    probe = importlib.util.module_from_spec(spec)
+
+    # Snapshot the SDK modules already loaded (may or may not be present on
+    # this box), then execute the driver and report only what is *new*.
+    before = {n for n in sys.modules if n.startswith("unitree_sdk2py")}
+    spec.loader.exec_module(probe)
+    after = {n for n in sys.modules if n.startswith("unitree_sdk2py")}
+    return after - before
+
+
 def test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time() -> None:
     """Importing :mod:`strands_robots.drivers.g1` does not import the SDK.
 
@@ -1378,15 +1426,36 @@ def test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time() -> None:
     module-level ``import unitree_sdk2py.idl.default`` fails here.  Thor
     and CI both need the driver module importable without the SDK.
     """
-    import importlib
-    import sys
+    pulled_in = _sdk_modules_pulled_in_by_executing_the_driver()
+    assert pulled_in == set(), (
+        f"importing strands_robots.drivers.g1 pulled in unitree_sdk2py modules: {sorted(pulled_in)}"
+    )
 
-    # Snapshot the SDK modules already loaded (may or may not be present on
-    # this box).  Then reimport the driver module and confirm no *new*
-    # unitree_sdk2py submodule crept in - just importing the driver.
-    before = {n for n in sys.modules if n.startswith("unitree_sdk2py")}
-    importlib.reload(importlib.import_module("strands_robots.drivers.g1"))
-    after = {n for n in sys.modules if n.startswith("unitree_sdk2py")}
-    assert after == before, (
-        f"importing strands_robots.drivers.g1 pulled in unitree_sdk2py modules: {sorted(after - before)}"
+
+def test_the_load_time_probe_leaves_the_g1_registration_reachable() -> None:
+    """Probing the driver's load-time imports does not orphan its registration.
+
+    The probe above is the only thing in the tree that re-executes a shipped
+    driver module, and it used to do so with ``importlib.reload``. That left
+    :func:`~strands_robots.drivers.get_native_driver_class` answering with the
+    pre-reload class while ``strands_robots.drivers.g1.G1Driver`` named the
+    post-reload one, for every test that ran afterwards - a session-wide orphan
+    from a cell that only meant to read an import list.
+
+    Graded here rather than in the file that first tripped over it, because the
+    defect belongs to the probe: a test that reads the registration by identity
+    is entitled to assume the two names agree, and any of them would do as the
+    witness. Asserting it next to the probe keeps the cost visible to whoever
+    edits the probe.
+    """
+    import strands_robots.drivers.g1 as g1_mod
+    from strands_robots.drivers import get_native_driver_class
+
+    assert get_native_driver_class("unitree_g1") is g1_mod.G1Driver, (
+        "premise: the registry holds the class object the driver module exports"
+    )
+    _sdk_modules_pulled_in_by_executing_the_driver()
+    assert get_native_driver_class("unitree_g1") is g1_mod.G1Driver, (
+        "the load-time probe rebound strands_robots.drivers.g1.G1Driver and left "
+        "the registry holding a class object nothing can import"
     )

--- a/tests/drivers/test_reachy_transport_guards_are_reachable.py
+++ b/tests/drivers/test_reachy_transport_guards_are_reachable.py
@@ -23,14 +23,21 @@ packaging accident, that the reason reaches a mesh peer, and that a working inst
 is unaffected.
 
 The absence is simulated rather than installed, since the suite runs where the
-extra is present: :func:`_hide_extra` makes ``device_connect_edge`` unimportable and
-evicts the already-imported ``strands_robots.device_connect`` package so the next
-import re-executes the ``__init__`` that fails. That is the same failure a stock
-install produces, at the same place, and ``monkeypatch`` restores both halves.
+transport is importable. :func:`_block_transport` blocks the one module
+:func:`~strands_robots.drivers.reachy._resolve_transport` imports, and ``monkeypatch``
+restores it. Blocking that module is what ties the simulation to the resolver rather
+than to a packaging detail upstream of it: the resolver reports on this import and on
+nothing before it, so an absence staged anywhere else is only a refusal by
+coincidence. Staging it by making ``device_connect_edge`` unimportable and evicting
+the ``strands_robots.device_connect`` subtree - so the next import re-executes an
+``__init__`` that fails - stops simulating anything as soon as that ``__init__``
+stops needing the extra, and the driver then reaches the real daemon instead of
+refusing.
 """
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import sys
 from pathlib import Path
@@ -41,24 +48,32 @@ import pytest
 import strands_robots.drivers.reachy as reachy_mod
 from strands_robots.drivers.reachy import ReachyDriver
 
-#: The dependency the ``[device-connect]`` extra supplies, and the only reason the
-#: transport package needs the extra at all.
+#: The dependency the ``[device-connect]`` extra supplies. The transport leaf needs
+#: nothing from it; only the drivers its parent package ships do.
 _EXTRA_DEP = "device_connect_edge"
+
+#: The module :func:`~strands_robots.drivers.reachy._resolve_transport` imports. A
+#: refusal-by-name has to be measured against this one being unimportable, because
+#: this import is the only thing the resolver reports on.
+_TRANSPORT_MODULE = reachy_mod._TRANSPORT_MODULE
 
 #: A daemon status body shaped like the real one. ``wireless_version=False`` is a
 #: Lite, the variant that needs no Zenoh transport and so is simplest to bring up.
 _LITE_STATUS: dict[str, Any] = {"wireless_version": False, "motors": "on"}
 
 
-def _hide_extra(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make the ``[device-connect]`` extra unimportable for the current test.
+def _block_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the transport module unimportable for the current test.
+
+    Blocks that one entry and leaves the rest of ``sys.modules`` alone. Evicting the
+    ``strands_robots.device_connect`` subtree instead lets the next import build a
+    second module object for a name a later test patches through the first, so a
+    double installed on one is not read through the other.
 
     Args:
-        monkeypatch: pytest's patcher, which restores every change made here.
+        monkeypatch: pytest's patcher, which restores the entry after the test.
     """
-    for name in [n for n in list(sys.modules) if n.startswith("strands_robots.device_connect")]:
-        monkeypatch.delitem(sys.modules, name)
-    monkeypatch.setitem(sys.modules, _EXTRA_DEP, None)
+    monkeypatch.setitem(sys.modules, _TRANSPORT_MODULE, None)
 
 
 def _names_the_extra(text: str) -> bool:
@@ -125,7 +140,8 @@ class TestTheExtraIsAPackagingAccident:
     If the transport genuinely needed ``device_connect_edge``, requiring the extra
     would be correct and a refusal would be the wrong answer - the driver would
     simply not be a core-install driver. These pin that the leaf needs nothing from
-    it and that the parent package is what pulls it in.
+    it, and that nothing on the load path pulls it in either - which is why the
+    absence a refusal is measured against has to be staged at the leaf itself.
     """
 
     def test_the_transport_module_never_mentions_the_extras_dependency(self) -> None:
@@ -133,10 +149,31 @@ class TestTheExtraIsAPackagingAccident:
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
         assert _EXTRA_DEP not in (package / "reachy_transport.py").read_text(encoding="utf-8")
 
-    def test_the_package_init_is_what_pulls_the_extra_in(self) -> None:
-        """The package ``__init__`` imports the dependency at module scope."""
+    def test_the_package_init_does_not_pull_the_extra_in_at_runtime(self) -> None:
+        """No runtime module-scope import of the extra, so blocking it stages nothing.
+
+        Read off the statements that actually execute. A ``TYPE_CHECKING`` block
+        carries the same text and never runs, so a source scan that does not exclude
+        it reports an eager import where there is none - and a simulation built on
+        that reading refuses nothing.
+        """
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
-        assert f"from {_EXTRA_DEP} import" in (package / "__init__.py").read_text(encoding="utf-8")
+        module = ast.parse((package / "__init__.py").read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        pending = [
+            node for node in module.body if not (isinstance(node, ast.If) and "TYPE_CHECKING" in ast.unparse(node.test))
+        ]
+        while pending:
+            node = pending.pop()
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add(node.module or "")
+            elif not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                pending.extend(ast.iter_child_nodes(node))
+        assert not [name for name in imported if name.split(".")[0] == _EXTRA_DEP], (
+            f"{_EXTRA_DEP} is imported where the package load will execute it: {sorted(imported)}"
+        )
 
     def test_the_resolver_answers_with_the_module_when_the_extra_is_present(self) -> None:
         """The control: nothing here refuses in an install that has the extra."""
@@ -150,13 +187,13 @@ class TestEachGuardIsReachedOnItsOwn:
 
     def test_the_daemon_probe_reports_an_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``_daemon_get`` answers in the ``{"error": ...}`` shape its callers read."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         assert _names_the_extra(driver._daemon_get(reachy_mod._PATH_STATUS)["error"])
 
     def test_the_link_builder_returns_the_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``_build_link`` answers in the reason contract it already documents."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         assert _names_the_extra(driver._build_link(is_lite=True))
 
@@ -166,7 +203,7 @@ class TestTheReasonReachesAMeshPeer:
 
     def test_get_status_answers_and_carries_the_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``get_status`` succeeds, reporting the reason as ``connect_error``."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         driver.connect_eagerly()
         status = asyncio.run(driver.get_status())
@@ -187,7 +224,7 @@ class TestSendActionRefusesInsteadOfMisdiagnosing:
         """A valid axis name must not be reported as an unrecognised one."""
         driver, _link = _connected_driver(monkeypatch)
         try:
-            _hide_extra(monkeypatch)
+            _block_transport(monkeypatch)
             assert "nothing to send" not in driver.send_action({"body_yaw": 10.0})["content"][0]["text"]
         finally:
             driver.cleanup()
@@ -196,7 +233,7 @@ class TestSendActionRefusesInsteadOfMisdiagnosing:
         """A refused action sends no partial command."""
         driver, link = _connected_driver(monkeypatch)
         try:
-            _hide_extra(monkeypatch)
+            _block_transport(monkeypatch)
             driver.send_action({"body_yaw": 10.0})
             assert link.commands == []
         finally:

--- a/tests/drivers/test_reachy_transport_guards_are_reachable.py
+++ b/tests/drivers/test_reachy_transport_guards_are_reachable.py
@@ -160,7 +160,7 @@ class TestTheExtraIsAPackagingAccident:
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
         module = ast.parse((package / "__init__.py").read_text(encoding="utf-8"))
         imported: set[str] = set()
-        pending = [
+        pending: list[ast.AST] = [
             node for node in module.body if not (isinstance(node, ast.If) and "TYPE_CHECKING" in ast.unparse(node.test))
         ]
         while pending:


### PR DESCRIPTION
`main` is red, in two independent places, and every open pull request is blocked by one or the other. Both defects are the same shape: a test stages a module absence or re-execution and leaves `sys.modules` holding something no importer can reach, so a *different* file fails with no local cause.

This branch repairs both. It is test-only: no `strands_robots/` source changes.

## The two defects

**A - `tests/drivers/test_g1_driver.py` orphans the G1 registration.** The load-hygiene cell re-executed `strands_robots.drivers.g1` with `importlib.reload` to observe its module-scope imports. `reload` re-executes into the *live* module object, rebinding every attribute, so `strands_robots.drivers.g1.G1Driver` became a different class object from the one `strands_robots.drivers` registered from `_SHIPPED_DRIVERS` at first import - and nothing put the original back. The registry answered with an unreachable class for the rest of the session.

It surfaced in `test_reachy_driver.py`, which compares the two by identity:

```
assert get_native_driver_class("unitree_g1") is G1Driver
E  AssertionError: assert <class 'strands_robots.drivers.g1.G1Driver'> is <class 'strands_robots.drivers.g1.G1Driver'>
```

Two identically named classes, on branches touching neither file. Reproduced deterministically in a two-cell session:

```
pytest tests/drivers/test_g1_driver.py::test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time \
       "tests/drivers/test_reachy_driver.py::TestTheLerobotPathIsUnaffected::test_the_g1_registration_survives_a_second_shipped_driver"
1 failed, 1 passed
```

That is the orphan AGENTS.md > Testing Patterns forbids for a `sys.modules` removal, reached through `reload` instead, and it carries the same cost the rule records: a double installed on the module attribute is not read through the registered class. The identity assertion was reporting correctly, so it is left as it was.

**B - the Reachy transport guards stage an absence that no longer exists.** `#2774` deferred `device_connect_edge` out of the `strands_robots.device_connect` package `__init__` - the point of the lazy export table it now carries. `test_reachy_transport_guards_are_reachable.py` staged the extra's absence by making `device_connect_edge` unimportable and evicting the `strands_robots.device_connect` subtree, relying on the next import to re-execute an `__init__` that fails. That `__init__` now succeeds, the stdlib-only transport leaf imports, and `_resolve_transport` hands back the real module - so the driver reaches the daemon from a unit test (`daemon unreachable (localhost:8000): <urlopen error [Errno 111] Connection refused>`).

The absence is now staged at the one module `_resolve_transport` imports, and nothing else in `sys.modules` is touched. The premise cell that should have caught the drift asserted `from device_connect_edge import` appeared in `__init__.py` - which the `TYPE_CHECKING` block satisfies, a block the source itself annotates `never executed`. It now reads the executed module-scope imports via `ast`, so a typing-only import no longer reads as an eager one.

## Why both in one branch

Because neither half can go green alone. `#2774` (defect B's cause) merged 19 minutes after `#2762` (defect A's witness and B's test), so `#2774`'s own run never executed the file it broke - a semantic merge conflict the merge-base overlap check cannot see, since the two diffs share no file.

Measured on the current heads:

| PR | fails on | fixes |
| --- | --- | --- |
| #2785 (before this push) | A | B |
| #2787 | B | A |
| #2784 (approved) | A | - |
| #2786 | A | - |

A branch fixing only A is red on B; a branch fixing only B is red on A. Splitting the repair is what produced the deadlock, so the repair is one branch.

## Relationship to #2787

`#2787` addresses defect A by relaxing the witness: comparing `__module__`/`__qualname__` instead of the class object. That clears the red, and its reading of the mechanism is right, but it leaves the orphan in place - the registry still holds a class no importer can reach, so `Robot("unitree_g1", mode="real", driver="strands")` and any `monkeypatch.setattr` on the module attribute still disagree for the rest of the session, which is the cost the AGENTS.md rule is about rather than the assertion that noticed it.

Fixing the probe instead removes the orphan, so the identity assertion stays valid and keeps grading what it was written to grade. `#2787` becomes unnecessary if this lands and should close as superseded - flagging rather than closing it here, since that call is the reviewer's.

## Verification

- `pytest tests/drivers/` - 342 passed, 30 skipped
- `pytest tests/drivers/test_reachy_transport_guards_are_reachable.py` - 9 passed (6 failed before)
- the two-cell ordering repro above - 2 passed (was 1 failed)
- `test_the_load_time_probe_leaves_the_g1_registration_reachable` reverted against `importlib.reload` - fails with `the load-time probe rebound strands_robots.drivers.g1.G1Driver and left the registry holding a class object nothing can import`, so the pin grades the defect rather than restating the fix
- `pytest tests/test_changelog_fragments.py tests/test_changelog_format.py` - 30 passed; `assemble_changelog.py --check` - OK
- `ruff check` / `ruff format --check` / `mypy` on both changed files - clean

## §13 Round changelog

**Round 2** - one concern, one commit, plain push (no force-push; prior head `aff60de` is an ancestor).

- `72010bf` - defect A at its source: the load-time probe executes the driver's source into a throwaway module object instead of `importlib.reload`, leaving the live module and the registration untouched. Adds `test_the_load_time_probe_leaves_the_g1_registration_reachable`, which fails on the old probe.
- `7333a5e` - changelog fragment for that half.
- Round 1 (`1f96d0e`, `aff60de`, defect B) is unchanged.

Diff: test-only, 2 test files + 2 changelog fragments.
