### PR TITLE
fix(rendering): check a background's alignment numbers instead of coercing them

### DIFF
--- a/changelog.d/2824-background-numbers-are-checked-not-coerced.md
+++ b/changelog.d/2824-background-numbers-are-checked-not-coerced.md
@@ -1,0 +1,29 @@
+### Fixed: a background's alignment numbers are checked instead of coerced
+
+`PanoramaBackground` and `GsplatBackground` handed every scalar number a caller
+supplies to a bare `float()`, which accepts `nan` and `inf`. A non-finite
+`rotation_deg` built the rotation matrix every output ray is turned by, so each
+world direction became `nan`, the equirectangular lookup sampled nothing, and
+`render()` returned a uniformly black backdrop -- `rgb.mean() == 0.0` with a
+single distinct value -- while reporting no error at all. That last part is what
+made it costly: in app contexts the photoreal background sits inside a catch-all
+that demotes it to a procedural fallback, and a silent black frame never raises,
+so the fallback could not fire.
+
+The gsplat numbers feed the fitted `world_from_gs`. A non-finite `up_sign`,
+`yaw_deg`, `radius`, `floor_z` or `backdrop_radius` produced a 4x4 with
+non-finite cells, so every gaussian was placed nowhere; `min_opacity` was worse
+than nowhere, because `nan > 0` is `False` and that skips the opacity filter the
+value asks to apply.
+
+The posture flags beside these were already closed on `boolean_flag_error`, a
+domain documented as being for a flag that selects a posture rather than scaling
+a quantity. The quantities were the other half, and they now take
+`finite_number_error`, the shared signed domain for a physical quantity a caller
+supplies verbatim -- the same rule `_shadow_plane_z_error` states one module
+over for a plane height. `up_sign` and `clip_below` carry a documented `None`
+sentinel, so the domain applies to the number and the sentinel passes through.
+
+Bounds are deliberately not imposed: whether `min_opacity` belongs in `[0, 1]`
+and `floor_pct` in `[0, 100]` is a separate question, and `numpy.percentile`
+already refuses a non-finite `floor_pct` on its own.

--- a/strands_robots/rendering/backgrounds.py
+++ b/strands_robots/rendering/backgrounds.py
@@ -37,7 +37,7 @@ from typing import Any, Protocol
 
 import numpy as np
 
-from strands_robots.utils import boolean_flag_error, require_optional
+from strands_robots.utils import boolean_flag_error, finite_number_error, require_optional
 
 from .camera import CameraParams
 
@@ -95,6 +95,13 @@ class PanoramaBackground:
         rotation_deg: yaw rotation of the panorama in degrees (rotates around
             the world +Z axis). Useful for aligning the panorama with the
             scene without re-rendering it.
