### PR TITLE
fix(drivers/g1): read whether the control loop actually halted before releasing the wire

### DIFF
--- a/changelog.d/2816-cleanup-reads-the-loop-halt-outcome.md
+++ b/changelog.d/2816-cleanup-reads-the-loop-halt-outcome.md
@@ -1,0 +1,33 @@
+### Fixed: the G1 zero-torque shutdown frame survives a policy that overruns the stop budget
+
+`_ControlLoop.stop` signals the control loop, joins its thread within a budget,
+and returns whether the thread actually joined. `G1Driver.stop_task` reads that
+value and reports `stopped=False` when the join times out - its docstring
+explains why, and names the case: a caller-supplied policy that outlasts the
+budget, "a remote inference call is the ordinary case". The two teardown paths
+called the same method and dropped the answer.
+
+For `cleanup` that was load-bearing rather than cosmetic. It halted the loop and
+then closed `_pubs` and set it to `None` regardless of whether the halt had
+taken, so on an overrun it removed the publisher from underneath a live 500 Hz
+thread. `_emit_zero_torque` reads `self._driver._pubs` and returns silently when
+it is `None`, so the zero-torque shutdown frame was never published: not by
+`cleanup`, and not later when the policy finally returned and the loop reached
+its own `finally`. That is the fall `cleanup`'s docstring says the path exists to
+prevent, and the loop still recorded a clean caller-driven `exit_reason` of
+`stop_task` on the way out.
+
+`cleanup` now releases the publisher only once the loop is provably gone. A loop
+that is still running keeps it, so the frame that loop publishes from its own
+`finally` reaches the wire, and the overrun is reported at ERROR naming the
+remedy - call `cleanup` again once the loop has exited. The subscribers close
+either way, because the loop never reads them, and a second `cleanup` releases
+the rest. `stop` carries no envelope and releases nothing, so its frame was
+never at risk; it now logs the overrun rather than returning from shutdown in
+silence while a thread still holds the wire.
+
+The zero-torque contract already had a test, and it drives a policy that returns
+immediately. Its join therefore always succeeded and the discarded value was
+always `True`, so the fast path could not distinguish a checked halt from an
+unchecked one. The new cells block a policy past the join budget, which is the
+regime `stop_task` calls ordinary.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -502,12 +502,25 @@ class G1Driver:
         its thread before returning - a controlled stop rather than
         abrupt frame cessation mid-policy on a robot whose FSM has just
         gone away.  Idempotent: no running task returns immediately.
+
+        A loop that outlasts the join budget is reported rather than
+        returned: this signature carries no envelope, and returning from
+        shutdown while a thread still holds the wire is exactly what the
+        log exists to say.  Unlike :meth:`cleanup` this leaves the
+        publisher open either way, so that loop still publishes its
+        zero-torque frame when the policy finally returns.
         """
         with self._task_admission:
             loop = self._loop
         if loop is not None and loop.is_running:
             logger.debug("%s.stop() halting control loop", self._tool_name)
-            loop.stop("stop_task")
+            if not loop.stop("stop_task"):
+                logger.error(
+                    "%s.stop(): control loop did not join within the stop budget "
+                    "and still holds the wire; its zero-torque frame publishes "
+                    "when the policy returns",
+                    self._tool_name,
+                )
 
     def cleanup(self) -> None:
         """Release every DDS subscriber and publisher. Idempotent.
@@ -517,17 +530,38 @@ class G1Driver:
         ``_pubs`` under a live 500 Hz thread would drop the loop into
         its ``publish`` branch and skip the zero-torque frame - the fall
         this whole path exists to prevent.
