### PR TITLE
test(deps): grade a system_install= remedy by its value, not the keyword's presence

### DIFF
--- a/changelog.d/2801-system-install-remedy-graded-by-value.md
+++ b/changelog.d/2801-system-install-remedy-graded-by-value.md
@@ -1,0 +1,54 @@
+### Tests: a `system_install=` remedy is graded by the string it carries, not the keyword's presence
+
+`tests/test_dependency_audit.py::test_require_optional_offers_no_pip_remedy_for_a_system_provided_module`
+exists because `rclpy` and `rosidl_runtime_py` are not published on PyPI, so every
+`pip install` line offered for them is an instruction a caller can follow to no
+effect: `pip install 'strands-robots[ros2]'` exits 0 having installed only the
+cyclonedds RMW binding and leaving the module exactly as missing, and
+`pip install rclpy` does not resolve at all. `require_optional(system_install=...)`
+replaces that block with the step that does supply the module, and the sweep
+required every such call site to pass it.
+
+It required the keyword and not the string. Those are different claims, and the
+gap is not narrow - measured against `require_optional` itself with the module
+made unimportable, three literals satisfy the keyword's presence and defeat what
+it is for:
+
+* `system_install=None` renders the pip block **byte-for-byte identical** to
+  omitting the keyword. It is the parameter's own default and inside its declared
+  `str | None` annotation, so it is the natural spelling for a caller forwarding a
+  per-platform hint that turned out to be absent - and it produces exactly the
+  message this sweep was written to forbid.
+* `system_install=""` (or any blank string) leaves the refusal naming the module
+  and carrying no remedy at all.
+* A non-string remedy replaces the documented failure: `str.join` raises
+  `TypeError`, so a caller writing `except ImportError` around an optional import
+  misses the refusal entirely.
+
+Both production sites pass a module-level constant, so nothing in the tree is an
+offender and this is a hole in the guard rather than a live defect. It is not
+covered elsewhere either. `test_the_rclpy_refusals_name_the_step_that_supplies_it`
+does assert on the real messages, which is why planting `system_install=None` at
+the `rclpy` site is caught - but it names two `rclpy` call sites explicitly, and
+`rosidl_runtime_py` is the other member of the set the sweep grades and has no
+behavioural test at all. Planting `require_optional("rosidl_runtime_py",
+system_install=None)` therefore fired nothing: the sweep reported the keyword as
+present and the suite passed.
+
+The rule now reads the value, through one predicate the sweep and the exemplars
+share, and each reason names the message that spelling really renders rather than
+only reporting that the value was rejected. Its boundary is deliberate: only a
+literal is judged. A name, an attribute or an f-string is the shipped form, whose
+text a syntax tree cannot know, so it is accepted here and left to the runtime
+tests in `tests/test_utils.py`. Because the tree holds no offender the corpus
+cannot exercise the new branch, so the exemplars grade the predicate directly -
+four accepted forms, five refused ones, and a non-vacuity check that the rule
+reaches both verdicts - with the consequence of each refused literal measured
+against `require_optional` beside them.
+
+`require_optional` is unchanged, and that is a measurement rather than an
+omission. Reading `system_install` for truth instead of for `None` would send a
+blank *and* a non-string remedy back to the pip block, which for these libraries
+is the dead-end instruction; the current `is not None` branch is the safer of the
+two, and the spellings that should never be written are now refused where they
+are written rather than absorbed where they are read.

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -14,6 +14,7 @@ import importlib.util
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
@@ -1138,15 +1139,51 @@ def test_the_lockfile_pins_a_diffusers_that_ships_the_omni_pipeline() -> None:
 _SYSTEM_PROVIDED_MODULES = frozenset({"rclpy", "rosidl_runtime_py"})
 
 
-def _require_optional_call_sites() -> list[tuple[str, int, str, set[str]]]:
-    """Every ``require_optional``/``require_optionals`` call site in the package.
+def _unusable_remedy_reason(value: ast.expr) -> str | None:
+    """Return why ``value`` cannot serve as a ``system_install=`` remedy.
+
+    Only a literal is judged. The shipped form is a reference to a module-level
+    constant, whose text is not knowable from the syntax tree, so a name, an
+    attribute or an f-string is accepted here and left to the runtime tests in
+    ``tests/test_utils.py``. A literal, though, is decidable, and three literals
+    that satisfy the keyword's *presence* defeat what it is for -- each reason
+    below names the message ``require_optional`` really renders for it.
+
+    Args:
+        value: The expression a call site passes as ``system_install=``.
 
     Returns:
