### PR TITLE
fix(teleop): report whether stop_teleoperate actually stopped the loop

### DIFF
--- a/changelog.d/2809-stop-teleoperate-reports-the-join-outcome.md
+++ b/changelog.d/2809-stop-teleoperate-reports-the-join-outcome.md
@@ -1,0 +1,54 @@
+### Fixed: `stop_teleoperate` reports whether the teleop loop actually stopped
+
+`threading.Thread.join(timeout=...)` returns `None` whether or not the thread
+finished, so the liveness read after it is the only thing that distinguishes a
+stopped loop from one that outlasted the budget. `TeleopMixin.stop_teleoperate`
+joined with a 3 s budget and never took that read: it then set the thread handle
+to `None`, disconnected every attached device, and answered
+`_teleop_stats(blocking=False)`. A leader whose `get_action()` was still blocking
+- a serial read on a wedged bus is the ordinary case a join budget exists for -
+was therefore reported as stopped while its loop was still polling that leader
+and writing to the follower, and the handle that was the only route to
+discovering it had already been discarded. Measured on a session whose leader
+blocks inside `get_action()`:
+
+```
+                                     before          after
+stop_teleoperate status              success         error
+payload stopped                      (absent)        False
+loop thread still alive              True            True
+thread handle after the call         None            <Thread ...>
+device disconnect() calls            1               0
+get_teleoperate_status thread_alive  (absent)        True
+frame delivered after the call       1               1
+```
+
+The last row is the consequence the success claim hid: the follower is written to
+after the caller has been told teleoperation stopped.
+
+The session counters cannot express this. `_teleop_stats` derives its status from
+them precisely so a dead teleop is not reported as healthy, and it distinguishes
+three signatures - a softly failing follower, a dead leader, and a frame the slew
+bound refused - but a session that ran cleanly until its leader wedged carries
+healthy counters, so "the loop is still running" is outside that vocabulary. The
+join outcome is now reported beside them rather than through them, in the shape
+`G1Driver.stop_task` already documents: `status="error"` naming the budget with
+`stopped=False` in the payload, so a caller cannot read "success" while the loop
+still holds the wire.
+
+Two consequences follow from reading the outcome. The devices are disconnected
+only once the loop has joined, because tearing the bus down under a live writer
+is what `G1Driver.cleanup` refuses for the same reason; and the handle is cleared
+only on a real join, so a second `stop_teleoperate()` re-joins that loop instead
+of reporting an idle session. `get_teleoperate_status` gained `thread_alive`
+alongside `running`: `running` is the session flag, which the stop clears before
+it joins, and without the second reading a caller polling after a stop that
+reported `stopped=False` would be told `running=False` by the status verb.
+
+A joined stop is unchanged - it still reports the counter-derived status, still
+disconnects its devices, still clears the handle, and stopping an idle host is
+still a no-op success. `stopped` is now present on both paths so a caller reading
+it never has to tell an absent key from a false one. Of the seven timed thread
+joins in the package, three already read liveness; the other three answer
+different contracts (a `-> None` server teardown, a stats property, and a
+recording flush whose window is one frame) and are deliberately untouched.

--- a/docs/hardware/teleoperation.md
+++ b/docs/hardware/teleoperation.md
@@ -87,7 +87,7 @@ Every hardware `Robot` and `Simulation` host exposes:
 | `attach_teleop(device_or_spec, *, name=None, method=None, map_fn=None, **kwargs)` | Register an input stream (lazy - no hardware touched). `device_or_spec` is a built teleop instance **or** a type string built via `Teleoperator(**kwargs)`. |
 | `teleoperate(*, names=None, robot_name=None, hz=50.0, publish=False, block=False, duration=None)` | Run the control loop. |
 | `detach_teleop(name=None)` | Remove one (or all) attached streams. |
-| `stop_teleoperate()` | Stop the loop, any mesh publishers, and disconnect devices. |
+| `stop_teleoperate()` | Stop the loop, any mesh publishers, and disconnect devices. Reports `status="error"` with `stopped: false` when the loop outlasts its 3 s join budget - the devices are left connected rather than torn down mid-write, and a second call re-joins the same loop. |
 
 ### `attach_teleop`
 
