### PR TITLE
fix(teleop): join the teleop loop before detach_teleop disconnects what it reads

### DIFF
--- a/changelog.d/2826-detach-teleop-joins-before-it-disconnects.md
+++ b/changelog.d/2826-detach-teleop-joins-before-it-disconnects.md
@@ -1,0 +1,62 @@
+### Fixed: `detach_teleop` joins the teleop loop before it disconnects what that loop reads
+
+`_teleop_loop` indexes `self._teleops[name]` on every tick, and `detach_teleop`
+removes entries from that mapping. It removed them - and disconnected each
+device - and only then stopped the loop, discarding the outcome. So a detach that
+would leave the loop with nothing to drive tore the leader down under a loop that
+was still parked reading from it, and answered `status="success"`. The method's
+own docstring already said "Stops the local loop first".
+
+`stop_teleoperate` declines exactly that teardown for itself: on a leader whose
+`get_action()` is still blocking it answers `status="error"` with `stopped: False`
+and deliberately leaves the devices connected, because "Tearing the bus down
+under a live writer is what `G1Driver.cleanup` refuses for the same reason". The
+same state through each verb, on one wedged leader:
+
+```
+verb                  status   stopped   leader disconnected   loop alive
+stop_teleoperate()    error    False     no                    yes
+detach_teleop()       success  -         YES                   yes
+```
+
+Three things were wrong and the order repairs all three. The verdict: the detach
+answered `success` where its own callee answered `error`, and carried no `json`
+block, so `_stop_reported_stopped` read `True` on it and a caller had no way to
+tell. The teardown: the leader was disconnected, undoing the protection
+`stop_teleoperate` had just decided to apply. And the diagnosis: because the
+entries were popped first, the refusal that got discarded described "the loop is
+still polling `[]`" while claiming "The devices are left connected", which this
+caller had already falsified.
+
+There are two routes in and the second is the one an operator is told to take.
+`stop_teleoperate` clears `_teleop_running` *before* it joins and keeps the thread
+handle when the join fails, so after a failed stop - the state whose message says
+to call it again - the session flag alone reports an idle session while the loop
+is still writing. The guard therefore tests the thread handle as well as the flag;
+keyed on the flag alone it sees the first route only.
+
+```
+                                          before      after
+detach under a running loop: status       success     error
+  leader disconnected                     yes         no
+  streams left attached                   0 of 1      1 of 1
+  detached: [] reported                   (no json)   yes
+detach after a failed stop: status        success     error
+  leader disconnected                     yes         no
+forwarded diagnosis names the device      devices: [] devices: ['leader']
+```
+
+A live loop now refuses the whole detach: `status="error"` with `detached: []`,
+every stream left attached and connected so a later call re-joins that same loop,
+and the callee's reason forwarded rather than re-invented. The outcome is read
+through the shared `_stop_reported_stopped` helper from a single call site that
+precedes the pop - on `stopped` rather than `status`, because the status is
+derived from the session counters and a session whose every frame errored reports
+`"error"` after a perfectly clean join, which would refuse a detach that is safe.
+
+Unchanged: a clean stop still detaches and disconnects exactly as before, a name
+matching no attached stream still gets the not-found refusal, and `detach_teleop("")`
+still leaves a running session alone. A partial detach - one of several devices,
+leaving the loop with something to drive - is deliberately out of scope and pinned
+unchanged; whether the loop should be re-selected or the detach refused there is a
+contract question about multi-device sessions rather than this ordering defect.

--- a/docs/hardware/teleoperation.md
+++ b/docs/hardware/teleoperation.md
@@ -86,7 +86,7 @@ Every hardware `Robot` and `Simulation` host exposes:
 |--------|------|
 | `attach_teleop(device_or_spec, *, name=None, method=None, map_fn=None, **kwargs)` | Register an input stream (lazy - no hardware touched). `device_or_spec` is a built teleop instance **or** a type string built via `Teleoperator(**kwargs)`. |
 | `teleoperate(*, names=None, robot_name=None, hz=50.0, publish=False, block=False, duration=None)` | Run the control loop. |
