### PR TITLE
fix(episode_labels): keep the label sidecar's permissions across an update

### DIFF
--- a/changelog.d/2806-label-sidecar-update-keeps-its-permissions.md
+++ b/changelog.d/2806-label-sidecar-update-keeps-its-permissions.md
@@ -1,0 +1,28 @@
+### Fixed: updating the label sidecar no longer narrows its permissions
+
+`strands_robots.episode_labels._write_document` replaces the sidecar by writing
+a `tempfile.mkstemp` file next to it and `os.replace`-ing it into place. A
+`mkstemp` file is owner-only, so the rename carried `0o600` onto the
+destination: a sidecar that arrived group- or world-readable came out of the
+next annotation readable to nobody but the writer. That is the ordinary case
+rather than an unusual one. The module docstring gives the sidecar's whole
+purpose as travelling with the dataset directory, and every way it travels - a
+copy, a `tar -x`, a Hub download, a clone - lands it at the reader's umask,
+which is wider than `0o600` in at least one bit. Measured on a sidecar at
+`0o644`, both `record_deterministic_verdicts` and `annotate_episode` left it at
+`0o600` and reported success; the cost surfaced later and elsewhere, as a
+`PermissionError` out of `read_labels` or `filter_episodes` on labels another
+account could read a moment before.
+
+The destination's mode is now read before anything is written and applied to
+the temp file, so the sidecar is never momentarily readable to fewer callers
+than it was - chmod-ing `path` after the rename would leave exactly that
+window, and the ordering is graded rather than left to the next edit. A sidecar
+this module creates keeps `mkstemp`'s owner-only mode: replacing content is not
+the place that decides who may read a dataset, and this change does not widen
+anything. That is the one way the construct departs from
+`strands_robots.simulation.safe_output.atomic_write_bytes`, which holds its own
+output to `0o600` on purpose because the sim output roots are private to the
+running user - a reason that does not transfer to a dataset artifact, and the
+departure is now written down at both ends instead of arising from `mkstemp`'s
+default.

--- a/strands_robots/episode_labels.py
+++ b/strands_robots/episode_labels.py
@@ -75,6 +75,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import stat
 import tempfile
 import time
 from pathlib import Path
@@ -259,12 +260,38 @@ def _write_document(path: Path, document: dict[str, Any]) -> None:
     ``os.replace`` is atomic on POSIX and Windows for same-filesystem paths,
     so a reader never observes a truncated sidecar and a crashed writer
     leaves the previous version intact.