@@ -307,6 +307,8 @@ robot.teleoperate(block=True, duration=60)   # 60 s then stop + disconnect
 robot.teleoperate()
 ...
 robot.stop_teleoperate()                     # stop loop + publishers + disconnect
+#   -> status="error" + stopped=false if the loop is still polling the leader;
+#      get_teleoperate_status()["thread_alive"] reads the loop thread itself.
 ```
 
 ## How it relates to mesh teleop

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -53,6 +53,9 @@ logger = logging.getLogger(__name__)
 
 # Default local control loop frequency (Hz). Matches InputPublisher.
 _TELEOP_HZ_DEFAULT = 50.0
+# Budget for joining the background teleop thread in stop_teleoperate.
+# Named so the docstring, the refusal text and the tests read one value.
+_TELEOP_JOIN_TIMEOUT_S = 3.0
 
 ActionDict = dict[str, float]
 MapFn = Callable[[ActionDict], ActionDict]
@@ -642,7 +645,29 @@ class TeleopMixin:
         }
 
     def stop_teleoperate(self) -> dict[str, Any]:
-        """Stop the local teleop loop, any mesh publishers, and disconnect devices."""
+        """Stop the local teleop loop, any mesh publishers, and disconnect devices.
+
+        The returned envelope reports the join outcome honestly. ``join()``
+        returns ``None`` whether or not the thread finished, so the liveness read
+        after it is the only thing that tells a stopped loop from one that
+        outlasted the budget. A leader whose ``get_action()`` blocks past
+        :data:`_TELEOP_JOIN_TIMEOUT_S` - a serial read on a wedged bus is the
+        ordinary case - surfaces as ``status="error"`` naming the timeout and
+        ``stopped=False`` in the payload, so a caller cannot read "success" while
+        the loop is still polling that leader and writing to the follower.
+
+        :meth:`_teleop_stats` derives its status from the session counters so a
+        dead teleop is not reported as healthy, but a session that ran cleanly
+        until its leader wedged carries healthy counters: "the loop is still
+        running" is a condition those counters cannot express, which is why the
+        join outcome is reported beside them rather than through them.
+
+        The attached devices are disconnected only once the loop has joined.
+        Tearing the bus down under a live writer is what ``G1Driver.cleanup``
+        refuses for the same reason, and the thread handle is kept when the join
+        fails so a later call re-joins that loop instead of reporting an idle
+        session.
+        """
         self._ensure_teleop_state()
 
         if not self._teleop_running and self._teleop_thread is None:
@@ -652,11 +677,36 @@ class TeleopMixin:
 
         self._teleop_running = False
         self._teleop_stop_event.set()
-        if self._teleop_thread is not None:
-            self._teleop_thread.join(timeout=3.0)
-            self._teleop_thread = None
+        thread = self._teleop_thread
+        joined = True
+        if thread is not None:
+            thread.join(timeout=_TELEOP_JOIN_TIMEOUT_S)
+            joined = not thread.is_alive()
+            if joined:
+                # Cleared only on a real join: the handle is the only route by
+                # which a later call, or a status read, can still see the loop.
+                self._teleop_thread = None
 
         self._stop_publishers()
+
+        if not joined:
+            devices = sorted(self._teleops)
+            target = self.tool_name_label(self._teleop_robot_name)
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Teleoperation did not stop within {_TELEOP_JOIN_TIMEOUT_S:.1f}s: the "
+                            f"loop is still polling {devices} and writing to {target}. The leader's "
+                            f"get_action() is most likely blocking. The devices are left connected "
+                            f"so the loop is not torn down mid-write; call stop_teleoperate() again "
+                            f"to re-join it."
+                        )
+                    },
+                    {"json": {"stopped": False, "devices": devices, "target": target}},
+                ],
+            }
 
         # Disconnect devices we connected.
         for n, att in self._teleops.items():
@@ -667,7 +717,16 @@ class TeleopMixin:
         return self._teleop_stats(blocking=False)
 
     def get_teleoperate_status(self) -> dict[str, Any]:
-        """Status of the local teleop loop (distinct from mesh get_teleop_status)."""
+        """Status of the local teleop loop (distinct from mesh get_teleop_status).
+
+        ``running`` is the session flag: :meth:`stop_teleoperate` clears it before
+        it joins. ``thread_alive`` reads the loop thread itself, so the two differ
+        for exactly as long as a loop outlives the stop that asked it to exit -
+        the window in which the follower can still be written to. Without the
+        second reading a caller polling after a stop that reported
+        ``stopped=False`` would be told ``running=False`` by this verb, which is
+        the contradiction the join outcome exists to remove.
+        """
         self._ensure_teleop_state()
         elapsed = time.monotonic() - self._teleop_start_mono if self._teleop_start_mono else 0
         hz = self._teleop_frames / elapsed if elapsed > 0 else 0
@@ -676,6 +735,7 @@ class TeleopMixin:
             "content": [
                 {
                     "text": f"Local teleop: running={self._teleop_running}, "
+                    f"thread_alive={self._teleop_thread is not None and self._teleop_thread.is_alive()}, "
                     f"frames={self._teleop_frames}, errors={self._teleop_errors}, "
                     f"slew_rejected={self._teleop_slew_rejected}, "
                     f"hz={hz:.1f}, devices={list(self._teleops)}"
@@ -683,6 +743,7 @@ class TeleopMixin:
                 {
                     "json": {
                         "running": self._teleop_running,
+                        "thread_alive": self._teleop_thread is not None and self._teleop_thread.is_alive(),
                         "frames": self._teleop_frames,
                         "errors": self._teleop_errors,
                         "slew_rejected": self._teleop_slew_rejected,
@@ -882,7 +943,9 @@ class TeleopMixin:
             with contextlib.suppress(Exception):
                 stop_pub()  # stops all publishers/receivers on the host
 
-    def _teleop_stats(self, *, blocking: bool, publish_results: list | None = None) -> dict[str, Any]:
+    def _teleop_stats(
+        self, *, blocking: bool, publish_results: list | None = None, stopped: bool = True
+    ) -> dict[str, Any]:
         elapsed = time.monotonic() - self._teleop_start_mono if self._teleop_start_mono else 0
         hz = self._teleop_frames / elapsed if elapsed > 0 else 0
         note = ""
@@ -918,6 +981,7 @@ class TeleopMixin:
             "elapsed_s": elapsed,
             "status": status,
             "blocking": blocking,
+            "stopped": stopped,
             "publish_count": len(publish_results) if publish_results else 0,
         }
         return {

--- a/tests/test_stop_teleoperate_reports_the_join_outcome.py
+++ b/tests/test_stop_teleoperate_reports_the_join_outcome.py
@@ -138,13 +138,18 @@ def wedged(monkeypatch: pytest.MonkeyPatch):
 class TestThePremise:
     """What the graded behaviour rests on."""
 
-    def test_a_timed_join_cannot_report_whether_the_thread_finished(self) -> None:
-        """``join(timeout=)`` returns None either way, so liveness is the only route."""
+    def test_a_timed_join_can_return_with_the_thread_still_alive(self) -> None:
+        """A timed join carries no verdict, so liveness is the only route.
+
+        ``Thread.join`` is annotated ``-> None`` and mypy refuses to read a value
+        from it, so the type checker already states that half; what a test can add
+        is the other one - the call returns normally while the thread runs on.
+        """
         blocked = threading.Event()
         thread = threading.Thread(target=lambda: blocked.wait(20.0), daemon=True)
         thread.start()
         try:
-            assert thread.join(timeout=0.05) is None
+            thread.join(timeout=0.05)
             assert thread.is_alive() is True, "the probe thread was supposed to outlast the join"
         finally:
             blocked.set()

--- a/tests/test_stop_teleoperate_reports_the_join_outcome.py
+++ b/tests/test_stop_teleoperate_reports_the_join_outcome.py
@@ -1,0 +1,319 @@
+"""Guard: ``stop_teleoperate`` reports whether the loop actually stopped.
+
+``threading.Thread.join(timeout=...)`` returns ``None`` whether or not the
+thread finished, so the liveness read after it is the only thing that
+distinguishes a stopped loop from one that outlasted the budget. Without that
+read the verb answered ``status="success"`` for a leader whose ``get_action()``
+was still blocking - a serial read on a wedged bus is the ordinary case the
+timeout exists for - and then disconnected the devices under the live loop and
+set the thread handle to ``None``, so no later call and no status read could
+discover the loop was still polling that leader and writing to the follower.
+
+Two properties are graded, because either alone leaves the other reachable:
+
+* the envelope: an unjoined stop is an ``error`` naming the budget, carrying
+  ``stopped=False``, and it leaves the devices connected rather than tearing the
+  bus down mid-write;
+* the handle: it is cleared only on a real join, so a second call re-joins the
+  same loop and ``get_teleoperate_status`` can report ``thread_alive``.
+
+The counters ``_teleop_stats`` derives its status from cannot express this. A
+session that ran cleanly until its leader wedged carries healthy ones, which is
+why the join outcome is reported beside them rather than through them.
+
+The budget is shortened through the module constant in most cells so the suite
+does not spend the shipped 3 s per case; one cell drives the real constant.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import strands_robots.teleop_mixin as tm
+
+# Stated locally rather than imported, so these cells grade the shipped budget
+# instead of following it. Exactly one cell asserts the two agree.
+SHIPPED_JOIN_TIMEOUT_S = 3.0
+
+# Short budget for the cells whose subject is the verdict, not the wait.
+FAST_JOIN_TIMEOUT_S = 0.2
+
+
+class WedgedLeader:
+    """A leader whose ``get_action()`` blocks, as a serial read on a hung bus does."""
+
+    name = "so101_leader"
+    id = "leader"
+
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.disconnect_calls = 0
+        self.get_action_calls = 0
+
+    def connect(self, calibrate: bool = True) -> None:  # noqa: ARG002
+        self.is_connected = True
+
+    def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self.is_connected = False
+
+    def get_action(self) -> dict[str, float]:
+        self.get_action_calls += 1
+        self.entered.set()
+        self.release.wait(20.0)
+        return {"shoulder_pan.pos": 1.0}
+
+
+class PromptLeader:
+    """A leader that answers immediately - the healthy control."""
+
+    name = "so101_leader"
+    id = "leader"
+
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.disconnect_calls = 0
+
+    def connect(self, calibrate: bool = True) -> None:  # noqa: ARG002
+        self.is_connected = True
+
+    def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self.is_connected = False
+
+    def get_action(self) -> dict[str, float]:
+        return {"shoulder_pan.pos": 1.0}
+
+
+class Host(tm.TeleopMixin):
+    """Minimal teleop host: the mixin needs only ``send_action``."""
+
+    tool_name_str = "probe_robot"
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, float]] = []
+        self._send_lock = threading.Lock()
+
+    def send_action(self, action: dict[str, float], robot_name: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+        with self._send_lock:
+            self.sent.append(dict(action))
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+def _json(result: dict[str, Any]) -> dict[str, Any]:
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+@pytest.fixture
+def wedged(monkeypatch: pytest.MonkeyPatch):
+    """A running session whose leader is blocked inside ``get_action()``."""
+    # raising=False so this fixture installs against a tree that has not
+    # named the budget yet: a pre-fix run then reports which behaviour is
+    # missing instead of an AttributeError from the fixture itself.
+    monkeypatch.setattr(tm, "_TELEOP_JOIN_TIMEOUT_S", FAST_JOIN_TIMEOUT_S, raising=False)
+    host = Host()
+    device = WedgedLeader()
+    host.attach_teleop(device, name="leader")
+    assert host.teleoperate(hz=100.0, block=False)["status"] == "success"
+    assert device.entered.wait(5.0), "the loop never reached the leader's get_action()"
+    thread = host._teleop_thread
+    assert thread is not None and thread.is_alive()
+    try:
+        yield host, device, thread
+    finally:
+        device.release.set()
+        thread.join(timeout=5.0)
+
+
+class TestThePremise:
+    """What the graded behaviour rests on."""
+
+    def test_a_timed_join_cannot_report_whether_the_thread_finished(self) -> None:
+        """``join(timeout=)`` returns None either way, so liveness is the only route."""
+        blocked = threading.Event()
+        thread = threading.Thread(target=lambda: blocked.wait(20.0), daemon=True)
+        thread.start()
+        try:
+            assert thread.join(timeout=0.05) is None
+            assert thread.is_alive() is True, "the probe thread was supposed to outlast the join"
+        finally:
+            blocked.set()
+            thread.join(timeout=5.0)
+
+    def test_the_wedged_leader_really_outlasts_the_budget(self, wedged) -> None:
+        """Without this the regression cells would grade a loop that simply exited."""
+        _host, _device, thread = wedged
+        thread.join(timeout=FAST_JOIN_TIMEOUT_S)
+        assert thread.is_alive() is True
+
+
+class TestAnUnjoinedStopIsReportedHonestly:
+    """The envelope a caller reads must not claim a stop that did not happen."""
+
+    def test_the_status_is_an_error(self, wedged) -> None:
+        host, _device, _thread = wedged
+        assert host.stop_teleoperate()["status"] == "error"
+
+    def test_the_payload_says_it_did_not_stop(self, wedged) -> None:
+        host, _device, _thread = wedged
+        assert _json(host.stop_teleoperate())["stopped"] is False
+
+    def test_the_reason_names_the_budget_that_elapsed(self, wedged) -> None:
+        host, _device, _thread = wedged
+        assert f"{tm._TELEOP_JOIN_TIMEOUT_S:.1f}s" in _text(host.stop_teleoperate())
+
+    def test_the_reason_names_what_is_still_being_driven(self, wedged) -> None:
+        """The leader still being polled and the follower still being written."""
+        host, _device, _thread = wedged
+        text = _text(host.stop_teleoperate())
+        assert "leader" in text
+        assert "probe_robot" in text
+
+    def test_the_shipped_budget_is_honoured_when_it_is_not_shortened(self) -> None:
+        """One cell drives the real constant, so the budget itself is graded."""
+        host = Host()
+        device = WedgedLeader()
+        host.attach_teleop(device, name="leader")
+        host.teleoperate(hz=100.0, block=False)
+        assert device.entered.wait(5.0)
+        thread = host._teleop_thread
+        try:
+            started = time.monotonic()
+            result = host.stop_teleoperate()
+            waited = time.monotonic() - started
+            assert result["status"] == "error"
+            assert waited >= SHIPPED_JOIN_TIMEOUT_S
+        finally:
+            device.release.set()
+            if thread is not None:
+                thread.join(timeout=5.0)
+
+    def test_a_frame_can_still_reach_the_follower_after_the_stop_returned(self, wedged) -> None:
+        """The consequence the success claim hid: the loop is still writing."""
+        host, device, thread = wedged
+        result = host.stop_teleoperate()
+        assert result["status"] == "error"
+        before = len(host.sent)
+        device.release.set()
+        thread.join(timeout=5.0)
+        assert len(host.sent) > before, "the loop was supposed to still be mid-write"
+
+
+class TestTheHandleSurvivesAnUnjoinedStop:
+    """The handle is the only route by which the live loop stays discoverable."""
+
+    def test_the_thread_handle_is_kept(self, wedged) -> None:
+        host, _device, thread = wedged
+        host.stop_teleoperate()
+        assert host._teleop_thread is thread
+
+    def test_the_status_verb_reports_the_thread_as_alive(self, wedged) -> None:
+        host, _device, _thread = wedged
+        host.stop_teleoperate()
+        assert _json(host.get_teleoperate_status())["thread_alive"] is True
+
+    def test_a_second_call_re_joins_the_same_loop_and_succeeds(self, wedged) -> None:
+        host, device, thread = wedged
+        assert host.stop_teleoperate()["status"] == "error"
+        device.release.set()
+        thread.join(timeout=5.0)
+        again = host.stop_teleoperate()
+        assert again["status"] == "success"
+        assert _json(again)["stopped"] is True
+        assert host._teleop_thread is None
+
+
+class TestTheBusIsNotTornDownMidWrite:
+    """A device is disconnected once the loop has joined, not before."""
+
+    def test_the_devices_stay_connected_while_the_loop_lives(self, wedged) -> None:
+        host, device, _thread = wedged
+        host.stop_teleoperate()
+        assert device.disconnect_calls == 0
+        assert device.is_connected is True
+
+
+class TestAJoinedStopIsUnchanged:
+    """Over-reach controls: every expectation here held before the change too."""
+
+    def test_a_healthy_session_still_reports_success(self) -> None:
+        host = Host()
+        device = PromptLeader()
+        host.attach_teleop(device, name="leader")
+        host.teleoperate(hz=200.0, block=False)
+        deadline = time.monotonic() + 5.0
+        while not host.sent and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert host.stop_teleoperate()["status"] == "success"
+
+    def test_a_healthy_session_still_disconnects_its_devices(self) -> None:
+        host = Host()
+        device = PromptLeader()
+        host.attach_teleop(device, name="leader")
+        host.teleoperate(hz=200.0, block=False)
+        host.stop_teleoperate()
+        assert device.disconnect_calls == 1
+        assert device.is_connected is False
+
+    def test_a_healthy_session_still_clears_the_handle(self) -> None:
+        host = Host()
+        host.attach_teleop(PromptLeader(), name="leader")
+        host.teleoperate(hz=200.0, block=False)
+        host.stop_teleoperate()
+        assert host._teleop_thread is None
+
+    def test_stopping_an_idle_host_is_still_a_no_op_success(self) -> None:
+        result = Host().stop_teleoperate()
+        assert result["status"] == "success"
+        assert "No active teleoperation" in _text(result)
+
+
+class TestTheLivenessReadIsStructurallyPresent:
+    """Pin the read itself, so a revert to a bare timed join fails here.
+
+    Scoped to this module rather than derived tree-wide: three other timed
+    thread joins in the package answer different contracts (a ``-> None``
+    teardown, a stats property, and a recording flush), so a tree-wide rule
+    would grade surfaces this change does not touch.
+    """
+
+    def test_the_budget_is_a_named_constant(self) -> None:
+        """The single cell that couples this file to the shipped constant.
+
+        Named so the docstring, the refusal text and these cells read one value -
+        and so a case whose subject is the verdict can shorten it.
+        """
+        assert tm._TELEOP_JOIN_TIMEOUT_S == SHIPPED_JOIN_TIMEOUT_S
+
+    def test_the_timed_join_is_followed_by_a_liveness_read(self) -> None:
+        import ast
+        import inspect
+        import textwrap
+
+        body = ast.parse(textwrap.dedent(inspect.getsource(tm.TeleopMixin.stop_teleoperate)))
+        joins = [
+            node
+            for node in ast.walk(body)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "join"
+            and (node.args or node.keywords)
+        ]
+        assert len(joins) == 1, "expected exactly one timed join to grade"
+        alive = [
+            node
+            for node in ast.walk(body)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "is_alive"
+        ]
+        assert alive, "the timed join's outcome is never read"
+        assert joins[0].lineno < alive[0].lineno, "liveness must be read after the join"


### PR DESCRIPTION
## Problem

`threading.Thread.join(timeout=...)` returns `None` whether or not the thread
finished, so the liveness read after it is the only thing that distinguishes a
stopped loop from one that outlasted the budget. `TeleopMixin.stop_teleoperate`
joined with a 3 s budget and never took that read. It then set the thread handle
to `None`, disconnected every attached device, and answered
`_teleop_stats(blocking=False)`.

A leader whose `get_action()` is still blocking - a serial read on a wedged bus
is the ordinary case a join budget exists for - was therefore reported as
stopped while its loop was still polling that leader and writing to the
follower, and the handle that was the only route to discovering it had already
been discarded.

Measured on a session whose leader blocks inside `get_action()` (a stand-in
device; `attach_teleop` needs only a callable `get_action`):

| reading | before | after |
|---|---|---|
| `stop_teleoperate` status | `success` | `error` |
| payload `stopped` | absent | `False` |
| wall time in the call | 3.00 s | 3.00 s |
| loop thread still alive | `True` | `True` |
| thread handle after the call | `None` | `<Thread ...>` |
| device `disconnect()` calls | 1 | 0 |
| `get_teleoperate_status` `thread_alive` | absent | `True` |
| frame delivered to the follower after the call returned | 1 | 1 |

The last row is the consequence the success claim hid: the follower is written
to after the caller has been told teleoperation stopped.

## Why the session counters cannot express this

`_teleop_stats` derives its status from the counters rather than hardcoding
`"success"`, and its comment says why - "so a dead teleop is not reported as
healthy". It distinguishes three signatures: a softly failing follower
(`errors == frames`), a dead leader (`frames == 0`), and a frame the slew bound
refused. A session that ran cleanly until its leader wedged carries healthy
counters, so "the loop is still running" is outside that vocabulary. The join
outcome is now reported beside them rather than through them.

`G1Driver.stop_task` already documents the shape this takes: "a caller-supplied
policy that outlasts the join budget ... surfaces as `status="error"` naming the
timeout and `stopped=False` in the payload, so the caller cannot read 'success'
while the payload's own `running=True` says the loop is still writing frames."

## Change

Read the join outcome, and let two things follow from it.

* The devices are disconnected only once the loop has joined. Tearing the bus
  down under a live writer is what `G1Driver.cleanup` refuses for the same
  reason ("Closing `_pubs` under a live 500 Hz thread would drop the loop into
  its `publish` branch and skip the zero-torque frame").
* The handle is cleared only on a real join, so a second `stop_teleoperate()`
  re-joins that loop instead of taking the idle branch - and
  `get_teleoperate_status` gained `thread_alive` beside `running`. `running` is
  the session flag, which the stop clears before it joins, so without the second
  reading a caller polling after a stop that reported `stopped=False` would be
  told `running=False` by the status verb.

The 3 s budget became `_TELEOP_JOIN_TIMEOUT_S` so the docstring, the refusal text
and the tests read one value. `stopped` is present on both paths, so a caller
reading it never has to tell an absent key from a false one.

## Why nothing caught it

Every `FakeTeleop.get_action()` in the shipped suite returns immediately, so
every join in it succeeds. The nearest existing cell,
`test_teleoperate_block_keyboard_interrupt_tears_down`, grades the `block=True`
path, which runs the loop inline and has no thread to join at all. The four
cells in the suite's own "session-end status honesty" section grade the three
counter signatures above.

## Scope

Seven timed thread joins exist in the package. Three already read liveness
(`G1ControlLoop.stop`, `HardwareRosBridge.shutdown`,
`HardwareRtpsBridge.shutdown`); four did not. The other three are deliberately
untouched because they answer different contracts: `PolicyServer.stop` returns
`None` and has no envelope to lie in, `InputPublisher.stop` returns a documented
`stats` property, and `stop_cameras_recording`'s window is a single render
because its loop re-reads `running` per camera.

## Verification

Pre-fix split (source reverted, tests kept): **11 failed / 6 passed**, with
0 failures in `TestThePremise` (2 cells) and 0 in `TestAJoinedStopIsUnchanged`
(4 cells). The headline failure is `assert 'success' == 'error'`.

Mutation table - 13 rows, control clean, `collected` stable at 17/18 throughout
so no row hides a deselection. `sib` counts failures in the seven pre-existing
teleop and hardware-lifecycle suites (119 files, 256 cells in the five that
matter here).

| row | fires | sib | mutation |
|---|---|---|---|
| b0 | 0 | 0 | control |
| b1 | 10 | 0 | liveness never read (the defect) |
| b2 | 3 | 0 | handle cleared unconditionally |
| b3 | 7 | 0 | devices disconnected regardless of the join |
| b4 | 4 | 0 | unjoined stop still reports `success` |
| b5 | 1 | 0 | `stopped` dropped from the unjoined payload |
| b6 | 1 | 0 | refusal text drops the budget |
| b7 | 1 | 0 | refusal text names neither leader nor follower |
| b8 | 1 | 0 | `stopped` never added to `_teleop_stats` |
| b9 | 1 | 0 | `thread_alive` dropped from the status verb |
| b10 | 4 | **2** | liveness read *before* the join |
| b11 | 4 | 0 | alternative disposition: `degraded` instead of `error` |
| b12 | 7 | 0 | tempting wrong fix: warn but keep the success envelope |

Ten distinct firing sets. Two collisions, both structural: b3 == b12 (each
routes an unjoined stop down the joined path) and b4 == b11 (each moves the
status off `error`). b10 is the informative row - reading liveness before the
join fires the three healthy-session controls plus the structural cell, and
**trips 2 pre-existing tests**, so the ordering is load-bearing at runtime and
not only in the AST assertion. b12 is the reviewer's first instinct measured:
warning while keeping the success envelope leaves 7 cells failing.

Gate, on an identical 529-file selection (every test naming teleop, a thread
join, or the hardware wrapper, plus every guard that walks the tree, parses
source, or reads docstrings and `docs/`), the new test file excluded from both
trees and every path verified present on both:

```
                collected   result                                        rootdir
