### PR TITLE
fix(drivers): stop the Dynamixel codec citing a vendor unstuffer that loses a byte

### DIFF
--- a/changelog.d/2802-dynamixel-unstuff-vendor-divergence.md
+++ b/changelog.d/2802-dynamixel-unstuff-vendor-divergence.md
@@ -1,0 +1,24 @@
+### Fixed: the Dynamixel codec no longer cites a vendor unstuffer that loses a byte
+
+`strands_robots.drivers.dynamixel.protocol` opened with the claim that every
+function in it is verifiable against Robotis' `dynamixel_sdk` byte-for-byte, and
+`_unstuff` described itself as the mirror of the SDK's `removeStuffing`. Measured
+over every payload that can carry a Protocol 2.0 reserved run - 21760 cases,
+lengths four through seven over `{FF, FD, 00, 01}` - the two stuffers agree
+byte-for-byte, and the vendor's unstuffer is lossy on twelve of them. Its loop
+compacts the packet in place, so the two-byte look-back that decides whether an
+`FD` is an escape reads positions the loop has already overwritten; on a payload
+carrying two reserved runs it matches an `FF FF` that is no longer there and
+drops a data byte. The shortest witness is `FF FF FD FF FD FD`, which comes back
+from `removeStuffing` as `FF FF FD FF FD`.
+
+The shipped implementation is correct and is unchanged. What the docstrings did
+was point a future reader at the broken side as the thing to match: substituting
+the vendor algorithm for the shipped one leaves this module's own suite at 68
+passed, so the byte loss would have landed silently. Both docstrings now state
+the divergence and its cause, and the round-trip identity is graded over the
+whole reserved-run corpus rather than a hand-picked list - an escape and
+unescape pair that is not the identity is broken whichever implementation is
+older, which is the adjudicator the SDK cannot serve as. Two further cells
+consult the SDK to grade the divergence claim itself and skip where it is
+absent, since it is not a declared dependency.

--- a/strands_robots/drivers/dynamixel/protocol.py
+++ b/strands_robots/drivers/dynamixel/protocol.py
@@ -1,7 +1,10 @@
 """Dynamixel Protocol 2.0 wire format. Pure, no I/O.
 
 Every function here is verifiable against Robotis' ``dynamixel_sdk`` byte-for
--byte. The point of extracting the codec from the SDK is not to avoid the
+-byte, with one deliberate exception documented on :func:`_unstuff`: the SDK's
+``removeStuffing`` is not the inverse of its own ``addStuffing``, so grading
+against it would reintroduce a byte loss. The point of extracting the codec
+from the SDK is not to avoid the
 dependency - ``dynamixel_sdk`` is on PyPI and small - but to make the wire
 format part of the driver's own test surface. The SDK's parser lives inside
 ``PacketHandler.readTxRx`` and cannot be exercised without opening a port,
@@ -208,9 +211,29 @@ def _stuff(frame: bytes) -> bytes:
 def _unstuff(payload: bytes) -> bytes:
     """Remove Protocol 2.0 escape bytes from a received payload.
 
-    The inverse of :func:`_stuff`, and the mirror of Robotis'
-    ``removeStuffing``: a ``0xFD`` that follows a ``FF FF FD`` run is an
-    escape the servo inserted and is not part of the data.
+    The exact inverse of :func:`_stuff`: a ``0xFD`` that follows a ``FF FF FD``
+    run is an escape the servo inserted and is not part of the data.
+
+    This is the one function in the module that is **not** a port of its
+    ``dynamixel_sdk`` counterpart, and the divergence is deliberate. Robotis'
+    ``removeStuffing`` compacts the packet in place, so its two-byte look-back
+    reads buffer positions the same loop has already overwritten. On a payload
+    carrying two reserved runs it therefore matches an ``FF FF`` that is not
+    there and drops a data byte: ``FF FF FD FF FD FD`` survives this function
+    unchanged and comes back from ``removeStuffing`` as ``FF FF FD FF FD``.
+
+    What goes wrong there is the in-place compaction, not the choice of buffer:
+    reading the emitted output (as below) and reading the untouched input are
+    equivalent, because a stuffed payload still carries the run intact at the
+    position being examined. Only a buffer the same loop is rewriting can
+    answer with a byte that is no longer there. The round trip is therefore the
+    adjudicator rather than parity with the SDK: an escape/unescape pair that
+    is not the identity is broken whichever implementation is older.
+
+    Do not "restore parity" by porting ``removeStuffing`` in. The invariant to
+    preserve is that ``_unstuff`` recovers exactly what :func:`_stuff` was
+    given, for every payload including one carrying two reserved runs - not
+    agreement with the SDK, which does not hold that invariant itself.
 
     Args:
         payload: The bytes from ``INST`` through the last parameter of a