+
+    Raises:
+        ValueError: if ``rotation_deg`` is not a finite number. The yaw builds
+            the rotation matrix every output ray is turned by, so a non-finite
+            angle turns every ray into ``nan`` and the panorama samples nothing
+            -- the backdrop renders black rather than rotated, and nothing
+            raises to trigger a caller's fallback.
     """
 
     name = "panorama"
@@ -105,6 +112,17 @@ class PanoramaBackground:
         rotation_deg: float = 0.0,
     ) -> None:
         self._image_path = Path(image_path) if image_path else None
+        # Checked before the coercion, on the shared signed-finite domain, for
+        # the reason :func:`~strands_robots.rendering.compositor._shadow_plane_z_error`
+        # gives for a plane height: only a finite number can be honored. The
+        # yaw builds the ``Rz`` every world ray is turned by, so ``nan``/``inf``
+        # turned every direction into ``nan``, the equirect lookup sampled
+        # nothing, and the backdrop came back uniformly black -- with no
+        # exception, so a caller's photoreal-to-procedural fallback never fired.
+        # A signed domain because both senses of yaw are legitimate and a
+        # rotation wraps, so there is no floor or ceiling to impose.
+        if text := finite_number_error(rotation_deg, "rotation_deg", "PanoramaBackground"):
+            raise ValueError(text)
         self._rotation_rad = float(np.deg2rad(rotation_deg))
         self._panorama: np.ndarray | None = None
 
@@ -416,6 +434,33 @@ class GsplatBackground:
             ("own_floor", own_floor),
         ):
             if text := boolean_flag_error(_value, _param, "GsplatBackground"):
+                raise ValueError(text)
+        # The alignment *numbers*, on the shared signed-finite domain, beside
+        # the posture flags above. The flags decide which branch the fit takes;
+        # these are the quantities that branch scales and offsets by, and each
+        # was coerced with a bare ``float()`` that accepts ``nan``/``inf``. A
+        # non-finite value here poisons the whole ``world_from_gs``: the fitted
+        # 4x4 comes back with non-finite cells, so every gaussian is placed
+        # nowhere and the photoreal scene silently does not appear. ``bool`` is
+        # rejected for the reason the flags' own domain gives in reverse -- a
+        # truth value is not a length, an angle or a fraction. Signed because a
+        # yaw, a floor height and an up-sign are all legitimately negative; the
+        # domain constrains finiteness only, so no bound is imposed here.
+        for _param, _value in (
+            ("backdrop_radius", backdrop_radius),
+            ("yaw_deg", yaw_deg),
+            ("radius", radius),
+            ("floor_z", floor_z),
+            ("min_opacity", min_opacity),
+            ("floor_pct", floor_pct),
+        ):
+            if text := finite_number_error(_value, _param, "GsplatBackground"):
+                raise ValueError(text)
+        # ``up_sign`` (``None`` = auto-detect from PCA) and ``clip_below``
+        # (``None`` = drop nothing) carry a sentinel, so the domain applies to
+        # the supplied number and the sentinel passes through untouched.
+        for _param, _value in (("up_sign", up_sign), ("clip_below", clip_below)):
+            if _value is not None and (text := finite_number_error(_value, _param, "GsplatBackground")):
                 raise ValueError(text)
         self._device = device
         self._explicit_transform = transform is not None

--- a/strands_robots/rendering/backgrounds.py
+++ b/strands_robots/rendering/backgrounds.py
@@ -446,7 +446,7 @@ class GsplatBackground:
         # truth value is not a length, an angle or a fraction. Signed because a
         # yaw, a floor height and an up-sign are all legitimately negative; the
         # domain constrains finiteness only, so no bound is imposed here.
-        for _param, _value in (
+        for _number_param, _number in (
             ("backdrop_radius", backdrop_radius),
             ("yaw_deg", yaw_deg),
             ("radius", radius),
@@ -454,13 +454,13 @@ class GsplatBackground:
             ("min_opacity", min_opacity),
             ("floor_pct", floor_pct),
         ):
-            if text := finite_number_error(_value, _param, "GsplatBackground"):
+            if text := finite_number_error(_number, _number_param, "GsplatBackground"):
                 raise ValueError(text)
         # ``up_sign`` (``None`` = auto-detect from PCA) and ``clip_below``
         # (``None`` = drop nothing) carry a sentinel, so the domain applies to
         # the supplied number and the sentinel passes through untouched.
-        for _param, _value in (("up_sign", up_sign), ("clip_below", clip_below)):
-            if _value is not None and (text := finite_number_error(_value, _param, "GsplatBackground")):
+        for _opt_param, _opt in (("up_sign", up_sign), ("clip_below", clip_below)):
+            if _opt is not None and (text := finite_number_error(_opt, _opt_param, "GsplatBackground")):
                 raise ValueError(text)
         self._device = device
         self._explicit_transform = transform is not None

--- a/tests/rendering/test_background_numeric_option_domain.py
+++ b/tests/rendering/test_background_numeric_option_domain.py
@@ -94,7 +94,7 @@ def _scalar_numeric_params(cls: type) -> list[tuple[str, str]]:
     Derived from the annotation rather than a hardcoded list, so a background
     that grows a tenth number is held to the same rule the hour it lands.
     """
-    tree = ast.parse(textwrap.dedent(inspect.getsource(cls.__init__)))
+    tree = ast.parse(textwrap.dedent(inspect.getsource(getattr(cls, "__init__"))))
     fn = tree.body[0]
     assert isinstance(fn, ast.FunctionDef)
     found: list[tuple[str, str]] = []
