### PR TITLE
fix(isaac): refuse a non-finite geom instead of measuring a body around it

### DIFF
--- a/changelog.d/2813-non-finite-geom-is-refused-not-measured-around.md
+++ b/changelog.d/2813-non-finite-geom-is-refused-not-measured-around.md
@@ -1,0 +1,38 @@
+### Fixed: a geom declaring a placement or extent that is not finite is refused, not measured around
+
+`_geom_aabb` folds each of a body's geoms into the axis-aligned box
+`load_mjcf_scene_objects` reports as a `SceneObject`'s `size` and `position` - the collision proxy
+the Isaac realization stands the object up with. `_body_collision_aabb` unions those with a running
+`min`/`max`, and Python orders a NaN as neither smaller nor larger than anything, so the comparison
+keeps the accumulator it started with. The geom carrying it disappeared from the bound and nothing
+reported that.
+
+A static fixture whose leg declares `euler="nan 0 0"` was measured as its tabletop alone: `size
+(0.8, 0.6, 0.04)` where the file declares `(0.8, 0.6, 0.77)` - 19.2x too short, and byte-identical
+to the same fixture with the leg deleted, under a successful load. Each spelling failed differently:
+`pos="nan ..."` dropped the geom on the axis that was not finite and kept it on the others;
+`pos="inf ..."` reported an infinite centre and a NaN extent; `size="inf ..."` reported a NaN centre
+and, because `inf - inf` is a NaN that `_recursive_collision_aabb`'s own accumulator drops in turn,
+sized that axis at the `1e-4` floor - the smallest proxy the reader can emit, for the largest geom
+the file can declare.
+
+Reachability is specific. MuJoCo refuses a non-finite geom on a body with a free joint, because the
+inertia it derives is then not finite; it *compiles* the same geom on a body without one - and a
+body without a free joint is exactly what this loader calls a fixture, the tables and cabinets whose
+footprint a manipulation scene is planned against. So the affected scenes are precisely the ones
+that load, which is why the reader cannot defer the question to a compile step.
+
+MuJoCo is also the oracle for the disposition: it refuses a non-finite geom quantity wherever it
+checks one (`nan size in geom`) and warns about the document as a whole (`XML contains a 'NaN'`), so
+refusing is the format's own answer rather than a policy invented here. It is also what this
+module's stated failure semantics already promise - loaders never silently return a phantom robot.
+The same defect class was closed one module over for mesh assets, whose refusal describes this
+mechanism in the same words; `loaders.py` carried no finiteness guard at all.
+
+One guard covers all four parse paths - `pos`, `size`, whichever orientation spelling the geom used,
+and `fromto` - so no one spelling drifts into tolerating what its siblings refuse, and the refusal
+names both the offending attribute and the geom. Only a value that *parsed* is graded, so an
+unreadable attribute keeps falling back to its documented default exactly as before, and a geom with
+no analytic AABB still returns `None` so the caller falls back to another geom. Over the shipped
+corpus - 542 MJCF documents, 14940 `<geom>` elements - zero declare a non-finite placement or
+extent, so no shipped asset changes behaviour.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import math
 import os
 import xml.etree.ElementTree as ET
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -1831,6 +1831,68 @@ def _segment_aabb(
     return center, half  # type: ignore[return-value]
 
 
+def _refuse_non_finite_geom(attrs: Mapping[str, str], attribute: str, values: Sequence[float]) -> None:
+    """Refuse a geom whose placement or extent parsed but is not finite.
+
+    A NaN or infinite coordinate is not a position, and neither of the two ways
+    this module folds a geom into a bound reports that.
+    :func:`_body_collision_aabb` unions a body's geoms with a running
+    ``min``/``max``, which orders a NaN as neither smaller nor larger than
+    anything and so drops it - returning the bounds of the geoms that *are*
+    finite, the same numbers a body declaring only those would produce, under
+    no error at all. A fixture whose leg declares ``euler="nan 0 0"`` is
+    measured as its tabletop alone: a 4 cm slab where the file declares a 77 cm
+    table, byte-identical to the same fixture with no leg. An infinite
+    coordinate fails the other way and no more usefully: it makes one axis of
+    the reported extent unbounded, and the ``inf - inf`` that leaves is a NaN
+    which :func:`_recursive_collision_aabb`'s own accumulator drops in turn, so
+    the widest geom in a subtree can size the proxy at the ``1e-4`` floor.
+    Either way the object :func:`load_mjcf_scene_objects` emits is a collision
+    proxy for geometry the scene does not contain, which is the phantom this
+    module's failure semantics exist to refuse.
+
+    MuJoCo - the owner of the format - refuses a non-finite geom quantity
+    wherever it checks one (``nan size in geom``) and warns about the document
+    as a whole (``XML contains a 'NaN'``), so refusing is the format's own
+    disposition rather than a policy invented here. It nevertheless compiles a
+    non-finite ``pos`` or orientation on a body with no free joint, which is
+    why this reader cannot defer the question to a compile step: the scenes
+    that reach it are exactly the ones that load.
+
+    One wording for all four parse paths - ``pos``, ``size``, whichever
+    orientation spelling the geom used, and ``fromto`` - so no one spelling
+    drifts into tolerating what its siblings refuse. Only a value that
+    *parsed* is graded, so an unreadable attribute keeps falling back to the
+    documented default exactly as before.
+
+    The locator is read from the *resolved* attributes rather than the element,
+    which is the rule every other reader in this module follows: a ``<default>``
+    class may supply what a geom does not spell itself. ``name`` is the one
+    attribute a class cannot supply - MuJoCo rejects it in a ``<default>`` as a
+    schema violation - so going through the resolver costs nothing there and
+    keeps one rule answering the question for every reader.
+
+    Args:
+        attrs: The geom's attributes with ``<default>`` inheritance resolved,
+            read for the ``name`` and ``type`` that locate it. MJCF geoms are
+            frequently unnamed, so the type is the fallback locator.
+        attribute: The MJCF attribute whose parsed value is not finite.
+        values: The parsed components, reported so the caller sees which.
+
+    Raises:
+        ValueError: If any component of ``values`` is not finite.
+    """
+    if all(map(math.isfinite, values)):
+        return
+    name = attrs.get("name")
+    where = f"geom {name!r}" if name else f'unnamed <geom type="{attrs.get("type", "sphere")}">'
+    raise ValueError(
+        f"{where}: {attribute} has a component that is not finite ({tuple(values)!r}) - a body "
+        f"measured around it reports a collision bound for geometry the scene does not declare, "
+        f"so the geom is refused instead of measured around"
+    )
+
+
 def _geom_aabb(
     geom: ET.Element,
     defaults: dict[str, dict[str, str]],
@@ -1877,16 +1939,33 @@ def _geom_aabb(
     ``type``, ``pos``, ``size``, ``fromto`` and the orientation are read through
     :func:`_class_attrs`: MJCF's ``<default>`` classes may supply any of them, so
     asking the element directly sees only the half the geom spells itself.
+
+    A quantity that parses to a non-finite value is refused by
+    :func:`_refuse_non_finite_geom` rather than returned, because ``None``
+    here means "no analytic AABB, fall back to another geom" and the caller
+    would silently measure the body around the geoms that remain.
+
+    Raises:
+        ValueError: If ``pos``, ``size``, ``fromto`` or the orientation
+            resolves to a value that is not finite
+            (:func:`_refuse_non_finite_geom`).
     """
     attrs = _class_attrs(geom, defaults, childclass)
     gtype = attrs.get("type", "sphere")
     pos = _parse_xyz(attrs.get("pos"))
+    _refuse_non_finite_geom(attrs, "pos", pos)
     size_str = attrs.get("size", "")
     try:
         sizes = [float(p) for p in size_str.replace(",", " ").split()] if size_str else []
     except (ValueError, TypeError):
         sizes = []
-    rot = _quat_matrix(_parse_orientation(attrs, own=geom.attrib, angle_scale=angle_scale, eulerseq=eulerseq))
+    _refuse_non_finite_geom(attrs, "size", sizes)
+    quat = _parse_orientation(attrs, own=geom.attrib, angle_scale=angle_scale, eulerseq=eulerseq)
+    # Name the spelling the file used, so the refusal points at an attribute a
+    # reader can go and look at rather than at the resolved quaternion.
+    spelling = next((a for a in _ORIENTATION_SPELLINGS if attrs.get(a)), "quat")
+    _refuse_non_finite_geom(attrs, spelling, quat)
+    rot = _quat_matrix(quat)
 
     if gtype == "box":
         if len(sizes) >= 3:
@@ -1906,6 +1985,7 @@ def _geom_aabb(
         # the endpoints carrying the placement and the axis extent.
         segment = _parse_fromto(attrs.get("fromto"))
         if segment is not None:
+            _refuse_non_finite_geom(attrs, "fromto", (*segment[0], *segment[1]))
             # MuJoCo takes a ``fromto`` geom's axis from the endpoints and
             # discards a declared orientation, so ``rot`` is not applied here.
             return _segment_aabb(gtype, segment[0], segment[1], sizes[0]) if sizes else None
@@ -1963,6 +2043,13 @@ def _body_collision_aabb(
     extent by :func:`_geom_aabb` - a body whose collision primitive is turned
     onto another axis is bounded on the axes it really occupies. Returns
     ``None`` when no analytic geom is found (e.g. a mesh-only visual body).
+
+    The union below is a running ``min``/``max``, which would order a NaN as
+    neither smaller nor larger than anything and drop the geom carrying it -
+    reporting the bounds of the geoms that are finite, under no error. That
+    input never arrives here: :func:`_geom_aabb` refuses a non-finite
+    placement or extent at the parse (:func:`_refuse_non_finite_geom`), so
+    every AABB folded in is finite by the time it reaches this comparison.
 
     ``angle_scale`` and ``eulerseq`` come from the model's ``<compiler>`` and
     are only forwarded; they default to MJCF's own defaults (degrees, ``xyz``)
@@ -2079,7 +2166,10 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
         If ``path`` doesn't exist.
     ValueError
         If the XML is malformed, the root isn't ``<mujoco>``, there is no
-        ``<worldbody>``, or a selected mesh asset file is missing on disk.
+        ``<worldbody>``, a selected mesh asset file is missing on disk, or a
+        geom declares a placement or extent that is not finite (a body
+        measured around one reports a collision bound for geometry the scene
+        does not declare, so it is refused rather than approximated).
     """
     from strands_robots.simulation.isaac.mesh_assets import MESH_EXTENSIONS, USD_EXTENSIONS, mesh_aabb
 

--- a/tests/simulation/isaac/test_non_finite_geom_is_refused_not_measured_around.py
+++ b/tests/simulation/isaac/test_non_finite_geom_is_refused_not_measured_around.py
@@ -1,0 +1,363 @@
+"""A geom whose placement or extent is not finite is refused, not measured around.
+
+``_geom_aabb`` folds each of a body's geoms into the axis-aligned box
+``load_mjcf_scene_objects`` reports as a
+:class:`~strands_robots.simulation.isaac.loaders.SceneObject`'s ``size`` and
+``position`` -- the collision proxy the Isaac realization stands the object up
+with. ``_body_collision_aabb`` unions those with a running ``min``/``max``, and
+Python orders a NaN as neither smaller nor larger than anything, so a comparison
+against one keeps the accumulator it started with. The geom carrying it
+disappears from the bound and nothing reports that.
+
+The consequence is not a small error. A static fixture whose leg declares
+``euler="nan 0 0"`` was measured as its tabletop alone::
+
+    kitchen_table with a healthy leg   -> size (0.8, 0.6, 0.77)
+    kitchen_table, leg euler="nan 0 0" -> size (0.8, 0.6, 0.04)
+    kitchen_table with no leg at all   -> size (0.8, 0.6, 0.04)
+
+-- a 4 cm slab where the file declares a 77 cm table, and byte-identical to the
+same fixture with the leg deleted, under ``status`` success. Every flavour is
+reachable and each is wrong differently: ``pos="nan ..."`` drops the geom on the
+axis that is not finite and keeps it on the others; ``pos="inf ..."`` reports an
+infinite centre and a NaN extent; ``size="inf ..."`` reports a NaN centre and,
+because ``inf - inf`` is a NaN that the *outer* accumulator in
+``_recursive_collision_aabb`` drops in turn, sizes that axis at the ``1e-4``
+floor -- the smallest proxy the reader can emit, for the largest geom the file
+can declare.
+
+Reachability is the part worth being precise about. MuJoCo refuses a non-finite
+geom on a body with a free joint, because the inertia it derives is then not
+finite (``mass and inertia of moving bodies must be larger than mjMINVAL``). It
+*compiles* the same geom on a body without one -- and a body without a free
+joint is exactly what this loader calls a fixture, the tables and cabinets whose
+footprint a manipulation scene is planned against. So the scenes that reach the
+reader are precisely the ones that load, which is why the reader cannot defer the
+question to a compile step.
+
+MuJoCo is the oracle for the disposition as well as for reachability. It refuses
+a non-finite geom quantity wherever it checks one -- ``fromto="0 0 0 nan 0 0.5"``
+is rejected as ``nan size in geom`` -- and warns about the document as a whole
+(``XML contains a 'NaN'``). Refusing is the format's own answer; measuring around
+it silently is not an answer either half of MuJoCo gives. It is also what this
+module's stated failure semantics already promise: *"Loaders never silently
+return a phantom robot."*
+
+The same defect class was closed one module over for mesh assets in #2740, whose
+``_non_finite_vertex_error`` describes this mechanism in the same words -- bounds
+"the same numbers a mesh declaring only those would produce, under no error at
+all". ``loaders.py`` carried no finiteness guard at all.
+
+Deliberately unchanged, and pinned below:
+
+* An attribute that cannot be *parsed* keeps falling back to its documented
+  default. Only a value that parsed and is non-finite is refused, so
+  ``pos="garbage"`` still reads as the origin exactly as before.
+* A geom with no analytic AABB (mesh, plane) still returns ``None`` so the
+  caller falls back to another geom.
+* Finite values are untouched, including extreme ones -- the guard tests
+  finiteness, not magnitude.
+
+Over the shipped corpus -- 542 MJCF documents, 14940 ``<geom>`` elements under
+``robot_descriptions`` and this package's own assets -- zero declare a non-finite
+placement or extent, so no shipped asset changes behaviour. The fix is latent by
+that measurement and the measurement is also the regression proof.
+"""
+
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import (
+    _ORIENTATION_SPELLINGS,
+    _body_collision_aabb,
+    _geom_aabb,
+    _mjcf_class_defaults,
+    _refuse_non_finite_geom,
+    load_mjcf_scene_objects,
+)
+
+mujoco = pytest.importorskip("mujoco")
+
+#: A static fixture: a tabletop plus one leg, no free joint. The tabletop alone
+#: spans z 0.73..0.77 and the leg carries the fixture down to the floor, so
+#: losing the leg collapses the reported height from 0.77 m to 0.04 m.
+FIXTURE = """<mujoco model="t">
+  <worldbody>
+    <body name="floor"><geom name="fl" type="plane" size="2 2 0.1"/></body>
+    <body name="kitchen_table" pos="0.4 0.1 0.0">
+      <geom name="t_top" type="box" size="0.40 0.30 0.02" pos="0 0 0.75"/>
+      {LEG}
+    </body>
+  </worldbody>
+</mujoco>"""
+
+HEALTHY_LEG = '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="0.35 0.25 0.375"/>'
+
+#: One spelling per row, each stating the attribute the refusal must name. Every
+#: one of these compiles in MuJoCo on this fixture -- asserted as a premise
+#: rather than assumed, because the whole finding rests on it.
+NON_FINITE_LEGS: list[tuple[str, str, str]] = [
+    ("pos-nan", "pos", '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="nan 0.25 0.375"/>'),
+    ("pos-inf", "pos", '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="inf 0.25 0.375"/>'),
+    ("size-inf", "size", '<geom name="t_leg" type="box" size="inf 0.03 0.375" pos="0.35 0.25 0.375"/>'),
+    (
+        "euler-nan",
+        "euler",
+        '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="0.35 0.25 0.375" euler="nan 0 0"/>',
+    ),
+    (
+        "quat-nan",
+        "quat",
+        '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="0.35 0.25 0.375" quat="nan 0 0 0"/>',
+    ),
+    (
+        "axisangle-nan",
+        "axisangle",
+        '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="0.35 0.25 0.375" axisangle="0 0 1 nan"/>',
+    ),
+    (
+        "zaxis-nan",
+        "zaxis",
+        '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="0.35 0.25 0.375" zaxis="nan 0 1"/>',
+    ),
+    (
+        "xyaxes-nan",
+        "xyaxes",
+        '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="0.35 0.25 0.375" xyaxes="nan 0 0 0 1 0"/>',
+    ),
+    (
+        "fromto-inf",
+        "fromto",
+        '<geom name="t_leg" type="capsule" size="0.03" fromto="0.35 0.25 0 inf 0.25 0.75"/>',
+    ),
+]
+
+_IDS = [row[0] for row in NON_FINITE_LEGS]
+
+
+def _scene(leg: str) -> str:
+    return FIXTURE.format(LEG=leg)
+
+
+def _write(tmp_path: Path, leg: str) -> str:
+    path = tmp_path / "scene.xml"
+    path.write_text(_scene(leg))
+    return str(path)
+
+
+def _table(tmp_path: Path, leg: str):
+    """The loader's ``SceneObject`` for the fixture body."""
+    objects = load_mjcf_scene_objects(_write(tmp_path, leg))
+    return next(obj for obj in objects if obj.name == "kitchen_table")
+
+
+def _bound(leg: str):
+    """``_body_collision_aabb`` for the fixture body, defaults resolved."""
+    root = ET.fromstring(_scene(leg))
+    body = root.find(".//body[@name='kitchen_table']")
+    assert body is not None
+    return _body_collision_aabb(body, _mjcf_class_defaults(root, ".", "geom"), "")
+
+
+class TestThePremisesTheFindingRestsOn:
+    """These hold before and after the fix; the report is unfounded without them."""
+
+    @pytest.mark.parametrize(("_label", "_attribute", "leg"), NON_FINITE_LEGS, ids=_IDS)
+    def test_mujoco_compiles_the_fixture(self, tmp_path: Path, _label: str, _attribute: str, leg: str) -> None:
+        # A non-finite geom on a body with no free joint is a model MuJoCo
+        # accepts, so the reader really does meet these scenes.
+        model = mujoco.MjModel.from_xml_path(_write(tmp_path, leg))
+        assert model.ngeom == 3
+
+    def test_mujoco_refuses_the_same_class_where_it_checks_one(self, tmp_path: Path) -> None:
+        # The format's own disposition: refuse, not measure around. A NaN in a
+        # ``fromto`` reaches MuJoCo's size derivation and is rejected there.
+        leg = '<geom name="t_leg" type="capsule" size="0.03" fromto="0.35 0.25 0 nan 0.25 0.75"/>'
+        with pytest.raises(ValueError, match="nan size in geom"):
+            mujoco.MjModel.from_xml_path(_write(tmp_path, leg))
+
+    def test_a_moving_body_is_refused_by_mujoco_so_only_fixtures_reach_the_reader(self, tmp_path: Path) -> None:
+        # Scoping the claim: with a free joint the derived inertia is not
+        # finite and MuJoCo refuses, which is why the finding is about fixtures.
+        leg = '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="nan 0.25 0.375"/>'
+        scene = _scene(leg).replace('<geom name="t_top"', '<freejoint/><geom name="t_top"')
+        path = tmp_path / "moving.xml"
+        path.write_text(scene)
+        with pytest.raises(ValueError, match="mass and inertia"):
+            mujoco.MjModel.from_xml_path(str(path))
+
+    def test_a_running_min_max_drops_a_nan_rather_than_propagating_it(self) -> None:
+        # The mechanism itself, so a reader need not take it on trust.
+        assert min(float("inf"), float("nan")) == float("inf")
+        assert max(float("-inf"), float("nan")) == float("-inf")
+        # And the outer accumulator's input: ``inf - inf`` is a NaN, which is
+        # why an infinite extent lands at the floor rather than unbounded.
+        assert math.isnan(float("inf") - float("inf"))
+
+    def test_the_orientation_spellings_are_the_modules_own_vocabulary(self) -> None:
+        # The refusal names the attribute the file used, taken from the list the
+        # reader already resolves orientation through rather than a second copy.
+        named = {attribute for _, attribute, _ in NON_FINITE_LEGS}
+        assert set(_ORIENTATION_SPELLINGS) <= named | {"quat"}
+        assert "quat" in _ORIENTATION_SPELLINGS
+
+
+class TestANonFiniteGeomIsRefusedByName:
+    """The regression: every spelling refuses, naming the attribute at fault."""
+
+    @pytest.mark.parametrize(("_label", "attribute", "leg"), NON_FINITE_LEGS, ids=_IDS)
+    def test_the_public_loader_refuses(self, tmp_path: Path, _label: str, attribute: str, leg: str) -> None:
+        with pytest.raises(ValueError, match="is not finite") as excinfo:
+            load_mjcf_scene_objects(_write(tmp_path, leg))
+        message = str(excinfo.value)
+        assert attribute in message, message
+        # The locator, so a reader can find the geom in a scene of hundreds.
+        assert "'t_leg'" in message, message
+
+    @pytest.mark.parametrize(("_label", "_attribute", "leg"), NON_FINITE_LEGS, ids=_IDS)
+    def test_the_body_bound_refuses_too(self, _label: str, _attribute: str, leg: str) -> None:
+        # Refused at the geom parse, so every consumer of the bound inherits it
+        # rather than each having to guard separately.
+        with pytest.raises(ValueError, match="is not finite"):
+            _bound(leg)
+
+    def test_the_fixture_is_no_longer_measured_as_its_tabletop_alone(self, tmp_path: Path) -> None:
+        # The headline. Pre-fix this reported the leg-absent bound exactly.
+        absent = _table(tmp_path, "")
+        assert absent.size == pytest.approx((0.8, 0.6, 0.04), abs=1e-9)
+        healthy = _table(tmp_path, HEALTHY_LEG)
+        assert healthy.size == pytest.approx((0.8, 0.6, 0.77), abs=1e-9)
+        # ... and the two differ, so "same as absent" is a real accusation.
+        assert healthy.size != pytest.approx(absent.size, abs=1e-9)
+        nan_leg = dict((label, leg) for label, _, leg in NON_FINITE_LEGS)["euler-nan"]
+        with pytest.raises(ValueError, match="euler has a component that is not finite"):
+            _table(tmp_path, nan_leg)
+
+    def test_an_infinite_extent_is_not_reported_at_the_floor(self, tmp_path: Path) -> None:
+        # The inverted case: the widest geom the file can declare had sized the
+        # proxy at 1e-4 on that axis, the narrowest the reader can emit.
+        size_inf = dict((label, leg) for label, _, leg in NON_FINITE_LEGS)["size-inf"]
+        with pytest.raises(ValueError, match="size has a component that is not finite"):
+            _table(tmp_path, size_inf)
+
+    def test_the_refusal_says_what_the_alternative_would_have_been(self, tmp_path: Path) -> None:
+        # A refusal a caller cannot act on is half a refusal, so the message
+        # states the consequence being avoided rather than only the fact.
+        with pytest.raises(ValueError) as excinfo:
+            _table(tmp_path, dict((label, leg) for label, _, leg in NON_FINITE_LEGS)["pos-nan"])
+        assert "does not declare" in str(excinfo.value)
+
+
+class TestWhatIsDeliberatelyUnchanged:
+    """Controls. Each of these passes before and after the fix."""
+
+    def test_a_healthy_fixture_reports_exactly_what_it_did(self, tmp_path: Path) -> None:
+        table = _table(tmp_path, HEALTHY_LEG)
+        assert table.position == pytest.approx((0.4, 0.1, 0.385), abs=1e-9)
+        assert table.size == pytest.approx((0.8, 0.6, 0.77), abs=1e-9)
+        assert table.is_static is True
+
+    def test_an_unparseable_attribute_still_falls_back_to_its_default(self) -> None:
+        # ``_parse_xyz`` tolerates a value it cannot read, and that is the
+        # documented behaviour. Only a value that *parsed* is graded, so this
+        # keeps reading as the body origin rather than becoming a refusal.
+        leg = '<geom name="t_leg" type="box" size="0.03 0.03 0.375" pos="garbage"/>'
+        centre, size = _bound(leg)
+        assert all(math.isfinite(v) for v in (*centre, *size))
+        # The leg reads at the body origin, spanning z -0.375..0.375, and the
+        # top spans 0.73..0.77, so the union is 1.145 m tall.
+        assert size == pytest.approx((0.8, 0.6, 1.145), abs=1e-9)
+
+    def test_a_geom_with_no_analytic_aabb_still_returns_none(self) -> None:
+        # ``None`` means "fall back to another geom" and must not be confused
+        # with a refusal; a mesh geom keeps that answer.
+        root = ET.fromstring(_scene('<geom name="t_leg" type="mesh" mesh="m"/>'))
+        body = root.find(".//body[@name='kitchen_table']")
+        assert body is not None
+        mesh_geom = body.findall("geom")[1]
+        assert _geom_aabb(mesh_geom, _mjcf_class_defaults(root, ".", "geom"), "") is None
+
+    def test_an_extreme_but_finite_extent_is_accepted(self) -> None:
+        # The guard tests finiteness, not magnitude: a implausibly large but
+        # representable value is a measurement, and stays one.
+        leg = '<geom name="t_leg" type="box" size="1e30 0.03 0.375" pos="0.35 0.25 0.375"/>'
+        _centre, size = _bound(leg)
+        assert size[0] == pytest.approx(2e30, rel=1e-12)
+
+    def test_the_helper_is_silent_on_finite_input(self) -> None:
+        attrs = {"name": "g", "type": "box"}
+        # Finite input raises nothing, and an empty tuple - a geom spelling no
+        # size at all - is vacuously finite rather than a refusal. That the
+        # helper returns nothing is mypy's to state, not a runtime assertion's.
+        _refuse_non_finite_geom(attrs, "pos", (0.0, -1.5, 2.0))
+        _refuse_non_finite_geom(attrs, "size", ())
+
+
+class TestTheRefusalLocatesAnUnnamedGeom:
+    """MJCF geoms are frequently unnamed, so the locator cannot rely on a name."""
+
+    def test_an_unnamed_geom_is_located_by_its_resolved_type(self, tmp_path: Path) -> None:
+        leg = '<geom type="box" size="0.03 0.03 0.375" pos="nan 0.25 0.375"/>'
+        with pytest.raises(ValueError, match=r'unnamed <geom type="box">'):
+            _table(tmp_path, leg)
+
+    def test_the_type_comes_from_default_inheritance_not_the_element(self) -> None:
+        # A geom need not spell its own type; the locator must still be right.
+        scene = """<mujoco>
+          <default><default class="leg"><geom type="ellipsoid"/></default></default>
+          <worldbody><body name="kitchen_table">
+            <geom class="leg" size="0.1 0.2 0.3" pos="nan 0 0"/>
+          </body></worldbody>
+        </mujoco>"""
+        root = ET.fromstring(scene)
+        body = root.find(".//body")
+        assert body is not None
+        with pytest.raises(ValueError, match=r'unnamed <geom type="ellipsoid">'):
+            _body_collision_aabb(body, _mjcf_class_defaults(root, ".", "geom"), "")
+
+
+class TestOneOwnerForTheWording:
+    """One guard for all four parse paths, so no spelling drifts from the rest."""
+
+    def test_every_finiteness_refusal_in_the_module_is_the_shared_one(self) -> None:
+        import ast
+        import inspect
+
+        from strands_robots.simulation.isaac import loaders
+
+        source = inspect.getsource(loaders)
+        owners: set[str] = set()
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            # ``math.isfinite`` is passed to ``map`` rather than called, so the
+            # reference is an attribute load, not a callee. Grade any mention.
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Attribute) and inner.attr == "isfinite":
+                    owners.add(node.name)
+        assert owners, "the scan found no finiteness test at all - it is looking in the wrong place"
+        assert owners == {"_refuse_non_finite_geom"}, owners
+
+    def test_the_guard_is_reached_from_every_parse_path(self) -> None:
+        import ast
+        import inspect
+
+        from strands_robots.simulation.isaac.loaders import _geom_aabb as target
+
+        calls = [
+            ast.unparse(node.args[1])
+            for node in ast.walk(ast.parse(inspect.getsource(target).strip()))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_refuse_non_finite_geom"
+        ]
+        assert "'pos'" in calls and "'size'" in calls and "'fromto'" in calls
+        # The orientation call names the spelling the file used rather than a
+        # literal, which is what lets one call cover five attributes.
+        assert "spelling" in calls
+        assert len(calls) == 4, calls


### PR DESCRIPTION
## Problem

`_geom_aabb` folds each of a body's geoms into the axis-aligned box `load_mjcf_scene_objects` reports as a `SceneObject`'s `size` and `position` -- the collision proxy the Isaac realization stands the object up with. `_body_collision_aabb` unions those with a running `min`/`max`, and Python orders a NaN as neither smaller nor larger than anything, so a comparison against one keeps the accumulator it started with. The geom carrying it disappears from the bound, and nothing reports it.

A static fixture whose leg declares `euler="nan 0 0"` was measured as its tabletop alone:

| fixture | reported `size` |
| --- | --- |
| tabletop + healthy leg | `(0.8, 0.6, 0.77)` |
| tabletop + leg `euler="nan 0 0"` | `(0.8, 0.6, 0.04)` |
| tabletop, **no leg at all** | `(0.8, 0.6, 0.04)` |

A 4 cm slab where the file declares a 77 cm table -- **19.2x too short**, byte-identical to the same fixture with the leg deleted, under a successful load. Each spelling failed differently:

| spelling | MuJoCo | reported `position` | reported `size` |
| --- | --- | --- | --- |
| healthy | compiles | `(0.4, 0.1, 0.385)` | `(0.8, 0.6, 0.77)` |
| `pos="nan ..."` | compiles | `(0.4, 0.1, 0.385)` | `(0.8, 0.6, 0.77)` |
| `pos="inf ..."` | compiles | `(inf, 0.1, 0.385)` | `(nan, 0.6, 0.77)` |
| `size="inf ..."` | compiles | `(nan, 0.1, 0.75)` | `(0.001, 0.6, 0.04)` |
| `euler="nan 0 0"` | compiles | `(0.4, 0.1, 0.75)` | `(0.8, 0.6, 0.04)` |
| `quat="nan 0 0 0"` | compiles | `(0.4, 0.1, 0.75)` | `(0.8, 0.6, 0.04)` |

`pos="nan ..."` drops the geom on the axis that is not finite and keeps it on the others. `size="inf ..."` is inverted: `inf - inf` is a NaN that `_recursive_collision_aabb`'s own accumulator drops in turn, so that axis lands at the `1e-4` floor -- the narrowest proxy the reader can emit, for the widest geom the file can declare.

## Reachability

MuJoCo refuses a non-finite geom on a body with a **free joint**, because the inertia it derives is then not finite (`mass and inertia of moving bodies must be larger than mjMINVAL`). It *compiles* the same geom on a body **without** one -- and a body without a free joint is exactly what this loader calls a fixture, the tables and cabinets a manipulation scene is planned against. So the scenes that reach the reader are precisely the ones that load, which is why the reader cannot defer the question to a compile step.

## Why refuse

MuJoCo is the oracle for the disposition too. It refuses a non-finite geom quantity wherever it checks one -- `fromto="0 0 0 nan 0 0.5"` is rejected as `nan size in geom` -- and warns about the document as a whole (`XML contains a 'NaN'`). Measuring around it silently is not an answer either half of MuJoCo gives, and it is not what this module's stated failure semantics promise: *"Loaders never silently return a phantom robot."*

The same defect class was closed one module over for mesh assets in #2740, whose `_non_finite_vertex_error` describes this mechanism in the same words -- bounds "the same numbers a mesh declaring only those would produce, under no error at all". `loaders.py` carried no finiteness guard at all.

Propagating instead of refusing does not work: a NaN bound returned from `_geom_aabb` is dropped again by the outer accumulator in `_recursive_collision_aabb`, so the loss simply moves one frame up.

## Change

One guard, `_refuse_non_finite_geom`, reached from all four parse paths in `_geom_aabb` -- `pos`, `size`, whichever orientation spelling the geom used, and `fromto` -- so no one spelling drifts into tolerating what its siblings refuse. The refusal names both the offending attribute and the geom, falling back to the resolved `type` because MJCF geoms are frequently unnamed.

Only a value that **parsed** is graded, so an unreadable attribute keeps falling back to its documented default exactly as before. The locator is read from the `<default>`-resolved attributes rather than off the element, which is the rule every other reader in this module follows and which `test_every_geom_attribute_read_goes_through_the_resolver` enforces.

`load_mjcf_scene_objects`' public `Raises:` clause and `_body_collision_aabb`'s docstring are updated in the same change -- the latter now states why its running `min`/`max` is safe.

## Verification

Regression suite: `tests/simulation/isaac/test_non_finite_geom_is_refused_not_measured_around.py`, 43 cells.

| class | pre-fix | role |
| --- | --- | --- |
| `TestThePremisesTheFindingRestsOn` | 0 / 13 | premise -- MuJoCo compiles each fixture, refuses `fromto`, refuses a moving body |
| `TestANonFiniteGeomIsRefusedByName` | **21 / 21** | regression |
| `TestTheRefusalLocatesAnUnnamedGeom` | **2 / 2** | regression -- locator |
| `TestWhatIsDeliberatelyUnchanged` | 0 / 5 | control |
| `TestOneOwnerForTheWording` | 1 / 2 | structural -- one guard, reached from four paths |

Pre-fix split **24 failed / 19 passed**, with both control classes clean. The raw revert is a collection error (the suite imports the new helper), so the split above is the behavioural revert: the helper kept, its four call sites neutered.

Deliberately unchanged and pinned: a healthy fixture reports exactly what it did; `pos="garbage"` still falls back to the body origin rather than becoming a refusal; a mesh geom still returns `None` so the caller falls back to another geom; and an extreme-but-finite `1e30` extent is still a measurement -- the guard tests finiteness, not magnitude.

Corpus: **542 MJCF documents, 14940 `<geom>` elements** under `robot_descriptions` and this package's own assets declare **zero** non-finite placements or extents; re-measuring **2850 bodies** through `_body_collision_aabb` after the change raises **0** times. No shipped asset changes behaviour.

Gate: `ruff check` and `ruff format --check` clean over 1626 files; `mypy strands_robots tests tests_integ` reports `Success: no issues found in 1618 source files`; `tests/simulation/isaac/` plus the `Raises:`/`Args:` docstring graders **2254 passed, 5 skipped**; the 162-file tree-walking guard set **6802 passed, 56 skipped** with 5 pre-existing failures reproduced identically on a pristine `upstream/main` worktree (they assert `rclpy` is absent and it resolves on this machine).

## Rendered

The fixture as MuJoCo compiles it, beside the collision proxy the loader reports for it. The two proxy silhouettes are measured from separate segmentation passes, so transparency cannot affect the count; the fixture geometry is asserted byte-identical between the two panels and the lighting and camera are asserted equal.

![collision proxy for a non-finite geom](https://github.com/cagataycali/robots/releases/download/artifacts/non_finite_geom_collision_proxy.png)

Fixture pixels falling **outside** the reported proxy: **0** for the healthy leg, **3956** for `euler="nan 0 0"` -- the leg standing entirely outside the box that is supposed to contain it.