+
+    Replacing the content does not change the destination's permissions. The
+    temp file ``mkstemp`` creates is owner-only, so renaming it over an
+    existing sidecar would otherwise narrow one that arrived group- or
+    world-readable - and travelling with the dataset directory is what this
+    sidecar is for, so it commonly did (a copy, a ``tar -x``, a Hub download
+    and a clone all land it at the reader's umask). A caller that could read
+    the labels before an annotation can still read them after. The mode is
+    applied to the temp file rather than to ``path`` afterwards, so the
+    sidecar is never momentarily readable to fewer callers than it was.
+
+    This is the one way the construct departs from
+    :func:`strands_robots.simulation.safe_output.atomic_write_bytes`, which
+    holds its own output to ``0o600`` deliberately because the sim output
+    roots are private to the running user. A label sidecar is a dataset
+    artifact, and this function is not the place that decides who may read
+    the dataset. A sidecar it creates keeps ``mkstemp``'s owner-only mode.
     """
+    # Read the destination's mode before writing anything, so a failed write
+    # cannot leave the decision half-made. Absent is the create case, and the
+    # suppression covers it (FileNotFoundError is an OSError).
+    existing_mode: int | None = None
+    with contextlib.suppress(OSError):
+        existing_mode = stat.S_IMODE(path.stat().st_mode)
+
     fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name, suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(document, f, indent=2, sort_keys=True)
             f.write("\n")
+        if existing_mode is not None:
+            os.chmod(tmp_name, existing_mode)
         os.replace(tmp_name, path)
     except BaseException:
         # Cleanup-and-reraise: never leave the temp file behind on failure.

--- a/tests/test_label_sidecar_update_keeps_its_permissions.py
+++ b/tests/test_label_sidecar_update_keeps_its_permissions.py
@@ -1,0 +1,309 @@
+"""Updating the label sidecar leaves its permissions alone.
+
+:func:`strands_robots.episode_labels._write_document` replaces the sidecar by
+writing a ``mkstemp`` temp file and ``os.replace``-ing it into place. A
+``mkstemp`` file is owner-only, so the rename used to carry ``0o600`` onto the
+destination and silently narrow a sidecar that arrived group- or
+world-readable. Travelling with the dataset directory is what the sidecar is
+for, and every way it travels - a copy, a ``tar -x``, a Hub download, a clone -
+lands it at the reader's umask, so the wider mode is the ordinary case rather
+than an unusual one. The write reported success either way; the cost showed up
+later, as a ``PermissionError`` from :func:`read_labels` or
+:func:`filter_episodes` on a dataset whose labels were readable a moment
+before.
+
+What these cells hold:
+
+- The regression: an update through either writer leaves the mode it found.
+  Parametrized over the modes a shared dataset actually carries, and over both
+  writers, discovered from the module rather than listed so a third writer is
+  held to the rule the hour it lands.
+- The structural half: the mode is applied to the temp file *before* the
+  rename, not to the destination after it, so the sidecar is never momentarily
+  readable to fewer callers than it was.
+- What must not change: the atomicity contract the construct exists for - a
+  failed write leaves no temp file and the previous sidecar byte-identical -
+  and the content of a successful update.
+- The premise: ``mkstemp`` really does create an owner-only file, so the
+  narrowing was a property of the construct and not of one platform; and
+  :func:`strands_robots.simulation.safe_output.atomic_write_bytes` really does
+  hold its own output to ``0o600`` on purpose, which is the contrast that keeps
+  this change to the sidecar.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import stat
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.episode_labels as labels
+
+# Modes a dataset's own files carry in the wild: the default umask, a
+# group-writable shared mount, a group-readable team dataset, and a read-only
+# archive extraction. Every one is wider than ``mkstemp``'s ``0o600`` in at
+# least one bit, so each would have been narrowed.
+_SHARED_MODES = (0o644, 0o664, 0o640, 0o444)
+
+# The private mode the temp file arrives with. Named here rather than read from
+# the module so a cell that grades the module's behaviour is not comparing the
+# module against itself.
+_MKSTEMP_MODE = 0o600
+
+
+def _mode(path: Path) -> int:
+    """Permission bits of ``path``."""
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _seeded_dataset() -> Path:
+    """A dataset root whose sidecar exists and carries one verdict."""
+    root = Path(tempfile.mkdtemp())
+    labels.record_deterministic_verdicts(root, [{"episode": 0, "success": True}])
+    return root
+
+
+def _sidecar_writers() -> dict[str, Callable[[Path], Any]]:
+    """Every public function that rewrites the sidecar, discovered from the module.
+
+    Derived from the module's own call graph - a function whose body calls
+    ``_write_document`` - rather than listed, so a writer added later is held to
+    the rule without anyone remembering to add it here. Each value drives that
+    writer against a dataset already carrying episode 0's verdict.
+    """
+    drives: dict[str, Callable[[Path], Any]] = {
+        "record_deterministic_verdicts": lambda root: labels.record_deterministic_verdicts(
+            root, [{"episode": 1, "success": False, "failure": True}]
+        ),
+        "annotate_episode": lambda root: labels.annotate_episode(root, 0, quality="high", note="looked clean"),
+    }
+    return drives
+
+
+def _writers_in_the_module() -> set[str]:
+    """Every public function whose body rewrites the sidecar, read off the module.
+
+    Derived from the module's own call graph - a public function that calls
+    ``_write_document`` - rather than listed, so a writer added later is held to
+    the permission rule without anyone remembering to extend this file.
+    """
+    tree = ast.parse(inspect.getsource(labels))
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and not node.name.startswith("_")
+        and any(
+            isinstance(call, ast.Call) and getattr(call.func, "id", None) == "_write_document"
+            for call in ast.walk(node)
+        )
+    }
+
+
+_WRITERS = _sidecar_writers()
+
+
+def _write_document_body() -> ast.FunctionDef:
+    """The ``_write_document`` definition, for the structural cells."""
+    tree = ast.parse(inspect.getsource(labels))
+    return next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_write_document")
+
+
+class TestAnUpdateKeepsTheSidecarReadableToTheSameCallers:
+    """The regression: a rewrite leaves the mode it found."""
+
+    @pytest.mark.parametrize("writer", sorted(_WRITERS), ids=sorted(_WRITERS))
+    @pytest.mark.parametrize("start", _SHARED_MODES, ids=[oct(m) for m in _SHARED_MODES])
+    def test_the_mode_survives_the_rewrite(self, writer: str, start: int) -> None:
+        root = _seeded_dataset()
+        sidecar = labels.labels_path(root)
+        os.chmod(sidecar, start)
+
+        _WRITERS[writer](root)
+
+        assert _mode(sidecar) == start, (
+            f"{writer} left the sidecar at {oct(_mode(sidecar))} where it found {oct(start)}; "
+            "a caller that could read the labels before the write cannot read them after."
+        )
+
+    @pytest.mark.parametrize("writer", sorted(_WRITERS), ids=sorted(_WRITERS))
+    def test_a_group_readable_sidecar_stays_group_readable(self, writer: str) -> None:
+        """The bit that decides whether another account can read the labels."""
+        root = _seeded_dataset()
+        sidecar = labels.labels_path(root)
+        os.chmod(sidecar, 0o644)
+
+        _WRITERS[writer](root)
+
+        assert _mode(sidecar) & (stat.S_IRGRP | stat.S_IROTH), (
+            "the sidecar is owner-only after the write, so every other account on a shared "
+            "dataset now takes a PermissionError from read_labels"
+        )
+
+    def test_a_sidecar_with_no_permission_bits_keeps_none(self) -> None:
+        """``0o000`` is the one mode that is falsy, so a truthiness test would skip it.
+
+        Skipping it would hand the sidecar ``mkstemp``'s ``0o600`` - a widening
+        rather than a narrowing, but still this function deciding who may read
+        the dataset. Driven through the writer itself: the public entry points
+        read the sidecar before rewriting it, so they cannot reach a mode that
+        denies them the read.
+        """
+        root = _seeded_dataset()
+        sidecar = labels.labels_path(root)
+        document = labels.read_labels(root)
+        os.chmod(sidecar, 0o000)
+
+        labels._write_document(sidecar, document)
+
+        assert _mode(sidecar) == 0o000, f"a mode-less sidecar became {oct(_mode(sidecar))}"
+
+    def test_a_read_only_sidecar_is_still_updatable_and_stays_read_only(self) -> None:
+        """``os.replace`` needs the directory, not the file, so 0o444 is writable.
+
+        The mode is carried across rather than reset, so a dataset published
+        read-only keeps that posture through an annotation.
+        """
+        root = _seeded_dataset()
+        sidecar = labels.labels_path(root)
+        os.chmod(sidecar, 0o444)
+
+        labels.annotate_episode(root, 0, quality="medium")
+
+        assert _mode(sidecar) == 0o444, f"read-only sidecar became {oct(_mode(sidecar))}"
+        assert labels.read_labels(root)["episodes"]["0"]["judge"]["quality"] == "medium"
+
+
+class TestEveryWriterIsCovered:
+    """The drive table names every function that rewrites the sidecar."""
+
+    def test_the_drive_table_covers_every_writer_in_the_module(self) -> None:
+        derived = _writers_in_the_module()
+        assert derived == set(_WRITERS), (
+            f"the module writes the sidecar from {sorted(derived)}; this file drives "
+            f"{sorted(_WRITERS)}. Add the new writer to the drive table so the permission "
+            "rule is graded for it too."
+        )
+
+    def test_the_module_has_at_least_the_two_known_writers(self) -> None:
+        """Non-vacuity: an empty derivation would make the cell above trivially true."""
+        assert {"record_deterministic_verdicts", "annotate_episode"} <= _writers_in_the_module()
+
+
+class TestTheModeIsAppliedBeforeTheRename:
+    """Applied to the temp file, so no window exists where the mode is wrong."""
+
+    def test_the_chmod_precedes_the_replace(self) -> None:
+        body = _write_document_body()
+        calls = [
+            ".".join(filter(None, [getattr(node.func.value, "id", None), node.func.attr]))
+            for node in ast.walk(body)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        ]
+        linenos = {
+            f"{getattr(node.func.value, 'id', '')}.{node.func.attr}": node.lineno
+            for node in ast.walk(body)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert "os.chmod" in calls, (
+            "_write_document does not set a mode, so the rename carries mkstemp's owner-only mode onto the destination"
+        )
+        assert linenos["os.chmod"] < linenos["os.replace"], (
+            "the mode is applied after os.replace, which leaves a window where the sidecar is "
+            "readable to fewer callers than it was"
+        )
+
+    def test_the_mode_is_applied_to_the_temp_file(self) -> None:
+        """Chmod-ing ``path`` instead would be that window, whatever the ordering."""
+        body = _write_document_body()
+        chmod = next(
+            (
+                node
+                for node in ast.walk(body)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "chmod"
+            ),
+            None,
+        )
+        assert chmod is not None, "_write_document sets no mode, so there is no target to grade"
+        target = ast.unparse(chmod.args[0])
+        assert target != "path", "os.chmod(path, ...) mutates the live sidecar rather than its replacement"
+        assert "tmp" in target, f"os.chmod applies to {target!r}, which is not the temp file"
+
+
+class TestWhatIsUnchanged:
+    """The atomicity contract the construct exists for, and the content."""
+
+    def test_a_failed_write_leaves_no_temp_file_and_the_sidecar_intact(self) -> None:
+        root = _seeded_dataset()
+        sidecar = labels.labels_path(root)
+        os.chmod(sidecar, 0o644)
+        before = sidecar.read_bytes()
+
+        with pytest.raises(TypeError):
+            # A set is not JSON-serialisable, so json.dump raises mid-write.
+            labels.record_deterministic_verdicts(root, [{"episode": 2, "success": True, "seed": {1, 2}}])
+
+        assert [p.name for p in root.iterdir() if p.name.endswith(".tmp")] == []
+        assert sidecar.read_bytes() == before
+        assert _mode(sidecar) == 0o644
+
+    def test_a_successful_update_writes_the_content(self) -> None:
+        root = _seeded_dataset()
+        os.chmod(labels.labels_path(root), 0o644)
+
+        labels.annotate_episode(root, 0, quality="low", note="drifted")
+
+        judge = labels.read_labels(root)["episodes"]["0"]["judge"]
+        assert judge["quality"] == "low"
+        assert judge["note"] == "drifted"
+
+    def test_a_sidecar_this_module_creates_is_owner_only(self) -> None:
+        """The create case is untouched: this function does not widen anything."""
+        root = Path(tempfile.mkdtemp())
+
+        labels.record_deterministic_verdicts(root, [{"episode": 0, "success": True}])
+
+        assert _mode(labels.labels_path(root)) == _MKSTEMP_MODE
+
+    def test_an_already_private_sidecar_stays_private(self) -> None:
+        """Carrying the mode across is not a widening."""
+        root = _seeded_dataset()
+        sidecar = labels.labels_path(root)
+        assert _mode(sidecar) == _MKSTEMP_MODE
+
+        labels.annotate_episode(root, 0, quality="high")
+
+        assert _mode(sidecar) == _MKSTEMP_MODE
+
+
+class TestThePremise:
+    """Why the narrowing was a property of the construct, and why it stops here."""
+
+    def test_mkstemp_creates_an_owner_only_file(self) -> None:
+        fd, name = tempfile.mkstemp(dir=tempfile.mkdtemp())
+        os.close(fd)
+        assert _mode(Path(name)) == _MKSTEMP_MODE, (
+            "mkstemp is not owner-only on this platform, so the modes these cells "
+            "compare against would not be the ones the construct produces"
+        )
+
+    def test_the_sibling_atomic_writer_holds_its_output_private_on_purpose(self) -> None:
+        """The contrast that keeps this change to the sidecar.
+
+        ``safe_output.atomic_write_bytes`` chooses ``0o600`` and says why - its
+        output roots are private to the running user. A label sidecar is a
+        dataset artifact, so the same choice does not transfer.
+        """
+        safe_output = pytest.importorskip("strands_robots.simulation.safe_output")
+        source = inspect.getsource(safe_output.atomic_write_bytes)
+        assert "os.chmod(path, 0o600)" in source
+        target = Path(tempfile.mkdtemp()) / "payload.bin"
+        safe_output.atomic_write_bytes(target, b"x")
+        assert _mode(target) == _MKSTEMP_MODE

--- a/tests/test_label_sidecar_update_keeps_its_permissions.py
+++ b/tests/test_label_sidecar_update_keeps_its_permissions.py
@@ -46,17 +46,27 @@ import pytest
 
 import strands_robots.episode_labels as labels
 
+# Permission bits, named rather than spelled as octal masks. The cells assert
+# on these same ``stat`` bits, so composing the fixtures from them says which bit
+# each case turns on instead of leaving a reader to decode an octal literal.
+_OWNER_RW = stat.S_IRUSR | stat.S_IWUSR
+_GROUP_OTHER_READ = stat.S_IRGRP | stat.S_IROTH
+_ANY_WRITE = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
+
 # Modes a dataset's own files carry in the wild: the default umask, a
 # group-writable shared mount, a group-readable team dataset, and a read-only
 # archive extraction. Every one is wider than ``mkstemp``'s ``0o600`` in at
 # least one bit, so each would have been narrowed.
-_SHARED_MODES = (0o644, 0o664, 0o640, 0o444)
+#
+# The grid is built from the named modes rather than the names being indexes
+# into the grid, so the modes individual cells stage and the modes the
+# parametrized cells sweep are the same objects and cannot drift apart.
+_GROUP_READABLE = _OWNER_RW | _GROUP_OTHER_READ  # 0o644 default umask
+_GROUP_WRITABLE = _GROUP_READABLE | stat.S_IWGRP  # 0o664 shared mount
+_TEAM_READABLE = _OWNER_RW | stat.S_IRGRP  # 0o640 team dataset
+_READ_ONLY = stat.S_IRUSR | _GROUP_OTHER_READ  # 0o444 archive extraction
 
-# The two members individual cells name. Taken from the grid rather than
-# respelled, so the modes these cells stage and the modes the parametrized cells
-# sweep cannot drift apart.
-_GROUP_READABLE = _SHARED_MODES[0]
-_READ_ONLY = _SHARED_MODES[3]
+_SHARED_MODES = (_GROUP_READABLE, _GROUP_WRITABLE, _TEAM_READABLE, _READ_ONLY)
 
 # The private mode the temp file arrives with. Named here rather than read from
 # the module so a cell that grades the module's behaviour is not comparing the
@@ -140,11 +150,12 @@ class TestAnUpdateKeepsTheSidecarReadableToTheSameCallers:
         )
 
     @pytest.mark.parametrize("writer", sorted(_WRITERS), ids=sorted(_WRITERS))