@@ -118,7 +118,7 @@ def _guarded_params(cls: type) -> set[str]:
     checked. The context argument is not a parameter name, so it is read from
     its own position and never swept in as one.
     """
-    tree = ast.parse(textwrap.dedent(inspect.getsource(cls.__init__)))
+    tree = ast.parse(textwrap.dedent(inspect.getsource(getattr(cls, "__init__"))))
     fn = tree.body[0]
     assert isinstance(fn, ast.FunctionDef)
     guarded: set[str] = set()
@@ -301,5 +301,6 @@ class TestThePremisesTheseTestsRestOn:
         rng = np.random.default_rng(7)
         means = rng.normal(size=(400, 3)) * np.array([2.0, 2.0, 0.7])
         assert np.isfinite(_fit_skybox_transform(means)).all()
-        poisoned = _fit_skybox_transform(means, **{param: float("nan")})
+        override: dict[str, Any] = {param: float("nan")}
+        poisoned = _fit_skybox_transform(means, **override)
         assert not np.isfinite(poisoned).all()

--- a/tests/rendering/test_background_numeric_option_domain.py
+++ b/tests/rendering/test_background_numeric_option_domain.py
@@ -1,0 +1,305 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A background's alignment *numbers* are checked, not coerced with a bare ``float()``.
+
+``strands_robots.rendering`` closed its posture flags on
+:func:`~strands_robots.utils.boolean_flag_error`, and that domain is documented
+as the one "for a flag that selects a posture rather than scaling a quantity".
+The quantities were the other half. Every scalar number
+:class:`~strands_robots.rendering.PanoramaBackground` and
+:class:`~strands_robots.rendering.GsplatBackground` take was handed to a bare
+``float()``, which accepts ``nan`` and ``inf``, so a non-finite angle, radius,
+height or fraction was stored and read as if it were a measurement.
+
+Two consequences follow, and both are pinned here.
+
+``PanoramaBackground.rotation_deg`` builds the ``Rz`` every world ray is turned
+by. A non-finite yaw turned each direction into ``nan``, the equirectangular
+lookup sampled nothing, and ``render`` returned a **uniformly black** backdrop
+-- ``rgb.mean() == 0.0`` with a single distinct value -- while reporting no
+error at all. That is the failure mode :class:`GsplatBackground`'s own path
+comment warns about from the other side: in app contexts the photoreal
+background sits inside a catch-all that demotes it to a procedural fallback, and
+a silent black frame never raises, so the fallback cannot fire.
+
+``GsplatBackground``'s numbers feed the fitted ``world_from_gs``. A non-finite
+``up_sign``, ``yaw_deg``, ``radius``, ``floor_z`` or ``backdrop_radius``
+produced a 4x4 with non-finite cells, so every gaussian was placed nowhere;
+``min_opacity`` was worse than nowhere because ``nan > 0`` is ``False``, which
+skips the opacity filter the value asks to apply.
+
+The domain is :func:`~strands_robots.utils.finite_number_error`, the shared one
+for a signed physical quantity a caller supplies verbatim, and it is the
+authority these tests parametrize over, so a spelling added there is covered
+here without an edit. It is the same rule
+:func:`~strands_robots.rendering.compositor._shadow_plane_z_error` states for a
+plane height -- "only a finite number can be honored: a non-finite plane
+intersects no ray and the shadow pass would silently never fire".
+
+Deliberately not in scope: **bounds**. Whether ``min_opacity`` belongs in
+``[0, 1]`` and ``floor_pct`` in ``[0, 100]`` is a policy question this change
+does not answer, and ``numpy.percentile`` already refuses a non-finite
+``floor_pct`` loudly on its own. Vector options (``center``, ``backdrop_center``,
+``up_axis``, ``major_axis``) are tuples and want an element-wise domain rather
+than this scalar one.
+
+Dependency-free: both constructors defer every ``gsplat``/``torch`` import to
+the first render, the panorama is pure NumPy, and the transform consequence is
+measured through the pure-NumPy skybox fit -- nothing here needs the ``sim-gs``
+extra.
+"""
+
+import ast
+import inspect
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import GsplatBackground, PanoramaBackground
+from strands_robots.rendering import backgrounds as backgrounds_module
+from strands_robots.rendering.backgrounds import _fit_skybox_transform
+from strands_robots.rendering.compositor import CameraParams
+from strands_robots.utils import finite_number_error
+
+#: The shared domain's name, as the module under test must spell it.
+SHARED_DOMAIN = "finite_number_error"
+
+#: Annotations that mark a constructor parameter as a caller-supplied scalar
+#: number. A ``| None`` spelling carries a sentinel the domain must let past.
+SCALAR_ANNOTATIONS: frozenset[str] = frozenset({"float", "float | None"})
+
+#: Values that are not a finite number. Each was accepted before this change.
+NON_FINITE_SPELLINGS: list[Any] = [
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    True,
+    False,
+    "90",
+    None,
+    [90.0],
+    10**400,
+]
+
+#: Numbers a caller legitimately supplies, including both signs and a NumPy
+#: scalar read out of a config or a policy action.
+USABLE_NUMBERS: list[Any] = [0.0, 1.0, -1.0, 90.0, -90.0, 720.0, 2, np.float32(45.0)]
+
+
+def _scalar_numeric_params(cls: type) -> list[tuple[str, str]]:
+    """The ``(name, annotation)`` of every scalar-number ctor parameter of ``cls``.
+
+    Derived from the annotation rather than a hardcoded list, so a background
+    that grows a tenth number is held to the same rule the hour it lands.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(cls.__init__)))
+    fn = tree.body[0]
+    assert isinstance(fn, ast.FunctionDef)
+    found: list[tuple[str, str]] = []
+    for arg in list(fn.args.args)[1:] + list(fn.args.kwonlyargs):
+        if arg.annotation is None:
+            continue
+        annotation = ast.unparse(arg.annotation)
+        if annotation in SCALAR_ANNOTATIONS:
+            found.append((arg.arg, annotation))
+    return found
+
+
+def _guarded_params(cls: type) -> set[str]:
+    """Every parameter name handed to the shared domain inside ``cls.__init__``.
+
+    Reads the guard's own argument rather than the stored attribute: two classes
+    holding equal numbers is exactly what the unguarded state looked like, so
+    the call is the property. Both spellings the module uses are understood -- a
+    name passed directly, and a name supplied by a ``for`` over a tuple of
+    ``(name, value)`` pairs, which is how the posture flags beside these are
+    checked. The context argument is not a parameter name, so it is read from
+    its own position and never swept in as one.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(cls.__init__)))
+    fn = tree.body[0]
+    assert isinstance(fn, ast.FunctionDef)
+    guarded: set[str] = set()
+    for statement in fn.body:
+        calls = [
+            node
+            for node in ast.walk(statement)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == SHARED_DOMAIN
+        ]
+        if not calls:
+            continue
+        if isinstance(statement, ast.For) and isinstance(statement.iter, ast.Tuple):
+            for pair in statement.iter.elts:
+                if isinstance(pair, ast.Tuple) and pair.elts:
+                    name = pair.elts[0]
+                    if isinstance(name, ast.Constant) and isinstance(name.value, str):
+                        guarded.add(name.value)
+            continue
+        for call in calls:
+            if len(call.args) < 2:
+                continue
+            name = call.args[1]
+            if isinstance(name, ast.Constant) and isinstance(name.value, str):
+                guarded.add(name.value)
+    return guarded
+
+
+def _sentinel_params(cls: type) -> set[str]:
+    """Scalar parameters whose annotation admits ``None``."""
+    return {name for name, ann in _scalar_numeric_params(cls) if ann == "float | None"}
+
+
+#: The backgrounds that take caller-supplied numbers, discovered by annotation.
+NUMERIC_BACKGROUNDS: list[type] = [PanoramaBackground, GsplatBackground]
+
+
+@pytest.fixture
+def scene_ply(tmp_path):
+    """An existing placeholder scene file: construction validates the path but
+    defers the decode to the first render, so no ``sim-gs`` extra is needed."""
+    path = tmp_path / "scene.ply"
+    path.write_text("ply\nformat ascii 1.0\nelement vertex 0\nend_header\n")
+    return path
+
+
+def _build(cls: type, scene_ply, **overrides: Any) -> Any:
+    """Construct ``cls`` with its required arguments plus ``overrides``."""
+    if cls is GsplatBackground:
+        return cls(scene_ply, **overrides)
+    return cls(**overrides)
+
+
+def _camera() -> CameraParams:
+    """A small pinhole camera, big enough for the equirect lookup to vary."""
+    intrinsics = np.array([[200.0, 0.0, 80.0], [0.0, 200.0, 60.0], [0.0, 0.0, 1.0]])
+    pose = np.eye(4)
+    pose[:3, 3] = [0.4, -0.5, 0.3]
+    return CameraParams(width=160, height=120, K=intrinsics, T_world_cam=pose, znear=0.01, zfar=50.0)
+
+
+class TestEveryScalarNumberIsCheckedOnTheSharedDomain:
+    """The derived inventory: no background keeps a number outside the domain."""
+
+    @pytest.mark.parametrize("cls", NUMERIC_BACKGROUNDS, ids=lambda c: c.__name__)
+    def test_every_scalar_numeric_parameter_reaches_the_shared_domain(self, cls: type) -> None:
+        declared = {name for name, _ in _scalar_numeric_params(cls)}
+        assert declared, f"{cls.__name__} declares no scalar number, so this rule grades nothing"
+        assert declared - _guarded_params(cls) == set(), (
+            f"{cls.__name__} takes a caller-supplied number that never reaches {SHARED_DOMAIN}"
+        )
+
+    @pytest.mark.parametrize("cls", NUMERIC_BACKGROUNDS, ids=lambda c: c.__name__)
+    def test_the_domain_is_not_invoked_for_a_parameter_that_is_not_one(self, cls: type) -> None:
+        declared = {name for name, _ in _scalar_numeric_params(cls)}
+        assert _guarded_params(cls) - declared == set(), (
+            f"{cls.__name__} guards a name that is not one of its scalar numbers"
+        )
+
+    def test_the_module_reads_the_shared_domain_rather_than_restating_it(self) -> None:
+        # A local re-implementation holding today's identical rule is exactly
+        # what the unguarded state looked like, so the import is the property.
+        imported: set[str] = set()
+        for node in ast.walk(ast.parse(inspect.getsource(backgrounds_module))):
+            if isinstance(node, ast.ImportFrom) and node.module == "strands_robots.utils":
+                imported |= {alias.name for alias in node.names}
+        assert SHARED_DOMAIN in imported
+
+
+class TestANonFiniteYawRenderedAnEntirelyBlackBackdrop:
+    """The panorama consequence, measured through the shipped render."""
+
+    @pytest.mark.parametrize("value", NON_FINITE_SPELLINGS, ids=repr)
+    def test_construction_refuses_the_value_naming_the_parameter(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="PanoramaBackground: rotation_deg must be"):
+            PanoramaBackground(rotation_deg=value)
+
+    def test_the_refusal_precedes_the_coercion_that_swallowed_the_value(self) -> None:
+        # ``float(np.deg2rad(nan))`` is a perfectly good float, so a guard placed
+        # after the coercion would inspect a value the defect has already made
+        # indistinguishable from a measurement.
+        source = inspect.getsource(PanoramaBackground.__init__)
+        assert SHARED_DOMAIN in source, f"the constructor never reaches {SHARED_DOMAIN}"
+        assert source.index(SHARED_DOMAIN) < source.index("np.deg2rad")
+
+
+class TestANonFiniteAlignmentNumberPoisonedTheFittedTransform:
+    """The gsplat consequence, measured through the pure-NumPy skybox fit."""
+
+    @pytest.mark.parametrize("param", ["backdrop_radius", "yaw_deg", "radius", "floor_z", "min_opacity", "floor_pct"])
+    @pytest.mark.parametrize("value", NON_FINITE_SPELLINGS, ids=repr)
+    def test_construction_refuses_the_value_naming_the_parameter(self, scene_ply, param: str, value: Any) -> None:
+        with pytest.raises(ValueError, match=f"GsplatBackground: {param} must be"):
+            _build(GsplatBackground, scene_ply, **{param: value})
+
+    @pytest.mark.parametrize("param", ["up_sign", "clip_below"])
+    @pytest.mark.parametrize("value", [v for v in NON_FINITE_SPELLINGS if v is not None], ids=repr)
+    def test_a_sentinel_bearing_number_is_refused_like_the_rest(self, scene_ply, param: str, value: Any) -> None:
+        with pytest.raises(ValueError, match=f"GsplatBackground: {param} must be"):
+            _build(GsplatBackground, scene_ply, **{param: value})
+
+
+class TestWhatTheRefusalMustNotCost:
+    """Over-reach controls: every number the fit can honor is still accepted."""
+
+    def test_a_usable_yaw_still_rotates_rather_than_blanking_the_backdrop(self) -> None:
+        camera = _camera()
+        unrotated, _ = PanoramaBackground(rotation_deg=0.0).render(camera)
+        rotated, _ = PanoramaBackground(rotation_deg=90.0).render(camera)
+        # The consequence the refusal exists to prevent: a rotated backdrop is a
+        # different image, not an absent one.
+        assert not np.array_equal(unrotated, rotated)
+        for frame in (unrotated, rotated):
+            assert frame.mean() > 0.0
+            assert len(np.unique(frame)) > 1
+
+    @pytest.mark.parametrize("value", USABLE_NUMBERS, ids=repr)
+    def test_a_usable_yaw_is_still_accepted(self, value: Any) -> None:
+        assert PanoramaBackground(rotation_deg=value) is not None
+
+    @pytest.mark.parametrize("param", ["backdrop_radius", "yaw_deg", "radius", "floor_z", "min_opacity", "floor_pct"])
+    def test_a_usable_alignment_number_is_still_accepted(self, scene_ply, param: str) -> None:
+        for value in (0.0, 1.0, -1.0, np.float32(2.5)):
+            assert _build(GsplatBackground, scene_ply, **{param: value}) is not None
+
+    @pytest.mark.parametrize("param", ["up_sign", "clip_below"])
+    def test_the_sentinel_still_selects_its_documented_default(self, scene_ply, param: str) -> None:
+        # ``None`` is the documented spelling of "auto-detect" / "drop nothing",
+        # so the domain must let it past rather than reading it as a bad number.
+        background = _build(GsplatBackground, scene_ply, **{param: None})
+        assert getattr(background, f"_{param}") is None
+
+    def test_the_defaults_the_signature_declares_are_all_usable(self, scene_ply) -> None:
+        # A guard that refused its own default would be caught nowhere else.
+        assert PanoramaBackground() is not None
+        assert _build(GsplatBackground, scene_ply) is not None
+
+
+class TestThePremisesTheseTestsRestOn:
+    """The shared domain and the sentinel set behave as the rule assumes."""
+
+    @pytest.mark.parametrize("value", NON_FINITE_SPELLINGS, ids=repr)
+    def test_the_shared_domain_refuses_every_spelling_graded_above(self, value: Any) -> None:
+        assert finite_number_error(value, "p", "C") is not None
+
+    @pytest.mark.parametrize("value", USABLE_NUMBERS, ids=repr)
+    def test_the_shared_domain_accepts_every_number_graded_above(self, value: Any) -> None:
+        assert finite_number_error(value, "p", "C") is None
+
+    def test_both_classes_carry_a_sentinel_free_and_a_sentinel_bearing_number(self) -> None:
+        # Without both kinds present the two-loop shape in the source would be
+        # untested on one of its branches.
+        assert _sentinel_params(GsplatBackground) == {"up_sign", "clip_below"}
+        assert _sentinel_params(PanoramaBackground) == set()
+
+    @pytest.mark.parametrize("param", ["up_sign", "yaw_deg", "radius", "floor_z"])
+    def test_the_fit_returns_a_non_finite_transform_for_a_non_finite_number(self, param: str) -> None:
+        # The premise for the constructor's refusal: this is what the fit does
+        # with the value, so refusing it up front is the only way to keep the
+        # transform a placement rather than a hole.
+        rng = np.random.default_rng(7)
+        means = rng.normal(size=(400, 3)) * np.array([2.0, 2.0, 0.7])
+        assert np.isfinite(_fit_skybox_transform(means)).all()
+        poisoned = _fit_skybox_transform(means, **{param: float("nan")})
+        assert not np.isfinite(poisoned).all()


