### PR TITLE
fix(simulation): answer gripper_body from one gripper-hint vocabulary

### DIFF
--- a/changelog.d/2807-gripper-mount-vocabulary-is-shared.md
+++ b/changelog.d/2807-gripper-mount-vocabulary-is-shared.md
@@ -1,0 +1,25 @@
+### Fixed: `gripper_body` is answered from one gripper-hint vocabulary
+
+`list_bodies(robot_name=...)` advertises a best-guess gripper/end-effector mount in its
+`gripper_body` field -- the surface a caller reads to resolve `add_camera(parent_body=...)` for a
+wrist view. Both backends matched that field through one shared rule, `hint_matches_name`, and each
+kept a hint vocabulary of its own. The vocabularies had drifted: only one of them carried `jaw`.
+
+So the SO-100 reported its mount on one backend and reported `gripper_body: None` on the other, in
+the same payload that listed both of its jaw bodies. It is a shipped registry robot whose gripper
+bodies are named `Fixed_Jaw` and `Moving_Jaw`, `docs/simulation/newton.md` already documented its
+`gripper_body` as a jaw, and `docs/simulation/world-building.md` documented the narrower vocabulary
+as the whole rule and told the reader that `None` means the robot has no gripper-like body. On a
+loaded SO-100 the field read `None` while the bodies list beside it read `arm/Fixed_Jaw`,
+`arm/Moving_Jaw`.
+
+Sharing the matcher is not on its own enough for two surfaces to agree; they agree only where they
+also read the same vocabulary. `gripper_body` is one question about one robot, so the vocabulary
+behind it now has one owner, `simulation.ik.GRIPPER_BODY_HINTS`, which both backends read.
+`discover_ee_frame` keeps its own words on purpose: it answers a different question -- which frame to
+solve IK *to* -- and still resolves the SO-100's wrist rather than a jaw. The two are pinned as a
+difference so neither can be quietly folded into the other.
+
+Measured over the 59 loadable registry assets, 58 report the mount they always reported and one
+changes: `so100`, from `None` to `Fixed_Jaw`. The added word matches three bodies in the whole
+corpus and every one of them is a real gripper jaw, so no asset gains a mount it should not have.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -592,7 +592,7 @@ sim.add_camera(name="wrist", parent_body=mount,
 
 `list_bodies()` (no `robot_name`) lists every body in the world; with `robot_name` it scopes to that robot and also returns `gripper_body`, the best-guess end-effector mount.
 
-The guess matches its hint words (`gripper`, `hand`, `ee`, `tool`) on word boundaries, so a short hint cannot fire inside an unrelated word - a `knee` link or a `wheel` hub is not a gripper mount because `ee` occurs in its name. A robot with no gripper-like body reports `gripper_body: None` and omits the mount line rather than naming an unrelated body; pick the mount from the full `bodies` list in that case.
+The guess matches its hint words (`gripper`, `hand`, `jaw`, `ee`, `tool` - one set, read by every backend) on word boundaries, so a short hint cannot fire inside an unrelated word - a `knee` link or a `wheel` hub is not a gripper mount because `ee` occurs in its name. A robot with no gripper-like body reports `gripper_body: None` and omits the mount line rather than naming an unrelated body; pick the mount from the full `bodies` list in that case. `jaw` is in the set because the SO-100 family names its gripper bodies `Fixed_Jaw` / `Moving_Jaw`, so the mount resolves for those arms too.
 
 A mounted camera survives `remove_robot`, which rebuilds the whole scene: it is
 re-mounted on its body once every surviving robot is re-attached, keeping its

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -386,6 +386,19 @@ class MinkIKBridge:
 
 _SITE_HINTS = ("attachment_site", "attachment", "grasp", "pinch", "tcp", "ee_site", "ee", "flange")
 _BODY_HINTS = ("hand", "gripper", "tool", "tcp", "ee", "wrist", "flange", "end_effector", "eef")
+
+# Hint words for the gripper/EEF mount every backend's ``list_bodies``
+# advertises in its ``gripper_body`` field. Shared rather than per-backend:
+# ``gripper_body`` is one question about one robot, so a body that is the mount
+# on one backend has to be the mount on every other. ``jaw`` is here because
+# the SO-100 family names its gripper bodies ``Fixed_Jaw`` / ``Moving_Jaw`` -
+# see :data:`~strands_robots.simulation.motion_primitives_base._GRIPPER_HINTS`,
+# which reads the same vocabulary to resolve the gripper *joint*.
+#
+# Distinct from :data:`_BODY_HINTS` above, which answers a different question:
+# which frame IK should solve *to*. That one legitimately prefers a wrist or a
+# flange over a jaw, so the two vocabularies are not interchangeable.
+GRIPPER_BODY_HINTS = ("gripper", "hand", "jaw", "ee", "tool")
 # Rung 1's search order: TCP-specific site names first, then the end-effector
 # names rung 2 matches on bodies. Order-preserving dedupe, because the two
 # tuples share tokens and the first occurrence is the one that decides.
@@ -429,9 +442,16 @@ def hint_matches_name(hint: str, name: str) -> bool:
 
     This is the one matcher for every surface that answers "which element names
     an end-effector" - :func:`discover_ee_frame` here, and the ``gripper_body``
-    each backend's ``list_bodies`` advertises - so the same name cannot be an
-    end-effector to one surface and not to another. Each caller keeps its own
-    hint vocabulary; only the matching rule is shared.
+    each backend's ``list_bodies`` advertises.
+
+    Sharing the matcher is not on its own enough for two surfaces to agree: they
+    agree only where they also read the same vocabulary. So the two backends'
+    ``list_bodies`` read one shared :data:`GRIPPER_BODY_HINTS`, because
+    ``gripper_body`` is one question about one robot and a name cannot be that
+    robot's mount on one backend and not on another. :func:`discover_ee_frame`
+    keeps :data:`_BODY_HINTS` / :data:`_SITE_HINTS` of its own because it
+    answers a different question - which frame to solve IK *to* - and may
+    legitimately prefer a wrist to a jaw on the very same robot.
 
     Args:
         hint: An end-effector hint word, e.g. one of :data:`_SITE_HINTS` /

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -60,7 +60,7 @@ from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolSpec, ToolUse
 
 from strands_robots.simulation.base import SimEngine, close_match_hint, reject_setup_kwargs
-from strands_robots.simulation.ik import hint_matches_name
+from strands_robots.simulation.ik import GRIPPER_BODY_HINTS, hint_matches_name
 from strands_robots.simulation.model_registry import (
     count_sim_robots,
     list_available_models,
@@ -300,12 +300,6 @@ def _resolve_policy_stop_timeout(policy_stop_timeout: float | None, default: flo
 # default and the per-robot mapping fallback cannot drift apart.
 _DEFAULT_ACTION_HORIZON = 8
 
-# Hint words for the best-guess gripper/EEF mount ``list_bodies`` advertises.
-# Matched on word boundaries by
-# :func:`~strands_robots.simulation.ik.hint_matches_name` - the same rule
-# :func:`~strands_robots.simulation.ik.discover_ee_frame` applies - so the short
-# hint "ee" cannot fire inside "knee" or "wheel".
-_GRIPPER_BODY_HINTS = ("gripper", "hand", "ee", "tool")
 
 # The ``create_world`` parameters a LIVE world can still adopt, paired with the
 # published action that applies each one in place without discarding the scene.
@@ -3343,8 +3337,10 @@ class MuJoCoSimEngine(
             ``bodies`` is the ordered list of body names; the ``text`` block
             mirrors it for human display. When ``robot_name`` is given the
             json also carries ``"gripper_body"`` -- the best-guess gripper/
-            end-effector mount (a body one of whose *name components* is
-            ``gripper``, ``hand``, ``ee``, or ``tool``), or ``null`` if none
+            end-effector mount (a body one of whose *name components* is one of
+            :data:`~strands_robots.simulation.ik.GRIPPER_BODY_HINTS`, the set
+            every backend reads: ``gripper``, ``hand``, ``jaw``, ``ee`` or
+            ``tool``), or ``null`` if none
             matches. Hints match components rather than bare substrings, so a
             short hint cannot fire inside an unrelated word: a ``knee`` or a
             drive ``wheel`` is not an end-effector because ``ee`` occurs in its
@@ -3383,7 +3379,7 @@ class MuJoCoSimEngine(
             gripper_body: str | None = None
             for name in bodies:
                 short = name.rsplit("/", 1)[-1]
-                if any(hint_matches_name(hint, short) for hint in _GRIPPER_BODY_HINTS):
+                if any(hint_matches_name(hint, short) for hint in GRIPPER_BODY_HINTS):
                     gripper_body = name
                     break
             json_payload["gripper_body"] = gripper_body

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -39,7 +39,7 @@ import numpy as np
 from strands_robots.assets import resolve_model_path, resolve_robot_name
 from strands_robots.registry.discovery import discover_urdf_path, list_urdf_discoverable
 from strands_robots.simulation.base import SimEngine, reject_setup_kwargs
-from strands_robots.simulation.ik import hint_matches_name
+from strands_robots.simulation.ik import GRIPPER_BODY_HINTS, hint_matches_name
 from strands_robots.simulation.model_registry import (
     list_available_models,
     resolve_model,
@@ -95,13 +95,6 @@ logger = logging.getLogger(__name__)
 # example cadence and keeps position-servo arms tracking their targets.
 _DEFAULT_TIMESTEP = 1.0 / 600.0
 
-# Hint words for the best-guess gripper/EEF mount ``list_bodies`` advertises.
-# Newton adds "jaw" (its own MJCF vocabulary) to the MuJoCo backend's set.
-# Matched on word boundaries by
-# :func:`~strands_robots.simulation.ik.hint_matches_name` - the same rule
-# :func:`~strands_robots.simulation.ik.discover_ee_frame` applies - so the short
-# hint "ee" cannot fire inside "knee" or "wheel".
-_GRIPPER_BODY_HINTS = ("gripper", "hand", "jaw", "ee", "tool")
 
 # Valid ``add_robot(source=...)`` selectors. ``None``/``"registry"`` resolve
 # the curated registry + MJCF asset manager (the same path the MuJoCo backend
@@ -2143,7 +2136,9 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         path (``so_arm100/.../Moving_Jaw``); the ``json`` block returns the
         full labels and, when ``robot_name`` is given, a best-guess
         ``gripper_body`` one of whose trailing segment's *name components* is
-        ``gripper``, ``hand``, ``jaw``, ``ee``, or ``tool``. Hints match
+        one of :data:`~strands_robots.simulation.ik.GRIPPER_BODY_HINTS`, the set
+        every backend reads: ``gripper``, ``hand``, ``jaw``, ``ee`` or ``tool``.
+        Hints match
         components rather than bare substrings, so a short hint cannot fire
         inside an unrelated word: a ``knee`` or a drive ``wheel`` is not an
         end-effector because ``ee`` occurs in its name.
@@ -2181,7 +2176,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             gripper_body: str | None = None
             for name in bodies:
                 short = _short_joint_name(name)
-                if any(hint_matches_name(hint, short) for hint in _GRIPPER_BODY_HINTS):
+                if any(hint_matches_name(hint, short) for hint in GRIPPER_BODY_HINTS):
                     gripper_body = name
                     break
             json_payload["gripper_body"] = gripper_body

--- a/tests/simulation/test_ee_frame_hint_word_boundary.py
+++ b/tests/simulation/test_ee_frame_hint_word_boundary.py
@@ -274,7 +274,13 @@ def test_newton_list_bodies_does_not_advertise_a_knee_or_a_wheel() -> None:
 
 
 def test_newton_list_bodies_still_advertises_a_jaw() -> None:
-    """Newton's own extra hint (``jaw``) keeps matching a real jaw body."""
+    """The fleet-wide ``jaw`` hint keeps matching a real jaw body here.
+
+    ``jaw`` used to be this backend's own extra word; it is now one entry of the
+    shared :data:`~strands_robots.simulation.ik.GRIPPER_BODY_HINTS` both
+    backends read, so this cell measures that sharing it did not cost the match
+    it was carried for.
+    """
     labels = ["bot/base/left_knee_link", "bot/base/Moving_Jaw"]
     assert _newton_gripper_body(labels) == "bot/base/Moving_Jaw"
 

--- a/tests/simulation/test_gripper_mount_vocabulary_is_shared.py
+++ b/tests/simulation/test_gripper_mount_vocabulary_is_shared.py
@@ -1,0 +1,320 @@
+"""Every backend answers ``gripper_body`` from one gripper-hint vocabulary.
+
+``list_bodies(robot_name=...)`` advertises a best-guess gripper/end-effector
+mount in its ``gripper_body`` field - the surface a caller reads to resolve
+``add_camera(parent_body=...)`` for a wrist view. The backends matched on that
+field through one shared rule
+(:func:`~strands_robots.simulation.ik.hint_matches_name`) and each kept a hint
+vocabulary of its own, and the two vocabularies had drifted: only one of them
+carried ``jaw``. So the SO-100 - whose gripper bodies are named ``Fixed_Jaw``
+and ``Moving_Jaw``, and which is a shipped registry robot - reported its mount
+on one backend and reported ``gripper_body: None`` on the other, while that same
+payload listed both jaw bodies.
+
+Sharing the *matcher* is not enough for two surfaces to agree; they agree only
+where they also read the same vocabulary. ``gripper_body`` is one question about
+one robot, so the vocabulary behind it has one owner:
+:data:`~strands_robots.simulation.ik.GRIPPER_BODY_HINTS`.
+
+:func:`~strands_robots.simulation.ik.discover_ee_frame` deliberately keeps its
+own words. It answers a different question - which frame to solve IK *to* - and
+may prefer a wrist to a jaw on the very same arm. The cells here pin that
+difference rather than erasing it.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import textwrap
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation import ik
+from strands_robots.simulation.factory import _BUILTIN_BACKENDS
+from strands_robots.simulation.ik import GRIPPER_BODY_HINTS, hint_matches_name
+from strands_robots.simulation.models import SimRobot, SimWorld
+
+mujoco = pytest.importorskip("mujoco")
+
+# The vocabulary as this file states it, independently of the module under test.
+# Only one cell compares the two, so a mutation to the shipped constant cannot
+# quietly move every expectation here with it.
+EXPECTED_HINTS = ("gripper", "hand", "jaw", "ee", "tool")
+
+# The word whose absence was the defect, and a body name spelled with it. The
+# SO-100 family names its gripper bodies this way.
+JAW_HINT = "jaw"
+JAW_BODY = "Moving_Jaw"
+
+# A body-name set whose only end-effector-like member is a jaw. This is what
+# makes the parity cells able to see the drift at all: a fixture whose mount is
+# named ``gripper`` matches every candidate vocabulary and so cannot distinguish
+# them.
+DISTINGUISHING_BODIES = ("left_knee_link", "wheel_hub_back_link", JAW_BODY)
+
+
+def _chain(links: str) -> str:
+    """A serial chain of hinge-jointed bodies named by ``links``."""
+    names = links.split()
+    xml = '<mujoco><worldbody><body name="base">'
+    xml += '<joint name="j0" type="hinge"/><geom type="box" size=".1 .1 .1"/>'
+    for i, name in enumerate(names):
+        xml += f'<body name="{name}">'
+        xml += f'<joint name="j{i + 1}" type="hinge"/><geom type="box" size=".05 .05 .05"/>'
+    xml += "</body>" * len(names)
+    xml += "</body></worldbody></mujoco>"
+    return xml
+
+
+def _mujoco_mount(tmp_path: Path, bodies: tuple[str, ...]) -> str | None:
+    """``gripper_body`` from the real MuJoCo backend for an inline chain."""
+    from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+    path = tmp_path / "arm.xml"
+    path.write_text(_chain(" ".join(bodies)))
+    sim: Any = MuJoCoSimEngine()
+    try:
+        sim.create_world(ground_plane=False)
+        added = sim.add_robot(name="bot", urdf_path=str(path))
+        assert added["status"] == "success", added["content"][0]["text"]
+        payload = sim.list_bodies(robot_name="bot")["content"][1]["json"]
+        assert payload["bodies"], "the chain must contribute bodies to search"
+        return payload["gripper_body"]
+    finally:
+        sim.destroy()
+
+
+def _newton_mount(bodies: tuple[str, ...]) -> str | None:
+    """``gripper_body`` from the real Newton ``list_bodies``, no Newton runtime.
+
+    The method reads only the robot registry and the per-robot body map, so a
+    stand-in ``self`` carrying those drives the shipped code - the pattern the
+    sibling word-boundary suite uses.
+    """
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    labels = [f"bot/base/{name}" for name in bodies]
+    world = SimWorld()
+    world.robots["bot"] = SimRobot(name="bot", urdf_path="bot.xml", data_config="bot", joint_names=[])
+    engine: Any = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._world = world
+    engine._model = types.SimpleNamespace(body_label=list(labels))
+    engine._robot_body_map = {"bot": list(labels)}
+    result = NewtonSimEngine.list_bodies(engine, "bot")
+    assert result["status"] == "success"
+    return result["content"][1]["json"]["gripper_body"]
+
+
+# Backends whose ``gripper_body`` this file drives end to end. A premise cell
+# below asserts this covers every backend that answers the question at all, so a
+# backend added later is either driven here or fails that cell.
+MOUNT_DRIVERS = ("mujoco", "newton")
+
+
+def _backend_classes() -> dict[str, type]:
+    """Every registered backend class, by the name ``create_simulation`` takes."""
+    resolved: dict[str, type] = {}
+    for name, (module_path, class_name) in _BUILTIN_BACKENDS.items():
+        resolved[name] = getattr(importlib.import_module(module_path), class_name)
+    return resolved
+
+
+def _backends_answering_the_mount_question() -> set[str]:
+    """Backends whose ``list_bodies`` puts a ``gripper_body`` in its payload."""
+    answering = set()
+    for name, cls in _backend_classes().items():
+        method = getattr(cls, "list_bodies", None)
+        if method is None:
+            continue
+        if '"gripper_body"' in inspect.getsource(method):
+            answering.add(name)
+    return answering
+
+
+def _vocabularies_read_for_the_mount() -> dict[str, set[str]]:
+    """The hint-vocabulary name each backend's ``list_bodies`` reads.
+
+    Read off the source rather than the value so two backends that happen to
+    hold equal tuples today still register as two vocabularies. Equal contents
+    are what the drift looked like before it drifted.
+    """
+    read: dict[str, set[str]] = {}
+    for name in sorted(_backends_answering_the_mount_question()):
+        cls = _backend_classes()[name]
+        source = textwrap.dedent(inspect.getsource(cls.list_bodies))  # type: ignore[attr-defined]
+        tree = ast.parse(source)
+        names = {
+            node.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name) and node.id.upper().endswith("GRIPPER_BODY_HINTS")
+        }
+        read[name] = names
+    return read
+
+
+class TestThePremiseIsReal:
+    """The drift was reachable through a shipped asset, not only a fixture."""
+
+    def test_the_shipped_so100_names_its_gripper_bodies_with_the_jaw_word(self) -> None:
+        """SO-100's gripper bodies carry ``jaw`` and no other hint word.
+
+        This is why the missing word cost the mount outright rather than merely
+        picking a different body: nothing else in the arm matches at all.
+        """
+        from strands_robots.simulation.model_registry import resolve_model_path
+
+        model = mujoco.MjModel.from_xml_path(str(resolve_model_path("so100")))
+        bodies = [
+            name for index in range(model.nbody) if (name := mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, index))
+        ]
+        jaws = [name for name in bodies if hint_matches_name(JAW_HINT, name)]
+        assert jaws, bodies
+        others = [
+            name for name in bodies for hint in EXPECTED_HINTS if hint != JAW_HINT and hint_matches_name(hint, name)
+        ]
+        assert others == [], others
+
+    def test_the_matcher_is_shared_by_both_surfaces(self) -> None:
+        """One matcher; the vocabularies are what this file is about."""
+        assert callable(hint_matches_name)
+        assert "hint_matches_name" in inspect.getsource(ik.discover_ee_frame)
+
+    def test_the_driven_backends_are_every_backend_that_answers(self) -> None:
+        """A backend that later advertises a mount is driven here, or fails.
+
+        Without this the parity cells could silently cover a shrinking share of
+        the backends that answer the question.
+        """
+        assert _backends_answering_the_mount_question() == set(MOUNT_DRIVERS)
+
+    def test_the_distinguishing_fixture_really_distinguishes(self) -> None:
+        """The fixture's only mount candidate is the contested word.
+
+        A fixture named ``gripper`` matches every candidate vocabulary, so it
+        cannot see a vocabulary drift - which is how the drift survived.
+        """
+        matched = [hint for hint in EXPECTED_HINTS for name in DISTINGUISHING_BODIES if hint_matches_name(hint, name)]
+        assert matched == [JAW_HINT], matched
+
+
+class TestBothBackendsAdvertiseTheSameMount:
+    """The same robot reports the same mount whichever backend answers."""
+
+    def test_the_two_backends_agree_on_a_jaw_only_arm(self, tmp_path: Path) -> None:
+        """Pre-fix MuJoCo answered ``None`` here and Newton answered the jaw."""
+        assert _mujoco_mount(tmp_path, DISTINGUISHING_BODIES) == f"bot/{JAW_BODY}"
+        assert _newton_mount(DISTINGUISHING_BODIES) == f"bot/base/{JAW_BODY}"
+
+    def test_neither_backend_reports_no_mount_for_a_jaw_only_arm(self, tmp_path: Path) -> None:
+        """Stated as the absence, because the pre-fix answer was an absence."""
+        assert _mujoco_mount(tmp_path, DISTINGUISHING_BODIES) is not None
+        assert _newton_mount(DISTINGUISHING_BODIES) is not None
+
+    @pytest.mark.parametrize("hint", EXPECTED_HINTS)
+    def test_every_hint_resolves_a_mount_on_both_backends(self, tmp_path: Path, hint: str) -> None:
+        """No entry of the shared set is honoured by only one backend."""
+        bodies = ("shoulder_link", f"{hint}_link")
+        assert _mujoco_mount(tmp_path, bodies) == f"bot/{hint}_link"
+        assert _newton_mount(bodies) == f"bot/base/{hint}_link"
+
+
+class TestTheShippedAssetResolvesItsMount:
+    """The registry robot the drift affected now reports its mount."""
+
+    def test_so100_advertises_a_jaw_as_its_mount(self) -> None:
+        """The payload listed both jaws while saying there was no mount."""
+        from strands_robots.simulation import create_simulation
+        from strands_robots.simulation.model_registry import resolve_model_path
+
+        sim: Any = create_simulation("mujoco")
+        try:
+            sim.create_world()
+            added = sim.add_robot(name="arm", urdf_path=str(resolve_model_path("so100")))
+            assert added["status"] == "success", added["content"][0]["text"]
+            result = sim.list_bodies(robot_name="arm")
+            payload = next(block["json"] for block in result["content"] if "json" in block)
+            text = next(block["text"] for block in result["content"] if "text" in block)
+        finally:
+            sim.destroy()
+
+        mount = payload["gripper_body"]
+        assert mount is not None, payload["bodies"]
+        assert hint_matches_name(JAW_HINT, mount.rsplit("/", 1)[-1]), mount
+        assert mount in payload["bodies"], (mount, payload["bodies"])
+        assert "Gripper/EEF mount" in text
+
+
+class TestTheVocabularyHasOneOwner:
+    """One question, one vocabulary - derived, so a third backend is graded."""
+
+    def test_every_answering_backend_reads_the_shared_name(self) -> None:
+        read = _vocabularies_read_for_the_mount()
+        assert read, "no backend was found answering the mount question"
+        for backend, names in read.items():
+            assert names == {"GRIPPER_BODY_HINTS"}, (backend, names)
+
+    def test_no_backend_defines_a_gripper_vocabulary_of_its_own(self) -> None:
+        """A per-backend copy is the shape that drifted; refuse a second one."""
+        owners = []
+        for path in sorted(Path("strands_robots/simulation").rglob("*.py")):
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if not isinstance(node, ast.Assign):
+                    continue
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id.upper().endswith("GRIPPER_BODY_HINTS"):
+                        owners.append(f"{path}:{node.lineno} {target.id}")
+        assert len(owners) == 1, owners
+        assert owners[0].startswith("strands_robots/simulation/ik.py"), owners
+
+    def test_the_shipped_vocabulary_is_the_one_this_file_expects(self) -> None:
+        """The single cell that couples this file to the shipped constant."""
+        assert GRIPPER_BODY_HINTS == EXPECTED_HINTS
+
+
+class TestWhatMustNotChange:
+    """Sharing the vocabulary must not widen it or move a settled answer."""
+
+    def test_a_knee_or_a_wheel_is_still_not_a_mount(self, tmp_path: Path) -> None:
+        legs = ("left_knee_link", "wheel_hub_back_link")
+        assert _mujoco_mount(tmp_path, legs) is None
+        assert _newton_mount(legs) is None
+
+    def test_so101_reports_the_mount_it_always_reported(self) -> None:
+        """Its ``gripper`` body precedes its jaw, so the answer is unchanged."""
+        from strands_robots.simulation import create_simulation
+        from strands_robots.simulation.model_registry import resolve_model_path
+
+        sim: Any = create_simulation("mujoco")
+        try:
+            sim.create_world()
+            assert sim.add_robot(name="arm", urdf_path=str(resolve_model_path("so101")))["status"] == "success"
+            payload = next(block["json"] for block in sim.list_bodies(robot_name="arm")["content"] if "json" in block)
+        finally:
+            sim.destroy()
+        assert payload["gripper_body"] == "arm/gripper"
+
+    def test_ik_still_prefers_a_wrist_to_a_jaw_on_the_same_arm(self) -> None:
+        """The IK surface answers a different question and keeps its words.
+
+        Its target frame for the SO-100 is the wrist, not a jaw. Folding the two
+        vocabularies together would move it.
+        """
+        from strands_robots.simulation.model_registry import resolve_model_path
+
+        model = mujoco.MjModel.from_xml_path(str(resolve_model_path("so100")))
+        discovered = ik.discover_ee_frame(model)
+        assert discovered is not None
+        frame, kind = discovered
+        assert kind == "body"
+        assert hint_matches_name("wrist", frame), frame
+        assert not hint_matches_name(JAW_HINT, frame), frame
+
+    def test_the_ik_vocabulary_is_not_the_mount_vocabulary(self) -> None:
+        """Pinned as a difference so neither can be quietly made the other."""
+        assert JAW_HINT not in ik._BODY_HINTS
+        assert JAW_HINT in GRIPPER_BODY_HINTS


### PR DESCRIPTION
## The defect

`list_bodies(robot_name=...)` advertises a best-guess gripper/end-effector mount in its `gripper_body` field -- the surface a caller reads to resolve `add_camera(parent_body=...)` for a wrist view. Both backends matched that field through one shared rule, `simulation.ik.hint_matches_name`, and each kept a hint vocabulary of its own under the same name:

| constant | value |
|---|---|
| `mujoco.simulation._GRIPPER_BODY_HINTS` | `("gripper", "hand", "ee", "tool")` |
| `newton.simulation._GRIPPER_BODY_HINTS` | `("gripper", "hand", "jaw", "ee", "tool")` |

Same name, same purpose, and `newton - mujoco == ("jaw",)` with `mujoco - newton == ()`. So on a shipped registry robot the two backends answer differently:

| robot | MuJoCo advertises | Newton advertises |
|---|---|---|
| `so100` | *nothing* | `Fixed_Jaw`, `Moving_Jaw` |
| `so101` | `gripper` | `gripper`, `moving_jaw_so101_v1` |

Driven end to end through the real MuJoCo backend on `so100` (7 bodies), the payload contradicts itself:

```
list_bodies status : success
gripper_body       : None
bodies containing 'jaw' : ['arm/Fixed_Jaw', 'arm/Moving_Jaw']
```

The field says there is no mount; the list beside it names two. The `text` block's `Gripper/EEF mount:` line is omitted entirely.

## Why the narrower set is the wrong one

Three places in the tree already say `jaw` belongs:

- `motion_primitives_base._GRIPPER_HINTS` is `("gripper", "finger", "jaw")`, and its comment gives the reason outright: *"SO-100's gripper joint is the 'Jaw'"*. It reads the same vocabulary to resolve the gripper *joint*.
- `docs/simulation/newton.md` documents `sim.list_bodies("so100")[...]["gripper_body"]` with the output `"so_arm100/.../Fixed_Jaw"` -- the answer MuJoCo could not give.
- `docs/simulation/world-building.md` taught the narrower list as the whole rule and told the reader that `gripper_body: None` means *"A robot with no gripper-like body"*. For an SO-100 that reads as a false statement about the arm.

The Newton constant's own comment justified the divergence as *"Newton adds 'jaw' (its own MJCF vocabulary)"*. Both backends read MJCF, and here they read the same file, so that reason does not hold.

## The change

`hint_matches_name`'s docstring claimed that sharing the matcher meant *"the same name cannot be an end-effector to one surface and not to another"*, in the same paragraph that licensed *"Each caller keeps its own hint vocabulary"*. The second sentence is how the first stops being true: agreement needs a shared vocabulary as well as a shared rule.

So `gripper_body` -- one question about one robot -- gets one owner, `simulation.ik.GRIPPER_BODY_HINTS`, which both backends read. `discover_ee_frame` keeps `_BODY_HINTS` / `_SITE_HINTS` of its own on purpose: it answers a different question, which frame to solve IK *to*, and it still resolves the SO-100's `Wrist_Pitch_Roll` rather than a jaw. The two are pinned as a difference so neither can be quietly folded into the other. Both docstrings that enumerated the words in prose, and the docs page, now name the shared set.

## Corpus safety

Over the 59 loadable registry assets:

| | |
|---|---|
| answer unchanged | **58** |
| answer changed | **1** -- `so100`, `None` -> `Fixed_Jaw` |
| bodies the added word matches, corpus-wide | **3** -- `so100/Fixed_Jaw`, `so100/Moving_Jaw`, `so101/moving_jaw_so101_v1` |
| of those, not a real gripper jaw | **0** |

`so101` is unchanged because its `gripper` body precedes its jaw in body order.

## Why nothing caught it

`tests/simulation/test_ee_frame_hint_word_boundary.py` states the property in its own section comment -- *"the parity that matters to a caller - the same robot reports the same mount on either backend"* -- and never measures it:

- `test_both_surfaces_agree_on_the_same_robot` compares `list_bodies` against `discover_ee_frame`, not one backend against the other, and its fixture body is `link_gripper_slider`, which matches `gripper` -- a hint **both** vocabularies carry. A fixture spelled that way cannot see a vocabulary drift.
- `test_newton_list_bodies_still_advertises_a_jaw` pinned the divergence as intentional (*"Newton's own extra hint"*). Its docstring is corrected here; the cell now measures that sharing the word did not cost the match it was carried for.

Every mutation below fires **0** tests in the pre-existing suites except the two noted.

## Tests

`tests/simulation/test_gripper_mount_vocabulary_is_shared.py`, 19 cells. Pre-fix split with the MuJoCo backend given its own narrow set back: **6 failed / 13 passed**.

| class | hit | role |
|---|---|---|
| `TestThePremiseIsReal` | 0/4 | the drift was reachable through a shipped asset |
| `TestBothBackendsAdvertiseTheSameMount` | 3/3 | regression |
| `TestTheShippedAssetResolvesItsMount` | 1/1 | regression |
| `TestTheVocabularyHasOneOwner` | 2/3 | derived, so a third backend is graded on arrival |
| `TestWhatMustNotChange` | 0/4 | over-reach controls |

### Mutations

| mutation | fires | pre-existing | note |
|---|---|---|---|
| control | 0 | 0 | 19 collected throughout |
| MuJoCo keeps its own narrow set (the defect) | 6 | **0** | nothing in the tree sees it |
| Newton keeps its own set, contents equal | 2 | 0 | structural only; behaviourally a no-op today |
| both keep own sets, contents equal | 2 | 0 | same set - the drift guard, not a behaviour |
| shared set loses `jaw` | 6 | 1 | trips the pre-existing Newton jaw pin |
| shared set gains `knee` (over-reach) | 3 | **3** | pre-existing knee/wheel tests refuse it |
| IK's `_BODY_HINTS` gains `jaw` (vocabularies folded) | 2 | 0 | the difference is pinned |

All three sources restored byte-identical after every row (md5 asserted).

## Gate

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean, 1614 files.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the merge-base, normalized message sets byte-identical both directions, 0 attributable to the changed files.
- Paired run, identical 823-file selection (all of `tests/simulation`, plus every guard that walks the tree, parses source, or reads docstrings and `docs/`), the new file excluded from both and every path verified present on both: identical **30731 collected** and `25 failed, 30412 passed, 294 skipped` on each tree, **25 == 25 failing ids with `comm` empty in both directions**, distinct rootdirs. Of the 25: 17 need `awsiot`/`awscrt` (`find_spec` False, declared in the `[mesh-iot]` extra), 3 are the lerobot-from-source `encode()` drift, and 5 pass **29/29 in isolation on both trees**.

## Artifact

`gripper_body` exists so a caller can mount a wrist camera, so the artifact is that call. One capture script run against each tree with the same scene, asset, camera parameters and headlight; the external view agrees between the two runs to within **1** intensity level, which is EGL's cross-process reproducibility rather than a difference between the trees. Panel 2 is a text panel because the call that would create its camera cannot be made.

![gripper_body resolves the mount the payload already listed](https://github.com/cagataycali/robots/releases/download/artifacts/gripper_mount.png)