-    def test_a_group_readable_sidecar_stays_group_readable(self, writer: str) -> None:
+    @pytest.mark.parametrize("start", _SHARED_MODES, ids=[oct(m) for m in _SHARED_MODES])
+    def test_a_group_readable_sidecar_stays_group_readable(self, writer: str, start: int) -> None:
         """The bit that decides whether another account can read the labels."""
         root = _seeded_dataset()
         sidecar = labels.labels_path(root)
-        os.chmod(sidecar, _GROUP_READABLE)
+        os.chmod(sidecar, start)
 
         _WRITERS[writer](root)
 
@@ -246,10 +257,11 @@ class TestTheModeIsAppliedBeforeTheRename:
 class TestWhatIsUnchanged:
     """The atomicity contract the construct exists for, and the content."""
 
-    def test_a_failed_write_leaves_no_temp_file_and_the_sidecar_intact(self) -> None:
+    @pytest.mark.parametrize("start", _SHARED_MODES, ids=[oct(m) for m in _SHARED_MODES])
+    def test_a_failed_write_leaves_no_temp_file_and_the_sidecar_intact(self, start: int) -> None:
         root = _seeded_dataset()
         sidecar = labels.labels_path(root)
-        os.chmod(sidecar, _GROUP_READABLE)
+        os.chmod(sidecar, start)
         before = sidecar.read_bytes()
 
         with pytest.raises(TypeError):
