### PR TITLE
fix(transforms): bind a pipeline class the same way its import path binds it

### DIFF
--- a/changelog.d/2808-pipeline-class-binds-like-its-import-path.md
+++ b/changelog.d/2808-pipeline-class-binds-like-its-import-path.md
@@ -1,0 +1,22 @@
+### Fixed: a `cosmos_transfer` pipeline class now binds the same way its import path binds it
+
+The video2video pipeline seam accepts a backend two ways - as an object, or as
+a dotted import path resolved lazily - and only one of them applied the
+construction step. The dotted-path branch constructs a class or zero-arg
+factory target before probing it, because an unconstructed class passes the
+`generate()` probe as a plain function and then receives the video as its
+`self`. The object branch skipped that step, so the same class bound cleanly
+through one form and failed through the other: `validate()` returned no
+problems for `pipeline=Adapter`, and generation then raised
+`TypeError: Adapter.generate() missing 1 required positional argument: 'video'`
+from inside the run - neither the `error` envelope `transform()` returns for a
+wiring problem nor the `ValueError` it documents, and after the source dataset
+was opened and an output recorder created.
+
+`validate()` exists so a wiring mistake is reported before any of that work
+happens, and the documented adapter recipe is spelled `class Adapter:`, so
+`Adapter` against `Adapter()` is a one-character slip. Construction is now a
+single owner both branches consult, so neither can re-derive it. A class whose
+`generate` is a `staticmethod` or a `classmethod` already bound usably and
+still does; a class whose constructor needs arguments now names its
+constructor rather than a missing `video`.

--- a/strands_robots/transforms/cosmos_transfer.py
+++ b/strands_robots/transforms/cosmos_transfer.py
@@ -122,6 +122,58 @@ def _generate_surface(obj: Any, subject: str) -> tuple[Any, str | None]:
         )
 
 
+def _pipeline_subject(obj: Any) -> str:
+    """Name the caller's binding in a problem, so a class names itself.
+
+    ``type(a_class).__name__`` is ``"type"``, which would report the remedy
+    against a subject the caller never wrote.
+    """
+    return f"pipeline object {obj.__name__ if isinstance(obj, type) else type(obj).__name__}"
+
+
+def _constructed_if_needed(candidate: Any, surface: Any, subject: str) -> tuple[Any, Any, list[str]]:
+    """Construct a class / zero-arg factory target, or report why it could not be.
+
+    Shared by both binding forms rather than restated in one of them. An
+    unconstructed class passes the ``generate`` probe as a plain function and
+    then receives the video as its ``self``, so the rule has to hold whether
+    the class reached the seam as an object or as a dotted import path - the
+    same value, bound two ways, has to resolve one way.
+
+    Args:
+        candidate: The resolved binding target.
+        surface: Its ``generate`` attribute as :func:`_generate_surface` read
+            it, or :data:`_UNSET` when it exposes none.
+        subject: How the caller named it, for the problem text.
+
+    Returns:
+        ``(candidate, surface, problems)`` - the constructed object and its
+        re-read surface when construction happened, the inputs unchanged when
+        it was not needed, and a one-problem list when it failed.
+    """
+    if not (isinstance(candidate, type) or (callable(candidate) and surface is _UNSET)):
+        return candidate, surface, []
+    try:
+        candidate = candidate()
+    except TypeError as exc:
+        return candidate, surface, [f"{subject} is not constructible zero-arg ({exc}) - {_PIPELINE_HELP}"]
+    except Exception as exc:  # noqa: BLE001 - never fatal during name resolution
+        # Constructing a real generation pipeline loads weights and touches a
+        # device, so the failures are the deployment's, not the signature's: no
+        # driver (``RuntimeError``), weights absent (``OSError``), an optional
+        # dep imported inside the factory body (``ImportError``), a malformed
+        # config (``ValueError``). Reported with an accurate subject rather
+        # than folded into the zero-arg wording above, which would name the
+        # wrong cause.
+        return (
+            candidate,
+            surface,
+            [f"{subject} raised {type(exc).__name__} while being constructed ({exc}) - {_PIPELINE_HELP}"],
+        )
+    surface, problem = _generate_surface(candidate, subject)
+    return candidate, surface, [problem] if problem else []
+
+
 class CosmosTransferTransform(DatasetTransform):
     """Video2video episode augmentation behind a vendor-neutral pipeline seam.
 
@@ -137,16 +189,22 @@ class CosmosTransferTransform(DatasetTransform):
         Args:
             pipeline: One of:
 
-                * a constructed object exposing
+                * an object exposing
                   ``generate(video, prompt=..., seed=...) -> ndarray`` (the
-                  pipeline protocol in the module docstring);
+                  pipeline protocol in the module docstring), or a class /
+                  zero-arg factory returning one - the same targets a dotted
+                  path may name, resolved by the same rule, so a value binds
+                  identically whichever of the two forms carries it;
                 * a dotted import path (``"pkg.mod:attr"`` or
-                  ``"pkg.mod.attr"``) naming such an object, or a zero-arg
-                  factory returning one - resolved lazily, so constructing
-                  this transform never imports a generation stack;
+                  ``"pkg.mod.attr"``) naming any of those - resolved lazily, so
+                  constructing this transform never imports a generation stack;
                 * ``None`` - the transform constructs but
                   :meth:`validate` reports the missing pipeline, so nothing is
                   read or written without one.
+
+                A class or factory is constructed once, during
+                :meth:`validate`, and the resulting object is what
+                :meth:`transform_frames` and :attr:`transform_version` read.
         """
         self._pipeline_spec = pipeline
         self._pipeline: Any | None = pipeline if pipeline is not None and not isinstance(pipeline, str) else None
