### PR TITLE
fix(drivers): stop the Reachy transport refusal prescribing an install it cannot establish

### DIFF
--- a/changelog.d/2798-reachy-transport-reason-reports-without-prescribing.md
+++ b/changelog.d/2798-reachy-transport-reason-reports-without-prescribing.md
@@ -1,0 +1,26 @@
+### Fixed: the Reachy transport refusal no longer prescribes an install it cannot establish
+
+`ReachyDriver` resolves its daemon transport lazily and reports a reason rather than
+raising when that import fails. The reason named the `[device-connect]` extra as both
+the cause and the remedy - correct once, when the transport's parent package imported
+`device_connect_edge` at module scope and the extra's absence really did make the leaf
+unimportable. That import is now lazy, and the leaf itself imports nothing outside the
+standard library, so no `pip install` supplies a module whose absence can reach that
+branch. Every cause that still can - a shadowing module, a partial wheel, a corrupt
+install - is untouched by installing an extra, so the remedy was advice that cannot
+help offered with the confidence of a diagnosis, which is the failure mode the named
+refusal exists to prevent, pointed the wrong way.
+
+The reason now reports the module and the underlying `ImportError` and stops there.
+That is the shape `drivers.g1._resolve_message_class` already uses, which this
+function's own docstring documents itself as sharing, and it is the position
+`utils.require_optional` refuses to print a pip line in when it is told a module
+arrives from somewhere pip cannot reach: such a line "would hand the caller an
+instruction that reports success without supplying the module".
+
+`docs/getting-started/robot-factory.md` quoted the old reason verbatim, including the
+remedy and a `ModuleNotFoundError` naming a package that can no longer be the cause.
+Nothing graded that block, so it is corrected against the resolver and pinned to it.
+The one other site that names the same extra is left alone: it reports a Device
+Connect bring-up failure, on a path whose modules do import `device_connect_edge` at
+module scope, so there the extra is a real cause and installing it is a real remedy.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -131,22 +131,28 @@ has a class for it, so `driver="lerobot"` remains a usable fallback. The Reachy 
 declares none: lerobot has no robot type for it, so the native driver is the only way
 to reach it and `driver="lerobot"` is refused by name.
 
-A native driver may need an extra to reach its hardware, and says so rather than
-raising. The Reachy Mini's daemon transport ships in the
-[`device-connect`](../device-connect.md) extra, so on a core install the driver still
-builds, registers and answers `get_status` - and every surface that would touch the
-daemon returns a reason naming the extra instead:
+A native driver reports what it cannot reach rather than raising. The Reachy Mini's
+daemon transport is a standard-library-only module in the core distribution, so
+nothing an extra installs decides whether it loads - but if it cannot be imported at
+all, on a broken install or behind a shadowing module, the driver still builds,
+registers and answers `get_status`, and every surface that would touch the daemon
+returns a reason naming the module and the error instead:
 
 ```python
 >>> Robot("reachy_mini", mode="real").connect_eagerly()
 "cannot import strands_robots.device_connect.reachy_transport: No module named
-'device_connect_edge' - the Reachy transport helpers ship behind an extra:
-pip install 'strands-robots[device-connect]'"
+'strands_robots.device_connect.reachy_transport'"
 ```
 
+The reason stops at what it can establish. It prescribes no `pip install`, because no
+install supplies a module that ships in the core distribution, and a remedy that
+cannot help is worse than none - the same rule
+[`require_optional`](../../strands_robots/utils.py) applies when it is told a module
+arrives from a system package rather than an index.
+
 The same reason arrives as `connect_error` in `get_status`, so a mesh peer for a Mini
-on an install without the extra is still constructible and still reports why it is
-not connected.
+whose transport will not load is still constructible and still reports why it is not
+connected.
 
 `hardware.driver` is optional and validated when the registry loads: a value that is not a
 driver name is refused there, naming the robot, rather than being read as "no preference".

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -147,7 +147,7 @@ returns a reason naming the module and the error instead:
 The reason stops at what it can establish. It prescribes no `pip install`, because no
 install supplies a module that ships in the core distribution, and a remedy that
 cannot help is worse than none - the same rule