+
+        Halting is not the same as having halted.
+        :meth:`_ControlLoop.stop` reports whether the thread actually
+        joined, and a caller-supplied policy that outlasts the join
+        budget - a remote inference call is the ordinary case - leaves it
+        running.  The publisher is therefore released only once the loop
+        is provably gone: a loop that is still running keeps it, so the
+        zero-torque frame that loop publishes from its own ``finally``
+        reaches the wire instead of being dropped by
+        :meth:`_ControlLoop._emit_zero_torque`'s ``pubs is None`` return.
+        The subscribers close either way - the loop never reads them - and
+        a second ``cleanup()`` once the loop has exited releases the rest.
         """
         with self._task_admission:
             loop = self._loop
+        joined = True
         if loop is not None and loop.is_running:
-            loop.stop("stop_task")
+            joined = loop.stop("stop_task")
         if self._subs is not None:
             self._subs.close()
             self._subs = None
-        if self._pubs is not None:
-            self._pubs.close()
-            self._pubs = None
+        if joined:
+            if self._pubs is not None:
+                self._pubs.close()
+                self._pubs = None
+        else:
+            logger.error(
+                "%s.cleanup(): control loop did not join within the stop budget, "
+                "so the publisher stays open for its zero-torque frame; call "
+                "cleanup() again once the loop has exited",
+                self._tool_name,
+            )
         self._connected = False
 
     # ------------------------------------------------------------------ #

--- a/tests/drivers/test_g1_cleanup_reads_the_loop_halt_outcome.py
+++ b/tests/drivers/test_g1_cleanup_reads_the_loop_halt_outcome.py
@@ -23,14 +23,62 @@ cost about two seconds each.
 from __future__ import annotations
 
 import logging
+import sys
 import threading
 import time
+import types
 from typing import Any
 
 import pytest
 
 import strands_robots.drivers.g1 as g1_mod
-from tests.drivers.test_g1_control_loop import _ControlLoop, _RecordingPublisher
+from tests.drivers.test_g1_control_loop import (
+    _ControlLoop,
+    _RecordingPublisher,
+    _StubCRC,
+    _StubLowCmd,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a ``unitree_sdk2py`` stub for the duration of one test.
+
+    The loop's write path and its zero-torque ``finally`` both call
+    ``from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowCmd_`` inside
+    the function body.  On a CI box without the SDK installed that import
+    is an :class:`ImportError` the callers explicitly swallow, so the wire
+    frames these cells count never leave the loop.  The stub matches the
+    one :mod:`tests.drivers.test_g1_control_loop` installs for the same
+    reason - imported alongside the reused fake ``_RecordingPublisher`` so
+    both files run the same production lane.  ``monkeypatch.setitem``
+    restores the previous entries on teardown.
+    """
+    root = types.ModuleType("unitree_sdk2py")
+    idl = types.ModuleType("unitree_sdk2py.idl")
+    default = types.ModuleType("unitree_sdk2py.idl.default")
+    unitree_hg = types.ModuleType("unitree_sdk2py.idl.unitree_hg")
+    unitree_hg_msg = types.ModuleType("unitree_sdk2py.idl.unitree_hg.msg")
+    dds_ = types.ModuleType("unitree_sdk2py.idl.unitree_hg.msg.dds_")
+    utils = types.ModuleType("unitree_sdk2py.utils")
+    crc = types.ModuleType("unitree_sdk2py.utils.crc")
+
+    default.unitree_hg_msg_dds__LowCmd_ = _StubLowCmd  # type: ignore[attr-defined]
+    dds_.LowCmd_ = _StubLowCmd  # type: ignore[attr-defined]
+    crc.CRC = _StubCRC  # type: ignore[attr-defined]
+
+    for name, mod in [
+        ("unitree_sdk2py", root),
+        ("unitree_sdk2py.idl", idl),
+        ("unitree_sdk2py.idl.default", default),
+        ("unitree_sdk2py.idl.unitree_hg", unitree_hg),
+        ("unitree_sdk2py.idl.unitree_hg.msg", unitree_hg_msg),
+        ("unitree_sdk2py.idl.unitree_hg.msg.dds_", dds_),
+        ("unitree_sdk2py.utils", utils),
+        ("unitree_sdk2py.utils.crc", crc),
+    ]:
+        monkeypatch.setitem(sys.modules, name, mod)
+
 
 #: The joint every fixture commands.  Its commanded gain is the discriminator:
 #: the zero-torque frame is the one that asks for zero stiffness.

