### PR TITLE
fix(registry): declare the joint count each robot's own asset has

### DIFF
--- a/changelog.d/2818-registry-joint-counts-match-their-asset.md
+++ b/changelog.d/2818-registry-joint-counts-match-their-asset.md
@@ -1,0 +1,51 @@
+### Fixed: two registry entries declare the joint count their own asset has
+
+Every robot in `registry/robots.json` carries a `joints` figure, and two
+discovery surfaces report it verbatim: `get_robot` returns it, and `list_robots`
+prints it in the `Joints` column an agent reads to size an action vector. Two
+entries disagreed with a sibling built from an indistinguishable model - same
+joint names, same joint types, same actuator names - so one compiled shape was
+described by two different numbers:
+
+```
+robot        declared   asset njnt   movable   actuators   sibling declares
+ur5e         8          6            6         6           ur10e -> 6
+unitree_a1   16         13           12        12          aliengo, go1 -> 13
+```
+
+`ur5e` is a six-axis arm with no gripper and no floating base; its own
+description says so ("6-DOF industrial"), and `ur10e` - whose compiled model is
+byte-identical in joint names, joint types and actuator names - declared `6`.
+`unitree_a1` shares its model with `aliengo` and `go1`, which both declared `13`,
+the model's `njnt` of twelve movable joints plus the floating base;
+`anymal_b` and `anymal_c`, a separate quadruped family whose model has the same
+13/12/12 shape, declare `13` too. Both figures are now what the shared asset has,
+and `docs/robots/arms.md` and `docs/robots/mobile.md` - which rendered `8` and
+`16` in tables directly above and below the siblings' correct rows - agree.
+
+What `joints` counts registry-wide is deliberately not settled here.
+`docs/robots/arms.md` says "Joint counts include any free joints / gripper
+actuators", which reads as MuJoCo's `njnt` and holds for `anymal_b`/`anymal_c`
+(13 against a 12-DOF description, the extra one being the base). But `panda`
+declares `7` against an `njnt` of 9 - the arm without its two finger joints - and
+`arx_l5`/`piper` both declare `11` against an `njnt` of 8. Of the 50 registry
+robots whose asset loads, 22 declare a figure that is neither their `njnt` nor
+their movable-joint count. Choosing one convention would rewrite those 22 numbers
+on a guess about what each was counting, so the regression test grades a weaker
+property that needs no such decision: two robots whose compiled models are
+indistinguishable must be described by the same number, whatever that number is
+counting. That holds under every convention above, because the models agree on
+all of them - and it is the in-family control that makes these two figures
+decidable while the registry-wide question stays open.
+
+The assets group the 59 resolvable entries into six such families. Four already
+agreed; the two that did not are corrected here, except `vx300s`/`wx250s`, which
+declare `19` and `16` against an `njnt` of 8 while describing the same shape as
+each other ("6-DOF + gripper"). Unlike the two fixed above, nothing there says
+which figure is right, or whether either is - a two-member family has no majority
+- so the pair is recorded as an unresolved family with that reason rather than
+guessed at, and removing it from that set is how the convention decision gets
+enforced. The test re-derives the grouping from the compiled models and fails if
+a family it names no longer groups together, or if the assets group robots that
+no family names, so the frozen table cannot drift into agreeing with a wrong
+registry.

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -35,7 +35,7 @@ sim = Robot("so100")            # SO-ARM100 (low-cost Feetech)
 | `so100` | TrossenRobotics SO-ARM100 (6-DOF, Feetech servos) | 6 | `so100_4cam`, `so100_dualcam`, `so100_follower`, `so_arm100`, `trs_so_arm100` |
 | `so101` | RobotStudio SO-101 (6-DOF, upgraded SO-100) | 6 | `robotstudio_so101`, `so101_dualcam`, `so101_follower`, `so101_tricam` |
 | `ur10e` | Universal Robots UR10e (6-DOF industrial) | 6 | - |
