### PR TITLE
test(drivers): make main's driver suite order-independent, at both root causes

### DIFF
--- a/changelog.d/2792-g1-sdk-import-pin-does-not-rebind-the-driver-class.md
+++ b/changelog.d/2792-g1-sdk-import-pin-does-not-rebind-the-driver-class.md
@@ -1,0 +1,28 @@
+### Fixed: the G1 SDK-import pin no longer rebinds the registered driver class
+
+`test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time` pinned a
+real contract - importing `strands_robots.drivers.g1` must not pull in the
+vendor SDK, so the module stays importable on a stock install - by reloading
+the driver module inside the running test session.
+
+`importlib.reload` re-executes a module body into the *same* namespace, so it
+rebinds every class that body defines. The driver registry captures
+`G1Driver` by reference when the shipped table is registered, so after the
+reload the registry's class and the class the module's own name resolves to
+are two distinct objects with an identical `repr`. Every identity assertion
+made later in the same session then fails, reporting
+`assert <class '...G1Driver'> is <class '...G1Driver'>` - a message that names
+the same class twice and points at neither the reload nor the file containing
+it.
+
+The pin now measures the import graph in a clean interpreter. Nothing in the
+test session is rebound, and the contract is stated more strongly: no
+`unitree_sdk2py` module is loaded at all, rather than none beyond whatever an
+earlier test in the session already imported - an assertion that holds even on
+a box where the SDK is installed.
+
+A second cell reads the rebind directly, calling the pin and then comparing the
+registry's class against the module's own name. Without it the file is silent:
+the symptom surfaced only in `tests/drivers/test_reachy_driver.py`, whose
+`test_the_g1_registration_survives_a_second_shipped_driver` compares those two
+references and runs after the pin in collection order.