@@ -175,12 +233,16 @@ class CosmosTransferTransform(DatasetTransform):
         instance validate approved.
         """
         if self._pipeline is not None:
-            subject = f"pipeline object {type(self._pipeline).__name__}"
+            subject = _pipeline_subject(self._pipeline)
             surface, problem = _generate_surface(self._pipeline, subject)
             if problem:
                 return [problem]
+            candidate, surface, problems = _constructed_if_needed(self._pipeline, surface, subject)
+            if problems:
+                return problems
             if not callable(surface):
                 return [f"{subject} has no callable generate() - {_PIPELINE_HELP}"]
+            self._pipeline = candidate
             return []
         if self._pipeline_spec is None:
             return [f"no video2video pipeline is bound - {_PIPELINE_HELP}"]
@@ -201,26 +263,9 @@ class CosmosTransferTransform(DatasetTransform):
         surface, problem = _generate_surface(candidate, subject)
         if problem:
             return [problem]
-        # A class target (or a factory with no generate of its own) is
-        # constructed zero-arg; an unconstructed class would otherwise pass the
-        # generate() probe and then receive the video as its ``self``.
-        if isinstance(candidate, type) or (callable(candidate) and surface is _UNSET):
-            try:
-                candidate = candidate()
-            except TypeError as exc:
-                return [f"{subject} is not constructible zero-arg ({exc}) - {_PIPELINE_HELP}"]
-            except Exception as exc:  # noqa: BLE001 - never fatal during name resolution
-                # Constructing a real generation pipeline loads weights and
-                # touches a device, so the failures are the deployment's, not
-                # the signature's: no driver (``RuntimeError``), weights absent
-                # (``OSError``), an optional dep imported inside the factory
-                # body (``ImportError``), a malformed config (``ValueError``).
-                # Reported with an accurate subject rather than folded into the
-                # zero-arg wording above, which would name the wrong cause.
-                return [f"{subject} raised {type(exc).__name__} while being constructed ({exc}) - {_PIPELINE_HELP}"]
-            surface, problem = _generate_surface(candidate, subject)
-            if problem:
-                return [problem]
+        candidate, surface, problems = _constructed_if_needed(candidate, surface, subject)
+        if problems:
+            return problems
         if not callable(surface):
             return [f"{subject} resolves to no generate() surface - {_PIPELINE_HELP}"]
         self._pipeline = candidate

--- a/tests/transforms/test_cosmos_transfer.py
+++ b/tests/transforms/test_cosmos_transfer.py
@@ -224,6 +224,16 @@ class TestEveryProbePointReportsInsteadOfRaising:
             assert any(expected in p for p in problems), problems
 
 
+def _guarded_probe_functions() -> list[str]:
+    """Module-level view of the derived probe universe, for parametrize."""
+    tree = ast.parse(pathlib.Path(cosmos_transfer.__file__).read_text(encoding="utf-8"))
+    return sorted(
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and any(isinstance(n, ast.Try) for n in ast.walk(node))
+    )
+
+
 class TestTheSeamHasOneGuardedProbeRule:
     """Structural: a probe point added later cannot re-derive an unguarded read.
 
