### PR TITLE
fix(isaac): keep only joint types URDF declares in the movable set

### DIFF
--- a/changelog.d/2800-urdf-movable-joint-types.md
+++ b/changelog.d/2800-urdf-movable-joint-types.md
@@ -1,0 +1,55 @@
+### Fixed: the Isaac backend's two URDF readers agree on what a joint type is
+
+Two functions in `strands_robots.simulation.isaac` read a joint's `type` out of
+a URDF. `joint_names.urdf_joint_names` keeps the ones that produce a named
+articulation DOF and hands that list to `demangle_usd_joint_names` as the pool
+of URDF names a mangled DOF name may decode to. `loaders.load_urdf` maps the
+type onto a `JointDef` kind and *refuses* a type it does not recognise, naming
+the set it accepts in the refusal - which makes it this package's record of
+what URDF declares.
+
+The movable set carried `spherical`. URDF declares six joint types -
+`revolute`, `continuous`, `prismatic`, `fixed`, `floating`, `planar` - and that
+is not one of them. So the two readers, handed the same file, disagreed:
+
+```
+type         urdf_joint_names        load_urdf
+revolute     ['j1']                  j1 revolute
+continuous   ['j1']                  j1 revolute
+prismatic    ['j1']                  j1 prismatic
+fixed        []                      j1 fixed
+floating     []                      j1 fixed
+planar       []                      j1 fixed
+spherical    ['j1']                  ValueError: unknown joint type
+                                     (expected one of ['continuous', 'fixed',
+                                     'floating', 'planar', 'prismatic',
+                                     'revolute'])
+```
+
+A name in the decode pool that no URDF can declare has two ways to do harm,
+both reachable from a file. A `spherical` joint named `1` gave the DOF name
+`tn__1_` a candidate to decode to, so the public vocabulary reported `1` - the
+name of a joint the format cannot express. And `a-b` and `a.b` both substitute
+to `a_b` under the legacy mangle, so a `revolute` joint named `a-b` beside a
+`spherical` one named `a.b` made that decode ambiguous; an ambiguous decode
+keeps the USD name, so the joint the URDF really declares surfaced as `a_b` on
+`robot_joint_names`, on `get_observation` keys and in `send_action` resolution.
+That is the #1900 leak the module exists to close, reintroduced by a candidate
+URDF cannot declare.
+
+No valid URDF reaches either, because no valid URDF carries the type: none of
+the 68 URDFs the registry downloads declares one, and `load_urdf` refuses such
+a file outright. The fix is the vocabulary and the documented accepted set,
+which said `spherical` produces a DOF.
+
+The set is now pinned between the loader's two answers - every member must be a
+type the loader recognises, and no type the loader reads as moving may be left
+out. The bounds are deliberately not collapsed into an equality: were the
+importer found to surface a named DOF for a type the loader reads as `fixed`,
+that belongs in the movable set without the loader's own mapping changing.
+
+The comment's reason for excluding `floating` and `planar` also said the
+registry URDFs do not use them. Five of the 68 declare a `floating` base - a1,
+aliengo, go1, laikago and b2 - so the exclusion rests on the importer not
+mapping a multi-DOF joint onto single named DOFs, which is why the loader reads
+both as `fixed` too, and not on their absence.

--- a/strands_robots/simulation/isaac/joint_names.py
+++ b/strands_robots/simulation/isaac/joint_names.py
@@ -51,10 +51,20 @@ _BASIC_CHAR_RE = re.compile(r"[A-Za-z0-9_]")
 # (Isaac Sim 6.0.x URDF importer output, e.g. ``tn__1_`` for joint ``1``).
 _TRANSCODING_PREFIX = "tn__"
 
-# URDF joint types that produce articulation DOFs on import. ``fixed`` never
-# does; ``floating``/``planar`` are multi-DOF types the Isaac importer does
-# not map onto single named DOFs, and the registry URDFs do not use them.
-_MOVABLE_URDF_JOINT_TYPES = frozenset({"revolute", "continuous", "prismatic", "spherical"})
+# URDF joint types that produce articulation DOFs on import. The format
+# declares exactly six, and this package already records them: the map
+# ``loaders._URDF_JOINT_TYPE_MAP`` keys on all six, and ``loaders.load_urdf``
+# names that set in the refusal it raises for any other type. This set is
+# therefore drawn from those six - naming a seventh would put a joint no URDF
+# can declare into the candidate pool ``demangle_usd_joint_names`` draws
+# translations from.
+#
+# ``fixed`` produces no DOF at all. ``floating`` and ``planar`` are multi-DOF
+# types the Isaac importer does not map onto single named DOFs, which is why
+# the loader reads both as ``fixed`` too - not because they are unused: 5 of
+# the 68 URDFs the registry downloads declare a ``floating`` base (a1,
+# aliengo, go1, laikago, b2).
+_MOVABLE_URDF_JOINT_TYPES = frozenset({"revolute", "continuous", "prismatic"})
 
 
 def urdf_joint_names(urdf_path: str) -> list[str]:
@@ -63,9 +73,12 @@ def urdf_joint_names(urdf_path: str) -> list[str]:
     Stdlib-XML parse (no kit / importer dependency), so the mapping side of
     the #1900 fix is testable anywhere. Only joints whose type produces an
     articulation DOF are returned (``revolute``, ``continuous``,
-    ``prismatic``, ``spherical``) - ``fixed`` joints never surface in
-    ``dof_names``, and including them could only make a mangled-name match
-    ambiguous.
+    ``prismatic``). URDF's other three declared types never surface in
+    ``dof_names``: a ``fixed`` joint has no DOF, and ``floating`` / ``planar``
+    are multi-DOF types the importer does not map onto single named DOFs.
+    Reporting a joint the articulation cannot name could only make a
+    mangled-name match ambiguous, which is the one decode
+    :func:`demangle_usd_joint_names` refuses.
 
     Parameters
     ----------

--- a/tests/simulation/isaac/test_urdf_joint_type_vocabulary.py
+++ b/tests/simulation/isaac/test_urdf_joint_type_vocabulary.py
@@ -1,0 +1,240 @@
+"""The Isaac backend's two URDF readers agree about what a joint type is.
+
+Two functions in this package read a joint's ``type`` attribute out of a URDF
+and reach opposite conclusions about the same file:
+
+* :func:`~strands_robots.simulation.isaac.joint_names.urdf_joint_names` keeps
+  the joints whose type produces a named articulation DOF, and hands that list
+  to :func:`~strands_robots.simulation.isaac.joint_names.demangle_usd_joint_names`
+  as the pool of URDF names a mangled DOF name may decode to.
+* :func:`~strands_robots.simulation.isaac.loaders.load_urdf` maps the type onto
+  a ``JointDef`` kind, and *refuses* a type it does not recognise - naming the
+  set it accepts in the refusal, which makes it this package's record of what
+  URDF declares.
+
+The movable set used to carry ``spherical``, which URDF does not declare. So
+``urdf_joint_names`` reported such a joint as movable while ``load_urdf``,
+handed the very same file, refused it as an unknown joint type - and the name
+of a joint no URDF can declare entered the candidate pool, where a spurious
+candidate can only make a decode ambiguous. An ambiguous decode is the one
+outcome ``demangle_usd_joint_names`` declines to make, so it keeps the mangled
+USD name: exactly the #1900 leak the module exists to close.
+
+Nothing graded it. ``test_urdf_joint_name_demangle.py`` builds its fixtures
+from ``revolute``, ``continuous``, ``prismatic`` and ``fixed`` only - the four
+types an author writing a URDF would reach for - so the vocabulary's fourth
+member, and both of URDF's excluded real types, were never exercised.
+
+These tests need no Isaac Kit install and no ``pxr``: both readers are stdlib
+XML parsers.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from strands_robots.simulation.isaac import joint_names as jn
+from strands_robots.simulation.isaac import loaders
+
+# URDF's declared joint types, stated here rather than read from the code, so
+# these tests are an independent oracle for the vocabulary rather than a
+# restatement of it. See the URDF joint specification.
+URDF_DECLARED_TYPES = ("revolute", "continuous", "prismatic", "fixed", "floating", "planar")
+
+# The three that carry a single degree of freedom, and so can be named by an
+# articulation. Also stated locally, for the same reason.
+URDF_SINGLE_DOF_TYPES = ("revolute", "continuous", "prismatic")
+
+
+def _one_joint_urdf(tmp_path: pathlib.Path, joint_type: str) -> str:
+    """Write a two-link URDF whose single joint carries ``joint_type``."""
+    path = tmp_path / f"{joint_type}.urdf"
+    path.write_text(
+        '<robot name="r">'
+        '<link name="base"/><link name="tip"/>'
+        f'<joint name="j1" type="{joint_type}">'
+        '<parent link="base"/><child link="tip"/>'
+        "</joint>"
+        "</robot>"
+    )
+    return str(path)
+
+
+def _loader_reads_as_moving(joint_type: str) -> bool:
+    """Whether ``load_urdf`` maps ``joint_type`` onto a moving ``JointDef``."""
+    return loaders._URDF_JOINT_TYPE_MAP.get(joint_type, "fixed") != "fixed"
+
+
+class TestTheLoaderRecordsTheFormat:
+    """Premise: the loader's accepted set is this package's record of URDF.
+
+    Both cells would hold before the fix too - they establish that the type
+    map is a faithful record of the format, which is what makes it usable as
+    the authority the movable set is checked against.
+    """
+
+    def test_the_type_map_keys_are_exactly_the_declared_types(self) -> None:
+        assert set(loaders._URDF_JOINT_TYPE_MAP) == set(URDF_DECLARED_TYPES)
+
+    def test_the_refusal_names_the_accepted_set(self, tmp_path: pathlib.Path) -> None:
+        path = _one_joint_urdf(tmp_path, "screw")  # not a URDF joint type
+        with pytest.raises(ValueError, match="unknown joint type") as excinfo:
+            loaders.load_urdf(path)
+        message = str(excinfo.value)
+        for declared in URDF_DECLARED_TYPES:
+            assert declared in message, f"the refusal does not name {declared!r}: {message}"
+
+
+class TestTheMovableSetIsDrawnFromTheFormat:
+    """The movable set sits between the loader's two answers.
+
+    ``{types the loader reads as moving} <= movable <= {types the loader
+    recognises}``. The upper bound refuses a type URDF does not declare; the
+    lower bound refuses dropping one that does move. The bounds are deliberately
+    not collapsed into an equality: were the importer found to surface a named
+    DOF for a type the loader reads as ``fixed``, that belongs in the movable
+    set without the loader's own mapping changing.
+    """
+
+    def test_every_movable_type_is_a_type_urdf_declares(self) -> None:
+        invented = jn._MOVABLE_URDF_JOINT_TYPES - set(URDF_DECLARED_TYPES)
+        assert invented == set(), f"not URDF joint types: {sorted(invented)}"
+
+    def test_every_movable_type_is_one_the_loader_recognises(self) -> None:
+        unknown = jn._MOVABLE_URDF_JOINT_TYPES - set(loaders._URDF_JOINT_TYPE_MAP)
+        assert unknown == set(), f"movable here and refused by load_urdf as an unknown joint type: {sorted(unknown)}"
+
+    def test_no_type_the_loader_reads_as_moving_is_left_out(self) -> None:
+        moving = {t for t in loaders._URDF_JOINT_TYPE_MAP if _loader_reads_as_moving(t)}
+        assert moving <= jn._MOVABLE_URDF_JOINT_TYPES, (
+            f"the loader reads these as moving but they are not movable here: "
+            f"{sorted(moving - jn._MOVABLE_URDF_JOINT_TYPES)}"
+        )
+
+    def test_the_set_is_the_single_dof_types(self) -> None:
+        assert jn._MOVABLE_URDF_JOINT_TYPES == set(URDF_SINGLE_DOF_TYPES)
+
+    def test_the_public_docstring_names_the_set_it_returns(self) -> None:
+        """The documented accepted set is the one the code applies.
+
+        ``urdf_joint_names`` is exported, and its docstring is where a caller
+        reads which joint types it keeps. Deriving the expectation from the
+        constant means the prose cannot drift away from the behaviour.
+        """
+        doc = " ".join((jn.urdf_joint_names.__doc__ or "").split())
+        match = re.search(r"are returned \(([^)]*)\)", doc)
+        assert match is not None, f"no 'are returned (...)' clause in the docstring: {doc!r}"
+        documented = set(re.findall(r"``([a-z]+)``", match.group(1)))
+        assert documented == jn._MOVABLE_URDF_JOINT_TYPES, (
+            f"docstring says {sorted(documented)}, code keeps {sorted(jn._MOVABLE_URDF_JOINT_TYPES)}"
+        )
+
+
+class TestTheTwoReadersAgreeOnEveryDeclaredType:
+    """For each type URDF declares, both readers reach the same verdict."""
+
+    @pytest.mark.parametrize("joint_type", URDF_DECLARED_TYPES)
+    def test_reported_as_movable_exactly_when_the_loader_reads_it_as_moving(
+        self, tmp_path: pathlib.Path, joint_type: str
+    ) -> None:
+        path = _one_joint_urdf(tmp_path, joint_type)
+        reported = jn.urdf_joint_names(path)
+        robot = loaders.load_urdf(path)
+        moving = [j.name for j in robot.joints if j.joint_type != "fixed"]
+        assert (reported == ["j1"]) == (moving == ["j1"]), (
+            f"type={joint_type!r}: urdf_joint_names -> {reported}, load_urdf moving joints -> {moving}"
+        )
+
+
+class TestATypeTheLoaderRefusesIsNotReportedAsMovable:
+    """A type URDF does not declare is not a movable joint on either reader.
+
+    ``spherical`` is the value that shipped in the movable set; ``screw`` and
+    ``ball`` are two more names a reader might reasonably expect a joint format
+    to have. None is a URDF joint type, so the two readers must not disagree
+    about any of them.
+    """
+
+    @pytest.mark.parametrize("joint_type", ["spherical", "screw", "ball"])
+    def test_the_loader_refuses_it(self, tmp_path: pathlib.Path, joint_type: str) -> None:
+        with pytest.raises(ValueError, match="unknown joint type"):
+            loaders.load_urdf(_one_joint_urdf(tmp_path, joint_type))
+
+    @pytest.mark.parametrize("joint_type", ["spherical", "screw", "ball"])
+    def test_it_is_not_reported_as_a_movable_joint(self, tmp_path: pathlib.Path, joint_type: str) -> None:
+        assert jn.urdf_joint_names(_one_joint_urdf(tmp_path, joint_type)) == []
+
+
+class TestASpuriousCandidateDamagesTheDecode:
+    """What a joint URDF cannot declare does to the name translation.
+
+    ``urdf_joint_names`` feeds ``demangle_usd_joint_names`` the pool of URDF
+    names a mangled DOF name may decode to. A name in that pool that no URDF
+    can declare has two ways to do harm, and both are reachable from a file.
+    """
+
+    def test_a_dof_is_not_translated_to_a_joint_urdf_cannot_declare(self, tmp_path: pathlib.Path) -> None:
+        """The importer's own name is kept rather than a name from nowhere."""
+        path = tmp_path / "mistranslate.urdf"
+        path.write_text(
+            '<robot name="r">'
+            '<link name="base"/><link name="tip"/>'
+            '<joint name="1" type="spherical"><parent link="base"/><child link="tip"/></joint>'
+            "</robot>"
+        )
+        declared = jn.urdf_joint_names(str(path))
+        public, usd_to_urdf = jn.demangle_usd_joint_names(["tn__1_"], declared)
+        assert public == ["tn__1_"]
+        assert usd_to_urdf == {}
+
+    def test_a_real_joint_keeps_its_urdf_name(self, tmp_path: pathlib.Path) -> None:
+        """A declarable joint is not robbed of its translation.
+
+        ``a-b`` and ``a.b`` both substitute to ``a_b`` under the legacy
+        mangle, so both are candidates for that DOF name. With the second one
+        in the pool the decode is ambiguous, and an ambiguous decode keeps the
+        USD name - so the revolute joint the URDF really declares surfaces
+        under Isaac's mangled name on every public surface. That is the #1900
+        leak, reintroduced by a candidate URDF cannot declare.
+        """
+        path = tmp_path / "ambiguous.urdf"
+        path.write_text(
+            '<robot name="r">'
+            '<link name="base"/><link name="mid"/><link name="tip"/>'
+            '<joint name="a-b" type="revolute"><parent link="base"/><child link="mid"/></joint>'
+            '<joint name="a.b" type="spherical"><parent link="mid"/><child link="tip"/></joint>'
+            "</robot>"
+        )
+        declared = jn.urdf_joint_names(str(path))
+        public, usd_to_urdf = jn.demangle_usd_joint_names(["a_b"], declared)
+        assert public == ["a-b"]
+        assert usd_to_urdf == {"a_b": "a-b"}
+
+
+class TestWhatTheRealTypesStillDo:
+    """Unchanged behaviour: every expectation here held before the fix too."""
+
+    def test_the_single_dof_types_are_reported_in_file_order(self, tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "arm.urdf"
+        path.write_text(
+            '<robot name="r">'
+            '<link name="l0"/><link name="l1"/><link name="l2"/><link name="l3"/><link name="l4"/>'
+            '<joint name="slide" type="prismatic"><parent link="l0"/><child link="l1"/></joint>'
+            '<joint name="weld" type="fixed"><parent link="l1"/><child link="l2"/></joint>'
+            '<joint name="spin" type="continuous"><parent link="l2"/><child link="l3"/></joint>'
+            '<joint name="hinge" type="revolute"><parent link="l3"/><child link="l4"/></joint>'
+            "</robot>"
+        )
+        assert jn.urdf_joint_names(str(path)) == ["slide", "spin", "hinge"]
+
+    @pytest.mark.parametrize("joint_type", ["fixed", "floating", "planar"])
+    def test_a_multi_dof_or_fixed_type_is_not_reported(self, tmp_path: pathlib.Path, joint_type: str) -> None:
+        assert jn.urdf_joint_names(_one_joint_urdf(tmp_path, joint_type)) == []
+
+    @pytest.mark.parametrize("joint_type", ["fixed", "floating", "planar"])
+    def test_the_loader_still_accepts_it_as_a_fixed_joint(self, tmp_path: pathlib.Path, joint_type: str) -> None:
+        robot = loaders.load_urdf(_one_joint_urdf(tmp_path, joint_type))
+        assert [(j.name, j.joint_type) for j in robot.joints] == [("j1", "fixed")]


### PR DESCRIPTION
## The two URDF readers in this package disagreed about one file

`strands_robots.simulation.isaac` reads a joint's `type` attribute out of a URDF
in two places.

`joint_names.urdf_joint_names` keeps the joints whose type produces a named
articulation DOF, and hands that list to `demangle_usd_joint_names` as the pool
of URDF names a mangled DOF name may decode to. `loaders.load_urdf` maps the
type onto a `JointDef` kind and **refuses** a type it does not recognise,
naming the set it accepts in the refusal - which makes it this package's own
record of what URDF declares.

The movable set carried `spherical`. URDF declares six joint types and that is
not one of them, so the two readers, handed the same one-joint file, disagreed:

| `type` | `urdf_joint_names` | `load_urdf` |
|---|---|---|
| `revolute` | `['j1']` | `j1 revolute` |
| `continuous` | `['j1']` | `j1 revolute` |
| `prismatic` | `['j1']` | `j1 prismatic` |
| `fixed` | `[]` | `j1 fixed` |
| `floating` | `[]` | `j1 fixed` |
| `planar` | `[]` | `j1 fixed` |
| `spherical` | **`['j1']`** | **`ValueError: unknown joint type (expected one of ['continuous', 'fixed', 'floating', 'planar', 'prismatic', 'revolute'])`** |

One reader called the joint movable; the other called the file unloadable, and
enumerated the accepted set in the message - a set that does not contain
`spherical`. `load_urdf`'s six keys are exactly URDF's six declared types.

## What a name from nowhere does to the decode

`demangle_usd_joint_names` draws translations from the pool
`urdf_joint_names` builds. A candidate in that pool that no URDF can declare
has two ways to do harm, and both are reachable from a file:

```
A) a spherical joint named "1"
   pool ['1']    DOF tn__1_ -> public ['1']       usd_to_urdf {'tn__1_': '1'}
   pool []       DOF tn__1_ -> public ['tn__1_']  usd_to_urdf {}

B) a revolute joint "a-b" beside a spherical joint "a.b"
   (both substitute to "a_b" under the legacy mangle)
   pool ['a-b','a.b']  DOF a_b -> public ['a_b']  usd_to_urdf {}
   pool ['a-b']        DOF a_b -> public ['a-b']  usd_to_urdf {'a_b': 'a-b'}
```

In A the public vocabulary reports the name of a joint the format cannot
express. B is the worse one: the spurious candidate makes the decode ambiguous,
an ambiguous decode keeps the USD name, and so the joint the URDF **really**
declares surfaces as `a_b` on `robot_joint_names`, on `get_observation` keys and
in `send_action` resolution. That is the #1900 leak this module exists to close,
reintroduced by a candidate URDF cannot declare.

## Reachability

Latent. No valid URDF carries the type, so no valid URDF reaches either harm:
none of the 68 URDFs the registry downloads declares one, and `load_urdf`
refuses such a file outright. What shipped wrong is the vocabulary and the
documented accepted set - `urdf_joint_names` is exported, and its docstring told
a caller that `spherical` produces a DOF.

## The change

`_MOVABLE_URDF_JOINT_TYPES` drops `spherical`; the docstring's accepted set and
the constant's comment are corrected with it. No behaviour changes for any type
URDF declares - the 6-row table above is identical before and after.

The set is now pinned **between** the loader's two answers:

```
{types the loader reads as moving}  <=  movable  <=  {types the loader recognises}
```

The upper bound refuses a type URDF does not declare. The lower bound refuses
dropping one that does move. The bounds are deliberately not collapsed into an
equality: were the importer found to surface a named DOF for a type the loader
reads as `fixed`, that belongs in the movable set without the loader's own
mapping changing.

The comment's reason for excluding `floating` and `planar` also said the
registry URDFs do not use them. Five of the 68 declare a `floating` base (a1,
aliengo, go1, laikago, b2), so that clause is corrected: the exclusion rests on
the importer not mapping a multi-DOF joint onto single named DOFs, which is why
the loader reads both as `fixed` too.

## Why nothing caught it

`test_urdf_joint_name_demangle.py` builds every fixture from `revolute`,
`continuous`, `prismatic` and `fixed` - the four types an author writing a URDF
reaches for. The vocabulary's fourth member and both of URDF's excluded real
types were never exercised, and no test read the constant at all. Every
mutation below leaves that suite and the three other URDF-reading suites green
except one, noted in the table.

## Tests

New `tests/simulation/isaac/test_urdf_joint_type_vocabulary.py`, 28 cases, no
Isaac Kit and no `pxr` (both readers are stdlib XML parsers). URDF's six
declared types are stated locally in the test rather than read from the code, so
the file is an independent oracle for the vocabulary.

Pre-fix split: **6 failed / 21 passed**, with 0 of the 2 premise cells, 0 of the
3 unchanged-behaviour cells and 0 of the 6 declared-type agreement cells firing.
The two headline failures read `assert ['1'] == ['tn__1_']` and
`assert ['a_b'] == ['a-b']`.

| mutation | fires | collected | pre-existing suites |
|---|---|---|---|
| control (fix intact) | 0 | 28 | 0 |
| full revert | 6 | 28 | 0 |
| constant reverted, docstring left correct | 7 | 28 | 0 |
| docstring reverted, constant left correct | 1 | 28 | 0 |
| a fourth invented type added (`screw`) | 5 | 28 | 0 |
| a real single-DOF type dropped (`prismatic`) | 5 | 28 | 5 |
| alternative fix: loader taught to accept `spherical` | 7 | 28 | 0 |
| set derived from the loader map in production | 0 | 28 | 0 |
| the test's own URDF oracle corrupted | 8 | 29 | 0 |

9 mutations, 8 distinct firing sets, source restored byte-identically.

Three rows carry the argument. **The alternative fix** - closing the
disagreement by teaching `load_urdf` about `spherical` instead - fires 7,
including the premise cell that the type map's keys are exactly URDF's declared
types: the direction of the fix is graded, not asserted. **Dropping a real
single-DOF type** fires the lower bound and trips 5 pre-existing tests, so the
sandwich is load-bearing in both directions. **Deriving the set from the loader
map in production** fires 0 - which is the honest reason it is not done here: a
derivation makes the guard vacuous and collapses the sandwich to an equality.

`collected` is recorded per row because a narrowed universe runs fewer tests
while still reporting success; the last row moves it 28 to 29.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1611 files).
- mypy **24 == 24** against a pristine worktree of the merge-base, normalized message sets byte-identical in both directions, 0 attributable to either changed file.
- Paired run over an identical 360-file selection (all of `tests/simulation/isaac/`, every guard that walks the tree or reads source, docstrings or `changelog.d`, and everything naming the two readers), the new file excluded from both trees and every path verified present on both: identical **16132 collected** and `4 failed, 15974 passed, 154 skipped` on each, 4 identical failing ids, `comm` empty in both directions. Those 4 pass **13/13 in isolation on both trees** - a module-caching artifact of the large selection, not a regression.
- No visual artifact: this changes a vocabulary and a refusal boundary, not a policy, a simulation, a render or a recording. The measured 6-row agreement table and the two decode readings are the evidence.