--- a/tests/drivers/test_dynamixel_unstuff_is_the_exact_inverse.py
+++ b/tests/drivers/test_dynamixel_unstuff_is_the_exact_inverse.py
@@ -1,0 +1,192 @@
+"""The Protocol 2.0 escape pair is the identity, and the vendor's is not.
+
+``strands_robots.drivers.dynamixel.protocol`` states in its module docstring
+that every function is verifiable against Robotis' ``dynamixel_sdk``
+byte-for-byte. That holds for the whole module except :func:`_unstuff`, whose
+SDK counterpart ``removeStuffing`` compacts the packet in place and therefore
+reads look-back positions its own loop has already overwritten. On a payload
+carrying two reserved runs it matches an ``FF FF`` that is not there and drops
+a data byte.
+
+The module's docstring used to name ``removeStuffing`` as the implementation
+this function mirrors, which is an instruction to port a byte loss in. Nothing
+graded the divergence: with the SDK's algorithm substituted for the shipped
+one, ``tests/drivers/test_dynamixel_driver.py`` is ``68 passed``.
+
+These cells fix the adjudicator rather than the parity. An escape/unescape pair
+that is not the identity is broken whichever implementation is older, so the
+round trip is what is asserted here - over every payload that can carry a
+reserved run, not over a hand-picked list. The two cells that consult the SDK
+skip where it is absent (it is not a declared dependency of this project); the
+identity cells need nothing but the module itself, so they run everywhere.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from strands_robots.drivers.dynamixel import protocol
+
+#: Bytes that can form or break the reserved ``FF FF FD`` run. A payload drawn
+#: from any wider alphabet reduces to one of these for the purpose of stuffing,
+#: so exhausting this alphabet exhausts the behaviour.
+_RESERVED_ALPHABET = (0xFF, 0xFD, 0x00, 0x01)
+
+#: Payload lengths short enough to exhaust and long enough to carry two runs.
+#: Six is the shortest length at which the vendor's look-back can read a byte
+#: it has already overwritten, so a corpus capped below six cannot see it.
+_LENGTHS = (4, 5, 6, 7)
+
+#: The shortest payload the vendor implementation mishandles. Two reserved runs
+#: sharing the ``FD`` that ends the first: the second run's escape is inserted
+#: at a position whose look-back the in-place compaction has already moved.
+_WITNESS = bytes.fromhex("fffffdfffdfd")
+
+
+def _frame(payload: bytes) -> bytes:
+    """Wrap ``payload`` in a Protocol 2.0 frame with an unstuffed ``LEN``.
+
+    Args:
+        payload: The ``INST`` through last-parameter bytes.
+
+    Returns:
+        ``HEADER RESERVED ID LEN_L LEN_H`` followed by ``payload``, with
+        ``LEN`` holding the count the format requires (payload plus the two
+        CRC bytes that are appended later).
+    """
+    declared = len(payload) + 2
+    header = (0xFF, 0xFF, 0xFD, 0x00, 0x01, declared & 0xFF, (declared >> 8) & 0xFF)
+    return bytes(header) + payload
+
+
+def _round_trip(payload: bytes) -> bytes:
+    """Stuff ``payload`` into a frame and unstuff it back out.
+
+    Args:
+        payload: The bytes to send through both halves of the escape pair.
+
+    Returns:
+        What :func:`~strands_robots.drivers.dynamixel.protocol._unstuff`
+        recovers from the stuffed frame.
+    """
+    stuffed = protocol._stuff(_frame(payload))
+    return protocol._unstuff(stuffed[protocol._INST_INDEX :])
+
+
+def _every_payload() -> list[bytes]:
+    """Return every payload over the reserved alphabet at the graded lengths."""
+    return [
+        bytes(combination)
+        for length in _LENGTHS
+        for combination in itertools.product(_RESERVED_ALPHABET, repeat=length)
+    ]
+
+
+class TestTheEscapePairIsTheIdentity:
+    """The property that makes the codec usable, asserted over a full corpus.
+
+    This is the pin. It passes on the shipped implementation and fails on any
+    edit that adopts the vendor's look-back, which is the edit the old
+    docstring invited.
+    """
+
+    def test_the_corpus_is_large_enough_to_contain_a_double_run(self) -> None:
+        payloads = _every_payload()
+        assert len(payloads) == 21760
+        doubles = [p for p in payloads if p.count(b"\xff\xff\xfd") >= 2]
+        assert doubles, "a corpus with no doubled reserved run cannot see the divergence"
+        assert _WITNESS in payloads
+
+    def test_every_payload_survives_the_escape_pair_unchanged(self) -> None:
+        lossy = [p.hex() for p in _every_payload() if _round_trip(p) != p]
+        assert lossy == []
+
+    def test_the_shortest_mishandled_payload_survives(self) -> None:
+        assert _round_trip(_WITNESS) == _WITNESS
+
+    def test_a_payload_with_no_reserved_run_is_returned_byte_for_byte(self) -> None:
+        plain = bytes(range(0x10, 0x20))
+        assert protocol._unstuff(plain) == plain
+
+
+class TestTheVendorImplementationIsTheOneThatDiverges:
+    """Grade the divergence the docstring now claims, against the SDK itself.
+
+    Without these cells the docstring's account of ``removeStuffing`` is prose
+    nobody checks, and a reader has no way to tell a deliberate divergence
+    from drift.
+    """
+
+    @pytest.fixture
+    def handler(self) -> object:
+        sdk = pytest.importorskip(
+            "dynamixel_sdk.protocol2_packet_handler",
+            reason="dynamixel_sdk is not a declared dependency; the identity cells cover the module",
+        )
+        return sdk.Protocol2PacketHandler()
+
+    @staticmethod
+    def _vendor_unstuff(handler: object, stuffed: bytes) -> bytes:
+        """Run the SDK's ``removeStuffing`` over a stuffed frame."""
+        packet = list(stuffed) + [0x00, 0x00]
+        out = handler.removeStuffing(packet)  # type: ignore[attr-defined]
+        declared = out[5] | (out[6] << 8)
+        return bytes(out[protocol._INST_INDEX : protocol._INST_INDEX + declared - 2])
+
+    def test_the_two_stuffers_agree_byte_for_byte(self, handler: object) -> None:
+        """The control: the divergence is in the unstuffer alone."""
+        disagreed = []
+        for payload in _every_payload():
+            ours = protocol._stuff(_frame(payload))
+            theirs = bytes(handler.addStuffing(list(_frame(payload)) + [0x00, 0x00]))  # type: ignore[attr-defined]
+            if ours != theirs[: len(ours)]:
+                disagreed.append(payload.hex())
+        assert disagreed == []
+
+    def test_the_vendor_unstuffer_drops_a_byte_on_the_witness(self, handler: object) -> None:
+        stuffed = protocol._stuff(_frame(_WITNESS))
+        assert self._vendor_unstuff(handler, stuffed) == bytes.fromhex("fffffdfffd")
+
+    def test_the_vendor_round_trip_is_not_the_identity(self, handler: object) -> None:
+        """Measured through the SDK's own stuffer, so our code is not in the loop."""
+        lossy = []
+        for payload in _every_payload():
+            theirs = bytes(handler.addStuffing(list(_frame(payload)) + [0x00, 0x00]))  # type: ignore[attr-defined]
+            if self._vendor_unstuff(handler, theirs[: len(protocol._stuff(_frame(payload)))]) != payload:
+                lossy.append(payload.hex())
+        assert len(lossy) == 12
+        assert _WITNESS.hex() in lossy
+
+
+class TestTheDocstringsNameTheDivergence:
+    """A reader who follows the module's own instruction must not port the bug.
+
+    These are the cells the change is for. The behaviour above was already
+    correct; what was missing was any statement that the SDK is the wrong
+    oracle for this one function, and any grading of that statement.
+    """
+
+    @staticmethod
+    def _flat(text: str | None) -> str:
+        """Collapse a docstring's wrapping so a phrase can be matched across lines."""
+        return " ".join((text or "").split())
+
+    def test_the_unstuff_docstring_does_not_present_the_vendor_as_its_model(self) -> None:
+        doc = self._flat(protocol._unstuff.__doc__)
+        assert "the mirror of Robotis' ``removeStuffing``" not in doc
+
+    def test_the_unstuff_docstring_states_that_it_diverges_deliberately(self) -> None:
+        doc = self._flat(protocol._unstuff.__doc__)
+        assert "not** a port" in doc or "not* a port" in doc or "not a port" in doc
+        assert "removeStuffing" in doc, "the divergence must name what it diverges from"
+
+    def test_the_unstuff_docstring_warns_against_restoring_parity(self) -> None:
+        doc = self._flat(protocol._unstuff.__doc__)
+        assert "Do not" in doc and "removeStuffing" in doc
+
+    def test_the_module_docstring_qualifies_its_byte_for_byte_claim(self) -> None:
+        doc = self._flat(protocol.__doc__)
+        assert "verifiable against Robotis' ``dynamixel_sdk`` byte-for -byte" in doc
+        assert "exception" in doc, "an unqualified claim sends a reader to the wrong oracle"


