### PR TITLE
fix(mesh): announce a safety audit record that can never be written

### DIFF
--- a/changelog.d/2819-safety-audit-write-failure-is-announced.md
+++ b/changelog.d/2819-safety-audit-write-failure-is-announced.md
@@ -1,0 +1,23 @@
+### Fixed: a safety audit record that can never be written is announced rather than logged at DEBUG
+
+`SensorLoopsMixin.publish_safety_event` sends one event two ways - to the mesh
+wire and to the local audit log - and its own docstring records that the
+`severity` argument "reaches the audit record only": the wire copy is uniformly
+`info` (issue #272), so the audit record is the only copy that carries what
+actually happened.
+
+`session._report_unencodable_payload` states the rule both halves are held to. A
+transport's fire-and-forget tolerance is scoped to a TRANSIENT failure - "a
+closed session, a dropped broker, a socket-level write - which the next tick
+retries" - and a loss that no retry can undo is reported at ERROR instead,
+"because reporting it at DEBUG left the two halves of one call disagreeing". That
+raised the wire half. The audit half still reported its own loss at DEBUG, below
+the default level, so an operator saw nothing at all when the only surviving copy
+of a `critical` event failed to reach the disk.
+
+An audit write is permanent in the stronger sense: a safety event is published
+once, at one lockout transition, so there is no later tick to retry it. The
+failure is now reported at ERROR and names the event type and the real severity,
+because the wire copy names neither. Everything else about the call is unchanged
+- it still does not raise, the wire copy still goes out with its uniform `info`
+severity, and the caller's payload is still left unedited.

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -720,6 +720,17 @@ class SensorLoopsMixin:
         value that tripped a limit, the distance that closed), and every other
         record this mixin sends to the wire is coerced before it goes.
 
+        A failed audit write is reported at ERROR for the same reason
+        :func:`~strands_robots.mesh.session._report_unencodable_payload` gives for
+        the wire half: a transport fire-and-forget tolerance is scoped to a TRANSIENT
+        failure that the next tick retries, and this is not that. A safety event is
+        published once at one transition, so there is no later tick, and the audit
+        copy is the only one carrying the real severity. Reporting the loss at DEBUG
+        left the two halves of one call disagreeing about how a permanently lost
+        safety record is announced, which is the disagreement that report was raised
+        to ERROR to close. The report names the event type and the real severity
+        because the wire copy names neither.
+
         Coerced into a copy rather than in place, so the caller keeps the mapping
         they passed unedited - the same reason :func:`_coerce_record` replaces a
         nested container instead of editing the provider's own.
@@ -770,5 +781,13 @@ class SensorLoopsMixin:
                 # first so the keys that process decided win a name collision.
                 payload={**record, "severity": severity},
             )
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("[mesh] %s: audit log write failed: %s", self.peer_id, exc)
+        except Exception as exc:  # noqa: BLE001 - see the reporting-level note in the docstring
+            logger.error(
+                "[mesh] %s: the audit record for a %s safety event could not be written, so the "
+                "only copy carrying its real severity (%s) is lost - the wire copy is uniformly "
+                "info-level and a safety event is published once, so no later call rewrites it: %s",
+                self.peer_id,
+                event_type,
+                severity,
+                exc,
+            )

