### PR TITLE
fix(mesh): report whether InputPublisher.stop actually stopped the loop

### DIFF
--- a/changelog.d/2815-input-publisher-stop-reports-the-join-outcome.md
+++ b/changelog.d/2815-input-publisher-stop-reports-the-join-outcome.md
@@ -1,0 +1,45 @@
+### Fixed: `InputPublisher.stop` reports whether the publish loop actually stopped
+
+`threading.Thread.join(timeout=...)` returns `None` whether or not the thread
+finished, so the liveness read after it is the only thing that distinguishes a
+stopped loop from one that outlasted the budget. `InputPublisher.stop` cleared
+the session flag, joined with a 2 s budget and never took that read: it then
+logged `input publisher stopped` unconditionally and returned `stats`, whose
+`running` key it had already set to `False`. A teleoperator whose `get_action()`
+was still blocking - a serial read on a wedged bus is the ordinary case a join
+budget exists for - was therefore reported as stopped while its loop was still
+free to put another frame on `strands/{peer}/input/{device}`, which is an
+actuator command every subscribed follower mirrors. Measured on a publisher
+whose leader blocks inside `get_action()`:
+
+```
+                                        before      after
+stop() elapsed                          2.00s       2.00s
+stats running                           False       False
+stats thread_alive                      (absent)    True
+loop thread still alive after the call   True        True
+log level for the outcome               INFO        WARNING
+log claims "publisher stopped"          yes         no
+second stop() can re-join the loop      no          yes
+frame published after stop() returned   1           1
+```
+
+The last row is the consequence the stop claim hid: a frame reaches subscribers
+after the caller has been told the publisher stopped. Nothing in the returned
+stats could say so, because `running` is the session flag `stop` clears *before*
+it joins - so a caller polling afterwards was told `running=False` about a loop
+that was still publishing. `thread_alive` reads the publish thread itself, and
+the two now differ for exactly as long as a loop outlives the stop that asked it
+to exit.
+
+`running` keeps its meaning rather than being widened, because the loop's own
+`while` reads that flag; the join outcome is reported beside it. This mirrors
+`TeleopMixin.stop_teleoperate`, whose status verb gained `thread_alive` for the
+same reason, and `G1Driver.cleanup`, which refuses to tear a transport down
+under a live writer.
+
+A publisher whose join timed out also stays stoppable. The guard now admits a
+call that has a live thread left to join, where returning early on the session
+flag alone left the only handle to that loop unreachable through `stop()`. The
+2 s budget is named `_INPUT_JOIN_TIMEOUT_S` so the docstring, the warning text
+and the tests read one value.

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -55,6 +55,11 @@ logger = logging.getLogger(__name__)
 
 INPUT_HZ_DEFAULT = 50.0
 
+# Budget for joining the background publish thread in InputPublisher.stop.
+# Named so the docstring, the ``thread_alive`` stat and the tests read one
+# value. Matches the teleop mixin's _TELEOP_JOIN_TIMEOUT_S in purpose.
+_INPUT_JOIN_TIMEOUT_S = 2.0
+
 #: How many times each :class:`InputPublisher` loop failure is logged before
 #: going quiet. The loop runs at ``hz`` (50 Hz by default), so an unbounded
 #: log of a persistent fault - a dead publish transport, a teleoperator whose
@@ -212,17 +217,25 @@ class InputPublisher:
     @property
     def stats(self) -> dict[str, Any]:
         """Live publishing counters: the target device/method, whether the
-        loop is ``running``, cumulative ``frames`` published and ``errors``
-        hit, ``event_read_errors`` (frames published with ``events: null``
-        because ``get_teleop_events()`` raised, rather than because the
-        teleoperator has no event surface), and the achieved vs. requested rate
-        (``hz_actual`` / ``hz_target``).
+        loop is ``running``, whether its ``thread_alive``, cumulative ``frames``
+        published and ``errors`` hit, ``event_read_errors`` (frames published
+        with ``events: null`` because ``get_teleop_events()`` raised, rather
+        than because the teleoperator has no event surface), and the achieved
+        vs. requested rate (``hz_actual`` / ``hz_target``).
+
+        ``running`` is the session flag, which :meth:`stop` clears before it
+        joins; ``thread_alive`` reads the publish thread itself. The two differ
+        for exactly as long as a loop outlives the stop that asked it to exit -
+        the window in which this publisher can still put a frame on the wire.
+        Without the second reading a caller polling after a stop would be told
+        ``running=False`` about a loop that is still publishing.
         """
         elapsed = time.monotonic() - self._start_mono if self._start_mono else 0
         return {
             "device": self.device_name,
             "method": self.method,
             "running": self._running,
+            "thread_alive": self._thread is not None and self._thread.is_alive(),
             "frames": self._frame_count,
             "errors": self._error_count,
             "event_read_errors": self._event_read_error_count,
@@ -251,18 +264,46 @@ class InputPublisher:
         )
 
     def stop(self) -> dict[str, Any]:
-        """Stop the input publishing loop and return stats."""
-        if not self._running:
+        """Stop the input publishing loop and return stats.
+
+        ``join()`` returns ``None`` whether or not the thread finished, so the
+        liveness read after it is the only thing that tells a stopped loop from
+        one that outlasted :data:`_INPUT_JOIN_TIMEOUT_S`. A teleoperator whose
+        ``get_action()`` blocks past that budget - a serial read on a wedged bus
+        is the ordinary case - leaves the loop free to publish one more frame
+        after this call returns, so the outcome rides back in
+        ``stats["thread_alive"]`` and is logged at WARNING rather than being
+        announced as a stop that happened.
+
+        A publisher whose join timed out is still stoppable: the session flag is
+        already clear, so the guard below admits a call that has a live thread
+        left to join. Returning early on the flag alone would make the only
+        handle to that loop unreachable through this surface.
+        """
+        thread = self._thread
+        if not self._running and not (thread is not None and thread.is_alive()):
             return self.stats
         self._running = False
         self._stop_event.set()
-        if self._thread:
-            self._thread.join(timeout=2.0)
-        logger.info(
-            "[mesh] input publisher stopped: %s (%d frames)",
-            self.device_name,
-            self._frame_count,
-        )
+        if thread is not None:
+            thread.join(timeout=_INPUT_JOIN_TIMEOUT_S)
+        if thread is not None and thread.is_alive():
+            logger.warning(
+                "[mesh] input publisher did not stop within %.1fs: %s is still "
+                "publishing to %s after %d frames. The teleoperator's "
+                "get_action() is most likely blocking; call stop() again to "
+                "re-join that loop.",
+                _INPUT_JOIN_TIMEOUT_S,
+                self.device_name,
+                self.topic,
+                self._frame_count,
+            )
+        else:
+            logger.info(
+                "[mesh] input publisher stopped: %s (%d frames)",
+                self.device_name,
+                self._frame_count,
+            )
         return self.stats
 
     def _publish_loop(self) -> None:

--- a/tests/mesh/test_input_publisher_stop_reports_the_join_outcome.py
+++ b/tests/mesh/test_input_publisher_stop_reports_the_join_outcome.py
@@ -1,0 +1,299 @@
+"""``InputPublisher.stop`` reports whether the publish loop actually stopped.
+
+``Thread.join(timeout=...)`` returns ``None`` whether or not the thread
+finished, so the liveness read after it is the only thing that distinguishes a
+stopped loop from one that outlasted its budget. Before this suite ``stop()``
+cleared the session flag, joined with a two-second budget, ignored the outcome
+and logged "input publisher stopped" unconditionally - so a teleoperator whose
+``get_action()`` was blocking left the loop free to put one more actuator frame
+on the wire *after* the caller had been told the publisher stopped, with nothing
+in the returned stats able to say so.
+
+Every wedged cell parks the loop inside ``get_action()`` deterministically: the
+double signals on entry and then blocks, so the caller knows the loop is in the
+read rather than in the ticker before it calls ``stop()``. The budget is
+shrunk for those cells so they cost milliseconds, and one cell drives the
+shipped value so the budget itself stays graded.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import strands_robots.mesh.input as input_mod
+from strands_robots.mesh.input import InputPublisher
+
+# Stated here rather than read off the module so a tree without the fix fails by
+# name on the property under test instead of erroring on a missing attribute.
+BUDGET_ATTR = "_INPUT_JOIN_TIMEOUT_S"
+SHRUNK_BUDGET = 0.2
+
+
+class _PubMesh:
+    """Recording publish chokepoint, stamped so post-stop frames are visible."""
+
+    peer_id = "leader-1"
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any], float]] = []
+
+    def publish(self, topic: str, payload: dict[str, Any]) -> None:
+        self.published.append((topic, payload, time.monotonic()))
+
+
+class _WedgingTeleop:
+    """A leader whose second read blocks, like a serial read on a wedged bus.
+
+    The first read answers immediately so a frame is published and the loop is
+    provably running; the second signals ``entered`` and then blocks, which is
+    what lets a test park the loop inside the read with no sleeps.
+    """
+
+    def __init__(self) -> None:
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.calls = 0
+
+    def get_action(self) -> dict[str, float]:
+        self.calls += 1
+        if self.calls > 1:
+            self.entered.set()
+            self.release.wait(30.0)
+        return {"j0": 0.4}
+
+
+class _HealthyTeleop:
+    def get_action(self) -> dict[str, float]:
+        return {"j0": 0.4}
+
+
+def _parked(monkeypatch: pytest.MonkeyPatch) -> tuple[InputPublisher, _PubMesh, _WedgingTeleop]:
+    """Return a publisher whose loop is parked inside ``get_action()``."""
+    monkeypatch.setattr(input_mod, BUDGET_ATTR, SHRUNK_BUDGET, raising=False)
+    mesh, tele = _PubMesh(), _WedgingTeleop()
+    # peer_id + publish is the whole of Mesh this publisher touches.
+    stand_in: Any = mesh
+    pub = InputPublisher(stand_in, tele, device_name="leader", method="arm", hz=200.0)
+    pub.start()
+    assert tele.entered.wait(5.0), "the loop never reached the blocking read"
+    return pub, mesh, tele
+
+
+def _running(mesh: _PubMesh, tele: _HealthyTeleop) -> InputPublisher:
+    stand_in: Any = mesh
+    pub = InputPublisher(stand_in, tele, device_name="leader", method="arm", hz=200.0)
+    pub.start()
+    deadline = time.monotonic() + 2.0
+    while not mesh.published and time.monotonic() < deadline:
+        time.sleep(0.005)
+    return pub
+
+
+class TestAWedgedLoopIsReportedNotAnnounced:
+    """The join outcome reaches the caller instead of being discarded."""
+
+    def test_the_stats_report_the_thread_is_still_alive(self, monkeypatch):
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            assert pub.stop()["thread_alive"] is True
+        finally:
+            tele.release.set()
+
+    def test_the_session_flag_still_reads_stopped(self, monkeypatch):
+        # running is the flag stop() clears; thread_alive reads the thread. The
+        # two differing is the window a caller needs to see, so running must
+        # keep its meaning - the loop's own while reads it.
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            stats = pub.stop()
+            assert (stats["running"], stats["thread_alive"]) == (False, True)
+        finally:
+            tele.release.set()
+
+    def test_the_outcome_is_logged_at_warning(self, monkeypatch, caplog):
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            with caplog.at_level(logging.INFO, logger=input_mod.__name__):
+                pub.stop()
+            levels = {r.levelno for r in caplog.records}
+            assert logging.WARNING in levels, [r.getMessage() for r in caplog.records]
+        finally:
+            tele.release.set()
+
+    def test_the_warning_names_the_budget_it_waited(self, monkeypatch, caplog):
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            with caplog.at_level(logging.WARNING, logger=input_mod.__name__):
+                pub.stop()
+            budget = getattr(input_mod, BUDGET_ATTR)
+            text = " ".join(r.getMessage() for r in caplog.records)
+            assert f"{budget:.1f}s" in text, text
+        finally:
+            tele.release.set()
+
+    def test_the_warning_names_the_topic_still_being_published_to(self, monkeypatch, caplog):
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            with caplog.at_level(logging.WARNING, logger=input_mod.__name__):
+                pub.stop()
+            text = " ".join(r.getMessage() for r in caplog.records)
+            assert pub.topic in text, text
+        finally:
+            tele.release.set()
+
+    def test_no_stop_is_announced_that_did_not_happen(self, monkeypatch, caplog):
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            with caplog.at_level(logging.INFO, logger=input_mod.__name__):
+                pub.stop()
+            stopped_claims = [r.getMessage() for r in caplog.records if "publisher stopped" in r.getMessage()]
+            assert stopped_claims == [], stopped_claims
+        finally:
+            tele.release.set()
+
+    def test_a_frame_reaching_the_wire_after_the_stop_is_accounted_for(self, monkeypatch):
+        # The frame the loop publishes once released lands after stop() returned.
+        # thread_alive is what lets a caller know that is still possible.
+        pub, mesh, tele = _parked(monkeypatch)
+        stats = pub.stop()
+        returned_at = time.monotonic()
+        tele.release.set()
+        pub.stop()
+        after = [entry for entry in mesh.published if entry[2] > returned_at]
+        assert stats["thread_alive"] is True
+        assert after, "expected the released loop to publish once more"
+
+
+class TestAJoinThatTimedOutIsStillStoppable:
+    """The live loop stays reachable through the same surface."""
+
+    def test_a_second_stop_rejoins_the_live_loop(self, monkeypatch):
+        pub, _, tele = _parked(monkeypatch)
+        assert pub.stop()["thread_alive"] is True
+        tele.release.set()
+        assert pub.stop()["thread_alive"] is False
+
+
+class TestTheCleanPathIsUnchanged:
+    """Every expectation here is one the pre-fix code also met."""
+
+    def test_a_clean_stop_reports_not_running(self):
+        mesh = _PubMesh()
+        pub = _running(mesh, _HealthyTeleop())
+        stats = pub.stop()
+        assert stats["running"] is False
+        assert mesh.published
+
+    def test_a_clean_stop_returns_promptly(self):
+        pub = _running(_PubMesh(), _HealthyTeleop())
+        start = time.monotonic()
+        pub.stop()
+        assert time.monotonic() - start < 1.0
+
+    def test_a_clean_stop_logs_at_info(self, caplog):
+        pub = _running(_PubMesh(), _HealthyTeleop())
+        with caplog.at_level(logging.INFO, logger=input_mod.__name__):
+            pub.stop()
+        text = " ".join(r.getMessage() for r in caplog.records)
+        assert "publisher stopped" in text, text
+        assert logging.WARNING not in {r.levelno for r in caplog.records}
+
+    def test_a_never_started_publisher_returns_stats(self):
+        pub = InputPublisher(_PubMesh(), _HealthyTeleop())
+        stats = pub.stop()
+        assert stats["running"] is False
+        assert stats["frames"] == 0
+
+    def test_the_counters_are_still_reported(self):
+        mesh = _PubMesh()
+        pub = _running(mesh, _HealthyTeleop())
+        stats = pub.stop()
+        assert set(stats) >= {
+            "device",
+            "method",
+            "running",
+            "frames",
+            "errors",
+            "event_read_errors",
+            "hz_actual",
+            "hz_target",
+        }
+
+
+class TestThePremises:
+    """What the wedged cells rely on, asserted rather than assumed."""
+
+    def test_a_timed_out_stop_leaves_the_flag_clear_and_the_thread_live(self, monkeypatch):
+        # Holds either way: it is the state that makes the guard necessary. A
+        # guard reading the session flag alone returns early here, leaving the
+        # only handle to that live loop unreachable through stop().
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            pub.stop()
+            assert pub._running is False
+            assert pub._thread is not None and pub._thread.is_alive()
+        finally:
+            tele.release.set()
+            pub.stop()
+
+    def test_the_loop_parks_inside_the_device_read(self, monkeypatch):
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            assert tele.calls >= 2, "the double was not reached a second time"
+            assert not tele.release.is_set()
+        finally:
+            tele.release.set()
+            pub.stop()
+
+    def test_the_shrunk_budget_is_shorter_than_the_wedge(self, monkeypatch):
+        pub, _, tele = _parked(monkeypatch)
+        try:
+            start = time.monotonic()
+            pub.stop()
+            waited = time.monotonic() - start
+            assert waited >= SHRUNK_BUDGET
+            assert waited < 5.0, "stop() waited past the shrunk budget"
+        finally:
+            tele.release.set()
+            pub.stop()
+
+
+class TestTheBudgetIsNamedOnce:
+    """The budget the docstring, the warning and the tests read is one value."""
+
+    def test_the_join_timeout_is_a_name_not_a_literal(self):
+        tree = ast.parse(inspect.getsource(InputPublisher.stop).lstrip())
+        joins = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "join"
+        ]
+        assert len(joins) == 1, ast.unparse(tree)
+        timeouts = [kw.value for kw in joins[0].keywords if kw.arg == "timeout"]
+        assert len(timeouts) == 1
+        assert isinstance(timeouts[0], ast.Name), ast.unparse(timeouts[0])
+        assert timeouts[0].id == BUDGET_ATTR
+
+    def test_the_shipped_budget_is_what_an_unshrunk_stop_waits(self):
+        mesh, tele = _PubMesh(), _WedgingTeleop()
+        pub = InputPublisher(mesh, tele, device_name="leader", method="arm", hz=200.0)
+        pub.start()
+        assert tele.entered.wait(5.0)
+        try:
+            start = time.monotonic()
+            stats = pub.stop()
+            waited = time.monotonic() - start
+            budget = getattr(input_mod, BUDGET_ATTR, None)
+            assert budget is not None, f"{BUDGET_ATTR} is not named on the module"
+            assert stats["thread_alive"] is True
+            assert budget <= waited < budget + 2.0
+        finally:
+            tele.release.set()
+            pub.stop()


### PR DESCRIPTION
## What is wrong

`InputPublisher.stop` joined its publish thread with a two-second budget and
discarded the outcome. `Thread.join(timeout=...)` returns `None` whether or not
the thread finished, so the liveness read after it is the only thing that
distinguishes a stopped loop from one that outlasted the budget. `stop` took no
such read: it cleared the session flag, joined, logged `input publisher stopped`
unconditionally, and returned `stats` whose `running` key it had already set to
`False`.

A teleoperator whose `get_action()` is blocking is the ordinary case a join
budget exists for. That loop stays free to publish another frame to
`strands/{peer}/input/{device}` after `stop()` has returned - an actuator command
every subscribed follower mirrors - and nothing in the returned stats could say
so.

## Measured

A publisher whose leader blocks inside `get_action()`. The loop is parked in the
read deterministically: the double signals on entry and then blocks, so the
caller knows the loop is in the device read rather than in the ticker before it
calls `stop()`.

```
                                         before      after
stop() elapsed                           2.00s       2.00s
stats running                            False       False
stats thread_alive                       (absent)    True
loop thread still alive after the call    True        True
log level for the outcome                INFO        WARNING
log claims "publisher stopped"           yes         no
second stop() can re-join the loop       no          yes
frame published after stop() returned    1           1
```

The last row is the consequence the stop claim hid. The first frame is published,
the loop re-enters `get_action()` and blocks, `stop()` waits out its budget and
reports a stop that did not happen; once the read returns, that frame reaches
subscribers.

Two further readings from the same run:

- `running` is the session flag `stop` clears **before** it joins, so a caller
  polling afterwards was told `running=False` about a loop that was still
  publishing. `thread_alive` reads the thread itself, and the two now differ for
  exactly as long as a loop outlives the stop that asked it to exit.
- The guard `if not self._running` made a timed-out stop terminal: the flag was
  already clear, so a second call returned early and the only handle to that live
  loop was unreachable through this surface.

## The change

`strands_robots/mesh/input.py`, +55/-14.

- The join budget is named `_INPUT_JOIN_TIMEOUT_S = 2.0`, so the docstring, the
  warning text and the tests read one value.
- `stop` reads liveness after the join. On failure it logs at WARNING naming the
  budget, the topic still being written to and the remedy, instead of announcing
  a stop that did not happen.
- `stats` gains `thread_alive` beside `running`. `running` keeps its meaning
  rather than being widened, because the loop's own `while` reads that flag.
- The guard admits a call that has a live thread left to join, so a publisher
  whose join timed out stays stoppable.

This is the shape `TeleopMixin.stop_teleoperate` already carries: its status verb
gained `thread_alive` for the same reason, and `G1Driver.cleanup` refuses to tear
a transport down under a live writer. This is the sibling loop that was left.

## Why nothing caught it

`TestPublisherLifecycle` has three cells - a repr read, a stop on a
never-started publisher, and a start/stop that returns stats - and every one is a
clean path. `is_alive`, `join` and any wedged device appear nowhere in the seven
`tests/mesh/test_input_*.py` suites, so no cell could reach the branch where the
budget expires. The `sib` column below is `0` on all eleven mutations, across
those seven files.

## Verification

Pre-fix, source reverted and the new suite kept: **10 failed / 8 passed**.

| class | role | failed/total |
|---|---|---|
| `TestAWedgedLoopIsReportedNotAnnounced` | regression | 7/7 |
| `TestAJoinThatTimedOutIsStillStoppable` | regression | 1/1 |
| `TestTheBudgetIsNamedOnce` | structural | 2/2 |
| `TestTheCleanPathIsUnchanged` | control | 0/5 |
| `TestThePremises` | premise | 0/3 |

Every expectation in the control class is one the pre-fix code also met.

Mutations against the fixed tree. `new` counts failures in the new suite, `sib`
in the seven pre-existing input suites, and `coll` is stable at 18 throughout so
no row is hidden by a deselection.

| # | mutation | new | sib |
|---|---|---|---|
| b0 | control, no mutation | 0 | 0 |
| b1 | liveness read dropped, INFO unconditional | 4 | 0 |
| b2 | `thread_alive` stat removed | 5 | 0 |
| b3 | `thread_alive` hardcoded `False` | 5 | 0 |
| b4 | `thread_alive` reads the session flag, not the thread | 5 | 0 |
| b5 | join budget back to a literal | 1 | 0 |
| b6 | warning downgraded to INFO | 3 | 0 |
| b7 | guard returns early on the session flag alone | 2 | 0 |
| b8 | liveness read taken **before** the join | 1 | 0 |
| b9 | budget name kept, set to `0.0` | 1 | 0 |
| b10 | warning names a placeholder, not the real topic | 1 | 0 |
| b11 | warning names a placeholder, not the device | 0 | 0 |

Eleven mutations, ten detected, seven distinct firing sets, control clean, source
restored byte-identically.

Four rows are worth reading:

- **b2/b3/b4 share one firing set.** All three leave `thread_alive` unable to
  report a live thread, so they are one mutation class spelled three ways.
- **b8 and b9 both fire a *control*** - `test_a_clean_stop_logs_at_info`. Reading
  liveness before the join, or waiting zero, makes a healthy stop report a
  warning. The ordering and the budget are load-bearing at runtime, not only in
  the AST assertion.
- **b11 fires nothing, and that is correct.** The topic's last segment *is* the
  device name, so a message that names the topic still identifies the publisher.
  The device is reported twice; dropping one copy loses nothing a caller needs.

Gate, on an identical 573-file selection (all of `tests/mesh/`, plus every suite
that walks the tree, parses source, or reads docstrings, `Args:`, `Raises:` or
`changelog.d/`), with the new file excluded from both trees and every path
verified present on both:

```
                       branch                          base
collected              23506                           23506
failing ids            48                              48
rootdir                robots-src                      run-.../base
```

Failing-ID sets identical, `comm` empty in both directions. Of the 48, **45**
need `awsiot`/`awscrt` - `find_spec` is `None` for both, and they are declared in
the `[mesh-iot]` extra, which CI installs - and **3** are the pre-existing
lerobot-from-source `encode()` drift in `tests/training/test_lerobot*`.

`ruff check` and `ruff format --check` clean over `strands_robots tests
tests_integ`. mypy **24 == 24** against a worktree pinned at the merge base,
normalized message sets byte-identical in both directions, 0 attributable to
either changed file.

No visual artifact: this changes what a teardown reports, not a policy,
simulation, rendering, recording or asset. The measured before/after table is the
evidence. The `stats` docstring is the documented surface for these keys - no
`docs/` page enumerates them - and it is updated in the same change.