### PR DESCRIPTION
## Problem

`strands_robots.rendering` closed its **posture flags** on `boolean_flag_error` — a domain whose own docstring says it is "for a flag that selects a posture *rather than scaling a quantity*", and whose suite states the boundary outright: "these four were the remaining **posture flags** in `strands_robots.rendering` that did not."

The quantities were the other half. Every scalar number `PanoramaBackground` and `GsplatBackground` take was handed to a bare `float()`, which accepts `nan` and `inf`.

`PanoramaBackground.rotation_deg` builds the `Rz` every output ray is turned by, so a non-finite yaw turned each world direction into `nan`, the equirectangular lookup sampled nothing, and `render()` returned a **uniformly black backdrop** — while reporting no error at all:

| `rotation_deg` | before | after |
|---|---|---|
| `0.0` (default) | rendered, mean 80.59, 101 distinct | unchanged, md5 `440ab1cb8d30` |
| `90.0` | rendered, mean 80.65, 102 distinct | unchanged, md5 `dbe0aaa1bc71` |
| `nan` | **rendered, mean 0.00, 1 distinct** | `ValueError: PanoramaBackground: rotation_deg must be a finite number, got nan.` |
| `inf` / `-inf` | **rendered, mean 0.00, 1 distinct** | refused, naming the parameter |
| `True` | silently a 0.0175 rad yaw | refused |
| `"90"` / `None` / `10**400` | bare `TypeError` from the coercion | refused, naming the parameter |

