### PR TITLE
fix(tools): refuse the Feetech broadcast where serial_tool is about to read one reply

### DIFF
--- a/changelog.d/2820-feetech-broadcast-is-not-a-reply-address.md
+++ b/changelog.d/2820-feetech-broadcast-is-not-a-reply-address.md
@@ -1,0 +1,32 @@
+### Fixed: a broadcast is refused where the tool is about to read one servo's reply
+
+The Feetech Protocol 1 ID byte carries every unicast address and one address that
+is no servo: `0xfe` is the broadcast. `serial_tool` bounded `motor_id` at 254 for
+a reason keyed to the field's width - "the packet carries the ID in one byte, and
+255 is the frame header" - which is true of the byte and says nothing about which
+of its values a servo can hold. So `action="feetech_ping"` accepted the
+broadcast: the tool wrote `FF FF FE 02 01 FE`, read ten bytes back and reported
+`Feetech Motor 254 responded: <hex>`. Every servo on the bus receives that frame
+and, because `PING` is answered, every one of them replies at once; on a
+half-duplex bus those replies collide, so the bytes read back belong to no single
+servo and the ID quoted beside them belongs to none either. With a single servo
+attached it would appear to work, which is worse - it reads like a discovery
+feature.
+
+The address space is not this module's to decide.
+`strands_robots.drivers.feetech.protocol` declares `BROADCAST_ID` and
+`MAX_UNICAST_ID` ("Highest ID a specific servo may hold. 0xFE is the broadcast")
+and already refuses the same intent from `build_packet` unless a caller passes
+`allow_broadcast=True` "for `SYNC_WRITE` and other reply-less instructions that
+legitimately target the broadcast ID". The tool now reads those two constants
+rather than restating them, and applies that same rule at its own boundary,
+before the port is opened.
+
+A reply-less write keeps the whole range. `feetech_position` and
+`feetech_velocity` never read a status packet, so addressing every servo with one
+frame means exactly what it says and is still accepted; only an action that reads
+a reply is held to a single servo. That set is derived from the tool's own body -
+an action both reading the port back and consuming `motor_id` - so an action
+added later that reads a reply for a caller-supplied ID is held to the same rule
+the hour it lands. The refusal names the broadcast, why no single reply can come
+back, and the range that can answer.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -92,9 +92,21 @@ speed in the opposite direction, and `velocity=32768` read as magnitude zero,
 stopping a servo the caller had just asked to run. `position` was already inside
 that limit at 4095; `velocity` now is too.
 
+`motor_id` takes more than the byte width for a different reason: the ID byte
+carries one address that is no servo. `0xfe` is the broadcast, which every servo
+on the bus receives, and for an instruction that expects a reply every servo
+answers at once - on a half-duplex bus those replies collide, so what
+`action="feetech_ping"` reads back belongs to no single servo. A reply-less
+write to the broadcast means what it says and is still accepted, so
+`feetech_position` and `feetech_velocity` take the whole `[1, 254]`; only a
+reply-expecting action is held to a single servo. The Protocol 1 codec applies
+the same rule to the frames it builds
+(`build_packet(..., allow_broadcast=False)`), so the tool and the driver cannot
+disagree about which address is a servo and which is the whole bus.
+
 | Option | Accepted | Why the bound is where it is |
 |--------|----------|------------------------------|
-| `motor_id` | integer in `[1, 254]` | the frame carries the ID in one byte, and `255` is the header value |
+| `motor_id` | integer in `[1, 254]`, or `[1, 253]` for an action that reads a reply | the frame carries the ID in one byte, of which `0xfd` is the highest a servo may hold and `0xfe` is the broadcast, while `0xff` is the header value |
 | `position` | integer in `[0, 4095]` | `Goal_Position` is a 12-bit register - the same full scale the reported angle divides by |
 | `velocity` | integer in `[0, 32767]` | `Goal_Velocity` is sign-magnitude with bit 15 the direction bit, so a larger magnitude commands the opposite direction |
 | `baudrate` | positive integer | pyserial coerces rather than checks, so `2.7` opens the port at 2 baud |

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -21,6 +21,15 @@ opposite direction, and ``velocity=32768`` read as magnitude zero -- stopping a
 servo the caller had just asked to run -- both reported as success quoting the
 number supplied.
 