--- a/changelog.d/2793-reachy-guards-stage-the-absence-at-the-resolver.md
+++ b/changelog.d/2793-reachy-guards-stage-the-absence-at-the-resolver.md
@@ -1,0 +1,29 @@
+### Fixed: the Reachy transport guards stage the absence at the module the resolver imports
+
+`tests/drivers/test_reachy_transport_guards_are_reachable.py` grades the two
+`_resolve_transport` guards that `ReachyDriver.connect_eagerly`'s pre-check
+hides, so a stock install is refused by name rather than crashing. It staged
+that absence by making `device_connect_edge` unimportable and evicting the
+`strands_robots.device_connect` subtree from `sys.modules`, relying on the next
+import to re-execute a package `__init__` that fails.
+
+That `__init__` no longer imports the extra - deferring it is the whole point of
+the lazy export table it now carries - so the eviction re-executes an `__init__`
+that succeeds, the stdlib-only transport leaf imports, and `_resolve_transport`
+hands back the real module. The driver then reaches the daemon: six of the
+file's nine cells failed with `daemon unreachable (localhost:8000): <urlopen
+error [Errno 111] Connection refused>`, a real network call from a unit test.
+
+The eviction had a second cost. Deleting the subtree let the next import build a
+fresh module object for `strands_robots.device_connect.reachy_transport`, so a
+double installed on one object was not read through the other. Run before its
+sibling, this file took `tests/drivers/test_reachy_driver.py` from 109 passed to
+46 passed / 72 failed, and the pair from 0.30s to 21.49s of real connection
+timeouts.
+
+The absence is now staged at the one module `_resolve_transport` imports, and
+nothing else in `sys.modules` is touched. The premise test that should have
+caught the drift asserted `from device_connect_edge import` appeared in
+`__init__.py`, which the `TYPE_CHECKING` block satisfies - a block the source
+itself annotates `never executed`. It now reads the executed module-scope
+imports, so a typing-only import no longer reads as an eager one.

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -1382,16 +1382,48 @@ def test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time() -> None:
     it for the driver module itself so a future edit that reaches for a
     module-level ``import unitree_sdk2py.idl.default`` fails here.  Thor
     and CI both need the driver module importable without the SDK.
+
+    Measured in a clean interpreter rather than by reloading the module in
+    this one. :func:`importlib.reload` re-executes a module body into the same
+    namespace, which rebinds every class the body defines. The driver registry
+    captures :class:`~strands_robots.drivers.g1.G1Driver` by reference when the
+    shipped table is registered, so a reload leaves that reference pointing at
+    a class object that is no longer what the module's own name resolves to:
+    every later ``is`` comparison in the session then fails between two classes
+    with an identical ``repr``. A subprocess cannot rebind anything here, and it
+    states the contract more strongly - no SDK module is loaded at all, rather
+    than none beyond whatever an earlier test in this session already imported.
     """
-    import importlib
+    import subprocess
     import sys
 
-    # Snapshot the SDK modules already loaded (may or may not be present on
-    # this box).  Then reimport the driver module and confirm no *new*
-    # unitree_sdk2py submodule crept in - just importing the driver.
-    before = {n for n in sys.modules if n.startswith("unitree_sdk2py")}
-    importlib.reload(importlib.import_module("strands_robots.drivers.g1"))
-    after = {n for n in sys.modules if n.startswith("unitree_sdk2py")}
-    assert after == before, (
-        f"importing strands_robots.drivers.g1 pulled in unitree_sdk2py modules: {sorted(after - before)}"
+    probe = (
+        "import sys; import strands_robots.drivers.g1; "
+        "print(sorted(n for n in sys.modules if n.startswith('unitree_sdk2py')))"
     )
+    completed = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=False)
+    assert completed.returncode == 0, f"importing the driver module failed: {completed.stderr}"
+    assert completed.stdout.strip() == "[]", (
+        f"importing strands_robots.drivers.g1 pulled in unitree_sdk2py modules: {completed.stdout.strip()}"
+    )
+
+
+def test_the_sdk_import_pin_leaves_the_registered_driver_class_reachable_by_name() -> None:
+    """The pin above must not leave a second ``G1Driver`` class behind.
+
+    The registry hands back the class object it was registered with. A pin that
+    re-executed the driver module in this interpreter would rebind the module's
+    own ``G1Driver`` to a new object, so this assertion is the one that reads
+    the two apart - the failure names two classes with the same ``repr``, which
+    is the only symptom a rebind produces. Calling the pin directly rather than
+    relying on collection order means the coupling is graded in one file.
+    """
+    import importlib
+
+    from strands_robots.drivers.g1 import G1Driver
+    from strands_robots.drivers.registry import get_native_driver_class
+
+    test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time()
+
+    assert get_native_driver_class("unitree_g1") is G1Driver
+    assert importlib.import_module("strands_robots.drivers.g1").G1Driver is G1Driver

--- a/tests/drivers/test_reachy_transport_guards_are_reachable.py
+++ b/tests/drivers/test_reachy_transport_guards_are_reachable.py
@@ -23,14 +23,21 @@ packaging accident, that the reason reaches a mesh peer, and that a working inst
 is unaffected.
 
 The absence is simulated rather than installed, since the suite runs where the
-extra is present: :func:`_hide_extra` makes ``device_connect_edge`` unimportable and
-evicts the already-imported ``strands_robots.device_connect`` package so the next
-import re-executes the ``__init__`` that fails. That is the same failure a stock
-install produces, at the same place, and ``monkeypatch`` restores both halves.
+transport is importable. :func:`_block_transport` blocks the one module
+:func:`~strands_robots.drivers.reachy._resolve_transport` imports, and ``monkeypatch``
+restores it. Blocking that module is what ties the simulation to the resolver rather
+than to a packaging detail upstream of it: the resolver reports on this import and on
+nothing before it, so an absence staged anywhere else is only a refusal by
+coincidence. Staging it by making ``device_connect_edge`` unimportable and evicting
+the ``strands_robots.device_connect`` subtree - so the next import re-executes an
+``__init__`` that fails - stops simulating anything as soon as that ``__init__``
+stops needing the extra, and the driver then reaches the real daemon instead of
+refusing.
 """
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import sys
 from pathlib import Path
@@ -41,24 +48,32 @@ import pytest
 import strands_robots.drivers.reachy as reachy_mod
 from strands_robots.drivers.reachy import ReachyDriver
 
-#: The dependency the ``[device-connect]`` extra supplies, and the only reason the
-#: transport package needs the extra at all.
+#: The dependency the ``[device-connect]`` extra supplies. The transport leaf needs
+#: nothing from it; only the drivers its parent package ships do.
 _EXTRA_DEP = "device_connect_edge"
+
+#: The module :func:`~strands_robots.drivers.reachy._resolve_transport` imports. A
+#: refusal-by-name has to be measured against this one being unimportable, because
+#: this import is the only thing the resolver reports on.
+_TRANSPORT_MODULE = reachy_mod._TRANSPORT_MODULE
 
 #: A daemon status body shaped like the real one. ``wireless_version=False`` is a
 #: Lite, the variant that needs no Zenoh transport and so is simplest to bring up.
 _LITE_STATUS: dict[str, Any] = {"wireless_version": False, "motors": "on"}
 
 
-def _hide_extra(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make the ``[device-connect]`` extra unimportable for the current test.
+def _block_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the transport module unimportable for the current test.
+
+    Blocks that one entry and leaves the rest of ``sys.modules`` alone. Evicting the
+    ``strands_robots.device_connect`` subtree instead lets the next import build a
+    second module object for a name a later test patches through the first, so a
+    double installed on one is not read through the other.
 
     Args:
-        monkeypatch: pytest's patcher, which restores every change made here.
+        monkeypatch: pytest's patcher, which restores the entry after the test.
     """
-    for name in [n for n in list(sys.modules) if n.startswith("strands_robots.device_connect")]:
-        monkeypatch.delitem(sys.modules, name)
-    monkeypatch.setitem(sys.modules, _EXTRA_DEP, None)
+    monkeypatch.setitem(sys.modules, _TRANSPORT_MODULE, None)
 
 
 def _names_the_extra(text: str) -> bool:
@@ -125,7 +140,8 @@ class TestTheExtraIsAPackagingAccident:
     If the transport genuinely needed ``device_connect_edge``, requiring the extra
     would be correct and a refusal would be the wrong answer - the driver would
     simply not be a core-install driver. These pin that the leaf needs nothing from
-    it and that the parent package is what pulls it in.
+    it, and that nothing on the load path pulls it in either - which is why the
+    absence a refusal is measured against has to be staged at the leaf itself.
     """
 
     def test_the_transport_module_never_mentions_the_extras_dependency(self) -> None:
@@ -133,10 +149,31 @@ class TestTheExtraIsAPackagingAccident:
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
         assert _EXTRA_DEP not in (package / "reachy_transport.py").read_text(encoding="utf-8")
 
-    def test_the_package_init_is_what_pulls_the_extra_in(self) -> None:
-        """The package ``__init__`` imports the dependency at module scope."""
+    def test_the_package_init_does_not_pull_the_extra_in_at_runtime(self) -> None:
+        """No runtime module-scope import of the extra, so blocking it stages nothing.
+
+        Read off the statements that actually execute. A ``TYPE_CHECKING`` block
+        carries the same text and never runs, so a source scan that does not exclude
+        it reports an eager import where there is none - and a simulation built on
+        that reading refuses nothing.
+        """
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
-        assert f"from {_EXTRA_DEP} import" in (package / "__init__.py").read_text(encoding="utf-8")
+        module = ast.parse((package / "__init__.py").read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        pending = [
+            node for node in module.body if not (isinstance(node, ast.If) and "TYPE_CHECKING" in ast.unparse(node.test))
+        ]
+        while pending:
+            node = pending.pop()
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add(node.module or "")
+            elif not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                pending.extend(ast.iter_child_nodes(node))
+        assert not [name for name in imported if name.split(".")[0] == _EXTRA_DEP], (
+            f"{_EXTRA_DEP} is imported where the package load will execute it: {sorted(imported)}"
+        )
 
     def test_the_resolver_answers_with_the_module_when_the_extra_is_present(self) -> None:
         """The control: nothing here refuses in an install that has the extra."""
@@ -150,13 +187,13 @@ class TestEachGuardIsReachedOnItsOwn:
 
     def test_the_daemon_probe_reports_an_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``_daemon_get`` answers in the ``{"error": ...}`` shape its callers read."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         assert _names_the_extra(driver._daemon_get(reachy_mod._PATH_STATUS)["error"])
 
     def test_the_link_builder_returns_the_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``_build_link`` answers in the reason contract it already documents."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         assert _names_the_extra(driver._build_link(is_lite=True))
 
@@ -166,7 +203,7 @@ class TestTheReasonReachesAMeshPeer:
 
     def test_get_status_answers_and_carries_the_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``get_status`` succeeds, reporting the reason as ``connect_error``."""
-        _hide_extra(monkeypatch)
+        _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
         driver.connect_eagerly()
         status = asyncio.run(driver.get_status())
@@ -187,7 +224,7 @@ class TestSendActionRefusesInsteadOfMisdiagnosing:
         """A valid axis name must not be reported as an unrecognised one."""
         driver, _link = _connected_driver(monkeypatch)
         try:
-            _hide_extra(monkeypatch)
+            _block_transport(monkeypatch)
             assert "nothing to send" not in driver.send_action({"body_yaw": 10.0})["content"][0]["text"]
         finally:
             driver.cleanup()
@@ -196,7 +233,7 @@ class TestSendActionRefusesInsteadOfMisdiagnosing:
         """A refused action sends no partial command."""
         driver, link = _connected_driver(monkeypatch)
         try:
-            _hide_extra(monkeypatch)
+            _block_transport(monkeypatch)
             driver.send_action({"body_yaw": 10.0})
             assert link.commands == []
         finally:

--- a/tests/drivers/test_reachy_transport_guards_are_reachable.py
+++ b/tests/drivers/test_reachy_transport_guards_are_reachable.py
@@ -160,7 +160,7 @@ class TestTheExtraIsAPackagingAccident:
         package = Path(reachy_mod.__file__).parent.parent / "device_connect"
         module = ast.parse((package / "__init__.py").read_text(encoding="utf-8"))
         imported: set[str] = set()
-        pending = [
+        pending: list[ast.AST] = [
             node for node in module.body if not (isinstance(node, ast.If) and "TYPE_CHECKING" in ast.unparse(node.test))
         ]
         while pending:


### PR DESCRIPTION
Repairs the two independent defects that make `tests/drivers/` order-dependent on `main`, each at its cause. Test-and-changelog only; no production surface is touched.

Fixes #2793

## The two defects

**A. A reload rebinds the driver class.** `test_g1_driver.py::test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time` pins a real contract — importing `strands_robots.drivers.g1` must not pull in the vendor SDK — but measured it with `importlib.reload` inside the running session. `reload` re-executes a module body into the *same* namespace, so it rebinds every class that body defines. The registry captured `G1Driver` **by reference** when the shipped table was registered, so afterwards the registry's class and the name's class are two distinct objects with an identical `repr`. Every later identity assertion fails, and the symptom surfaces in a different file:

```
tests/drivers/test_reachy_driver.py::TestTheLerobotPathIsUnaffected::test_the_g1_registration_survives_a_second_shipped_driver
    assert get_native_driver_class("unitree_g1") is G1Driver
