### PR TITLE
fix(drivers): name a robot's native driver instead of lerobot's vocabulary

### DIFF
--- a/changelog.d/2817-native-driver-named-not-lerobots-vocabulary.md
+++ b/changelog.d/2817-native-driver-named-not-lerobots-vocabulary.md
@@ -1,0 +1,47 @@
+### Fixed: a robot with a native driver is named as one, not answered with lerobot's list
+
+Two registries answer "what builds this robot": lerobot's `RobotConfig`
+ChoiceRegistry and this package's native-driver registry. A robot can be in the
+second and not the first - that gap is what a native driver exists to close, and
+`drivers/reachy.py` records it in as many words: "the Reachy Mini has no lerobot
+robot type, so before this driver `mode="real"` raised `ValueError: Unsupported
+robot type: 'reachy_mini'`".
+
+The Reachy Mini also declares `hardware.driver="strands"`, so `resolve_driver`
+sends it to its driver and it never meets that refusal. Four robots the
+Dynamixel driver serves - `vx300s`, `wx250s`, `trossen_wxai` and `dynamixel_2r` -
+declare nothing, so the default routes them to lerobot, which has no robot type
+for any of them. They reached the generic listing of lerobot's sixteen robot
+types, and that listing never mentioned that this package ships the driver that
+builds them. A caller with no reason to guess `driver="strands"` was at a dead
+end, holding a list of sixteen names none of which was the robot they asked for.
+
+The site already had this shape for the other wrong entry point. A leader arm is
+a lerobot *teleoperator*, and `teleoperator._other_lerobot_kind_refusal` names it
+as one rather than listing follower types - its docstring is where "answering it
+with the names of the kind it is not answers the wrong question" is written down.
+`drivers.registry._native_driver_refusal` is that function's sibling for a
+natively driven robot: consulted at the same site, returning a reason or `None`
+the same way, so a name with no native driver keeps the listing that is the right
+answer for it. Of the fifty-five registry robots that reach this refusal, four
+now name their driver and fifty-one are unchanged - including `robotiq_2f85`,
+which has no driver of either kind.
+
+It is consulted before the teleoperator arm rather than after, because the two
+populations overlap: `unitree_g1` is a lerobot teleoperator type as well as a
+natively driven robot, and for a name in that overlap the driver is what a
+`Robot()` caller asked for, not an instruction to build the leader that
+teleoperates it. Nothing observable turns on that order today - lerobot's robot
+registry knows `unitree_g1` too, so it resolves and never arrives - which is why
+the ordering is pinned structurally.
+
+Resolution precedence is untouched and no registry entry gains a declaration.
+Which driver wins is unchanged: `koch` and `aloha` have both a working lerobot
+type and a native driver, and whether they should prefer the native one is a
+preference the registry is where to declare - `unitree_g1` shows that. This
+changes only what a caller is told when the driver they were routed to cannot
+build the robot at all. `get_driver`'s docstring, which claimed
+`hardware.driver` is "absent everywhere in the package registry, because every
+robot here is driven through lerobot", is corrected alongside: two robots declare
+it, and an absent declaration means "no preference" rather than "no native
+driver".

