### PR TITLE
fix(g1): hold the battery floor to a numeric domain before it is stored

### DIFF
--- a/changelog.d/2804-g1-battery-floor-domain.md
+++ b/changelog.d/2804-g1-battery-floor-domain.md
@@ -1,0 +1,33 @@
+### Fixed: the G1's battery floor is held to a numeric domain before it is stored
+
+`G1Driver.__init__` took `battery_floor_pct` and stored `float(battery_floor_pct)`
+with no domain, and that floor is the only constructor value
+`_check_motion_gates` compares a live reading against. `float("nan")` survives
+the coercion, and `battery_pct < nan` is False for every reading, so the driver
+stored a floor it reported through `get_status` and enforced nowhere: the gate
+opened on a critically low pack. The string `"nan"` - how a config file spells
+it - took the same path, and `True` became a silent `1.0%` because `bool` is an
+`int` subclass. Measured on a connected driver whose FSM and lowstate were both
+healthy, with the pack at 3.0%:
+
+```
+battery_floor_pct        construction   outcome at battery = 3.0%
+15.0 (the default)       accepted       battery 3.0% is under floor 15.0%
+float("nan")             accepted       gate open - the write was allowed
+"nan"                    accepted       gate open - the write was allowed
+True                     accepted       gate open - the write was allowed   (floor 1.0)
+```
+
+The two sibling numbers this driver takes, `duration` and `n_steps` on
+`run_policy`, already go through a shared domain from `strands_robots.utils`.
+The floor now goes through `finite_number_error`, the shared domain whose own
+contract covers this hazard, before the coercion rather than after it - a guard
+placed after `float()` would judge a value already stored, and would turn the
+named refusals for `None`, a list and a value past the float64 range into bare
+`TypeError`/`OverflowError` escaping the constructor's documented contract.
+
+Every value that behaves as `battery_pct < floor` reads is untouched: `0.0` and
+`-10.0` still never trip, `500.0` still always does, and a NumPy float still
+passes. Whether a percentage should be bounded to `[0, 100]` is a separate
+question about what a percentage may mean rather than a correction, and it is
+deliberately left open.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -44,7 +44,11 @@ from typing import TYPE_CHECKING, Any, cast
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.tools.g1 import HANDSHAKE_FSMS, WALK_FSMS, decode_code
 from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
-from strands_robots.utils import positive_count_error, positive_finite_number_error
+from strands_robots.utils import (
+    finite_number_error,
+    positive_count_error,
+    positive_finite_number_error,
+)
 
 if TYPE_CHECKING:
     from strands.types.tools import ToolSpec, ToolUse
@@ -222,6 +226,9 @@ class G1Driver:
                 a caller can see which check refused.
             **kwargs: Ignored; accepted so the factory can forward extras
                 without the driver knowing what they are.