--- a/tests/drivers/test_g1_cleanup_reads_the_loop_halt_outcome.py
+++ b/tests/drivers/test_g1_cleanup_reads_the_loop_halt_outcome.py
@@ -1,0 +1,304 @@
+"""``cleanup`` and ``stop`` read whether the control loop actually halted.
+
+:meth:`~strands_robots.drivers.g1._ControlLoop.stop` signals the loop and joins
+its thread within a budget, and *returns whether the thread joined*.  A
+caller-supplied policy that outlasts that budget - a remote inference call is
+the ordinary case, which :meth:`G1Driver.stop_task`'s own docstring says - leaves
+the loop running and the return value ``False``.
+
+``stop_task`` reads it.  The two teardown paths did not, and for ``cleanup`` that
+was load-bearing: it closed ``_pubs`` and set it to ``None`` under the live
+thread, so :meth:`_ControlLoop._emit_zero_torque` took its silent
+``pubs is None`` return and the zero-torque shutdown frame was never published -
+by ``cleanup``, nor later when the policy returned.  That is the fall
+``cleanup``'s docstring says the path exists to prevent.
+
+The shipped zero-torque test drives a policy that returns immediately, so its
+join always succeeds and the discarded value is always ``True``: the fast path
+cannot distinguish a checked halt from an unchecked one.  Every cell here that
+grades the fix therefore blocks a policy past the join budget, which is why they
+cost about two seconds each.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers.g1 as g1_mod
+from tests.drivers.test_g1_control_loop import _ControlLoop, _RecordingPublisher
+
+#: The joint every fixture commands.  Its commanded gain is the discriminator:
+#: the zero-torque frame is the one that asks for zero stiffness.
+_JOINT = "left_knee"
+
+#: Longer than :meth:`_ControlLoop.stop`'s join budget, so a policy parked on
+#: this event is guaranteed to outlast it.
+_LONGER_THAN_THE_JOIN_BUDGET = 30.0
+
+
+def _connected_driver(publisher: _RecordingPublisher) -> Any:
+    """A real ``G1Driver`` wired to ``publisher``, in the state a rollout runs in.
+
+    Constructed without DDS: the lifecycle methods and the task-admission lock
+    are what these cells grade, and every attribute the loop reads is a real
+    value so a typo fails on ``AttributeError`` rather than reading a stand-in.
+    """
+    driver = g1_mod.G1Driver(port="127.0.0.1", network_interface="lo")
+    driver._pubs = publisher  # type: ignore[assignment]
+    driver._subs = None
+    driver._connected = True
+    driver._mode_machine = 9
+    driver._fsm_id = 500
+    driver._battery = {"pct": 80.0}
+    driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+    return driver
+
+
+def _zero_torque_frames(publisher: _RecordingPublisher) -> int:
+    """Count frames on ``publisher`` that command zero stiffness on ``_JOINT``."""
+    slot = g1_mod._G1_JOINT_INDEX[_JOINT]
+    return sum(1 for call in publisher.calls if call[2].motor_cmd[slot].kp == 0.0)
+
+
+def _await_exit(loop: _ControlLoop, timeout: float = 10.0) -> None:
+    """Poll until ``loop`` has left its thread, so a frame count is settled."""
+    deadline = time.monotonic() + timeout
+    while loop.is_running and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not loop.is_running, "loop did not exit within timeout"
+
+
+class _Rollout:
+    """A started loop whose policy parks until :meth:`release` is called.
+
+    ``blocking=False`` gives the fast path the shipped suite already drives, so
+    one helper serves both the regression cells and their controls.
+    """
+
+    def __init__(self, blocking: bool) -> None:
+        self.publisher = _RecordingPublisher()
+        self.driver = _connected_driver(self.publisher)
+        self._released = threading.Event()
+
+        def policy(_observation: Any) -> dict[str, float]:
+            if blocking:
+                self._released.wait(_LONGER_THAN_THE_JOIN_BUDGET)
+            return {_JOINT: 0.0}
+
+        self.loop = _ControlLoop(driver=self.driver, policy=policy, duration=60.0, n_steps=None)
+        self.driver._loop = self.loop
+        self.loop.start()
+        # Let the loop reach the policy call before the teardown under test.
+        time.sleep(0.05)
+
+    def release(self) -> None:
+        """Let a parked policy return, then wait for the loop to exit."""
+        self._released.set()
+        _await_exit(self.loop)
+
+
+@pytest.fixture
+def unjoined() -> Any:
+    """A rollout whose policy outlasts the join budget.  Always released."""
+    rollout = _Rollout(blocking=True)
+    try:
+        yield rollout
+    finally:
+        rollout.release()
+
+
+@pytest.fixture
+def joins() -> Any:
+    """A rollout whose policy returns immediately, so the join succeeds."""
+    rollout = _Rollout(blocking=False)
+    try:
+        yield rollout
+    finally:
+        rollout.release()
+
+
+class TestThePremise:
+    """The facts the regression cells rest on, stated independently."""
+
+    def test_stop_reports_whether_the_thread_joined(self, unjoined: Any) -> None:
+        assert unjoined.loop.stop("stop_task") is False
+        assert unjoined.loop.is_running
+
+    def test_a_returning_policy_joins_inside_the_budget(self, joins: Any) -> None:
+        assert joins.loop.stop("stop_task") is True
+
+    def test_the_zero_torque_frame_is_dropped_when_the_publisher_is_gone(self) -> None:
+        """``_emit_zero_torque`` returns silently, which is why losing it is quiet."""
+        publisher = _RecordingPublisher()
+        driver = _connected_driver(publisher)
+        loop = _ControlLoop(driver=driver, policy=lambda _o: {_JOINT: 0.0}, duration=1.0, n_steps=None)
+        driver._pubs = None
+        # Its ``-> None`` return is the type checker's to state; what a cell
+        # can add is that the frame is dropped rather than raised.
+        loop._emit_zero_torque()
+        assert publisher.calls == []
+
+
+class TestCleanupKeepsThePublisherForAnUnjoinedLoop:
+    """The regression: the shutdown frame survives a policy that overruns."""
+
+    def test_the_zero_torque_frame_reaches_the_wire(self, unjoined: Any) -> None:
+        unjoined.driver.cleanup()
+        unjoined.release()
+        assert _zero_torque_frames(unjoined.publisher) == 1
+
+    def test_the_publisher_is_not_closed_under_the_live_loop(self, unjoined: Any) -> None:
+        unjoined.driver.cleanup()
+        assert unjoined.loop.is_running
+        assert unjoined.publisher.closed is False
+
+    def test_the_publisher_reference_is_kept(self, unjoined: Any) -> None:
+        unjoined.driver.cleanup()
+        assert unjoined.driver._pubs is unjoined.publisher
+
+    def test_the_overrun_is_reported_at_error(self, unjoined: Any, caplog: Any) -> None:
+        with caplog.at_level(logging.ERROR, logger=g1_mod.__name__):
+            unjoined.driver.cleanup()
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("did not join" in message for message in messages), messages
+
+    def test_the_report_names_calling_cleanup_again(self, unjoined: Any, caplog: Any) -> None:
+        with caplog.at_level(logging.ERROR, logger=g1_mod.__name__):
+            unjoined.driver.cleanup()
+        assert any("cleanup() again" in record.getMessage() for record in caplog.records)
+
+
+class TestStopReportsAnUnjoinedLoop:
+    """``stop`` has no envelope, so an overrun is logged rather than returned."""
+
+    def test_the_overrun_is_reported_at_error(self, unjoined: Any, caplog: Any) -> None:
+        import asyncio
+
+        with caplog.at_level(logging.ERROR, logger=g1_mod.__name__):
+            asyncio.run(unjoined.driver.stop())
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("did not join" in message for message in messages), messages
+
+
+class TestNothingLeaksEitherWay:
+    """Holds on both trees, and is the reason keeping the publisher is safe.
+
+    Deferring the release is only defensible if the resources are still
+    released, so these say what must stay true whichever branch ``cleanup``
+    takes.  They are guards rather than regression cells: each one passes on
+    the pre-fix code too, where the first ``cleanup`` had already closed the
+    publisher.
+    """
+
+    def test_a_second_cleanup_releases_the_publisher(self, unjoined: Any) -> None:
+        unjoined.driver.cleanup()
+        unjoined.release()
+        unjoined.driver.cleanup()
+        assert unjoined.driver._pubs is None
+        assert unjoined.publisher.closed is True
+
+    def test_the_subscribers_close_either_way(self, unjoined: Any) -> None:
+        """The loop never reads them, so holding them back buys nothing."""
+        subscribers = _RecordingPublisher()
+        unjoined.driver._subs = subscribers  # type: ignore[assignment]
+        unjoined.driver.cleanup()
+        assert subscribers.closed is True
+        assert unjoined.driver._subs is None
+
+    def test_stop_releases_no_resources_at_all(self, unjoined: Any) -> None:
+        """``stop`` halts the loop; ``cleanup`` is what releases the wire."""
+        import asyncio
+
+        asyncio.run(unjoined.driver.stop())
+        assert unjoined.driver._pubs is unjoined.publisher
+        assert unjoined.publisher.closed is False
+
+
+class TestTheJoinedPathIsUnchanged:
+    """Over-reach controls: reading the outcome must cost the fast path nothing."""
+
+    def test_the_publisher_is_released(self, joins: Any) -> None:
+        joins.driver.cleanup()
+        assert joins.driver._pubs is None
+        assert joins.publisher.closed is True
+
+    def test_the_zero_torque_frame_still_goes_out(self, joins: Any) -> None:
+        joins.driver.cleanup()
+        assert _zero_torque_frames(joins.publisher) == 1
+
+    def test_nothing_is_reported_at_error(self, joins: Any, caplog: Any) -> None:
+        with caplog.at_level(logging.ERROR, logger=g1_mod.__name__):
+            joins.driver.cleanup()
+        assert [record.getMessage() for record in caplog.records] == []
+
+    def test_cleanup_with_no_loop_still_releases_everything(self) -> None:
+        publisher = _RecordingPublisher()
+        driver = _connected_driver(publisher)
+        driver.cleanup()
+        assert driver._pubs is None
+        assert publisher.closed is True
+        assert driver._connected is False
+
+    def test_cleanup_is_still_idempotent(self) -> None:
+        driver = _connected_driver(_RecordingPublisher())
+        driver.cleanup()
+        driver.cleanup()
+        assert driver._pubs is None
+
+
+class TestEveryTeardownPathReadsTheOutcome:
+    """Derived, so a fourth path cannot land discarding the join result.
+
+    Read structurally rather than behaviourally: a teardown added later would
+    have no cell here, and the point is that it is held to the rule on arrival.
+    """
+
+    @staticmethod
+    def _halt_call_sites() -> dict[str, bool]:
+        """Map enclosing function name -> whether it reads ``loop.stop``'s value."""
+        import ast
+
+        source = g1_mod.__loader__.get_source(g1_mod.__name__)  # type: ignore[union-attr]
+        assert source is not None
+        tree = ast.parse(source)
+        discarded: dict[str, bool] = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for statement in ast.walk(node):
+                if not isinstance(statement, ast.Expr):
+                    continue
+                call = statement.value
+                if (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "stop"
+                    and "loop" in ast.unparse(call.func.value)
+                ):
+                    discarded[node.name] = True
+        return discarded
+
+    def test_the_scan_finds_the_halt_calls_at_all(self) -> None:
+        """Non-vacuity: the pattern this rule bans must be expressible."""
+        import ast
+
+        planted = ast.parse("def teardown(self):\n    loop.stop('x')\n")
+        found = [
+            node.name
+            for node in ast.walk(planted)
+            if isinstance(node, ast.FunctionDef)
+            for statement in ast.walk(node)
+            if isinstance(statement, ast.Expr)
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Attribute)
+            and statement.value.func.attr == "stop"
+        ]
+        assert found == ["teardown"]
+
+    def test_no_function_discards_the_halt_outcome(self) -> None:
+        assert self._halt_call_sites() == {}