-        One ``(relative path, line number, module name, keyword names)`` tuple
+        A reason naming the consequence, or ``None`` when the value is a usable
+        remedy or is not statically decidable.
+    """
+    if not isinstance(value, ast.Constant):
+        return None
+    literal = value.value
+    if literal is None:
+        return "is None, which renders the pip block verbatim - the message passing nothing gives"
+    if not isinstance(literal, str):
+        return (
+            f"is {type(literal).__name__} rather than a string, so str.join raises TypeError "
+            f"and the documented ImportError never reaches the caller"
+        )
+    if not literal.strip():
+        return "is blank, so the refusal names the module and carries no remedy at all"
+    return None
+
+
+def _require_optional_call_sites() -> list[tuple[str, int, str, dict[str, ast.expr]]]:
+    """Every ``require_optional``/``require_optionals`` call site in the package.
+
+    The keyword *values* are carried, not only their names: whether a remedy is
+    usable is a property of the string it names, so a caller that reads only the
+    names cannot tell a real hint from one that renders nothing.
+
+    Returns:
+        One ``(relative path, line number, module name, keyword-to-value)`` tuple
         per requested module -- the aggregate helper takes a list, so a single
         call can request several.
     """
-    sites: list[tuple[str, int, str, set[str]]] = []
+    sites: list[tuple[str, int, str, dict[str, ast.expr]]] = []
     for path in sorted((_REPO_ROOT / "strands_robots").rglob("*.py")):
         if "__pycache__" in path.parts:
             continue
@@ -1165,9 +1202,9 @@ def _require_optional_call_sites() -> list[tuple[str, int, str, set[str]]]:
                 modules = [e.value for e in first.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)]
             else:
                 continue
-            keywords = {kw.arg for kw in node.keywords if kw.arg}
+            remedies = {kw.arg: kw.value for kw in node.keywords if kw.arg}
             rel = path.relative_to(_REPO_ROOT).as_posix()
-            sites.extend((rel, node.lineno, module, keywords) for module in modules)
+            sites.extend((rel, node.lineno, module, remedies) for module in modules)
     return sites
 
 
@@ -1178,18 +1215,25 @@ def test_require_optional_offers_no_pip_remedy_for_a_system_provided_module() ->
     libraries every such line is an instruction the caller can follow to no
     effect. ``system_install`` replaces the block with the step that does supply
     the module, so passing it is what makes the refusal actionable.
+
+    What makes a refusal actionable is the string, not the keyword: a
+    ``system_install=`` carrying ``None`` renders the pip block byte-for-byte,
+    which is the message this guard exists to forbid. So the value is graded too,
+    by :func:`_unusable_remedy_reason`.
     """
     offenders: list[str] = []
     checked = 0
-    for rel, lineno, module, keywords in _require_optional_call_sites():
+    for rel, lineno, module, remedies in _require_optional_call_sites():
         if module.split(".")[0] not in _SYSTEM_PROVIDED_MODULES:
             continue
         checked += 1
-        pip_remedies = sorted(keywords & {"pip_install", "extra"})
+        pip_remedies = sorted(remedies.keys() & {"pip_install", "extra"})
         if pip_remedies:
             offenders.append(f"{rel}:{lineno} requests {module!r} but passes {', '.join(pip_remedies)}")
-        elif "system_install" not in keywords:
+        elif "system_install" not in remedies:
             offenders.append(f"{rel}:{lineno} requests {module!r} with no system_install= remedy")
+        elif (reason := _unusable_remedy_reason(remedies["system_install"])) is not None:
+            offenders.append(f"{rel}:{lineno} requests {module!r} but its system_install= {reason}")
     assert checked, (
         f"no require_optional site requests any of {sorted(_SYSTEM_PROVIDED_MODULES)}; "
         f"the sweep has stopped seeing them and would pass vacuously"
@@ -1200,6 +1244,143 @@ def test_require_optional_offers_no_pip_remedy_for_a_system_provided_module() ->
         "and exits 0, or a distribution name that does not resolve. Pass "
         "system_install=ROS2_SYSTEM_INSTALL_HINT instead.\n" + "\n".join(offenders)
     )
