### PR TITLE
fix(simulation): name every registered asset in the listing that advertises it

### DIFF
--- a/changelog.d/2803-registered-assets-appear-in-the-listing.md
+++ b/changelog.d/2803-registered-assets-appear-in-the-listing.md
@@ -1,0 +1,26 @@
+### Fixed: a registered asset is named by the listing that advertises it
+
+`list_urdfs` is the discovery entry point an agent uses to learn what it can spawn without guessing
+a model name, and its docstring promises "built-in *and* user-registered". It returns
+`list_available_models`, which promises "Menagerie + custom" and returned the asset-manager table
+alone whenever the asset manager was importable -- which is every normal install, so the two halves
+were an either/or rather than a union. The half that was dropped was the one the caller had just
+written. `register_urdf("widget_arm", path)` answers `Registered 'widget_arm' -> <path>` followed by
+`Resolved: <path>`, `resolve_urdf` returns that path, `list_registered_urdfs` maps the name to it,
+and `add_robot` spawns it -- and `list_urdfs` reported 76 lines of built-in robots with no mention of
+`widget_arm`. `add_robot`'s own unresolved-model message sends the caller to `list_urdfs` to "pick a
+registered model", so the documented recovery path pointed at the one surface that denied the
+registration existed.
+
+Both halves are now reported: the built-in table leads, then a `Registered URDFs:` section naming
+each registration and whether it currently resolves (`[OK]` / `[MISSING]`). A dangling registration
+is reported rather than dropped, since a path typo is the likelier mistake and the listing is where
+it is visible. The section is omitted entirely when nothing has been registered, so a default
+install's listing is byte-for-byte what it was. The row format is written down once, in a helper both
+branches call, so the asset-manager branch and the asset-manager-absent branch cannot drift into two
+vocabularies for the same rows -- the shipped fallback test now grades the format for both.
+
+The custom half was only ever exercised through the asset-manager-*absent* branch, reached by
+monkeypatching `_HAS_ASSET_MANAGER` to `False`, which no real install takes; the present-branch test
+asserted only that the built-in columns appear. That is why the suite was green, and reverting this
+change fails none of the surrounding model-registry, foundation, MuJoCo or Newton discovery suites.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -316,8 +316,8 @@ Destructive - writes into model arrays. Recompile scene to undo.
 
 | Action | Notes |
 |--------|-------|
-| `list_urdfs` | Loaded URDFs/MJCFs in current world |
-| `register_urdf(name, path)` | Register additional asset |
+| `list_urdfs` | Built-in robot table, plus a `Registered URDFs:` section naming every `register_urdf` asset and whether it resolves |
+| `register_urdf(name, path)` | Register additional asset - it is named by `list_urdfs` from then on |
 | `get_features(robot_name=None)` | Joint / actuator / camera / robot names of the scene (scoped to one robot with `robot_name`) - the source of truth for the action keys a policy must emit, and the feature schema used for recording |
 
 !!! tip "Discover the expected action keys"

--- a/strands_robots/simulation/model_registry.py
+++ b/strands_robots/simulation/model_registry.py
@@ -153,17 +153,48 @@ def list_registered_urdfs() -> dict[str, str | None]:
     return {config_name: resolve_urdf(config_name) for config_name in _URDF_REGISTRY}
 
 
-def list_available_models() -> str:
-    """List all available robot models (Menagerie + custom)."""
-    if _HAS_ASSET_MANAGER:
-        return str(format_robot_table())
+def _registered_urdf_lines() -> list[str]:
+    """One ``[OK]`` / ``[MISSING]`` line per user-registered URDF.
 
-    lines = ["Registered URDFs:"]
+    Single-sources the section :func:`list_available_models` appends, so the
+    built-in-table branch and the asset-manager-absent branch cannot drift into
+    two vocabularies for the same rows.
+
+    Returns:
+        One line per entry in the runtime registry, in registration order.
+        Empty when nothing has been registered.
+    """
+    lines: list[str] = []
     for name, path in _URDF_REGISTRY.items():
-        resolved = resolve_urdf(name)
-        status = "[OK]" if resolved else "[MISSING]"
+        status = "[OK]" if resolve_urdf(name) else "[MISSING]"
         lines.append(f"{status} {name}: {path}")