-| `ur5e` | Universal Robots UR5e (6-DOF industrial) | 8 | - |
+| `ur5e` | Universal Robots UR5e (6-DOF industrial) | 6 | - |
 | `vx300s` | Trossen ViperX 300s (6-DOF + gripper) | 19 | `oxe_widowx`, `trossen_vx300s`, `viper_x300s` |
 | `wx250s` | Trossen WidowX 250s (6-DOF + gripper) | 16 | `widowx_250s`, `trossen_wx250s` |
 | `xarm7` | UFactory xArm 7 (7-DOF + gripper) | 13 | `ufactory_xarm7` |

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -33,7 +33,7 @@ sim = Robot("crazyflie")        # Bitcraze Crazyflie 2 quadcopter
 | `stretch` | Hello Robot Stretch (original, mobile manipulator) | 18 | `hello_robot_stretch_original` |
 | `stretch3` | Hello Robot Stretch 3 (mobile manipulator) | 41 | `hello_robot_stretch`, `hello_robot_stretch_3` |
 | `tiago_dual` | PAL Robotics TIAGo++ Dual-Arm Mobile (26-DOF) | 26 | `tiago++`, `pal_tiago_dual` |
-| `unitree_a1` | Unitree A1 Quadruped | 16 | `a1` |
+| `unitree_a1` | Unitree A1 Quadruped | 13 | `a1` |
 | `unitree_go2` | Unitree Go2 Quadruped | 40 | `go2` |
 
 ## Featured renders

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -301,7 +301,7 @@
     "ur5e": {
       "description": "Universal Robots UR5e (6-DOF industrial)",
       "category": "arm",
-      "joints": 8,
+      "joints": 6,
       "asset": {
         "dir": "universal_robots_ur5e",
         "model_xml": "ur5e.xml",
@@ -994,7 +994,7 @@
     "unitree_a1": {
       "description": "Unitree A1 Quadruped",
       "category": "mobile",
-      "joints": 16,
+      "joints": 13,
       "asset": {
         "dir": "unitree_a1",
         "model_xml": "xml/a1.xml",

--- a/tests/registry/test_asset_family_joint_counts.py
+++ b/tests/registry/test_asset_family_joint_counts.py
@@ -1,0 +1,235 @@
+"""Robots compiled from the same model must declare the same joint count.
+
+``robots.json`` gives every robot a ``joints`` figure, and two discovery
+surfaces report it verbatim: :func:`~strands_robots.registry.get_robot` returns
+it and :func:`~strands_robots.registry.list_robots` prints it in the ``Joints``
+column an agent reads to size an action vector. Two entries disagreed with a
+sibling built from an indistinguishable model:
+
+* ``ur5e`` declared ``8``. Its asset has six hinge joints, six actuators and no
+  free joint - and ``ur10e``, whose compiled model has byte-identical joint
+  names, joint types and actuator names, declared ``6``.
+* ``unitree_a1`` declared ``16`` where ``aliengo`` and ``go1`` - same
+  indistinguishable model - both declared ``13``, which is that model's
+  ``njnt`` (twelve movable joints and the floating base). ``anymal_b`` and
+  ``anymal_c``, a separate family whose model has the same 13/12/12 shape,
+  declare ``13`` too.
+
+One compiled shape, two answers, in both cases.
+
+What ``joints`` MEANS across the whole registry is deliberately not settled
+here. The figure follows no single rule today: ``docs/robots/arms.md`` says
+"Joint counts include any free joints / gripper actuators", which reads as
+MuJoCo's ``njnt`` and holds for ``anymal_b``/``anymal_c`` (13 against a 12-DOF
+description, the extra one being the floating base), while ``panda`` declares
+``7`` against an ``njnt`` of 9 - the arm without its two finger joints - and
+``arx_l5``/``piper`` both declare ``11`` against an ``njnt`` of 8. Of the 50
+registry robots whose asset loads, 22 declare a figure that is neither their
+``njnt`` nor their movable-joint count. Picking one convention would rewrite
+those 22 numbers on a guess about what each was counting, so this file grades a
+weaker property that needs no such decision:
+
+    two robots whose compiled models are indistinguishable must be described
+    by the same number, whatever that number is counting.
+
+That holds under every convention above - ``njnt``, movable joints, actuated
+DOF, hardware DOF - because the models agree on all of them. It is the in-family
+control that makes both figures decidable without settling the registry-wide
+question: ``ur5e``'s own description ("6-DOF industrial") agrees with the
+sibling it disagreed with, and ``unitree_a1``'s two siblings agree with each
+other, with their shared model and with a second quadruped family of the same
+shape.
+
+Two layers, because the oracle is not available everywhere:
+
+* :class:`TestEveryAssetFamilyAgrees` reads ``robots.json`` alone, so it grades
+  the property on any install - including one with no MuJoCo and no downloaded
+  assets, which is where the registry is most often read.
+* :class:`TestTheFrozenFamiliesStillMatchTheAssets` re-derives the grouping from
+  the real compiled models and asserts :data:`_ASSET_FAMILIES` still describes
+  them. Without it the frozen table could drift into agreeing with a wrong
+  registry, which is the failure a hand-maintained copy always has. It skips
+  where the assets are absent rather than downloading them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REGISTRY_PATH = Path(__file__).resolve().parents[2] / "strands_robots" / "registry" / "robots.json"
+
+#: Registry robots whose compiled MJCF models are indistinguishable - identical
+#: joint names, identical joint types and identical actuator names. Measured
+#: against the shipped assets on mujoco 3.5.0 over the 50 registry entries whose
+#: model loads; :class:`TestTheFrozenFamiliesStillMatchTheAssets` re-derives this
+#: from the assets so the copy cannot go stale.
+_ASSET_FAMILIES: tuple[tuple[str, ...], ...] = (
+    ("aliengo", "go1", "unitree_a1"),
+    ("anymal_b", "anymal_c"),
+    ("arx_l5", "piper"),
+    ("toddlerbot_2xc", "toddlerbot_2xm"),
+    ("ur10e", "ur5e"),
+    ("vx300s", "wx250s"),
+)
+
+#: Families this file does not require to agree yet, each with the reason.
+#:
+#: ``vx300s``/``wx250s`` declare ``19`` and ``16`` against an ``njnt`` of 8 and
+#: an actuator count of 7, and their descriptions state the same shape as each
+#: other ("6-DOF + gripper"). So they are the same defect as ``ur5e`` - but
+#: unlike ``ur5e``, whose sibling and description both name ``6``, nothing here
+#: says which of the two figures is right, or whether either is. Choosing needs
+#: the registry-wide convention decision this file declines to make, so the pair
+#: is recorded rather than guessed at. Removing an entry from this set is how
+#: that decision gets enforced.
+_UNRESOLVED_FAMILIES: frozenset[tuple[str, ...]] = frozenset({("vx300s", "wx250s")})
+
+
+@pytest.fixture(scope="module")
+def registry() -> dict[str, Any]:
+    """Load the shipped robot registry once."""
+    data = json.loads(REGISTRY_PATH.read_text())
+    return dict(data.get("robots", data))
+
+
+def _graded_families() -> tuple[tuple[str, ...], ...]:
+    """The families this file requires to agree."""
+    return tuple(f for f in _ASSET_FAMILIES if f not in _UNRESOLVED_FAMILIES)
+
+
+class TestTheFamilyTableIsUsable:
+    """Premises the graded property rests on, so it cannot pass vacuously."""
+
+    def test_every_family_names_at_least_two_robots(self) -> None:
+        """A one-robot family agrees with itself and grades nothing."""
+        assert _ASSET_FAMILIES
+        for family in _ASSET_FAMILIES:
+            assert len(family) >= 2, family
+            assert len(set(family)) == len(family), family
+
+    def test_every_named_robot_is_in_the_registry(self, registry: dict[str, Any]) -> None:
+        """A typo would silently drop a robot out of the graded set."""
+        missing = sorted({n for f in _ASSET_FAMILIES for n in f} - set(registry))
+        assert not missing, f"families name robots absent from the registry: {missing}"
+
+    def test_something_is_actually_graded(self) -> None:
+        """Exempting every family would leave the agreement rule inert."""
+        graded = _graded_families()
+        assert graded, "every family is exempt, so nothing is graded"
+        for family in (("ur10e", "ur5e"), ("aliengo", "go1", "unitree_a1")):
+            assert family in graded, f"{family} carried a corrected value and must stay graded"
+
+    def test_every_exemption_names_a_real_family(self) -> None:
+        """An exemption for a family that no longer exists hides a regression."""
+        stale = sorted(f for f in _UNRESOLVED_FAMILIES if f not in _ASSET_FAMILIES)
+        assert not stale, f"exemptions for families that are not declared: {stale}"
+
+
+class TestEveryAssetFamilyAgrees:
+    """The graded property, on the registry alone."""
+
+    @pytest.mark.parametrize("family", _graded_families(), ids=lambda f: "-".join(f))
+    def test_one_compiled_shape_is_described_by_one_number(
+        self, family: tuple[str, ...], registry: dict[str, Any]
+    ) -> None:
+        """Robots with indistinguishable models declare the same ``joints``."""
+        declared = {name: registry[name].get("joints") for name in family}
+        assert len(set(declared.values())) == 1, (
+            f"{' and '.join(family)} compile to the same model - identical joint names, "
+            f"joint types and actuator names - so they must declare the same joint count, "
+            f"but the registry says {declared}"
+        )
+
+    @pytest.mark.parametrize(
+        ("name", "expected", "why"),
+        [
+            ("ur5e", 6, "six hinge joints, six actuators, no free joint and no gripper"),
+            ("ur10e", 6, "six hinge joints, six actuators, no free joint and no gripper"),
+            ("aliengo", 13, "twelve movable joints and the floating base"),
+            ("go1", 13, "twelve movable joints and the floating base"),
+            ("unitree_a1", 13, "twelve movable joints and the floating base"),
+        ],
+    )
+    def test_the_corrected_entries_declare_what_their_asset_has(
+        self, name: str, expected: int, why: str, registry: dict[str, Any]
+    ) -> None:
+        """The value, not only the agreement.
+
+        Agreement alone is satisfied by moving the majority to the outlier -
+        ``ur10e`` up to ``8``, or ``aliengo`` and ``go1`` up to ``16``. These
+        pin the figure the shared asset actually has, so the family cannot
+        settle on the wrong number.
+        """
+        assert registry[name].get("joints") == expected, (
+            f"{name} declares {registry[name].get('joints')!r}; its asset has {why}"
+        )
+
+    def test_the_declared_count_reaches_the_discovery_surface(self) -> None:
+        """The figure is reported, so a wrong one is read rather than inert."""
+        from strands_robots.registry import get_robot, list_robots
+
+        entry = get_robot("ur5e")
+        assert entry is not None
+        assert entry["joints"] == 6
+        listed = {r["name"]: r["joints"] for r in list_robots()}
+        assert listed["ur5e"] == 6
+        assert listed["ur10e"] == 6
+        assert listed["unitree_a1"] == 13
+
+
+class TestTheFrozenFamiliesStillMatchTheAssets:
+    """Keep :data:`_ASSET_FAMILIES` honest against the compiled models."""
+
+    def test_the_families_are_what_the_assets_say_they_are(self, registry: dict[str, Any]) -> None:
+        """Re-derive the grouping; the frozen table must still describe it.
+
+        Restricted to the robots whose assets are present: a family whose
+        members are not all loadable here cannot be confirmed or refuted, so it
+        is neither.
+        """
+        mujoco = pytest.importorskip("mujoco")
+        from strands_robots.assets.manager import resolve_model_path
+
+        signatures: dict[str, tuple[Any, ...]] = {}
+        for name in registry:
+            try:
+                path = resolve_model_path(name)
+            except Exception:  # pragma: no cover - a resolver failure is not this test's subject
+                continue
+            if path is None or not Path(path).exists():
+                continue
+            try:
+                model = mujoco.MjModel.from_xml_path(str(path))
+            except Exception:  # pragma: no cover - an unloadable asset is not this test's subject
+                continue
+            signatures[name] = (
+                tuple(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i) for i in range(model.njnt)),
+                tuple(int(model.jnt_type[i]) for i in range(model.njnt)),
+                tuple(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)),
+            )
+
+        if len(signatures) < 2:
+            pytest.skip("registry assets unavailable, so the grouping cannot be re-derived")
+
+        derived: dict[tuple[Any, ...], list[str]] = {}
+        for name, signature in signatures.items():
+            derived.setdefault(signature, []).append(name)
+        derived_families = {tuple(sorted(names)) for names in derived.values() if len(names) > 1}
+
+        for family in _ASSET_FAMILIES:
+            if not set(family) <= set(signatures):
+                continue
+            assert tuple(sorted(family)) in derived_families, (
+                f"{family} is declared a family but the assets no longer group them together"
+            )
+
+        confirmable = {f for f in derived_families if set(f) <= set(signatures)}
+        undeclared = sorted(confirmable - {tuple(sorted(f)) for f in _ASSET_FAMILIES})
+        assert not undeclared, (
+            "the assets group these robots identically but no family declares them, "
+            f"so their joint counts are ungraded: {undeclared}"
+        )


### PR DESCRIPTION
## Problem

Every robot in `registry/robots.json` carries a `joints` figure, and two discovery surfaces report it verbatim: `get_robot` returns it, and `list_robots` prints it in the `Joints` column an agent reads to size an action vector. Two entries disagreed with a sibling built from an **indistinguishable** compiled model - same joint names, same joint types, same actuator names - so one compiled shape was described by two different numbers.

| robot | declared | asset `njnt` | movable | actuators | sibling declares |
|---|---|---|---|---|---|
| `ur5e` | **8** | 6 | 6 | 6 | `ur10e` -> 6 |
| `unitree_a1` | **16** | 13 | 12 | 12 | `aliengo`, `go1` -> 13 |

`ur5e` is a six-axis arm with no gripper and no floating base. Its own description says so ("6-DOF industrial"), and `ur10e` declared `6`. `unitree_a1` shares its model with `aliengo` and `go1`, which both declared `13` - that model's `njnt` of twelve movable joints plus the floating base - and `anymal_b`/`anymal_c`, a separate quadruped family whose model has the same 13/12/12 shape, declare `13` too.

Both wrong figures were also rendered in user-facing tables, immediately adjacent to the siblings' correct rows: `docs/robots/arms.md:38` (`8`, one line below `ur10e`'s `6`) and `docs/robots/mobile.md:36` (`16`, between `aliengo` and `go1` at `13`).

## What is deliberately not decided

What `joints` counts registry-wide is left alone. `docs/robots/arms.md` says "Joint counts include any free joints / gripper actuators", which reads as MuJoCo's `njnt` and holds for `anymal_b`/`anymal_c` (13 against a 12-DOF description, the extra one being the base). But `panda` declares `7` against an `njnt` of 9 - the arm without its two finger joints - and `arx_l5`/`piper` both declare `11` against an `njnt` of 8. **Of the 50 registry robots whose asset loads, 22 declare a figure that is neither their `njnt` nor their movable-joint count.** Choosing one convention would rewrite those 22 numbers on a guess about what each was counting.

So the regression test grades a weaker property that needs no such decision:

> two robots whose compiled models are indistinguishable must be described by the same number, whatever that number is counting.

That holds under every convention above - `njnt`, movable joints, actuated DOF, hardware DOF - because the models agree on all of them. It is the in-family control that makes these two figures decidable while the registry-wide question stays open.

## The families

The assets group the 59 resolvable entries into six such families:

| family | declared | `njnt`/movable/`nu` | |
|---|---|---|---|
| `aliengo`, `go1`, `unitree_a1` | 13, 13, **16** | 13/12/12 | fixed here |
| `ur10e`, `ur5e` | 6, **8** | 6/6/6 | fixed here |
| `anymal_b`, `anymal_c` | 13, 13 | 13/12/12 | already agreed |
| `arx_l5`, `piper` | 11, 11 | 8/8/7 | already agreed |
| `toddlerbot_2xc`, `toddlerbot_2xm` | 45, 45 | 45/44/30 | already agreed |
| `vx300s`, `wx250s` | 19, 16 | 8/8/7 | **unresolved, recorded** |

`vx300s`/`wx250s` is the same defect, but unlike the two fixed above nothing there says which figure is right, or whether either is - a two-member family has no majority, and both descriptions state the same shape ("6-DOF + gripper"). It is recorded as an unresolved family with that reason rather than guessed at; removing it from that set is how the convention decision gets enforced.

## Tests

`tests/registry/test_asset_family_joint_counts.py`, 16 cells in two layers because the oracle is not available everywhere:

- **`TestEveryAssetFamilyAgrees`** reads `robots.json` alone, so it grades the property on any install - including one with no MuJoCo and no downloaded assets, which is where the registry is most often read.
- **`TestTheFrozenFamiliesStillMatchTheAssets`** re-derives the grouping from the real compiled models and asserts the frozen table still describes them, so the hand-maintained copy cannot drift into agreeing with a wrong registry. It skips where assets are absent rather than downloading them. This layer earned its place during development: it caught that my first frozen table was **missing the `aliengo`/`go1`/`unitree_a1` family entirely**, because I had walked the raw asset cache instead of `resolve_model_path`.
- **`TestTheFamilyTableIsUsable`** holds the premises - every family has >=2 members, every named robot is in the registry, the graded set is non-empty and still contains both corrected families, and no exemption names a family that is not declared.

Pre-fix split, with the registry values reverted and the test kept: **5 failed / 11 passed**, all five in the regression class, `0` of the 4 premise cells and `0` in the fidelity layer.

### Mutations

`collected` is recorded because two rows change it - a silently narrowed parametrization runs fewer tests while still reporting success.

| mutation | fails | collected | firing |
|---|---|---|---|
| control (no mutation) | 0 | 16 | - |
| `ur5e` reverted to 8 | 3 | 16 | agreement + value + discovery |
| `unitree_a1` reverted to 16 | 3 | 16 | agreement + value + discovery |
| both reverted (raw pre-fix) | 5 | 16 | union; `3 + 3 - 1` shared |
| family AGREES at the wrong value (`ur10e` -> 8) | 3 | 16 | value cells only |
| quadrupeds AGREE at the wrong value (all -> 16) | 4 | 16 | value cells only |
| UR family exempted | 1 | **15** | premise: must stay graded |
| UR family dropped from the table | 2 | **15** | premise + **fidelity layer** |
| exemption for a family that is not declared | 1 | 16 | premise |
| typo in a family member name | 3 | 16 | premise + fidelity + agreement |

9 mutations, **9 distinct firing sets**, control clean, both files restored byte-identical.

Two rows carry the design. The **"family agrees at the wrong value"** rows show agreement alone is satisfied by moving the majority to the outlier, so the value assertions are load-bearing rather than decorative. The **"family dropped from the table"** row is why the fidelity layer exists: a hand-maintained table that omits a family is silent on it, and only re-deriving from the assets notices.

## Gate

- Paired selection of **560 files** (all of `tests/registry/`, every suite walking the tree / parsing source / reading docstrings, `robots.json`, `docs/robots/` or `changelog.d/`, plus everything naming the affected robots), the new file excluded from both trees and every path verified present on both: identical **`23 failed, 24492 passed, 195 skipped`** on branch and base, **23 identical failing ids, `comm` empty in both directions**, distinct rootdirs.
- Those 23 are pre-existing and environmental: **17** need `awsiot`/`awscrt` (`find_spec` False locally; declared in the `[mesh-iot]` extra, which CI installs), **4** in `test_recording_frame_loss_is_not_tolerated.py` are a large-selection module-caching artifact (**13 passed in isolation** on both trees), **2** are lerobot-from-source `TypeError: encode()` drift.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine worktree of the same base, normalized message sets identical in both directions, **0 attributable** to the changed files.
- `ruff check` and `ruff format --check` clean over 1620 files.
- Registry + changelog suites on the rebased base: **841 passed**.

No visual artifact: this changes two reported integers and two documentation tables. Nothing renders, simulates, records or moves differently - the measured tables above are the evidence.