branch          24919       23 failed, 24772 passed, 100 skipped, 24 err  robots-src
base (636abbb2) 24919       23 failed, 24772 passed, 100 skipped, 24 err  run-.../base
```

47 failing/erroring ids each, `comm` empty in both directions. Classified rather
than assumed: 44 are `tests/mesh/test_iot_*` needing `awsiot` (`find_spec` is
`False` here; declared in the `mesh-iot` extra, which CI installs), 3 are the
lerobot-from-source `TypeError: encode() takes 1 positional argument` drift.

`ruff check` and `ruff format --check` clean over `strands_robots tests
tests_integ` (1616 files). mypy **24 == 24** against a pristine worktree of the
same base, normalized message sets byte-identical in both directions, 0
attributable. The changed file plus the four teleop suites: **256 passed** on the
rebased tree, and both load-bearing mutation rows re-measured unchanged there
(b1 10, b3 7).

No visual artifact: this is a teardown-reporting change, not a policy,
simulation, rendering, recording or asset one. The measured before/after table
above is the evidence.

## §13 Round changelog

**Round 2** — the lint finding the required check named, and a process error worth
naming beside it. One push, and it was the wrong shape.

- **The mypy finding is fixed.** `TestThePremise`'s first cell asserted
  `thread.join(timeout=0.05) is None`. `Thread.join` is annotated `-> None`, so
  mypy refuses to read a value from it at all:
  `error: "join" of "Thread" does not return a value (it only ever returns None)
  [func-returns-value]`. The assertion is now a bare call, and the cell keeps the
  half a test can actually add — `assert thread.is_alive() is True`, that the call
  returns normally while the thread runs on. The docstring says why the other half
  is the type checker's to state rather than the suite's, so the cell is not left
  looking like it dropped a claim.

  Confirmed load-bearing rather than assumed: reverted the line to the asserted
  form, ran mypy, got the finding back verbatim at that line; restored, `Success:
  no issues found in 1 source file`. Source md5-identical before and after. This
  was the right fix rather than a `type: ignore` — the annotation is correct and
  the assertion was the thing making an unsupportable claim, so silencing the
  checker would have preserved the defect in the test's reasoning.

- **The push that carried it should not have been a force-push.** The fragment
  `changelog.d/2809-...md` was folded into the first commit and the branch rebased,
  which force-pushed `9fb0ccc` → `07306f2` and dismissed the review that had landed
  twelve minutes earlier. AGENTS.md step 3 forbids precisely this: "Do not reach for
  `--amend --force-with-lease` to fold the fragment into the first commit once review
  has started: that destroys the review trail." The timings put this PR in that
  section's own dismissed rows — opened 00:30:35, review 00:42:51, fragment 00:54:41
  (+24m) — alongside #2801 (+33m) and #2799 (+61m), rather than in the surviving rows
  that pushed the fragment inside two minutes. The rule landed in this branch's own
  base (#2805, `0171573`). Nothing in the tree needs changing for it; the cost is one
  re-approval round on unchanged behaviour, and it is already spent. The remedy for
  the next one is the section's own: push the fragment immediately after opening, or
  open as a draft and mark ready once it is in.

- **So that the re-review can be the delta rather than the diff**, measured by blob
  identity between the reviewed tree and the current head:

  | file | reviewed `9fb0ccc` → head `07306f2` |
  |---|---|
  | `strands_robots/teleop_mixin.py` | **identical** (same blob) |
  | `docs/hardware/teleoperation.md` | **identical** (same blob) |
  | `tests/test_stop_teleoperate_reports_the_join_outcome.py` | +8 / -3, the cell above |
  | `changelog.d/2809-...md` | added (the fold that cost the round) |

  A two-dot diff between those commits shows 15 files. The other 13 are main's
  #2808, #2806 and #2807 arriving through the rebase, not this branch's work. The
  behaviour that was reviewed is byte-for-byte the behaviour that is here.

**Round 1** — initial fix, 18-cell suite, mutation table.