The silence is what made it costly. `GsplatBackground`'s own path comment describes the mechanism from the other side: in app contexts the photoreal background "sits inside a catch-all that demotes the photoreal background to a procedural fallback". A black frame raises nothing, so that fallback could not fire.

`GsplatBackground`'s numbers feed the fitted `world_from_gs`. Measured through the pure-NumPy skybox fit, a non-finite value in any of them produces a 4x4 with non-finite cells, so every gaussian is placed nowhere:

| parameter | `nan` through the fit | `True` |
|---|---|---|
| `up_sign` | 12 non-finite cells | silently `1.0` |
| `yaw_deg` | 12 non-finite cells | silently a 1-degree yaw |
| `radius` | 12 non-finite cells | silently 1 m |
| `floor_z` | 1 non-finite cell | silently 1 m |
| `backdrop_radius` | 12 non-finite cells | silently 1 m |
| `min_opacity` | filter skipped — `nan > 0` is `False` | silently 1.0 |
| `floor_pct` | already refused by `numpy.percentile` | silently 1.0 |

`min_opacity` is the sharpest: the guard reads `if min_opacity > 0`, and `nan > 0` is `False`, so a non-finite threshold skips the opacity filter the value asks to apply.

## Change

Every caller-supplied scalar number in `backgrounds.py` now goes through `finite_number_error`, the shared signed domain for "a physical quantity a caller supplies verbatim". It is the same rule `_shadow_plane_z_error` states one module over for a plane height — *"only a finite number can be honored: a non-finite plane intersects no ray and the shadow pass would silently never fire."*

