### PR TITLE
fix(hardware): do not close the devices under a teleop loop that is still writing

### DIFF
--- a/changelog.d/2821-cleanup-defers-the-close-under-a-live-teleop-writer.md
+++ b/changelog.d/2821-cleanup-defers-the-close-under-a-live-teleop-writer.md
@@ -1,0 +1,46 @@
+### Fixed: `cleanup()` does not close the devices under a teleop loop that is still writing
+
+`stop_teleoperate` reports its join outcome honestly: a leader whose
+`get_action()` is still blocking - a serial read on a wedged bus is the ordinary
+case a join budget exists for - yields `status="error"` with `stopped: False`,
+and that branch deliberately leaves the attached devices connected. Its
+docstring says why, and names the precedent: "Tearing the bus down under a live
+writer is what `G1Driver.cleanup` refuses for the same reason." `cleanup()`
+called it, discarded the envelope, and closed the motors bus anyway - so the two
+functions disagreed about the same state and `cleanup()` undid the protection
+`stop_teleoperate` had just provided.
+
+Closing there is worse than deferring on both of the counts `cleanup()` cares
+about, which is what makes this a defect rather than a trade-off. The release
+does not hold: `send_action` re-opens the robot lazily on a command that finds it
+disconnected, the live loop's next write goes through it, and nothing remains to
+close the port again because `cleanup()` is terminal and the executor is already
+down - exactly the harm the comment above `_disconnect_devices()` describes, with
+the teleop loop first in its own list of command sources. And the torque disable
+is undone: `_disconnect_devices` prefers the driver's own `disconnect()` because
+that is where torque disable and gripper release live, and the loop's write then
+lands after it. Measured on a one-camera arm whose leader is wedged, with the
+port's exclusivity modelled:
+
+```
+                                        before      after
+stop_teleoperate() alone: bus closed    no          no
+cleanup(): bus closed                   yes         no
+cleanup(): port held afterwards         no          yes
+cleanup(): driver disconnect() calls    1           0
+teleop thread alive throughout          yes         yes
+bus connect_calls after the live write  2           1
+command lands after torque disable      yes         no
+deferral reported                       (nothing)   ERROR + remedy
+```
+
+`cleanup()` now reads the outcome through a `_stop_reported_stopped` helper on
+the envelope's `stopped` key and holds the devices when the loop is still
+running, recording the reason and the remedy at ERROR - the only report it has,
+since it returns `None`. The key is `stopped` rather than `status`, because the
+status is derived from the session counters: a session whose every frame errored
+reports `"error"` after a perfectly clean join, and a caller keying on it would
+read a healthy teardown as a live loop. The software teardown is unchanged, a
+clean stop still closes every device exactly once, and a `stop_teleoperate` that
+raises leaves the outcome unknown and keeps the existing "a teleop teardown
+failure must not block the rest of hardware cleanup" contract.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -39,7 +39,7 @@ from strands.types.tools import ToolResult, ToolSpec, ToolUse
 from strands_robots._serial_discovery import describe_serial_candidates, scan_serial_devices
 from strands_robots.bus_access import read_observation, write_action
 from strands_robots.ros_telemetry import ROS2_SYSTEM_INSTALL_HINT