@@ -258,7 +270,7 @@ class TestWhatIsUnchanged:
 
         assert [p.name for p in root.iterdir() if p.name.endswith(".tmp")] == []
         assert sidecar.read_bytes() == before
-        assert _mode(sidecar) == _GROUP_READABLE
+        assert _mode(sidecar) == start
 
     def test_a_successful_update_writes_the_content(self) -> None:
         root = _seeded_dataset()
@@ -287,6 +299,34 @@ class TestWhatIsUnchanged:
         labels.annotate_episode(root, 0, quality="high")
 
         assert _mode(sidecar) == _MKSTEMP_MODE
+
+
+class TestTheModeFixturesAreTheModesTheyName:
+    """The composed bits denote the octal modes the comments claim.
+
+    Composing the fixtures from ``stat`` bits puts them in the same vocabulary
+    the assertions use, which is only an improvement while the names still mean
+    what they say.
+    """
+
+    def test_each_named_mode_is_the_octal_mode_its_comment_claims(self) -> None:
+        named = (_GROUP_READABLE, _GROUP_WRITABLE, _TEAM_READABLE, _READ_ONLY)
+        assert named == (0o644, 0o664, 0o640, 0o444), (
+            f"the composed bits denote {tuple(oct(m) for m in named)}, so the cells no longer "
+            "drive the modes their comments describe"
+        )
+
+    def test_every_shared_mode_is_wider_than_the_temp_file_s(self) -> None:
+        """Non-vacuity: a mode no wider than ``mkstemp``'s could not be narrowed."""
+        for mode in _SHARED_MODES:
+            assert mode & ~_MKSTEMP_MODE, (
+                f"{oct(mode)} grants nothing {oct(_MKSTEMP_MODE)} withholds, so carrying it "
+                "across proves nothing about the narrowing"
+            )
+
+    def test_the_read_only_mode_really_carries_no_write_bit(self) -> None:
+        """The read-only cell's claim is about ``os.replace``, not a writable file."""
+        assert not _READ_ONLY & _ANY_WRITE, f"{oct(_READ_ONLY)} is writable"
 
 
 class TestThePremise:

--- a/tests/test_label_sidecar_update_keeps_its_permissions.py
+++ b/tests/test_label_sidecar_update_keeps_its_permissions.py
@@ -52,6 +52,12 @@ import strands_robots.episode_labels as labels
 # least one bit, so each would have been narrowed.
 _SHARED_MODES = (0o644, 0o664, 0o640, 0o444)
 
+# The two members individual cells name. Taken from the grid rather than
+# respelled, so the modes these cells stage and the modes the parametrized cells
+# sweep cannot drift apart.
+_GROUP_READABLE = _SHARED_MODES[0]
+_READ_ONLY = _SHARED_MODES[3]
+
 # The private mode the temp file arrives with. Named here rather than read from
 # the module so a cell that grades the module's behaviour is not comparing the
 # module against itself.
@@ -138,7 +144,7 @@ class TestAnUpdateKeepsTheSidecarReadableToTheSameCallers:
         """The bit that decides whether another account can read the labels."""
         root = _seeded_dataset()
         sidecar = labels.labels_path(root)
-        os.chmod(sidecar, 0o644)
+        os.chmod(sidecar, _GROUP_READABLE)
 
         _WRITERS[writer](root)
 
@@ -173,11 +179,11 @@ class TestAnUpdateKeepsTheSidecarReadableToTheSameCallers:
         """
         root = _seeded_dataset()
         sidecar = labels.labels_path(root)
-        os.chmod(sidecar, 0o444)
+        os.chmod(sidecar, _READ_ONLY)
 
         labels.annotate_episode(root, 0, quality="medium")
 
-        assert _mode(sidecar) == 0o444, f"read-only sidecar became {oct(_mode(sidecar))}"
+        assert _mode(sidecar) == _READ_ONLY, f"read-only sidecar became {oct(_mode(sidecar))}"
         assert labels.read_labels(root)["episodes"]["0"]["judge"]["quality"] == "medium"
 
 
@@ -243,7 +249,7 @@ class TestWhatIsUnchanged:
     def test_a_failed_write_leaves_no_temp_file_and_the_sidecar_intact(self) -> None:
         root = _seeded_dataset()
         sidecar = labels.labels_path(root)
-        os.chmod(sidecar, 0o644)
+        os.chmod(sidecar, _GROUP_READABLE)
         before = sidecar.read_bytes()
 
         with pytest.raises(TypeError):
@@ -252,11 +258,11 @@ class TestWhatIsUnchanged:
 
         assert [p.name for p in root.iterdir() if p.name.endswith(".tmp")] == []
         assert sidecar.read_bytes() == before
-        assert _mode(sidecar) == 0o644
+        assert _mode(sidecar) == _GROUP_READABLE
 
     def test_a_successful_update_writes_the_content(self) -> None:
         root = _seeded_dataset()
-        os.chmod(labels.labels_path(root), 0o644)
+        os.chmod(labels.labels_path(root), _GROUP_READABLE)
 
         labels.annotate_episode(root, 0, quality="low", note="drifted")
 


### PR DESCRIPTION
## The defect

`episode_labels._write_document` replaces the label sidecar the standard way: write a
`tempfile.mkstemp` file beside it, `os.replace` it into place. A `mkstemp` file is owner-only, so
the rename carried `0o600` onto the destination. A sidecar that arrived group- or world-readable
came out of the next write readable to nobody but the writer, and the write reported success.

Measured, on a sidecar at `0o644`:

| starting mode | after `record_deterministic_verdicts` | after `annotate_episode` |
|---|---|---|
| `0o644` | `0o600` | `0o600` |
| `0o664` | `0o600` | `0o600` |
| `0o640` | `0o600` | `0o600` |
| `0o444` | `0o600` | `0o600` |

The wider mode is the ordinary case, not an unusual one. The module docstring gives the sidecar's
whole purpose as travelling with the dataset directory - "at the dataset root, next to LeRobot's
own `meta/` / `data/` / `videos/` ... The sidecar travels with the dataset directory" - and every
way it travels lands it at the reader's umask: a `cp -r`, a `tar -x`, a Hub download, a clone. Each
of those is wider than `0o600` in at least one bit, so each is narrowed by the first annotation
written afterwards.

The cost surfaces later and elsewhere. With the sidecar unreadable, both readers fail:

```
read_labels      -> PermissionError: [Errno 13] Permission denied: .../episode_labels.json
filter_episodes  -> PermissionError: [Errno 13] Permission denied: .../episode_labels.json
```

So a training run on a shared dataset - a container on a non-root UID, a group-shared mount, a
second account on a training box - takes a `PermissionError` on labels it could read before, and
the write that caused it reported success and is long gone.

## Why this construct and not its sibling

`simulation/safe_output.atomic_write_bytes` is the same two-phase write and it ends with
`os.chmod(path, 0o600)`, documented: "the final file is `0o600` (the sim output roots are private
to the running user)". That is a decision with a stated reason. Here the same value arrived as
`mkstemp`'s default, with nothing said about it, on a file whose reason for existing is to be
carried around with a dataset. The two are the only `mkstemp`-based writers in the package; the
sibling sets a mode deliberately and this one did not set one at all.

## The change

The destination's mode is read before anything is written and applied to the **temp file**, so the
sidecar is never momentarily readable to fewer callers than it was - chmod-ing `path` after the
rename would leave exactly that window, and the ordering is graded rather than left to the next
edit.

A sidecar this module *creates* keeps `mkstemp`'s owner-only mode. Replacing content is not the
place that decides who may read a dataset, so this change does not widen anything; whether a freshly
created sidecar should match its dataset's umask is a separate question and is not answered here.

`0o444` is preserved too, and still updatable: `os.replace` needs write permission on the
directory, not on the file. A dataset published read-only keeps that posture through an annotation.

## Regression test

`tests/test_label_sidecar_update_keeps_its_permissions.py`, 22 cells. Pre-fix **14 failed / 8
passed**, by class:

| class | role | failed / total |
|---|---|---|
| `TestAnUpdateKeepsTheSidecarReadableToTheSameCallers` | regression | 12 / 12 |
| `TestTheModeIsAppliedBeforeTheRename` | structural | 2 / 2 |
| `TestEveryWriterIsCovered` | derived inventory | 0 / 2 |
| `TestWhatIsUnchanged` | controls | 0 / 4 |
| `TestThePremise` | premise | 0 / 2 |

The headline failure is the one a reader can act on directly:

```
AssertionError: annotate_episode left the sidecar at 0o600 where it found 0o644;
a caller that could read the labels before the write cannot read them after.
```

The writers are discovered from the module's own call graph - a public function whose body calls
`_write_document` - rather than listed, so a third writer is held to the rule when it lands.

## Mutations

`mine` is the new file, `sib` is `test_episode_labels.py` + `test_episode_judge.py` +
`test_holdout_failure_mode_vocabulary.py` + `test_output_path_sandbox.py` (106 cells). `coll` is
recorded because two rows change it.

| mutation | coll | mine | sib |
|---|---|---|---|
| control | 22 | 0 | 0 |
| the fix reverted | 22 | 14 | 0 |
| `chmod(path)` **after** `os.replace` | 22 | 2 | 0 |
| `chmod(tmp_name)` after `os.replace` | 22 | 15 | 106 |
| a hardcoded `0o644` replaces the mode found | 22 | 9 | 0 |
| a **created** sidecar widened to `0o644` | 22 | 2 | 0 |
| raw `st_mode` carried across | 22 | 0 | 0 |
| suppression narrowed to `FileNotFoundError` | 22 | 0 | 0 |
| the mode read inside the `try` | 22 | 0 | 0 |
| an Nth writer planted, inventory **derived** | 22 | 1 | 0 |
| the same plant, inventory **hardcoded** | 22 | 0 | 0 |
| the mode grid narrowed to `0o644`, fix reverted | **16** | 8 | 0 |
| `if existing_mode:` instead of `is not None` | 22 | 1 | 0 |

Reading the rows that matter:

- **`chmod(path)` after the rename fires exactly the 2 structural cells and nothing else.** The end
  state is correct, so no behavioural cell can see it; the window it opens is why the structural
  half is there rather than decoration.
- **Widening a created sidecar fires 2 control cells.** The scope boundary is graded, not asserted.
- **`chmod(tmp_name)` after the rename takes out 106 sibling cells** - the temp no longer exists, so
  that ordering is a hard error rather than a policy. It is in the table because it shows the
  ordering is load-bearing at runtime as well as structurally.
- **The derived / hardcoded pair**: the same planted third writer is caught by the derived
  inventory (1, naming it) and is completely silent against a hardcoded list of today's two. A
  hardcoded list equal to the derived set fires nothing and still looks like a working test.
- **A narrowed mode grid runs 6 fewer cells** (22 -> 16) and reports 8 failures instead of 14, which
  is why `coll` is in the table.

Three rows fire 0 and each has a reason rather than a gap:

- Raw `st_mode` is a **semantic no-op** on Linux - `chmod` masks the file-type bits, so
  `0o100644` sets `0o644`. Measured, not assumed.
- Narrowing the suppression to `FileNotFoundError` is a no-op for the reachable case, which *is* the
  absent file.
- Reading the mode inside the `try` changes no observable behaviour; it is placed before the write
  so a failed write cannot leave the decision half-made.

One case is only reachable through the unit: `0o000` is the single falsy mode, so a truthiness
test would skip it and hand the file `0o600` - a widening. The public writers cannot reach it,
because they read the sidecar before rewriting it, so that cell drives `_write_document` directly
and says so.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1612 files).
- `mypy` **24 == 24** against a worktree of the merge-base, normalized message sets byte-identical
  in both directions, **0** attributable to the changed files.
- 417-file paired selection (every suite that walks the tree, parses source, or reads docstrings /
  `Args:` / `Raises:` / `changelog.d`, plus everything naming `episode_labels`, `episode_judge`,
  `safe_output` or `atomic_write`), the new file excluded from both and every path verified present
  on both trees: identical **20281 collected** and `20 failed, 20191 passed, 70 skipped` on each,
  the same 20 ids, `comm` empty in both directions, two distinct rootdirs.
- The 20 are pre-existing and environmental: **17** need `awsiot` / `awscrt` (`find_spec` False
  here, both declared in the `[mesh-iot]` extra) and **3** are the lerobot-from-source
  `TypeError: encode() takes 1 positional argument but 2 were given` drift in
  `tests/training/test_lerobot*`.

No visual artifact: this changes a file's permission bits and a docstring, not a policy, a
simulation, rendering, recording or an asset. The measured mode tables are the evidence.