`up_sign` and `clip_below` carry a documented `None` sentinel (auto-detect / drop nothing), so the domain applies to the supplied number and the sentinel passes through untouched.

**Bounds are deliberately not imposed.** Whether `min_opacity` belongs in `[0, 1]` and `floor_pct` in `[0, 100]` is a policy question this change does not answer, and `numpy.percentile` already refuses a non-finite `floor_pct` loudly on its own. Vector options (`center`, `backdrop_center`, `up_axis`, `major_axis`) are tuples and want an element-wise domain rather than this scalar one.

## Why nothing caught it

`test_panorama_yaw_rotation_changes_the_background` drives `rotation_deg` at `0.0` and `90.0` — the two values that work. The sibling class has a dedicated domain suite (`test_gsplat_background_posture_flag_domain.py`); the numbers had none. Every mutation below fires **0** of the 900 pre-existing cells in `tests/rendering/` except the two over-reach rows.

## Tests

New `tests/rendering/test_background_numeric_option_domain.py`, 125 cells, dependency-free (both constructors defer every `gsplat`/`torch` import to the first render; the transform consequence is measured through the pure-NumPy fit).

Pre-fix split — **83 failed / 42 passed**:

| class | failed / total | role |
|---|---|---|
| `TestEveryScalarNumberIsCheckedOnTheSharedDomain` | 3 / 5 | derived inventory |
| `TestANonFiniteYawRenderedAnEntirelyBlackBackdrop` | 10 / 10 | regression |
| `TestANonFiniteAlignmentNumberPoisonedTheFittedTransform` | 70 / 70 | regression |
| `TestWhatTheRefusalMustNotCost` | **0 / 18** | over-reach controls |
| `TestThePremisesTheseTestsRestOn` | **0 / 22** | premises |

