### PR TITLE
fix(drivers/g1): the stop verb reports the halt outcome instead of asserting one

### DIFF
--- a/changelog.d/2828-g1-stop-reports-the-halt-outcome-not-a-stale-refusal.md
+++ b/changelog.d/2828-g1-stop-reports-the-halt-outcome-not-a-stale-refusal.md
@@ -1,18 +1,34 @@
-### Docs: g1 driver's ``stop`` verb reports the halt outcome, not a stale #358 refusal
+### Fixed: g1 driver's ``stop`` verb reports the halt outcome instead of asserting one
 
-``G1Driver.stream({"action": "stop"})`` mapped to a text envelope claiming
-"no motion path wired yet (issue #358)". That claim was stale: issue #361
-already landed the transport primitive - :class:`DDSPublisher` on
-``rt/lowcmd``, :meth:`send_action` publishing ``LowCmd_``, the 500 Hz
-control loop, and :meth:`stop_task` publishing a zero-torque frame on the
-way out. The verb was calling the wired :meth:`stop` and lying about it.
+``G1Driver.stream({"action": "stop"})`` built its envelope beside
+``await self.stop()`` and hardcoded ``status="success"``. Two things were wrong
+with the text it carried. It named issue #358 and claimed no motion path was
+wired, which is stale - #361 landed :class:`DDSPublisher` on ``rt/lowcmd``,
+:meth:`send_action`, the 500 Hz control loop and the zero-torque frame the loop
+publishes on exit. And the envelope could not report what the stop achieved,
+because ``stop`` is the protocol's shutdown hook and returns ``None``: an
+envelope written next to it can only restate the intent.
 
-Now the envelope names what the code does: "control loop halted; a running
-task publishes a zero-torque frame on exit". The ``inputSchema`` description
-for the ``stop`` action is updated to match, and
-``test_stream_stop_action_calls_stop`` pins both the new text and a guard
-against the pre-#361 refusal text sneaking back through a rebase.
+That mattered on the case :meth:`_ControlLoop.stop`'s own docstring names. It
+returns whether the thread joined, and a caller-supplied policy that outlasts
+the join budget - a remote inference call is the ordinary case - leaves the loop
+publishing frames. ``stop_task`` already reads that verdict and answers
+``status="error"`` with ``stopped=False`` and ``running=True``; ``cleanup`` and
+``stop`` were taught to read it too. The verb an agent reaches was the one
+surface left that could not say the stop had failed:
 
-No behaviour change - the wire path was already live. This is a docs and
-observability fix so an agent that reads the tool spec sees the surface it
-gets.
+```text
+policy parked past the 2.0s join budget, same driver, same wedge
+
+  stream({"action": "stop"})   status="success"   text only, loop still running
+  stop_task()                  status="error"     stopped=False, running=True
+```
+
+The verb now returns ``stop_task``'s envelope, so the verdict has one owner
+rather than two: a joined stop is still ``success`` and carries
+``stopped=True``, an unjoined one is an ``error`` naming the timeout, and a
+driver with nothing running says so instead of claiming a halt it did not
+perform. The ``inputSchema`` description promises the report the verb now
+delivers, and ``tests/drivers/test_g1_stream_stop_reports_the_halt_outcome.py``
+parks a policy past the budget to grade it - the fast path the shipped suite
+drives cannot distinguish a reported outcome from an asserted one.