@@ -251,7 +261,27 @@ class TestTheSeamHasOneGuardedProbeRule:
                     owners.add(func.name)
         assert owners == {"_generate_surface"}, f"the generate read must have one guarded owner, found {owners}"
 
-    @pytest.mark.parametrize("func_name", ["_generate_surface", "_pipeline_problems"])
+    @staticmethod
+    def _functions_guarding_a_probe() -> list[str]:
+        """Every function in the module that guards a probe with a ``try``.
+
+        Derived rather than listed: the class promises a probe point added
+        later is held to the rule, and a hardcoded pair cannot keep that
+        promise for a function the module does not have yet.
+        """
+        tree = ast.parse(pathlib.Path(cosmos_transfer.__file__).read_text(encoding="utf-8"))
+        return sorted(
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and any(isinstance(n, ast.Try) for n in ast.walk(node))
+        )
+
+    def test_the_derived_probe_universe_reaches_every_guarded_function(self):
+        """Premise: the derivation finds the handlers the behavioural tests drive."""
+        found = self._functions_guarding_a_probe()
+        assert {"_generate_surface", "_pipeline_problems"} <= set(found), found
+
+    @pytest.mark.parametrize("func_name", _guarded_probe_functions())
     def test_every_probe_handler_reports_rather_than_raises(self, func_name):
         """Each ``try`` in the resolution names ``Exception`` in some handler."""
         func = self._func(func_name)
@@ -399,3 +429,148 @@ class TestCallShapedAdapterExample:
         # An unseeded spec stays unseeded: no generator is fabricated for None.
         transform.transform_frames("cam", _frames(), TransformSpec(), source_episode=0, variant=0)
         assert pipe.calls[1]["generator"] is None