### PR DESCRIPTION
`strands_robots.drivers.dynamixel.protocol` opened with "Every function here is
verifiable against Robotis' `dynamixel_sdk` byte-for-byte", and `_unstuff`
described itself as "the mirror of Robotis' `removeStuffing`". The first claim
has one exception and the second names it: the vendor's unstuffer is not the
inverse of the vendor's own stuffer, so a reader who follows that instruction
ports a byte loss in.

The shipped implementation is correct and is unchanged. This corrects the two
docstrings and grades the property that makes it correct.

## The vendor's escape pair is not the identity

Exhaustive over every payload that can carry a Protocol 2.0 reserved run -
lengths 4 through 7 over `{FF, FD, 00, 01}`, **21760 payloads** - with the SDK
installed as an oracle (`dynamixel-sdk` 4.0.5, pure Python, no hardware, no
serial port):

| measurement | result |
| --- | --- |
| `_stuff` vs `addStuffing`, byte-for-byte | **0 divergences** (the control) |
| `_unstuff(_stuff(x)) == x` | **0 lossy** |
| `removeStuffing(addStuffing(x)) == x` | **12 lossy** |
| `_unstuff` vs `removeStuffing` over the same stuffed bytes | **12 divergences** |

The vendor round trip is measured through the SDK's **own** stuffer, so none of
this project's code is in that loop. The two stuffers agreeing on all 21760 is
what localises the divergence to the unstuffer alone.