--- a/changelog.d/2828-g1-stop-reports-the-halt-outcome-not-a-stale-refusal.md
+++ b/changelog.d/2828-g1-stop-reports-the-halt-outcome-not-a-stale-refusal.md
@@ -1,0 +1,18 @@
+### Docs: g1 driver's ``stop`` verb reports the halt outcome, not a stale #358 refusal
+
+``G1Driver.stream({"action": "stop"})`` mapped to a text envelope claiming
+"no motion path wired yet (issue #358)". That claim was stale: issue #361
+already landed the transport primitive - :class:`DDSPublisher` on
+``rt/lowcmd``, :meth:`send_action` publishing ``LowCmd_``, the 500 Hz
+control loop, and :meth:`stop_task` publishing a zero-torque frame on the
+way out. The verb was calling the wired :meth:`stop` and lying about it.
+
+Now the envelope names what the code does: "control loop halted; a running
+task publishes a zero-torque frame on exit". The ``inputSchema`` description
+for the ``stop`` action is updated to match, and
+``test_stream_stop_action_calls_stop`` pins both the new text and a guard
+against the pre-#361 refusal text sneaking back through a rebase.
+
+No behaviour change - the wire path was already live. This is a docs and
+observability fix so an agent that reads the tool spec sees the surface it
+gets.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -349,7 +349,8 @@ class G1Driver:
                                 "description": (
                                     "sensors: return the latest cached IMU/battery/lidar; "
                                     "status: report connection and FSM; "
-                                    "stop: halt any running control loop and publish a zero-torque frame"
+                                    "stop: halt any running control loop - it publishes a zero-torque "
+                                    "frame on exit - and report whether it joined"
                                 ),
                                 "enum": ["sensors", "status", "stop"],
                                 "default": "sensors",
@@ -370,10 +371,11 @@ class G1Driver:
         """Handle one agent invocation and yield exactly one tool result.
 
         The three verbs the spec declares are all agent-safe: ``sensors`` and
-        ``status`` are read-only, and ``stop`` is a controlled stop that runs
-        :meth:`stop` (which joins any running control loop and publishes a
-        zero-torque frame on the way out - see :meth:`stop_task`).  The rich
-        motion verb set (``arm``, ``walk``, ``posture``, ``speak``,
+        ``status`` are read-only, and ``stop`` is a controlled stop that
+        delegates to :meth:`stop_task` - it joins any running control loop,
+        the loop publishes a zero-torque frame on the way out, and the
+        returned envelope reports whether the thread actually joined.  The
+        rich motion verb set (``arm``, ``walk``, ``posture``, ``speak``,
         ``lidar_snapshot``) lands in issue #358 as vendored neon tools that
         the agent gets in addition to the driver-as-tool; the transport
         primitive those verbs will call - :meth:`send_action` publishing on
@@ -403,13 +405,16 @@ class G1Driver:
                 "content": [{"json": await self.get_status()}],
             }
         else:  # "stop"
-            await self.stop()
-            envelope = {
-                "status": "success",
-                "content": [
-                    {"text": "stop: control loop halted; a running task publishes a zero-torque frame on exit"}
-                ],
-            }
+            # Report the halt outcome rather than assert one.  ``stop()`` is
+            # the protocol's shutdown hook and returns ``None``, so an
+            # envelope built beside it can only restate the intent: a policy
+            # that outlasts the join budget - a remote inference call is the
+            # ordinary case - leaves the loop writing frames while the agent
+            # reads ``success``.  ``stop_task`` performs the same halt and
+            # already decides the verdict (``stopped``, ``running`` and the
+            # timeout reason), so the verb returns that envelope rather than
+            # re-deriving it from the loop handle.
+            envelope = self.stop_task()
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -406,7 +406,9 @@ class G1Driver:
             await self.stop()
             envelope = {
                 "status": "success",
-                "content": [{"text": "stop: control loop halted; a running task publishes a zero-torque frame on exit"}],
+                "content": [
+                    {"text": "stop: control loop halted; a running task publishes a zero-torque frame on exit"}
+                ],
             }
         yield {"toolUseId": tool_use_id, **envelope}
 

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -349,7 +349,7 @@ class G1Driver:
                                 "description": (
                                     "sensors: return the latest cached IMU/battery/lidar; "
                                     "status: report connection and FSM; "
-                                    "stop: refuse further writes (a no-op today until #358 lands the motion verbs)"
+                                    "stop: halt any running control loop and publish a zero-torque frame"
                                 ),
                                 "enum": ["sensors", "status", "stop"],
                                 "default": "sensors",
@@ -369,11 +369,15 @@ class G1Driver:
     ) -> AsyncGenerator[Any, None]:
         """Handle one agent invocation and yield exactly one tool result.
 