### PR DESCRIPTION
## Problem

`_ControlLoop.stop` signals the loop, joins its thread within a budget, and
**returns whether the thread joined**. Its own docstring says why that return
value exists:

> `False` when the loop is still running - a caller-supplied policy that
> outlasts the join budget (a remote inference call is the ordinary case) needs
> the honest `stopped=False` in the `stop_task` envelope rather than a `success`
> claim the payload's `running=True` contradicts.

Three call sites, one of which read it:

| caller | reads the outcome | closes `_pubs` after |
|---|---|---|
| `stop_task` | yes | no |
| `G1Driver.stop` | **no** | no |
| `G1Driver.cleanup` | **no** | **yes** |

For `cleanup` that was load-bearing. `_emit_zero_torque` reads
`self._driver._pubs` and returns silently when it is `None`, so closing the
publisher under a live thread does not merely release a resource early - it
discards the shutdown frame. `cleanup`'s own docstring names that outcome as the
thing the path exists to prevent:

> Closing `_pubs` under a live 500 Hz thread would drop the loop into its
> `publish` branch and skip the zero-torque frame - the fall this whole path
> exists to prevent.

## Measured

One rollout, one `cleanup()`, two policies. The zero-torque frame is the one
commanding zero stiffness on the commanded joint.

| | policy returns at once | policy outlasts the join budget |
|---|---|---|
| `cleanup()` returned after | 0.05 s | 2.00 s |
| loop still running | False | **True** |
| `_pubs` | `None` | `None` |
| publisher closed | True | **True, under the live thread** |
| zero-torque frames at that point | 1 | 0 |
| **zero-torque frames after the policy returns** | 1 | **0** |