+
+
+# ---------------------------------------------------------------------------
+# A ``system_install=`` remedy is graded by the string it carries.
+#
+# The sweep above once asked only whether the keyword was present. Three
+# literals satisfy that and defeat what the keyword is for, one of them
+# byte-for-byte reproducing the message the sweep exists to forbid. Both
+# production sites pass a module-level constant, so nothing in the tree is an
+# offender today and the corpus cannot exercise the rule -- the exemplars below
+# grade the predicate directly instead, and the premises measure each refused
+# literal against ``require_optional`` itself.
+# ---------------------------------------------------------------------------
+
+#: A module name no distribution supplies, so ``require_optional`` always
+#: refuses it. Using an absent name rather than blocking a real one keeps these
+#: probes hermetic: nothing is patched, and no import cache is disturbed.
+_ABSENT_MODULE = "strands_robots_no_such_optional_dependency"
+
+#: Call sources whose ``system_install=`` the rule must accept. The first two are
+#: the shipped form (a reference to a constant, whose text the syntax tree cannot
+#: know); the rest are values that do name a step a caller can take.
+_ACCEPTED_REMEDIES = (
+    'require_optional("rclpy", system_install=ROS2_SYSTEM_INSTALL_HINT)',
+    'require_optional("rclpy", system_install=ros_telemetry.ROS2_SYSTEM_INSTALL_HINT)',
+    'require_optional("rclpy", system_install="Source a distro: source /opt/ros/jazzy/setup.bash")',
+    'require_optional("rclpy", system_install=f"Source {distro}/setup.bash")',
+)
+
+#: Call sources whose ``system_install=`` the rule must refuse, each with a
+#: phrase its reason has to carry so a reader learns the consequence, not just
+#: that the value was rejected. The phrases are chosen to distinguish the
+#: branches from one another: ``"None"`` would not, because the non-string branch
+#: reports ``NoneType`` and so satisfies it.
+_REFUSED_REMEDIES = (
+    ('require_optional("rclpy", system_install=None)', "pip block"),
+    ('require_optional("rclpy", system_install="")', "blank"),
+    ('require_optional("rclpy", system_install="   ")', "blank"),
+    ('require_optional("rclpy", system_install=0)', "TypeError"),
+    ('require_optional("rclpy", system_install=False)', "TypeError"),
+)
+
+
+def _remedy_node(source: str) -> ast.expr:
+    """Return the ``system_install=`` value node of a single-call ``source``.
+
+    Args:
+        source: One Python expression statement calling ``require_optional``.
+
+    Returns:
+        The expression the call passes as ``system_install=``.
+    """
+    statement = ast.parse(source).body[0]
+    assert isinstance(statement, ast.Expr), source
+    call = statement.value
+    assert isinstance(call, ast.Call), source
+    return next(kw.value for kw in call.keywords if kw.arg == "system_install")
+
+
+def _refusal_for(**overrides: Any) -> str:
+    """Return the ``ImportError`` text ``require_optional`` renders for an absent module.
+
+    Args:
+        **overrides: Keyword arguments forwarded verbatim, so a probe may pass a
+            value deliberately outside the declared ``str | None`` annotation.
+
+    Returns:
+        The refusal message.
+    """
+    from strands_robots import utils
+
+    with pytest.raises(ImportError) as raised:
+        utils.require_optional(_ABSENT_MODULE, purpose="a probe", **overrides)
+    return str(raised.value)
+
+
+@pytest.mark.parametrize("source", _ACCEPTED_REMEDIES)
+def test_a_usable_system_install_remedy_is_accepted(source: str) -> None:
+    """Over-reach control: grading the value must not refuse a real remedy."""
+    assert _unusable_remedy_reason(_remedy_node(source)) is None, source
+
+
+@pytest.mark.parametrize(("source", "expected_word"), _REFUSED_REMEDIES)
+def test_a_system_install_remedy_that_supplies_nothing_is_refused(source: str, expected_word: str) -> None:
+    """A literal that satisfies the keyword's presence but not its purpose."""
+    reason = _unusable_remedy_reason(_remedy_node(source))
+    assert reason is not None, source
+    assert expected_word in reason, f"{source} -> {reason!r} does not name {expected_word!r}"
+
+
+def test_the_remedy_rule_reaches_both_outcomes() -> None:
+    """Non-vacuity: the exemplars are not all judged the same way."""
+    verdicts = {
+        _unusable_remedy_reason(_remedy_node(source)) is None
+        for source in (*_ACCEPTED_REMEDIES, *(source for source, _ in _REFUSED_REMEDIES))
+    }
+    assert verdicts == {True, False}, f"the rule only ever answered {verdicts}"
+
+
+def test_a_none_remedy_renders_the_pip_block_it_exists_to_replace() -> None:
+    """Premise: ``system_install=None`` is byte-identical to omitting the keyword.
+
+    This is why ``None`` is refused rather than merely discouraged. The keyword
+    is present, so a presence check passes, and the message a caller reads is the
+    dead-end pip instruction the guard above was written to forbid.
+    """
+    with_none = _refusal_for(system_install=None)
+    assert with_none == _refusal_for(), "None must not be distinguishable from omitting the keyword"
+    assert f"pip install {_ABSENT_MODULE}" in with_none
+
+
+def test_a_blank_remedy_renders_no_remedy_at_all() -> None:
+    """Premise: a blank ``system_install=`` leaves the refusal with no next step."""
+    message = _refusal_for(system_install="")
+    assert message.strip() == f"'{_ABSENT_MODULE}' is required for a probe"
+    assert "pip install" not in message
+    assert "Install with:" not in message
+
+
+def test_a_non_string_remedy_replaces_the_documented_importerror() -> None:
+    """Premise: a non-string remedy raises ``TypeError`` from ``str.join``.
+
+    ``require_optional`` documents ``ImportError``, and a caller writing
+    ``except ImportError`` around an optional import misses this entirely.
+    """
+    from strands_robots import utils
+
+    overrides: dict[str, Any] = {"system_install": 0}
+    with pytest.raises(TypeError, match="expected str instance"):
+        utils.require_optional(_ABSENT_MODULE, purpose="a probe", **overrides)
+
+
+def test_a_real_remedy_replaces_the_pip_block() -> None:
+    """Premise: the accepted form does what the keyword promises."""
+    message = _refusal_for(system_install="Source a distro first.")
+    assert message.endswith("Source a distro first.")
+    assert "pip install" not in message
 
 
 def test_the_rclpy_refusals_name_the_step_that_supplies_it() -> None:


### PR DESCRIPTION
## Problem

`tests/test_dependency_audit.py::test_require_optional_offers_no_pip_remedy_for_a_system_provided_module`
exists because `rclpy` and `rosidl_runtime_py` are not on PyPI. Every `pip install`
line offered for them is an instruction the caller can follow to no effect:
`pip install 'strands-robots[ros2]'` exits 0 having installed only the cyclonedds
RMW binding and leaving the module exactly as missing, and `pip install rclpy` does
not resolve at all. `require_optional(system_install=...)` replaces that block with
the step that does supply the module, and the sweep required every such call site
to pass it.

It required the **keyword**, not the **string**:

```python
elif "system_install" not in keywords:
    offenders.append(...)
```

while the failure message it raises prescribes a specific value
(`Pass system_install=ROS2_SYSTEM_INSTALL_HINT instead`). Those are different
claims. Measured against `require_optional` itself, with the requested module made
unimportable:

| `system_install=` | message the caller reads | old guard |
|---|---|---|
| *omitted* | `Install with:` / `pip install <mod>` | flagged (correct) |
| `None` | `Install with:` / `pip install <mod>` -- **byte-identical to omitting it** | **passes** |
| `""` | `'<mod>' is required for ...` and nothing else | **passes** |
| `"   "` | the same, plus a blank line | **passes** |
| `0` | **`TypeError` from `str.join`**, not the documented `ImportError` | **passes** |
| `False` | the same `TypeError` | **passes** |
| a real hint | the hint | passes (correct) |

`None` is the parameter's own default and inside its declared `str | None`
annotation, so it is the natural spelling for a call site forwarding a
per-platform hint that turned out to be absent. It produces exactly the message
this sweep was written to forbid. The non-string rows are worse than wrong text:
`require_optional` documents `ImportError`, and a caller writing
`except ImportError` around an optional import misses the refusal entirely.

## Why nothing caught it

Both production sites pass a module-level constant, so the tree holds no offender
and this is a hole in the guard rather than a live defect. It is not covered
elsewhere either, and the boundary is exact.