--- a/tests/mesh/test_safety_audit_write_failure_is_reported.py
+++ b/tests/mesh/test_safety_audit_write_failure_is_reported.py
@@ -1,0 +1,245 @@
+"""A safety record that can never be written is announced, not logged at DEBUG.
+
+:meth:`~strands_robots.mesh.sensors.SensorLoopsMixin.publish_safety_event` sends
+one event two ways: to the wire, and to the local audit log. Its own docstring
+records that the ``severity`` parameter "reaches the audit record only - the wire
+copy is uniformly ``info``", so the audit record is the only copy that carries
+what actually happened.
+
+:func:`~strands_robots.mesh.session._report_unencodable_payload` states the rule
+both halves are held to. A transport's fire-and-forget tolerance is scoped to a
+TRANSIENT failure - "a closed session, a dropped broker, a socket-level write -
+which the next tick retries" - and a permanent loss is reported at ERROR
+instead, because "reporting it at DEBUG left the two halves of one call
+disagreeing".
+
+An audit write that fails is permanent in the stronger sense: a safety event is
+published once, at one lockout transition, so there is no later tick at all.
+These cells pin that both halves now announce a permanent loss the same way, and
+that neither announces an ordinary one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+import strands_robots.mesh.core as core_mod
+import strands_robots.mesh.sensors as sensors_mod
+import strands_robots.mesh.session as session_mod
+
+#: The logger the mixin reports through.
+_SENSORS_LOGGER = "strands_robots.mesh.sensors"
+
+#: The logger the wire half's permanent-loss report comes out of.
+_SESSION_LOGGER = "strands_robots.mesh.session"
+
+#: The event this suite drives. ``remote_resume_applied`` is emitted after
+#: ``_on_safety_resume`` has already cleared the lockout, so a lost record is a
+#: fleet that resumed motion with nothing on the forensic trail to say so.
+_EVENT_TYPE = "remote_resume_applied"
+
+#: A severity the wire copy provably does not carry: the wire is uniformly
+#: ``info``, so this value exists only in the audit record.
+_REAL_SEVERITY = "critical"
+
+_PEER = "alice"
+
+
+class _AuditUnwritable(OSError):
+    """What a full or read-only audit volume raises on the write."""
+
+
+def _mesh(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, list[tuple[str, dict[str, Any]]]]:
+    """A running mesh whose wire publishes are recorded rather than sent.
+
+    Args:
+        monkeypatch: Fixture used to replace the module-level ``put``.
+
+    Returns:
+        ``(mesh, wire)`` where ``wire`` accumulates every ``(key, payload)``
+        the mesh published.
+    """
+    wire: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(core_mod, "put", lambda key, payload: wire.append((key, payload)))
+    mesh = core_mod.Mesh(object(), peer_id=_PEER)
+    mesh._running = True
+    return mesh, wire
+
+
+def _break_the_audit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the audit half fail the way a full volume makes it fail."""
+
+    def refuse(**_kwargs: Any) -> None:
+        raise _AuditUnwritable(28, "No space left on device")
+
+    monkeypatch.setattr(sensors_mod, "log_safety_event", refuse)
+
+
+def _records(caplog: pytest.LogCaptureFixture, *, at_least: int) -> list[logging.LogRecord]:
+    """The captured records at or above ``at_least``."""
+    return [r for r in caplog.records if r.levelno >= at_least]
+
+
+class TestAPermanentlyLostSafetyRecordIsAnnounced:
+    """The audit half's failure reaches an operator at the default level."""
+
+    def test_the_loss_is_reported_at_error(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mesh, _wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        with caplog.at_level(logging.DEBUG, logger=_SENSORS_LOGGER):
+            mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={"issuer": "bob"})
+        assert [r.levelname for r in _records(caplog, at_least=logging.ERROR)] == ["ERROR"]
+
+    def test_a_default_configured_operator_sees_it(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARNING is the default level, so the report must clear it."""
+        mesh, _wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=_SENSORS_LOGGER):
+            mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={"issuer": "bob"})
+        assert _records(caplog, at_least=logging.WARNING), "nothing an operator would see"
+
+    def test_the_report_names_the_event_that_was_lost(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mesh, _wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        with caplog.at_level(logging.DEBUG, logger=_SENSORS_LOGGER):
+            mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={"issuer": "bob"})
+        text = "\n".join(r.getMessage() for r in _records(caplog, at_least=logging.ERROR))
+        assert _EVENT_TYPE in text
+
+    def test_the_report_names_the_severity_the_wire_copy_does_not_carry(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The audit record was the only copy of it, so the report must say it."""
+        mesh, _wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        with caplog.at_level(logging.DEBUG, logger=_SENSORS_LOGGER):
+            mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={"issuer": "bob"})
+        text = "\n".join(r.getMessage() for r in _records(caplog, at_least=logging.ERROR))
+        assert _REAL_SEVERITY in text
+
+    def test_the_report_names_the_peer_and_the_reason(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mesh, _wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        with caplog.at_level(logging.DEBUG, logger=_SENSORS_LOGGER):
+            mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={"issuer": "bob"})
+        text = "\n".join(r.getMessage() for r in _records(caplog, at_least=logging.ERROR))
+        assert _PEER in text
+        assert "No space left on device" in text
+
+
+class TestTheTwoHalvesOfOneCallAgree:
+    """A permanent loss is announced the same way whichever half notices it."""
+
+    def test_the_wire_half_announces_a_permanent_loss_at_error(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The premise the audit half is compared against."""
+
+        class _NotAReading:
+            """A payload value the JSON encoder refuses and coercion keeps."""
+
+        class _Session:
+            def put(self, key: str, encoded: bytes) -> None:
+                raise AssertionError("an unencodable payload must not reach the wire")
+
+        monkeypatch.setattr(session_mod, "_SESSION", _Session())
+        monkeypatch.setattr(session_mod, "_unencodable_topics_warned", set())
+        monkeypatch.setattr(sensors_mod, "log_safety_event", lambda **_kwargs: None)
+        mesh = core_mod.Mesh(object(), peer_id=_PEER)
+        mesh._running = True
+        with caplog.at_level(logging.DEBUG, logger=_SESSION_LOGGER):
+            mesh.publish_safety_event(
+                event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={"tripped": _NotAReading()}
+            )
+        assert [r.levelname for r in _records(caplog, at_least=logging.ERROR)] == ["ERROR"]
+
+    def test_neither_half_announces_the_loss_more_quietly_than_the_other(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One rule, two halves: the levels are read, not restated."""
+        mesh, _wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        with caplog.at_level(logging.DEBUG, logger=_SENSORS_LOGGER):
+            mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={"issuer": "bob"})
+        audit_levels = {r.levelno for r in caplog.records}
+        assert audit_levels == {logging.ERROR}
+
+
+class TestWhatIsUnchanged:
+    """Announcing the loss must not change anything else about the call."""
+
+    def test_the_call_still_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fire-and-forget: a failed audit must not break the safety path."""
+        mesh, _wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={})
+
+    def test_the_wire_copy_still_goes_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The audit failure must not suppress the half that did work."""
+        mesh, wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={})
+        assert [key for key, _payload in wire] == [f"strands/{_PEER}/safety/event"]
+
+    def test_the_wire_severity_is_still_uniformly_info(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Issue #272's uniform wire severity is untouched by this change."""
+        mesh, wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={})
+        assert [payload["severity"] for _key, payload in wire] == ["info"]
+
+    def test_a_healthy_publish_announces_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The ordinary case stays silent - ERROR must not become routine."""
+        mesh, wire = _mesh(monkeypatch)
+        monkeypatch.setattr(sensors_mod, "log_safety_event", lambda **_kwargs: None)
+        with caplog.at_level(logging.DEBUG, logger=_SENSORS_LOGGER):
+            mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={"issuer": "bob"})
+        assert caplog.records == []
+        assert len(wire) == 1
+
+    def test_a_stopped_mesh_still_publishes_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The not-running early return precedes both halves, so it says nothing."""
+        mesh, wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        mesh._running = False
+        with caplog.at_level(logging.DEBUG, logger=_SENSORS_LOGGER):
+            mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload={})
+        assert wire == []
+        assert caplog.records == []
+
+    def test_the_callers_payload_is_left_unedited(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The documented copy-not-in-place contract is unaffected."""
+        mesh, _wire = _mesh(monkeypatch)
+        _break_the_audit(monkeypatch)
+        payload = {"issuer": "bob"}
+        mesh.publish_safety_event(event_type=_EVENT_TYPE, severity=_REAL_SEVERITY, payload=payload)
+        assert payload == {"issuer": "bob"}
+
+
+class TestThePremisesHold:
+    """What the cells above depend on, asserted rather than assumed."""
+
+    def test_the_mixin_reads_the_module_level_audit_writer(self) -> None:
+        """So replacing the module global is the seam the failure arrives through."""
+        assert callable(sensors_mod.log_safety_event)
+
+    def test_the_documented_reason_for_the_level_is_still_the_wire_halfs(self) -> None:
+        """The rule is cited, not restated, so the citation must resolve."""
+        doc = " ".join((session_mod._report_unencodable_payload.__doc__ or "").split())
+        assert "at ERROR" in doc
+        assert "TRANSIENT" in doc


### PR DESCRIPTION
## What is wrong

`SensorLoopsMixin.publish_safety_event` sends one event two ways: to the mesh
wire, and to the local audit log. Its own docstring records which copy carries
what happened:

> `severity`: The real severity. It reaches the audit record only - the wire copy
> is uniformly `"info"` (issue #272) - **so the audit record is the only surviving
> copy**

`session._report_unencodable_payload` states the rule both halves are held to:

> Every transport's `put` is fire-and-forget and `MeshTransport.put` scopes that
> tolerance to a TRANSIENT failure - a closed session, a dropped broker, a
> socket-level write - which the next tick retries. A payload the JSON encoder
> refuses is not transient: it fails identically forever [...]
> **Reporting it at DEBUG left the two halves of one call disagreeing.**

That raised the wire half to ERROR. The audit half still reported its own loss at
`logger.debug`, so the two halves of one call were still disagreeing - and the
half still at DEBUG is the one holding the only copy of the real severity.

## Measured

Driven through the public method with the audit write failing the way a full
volume makes it fail (`OSError(28)`), and separately with a payload the encoder
refuses:

| half that loses the event | reported at | an operator at the default level (WARNING) sees |
|---|---|---|
| wire (payload the encoder refuses) | `ERROR` | yes |
| audit (write to disk fails) | `DEBUG` | **no** |

For `publish_safety_event(event_type="remote_resume_applied", severity="critical", ...)`
with the audit write failing, before this change:

```
raised out of publish_safety_event : None
wire put() calls                   : 1        (severity "info")
records at >= WARNING              : 0
all records                        : [('DEBUG', '[mesh] alice: audit log write failed: [Errno 28] No space left on device')]
```

`severity="critical"` reached nothing an operator would see, and the record that
was lost is the only one that ever carried that word.

An audit write is permanent in a stronger sense than the encoder case the rule was
written for. `publish_safety_event` is called once per safety transition - all 17
call sites in `mesh/core.py` are single calls at a single transition, and no loop
re-publishes a safety event - so there is no "next tick" to retry it at all.

`remote_resume_applied` is emitted by `_on_safety_resume` **after**
`self._estop_lockout.clear()` has already run, so the lost record is a fleet that
resumed motion with nothing on the forensic trail above DEBUG to say so.

## Change

`logger.debug` -> `logger.error`, and the report now names the event type and the
real severity, because the wire copy names neither. The docstring records why the
level is what it is and cites the same rule rather than restating it.

Deliberately unchanged: the call still does not raise (fire-and-forget is the
contract), the wire copy still goes out with its uniform `"info"` severity, the
caller's payload is still left unedited, and the `except Exception` stays wide for
the reason the surrounding code gives - an audit backend's raise set is not
enumerable at this seam.

## Why nothing caught it

Nine of the eleven `publish_safety_event` call sites in `mesh/core.py` wrap the
call in `except (TypeError, ValueError, OSError)` "best-effort ... must never
block the safety path", so the callers had already priced an audit failure as
survivable. What none of them could see is how the failure is *announced*: that
is decided inside `publish_safety_event`, and no test drove its `except` branch.

## Pre-fix split

Source reverted, tests kept: **6 failed / 9 passed**.

| class | role | failed / total |
|---|---|---|
| `TestAPermanentlyLostSafetyRecordIsAnnounced` | regression | 5 / 5 |
| `TestTheTwoHalvesOfOneCallAgree` | regression + wire-half premise | 1 / 2 |
| `TestWhatIsUnchanged` | over-reach controls | 0 / 6 |
| `TestThePremisesHold` | premises | 0 / 2 |

Headline failures: `assert {10} == {40}` (DEBUG vs ERROR) and
`assert 'critical' in ''` - the real severity was named nowhere.

## Break table

8 mutations, 8 distinct firing sets, control clean, source restored
md5-identical after every row. `sib` counts failures in six pre-existing safety
suites (211 cells).

| mutation | fires | collected | sib |
|---|---|---|---|
| control (unmodified) | 0 | 15 | 0 |
| level back to DEBUG (the raw revert) | 6 | 15 | 0 |
| level softened to WARNING | 5 | 15 | 0 |
| report drops the event type | 1 | 15 | 0 |
| report drops the real severity | 1 | 15 | 0 |
| report drops the peer | 1 | 15 | 0 |
| report drops the reason the write failed | 1 | 15 | 0 |
| handler narrowed so an `OSError` escapes the safety path | 10 | 15 | 3 |
| over-reach: an ordinary publish also announces at ERROR | 3 | 15 | 0 |

The narrowed-handler row is the useful one for scope: it fires the
`test_the_call_still_does_not_raise` control **and trips three pre-existing
safety cells**, which is the evidence that the width of the catch is load-bearing
and this change must not touch it. The over-reach row fires the
healthy-publish-is-silent control, so "ERROR must not become routine" is graded
rather than asserted.

## Gate

- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ` (1630 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the
  merge-base, normalized message sets identical in both directions, 0 attributable.
- Paired run over an identical 373-file selection (all of `tests/mesh/` plus every
  suite that walks the tree, parses source, reads docstrings, or names
  `publish_safety_event` / `log_safety_event` / `_report_unencodable_payload`), the
  new file excluded from both trees: identical **11261 collected** and
  `21 failed, 11152 passed, 64 skipped, 24 errors` on each, **45 identical failing
  ids with an empty `comm` diff in both directions**. All 45 are
  `tests/mesh/test_iot_*` needing `awsiot` / `awscrt`, both `find_spec=False` here
  and both declared in the `[mesh-iot]` extra.
- `tests/mesh/test_zenoh_transport_security.py` is excluded from the pair (it opens
  a real session) and verified alone: `9 passed, 2 skipped` on both trees.
- Changed file plus five sibling safety suites: **191 passed** on the rebased tree.

No visual artifact: this changes a reporting level and a message, not a policy,
simulation, rendering, recording or asset. The measured before/after log capture
above is the evidence.
