### PR TITLE
docs(agents): time the changelog fragment against the review, not the push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,44 @@ hatch run format            # ruff check --fix, ruff format
    This is enforced by `.github/workflows/changelog-fragment.yml`: the rule was
    documented in two places and enforced by nothing until #1784, and a pull
    request reached `APPROVED` / `SUCCESS` / `CLEAN` having appended to the log.
+
+   **The fragment lands before a review can arrive, because its own filename
+   forces a second push.** The name is `<number>-<slug>.md` where `<number>` is
+   the pull request's, and that number does not exist until the pull request is
+   open - so for the 249 of the last 300 pull requests that claim no issue,
+   the fragment is necessarily a *second* commit onto an already-open branch.
+   `dismiss_stale_reviews_on_push` does not care that the pushed file is a
+   changelog entry, so whether that push is free depends only on whether an
+   approval has already landed. Four pull requests, one hour, same author, same
+   fragment-as-second-commit shape:
+
+   | pull request | opened | fragment pushed | approval | outcome |
+   |---|---|---|---|---|
+   | #2800 | 21:16:19 | 21:16:56 (+37s) | 21:20:23 | survived |
+   | #2802 | 21:47:47 | 21:48:54 (+67s) | 21:56:13 | survived |
+   | #2801 | 21:22:49 | 21:55:53 (+33m) | 21:27:54 | **dismissed** |
+   | #2799 | 20:46:12 | 21:47:22 (+61m) | 20:53:27, 21:31:17 | **dismissed twice** |
+
+   The ordering is the whole variable: the two that pushed the fragment inside
+   the first two minutes kept the approval that arrived afterwards, and the two
+   that pushed it after an approval had landed paid a re-approval round each -
+   #2799 twice, on a one-line documentation link fix, which is three rounds
+   spent on nothing a reviewer had asked for. Review latency is what sizes the
+   window, and here it is minutes: those two approvals arrived 3m27s and 7m19s
+   after the fragment.
+
+   So push the fragment **immediately** after opening, before requesting review
+   - or open the pull request as a draft, add it, and only then mark it ready,
+   which removes the race rather than winning it. Where the change does claim an
+   issue, use the *issue* number: that one is known at intake, so the fragment
+   ships inside the first push and there is no second push to time at all.
+
+   This is the same cost the paragraph above attributes to `CHANGELOG.md`
+   conflicts, arriving by a different route - the fragment convention removed
+   the conflict and left the extra push - so it is worth stating separately.
+   Do not reach for `--amend --force-with-lease` to fold the fragment into the
+   first commit once review has started: that destroys the review trail, and on
+   #2799 the two force-pushes are exactly what dismissed the two approvals.
 4. All tests must pass, lint must be clean
 5. Open PR from your fork, address all review comments
 

--- a/changelog.d/2805-fragment-lands-before-review-can-arrive.md
+++ b/changelog.d/2805-fragment-lands-before-review-can-arrive.md
@@ -1,0 +1,18 @@
+### Docs: time the changelog fragment against the review, not the push
+
+`AGENTS.md` step 3 explained why a news fragment replaces a direct
+`CHANGELOG.md` append, but said nothing about the push the fragment convention
+itself introduces. The fragment is named `changelog.d/<number>-<slug>.md` with
+the pull request's number, which does not exist until the pull request is open,
+so a change claiming no issue can only add it as a second commit onto an
+already-open branch -- and `dismiss_stale_reviews_on_push` does not exempt it.
+
+Step 3 now records that the push is free only while no approval has landed,
+measured over four pull requests where the two that pushed the fragment within
+about a minute of opening kept their approvals and the two that pushed it after
+an approval each paid a re-approval round. It names the three ways out: push the
+fragment immediately, open the pull request as a draft and mark it ready once the
+fragment is in, or use the issue number when the change claims an issue, which is
+known at intake and needs no second push. It also records that folding the
+fragment in with `--amend --force-with-lease` after review has started is what
+dismisses an approval rather than what avoids one.


### PR DESCRIPTION
## What

Amends `AGENTS.md` PR-workflow step 3 with the rule that decides whether the
changelog fragment's push costs a re-approval round: **when** it lands relative
to the first review, not whether it is a fragment.

## Why

Step 3 already explains why fragments exist -- appending to `CHANGELOG.md`
conflicts on one anchor, and clearing that conflict costs a re-approval round.
It is silent on the push the fragment convention itself introduces.

The fragment name is `changelog.d/<number>-<slug>.md`, and `<number>` is the
pull request's. That number does not exist until the pull request is open, so
for a change claiming no issue -- 249 of the last 300 here, per step 1 -- the
fragment can only arrive as a *second* commit onto an already-open branch.
`dismiss_stale_reviews_on_push` does not exempt it.

So the push is free while no approval has landed and costs a round once one has.
Four pull requests, one hour, same author, same fragment-as-second-commit shape:

| pull request | opened | fragment pushed | approval | outcome |
|---|---|---|---|---|
| #2800 | 21:16:19 | 21:16:56 (+37s) | 21:20:23 | survived |
| #2802 | 21:47:47 | 21:48:54 (+67s) | 21:56:13 | survived |
| #2801 | 21:22:49 | 21:55:53 (+33m) | 21:27:54 | dismissed |
| #2799 | 20:46:12 | 21:47:22 (+61m) | 20:53:27, 21:31:17 | dismissed twice |

The ordering is the only variable that moves the outcome. #2799 is the cost
stated plainly: three approval rounds on a one-line documentation link fix,
none of them reviewing anything a reviewer had asked about.

## The remedy recorded

- Push the fragment immediately after opening, ahead of any review; or
- open the pull request as a **draft**, add the fragment, then mark it ready --
  which removes the race instead of winning it; or
- when the change claims an issue, use the **issue** number, which is known at
  intake, so the fragment ships inside the first push and there is no second
  push to time.

It also records that `--amend --force-with-lease` is the wrong way to fold the
fragment in once review has started: on #2799 the two force-pushes are precisely
what dismissed the two approvals.

## Scope

Documentation only -- one paragraph block added to step 3, no code, no test, no
behaviour change. This is a process rule in the same register as the rest of
step 3, and the durability argument is AGENTS.md's own closing line for step 8:
a decision recorded only in a pull request comment is not durable.

This pull request was opened as a draft and its fragment pushed before it was
marked ready, which is the remedy it documents.

## Changelog

**Round 0** -- initial submission.
