### PR TITLE
fix(ci): collide two branches on the change they describe, not only on the file they create

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,21 @@ hatch run format            # ruff check --fix, ruff format
    that window which add a fragment there are **350 distinct slugs**, and the only
    two used twice are the two duplicate pairs above that reused one.
 
+   That key reads a **name**, though, and a name is what two authors describing one
+   change need not share. #2820 and #2822 fixed one defect thirteen minutes apart
+   and called it `feetech-broadcast-is-not-a-reply-address` and
+   `feetech-motor-id-excludes-the-broadcast`; two names, so the sweep reported
+   `unique-additions` with both open (#2823). So the same command asks a second,
+   weaker question beside it: do two branches' fragments share at least **two
+   words** *and* both edit one pre-existing test? Two authors fixing one defect
+   describe the same subject and correct the same case, and the conjunction is what
+   makes that usable - measured over the 2199 co-open pairs in #2345 through #2825,
+   against the eleven pairs whose closed half names its supersedor, shared words
+   alone is 30.3% precise and fires on 37.2% of sweeps, a shared edited test alone
+   is 11.5%, and together they are **64.3% precise at 81.8% recall**, firing on
+   5.6%. Read the report's second section as a pair to check rather than a fact:
+   roughly one in three is two branches on one subject without one change.
+
    Two branches *editing* one file is a different question with a different remedy
    (a merge order, possibly one composition run), and
    `scripts/check_merge_base_overlap.py --github-repo <owner/name> --all-open`

--- a/changelog.d/2830-duplicate-sweep-reads-a-described-change.md
+++ b/changelog.d/2830-duplicate-sweep-reads-a-described-change.md
@@ -1,0 +1,31 @@
+### Fixed: the duplicate-work sweep collides two branches on the change they describe, not only on the file they create
+
+`scripts/check_duplicate_claim.py --all-open` paired open branches on what they
+create - a path, or the slug of a changelog fragment. That key reads a name, and a
+name is what two authors describing one change need not share: #2820 and #2822
+fixed one defect thirteen minutes apart and called it
+`feetech-broadcast-is-not-a-reply-address` and
+`feetech-motor-id-excludes-the-broadcast`, so the sweep reported
+`unique-additions` while both were open.
+
+The sweep now asks a second question beside the first: do two branches' fragments
+share at least two words *and* do both edit one pre-existing test? Two authors
+fixing one defect describe the same subject and correct the same case. The
+conjunction is the relation - neither half is usable alone, and the report keeps
+the two keys apart because they support different conclusions. A shared created
+path is a fact about the branches; a shared description over a shared test is a
+pair to read.
+
+Measured over the 2199 pairs open at the same instant in #2345 through #2825,
+against the eleven pairs whose closed half names, in its own closing comment, the
+pull request that superseded it: the created-path key alone reaches five of the
+eleven, the new key reaches nine, and the two together reach ten. Shared words
+alone would select 33 pairs and fire on 37.2% of replayed sweeps - the repository
+names its changes in a house style, so `names` and `the` collide constantly - and
+a shared edited source file, the obvious widening, is 8.8% precise and fires on
+29.9%. The conjunction selects 14 pairs at 64.3% precision and fires on 5.6%.
+
+The measurement also corrects a denominator: eleven declared duplicate pairs is
+more than the five this module counted before, because a closing comment reaches
+pairs neither key found. The created-path key's recall is 45.5% of that set, not
+most of it.

--- a/scripts/check_duplicate_claim.py
+++ b/scripts/check_duplicate_claim.py
@@ -82,9 +82,9 @@ Three questions, two keys
     always shares its own claim.
 
 ``--all-open``
-    Review, keyed on what a branch creates. Do two open pull requests create the
-    same file, or two fragments naming one changelog entry? Needs no issue
-    number, which is the point: see below.
+    Review, keyed on what a branch creates and what it says. Do two open pull
+    requests create the same file, name one changelog entry, or describe one
+    change over one test? Needs no issue number, which is the point: see below.
 
 The key a claim-free pair collides on
 -------------------------------------
@@ -122,6 +122,50 @@ All three are duplicates, and none was reachable from a claim::
     tests/test_recorder_counters_track_on_disk_frames.py     #2388, #2389   #2389
     tests/training/test_checkpoint_cadence_domain.py         #2707, #2708   #2707
     changelog.d/*-g1-send-action-wired.md                    #2766, #2767   open
+
+When two authors choose two names for one change
+-----------------------------------------------
+The created-path key pairs on a name: a path, or the slug of a changelog
+fragment. That is exactly what two authors describing one change need not share.
+#2820 and #2822 fixed one defect thirteen minutes apart and wrote
+``feetech-broadcast-is-not-a-reply-address`` and
+``feetech-motor-id-excludes-the-broadcast``; two names, no collision, and
+``--all-open`` reported ``unique-additions`` while both were open (#2823).
+
+So there is a second, weaker key: two branches whose fragments share at least
+:data:`FRAGMENT_TOKEN_FLOOR` **words** and which both edit one pre-existing test.
+The conjunction is the relation -- neither half is usable alone.
+
+Measured over the 2199 pairs open at the same instant in #2345 through #2825,
+against the **eleven** pairs whose closed half names, in its own closing comment,
+the pull request that superseded it::
+
+    relation                            pairs  precision  recall  sweeps firing
+    both edit a source file                80       8.8%   63.6%          29.9%
+    fragments share one word              151       6.6%   90.9%             -
+    fragments share two words              33      30.3%   90.9%          37.2%
+    both edit one test                     26      11.5%   81.8%             -
+    two words AND one test                 14      64.3%   81.8%           5.6%
+    created path (the first key)            7      71.4%   45.5%           1.3%
+    both keys together                     15      66.7%   90.9%           5.9%
+
+"Sweeps firing" replays ``--all-open`` at each of the 374 moments a pull request
+was opened with another already open, because that -- a median of six open pull
+requests -- is what the sweep reads, not a corpus.
+
+Two results decided the shape. Pairing on a shared *edited source file*, the
+obvious widening and the one #2823 proposed, is 8.8% precise and fires on nearly
+a third of sweeps: `strands_robots/simulation/mujoco/simulation.py` alone accounts
+for 17 of its 80 pairs. And one shared *word* is the repository's own house style
+rather than a subject -- ``names`` and ``the`` appear in 39 and 20 of the window's
+401 fragments. Only the conjunction is precise, and it needs no stop list, no
+path exclusions and no tuning against the corpus it was measured on.
+
+That eleven is larger than the five this file counted before, because a closing
+comment reaches pairs neither key found: #2370/#2373, #2383/#2384 and #2429/#2431
+are three duplicate pairs in the earlier window that the created-path table above
+does not list. The denominator was undercounted, so the first key's recall was
+too -- it is 45.5% of the declared set, not most of it.
 
 The two keys are complementary rather than nested, which is why this is a second
 key and not a replacement for the first. The same window holds two *issue-keyed*
@@ -189,8 +233,8 @@ What this reports, and what it deliberately does not
 ``--all-open`` reports the same three shapes over the other key:
 
 ``unique-additions``
-    No two open pull requests create the same file, and no two name one changelog
-    entry. The convention working.
+    No two open pull requests create the same file, name one changelog entry, or
+    describe one change over one test. The convention working.
 
 ``duplicate-addition``
     The finding.
@@ -231,7 +275,8 @@ Usage
               flags is required.
 ``--pr``      a pull request number (default: ``$PR_NUMBER``).
 ``--all-open``
-              sweep the open set for two pull requests creating one file. Takes no
+              sweep the open set for two pull requests answering one question,
+              on both keys. Takes no
               number, and keeps the inferred repository default for the reason
               ``--pr`` does: its caller is a workflow running where the pull
               requests live. Unlike an issue number, a sweep of the wrong
@@ -294,6 +339,13 @@ UNKNOWN_ADDITIONS = "unknown-additions"
 #: The directory whose created files name a change rather than being one.
 FRAGMENT_DIR = "changelog.d/"
 
+#: The tree the second key's shared-edit half reads. A pre-existing test is what
+#: two authors fixing one defect both correct, and unlike a source file it is
+#: rarely edited by two branches for unrelated reasons: pairing on a shared
+#: edited test alone selects 26 of the 2199 co-open pairs where a shared edited
+#: source file selects 80.
+TESTS_DIR = "tests/"
+
 
 def _load_assembler() -> ModuleType:
     """Load ``assemble_changelog`` from beside this script, for the naming rule.
@@ -333,6 +385,40 @@ _ASSEMBLER = _load_assembler()
 #: sibling sweep's composition question rather than this one. Reading them here
 #: is what turns a 2-of-1802 relation into a 117-of-1802 one.
 ADDED_CHANGE_TYPE = "ADDED"
+
+#: The change type the second key reads. A ``MODIFIED`` path is a file that
+#: exists on the base, so on its own it is the sibling sweep's composition
+#: question -- measured over the 2199 co-open pairs in #2345..#2825, pairing on a
+#: shared modified path under ``strands_robots/`` selects 80 of them at 8.8%
+#: precision and fires on 29.9% of replayed sweeps. It carries the second key
+#: only in conjunction with :data:`FRAGMENT_TOKEN_FLOOR`, which is what makes the
+#: pair precise: 14 selected, 64.3% precise.
+EDITED_CHANGE_TYPE = "MODIFIED"
+
+#: How many words two changelog slugs must share before the pair is reported.
+#: :func:`addition_key` already treats a slug as a name for a piece of work, and
+#: two authors describing one change write two names for it rather than one -- so
+#: the exact-slug key misses them. Words rather than the whole slug is the
+#: weakening that reaches them; two rather than one is what keeps it usable.
+#:
+#: Measured over the same 2199 pairs, against the 11 pairs whose closed half says
+#: in its own closing comment which pull request superseded it:
+#:
+#: ===============================  ========  =========  ======  =============
+#: relation                         selected  precision  recall  sweeps firing
+#: ===============================  ========  =========  ======  =============
+#: one shared word                       151       6.6%   90.9%          n/a
+#: two shared words                       33      30.3%   90.9%         37.2%
+#: three shared words                     13      53.8%   63.6%          8.0%
+#: two shared words + shared test         14      64.3%   81.8%          5.6%
+#: ===============================  ========  =========  ======  =============
+#:
+#: One word is the repository's own house style rather than a subject -- ``names``
+#: and ``the`` appear in 39 and 20 of the 401 fragments in the window, so a
+#: one-word rule fires on more than a third of sweeps. Three words loses a third
+#: of the duplicates. Two words *and* a shared pre-existing test is the pair that
+#: holds: neither half is usable alone and together they are 64.3% precise.
+FRAGMENT_TOKEN_FLOOR = 2
 
 #: ``closingIssuesReferences`` is GraphQL-only -- no REST field carries it.
 _SELF_QUERY = """
@@ -454,6 +540,21 @@ class Verdict:
 
 
 @dataclass(frozen=True)
+class PullFiles:
+    """The paths one pull request creates and the paths it edits.
+
+    Both sets come from one file list, so they are read together rather than by
+    two walks of the same response: the sweep's two keys ask different questions
+    of the same data.
+    """
+
+    #: Paths whose ``changeType`` is :data:`ADDED_CHANGE_TYPE`, sorted.
+    created: tuple[str, ...] = ()
+    #: Paths whose ``changeType`` is :data:`EDITED_CHANGE_TYPE`, sorted.
+    edited: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class AdditionVerdict:
     """The outcome of the added-path sweep and the pairs it was computed from."""
 
@@ -462,6 +563,12 @@ class AdditionVerdict:
     #: axes, so a diff of two reports shows changed verdicts rather than
     #: reordered rows.
     collisions: tuple[tuple[int, int, tuple[str, ...]], ...] = ()
+    #: ``(left, right, the words both slugs use, the tests both branches edit)``
+    #: for the second key. Kept apart from :attr:`collisions` because the two
+    #: support different conclusions: a shared created path means one of the two
+    #: branches is redundant, and a shared description over a shared test means
+    #: they may be answering one question -- which is a pair to read, not a fact.
+    echoes: tuple[tuple[int, int, tuple[str, ...], tuple[str, ...]], ...] = ()
     #: How many open pull requests were read.
     scanned: int = 0
     detail: str = ""
@@ -477,8 +584,10 @@ class AdditionVerdict:
 
     @property
     def implicated(self) -> tuple[int, ...]:
-        """Every pull request in a collision, sorted and deduplicated."""
-        return tuple(sorted({number for left, right, _ in self.collisions for number in (left, right)}))
+        """Every pull request either key reports, sorted and deduplicated."""
+        pairs = [(left, right) for left, right, _ in self.collisions]
+        pairs += [(left, right) for left, right, _, _ in self.echoes]
+        return tuple(sorted({number for pair in pairs for number in pair}))
 
     @property
     def summary(self) -> str:
@@ -489,16 +598,20 @@ class AdditionVerdict:
             )
         if self.outcome == UNIQUE_ADDITIONS:
             return (
-                f"No two of the {self.scanned} open pull requests create the same file or name the "
-                f"same changelog entry ({self.compared} pair(s) compared)."
+                f"No two of the {self.scanned} open pull requests create the same file, name the "
+                f"same changelog entry, or describe one change over one test "
+                f"({self.compared} pair(s) compared)."
             )
-        parts = "; ".join(
-            f"{_pulls((left, right))} both create {_paths(paths)}" for left, right, paths in self.collisions
-        )
+        parts = [f"{_pulls((left, right))} both create {_paths(paths)}" for left, right, paths in self.collisions]
+        parts += [
+            f"{_pulls((left, right))} describe their change with {_paths(words)} and both edit {_paths(tests)}"
+            for left, right, words, tests in self.echoes
+        ]
         return (
-            f"{parts}. Two branches creating one file, or two fragments declaring one changelog "
-            "entry, are two answers to one question rather than a composition to verify, and "
-            "whichever is closed spends a review approval on a change that will not ship."
+            f"{'; '.join(parts)}. Two branches creating one file, two fragments declaring one "
+            "changelog entry, or two descriptions of one change over one test, are two answers to "
+            "one question rather than a composition to verify, and whichever is closed spends a "
+            "review approval on a change that will not ship."
         )
 
 
@@ -614,20 +727,109 @@ def find_addition_collisions(
     return tuple(found)
 
 
-def classify_additions(additions: Mapping[int, Sequence[str]] | None, detail: str = "") -> AdditionVerdict:
-    """Decide which of the three added-path states the open set is in.
+def fragment_tokens(paths: Sequence[str]) -> frozenset[str]:
+    """Return the words the changelog fragments among ``paths`` use.
+
+    :func:`addition_key` already reads a fragment's slug as a name for a piece of
+    work. This reads the same slug one notch weaker, as the *words* of that name,
+    which is what two authors describing one change have in common when they did
+    not happen to choose the same name for it: #2820 wrote
+    ``feetech-broadcast-is-not-a-reply-address`` and #2822 wrote
+    ``feetech-motor-id-excludes-the-broadcast`` for one defect, so the exact-slug
+    key sees nothing and the words ``feetech`` and ``broadcast`` are shared.
+
+    A path that is not a fragment contributes nothing, and a fragment whose name
+    the assembler would reject contributes nothing either -- the same
+    conservative direction :func:`addition_key` takes, for the same reason: this
+    can only fail to report a pair, never invent one.
+
+    No stop list. Measured over #2345..#2825 a frequency-derived one is a
+    refinement rather than a requirement (43.5% precision against 30.3% at the
+    same recall), and it cannot be computed where this runs: the sweep sees the
+    open set, which is a median of 6 pull requests, not a corpus. What replaces
+    it is the conjunction in :func:`find_echo_collisions`, which is both
+    parameter-free and more precise than any stop list measured here.
+    """
+    words: set[str] = set()
+    for path in paths:
+        if not path.startswith(FRAGMENT_DIR):
+            continue
+        name = path[len(FRAGMENT_DIR) :]
+        if name in _ASSEMBLER.RESERVED_NAMES:
+            continue
+        match = _ASSEMBLER.FRAGMENT_NAME.match(name)
+        if match is None:
+            continue
+        words.update(name[match.end("number") + 1 : -len(".md")].split("-"))
+    return frozenset(words)
+
+
+def find_echo_collisions(
+    files: Mapping[int, PullFiles],
+) -> tuple[tuple[int, int, tuple[str, ...], tuple[str, ...]], ...]:
+    """Return every pair of open pull requests that describes one change twice.
+
+    Two conditions, and the conjunction is the whole relation:
+
+    * their changelog fragments share at least :data:`FRAGMENT_TOKEN_FLOOR`
+      words, so both branches are describing the same subject; and
+    * both edit at least one pre-existing file under :data:`TESTS_DIR`, so both
+      are correcting the same case rather than writing about the same area.
+
+    Either half alone is unusable. Over the 2199 co-open pairs in #2345..#2825,
+    two shared words selects 33 pairs and fires on 37.2% of replayed sweeps --
+    the repository names its changes in a house style, so ``names`` and ``the``
+    collide constantly. A shared edited test selects 26. Together they select 14,
+    of which 9 are among the 11 pairs whose closed half names its supersedor:
+    64.3% precision at 81.8% recall, firing on 5.6% of sweeps.
+
+    This is a strictly weaker signal than :func:`find_addition_collisions`, and
+    that is why the two are reported apart. A shared created path is a fact about
+    the branches -- neither file exists on the base, so one of the two is
+    redundant. A shared description over a shared test is a question: of the five
+    pairs it selects that are not declared duplicates, two are members of the
+    #2785/#2787/#2790/#2792 supersede cluster and one (#2713/#2714) is two
+    branches on one subject that both shipped. So the remedy is to read the other
+    pull request, not to close one.
+
+    Deterministic in all four axes for the reason :func:`find_collisions` gives.
+    """
+    ordered = sorted(files)
+    found: list[tuple[int, int, tuple[str, ...], tuple[str, ...]]] = []
+    for left, right in itertools.combinations(ordered, 2):
+        words = fragment_tokens(files[left].created) & fragment_tokens(files[right].created)
+        if len(words) < FRAGMENT_TOKEN_FLOOR:
+            continue
+        tests = {path for path in files[left].edited if path.startswith(TESTS_DIR)} & {
+            path for path in files[right].edited if path.startswith(TESTS_DIR)
+        }
+        if not tests:
+            continue
+        found.append((left, right, tuple(sorted(words)), tuple(sorted(tests))))
+    return tuple(found)
+
+
+def classify_additions(files: Mapping[int, PullFiles] | None, detail: str = "") -> AdditionVerdict:
+    """Decide which of the three states the open set is in, on both keys.
 
     ``None`` means the set could not be read, which is its own outcome for the
     reason :func:`classify` gives: a silent API or permission change must not be
     able to turn this sweep into a no-op that always agrees.
+
+    Both keys are computed from one argument rather than from an optional second
+    mapping. An ``edits`` that defaulted to empty would let the second key report
+    nothing while looking like it had run, which is the failure mode this module
+    refuses everywhere else: an unread set and an empty one must not collapse.
     """
-    if additions is None:
-        return AdditionVerdict(UNKNOWN_ADDITIONS, (), 0, detail)
-    collisions = find_addition_collisions(additions)
+    if files is None:
+        return AdditionVerdict(UNKNOWN_ADDITIONS, (), (), 0, detail)
+    collisions = find_addition_collisions({number: pull.created for number, pull in files.items()})
+    echoes = find_echo_collisions(files)
     return AdditionVerdict(
-        DUPLICATE_ADDITION if collisions else UNIQUE_ADDITIONS,
+        DUPLICATE_ADDITION if collisions or echoes else UNIQUE_ADDITIONS,
         collisions,
-        len(additions),
+        echoes,
+        len(files),
     )
 
 
@@ -700,16 +902,19 @@ def link_numbers(pull: Mapping[str, object]) -> tuple[int, ...]:
     return tuple(sorted({int(node["number"]) for node in nodes if isinstance(node, dict) and "number" in node}))
 
 
-def added_paths(pull: Mapping[str, object]) -> tuple[str, ...]:
-    """Return the paths one pull-request node creates, refusing a truncated list.
+def file_sets(pull: Mapping[str, object]) -> PullFiles:
+    """Return the paths one pull-request node creates and edits, refusing a truncated list.
 
-    Only ``ADDED`` entries, which is the whole narrowness of this relation: a
-    ``MODIFIED`` path is a file that exists on the base, and two branches
-    touching one of those is the sibling sweep's question.
+    The two change types the sweep's two keys read, split out of one file list.
+    Every other ``changeType`` GitHub's enum carries -- ``REMOVED``, ``RENAMED``,
+    ``COPIED``, ``CHANGED`` -- is dropped: a removal is not work either key asks
+    about, and a rename is the sibling sweep's composition question.
 
     A list cut off at :data:`FILE_PAGE_SIZE` is refused rather than read short,
     exactly as :func:`link_numbers` refuses a truncated link set -- the one thing
     this sweep must never do is report clean because it did not look far enough.
+    Refused once here rather than once per key, so neither key can be computed
+    from a prefix while the other is refused.
     """
     files = pull.get("files") or {}
     if not isinstance(files, dict):
@@ -718,15 +923,19 @@ def added_paths(pull: Mapping[str, object]) -> tuple[str, ...]:
     total = files.get("totalCount")
     if isinstance(total, int) and total > len(nodes):
         raise ClaimSetUnreadable(f"#{pull.get('number')}'s file list is truncated ({total} files, {len(nodes)} read).")
-    return tuple(
-        sorted(
-            {
-                str(node["path"])
-                for node in nodes
-                if isinstance(node, dict) and node.get("changeType") == ADDED_CHANGE_TYPE and node.get("path")
-            }
+
+    def paths(change_type: str) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                {
+                    str(node["path"])
+                    for node in nodes
+                    if isinstance(node, dict) and node.get("changeType") == change_type and node.get("path")
+                }
+            )
         )
-    )
+
+    return PullFiles(created=paths(ADDED_CHANGE_TYPE), edited=paths(EDITED_CHANGE_TYPE))
 
 
 def resolve_claim(repo: str, pr: int, token: str) -> tuple[int, ...]:
@@ -795,8 +1004,8 @@ def resolve_open_claims(repo: str, token: str, pr: int | None = None) -> dict[in
     raise ClaimSetUnreadable(f"more than {MAX_OPEN_PAGES * OPEN_PAGE_SIZE} open pull requests; the list was truncated.")
 
 
-def resolve_open_additions(repo: str, token: str) -> dict[int, tuple[str, ...]]:
-    """Return ``{open pull request number: the paths it creates}``.
+def resolve_open_file_sets(repo: str, token: str) -> dict[int, PullFiles]:
+    """Return ``{open pull request number: the paths it creates and edits}``.
 
     Nothing is excluded: unlike the claim-keyed review question there is no pull
     request "under test" here, so there is no self-comparison to leave out. The
@@ -809,7 +1018,7 @@ def resolve_open_additions(repo: str, token: str) -> dict[int, tuple[str, ...]]:
     owner, _, name = repo.partition("/")
     if not owner or not name:
         raise ClaimSetUnreadable(f"repository {repo!r} is not in owner/name form.")
-    additions: dict[int, tuple[str, ...]] = {}
+    files: dict[int, PullFiles] = {}
     cursor: str | None = None
     for _ in range(MAX_OPEN_PAGES):
         repository = _repository(
@@ -831,10 +1040,10 @@ def resolve_open_additions(repo: str, token: str) -> dict[int, tuple[str, ...]]:
         for node in page.get("nodes") or []:
             if not isinstance(node, dict) or "number" not in node:
                 continue
-            additions[int(node["number"])] = added_paths(node)
+            files[int(node["number"])] = file_sets(node)
         info = page.get("pageInfo") or {}
         if not info.get("hasNextPage"):
-            return additions
+            return files
         cursor = info.get("endCursor")
         if not isinstance(cursor, str):
             raise ClaimSetUnreadable("the open pull request list is paged but carried no cursor.")
@@ -849,7 +1058,7 @@ def render_additions(verdict: AdditionVerdict, repo: str) -> str:
     a list of report lines is indistinguishable from a forgotten comma.
     """
     lines = [
-        "## Duplicate work - two branches creating one file or one changelog entry",
+        "## Duplicate work - two branches answering one question",
         "",
         f"Outcome: **{verdict.outcome}**",
         "",
@@ -863,33 +1072,45 @@ def render_additions(verdict: AdditionVerdict, repo: str) -> str:
     ]
     if not verdict.is_finding:
         return "\n".join(lines)
-    lines += [
-        f"| pull requests implicated | {_pulls(verdict.implicated)} |",
-        "",
-        "| pull requests | what both create |",
-        "|---|---|",
-    ]
-    for left, right, paths in verdict.collisions:
-        lines.append(f"| #{left} + #{right} | {_paths(paths)} |")
-    why = (
-        "Neither branch's file exists on the base, so this is not a merge order to decide: "
-        + "the two are answering the same question, and the second one to be read is work that "
-        + "was already done. Read the other pull request before continuing with either."
-    )
+    lines += [f"| pull requests implicated | {_pulls(verdict.implicated)} |"]
+    if verdict.collisions:
+        lines += ["", "| pull requests | what both create |", "|---|---|"]
+        for left, right, paths in verdict.collisions:
+            lines.append(f"| #{left} + #{right} | {_paths(paths)} |")
+        created = (
+            "Neither branch's file exists on the base, so this is not a merge order to decide: "
+            + "the two are answering the same question, and the second one to be read is work that "
+            + "was already done. Read the other pull request before continuing with either."
+        )
+        lines += ["", "### What this means - a created path", "", created]
+    if verdict.echoes:
+        lines += ["", "| pull requests | words both descriptions use | tests both edit |", "|---|---|---|"]
+        for left, right, words, tests in verdict.echoes:
+            lines.append(f"| #{left} + #{right} | {_paths(words)} | {_paths(tests)} |")
+        described = (
+            "These two name their change with the same words and correct the same pre-existing "
+            + "test, which is what two authors fixing one defect do when they did not happen to "
+            + "choose the same file name for the fix. This is the weaker of the two keys and it "
+            + "reports a pair to read rather than a fact: measured over #2345..#2825 it is 64.3% "
+            + "precise, so roughly one pair in three is two branches that share a subject without "
+            + "sharing a change. Read both descriptions before continuing with either."
+        )
+        lines += ["", "### What this means - one change described twice", "", described]
     clears = (
         "Close whichever of the two is redundant, or -- if both are wanted -- change one so it "
-        + "no longer creates the same path or names the same changelog entry, which is the case "
-        + "where the shared name was the accident rather than the work. "
+        + "no longer creates the same path, names the same changelog entry, or describes the same "
+        + "change over the same test, which is the case where the shared name was the accident "
+        + "rather than the work. "
         + "This is a report rather than a branch-clearable gate: "
         + "the remedy is a decision between two authors, and no push by one of them settles it."
     )
     blind = (
         "Neither pull request need have claimed an issue for this to be reported, which is the "
-        + "point of the second key: measured over #2345..#2767, two duplicate pairs were reachable "
-        + "from a claim and three only from something they both create, with no pair reachable "
-        + "from both."
+        + "point of these keys: measured over #2345..#2825, of the eleven pairs whose closed half "
+        + "names the pull request that superseded it, the created-path key reaches five and the "
+        + "described-change key reaches nine, for ten of eleven between them."
     )
-    lines += ["", "### What this means", "", why, "", "### What clears this", "", clears, "", blind]
+    lines += ["", "### What clears this", "", clears, "", blind]
     return "\n".join(lines)
 
 
@@ -993,19 +1214,19 @@ def _emit(report: str) -> None:
 
 
 def _run_addition_sweep(repo: str, token: str) -> int:
-    """Sweep the open set for two pull requests creating one file."""
-    additions: dict[int, tuple[str, ...]] | None
+    """Sweep the open set on both keys: one created path, or one change described twice."""
+    files: dict[int, PullFiles] | None
     detail = ""
     try:
-        additions = resolve_open_additions(repo, token)
+        files = resolve_open_file_sets(repo, token)
     except (ClaimSetUnreadable, urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
-        additions, detail = None, str(exc)
+        files, detail = None, str(exc)
         print(f"check_duplicate_claim: {detail}", file=sys.stderr)
 
-    verdict = classify_additions(additions, detail)
+    verdict = classify_additions(files, detail)
     _emit(render_additions(verdict, repo))
     if verdict.is_finding:
-        print(f"::error title=Two open pull requests create the same file::{verdict.summary}")
+        print(f"::error title=Two open pull requests answer one question::{verdict.summary}")
         return 1
     return 0
 
@@ -1030,7 +1251,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if [bool(args.pr), bool(args.issue), args.all_open].count(True) != 1:
         parser.error(
             "pass exactly one of --pr (review a pull request's claims), --issue (intake) "
-            "and --all-open (sweep the open set for two branches creating one file)"
+            "and --all-open (sweep the open set for two branches answering one question)"
         )
     if args.repo is None and args.issue:
         parser.error(inferred_repository_refusal(repo))

--- a/tests/test_duplicate_work_added_path_key.py
+++ b/tests/test_duplicate_work_added_path_key.py
@@ -169,6 +169,26 @@ def _added(*paths: str) -> list[dict[str, str]]:
     return [{"path": path, "changeType": check.ADDED_CHANGE_TYPE} for path in paths]
 
 
+def _edited(*paths: str) -> list[dict[str, str]]:
+    return [{"path": path, "changeType": check.EDITED_CHANGE_TYPE} for path in paths]
+
+
+def _creates(*paths: str) -> Any:
+    """A pull request that creates these paths and edits nothing."""
+    return check.PullFiles(created=tuple(sorted(paths)))
+
+
+def _open_set(additions: dict[int, tuple[str, ...]]) -> dict[int, Any]:
+    """``{number: the paths it added}`` as the open set the sweep classifies.
+
+    The measured fixtures record what each branch *added*, which is the evidence
+    that outlives the state change closing one half of a pair. The second key
+    reads edited paths as well, so they are the created half of a file set here
+    and the pairs stay reachable from the first key alone.
+    """
+    return {number: _creates(*paths) for number, paths in additions.items()}
+
+
 _IDS = [row[0] for row in _CLAIM_FREE_PAIRS]
 
 
@@ -179,7 +199,7 @@ class TestTheMeasuredClaimFreePairsAreReported:
     def test_the_pair_is_the_finding(
         self, label: str, additions: dict[int, tuple[str, ...]], subjects: tuple[str, ...]
     ) -> None:
-        verdict = check.classify_additions(additions)
+        verdict = check.classify_additions(_open_set(additions))
         assert verdict.outcome == check.DUPLICATE_ADDITION, label
         assert verdict.is_finding
 
@@ -188,13 +208,13 @@ class TestTheMeasuredClaimFreePairsAreReported:
         self, label: str, additions: dict[int, tuple[str, ...]], subjects: tuple[str, ...]
     ) -> None:
         left, right = sorted(additions)
-        assert check.classify_additions(additions).collisions == ((left, right, subjects),)
+        assert check.classify_additions(_open_set(additions)).collisions == ((left, right, subjects),)
 
     @pytest.mark.parametrize(("label", "additions", "subjects"), _CLAIM_FREE_PAIRS, ids=_IDS)
     def test_both_pull_requests_are_named(
         self, label: str, additions: dict[int, tuple[str, ...]], subjects: tuple[str, ...]
     ) -> None:
-        summary = check.classify_additions(additions).summary
+        summary = check.classify_additions(_open_set(additions)).summary
         for number in additions:
             assert f"#{number}" in summary
         for subject in subjects:
@@ -210,7 +230,7 @@ class TestTheMeasuredClaimFreePairsAreReported:
         subject has to have been added by both; a glob subject has to be what
         :func:`addition_key` makes of a path each side really added.
         """
-        for left, right, reported in check.classify_additions(additions).collisions:
+        for left, right, reported in check.classify_additions(_open_set(additions)).collisions:
             for subject in reported:
                 for number in (left, right):
                     matches = [path for path in additions[number] if check.addition_key(path) == subject]
@@ -234,8 +254,8 @@ class TestAFragmentCollidesOnItsSlugAndNotItsNumber:
 
     def test_two_fragments_with_one_slug_collide_under_different_numbers(self) -> None:
         additions = {
-            2766: check.added_paths(_node(2766, _added("changelog.d/2765-g1-send-action-wired.md"))),
-            2767: check.added_paths(_node(2767, _added("changelog.d/2761-g1-send-action-wired.md"))),
+            2766: check.file_sets(_node(2766, _added("changelog.d/2765-g1-send-action-wired.md"))),
+            2767: check.file_sets(_node(2767, _added("changelog.d/2761-g1-send-action-wired.md"))),
         }
         verdict = check.classify_additions(additions)
         assert verdict.outcome == check.DUPLICATE_ADDITION
@@ -244,15 +264,15 @@ class TestAFragmentCollidesOnItsSlugAndNotItsNumber:
     def test_two_fragments_with_different_slugs_do_not_collide(self) -> None:
         """The over-reach control: every branch adds a fragment, so this is the norm."""
         additions = {
-            11: check.added_paths(_node(11, _added("changelog.d/11-one-change.md"))),
-            12: check.added_paths(_node(12, _added("changelog.d/12-another-change.md"))),
+            11: check.file_sets(_node(11, _added("changelog.d/11-one-change.md"))),
+            12: check.file_sets(_node(12, _added("changelog.d/12-another-change.md"))),
         }
         assert check.classify_additions(additions).outcome == check.UNIQUE_ADDITIONS
 
     def test_the_same_slug_under_the_same_number_still_collides(self) -> None:
         """Dropping the number must not lose the identical-path case it contained."""
         shared = _added("changelog.d/11-one-change.md")
-        additions = {n: check.added_paths(_node(n, shared)) for n in (11, 12)}
+        additions = {n: check.file_sets(_node(n, shared)) for n in (11, 12)}
         assert check.classify_additions(additions).outcome == check.DUPLICATE_ADDITION
 
     @pytest.mark.parametrize(
@@ -319,7 +339,7 @@ class TestTheTwoKeysAreComplementary:
     def test_an_issue_keyed_pair_is_invisible_to_the_created_thing_key(
         self, left: int, right: int, issue: int, additions: dict[int, tuple[str, ...]]
     ) -> None:
-        assert check.classify_additions(additions).outcome == check.UNIQUE_ADDITIONS
+        assert check.classify_additions(_open_set(additions)).outcome == check.UNIQUE_ADDITIONS
 
     @pytest.mark.parametrize(("left", "right", "issue", "additions"), _ISSUE_KEYED_PAIRS)
     def test_the_claim_key_still_reports_that_pair(
@@ -345,19 +365,19 @@ class TestOnlyACreatedPathCollides:
     @pytest.mark.parametrize("change_type", ["MODIFIED", "REMOVED", "RENAMED", "COPIED", "CHANGED"])
     def test_a_path_both_branches_merely_touch_is_not_a_finding(self, change_type: str) -> None:
         shared = [{"path": "strands_robots/utils.py", "changeType": change_type}]
-        additions = {n: check.added_paths(_node(n, shared)) for n in (11, 12)}
+        additions = {n: check.file_sets(_node(n, shared)) for n in (11, 12)}
         assert check.classify_additions(additions).outcome == check.UNIQUE_ADDITIONS
 
     def test_the_same_path_created_by_both_is_the_finding(self) -> None:
         """The control for the row above: only ``changeType`` differs."""
         shared = _added("strands_robots/utils.py")
-        additions = {n: check.added_paths(_node(n, shared)) for n in (11, 12)}
+        additions = {n: check.file_sets(_node(n, shared)) for n in (11, 12)}
         assert check.classify_additions(additions).outcome == check.DUPLICATE_ADDITION
 
     def test_one_branch_creating_what_the_other_edits_is_not_a_finding(self) -> None:
         """Impossible on one base, and if the API says it the sibling sweep owns it."""
-        creator = check.added_paths(_node(11, _added("docs/new.md")))
-        editor = check.added_paths(_node(12, [{"path": "docs/new.md", "changeType": "MODIFIED"}]))
+        creator = check.file_sets(_node(11, _added("docs/new.md")))
+        editor = check.file_sets(_node(12, [{"path": "docs/new.md", "changeType": "MODIFIED"}]))
         assert check.classify_additions({11: creator, 12: editor}).outcome == check.UNIQUE_ADDITIONS
 
     def test_prose_is_not_exempt(self) -> None:
@@ -367,7 +387,7 @@ class TestOnlyACreatedPathCollides:
         does and git reports the conflict anyway. Two branches each *writing* one
         new page is duplicated authoring whatever the suffix.
         """
-        additions = {n: check.added_paths(_node(n, _added("docs/guide.md"))) for n in (11, 12)}
+        additions = {n: check.file_sets(_node(n, _added("docs/guide.md"))) for n in (11, 12)}
         verdict = check.classify_additions(additions)
         assert verdict.outcome == check.DUPLICATE_ADDITION
         assert verdict.collisions == ((11, 12, ("docs/guide.md",)),)
@@ -398,7 +418,11 @@ class TestEveryPairIsComparedAndTheReportIsStable:
             (11, 13, ("tests/test_a.py",)),
             (12, 13, ("tests/test_a.py",)),
         )
-        assert check.classify_additions(additions).implicated == (11, 12, 13)
+        assert check.classify_additions({n: _creates("tests/test_a.py") for n in (11, 12, 13)}).implicated == (
+            11,
+            12,
+            13,
+        )
 
     def test_an_empty_open_set_is_clean_and_says_so(self) -> None:
         verdict = check.classify_additions({})
@@ -406,7 +430,7 @@ class TestEveryPairIsComparedAndTheReportIsStable:
         assert verdict.compared == 0
 
     def test_the_pair_count_is_the_number_of_comparisons(self) -> None:
-        assert check.classify_additions({n: () for n in range(1, 5)}).compared == 6
+        assert check.classify_additions({n: _creates() for n in range(1, 5)}).compared == 6
 
 
 class TestAnIncompleteAnswerIsNotAFinding:
@@ -421,23 +445,23 @@ class TestAnIncompleteAnswerIsNotAFinding:
     def test_a_truncated_file_list_is_refused_rather_than_read_short(self) -> None:
         node = _node(11, _added("tests/test_a.py"), total=check.FILE_PAGE_SIZE + 1)
         with pytest.raises(check.ClaimSetUnreadable, match="file list is truncated"):
-            check.added_paths(node)
+            check.file_sets(node)
 
     def test_a_complete_file_list_is_read(self) -> None:
-        assert check.added_paths(_node(11, _added("b", "a"))) == ("a", "b")
+        assert check.file_sets(_node(11, _added("b", "a"))).created == ("a", "b")
 
     def test_a_node_without_a_file_list_is_unreadable(self) -> None:
         with pytest.raises(check.ClaimSetUnreadable, match="carried no file list"):
-            check.added_paths({"number": 11, "files": "not a list"})
+            check.file_sets({"number": 11, "files": "not a list"})
 
     def test_a_repository_that_is_not_in_owner_name_form_is_refused(self) -> None:
         with pytest.raises(check.ClaimSetUnreadable, match="owner/name form"):
-            check.resolve_open_additions("robots", "token")
+            check.resolve_open_file_sets("robots", "token")
 
     def test_an_api_error_is_unreadable_rather_than_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(check, "_post", lambda *a, **k: {"errors": [{"message": "nope"}]})
         with pytest.raises(check.ClaimSetUnreadable, match="the API returned errors"):
-            check.resolve_open_additions("owner/name", "token")
+            check.resolve_open_file_sets("owner/name", "token")
 
     def test_a_page_without_a_cursor_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
         payload = {
@@ -447,7 +471,7 @@ class TestAnIncompleteAnswerIsNotAFinding:
         }
         monkeypatch.setattr(check, "_post", lambda *a, **k: payload)
         with pytest.raises(check.ClaimSetUnreadable, match="carried no cursor"):
-            check.resolve_open_additions("owner/name", "token")
+            check.resolve_open_file_sets("owner/name", "token")
 
     def test_a_list_longer_than_the_page_bound_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
         payload = {
@@ -457,7 +481,7 @@ class TestAnIncompleteAnswerIsNotAFinding:
         }
         monkeypatch.setattr(check, "_post", lambda *a, **k: payload)
         with pytest.raises(check.ClaimSetUnreadable, match="the list was truncated"):
-            check.resolve_open_additions("owner/name", "token")
+            check.resolve_open_file_sets("owner/name", "token")
 
 
 class TestTheOpenSetIsReadLiveAndWholeAndIncludesDrafts:
@@ -493,7 +517,7 @@ class TestTheOpenSetIsReadLiveAndWholeAndIncludesDrafts:
             return pages[len(seen) - 1]
 
         monkeypatch.setattr(check, "_post", fake_post)
-        additions = check.resolve_open_additions("owner/name", "token")
+        additions = check.resolve_open_file_sets("owner/name", "token")
         assert seen == [None, "c1"]
         # The finding only exists across the page boundary, so a single-page read
         # would report clean here.
@@ -512,7 +536,7 @@ class TestTheOpenSetIsReadLiveAndWholeAndIncludesDrafts:
         one would hide a collision for as long as either side stayed a draft.
         """
         source = _SCRIPT.read_text(encoding="utf-8")
-        sweep = source[source.index("def resolve_open_additions") : source.index("def render_additions")]
+        sweep = source[source.index("def resolve_open_file_sets") : source.index("def render_additions")]
         assert "draft" not in sweep.lower()
         assert "draft" not in check._ADDITIONS_QUERY.lower()
 
@@ -529,7 +553,7 @@ class TestTheOpenSetIsReadLiveAndWholeAndIncludesDrafts:
             }
         }
         monkeypatch.setattr(check, "_post", lambda *a, **k: payload)
-        assert sorted(check.resolve_open_additions("owner/name", "token")) == [11, 12]
+        assert sorted(check.resolve_open_file_sets("owner/name", "token")) == [11, 12]
 
 
 class TestTheReportNamesBothPullRequestsAndTheRemedy:
@@ -538,7 +562,7 @@ class TestTheReportNamesBothPullRequestsAndTheRemedy:
     @staticmethod
     def _finding() -> str:
         _, additions, _ = _CLAIM_FREE_PAIRS[1]
-        return check.render_additions(check.classify_additions(additions), "strands-labs/robots")
+        return check.render_additions(check.classify_additions(_open_set(additions)), "strands-labs/robots")
 
     def test_the_finding_names_both_pull_requests_and_the_shared_file(self) -> None:
         report = self._finding()
@@ -555,17 +579,17 @@ class TestTheReportNamesBothPullRequestsAndTheRemedy:
         assert "not a merge order to decide" in self._finding()
 
     def test_a_clean_report_carries_no_remedy_section(self) -> None:
-        report = check.render_additions(check.classify_additions({11: ("a.py",)}), "owner/name")
+        report = check.render_additions(check.classify_additions({11: _creates("a.py")}), "owner/name")
         assert check.UNIQUE_ADDITIONS in report
         assert "What clears this" not in report
 
     def test_a_clean_report_states_what_it_looked_at(self) -> None:
-        report = check.render_additions(check.classify_additions({n: () for n in (11, 12, 13)}), "owner/name")
+        report = check.render_additions(check.classify_additions({n: _creates() for n in (11, 12, 13)}), "owner/name")
         assert "| open pull requests read | 3 |" in report
         assert "| pairs compared | 3 |" in report
 
     def test_one_row_per_colliding_pair(self) -> None:
-        additions = {n: ("tests/test_a.py",) for n in (11, 12, 13)}
+        additions = {n: _creates("tests/test_a.py") for n in (11, 12, 13)}
         report = check.render_additions(check.classify_additions(additions), "owner/name")
         for pair in ("#11 + #12", "#11 + #13", "#12 + #13"):
             assert pair in report
@@ -577,22 +601,20 @@ class TestTheExitStatusIsOneOnlyForTheFinding:
     @pytest.mark.parametrize(
         ("additions", "expected"),
         [
-            ({11: ("a.py",), 12: ("a.py",)}, 1),
-            ({11: ("a.py",), 12: ("b.py",)}, 0),
+            ({11: _creates("a.py"), 12: _creates("a.py")}, 1),
+            ({11: _creates("a.py"), 12: _creates("b.py")}, 0),
         ],
     )
-    def test_the_exit_status(
-        self, monkeypatch: pytest.MonkeyPatch, additions: dict[int, tuple[str, ...]], expected: int
-    ) -> None:
-        monkeypatch.setattr(check, "resolve_open_additions", lambda *a, **k: additions)
+    def test_the_exit_status(self, monkeypatch: pytest.MonkeyPatch, additions: dict[int, Any], expected: int) -> None:
+        monkeypatch.setattr(check, "resolve_open_file_sets", lambda *a, **k: additions)
         argv = ["--repo", "owner/name", "--all-open", "--token", "t"]
         assert check.main(argv) == expected
 
     def test_a_lookup_failure_exits_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def boom(*args: object, **kwargs: object) -> dict[int, tuple[str, ...]]:
+        def boom(*args: object, **kwargs: object) -> dict[int, Any]:
             raise check.ClaimSetUnreadable("the response carried no repository.")
 
-        monkeypatch.setattr(check, "resolve_open_additions", boom)
+        monkeypatch.setattr(check, "resolve_open_file_sets", boom)
         assert check.main(["--repo", "owner/name", "--all-open", "--token", "t"]) == 0
 
     @pytest.mark.parametrize(
@@ -613,7 +635,7 @@ class TestTheExitStatusIsOneOnlyForTheFinding:
         """Its caller is a workflow running where the pull requests live, and a
         sweep of the wrong repository is visible in its own report."""
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/name")
-        monkeypatch.setattr(check, "resolve_open_additions", lambda *a, **k: {})
+        monkeypatch.setattr(check, "resolve_open_file_sets", lambda *a, **k: {})
         assert check.main(["--all-open", "--token", "t"]) == 0
 
     def test_the_sweep_reads_no_claim_and_no_single_pull_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -624,7 +646,7 @@ class TestTheExitStatusIsOneOnlyForTheFinding:
 
         monkeypatch.setattr(check, "resolve_claim", forbidden)
         monkeypatch.setattr(check, "resolve_open_claims", forbidden)
-        monkeypatch.setattr(check, "resolve_open_additions", lambda *a, **k: {11: ("a.py",)})
+        monkeypatch.setattr(check, "resolve_open_file_sets", lambda *a, **k: {11: _creates("a.py")})
         assert check.main(["--repo", "owner/name", "--all-open", "--token", "t"]) == 0
 
 

--- a/tests/test_duplicate_work_described_change_key.py
+++ b/tests/test_duplicate_work_described_change_key.py
@@ -1,0 +1,442 @@
+"""Pins the described-change key against the duplicate pairs the created-path key misses.
+
+``scripts/check_duplicate_claim.py`` pairs open branches on what they *create* --
+a path, or the slug of a changelog fragment. That key reads a **name**, and a name
+is exactly what two authors describing one change need not share. #2820 and #2822
+fixed one defect thirteen minutes apart and named it
+``feetech-broadcast-is-not-a-reply-address`` and
+``feetech-motor-id-excludes-the-broadcast``; two names, no collision, and
+``--all-open`` reported ``unique-additions`` while both were open. Issue #2823 is
+that instance.
+
+So there is a second key: two branches whose fragments share at least
+:data:`FRAGMENT_TOKEN_FLOOR` **words** and which both edit one pre-existing test.
+
+:data:`_ECHO_PAIRS` fixes four measured pairs in place -- every path is the real
+one, taken from ``pulls/<n>/files``, which outlives the state change that closed
+one half of each. Each is a pair whose closed half names, in its own closing
+comment, the pull request that superseded it.
+
+Three pins carry design decisions rather than behaviour:
+
+``TestTheCreatedPathKeyCannotSeeThesePairs``
+    The non-vacuity half, and the reason this is a second key rather than a
+    tightening of the first. Every pair here reports ``unique-additions`` when only
+    what the branches create is read. Without this, a test that the sweep reports
+    these pairs would pass on the first key alone.
+
+``TestBothHalvesOfTheConjunctionAreLoadBearing``
+    Shared words alone selects 33 of the 2199 co-open pairs in #2345..#2825 and
+    fires on 37.2% of replayed sweeps, because the repository names its changes in
+    a house style -- ``names`` and ``the`` appear in 39 and 20 of the window's 401
+    fragments. A shared edited test alone selects 26. Together they select 14, of
+    which 9 are declared duplicates. So neither half may be dropped, and both
+    directions are asserted.
+
+``TestTheTwoKeysReportApart``
+    The keys support different conclusions and are not merged into one list. A
+    shared created path is a fact -- neither file exists on the base, so one of the
+    two branches is redundant. A shared description over a shared test is a
+    question: it is 64.3% precise, so roughly one pair in three shares a subject
+    without sharing a change. The report says which of the two it found, and the
+    created-path reasoning must not be attached to an echo.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_duplicate_claim.py"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("check_duplicate_claim", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load()
+
+
+def _pull(created: tuple[str, ...] = (), edited: tuple[str, ...] = ()) -> Any:
+    return check.PullFiles(created=tuple(sorted(created)), edited=tuple(sorted(edited)))
+
+
+#: ``(label, {number: (created, edited)}, the words shared, the tests shared)``.
+#: Real paths, from ``pulls/<n>/files``. The closed half of each pair names its
+#: supersedor in its own closing comment: #2373 -> #2370, #2383 -> #2384,
+#: #2431 -> #2429, #2822 -> #2820.
+_ECHO_PAIRS: list[tuple[str, dict[int, tuple[tuple[str, ...], tuple[str, ...]]], tuple[str, ...], tuple[str, ...]]] = [
+    (
+        "#2370/#2373 - carry a latched applied force across a scene rebuild",
+        {
+            2370: (
+                (
+                    "changelog.d/2370-scene-rebuild-carries-latched-wrench.md",
+                    "tests/simulation/mujoco/test_scene_rebuild_carries_latched_wrench.py",
+                ),
+                ("tests/simulation/mujoco/test_scene_ops_guardrails.py",),
+            ),
+            2373: (
+                (
+                    "changelog.d/2373-scene-rebuild-preserves-applied-forces.md",
+                    "tests/simulation/mujoco/test_scene_rebuild_preserves_applied_forces.py",
+                ),
+                ("tests/simulation/mujoco/test_scene_ops_guardrails.py",),
+            ),
+        },
+        ("rebuild", "scene"),
+        ("tests/simulation/mujoco/test_scene_ops_guardrails.py",),
+    ),
+    (
+        "#2383/#2384 - the actuator command a keyframe pairs with its pose",
+        {
+            2383: (
+                ("changelog.d/2383-keyframe-ctrl-holds-the-keyed-pose.md",),
+                ("tests/simulation/mujoco/test_add_robot_keyframe.py",),
+            ),
+            2384: (
+                (
+                    "changelog.d/2384-keyframe-applies-the-command-that-holds-its-pose.md",
+                    "tests/simulation/mujoco/test_keyframe_restores_the_command_that_holds_it.py",
+                ),
+                ("tests/simulation/mujoco/test_add_robot_keyframe.py",),
+            ),
+        },
+        ("holds", "keyframe", "pose", "the"),
+        ("tests/simulation/mujoco/test_add_robot_keyframe.py",),
+    ),
+    (
+        "#2429/#2431 - the shape contract EmpiricalNormalization refuses",
+        {
+            2429: (
+                ("changelog.d/2429-normalization-batch-shape-contract.md",),
+                ("tests/training/test_rl_normalization.py",),
+            ),
+            2431: (
+                ("changelog.d/2431-rl-normalizer-shape-contract.md",),
+                ("tests/training/test_rl_normalization.py",),
+            ),
+        },
+        ("contract", "shape"),
+        ("tests/training/test_rl_normalization.py",),
+    ),
+    (
+        "#2820/#2822 - refuse the Feetech broadcast as a single servo's ID",
+        {
+            2820: (
+                (
+                    "changelog.d/2820-feetech-broadcast-is-not-a-reply-address.md",
+                    "tests/tools/test_feetech_broadcast_is_not_a_reply_address.py",
+                ),
+                ("tests/tools/test_serial_tool_numeric_domain.py",),
+            ),
+            2822: (
+                (
+                    "changelog.d/2822-feetech-motor-id-excludes-the-broadcast.md",
+                    "tests/tools/test_feetech_motor_id_excludes_the_broadcast.py",
+                ),
+                ("tests/tools/test_serial_tool_numeric_domain.py",),
+            ),
+        },
+        ("broadcast", "feetech"),
+        ("tests/tools/test_serial_tool_numeric_domain.py",),
+    ),
+]
+
+_IDS = [row[0] for row in _ECHO_PAIRS]
+
+
+def _open_set(rows: dict[int, tuple[tuple[str, ...], tuple[str, ...]]]) -> dict[int, Any]:
+    return {number: _pull(created, edited) for number, (created, edited) in rows.items()}
+
+
+class TestTheMeasuredEchoPairsAreReported:
+    """Each measured pair is the finding, and names what both branches said and edited."""
+
+    @pytest.mark.parametrize(("label", "rows", "words", "tests"), _ECHO_PAIRS, ids=_IDS)
+    def test_the_pair_is_the_finding(
+        self, label: str, rows: dict[int, Any], words: tuple[str, ...], tests: tuple[str, ...]
+    ) -> None:
+        verdict = check.classify_additions(_open_set(rows))
+        assert verdict.outcome == check.DUPLICATE_ADDITION, label
+        assert verdict.is_finding, label
+
+    @pytest.mark.parametrize(("label", "rows", "words", "tests"), _ECHO_PAIRS, ids=_IDS)
+    def test_the_shared_words_and_tests_are_reported(
+        self, label: str, rows: dict[int, Any], words: tuple[str, ...], tests: tuple[str, ...]
+    ) -> None:
+        left, right = sorted(rows)
+        assert check.classify_additions(_open_set(rows)).echoes == ((left, right, words, tests),), label
+
+    @pytest.mark.parametrize(("label", "rows", "words", "tests"), _ECHO_PAIRS, ids=_IDS)
+    def test_both_pull_requests_are_named(
+        self, label: str, rows: dict[int, Any], words: tuple[str, ...], tests: tuple[str, ...]
+    ) -> None:
+        verdict = check.classify_additions(_open_set(rows))
+        assert verdict.implicated == tuple(sorted(rows)), label
+        for number in rows:
+            assert f"#{number}" in verdict.summary, label
+
+    @pytest.mark.parametrize(("label", "rows", "words", "tests"), _ECHO_PAIRS, ids=_IDS)
+    def test_no_reported_word_is_invented(
+        self, label: str, rows: dict[int, Any], words: tuple[str, ...], tests: tuple[str, ...]
+    ) -> None:
+        """Every word reported is one both branches' fragments really use.
+
+        The report must not name a word neither author wrote, for the reason the
+        created-path key must not name a file that exists on neither branch.
+        """
+        files = _open_set(rows)
+        for left, right, reported, shared_tests in check.classify_additions(files).echoes:
+            for word in reported:
+                for number in (left, right):
+                    assert word in check.fragment_tokens(files[number].created), f"{label}: #{number}"
+            for path in shared_tests:
+                assert path in files[left].edited and path in files[right].edited, label
+
+
+class TestTheCreatedPathKeyCannotSeeThesePairs:
+    """The non-vacuity half: this is a second key, not a tightening of the first."""
+
+    @pytest.mark.parametrize(("label", "rows", "words", "tests"), _ECHO_PAIRS, ids=_IDS)
+    def test_reading_only_what_the_branches_create_reports_nothing(
+        self, label: str, rows: dict[int, Any], words: tuple[str, ...], tests: tuple[str, ...]
+    ) -> None:
+        created = {number: pull.created for number, pull in _open_set(rows).items()}
+        assert check.find_addition_collisions(created) == (), label
+
+    @pytest.mark.parametrize(("label", "rows", "words", "tests"), _ECHO_PAIRS, ids=_IDS)
+    def test_the_two_branches_name_their_change_differently(
+        self, label: str, rows: dict[int, Any], words: tuple[str, ...], tests: tuple[str, ...]
+    ) -> None:
+        """Which is why the exact-slug key misses them, and is the premise of this file."""
+        left, right = sorted(rows)
+        files = _open_set(rows)
+        keys = [{check.addition_key(path) for path in files[number].created} for number in (left, right)]
+        assert not (keys[0] & keys[1]), label
+
+
+class TestBothHalvesOfTheConjunctionAreLoadBearing:
+    """Neither shared words nor a shared test is usable on its own."""
+
+    def test_one_shared_word_is_not_enough(self) -> None:
+        files = {
+            11: _pull(("changelog.d/11-the-refusal-names-its-cause.md",), ("tests/test_a.py",)),
+            12: _pull(("changelog.d/12-the-camera-reports-a-rate.md",), ("tests/test_a.py",)),
+        }
+        assert check.fragment_tokens(files[11].created) & check.fragment_tokens(files[12].created) == {"the"}
+        assert check.classify_additions(files).outcome == check.UNIQUE_ADDITIONS
+
+    def test_shared_words_without_a_shared_test_is_not_enough(self) -> None:
+        files = {
+            11: _pull(("changelog.d/11-feetech-broadcast-refused.md",), ("tests/test_a.py",)),
+            12: _pull(("changelog.d/12-feetech-broadcast-excluded.md",), ("tests/test_b.py",)),
+        }
+        assert check.classify_additions(files).outcome == check.UNIQUE_ADDITIONS
+
+    def test_a_shared_edited_source_file_alone_is_not_enough(self) -> None:
+        """The widening #2823 proposed, measured at 8.8% precision over #2345..#2825.
+
+        Two branches editing one source file is the sibling sweep's composition
+        question. It is read here only in conjunction with a shared description.
+        """
+        files = {
+            11: _pull(("changelog.d/11-one-change.md",), ("strands_robots/utils.py",)),
+            12: _pull(("changelog.d/12-another-change.md",), ("strands_robots/utils.py",)),
+        }
+        assert check.classify_additions(files).outcome == check.UNIQUE_ADDITIONS
+
+    def test_the_floor_is_two_words(self) -> None:
+        assert check.FRAGMENT_TOKEN_FLOOR == 2
+
+    def test_a_shared_edited_file_outside_the_test_tree_is_not_the_shared_test(self) -> None:
+        files = {
+            11: _pull(("changelog.d/11-feetech-broadcast-refused.md",), ("strands_robots/tools/serial_tool.py",)),
+            12: _pull(("changelog.d/12-feetech-broadcast-excluded.md",), ("strands_robots/tools/serial_tool.py",)),
+        }
+        assert check.classify_additions(files).outcome == check.UNIQUE_ADDITIONS
+
+    def test_a_created_test_is_not_an_edited_one(self) -> None:
+        """Both branches writing a new test is the created-path key's question.
+
+        This half asks whether both corrected the *same existing* case, which is
+        what two authors fixing one defect do.
+        """
+        files = {
+            11: _pull(("changelog.d/11-feetech-broadcast-refused.md", "tests/test_shared.py"), ()),
+            12: _pull(("changelog.d/12-feetech-broadcast-excluded.md", "tests/test_shared.py"), ()),
+        }
+        verdict = check.classify_additions(files)
+        assert verdict.echoes == ()
+        assert verdict.collisions == ((11, 12, ("tests/test_shared.py",)),)
+
+
+class TestTheTwoKeysReportApart:
+    """A created path is a fact; a described change is a pair to read."""
+
+    @staticmethod
+    def _echo_report() -> str:
+        _, rows, _, _ = _ECHO_PAIRS[3]
+        return check.render_additions(check.classify_additions(_open_set(rows)), "strands-labs/robots")
+
+    def test_an_echo_lands_in_echoes_and_not_in_collisions(self) -> None:
+        _, rows, _, _ = _ECHO_PAIRS[3]
+        verdict = check.classify_additions(_open_set(rows))
+        assert verdict.collisions == ()
+        assert len(verdict.echoes) == 1
+
+    def test_the_echo_section_names_the_words_and_the_test(self) -> None:
+        report = self._echo_report()
+        assert "#2820 + #2822" in report
+        assert "feetech" in report and "broadcast" in report
+        assert "tests/tools/test_serial_tool_numeric_domain.py" in report
+
+    def test_the_echo_section_says_it_is_the_weaker_key(self) -> None:
+        report = self._echo_report()
+        assert "one change described twice" in report
+        assert "weaker of the two keys" in report
+        assert "64.3%" in report
+
+    def test_an_echo_does_not_claim_the_created_path_reasoning(self) -> None:
+        """ "Neither branch's file exists on the base" is false of an edited test."""
+        assert "not a merge order to decide" not in self._echo_report()
+
+    def test_a_created_path_pair_keeps_its_own_reasoning(self) -> None:
+        files = {n: _pull(("tests/test_a.py",), ()) for n in (11, 12)}
+        report = check.render_additions(check.classify_additions(files), "owner/name")
+        assert "not a merge order to decide" in report
+        assert "one change described twice" not in report
+
+    def test_both_keys_firing_reports_both_sections(self) -> None:
+        files = {
+            11: _pull(("changelog.d/11-feetech-broadcast-refused.md", "tests/test_new.py"), ("tests/test_old.py",)),
+            12: _pull(("changelog.d/12-feetech-broadcast-excluded.md", "tests/test_new.py"), ("tests/test_old.py",)),
+        }
+        verdict = check.classify_additions(files)
+        assert verdict.collisions and verdict.echoes
+        report = check.render_additions(verdict, "owner/name")
+        assert "not a merge order to decide" in report
+        assert "one change described twice" in report
+
+    def test_the_clean_summary_names_the_second_key(self) -> None:
+        files = {n: _pull((f"changelog.d/{n}-unrelated-{n}.md",), ()) for n in (11, 12)}
+        verdict = check.classify_additions(files)
+        assert verdict.outcome == check.UNIQUE_ADDITIONS
+        assert "describe one change over one test" in verdict.summary
+
+
+class TestWhatContributesAWord:
+    """Only a fragment the assembler would accept, which is the safe direction."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/test_x.py",
+            "strands_robots/utils.py",
+            "changelog.d/README.md",
+            "changelog.d/no-leading-number.md",
+            "changelog.d/2765-Not_A_Slug.md",
+            "changelog.d/nested/2765-slug.md",
+            # ``docs/robots/`` is exactly as long as ``changelog.d/``, so this
+            # path's tail is a well-formed fragment name. The directory has to be
+            # checked; the name pattern alone would read words out of it.
+            "docs/robots/2820-feetech-broadcast.md",
+        ],
+    )
+    def test_anything_that_is_not_a_fragment_contributes_no_word(self, path: str) -> None:
+        assert check.fragment_tokens((path,)) == frozenset()
+
+    def test_a_fragment_contributes_its_slug_words_and_not_its_number(self) -> None:
+        assert check.fragment_tokens(("changelog.d/2820-feetech-broadcast-refused.md",)) == {
+            "feetech",
+            "broadcast",
+            "refused",
+        }
+
+    def test_a_reserved_name_contributes_nothing_even_if_it_looks_like_a_fragment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The assembler's list is the authority, not the pattern's happy accident."""
+        monkeypatch.setattr(check._ASSEMBLER, "RESERVED_NAMES", frozenset({"0-release-notes.md"}))
+        assert check.fragment_tokens(("changelog.d/0-release-notes.md",)) == frozenset()
+
+    def test_several_fragments_contribute_every_slug(self) -> None:
+        assert check.fragment_tokens(("changelog.d/11-one-thing.md", "changelog.d/12-other-thing.md")) == {
+            "one",
+            "other",
+            "thing",
+        }
+
+
+class TestDeterminism:
+    """Stable in all four axes, so a diff of two reports shows changed verdicts."""
+
+    def test_pairs_words_and_tests_are_sorted(self) -> None:
+        files = {
+            99: _pull(("changelog.d/99-zebra-apple-mango.md",), ("tests/test_z.py", "tests/test_a.py")),
+            11: _pull(("changelog.d/11-mango-apple-zebra.md",), ("tests/test_z.py", "tests/test_a.py")),
+        }
+        assert check.find_echo_collisions(files) == (
+            (11, 99, ("apple", "mango", "zebra"), ("tests/test_a.py", "tests/test_z.py")),
+        )
+
+    def test_three_branches_describing_one_change_report_all_three_pairs(self) -> None:
+        files = {
+            n: _pull((f"changelog.d/{n}-feetech-broadcast-refused.md",), ("tests/test_a.py",)) for n in (11, 12, 13)
+        }
+        assert [(left, right) for left, right, _, _ in check.find_echo_collisions(files)] == [
+            (11, 12),
+            (11, 13),
+            (12, 13),
+        ]
+        assert check.classify_additions(files).implicated == (11, 12, 13)
+
+    def test_an_empty_open_set_finds_no_echo(self) -> None:
+        assert check.find_echo_collisions({}) == ()
+
+    def test_an_unreadable_open_set_is_not_an_echo_finding(self) -> None:
+        verdict = check.classify_additions(None, "the API returned errors.")
+        assert verdict.outcome == check.UNKNOWN_ADDITIONS
+        assert verdict.echoes == ()
+
+
+class TestTheNodeReaderSplitsOneFileListByChangeType:
+    """Both keys read one response, and a truncated list is refused once for both."""
+
+    @staticmethod
+    def _node(number: int, files: list[dict[str, str]], total: int | None = None) -> dict[str, Any]:
+        return {
+            "number": number,
+            "files": {"totalCount": len(files) if total is None else total, "nodes": files},
+        }
+
+    def test_created_and_edited_are_read_from_one_list(self) -> None:
+        node = self._node(
+            11,
+            [
+                {"path": "b.py", "changeType": check.ADDED_CHANGE_TYPE},
+                {"path": "a.py", "changeType": check.ADDED_CHANGE_TYPE},
+                {"path": "d.py", "changeType": check.EDITED_CHANGE_TYPE},
+                {"path": "c.py", "changeType": check.EDITED_CHANGE_TYPE},
+            ],
+        )
+        assert check.file_sets(node) == check.PullFiles(created=("a.py", "b.py"), edited=("c.py", "d.py"))
+
+    @pytest.mark.parametrize("change_type", ["REMOVED", "RENAMED", "COPIED", "CHANGED"])
+    def test_no_other_change_type_reaches_either_key(self, change_type: str) -> None:
+        node = self._node(11, [{"path": "a.py", "changeType": change_type}])
+        assert check.file_sets(node) == check.PullFiles()
+
+    def test_a_truncated_list_is_refused_rather_than_read_short_for_either_key(self) -> None:
+        node = self._node(11, [{"path": "a.py", "changeType": check.EDITED_CHANGE_TYPE}], total=101)
+        with pytest.raises(check.ClaimSetUnreadable, match="truncated"):
+            check.file_sets(node)


### PR DESCRIPTION
## The defect

`scripts/check_duplicate_claim.py --all-open` pairs open branches on what they
**create** — a path, or the slug of a changelog fragment. That key reads a *name*,
and a name is exactly what two authors describing one change need not share.

#2820 and #2822 fixed one defect thirteen minutes apart, both modifying
`strands_robots/tools/serial_tool.py`, and named the change
`feetech-broadcast-is-not-a-reply-address` and
`feetech-motor-id-excludes-the-broadcast`. Two names, no collision. Run against
the live open set with both in it, the sweep answered:

```
Outcome: **unique-additions**
No two of the 4 open pull requests create the same file or name the same
changelog entry (6 pair(s) compared).
```

#2822 was later closed as the duplicate. So this is the relation's answer to a
real instance of what it exists to find.

## What the second key is

Two branches whose changelog fragments share at least **two words** *and* which
both edit at least one **pre-existing test**. Two authors fixing one defect
describe the same subject and correct the same case. The conjunction is the
relation — neither half is usable alone.

## Measurement

Ground truth is the **eleven** pairs in #2345 through #2825 whose closed half
names, in its own closing comment, the pull request that superseded it (`#2373 ->
#2370`, `#2383 -> #2384`, `#2389 -> #2388`, `#2431 -> #2429`, `#2571 -> #2570`,
`#2707 -> #2708`, `#2766 -> #2767`, `#2785 -> #2792`, `#2787 -> #2792`, `#2790 ->
#2792`, `#2822 -> #2820`). All eleven were open at the same instant. #2646 is
excluded: its comment says "superseded by the 0.5 -> 1.0 backlog sequencing, not
because it is blocked", which is a scope change rather than a duplicate.

Over the 2199 pairs open at the same instant in that window, and over 374
replayed sweeps — one at each moment a pull request was opened with another
already open, which is what `--all-open` actually reads (median open set: six):

| relation | pairs | precision | recall | sweeps firing |
|---|---|---|---|---|
| both edit a source file | 80 | 8.8% | 63.6% | 29.9% |
| fragments share one word | 151 | 6.6% | 90.9% | — |
| fragments share two words | 33 | 30.3% | 90.9% | 37.2% |
| both edit one test | 26 | 11.5% | 81.8% | — |
| **two words AND one test** | **14** | **64.3%** | **81.8%** | **5.6%** |
| created path (the existing key) | 7 | 71.4% | 45.5% | 1.3% |
| both keys together | 15 | 66.7% | 90.9% | 5.9% |

The new key reaches four pairs the created-path key structurally cannot:
`#2370/#2373`, `#2383/#2384`, `#2429/#2431`, `#2820/#2822`.

## Two results decided the shape

**Pairing on a shared edited source file is refused, with a number.** It is the
obvious widening: 8.8% precise, and it fires on nearly a third of sweeps.
`strands_robots/simulation/mujoco/simulation.py` alone accounts for 17 of its 80
pairs. That is worse than the 117-of-1802 figure `ADDED_CHANGE_TYPE` already
refuses on precision grounds, so it is asserted from both sides rather than left
as a comment.

**One shared word is the repository's house style, not a subject.** `names` and
`the` appear in 39 and 20 of the window's 401 fragments, so a one-word rule fires
on 37.2% of sweeps. Three words loses a third of the duplicates (63.6% recall).
Only the conjunction is precise, and it needs no stop list, no path exclusions and
no parameter tuned against the corpus it was measured on — a frequency-derived
stop list is a refinement rather than a requirement (43.5% against 30.3% at the
same recall) and cannot be computed where this runs, since the sweep sees a median
of six pull requests rather than a corpus.

## The two keys are reported apart

They support different conclusions, so they are not merged into one list:

- a shared **created path** is a fact — neither file exists on the base, so one of
  the two branches is redundant;
- a shared **description over a shared test** is a question. At 64.3% precision
  roughly one pair in three shares a subject without sharing a change, so the
  report says so and asks the reader to read both descriptions.

The existing report's reasoning ("Neither branch's file exists on the base, so
this is not a merge order to decide") is *false* of an edited test, so it is not
attached to an echo. Of the five non-duplicate pairs the new key selects, two are
members of the `#2785`/`#2787`/`#2790`/`#2792` supersede cluster and one
(`#2713`/`#2714`) is two branches on one subject that both shipped.

## A denominator correction

Eleven declared duplicate pairs is more than the five this module counted before,
because a closing comment reaches pairs neither key found: `#2370/#2373`,
`#2383/#2384` and `#2429/#2431` are three duplicate pairs in the earlier window
that the module's own table does not list. So the created-path key's recall is
45.5% of the declared set, not most of it. Both the module docstring and AGENTS.md
step 1 now say so.

## Tests

`tests/test_duplicate_work_described_change_key.py`, 57 cases. Every path in
`_ECHO_PAIRS` is the real one from `pulls/<n>/files`, which outlives the state
change that closed one half of each pair.

Pre-fix split, with the relation neutered and every new symbol kept:
**18 failed / 38 passed**, and the failures are 12 in
`TestTheMeasuredEchoPairsAreReported`, 4 in `TestTheTwoKeysReportApart`, 2 in
`TestDeterminism` — **0 in all four premise and control classes**. Against the
current `main` script the whole file is 56 failures, which is the collection-error
shape of a raw revert.

`TestTheCreatedPathKeyCannotSeeThesePairs` is the non-vacuity half: every pair
here reports `unique-additions` when only what the branches create is read, so a
test that the sweep reports them cannot pass on the first key alone.

Mutation table — 12 mutations, 12 detected, control clean, `collected` stable at
57 in every row, source restored byte-identically:

| mutation | new file | sibling suites |
|---|---|---|
| control | 0 | 0 |
| the relation reports nothing | 18 | 0 |
| floor lowered to one word | 2 | 0 |
| floor raised to three words | 14 | 0 |
| shared-test half dropped (words alone) | 3 | **1** |
| shared-words half dropped (test alone) | 1 | 0 |
| reads an edited source file instead of a test | 19 | 0 |
| echoes merged into the created-path list | 1 | 0 |
| a fragment contributes its whole slug, not words | 21 | 0 |
| a reserved name contributes words | 1 | 0 |
| the fragment number becomes a word | 2 | 0 |
| a non-fragment path contributes words | 1 | 0 |

Dropping the shared-test half trips a pre-existing test as well, which is the
over-reach evidence for keeping the conjunction.

The last row was 0 until a `docs/robots/2820-feetech-broadcast.md` exemplar was
added: `docs/robots/` is exactly as long as `changelog.d/`, so that path's tail is
a well-formed fragment name and the directory check is load-bearing rather than
belt-and-braces.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests
  tests_integ` and the script; `mypy` **`Success: no issues found in 1632 source
  files`**.
- Paired against the merge-base on an identical 434-file selection — every suite
  that walks the tree, parses source, or reads docstrings, `AGENTS.md`,
  `changelog.d/` or `scripts/` — with the new file excluded from both:
  **20492 collected and `5 failed, 20414 passed, 73 skipped` on each**, the same
  five failing ids, both `comm` directions empty. All five are pre-existing on a
  pristine `main` worktree: they assert `rclpy` is absent and it resolves here.
- Run against the live open set, the sweep reports `unique-additions` over four
  pull requests and six pairs, exit 0 — no false positive on the current queue.

No visual artifact: this changes a repository check's report, not a policy,
simulation, rendering, recording or asset path. The measured tables are the
evidence.

Closes #2823.