-| `detach_teleop(name=None)` | Remove one (or all) attached streams. |
+| `detach_teleop(name=None)` | Remove one (or all) attached streams. Stops the loop before touching a device when the detach would leave it with nothing to drive, and refuses with `detached: []` if that loop does not stop. |
 | `stop_teleoperate()` | Stop the loop, any mesh publishers, and disconnect devices. Reports `status="error"` with `stopped: false` when the loop outlasts its 3 s join budget - the devices are left connected rather than torn down mid-write, and a second call re-joins the same loop. |
 
 ### `attach_teleop`
@@ -169,6 +169,13 @@ the bound for those.
   `No teleop named ''.` and leaves every stream attached. That matters mid-
   session: `detach_teleop` stops the loop once nothing is left to drive, so a
   detach widened to all streams would also end a running session.
+- **Order** - when the detach would leave the loop with nothing to drive, the
+  loop is joined *before* any device is disconnected. `_teleop_loop` reads
+  `self._teleops[name]` on every tick, so removing an entry under a live loop
+  tears down the leader it is parked reading from. If that join fails the whole
+  detach is refused: `status="error"` with `detached: []`, every stream left
+  attached and connected, and the reason forwarded from `stop_teleoperate` - call
+  it again to re-join the same loop.
 
 ## Action-key compatibility
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -3187,8 +3187,9 @@ class MuJoCoSimEngine(
         )
         base["methods"]["detach_teleop"] = (
             "(name: str | None = None) -> dict  # detach one teleoperator by "
-            "name, or all when name is None; disconnects each and stops the loop "
-            "if it would be left with no devices. The inverse of attach_teleop"
+            "name, or all when name is None; stops the loop first if it would be "
+            "left with no devices, then disconnects each. Refuses with "
+            "detached: [] if that loop does not stop. The inverse of attach_teleop"
         )
 
         # Live interactive viewer. describe() teaches how to build a scene, drive

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -335,7 +335,20 @@ class TeleopMixin:
         """Detach a specific teleoperator, or all when ``name`` is None.
 
         Stops the local loop first if it's running and would be left with no
-        devices. Disconnects each detached device if it was connected.
+        devices, and refuses the detach outright when that loop does not stop.
+        Disconnects each detached device if it was connected.
+
+        The order is the contract, not an implementation detail.
+        :meth:`_teleop_loop` indexes ``self._teleops[n]`` on every tick and this
+        method removes entries from it, so a detach that would leave the loop
+        with nothing to drive has to join it before touching a device. Stopping
+        afterwards disconnected the leader the loop was parked reading from and
+        still answered ``status="success"`` - the teardown-under-a-live-writer
+        that :meth:`stop_teleoperate` declines for itself: called alone on that
+        same state it answers ``status="error"`` with ``stopped: False`` and
+        leaves the devices connected, saying so. Joining first also repairs that
+        refusal's own diagnosis, which reported ``devices: []`` because the
+        entries had already been popped out from under it.
 
         Args:
             name: Which attached stream to detach. ``None`` = every attached
@@ -344,7 +357,11 @@ class TeleopMixin:
                 stream is refused rather than widened to the whole set.
 
         Returns:
-            Status dict; error when ``name`` names no attached teleoperator.
+            Status dict; error when ``name`` names no attached teleoperator, and
+            error carrying ``detached: []`` when the loop this detach would leave
+            with nothing to drive did not stop. Nothing is detached in that case,
+            so the devices stay attached and connected and a later call re-joins
+            the same loop rather than reporting an idle session.
         """
         self._ensure_teleop_state()
 
@@ -352,11 +369,35 @@ class TeleopMixin:
         # read by membership: ``None`` is the documented "detach every attached
         # device", and any other value names one. Read by truthiness, ``""`` took
         # the all-devices branch, so a detach aimed at a single stream removed the