The inventory is derived from the annotation (`float`, `float | None`) rather than a hardcoded list, so a background that grows a tenth number is held to the same rule the hour it lands — `b10` below is that property.

### Mutation table

`mine` = failures in the new file, `sib` = failures in the other 900 cells of `tests/rendering/`. `collected` stayed 125 on every row, so no row hid a deselection.

| # | mutation | mine | sib |
|---|---|---|---|
| b0 | control — no mutation | 0 | 0 |
| b1 | panorama `rotation_deg` guard removed | 11 | 0 |
| b2 | gsplat plain-numeric loop removed | 55 | 0 |
| b3 | gsplat sentinel loop removed | 17 | 0 |
| b4 | all three removed (raw revert) | 82 | 0 |
| b5 | panorama guard moved **after** the coercion | 4 | 0 |
| b6 | domain swapped to `positive_finite_number_error` | 66 | **50** |
| b7 | sentinel loop drops the `is not None` exemption | 17 | **40** |
| b8 | domain re-implemented locally instead of imported | 75 | 0 |
| b9 | guard reports the context where the parameter belongs | 11 | 0 |
| b10 | `min_opacity` dropped from the guarded numerics | 10 | 0 |

10 distinct firing sets; `b1 | b2 | b3 == b4` exactly, so each guard is independently pinned. Source restored byte-identical after every row.

