### PR TITLE
fix(isaac): refuse a non-finite body placement instead of measuring around it

### DIFF
--- a/changelog.d/2827-non-finite-body-placement-is-refused.md
+++ b/changelog.d/2827-non-finite-body-placement-is-refused.md
@@ -1,0 +1,36 @@
+### Fixed: a body declaring a placement that is not finite is refused, not measured around
+
+`load_mjcf_scene_objects` composes a `SceneObject` from three placements: the top-level body's `pos`
+becomes the object's `position`, its orientation becomes `quat`, and each nested body's `pos` becomes
+the running offset every geom below it is measured from. `_geom_aabb` refuses a non-finite value on
+all four of a *geom*'s parse paths. The *body* placements the same bound is composed from were read
+straight through `_parse_xyz` / `_parse_orientation`, whose contract is to fall back to a documented
+default on an unreadable attribute and to return whatever a readable one parsed to.
+
+The nested case is the one nothing can detect. A non-finite offset makes every bound below it
+non-finite, and the running `min`/`max` in `_recursive_collision_aabb` orders a NaN as neither
+smaller nor larger than anything, so the whole subtree disappears from the union while the walk still
+reports that it found analytic geometry:
+
+    table, leg body pos="0 0 -0.37"  ->  size (0.8, 0.8, 0.76)
+    table, leg body pos="0 0 nan"    ->  size (0.8, 0.8, 0.04)
+    table with the leg deleted       ->  size (0.8, 0.8, 0.04)
+
+A 4 cm slab where the file declares a 76 cm table, byte-identical to the same fixture with the leg
+deleted, under a successful load - and with every field the loader reports finite, which is what
+separates it from the geom spellings: a consumer cannot screen for it. The other placements fail more
+loudly but no more correctly. A non-finite top-level `pos` or orientation is reported verbatim as the
+object's own, and `pos="0 0 inf"` on a nested body reports an infinite extent, because `inf - inf` is
+a NaN the outer accumulator drops in turn.
+
+Reachability is wider here than for the geom spellings. That finding is scoped to fixtures, because a
+non-finite geom makes the inertia MuJoCo derives non-finite and MuJoCo refuses a body with a free
+joint. A body's own `pos` is not an input to that derivation, so MuJoCo compiles a non-finite body
+placement with or without a free joint - movable task objects as well as the tables and cabinets
+whose footprint a manipulation scene is planned against.
+
+The disposition follows the sibling rather than inventing one: refuse, naming the body and the
+attribute the file used. The finiteness test moves into `_refuse_non_finite_placement`, the single
+owner the geom locator and the new body locator both delegate to, so neither can drift into
+tolerating what the other refuses; the guard's own docstring already named this accumulator as the
+step that drops a non-finite value, while the accumulator's own input went ungraded.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -1831,6 +1831,61 @@ def _segment_aabb(
     return center, half  # type: ignore[return-value]
 
 
+def _refuse_non_finite_placement(where: str, attribute: str, values: Sequence[float]) -> None:
+    """Refuse a placement or extent that parsed but is not finite.
+
+    The single owner of the finiteness test, so the geom paths and the body
+    paths cannot drift into tolerating what the other refuses. ``where`` is the
+    locator its caller built - :func:`_refuse_non_finite_geom` for a geom,
+    :func:`_refuse_non_finite_body` for a body - because the two elements are
+    located differently and only the wording below is shared.
+
+    Args:
+        where: The element at fault, already rendered for the message.
+        attribute: The MJCF attribute whose parsed value is not finite.
+        values: The parsed components, reported so the caller sees which.
+
+    Raises:
+        ValueError: If any component of ``values`` is not finite.
+    """
+    if all(map(math.isfinite, values)):
+        return
+    raise ValueError(
+        f"{where}: {attribute} has a component that is not finite ({tuple(values)!r}) - a body "
+        f"measured around it reports a collision bound for geometry the scene does not declare, "
+        f"so the geom is refused instead of measured around"
+    )
+
+
+def _refuse_non_finite_body(body_el: ET.Element, attribute: str, values: Sequence[float]) -> None:
+    """Refuse a body whose own placement parsed but is not finite.
+
+    A body's ``pos`` is folded into the bound exactly as a geom's is - the
+    top-level one becomes the object's reported ``position``, and a nested
+    one becomes the running offset every geom below it is measured from. A
+    non-finite component there is dropped by the same running ``min``/``max``
+    :func:`_refuse_non_finite_geom` describes, so the whole subtree disappears
+    from the bound while every field the loader reports stays finite: a table
+    whose leg hangs off a ``pos="0 0 nan"`` body is measured as its tabletop
+    alone, byte-identical to the same fixture with the leg deleted.
+
+    Bodies carry no ``type``, so an unnamed one is located as ``<body>`` rather
+    than by the resolved-type fallback the geom locator uses. The element is
+    read directly rather than through :func:`_class_attrs`: MJCF ``<default>``
+    classes supply geom attributes, not a body's own placement.
+
+    Args:
+        body_el: The ``<body>`` whose parsed placement is not finite.
+        attribute: The MJCF attribute at fault (``pos`` or the orientation).
+        values: The parsed components, reported so the caller sees which.
+
+    Raises:
+        ValueError: If any component of ``values`` is not finite.
+    """
+    name = body_el.get("name")
+    _refuse_non_finite_placement(f"body {name!r}" if name else "unnamed <body>", attribute, values)
+
+
 def _refuse_non_finite_geom(attrs: Mapping[str, str], attribute: str, values: Sequence[float]) -> None:
     """Refuse a geom whose placement or extent parsed but is not finite.
 
@@ -1882,15 +1937,9 @@ def _refuse_non_finite_geom(attrs: Mapping[str, str], attribute: str, values: Se
     Raises:
         ValueError: If any component of ``values`` is not finite.
     """
