### PR TITLE
fix(ci): collide two branches on a module one of their tests names, not only on a path

### DIFF
--- a/changelog.d/2797-overlap-named-module-relation.md
+++ b/changelog.d/2797-overlap-named-module-relation.md
@@ -1,0 +1,35 @@
+### Fixed: two branches are collided on a module one of their tests names, not only on a path they share
+
+`scripts/check_merge_base_overlap.py` intersected changed **paths**. `main` went red at
+`828f80eb` from #2762 and #2774 with that intersection not merely unhelpful but empty. #2762
+added `tests/drivers/test_reachy_transport_guards_are_reachable.py`, whose fixture evicts
+`"strands_robots.device_connect"` from `sys.modules` and patches
+`"strands_robots.device_connect.reachy_transport.api"` by string; #2774 rewrote
+`strands_robots/device_connect/__init__.py` to resolve its names lazily. Six of that file's nine
+tests failed on the composition, five of them standalone, and the two branches changed no path in
+common -- so the sweep reported `no pair in the open set shares a changed path` while both sat in
+the queue, and the first tree in which the two were compiled together was `main`.
+
+The exclusion was reasoned rather than accidental, and the reasoning covered a different case.
+The file already measured and rejected widening the path set to a test's *walked root*, on the
+grounds that a relation firing on 11 of 36 pairs and naming no defect reads as boilerplate. That
+argument is about a population a grader never names. A test that reaches into a module *by name*
+writes the coupling down, and the name is not a path.
+
+There is now a second relation over the same two path sets and one further input: the dotted
+module names a pull request's test diff writes as string literals, resolved to the module files
+they name. Every prefix resolves, because importing `a.b.c` executes `a/b/__init__.py`, and that
+prefix is two segments shallower than the literal #2762 wrote -- it is where the #2774 edit was.
+Measured over the 2676 co-open pairs in #2309 through #2792, the path relation selects 104 pairs
+and this one selects 25, of which 9 are not already reported: 0.34% of the population against the
+rejected widening's 31%. The nine name couplings a reader can act on -- #2774 + #2762 is the
+composition above, #2767 + #2762 and #2767 + #2750 are three driver branches contending for
+`strands_robots/drivers/__init__.py`'s registration table, and #2546 + #2545 pairs a branch
+removing an export from `strands_robots/mesh/__init__.py` with one whose test names that package.
+
+The bare package root is deliberately not resolved: including it adds four findings, all of them
+pairs with one branch's edit to `strands_robots/__init__.py`, which every literal in the tree
+names by its first segment. Literals are read from the `patch` field of the entries the path set is
+already built from, so the sweep makes no additional request, and both modes hand `(path, patch)`
+pairs to one extractor so neither can disagree with the other about what a literal is. What stays
+out of reach is unchanged and is still the filesystem walk, which the report continues to name.

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -131,6 +131,45 @@ directory that is not a repository). So the honest change here is scope, not a
 new heuristic: this mode reports what it measured -- shared paths -- and names
 the composition class it cannot describe. See #2561.
 