-    return "\n".join(lines)
+    return lines
+
+
+def list_available_models() -> str:
+    """List all available robot models (Menagerie + custom).
+
+    Both halves are always reported. The asset-manager table alone used to be
+    returned whenever the asset manager was importable - which is every normal
+    install - so a caller who had just registered an asset with
+    :func:`register_urdf` was told by the discovery surface that it did not
+    exist, while :func:`resolve_urdf` resolved it and ``add_robot`` spawned it.
+    The registered section is omitted entirely when nothing is registered, so a
+    default install's listing is unchanged.
+
+    Returns:
+        The built-in robot table, followed by a ``Registered URDFs:`` section
+        when :func:`register_urdf` has been called. Without the asset manager
+        only the registered section is available, so that is returned alone.
+    """
+    registered = _registered_urdf_lines()
+    if _HAS_ASSET_MANAGER:
+        table = str(format_robot_table())
+        if registered:
+            table += "\n\nRegistered URDFs:\n" + "\n".join(registered)
+        return table
+
+    return "\n".join(["Registered URDFs:", *registered])
 
 
 def count_sim_robots() -> int:

--- a/tests/simulation/test_registered_asset_appears_in_the_listing.py
+++ b/tests/simulation/test_registered_asset_appears_in_the_listing.py
@@ -1,0 +1,170 @@
+"""A ``register_urdf`` asset is named by the listing that advertises it.
+
+``MuJoCoSimEngine.list_urdfs`` is the discovery entry point an agent uses to
+learn what it can spawn, and its docstring promises "built-in *and*
+user-registered". It returns
+:func:`strands_robots.simulation.model_registry.list_available_models`, which
+promises "Menagerie + custom" and used to return the asset-manager table
+alone whenever the asset manager was importable - which is every normal
+install. So the two halves were an either/or, and the half that was dropped
+was the one the caller had just written:
+``register_urdf`` reported ``Registered ... Resolved: <path>``,
+``resolve_urdf`` resolved it, ``add_robot`` spawned it, and the listing denied
+it existed. ``add_robot``'s own unresolved-model message sends the caller to
+``list_urdfs`` to "pick a registered model", so the recovery path pointed at
+the listing that omitted the registration.
+
+The custom half was graded only through the asset-manager-*absent* branch
+(``monkeypatch.setattr(mr, "_HAS_ASSET_MANAGER", False)``), a branch that never
+executes in a real install, and the present-branch test asserted only that the
+built-in columns appear. That is why the suite was green.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.simulation.model_registry as mr
+
+_SECTION = "Registered URDFs:"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give every case its own runtime registry.
+
+    ``_URDF_REGISTRY`` is a module global that ``register_urdf`` mutates and
+    that no shipped test clears, so without this a case would read whatever
+    earlier files registered.
+    """
+    monkeypatch.setattr(mr, "_URDF_REGISTRY", {})
+
+
+def _asset(tmp_path: Path, name: str) -> Path:
+    path = tmp_path / f"{name}.xml"
+    path.write_text("<mujoco/>")
+    return path
+
+
+class TestThePremise:
+    """The configuration under test is the one that ships."""
+
+    def test_the_asset_manager_is_importable_here(self) -> None:
+        """Otherwise these cases would grade the fallback branch instead."""
+        assert mr._HAS_ASSET_MANAGER is True
+
+    def test_a_registered_asset_really_resolves(self, tmp_path: Path) -> None:
+        """The listing is the only surface that disagreed - resolution worked."""
+        asset = _asset(tmp_path, "premise_arm")
+        mr.register_urdf("premise_arm", str(asset))
+
+        assert mr.resolve_urdf("premise_arm") == str(asset)
+        assert mr.list_registered_urdfs()["premise_arm"] == str(asset)
+
+
+class TestARegisteredAssetIsNamedByTheListing:
+    """The regression: what was written is what is read back."""
+
+    def test_the_listing_names_a_registered_asset(self, tmp_path: Path) -> None:
+        asset = _asset(tmp_path, "widget_arm")
+        mr.register_urdf("widget_arm", str(asset))
+
+        out = mr.list_available_models()
+
+        assert "widget_arm" in out
+        assert f"[OK] widget_arm: {asset}" in out
+
+    def test_a_registered_asset_that_does_not_resolve_is_marked_missing(self) -> None:
+        """A dangling registration is reported, not dropped - it is the likelier typo."""
+        mr.register_urdf("ghost_arm", "/no/such/file.xml")
+
+        out = mr.list_available_models()
+
+        assert "[MISSING] ghost_arm: /no/such/file.xml" in out
+
+    def test_every_registered_asset_is_named_not_just_the_first(self, tmp_path: Path) -> None:
+        for name in ("alpha_arm", "beta_arm", "gamma_arm"):
+            mr.register_urdf(name, str(_asset(tmp_path, name)))
+
+        out = mr.list_available_models()
+
+        assert [n for n in ("alpha_arm", "beta_arm", "gamma_arm") if n not in out] == []
+
+    def test_the_registered_section_follows_the_built_in_table(self, tmp_path: Path) -> None:
+        """Appended, not prepended - the built-in table stays the listing's lead."""
+        mr.register_urdf("widget_arm", str(_asset(tmp_path, "widget_arm")))
+
+        out = mr.list_available_models()
+
+        assert out.index("Name") < out.index(_SECTION)
+
+    def test_the_engine_discovery_surface_names_it(self, tmp_path: Path) -> None:
+        """``list_urdfs`` is the agent-facing route, and the one whose docstring promises the union."""
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation import create_simulation
+
+        asset = _asset(tmp_path, "engine_arm")
+        # ``create_simulation`` is annotated ``SimEngine``; the discovery pair
+        # under test is declared on the MuJoCo engine, not on the base class.
+        sim: Any = create_simulation("mujoco")
+        assert sim.register_urdf("engine_arm", str(asset))["status"] == "success"
+
+        text = sim.list_urdfs()["content"][0]["text"]
+
+        assert "engine_arm" in text
+
+
+class TestTheBuiltInListingIsUnchanged:
+    """Naming the registered assets must not cost the built-in table."""
+
+    def test_the_built_in_table_is_still_reported(self, tmp_path: Path) -> None:
+        mr.register_urdf("widget_arm", str(_asset(tmp_path, "widget_arm")))
+
+        out = mr.list_available_models()
+
+        assert "Name" in out and "Category" in out
+
+    def test_an_empty_registry_adds_no_section(self) -> None:
+        """A default install's listing is byte-for-byte what it was."""
+        assert _SECTION not in mr.list_available_models()
+
+    def test_a_name_that_was_never_registered_is_not_claimed(self, tmp_path: Path) -> None:
+        mr.register_urdf("widget_arm", str(_asset(tmp_path, "widget_arm")))
+
+        assert "unregistered_arm" not in mr.list_available_models()
+
+    def test_the_fallback_branch_still_reports_both_states(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the asset manager the registered section is the whole listing."""
+        mr.register_urdf("present_arm", str(_asset(tmp_path, "present_arm")))
+        mr.register_urdf("absent_arm", "/no/such/file.xml")
+        monkeypatch.setattr(mr, "_HAS_ASSET_MANAGER", False)
+
+        out = mr.list_available_models()
+
+        assert out.startswith(_SECTION)
+        assert "[OK] present_arm" in out
+        assert "[MISSING] absent_arm" in out
+
+
+class TestOneVocabularyForTheRegisteredSection:
+    """Both branches render the rows through one helper, so they cannot drift."""
+
+    def test_the_row_format_is_written_down_once(self) -> None:
+        source = Path(mr.__file__).read_text(encoding="utf-8")
+
+        assert source.count('"[OK]"') == 1
+        assert source.count('"[MISSING]"') == 1
+
+    def test_the_listing_renders_no_row_of_its_own(self) -> None:
+        import inspect
+
+        body = inspect.getsource(mr.list_available_models)
+
+        assert "[OK]" not in body
+        assert "[MISSING]" not in body
+        assert "_registered_urdf_lines()" in body


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.list_urdfs` is the discovery entry point an agent uses to learn what it can spawn without guessing a model name, and its docstring promises "List every robot/URDF known to the registry (**built-in + user-registered**)" and "`register_urdf` adds a new one". It returns `model_registry.list_available_models`, whose own docstring promises "**Menagerie + custom**". `docs/simulation/newton.md` states the round trip outright: "`list_urdfs()` / `register_urdf(data_config, urdf_path)` read from and write to the shared model registry".

The implementation returned the asset-manager table **alone** whenever the asset manager was importable, which is every normal install (`_HAS_ASSET_MANAGER` measures `True`). So the two halves were an either/or rather than a union, and the half that was dropped was the one the caller had just written.

Measured on `upstream/main`, registering two assets and re-reading the listing:

| | `main` | this branch |
|---|---|---|
| `register_urdf` reports it resolves | yes | yes |
| `resolve_urdf("widget_arm")` | the path | the path |
| `list_registered_urdfs()` | resolves / dangling | resolves / dangling |
| listing lines before -> after | **76 -> 76** | 76 -> 80 |
| listing names `widget_arm` | **no** | yes |
| listing names the dangling `ghost_arm` | **no** | yes |
| `sim.list_urdfs()` names `widget_arm` | **no** | yes |

Registering two assets changed the listing by zero lines. `register_urdf` answers `Registered 'widget_arm' -> <path>` followed by `Resolved: <path>`, `add_robot` spawns it, and the discovery surface reports 76 lines of built-in robots with no mention of it. `add_robot`'s own unresolved-model message sends the caller to `list_urdfs` to "pick a registered model", so the documented recovery path pointed at the one surface that denied the registration existed.

## Change

`list_available_models` reports both halves: the built-in table leads, then a `Registered URDFs:` section naming each registration and whether it currently resolves.

```
Name                 Category        Joints   Sim   Real  Description
...
Total: 72 robots | Aliases: 119

Registered URDFs:
[OK] widget_arm: /tmp/.../widget_arm.xml
[MISSING] ghost_arm: /no/such/file.xml
```

Three decisions, each pinned by a mutation below:

- **A dangling registration is reported, not dropped.** A path typo is the likelier mistake and the listing is where it is visible.
- **The section is omitted when nothing is registered**, so a default install's listing is byte-for-byte what it was (76 lines, unchanged).
- **The row format is written down once**, in `_registered_urdf_lines`, which both the asset-manager branch and the asset-manager-absent branch call. They cannot drift into two vocabularies for the same rows, and the shipped fallback test now grades the format for both.

`docs/simulation/overview.md`'s registry table described `list_urdfs` as "Loaded URDFs/MJCFs in current world", which is neither what it read before nor what it reads now; it is corrected to describe the listing.

## Why the suite was green

The custom half was only ever exercised through the asset-manager-**absent** branch, reached by `monkeypatch.setattr(mr, "_HAS_ASSET_MANAGER", False)` - a branch no real install takes. The present-branch test asserted only that the built-in columns appear. So the one configuration that ships was the one nothing graded.

Reverting the fix fails **0** tests in `tests/simulation/test_model_registry.py`, `test_foundation.py`, `mujoco/test_simulation.py` or `newton/test_discovery_and_state.py` (the `sib` column below).

## Tests

`tests/simulation/test_registered_asset_appears_in_the_listing.py`, 13 cases. Pre-fix split against `upstream/main`: **6 failed, 7 passed**.

| class | role | failed/total pre-fix |
|---|---|---|
| `TestThePremise` | premise | 0/2 |
| `TestARegisteredAssetIsNamedByTheListing` | regression | 5/5 |
| `TestTheBuiltInListingIsUnchanged` | control / over-reach | 0/4 |
| `TestOneVocabularyForTheRegisteredSection` | structural | 1/2 |

Every case gets its own `_URDF_REGISTRY` through an autouse fixture: it is a module global that `register_urdf` mutates and that no shipped test clears, so without that a case would read whatever earlier files registered.

## Mutation table

9 mutations, 8 distinct firing sets, none undetected, `collected` stable at 13, source restored byte-identical. `sib` counts failures in the four pre-existing suites above.

| | mutation | mine | sib |
|---|---|---|---|
| b0 | control - no mutation | 0 | 0 |
| b1 | the whole fix reverted to `upstream/main` | 6 | **0** |
| b2 | section computed, never appended to the table | 5 | 0 |
| b3 | section prepended instead of appended | 1 | 0 |
| b4 | rows re-derived inline in the listing, helper unused | 2 | 0 |
| b5 | unresolvable registrations dropped from the section | 2 | 1 |
| b6 | only the first registration listed | 2 | 1 |
| b7 | empty-registry guard dropped - section always appended | 1 | 0 |
| b8 | resolution not consulted - every row reported `[OK]` | 3 | 1 |
| b9 | fallback branch re-derives its own rows | 2 | 0 |

b4 and b9 share a firing set for a structural reason: both mean the row format is written down twice, so the same two single-sourcing cells report it. b7 fires only the empty-registry control, which is what keeps the section from becoming noise on a default install. b5/b6/b8 each fire one **pre-existing** test - a consequence of the single-sourcing, since the shipped fallback test now grades the shared helper.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1612 files).
- mypy **24 == 24** against a pristine worktree of the same base, normalized message sets byte-identical in both directions, 0 attributable to the changed files.
- Paired run over an identical 782-file selection (all of `tests/simulation/`, every guard that walks the tree / parses source / reads docstrings, `docs/` or `changelog.d/`, and everything naming the model registry), the new file excluded from both: identical **28568 collected** and `25 failed, 28282 passed, 261 skipped` on each tree, **25 identical failing ids, `comm` empty in both directions**, distinct rootdirs.
- All 25 classified by measurement, not assumption: 17 in `tests/mesh/test_iot_*` need `awsiot` / `awscrt` (`find_spec` False, declared in the `[mesh-iot]` extra); 3 in `tests/training/test_lerobot*` are `TypeError: encode() takes 1 positional argument but 2 were given` from lerobot-from-source; the remaining 5 pass **29/29 in isolation on both trees**.

No visual artifact: this changes a discovery listing's text, not a policy, simulation behaviour, rendering, recording or robot asset. The measured before/after listing above is the artifact.

The branch carries a merge of `main` so its head is tested against the current base: it forked before the Markdown-link guard landed, and that guard reads a README the base has since fixed. On the merged head `tests/test_markdown_links_resolve.py`, `tests/test_dependency_audit.py` and the new file are **87 passed, 1 skipped**; ruff is clean over 1614 files; mypy is **24 == 24** against a pristine worktree of the new base with both `comm` directions empty; and the two load-bearing mutations still fire 6 and 2. The paired 782-file run above was measured one base earlier, and none of the three commits since touches any file this branch changes.