+
+        Raises:
+            ValueError: If ``battery_floor_pct`` is not a finite number.
         """
         del cameras, data_config  # accepted for parity; unused here
         if kwargs:
@@ -229,6 +236,16 @@ class G1Driver:
         self._tool_name = tool_name
         self._port = port
         self._network_interface = network_interface
+        # The floor is the only constructor value the safety gate compares a
+        # reading against, so it is held to the same shared domain
+        # ``run_policy`` holds ``duration`` to.  A bare ``float()`` accepted
+        # ``nan``: every ``battery_pct < nan`` is False, so the driver stored a
+        # floor it reported in :meth:`get_status` and enforced nowhere, and the
+        # gate opened on a critically low pack.  ``finite_number_error`` also
+        # rejects ``bool`` (``True`` would act as a silent 1.0%) and a numeric
+        # string, which is how a config file spells ``nan``.
+        if reason := finite_number_error(battery_floor_pct, "battery_floor_pct", "G1Driver"):
+            raise ValueError(reason)
         self._battery_floor_pct = float(battery_floor_pct)
 
         # Cached DDS decode results. Every one is optional per the mesh

--- a/tests/drivers/test_g1_battery_floor_is_a_finite_percentage.py
+++ b/tests/drivers/test_g1_battery_floor_is_a_finite_percentage.py
@@ -1,0 +1,221 @@
+"""The G1's battery floor is held to a numeric domain before it is stored.
+
+``battery_floor_pct`` is the only value :meth:`G1Driver._check_motion_gates`
+compares a live reading against, and it was the one constructor parameter with
+no domain: a bare ``float()`` coerced it and stored the result.  ``float("nan")``
+survives that coercion, and ``battery_pct < nan`` is False for every reading, so
+the driver stored a floor it advertised and enforced nowhere -- the gate opened
+on a critically low pack while :meth:`get_status` still reported a floor.
+
+The two sibling numbers this driver takes (``duration`` and ``n_steps``, on
+:meth:`run_policy`) both go through a shared domain from
+:mod:`strands_robots.utils`.  This file grades the floor against the same shared
+domain, and grades the values that are *not* refused just as hard: a floor of
+``0.0`` or ``-10.0`` never trips, but that is what its arithmetic says and a
+caller can mean it, so the fix must leave those alone.
+
+Deliberately out of scope: whether a percentage should be bounded to
+``[0, 100]``.  ``500.0`` is accepted here and refuses every pack, and ``-10.0``
+is accepted and refuses none; both behave exactly as the comparison reads, so
+narrowing them is a policy choice about what a percentage may mean rather than a
+correction, and it is left for whoever wants to make it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.drivers.g1 as g1_module
+from strands_robots.drivers.g1 import G1Driver
+from strands_robots.utils import finite_number_error
+
+# The reading the gate compares the floor against is a state-of-charge
+# percentage decoded from ``rt/lf/bmsstate``; 3.0% is a pack that must not be
+# asked to hold a 1.3 m biped upright.
+_CRITICAL_PCT = 3.0
+
+# Spellings a bare ``float()`` either accepted silently or turned into a bare
+# builtin exception escaping the constructor's documented contract.
+_UNUSABLE: list[tuple[str, Any]] = [
+    ("nan", float("nan")),
+    ("inf", float("inf")),
+    ("negative-inf", float("-inf")),
+    ("nan-as-a-string", "nan"),
+    ("number-as-a-string", "20"),
+    ("True", True),
+    ("False", False),
+    ("None", None),
+    ("a-list", [20.0]),
+    ("past-float64", 10**400),
+]
+
+# Every one of these behaves exactly as ``battery_pct < floor`` reads, so the
+# fix must not touch them.  ``0.0``/``-10.0`` never trip; ``500.0`` always does.
+_USABLE: list[tuple[str, Any]] = [
+    ("the-default", 15.0),
+    ("zero", 0.0),
+    ("negative", -10.0),
+    ("full", 100.0),
+    ("above-a-hundred", 500.0),
+    ("numpy-float32", np.float32(18.5)),
+    ("numpy-float64", np.float64(18.5)),
+    ("an-int", 20),
+]
+
+
+def _driver(**kwargs: Any) -> G1Driver:
+    return G1Driver(tool_name="g1", port="1.2.3.4", **kwargs)
+
+
+def _open_gate_on_a_critical_pack(driver: G1Driver) -> dict[str, Any] | None:
+    """Put the driver one step from a write, with only the battery in doubt."""
+    driver._connected = True
+    driver._mode_machine = 5  # the uint8 layout id lowstate really delivers
+    driver._fsm_id = 500  # inside HANDSHAKE_FSMS, so the FSM is not the reason
+    driver._battery = {"pct": _CRITICAL_PCT}
+    return driver._check_motion_gates("arm")
+
+
+class TestANonFiniteFloorIsRefused:
+    """The regression: a floor that cannot be enforced is refused up front."""
+
+    @pytest.mark.parametrize("value", [v for _, v in _UNUSABLE], ids=[i for i, _ in _UNUSABLE])
+    def test_construction_refuses_it(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="battery_floor_pct"):
+            _driver(battery_floor_pct=value)
+
+    def test_a_nan_floor_can_no_longer_open_the_gate(self) -> None:
+        """The money case: ``nan`` used to disable the floor silently.
+
+        Every ``battery_pct < nan`` is False, so the comparison passed a
+        critically low pack while the stored floor still read ``nan``.
+        """
+        with pytest.raises(ValueError):
+            _driver(battery_floor_pct=float("nan"))
+
+    def test_the_refusal_names_the_parameter_and_the_value(self) -> None:
+        with pytest.raises(ValueError) as caught:
+            _driver(battery_floor_pct=float("nan"))
+        text = str(caught.value)
+        assert "G1Driver" in text  # the surface that received it
+        assert "battery_floor_pct" in text  # the caller's own parameter name
+        assert "nan" in text  # the value, so a log names what was passed
+
+
+class TestAFloorThatBehavesAsItReadsIsUntouched:
+    """Over-reach controls: every value the comparison can honour still works."""
+
+    @pytest.mark.parametrize("value", [v for _, v in _USABLE], ids=[i for i, _ in _USABLE])
+    def test_construction_accepts_it(self, value: Any) -> None:
+        driver = _driver(battery_floor_pct=value)
+        assert math.isclose(driver._battery_floor_pct, float(value))
+
+    def test_the_default_floor_still_refuses_a_critical_pack(self) -> None:
+        refusal = _open_gate_on_a_critical_pack(_driver())
+        assert refusal is not None
+        assert "under floor" in refusal["content"][0]["text"]
+
+    def test_a_floor_of_zero_still_admits_a_critical_pack(self) -> None:
+        """``0.0`` means "no floor" and is left meaning that.
+
+        This is the value a stricter domain would have refused, so it is the
+        control that keeps the fix from becoming a policy change.
+        """
+        assert _open_gate_on_a_critical_pack(_driver(battery_floor_pct=0.0)) is None
+
+    def test_a_healthy_pack_is_admitted_under_the_default_floor(self) -> None:
+        driver = _driver()
+        driver._connected = True
+        driver._mode_machine = 5
+        driver._fsm_id = 500
+        driver._battery = {"pct": 95.0}
+        assert driver._check_motion_gates("arm") is None
+
+    def test_a_driver_with_no_battery_reading_is_not_refused_for_the_battery(self) -> None:
+        """An unread pack is not a low pack - the gate skips the comparison."""
+        driver = _driver()
+        driver._connected = True
+        driver._mode_machine = 5
+        driver._fsm_id = 500
+        driver._battery = None
+        assert driver._check_motion_gates("arm") is None
+
+
+class TestThePremisesTheseCellsRestOn:
+    """What must be true for the cells above to mean what they claim."""
+
+    @pytest.mark.parametrize("value", [v for _, v in _UNUSABLE], ids=[i for i, _ in _UNUSABLE])
+    def test_the_shared_domain_refuses_it(self, value: Any) -> None:
+        assert finite_number_error(value, "battery_floor_pct", "G1Driver") is not None
+
+    @pytest.mark.parametrize("value", [v for _, v in _USABLE], ids=[i for i, _ in _USABLE])
+    def test_the_shared_domain_accepts_it(self, value: Any) -> None:
+        assert finite_number_error(value, "battery_floor_pct", "G1Driver") is None
+
+    def test_a_nan_floor_would_pass_the_comparison_the_gate_makes(self) -> None:
+        """Why ``nan`` is the dangerous spelling rather than merely odd.
+
+        The gate is ``battery_pct < floor``.  With a ``nan`` floor that is
+        False for every reading, so the pack is never the reason - which is
+        indistinguishable from a healthy pack.
+        """
+        assert (_CRITICAL_PCT < float("nan")) is False
+        assert (0.0 < float("nan")) is False
+
+    def test_the_battery_reading_is_a_percentage(self) -> None:
+        """The floor is compared against a state-of-charge percentage."""
+        source = inspect.getsource(G1Driver._on_bms)
+        assert '"pct"' in source
+        assert "soc" in source  # the BMS field it is decoded from
+
+
+class TestTheGuardIsWiredWhereItHasToBe:
+    """Structural: placement and single-sourcing, read off the module."""
+
+    @staticmethod
+    def _init_ast() -> ast.FunctionDef:
+        tree = ast.parse(inspect.getsource(g1_module))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "G1Driver":
+                for child in node.body:
+                    if isinstance(child, ast.FunctionDef) and child.name == "__init__":
+                        return child
+        raise AssertionError("G1Driver.__init__ not found")
+
+    def test_the_guard_precedes_the_coercion_that_would_accept_nan(self) -> None:
+        """A guard after ``float()`` would judge a value already stored."""
+        init = self._init_ast()
+        guards = [
+            node.lineno
+            for node in ast.walk(init)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "finite_number_error"
+        ]
+        stores = [
+            node.lineno
+            for node in ast.walk(init)
+            if isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Attribute) and t.attr == "_battery_floor_pct" for t in node.targets)
+        ]
+        assert len(guards) == 1, f"expected one domain call, found {guards}"
+        assert len(stores) == 1, f"expected one store, found {stores}"
+        assert guards[0] < stores[0]
+
+    def test_the_domain_is_the_shared_one_rather_than_a_local_copy(self) -> None:
+        """A re-implemented check here could drift from ``duration``'s."""
+        source = inspect.getsource(G1Driver.__init__)
+        assert "finite_number_error(" in source
+        assert "math.isnan" not in source
+        assert "isfinite" not in source
+
+    def test_the_constructor_documents_the_refusal_it_makes(self) -> None:
+        """The tree-wide grader requires it; assert it here too."""
+        doc = G1Driver.__init__.__doc__ or ""
+        assert "Raises:" in doc
+        assert "ValueError" in doc
+        assert "battery_floor_pct" in doc