-        # whole set - and, with a session running, ended it, because the branch
-        # below stops the loop once nothing is left to drive. An empty name is not
-        # a spelling of "all"; it names no attached device, so it now reaches the
+        # whole set - and, with a session running, ended it, because the loop is
+        # stopped once nothing is left to drive it. An empty name is not a
+        # spelling of "all"; it names no attached device, so it reaches the
         # not-found refusal below.
         names = list(self._teleops) if name is None else [name]
+
+        # Join the loop before removing anything it reads. The condition tests the
+        # thread handle as well as the session flag because ``stop_teleoperate``
+        # clears the flag *before* it joins and keeps the handle when the join
+        # fails: after a failed stop - the state its own message tells the operator
+        # to call it again from - the flag alone reports an idle session while that
+        # loop is still polling its leader and writing to the follower.
+        attached = [n for n in names if n in self._teleops]
+        if (self._teleop_running or self._teleop_thread is not None) and not (set(self._teleops) - set(attached)):
+            envelope = self.stop_teleoperate()
+            # Read the outcome through the shared helper rather than ``status``:
+            # the status is derived from the session counters, so a session whose
+            # every frame errored reports ``"error"`` after a perfectly clean
+            # join, and keying on it would refuse a detach that is safe.
+            if not _stop_reported_stopped(envelope):
+                reason = " ".join(block["text"] for block in envelope.get("content", []) if "text" in block)
+                return {
+                    "status": "error",
+                    "content": [
+                        {"text": f"Nothing was detached: the teleop loop is still writing. {reason}"},
+                        {"json": {"detached": [], "stopped": False}},
+                    ],
+                }
+
         detached = []
         for n in names:
             att = self._teleops.pop(n, None)
@@ -369,9 +410,6 @@ class TeleopMixin:
             except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
                 logger.warning("[teleop] disconnect of %r failed: %s", n, exc)
             detached.append(n)
-
-        if not self._teleops and self._teleop_running:
-            self.stop_teleoperate()
 
         if not detached:
             return {"status": "error", "content": [{"text": f"No teleop named {name!r}."}]}

--- a/tests/test_detach_teleop_joins_before_it_disconnects.py
+++ b/tests/test_detach_teleop_joins_before_it_disconnects.py
@@ -90,6 +90,13 @@ def _json(envelope: dict[str, Any]) -> dict[str, Any] | None:
     return next((b["json"] for b in envelope.get("content", []) if "json" in b), None)
 
 
+def _payload(envelope: dict[str, Any]) -> dict[str, Any]:
+    """The ``json`` block, for a cell that requires the envelope to carry one."""
+    payload = _json(envelope)
+    assert payload is not None, "the envelope carries no json block"
+    return payload
+
+
 def _second_device(session: _Session) -> Any:
     """Attach a second stream so a detach can be partial."""
 
@@ -114,7 +121,7 @@ class TestThePremiseStopTeleoperateDeclinesThisTeardown:
         session = _Session(wedged=True)
         envelope = session.robot.stop_teleoperate()
         assert envelope["status"] == "error"
-        assert _json(envelope)["stopped"] is False
+        assert _payload(envelope)["stopped"] is False
         assert not _stop_reported_stopped(envelope)
         session.release()
 