-    if all(map(math.isfinite, values)):
-        return
     name = attrs.get("name")
     where = f"geom {name!r}" if name else f'unnamed <geom type="{attrs.get("type", "sphere")}">'
-    raise ValueError(
-        f"{where}: {attribute} has a component that is not finite ({tuple(values)!r}) - a body "
-        f"measured around it reports a collision bound for geometry the scene does not declare, "
-        f"so the geom is refused instead of measured around"
-    )
+    _refuse_non_finite_placement(where, attribute, values)
 
 
 def _geom_aabb(
@@ -2047,9 +2096,12 @@ def _body_collision_aabb(
     The union below is a running ``min``/``max``, which would order a NaN as
     neither smaller nor larger than anything and drop the geom carrying it -
     reporting the bounds of the geoms that are finite, under no error. That
-    input never arrives here: :func:`_geom_aabb` refuses a non-finite
-    placement or extent at the parse (:func:`_refuse_non_finite_geom`), so
-    every AABB folded in is finite by the time it reaches this comparison.
+    input never arrives here: :func:`_geom_aabb` refuses a non-finite geom
+    placement or extent at the parse (:func:`_refuse_non_finite_geom`), and
+    :func:`_recursive_collision_aabb` refuses a non-finite body ``pos`` before
+    it becomes the offset a subtree is measured from
+    (:func:`_refuse_non_finite_body`), so every AABB folded in is finite by the
+    time it reaches this comparison.
 
     ``angle_scale`` and ``eulerseq`` come from the model's ``<compiler>`` and
     are only forwarded; they default to MJCF's own defaults (degrees, ``xyz``)
@@ -2107,6 +2159,11 @@ def _recursive_collision_aabb(
         found = True
     for child in body_el.findall("body"):
         child_off = _parse_xyz(child.get("pos"))
+        # The running offset every geom below this child is measured from, so a
+        # non-finite component makes each of their bounds non-finite and the
+        # min/max above drops the whole subtree - leaving every field the loader
+        # reports finite and the bound describing the geoms that remain.
+        _refuse_non_finite_body(child, "pos", child_off)
         new_off = (offset[0] + child_off[0], offset[1] + child_off[1], offset[2] + child_off[2])
         found = (
             _recursive_collision_aabb(
@@ -2167,7 +2224,7 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
     ValueError
         If the XML is malformed, the root isn't ``<mujoco>``, there is no
         ``<worldbody>``, a selected mesh asset file is missing on disk, or a
-        geom declares a placement or extent that is not finite (a body
+        geom or body declares a placement or extent that is not finite (a body
         measured around one reports a collision bound for geometry the scene
         does not declare, so it is refused rather than approximated).
     """
@@ -2203,7 +2260,13 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
             continue
 
         body_pos = _parse_xyz(body_el.get("pos"))
+        _refuse_non_finite_body(body_el, "pos", body_pos)
         body_quat = _parse_orientation(body_el.attrib, angle_scale=angle_scale, eulerseq=eulerseq)
+        # Name the spelling the file used, so the refusal points at an attribute
+        # a reader can go and look at rather than at the resolved quaternion -
+        # the rule _geom_aabb already follows for a geom's orientation.
+        body_spelling = next((a for a in _ORIENTATION_SPELLINGS if body_el.get(a)), "quat")
+        _refuse_non_finite_body(body_el, body_spelling, body_quat)
 
         # Movable object? -> has a free joint (``<freejoint>`` or
         # ``<joint type="free">``). Otherwise treat as a static fixture.

--- a/tests/simulation/isaac/test_non_finite_body_placement_is_refused_not_measured_around.py
+++ b/tests/simulation/isaac/test_non_finite_body_placement_is_refused_not_measured_around.py
@@ -1,0 +1,313 @@
+"""A body whose own placement is not finite is refused, not measured around.
+
+``load_mjcf_scene_objects`` composes a
+:class:`~strands_robots.simulation.isaac.loaders.SceneObject` from three
+placements: the top-level body's ``pos`` becomes the object's ``position``, its
+orientation becomes ``quat``, and each nested body's ``pos`` becomes the running
+offset every geom below it is measured from. ``_geom_aabb`` refuses a non-finite
+value on all four of a *geom*'s parse paths. The *body* placements the same
+bound is composed from were read straight through ``_parse_xyz`` /
+``_parse_orientation``, whose contract is to fall back to a default on an
+unreadable attribute and to return whatever a readable one parsed to.
+
+The nested case is the one nothing can detect. ``_recursive_collision_aabb``
+unions its subtree with a running ``min``/``max``, and Python orders a NaN as
+neither smaller nor larger than anything, so a comparison against one keeps the
+accumulator it started with. A non-finite offset makes every bound below it
+non-finite, so the whole subtree disappears from the union::
+
+    table, leg body pos="0 0 -0.37"  -> size (0.8, 0.8, 0.76)
+    table, leg body pos="0 0 nan"    -> size (0.8, 0.8, 0.04)
+    table with the leg deleted       -> size (0.8, 0.8, 0.04)
+
+-- a 4 cm slab where the file declares a 76 cm table, byte-identical to the same
+fixture with the leg deleted, under ``status`` success, and with every field the
+loader reports finite. That last part is what separates it from the geom
+spellings: a consumer cannot screen for it. The other placements fail more
+loudly but no more correctly - a non-finite top-level ``pos`` or orientation is
+reported verbatim as the object's own, and ``pos="0 0 inf"`` on a nested body
+reports an infinite extent, because ``inf - inf`` is a NaN the outer accumulator
+drops in turn.
+
+Reachability is wider here than for the geom spellings, and the difference is
+worth being precise about. The geom finding is scoped to fixtures: a non-finite
+geom makes the inertia MuJoCo derives non-finite, so it refuses a body with a
+free joint and compiles the same geom on one without. A body's own ``pos`` is
+not an input to that derivation, so MuJoCo compiles a non-finite body placement
+with or without a free joint -- movable task objects as well as the tables and
+cabinets whose footprint a manipulation scene is planned against. Every scene
+carrying one reaches the reader, which is why it cannot defer the question to a
+compile step.
+
+The disposition follows the sibling rather than inventing one: refuse, naming
+the body and the attribute, because ``None`` from these readers means "this
+attribute was unreadable, use the documented default" and a caller cannot tell
+that apart from "this attribute was read and is not a number".
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+from pathlib import Path
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.isaac.loaders import (  # noqa: E402
+    _ORIENTATION_SPELLINGS,
+    _refuse_non_finite_body,
+    _refuse_non_finite_placement,
+    load_mjcf_scene_objects,
+)
+
+_TOP_GEOM = '<geom name="t_top" type="box" size="0.40 0.40 0.02"/>'
+_LEG_GEOM = '<geom name="t_leg" type="box" size="0.03 0.03 0.37"/>'
+
+# Every spelling of a non-finite body placement, as (label, attribute, scene).
+# The leg hangs BELOW the tabletop, so the nested body's own pos is what extends
+# the bound downward: a fixture whose child sits inside the parent's span cannot
+# show a dropped contribution at all.
+_NESTED_NON_FINITE = [
+    ("nested-pos-nan", "pos", '<body name="t_leg_body" pos="0 0 nan">'),
+    ("nested-pos-inf", "pos", '<body name="t_leg_body" pos="0 0 inf">'),
+    ("nested-pos-negative-inf", "pos", '<body name="t_leg_body" pos="0 0 -inf">'),
+]
+_TOP_NON_FINITE = [
+    ("top-pos-nan", "pos", 'pos="nan 0 0.75"'),
+    ("top-pos-inf", "pos", 'pos="inf 0 0.75"'),
+    ("top-quat-nan", "quat", 'pos="0 0 0.75" quat="nan 0 0 1"'),
+    ("top-euler-nan", "euler", 'pos="0 0 0.75" euler="nan 0 0"'),
+    ("top-axisangle-nan", "axisangle", 'pos="0 0 0.75" axisangle="0 0 1 nan"'),
+    ("top-zaxis-nan", "zaxis", 'pos="0 0 0.75" zaxis="nan 0 1"'),
+]
+
+
+def _ids(rows: list[tuple[str, str, str]]) -> list[str]:
+    return [row[0] for row in rows]
+
+
+def _scene(*, top: str = 'pos="0 0 0.75"', leg_open: str = '<body name="t_leg_body" pos="0 0 -0.37">') -> str:
+    """A static table fixture: a tabletop plus a leg on a nested body.
+
+    Args:
+        top: The top-level body's own attributes.
+        leg_open: The opening tag of the nested body carrying the leg.
+
+    Returns:
+        A complete MJCF document.
+    """
+    return (
+        f'<mujoco model="kitchen"><worldbody>'
+        f'<body name="kitchen_table" {top}>{_TOP_GEOM}'
+        f"{leg_open}{_LEG_GEOM}</body>"
+        f"</body></worldbody></mujoco>"
+    )
+
+
+def _write(tmp_path: Path, scene: str) -> str:
+    path = tmp_path / "kitchen.xml"
+    path.write_text(scene)
+    return str(path)
+
+
+def _size(tmp_path: Path, scene: str) -> tuple[float, float, float]:
+    objects = load_mjcf_scene_objects(_write(tmp_path, scene))
+    assert objects, "the fixture declares one object; the reader found none"
+    return tuple(round(v, 4) for v in objects[0].size)  # type: ignore[return-value]
+
+
+class TestThePremisesTheFindingRestsOn:
+    """These hold before and after the fix; the report is unfounded without them."""
+
+    @pytest.mark.parametrize(("_label", "_attribute", "leg_open"), _NESTED_NON_FINITE, ids=_ids(_NESTED_NON_FINITE))
+    def test_mujoco_compiles_a_non_finite_nested_body(
+        self, tmp_path: Path, _label: str, _attribute: str, leg_open: str
+    ) -> None:
+        # A non-finite body placement on a fixture is a model MuJoCo accepts, so
+        # the reader really does meet these scenes.
+        model = mujoco.MjModel.from_xml_path(_write(tmp_path, _scene(leg_open=leg_open)))
+        assert model.ngeom == 2
+
+    @pytest.mark.parametrize(("_label", "_attribute", "top"), _TOP_NON_FINITE, ids=_ids(_TOP_NON_FINITE))
+    def test_mujoco_compiles_a_non_finite_top_level_body(
+        self, tmp_path: Path, _label: str, _attribute: str, top: str
+    ) -> None:
+        model = mujoco.MjModel.from_xml_path(_write(tmp_path, _scene(top=top)))
+        assert model.ngeom == 2
+
+    def test_a_free_joint_does_not_narrow_the_reachability_the_way_it_does_for_a_geom(self, tmp_path: Path) -> None:
+        # The geom finding is scoped to fixtures: a non-finite geom makes the
+        # inertia MuJoCo derives non-finite, so it refuses a moving body. A
+        # body's own pos is not an input to that derivation, so MuJoCo compiles
+        # it either way and this finding is NOT scoped to fixtures. A free joint
+        # is only legal on a top-level body, so that is where it is declared.
+        moving = (
+            '<mujoco model="kitchen"><worldbody>'
+            '<body name="kitchen_table" pos="0 0 0.75"><freejoint/>'
+            f'{_TOP_GEOM}<body name="t_leg_body" pos="0 0 nan">{_LEG_GEOM}</body>'
+            "</body></worldbody></mujoco>"
+        )
+        assert mujoco.MjModel.from_xml_path(_write(tmp_path, moving)).ngeom == 2
+        assert mujoco.MjModel.from_xml_path(_write(tmp_path, _scene(leg_open='<body pos="0 0 nan">'))).ngeom == 2
+
+    def test_a_running_min_max_drops_a_nan_rather_than_propagating_it(self) -> None:
+        # The mechanism itself, so a reader need not take it on trust.
+        assert min(float("inf"), float("nan")) == float("inf")
+        assert max(float("-inf"), float("nan")) == float("-inf")
+        # And why an infinite offset lands as an infinite extent rather than
+        # being dropped: the subtraction that leaves is a NaN one level up.
+        assert math.isnan(float("inf") - float("inf"))
+
+    def test_the_geom_spellings_were_already_refused(self, tmp_path: Path) -> None:
+        # The in-file control for the whole finding: the sibling guard covers a
+        # geom's own placement, which is why only the body placements remained.
+        scene = (
+            '<mujoco model="kitchen"><worldbody><body name="kitchen_table" pos="0 0 0.75">'
+            f'{_TOP_GEOM}<geom name="t_side" type="box" size="0.1 0.1 0.1" pos="nan 0 0"/>'
+            "</body></worldbody></mujoco>"
+        )
+        with pytest.raises(ValueError, match=r"geom 't_side': pos has a component that is not finite"):
+            load_mjcf_scene_objects(_write(tmp_path, scene))
+
+    def test_the_orientation_spellings_are_the_modules_own_vocabulary(self) -> None:
+        # The refusal names the attribute the file used, taken from the list the
+        # reader already resolves orientation through rather than a second copy.
+        named = {attribute for _, attribute, _ in _TOP_NON_FINITE}
+        assert named & set(_ORIENTATION_SPELLINGS) == named - {"pos"}
+
+
+class TestANonFiniteBodyPlacementIsRefusedByName:
+    """The regression: every spelling refuses, naming the body and the attribute."""
+
+    @pytest.mark.parametrize(("_label", "attribute", "leg_open"), _NESTED_NON_FINITE, ids=_ids(_NESTED_NON_FINITE))
+    def test_a_nested_body_is_refused(self, tmp_path: Path, _label: str, attribute: str, leg_open: str) -> None:
+        with pytest.raises(ValueError, match="is not finite") as excinfo:
+            load_mjcf_scene_objects(_write(tmp_path, _scene(leg_open=leg_open)))
+        assert f"{attribute} has a component that is not finite" in str(excinfo.value)
+
+    @pytest.mark.parametrize(("_label", "attribute", "top"), _TOP_NON_FINITE, ids=_ids(_TOP_NON_FINITE))
+    def test_a_top_level_body_is_refused(self, tmp_path: Path, _label: str, attribute: str, top: str) -> None:
+        with pytest.raises(ValueError, match="is not finite") as excinfo:
+            load_mjcf_scene_objects(_write(tmp_path, _scene(top=top)))
+        assert f"{attribute} has a component that is not finite" in str(excinfo.value)
+
+    def test_the_refusal_names_the_body_rather_than_a_geom(self, tmp_path: Path) -> None:
+        # Bodies and geoms are located differently; reporting one as the other
+        # sends a reader to an element that is not at fault.
+        with pytest.raises(ValueError, match=r"^body 't_leg_body': ") as excinfo:
+            load_mjcf_scene_objects(_write(tmp_path, _scene(leg_open='<body name="t_leg_body" pos="0 0 nan">')))
+        assert "geom" not in str(excinfo.value).split(":")[0]
+
+    def test_an_unnamed_nested_body_is_located_as_a_body(self, tmp_path: Path) -> None:
+        # A body carries no ``type``, so the geom locator's resolved-type
+        # fallback has nothing to report; ``<body>`` is what is left.
+        with pytest.raises(ValueError, match=r"^unnamed <body>: pos has a component"):
+            load_mjcf_scene_objects(_write(tmp_path, _scene(leg_open='<body pos="0 0 nan">')))
+
+    def test_the_fixture_is_no_longer_measured_as_its_tabletop_alone(self, tmp_path: Path) -> None:
+        # The headline: the reported size was byte-identical to the same fixture
+        # with the leg deleted, and every field it reported was finite.
+        healthy = _size(tmp_path, _scene())
+        deleted = _size(
+            tmp_path,
+            '<mujoco model="kitchen"><worldbody><body name="kitchen_table" pos="0 0 0.75">'
+            f"{_TOP_GEOM}</body></worldbody></mujoco>",
+        )
+        assert healthy != deleted, "the fixture cannot show a dropped subtree"
+        assert healthy[2] == pytest.approx(0.76)
+        assert deleted[2] == pytest.approx(0.04)
+        with pytest.raises(ValueError, match="is not finite"):
+            load_mjcf_scene_objects(_write(tmp_path, _scene(leg_open='<body name="t_leg_body" pos="0 0 nan">')))
+
+    def test_an_infinite_offset_is_not_reported_as_an_infinite_extent(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="is not finite"):
+            load_mjcf_scene_objects(_write(tmp_path, _scene(leg_open='<body name="t_leg_body" pos="0 0 inf">')))
+
+    def test_a_grandchild_under_a_non_finite_parent_is_refused(self, tmp_path: Path) -> None:
+        # The offset is composed as the walk descends, so a non-finite component
+        # anywhere above a geom drops it. The refusal names the body at fault
+        # rather than the deepest one carrying geometry.
+        scene = (
+            '<mujoco model="kitchen"><worldbody><body name="kitchen_table" pos="0 0 0.75">'
+            f'{_TOP_GEOM}<body name="t_frame" pos="0 0 nan">'
+            f'<body name="t_leg_body" pos="0 0 -0.37">{_LEG_GEOM}</body></body>'
+            "</body></worldbody></mujoco>"
+        )
+        with pytest.raises(ValueError, match=r"^body 't_frame': pos has a component"):
+            load_mjcf_scene_objects(_write(tmp_path, scene))
+
+    def test_the_refusal_says_what_the_alternative_would_have_been(self, tmp_path: Path) -> None:
+        # The message earns the refusal by naming the reading it declined to
+        # emit, which is what tells a reader why a load stopped.
+        with pytest.raises(ValueError, match="collision bound for geometry the scene does not declare"):
+            load_mjcf_scene_objects(_write(tmp_path, _scene(leg_open='<body name="t_leg_body" pos="0 0 nan">')))
+
+
+class TestWhatIsDeliberatelyUnchanged:
+    """A finite fixture, and an unreadable attribute, behave exactly as before."""
+
+    def test_a_healthy_fixture_reports_exactly_what_it_did(self, tmp_path: Path) -> None:
+        assert _size(tmp_path, _scene()) == pytest.approx((0.8, 0.8, 0.76))
+
+    def test_an_unparseable_placement_still_falls_back_to_its_default(self, tmp_path: Path) -> None:
+        # ``_parse_xyz`` returns its documented default for an attribute it
+        # cannot read. Only a value that PARSED is graded, so this is unchanged:
+        # the leg sits at the body origin rather than the scene being refused.
+        size = _size(tmp_path, _scene(leg_open='<body name="t_leg_body" pos="not a vector">'))
+        assert all(map(math.isfinite, size))
+
+    @pytest.mark.parametrize("value", ["1e308", "-1e308", "0", "1e-300"])
+    def test_an_extreme_but_finite_placement_is_accepted(self, tmp_path: Path, value: str) -> None:
+        size = _size(tmp_path, _scene(leg_open=f'<body name="t_leg_body" pos="0 0 {value}">'))
+        assert all(map(math.isfinite, size))
+
+    def test_the_helper_is_silent_on_finite_input(self) -> None:
+        element = ast_element('<body name="t_leg_body"/>')
+        _refuse_non_finite_body(element, "pos", (0.0, -1.5, 2.0))
+        _refuse_non_finite_body(element, "pos", ())
+        _refuse_non_finite_placement("body 't'", "pos", (1.0, 2.0, 3.0))
+
+
+class TestTheAccumulatorsGuardCoversTheMeshWalkToo:
+    """Two walks compose the same offsets, so one guard answers for both.
+
+    ``_find_body_mesh`` composes a nested body's ``pos`` into the mesh offset
+    exactly as ``_recursive_collision_aabb`` composes it into the bound. Both
+    descend the same ``findall("body")`` traversal from the same root, so every
+    body the mesh walk reads is a body the guarded accumulator also reads - a
+    second guard there would be unreachable, and it would mask the one whose
+    harm this file measures.
+    """
+
+    def test_both_walks_descend_the_same_traversal(self) -> None:
+        from strands_robots.simulation.isaac import loaders
+
+        for name in ("_recursive_collision_aabb", "_find_body_mesh"):
+            source = inspect.getsource(getattr(loaders, name)).strip()
+            loops = [ast.unparse(node.iter) for node in ast.walk(ast.parse(source)) if isinstance(node, ast.For)]
+            # ``ast.unparse`` normalizes string quotes, so match its spelling.
+            assert "body_el.findall('body')" in loops, (name, loops)
+
+    def test_the_mesh_walk_carries_no_finiteness_test_of_its_own(self) -> None:
+        from strands_robots.simulation.isaac import loaders
+
+        source = inspect.getsource(loaders._find_body_mesh)
+        assert "isfinite" not in source
+        assert "_refuse_non_finite" not in source
+
+
+def ast_element(xml: str):
+    """Parse a single XML element, for driving the helper directly.
+
+    Args:
+        xml: A one-element document.
+
+    Returns:
+        The parsed element.
+    """
+    import xml.etree.ElementTree as ET
+
+    return ET.fromstring(xml)

--- a/tests/simulation/isaac/test_non_finite_geom_is_refused_not_measured_around.py
+++ b/tests/simulation/isaac/test_non_finite_geom_is_refused_not_measured_around.py
@@ -322,7 +322,11 @@ class TestTheRefusalLocatesAnUnnamedGeom:
 
 
 class TestOneOwnerForTheWording:
-    """One guard for all four parse paths, so no spelling drifts from the rest."""
+    """One guard for every parse path, so no spelling drifts from the rest.
+
+    Four geom paths (``pos``, ``size``, the orientation spelling, ``fromto``)
+    and the body placements the same bound is composed from.
+    """
 
     def test_every_finiteness_refusal_in_the_module_is_the_shared_one(self) -> None:
         import ast
@@ -341,7 +345,26 @@ class TestOneOwnerForTheWording:
                 if isinstance(inner, ast.Attribute) and inner.attr == "isfinite":
                     owners.add(node.name)
         assert owners, "the scan found no finiteness test at all - it is looking in the wrong place"
-        assert owners == {"_refuse_non_finite_geom"}, owners
+        assert owners == {"_refuse_non_finite_placement"}, owners
+
+    def test_every_locator_delegates_to_that_one_owner(self) -> None:
+        # Geoms and bodies are located differently but share the wording, so
+        # each locator must reach the single owner rather than raise its own.
+        import ast
+        import inspect
+
+        from strands_robots.simulation.isaac import loaders
+
+        for wrapper in ("_refuse_non_finite_geom", "_refuse_non_finite_body"):
+            tree = ast.parse(inspect.getsource(getattr(loaders, wrapper)).strip())
+            called = {
+                node.func.id
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            assert "_refuse_non_finite_placement" in called, (wrapper, called)
+            raises = [n for n in ast.walk(tree) if isinstance(n, ast.Raise)]
+            assert raises == [], (wrapper, "a locator must not carry its own wording")
 
     def test_the_guard_is_reached_from_every_parse_path(self) -> None:
         import ast


### PR DESCRIPTION
## What is wrong

`load_mjcf_scene_objects` composes a `SceneObject` from three placements: the top-level body's `pos`
becomes the object's `position`, its orientation becomes `quat`, and each nested body's `pos` becomes
the running offset every geom below it is measured from.

`_geom_aabb` refuses a non-finite value on all four of a *geom*'s parse paths (#2813). The *body*
placements the same bound is composed from were read straight through `_parse_xyz` /
`_parse_orientation`, whose contract is to fall back to a documented default on an unreadable
attribute and to return whatever a readable one parsed to.

The nested case is the one nothing can detect. A non-finite offset makes every bound below it
non-finite, and the running `min`/`max` in `_recursive_collision_aabb` orders a NaN as neither smaller
nor larger than anything, so the whole subtree disappears from the union while the walk still reports
that it found analytic geometry.

Measured through the public loader on a table fixture whose leg hangs off a nested body. All ten rows
compile in MuJoCo:

| input | outcome | non-finite fields reported | reported `size` |
|---|---|---|---|
| finite placement (control) | success | none | `(0.8, 0.8, 0.76)` |
| nested body `pos="0 0 nan"` | success | **none** | **`(0.8, 0.8, 0.04)`** |
| nested body `pos="0 0 inf"` | success | position, size, offset | `(0.8, 0.8, inf)` |
| top body `pos="nan 0 0.75"` | success | position | `(0.8, 0.8, 0.76)` |
| top body `pos="inf 0 0.75"` | success | position | `(0.8, 0.8, 0.76)` |
| top body `quat="nan 0 0 1"` | success | quat | `(0.8, 0.8, 0.76)` |
| top body `euler="nan 0 0"` | success | quat | `(0.8, 0.8, 0.76)` |
| top body `axisangle="0 0 1 nan"` | success | quat | `(0.8, 0.8, 0.76)` |
| geom `pos="nan 0 0"` | **refused** | - | - |

The second row is the defect worth leading with. `(0.8, 0.8, 0.04)` is a 4 cm slab where the file
declares a 76 cm table, it is **byte-identical to the same fixture with the leg deleted**, and every
field the loader reports is finite - so unlike the geom spellings a consumer cannot screen for it. The
last row is the in-file control: the sibling guard already covers a geom's own placement, which is why
only the body placements remained.

Reachability is **wider** here than for the geom spellings, and this is the one place I do not simply
inherit that finding's argument. #2813 is scoped to fixtures because a non-finite geom makes the
inertia MuJoCo derives non-finite, so MuJoCo refuses a body with a free joint. A body's own `pos` is
not an input to that derivation, so MuJoCo compiles a non-finite body placement **with or without** a
free joint - movable task objects as well as static fixtures. Verified both ways.

## The change

The finiteness test moves into `_refuse_non_finite_placement`, the single owner that the geom locator
and a new body locator both delegate to, so neither can drift into tolerating what the other refuses.
`_refuse_non_finite_geom` keeps its name, signature and message, and all four of its call sites are
untouched. Three new call sites: the nested body's `pos` in `_recursive_collision_aabb`, and the
top-level body's `pos` and orientation in `load_mjcf_scene_objects`. The orientation refusal names the
spelling the file used, which is the rule `_geom_aabb` already follows.

The disposition follows the sibling rather than inventing one. `None` from these readers means "this
attribute was unreadable, use the documented default", and a caller cannot tell that apart from "this
attribute was read and is not a number".

`_geom_aabb`'s own docstring already named `_recursive_collision_aabb`'s accumulator as the step that
drops a non-finite value one level up - while that accumulator's own input went ungraded. Both
docstring claims are corrected in the same change, as is `load_mjcf_scene_objects`' `Raises:` block.

### Scope boundary

`_find_body_mesh` composes a nested body's `pos` into the mesh offset the same way, and it is
deliberately **not** guarded. Both walks descend the same `body_el.findall("body")` traversal from the
same root, so every body the mesh walk reads is a body the guarded accumulator also reads: a second
guard there would be unreachable, and because the mesh walk runs first it would mask the one whose
harm this change measures. That traversal identity is pinned by a test rather than asserted here.

## Evidence

Pre-fix split (behavioural revert - the helpers kept, the three call sites removed): **15 failed / 66
passed**, all 15 in the regression class, and **0** in all 6 premise cells, **0** in all 4 controls,
**0** in the scope-boundary class and **0** in every one of the 5 pre-existing geom classes. A raw
revert is a collection error instead, since the suite imports the helpers the change introduces.

Mutation table - 11 mutations, **9 distinct firing sets**, control 0, `collected` stable at 37 on every
row (so no row hides a deselection):

| mutation | fires | sibling suites | note |
|---|---|---|---|
| control | 0 | 0 | |
| nested-body `pos` guard dropped | 9 | 0 | |
| top-level `pos` guard dropped | 2 | 0 | |
| top-level orientation guard dropped | 4 | 0 | union of the three = **15**, disjoint, = the pre-fix split |
| body locator reports `geom` | 3 | 0 | |
| unnamed body borrows the geom type fallback | 1 | 0 | |
| orientation spelling hardcoded to `quat` | 3 | 0 | |
| finiteness test weakened to `any()` | 13 | **14** | it is the shared owner, so it breaks the geom paths too |
| body wrapper raises its own wording | 2 | **2** | trips the pre-existing one-owner test |
| guard reads only the first component | 9 | 0 | |
| guard placed after the offset is composed | **0** | 0 | measured no-op: it still refuses before the recursion |

Gate: `ruff check` and `ruff format --check` clean over 1635 files; `mypy` 24 errors, byte-identical to
the pre-change baseline on this tree with **0 attributable** to the changed files;
`tests/simulation/isaac/` **1804 passed, 5 skipped, 0 failed**.

## Visual

The reported collision proxy drawn over the geometry it claims to bound. One camera, one lighting
setup, one crop and one alpha for all three panels; the middle proxy leaves **8,106 of 16,782** of the
table's silhouette (48%) outside the box that is supposed to contain it, against **0 px** for the
finite placement.

![reported collision proxy against the geometry it bounds](https://github.com/cagataycali/robots/releases/download/artifacts/2827-non-finite-body-placement.png)