### PR DESCRIPTION
## The defect

`G1Driver.__init__` accepted `battery_floor_pct` and stored `float(battery_floor_pct)`
with no domain. That floor is the only constructor value `_check_motion_gates`
compares a live reading against, and the comparison is `battery_pct < floor`.

`float("nan")` survives the coercion, and `battery_pct < nan` is **False for
every reading**. So the driver stored a floor it reported through `get_status`
and enforced nowhere: the gate opened on a critically low pack. The string
`"nan"` took the same path, and `True` became a silent `1.0%` because `bool` is
an `int` subclass.

Measured on a connected driver whose FSM and lowstate were both healthy, so the
battery is the only thing in doubt, with the pack at 3.0%:

| `battery_floor_pct` | construction | outcome at battery = 3.0% |
|---|---|---|
| `15.0` (the default) | accepted | `battery 3.0% is under floor 15.0%` |
| `float("nan")` | accepted | **gate open, the write was allowed** |
| `"nan"` | accepted | **gate open, the write was allowed** |
| `True` | accepted | **gate open, the write was allowed** (floor `1.0`) |
| `None` | `TypeError` | bare builtin, outside the documented contract |

The two sibling numbers this driver takes, `duration` and `n_steps` on
`run_policy`, already go through a shared domain from `strands_robots.utils`.
The floor was the one parameter that did not.