E   AssertionError: assert <class 'strands_robots.drivers.g1.G1Driver'> is <class 'strands_robots.drivers.g1.G1Driver'>
```

**B. A simulation stopped simulating.** `test_reachy_transport_guards_are_reachable.py` staged a missing `[device-connect]` extra by making `device_connect_edge` unimportable and evicting the `strands_robots.device_connect` subtree, relying on the next import to re-execute an `__init__` that fails. #2774 removed that eager import deliberately (the point of #2771), so the re-import now succeeds, `_resolve_transport` returns the real module, and the driver reaches the daemon — six of nine cells failed on a real `urlopen [Errno 111] Connection refused` from a unit test.

## The changes

**A** — measure the import graph in a clean interpreter. Nothing in the session is rebound, and the contract becomes strictly *stronger*: **no** `unitree_sdk2py` module is loaded at all, rather than none beyond what an earlier test already imported — an assertion that holds even where the SDK is installed. A second cell reads the rebind directly, so the coupling is graded in the file that owns the pin.

**B** — stage the absence at the one module `_resolve_transport` imports, via `monkeypatch.setitem(sys.modules, _TRANSPORT_MODULE, None)`, touching nothing else in `sys.modules`. Per AGENTS.md > "Restore a sys.modules entry you remove". The premise test that should have caught the drift asserted `from device_connect_edge import` appeared in `__init__.py` — which the `TYPE_CHECKING` block satisfies, a block the source itself annotates `never executed`. It now reads executed module-scope imports via AST, so a typing-only import no longer reads as an eager one.

### Why B is staged rather than deleted

#2793 sets out two coherent directions and calls the choice a decision about the driver's public failure surface. This takes **Direction 1** (repoint the staging, keep the guards) because it is test-only and reversible, where Direction 2 deletes a documented public refusal. The residual question Direction 1 leaves — the reason string names an extra that is no longer the cause, so its remedy does not fit the only failures that can still reach it — is about a production message, not test hygiene, and is filed separately rather than decided here.

### Why the two are one PR

They cannot land apart. `tests/drivers/` on `main` is `7 failed`: one from A, six from B. A branch fixing only A is still red on B's six; a branch fixing only B is still red on A's one. Neither can show a green `call-test-lint`, which is what put #2785, #2787 and #2790 in a supersession cycle. Both are test-isolation repairs in the same directory, so landing them together is the smallest change that can be verified green.

## Verification

Measured on `3b235185` with `pytest tests/drivers/`:

| tree | result |
|---|---|
| `main` (pristine) | `7 failed, 381 passed, 30 skipped` |
| this branch | **`388 passed, 30 skipped`** |

Per-defect, on the file selection that reproduces the cross-file symptom (`test_g1_driver.py` + `test_reachy_driver.py`, in collection order):

| tree | result |
|---|---|
| `main` | `1 failed, 160 passed, 20 skipped` |
| defect-A fix only | `162 passed, 20 skipped` |

The guards file alone: `6 failed, 3 passed` on `main` → `9 passed` here.

**The registry contract is preserved, not relaxed.** `tests/drivers/test_reachy_driver.py` is not modified by this PR: `assert get_native_driver_class("unitree_g1") is G1Driver` stands unchanged at line 722 and passes, because the rebind that broke it is gone. Fixing A at its cause is what makes weakening that assertion unnecessary.

Gates: `ruff check` clean; `ruff format --check` clean; changelog fragment gates `89 passed` (`test_changelog_fragments.py`, `test_changelog_format.py`, `test_changelog_fragment_gate.py`).

No visual artifact: no policy, simulation, rendering, recording or asset behaviour changes.

## §13 Round changelog

**Round 2** — folded in the defect-B repair so this branch can show a green `call-test-lint`, and closed the supersession cycle:

- Added the transport-guard staging fix and its AST premise-test correction (defect B), previously carried by #2785 and #2790.
- Retargeted the guards changelog fragment from `2785-` to `2793-`, so it names the tracked issue rather than a superseded PR.
- Stated the Direction-1 choice #2793 asks for, and scoped the refusal-message question out of it.
- Supersedes #2785, #2787, #2790, all closed. Their approach to defect A graded the registration by `__module__` + `__qualname__` instead of `is`. The measurement above shows that relaxation is not needed: with the reload removed, the identity assertion passes as written. It also carried a comment attributing the second class object to "the shipped-drivers registration loop running twice", which is not the mechanism — the rebind comes from `importlib.reload` in `test_g1_driver.py`, as #2793 records.

**Round 1** — defect A only (`test_g1_driver.py`), with the mutation table for the pin.