The frame is not delayed, it is lost: the loop reaches its own `finally`, calls
`_emit_zero_torque`, finds `_pubs is None` and returns. The recorded
`exit_reason` is `stop_task`, so the run also reports a clean caller-driven stop.

After this change the right-hand column reads `_pubs` kept, `closed False`, and
**1** zero-torque frame once the policy returns.

## Change

`cleanup` releases the publisher only once the loop is provably gone. A loop that
is still running keeps it, so the frame that loop publishes from its own
`finally` reaches the wire, and the overrun is reported at ERROR naming the
remedy. The subscribers close either way - the loop never reads them - and a
second `cleanup` releases the rest.

`stop` carries no envelope and releases nothing, so its frame was never at risk.
It now logs the overrun rather than returning from shutdown in silence while a
thread still holds the wire. The two are deliberately different: one is a
behaviour change, the other a diagnostic.

## Why nothing caught it

The zero-torque contract already has a test, and its policy returns
immediately:

```python
def policy(_obs: Any) -> dict[str, float]:
    return {"left_knee": 0.0}
```

so its join always succeeded and the discarded value was always `True`. The fast
path cannot distinguish a checked halt from an unchecked one. Every regression
cell here blocks a policy past the join budget - the regime `stop_task`'s
docstring calls ordinary - which is why they cost about two seconds each.