## The change

Hold the floor to `finite_number_error` - the same shared domain, whose own
docstring covers this hazard ("`nan`/`inf` ... a silently poisoned pose rather
than a rejected command", and it "rejects `bool` explicitly") - **before** the
coercion, and name the refusal in a `Raises:` block.

Placement is load-bearing rather than stylistic: a guard after `float()` would
judge a value already stored, and would leave the refusals for `None`, a list
and a value past the float64 range as bare `TypeError`/`OverflowError` escaping
the constructor's contract. The break table below measures both.

## What is deliberately unchanged

Every value that behaves exactly as `battery_pct < floor` reads is untouched:
`0.0` and `-10.0` still never trip, `500.0` still always does, `20` and a NumPy
float still pass. A caller who writes `0.0` means "no floor" and gets it.

Whether a percentage should be bounded to `[0, 100]` is a question about what a
percentage may mean, not a correction - `500.0` refuses every pack and `-10.0`
refuses none, and both are consistent with the arithmetic. It is left open, and
the over-reach row below measures what narrowing it would cost.

## Why the shipped suite was silent

`sib` in the table is failures in the three pre-existing g1 suites
(`test_g1_driver.py`, `test_g1_control_loop.py`,
`test_g1_control_loop_terminal_observability.py`, 119 cells). It is **0 on every
row**: none of them constructs a driver with a floor other than a plain float,
so no mutation to this guard is visible to any of them.

## Mutation table

`mine` is failures in the new file, `coll` its collected count (stable at 47, so
no row hides behind a deselection).

| row | mutation | mine | coll | sib | fires |
|---|---|---|---|---|---|
| b0 | control, no mutation | 0 | 47 | 0 | - |
| b1 | guard removed (back to a bare `float()`) | 14 | 47 | 0 | regression + structural |
| b2 | guard moved **after** the store | 4 | 47 | 0 | structural + the 3 cases that become bare builtins |
| b3 | over-reach: `positive_finite_number_error` instead | 4 | 47 | 0 | the `0.0`/`-10.0` controls + structural |
| b4 | re-implemented locally with `math.isnan` only | 10 | 47 | 0 | misses `bool`, the string, `None`, a list, past-float64 |
| b5 | re-implemented with `not math.isfinite(float(v))` | 8 | 47 | 0 | misses `bool` and the non-real spellings |
| b6 | refusal logged instead of raised | 12 | 47 | 0 | regression |
| b7 | refusal coerced to the default instead of raised | 12 | 47 | 0 | regression |
| b8 | message drops the parameter name | 11 | 47 | 0 | regression |
| b9 | `Raises:` block dropped | 1 | 47 | 0 | structural |

9 mutations, **8 distinct firing sets**, control clean, source restored
md5-identical. b6 and b7 share a set for a structural reason - both mean "accept
instead of refuse", and the cells grade the refusal rather than which
substitution replaced it.

b4/b5 were re-run after a first attempt measured a broken probe: `math` is not
imported in this module, so the naive mutation raised `NameError` on every
construction and reported 70 sibling failures. The rows above add the import the
mutation would need, so they measure a weaker guard rather than a broken module.

## Pre-fix split

Source reverted, tests kept: **15 failed / 32 passed**.

| class | role | pre-fix |
|---|---|---|
| `TestANonFiniteFloorIsRefused` | regression | 12 of 12 |
| `TestTheGuardIsWiredWhereItHasToBe` | structural | 3 of 3 |
| `TestAFloorThatBehavesAsItReadsIsUntouched` | over-reach control | **0 of 12** |
| `TestThePremisesTheseCellsRestOn` | premise | **0 of 20** |

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1612 files).
- `mypy` **24 == 24** against a worktree of the merge-base, normalized message
  sets byte-identical in both directions, **0 attributable** to either changed file.
- Paired run over an identical 440-file selection (all `tests/drivers/`, all
  `tests/tools/g1/`, and every test that walks the tree, parses source or reads
  docstrings), the new file excluded from both trees and every path verified
  present on both: identical **22399 collected** and
  `20 failed, 22309 passed, 70 skipped` on each, **20 identical failing ids,
  `comm` empty in both directions**. All 20 are pre-existing and environmental:
  17 in `tests/mesh/test_iot_*` need `awsiot`/`awscrt` (`find_spec` False here,
  declared in the `[mesh-iot]` extra, which CI installs) and 3 in
  `tests/training/test_lerobot*` are the known lerobot-from-source
  `encode() takes 1 positional argument` drift.
- New file: **47 passed**.

No visual artifact: this changes a refusal and a stored value, not a policy,
simulation, render, recording or asset. The measured tables above are the evidence.