--- a/tests/test_detach_teleop_joins_before_it_disconnects.py
+++ b/tests/test_detach_teleop_joins_before_it_disconnects.py
@@ -1,0 +1,335 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""``detach_teleop`` must join the teleop loop before it removes what that loop reads.
+
+``_teleop_loop`` indexes ``self._teleops[name]`` on every tick, and
+``detach_teleop`` removes entries from that mapping. So a detach which would
+leave the loop with nothing to drive has to join it *before* touching a device -
+which is what ``detach_teleop``'s own docstring said ("Stops the local loop
+first") while the implementation stopped it last, and discarded the outcome.
+
+``stop_teleoperate`` declines exactly this teardown for itself: on a leader whose
+``get_action()`` blocks past the join budget it answers ``status="error"`` with
+``stopped: False`` and deliberately leaves the devices connected, because
+"Tearing the bus down under a live writer is what ``G1Driver.cleanup`` refuses
+for the same reason". Measured on one wedged leader, the same state through each
+verb:
+
+    verb                  status   stopped   leader disconnected   loop alive
+    stop_teleoperate()    error    False     no                    yes
+    detach_teleop()       success  -         YES                   yes
+
+Three things were wrong, and joining first repairs all three:
+
+- the verdict. ``detach_teleop`` answered ``success`` where its own callee
+  answered ``error``/``stopped: False``, and carried no ``json`` block, so
+  ``_stop_reported_stopped`` on the detach envelope read ``True``: a caller had
+  no way to tell.
+- the teardown. The leader the loop was parked reading from was disconnected,
+  undoing the protection ``stop_teleoperate`` had just decided to apply.
+- the diagnosis. Because the entries were popped first, the refusal that got
+  discarded described "the loop is still polling ``[]``" and claimed "The devices
+  are left connected", which this caller had already falsified.
+
+There are two routes in, and the second is the one an operator is told to take:
+``stop_teleoperate`` clears ``_teleop_running`` *before* it joins and keeps the
+thread handle when the join fails, so after a failed stop the session flag alone
+reports an idle session while the loop is still writing. A guard keyed on
+``_teleop_running`` sees route 1 only; the thread handle sees both.
+
+What these cells pin:
+
+    - a live writer makes ``detach_teleop`` refuse, detach nothing, and leave
+      every device attached and connected so a later call re-joins that loop;
+    - the refusal is machine-readable (``detached: []``, ``stopped: False``) and
+      forwards the callee's reason, whose device list is now accurate;
+    - both routes in are covered, including the failed-stop remedy path;
+    - a clean stop still detaches and disconnects exactly as before, a bogus name
+      still gets the not-found refusal, and a partial detach is untouched;
+    - the outcome is read through the shared ``_stop_reported_stopped`` helper
+      rather than re-derived, from a single call site that precedes the pop.
+
+A partial detach - one of several devices, leaving the loop with something to
+drive - is deliberately out of scope and pinned unchanged below. Whether the loop
+should be re-selected or the detach refused there is a contract question about
+multi-device sessions, not this ordering defect.
+
+No serial port and no camera is opened; the device doubles are the ones
+``test_cleanup_defers_the_close_under_a_live_teleop_writer`` uses, so port
+exclusivity is modelled and the consequence is asserted rather than the call.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from typing import Any
+
+import pytest
+
+import strands_robots.teleop_mixin as teleop_mixin
+from strands_robots.teleop_mixin import TeleopMixin, _stop_reported_stopped
+from tests.test_cleanup_defers_the_close_under_a_live_teleop_writer import _Session
+
+# Short enough to keep every cell fast. The budget is pre-existing and pinned by
+# ``test_stop_teleoperate_reports_the_join_outcome``; what matters here is only
+# that a join can fail.
+_FAST_JOIN_S = 0.3
+
+
+@pytest.fixture(autouse=True)
+def _fast_join(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(teleop_mixin, "_TELEOP_JOIN_TIMEOUT_S", _FAST_JOIN_S)
+
+
+def _text(envelope: dict[str, Any]) -> str:
+    return " ".join(b["text"] for b in envelope.get("content", []) if "text" in b)
+
+
+def _json(envelope: dict[str, Any]) -> dict[str, Any] | None:
+    return next((b["json"] for b in envelope.get("content", []) if "json" in b), None)
+
+
+def _second_device(session: _Session) -> Any:
+    """Attach a second stream so a detach can be partial."""
+
+    class _Extra:
+        is_connected = True
+
+        def get_action(self) -> dict[str, float]:
+            return {"j1.pos": 0.0}
+
+        def disconnect(self) -> None:
+            type(self).is_connected = False
+
+    device = _Extra()
+    session.robot._teleops["second"] = type("_Att", (), {"device": device, "map_fn": None})()
+    return device
+
+
+class TestThePremiseStopTeleoperateDeclinesThisTeardown:
+    """What ``detach_teleop`` has to respect: the outcome exists and is acted on."""
+
+    def test_a_wedged_leader_makes_the_join_fail_and_says_so(self) -> None:
+        session = _Session(wedged=True)
+        envelope = session.robot.stop_teleoperate()
+        assert envelope["status"] == "error"
+        assert _json(envelope)["stopped"] is False
+        assert not _stop_reported_stopped(envelope)
+        session.release()
+
+    def test_stop_teleoperate_alone_leaves_the_leader_connected(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.stop_teleoperate()
+        assert session.leader.is_connected, "premise: it declines the teardown"
+        assert session.thread.is_alive()
+        session.release()
+
+    def test_a_failed_stop_leaves_the_flag_clear_while_the_loop_writes(self) -> None:
+        """Route 2's state: the session flag alone cannot see this live writer."""
+        session = _Session(wedged=True)
+        session.robot.stop_teleoperate()
+        assert session.robot._teleop_running is False, "the flag is cleared before the join"
+        assert session.robot._teleop_thread is not None, "the handle is kept for a re-join"
+        assert session.thread.is_alive()
+        session.release()
+
+    def test_the_loop_reads_the_registry_by_key_on_every_tick(self) -> None:
+        """Why the order matters: the loop indexes what this method removes."""
+        body = textwrap.dedent(inspect.getsource(TeleopMixin._teleop_loop))
+        assert "self._teleops[n]" in body
+
+
+class TestALiveWriterMakesTheDetachRefuse:
+    """Route 1: the loop is running when the detach arrives."""
+
+    def test_the_detach_reports_the_failure_rather_than_success(self) -> None:
+        session = _Session(wedged=True)
+        envelope = session.robot.detach_teleop()
+        assert envelope["status"] == "error"
+        session.release()
+
+    def test_the_leader_is_not_disconnected_under_the_live_loop(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.detach_teleop()
+        assert session.thread.is_alive(), "premise: the loop must still be running"
+        assert session.leader.is_connected
+        session.release()
+
+    def test_nothing_is_detached_so_a_later_call_can_re_join(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.detach_teleop()
+        assert sorted(session.robot._teleops) == ["leader"]
+        assert session.robot._teleop_thread is not None
+        session.release()
+
+    def test_the_refusal_is_machine_readable(self) -> None:
+        session = _Session(wedged=True)
+        payload = _json(session.robot.detach_teleop())
+        assert payload == {"detached": [], "stopped": False}
+        session.release()
+
+    def test_a_caller_can_read_the_outcome_with_the_shared_helper(self) -> None:
+        """The detach envelope answers the same question its callee's does."""
+        session = _Session(wedged=True)
+        assert not _stop_reported_stopped(session.robot.detach_teleop())
+        session.release()
+
+    def test_the_reason_is_forwarded_rather_than_re_invented(self) -> None:
+        session = _Session(wedged=True)
+        text = _text(session.robot.detach_teleop())
+        assert "Nothing was detached" in text
+        assert f"did not stop within {_FAST_JOIN_S:.1f}s" in text
+        session.release()
+
+    def test_the_forwarded_diagnosis_names_the_device_it_is_polling(self) -> None:
+        """Popping first made the callee's own message report ``devices: []``.
+
+        Matched on the phrase only that diagnosis produces: a bare ``['leader']``
+        is also in the success message this used to return.
+        """
+        session = _Session(wedged=True)
+        assert "still polling ['leader']" in _text(session.robot.detach_teleop())
+        session.release()
+
+
+class TestTheFailedStopRemedyPathRefusesToo:
+    """Route 2: ``_teleop_running`` is already False while the loop still writes."""
+
+    def test_the_detach_still_refuses_after_a_failed_stop(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.stop_teleoperate()
+        envelope = session.robot.detach_teleop()
+        assert envelope["status"] == "error"
+        assert _json(envelope) == {"detached": [], "stopped": False}
+        session.release()
+
+    def test_the_devices_survive_the_remedy_path(self) -> None:
+        session = _Session(wedged=True)
+        session.robot.stop_teleoperate()
+        session.robot.detach_teleop()
+        assert session.leader.is_connected
+        assert sorted(session.robot._teleops) == ["leader"]
+        session.release()
+
+
+class TestWhatIsUnchanged:
+    """Every path that did not involve a live writer answers exactly as before."""
+
+    def test_a_clean_stop_still_detaches_and_disconnects(self) -> None:
+        session = _Session(wedged=False)
+        envelope = session.robot.detach_teleop()
+        assert envelope["status"] == "success"
+        assert "Detached: ['leader']" in _text(envelope)
+        assert session.robot._teleops == {}
+        assert not session.leader.is_connected
+
+    def test_a_clean_stop_leaves_no_running_session(self) -> None:
+        session = _Session(wedged=False)
+        session.robot.detach_teleop()
+        assert session.robot._teleop_running is False
+        assert session.robot._teleop_thread is None
+
+    def test_a_name_that_matches_nothing_is_still_refused(self) -> None:
+        session = _Session(wedged=True)
+        envelope = session.robot.detach_teleop("ghost")
+        assert envelope["status"] == "error"
+        assert "No teleop named 'ghost'." in _text(envelope)
+        assert sorted(session.robot._teleops) == ["leader"]
+        session.release()
+
+    def test_an_empty_name_still_does_not_stop_a_running_session(self) -> None:
+        """The membership contract: ``""`` names no device, so nothing happens."""
+        session = _Session(wedged=True)
+        _second_device(session)
+        envelope = session.robot.detach_teleop("")
+        assert envelope["status"] == "error"
+        assert session.robot._teleop_running is True
+        assert session.leader.is_connected
+        session.release()
+
+    def test_a_partial_detach_is_out_of_scope_and_unchanged(self) -> None:
+        """One of two devices: the loop keeps something to drive, so it is not joined."""
+        session = _Session(wedged=True)
+        extra = _second_device(session)
+        envelope = session.robot.detach_teleop("second")
+        assert envelope["status"] == "success"
+        assert sorted(session.robot._teleops) == ["leader"]
+        assert not extra.is_connected
+        session.release()
+
+    def test_a_clean_join_whose_every_frame_errored_still_detaches(self) -> None:
+        """Why the verdict is ``stopped`` and not ``status``.
+
+        ``_teleop_stats`` derives the status from the session counters, so a
+        session whose every frame errored answers ``status="error"`` with
+        ``stopped: True`` after a perfectly clean join. Keying the guard on the
+        status would refuse this detach, which is safe.
+        """
+        session = _Session(wedged=False)
+        session.robot._teleop_frames = 1
+        session.robot._teleop_errors = 1
+        envelope = session.robot.detach_teleop()
+        assert envelope["status"] == "success"
+        assert session.robot._teleops == {}
+
+    def test_an_idle_robot_with_devices_still_detaches(self) -> None:
+        session = _Session(wedged=False)
+        session.robot.stop_teleoperate()
+        envelope = session.robot.detach_teleop()
+        assert envelope["status"] == "success"
+        assert session.robot._teleops == {}
+
+
+class TestTheOutcomeIsReadFromOneSingleSourcedCallSite:
+    """Structural: the drift this fixes is a discarded return value."""
+
+    def _detach_source(self) -> ast.FunctionDef:
+        module = ast.parse(textwrap.dedent(inspect.getsource(TeleopMixin.detach_teleop)))
+        node = module.body[0]
+        assert isinstance(node, ast.FunctionDef)
+        return node
+
+    def test_the_stop_is_called_exactly_once_and_its_value_is_never_discarded(self) -> None:
+        fn = self._detach_source()
+        calls = [
+            n
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "stop_teleoperate"
+        ]
+        assert len(calls) == 1, f"expected one stop_teleoperate() call site, found {len(calls)}"
+        discarded = [
+            n
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Expr)
+            and isinstance(n.value, ast.Call)
+            and isinstance(n.value.func, ast.Attribute)
+            and n.value.func.attr == "stop_teleoperate"
+        ]
+        assert discarded == [], "the stop outcome is discarded as a bare expression"
+
+    def test_the_verdict_comes_from_the_shared_helper(self) -> None:
+        """Not re-derived from ``status`` or from the thread handle."""
+        fn = self._detach_source()
+        names = {n.func.id for n in ast.walk(fn) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)}
+        assert "_stop_reported_stopped" in names
+
+    def test_the_join_precedes_the_removal(self) -> None:
+        fn = self._detach_source()
+        stop_line = next(
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "stop_teleoperate"
+        )
+        pop_line = next(
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "pop"
+        )
+        assert stop_line < pop_line, "the loop must be joined before the registry is emptied"
+
+    def test_the_guard_consults_the_thread_handle_not_only_the_session_flag(self) -> None:
+        """``_teleop_running`` is already False on the failed-stop remedy path."""
+        fn = self._detach_source()
+        source = ast.unparse(fn)
+        assert "_teleop_thread" in source


### PR DESCRIPTION
## The defect

`_teleop_loop` indexes `self._teleops[name]` on every tick. `detach_teleop`
removes entries from that mapping - and disconnects each device - and only then
stopped the loop, discarding the outcome. So a detach that would leave the loop
with nothing to drive tore the leader down under a loop still parked reading from
it, and answered `status="success"`.

`stop_teleoperate` declines exactly that teardown for itself: on a leader whose
`get_action()` is still blocking it answers `status="error"` with `stopped: False`
and deliberately leaves the devices connected, because "Tearing the bus down under
a live writer is what `G1Driver.cleanup` refuses for the same reason". The same
state through each verb, on one wedged leader:

| verb | status | `stopped` | leader disconnected | loop alive |
|---|---|---|---|---|
| `stop_teleoperate()` | `error` | `False` | no | yes |
| `detach_teleop()` | **`success`** | - | **YES** | yes |

`detach_teleop`'s own docstring already said "Stops the local loop first".

Three things were wrong, and joining first repairs all three:

- **the verdict.** The detach answered `success` where its own callee answered
  `error`, and carried no `json` block - so `_stop_reported_stopped` read `True`
  on the detach envelope and a caller had no way to tell.
- **the teardown.** The leader was disconnected, undoing the protection
  `stop_teleoperate` had just decided to apply.
- **the diagnosis.** Because the entries were popped first, the refusal that got
  discarded described "the loop is still polling `[]`" while claiming "The devices
  are left connected", which this caller had already falsified.

## Two routes in, and the second is the documented remedy

`stop_teleoperate` clears `_teleop_running` *before* it joins and keeps the thread
handle when the join fails. So after a failed stop - the state whose own message
says to call it again - the session flag alone reports an idle session while the
loop is still writing:

| route | `_teleop_running` | `_teleop_thread is not None` |
|---|---|---|
| loop running | `True` | `True` |
| after a failed stop | **`False`** | `True` |

The guard therefore tests the thread handle as well as the flag. Keyed on the flag
alone it sees the first route only - which is what break row b2 measures.

## Before / after

```
                                          before      after
detach under a running loop: status       success     error
  leader disconnected                     yes         no
  streams left attached                   0 of 1      1 of 1
  detached: [] reported                   (no json)   yes
detach after a failed stop: status        success     error
  leader disconnected                     yes         no
forwarded diagnosis names the device      devices: [] devices: ['leader']
```

A live loop now refuses the whole detach: `status="error"` with `detached: []`,
every stream left attached and connected so a later call re-joins that same loop,
and the callee's reason forwarded rather than re-invented. The outcome is read
through the shared `_stop_reported_stopped` helper from a single call site that
precedes the pop - on `stopped` rather than `status`, because the status is derived
from the session counters and a session whose every frame errored answers
`"error"` after a perfectly clean join, which would refuse a detach that is safe.

## Why nothing caught it

The whole defect fires **0** of the 7 pre-existing teleop suites (`sib` column
below). The existing coverage grades the two extremes - a `FakeTeleop` that returns
instantly, so its join always succeeds and the discarded value is always `True` -
and `detach_teleop("")`, which selects nothing and so cannot reach the branch.

## Pre-fix split

`13 failed / 11 passed`, by class:

| class | role | failed / total |
|---|---|---|
| `TestThePremiseStopTeleoperateDeclinesThisTeardown` | premise | 0 / 4 |
| `TestALiveWriterMakesTheDetachRefuse` | regression (route 1) | 7 / 7 |
| `TestTheFailedStopRemedyPathRefusesToo` | regression (route 2) | 2 / 2 |
| `TestTheOutcomeIsReadFromOneSingleSourcedCallSite` | structural | 4 / 4 |
| `TestWhatIsUnchanged` | over-reach controls | 0 / 7 |

One cell initially passed pre-fix and was tightened: `"['leader']"` is also in the
`Detached: ['leader']` success message this used to return, so it now matches the
phrase only the forwarded diagnosis produces.

## Mutation table

10 mutations, 10 firing, **10 distinct firing sets**, control clean, `collected`
stable at 24, source restored byte-identical. `sib` = failures in the 7 pre-existing
teleop suites with this file deselected.

| row | mine | sib | mutation |
|---|---|---|---|
| b0 | 0 | 0 | control |
| b1 | 13 | 0 | raw revert: no pre-flight join at all |
| b2 | 3 | 0 | guard keyed on `_teleop_running` only (drops the thread handle) |
| b3 | 2 | 0 | verdict read from `status` instead of the shared helper |
| b4 | 5 | 0 | guard moved AFTER the pop loop (original ordering, but checked) |
| b5 | 2 | 0 | refusal reports `success` |
| b6 | 3 | 0 | refusal carries no `json` block |
| b7 | 2 | 0 | refusal drops the forwarded reason |
| b8 | 3 | **1** | OVER-REACH: refuse any detach while the loop runs |
| b9 | 13 | **2** | the empties-the-registry test is inverted |
| b10 | 9 | 0 | ALTERNATIVE: log the live loop but detach anyway |

The scope rows are the load-bearing ones. **b8** trips
`test_an_empty_name_does_not_end_a_running_session` - a too-wide guard breaks the
membership contract a previous change pinned. **b9** trips that plus
`test_detach_all_stops_running_loop`. **b10** shows that reporting alone is not the
fix: logging and detaching anyway still fires 9, so declining the detach is the
behavioural content.

## Gate

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean, 1635 files
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the
  merge-base, normalized message sets identical both directions, **0 attributable**
- paired run, identical 460-file selection (every teleop suite plus every guard that
  walks the tree, parses source, or reads docstrings / `docs/` / `changelog.d`), new
  file excluded from both and every path verified present on both:

```
                     branch                              base
collected            21559                               21559
result               24 failed, 21459 passed, 76 skipped 24 failed, 21459 passed, 76 skipped
failing ids          24                                  24
comm both directions EMPTY
```

The 24 are classified rather than assumed: **17** need `awsiot`/`awscrt`
(`find_spec` False for both, both declared in the `[mesh-iot]` extra, which CI
installs), **3** are the lerobot-from-source `encode()` drift, and **4** in
`test_recording_frame_loss_is_not_tolerated.py` pass **13/13 in isolation on both
trees** - a large-selection module-caching artifact.

## Scope

A partial detach - one of several devices, leaving the loop with something to drive
- is deliberately out of scope and pinned unchanged. The loop's `except Exception`
counts a popped-device `KeyError` as an error frame, so whether the loop should be
re-selected or the detach refused there is a contract question about multi-device
sessions rather than this ordering defect.

`describe()`'s method line and `docs/hardware/teleoperation.md` both documented the
old order ("disconnects each and stops the loop"); both are corrected here.

No visual artifact: this is a teardown-ordering and reporting fix with no policy,
simulation, rendering, recording or asset behaviour. The measured tables above are
the evidence.
