### PR TITLE
fix(tools/pose_tool): report the joints an interpolated move actually commanded

### DIFF
--- a/changelog.d/2825-interpolated-move-reports-what-it-commanded.md
+++ b/changelog.d/2825-interpolated-move-reports-what-it-commanded.md
@@ -1,0 +1,42 @@
+### Fixed: an interpolated pose move reports the joints it actually commanded
+
+`MotorController._smooth_move` ended in a literal `return True` and threw away
+every `move_motor` result, so the interpolating path answered success whatever
+reached the bus. Two joints could go missing silently. A motor whose current
+position did not arrive has no start point, so no trajectory is built for it and
+the write loop never commands it - it was dropped from the move without a word.
+And a write the bus refused was logged by `move_motor` and then discarded by the
+loop.
+
+Every other commanding method on the class already answered for what it did.
+`move_multiple_motors(smooth=False)` reads each `move_motor` outcome,
+`disable_torque` returns the motors it could not reach - its docstring explains
+why, that a caller told the whole arm was released when part of it is still
+driven is worse than no stop at all - and `incremental_move` refuses outright
+when the current position is unreadable. So one method carried two contracts a
+single `smooth` flag apart, and `smooth` defaults to `True`: the default path was
+the one that could report a pose it had not commanded a single packet towards.
+`reset_to_home` passes `smooth=True` itself and had no honest branch to take,
+which made the action an operator reaches for to put the arm somewhere known the
+one that could not decline to interpolate.
+
+On a bus that accepts writes and answers no position read - an ordinary
+half-duplex symptom - `pose_tool(action="move_multiple")` listed both requested
+angles under `status="success"` with zero `Goal_Position` packets written, while
+the same call with `smooth=False` on the same bus wrote both and reported
+honestly. The interpolating branch now returns `False` when a joint was left
+uncommanded or a write failed, and logs which joints at ERROR, so the tool's own
+handlers turn it into an error envelope the way they already do for the one-shot
+branch.
+
+Every motor is still attempted, matching `disable_torque` and the one-shot
+branch: the reported outcome changed, the packets did not. A step count that runs
+no increments is deliberately still a success - `_smooth_move_option_error`
+refuses `steps <= 0` before any caller of `pose_tool` reaches the loop, and
+asking for no increments is not the same failure as a joint that could not move.
+
+The suite could not see any of this. `reset_to_home`'s existing ASCII test drove a
+serial double that answers no read, so it asserted `status="success"` on a call
+that wrote nothing; it now uses the answering double, promoted into the shared
+`tests/tools` conftest that a third module needed, and asserts the bus was really
+driven.

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -602,8 +602,9 @@ class MotorController:
             verified reply from this motor arrived. ``None`` is the established
             "could not read" signal every caller already handles:
             :func:`pose_tool`'s ``read_position`` turns it into an error envelope
-            instead of quoting a number, and the interpolating paths refuse to
-            build a trajectory from it.
+            instead of quoting a number, and the interpolating paths build no
+            trajectory from it and report the joint as uncommanded rather than
+            leaving it out of the move in silence.
         """
         if not self.serial_conn or not self.serial_conn.is_open:
             return None
@@ -666,7 +667,10 @@ class MotorController:
                 finite value.
 
         Returns:
-            True when every motor was commanded successfully.
+            True when every motor was commanded successfully. Both branches
+            answer for what they did: the one-shot branch reads each
+            :meth:`move_motor` outcome, and the interpolating branch reports
+            a motor it could not interpolate or could not write.
         """
         if smooth:
             return self._smooth_move(positions, steps=steps, step_delay=step_delay)
@@ -692,9 +696,42 @@ class MotorController:
                 :func:`pose_tool`.
 
         Returns:
-            True once every increment has been written.
+            True when every requested motor was interpolated and every write
+            reached the bus. False when a motor's current position could not be
+            read - it has no start point, so no trajectory is built for it and
+            it is never commanded - or when one of its writes failed.
+
+            Both are reported rather than passed over. Every other commanding
+            method on this class already answers for what it did:
+            ``move_multiple_motors(smooth=False)`` reads each
+            :meth:`move_motor` outcome, :meth:`disable_torque` returns the
+            motors it could not reach, and :meth:`incremental_move` refuses
+            outright when the current position is unreadable. Answering True
+            unconditionally left one method with two contracts a single
+            ``smooth`` flag apart, and ``smooth`` defaults to True - so the
+            default path was the one that could report a pose it had not
+            commanded a single packet towards.
+
+            Every motor is still attempted, matching those siblings: the
+            reported outcome changes, the packets do not. An empty loop
+            (``steps <= 0``, which :func:`_smooth_move_option_error` refuses
+            before any caller of :func:`pose_tool` reaches here) commands
+            nothing and drops nothing, so it still answers True - "you asked
+            for no increments" is not the same failure as "this joint did not
+            move".
         """
         current_positions = self.read_all_positions()
+
+        # A motor whose current position did not arrive has no start point, so
+        # the loop below builds no trajectory for it and never commands it.
+        # Name it: the caller asked for that joint to move and it will not.
+        unreadable = sorted(set(target_positions) - set(current_positions))
+        if unreadable:
+            logger.error(
+                "Interpolated move: no current position for %s, so %s left uncommanded",
+                ", ".join(unreadable),
+                "it was" if len(unreadable) == 1 else "they were",
+            )
 
         # Calculate step increments
         step_increments = {}
@@ -704,16 +741,25 @@ class MotorController:
                 step_increments[motor] = (target - current) / steps
 
         # Execute smooth movement
+        failed: set[str] = set()
         for step in range(steps + 1):
             for motor, target in target_positions.items():
                 if motor in current_positions and motor in step_increments:
                     current = current_positions[motor]
                     new_position = current + (step_increments[motor] * step)
-                    self.move_motor(motor, new_position)
+                    if not self.move_motor(motor, new_position):
+                        # Keep going: a later increment may land once the bus
+                        # recovers, and the remaining joints are still driven
+                        # towards the pose. disable_torque continues past a
+                        # failure for the same reason.
+                        failed.add(motor)
 
             time.sleep(step_delay)
 
-        return True
+        if failed:
+            logger.error("Interpolated move: writes failed for %s", ", ".join(sorted(failed)))
+
+        return not unreadable and not failed
 
     def incremental_move(self, motor_name: str, delta_degrees: float) -> bool:
         """Move motor by a small increment."""

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Shared serial-layer doubles for the ``pose_tool`` test modules.
 
-These live in a conftest rather than in one test module because two modules
-now need them, and importing a fixture across test modules re-binds the name
-in the importing module (ruff F811) as well as making the owning module an
-implicit dependency of the other.
+These live in a conftest rather than in one test module because several
+modules now need them, and importing a fixture across test modules re-binds
+the name in the importing module (ruff F811) as well as making the owning
+module an implicit dependency of the other.
 
 ``pose_tool``'s ``port`` defaults to ``/dev/ttyACM0`` and several actions --
 ``emergency_stop`` above all -- write to the bus, so every test that reaches
@@ -44,6 +44,49 @@ class FakeSerial:
 
     def close(self) -> None:
         self.is_open = False
+
+
+def position_packet(raw: int = 0x0800, motor_id: int = 0x01) -> bytes:
+    """A Feetech status packet reporting ``raw`` counts for ``motor_id``.
+
+    ``FF FF ID LEN ERR <lo> <hi> CHK``, with the checksum a servo would send so
+    the frame passes the verification ``read_motor_position`` performs. Framing
+    itself is graded in ``test_feetech_status_packet_framing``.
+    """
+    body = [motor_id, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF]
+    return bytes([0xFF, 0xFF, *body, (~sum(body)) & 0xFF])
+
+
+class ReadingSerial(FakeSerial):
+    """A ``FakeSerial`` that always answers a read with a decodable position.
+
+    ``_smooth_move`` reads the current pose before interpolating and builds a
+    trajectory only for the motors it could read, so a source that never
+    answers makes the interpolation vacuous -- and, until the interpolating path
+    reported the joints it had dropped, made a move that wrote nothing look
+    like a success.
+    """
+
+    def read(self, n: int = 1) -> bytes:
+        # Answer as the motor the outgoing packet addressed; a servo bus does,
+        # and a fake that always answered as motor 1 would let a read attribute
+        # one motor's position to another with no test able to see it.
+        asked = self.writes[-1][2] if self.writes else 0x01
+        return position_packet(motor_id=asked)
+
+
+@pytest.fixture
+def reading_serial(monkeypatch):
+    """Patch ``serial.Serial`` with an always-answering position source."""
+    instances: list[ReadingSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> ReadingSerial:
+        fs = ReadingSerial(port, baudrate, timeout)
+        instances.append(fs)
+        return fs
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return instances
 
 
 @pytest.fixture

--- a/tests/tools/test_interpolated_move_reports_what_it_commanded.py
+++ b/tests/tools/test_interpolated_move_reports_what_it_commanded.py
@@ -1,0 +1,326 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""An interpolated pose move must answer for the joints it actually commanded.
+
+``MotorController._smooth_move`` ended with a literal ``return True`` and threw
+away every ``move_motor`` result, so the interpolating path reported success no
+matter what reached the bus. Two things it did silently:
+
+* A motor whose current position did not arrive has no start point, so no
+  trajectory is built for it and it is never commanded. It was dropped from the
+  move without a word.
+* A write that raised - a pulled cable, a bus held by another process - was
+  logged by ``move_motor`` and then discarded by the loop.
+
+On an identical bus the sibling one flag away told the truth:
+``move_multiple_motors(smooth=False)`` reads every ``move_motor`` outcome. So a
+single ``smooth`` flag selected between two contracts, and ``smooth`` defaults
+to ``True`` - the default path was the lying one. ``reset_to_home`` passes
+``smooth=True`` itself and cannot opt out at all.
+
+The tests assert against the BYTES that reach the bus rather than the status
+text, for the reason the sibling emergency-stop module gives: the wording was
+already right, and only the packets say whether the arm moved.
+
+No real serial port is opened: ``serial.Serial`` is replaced and every call
+passes an explicit fake ``port`` -- ``pose_tool``'s ``port`` defaults to
+``/dev/ttyACM0``, so a portless call would drive an arm plugged into the machine
+running the suite.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import textwrap
+from typing import Any
+
+import pytest
+import serial
+
+from strands_robots.tools.pose_tool import MotorController, pose_tool
+
+from .conftest import FakeSerial, position_packet
+
+_PORT = "/dev/ttyTEST"
+_GOAL_POSITION_ADDR = 0x2A
+_INST_WRITE = 0x03
+# The two joints these tests drive, and the ids pose_tool assigns them.
+_TARGET = {"shoulder_pan": 10.0, "elbow_flex": -5.0}
+_IDS = {"shoulder_pan": 1, "elbow_flex": 3}
+# Enough increments to tell "wrote nothing" from "wrote a partial trajectory".
+_STEPS = 3
+_DELAY = 1e-6
+
+
+def _goal_position_ids(writes: list[bytes]) -> list[int]:
+    """Motor ids that received a ``Goal_Position`` write, in order."""
+    return [
+        w[2]
+        for w in writes
+        if len(w) >= 8 and w[:2] == b"\xff\xff" and w[4] == _INST_WRITE and w[5] == _GOAL_POSITION_ADDR
+    ]
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return " ".join(c["text"] for c in result["content"] if "text" in c)
+
+
+class _SelectiveSerial(FakeSerial):
+    """A bus where reads and position writes fail independently, per motor id.
+
+    Both are real half-duplex symptoms: a servo that has dropped off the chain
+    answers nothing, and a bus that has gone away raises on write. They are
+    separate knobs because the two are separate failures - a joint with no start
+    position is never commanded, a joint whose write was refused was commanded
+    and did not take it - and a fake that coupled them could not tell the two
+    halves of the fix apart. Only the ``Goal_Position`` write is refused, so a
+    refused motor still answers its position read.
+    """
+
+    answering: set[int] = set()
+    refusing: set[int] = set()
+
+    def write(self, data: bytes) -> None:
+        packet = bytes(data)
+        addressed = packet[2]
+        is_position_write = packet[4] == _INST_WRITE and packet[5] == _GOAL_POSITION_ADDR
+        if is_position_write and addressed in self.refusing:
+            raise serial.SerialException(f"bus write failed for id {addressed}")
+        super().write(packet)
+
+    def read(self, n: int = 1) -> bytes:
+        asked = self.writes[-1][2] if self.writes else 0x01
+        if asked not in self.answering:
+            return b""
+        return position_packet(motor_id=asked)
+
+
+@pytest.fixture
+def bus(monkeypatch: pytest.MonkeyPatch):
+    """A configurable bus. Mutate ``answering`` / ``refusing`` before the call."""
+    cfg: dict[str, set[int]] = {"answering": set(range(1, 7)), "refusing": set()}
+    made: list[_SelectiveSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _SelectiveSerial:
+        fs = _SelectiveSerial(port, baudrate, timeout)
+        fs.answering = cfg["answering"]
+        fs.refusing = cfg["refusing"]
+        made.append(fs)
+        return fs
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    cfg["made"] = made  # type: ignore[assignment]
+    return cfg
+
+
+def _connected(bus: dict[str, Any]) -> MotorController:
+    controller = MotorController(_PORT)
+    connected, error = controller.connect()
+    assert connected, error
+    return controller
+
+
+def _interpolate(bus: dict[str, Any], **kwargs: Any) -> bool:
+    """Drive the interpolating branch and return what it reported."""
+    controller = _connected(bus)
+    return bool(controller.move_multiple_motors(dict(_TARGET), smooth=True, steps=_STEPS, step_delay=_DELAY, **kwargs))
+
+
+def _one_shot(bus: dict[str, Any]) -> bool:
+    """Drive the one-shot branch on the same bus, for comparison."""
+    controller = _connected(bus)
+    return bool(controller.move_multiple_motors(dict(_TARGET), smooth=False))
+
+
+class TestTheInterpolatedMoveAnswersForWhatItCommanded:
+    """Every joint the caller asked for is either commanded or reported."""
+
+    def test_a_bus_that_answers_no_read_reports_the_move_it_never_made(self, bus: dict[str, Any]) -> None:
+        """With no start pose, nothing is interpolated - and nothing is claimed.
+
+        Pre-fix this returned True having written zero Goal_Position packets.
+        """
+        bus["answering"].clear()
+
+        reported = _interpolate(bus)
+
+        assert reported is False
+        assert _goal_position_ids(bus["made"][0].writes) == []
+
+    def test_a_motor_that_did_not_answer_is_reported_not_dropped(self, bus: dict[str, Any]) -> None:
+        """One silent joint is left uncommanded, so the move is not a success."""
+        bus["answering"].discard(_IDS["elbow_flex"])
+
+        reported = _interpolate(bus)
+
+        commanded = set(_goal_position_ids(bus["made"][0].writes))
+        assert reported is False
+        assert commanded == {_IDS["shoulder_pan"]}, "the silent joint was commanded after all"
+
+    def test_the_uncommanded_joint_is_named(self, bus: dict[str, Any], caplog: pytest.LogCaptureFixture) -> None:
+        """The operator is told which joint will not move, by name."""
+        bus["answering"].discard(_IDS["elbow_flex"])
+
+        with caplog.at_level(logging.ERROR, logger="strands_robots.tools.pose_tool"):
+            _interpolate(bus)
+
+        errors = " ".join(r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR)
+        assert "elbow_flex" in errors, errors
+        assert "shoulder_pan" not in errors, "a joint that was commanded was named as uncommanded"
+
+    def test_a_write_the_bus_refused_is_reported(self, bus: dict[str, Any]) -> None:
+        """A joint whose Goal_Position write raised did not reach the target."""
+        bus["refusing"].add(_IDS["elbow_flex"])
+
+        reported = _interpolate(bus)
+
+        assert reported is False
+        # The read succeeded, so this is the write half of the verdict on its own.
+        assert set(_goal_position_ids(bus["made"][0].writes)) == {_IDS["shoulder_pan"]}
+
+    def test_both_branches_now_agree_on_the_same_bus(self, bus: dict[str, Any]) -> None:
+        """The ``smooth`` flag selects a trajectory shape, not a contract.
+
+        Pre-fix the interpolating branch answered True on the bus where the
+        one-shot branch answered False.
+        """
+        bus["refusing"].update(_IDS.values())
+
+        assert _one_shot(bus) is False
+        assert _interpolate(bus) is False
+
+
+class TestTheToolReportsIt:
+    """The bool reaches the caller: each interpolating action refuses."""
+
+    def test_move_multiple_does_not_report_a_pose_it_never_commanded(self, cwd_tmp: Any, bus: dict[str, Any]) -> None:
+        """Pre-fix this listed both target angles under status="success"."""
+        bus["answering"].clear()
+
+        result = pose_tool(
+            action="move_multiple",
+            robot_id="hw_arm",
+            port=_PORT,
+            positions=dict(_TARGET),
+            smooth=True,
+            steps=_STEPS,
+            step_delay=0.001,
+        )
+
+        assert result["status"] == "error", _texts(result)
+        assert _goal_position_ids(bus["made"][0].writes) == []
+
+    def test_reset_to_home_cannot_opt_out_of_the_interpolating_path(self, cwd_tmp: Any, bus: dict[str, Any]) -> None:
+        """``reset_to_home`` passes ``smooth=True`` itself, so it had no honest branch.
+
+        This is the action an operator reaches for to put the arm somewhere
+        known, and it was the one that could not decline to interpolate.
+        """
+        bus["answering"].clear()
+
+        result = pose_tool(action="reset_to_home", robot_id="hw_arm", port=_PORT, steps=_STEPS, step_delay=0.001)
+
+        assert result["status"] == "error", _texts(result)
+        assert _goal_position_ids(bus["made"][0].writes) == []
+
+
+class TestEveryCommandingMethodAnswersForItself:
+    """Derived: no method on the controller may discard a ``move_motor`` result.
+
+    The rule rather than a list of methods, so a fourth commanding path is held
+    to it the hour it lands.
+    """
+
+    @staticmethod
+    def _callers_that_discard() -> list[str]:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(MotorController)))
+        discarding: list[str] = []
+        for fn in ast.walk(tree):
+            if not isinstance(fn, ast.FunctionDef):
+                continue
+            for stmt in ast.walk(fn):
+                # A bare expression statement throws the return value away.
+                if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+                    func = stmt.value.func
+                    if isinstance(func, ast.Attribute) and func.attr == "move_motor":
+                        discarding.append(fn.name)
+        return sorted(set(discarding))
+
+    @staticmethod
+    def _callers() -> list[str]:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(MotorController)))
+        callers: list[str] = []
+        for fn in ast.walk(tree):
+            if not isinstance(fn, ast.FunctionDef) or fn.name == "move_motor":
+                continue
+            for node in ast.walk(fn):
+                if isinstance(node, ast.Attribute) and node.attr == "move_motor":
+                    callers.append(fn.name)
+        return sorted(set(callers))
+
+    def test_the_scan_finds_every_commanding_path(self) -> None:
+        """Non-vacuity: the rule below is graded against real callers."""
+        callers = self._callers()
+        assert {"move_multiple_motors", "_smooth_move", "incremental_move"} <= set(callers), callers
+
+    def test_no_caller_discards_the_outcome(self) -> None:
+        assert self._callers_that_discard() == []
+
+
+class TestWhatIsUnchanged:
+    """The reported outcome changed; the packets and the healthy path did not."""
+
+    def test_a_healthy_move_still_reports_success(self, bus: dict[str, Any]) -> None:
+        assert _interpolate(bus) is True
+
+    def test_a_healthy_move_writes_one_increment_per_step_per_joint(self, bus: dict[str, Any]) -> None:
+        """``range(steps + 1)`` increments for each requested joint, as before."""
+        _interpolate(bus)
+
+        commanded = _goal_position_ids(bus["made"][0].writes)
+        assert len(commanded) == (_STEPS + 1) * len(_TARGET)
+        for motor_id in _IDS.values():
+            assert commanded.count(motor_id) == _STEPS + 1
+
+    def test_the_readable_joints_are_still_driven_past_a_silent_one(self, bus: dict[str, Any]) -> None:
+        """Reporting the failure must not abandon the joints that can move.
+
+        ``disable_torque`` attempts every motor past a failure for the same
+        reason; the return value is what changed, not the trajectory.
+        """
+        bus["answering"].discard(_IDS["elbow_flex"])
+
+        _interpolate(bus)
+
+        commanded = _goal_position_ids(bus["made"][0].writes)
+        assert commanded.count(_IDS["shoulder_pan"]) == _STEPS + 1
+
+    def test_the_readable_joints_are_still_driven_past_a_refused_write(self, bus: dict[str, Any]) -> None:
+        bus["refusing"].add(_IDS["elbow_flex"])
+
+        _interpolate(bus)
+
+        commanded = _goal_position_ids(bus["made"][0].writes)
+        assert commanded.count(_IDS["shoulder_pan"]) == _STEPS + 1
+
+    def test_an_empty_loop_is_not_reported_as_a_failure(self, bus: dict[str, Any]) -> None:
+        """A step count that runs no increments drops nothing, so it is not a failure.
+
+        ``steps <= 0`` is refused by ``_smooth_move_option_error`` before any
+        caller of ``pose_tool`` reaches here. Asking for no increments is not the
+        same as a joint that could not move, and the fix deliberately does not
+        conflate them.
+        """
+        controller = _connected(bus)
+
+        assert controller._smooth_move(dict(_TARGET), steps=-5, step_delay=_DELAY) is True
+        assert _goal_position_ids(bus["made"][0].writes) == []
+
+    def test_the_one_shot_branch_is_untouched(self, bus: dict[str, Any]) -> None:
+        """Its outcome reading predates this change; it must still hold."""
+        assert _one_shot(bus) is True
+
+        bus["refusing"].update(_IDS.values())
+        assert _one_shot(bus) is False

--- a/tests/tools/test_pose_tool.py
+++ b/tests/tools/test_pose_tool.py
@@ -308,11 +308,21 @@ def test_pose_tool_unknown_action(cwd_tmp) -> None:
     assert "Unknown action" in _texts(result)
 
 
-def test_pose_tool_reset_to_home_is_ascii(cwd_tmp, fake_serial) -> None:
+def test_pose_tool_reset_to_home_is_ascii(cwd_tmp, reading_serial) -> None:
+    """The success text is ASCII - on a bus that really answered.
+
+    ``reading_serial`` rather than ``fake_serial``: ``reset_to_home`` passes
+    ``smooth=True``, and the interpolating path builds a trajectory only for the
+    motors whose current position it could read. A source that answers nothing
+    leaves every joint uncommanded, which the tool now reports as an error, so
+    the success text this asserts about would never be produced.
+    """
     result = pose_tool(action="reset_to_home", robot_id="hw_arm", port="/dev/ttyTEST")
-    assert result["status"] == "success"
+    assert result["status"] == "success", _texts(result)
     _assert_ascii(result)
     assert "home_positions" in tool_json(result)
+    # The bus was really driven: assert the packets, not just the wording.
+    assert reading_serial[0].writes, "reset_to_home wrote nothing to the bus"
 
 
 def test_module_source_is_ascii() -> None:

--- a/tests/tools/test_pose_tool_interpolation_options.py
+++ b/tests/tools/test_pose_tool_interpolation_options.py
@@ -31,7 +31,6 @@ import math
 from typing import Any
 
 import pytest
-import serial
 
 import strands_robots.tools.pose_tool as pose_mod
 from strands_robots.tools.pose_tool import (
@@ -42,7 +41,7 @@ from strands_robots.tools.pose_tool import (
 )
 from strands_robots.utils import positive_count_error, positive_finite_number_error
 
-from .conftest import FakeSerial
+from .conftest import FakeSerial, ReadingSerial
 
 # Actions that build an interpolated trajectory, and how each one gets there.
 # ``reset_to_home`` passes ``smooth=True`` itself, so it interpolates whatever
@@ -80,47 +79,6 @@ def _call(**kwargs: Any) -> dict[str, Any]:
 def _texts(result: dict[str, Any]) -> str:
     """Concatenate every ``text`` field of a tool result."""
     return "\n".join(item.get("text", "") for item in result.get("content", []))
-
-
-def _position_packet(raw: int = 0x0800, motor_id: int = 0x01) -> bytes:
-    """A Feetech status packet reporting ``raw`` counts for ``motor_id``.
-
-    ``FF FF ID LEN ERR <lo> <hi> CHK``, with the checksum a servo would send so
-    the frame passes the verification ``read_motor_position`` performs. Framing
-    itself is graded in ``test_feetech_status_packet_framing``.
-    """
-    body = [motor_id, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF]
-    return bytes([0xFF, 0xFF, *body, (~sum(body)) & 0xFF])
-
-
-class _ReadingSerial(FakeSerial):
-    """A ``FakeSerial`` that always answers a read with a decodable position.
-
-    ``_smooth_move`` reads the current pose before interpolating and only steps
-    the motors it could read, so a source that never answers would make the
-    interpolation vacuous.
-    """
-
-    def read(self, n: int = 1) -> bytes:
-        # Answer as the motor the outgoing packet addressed; a servo bus does,
-        # and a fake that always answered as motor 1 would let a read attribute
-        # one motor's position to another with no test able to see it.
-        asked = self.writes[-1][2] if self.writes else 0x01
-        return _position_packet(motor_id=asked)
-
-
-@pytest.fixture
-def reading_serial(monkeypatch: pytest.MonkeyPatch) -> list[_ReadingSerial]:
-    """Patch ``serial.Serial`` with an always-answering position source."""
-    instances: list[_ReadingSerial] = []
-
-    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _ReadingSerial:
-        fs = _ReadingSerial(port, baudrate, timeout)
-        instances.append(fs)
-        return fs
-
-    monkeypatch.setattr(serial, "Serial", _ctor)
-    return instances
 
 
 @pytest.fixture
@@ -184,7 +142,7 @@ class TestTheRequestedPacingReachesTheLoop:
 
     @pytest.mark.parametrize("action", _INTERPOLATING)
     def test_the_requested_step_count_and_delay_are_the_ones_used(
-        self, action: str, cwd_tmp: Any, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+        self, action: str, cwd_tmp: Any, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
     ) -> None:
         _stored_pose(cwd_tmp)
         result = _drive(action, steps=4, step_delay=0.02)
@@ -195,7 +153,7 @@ class TestTheRequestedPacingReachesTheLoop:
 
     @pytest.mark.parametrize("action", _INTERPOLATING)
     def test_a_finer_request_writes_more_increments_than_a_coarser_one(
-        self, action: str, cwd_tmp: Any, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+        self, action: str, cwd_tmp: Any, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
     ) -> None:
         _stored_pose(cwd_tmp)
         assert _drive(action, steps=3, step_delay=0.01)["status"] == "success"
@@ -208,7 +166,7 @@ class TestTheRequestedPacingReachesTheLoop:
         assert fine == coarse * 13 // 4
 
     def test_omitting_the_options_keeps_the_documented_default_trajectory(
-        self, cwd_tmp: Any, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+        self, cwd_tmp: Any, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
     ) -> None:
         """The default path is unchanged: 20 increments at 0.05s, ~1s of travel."""
         assert _drive("move_multiple")["status"] == "success"
@@ -253,7 +211,7 @@ class TestAnUnusableOptionIsRefusedBeforeThePortOpens:
         assert "not found" not in text, text
 
     def test_a_usable_pair_is_accepted(
-        self, cwd_tmp: Any, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+        self, cwd_tmp: Any, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
     ) -> None:
         assert _drive("move_multiple", steps=1, step_delay=1e-6)["status"] == "success"
 
@@ -273,14 +231,14 @@ class TestOnlyTheInterpolatingActionsReadTheOptions:
         ],
     )
     def test_a_one_shot_action_ignores_the_interpolation_options(
-        self, action: str, extra: dict[str, Any], cwd_tmp: Any, reading_serial: list[_ReadingSerial]
+        self, action: str, extra: dict[str, Any], cwd_tmp: Any, reading_serial: list[ReadingSerial]
     ) -> None:
         result = _drive(action, steps=0, step_delay=-1, **extra)
         text = _texts(result)
         assert "steps" not in text and "step_delay" not in text, text
 
     def test_move_multiple_with_smooth_false_ignores_them(
-        self, cwd_tmp: Any, reading_serial: list[_ReadingSerial]
+        self, cwd_tmp: Any, reading_serial: list[ReadingSerial]
     ) -> None:
         result = _drive("move_multiple", smooth=False, steps=0, step_delay=-1)
         assert result["status"] == "success", _texts(result)
@@ -296,19 +254,19 @@ class TestWhyTheValuesAreRefused:
     """Each refused value measured against the loop that would have received it."""
 
     @staticmethod
-    def _connected(reading_serial: list[_ReadingSerial]) -> MotorController:
+    def _connected(reading_serial: list[ReadingSerial]) -> MotorController:
         controller = MotorController("/dev/ttyTEST")
         connected, error = controller.connect()
         assert connected, error
         return controller
 
-    def test_zero_steps_divides_by_zero(self, reading_serial: list[_ReadingSerial]) -> None:
+    def test_zero_steps_divides_by_zero(self, reading_serial: list[ReadingSerial]) -> None:
         controller = self._connected(reading_serial)
         with pytest.raises(ZeroDivisionError):
             _smooth(controller, steps=0)
 
     def test_a_negative_step_count_writes_nothing_yet_reports_success(
-        self, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+        self, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
     ) -> None:
         """``range(steps + 1)`` is empty, so the move is reported but never made."""
         controller = self._connected(reading_serial)
@@ -316,21 +274,21 @@ class TestWhyTheValuesAreRefused:
         assert pacing["moves"] == []
 
     def test_a_boolean_step_count_is_a_full_travel_jump(
-        self, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+        self, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
     ) -> None:
         """``True`` is a single increment - the jump interpolating exists to avoid."""
         controller = self._connected(reading_serial)
         assert _smooth(controller, steps=True) is True
         assert len(pacing["moves"]) == 2 * len(_MOTORS)
 
-    def test_a_fractional_step_count_cannot_bound_the_loop(self, reading_serial: list[_ReadingSerial]) -> None:
+    def test_a_fractional_step_count_cannot_bound_the_loop(self, reading_serial: list[ReadingSerial]) -> None:
         controller = self._connected(reading_serial)
         with pytest.raises(TypeError):
             _smooth(controller, steps=2.7)
 
     @pytest.mark.parametrize("delay,expected", [(-0.01, ValueError), (math.nan, ValueError), (math.inf, OverflowError)])
     def test_an_unusable_delay_raises_from_sleep(
-        self, delay: float, expected: type[BaseException], reading_serial: list[_ReadingSerial]
+        self, delay: float, expected: type[BaseException], reading_serial: list[ReadingSerial]
     ) -> None:
         controller = self._connected(reading_serial)
         with pytest.raises(expected):


### PR DESCRIPTION
## The defect

`MotorController._smooth_move` ended in a literal `return True` and threw away
every `move_motor` result, so the interpolating pose path reported success
whatever reached the bus. Two joints could go missing silently:

- **A motor whose current position did not arrive** has no start point, so the
  loop builds no trajectory for it and never commands it. It was dropped from
  the move without a word.
- **A write the bus refused** (a pulled cable, a bus held by another process) was
  logged by `move_motor` and then discarded by the loop.

## Every sibling already answered for itself

| method | outcome of `move_motor` |
|---|---|
| `move_multiple_motors(smooth=False)` | `if not self.move_motor(...): success = False` |
| `disable_torque` | returns the motors it could not reach |
| `incremental_move` | `return self.move_motor(...)`, and refuses outright when the position is unreadable |
| `_smooth_move` | discarded, then `return True` |

So one method carried two contracts a single `smooth` flag apart - and `smooth`
defaults to `True`, which made the default path the one that could report a pose
it had not commanded a single packet towards. `reset_to_home` passes
`smooth=True` itself and had no honest branch to take at all, so the action an
operator reaches for to put the arm somewhere known was the one that could not
decline to interpolate.

`disable_torque`'s docstring already argues the disposition: a caller told the
whole arm was released when part of it is still driven is worse than no stop at
all. `read_motor_position`'s docstring already claimed the interpolating paths
"refuse to build a trajectory from it" - true of the trajectory, and the joint
was still reported as moved.

## Measured

A bus that accepts writes and answers no position read is an ordinary
half-duplex symptom. Driving `pose_tool` against one, counting the
`Goal_Position` (`0x2A`) packets that reach it:

| call | before | after |
|---|---|---|
| `move_multiple`, `smooth=True` (default) | `status="success"`, both target angles listed, **0 packets** | `status="error"`, **0 packets** |
| `move_multiple`, `smooth=False`, same bus | `status="success"`, 2 packets | unchanged |
| `reset_to_home` (passes `smooth=True`) | `"Robot moved to home position"`, **0 packets** | `status="error"`, **0 packets** |

At the controller, with two joints requested and one silent:

| bus | before | after | packets |
|---|---|---|---|
| no motor answers a read | `True` | `False` | 0, unchanged |
| one motor silent | `True` | `False` | only the readable joint, unchanged |
| the position write is refused | `True` | `False` | only the readable joint, unchanged |
| healthy | `True` | `True` | `steps + 1` per joint, unchanged |

The packets are identical in every row. Only the reported outcome changed, which
is what the tool's own handlers already turn into an error envelope for the
one-shot branch.

## Scope

Every motor is still attempted, matching `disable_torque` and the one-shot
branch - reporting the failure must not abandon the joints that can still move,
and that is pinned. A step count that runs no increments is deliberately still a
success: `_smooth_move_option_error` refuses `steps <= 0` before any caller of
`pose_tool` reaches the loop, and asking for no increments is not the same
failure as a joint that could not move. Conflating them fires a pre-existing test
(`test_a_negative_step_count_writes_nothing_yet_reports_success`).

Which packets are written is unchanged. Whether a partial pose should be written
at all is a separate question and is not answered here.

## Why nothing caught it

`reset_to_home`'s existing ASCII test drove `fake_serial`, whose `read` answers
`b""`, so it asserted `status="success"` on a call that wrote nothing to the bus.
It now takes the answering double - promoted into the shared `tests/tools`
conftest, whose own docstring exists for exactly this ("several modules now need
them"), removing the duplicate copy in the interpolation module - and asserts the
bus was really driven.

The new tests assert against the **bytes** that reach the bus rather than the
status text, for the reason the sibling emergency-stop module gives: the wording
was already right, and only the packets say whether the arm moved.

## Gate

Pre-fix split, source reverted and tests kept: **8 failed / 181 passed** -
`TestTheInterpolatedMoveAnswersForWhatItCommanded` 5/5,
`TestTheToolReportsIt` 2/2, the derived scan 1/2 (its non-vacuity cell passes),
and **0 of 7** in `TestWhatIsUnchanged`. The headline failure reads
`AssertionError: Robot moved to home position`.

Mutation table, 12 rows, control clean, `collected` stable at 15 on every row:

| row | fires | sib | mutation |
|---|---|---|---|
| b0 | 0 | 0 | control |
| b1 | 8 | 0 | the whole method reverted |
| b2 | 4 | 0 | the uncommanded-joint half of the verdict dropped |
| b3 | 2 | 0 | the failed-write half of the verdict dropped |
| b4 | 3 | 0 | `move_motor`'s outcome discarded again |
| b5 | 6 | 9 | the uncommanded set computed the wrong way round |
| b6 | 1 | 0 | the error names no joint |
| b7 | 1 | 0 | the loop abandons the remaining joints at the first failure |
| b8 | 3 | 0 | an unreadable joint refuses the whole move instead of reporting it |
| b9 | 1 | 1 | an empty loop conflated with a joint that could not move |
| b10 | 3 | 0 | b4 composed, scan derived |
| b11 | 2 | 0 | b4 composed, scan hardcoded to today's caller names |

`b2` and `b3` are **disjoint**, their union is a subset of `b1`, and the two
`b1` cells outside it are the derived scan and the joint naming - so each half of
the verdict is independently pinned. `b7` and `b8` fire `TestWhatIsUnchanged`,
so the "attempt everything" contract is graded rather than asserted. `b9` fires a
pre-existing test, so the empty-loop boundary is not mine to move. `b10` vs `b11`
is why the scan derives its callers instead of listing them: with a discard
reintroduced, deriving names it and a hardcoded list goes silent.

Paired against `4b91089a` over an identical 455-file selection (all of
`tests/tools`, every suite walking the tree or parsing source, everything naming
`pose_tool`), the new file excluded from both trees: identical **21714
collected** and `20 failed, 21616 passed, 78 skipped` on each, **20 identical
failing ids with `comm` empty in both directions**. All 20 are pre-existing: 17
need `awsiot`/`awscrt` (both absent locally, both declared in `[mesh-iot]`) and 3
are lerobot-from-source `encode()` drift. `ruff check` and `ruff format --check`
clean over 1635 files; `mypy` **24 == 24** with the normalized message sets
differing by one `[annotation-unchecked]` note and **0 errors** attributable.

No visual artifact: this changes a hardware tool's reported outcome and its
logging, not a policy, simulation, render, recording or asset. The measured
packet counts above are the evidence.