Shortest witness, `FF FF FD FF FD FD`:

```
_unstuff(_stuff(...))        -> fffffdfffdfd   (identity)
removeStuffing(addStuffing)  -> fffffdfffd     (one byte short)
```

## Why: it compacts in place and reads what it has overwritten

`addStuffing` writes into a separate `temp` buffer, so its look-back reads the
original packet. `removeStuffing` compacts in place:

```python
packet[index] = packet[i + PKT_INSTRUCTION]      # index <= i + PKT_INSTRUCTION
...
and (packet[i + PKT_INSTRUCTION - 1] == 0xFF)    # may already have been rewritten
and (packet[i + PKT_INSTRUCTION - 2] == 0xFF)
```

With two reserved runs in one payload the second run's escape sits at a position
whose two preceding bytes the loop has already moved, so the condition matches an
`FF FF` that is no longer there and a data byte is dropped as if it were an
escape. Asymmetric quality inside one vendor module, which is why five of six
comparisons here are byte-perfect and one is not.

One thing the mutation table below corrected in my own first draft: the defect is
the in-place compaction, **not** the choice of buffer. Reading the untouched
input is equivalent to reading the emitted output (row b3 fires nothing), because
a stuffed payload still carries the run intact at the position being examined.
Only a buffer the same loop is rewriting can answer with a byte that is no longer
there. The docstring says that, rather than the stronger claim I first wrote.