`b6` and `b7` are the two rows that matter for scope: each trips **50** and **40** pre-existing rendering tests, which is the measurement that the domain must be the *signed* one and that the `None` sentinel must pass through. `b5` shows the placement is load-bearing — `float(np.deg2rad(nan))` is a perfectly good float, so a guard after the coercion inspects a value the defect has already made indistinguishable from a measurement. `b8` fires because a local re-implementation holding today's identical rule is exactly what the unguarded state looked like, so the *import* is the property.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1635 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the merge base, normalized message sets identical in both directions, **0 attributable**.
- Paired run over an identical 518-file selection (all of `tests/rendering/` plus every guard that walks the tree, parses source, or reads docstrings / `__all__` / `changelog.d`), the new file excluded from both trees: identical **24315 collected** and `18 failed, 24157 passed, 140 skipped` on each, **18 identical failing ids with `comm` empty in both directions**. Of those 18, 17 need `awsiot`/`awscrt` (`find_spec` is `None` here; both are declared in the `[mesh-iot]` extra, which CI installs) and 1 is the lerobot-from-source `encode()` drift.
- After rebasing onto `4b91089a`, ruff re-run clean and `tests/rendering/` plus the three test files `main` gained: **902 passed, 3 skipped**. Break rows `b0`/`b1`/`b4` re-measured unchanged (0 / 11 / 82).

## Artifact

One capture script, both trees, one camera. Columns 1 and 2 are byte-identical before and after (md5 `440ab1cb8d30` and `dbe0aaa1bc71`), so nothing legitimate moved; column 3 is the defect and column 4 is the refusal that replaces it. Procedural panorama, pure NumPy — no `sim-gs` extra.

![panorama yaw domain](https://github.com/cagataycali/robots/releases/download/artifacts/panorama_yaw_domain.png)