--- a/strands_robots/drivers/registry.py
+++ b/strands_robots/drivers/registry.py
@@ -154,3 +154,46 @@ def list_native_drivers() -> dict[str, str]:
         Canonical robot name -> driver class name, sorted by robot name.
     """
     return {name: cls.__name__ for name, cls in sorted(_NATIVE_DRIVERS.items())}
+
+
+def _native_driver_refusal(robot_type: str) -> str | None:
+    """Name ``robot_type``'s native driver, or ``None`` when it has none.
+
+    lerobot's ``RobotConfig`` registry and this package's native-driver registry
+    are two answers to "what builds this robot", and a robot may be in the
+    second and not the first: the Reachy Mini and the Trossen arms have no
+    lerobot robot type at all, which is the gap their native drivers exist to
+    close. When ``driver="lerobot"`` is chosen for such a robot -- and it is
+    chosen by default, because :func:`resolve_driver` falls back to
+    :data:`~strands_robots.drivers.base.DEFAULT_DRIVER` for a robot that
+    declares nothing -- lerobot cannot build it, and answering with the names of
+    the robots lerobot *does* know answers the wrong question. The driver that
+    builds this robot ships in this package, one keyword away.
+
+    The sibling of :func:`strands_robots.teleoperator._other_lerobot_kind_refusal`,
+    which does the same for the other kind of wrong entry point: that one names a
+    leader arm as a teleoperator, this one names a robot as natively driven. Both
+    are consulted before the generic listing, and both return ``None`` to leave
+    it in place -- for a name with no native driver the listing is the right
+    answer, which is why this reports rather than raises.
+
+    Args:
+        robot_type: The device type string handed to lerobot. That is the
+            robot's ``hardware.lerobot_type`` when it declares one, and its
+            canonical name otherwise -- so a robot with no lerobot type is
+            looked up here under the name a caller passed to
+            :func:`~strands_robots.robot.Robot`.
+
+    Returns:
+        A refusal naming the native driver and the ``driver="strands"`` keyword
+        that builds it, or ``None`` when no native driver serves ``robot_type``.
+    """
+    driver_cls = get_native_driver_class(robot_type)
+    if driver_cls is None:
+        return None
+    return (
+        f"Unsupported robot type: {robot_type!r}. lerobot has no robot type for it, but this "
+        f"package ships a native driver for it ({driver_cls.__name__}): build it with "
+        f"Robot({robot_type!r}, mode='real', driver='strands', ...). To make that the default "
+        f"for this robot, declare hardware.driver='strands' on its registry entry."
+    )

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1094,17 +1094,36 @@ class Robot(TeleopMixin, AgentTool):
         try:
             ConfigClass = RobotConfig.get_choice_class(robot_type)
         except KeyError:
-            # A leader arm is a teleoperator, not a robot, and lerobot keeps the
-            # two in separate registries. Listing the robot types for a leader
-            # name is the retry that torque-enables the arm a human is holding,
-            # so name the kind it really is instead. ``Robot()``'s own registry
-            # guard does this for an unregistered ``*_leader`` name; a leader
-            # that IS registered -- as itself, which is the honest thing to
-            # register -- reaches this site instead.
+            # Two registries can answer better than lerobot's own listing here,
+            # and each returns a reason or ``None`` so the listing survives when
+            # neither applies.
+            #
+            # First: a robot THIS package drives natively. Its driver ships
+            # here, and lerobot's listing does not mention it, so a caller with
+            # no reason to guess ``driver="strands"`` is left at a dead end.
+            # Checked before the teleoperator arm because the two populations
+            # overlap -- ``unitree_g1`` is a lerobot teleoperator type as well
+            # as a natively driven robot -- and for a name in that overlap the
+            # native answer is the right one: someone who asked ``Robot()`` for
+            # a robot this package drives wants its driver, not an instruction
+            # to build the leader that teleoperates it.
+            from strands_robots.drivers.registry import _native_driver_refusal
+
+            if native := _native_driver_refusal(robot_type):
+                raise ValueError(native) from None
+
+            # Then: a leader arm is a teleoperator, not a robot, and lerobot
+            # keeps the two in separate registries. Listing the robot types for
+            # a leader name is the retry that torque-enables the arm a human is
+            # holding, so name the kind it really is instead. ``Robot()``'s own
+            # registry guard does this for an unregistered ``*_leader`` name; a
+            # leader that IS registered -- as itself, which is the honest thing
+            # to register -- reaches this site instead.
             from strands_robots.teleoperator import _other_lerobot_kind_refusal
 
             if other := _other_lerobot_kind_refusal(robot_type, wanted="robot"):
                 raise ValueError(other) from None
+
             available = sorted(RobotConfig.get_known_choices().keys())
             # ``from None`` -- the KeyError is an internal detail of
             # lerobot's draccus registry; suppress the chained traceback

--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -116,10 +116,17 @@ def get_driver(name: str) -> str | None:
 
     A pure reader, like its sibling :func:`get_hardware_type`: it reports what
     the registry says and applies no default. ``hardware.driver`` is optional and
-    absent everywhere in the package registry, because every robot here is driven
-    through lerobot. Deciding what an absent - or ``"auto"`` - declaration means
-    is :func:`~strands_robots.drivers.resolve_driver`'s job, which is also where
-    a caller's explicit choice outranks the registry.
+    most robots declare none. Where it is declared it says which of two possible
+    drivers wins: one declarer has no lerobot robot type at all, so the native
+    driver is the only one that can build it; the other has a working lerobot
+    type and prefers its native driver anyway.
+
+    An absent declaration therefore means "no preference", not "no native
+    driver" - a robot may have one registered and declare nothing, in which case
+    the default still routes to lerobot. Deciding what an absent - or ``"auto"``
+    - declaration means is
+    :func:`~strands_robots.drivers.resolve_driver`'s job, which is also where a
+    caller's explicit choice outranks the registry.
 
     Args:
         name: Robot name, alias, or data_config.

--- a/tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py
+++ b/tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py
@@ -1,0 +1,337 @@
+"""A robot this package drives natively is named as such, not answered with lerobot's list.
+
+Two registries answer "what builds this robot": lerobot's ``RobotConfig``
+ChoiceRegistry, and this package's native-driver registry. A robot can be in the
+second and not the first - that gap is what a native driver exists to close, and
+:mod:`strands_robots.drivers.reachy` records it in as many words: "the Reachy
+Mini has no lerobot robot type, so before this driver ``mode="real"`` raised
+``ValueError: Unsupported robot type: 'reachy_mini'``".
+
+The Reachy Mini also declares ``hardware.driver="strands"`` on its registry
+entry, so :func:`~strands_robots.drivers.resolve_driver` sends it to its driver
+and it never meets that refusal. Four robots the Dynamixel driver serves declare
+nothing, so the default routes them to lerobot - which has no robot type for any
+of them. They reached the generic listing of lerobot's sixteen robot types, and
+that listing never mentioned that this package ships the driver that builds
+them: an answer to the wrong question, and a dead end for a caller who has no
+reason to guess at ``driver="strands"``.
+
+The site already had this shape for the other wrong entry point. A leader arm is
+a lerobot *teleoperator*, and
+:func:`strands_robots.teleoperator._other_lerobot_kind_refusal` names it as one
+rather than listing follower types - its docstring is where "answering it with
+the names of the kind it is not answers the wrong question" is written down.
+:func:`strands_robots.drivers.registry._native_driver_refusal` is that function's
+sibling for a natively driven robot, consulted at the same site and returning
+``None`` the same way, so a name with no native driver keeps the listing that is
+the right answer for it. It is consulted first, because the two populations
+overlap: the G1 is a lerobot teleoperator type as well as a natively driven
+robot, and for a name in that overlap the driver is what a ``Robot()`` caller
+asked for.
+
+What is deliberately unchanged: which driver *wins*. Resolution precedence is
+untouched, no registry entry gains a declaration, and a robot lerobot can build
+still goes to lerobot. Whether ``koch`` and ``aloha`` - which have both a
+working lerobot type and a native driver - should prefer the native one is a
+preference, and ``unitree_g1`` shows the registry is where such a preference is
+declared. This changes only what a caller is told when the driver they were
+routed to cannot build the robot at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers.registry as drivers_registry_mod
+from strands_robots import Robot
+from strands_robots.drivers import get_native_driver_class, resolve_driver
+from strands_robots.drivers.registry import _native_driver_refusal
+from strands_robots.registry import get_robot, list_robots
+
+#: The robots that reach lerobot with a native driver already registered for
+#: them. Literal rather than derived: a rule narrowed by mistake would
+#: *deselect* a derived case and still report success, where a literal keeps
+#: running and fails. :class:`TestTheDerivedPopulationIsExactlyThese` grades the
+#: rule itself, so a fifth robot arriving in this position is caught there.
+NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE = ("vx300s", "wx250s", "trossen_wxai", "dynamixel_2r")
+
+#: Robots that reach the same site with no native driver, so the listing of
+#: lerobot's robot types is the right answer and must survive. Two grippers and
+#: two arms: every one is a real registry entry with a simulation asset and no
+#: real-mode support of any kind.
+NO_DRIVER_OF_EITHER_KIND = ("robotiq_2f85", "robotiq_2f85_v4", "ur5e", "panda")
+
+#: The generic listing's own words, which must be absent from a refusal that has
+#: a better answer and present from one that does not.
+_LEROBOT_LISTING = "Known lerobot robot types"
+
+
+def _lerobot_robot_types() -> set[str]:
+    """Every robot type lerobot's ChoiceRegistry knows, after its own discovery."""
+    pytest.importorskip("lerobot")
+    from strands_robots.hardware_robot import _ensure_lerobot_robots_registered
+
+    _ensure_lerobot_robots_registered()
+    from lerobot.robots.config import RobotConfig
+
+    return set(RobotConfig.get_known_choices())
+
+
+def _type_handed_to_lerobot(name: str) -> str:
+    """The device type string ``hardware_robot`` receives for ``name``.
+
+    A robot's declared ``hardware.lerobot_type`` when it has one, and its
+    canonical name otherwise - which is why a robot with no lerobot type is
+    looked up in the native registry under the name the caller passed.
+    """
+    hardware = (get_robot(name) or {}).get("hardware") or {}
+    return str(hardware.get("lerobot_type") or name)
+
+
+def _refusal_for(name: str) -> str:
+    """Build ``name`` in real mode with no ``driver=`` and return the refusal."""
+    with pytest.raises(ValueError) as excinfo:
+        Robot(name, mode="real")
+    return str(excinfo.value)
+
+
+class TestThePremise:
+    """The facts the regression rests on, so a passing cell cannot be vacuous."""
+
+    @pytest.mark.parametrize("name", NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+    def test_lerobot_has_no_robot_type_for_it(self, name: str) -> None:
+        """lerobot structurally cannot build these, so there is no choice to make."""
+        assert _type_handed_to_lerobot(name) not in _lerobot_robot_types()
+
+    @pytest.mark.parametrize("name", NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+    def test_a_native_driver_is_registered_for_it(self, name: str) -> None:
+        """The better answer exists in this package, which is the whole point."""
+        assert get_native_driver_class(name) is not None
+
+    @pytest.mark.parametrize("name", NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+    def test_the_default_still_routes_it_to_lerobot(self, name: str) -> None:
+        """Why they meet this refusal at all: they declare no driver preference."""
+        assert resolve_driver(name, None) == "lerobot"
+
+    @pytest.mark.parametrize("name", NO_DRIVER_OF_EITHER_KIND)
+    def test_the_control_robots_have_no_native_driver(self, name: str) -> None:
+        """Otherwise the over-reach controls would be graded on the wrong robots."""
+        assert get_native_driver_class(name) is None
+
+
+class TestANativelyDrivenRobotIsNamed:
+    """The regression: the refusal names the driver that builds it."""
+
+    @pytest.mark.parametrize("name", NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+    def test_the_refusal_names_the_driver_class(self, name: str) -> None:
+        driver_cls = get_native_driver_class(name)
+        assert driver_cls is not None, "premise: this robot has a native driver"
+        assert driver_cls.__name__ in _refusal_for(name)
+
+    @pytest.mark.parametrize("name", NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+    def test_the_refusal_spells_out_the_call_that_builds_it(self, name: str) -> None:
+        """A caller cannot guess ``driver='strands'``, so the retry is written out.
+
+        The whole call, not the keyword alone: the message names that keyword a
+        second time as the registry declaration a maintainer could add, and a
+        caller cannot copy that one.
+        """
+        retry = f"Robot({name!r}, mode='real', driver='strands'"
+        assert retry in _refusal_for(name)
+
+    @pytest.mark.parametrize("name", NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+    def test_the_refusal_names_the_robot_that_was_asked_for(self, name: str) -> None:
+        assert repr(name) in _refusal_for(name)
+
+    @pytest.mark.parametrize("name", NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+    def test_the_refusal_does_not_answer_with_lerobots_vocabulary(self, name: str) -> None:
+        """Sixteen robot types, none of them this one, is the wrong question answered."""
+        assert _LEROBOT_LISTING not in _refusal_for(name)
+
+
+class TestTheDerivedPopulationIsExactlyThese:
+    """The rule, graded rather than the four names: a fifth robot is caught here."""
+
+    @staticmethod
+    def _routed_to_lerobot_with_a_native_driver() -> set[str]:
+        known = _lerobot_robot_types()
+        return {
+            entry["name"]
+            for entry in list_robots("all")
+            if resolve_driver(entry["name"], None) == "lerobot"
+            and _type_handed_to_lerobot(entry["name"]) not in known
+            and get_native_driver_class(entry["name"]) is not None
+        }
+
+    def test_every_such_robot_is_covered_by_the_regression(self) -> None:
+        assert self._routed_to_lerobot_with_a_native_driver() == set(NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+
+    def test_the_population_is_not_empty(self) -> None:
+        """Non-vacuity: an empty set would satisfy every containment above."""
+        assert self._routed_to_lerobot_with_a_native_driver()
+
+
+class TestTheGenericListingSurvivesWhereItIsTheRightAnswer:
+    """Over-reach: a robot with no native driver must still be told lerobot's names."""
+
+    @pytest.mark.parametrize("name", NO_DRIVER_OF_EITHER_KIND)
+    def test_lerobots_vocabulary_is_still_reported(self, name: str) -> None:
+        assert _LEROBOT_LISTING in _refusal_for(name)
+
+    @pytest.mark.parametrize("name", NO_DRIVER_OF_EITHER_KIND)
+    def test_no_native_driver_is_claimed_for_it(self, name: str) -> None:
+        """Naming a driver that does not exist would send a caller to a dead end."""
+        assert "native driver" not in _refusal_for(name)
+
+
+class TestTheTeleoperatorRefusalIsUnchanged:
+    """The sibling check at the same site, and the overlap that decides the order."""
+
+    def test_a_leader_arm_is_still_named_as_a_teleoperator(self) -> None:
+        pytest.importorskip("lerobot.teleoperators.so_leader")
+        refusal = _refusal_for("so101_leader")
+        assert "teleoperator" in refusal
+        assert _LEROBOT_LISTING not in refusal
+
+    @staticmethod
+    def _in_both_registries() -> set[str]:
+        """Names lerobot lists as a teleoperator that also have a native driver."""
+        pytest.importorskip("lerobot")
+        from strands_robots.teleoperator import _ensure_lerobot_teleoperators_registered
+
+        _ensure_lerobot_teleoperators_registered()
+        from lerobot.teleoperators.config import TeleoperatorConfig
+
+        return {name for name in TeleoperatorConfig.get_known_choices() if get_native_driver_class(name) is not None}
+
+    def test_the_two_checks_overlap_so_their_order_is_a_decision(self) -> None:
+        """The premise for checking the native driver first.
+
+        Were the populations disjoint the order would be free. They are not: the
+        G1 is a lerobot teleoperator type - the humanoid used as a motion source
+        - and a robot this package drives natively. A second name arriving in
+        this overlap needs the same question asked of it, which is why this reads
+        the registries rather than asserting a count.
+        """
+        assert self._in_both_registries() == {"unitree_g1"}
+
+    def test_the_overlapping_name_prefers_its_native_driver(self) -> None:
+        """For a name in the overlap, the native answer is the right one."""
+        from strands_robots.teleoperator import _other_lerobot_kind_refusal
+
+        for name in self._in_both_registries():
+            native = _native_driver_refusal(name)
+            assert native is not None, f"{name} has a native driver, so it has a native answer"
+            assert "driver='strands'" in native
+            teleop = _other_lerobot_kind_refusal(name, wanted="robot")
+            assert teleop is not None, f"{name} is in the teleoperator registry too"
+            assert "Teleoperator(" in teleop, "the answer the order must not let win for a robot"
+
+
+class TestTheHelperReportsRatherThanRaises:
+    """A unit view, so the rule is graded on an install with no lerobot at all."""
+
+    def test_a_robot_with_no_native_driver_gets_no_reason(self) -> None:
+        """``None`` is how the caller keeps its own listing."""
+        assert _native_driver_refusal("robotiq_2f85") is None
+
+    def test_a_name_no_registry_knows_gets_no_reason(self) -> None:
+        assert _native_driver_refusal("no-such-robot-anywhere") is None
+
+    def test_a_robot_with_a_native_driver_gets_a_reason(self) -> None:
+        reason = _native_driver_refusal("vx300s")
+        assert reason is not None
+        assert "DynamixelDriver" in reason
+
+    def test_an_alias_finds_the_same_driver_as_its_canonical_name(self) -> None:
+        """The lookup goes through ``resolve_name``, so an alias is not a miss."""
+        canonical = _native_driver_refusal("unitree_g1")
+        alias = _native_driver_refusal("g1")
+        assert canonical is not None and alias is not None
+        assert "G1Driver" in canonical and "G1Driver" in alias
+
+    def test_the_reason_quotes_the_name_the_caller_passed(self) -> None:
+        """An alias is echoed back as itself: the retry is the caller's own call."""
+        alias = _native_driver_refusal("g1")
+        assert alias is not None
+        assert "Robot('g1'" in alias, alias
+
+    def test_a_driver_registered_later_is_named_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Read from the registry, not from a list of today's four robots."""
+
+        class _PlantedDriver:
+            pass
+
+        assert _native_driver_refusal("ur5e") is None, "premise: ur5e has no driver today"
+        monkeypatch.setitem(drivers_registry_mod._NATIVE_DRIVERS, "ur5e", _PlantedDriver)
+        reason = _native_driver_refusal("ur5e")
+        assert reason is not None
+        assert "_PlantedDriver" in reason
+
+
+class TestTheOrderIsStated:
+    """Structural: the better answer is consulted before the generic listing."""
+
+    @staticmethod
+    def _except_handler() -> ast.ExceptHandler:
+        from strands_robots import hardware_robot
+
+        source = inspect.getsource(hardware_robot)
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.ExceptHandler) and _LEROBOT_LISTING in (ast.get_source_segment(source, node) or ""):
+                return node
+        raise AssertionError(f"no except handler raises the {_LEROBOT_LISTING!r} listing")
+
+    @staticmethod
+    def _sole_line(handler: ast.ExceptHandler, node_type: type, marker: str, what: str) -> int:
+        """The line of the one statement of ``node_type`` whose source holds ``marker``."""
+        found = [
+            # ``ast.stmt`` first: that is the node kind carrying ``lineno``, which
+            # a dynamic ``node_type`` cannot tell a type checker on its own.
+            node.lineno
+            for node in ast.walk(handler)
+            if isinstance(node, ast.stmt) and isinstance(node, node_type) and marker in ast.unparse(node)
+        ]
+        assert len(found) == 1, f"expected one {what}, found {len(found)}"
+        return found[0]
+
+    def test_the_native_check_precedes_the_generic_listing(self) -> None:
+        handler = self._except_handler()
+        guard = self._sole_line(handler, ast.If, "_native_driver_refusal", "native-driver guard")
+        listing = self._sole_line(handler, ast.Raise, _LEROBOT_LISTING, "generic listing")
+        assert guard < listing, "the listing would win and the better answer never run"
+
+    def test_the_native_check_precedes_the_teleoperator_check(self) -> None:
+        """Pinned here because no name in the overlap reaches this site today.
+
+        ``unitree_g1`` is in both registries, so the order decides which answer
+        it would get - and lerobot's robot registry also knows it, so it resolves
+        and never arrives. Nothing observable turns on the order until that
+        changes, which is exactly when a silent reordering would start handing a
+        natively driven robot an instruction to build a teleoperator.
+        """
+        handler = self._except_handler()
+        native = self._sole_line(handler, ast.If, "_native_driver_refusal", "native-driver guard")
+        teleop = self._sole_line(handler, ast.If, "_other_lerobot_kind_refusal", "teleoperator guard")
+        assert native < teleop, "a robot in both registries would be named as a teleoperator"
+
+
+class TestNothingElseChanged:
+    """Over-reach: which driver wins, and every other refusal, are untouched."""
+
+    @pytest.mark.parametrize("name", NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE)
+    def test_an_explicit_strands_choice_still_builds_the_driver(self, name: str) -> None:
+        robot: Any = Robot(name, mode="real", driver="strands", port="/dev/ttyUSB0")
+        assert type(robot) is get_native_driver_class(name)
+
+    @pytest.mark.parametrize("name", ["koch", "aloha"])
+    def test_a_robot_lerobot_can_resolve_is_not_diverted(self, name: str) -> None:
+        """These have both drivers, so the preference is the registry's to declare."""
+        assert _type_handed_to_lerobot(name) in _lerobot_robot_types()
+        refusal = _refusal_for(name)
+        assert "driver='strands'" not in refusal
+        assert _LEROBOT_LISTING not in refusal, "it resolved, so it fails on config fields"

--- a/tests/test_driver_seam.py
+++ b/tests/test_driver_seam.py
@@ -201,7 +201,7 @@ class TestDriverResolutionPrecedence:
         )
 
     def test_no_declaration_and_no_choice_is_the_default(self) -> None:
-        assert get_driver(_ROBOT) is None, "no package robot declares a driver"
+        assert get_driver(_ROBOT) is None, f"{_ROBOT} declares no driver, so the default decides"
         assert resolve_driver(_ROBOT) == DEFAULT_DRIVER
 
     def test_a_registry_declaration_beats_the_default(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What is wrong

`Robot("vx300s", mode="real")` is refused with a list of the sixteen robot types
lerobot knows, none of which is `vx300s` — and never mentions that this package
ships the driver that builds it. Four registry entries are in that position.

```
ValueError: Unsupported robot type: 'vx300s'. Known lerobot robot types:
['bi_openarm_follower', 'bi_rebot_b601_follower', 'bi_so_follower',
 'earthrover_mini_plus', 'hope_jr_arm', 'hope_jr_hand', 'koch_follower',
 'lekiwi', 'lekiwi_client', 'omx_follower', 'openarm_follower',
 'rebot_b601_follower', 'reachy2', 'so100_follower', 'so101_follower',
 'unitree_g1']
```

Two registries answer "what builds this robot": lerobot's `RobotConfig`
ChoiceRegistry, and this package's native-driver registry. A robot can be in the
second and not the first — that gap is what a native driver exists to close, and
`drivers/reachy.py` records it in as many words:

> the Reachy Mini has no lerobot robot type, so before this driver `mode="real"`
> raised `ValueError: Unsupported robot type: 'reachy_mini'`.

The Reachy Mini also declares `hardware.driver="strands"`, so `resolve_driver`
sends it to its driver and it never meets that refusal. The four robots the
Dynamixel driver serves that have no lerobot type declare nothing, so the default
routes them to lerobot, which cannot build them — and the refusal they get points
nowhere a caller can go.

Measured on `main`, over every registry robot:

| | count |
|---|---|
| registry robots reaching this refusal | 55 |
| of those, a native driver exists in this package | **4** |
| of those, no driver of either kind (listing is the right answer) | 51 |

The four are `vx300s`, `wx250s`, `trossen_wxai` and `dynamixel_2r`. All four
build fine today with `driver="strands"` — there is simply no way for a caller to
learn that.

## The change

The site already had this shape for the other wrong entry point. A leader arm is
a lerobot *teleoperator*, and `teleoperator._other_lerobot_kind_refusal` names it
as one rather than answering with follower types. Its docstring is where the rule
is written down:

> a request for one kind that names a device of the other kind is a wrong entry
> point, not a typo — and answering it with the names of the kind it is not
> answers the wrong question. […] `None` means the name is genuinely unknown, so
> the caller keeps its own listing of the kind that was asked for.

`drivers.registry._native_driver_refusal` is that function's sibling for a
natively driven robot: same site, same report-or-`None` contract, so a name with
no native driver keeps the listing that is right for it.

```
ValueError: Unsupported robot type: 'vx300s'. lerobot has no robot type for it,
but this package ships a native driver for it (DynamixelDriver): build it with
Robot('vx300s', mode='real', driver='strands', ...). To make that the default
for this robot, declare hardware.driver='strands' on its registry entry.
```

**Deliberately unchanged: which driver wins.** Resolution precedence is
untouched and no registry entry gains a declaration. `koch` and `aloha` have both
a working lerobot type and a native driver; whether they should prefer the native
one is a preference, and `unitree_g1` shows the registry is where such a
preference is declared. This changes only what a caller is told when the driver
they were routed to cannot build the robot at all.

### Why the native check goes first

The two checks' populations overlap, so the order is a decision rather than a
free choice: `unitree_g1` is a lerobot teleoperator type *and* a natively driven
robot. For a name in that overlap the driver is what a `Robot()` caller asked
for, not an instruction to build the leader that teleoperates it.

Nothing observable turns on the order today — lerobot's robot registry knows
`unitree_g1` too, so it resolves and never reaches this handler — which is
exactly when a silent reordering would go unnoticed. It is pinned structurally
for that reason (`b3` below).

### One docstring corrected

`registry.get_driver` claimed `hardware.driver` is "absent everywhere in the
package registry, because every robot here is driven through lerobot". Measured:
two robots declare it, and six have native drivers. It now says that an absent
declaration means "no preference", not "no native driver" — the distinction this
fix turns on. The same stale belief appeared as an assertion message in
`test_driver_seam.py` and is corrected there.

## Tests

`tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py`, 59 cells.
The four robots are named as literals so a narrowed rule fails loudly instead of
deselecting a case; a separate derived cell grades the rule itself, so a fifth
robot arriving in this position is caught there.

Pre-fix split, behavioural revert (the helper kept, its call site removed):
**14 failed / 45 passed**, and the headline failure is the defect itself:

```
assert 'DynamixelDriver' in "Unsupported robot type: 'vx300s'. Known lerobot
robot types: ['bi_openarm_follower', ...]"
```

| class | failed / cells | role |
|---|---|---|
| `TestANativelyDrivenRobotIsNamed` | 12 / 16 | regression |
| `TestTheOrderIsStated` | 2 / 2 | structural |
| `TestThePremise` | 0 / 16 | premise |
| `TestTheDerivedPopulationIsExactlyThese` | 0 / 2 | derived inventory |
| `TestTheGenericListingSurvivesWhereItIsTheRightAnswer` | 0 / 8 | over-reach |
| `TestTheTeleoperatorRefusalIsUnchanged` | 0 / 3 | control |
| `TestTheHelperReportsRatherThanRaises` | 0 / 6 | unit |
| `TestNothingElseChanged` | 0 / 6 | over-reach |

### Mutations

`own` counts cells in the new file; `sib` counts the 618 pre-existing cells in
`tests/drivers/`, `tests/test_driver_seam.py` and
`tests/test_leader_arm_is_not_a_robot.py`. `collected` was 59 on every row, so no
row hid a deselection. Source restored byte-identical after each.

| # | mutation | own | sib |
|---|---|---|---|
| b0 | control, no change | 0 | 0 |
| b1 | the call site removed (behavioural revert) | 14 | 14 |
| b2 | helper answers `None` for a robot that has a driver | 27 | 34 |
| b3 | native check moved **after** the teleoperator arm | 1 | 1 |
| b4 | native check moved **after** the generic listing | 14 | 14 |
| b5 | message drops the driver class name | 7 | 7 |
| b6 | message drops the `driver='strands'` call | 5 | 5 |
| b7 | message drops the robot asked for | 0 | 0 |
| b8 | helper raises for a robot with **no** driver (over-reach) | 11 | 17 |
| b9 | lookup skips `resolve_name` (alias miss) | 2 | 7 |
| b10 | message appends lerobot's listing anyway | 4 | 4 |

Ten mutations, nine detected, eight distinct firing sets. Notes on the rest:

- **b1 and b4 fire the identical 14 cells** (verified as sets, not counts): a
  guard placed after the `raise` is unreachable, so it is the same as absent.
- **b7 fires nothing, and that is correct.** The message interpolates the robot
  name twice — once in the summary and once in the `Robot(...)` retry — so
  dropping the first leaves the property "names the robot asked for" true.
- **b8 is the over-reach row**: making the helper *raise* rather than report
  breaks the 51-robot control set and trips 17 pre-existing cells, which is why
  it reports.
- **b6 originally fired 1**, because `"driver='strands'" in refusal` was
  satisfied by the second, registry-declaration mention that a caller cannot
  copy. The cell now pins the whole retry call, and the row fires 5.
- **b3 originally fired 0**: the ordering was ungraded until the structural pin
  was added.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests
  tests_integ` (1626 files).
- mypy **24 == 24** against a worktree of the merge base, normalised message sets
  byte-identical in both directions, 0 attributable to the changed files
  (`checked 1617` vs `1616`, the +1 being the new test file).
- Paired run over an identical 612-file selection (every suite naming the driver
  seam, the registries, the refusals, plus every tree-walking guard), the new
  file excluded from both trees: identical **27133 collected** and
  `24 failed, 26911 passed, 198 skipped` on each, **24 identical failing ids with
  both `comm` directions empty**, distinct rootdirs. Of the 24: 17 need `awsiot`
  (absent here, declared in the `mesh-iot` extra — confirmed with `find_spec` and
  `tomllib`), 4 are a large-selection module-caching artifact that passes **13/13
  in isolation on both trees**, 3 are the lerobot-from-source
  `encode() takes 1 positional argument` drift.
- Rebased onto `7d80ff38` afterwards; `tests/drivers/`, the seam and the leader
  suite give **694 passed, 3 skipped** there, including the guards that base
  added.

No visual artifact: this changes a refusal string and the order two diagnostics
are consulted in, none of the policy, simulation, rendering, recording or asset
surfaces. The measured 55/4/51 table and the before/after refusals are the
evidence.
