### PR TITLE
fix(tools/serial_tool): refuse the bus broadcast as a single servo's ID

### DIFF
--- a/changelog.d/2822-feetech-motor-id-excludes-the-broadcast.md
+++ b/changelog.d/2822-feetech-motor-id-excludes-the-broadcast.md
@@ -1,0 +1,30 @@
+### Fixed: `serial_tool` no longer accepts the Feetech bus broadcast as a single servo's ID
+
+`motor_id` was bounded at 254 and gave the byte width as the reason ("the packet carries the
+ID in one byte, and 255 is the frame header"). Two of the 256 values that byte holds address
+no servo at all: `0xFF` is the frame header, and `0xFE` is the bus broadcast, which every
+servo on the bus reads. Only the header was excluded.
+
+All three of the tool's motor-addressed actions write to one servo and expect its reply, so
+`motor_id=254` was not a wider version of the request but a different one. `feetech_position`
+put a broadcast frame on the wire, driving every joint of the arm to the same angle while
+reporting `Feetech Motor 254 -> Position ...` as though one had moved; `feetech_velocity` did
+the same with a speed; and `feetech_ping` made every servo answer at once, colliding on the
+half-duplex bus, then read the collision back as one reply. Each returned `status="success"`.
+
+The vendor draws the line in the same place. `scservo_sdk` declares `BROADCAST_ID = 0xFE` and
+returns `COMM_NOT_AVAILABLE` for `scs_id >= BROADCAST_ID` in each of the three operations
+these actions perform - a ping, a single register read and a single register write - reserving
+the broadcast for `SYNC_READ` / `SYNC_WRITE`, which this tool has no action for.
+`strands_robots.drivers.feetech` states the same ceiling as `MAX_UNICAST_ID` beside its own
+`BROADCAST_ID`; the value is restated in the tool rather than imported because importing it
+executes `drivers/__init__`, which registers every driver and pulls in numpy, and a test pins
+the two together so they cannot drift.
+
+The ceiling is now 253, the largest ID that names one servo. The 253 values below it are
+unchanged, 255 is still refused for the reason it always was, and broadcasting is unchanged:
+`send` writes the bytes it is given and claims to address nothing, so a caller who wants a
+broadcast frame still has one. The tool's documented range is corrected to `[1, 253]`.
+
+`tests/tools/test_serial_tool_numeric_domain.py` parametrized 254 as an addressable ID, in a
+class named `TestARegisterFieldIsNeverSilentlyTruncated`; that case now uses 253.

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -21,6 +21,17 @@ opposite direction, and ``velocity=32768`` read as magnitude zero -- stopping a
 servo the caller had just asked to run -- both reported as success quoting the
 number supplied.
 
+``motor_id`` takes more than the byte width to bound for a different reason: two
+of the 256 values the byte holds do not address a servo at all. ``0xFF`` is the
+frame header, and ``0xFE`` is the bus broadcast -- a frame carrying it is read by
+every servo on the bus. Each action here that takes ``motor_id`` addresses one
+servo and expects its reply, so a broadcast is not a wider version of the request
+but a different one: ``feetech_position`` drove every joint of the arm to the same
+angle while reporting ``Feetech Motor 254 -> Position ...`` as though it had moved
+one, and ``feetech_ping`` made every servo answer at once, colliding on the
+half-duplex bus. Broadcasting is still reachable through ``send``, which writes
+the bytes it is given and claims to address nothing.
+
 ``baudrate`` and ``read_bytes`` are coerced rather than checked by pyserial
 (``2.7`` becomes 2 baud, and a non-positive ``read_bytes`` reads nothing and
 reports success, which is indistinguishable from a timed-out read on a healthy
@@ -58,13 +69,30 @@ _DIRECTION_BIT = 15
 # Largest magnitude either register carries with ``_DIRECTION_BIT`` still clear.
 _MAX_MAGNITUDE = (1 << _DIRECTION_BIT) - 1
 
+# Largest *unicast* ID, which is the ceiling rather than the byte's maximum: 0xFE
+# is the bus broadcast and 0xFF is the frame header, so neither names one servo.
+# The vendor SDK draws the same line -- ``scservo_sdk`` returns ``COMM_NOT_AVAILABLE``
+# for ``scs_id >= BROADCAST_ID`` on a ping, on a single read and on a single write,
+# and reserves the broadcast for SYNC_READ / SYNC_WRITE, which this module has no
+# action for. ``strands_robots.drivers.feetech`` states it as ``MAX_UNICAST_ID``;
+# the value is restated here rather than imported because importing it executes
+# ``drivers/__init__``, which registers every driver and pulls in numpy -- 1097
+# modules and 1.8 s for one integer, on a tool the package loads lazily. A test
+# pins the two values together so they cannot drift apart.
+_MAX_UNICAST_MOTOR_ID = 0xFD
+
 # Inclusive bounds and the reason for each ceiling, keyed by the parameter that
 # carries the field. The floor and the type are delegated to the shared count
 # domains so an off-type or negative value is reported in the words every other
 # surface uses; only the ceiling is decided here, because it is a property of
 # the packet field this module encodes into.
 _REGISTER_FIELDS: dict[str, tuple[int, int, str]] = {
-    "motor_id": (1, 254, "the packet carries the ID in one byte, and 255 is the frame header"),
+    "motor_id": (
+        1,
+        _MAX_UNICAST_MOTOR_ID,
+        "0xFE is the bus broadcast, so a frame carrying it is read by every servo "
+        "rather than the one this message names, and 0xFF is the frame header",
+    ),
     "position": (
         0,
         4095,
@@ -211,7 +239,8 @@ def serial_tool(
             pyserial's non-blocking mode (return what is already buffered)
         data: String data to send
         hex_data: Hex string data to send (e.g., "FF FF 01 04 03 00 64 92")
-        motor_id: Motor ID for Feetech commands; an integer in [1, 254]
+        motor_id: Motor ID for Feetech commands; an integer in [1, 253]. 254 is the
+            bus broadcast and 255 the frame header, so neither addresses one servo
         position: Target position for Feetech motors; an integer in [0, 4095]
         velocity: Target velocity for Feetech motors; an integer in [0, 65535]
         read_bytes: Number of bytes to read; a positive integer

--- a/tests/tools/test_feetech_motor_id_excludes_the_broadcast.py
+++ b/tests/tools/test_feetech_motor_id_excludes_the_broadcast.py
@@ -44,6 +44,7 @@ value, the one that means "everybody".
 
 from __future__ import annotations
 
+import inspect
 from typing import Any
 
 import pytest
@@ -269,12 +270,11 @@ class TestTheVendorSdkDrawsTheSameLine:
         assert scservo_def.BROADCAST_ID == BUS_BROADCAST_ID
 
     def test_the_sdk_refuses_the_broadcast_for_reply_expecting_operations(self) -> None:
-        pytest.importorskip("scservo_sdk")
-        import inspect
-
-        from scservo_sdk import protocol_packet_handler
-
-        source = inspect.getsource(protocol_packet_handler)
+        # Reached through importorskip rather than a static import: the SDK ships no
+        # py.typed marker, so naming it in an import statement is a mypy
+        # ``import-untyped`` error on an install that has it.
+        handler = pytest.importorskip("scservo_sdk.protocol_packet_handler")
+        source = inspect.getsource(handler)
         # ping, a single read and a single write each bail out before addressing
         # the frame when the caller named an id at or above the broadcast.
         assert source.count("if scs_id >= BROADCAST_ID:") >= 3

--- a/tests/tools/test_feetech_motor_id_excludes_the_broadcast.py
+++ b/tests/tools/test_feetech_motor_id_excludes_the_broadcast.py
@@ -1,0 +1,306 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The bus broadcast address is not accepted as a single servo's ID.
+
+:mod:`~strands_robots.tools.serial_tool` bounded ``motor_id`` at 254 and gave the
+byte width as the reason ("the packet carries the ID in one byte, and 255 is the
+frame header"). Two of the 256 values that byte holds do not address a servo at
+all: ``0xFF`` is the frame header, and ``0xFE`` is the bus broadcast, which every
+servo on the bus reads. Only the header was excluded.
+
+Each of this tool's three motor-addressed actions writes to one servo and expects
+its reply, so a broadcast is not a wider version of that request but a different
+one:
+
+===================  ==========================================================
+``motor_id=254``     what reached the bus
+===================  ==========================================================
+``feetech_position`` every servo driven to the same angle, reported as
+                     ``Feetech Motor 254 -> Position ...`` as though one moved
+``feetech_velocity`` every servo run at the same speed, reported the same way
+``feetech_ping``     every servo answering at once, colliding on the
+                     half-duplex bus, then read back as one reply
+===================  ==========================================================
+
+The vendor draws the line in the same place. ``scservo_sdk`` declares
+``BROADCAST_ID = 0xFE`` and returns ``COMM_NOT_AVAILABLE`` for ``scs_id >=
+BROADCAST_ID`` in each of the three operations these actions perform - a ping, a
+single register read and a single register write - and uses the broadcast only to
+address ``SYNC_READ`` / ``SYNC_WRITE``, which this tool has no action for.
+:class:`TestTheVendorSdkDrawsTheSameLine` pins that agreement whenever the SDK is
+installed. ``strands_robots.drivers.feetech`` states the same ceiling as
+``MAX_UNICAST_ID`` beside its own ``BROADCAST_ID``, and
+:class:`TestTheToolAndTheCodecAgree` pins the two together.
+
+Refusing the broadcast removes no capability: ``send`` writes the bytes it is
+given and claims to address nothing, so a caller who wants a broadcast frame
+still has one. :class:`TestBroadcastingIsStillReachable` grades that, so the
+refusal cannot be widened into a ban on broadcasting.
+
+The three sibling ``motor_id`` values below the broadcast are unchanged, and 255
+is still refused for the reason it always was - this narrows the ceiling by one
+value, the one that means "everybody".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import serial
+
+import strands_robots.tools.serial_tool as serial_mod
+
+#: The bus broadcast address. Stated here rather than read off the module under
+#: test so the premises and the controls grade the same wire semantics whether or
+#: not the module has been fixed.
+BUS_BROADCAST_ID = 0xFE
+
+#: The frame header byte, which was already excluded.
+FRAME_HEADER_BYTE = 0xFF
+
+#: Largest ID that names one servo.
+MAX_UNICAST_ID = 0xFD
+
+#: IDs that address a single servo and must keep working.
+UNICAST_IDS = (1, 2, 100, 252, MAX_UNICAST_ID)
+
+#: The extra options each motor-addressed action needs to reach the port at all,
+#: so a refusal in these tests is always the ``motor_id`` domain and never a
+#: missing-argument branch.
+_EXTRA_ARGS: dict[str, dict[str, Any]] = {
+    "feetech_position": {"position": 100},
+    "feetech_velocity": {"velocity": 100},
+    "feetech_ping": {},
+}
+
+
+def _actions_taking_motor_id() -> tuple[str, ...]:
+    """Every action the tool declares as consuming ``motor_id``.
+
+    Derived from the tool's own option map rather than listed, so an action added
+    later is held to this contract instead of inheriting an exemption by being
+    absent from a tuple here.
+    """
+    return tuple(sorted(action for action, options in serial_mod._OPTIONS_BY_ACTION.items() if "motor_id" in options))
+
+
+MOTOR_ADDRESSED_ACTIONS = _actions_taking_motor_id()
+
+#: The actions that took ``motor_id`` when this contract was written. Stated so a
+#: later edit that drops one is a failure rather than a quiet deselection.
+KNOWN_MOTOR_ADDRESSED_ACTIONS = {"feetech_ping", "feetech_position", "feetech_velocity"}
+
+
+class _FakeSerial:
+    """Stand-in for ``serial.Serial`` recording the bytes that reach the wire."""
+
+    def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.in_waiting = 0
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    def read(self, n: int = 1) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def opened(monkeypatch: pytest.MonkeyPatch) -> list[_FakeSerial]:
+    """Record every port this tool opens; empty means the bus was never touched."""
+    created: list[_FakeSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _FakeSerial:
+        instance = _FakeSerial(port, baudrate, timeout)
+        created.append(instance)
+        return instance
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return created
+
+
+def _call(action: str, motor_id: Any) -> dict[str, Any]:
+    """Invoke a motor-addressed action with everything else already valid."""
+    return serial_mod.serial_tool(action=action, port="/dev/fake0", motor_id=motor_id, **_EXTRA_ARGS[action])
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+def _written(opened: list[_FakeSerial]) -> list[bytes]:
+    return [frame for port in opened for frame in port.writes]
+
+
+class TestTheBroadcastIsNotAUnicastTarget:
+    """The one value that means "every servo" is refused by every action."""
+
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_the_broadcast_is_refused(self, action: str, opened: list[_FakeSerial]) -> None:
+        result = _call(action, BUS_BROADCAST_ID)
+        assert result["status"] == "error"
+        assert "motor_id" in _text(result)
+
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_no_frame_reaches_the_bus(self, action: str, opened: list[_FakeSerial]) -> None:
+        _call(action, BUS_BROADCAST_ID)
+        assert _written(opened) == []
+
+    def test_the_documented_range_names_the_unicast_ceiling(self) -> None:
+        """The range a caller reads must be the range the tool enforces."""
+        doc = " ".join((serial_mod.serial_tool.__doc__ or "").split())
+        assert f"an integer in [1, {MAX_UNICAST_ID}]" in doc
+
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_the_port_is_never_opened(self, action: str, opened: list[_FakeSerial]) -> None:
+        """The module's first promise is that options are checked before the open."""
+        _call(action, BUS_BROADCAST_ID)
+        assert opened == []
+
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_the_refusal_names_the_broadcast(self, action: str, opened: list[_FakeSerial]) -> None:
+        assert "broadcast" in _text(_call(action, BUS_BROADCAST_ID))
+
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_the_refusal_names_the_ceiling_that_replaces_it(self, action: str, opened: list[_FakeSerial]) -> None:
+        assert f"at most {MAX_UNICAST_ID}" in _text(_call(action, BUS_BROADCAST_ID))
+
+
+class TestEveryUnicastIdIsStillAccepted:
+    """Narrowing the ceiling by one value must not cost the 253 below it."""
+
+    @pytest.mark.parametrize("motor_id", UNICAST_IDS)
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_a_single_servo_is_addressed(self, action: str, motor_id: int, opened: list[_FakeSerial]) -> None:
+        assert "motor_id" not in _text(_call(action, motor_id))
+
+    @pytest.mark.parametrize("motor_id", UNICAST_IDS)
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_the_frame_carries_that_exact_id(self, action: str, motor_id: int, opened: list[_FakeSerial]) -> None:
+        _call(action, motor_id)
+        frames = _written(opened)
+        assert frames, "an accepted id must reach the bus"
+        assert frames[0][2] == motor_id
+
+
+class TestTheFrameHeaderIsStillRefused:
+    """The value the old ceiling did exclude is excluded for the same reason."""
+
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_the_header_byte_is_refused(self, action: str, opened: list[_FakeSerial]) -> None:
+        result = _call(action, FRAME_HEADER_BYTE)
+        assert result["status"] == "error"
+        assert "motor_id" in _text(result)
+
+    @pytest.mark.parametrize("action", MOTOR_ADDRESSED_ACTIONS)
+    def test_the_refusal_still_names_the_frame_header(self, action: str, opened: list[_FakeSerial]) -> None:
+        assert "frame header" in _text(_call(action, FRAME_HEADER_BYTE))
+
+
+class TestBroadcastingIsStillReachable:
+    """``send`` writes what it is given, so no capability is removed.
+
+    This holds before and after the change. It is what stops the refusal above
+    being widened into a ban on addressing the bus at all.
+    """
+
+    def test_a_hand_built_broadcast_frame_reaches_the_bus(self, opened: list[_FakeSerial]) -> None:
+        frame = "FF FF FE 05 03 2A 64 00 6B"
+        serial_mod.serial_tool(action="send", port="/dev/fake0", hex_data=frame)
+        assert _written(opened) == [bytes.fromhex(frame.replace(" ", ""))]
+
+    def test_send_does_not_read_motor_id_at_all(self) -> None:
+        assert "motor_id" not in serial_mod._OPTIONS_BY_ACTION["send"]
+
+
+class TestTheToolAndTheCodecAgree:
+    """The tool and the package's Feetech codec state one ceiling, not two.
+
+    The value is restated in the tool rather than imported: importing
+    ``strands_robots.drivers.feetech`` executes ``drivers/__init__``, which
+    registers every driver and pulls in numpy. This grades the agreement instead,
+    which a test can afford and the lazily-loaded tool cannot.
+    """
+
+    def test_the_ceiling_is_the_codecs_max_unicast_id(self) -> None:
+        from strands_robots.drivers.feetech import MAX_UNICAST_ID as codec_ceiling
+
+        _, ceiling, _ = serial_mod._REGISTER_FIELDS["motor_id"]
+        assert ceiling == codec_ceiling
+
+    def test_the_excluded_value_is_the_codecs_broadcast_id(self) -> None:
+        from strands_robots.drivers.feetech import BROADCAST_ID as codec_broadcast
+
+        _, ceiling, _ = serial_mod._REGISTER_FIELDS["motor_id"]
+        assert ceiling + 1 == codec_broadcast
+
+
+class TestThisSuiteStatesTheWireSemanticsIndependently:
+    """The constants above are the vendor's, so the controls grade real semantics.
+
+    These hold before and after the change. They are what make the rest of this
+    file an independent oracle rather than a restatement of the module under test.
+    """
+
+    def test_the_two_addresses_match_the_packages_codec(self) -> None:
+        from strands_robots.drivers.feetech import BROADCAST_ID
+        from strands_robots.drivers.feetech import MAX_UNICAST_ID as codec_ceiling
+
+        assert (MAX_UNICAST_ID, BUS_BROADCAST_ID) == (codec_ceiling, BROADCAST_ID)
+
+    def test_the_broadcast_sits_one_above_the_unicast_ceiling(self) -> None:
+        assert BUS_BROADCAST_ID == MAX_UNICAST_ID + 1
+        assert FRAME_HEADER_BYTE == BUS_BROADCAST_ID + 1
+
+
+class TestTheVendorSdkDrawsTheSameLine:
+    """The refused value is the vendor's broadcast, not this suite's opinion."""
+
+    def test_the_sdk_declares_the_same_broadcast_address(self) -> None:
+        scservo_def = pytest.importorskip("scservo_sdk.scservo_def")
+        assert scservo_def.BROADCAST_ID == BUS_BROADCAST_ID
+
+    def test_the_sdk_refuses_the_broadcast_for_reply_expecting_operations(self) -> None:
+        pytest.importorskip("scservo_sdk")
+        import inspect
+
+        from scservo_sdk import protocol_packet_handler
+
+        source = inspect.getsource(protocol_packet_handler)
+        # ping, a single read and a single write each bail out before addressing
+        # the frame when the caller named an id at or above the broadcast.
+        assert source.count("if scs_id >= BROADCAST_ID:") >= 3
+        assert "COMM_NOT_AVAILABLE" in source
+
+
+class TestTheContractCoversEveryMotorAddressedAction:
+    """The swept set is derived, and it is not empty."""
+
+    def test_every_action_taking_motor_id_is_swept(self) -> None:
+        assert set(MOTOR_ADDRESSED_ACTIONS) == set(_actions_taking_motor_id())
+
+    def test_every_known_motor_addressed_action_is_still_swept(self) -> None:
+        """Named here, so an action dropping ``motor_id`` fails instead of vanishing.
+
+        The derived sweep above cannot see that: it reads the same option map the
+        cells do, so removing an entry silently deselects its cases and the sweep
+        still agrees with itself.
+        """
+        assert KNOWN_MOTOR_ADDRESSED_ACTIONS <= set(MOTOR_ADDRESSED_ACTIONS)
+
+    def test_the_swept_set_is_not_empty(self) -> None:
+        assert MOTOR_ADDRESSED_ACTIONS
+
+    def test_every_swept_action_can_reach_the_port(self) -> None:
+        assert set(MOTOR_ADDRESSED_ACTIONS) <= set(_EXTRA_ARGS), (
+            "a new motor-addressed action needs its required options listed in "
+            "_EXTRA_ARGS, or its refusal here would be a missing-argument branch"
+        )

--- a/tests/tools/test_serial_tool_numeric_domain.py
+++ b/tests/tools/test_serial_tool_numeric_domain.py
@@ -178,7 +178,9 @@ class TestARegisterFieldIsNeverSilentlyTruncated:
         assert "motor_id" in _text(result)
         assert opened == []
 
-    @pytest.mark.parametrize("motor_id", (1, 2, 6, 254))
+    # 254 is the bus broadcast, not an address - it moved to
+    # test_feetech_motor_id_excludes_the_broadcast.py, which owns that case.
+    @pytest.mark.parametrize("motor_id", (1, 2, 6, 253))
     def test_an_addressable_motor_id_still_reaches_the_wire(self, motor_id: int, opened: list[_FakeSerial]) -> None:
         result = _call(action="feetech_position", motor_id=motor_id, position=100)
 


### PR DESCRIPTION
## What is wrong

`serial_tool` bounds `motor_id` at 254 and gives the byte width as the reason:

```
"motor_id": (1, 254, "the packet carries the ID in one byte, and 255 is the frame header"),
```

Two of the 256 values that byte holds address no servo at all. `0xFF` is the frame header, and `0xFE` is the bus broadcast, which every servo on the bus reads. Only the header was excluded, so the broadcast was accepted as if it named one motor.

All three actions that take `motor_id` write to a single servo and expect its reply, so 254 was not a wider version of the request but a different one.

## Measured

Driven through the tool with a recording stand-in for `serial.Serial`, so the bytes that reach the wire are observable:

| `motor_id` | before | after |
|---|---|---|
| 1, 2, 100, 252 | frame written, ID byte carries the value | unchanged |
| **253** | frame written | unchanged |
| **254** | **frame written with ID byte `0xFE`; `status="success"`** | refused, port never opened |
| 255 | refused (frame header) | unchanged |

Before, each of the three actions reported success for 254:

```
feetech_position  -> success  "Feetech Motor 254 -> Position 100 (8.8 deg)"
feetech_velocity  -> success  "Feetech Motor 254 -> Velocity 100"
feetech_ping      -> writes FF FF FE 02 01 ... then reads a reply
```

`feetech_position` therefore drove every joint of the arm to the same angle while the message named one motor; `feetech_ping` made every servo answer at once, colliding on the half-duplex bus, and read the collision back as one reply.

After:

```
feetech_position: motor_id must be at most 253 (0xFE is the bus broadcast, so a frame
carrying it is read by every servo rather than the one this message names, and 0xFF is
the frame header), got 254.
```

## The vendor draws the same line

`scservo_sdk` declares `BROADCAST_ID = 0xFE` and refuses it for exactly the three operations these actions perform:

| SDK site | operation | on `scs_id >= BROADCAST_ID` |
|---|---|---|
| `protocol_packet_handler.py:214` | ping | `return model_number, COMM_NOT_AVAILABLE, error` |
| `protocol_packet_handler.py:245` | single register write | `return COMM_NOT_AVAILABLE` |
| `protocol_packet_handler.py:286` | single register read | `return data, COMM_NOT_AVAILABLE, 0` |
| `:187` | any broadcast tx | returns without waiting for a reply |
| `:435`, `:454` | `SYNC_READ` / `SYNC_WRITE` | the only places it *uses* the broadcast |

The two sync instructions are the legitimate use of a broadcast, and this tool has no action for either: its actions are `list_ports`, `send`, `read`, `send_read`, `monitor`, `feetech_position`, `feetech_velocity`, `feetech_ping`.

`strands_robots.drivers.feetech` already states the same ceiling as `MAX_UNICAST_ID = 0xFD` beside its own `BROADCAST_ID = 0xFE`, and its `_validate_id(motor_id, allow_broadcast)` refuses the broadcast unless an instruction opts in. So the package answered this question in one module and not in the other.

## Restated rather than imported, and why

Importing that constant would single-source it, but `from strands_robots.drivers.feetech import MAX_UNICAST_ID` executes `drivers/__init__`, which registers every driver: measured at **1097 new modules and 1.8 s, including numpy**, for one integer, on a tool the package loads lazily. `drivers/g1.py` also imports `strands_robots.tools.g1`, so the direction is already occupied.

The value is restated with the reason in a comment, and `TestTheToolAndTheCodecAgree` asserts the tool's ceiling equals `MAX_UNICAST_ID` and that the excluded value equals `BROADCAST_ID`. A test can afford the import; the tool cannot.

## No capability is removed

`send` writes the bytes it is given and claims to address nothing, so a caller who wants a broadcast frame still has one. `TestBroadcastingIsStillReachable` grades that a hand-built `FF FF FE ...` frame reaches the wire, and that `send` does not read `motor_id` at all. It holds before and after, so the refusal cannot later be widened into a ban on addressing the bus.

## Why nothing caught it

`tests/tools/test_serial_tool_numeric_domain.py` pinned the defect. Inside a class named `TestARegisterFieldIsNeverSilentlyTruncated`:

```python
@pytest.mark.parametrize("motor_id", (1, 2, 6, 254))
def test_an_addressable_motor_id_still_reaches_the_wire(...)
```

254 is not an address. That case now uses 253, the largest ID that names one servo; the broadcast case moved to the new file, which names it for what it is. This is the same shape as the `Goal_Velocity` ceiling in #2747, where the suite likewise parametrized the out-of-domain value as valid.

## Tests

Pre-fix split, source reverted and tests kept: **18 failed / 46 passed**.

| class | failed / cells | role |
|---|---|---|
| `TestTheBroadcastIsNotAUnicastTarget` | 16 / 16 | regression |
| `TestTheToolAndTheCodecAgree` | 2 / 2 | drift guard |
| `TestEveryUnicastIdIsStillAccepted` | 0 / 30 | control |
| `TestTheFrameHeaderIsStillRefused` | 0 / 6 | control |
| `TestBroadcastingIsStillReachable` | 0 / 2 | over-reach control |
| `TestThisSuiteStatesTheWireSemanticsIndependently` | 0 / 2 | premise |
| `TestTheVendorSdkDrawsTheSameLine` | 0 / 2 | premise |
| `TestTheContractCoversEveryMotorAddressedAction` | 0 / 4 | derived non-vacuity |

Mutation table. `mine` is the new file, `coll` its collected count, `sib` the four pre-existing `serial_tool` suites (245 cells):

| row | mine | coll | sib | mutation |
|---|---|---|---|---|
| b0 | 0 | 64 | 0 | control, no mutation |
| b1 | 17 | 64 | 0 | ceiling reverted to the broadcast (the defect) |
| b2 | 11 | 64 | 1 | over-reach: ceiling narrowed one further, to 252 |
| b3 | 3 | 64 | 0 | reason no longer names the broadcast |
| b4 | 3 | 64 | 0 | reason no longer names the frame header |
| b5 | 0 | 64 | 0 | ceiling written as a bare literal, not the named constant |
| b6 | 3 | 64 | 54 | options checked after the port is opened |
| b7 | 1 | **47** | 8 | one action stops declaring `motor_id` |
| b8 | 1 | 64 | 0 | documented range reverted to `[1, 254]` |

Seven firing rows, seven distinct firing-ID sets, control clean, source restored byte-identical.

Two rows are worth reading together. **b2** is the over-reach check: narrowing one value too far costs the 253 controls here *and* trips the pre-existing suite's `[253]` case, so the boundary is graded from both sides. **b7** fires only one cell but drops `collected` from 64 to 47 - removing an action from the option map silently deselects 17 cases, which is why the swept set is pinned against locally-named actions as well as derived from the module.

**b5 fires nothing, correctly**: a bare `0xFD` literal is the same value, and the tests grade the ceiling's value rather than its spelling. The named constant is there to carry the reason, not to change behaviour.

## Gate

- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean, 1632 files.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the merge base, normalized message sets identical in both directions, nothing attributable to the changed files.
- Paired run over an identical 546-file selection (all of `tests/tools/`, plus every suite that walks the tree, parses source, or reads docstrings, `Args:`/`Raises:` or `changelog.d/`), the new file excluded from both trees: identical **25469 collected** and `20 failed, 25341 passed, 108 skipped` on each, with the failing-ID sets identical in both directions. Of the 20, 17 need `awsiot`/`awscrt` (`find_spec` is `None` here; declared in the `[mesh-iot]` extra, which CI installs) and 3 are the known lerobot-from-source `encode()` drift.
- The changed files plus the two guards that landed on `main` during this work: 310 passed.

No visual artifact: this changes a refusal and a documented range, not a policy, a simulation, a render, a recording or an asset. The measured before/after table above is the evidence.