+``motor_id`` takes more than the byte width too, because the ID byte carries
+one address that is not a servo: ``0xfe`` is the broadcast, which every servo
+on the bus receives and, for an instruction that expects a reply, every servo
+answers at once. On a half-duplex bus those replies collide, so the bytes
+``action="feetech_ping"`` reads back belong to no single servo -- and it
+reported them as one, quoting an ID no servo holds. A reply-less write to the
+broadcast means exactly what it says and stays accepted; the highest address a
+servo may hold is ``0xfd``, which is what a reply-expecting action is held to.
+
 ``baudrate`` and ``read_bytes`` are coerced rather than checked by pyserial
 (``2.7`` becomes 2 baud, and a non-positive ``read_bytes`` reads nothing and
 reports success, which is indistinguishable from a timed-out read on a healthy
@@ -42,6 +51,7 @@ import serial
 import serial.tools.list_ports
 from strands import tool
 
+from strands_robots.drivers.feetech.protocol import BROADCAST_ID, MAX_UNICAST_ID
 from strands_robots.utils import (
     finite_number_error,
     non_negative_count_error,
@@ -64,7 +74,12 @@ _MAX_MAGNITUDE = (1 << _DIRECTION_BIT) - 1
 # surface uses; only the ceiling is decided here, because it is a property of
 # the packet field this module encodes into.
 _REGISTER_FIELDS: dict[str, tuple[int, int, str]] = {
-    "motor_id": (1, 254, "the packet carries the ID in one byte, and 255 is the frame header"),
+    "motor_id": (
+        1,
+        BROADCAST_ID,
+        f"the packet carries the ID in one byte, of which {MAX_UNICAST_ID:#x} is the highest a servo "
+        f"may hold and {BROADCAST_ID:#x} is the broadcast, while 0xff is the frame header",
+    ),
     "position": (
         0,
         4095,
@@ -77,6 +92,16 @@ _REGISTER_FIELDS: dict[str, tuple[int, int, str]] = {
         "magnitude sets that bit and commands the opposite direction",
     ),
 }
+
+# Actions that read a status packet back after writing. A unicast is answered by
+# one servo; the broadcast is answered by every servo at once, and on a
+# half-duplex bus those replies collide, so the bytes read back belong to no
+# single servo. :func:`~strands_robots.drivers.feetech.protocol.build_packet`
+# refuses the broadcast for exactly these instructions -- its ``allow_broadcast``
+# defaults to ``False`` -- and this is that rule at the tool's own boundary,
+# before the port is opened. A reply-less write is absent from this set, so
+# addressing the whole bus with one stays available where it means what it says.
+_REPLY_EXPECTING_ACTIONS: frozenset[str] = frozenset({"feetech_ping"})
 
 # The options each action consumes. An action absent from this map reads none of
 # them and is never refused here: ``list_ports`` returns before the port is even
@@ -113,6 +138,32 @@ def _register_field_error(value: Any, param: str, action: str) -> str | None:
     return None
 
 
+def _motor_id_error(value: Any, param: str, action: str) -> str | None:
+    """Error text when ``value`` cannot address the servo ``action`` expects to hear from.
+
+    The frame's ID byte carries the broadcast alongside every unicast address, so
+    the field bound alone accepts it. An action that reads a status packet back
+    needs one servo to answer, which the broadcast cannot give it.
+
+    Args:
+        value: The caller-supplied motor ID.
+        param: The parameter it came from; always ``"motor_id"``.
+        action: The requested action; decides whether a reply is expected.
+
+    Returns:
+        An error message, or ``None`` when the ID is one this action can use.
+    """
+    if error := _register_field_error(value, param, action):
+        return error
+    if value == BROADCAST_ID and action in _REPLY_EXPECTING_ACTIONS:
+        return (
+            f"{action}: {param} {BROADCAST_ID:#x} is the broadcast, which every servo on the bus "
+            f"answers at once, so no single reply can be read back; address one servo in "
+            f"[1, {MAX_UNICAST_ID}], got {value}."
+        )
+    return None
+
+
 def _read_timeout_error(value: Any, param: str, action: str) -> str | None:
     """Error text when ``value`` is not a usable serial read budget in seconds.
 
@@ -144,7 +195,7 @@ _OPTION_DOMAINS: tuple[tuple[str, Callable[[Any, str, str], str | None]], ...] =
     ("baudrate", positive_count_error),
     ("timeout", _read_timeout_error),
     ("read_bytes", positive_count_error),
-    ("motor_id", _register_field_error),
+    ("motor_id", _motor_id_error),
     ("position", _register_field_error),
     ("velocity", _register_field_error),
 )
@@ -211,7 +262,9 @@ def serial_tool(
             pyserial's non-blocking mode (return what is already buffered)
         data: String data to send
         hex_data: Hex string data to send (e.g., "FF FF 01 04 03 00 64 92")
-        motor_id: Motor ID for Feetech commands; an integer in [1, 254]
+        motor_id: Motor ID for Feetech commands; an integer in [1, 254], of
+            which 254 (0xfe) is the broadcast every servo receives. An action
+            that reads a reply back accepts only a single servo, [1, 253]
         position: Target position for Feetech motors; an integer in [0, 4095]
         velocity: Target velocity for Feetech motors; an integer in [0, 65535]
         read_bytes: Number of bytes to read; a positive integer

--- a/tests/tools/test_feetech_broadcast_is_not_a_reply_address.py
+++ b/tests/tools/test_feetech_broadcast_is_not_a_reply_address.py
@@ -1,0 +1,275 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``serial_tool`` must not address the whole bus when it is about to read one reply.
+
+The Feetech Protocol 1 ID byte carries every unicast address and one address that
+is no servo: ``0xfe`` is the broadcast. ``motor_id`` was bounded at ``254`` for a
+reason about the field's width -- "the packet carries the ID in one byte, and 255
+is the frame header" -- which is true of the byte and says nothing about which of
+its values a servo can hold. So ``action="feetech_ping"`` accepted the broadcast:
+it wrote ``FF FF FE 02 01 FE``, slept, read ten bytes and reported
+``Feetech Motor 254 responded: <hex>``. Every servo on the bus receives that
+frame and, because ``PING`` is answered, every one of them replies at once; on a
+half-duplex bus those replies collide, so the bytes read back belong to no single
+servo and the ID quoted beside them belongs to none either.
+
+The address space is not this module's to invent.
+:mod:`~strands_robots.drivers.feetech.protocol` declares ``BROADCAST_ID`` and
+``MAX_UNICAST_ID`` ("Highest ID a specific servo may hold. 0xFE is the
+broadcast") and refuses the same intent from ``build_packet`` unless the caller
+passes ``allow_broadcast=True`` "for ``SYNC_WRITE`` and other reply-less
+instructions that legitimately target the broadcast ID". The tool now applies
+that same rule one layer up, before the port is opened, so the two cannot
+disagree about which address is a servo and which is the whole bus.
+
+A reply-less write is deliberately still allowed to address the broadcast:
+``feetech_position`` and ``feetech_velocity`` never read a status packet, so
+moving every servo with one frame means exactly what it says. That asymmetry is
+the point, and it is pinned in both directions here.
+
+Why nothing caught this: the numeric-domain suite's refusal sweep is
+``(0, 255, 256, 300, -1, True, 2.5, "1")`` -- the broadcast is inside the ID byte
+and so is absent from a sweep of values outside it -- while its acceptance sweep
+listed ``254`` under the name
+``test_an_addressable_motor_id_still_reaches_the_wire``. The broadcast is the one
+value in range that is not addressable, and that name recorded the opposite.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from typing import Any
+
+import pytest
+import serial
+
+import strands_robots.tools.serial_tool as serial_mod
+from strands_robots.drivers.feetech import protocol as feetech_protocol
+
+# Stated here rather than read off the module under test, so these cells grade
+# the Protocol 1 address space rather than agreeing with whatever the module
+# currently believes. One cell below asserts the module's constants are these.
+BROADCAST_ID = 0xFE
+MAX_UNICAST_ID = 0xFD
+
+# The action that writes and then reads a status packet back, and the two that
+# write and never read. Named rather than derived so the behavioural cells state
+# the split; the derived guard below is what keeps the module's own set honest.
+REPLY_EXPECTING_ACTION = "feetech_ping"
+REPLY_LESS_WRITES = (("feetech_position", {"position": 2048}), ("feetech_velocity", {"velocity": 100}))
+
+# A well-formed six-byte status packet, so an accepted ping reports success and
+# the control cells grade acceptance rather than a short read.
+_PING_REPLY = bytes([0xFF, 0xFF, 0x01, 0x02, 0x00, (~(0x01 + 0x02 + 0x00)) & 0xFF])
+
+
+class _FakeSerial:
+    """Stand-in for ``serial.Serial`` recording the bytes that reach the wire."""
+
+    def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.in_waiting = 0
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    def read(self, n: int = 1) -> bytes:
+        return _PING_REPLY[:n]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def opened(monkeypatch: pytest.MonkeyPatch) -> list[_FakeSerial]:
+    """Record every port this tool opens; empty means the bus was never touched."""
+    created: list[_FakeSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _FakeSerial:
+        instance = _FakeSerial(port, baudrate, timeout)
+        created.append(instance)
+        return instance
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return created
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool with a fake port, splatted so off-type values reach it."""
+    return serial_mod.serial_tool(port="/dev/fake0", **kwargs)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+def _actions_that_read_a_reply() -> set[str]:
+    """Actions whose own branch reads the port back and which consume ``motor_id``.
+
+    Derived from the tool's body rather than listed, so an action added later
+    that reads a status packet for a caller-supplied ID is held to the same rule
+    the hour it lands. An action that reads without consuming ``motor_id``
+    (``read``, ``send_read``, ``monitor``) addresses nothing, and a write that
+    consumes ``motor_id`` without reading (``feetech_position``,
+    ``feetech_velocity``) needs no reply, so neither is in scope.
+
+    Returns:
+        The action names that both read a reply and address a servo.
+    """
+    (body,) = [
+        node
+        for node in ast.parse(inspect.getsource(serial_mod)).body
+        if isinstance(node, ast.FunctionDef) and node.name == "serial_tool"
+    ]
+    reads_by_action: dict[str, bool] = {}
+    for node in ast.walk(body):
+        if not isinstance(node, ast.If) or "action" not in ast.unparse(node.test):
+            continue
+        reads = any(
+            isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) and call.func.attr == "read"
+            for statement in node.body
+            for call in ast.walk(statement)
+        )
+        for literal in ast.walk(node.test):
+            if isinstance(literal, ast.Constant) and isinstance(literal.value, str):
+                reads_by_action.setdefault(literal.value, reads)
+    return {
+        action
+        for action, reads in reads_by_action.items()
+        if reads and "motor_id" in serial_mod._OPTIONS_BY_ACTION.get(action, ())
+    }
+
+
+class TestAReplyExpectingActionRefusesTheBroadcast:
+    """The one address no servo holds is refused where a servo must answer."""
+
+    def test_ping_refuses_the_broadcast(self, opened: list[_FakeSerial]) -> None:
+        result = _call(action=REPLY_EXPECTING_ACTION, motor_id=BROADCAST_ID)
+
+        assert result["status"] == "error"
+
+    def test_ping_refuses_the_broadcast_before_the_port_is_opened(self, opened: list[_FakeSerial]) -> None:
+        _call(action=REPLY_EXPECTING_ACTION, motor_id=BROADCAST_ID)
+
+        assert opened == []
+
+    def test_no_broadcast_frame_reaches_the_wire(self, opened: list[_FakeSerial]) -> None:
+        _call(action=REPLY_EXPECTING_ACTION, motor_id=BROADCAST_ID)
+
+        assert [packet for port in opened for packet in port.writes] == []
+
+
+class TestTheRefusalNamesWhatWentWrong:
+    """A caller is told which address it used, why it cannot answer, and what can."""
+
+    @pytest.fixture
+    def refusal(self, opened: list[_FakeSerial]) -> str:
+        return _text(_call(action=REPLY_EXPECTING_ACTION, motor_id=BROADCAST_ID))
+
+    def test_the_refusal_names_the_action(self, refusal: str) -> None:
+        assert REPLY_EXPECTING_ACTION in refusal
+
+    def test_the_refusal_names_the_parameter(self, refusal: str) -> None:
+        assert "motor_id" in refusal
+
+    def test_the_refusal_names_the_broadcast_address(self, refusal: str) -> None:
+        assert f"{BROADCAST_ID:#x}" in refusal
+        assert "broadcast" in refusal
+
+    def test_the_refusal_says_why_no_reply_can_be_read(self, refusal: str) -> None:
+        assert "every servo" in refusal
+        assert "reply" in refusal
+
+    def test_the_refusal_names_the_range_that_can_answer(self, refusal: str) -> None:
+        assert f"[1, {MAX_UNICAST_ID}]" in refusal
+
+
+class TestAReplyLessWriteStillAddressesTheWholeBus:
+    """Moving every servo with one frame is not the defect and stays available."""
+
+    @pytest.mark.parametrize("action,field", REPLY_LESS_WRITES)
+    def test_a_write_accepts_the_broadcast(self, action: str, field: dict[str, int], opened: list[_FakeSerial]) -> None:
+        result = _call(action=action, motor_id=BROADCAST_ID, **field)
+
+        assert result["status"] == "success"
+
+    @pytest.mark.parametrize("action,field", REPLY_LESS_WRITES)
+    def test_the_broadcast_id_is_the_frames_id_byte(
+        self, action: str, field: dict[str, int], opened: list[_FakeSerial]
+    ) -> None:
+        _call(action=action, motor_id=BROADCAST_ID, **field)
+
+        assert opened[0].writes[0][2] == BROADCAST_ID
+
+    @pytest.mark.parametrize("motor_id", (1, 6, MAX_UNICAST_ID))
+    def test_ping_still_accepts_every_address_a_servo_can_hold(self, motor_id: int, opened: list[_FakeSerial]) -> None:
+        result = _call(action=REPLY_EXPECTING_ACTION, motor_id=motor_id)
+
+        assert result["status"] == "success"
+        assert opened[0].writes[0][2] == motor_id
+
+
+class TestTheAddressSpaceIsTheCodecs:
+    """The tool and the Protocol 1 codec answer the same question the same way."""
+
+    def test_the_codec_refuses_a_reply_expecting_broadcast(self) -> None:
+        with pytest.raises(ValueError, match="broadcast"):
+            feetech_protocol.ping_packet(BROADCAST_ID)
+
+    def test_the_codec_accepts_the_highest_single_servo(self) -> None:
+        assert feetech_protocol.ping_packet(MAX_UNICAST_ID)[2] == MAX_UNICAST_ID
+
+    def test_the_codec_allows_a_reply_less_broadcast(self) -> None:
+        frame = feetech_protocol.build_packet(BROADCAST_ID, 0x03, b"\x2a\x00\x08", allow_broadcast=True)
+
+        assert frame[2] == BROADCAST_ID
+
+    def test_the_module_reads_the_codecs_constants(self) -> None:
+        assert serial_mod.BROADCAST_ID == feetech_protocol.BROADCAST_ID == BROADCAST_ID
+        assert serial_mod.MAX_UNICAST_ID == feetech_protocol.MAX_UNICAST_ID == MAX_UNICAST_ID
+
+    def test_the_constants_are_imported_rather_than_restated(self) -> None:
+        """A second copy of the same numbers is what a drift looks like before it drifts.
+
+        Equal values are exactly what the previous state looked like, so the
+        agreement above cannot tell one owner from two. This reads the import.
+        """
+        module = ast.parse(inspect.getsource(serial_mod))
+        imported = {
+            alias.name
+            for node in ast.walk(module)
+            if isinstance(node, ast.ImportFrom) and node.module == feetech_protocol.__name__
+            for alias in node.names
+        }
+
+        assert {"BROADCAST_ID", "MAX_UNICAST_ID"} <= imported
+
+    def test_the_field_bound_alone_cannot_refuse_the_broadcast(self) -> None:
+        _, ceiling, _ = serial_mod._REGISTER_FIELDS["motor_id"]
+
+        assert ceiling == BROADCAST_ID
+
+    def test_the_field_reason_names_the_address_space(self) -> None:
+        _, _, why = serial_mod._REGISTER_FIELDS["motor_id"]
+
+        assert "broadcast" in why
+        assert f"{MAX_UNICAST_ID:#x}" in why
+
+
+class TestEveryReplyExpectingActionIsHeldToASingleServo:
+    """A new action that reads a reply for a caller's ID cannot ship unheld."""
+
+    def test_the_module_holds_every_action_that_reads_a_reply(self) -> None:
+        assert _actions_that_read_a_reply() == set(serial_mod._REPLY_EXPECTING_ACTIONS)
+
+    def test_the_derivation_separates_reading_from_addressing(self) -> None:
+        derived = _actions_that_read_a_reply()
+
+        assert REPLY_EXPECTING_ACTION in derived
+        assert {action for action, _ in REPLY_LESS_WRITES}.isdisjoint(derived)
+        assert {"read", "send_read"}.isdisjoint(derived)

--- a/tests/tools/test_serial_tool_numeric_domain.py
+++ b/tests/tools/test_serial_tool_numeric_domain.py
@@ -178,7 +178,12 @@ class TestARegisterFieldIsNeverSilentlyTruncated:
         assert "motor_id" in _text(result)
         assert opened == []
 
-    @pytest.mark.parametrize("motor_id", (1, 2, 6, 254))
+    # 253 replaces the 254 this case used to sweep. Both are inside the frame's
+    # ID byte, but 254 is the broadcast rather than a servo address, so it is not
+    # an addressable ID at all; 253 is the highest one a servo may hold.
+    # ``tests/tools/test_feetech_broadcast_is_not_a_reply_address.py`` grades what
+    # the broadcast may and may not be used for.
+    @pytest.mark.parametrize("motor_id", (1, 2, 6, 253))
     def test_an_addressable_motor_id_still_reaches_the_wire(self, motor_id: int, opened: list[_FakeSerial]) -> None:
         result = _call(action="feetech_position", motor_id=motor_id, position=100)
 


### PR DESCRIPTION
## Problem

The Feetech Protocol 1 ID byte carries every unicast address and one address that is no servo: `0xfe` is the broadcast. `serial_tool` bounded `motor_id` at `254` for a reason keyed to the field's *width*:

```
"motor_id": (1, 254, "the packet carries the ID in one byte, and 255 is the frame header")
```

That is true of the byte and says nothing about which of its values a servo can hold. So `action="feetech_ping"` accepted the broadcast, wrote `FF FF FE 02 01 FE`, read ten bytes back and reported them as one motor's answer.

Every servo on the bus receives that frame, and because `PING` is answered every one of them replies at once. On a half-duplex bus those replies collide, so the bytes read back belong to no single servo and the ID quoted beside them belongs to none either. With one servo attached it would appear to work, which is worse: it reads like a discovery feature.

The same intent through the two surfaces in this repository, measured:

| Surface | `motor_id=254` |
|---|---|
| `serial_tool` `action="feetech_ping"` | accepted -> `FF FF FE 02 01 FE` on the wire, reported `Feetech Motor 254 responded: FFFF010200FC` |
| `drivers.feetech.protocol.ping_packet` | `ValueError: motor_id=0xfe is the broadcast; this instruction expects a reply` |

`drivers/feetech/protocol.py` (landed as #2786) already owns this question. It declares `MAX_UNICAST_ID = 0xFD` ("Highest ID a specific servo may hold. 0xFE is the broadcast") and refuses the broadcast from `build_packet` unless a caller opts in `allow_broadcast=True` "for `SYNC_WRITE` and other reply-less instructions that legitimately target the broadcast ID. Every other caller passes `False` so a slip that addresses a broadcast where a reply is required is refused here rather than by a servo that never answers."

## Change

`serial_tool` now reads `BROADCAST_ID` and `MAX_UNICAST_ID` from that codec rather than restating them, and applies the same rule at its own boundary, before the port is opened.

A reply-less write keeps the whole range. `feetech_position` and `feetech_velocity` never read a status packet, so addressing every servo with one frame means exactly what it says. Only an action that reads a reply is held to a single servo, which mirrors the codec's own per-instruction `allow_broadcast` distinction.

| `motor_id` | `feetech_ping` | `feetech_position` | `feetech_velocity` |
|---|---|---|---|
| 1 .. 252 | accept | accept | accept |
| 253 (`MAX_UNICAST_ID`) | accept | accept | accept |
| 254 (`BROADCAST_ID`) | **refuse** | accept | accept |
| 255 | refuse (field bound) | refuse | refuse |

The refusal:

```
feetech_ping: motor_id 0xfe is the broadcast, which every servo on the bus answers
at once, so no single reply can be read back; address one servo in [1, 253], got 254.
```

The reply-expecting set is derived from the tool's own body - an action that both reads the port back and consumes `motor_id` - so an action added later that reads a reply for a caller-supplied ID is held to the same rule the hour it lands. Of the eight actions, `read` / `send_read` / `monitor` read without addressing a servo and `feetech_position` / `feetech_velocity` address one without reading, which is what makes the discriminator precise rather than a naming heuristic.

## Why nothing caught it

`tests/tools/test_serial_tool_numeric_domain.py` sweeps `motor_id` refusals over `(0, 255, 256, 300, -1, True, 2.5, "1")`. The broadcast is *inside* the ID byte, so it is absent from a sweep of values outside it. Its acceptance sweep listed `254` under the name `test_an_addressable_motor_id_still_reaches_the_wire` - and the broadcast is the one in-range value that is not addressable, so that name recorded the opposite. That case now sweeps `253`, the highest ID a servo may hold, and what the broadcast may and may not be used for is graded in the new file.

## Tests

`tests/tools/test_feetech_broadcast_is_not_a_reply_address.py`, 24 cells. Reverting the source and keeping the tests gives **12 failed / 12 passed**, and no over-reach control is among the failures:

| Class | Role | pre-fix failed/cells |
|---|---|---|
| `TestAReplyExpectingActionRefusesTheBroadcast` | regression | 3/3 |
| `TestTheRefusalNamesWhatWentWrong` | regression (message) | 5/5 |
| `TestAReplyLessWriteStillAddressesTheWholeBus` | over-reach control | **0/7** |
| `TestTheAddressSpaceIsTheCodecs` | premise + agreement | 3/7 |
| `TestEveryReplyExpectingActionIsHeldToASingleServo` | derived drift guard | 1/2 |
| **total** | | **12/24** |

The headline pre-fix failures are the tool's own output: `assert 'feetech_ping' in 'Feetech Motor 254 responded: FFFF010200FC'` and `assert [b'\xff\xff\xfe\x02\x01\xfe'] == []`.

Mutation table. `new` counts failing cells in the new file, `sib` in the 162 pre-existing cells of `test_serial_tool_numeric_domain.py` / `test_feetech_velocity_direction_bit.py` / `test_feetech_status_packet_framing.py`. `collected` was 24 on every row, so no row hid a deselection.

| Row | Mutation | new | sib |
|---|---|---|---|
| b0 | control, no mutation | 0 | 0 |
| b1 | the broadcast guard is dropped | 8 | 0 |
| b2 | the reply-expecting set is emptied | 9 | 0 |
| b3 | the reply-less writes are held to a reply too (over-reach) | 5 | 0 |
| b4 | the field ceiling narrowed to `MAX_UNICAST_ID` for every action | 7 | 0 |
| b5 | the broadcast is refused only after the port is opened | 1 | 0 |
| b6 | the comparison widened to `>=` the broadcast | 0 | 0 |
| b7 | the refusal stops naming the range that can answer | 1 | 0 |
| b8 | the refusal stops saying why no reply can be read | 1 | 0 |
| b9 | the field reason reverts to the byte width alone | 1 | 0 |
| b10 | the address space is hardcoded instead of read from the codec | 1 | 0 |

11 rows, 9 firing, **9 distinct firing sets, no two rows share one**, control clean, source restored byte-identically.

Rows worth reading:

- **b1 is a strict subset of b2**, and the one cell b2 adds is `test_the_module_holds_every_action_that_reads_a_reply` - the derived guard is what separates "the rule was removed" from "the rule is intact and reaches nothing".
- **b3 and b4 are the two tempting over-reaches** and both fire the reply-less-write controls. b4 is the uniform narrowing - holding *every* action to a single servo - which would refuse a broadcast write that means what it says.
- **b5 fires exactly one cell**, the placement assert. Refusing after the port is open is not equivalent: the guard belongs where every sibling option is already checked.
- **b6 fires 0 and is a measured semantic no-op**: the field bound already refuses anything above 254, so only the broadcast can reach the comparison and `>=` is `==` over the reachable domain.
- **b10 fires 1 and closed a real gap in my own test.** The value-agreement cell passes when the constants are hardcoded to the same numbers - equal values are exactly what the previous state looked like - so a structural cell reads the import instead.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1630 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the merge base, normalized message sets byte-identical in both directions, 0 attributable to the changed files.
- Paired run over an identical 462-file selection (all of `tests/tools/` and `tests/drivers/`, plus every suite that walks the tree, parses source, reads docstrings or reads `docs/`), with the new file excluded from both trees: `20 failed, 21837 passed, 78 skipped` on **both**, the same 20 failing ids, `comm` empty in both directions. 17 need `awsiot` (declared in the `[mesh-iot]` extra, absent here) and 3 are the lerobot-from-source `encode() takes 1 positional argument` drift.
- `mkdocs build --strict` clean.

No visual artifact: this changes an option domain and a refusal message, not a policy, simulation, rendering, recording or robot asset. The measured acceptance table and the two-surface comparison above are the evidence.

## Docs

`docs/hardware/tools.md` documented the same byte-width reason in its `motor_id` row. The row and a new paragraph now state which address is a servo, which is the whole bus, and why only a reply-expecting action is held to one.