-[`require_optional`](../../strands_robots/utils.py) applies when it is told a module
+[`require_optional`](https://github.com/strands-labs/robots/blob/main/strands_robots/utils.py) applies when it is told a module
 arrives from a system package rather than an index.
 
 The same reason arrives as `connect_error` in `get_status`, so a mesh peer for a Mini

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -84,40 +84,48 @@ _PATH_STATUS = "/api/daemon/status"
 _PATH_STOP = "/api/move/stop"
 
 #: The module every daemon touch here goes through. It is a leaf that imports
-#: nothing but the standard library, but it lives inside
-#: :mod:`strands_robots.device_connect`, whose package ``__init__`` imports
-#: ``device_connect_edge`` and the three Device Connect drivers unconditionally.
-#: That package ships only in the ``[device-connect]`` extra, so on a stock
-#: ``pip install strands-robots`` importing the leaf raises
-#: ``ModuleNotFoundError: No module named 'device_connect_edge'`` as a side
-#: effect of the parent, naming a package the caller never asked for.
+#: nothing but the standard library, and its parent package
+#: :mod:`strands_robots.device_connect` resolves ``device_connect_edge`` and the
+#: three Device Connect drivers lazily, so importing the leaf executes no
+#: third-party import. Nothing an extra installs can therefore decide whether
+#: this import succeeds: on a stock ``pip install strands-robots`` it does, and a
+#: failure that still reaches :func:`_resolve_transport` is a broken install of a
+#: module the core distribution ships rather than a missing optional dependency.
 _TRANSPORT_MODULE = "strands_robots.device_connect.reachy_transport"
 
 
 def _resolve_transport() -> Any:
-    """Return the Reachy transport module, or a reason naming what is missing.
+    """Return the Reachy transport module, or a reason naming what failed.
 
     The same shape as
     :func:`~strands_robots.drivers.g1._resolve_message_class`: the seam's other
     driver resolves its lazy SDK import through a helper that hands back a
     reason string, and every refusal boundary turns that string into a named
-    failure. Doing the same here keeps the driver's no-raise contract intact on
-    an install without the ``[device-connect]`` extra - ``connect_eagerly``
-    reports a reason and leaves the driver disconnected but usable, rather than
-    raising ``ModuleNotFoundError`` through the agent tool surface.
+    failure. Doing the same here keeps the driver's no-raise contract intact
+    when the transport module cannot be imported - ``connect_eagerly`` reports a
+    reason and leaves the driver disconnected but usable, rather than raising
+    ``ModuleNotFoundError`` through the agent tool surface.
+
+    The reason reports the module and the underlying ``ImportError`` and stops
+    there. It prescribes no install remedy because there is none this branch
+    could establish: the transport leaf imports nothing outside the standard
+    library, so no ``pip install`` supplies a module whose absence would reach
+    here. That is the position the shared optional-dependency helper
+    :func:`~strands_robots.utils.require_optional` already refuses to print a
+    pip line in, because such a line "would hand the caller an instruction that
+    reports success without supplying the module". Every cause that can still
+    reach this branch - a shadowing module, a partial wheel, a corrupt install -
+    is described by the ``ImportError`` itself.
 
     Returns:
-        The imported module, or a reason string naming the extra to install.
+        The imported module, or a reason string naming the module and the cause.
     """
     try:
         import importlib
 
         return importlib.import_module(_TRANSPORT_MODULE)
     except ImportError as exc:
-        return (
-            f"cannot import {_TRANSPORT_MODULE}: {exc} - the Reachy transport "
-            "helpers ship behind an extra: pip install 'strands-robots[device-connect]'"
-        )
+        return f"cannot import {_TRANSPORT_MODULE}: {exc}"
 
 
 #: Keys the daemon status payload might carry a battery percentage under. The

--- a/tests/drivers/test_reachy_driver.py
+++ b/tests/drivers/test_reachy_driver.py
@@ -763,37 +763,45 @@ def _run_tool(driver: ReachyDriver, action: str) -> dict[str, Any]:
     return asyncio.run(_drive())
 
 
-class TestAStockInstallIsRefusedByNameRatherThanCrashing:
-    """The transport lives behind an extra; its absence must not raise.
+class TestAnUnimportableTransportIsRefusedByNameRatherThanCrashing:
+    """An unimportable transport must be reported, not raised.
 
     Every daemon touch here goes through
-    :mod:`strands_robots.device_connect.reachy_transport`. That module is a
-    stdlib-only leaf, but its package ``__init__`` imports ``device_connect_edge``
-    and the three Device Connect drivers unconditionally, and that package ships
-    only in the ``[device-connect]`` extra. So on a stock
-    ``pip install strands-robots`` the lazy import raises
-    ``ModuleNotFoundError: No module named 'device_connect_edge'`` as a side
-    effect of the parent - naming a package the caller never asked for, through
-    surfaces that document a returned reason instead.
+    :mod:`strands_robots.device_connect.reachy_transport`, a stdlib-only leaf
+    whose parent package resolves its third-party imports lazily. Nothing an
+    extra installs decides whether that import succeeds, so a failure reaching
+    these surfaces is a broken install of a module the core distribution ships -
+    a shadowing module, a partial wheel - which the ``ImportError`` describes and
+    no ``pip install`` line repairs.
 
-    CI installs ``[all]``, so the absence is invisible to the rest of this file.
-    These tests simulate it the way Python itself signals a blocked module:
-    ``sys.modules[name] = None`` makes ``importlib.import_module`` raise
-    ``ImportError``, which is what an uninstalled parent produces.
+    What must hold either way is that it does not raise: these surfaces document
+    a returned reason, and an escaping ``ModuleNotFoundError`` becomes a
+    traceback through the agent tool surface instead.
+
+    The failure is simulated rather than installed, the way Python itself signals
+    a blocked module: ``sys.modules[name] = None`` makes
+    ``importlib.import_module`` raise ``ImportError``.
     """
 
     @staticmethod
     def _block_transport(monkeypatch: pytest.MonkeyPatch) -> None:
-        """Make the transport module unimportable, as a stock install would."""
+        """Make the transport module unimportable for the current test."""
         monkeypatch.setitem(sys.modules, reachy_mod._TRANSPORT_MODULE, None)
 
-    def test_the_reason_names_the_extra_to_install(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A reason nobody can act on is barely better than a traceback."""
+    def test_the_reason_names_the_module_and_the_cause(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A reason nobody can act on is barely better than a traceback.
+
+        What a caller can act on here is the module that failed and the error it
+        failed with. An install command is not part of that: no ``pip install``
+        supplies this module, so naming one would be a diagnosis this branch
+        cannot establish.
+        """
         self._block_transport(monkeypatch)
         reason = reachy_mod._resolve_transport()
         assert isinstance(reason, str)
-        assert "strands-robots[device-connect]" in reason
         assert reachy_mod._TRANSPORT_MODULE in reason
+        assert "halted" in reason, f"the underlying ImportError is not reported: {reason}"
+        assert "pip install" not in reason, f"prescribes an install it cannot establish: {reason}"
 
     def test_connect_eagerly_returns_the_reason_instead_of_raising(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``connect_eagerly`` documents a returned reason, so it must return one."""
@@ -801,7 +809,8 @@ class TestAStockInstallIsRefusedByNameRatherThanCrashing:
         driver = ReachyDriver(tool_name="reachy_mini", port="reachy-a.local")
         reason = driver.connect_eagerly()
         assert reason is not None
-        assert "strands-robots[device-connect]" in reason
+        assert reachy_mod._TRANSPORT_MODULE in reason
+        assert "pip install" not in reason
         # Left disconnected but usable, and the reason cached for a later gate.
         assert driver._connected is False
         assert driver._connect_error == reason
@@ -833,7 +842,8 @@ class TestAStockInstallIsRefusedByNameRatherThanCrashing:
         driver._connected = True
         envelope = driver.send_action({"head_pitch": 5.0})
         assert envelope["status"] == "error"
-        assert "strands-robots[device-connect]" in _text(envelope)
+        assert reachy_mod._TRANSPORT_MODULE in _text(envelope)
+        assert "pip install" not in _text(envelope)
 
     def test_stop_does_not_claim_a_halt_it_could_not_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A stop that never reached the daemon is not a stop.

--- a/tests/drivers/test_reachy_transport_guards_are_reachable.py
+++ b/tests/drivers/test_reachy_transport_guards_are_reachable.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import importlib.abc
 import sys
 from pathlib import Path
 from typing import Any
@@ -76,16 +77,22 @@ def _block_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(sys.modules, _TRANSPORT_MODULE, None)
 
 
-def _names_the_extra(text: str) -> bool:
-    """Whether ``text`` names the missing extra and how to install it.
+def _reports_without_prescribing(text: str) -> bool:
+    """Whether ``text`` names the module that failed and prescribes no install.
+
+    The resolver reports on one import and on nothing before it, so the module's
+    name is what makes the reason actionable. A ``pip install`` line is the part
+    it must not carry: the leaf imports nothing outside the standard library, so
+    no install supplies a module whose absence reaches that branch, and a remedy
+    that cannot help is offered with the confidence of a diagnosis.
 
     Args:
         text: A refusal reason.
 
     Returns:
-        True when the reason carries both the extra's name and a pip remedy.
+        True when the reason names the module and prescribes no pip remedy.
     """
-    return "strands-robots[device-connect]" in text and "pip install" in text
+    return _TRANSPORT_MODULE in text and "pip install" not in text
 
 
 class _StubLink:
@@ -189,13 +196,13 @@ class TestEachGuardIsReachedOnItsOwn:
         """``_daemon_get`` answers in the ``{"error": ...}`` shape its callers read."""
         _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
-        assert _names_the_extra(driver._daemon_get(reachy_mod._PATH_STATUS)["error"])
+        assert _reports_without_prescribing(driver._daemon_get(reachy_mod._PATH_STATUS)["error"])
 
     def test_the_link_builder_returns_the_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``_build_link`` answers in the reason contract it already documents."""
         _block_transport(monkeypatch)
         driver = ReachyDriver(host="reachy.local")
-        assert _names_the_extra(driver._build_link(is_lite=True))
+        assert _reports_without_prescribing(driver._build_link(is_lite=True))
 
 
 class TestTheReasonReachesAMeshPeer:
@@ -208,7 +215,7 @@ class TestTheReasonReachesAMeshPeer:
         driver.connect_eagerly()
         status = asyncio.run(driver.get_status())
         assert status["status"] == "success"
-        assert _names_the_extra(status["content"][0]["json"]["connect_error"])
+        assert _reports_without_prescribing(status["content"][0]["json"]["connect_error"])
 
 
 class TestSendActionRefusesInsteadOfMisdiagnosing:
@@ -252,3 +259,187 @@ class TestAWorkingInstallIsUnaffected:
             assert [sorted(c) for c in link.commands] == [["body_yaw"]]
         finally:
             driver.cleanup()
+
+
+class TestTheReasonPrescribesNothingItCannotEstablish:
+    """The refusal reports the failure; it does not diagnose a cause.
+
+    ``[device-connect]`` was once the cause: the parent package imported
+    ``device_connect_edge`` at module scope, so the extra's absence really did make
+    the leaf unimportable, and naming it was the one useful hint available. That
+    import is now lazy, which leaves the remedy attached to a cause it can no longer
+    establish - and a ``pip install`` that cannot supply the module is advice offered
+    with the confidence of a diagnosis, which is the failure mode this whole file
+    exists to prevent, pointed the wrong way.
+
+    The rule is the one the shared optional-dependency helper already applies. Where
+    :func:`~strands_robots.utils.require_optional` is given ``system_install`` it
+    prints no pip line at all, "because a pip command for such a module is a remedy
+    the caller can follow to no effect: it either installs something that leaves the
+    module exactly as missing, or fails outright". A stdlib-only leaf is that
+    position exactly.
+    """
+
+    def test_every_module_scope_import_of_the_leaf_is_in_the_standard_library(self) -> None:
+        """The premise the whole class rests on, derived rather than asserted.
+
+        If the leaf ever grows a third-party import this stops being true, and the
+        question of whether an install remedy is establishable reopens. Deriving it
+        means that shows up here rather than in a reason nobody re-read.
+        """
+        package = Path(reachy_mod.__file__).parent.parent / "device_connect"
+        module = ast.parse((package / "reachy_transport.py").read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        pending: list[ast.AST] = [
+            node for node in module.body if not (isinstance(node, ast.If) and "TYPE_CHECKING" in ast.unparse(node.test))
+        ]
+        while pending:
+            node = pending.pop()
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add(node.module or "")
+            elif not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                pending.extend(ast.iter_child_nodes(node))
+        assert imported, "no module-scope imports were found, so the derivation read nothing"
+        outside = sorted(name for name in imported if name.split(".")[0] not in sys.stdlib_module_names)
+        assert not outside, f"the leaf imports outside the standard library: {outside}"
+
+    def test_the_reason_prescribes_no_install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No install command, because none of them supplies this module."""
+        _block_transport(monkeypatch)
+        reason = reachy_mod._resolve_transport()
+        assert isinstance(reason, str)
+        assert "pip install" not in reason, f"prescribes an install: {reason}"
+
+    def test_the_reason_names_no_optional_extra(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Nor the extra itself, which is the cause the remedy asserted."""
+        _block_transport(monkeypatch)
+        reason = reachy_mod._resolve_transport()
+        assert isinstance(reason, str)
+        assert _EXTRA_DEP not in reason, f"names the extra's dependency: {reason}"
+        assert "device-connect" not in reason, f"names the extra: {reason}"
+
+    def test_the_reason_still_names_the_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The first of two facts dropping the remedy must not cost.
+
+        Checked as a prefix rather than by containment. For a blocked module the
+        ``ImportError`` text happens to repeat the dotted name, so a containment
+        check passes even when the reason's own prose has stopped naming it - and the
+        reason has to stand on its own, since the two are separated everywhere this
+        string is read back.
+        """
+        _block_transport(monkeypatch)
+        reason = reachy_mod._resolve_transport()
+        assert isinstance(reason, str)
+        assert reason.startswith(f"cannot import {_TRANSPORT_MODULE}:"), f"does not name the module: {reason}"
+
+    def test_the_reason_still_carries_the_underlying_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The second: with no remedy to offer, the cause is all a caller gets."""
+        _block_transport(monkeypatch)
+        reason = reachy_mod._resolve_transport()
+        assert isinstance(reason, str)
+        assert "halted" in reason, f"does not carry the underlying ImportError: {reason}"
+
+    def test_the_reason_is_the_shape_its_docstring_claims_parity_with(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The declared sibling is the whole specification for this string.
+
+        :func:`~strands_robots.drivers.reachy._resolve_transport` documents itself as
+        "the same shape as" :func:`~strands_robots.drivers.g1._resolve_message_class`.
+        Handed the same blocked module, the two must therefore answer identically -
+        which is the check a re-added remedy fails, whatever wording it arrives in.
+        """
+        from strands_robots.drivers import g1 as g1_mod
+
+        _block_transport(monkeypatch)
+        mine = reachy_mod._resolve_transport()
+        sibling = g1_mod._resolve_message_class((_TRANSPORT_MODULE, "api"))
+        assert isinstance(mine, str) and isinstance(sibling, str)
+        assert mine == sibling, f"diverges from the shape it claims parity with:\n  {mine!r}\n  {sibling!r}"
+
+
+class TestTheDocumentedReasonIsTheRealOne:
+    """The reference page quotes this reason, so the quote is part of the contract.
+
+    ``docs/getting-started/robot-factory.md`` shows the refusal as the output of
+    ``Robot("reachy_mini", mode="real").connect_eagerly()``. A quoted output rots the
+    moment the surface it quotes changes, and nothing read that block: the page's own
+    suite grades other sections, so the quote carried a remedy the code had stopped
+    offering. Deriving the expected text from the resolver means the page cannot drift
+    from it again without failing here.
+    """
+
+    @staticmethod
+    def _quoted_reason() -> str:
+        """The reason the reference page quotes, unwrapped to a single line."""
+        page = Path(reachy_mod.__file__).parents[2] / "docs" / "getting-started" / "robot-factory.md"
+        text = page.read_text(encoding="utf-8")
+        blocks = [chunk for chunk in text.split("```") if "connect_eagerly()" in chunk]
+        assert len(blocks) == 1, f"expected exactly one connect_eagerly block, found {len(blocks)}"
+        after = blocks[0].split("connect_eagerly()", 1)[1]
+        return " ".join(after.replace('"', " ").split())
+
+    @staticmethod
+    def _reason_for_an_absent_module() -> str:
+        """The reason the resolver gives when the leaf is genuinely not installed.
+
+        ``sys.modules[name] = None`` produces a different ``ImportError`` ("halted"),
+        which is the right stand-in for the other cells but the wrong one to document:
+        a reader meets the absent-module wording. A finder that refuses the name
+        reproduces it without touching the installed tree.
+        """
+
+        class _Absent(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> None:
+                if fullname == _TRANSPORT_MODULE or fullname.startswith(f"{_TRANSPORT_MODULE}."):
+                    raise ModuleNotFoundError(f"No module named {fullname!r}", name=fullname)
+                return None
+
+        saved = sys.modules.pop(_TRANSPORT_MODULE, None)
+        sys.meta_path.insert(0, _Absent())
+        try:
+            reason = reachy_mod._resolve_transport()
+        finally:
+            sys.meta_path.pop(0)
+            if saved is not None:
+                sys.modules[_TRANSPORT_MODULE] = saved
+        assert isinstance(reason, str), "the resolver returned a module for a name it cannot import"
+        return reason
+
+    def test_the_page_quotes_the_reason_the_resolver_returns(self) -> None:
+        """What the page shows is what the code says, word for word."""
+        assert self._quoted_reason() == self._reason_for_an_absent_module()
+
+    def test_the_page_prescribes_no_install_for_this_import(self) -> None:
+        """A reader must not be sent to an install that cannot supply the module."""
+        quoted = self._quoted_reason()
+        assert "pip install" not in quoted, f"the quoted reason prescribes an install: {quoted}"
+
+
+class TestTheSiteWhereTheExtraIsStillTheCauseKeepsIt:
+    """The over-reach control: this is not a sweep of the extra's name.
+
+    ``strands_robots.robot`` names the same extra when Device Connect bring-up
+    fails, and there it is correct: that path imports ``init_device_connect_sync``,
+    which resolves through modules that do import ``device_connect_edge`` at module
+    scope, so the extra's absence really is a cause and installing it really is the
+    remedy. Dropping the remedy wherever the string appears would take that with it.
+    """
+
+    def test_the_bring_up_path_still_names_the_extra(self) -> None:
+        """The remedy survives where a module on the path needs the extra."""
+        robot_source = (Path(reachy_mod.__file__).parent.parent / "robot.py").read_text(encoding="utf-8")
+        assert "strands-robots[device-connect]" in robot_source
+
+    def test_a_module_on_that_path_really_imports_the_extras_dependency(self) -> None:
+        """And it is a cause there, unlike at the leaf: the import is module-scope."""
+        package = Path(reachy_mod.__file__).parent.parent / "device_connect"
+        eager = [
+            path.name
+            for path in sorted(package.glob("*.py"))
+            if any(
+                line.startswith((f"from {_EXTRA_DEP}", f"import {_EXTRA_DEP}"))
+                for line in path.read_text(encoding="utf-8").splitlines()
+            )
+        ]
+        assert eager, f"no module in {package.name} imports {_EXTRA_DEP} at module scope"


### PR DESCRIPTION
Closes #2794.

`_resolve_transport` refused an unimportable transport with a reason that named the
`[device-connect]` extra as the cause and installing it as the remedy. That was true
once: the transport's parent package imported `device_connect_edge` at module scope, so
the extra's absence really did make the leaf unimportable. That import is now lazy, and
the leaf itself imports nothing outside the standard library, so nothing an extra
installs decides whether this import succeeds. The remedy outlived its cause.

## The extra can no longer be the cause

Measured with `device_connect_edge` made unimportable:

| import | result |
| --- | --- |
| `device_connect_edge` | `ImportError: No module named 'device_connect_edge'` |
| `strands_robots.device_connect` | imports |
| `strands_robots.device_connect.reachy_transport` | imports |

The leaf's executed module-scope imports are `abc, asyncio, collections.abc, functools,
json, logging, math, os, socket, typing` - ten names, all standard library. So no
`pip install` supplies a module whose absence can reach that `except ImportError`. Every
cause that still can - a shadowing module, a partial wheel, a corrupt install - is
untouched by installing an extra.

That makes it the case `require_optional` already refuses to print a pip line in. When
it is told a module arrives from somewhere pip cannot reach it drops the install block
entirely, and says why in its own docstring: such a command "is a remedy the caller can
follow to no effect: it either installs something that leaves the module exactly as
missing, or fails outright", and naming one "would hand the caller an instruction that
reports success without supplying the module". Two shipped call sites rely on that for
the ROS 2 client libraries.

## The declared sibling was already the answer

`_resolve_transport`'s docstring opens "The same shape as
`drivers.g1._resolve_message_class`". Handed the same blocked module the two now answer
identically; before, one appended a cause and a remedy the other does not:

| | reason for a blocked module |
| --- | --- |
| `g1._resolve_message_class` | `cannot import <module>: <exc>` |
| `_resolve_transport`, before | `cannot import <module>: <exc> - the Reachy transport helpers ship behind an extra: pip install 'strands-robots[device-connect]'` |
| `_resolve_transport`, after | `cannot import <module>: <exc>` |

The parity claim is now graded by asserting the two strings are equal, so a re-added
remedy fails whatever wording it arrives in.

## What the reason keeps

Both facts a caller can act on. For a genuinely absent module:

```
cannot import strands_robots.device_connect.reachy_transport: No module named
'strands_robots.device_connect.reachy_transport'
```

The module is pinned as a **prefix** rather than by containment - for a blocked module
the `ImportError` text happens to repeat the dotted name, so a containment check passes
even when the reason's own prose has stopped naming it. That gap was found by a mutation
firing one test where it should have fired two.

## Scope: one of the two sites

`strands_robots/robot.py` names the same extra when Device Connect bring-up fails, and
there it is correct - that path imports `init_device_connect_sync`, which resolves
through modules that *do* import `device_connect_edge` at module scope. It is untouched,
and pinned both ways: one cell asserts the remedy survives there, another asserts some
module on that path really does import the dependency eagerly. Four modules do.

## The reference page quoted the old reason

`docs/getting-started/robot-factory.md` showed the refusal as `connect_eagerly()`'s
output, carrying the remedy and a `ModuleNotFoundError` naming a package that can no
longer be the cause, under the claim that the transport "ships in the `device-connect`
extra". Its own suite grades other sections of the page - `grep` for the extra in
`tests/test_docs_robot_factory_reference.py` returns nothing - so the quote was ungraded
and drifted. It is corrected, and a cell now derives the expected text from the resolver
and compares it to the page, so the two cannot separate again.

## Tests

The three surfaces that assert this reason previously asserted the extra string, one of
them in a cell named `test_the_reason_names_the_extra_to_install` inside a class named
`TestAStockInstallIsRefusedByNameRatherThanCrashing`. Both names encoded the stale
premise, so both are renamed for the behaviour that is actually true, and every
assertion is repointed from "names the extra" to "names the module, carries the cause,
prescribes no install" - strictly more specific than what it replaced.

Pre-fix split with the source reverted and every test kept: **9 failed, 117 passed**.
Per class:

| class | failed / total | role |
| --- | --- | --- |
| `TestTheReasonPrescribesNothingItCannotEstablish` | 3 / 6 | regression, plus the premise and two "must not be lost" cells that hold either way |
| `TestTheDocumentedReasonIsTheRealOne` | 2 / 2 | regression: the page and the code agree |
| `TestEachGuardIsReachedOnItsOwn` | 2 / 2 | repointed |
| `TestTheReasonReachesAMeshPeer` | 1 / 1 | repointed |
| `TestAnUnimportableTransportIsRefusedByNameRatherThanCrashing` | 3 / 6 | repointed |
| `TestTheSiteWhereTheExtraIsStillTheCauseKeepsIt` | 0 / 2 | over-reach control |
| `TestTheExtraIsAPackagingAccident` | 0 / 3 | premise |
| `TestAWorkingInstallIsUnaffected` | 0 / 1 | control |
| every other class in both files | 0 / 79 | unaffected |

## Mutations

Selection is `tests/drivers/` plus `tests/test_docs_robot_factory_reference.py`. `coll`
is 435 on every row, so nothing is hidden by a deselection.

| mutation | new cells | other | firing (new) |
| --- | --- | --- | --- |
| control | 0 | 0 | |
| the extra remedy restored verbatim | 4 | 6 | page-quote, parity, no-extra, no-install |
| remedy re-added in other wording | 3 | 6 | page-quote, parity, no-install |
| extra named without a pip line | 3 | 0 | page-quote, parity, no-extra |
| module name dropped from the reason | 3 | 0 | page-quote, parity, still-names-module |
| underlying `ImportError` dropped | 4 | 1 | page-quote, parity, still-carries-error, still-names-module |
| trailing prose, no pip and no extra | 2 | 0 | page-quote, parity |
| over-reach: `robot.py` remedy swept too | 1 | 0 | bring-up-path-keeps-the-extra |
| leaf grows a third-party import | 1 | 0 | leaf-is-stdlib-only |
| docs quote reverted, code left fixed | 2 | 0 | page-quote, page-prescribes-no-install |

Nine mutations, nine distinct firing sets, control clean, both source files restored
byte-identically after the run. The rows that matter: the over-reach row shows this is
not a sweep of the extra's name; the third row shows the rule is about the claim rather
than the `pip install` substring; the last shows the docs pin catches drift in the
direction that produced this defect. The parity cell fires on every code-side mutation,
which is the point of grading against the sibling rather than against a literal.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`
  (1607 files).
- `mypy` **24 == 24** against the merge base, normalized message sets byte-identical in
  both directions, 0 attributable to the changed files.
- Paired 449-file selection (all of `tests/drivers/`, plus every suite that walks the
  tree, parses source, reads docstrings or reads `docs/`, plus everything naming the
  driver or the package): **22 failed on both trees, failing-ID sets identical, `comm`
  empty in both directions**, collected 21763 -> 21773 for exactly the ten added cells.
- The 22 are pre-existing and unrelated: 17 need `awsiot`/`awscrt` (declared in the
  `[mesh-iot]` extra, absent here), 3 are lerobot-from-source drift in
  `tests/training/test_lerobot*`, 2 are `tests/test_device_connect_hardening.py`.
- `tests/drivers/` is **425 -> 435 passed**, and the changelog and docs gates pass
  (524 passed together).

No visual artifact: this changes a refusal string, two docstrings, a docs page and
tests - none of the surfaces that call for one. The measured before/after reason and the
mutation table are the evidence.