Measured directly: on the pre-fix tree the whole defect fires **0** of the
**685** pre-existing cells in `tests/drivers/`, `tests/tools/g1/` and
`tests/test_driver_seam.py`.

## Tests

Pre-fix split, source reverted with the new file kept: **7 failed / 12 passed**.
By class - 5/5 `TestCleanupKeepsThePublisherForAnUnjoinedLoop`, 1/1
`TestStopReportsAnUnjoinedLoop`, 1/2 `TestEveryTeardownPathReadsTheOutcome`, and
**0 of 3 `TestThePremise`, 0 of 3 `TestNothingLeaksEitherWay`, 0 of 5
`TestTheJoinedPathIsUnchanged`**. The headline failure is the defect verbatim:
`assert 0 == 1` on the zero-torque frame count.

`TestNothingLeaksEitherWay` holds on both trees by design: deferring the release
is only defensible if the resources are still released.

### Mutations

`mine` = failures in the new file, `coll` = cells collected, `sib` = failures in
the three pre-existing suites.

| mutation | mine | coll | sib |
|---|---|---|---|
| control (no change) | 0 | 19 | 0 |
| both discards restored (raw revert) | 7 | 19 | 0 |
| `cleanup` discards the outcome | 6 | 19 | 0 |
| `stop` discards the outcome | 2 | 19 | 0 |
| `cleanup` reads it but closes `_pubs` anyway | 3 | 19 | 0 |
| overrun reported at DEBUG, not ERROR | 2 | 19 | 0 |
| report drops "did not join" | 1 | 19 | 0 |
| report drops the remedy | 1 | 19 | 0 |
| subscribers held back too (over-reach) | 1 | 19 | 0 |
| `joined` starts `False` (over-reach) | 3 | 19 | **1** |

10 mutations, 10 distinct firing sets, none undetected, `collected` stable at 19
so no row hid a deselection, source restored md5-identical.

Two rows carry most of the argument. **`cleanup` reads it but closes `_pubs`
anyway** is the tempting smaller fix - log the overrun and release regardless -
and it still fires the three frame-and-publisher cells, so deferring the release
is the behavioural content rather than the log. **`joined` starts `False`** is
the over-reach direction and it trips a pre-existing cell
(`test_cleanup_is_idempotent_with_no_loop`), because a driver with no loop at all
must still release everything.

Complementarity is exact: the `cleanup`-only revert fires 6, the `stop`-only
revert fires 2, they share the derived structural cell, and the union is the 7 of
the full revert.

`TestEveryTeardownPathReadsTheOutcome` is derived from the module's own AST, so a
fourth teardown path cannot land discarding the join result, with a non-vacuity
cell asserting the banned shape is expressible in the first place.

## Gate

Identical 430-file selection - all of `tests/drivers/`, `tests/tools/g1/`,
`tests/test_driver_seam.py` plus every suite that walks the tree, parses source
or reads docstrings - with the new file excluded from both trees and every path
verified present on both: identical **20680 collected** and
`20 failed, 20587 passed, 73 skipped` on each, 20 identical failing ids, `comm`
empty in both directions, two distinct rootdirs. All 20 are pre-existing: 17 need
`awsiot`/`awscrt` (absent here, declared in the `[mesh-iot]` extra) and 3 are the
lerobot-from-source `encode()` drift.

`ruff check` and `ruff format --check` clean over `strands_robots tests
tests_integ`. mypy **24 == 24** against a worktree of the merge base, normalized
message sets byte-identical in both directions, 0 attributable to the changed
files.

No visual artifact: this is a teardown-reporting change with no policy,
simulation, rendering, recording or asset behaviour in it. The measured
before/after frame counts are the evidence.