+
+
+class _InstanceMethodPipeline:
+    """The module docstring's documented adapter shape: ``generate(self, ...)``."""
+
+    version = "class-3.0"
+
+    def generate(self, video, prompt="", seed=None):
+        """Identity generation - schema-correct, so only the binding is under test."""
+        return np.asarray(video)
+
+
+class _StaticMethodPipeline:
+    """A class whose ``generate`` takes no ``self``."""
+
+    @staticmethod
+    def generate(video, prompt="", seed=None):
+        """Identity generation."""
+        return np.asarray(video)
+
+
+class _ClassMethodPipeline:
+    """A class whose ``generate`` binds the class rather than an instance."""
+
+    @classmethod
+    def generate(cls, video, prompt="", seed=None):
+        """Identity generation."""
+        return np.asarray(video)
+
+
+class _PipelineNeedingArguments:
+    """A pipeline whose constructor cannot be satisfied zero-arg."""
+
+    def __init__(self, weights):
+        self.weights = weights
+
+    def generate(self, video, prompt="", seed=None):
+        """Identity generation."""
+        return np.asarray(video)
+
+
+def _instance_factory():
+    """Zero-arg factory returning a bound pipeline."""
+    return _InstanceMethodPipeline()
+
+
+class TestAClassBindsTheSameWayAsItsImportPath:
+    """A class is a class whichever of the two binding forms carries it.
+
+    ``validate`` exists so a wiring mistake is a reported problem before an
+    episode is read or an output recorder is created. A class handed to
+    ``pipeline=`` reached that bar only when it arrived as a dotted path: the
+    object form skipped the construction step, approved the class, and then
+    called ``generate`` unbound - handing the video to ``self`` - from inside
+    generation, as a bare ``TypeError`` that is neither the ``error`` envelope
+    ``transform`` returns for a wiring problem nor the ``ValueError`` it
+    documents.
+    """
+
+    def test_a_class_bound_as_an_object_is_usable(self):
+        """The documented adapter shape, one character short of an instance."""
+        transform = CosmosTransferTransform(pipeline=_InstanceMethodPipeline)
+        assert transform._pipeline_problems() == []
+        out = transform.transform_frames("cam", _frames(), TransformSpec(), source_episode=0, variant=0)
+        assert out.shape == _frames().shape
+        assert out.dtype == _frames().dtype
+
+    def test_the_public_validate_reports_the_same_binding_verdict(self, tmp_path):
+        """Through the documented entry point, on a spec with nothing else wrong."""
+        spec = TransformSpec(source_root=str(tmp_path / "src"), output_root=str(tmp_path / "out"))
+        (tmp_path / "src").mkdir()
+        problems = CosmosTransferTransform(pipeline=_InstanceMethodPipeline).validate(spec)
+        assert not [p for p in problems if "pipeline" in p], problems
+
+    def test_the_two_binding_forms_agree_on_the_same_class(self):
+        """Same value, two spellings, one verdict and one resolved type."""
+        as_object = CosmosTransferTransform(pipeline=_InstanceMethodPipeline)
+        as_path = CosmosTransferTransform(pipeline=f"{__name__}:_InstanceMethodPipeline")
+        assert as_object._pipeline_problems() == as_path._pipeline_problems() == []
+        assert type(as_object._pipeline) is type(as_path._pipeline) is _InstanceMethodPipeline
+
+    def test_a_zero_arg_factory_bound_as_an_object_is_constructed(self):
+        """Parity with ``test_dotted_path_to_a_factory_is_constructed``."""
+        transform = CosmosTransferTransform(pipeline=_instance_factory)
+        assert transform._pipeline_problems() == []
+        assert isinstance(transform._pipeline, _InstanceMethodPipeline)
+
+    def test_a_class_needing_arguments_names_its_constructor(self):
+        """The refusal names the real cause, not a missing ``video`` argument."""
+        problems = CosmosTransferTransform(pipeline=_PipelineNeedingArguments)._pipeline_problems()
+        assert any("is not constructible zero-arg" in p for p in problems), problems
+        assert any("_PipelineNeedingArguments" in p for p in problems), problems
+
+    def test_the_resolved_object_is_what_the_version_is_read_from(self):
+        """Provenance pins the constructed instance, not the class handle."""
+        transform = CosmosTransferTransform(pipeline=_InstanceMethodPipeline)
+        assert transform._pipeline_problems() == []
+        assert transform.transform_version == "class-3.0"
+
+
+class TestTheBindingFormsShareOneConstructionRule:
+    """Structural: neither branch may re-derive the construction step."""
+
+    def test_the_construction_has_a_single_owner(self):
+        """No other function constructs the caller's binding target."""
+        tree = ast.parse(pathlib.Path(cosmos_transfer.__file__).read_text(encoding="utf-8"))
+        owners = set()
+        for func in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]:
+            for call in [n for n in ast.walk(func) if isinstance(n, ast.Call)]:
+                if ast.unparse(call.func) == "candidate" and not call.args and not call.keywords:
+                    owners.add(func.name)
+        assert owners == {"_constructed_if_needed"}, f"the zero-arg construction must have one owner, found {owners}"
+
+    def test_both_binding_branches_consult_the_shared_rule(self):
+        """``_pipeline_problems`` reaches the owner once per binding form."""
+        source = textwrap.dedent(inspect.getsource(CosmosTransferTransform._pipeline_problems))
+        assert source.count("_constructed_if_needed(") == 2, source
+
+
+class TestNoPreviouslyUsablePipelineIsRefused:
+    """Over-reach controls: every shape that already bound keeps binding."""
+
+    @pytest.mark.parametrize(
+        "pipeline",
+        [_StaticMethodPipeline, _ClassMethodPipeline],
+        ids=["staticmethod-class", "classmethod-class"],
+    )
+    def test_a_class_whose_generate_takes_no_instance_still_works(self, pipeline):
+        """These bound usably before the construction step was shared."""
+        transform = CosmosTransferTransform(pipeline=pipeline)
+        assert transform._pipeline_problems() == []
+        out = transform.transform_frames("cam", _frames(), TransformSpec(), source_episode=0, variant=0)
+        assert out.shape == _frames().shape
+
+    def test_an_instance_is_still_bound_as_itself(self):
+        """An already-constructed object is never re-constructed."""
+        pipeline = FakePipeline()
+        transform = CosmosTransferTransform(pipeline=pipeline)
+        assert transform._pipeline_problems() == []
+        assert transform._pipeline is pipeline
+
+    def test_an_object_with_no_generate_keeps_its_wording(self):
+        """``object()`` is not callable, so the construction step must skip it."""
+        problems = CosmosTransferTransform(pipeline=object())._pipeline_problems()
+        assert any("no callable generate()" in p for p in problems), problems


### PR DESCRIPTION
## Problem