+A module a test names is not a coupling it declined to write down
+-----------------------------------------------------------------
+The paragraph above is about a population the grader never names. A test that
+reaches into a module *by name* is the opposite case, and it produced the same
+outcome: ``main`` went red at ``828f80eb`` from #2762 and #2774 with the pairwise
+path intersection not merely unhelpful but ``[]``. #2762 added
+``tests/drivers/test_reachy_transport_guards_are_reachable.py``, whose fixture
+evicts ``"strands_robots.device_connect"`` from ``sys.modules`` and patches
+``"strands_robots.device_connect.reachy_transport.api"`` by string; #2774 rewrote
+``strands_robots/device_connect/__init__.py`` to resolve its names lazily. Six of
+that file's nine tests failed on the composition, five of them standalone, and
+neither branch changed a single path the other did (#2791, #2795).
+
+So there is a second relation here, over the same two path sets and one further
+input: the dotted module names a pull request's *test* diff writes as string
+literals, resolved to the module files they name -- every prefix, because
+importing ``a.b.c`` executes ``a/b/__init__.py``, which is where the #2774 edit
+was. Measured over 2676 co-open pairs drawn from 400 pull requests
+(#2309-#2792):
+
+- the path relation selects 104 pairs;
+- this one selects 25, of which 9 are not already reported;
+- the walked-root widening rejected above selected 11 of 36.
+
+That is 0.34% of the population against the rejected relation's 31%, and unlike
+it these nine name couplings a reader can act on: #2774 + #2762 is the
+composition above; #2767 + #2762 and #2767 + #2750 are three driver branches
+contending for ``strands_robots/drivers/__init__.py``'s registration table, which
+is the file behind the *other* test ``main`` was red in; #2546 + #2545 pairs a
+branch removing an export from ``strands_robots/mesh/__init__.py`` with one whose
+test names that package. The difference from the rejected widening is not the
+threshold but the input: a literal is written by the test author and says exactly
+which module is reached, where a walked root is inferred from a glob and says
+only that some file under it might be.
+
+What stays out of reach is unchanged, and is still the walk. A population
+resolved by ``rglob`` names nothing, so it shares neither a path nor a literal
+with the siblings it grades, and the report says so unconditionally.
+
 Prose is reported but does not block
 ------------------------------------
 An overlap confined to ``.md`` / ``.rst`` / ``.txt`` cannot change what the test
@@ -192,6 +231,7 @@ import dataclasses
 import itertools
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.error
@@ -265,6 +305,36 @@ def changed_paths(start: str, end: str, repo: Path | None = None) -> frozenset[s
     return frozenset(line for line in output.splitlines() if line)
 
 
+def diff_entries(start: str, end: str, repo: Path | None = None) -> tuple[tuple[str, str], ...]:
+    """Return ``(path, patch)`` for every test module changed between two commits.
+
+    The single-branch mode's source for :func:`module_literals`, giving it the
+    same ``(path, patch)`` shape the sweep builds from the API payload, so one
+    extractor serves both. Scoped to :data:`TEST_ROOTS` in the pathspec rather
+    than filtered afterwards: the diff of a whole tree is large and none of the
+    rest is read.
+
+    ``--no-renames`` for the reason :func:`changed_paths` gives, and because a
+    rename reported as a delete plus an add puts the added side's lines in the
+    patch, which is where a literal is.
+    """
+    output = _git("diff", "--no-renames", f"{start}..{end}", "--", *TEST_ROOTS, repo=repo)
+    collected: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in output.splitlines():
+        if line.startswith("diff --git "):
+            # 'diff --git a/<path> b/<path>'. The b-side is the post-image, which
+            # is the side an added line belongs to.
+            _, _, remainder = line.partition(" b/")
+            current = remainder or None
+            if current is not None:
+                collected.setdefault(current, [])
+            continue
+        if current is not None:
+            collected[current].append(line)
+    return tuple((path, "\n".join(body)) for path, body in sorted(collected.items()))
+
+
 def is_prose(path: str) -> bool:
     """Whether a path is documentation, and so reported without blocking."""
     return Path(path).suffix.lower() in PROSE_SUFFIXES
@@ -286,6 +356,96 @@ def partition_overlap(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str,
 def overlapping_paths(pr_paths: Iterable[str], base_paths: Iterable[str]) -> tuple[str, ...]:
     """Return the sorted paths edited both by the pull request and by its base."""
     return tuple(sorted(frozenset(pr_paths) & frozenset(base_paths)))
+
+
+#: The import root a dotted module literal must start with to be resolved here.
+#: Repo-specific on purpose, like the incident this file is named for: a relation
+#: that resolved *any* dotted string would report a stdlib or third-party name
+#: that no pull request in this repository can change.
+PACKAGE_ROOT = "strands_robots"
+
+#: Roots whose ``.py`` files are read for module literals. A test is the only
+#: population that reaches into a module by name for a reason the path relation
+#: cannot see -- production code that needs another module imports it, and an
+#: import is a path the diff already carries.
+TEST_ROOTS = ("tests/", "tests_integ/")
+
+#: How many dotted segments a literal must resolve to before its prefix counts.
+#: Two, so ``strands_robots.mesh`` resolves and the bare root does not. Measured
+#: over 2676 co-open pairs from 400 pull requests (#2309-#2792): resolving the
+#: bare root as well adds four findings, every one of them a pair with #2486,
+#: whose edit to ``strands_robots/__init__.py`` every literal in the tree names
+#: by its first segment. That is the shallowest coupling expressible and it is
+#: the one a reader can least act on, so the root is excluded.
+MIN_NAMED_MODULE_SEGMENTS = 2
+
+#: A dotted module path that is the *entire* contents of a string literal. Whole
+#: contents rather than a substring: ``"strands_robots.mesh.core"`` is a name
+#: handed to ``importlib`` or ``monkeypatch.setattr``, while the same characters
+#: inside a sentence are prose about a module, not a reach into one.
+_MODULE_LITERAL = re.compile(
+    r"""(?P<quote>['"])(?P<name>""" + PACKAGE_ROOT + r"""(?:\.[A-Za-z_][A-Za-z0-9_]*)+)(?P=quote)"""
+)
+
+
+def is_test_module(path: str) -> bool:
+    """Whether a path is a test module, and so read for module literals."""
+    return path.endswith(".py") and path.startswith(TEST_ROOTS)
+
+
+def added_lines(patch: str) -> tuple[str, ...]:
+    """Return the added lines of a unified diff, without their ``+`` marker.
+
+    Added lines only, and so the same ``M..head`` framing every other relation
+    here uses: the question is what this pull request introduces, not what the
+    file already said. ``+++`` is a header rather than content, and dropping it
+    also keeps a path out of the literal set.
+    """
+    return tuple(line[1:] for line in patch.splitlines() if line.startswith("+") and not line.startswith("+++"))
+
+
+def module_literals(entries: Iterable[tuple[str, str]]) -> frozenset[str]:
+    """Return the dotted module names a pull request's test diff names as strings.
+
+    ``entries`` is ``(path, patch)`` for every file the pull request touches, in
+    whichever form the calling mode can reach: the API's ``patch`` field for the
+    sweep, ``git diff`` for the single-branch check. One extractor over one input
+    shape is what keeps the two modes from disagreeing about what a literal is,
+    the same reason both already share the path-set helpers.
+    """
+    found: set[str] = set()
+    for path, patch in entries:
+        if not is_test_module(path):
+            continue
+        for line in added_lines(patch):
+            found.update(match.group("name") for match in _MODULE_LITERAL.finditer(line))
+    return frozenset(found)
+
+
+def named_module_paths(names: Iterable[str]) -> frozenset[str]:
+    """Return the module files a set of dotted literals names, prefixes included.
+
+    Every prefix, because importing ``a.b.c`` executes ``a/b/__init__.py`` as
+    well: the coupling that broke ``main`` at ``828f80eb`` was #2762's test
+    naming ``strands_robots.device_connect.reachy_transport.api`` against #2774's
+    edit to ``strands_robots/device_connect/__init__.py``, a prefix two segments
+    shorter than the literal. Both spellings of a module are emitted -- a
+    dotted name does not say whether it is a module or a package, and a path
+    neither branch touches cannot match anything.
+    """
+    found: set[str] = set()
+    for name in names:
+        segments = name.split(".")
+        for depth in range(MIN_NAMED_MODULE_SEGMENTS, len(segments) + 1):
+            stem = "/".join(segments[:depth])
+            found.add(f"{stem}.py")
+            found.add(f"{stem}/__init__.py")
+    return frozenset(found)
+
+
+def named_module_overlaps(literals: Iterable[str], paths: Iterable[str]) -> tuple[str, ...]:
+    """Return the sorted module files named by ``literals`` and changed in ``paths``."""
+    return tuple(sorted(named_module_paths(literals) & frozenset(paths)))
 
 
 API_ROOT = "https://api.github.com"
@@ -337,6 +497,11 @@ class OpenPullRequest:
     ceilings: the base side has no paginated equivalent and keeps
     ``_COMPARE_FILE_CAP``.
 
+    ``literals`` comes from the ``patch`` field of the same entries ``edits`` is
+    built from, so it costs no additional request: the endpoint already carries
+    it. A pull request touching no test module has an empty set, which excludes
+    it from the named-module relation and from nothing else.
+
     ``landed_since`` is ``None`` when that side could not be read. It is an input
     to the stale-base mode only, so an unreadable one excludes the pull request
     from that mode while leaving it in the pairwise comparison -- which matters:
@@ -350,6 +515,7 @@ class OpenPullRequest:
     merge_base: str
     behind_by: int
     edits: frozenset[str]
+    literals: frozenset[str]
     landed_since: frozenset[str] | None
 
 
@@ -475,8 +641,29 @@ def compare_fork_point(repo: str, base: str, head: str, token: str) -> tuple[str
     return merge_base_sha, behind_by
 
 
-def pull_request_paths(repo: str, number: int, token: str) -> frozenset[str]:
-    """Return the paths pull request ``number`` edits, from the paginated endpoint.
+def literals_from_entries(entries: Iterable[object]) -> frozenset[str]:
+    """Return the module literals a file-list payload's test diffs name.
+
+    Reads ``patch`` beside ``filename`` from the entries ``paths_from_entries``
+    already consumes. An entry carries no ``patch`` when the endpoint suppressed
+    it -- a binary file, or one past the per-file diff cap -- and a missing diff
+    contributes nothing rather than raising: this relation is additive, and a
+    pull request whose patches are unreadable is still fully evaluated by the
+    path relation, so failing here would cost a finding to gain nothing.
+    """
+    pairs: list[tuple[str, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("filename")
+        patch = entry.get("patch")
+        if isinstance(name, str) and isinstance(patch, str):
+            pairs.append((name, patch))
+    return module_literals(pairs)
+
+
+def pull_request_file_entries(repo: str, number: int, token: str) -> list[object]:
+    """Return every file-list entry for pull request ``number``, paginated.
 
     Below the compare cap this is the same set ``base...head`` reports -- measured
     on this repository at 7, 10 and 153 files (#1035, #1722, #1667), identical
@@ -487,6 +674,11 @@ def pull_request_paths(repo: str, number: int, token: str) -> frozenset[str]:
     Reaching that ceiling is reported like a capped compare, for the same reason:
     the endpoint stops there without saying so, and a silently short path set is
     how a missed overlap is manufactured.
+
+    Returned whole rather than reduced to paths, because two relations read them:
+    ``paths_from_entries`` takes ``filename``, ``literals_from_entries`` takes
+    ``patch``. One fetch feeding both is what keeps the named-module relation free
+    of additional requests.
     """
     collected: list[object] = []
     for page in range(1, _PULL_FILE_CAP // _PULL_FILE_PAGE + 1):
@@ -495,12 +687,21 @@ def pull_request_paths(repo: str, number: int, token: str) -> frozenset[str]:
         rows = payload if isinstance(payload, list) else []
         collected.extend(rows)
         if len(rows) < _PULL_FILE_PAGE:
-            return paths_from_entries(collected)
+            return collected
     raise ApiError(
         f"{API_ROOT}/repos/{repo}/pulls/{number}/files: the file list reached the "
         + f"{_PULL_FILE_CAP}-entry ceiling, so the path set is incomplete and an overlap "
         + "computed from it could be a false negative"
     )
+
+
+def pull_request_paths(repo: str, number: int, token: str) -> frozenset[str]:
+    """Return the paths pull request ``number`` edits.
+
+    Kept as the path-only accessor over :func:`pull_request_file_entries` so a
+    caller that needs one set is not handed the raw payload.
+    """
+    return paths_from_entries(pull_request_file_entries(repo, number, token))
 
 
 def collect_open_pull_requests(
@@ -521,7 +722,9 @@ def collect_open_pull_requests(
     for number, head_sha in resolve_open_pull_requests(repo, token):
         try:
             fork_point, behind_by = compare_fork_point(repo, base_ref, head_sha, token)
-            edits = pull_request_paths(repo, number, token)
+            entries = pull_request_file_entries(repo, number, token)
+            edits = paths_from_entries(entries)
+            literals = literals_from_entries(entries)
         except lookup_failures as error:
             unevaluated.append((number, f"not evaluated in either mode - own path set unreadable: {error}"))
             continue
@@ -538,6 +741,7 @@ def collect_open_pull_requests(
                 merge_base=fork_point,
                 behind_by=behind_by,
                 edits=edits,
+                literals=literals,
                 landed_since=landed_since,
             )
         )
@@ -554,6 +758,52 @@ def pair_overlaps(
         blocking, prose = partition_overlap(overlapping_paths(left.edits, right.edits))
         if blocking or prose:
             found.append((left.number, right.number, blocking, prose))
+    return found
+
+
+def named_module_pair_overlaps(
+    pull_requests: Iterable[OpenPullRequest],
+) -> list[tuple[int, int, tuple[str, ...]]]:
+    """Return ``(left, right, modules)`` for every pair coupled by a named module.
+
+    The path relation asks whether two branches edited the same file. This one
+    asks whether one branch's test *names* a module the other changed, which is a
+    coupling with no shared path at all: ``main`` went red at ``828f80eb`` from
+    #2762 and #2774, whose changed-path sets intersect to nothing.
+
+    Both directions, because the relation is not symmetric -- one side supplies
+    the literal and the other the edit -- and a pair is a finding whichever way
+    round that falls.
+    """
+    ordered = sorted(pull_requests, key=lambda row: row.number)
+    found: list[tuple[int, int, tuple[str, ...]]] = []
+    for left, right in itertools.combinations(ordered, 2):
+        modules = sorted(
+            frozenset(named_module_overlaps(left.literals, right.edits))
+            | frozenset(named_module_overlaps(right.literals, left.edits))
+        )
+        if modules:
+            found.append((left.number, right.number, tuple(modules)))
+    return found
+
+
+def named_module_stale_overlaps(
+    pull_requests: Iterable[OpenPullRequest],
+) -> list[tuple[int, int, tuple[str, ...]]]:
+    """Return ``(number, behind_by, modules)`` for every named module the base moved.
+
+    The named-module relation with the base branch substituted for a sibling's
+    head, mirroring :func:`stale_base_overlaps`. Only one direction is available
+    and only one is wanted: the base's own tests are already in the tree the
+    branch will be merged into.
+    """
+    found: list[tuple[int, int, tuple[str, ...]]] = []
+    for row in sorted(pull_requests, key=lambda row: row.number):
+        if row.landed_since is None or row.behind_by == 0:
+            continue
+        modules = named_module_overlaps(row.literals, row.landed_since)
+        if modules:
+            found.append((row.number, row.behind_by, modules))
     return found
 
 
@@ -584,6 +834,8 @@ def render_sweep(
     pull_requests: Sequence[OpenPullRequest],
     pairs: Sequence[tuple[int, int, tuple[str, ...], tuple[str, ...]]],
     stale: Sequence[tuple[int, int, tuple[str, ...], tuple[str, ...]]],
+    named_pairs: Sequence[tuple[int, int, tuple[str, ...]]],
+    named_stale: Sequence[tuple[int, int, tuple[str, ...]]],
     unevaluated: Sequence[tuple[int, str]],
 ) -> str:
     """Render the sweep report.
@@ -605,10 +857,11 @@ def render_sweep(
     prose_pairs = [row for row in pairs if not row[2]]
     blocking_stale = [row for row in stale if row[2]]
 
-    if not blocking_pairs and not blocking_stale:
+    if not blocking_pairs and not blocking_stale and not named_pairs and not named_stale:
         clean = (
-            "No pair in the open set shares a changed path, and no pull request shares one "
-            + "with what has landed on its base. Nothing here needs a merge-order decision."
+            "No pair in the open set shares a changed path, no pull request shares one "
+            + "with what has landed on its base, and no test names a module a sibling or the "
+            + "base changed. Nothing here needs a merge-order decision."
         )
         lines.append(clean)
         lines.append("")
@@ -646,6 +899,42 @@ def render_sweep(
             rendered = ", ".join(f"`{path}`" for path in paths)
             lines.append(f"| #{number} | {behind_by} | {rendered} |")
         lines.append("")
+    if named_pairs:
+        named_heading = f"### Pairs coupled by a module one of them names ({len(named_pairs)})"
+        named_why = (
+            "Neither pull request edits a path the other does, so the section above cannot "
+            + "report them. One of them has a test that reaches into the module below by name - "
+            + "through `importlib`, a `sys.modules` key or a string `monkeypatch` target - and "
+            + "the other changed that module's file. The name is the coupling, and a name is not "
+            + "a path. This is the relation `main` needed at `828f80eb`."
+        )
+        lines.append(named_heading)
+        lines.append("")
+        lines.append(named_why)
+        lines.append("")
+        lines.append("| pull requests | module(s) one names and the other changed |")
+        lines.append("|---|---|")
+        for left, right, modules in named_pairs:
+            rendered = ", ".join(f"`{module}`" for module in modules)
+            lines.append(f"| #{left} + #{right} | {rendered} |")
+        lines.append("")
+    if named_stale:
+        named_stale_heading = f"### Pull requests whose base changed a module their tests name ({len(named_stale)})"
+        named_stale_why = (
+            "Same relation, with the base branch in place of a sibling. The branch edits none "
+            + "of these files, so no path-based check reports it, and its own tests reach into "
+            + "them by name."
+        )
+        lines.append(named_stale_heading)
+        lines.append("")
+        lines.append(named_stale_why)
+        lines.append("")
+        lines.append(f"| pull request | behind `{base_ref}` by | module(s) its tests name |")
+        lines.append("|---|---|---|")
+        for number, behind_by, modules in named_stale:
+            rendered = ", ".join(f"`{module}`" for module in modules)
+            lines.append(f"| #{number} | {behind_by} | {rendered} |")
+        lines.append("")
     if prose_pairs:
         prose_heading = (
             f"Also sharing a path, not reported ({len(prose_pairs)} prose-only pair(s)) - prose "
@@ -680,9 +969,10 @@ def render_sweep(
     # populated one. A reader who sees no rows is entitled to know which
     # compositions the relations above were never able to describe.
     limits = (
-        "**What no relation above covers:** each one intersects changed *paths*. A test that "
-        + "resolves its population from a filesystem walk grades files it never names, so it "
-        + "shares no path with the siblings it grades and no row above can describe that "
+        "**What no relation above covers:** a test that resolves its population from a "
+        + "filesystem walk grades files it never names. The named-module relation reaches a "
+        + "coupling a test writes down; a walk writes nothing down, so it still shares no path "
+        + "and no name with the siblings it grades, and no row above can describe that "
         + "composition. Widening the path set to the walked root was measured and rejected as "
         + "unselective; only composing the branches and running the grader settles those, and "
         + "that needs a checkout this mode does not have. See #2561."
@@ -712,17 +1002,25 @@ def _run_sweep(repo: str, base_ref: str, token: str) -> int:
 
     pairs = pair_overlaps(pull_requests)
     stale = stale_base_overlaps(pull_requests)
+    named_pairs = named_module_pair_overlaps(pull_requests)
+    named_stale = named_module_stale_overlaps(pull_requests)
     _emit(
         render_sweep(
             repo=repo,
             base_ref=base_ref,
             pull_requests=pull_requests,
             pairs=pairs,
+            named_pairs=named_pairs,
+            named_stale=named_stale,
             stale=stale,
             unevaluated=unevaluated,
         )
     )
-    return 1 if any(row[2] for row in pairs) or any(row[2] for row in stale) else 0
+    # A named-module finding blocks on the same footing as a shared path: both say
+    # the composition has never been compiled, and this one resolves only to '.py'
+    # module files, so there is no prose half to suppress.
+    blocking = any(row[2] for row in pairs) or any(row[2] for row in stale) or bool(named_pairs) or bool(named_stale)
+    return 1 if blocking else 0
 
 
 def render_report(
@@ -731,6 +1029,7 @@ def render_report(
     merge_base_sha: str,
     blocking: Sequence[str],
     prose: Sequence[str],
+    named: Sequence[str],
     base_change_count: int,
 ) -> str:
     """Render the Markdown report written to stdout and the CI job summary.
@@ -744,7 +1043,7 @@ def render_report(
     """
     lines = ["## Merge-base overlap check", ""]
 
-    if not blocking and not prose:
+    if not blocking and not prose and not named:
         no_overlap = (
             f"No overlap. This branch edits nothing that `{base_ref}` has changed since "
             + f"the two diverged at `{merge_base_sha[:8]}` "
@@ -780,8 +1079,34 @@ def render_report(
         lines.append("")
         lines.append(remedy)
 
-    if prose:
+    if named:
         if blocking:
+            lines.append("")
+        named_heading = (
+            f"This branch's tests name **{len(named)}** module(s) that `{base_ref}` has "
+            + f"changed since the two diverged at `{merge_base_sha[:8]}`, and that this branch "
+            + "does not edit:"
+        )
+        named_why = (
+            "A path-based comparison cannot see this: the coupling is the name, written into a "
+            + "test as an `importlib` argument, a `sys.modules` key or a string `monkeypatch` "
+            + "target. The checks on this branch resolved those names against the older module."
+        )
+        named_remedy = (
+            f"**To clear this:** merge `{base_ref}` into this branch and push, having first run "
+            + "the tests that name the modules above. This is the relation `main` needed at "
+            + "`828f80eb`, where two branches with no shared path composed red."
+        )
+        lines.append(named_heading)
+        lines.append("")
+        lines += [f"- `{module}`" for module in named]
+        lines.append("")
+        lines.append(named_why)
+        lines.append("")
+        lines.append(named_remedy)
+
+    if prose:
+        if blocking or named:
             lines.append("")
         prose_heading = (
             f"Also overlapping, not blocking ({len(prose)} documentation path(s)) - "
@@ -855,6 +1180,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         fork_point = merge_base(base, head, repo=repo)
         pr_paths = changed_paths(fork_point, head, repo=repo)
         base_paths = changed_paths(fork_point, base, repo=repo)
+        literals = module_literals(diff_entries(fork_point, head, repo=repo))
     except GitError as error:
         # Loud and non-zero: a check that cannot compute its answer must not
         # report the reassuring one.
@@ -862,11 +1188,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     blocking, prose = partition_overlap(overlapping_paths(pr_paths, base_paths))
+    # Reported separately from 'blocking' rather than folded into it: the two are
+    # different relations with different remedial reading, and a module named but
+    # not edited is not something the branch "also changed".
+    named = tuple(module for module in named_module_overlaps(literals, base_paths) if module not in blocking)
     report = render_report(
         base_ref=args.base_ref,
         merge_base_sha=fork_point,
         blocking=blocking,
         prose=prose,
+        named=named,
         base_change_count=len(base_paths),
     )
 
@@ -883,8 +1214,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             + "branch diverged; the checks on this branch never compiled the two together."
         )
         print(annotation)
+    for module in named:
+        annotation = (
+            f"::error file={module}::{module} was changed on {args.base_ref} after this branch "
+            + "diverged, and a test on this branch names it as a string; the checks here "
+            + "resolved that name against the older module."
+        )
+        print(annotation)
 
-    return 1 if blocking else 0
+    return 1 if blocking or named else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -330,6 +330,7 @@ def test_report_names_every_blocking_path_and_the_remedy() -> None:
         merge_base_sha="32dc3f5b2ca5f226842e4f8e40aaa8e64108e383",
         blocking=[_SHARED],
         prose=["CHANGELOG.md"],
+        named=[],
         base_change_count=5,
     )
     assert _SHARED in report
@@ -345,6 +346,7 @@ def test_report_says_so_when_there_is_no_overlap() -> None:
         merge_base_sha="0123456789abcdef",
         blocking=[],
         prose=[],
+        named=[],
         base_change_count=0,
     )
     assert "No overlap" in report
@@ -428,20 +430,32 @@ def test_the_workflow_reads_the_script_from_the_base_and_names_the_head() -> Non
 # seam, so faking that is faking the network and nothing else.
 
 
-def _files(names: list[str], renamed: dict[str, str] | None = None) -> list[dict[str, object]]:
+def _files(
+    names: list[str],
+    renamed: dict[str, str] | None = None,
+    patches: dict[str, str] | None = None,
+) -> list[dict[str, object]]:
     """Build a file list in the shape both file-carrying endpoints return.
 
     ``renamed`` maps a new path to the path it was renamed from, which the API
     reports as ``previous_filename`` on that same entry rather than as a second
     entry -- so a rename is one row naming two paths, and reading only one of
     them is invisible in the payload.
+
+    ``patches`` maps a path to its unified diff, the ``patch`` field the endpoint
+    returns alongside ``filename``. Omitted by default, and omitting it is
+    meaningful rather than merely terse: an entry with no diff contributes no
+    module literal, which is the shape every path-relation test here wants.
     """
     previous = renamed or {}
+    diffs = patches or {}
     rows: list[dict[str, object]] = []
     for name in names:
         row: dict[str, object] = {"filename": name}
         if name in previous:
             row["previous_filename"] = previous[name]
+        if name in diffs:
+            row["patch"] = diffs[name]
         rows.append(row)
     return rows
 
@@ -452,12 +466,13 @@ def _compare(
     merge_base: str = "aaaa1111",
     behind_by: int = 0,
     renamed: dict[str, str] | None = None,
+    patches: dict[str, str] | None = None,
 ) -> dict[str, object]:
     """Build one ``compare`` payload in the shape the endpoint returns."""
     return {
         "merge_base_commit": {"sha": merge_base},
         "behind_by": behind_by,
-        "files": _files(files, renamed),
+        "files": _files(files, renamed, patches),
     }
 
 
@@ -1125,3 +1140,333 @@ def test_the_sweep_refuses_to_run_without_its_own_inputs(monkeypatch: pytest.Mon
     with pytest.raises(SystemExit) as raised:
         check.main(argv)
     assert raised.value.code == 2
+
+
+# --- the named-module relation ---------------------------------------------------
+#
+# `main` went red at `828f80eb` from #2762 and #2774 with the pairwise path
+# intersection empty: #2762's fixture reaches into
+# `strands_robots.device_connect` by string, #2774 rewrote that package's
+# `__init__`, and neither branch changed a path the other did. The relation these
+# pin keys on the name a test writes down rather than on a path, which is why it
+# reaches that composition. Issues #2791, #2795.
+
+#: The package #2774 rewrote, named by #2762's fixture two segments deeper.
+_NAMED_PACKAGE = "strands_robots/device_connect/__init__.py"
+
+#: The literal #2762's fixture patches, verbatim.
+_NAMED_LITERAL = "strands_robots.device_connect.reachy_transport.api"
+
+
+def _branch_naming_a_module(repo: Path, literal: str = _NAMED_LITERAL, *, in_test: bool = True) -> None:
+    """Branch off ``main`` and add a file reaching into ``literal`` by string.
+
+    ``in_test`` places the file under ``tests/`` or under the package. The
+    distinction is the relation's whole scope: production code that needs another
+    module imports it, and an import is a path the diff already carries.
+    """
+    _git(repo, "checkout", "-q", "-b", "pr")
+    body = f'monkeypatch.setattr("{literal}", stand_in)\n'
+    relative = "tests/drivers/test_reachy_transport_guards.py" if in_test else "strands_robots/drivers/reachy.py"
+    _write(repo, relative, body)
+    _commit(repo, "the pull request's commit")
+
+
+def _land_on_main_changing(repo: Path, relative: str) -> None:
+    """Land a commit on ``main`` rewriting ``relative``, as #2774 did."""
+    _git(repo, "checkout", "-q", "main")
+    _write(repo, relative, "def __getattr__(name):\n    raise AttributeError(name)\n")
+    _commit(repo, "the commit that landed on main first")
+    _git(repo, "checkout", "-q", "pr")
+
+
+def test_a_branch_whose_test_names_a_module_the_base_rewrote_is_flagged(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The #2762/#2774 topology in the single-branch mode: no shared path at all.
+
+    The branch adds a test that patches ``_NAMED_LITERAL`` by string; the base then
+    rewrites the package two segments up, which is the module that name resolves
+    through. The path intersection is empty -- the branch edits one file under
+    ``tests/`` and the base one under ``strands_robots/`` -- so the relation that
+    reaches this is the name, and the report has to say which module it was.
+    """
+    _branch_naming_a_module(repo)
+    _land_on_main_changing(repo, _NAMED_PACKAGE)
+
+    assert _run(repo) == 1
+
+    report = capsys.readouterr().out
+    assert _NAMED_PACKAGE in report
+    assert "name" in report.lower()
+
+
+def test_the_named_module_finding_shares_no_path_with_the_base(repo: Path) -> None:
+    """Premise: the path relation really is empty here, so it is not doing the work.
+
+    Without this the test above would pass on a tree where the two branches happen
+    to share a file, and the finding would be attributable to the relation that
+    already existed.
+    """
+    _branch_naming_a_module(repo)
+    _land_on_main_changing(repo, _NAMED_PACKAGE)
+
+    fork_point = check.merge_base("main", "HEAD", repo=repo)
+    branch_paths = check.changed_paths(fork_point, "HEAD", repo=repo)
+    base_paths = check.changed_paths(fork_point, "main", repo=repo)
+    assert check.overlapping_paths(branch_paths, base_paths) == ()
+    assert _NAMED_PACKAGE in base_paths
+
+
+def test_merging_the_base_clears_a_named_module_finding(repo: Path) -> None:
+    """Self-clearing, like the path relation: the remedy asked for is the remedy.
+
+    Merging the base advances the merge base, so the base-side path set is empty
+    and no module the branch names can be in it.
+    """
+    _branch_naming_a_module(repo)
+    _land_on_main_changing(repo, _NAMED_PACKAGE)
+    assert _run(repo) == 1
+
+    _git(repo, "merge", "-q", "--no-edit", "main")
+    assert _run(repo) == 0
+
+
+def test_a_module_named_by_a_test_and_changed_by_nobody_does_not_block(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Quiet where it cannot matter: a name is only a finding against a change.
+
+    Naming a module is the normal way a test reaches into one, so a relation that
+    fired on the name alone would fire on most test diffs in the tree.
+    """
+    _branch_naming_a_module(repo)
+    _git(repo, "checkout", "-q", "main")
+    _write(repo, "strands_robots/unrelated.py", "value = 1\n")
+    _commit(repo, "an unrelated commit on main")
+    _git(repo, "checkout", "-q", "pr")
+
+    assert _run(repo) == 0
+    assert _NAMED_PACKAGE not in capsys.readouterr().out
+
+
+def test_prose_naming_a_module_is_not_a_reach_into_it(repo: Path) -> None:
+    """A docstring that mentions a module is not a test that patches one.
+
+    The literal has to be the entire contents of the string for the same reason
+    the walked-root widening was rejected: a relation that fires on the characters
+    appearing anywhere would select every test whose docstring explains what it
+    covers, which is most of them.
+    """
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _write(
+        repo,
+        "tests/drivers/test_reachy_transport_guards.py",
+        '"""Covers strands_robots.device_connect.reachy_transport.api indirectly."""\n',
+    )
+    _commit(repo, "a test whose prose names the module")
+    _land_on_main_changing(repo, _NAMED_PACKAGE)
+
+    assert _run(repo) == 0
+
+
+def test_a_literal_in_production_code_is_not_read(repo: Path) -> None:
+    """Scoped to test modules, which is where a name is the only coupling.
+
+    Production code that needs another module imports it, and an import puts the
+    importing file in the diff -- so the path relation already carries it and a
+    second reading of the same coupling would double-report it.
+    """
+    _branch_naming_a_module(repo, in_test=False)
+    _land_on_main_changing(repo, _NAMED_PACKAGE)
+
+    assert _run(repo) == 0
+
+
+def test_the_bare_package_root_is_not_resolved(repo: Path) -> None:
+    """``strands_robots.mesh`` resolves; ``strands_robots`` alone does not.
+
+    Measured over 2676 co-open pairs from 400 pull requests: resolving the root as
+    well adds four findings, every one of them a pair with #2486's edit to
+    ``strands_robots/__init__.py``, which every literal in the tree names by its
+    first segment. That is the shallowest coupling expressible and the one a
+    reader can least act on.
+    """
+    assert "strands_robots/__init__.py" not in check.named_module_paths({"strands_robots.mesh.core"})
+    assert "strands_robots/mesh/__init__.py" in check.named_module_paths({"strands_robots.mesh.core"})
+    assert check.named_module_paths({"strands_robots"}) == frozenset()
+
+
+def test_a_prefix_of_the_literal_resolves_because_importing_runs_it(repo: Path) -> None:
+    """The #2774 edit was two segments shallower than the name #2762 wrote.
+
+    Importing ``a.b.c`` executes ``a/b/__init__.py``, so a change to the package
+    is a change to what the name resolves through. A relation reading only the
+    full dotted path would have missed the composition that broke ``main``.
+    """
+    resolved = check.named_module_paths({_NAMED_LITERAL})
+    assert _NAMED_PACKAGE in resolved
+    assert "strands_robots/device_connect/reachy_transport.py" in resolved
+
+
+def test_a_named_module_the_branch_also_edits_is_reported_once(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """One coupling, one row: the path relation already reports this one.
+
+    A branch that both names a module and edits it is the case where the two
+    relations agree, and reporting it twice would spend a reader's attention on a
+    second row carrying no further information.
+    """
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _write(repo, "tests/drivers/test_reachy_transport_guards.py", f'monkeypatch.setattr("{_NAMED_LITERAL}", x)\n')
+    _write(repo, _NAMED_PACKAGE, "value = 1\n")
+    _commit(repo, "a branch that both names and edits the module")
+    _land_on_main_changing(repo, _NAMED_PACKAGE)
+
+    assert _run(repo) == 1
+    report = capsys.readouterr().out
+    # It is in the shared-path finding, and there is no second section for it: the
+    # named-module list is what this branch's own edit already accounts for.
+    assert "behaviour-bearing path(s)" in report
+    assert "tests name" not in report
+
+
+def test_the_2762_2774_pair_is_flagged_in_the_sweep(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The incident, replayed in the mode that could have reported it before merge.
+
+    Both were open at once, so this is the pairwise relation's case, and the path
+    sets and the literal below are the real ones: #2762's ten files, #2774's five,
+    intersecting to nothing.
+    """
+    fixture = "tests/drivers/test_reachy_transport_guards_are_reachable.py"
+    patch = (
+        "@@ -0,0 +1,2 @@\n"
+        '+    for name in [n for n in list(sys.modules) if n.startswith("strands_robots.device_connect")]:\n'
+        f'+    monkeypatch.setattr("{_NAMED_LITERAL}", lambda *a, **k: dict(_LITE_STATUS))\n'
+    )
+    get = _api(
+        [_pull(2762, "head2762"), _pull(2774, "head2774")],
+        {
+            "main...head2762": _compare(
+                ["strands_robots/drivers/reachy.py", "strands_robots/drivers/__init__.py", fixture],
+                patches={fixture: patch},
+            ),
+            "head2762...main": _compare([]),
+            "main...head2774": _compare([_NAMED_PACKAGE, "strands_robots/device_connect/_impl.py"]),
+            "head2774...main": _compare([]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert "#2762 + #2774" in report
+    assert _NAMED_PACKAGE in report
+    # The path relation is silent, so the pair cannot be in the shared-path table.
+    assert "Pairs editing the same behaviour-bearing path" not in report
+
+
+def test_the_named_module_relation_costs_no_additional_request(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The literals come from the payload the path set is already built from.
+
+    ``patch`` arrives beside ``filename`` on the same entries, so a second reading
+    of them is free. A relation that fetched file contents per test module would
+    multiply the sweep's request count by the size of the queue, which is the cost
+    that keeps this mode runnable without a clone.
+    """
+    fixture = "tests/drivers/test_guards.py"
+    patch = f'@@ -0,0 +1 @@\n+monkeypatch.setattr("{_NAMED_LITERAL}", x)\n'
+    recorded = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare([fixture], patches={fixture: patch}),
+            "head10...main": _compare([]),
+            "main...head20": _compare([_NAMED_PACKAGE]),
+            "head20...main": _compare([]),
+        },
+    )
+    urls: list[str] = []
+
+    def counting(url: str, token: str) -> object:
+        urls.append(url)
+        return recorded(url, token)
+
+    assert _sweep(monkeypatch, counting, tmp_path) == 1
+    # Two pull requests, one page of files each: the relation adds no third fetch.
+    assert len([url for url in urls if "/files?" in url]) == 2
+
+
+def test_a_base_that_changed_a_module_the_branchs_tests_name_is_reported_with_its_distance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The stale-base half, mirroring ``stale_base_overlaps``.
+
+    Nothing re-runs a pull request idle in review, so a module its tests name can
+    be rewritten under it with its green result standing.
+    """
+    fixture = "tests/drivers/test_guards.py"
+    patch = f'@@ -0,0 +1 @@\n+import_module("{_NAMED_LITERAL}")\n'
+    get = _api(
+        [_pull(10, "head10")],
+        {
+            "main...head10": _compare([fixture], behind_by=4, patches={fixture: patch}),
+            "head10...main": _compare([_NAMED_PACKAGE]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert _NAMED_PACKAGE in report
+    assert "| #10 | 4 |" in report
+
+
+def test_both_modes_read_module_literals_through_one_extractor() -> None:
+    """Parity, for the reason the prose rule is shared: two readings would drift.
+
+    The sweep reads the API's ``patch`` field and the single-branch mode reads
+    ``git diff``, but both hand ``(path, patch)`` pairs to ``module_literals``, so
+    neither mode can disagree with the other about what a literal is.
+    """
+    sweep_side = inspect.getsource(check.literals_from_entries)
+    branch_side = inspect.getsource(check.main)
+    assert "module_literals(" in sweep_side
+    assert "module_literals(" in branch_side
+    assert "diff_entries(" in branch_side
+    # One definition of the pattern, so a change to it moves both modes together.
+    tree = ast.parse(_SCRIPT_PATH.read_text(encoding="utf-8"))
+    compiled = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign) and any(getattr(t, "id", "") == "_MODULE_LITERAL" for t in node.targets)
+    ]
+    assert len(compiled) == 1
+
+
+def test_the_walk_blind_spot_is_still_named_now_that_a_name_is_reachable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Reaching a named coupling must not read as reaching every coupling.
+
+    A population resolved by ``rglob`` writes nothing down, so it shares neither a
+    path nor a literal with the siblings it grades. The caveat stays unconditional,
+    and it stays true: this relation reaches couplings a test states, not couplings
+    inferred from a glob.
+    """
+    fixture = "tests/drivers/test_guards.py"
+    patch = f'@@ -0,0 +1 @@\n+import_module("{_NAMED_LITERAL}")\n'
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare([fixture], patches={fixture: patch}),
+            "head10...main": _compare([]),
+            "main...head20": _compare([_NAMED_PACKAGE]),
+            "head20...main": _compare([]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+    report = capsys.readouterr().out
+    assert "resolves its population from a filesystem walk" in report
+    assert "#2561" in report


### PR DESCRIPTION
`scripts/check_merge_base_overlap.py` intersects changed **paths**. `main` went red at `828f80eb`
from #2762 and #2774 with that intersection not merely unhelpful but empty, so the sweep reported
`no pair in the open set shares a changed path` while both branches sat in the queue.

## What composed red

#2762 added `tests/drivers/test_reachy_transport_guards_are_reachable.py`. Its fixture reaches into
a module by name, twice:

```python
for name in [n for n in list(sys.modules) if n.startswith("strands_robots.device_connect")]:
    monkeypatch.delitem(sys.modules, name)
...
monkeypatch.setattr("strands_robots.device_connect.reachy_transport.api", ...)
```

#2774 rewrote `strands_robots/device_connect/__init__.py` to resolve its names lazily. Six of that
file's nine tests failed on the composition, five of them with no other test in the session
(#2795). The two branches' changed-path sets:

| pull request | changed paths |
| --- | --- |
| #2762 | 2 changelog fragments, `docs/getting-started/robot-factory.md`, `strands_robots/drivers/{__init__,reachy}.py`, `strands_robots/registry/robots.json`, `strands_robots/tools/reachy/{__init__,_reachy_common}.py`, `tests/drivers/test_reachy_driver.py`, `tests/drivers/test_reachy_transport_guards_are_reachable.py` |
| #2774 | 1 changelog fragment, `strands_robots/device_connect/{__init__,_impl}.py`, `tests/device_connect/test_package_init_does_not_import_the_extra.py`, `tests/test_device_connect_sync_bringup_outcomes.py` |

Intersection: `[]`. Nothing in the sweep could describe the pair (#2791).

## Why the existing exclusion did not cover it

The file already measures and rejects widening the path set to a test's *walked root*, on the
grounds that a relation firing on 11 of 36 pairs while naming no defect "reads as boilerplate".
That argument is sound and it is about a different case: a population resolved by `rglob` never
names what it grades. A test that reaches into a module **by name** writes the coupling down, and a
dotted name is as explicit as a path -- it just is not one.

## The relation

The dotted module names a pull request's *test* diff writes as string literals, resolved to the
module files they name. Every prefix resolves, because importing `a.b.c` executes
`a/b/__init__.py` -- and that prefix is two segments shallower than the literal #2762 wrote, which
is exactly where #2774's edit was.

Scope is deliberate on three axes, each pinned:

- **Test modules only.** Production code that needs another module imports it, and an import is a
  path the diff already carries.
- **The whole contents of the string.** `"strands_robots.mesh.core"` is a name handed to
  `importlib` or `monkeypatch.setattr`; the same characters inside a sentence are prose about a
  module, not a reach into one.
- **Not the bare package root.** Resolving `strands_robots` alone adds four findings, all of them
  pairs with one branch's edit to `strands_robots/__init__.py`, which every literal in the tree
  names by its first segment. That is the shallowest coupling expressible and the one a reader can
  least act on.

## Measurement

Over the 2676 pairs in #2309 through #2792 that were open at the same instant, with both relations
run over identically reconstructed inputs:

| relation | pairs selected | share of population | not already reported |
| --- | --- | --- | --- |
| changed-path intersection | 104 | 3.9% | -- |
| named module (this change) | 25 | 0.93% | **9** |
| walked root (rejected above) | 11 of 36 | 31% | 9, none a defect |

The nine name couplings a reader can act on:

| pair | module | why it is a coupling |
| --- | --- | --- |
| #2774 + #2762 | `strands_robots/device_connect/__init__.py` | the composition that broke `main` |
| #2767 + #2762 | `strands_robots/drivers/__init__.py` | driver registration table, the file behind `main`'s *other* red test |
| #2767 + #2750 | `strands_robots/drivers/__init__.py` | same table, third contender |
| #2546 + #2545 | `strands_robots/mesh/__init__.py` | #2546 removes an export; #2545's test names that package |
| #2515 + #2510, #2510 + #2504, #2314 + #2312 | `strands_robots/mesh/core.py` | mesh branch beside a test naming a mesh module |
| #2515 + #2486 | `strands_robots/tools/__init__.py` | tools package edit beside a test naming a tools module |
| #2427 + #2331 | `strands_robots/rendering/__init__.py` | a docstring-reference grader beside new rendering exports |

The difference from the rejected widening is the input, not a threshold: a literal is written by the
test author and says which module is reached, where a walked root is inferred from a glob and says
only that some file under it might be.

## Cost

None. `patch` arrives beside `filename` on the entries the path set is already built from, so the
literals are a second reading of a payload already in hand -- pinned by a test that counts
`/files?` fetches. Both modes hand `(path, patch)` pairs to one extractor (the API's `patch` for the
sweep, `git diff` for the single-branch check), so neither can disagree with the other about what a
literal is, which is the parity property the file already asserts for its path-set helpers.

## Tests

`tests/test_merge_base_overlap.py` gains 13 cases; the git-topology ones replay the incident as real
commits in a real repository rather than as a hand-built path set, matching the file's existing
convention.

Reverting `scripts/check_merge_base_overlap.py` to this branch's base and keeping the tests gives
**11 failed, 59 passed**. The load-bearing failures are the four `assert 0 == 1` -- the gate
reporting clean, exit status 0, on a composition that broke `main`, including the #2762/#2774 replay
in the sweep. All five over-reach controls pass *both* before and after, which is what makes them
controls rather than regression cells:

| case | pre-fix | role |
| --- | --- | --- |
| branch names a module the base rewrote | fails | regression |
| the #2762/#2774 pair in the sweep | fails | regression |
| base changed a module the branch's tests name | fails | regression |
| merging the base clears the finding | fails | self-clearing |
| the path intersection here really is empty | passes | premise |
| a module named but changed by nobody | passes | control |
| prose naming a module | passes | control |
| a literal in production code | passes | control |
| a module the branch also edits, reported once | passes | control |
| the walk blind spot is still named | fails | scope |

## Gate

- `ruff check` and `ruff format --check` clean.
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1604 source files`, nothing
  attributable.
- 161-file selection (every suite that walks the tree, parses source, reads docstrings, reads
  `scripts/` or reads `changelog.d/`): `5 failed, 6773 passed, 56 skipped`. The five are
  pre-existing and environmental -- they assert `rclpy` is absent and it resolves in this
  environment; the identical five fail on this branch's merge base.
- `tests/test_merge_base_overlap.py`: 70 passed.
- Run against the live open set: 4 pull requests, 6 pairs, no findings, exit 0 -- no false positive
  on the current queue, this pull request included.

No visual artifact: this changes a repository check, its report text and its tests, none of the
surfaces that call for one.

Refs #2791, #2795.
