### PR TITLE
test(drivers): combined fix for both Reachy test flakes (supersedes #2785, #2787)

### DIFF
--- a/changelog.d/2785-reachy-guards-stage-the-absence-at-the-resolver.md
+++ b/changelog.d/2785-reachy-guards-stage-the-absence-at-the-resolver.md
@@ -1,0 +1,29 @@
+### Fixed: the Reachy transport guards stage the absence at the module the resolver imports
+
+`tests/drivers/test_reachy_transport_guards_are_reachable.py` grades the two
+`_resolve_transport` guards that `ReachyDriver.connect_eagerly`'s pre-check
+hides, so a stock install is refused by name rather than crashing. It staged
+that absence by making `device_connect_edge` unimportable and evicting the
+`strands_robots.device_connect` subtree from `sys.modules`, relying on the next
+import to re-execute a package `__init__` that fails.
+
+That `__init__` no longer imports the extra - deferring it is the whole point of
+the lazy export table it now carries - so the eviction re-executes an `__init__`
+that succeeds, the stdlib-only transport leaf imports, and `_resolve_transport`
+hands back the real module. The driver then reaches the daemon: six of the
+file's nine cells failed with `daemon unreachable (localhost:8000): <urlopen
+error [Errno 111] Connection refused>`, a real network call from a unit test.
+
+The eviction had a second cost. Deleting the subtree let the next import build a
+fresh module object for `strands_robots.device_connect.reachy_transport`, so a
+double installed on one object was not read through the other. Run before its
+sibling, this file took `tests/drivers/test_reachy_driver.py` from 109 passed to
+46 passed / 72 failed, and the pair from 0.30s to 21.49s of real connection
+timeouts.
+
+The absence is now staged at the one module `_resolve_transport` imports, and
+nothing else in `sys.modules` is touched. The premise test that should have
+caught the drift asserted `from device_connect_edge import` appeared in
+`__init__.py`, which the `TYPE_CHECKING` block satisfies - a block the source
+itself annotates `never executed`. It now reads the executed module-scope
+imports, so a typing-only import no longer reads as an eager one.

--- a/changelog.d/2787-g1-driver-class-identity-tolerant.md
+++ b/changelog.d/2787-g1-driver-class-identity-tolerant.md
@@ -1,0 +1,35 @@
+### Test: the G1-registration-survives assertion tolerates a second class object under a re-import
+
+`test_the_g1_registration_survives_a_second_shipped_driver` in
+`tests/drivers/test_reachy_driver.py` graded the registration by
+`get_native_driver_class("unitree_g1") is G1Driver`. Under some test orderings
+the `_register_shipped_drivers` loop reaches `strands_robots.drivers.g1` a
+second time - either via a test that reloads the module or via a stale
+`sys.modules` entry from an earlier suite phase - and the second import
+creates a fresh `G1Driver` class *object* with the same fully-qualified name.
+Both are the same registration for the registry's purposes (the qualname the
+seam looks up hasn't moved); the `is` check reports otherwise on the class
+object only, and the resulting failure is a false negative: the registration
+did survive, `is` just cannot tell.
+
+Fix: compare `__module__` and `__qualname__` instead of the class object. That
+is what a caller-facing consumer of the registry actually reads (drivers are
+looked up by module path, not by class object identity - `register_native_driver`
+stores by canonical robot name, not by class), and the pattern lerobot's own
+plugin registration uses.
+
+Observed on #2784's `call-test-lint` run on head `99efd10a` at
+`2026-08-26T17:36:18Z`:
+
+```
+tests/drivers/test_reachy_driver.py:722: AssertionError
+assert <class 'strands_robots.drivers.g1.G1Driver'> is <class 'strands_robots.drivers.g1.G1Driver'>
+```
+
+The two classes have the same repr because they *are* the same registration
+under a different identity. #2762 (which added
+`tests/drivers/test_reachy_driver.py`) shipped fine when it was the only
+driver in the suite; the flake surfaces when it sits alongside another
+driver-registering test that ordering-permutes ahead of it. This entry keeps
+the test's *intent* (registration must survive) without demanding a
+brittle-under-reimport identity check.

--- a/tests/drivers/test_reachy_driver.py
+++ b/tests/drivers/test_reachy_driver.py
@@ -717,9 +717,20 @@ class TestTheLerobotPathIsUnaffected:
 
     def test_the_g1_registration_survives_a_second_shipped_driver(self) -> None:
         # The registration loop must not let one driver's arrival cost another's.
+        # The identity is graded by fully-qualified name rather than ``is`` because
+        # a test ordering that re-imports ``strands_robots.drivers.g1`` (via the
+        # shipped-drivers registration loop running twice, once here and once
+        # elsewhere in the suite) creates a second ``G1Driver`` class object with
+        # the same qualname. Both are the same registration in the sense the
+        # registry's job cares about; the ``is`` check reports otherwise on the
+        # class *object* only, and the resulting failure is a false negative -
+        # the registration did survive, the identity check just cannot tell.
         from strands_robots.drivers.g1 import G1Driver
 
-        assert get_native_driver_class("unitree_g1") is G1Driver
+        registered = get_native_driver_class("unitree_g1")
+        assert registered is not None, "G1 was unregistered by adding another driver"
+        assert registered.__module__ == G1Driver.__module__
+        assert registered.__qualname__ == G1Driver.__qualname__
 
     def test_every_shipped_driver_satisfies_the_seam(self) -> None:
         # Derived from the shipped table, so a driver added later is held to the

--- a/tests/drivers/test_reachy_transport_guards_are_reachable.py
+++ b/tests/drivers/test_reachy_transport_guards_are_reachable.py
@@ -23,14 +23,21 @@ packaging accident, that the reason reaches a mesh peer, and that a working inst
 is unaffected.
 
 The absence is simulated rather than installed, since the suite runs where the
-extra is present: :func:`_hide_extra` makes ``device_connect_edge`` unimportable and
-evicts the already-imported ``strands_robots.device_connect`` package so the next
-import re-executes the ``__init__`` that fails. That is the same failure a stock
-install produces, at the same place, and ``monkeypatch`` restores both halves.
+transport is importable. :func:`_block_transport` blocks the one module
+:func:`~strands_robots.drivers.reachy._resolve_transport` imports, and ``monkeypatch``
+restores it. Blocking that module is what ties the simulation to the resolver rather
+than to a packaging detail upstream of it: the resolver reports on this import and on
+nothing before it, so an absence staged anywhere else is only a refusal by
+coincidence. Staging it by making ``device_connect_edge`` unimportable and evicting
+the ``strands_robots.device_connect`` subtree - so the next import re-executes an
+``__init__`` that fails - stops simulating anything as soon as that ``__init__``
+stops needing the extra, and the driver then reaches the real daemon instead of
+refusing.
 """
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import sys
 from pathlib import Path
@@ -41,24 +48,32 @@ import pytest
 import strands_robots.drivers.reachy as reachy_mod
 from strands_robots.drivers.reachy import ReachyDriver
 
-#: The dependency the ``[device-connect]`` extra supplies, and the only reason the
-#: transport package needs the extra at all.
+#: The dependency the ``[device-connect]`` extra supplies. The transport leaf needs
+#: nothing from it; only the drivers its parent package ships do.
 _EXTRA_DEP = "device_connect_edge"
+
+#: The module :func:`~strands_robots.drivers.reachy._resolve_transport` imports. A
+#: refusal-by-name has to be measured against this one being unimportable, because
+#: this import is the only thing the resolver reports on.
+_TRANSPORT_MODULE = reachy_mod._TRANSPORT_MODULE
 
 #: A daemon status body shaped like the real one. ``wireless_version=False`` is a
 #: Lite, the variant that needs no Zenoh transport and so is simplest to bring up.
 _LITE_STATUS: dict[str, Any] = {"wireless_version": False, "motors": "on"}
 
 
-def _hide_extra(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make the ``[device-connect]`` extra unimportable for the current test.
+def _block_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the transport module unimportable for the current test.
+
+    Blocks that one entry and leaves the rest of ``sys.modules`` alone. Evicting the
+    ``strands_robots.device_connect`` subtree instead lets the next import build a
+    second module object for a name a later test patches through the first, so a
+    double installed on one is not read through the other.
 
     Args:
-        monkeypatch: pytest's patcher, which restores every change made here.
+        monkeypatch: pytest's patcher, which restores the entry after the test.
     """
-    for name in [n for n in list(sys.modules) if n.startswith("strands_robots.device_connect")]:
-        monkeypatch.delitem(sys.modules, name)
-    monkeypatch.setitem(sys.modules, _EXTRA_DEP, None)
+    monkeypatch.setitem(sys.modules, _TRANSPORT_MODULE, None)
 
 
 def _names_the_extra(text: str) -> bool:
@@ -125,7 +140,8 @@ class TestTheExtraIsAPackagingAccident:
     If the transport genuinely needed ``device_connect_edge``, requiring the extra
     would be correct and a refusal would be the wrong answer - the driver would
     simply not be a core-install driver. These pin that the leaf needs nothing from
-    it and that the parent package is what pulls it in.
+    it, and that nothing on the load path pulls it in either - which is why the
+    absence a refusal is measured against has to be staged at the leaf itself.
     """
 
     def test_the_transport_module_never_mentions_the_extras_dependency(self) -> None:
@@ -133,10 +149,31 @@ class TestTheExtraIsAPackagingAccident:
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
         assert _EXTRA_DEP not in (package / "reachy_transport.py").read_text(encoding="utf-8")
 
-    def test_the_package_init_is_what_pulls_the_extra_in(self) -> None:
-        """The package ``__init__`` imports the dependency at module scope."""
+    def test_the_package_init_does_not_pull_the_extra_in_at_runtime(self) -> None:
+        """No runtime module-scope import of the extra, so blocking it stages nothing.
+
+        Read off the statements that actually execute. A ``TYPE_CHECKING`` block
+        carries the same text and never runs, so a source scan that does not exclude
+        it reports an eager import where there is none - and a simulation built on
+        that reading refuses nothing.
+        """
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
-        assert f"from {_EXTRA_DEP} import" in (package / "__init__.py").read_text(encoding="utf-8")
+        module = ast.parse((package / "__init__.py").read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        pending = [
+            node for node in module.body if not (isinstance(node, ast.If) and "TYPE_CHECKING" in ast.unparse(node.test))
+        ]
+        while pending:
+            node = pending.pop()
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add(node.module or "")
+            elif not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                pending.extend(ast.iter_child_nodes(node))
+        assert not [name for name in imported if name.split(".")[0] == _EXTRA_DEP], (
+            f"{_EXTRA_DEP} is imported where the package load will execute it: {sorted(imported)}"
+        )
 
     def test_the_resolver_answers_with_the_module_when_the_extra_is_present(self) -> None:
         """The control: nothing here refuses in an install that has the extra."""
@@ -150,13 +187,13 @@ class TestEachGuardIsReachedOnItsOwn:
 
     def test_the_daemon_probe_reports_an_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``_daemon_get`` answers in the ``{"error": ...}`` shape its callers read."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         assert _names_the_extra(driver._daemon_get(reachy_mod._PATH_STATUS)["error"])
 
     def test_the_link_builder_returns_the_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``_build_link`` answers in the reason contract it already documents."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         assert _names_the_extra(driver._build_link(is_lite=True))
 
@@ -166,7 +203,7 @@ class TestTheReasonReachesAMeshPeer:
 
     def test_get_status_answers_and_carries_the_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``get_status`` succeeds, reporting the reason as ``connect_error``."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         driver.connect_eagerly()
         status = asyncio.run(driver.get_status())
@@ -187,7 +224,7 @@ class TestSendActionRefusesInsteadOfMisdiagnosing:
         """A valid axis name must not be reported as an unrecognised one."""
         driver, _link = _connected_driver(monkeypatch)
         try:
-            _hide_extra(monkeypatch)
+            _block_transport(monkeypatch)
             assert "nothing to send" not in driver.send_action({"body_yaw": 10.0})["content"][0]["text"]
         finally:
             driver.cleanup()
@@ -196,7 +233,7 @@ class TestSendActionRefusesInsteadOfMisdiagnosing:
         """A refused action sends no partial command."""
         driver, link = _connected_driver(monkeypatch)
         try:
-            _hide_extra(monkeypatch)
+            _block_transport(monkeypatch)
             driver.send_action({"body_yaw": 10.0})
             assert link.commands == []
         finally:

--- a/tests/drivers/test_reachy_transport_guards_are_reachable.py
+++ b/tests/drivers/test_reachy_transport_guards_are_reachable.py
@@ -160,7 +160,7 @@ class TestTheExtraIsAPackagingAccident:
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
         module = ast.parse((package / "__init__.py").read_text(encoding="utf-8"))
         imported: set[str] = set()
-        pending = [
+        pending: list[ast.AST] = [
             node for node in module.body if not (isinstance(node, ast.If) and "TYPE_CHECKING" in ast.unparse(node.test))
         ]
         while pending:


### PR DESCRIPTION
Combined fix for the two interlocking Reachy driver test flakes that block #2784, #2786, #2787 and #2785 in a cycle. Each fix on its own hits the *other* flake in CI, so neither can go green independently.

## Included fixes

### 1. From #2787 (`test_reachy_driver.py`)
`test_the_g1_registration_survives_a_second_shipped_driver` graded G1 registration by `get_native_driver_class("unitree_g1") is G1Driver`. Under test orderings where `strands_robots.drivers.g1` is re-imported (via `importlib.reload` in `tests/drivers/test_g1_driver.py:1388`), a second class object with the same `__qualname__` is created — the registry is untouched but `is` returns False. Fix: compare `__module__` + `__qualname__`, with `assert registered is not None` ahead of it so a genuinely-lost registration still fails loudly.

### 2. From #2785 (`test_reachy_transport_guards_are_reachable.py`)
The staging file made `device_connect_edge` unimportable and evicted the `strands_robots.device_connect` subtree, expecting the next import to re-execute `__init__` and refuse. #2774 removed that eager import, so the simulation stopped simulating anything and the driver reached the daemon (real `urlopen [Errno 111] Connection refused`). Fix: stage the absence at the one module `_resolve_transport` imports via `monkeypatch.setitem(sys.modules, _TRANSPORT_MODULE, None)`, per AGENTS.md > "Restore a sys.modules entry you remove". The AST premise test now reads executed module-scope imports (skips TYPE_CHECKING blocks correctly).

## Why combined

CI on #2787's own branch fails on the guards flake #2785 fixes; CI on #2785's own branch fails on the identity flake #2787 fixes. Landing them together breaks the cycle and unblocks #2784 (spatial-tendon, APPROVED, red on identity flake) and #2786 (Feetech codec PR-A, red on identity flake).

## Verification

Fixes cherry-picked cleanly onto each other. No conflicts. Both are test-only changes (test files + one changelog fragment each), no production surface touched.

Once this lands: rebase #2784 and #2786 onto main → both go green. #2785 and #2787 close as superseded.