-from strands_robots.teleop_mixin import TeleopMixin
+from strands_robots.teleop_mixin import TeleopMixin, _stop_reported_stopped
 from strands_robots.utils import (
     boolean_flag_error,
     dds_domain_id_error,
@@ -2681,7 +2681,10 @@ class Robot(TeleopMixin, AgentTool):
 
         Terminal: this latches a shutdown, releases the task executor, tears
         down the mesh and ROS bridges, and disconnects the robot -- the motors
-        bus and every camera -- so no device node stays held. There is no
+        bus and every camera -- so no device node stays held. The one exception
+        is a teleop loop that did not join: the devices are left open rather
+        than closed under a live writer, and the reason is recorded at ERROR
+        with the remedy. There is no
         ``restart``, so
         ``run_policy`` / ``start_task`` / the ``execute`` action refuse
         permanently afterwards rather than admit a rollout that would command
@@ -2696,9 +2699,15 @@ class Robot(TeleopMixin, AgentTool):
             # Stop any local teleoperation loop + disconnect attached devices
             # (TeleopMixin). Best-effort: a teleop teardown failure must not
             # block the rest of hardware cleanup.
+            # ``stop_teleoperate`` reports whether the loop actually joined, and
+            # the devices must not be closed under one that did not - see the
+            # ``_disconnect_devices`` call below. A raise leaves the outcome
+            # unknown and keeps the pre-existing warn-and-continue contract:
+            # only a positive report of a live loop defers the close.
+            teleop_stopped = True
             if getattr(self, "_teleop_running", False) or getattr(self, "_teleops", None):
                 try:
-                    self.stop_teleoperate()
+                    teleop_stopped = _stop_reported_stopped(self.stop_teleoperate())
                 except Exception as teleop_exc:  # noqa: BLE001
                     logger.warning(
                         "%s: stop_teleoperate() raised during cleanup: %s",
@@ -2737,7 +2746,25 @@ class Robot(TeleopMixin, AgentTool):
             # task executor, the mesh and the ROS bridge have stopped can be
             # re-opened behind this teardown -- and would then stay open for
             # the life of the process, since nothing runs after ``cleanup()``.
-            self._disconnect_devices()
+            #
+            # The teleop loop is the one command source whose shutdown is not
+            # guaranteed by the ordering: its leader's ``get_action()`` can
+            # block past the join budget, which is why ``stop_teleoperate``
+            # reports the outcome instead of assuming it. Closing under a live
+            # one is worse than deferring on both counts -- the loop's next
+            # write re-opens the port through ``send_action``'s lazy connect, so
+            # the release does not hold, and that write lands *after* the
+            # driver's ``disconnect()`` disabled torque, leaving the arm
+            # energised at a fresh command. ``G1Driver.cleanup`` declines the
+            # same teardown for the same reason.
+            if teleop_stopped:
+                self._disconnect_devices()
+            else:
+                logger.error(
+                    "%s: devices left open because the teleop loop did not stop; "
+                    "call stop_teleoperate() to re-join it, then cleanup() again",
+                    self.tool_name_str,
+                )
 
             logger.info(f"{self.tool_name_str} cleanup completed")
 

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -998,6 +998,32 @@ class TeleopMixin:
         }
 
 
+def _stop_reported_stopped(envelope: dict[str, Any]) -> bool:
+    """Read whether a :meth:`TeleopMixin.stop_teleoperate` envelope stopped the loop.
+
+    The flag is ``stopped`` in the envelope's ``json`` block, which
+    :meth:`TeleopMixin._teleop_stats` always carries and the failed-join branch
+    sets to ``False``. Read that key rather than ``status``: the status is
+    derived from the session counters, so a session whose every frame errored
+    reports ``"error"`` after a perfectly clean join, and a caller keying on it
+    would read a healthy teardown as a live loop.
+
+    Args:
+        envelope: The envelope ``stop_teleoperate`` returned.
+
+    Returns:
+        ``True`` when the loop is known to have stopped, which includes the
+        "no active teleoperation" envelope that carries no ``json`` block at
+        all - there was nothing to stop. ``False`` only when the envelope
+        positively reports a loop that outlasted its join budget.
+    """
+    for block in envelope.get("content", []):
+        payload = block.get("json")
+        if isinstance(payload, dict) and "stopped" in payload:
+            return bool(payload["stopped"])
+    return True
+
+
 def _infer_method(teleop_type: str) -> str:
     """Map a teleoperator type string to an input-method label."""
     t = teleop_type.lower()

--- a/tests/test_cleanup_defers_the_close_under_a_live_teleop_writer.py
+++ b/tests/test_cleanup_defers_the_close_under_a_live_teleop_writer.py
@@ -1,0 +1,374 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""``cleanup()`` must not close the devices under a teleop loop that is still writing.
+
+``stop_teleoperate`` reports its join outcome honestly: a leader whose
+``get_action()`` blocks past the join budget - a serial read on a wedged bus is
+the ordinary case - yields ``status="error"`` with ``stopped: False``, and that
+branch deliberately leaves the attached devices connected. Its docstring says
+why, and names the precedent: "Tearing the bus down under a live writer is what
+``G1Driver.cleanup`` refuses for the same reason."
+
+``cleanup()`` called ``stop_teleoperate()`` and discarded that envelope, then
+closed the motors bus. Measured on a one-camera arm whose leader is wedged, with
+the port's exclusivity modelled:
+
+    call                       bus closed   port held   thread alive
+    stop_teleoperate() alone       no         yes           yes
+    cleanup()                     yes          no           yes
+
+So the two functions disagreed about the same state, and ``cleanup()`` undid the
+protection ``stop_teleoperate`` had just provided.
+
+Closing there is worse than deferring on both of the counts ``cleanup()`` cares
+about, which is why this is a defect rather than a trade-off:
+
+- the release does not hold. ``send_action`` re-opens the robot lazily on a
+  command that finds it disconnected, and the live loop's next write goes
+  through it, so the port is open again (``connect_calls`` 1 -> 2) with nothing
+  left to close it - ``cleanup()`` is terminal and the executor is already down.
+  That is exactly the harm the comment above ``_disconnect_devices()`` describes,
+  and the teleop loop is first in its own list of command sources.
+- the torque disable is undone. ``_disconnect_devices`` prefers the driver's own
+  ``disconnect()`` because that is where torque disable and gripper release
+  live; the loop's write then lands *after* it, leaving the arm energised at a
+  fresh commanded position.
+
+What these tests pin:
+
+    - a live teleop writer defers the close: the bus stays connected, the port
+      stays held, and no re-open cycle happens;
+    - the reason is recorded at ERROR with the remedy, because ``cleanup()``
+      returns ``None`` and has no envelope to report through;
+    - a clean stop still closes every device exactly once, and a robot with no
+      teleop session at all is untouched by the change;
+    - a ``stop_teleoperate`` that *raises* still closes the devices - the
+      outcome is unknown there, and the pre-existing "a teleop teardown failure
+      must not block the rest of hardware cleanup" contract is preserved;
+    - the outcome is read from ``stopped`` rather than from ``status``, because
+      the status is derived from the session counters: a session whose every
+      frame errored reports ``"error"`` after a perfectly clean join.
+
+No serial port and no camera is opened. The device doubles are the ones
+``test_hardware_cleanup_disconnects`` uses, so port exclusivity is modelled and
+the consequence is asserted rather than the call.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import strands_robots.teleop_mixin as teleop_mixin
+from strands_robots.teleop_mixin import _stop_reported_stopped
+from tests.test_hardware_cleanup_disconnects import _arm, _Bridge, _make_robot, _Mesh, _Port
+
+# Short enough to keep every cell fast. The budget itself is pre-existing and
+# pinned by ``test_stop_teleoperate_reports_the_join_outcome``; what matters here
+# is only that a join can fail.
+_FAST_JOIN_S = 0.3
+
+
+class _WedgedLeader:
+    """A leader whose ``get_action()`` blocks, as a serial read on a stuck bus does."""
+
+    def __init__(self, released: threading.Event) -> None:
+        self.is_connected = True
+        self._released = released
+        self.polls = 0
+
+    def get_action(self) -> dict[str, float]:
+        self.polls += 1
+        self._released.wait(30.0)
+        return {"j0.pos": 0.5}
+
+    def disconnect(self) -> None:
+        self.is_connected = False
+
+
+class _Session:
+    """A hardware robot with a teleop loop parked in its leader's read."""
+
+    def __init__(self, *, wedged: bool) -> None:
+        self.port = _Port()
+        self.log: list[str] = []
+        self.driver = _arm(self.port, self.log)
+        self.robot = _make_robot(self.driver)
+        self.driver.connect()
+        self.robot._ensure_teleop_state()
+        self.released = threading.Event()
+        if not wedged:
+            self.released.set()
+        self.leader = _WedgedLeader(self.released)
+        self.robot._teleops = {"leader": type("_Att", (), {"device": self.leader})()}
+        self.robot._teleop_robot_name = "test_arm"
+        self.robot._teleop_running = True
+        self.robot._teleop_start_mono = time.monotonic()
+        self.writes: list[dict[str, Any]] = []
+        entered = threading.Event()
+
+        def loop() -> None:
+            entered.set()
+            while self.robot._teleop_running and not self.robot._teleop_stop_event.is_set():
+                action = self.leader.get_action()
+                self.writes.append(self.robot.send_action(action))
+                break
+
+        self.thread = threading.Thread(target=loop, daemon=True)
+        self.robot._teleop_thread = self.thread
+        self.thread.start()
+        assert entered.wait(5.0), "the teleop loop never started"
+        if wedged:
+            time.sleep(0.05)  # let it reach the blocking read
+        else:
+            self.thread.join(5.0)
+
+    def release(self) -> None:
+        """Unblock the wedged leader and let the loop take its one write."""
+        self.released.set()
+        self.thread.join(5.0)
+
+
+@pytest.fixture(autouse=True)
+def _fast_join(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(teleop_mixin, "_TELEOP_JOIN_TIMEOUT_S", _FAST_JOIN_S)
+
+
+class TestThePremiseStopTeleoperateAlreadyDeclinesTheTeardown:
+    """What ``cleanup()`` has to read: the outcome is reported, and it is acted on."""
+
+    def test_a_wedged_leader_makes_the_join_fail_and_says_so(self) -> None:
+        session = _Session(wedged=True)
+        envelope = session.robot.stop_teleoperate()
+        payload = next(b["json"] for b in envelope["content"] if "json" in b)
+        assert envelope["status"] == "error"
+        assert payload["stopped"] is False
+        assert session.thread.is_alive()
+        session.release()
+
+    def test_stop_teleoperate_leaves_the_devices_open_on_a_failed_join(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.stop_teleoperate()
+        assert session.driver.bus.is_connected
+        assert session.port.held_by == "arm"
+        assert session.driver.bus.disconnect_calls == []
+        session.release()
+
+
+class TestTheCloseIsDeferredUnderALiveWriter:
+    """The regression: ``cleanup()`` reads the outcome and holds the devices."""
+
+    def test_the_bus_is_not_closed_while_the_loop_is_alive(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.cleanup()
+        assert session.thread.is_alive(), "premise: the loop must still be running"
+        assert session.driver.bus.is_connected
+        assert session.driver.bus.disconnect_calls == []
+
+    def test_the_port_stays_held_so_nothing_else_can_take_it(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.cleanup()
+        assert session.port.held_by == "arm"
+
+    def test_no_camera_is_closed_either(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.cleanup()
+        assert all(cam.is_connected for cam in session.driver.cameras.values())
+        assert session.log == []
+
+    def test_the_drivers_own_disconnect_is_not_called(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.cleanup()
+        assert session.driver.disconnect_calls == 0
+
+    def test_the_live_write_does_not_have_to_re_open_the_port(self) -> None:
+        """The whole point: the release did not hold, so do not perform it."""
+        session = _Session(wedged=True)
+        session.robot.cleanup()
+        opened_before = session.driver.bus.connect_calls
+        session.release()
+        assert session.writes and session.writes[0]["status"] == "success"
+        assert session.driver.bus.connect_calls == opened_before, (
+            "the loop's write had to re-open a port cleanup() closed"
+        )
+
+    def test_the_command_lands_on_a_bus_whose_torque_was_never_disabled(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.cleanup()
+        session.release()
+        assert len(session.driver.commands) == 1
+        assert session.driver.bus.disconnect_calls == [], "a fresh command landed after the driver disabled torque"
+
+    def _cleanup_errors(self, caplog: pytest.LogCaptureFixture) -> list[str]:
+        session = _Session(wedged=True)
+        with caplog.at_level(logging.ERROR, logger="strands_robots.hardware_robot"):
+            session.robot.cleanup()
+        session.release()
+        return [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+
+    def test_the_remedy_the_error_names_actually_works(self) -> None:
+        """Re-join the loop, then cleanup() again: the devices close."""
+        session = _Session(wedged=True)
+        session.robot.cleanup()
+        assert session.driver.bus.is_connected, "premise: the first cleanup deferred"
+        session.release()
+        session.robot.stop_teleoperate()
+        session.robot.cleanup()
+        assert not session.driver.bus.is_connected
+        assert session.port.held_by is None
+
+    def test_the_deferral_is_recorded_at_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """``cleanup()`` returns ``None``, so the log is the only report it has."""
+        messages = self._cleanup_errors(caplog)
+        assert any("devices left open" in m for m in messages), messages
+
+    def test_the_error_names_the_remedy(self, caplog: pytest.LogCaptureFixture) -> None:
+        messages = self._cleanup_errors(caplog)
+        assert any("stop_teleoperate()" in m for m in messages), messages
+        assert any("cleanup() again" in m for m in messages), messages
+
+
+class TestDeferringTheCloseCostsNothingElse:
+    """These hold either way: deferring must not skip the software teardown."""
+
+    def test_the_shutdown_is_still_latched(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.cleanup()
+        assert session.robot._shutdown_event.is_set()
+        session.release()
+
+    def test_the_mesh_and_the_ros_bridge_are_still_torn_down(self) -> None:
+        """Deferring the *device* close must not defer the software teardown.
+
+        ``TestTheDevicesCloseLast`` in ``test_hardware_cleanup_disconnects``
+        pins the mesh and the bridge going down before the devices; holding the
+        devices back must not turn that ordering into a skip.
+        """
+        session = _Session(wedged=True)
+        session.robot.mesh = _Mesh(session.log)
+        session.robot._ros_bridge = _Bridge(session.log)
+        session.robot.cleanup()
+        assert "mesh.stop" in session.log
+        assert "ros_bridge.shutdown" in session.log
+        session.release()
+
+
+class TestACleanStopStillClosesEverything:
+    """Over-reach guard: the deferral must not cost the ordinary teardown."""
+
+    def test_a_joined_loop_closes_the_bus_and_the_camera(self) -> None:
+        session = _Session(wedged=False)
+        assert not session.thread.is_alive(), "premise: this loop joins"
+        session.robot.cleanup()
+        assert not session.driver.bus.is_connected
+        assert session.port.held_by is None
+        assert session.driver.disconnect_calls == 1
+
+    def test_a_robot_with_no_teleop_session_is_unaffected(self) -> None:
+        port = _Port()
+        log: list[str] = []
+        driver = _arm(port, log)
+        robot = _make_robot(driver)
+        driver.connect()
+        robot.cleanup()
+        assert not driver.bus.is_connected
+        assert port.held_by is None
+
+    def test_a_clean_stop_logs_no_deferral(self, caplog: pytest.LogCaptureFixture) -> None:
+        session = _Session(wedged=False)
+        with caplog.at_level(logging.ERROR, logger="strands_robots.hardware_robot"):
+            session.robot.cleanup()
+        assert [r.getMessage() for r in caplog.records if "devices left open" in r.getMessage()] == []
+
+
+class TestAnUnknownOutcomeKeepsThePreExistingContract:
+    """A raise leaves the outcome unknown; warn and continue, as before."""
+
+    def test_a_stop_that_raises_still_closes_the_devices(self) -> None:
+        session = _Session(wedged=False)
+
+        def boom() -> dict[str, Any]:
+            raise RuntimeError("teleop teardown failed")
+
+        session.robot.stop_teleoperate = boom  # type: ignore[method-assign]
+        session.robot.cleanup()
+        assert not session.driver.bus.is_connected
+        assert session.port.held_by is None
+
+    def test_a_stop_that_raises_is_warned_not_propagated(self, caplog: pytest.LogCaptureFixture) -> None:
+        session = _Session(wedged=False)
+
+        def boom() -> dict[str, Any]:
+            raise RuntimeError("teleop teardown failed")
+
+        session.robot.stop_teleoperate = boom  # type: ignore[method-assign]
+        with caplog.at_level(logging.WARNING, logger="strands_robots.hardware_robot"):
+            session.robot.cleanup()
+        assert any("stop_teleoperate() raised" in r.getMessage() for r in caplog.records)
+
+
+class TestTheOutcomeIsReadFromStoppedNotFromStatus:
+    """``status`` is derived from the session counters, so it is the wrong key."""
+
+    @pytest.mark.parametrize(
+        ("envelope", "expected"),
+        [
+            pytest.param({"status": "error", "content": [{"json": {"stopped": False}}]}, False, id="failed-join"),
+            pytest.param({"status": "success", "content": [{"json": {"stopped": True}}]}, True, id="clean-join"),
+            pytest.param(
+                {"status": "error", "content": [{"json": {"stopped": True, "frames": 4, "errors": 4}}]},
+                True,
+                id="every-frame-errored-but-joined-cleanly",
+            ),
+            pytest.param(
+                {"status": "degraded", "content": [{"json": {"stopped": True}}]},
+                True,
+                id="degraded-but-joined-cleanly",
+            ),
+            pytest.param(
+                {"status": "success", "content": [{"text": "No active teleoperation."}]},
+                True,
+                id="nothing-to-stop-carries-no-json",
+            ),
+            pytest.param({"status": "success", "content": []}, True, id="empty-content"),
+            pytest.param({}, True, id="no-content-key"),
+        ],
+    )
+    def test_the_reader_keys_on_the_stopped_flag(self, envelope: dict[str, Any], expected: bool) -> None:
+        assert _stop_reported_stopped(envelope) is expected
+
+    def test_an_errored_session_that_joined_still_closes_the_devices(self) -> None:
+        """The end-to-end form of the same discrimination."""
+        session = _Session(wedged=False)
+        session.robot._teleop_errors = 7
+        session.robot._teleop_frames = 7
+        envelope = session.robot.stop_teleoperate()
+        assert envelope["status"] == "error", "premise: the counters make this an error"
+        assert _stop_reported_stopped(envelope) is True
+
+    def test_a_json_block_without_the_flag_is_not_read_as_a_live_loop(self) -> None:
+        assert _stop_reported_stopped({"content": [{"json": {"frames": 3}}]}) is True
+
+
+class TestTheDecisionIsSingleSourced:
+    """``cleanup()`` must not re-derive "did it stop" from the thread handle."""
+
+    def test_cleanup_reads_the_envelope_rather_than_the_thread(self) -> None:
+        import ast
+        import inspect
+        import textwrap
+
+        from strands_robots.hardware_robot import Robot as HwRobot
+
+        source = inspect.getsource(HwRobot.cleanup)
+        tree = ast.parse(textwrap.dedent(source))
+        calls = [
+            ast.unparse(node)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and "_stop_reported_stopped" in ast.unparse(node.func)
+        ]
+        assert len(calls) == 1, calls
+        assert "is_alive" not in source, "the join outcome is stop_teleoperate's to report"


### PR DESCRIPTION
## The defect

`stop_teleoperate` reports its join outcome honestly. A leader whose `get_action()` is still blocking - a serial read on a wedged bus is the ordinary case a join budget exists for - yields `status="error"` with `stopped: False`, and that branch **deliberately leaves the attached devices connected**. Its docstring says why, and names the precedent:

> The attached devices are disconnected only once the loop has joined. Tearing the bus down under a live writer is what `G1Driver.cleanup` refuses for the same reason.

`cleanup()` called `stop_teleoperate()`, discarded the envelope, and closed the motors bus anyway. So the two functions disagreed about the same state, and `cleanup()` undid the protection `stop_teleoperate` had just provided. Measured on a one-camera arm whose leader is wedged, with the port's exclusivity modelled:

| call | bus closed | port held | teleop thread alive |
|---|---|---|---|
| `stop_teleoperate()` alone | no | yes | yes |
| `cleanup()` | **yes** | **no** | yes |

## Why this is a defect and not a trade-off

Closing there is worse than deferring on **both** of the counts `cleanup()` cares about.

**The release does not hold.** `send_action` re-opens the robot lazily on a command that finds it disconnected (`hardware_robot.py:2854`), and the live loop's next write goes through it. Nothing remains to close the port again - `cleanup()` is terminal and the executor is already down:

| after the live write | before | after |
|---|---|---|
| bus `connect_calls` | 2 (re-opened) | 1 |
| port held afterwards | yes, for the process lifetime | yes, never closed |

That is exactly the harm the comment above `_disconnect_devices()` already describes, and the teleop loop is **first in its own list** of command sources:

> `send_action` re-opens the robot lazily on a command that finds it disconnected, so a port closed before the teleop loop, the task executor, the mesh and the ROS bridge have stopped can be re-opened behind this teardown.

**The torque disable is undone.** `_disconnect_devices` prefers the driver's own `disconnect()` because "that is where a follower disables torque and releases the gripper". The loop's write lands *after* it, leaving the arm energised at a fresh commanded position.

## The change

`cleanup()` reads the outcome and holds the devices when the loop is still running, recording the reason and the remedy at ERROR - the only report it has, since it returns `None`.

The outcome is read from `stopped`, not from `status`. The status is derived from the session counters, so a session whose every frame errored reports `"error"` after a perfectly clean join; a caller keying on it would read a healthy teardown as a live loop. `_stop_reported_stopped` lives in `teleop_mixin`, which owns the envelope, and defaults to "stopped" for an envelope that carries no flag (the "no active teleoperation" reply has nothing to stop).

Deliberately unchanged: the software teardown still runs, a clean stop still closes every device exactly once, and a `stop_teleoperate` that **raises** leaves the outcome unknown and keeps the existing contract that "a teleop teardown failure must not block the rest of hardware cleanup" (pinned by `TestCleanupFailSoft`).

## Why nothing caught it

`test_hardware_cleanup_disconnects` is the suite dedicated to this property, and it has a class named `TestTheDevicesCloseLast` whose docstring is *"A port closed while any command source is still live gets re-opened."* It grades the mesh, the ROS bridge and the draining executor. The teleop loop - the one command source that is a live **writer** to the bus being closed, and the only one whose shutdown the ordering does not guarantee - appears in that file **0 times**.

## Verification

Pre-fix split (behavioural revert - the gate dropped, the reader kept): **9 failed / 19 passed**

| class | role | failed / total |
|---|---|---|
| `TestTheCloseIsDeferredUnderALiveWriter` | regression | 9 / 9 |
| `TestThePremiseStopTeleoperateAlreadyDeclinesTheTeardown` | premise | 0 / 2 |
| `TestDeferringTheCloseCostsNothingElse` | over-reach | 0 / 2 |
| `TestACleanStopStillClosesEverything` | over-reach | 0 / 3 |
| `TestAnUnknownOutcomeKeepsThePreExistingContract` | control | 0 / 2 |
| `TestTheOutcomeIsReadFromStoppedNotFromStatus` | reader unit | 0 / 9 |
| `TestTheDecisionIsSingleSourced` | structural | 0 / 1 |

A raw revert is a collection error instead, because the tests import the new helper.

Mutation table - 11 rows, control clean, all 10 detected, **10 distinct firing sets**, `collected` stable at 28, source restored byte-identical. `sib` is failures in the five pre-existing suites (`test_hardware_cleanup_disconnects`, `test_stop_teleoperate_reports_the_join_outcome`, `test_hardware_robot_lifecycle`, `test_teleop`, `test_hardware_cleanup_survives_a_failed_robot_init`):

| row | mutation | fires | sib |
|---|---|---|---|
| b0 | control - no mutation | 0 | 0 |
| b1 | the gate dropped: close unconditionally (the defect) | 9 | 0 |
| b2 | reader keys on `status` instead of `stopped` | 9 | 0 |
| b3 | reader defaults to `False` when the flag is absent | 5 | 0 |
| b4 | reader reads the first `json` block without checking for the flag | 1 | 0 |
| b5 | the deferral is silent (ERROR dropped) | 2 | 0 |
| b6 | the ERROR names the state but not the remedy | 1 | 0 |
| b7 | a `stop_teleoperate` that raises is treated as a live loop (over-reach) | 1 | 0 |
| b8 | the gate also skips the mesh / bridge / executor teardown (over-reach) | 3 | 0 |
| b9 | `cleanup()` re-derives the outcome from the thread handle (drift) | 1 | 0 |
| b10 | reader coerces with a truthiness test on the whole payload | 10 | 0 |

`sib` is 0 on every row, which is the measured form of the section above: none of the pre-existing suites can see any of this. b7 is the scope decision - the pre-existing fail-soft test asserts only `stopped == ["mesh"]`, so it never grades the device close on the raise path, and the control in this file is what does.

Gate, paired against `efd18075` on an identical 441-file selection (every suite naming teleop, cleanup, the hardware wrapper, or walking the tree / reading source and docstrings), the new file excluded from both trees and every path verified present on both:

| | branch | base |
|---|---|---|
| collected | 21008 | 21008 |
| result | 20 failed, 20915 passed, 73 skipped | 20 failed, 20915 passed, 73 skipped |
| failing ids | 20 | 20 |

`comm` is empty in both directions. The 20 are environmental and identical on both trees: 17 in `tests/mesh/test_iot_*` need `awsiot`/`awscrt` (declared in the `[mesh-iot]` extra, absent here, installed in CI) and 3 in `tests/training/test_lerobot*` are the lerobot-from-source `encode() takes 1 positional argument` drift.

`ruff check` and `ruff format --check` clean over 1630 files. mypy 24 == 24 against a worktree of the merge base, normalized message sets byte-identical in both directions, 0 attributable to the changed files.

No visual artifact: this changes a teardown ordering and its report, not a policy, simulation, render, recording or asset. The measured tables above are the evidence.