`test_the_rclpy_refusals_name_the_step_that_supplies_it` does assert on the real
messages -- but it names **two `rclpy` call sites explicitly**
(`RosTelemetryBridge()` and `Robot._check_ros2_bridge_deps`). `rosidl_runtime_py`
is the other member of `_SYSTEM_PROVIDED_MODULES` and has no behavioural refusal
test at all. So planting an offending site for each member gives opposite answers:

| planted site | old guard | new guard |
|---|---|---|
| `require_optional("rclpy", system_install=None)` | 1 failure, from the behavioural sibling | 2 failures |
| `require_optional("rosidl_runtime_py", system_install=None)` | **0 -- silent, `39 passed, 1 skipped`** | 1, naming the site |
| `require_optional("rosidl_runtime_py", system_install="")` | **0 -- silent** | 1, naming the site |
| `require_optional("rosidl_runtime_py", system_install=ROS2_SYSTEM_INSTALL_HINT)` | 0 | 0 (no over-reach) |

## Change

The sweep already walked every call site; it discarded the keyword values. It now
carries them, and one predicate `_unusable_remedy_reason` decides whether a remedy
is usable, shared by the sweep and by the exemplars so the two cannot drift. Each
reason names the message that spelling really renders rather than only reporting
that the value was rejected.

Its boundary is deliberate: **only a literal is judged**. A name, an attribute or
an f-string is the shipped form, whose text a syntax tree cannot know, so it is
accepted here and left to the runtime tests in `tests/test_utils.py`.

Because the tree holds no offender, the corpus cannot exercise the new branch. The
exemplars grade the predicate directly instead -- 4 accepted forms, 5 refused ones,
and a non-vacuity check that the rule reaches both verdicts -- with the consequence
of each refused literal measured against `require_optional` beside them, using an
absent module name so the probes are hermetic (nothing patched, no import cache
disturbed).

`require_optional` itself is **unchanged**, and that is a measurement rather than
an omission: see the last mutation row.

## Mutations

Every row run against the whole file, with `collected` recorded so a silent
deselection cannot hide one. Control clean, source restored byte-identically
(md5-verified).

| mutation | fires | note |
|---|---|---|
| control (no mutation) | 0 | `53 passed, 1 skipped` |
| `None` branch dropped | 1 | the `None` exemplar |
| blank branch dropped | 2 | both blank exemplars |
| non-string branch dropped | 3 | both non-string exemplars + non-vacuity |
| predicate always accepts | 6 | every refused exemplar + non-vacuity |
| predicate always refuses | 4 | all 3 accepted-form controls + the corpus sweep |
| consumer reverted to presence-only, with the `None` plant | 1 | only the behavioural sibling; the sweep goes silent again |
| **runtime read for truth instead of `is not None`** | 2 | the tempting production change: a blank **and** a non-string remedy fall back to the pip block |

The last row is why production is untouched. `if system_install:` would send both
of those spellings to the dead-end pip line; `is not None` is the safer of the two
branches, and the spellings that should never be written are now refused where
they are written rather than absorbed where they are read.

One earlier version of the `None` exemplar expected the reason to contain
`"None"`, and the mutation that drops the `None` branch fired **0** against it --
the non-string branch reports `NoneType`, which satisfies that substring. The
expectation is now the phrase unique to that branch, and the row fires 1. The
tuple's comment records why.

## Gate

* `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ`.
* `mypy` **24 == 24** against a pristine worktree of the same base, normalized
  message sets byte-identical in both directions, 0 attributable to the changed file.
* Changed file: **53 passed, 1 skipped** (up from 40 collected).
* Paired run over an identical 524-file selection -- every test that walks the tree,
  parses source, reads docstrings, `pyproject.toml` or `changelog.d`, or names
  `require_optional`/`system_install` -- with the changed file excluded from both
  trees and every path verified present on both: identical **24731 collected** and
  **20 failed, 24606 passed, 105 skipped** on each, 20 identical failing ids, `comm`
  empty in both directions, distinct rootdirs. The 20 are pre-existing and
  classified: 17 need `awsiot` (`find_spec` False; declared in the `[mesh-iot]`
  extra) and 3 are lerobot-from-source `encode()` drift.

No visual artifact: this changes a static hygiene rule and no policy, simulation,
rendering, recording or asset behaviour. The measured message table is the evidence.