`CosmosTransferTransform` binds a video2video pipeline two ways: as an object, or as a dotted import path resolved lazily. Only the dotted-path branch applied the construction step, and its own comment states why the step exists:

> A class target (or a factory with no generate of its own) is constructed zero-arg; an unconstructed class would otherwise pass the generate() probe and then receive the video as its `self`.

The object branch skipped it. So the same class bound cleanly through one form and broke through the other. Measured on `main`:

| `pipeline=` | `validate()` | generation |
| --- | --- | --- |
| an instance | no problems | success |
| **a class (unconstructed)** | **no problems** | **`TypeError: Adapter.generate() missing 1 required positional argument: 'video'`** |
| dotted path to that class | no problems | success (constructed) |
| dotted path to a factory | no problems | success (constructed) |
| dotted path to an instance | no problems | success |

`validate()` exists so a wiring mistake is a reported problem *before* an episode is read or an output recorder is created — its own docstring says "nothing is read or written without one". Here it approved a pipeline that cannot be called, and the failure then arrived from inside generation as a bare `TypeError`: neither the `error` envelope `transform()` returns for a wiring problem, nor the `ValueError` its `Raises:` block documents. On a real generative backend that is minutes of work and a created output dataset before the report.

It is also a one-character slip, because the documented adapter recipe in the module docstring and in `_PIPELINE_HELP` is spelled `class Adapter:` — so `pipeline=Adapter` against `pipeline=Adapter()`.

## Fix

The construction step becomes a single owner (`_constructed_if_needed`) that both branches consult, rather than being restated in one of them. The read of `generate` already had one guarded owner and a structural test pinning it; the construction that must accompany that read did not.

Deliberately construct rather than refuse: constructing is what the sibling branch already does for the identical value, it makes a value bind identically whichever form carries it, and refusing would have regressed two shapes that work today.

## No previously usable pipeline is refused

Measured on `main` before choosing the fix's shape, which is what ruled out a blanket refusal:

| class shape | before | after |
| --- | --- | --- |
| `generate` is an instance method | `TypeError` at generation | success |
| `generate` is a `@staticmethod` | success | success |
| `generate` is a `@classmethod` | success | success |
| constructor needs arguments | `TypeError` naming `'video'` | refused, naming `is not constructible zero-arg` |

The last row is the second improvement: the refusal now names the constructor instead of blaming a missing `video` argument.

## Tests

`tests/transforms/test_cosmos_transfer.py` gains a regression class, a structural class, and an over-reach control class. Pre-fix split with the source at `main` and the new tests kept:

```
6 failed, 67 passed
  TestAClassBindsTheSameWayAsItsImportPath        4 of 6   REGRESSION
  TestTheBindingFormsShareOneConstructionRule     2 of 2   REGRESSION (structural)
  TestNoPreviouslyUsablePipelineIsRefused         0 of 3   over-reach control
  (six pre-existing classes)                     0 of 26
```

Post-fix: `74 passed`.

The class's existing probe-handler rule promises that "a probe point added later cannot re-derive an unguarded read", and its universe was a hardcoded pair of function names, which cannot keep that promise for a function the module does not have yet. It is now derived from the module, so the new owner is held to the rule on arrival — that is the `+1` in the collected count.

## End-to-end verification

Against a recorded three-episode LeRobotDataset (unequal lengths `[7, 13, 5]`, 25 frames), with the pipeline bound as a class — the exact call that raised `TypeError` before:

```
validate: []
transform: success  (read 3 episode(s), wrote 3 generated episode(s))
output parquet truth: 3 episodes, 25 frames, [7, 13, 5]
reopened via LeRobotDataset: 25 frames, 3 episodes, ['observation.images.default']
provenance: 3 records, transform_version = 'e2e-transfer-1.0'
pixels changed: True        action byte-identical to source: True
```

`transform_version` is read from the constructed instance, so provenance pins the object that produced the pixels. The non-image pass-through guarantee is unaffected.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1614 files).
- `mypy strands_robots tests tests_integ`: 19 pre-existing errors, all in `examples/isaac_gs/` (reached through followed imports), zero in the changed files.
- `tests/transforms/`: 380 passed.
- 118 tree-walking guard files plus the transforms suite: 5007 passed, 55 skipped.

Docs: `__init__`'s `pipeline:` entry documented the object form as "a constructed object"; it now documents the domain the seam actually resolves, and states that a class or factory is constructed once during `validate()`.