## Nothing graded it, and the docstring pointed at the broken side

Substituting the vendor algorithm for the shipped one - a port verified faithful
to the real `removeStuffing` on **21760 of 21760** payloads, and lossy on 12 -
leaves `tests/drivers/test_dynamixel_driver.py` at **68 passed**. So the edit the
old docstring invited lands green.

## What changed

- The module docstring's byte-for-byte claim now names its one exception.
- `_unstuff`'s docstring states the divergence, its cause, the witness, and the
  invariant to preserve instead of parity. It describes that invariant inline
  rather than citing a test filename, which
  `tests/test_docstrings_no_dangling_doc_refs.py` refuses - my first draft cited
  the file and the paired gate caught it.
- A new suite asserts the round trip over the whole corpus rather than a
  hand-picked list. An escape/unescape pair that is not the identity is broken
  whichever implementation is older, so the round trip is the adjudicator the SDK
  cannot serve as. Three cells consult the SDK to grade the divergence claim
  itself and skip where it is absent, since it is not a declared dependency of
  this project: **11 passed** with it installed, **8 passed / 3 skipped**
  without, so the identity cells run in CI either way.

## Pre-fix split

Both docstrings reverted, every test kept: **4 failed / 7 passed**. All four are
in `TestTheDocstringsNameTheDivergence`; `0 of 4` in `TestTheEscapePairIsTheIdentity`
and `0 of 3` in `TestTheVendorImplementationIsTheOneThatDiverges`, which is
correct - the behaviour was already right and those cells are the pin.

## Mutations

`new` is the added suite, `sib` is `tests/drivers/test_dynamixel_driver.py`.
`coll` is 11 on every row, so nothing is hidden by a deselection.

| mutation | new | sib | firing |
| --- | --- | --- | --- |
| control | 0 | 0 | |
| both docstrings reverted | 4 | 0 | the four docstring cells |
| `_unstuff` ports `removeStuffing` | 2 | 0 | corpus identity, witness identity |
| `_unstuff` look-back reads the input, not the emitted output | 0 | 0 | equivalent - see above |
| corpus lengths capped below six | 2 | 0 | corpus premise, vendor round trip |
| witness replaced by a single-run payload | 2 | 0 | both vendor cells |
| `_stuff` look-back reads the output | 0 | 0 | the claimed-equivalent form, measured |

`sib` is **0 on all seven rows**: the pre-existing suite cannot see any of this,
which is the reason the divergence survived. Rows b3 and b6 are measured zeros
with structural reasons rather than gaps - b6 grades a claim `_stuff`'s own
docstring already makes, and b3 is what made me weaken my account of the cause.
Both source files restored byte-identically (md5) after the run.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests`
  (1556 files already formatted).
- `mypy` **24 == 24** against the merge base, normalized message sets
  byte-identical in both directions, **0 attributable** to the changed files
  (`checked 1608` vs `1607`, the one new file).
- Paired 146-file selection (all of `tests/drivers/`, plus every suite that walks
  the tree, parses source or reads docstrings, `Args:`/`Raises:` blocks or
  cross-reference roles): identical **6078 collected** on both trees with the new
  file excluded from each, **6022 passed, 56 skipped, 0 failed**, and `comm`
  empty in **both** directions - zero failures on either side.
- `tests/drivers/` is **429 passed** with the SDK present and **426 passed,
  3 skipped** without.
- Changelog and docs gates: 89 passed; fragment resolves in the assembled log.

No visual artifact: this changes two docstrings and adds tests, none of the
surfaces that call for one. The measured divergence table and the mutation table
are the evidence.