-        The three verbs the spec declares are read-only or a no-op; each maps
-        to a dict already computed by the DDS callbacks. Motion belongs to
-        issue #358; this driver refuses ``stop`` in the same envelope shape it
-        will use once the motion path is wired, so a caller writes the same
-        error-checking code either way.
+        The three verbs the spec declares are all agent-safe: ``sensors`` and
+        ``status`` are read-only, and ``stop`` is a controlled stop that runs
+        :meth:`stop` (which joins any running control loop and publishes a
+        zero-torque frame on the way out - see :meth:`stop_task`).  The rich
+        motion verb set (``arm``, ``walk``, ``posture``, ``speak``,
+        ``lidar_snapshot``) lands in issue #358 as vendored neon tools that
+        the agent gets in addition to the driver-as-tool; the transport
+        primitive those verbs will call - :meth:`send_action` publishing on
+        ``rt/lowcmd`` - already ships (issue #361).
         """
         del kwargs  # forward-compat only
         del invocation_state
@@ -402,7 +406,7 @@ class G1Driver:
             await self.stop()
             envelope = {
                 "status": "success",
-                "content": [{"text": "stop: no motion path wired yet (issue #358)"}],
+                "content": [{"text": "stop: control loop halted; a running task publishes a zero-torque frame on exit"}],
             }
         yield {"toolUseId": tool_use_id, **envelope}
 
@@ -680,10 +684,6 @@ class G1Driver:
                 }
             ],
         }
-
-    # ------------------------------------------------------------------ #
-    # Task and policy paths (stubs until #358).                          #
-    # ------------------------------------------------------------------ #
 
     # ------------------------------------------------------------------ #
     # Task and policy paths.  The 500 Hz control loop lands here.        #

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -739,10 +739,14 @@ def test_stream_sensors_action_returns_the_cached_snapshots() -> None:
 
 
 def test_stream_stop_action_calls_stop() -> None:
-    """The ``stop`` verb runs :meth:`stop` and reports the no-op reason.
+    """The ``stop`` verb runs :meth:`stop` and reports the halt outcome.
 
-    Today ``stop`` is a debug log; the shape of the tool result already
-    matches what the motion-wired version will return.
+    The transport primitive that ``stop`` calls is wired: :meth:`stop`
+    joins any running control loop and the loop publishes a zero-torque
+    frame on the way out (see :meth:`stop_task`).  The envelope names
+    what happened rather than the pre-#361 refusal that claimed no
+    motion path was wired - a caller who reads the text sees the
+    behaviour the code has, not the behaviour it used to have.
     """
     driver = G1Driver(tool_name="g1", port="1.2.3.4")
 
@@ -753,7 +757,13 @@ def test_stream_stop_action_calls_stop() -> None:
 
     event = asyncio.run(_run())
     assert event["status"] == "success"
-    assert "issue #358" in event["content"][0]["text"]
+    text = event["content"][0]["text"]
+    assert "control loop halted" in text
+    # Guard against the pre-#361 refusal text sneaking back in a rebase:
+    # the driver's stop path now maps to a running behaviour, so the
+    # envelope must not claim otherwise.
+    assert "no motion path wired" not in text
+    assert "#358" not in text
 
 
 def test_cleanup_is_idempotent() -> None:

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -738,15 +738,17 @@ def test_stream_sensors_action_returns_the_cached_snapshots() -> None:
     assert payload["lidar_summary"] is None
 
 
-def test_stream_stop_action_calls_stop() -> None:
-    """The ``stop`` verb runs :meth:`stop` and reports the halt outcome.
+def test_stream_stop_action_reports_that_no_task_was_running() -> None:
+    """The ``stop`` verb names the state it found rather than a halt it did not perform.
 
-    The transport primitive that ``stop`` calls is wired: :meth:`stop`
-    joins any running control loop and the loop publishes a zero-torque
-    frame on the way out (see :meth:`stop_task`).  The envelope names
-    what happened rather than the pre-#361 refusal that claimed no
-    motion path was wired - a caller who reads the text sees the
-    behaviour the code has, not the behaviour it used to have.
+    The transport primitive is wired - :meth:`send_action` publishes on
+    ``rt/lowcmd`` and a running loop publishes a zero-torque frame on the
+    way out - so the pre-#361 refusal claiming no motion path exists is
+    stale.  But this driver has no loop, so "halted a control loop" would
+    be its own falsity: the verb delegates to :meth:`stop_task`, whose
+    idempotent branch names the state instead.  The loop-was-running
+    outcomes are graded in
+    ``tests/drivers/test_g1_stream_stop_reports_the_halt_outcome.py``.
     """
     driver = G1Driver(tool_name="g1", port="1.2.3.4")
 
@@ -758,7 +760,7 @@ def test_stream_stop_action_calls_stop() -> None:
     event = asyncio.run(_run())
     assert event["status"] == "success"
     text = event["content"][0]["text"]
-    assert "control loop halted" in text
+    assert "no task is running" in text
     # Guard against the pre-#361 refusal text sneaking back in a rebase:
     # the driver's stop path now maps to a running behaviour, so the
     # envelope must not claim otherwise.

--- a/tests/drivers/test_g1_stream_stop_reports_the_halt_outcome.py
+++ b/tests/drivers/test_g1_stream_stop_reports_the_halt_outcome.py
@@ -1,0 +1,205 @@
+"""The agent-facing ``stop`` verb reports the halt outcome it establishes.
+
+:meth:`~strands_robots.drivers.g1._ControlLoop.stop` signals the loop and joins
+its thread within a budget, and *returns whether the thread joined*.  Its own
+docstring says what a ``False`` needs: "the honest ``stopped=False`` in the
+:meth:`G1Driver.stop_task` envelope rather than a ``success`` claim the
+payload's ``running=True`` contradicts".
+
+``stop_task`` reads it.  ``cleanup`` and ``stop`` were taught to read it in the
+same pass.  The verb an *agent* reaches - ``stream({"action": "stop"})`` - built
+its envelope beside ``await self.stop()``, and ``stop`` returns ``None``: the
+protocol's shutdown hook carries no verdict, so an envelope written next to it
+can only restate the intent.  A caller-supplied policy that outlasts the join
+budget - a remote inference call is the ordinary case - therefore left the loop
+publishing frames on ``rt/lowcmd`` while the agent read ``status="success"``.
+
+One driver, two stop surfaces, two contracts, and the agent got the one that
+cannot say it failed.  The cells that grade the fix park a policy past the join
+budget, which is why they cost about two seconds each; the fast path cannot
+distinguish a reported outcome from an asserted one.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import textwrap
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers.g1 as g1_mod
+
+# Reused wholesale from the sibling that taught ``cleanup``/``stop`` to read the
+# same outcome: the rollout fixtures, the recording publisher, and the autouse
+# ``unitree_sdk2py`` stub the loop's write path needs.  A fixture is resolved in
+# the namespace of the module that declares it, so importing the helpers without
+# the stub would run these cells against a real-SDK import the loop swallows.
+from tests.drivers.test_g1_cleanup_reads_the_loop_halt_outcome import (  # noqa: F401
+    _Rollout,
+    _stub_unitree_sdk,
+)
+
+
+@pytest.fixture
+def unjoined() -> Any:
+    """A rollout whose policy outlasts the join budget.  Always released.
+
+    Wraps the sibling's ``_Rollout`` rather than importing its fixture:
+    importing a fixture re-binds the name in this module, so every cell that
+    takes it as a parameter reads as a redefinition (ruff ``F811``).
+    """
+    rollout = _Rollout(blocking=True)
+    try:
+        yield rollout
+    finally:
+        rollout.release()
+
+
+@pytest.fixture
+def joins() -> Any:
+    """A rollout whose policy returns immediately, so the join succeeds."""
+    rollout = _Rollout(blocking=False)
+    try:
+        yield rollout
+    finally:
+        rollout.release()
+
+
+def _stop_verb(driver: Any) -> dict[str, Any]:
+    """Invoke the agent-facing ``stop`` verb and return its one tool result."""
+
+    async def _run() -> Any:
+        async for event in driver.stream({"toolUseId": "u1", "name": "g1", "input": {"action": "stop"}}, {}):
+            return event
+        return None  # pragma: no cover - the generator always yields once
+
+    event = asyncio.run(_run())
+    assert event is not None
+    return dict(event)
+
+
+def _payload(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Return the envelope's JSON block, or fail naming what arrived instead."""
+    for block in envelope.get("content", []):
+        if "json" in block:
+            return dict(block["json"])
+    raise AssertionError(f"no json block in {envelope!r}")
+
+
+class TestThePremise:
+    """The facts the regression cells rest on, stated independently."""
+
+    def test_the_halt_primitive_returns_a_verdict(self) -> None:
+        """``_ControlLoop.stop`` is annotated ``bool``, so an outcome exists to read."""
+        signature = inspect.signature(g1_mod._ControlLoop.stop)
+        assert signature.return_annotation in (bool, "bool")
+
+    def test_the_protocol_hook_carries_no_verdict(self) -> None:
+        """``stop`` returns ``None``: an envelope beside it cannot report a halt.
+
+        This is why the verb has to delegate rather than build its own
+        envelope next to the shutdown hook.
+        """
+        signature = inspect.signature(g1_mod.G1Driver.stop)
+        assert signature.return_annotation in (None, "None")
+
+    def test_the_sibling_envelope_reports_the_timeout(self, unjoined: Any) -> None:
+        """``stop_task`` - the surface the verb delegates to - already reports it."""
+        envelope = unjoined.driver.stop_task()
+        assert envelope["status"] == "error"
+        assert _payload(envelope)["stopped"] is False
+
+    def test_the_loop_really_is_still_writing_when_the_verb_returns(self, unjoined: Any) -> None:
+        """The situation the report is about: the verb returns, the thread lives.
+
+        True on either tree - what changed is whether the envelope says so.
+        """
+        _stop_verb(unjoined.driver)
+        assert unjoined.loop.is_running is True
+
+
+class TestAnUnjoinedLoopIsReportedNotClaimedStopped:
+    """A policy outlasting the join budget must not read as a stopped task."""
+
+    def test_the_verb_reports_an_error(self, unjoined: Any) -> None:
+        assert _stop_verb(unjoined.driver)["status"] == "error"
+
+    def test_the_payload_says_the_loop_did_not_stop(self, unjoined: Any) -> None:
+        assert _payload(_stop_verb(unjoined.driver))["stopped"] is False
+
+    def test_the_payload_says_the_loop_is_still_running(self, unjoined: Any) -> None:
+        """The frames are still going out; the agent must be able to see that."""
+        assert _payload(_stop_verb(unjoined.driver))["running"] is True
+
+    def test_the_payload_names_the_timeout(self, unjoined: Any) -> None:
+        assert "did not join within timeout" in _payload(_stop_verb(unjoined.driver))["reason"]
+
+
+class TestTheJoinedOutcomeIsAlsoReported:
+    """A halt that succeeded says so in the payload, not only in the status."""
+
+    def test_the_payload_says_the_loop_stopped(self, joins: Any) -> None:
+        assert _payload(_stop_verb(joins.driver))["stopped"] is True
+
+
+class TestAJoinedLoopStillReportsSuccess:
+    """Over-reach controls: reporting honestly must not refuse the ordinary halt.
+
+    Both cells hold on either tree.  They are here so a future change that
+    reports a timeout by failing *every* stop is caught.
+    """
+
+    def test_the_verb_reports_success(self, joins: Any) -> None:
+        assert _stop_verb(joins.driver)["status"] == "success"
+
+    def test_the_loop_has_left_its_thread(self, joins: Any) -> None:
+        """Read the fixture's own handle: the driver releases ``_loop`` on exit."""
+        _stop_verb(joins.driver)
+        assert joins.loop.is_running is False
+
+
+class TestTheVerdictIsSingleSourced:
+    """The verb returns the reporting surface's envelope, not its own reading.
+
+    ``stop_task`` already decides ``stopped`` from the join outcome.  A verb
+    that re-derived it - from ``self._loop.is_running``, say - would put the
+    decision in two places and could drift from the surface a caller polls.
+    """
+
+    def test_the_stop_branch_delegates_to_stop_task(self) -> None:
+        source = textwrap.dedent(inspect.getsource(g1_mod.G1Driver.stream))
+        tree = ast.parse(source)
+        calls = {
+            ast.unparse(node.func)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert "self.stop_task" in calls
+
+    def test_the_branch_does_not_restate_the_verdict(self) -> None:
+        """No hardcoded halt claim survives in the verb's own source."""
+        source = inspect.getsource(g1_mod.G1Driver.stream)
+        assert "control loop halted" not in source
+
+    def test_the_spec_and_the_envelope_agree_that_the_outcome_is_reported(self) -> None:
+        """The schema promises a report, so the description must say so."""
+        description = g1_mod.G1Driver(port="127.0.0.1", network_interface="lo").tool_spec["inputSchema"]["json"][
+            "properties"
+        ]["action"]["description"]
+        assert "report whether it joined" in description
+
+
+class TestTheStaleRefusalStaysGone:
+    """Controls: the pre-#361 text claimed no motion path was wired.  It is wired.
+
+    These hold on either tree - the stale refusal was already removed - and
+    guard it against coming back through a rebase.
+    """
+
+    @pytest.mark.parametrize("stale", ["no motion path wired", "#358", "no-op"])
+    def test_no_outcome_text_carries_the_stale_refusal(self, unjoined: Any, stale: str) -> None:
+        envelope = _stop_verb(unjoined.driver)
+        assert stale not in str(envelope)


### PR DESCRIPTION
## The stop verb an agent reaches could not say the stop had failed

`G1Driver.stream({"action": "stop"})` built its envelope beside `await self.stop()` and hardcoded `status="success"`. Two separate things were wrong with the text it carried.

The **first** is what this PR opened for: it claimed no motion path was wired. That is stale - the transport primitive shipped some time ago. `DDSPublisher` publishes on `rt/lowcmd`, `send_action` builds and publishes a `LowCmd_`, the 500 Hz `_ControlLoop` rolls a policy out, and the loop publishes a zero-torque frame on exit.

The **second** is that the envelope could not report what the stop achieved. `stop` is the protocol's shutdown hook and returns `None`, so an envelope written next to it can only restate the intent. Replacing a stale refusal with `"control loop halted"` swaps a claim that is always out of date for one that is false on the case `_ControlLoop.stop`'s own docstring names:

> Returns `True` when the thread joined within `timeout`. `False` when the loop is still running - a caller-supplied policy that outlasts the join budget (a remote inference call is the ordinary case) needs the honest `stopped=False` in the `stop_task` envelope **rather than a `success` claim the payload's `running=True` contradicts**.

`stop_task` reads that verdict. `cleanup` and `stop` were taught to read it. The verb an *agent* reaches was the one surface left that could not.

### Measured, same driver, same wedge

A policy parked past the 2.0 s join budget, on a driver in the state healthy hardware produces (`_connected`, `_mode_machine=9`, battery 92 %, FSM in the allowed set):

| surface | elapsed | status | payload |
|---|---|---|---|
| `stream({"action": "stop"})` | 2.00 s | **`success`** | text only; loop still running |
| `stop_task()` | 2.00 s | `error` | `stopped=False`, `running=True`, reason names the timeout |

One driver, two stop surfaces, two contracts. `stop` does log the overrun at ERROR, so the information existed and the envelope discarded it.

### The change

The verb returns `stop_task`'s envelope, so the verdict has one owner rather than two:

- a joined stop is still `success` and now carries `stopped=True`
- an unjoined one is an `error` naming the timeout
- a driver with nothing running says so, instead of claiming a halt it did not perform

`stop` keeps its signature: it is the `HardwareDriver` shutdown hook the mesh calls, and `-> None` is why it cannot answer here. Re-deriving the verdict from `self._loop.is_running` was the alternative and is worse - it puts the decision in two places and can drift from the surface a caller polls.

The `inputSchema` description promises the report the verb now delivers.

### Why nothing caught it

The shipped cell drives `G1Driver(tool_name="g1", port="1.2.3.4")` - a driver with no loop at all - so it grades the string and cannot reach either running outcome. That is also why `"control loop halted"` was its own second falsity there: nothing was halted. The new cells park a policy past the budget, which costs about two seconds each; the fast path cannot distinguish a reported outcome from an asserted one.

### Gate

- **Pre-fix split** (source reverted to this branch's previous commit): **9 failed / 81 passed** - 9/9 regression, **0 of 9** premise + over-reach control.
- **Mutations**: 8 rows, **7 distinct firing sets**, none undetected, control 0, `collected` stable at 90, restored md5-identical. Failures in the three sibling g1 suites: **0 on every row**.

| row | fires | mutation |
|---|---|---|
| b0 | 0 | control |
| b1 | 8 | revert the branch: `await stop()` + hardcoded success text |
| b2 | 1 | delegate, then force `status="success"` (the "a tool must not error" fix) |
| b3 | 1 | delegate, then drop the timeout reason |
| b4 | 1 | `await stop()` first, then delegate - the double stop makes a joined rollout report "no task is running" |
| b5 | 5 | delegate but flatten the payload to text only |
| b6 | 1 | schema description reverted (behaviour untouched) |
| b7 | 1 | delegate but restate the halt claim in the branch |

`b1 | b6` is exactly the 9 pre-fix failures, disjoint - the behaviour and the schema promise are independently pinned.

- **Paired suite**, identical 353-file selection (all `tests/drivers/`, `tests/tools/g1/`, and every test that walks the tree, parses source, or reads docstrings), the new file excluded from both trees: identical **17494 collected** and `18 failed, 17413 passed, 63 skipped` on both, **18 == 18 failing ids with `comm` empty in both directions**, distinct rootdirs. Of the 18, 17 need `awsiot`/`awscrt` (`find_spec` False locally, declared in the `mesh-iot` extra) and 1 is the lerobot-from-source `encode()` drift.
- **mypy** `24 == 24` against this branch's previous commit, normalized message sets byte-identical in both directions, **0 attributable**.
- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`.
- `tests/drivers/ tests/tools/g1/`: **735 passed / 3 skipped** with the SDK present, **698 passed / 40 skipped / 0 failed** with `unitree_sdk2py` hidden behind a `find_spec` + `meta_path` blocker, so the CI box's disposition is measured rather than assumed (698 + 40 == 735 + 3: same collection, only disposition moves).

No visual artifact: this changes a tool envelope, not a policy, simulation, render, recording or asset.

### Note on the preceding commit

`f0d70c42` wrapped the over-long text line to fix `Run lint`. This change deletes that block, so the line cannot return; the commit is preserved in history and `upstream/main` is merged in rather than rebased over it.
