### PR TITLE
fix(device-connect): report an emergency stop the robot refused instead of discarding it

### DIFF
--- a/changelog.d/2831-estop-reports-a-robot-that-did-not-stop.md
+++ b/changelog.d/2831-estop-reports-a-robot-that-did-not-stop.md
@@ -1,0 +1,45 @@
+### Fixed: an emergency stop the robot refused is reported instead of discarded
+
+`RobotDeviceDriver.onEmergencyStop` called `self._robot.stop_task()` and dropped
+the envelope. Two of the four robot surfaces the driver can wrap answer a stop
+with an affirmative "I did not stop", and each was written deliberately to do
+so. `G1Driver.stop_task` returns `status="error"` with `stopped=False` when its
+control loop outlasts the join budget, and its own docstring says why: "so the
+caller cannot read 'success' while the payload's own `running=True` says the
+loop is still writing frames". `ReachyDriver.stop_task` reports a daemon that
+refused the stop. This handler was the caller that read neither field.
+
+So an operator's emergency stop was answered by a single WARNING line stating
+that the stop was being attempted - the intent, not the outcome - with nothing
+recorded above WARNING while the loop kept publishing. `Mesh.emergency_stop`
+grades exactly that verdict for every peer it fans out to, logs one that did not
+stop at CRITICAL, and names a hardware cutoff as the remedy, on the reasoning
+`_peers_that_did_not_stop` states: an emergency stop is only as trustworthy as
+its accounting. The same envelope reaching the mesh was reported and reaching
+Device Connect was not, so an operator's accounting depended on which transport
+the stop arrived over.
+
+The refusal is now read and, when the robot reports one, logged at CRITICAL
+carrying the source of the stop, the reason the robot itself gave, and the same
+cutoff remedy the mesh path names. Both spellings are read, because they differ:
+an explicit `stopped` flag is authoritative where a driver supplies one, and the
+envelope's status answers for the drivers that report through `_refuse`, whose
+envelope carries text and no flag at all. `teleop_mixin._stop_reported_stopped`
+asks the same question of a `stop_teleoperate` envelope and is deliberately not
+reused - it answers `True` for an envelope with no `json` block, which is right
+there (nothing was teleoperating) and wrong here, because that is the shape a
+refused `stop_task` arrives in.
+
+The reader is conservative for the reason `_peers_that_did_not_stop` gives: only
+an envelope that affirmatively reports a failure is flagged, because a false "did
+not stop" on the safety path trains operators to ignore the warning. A robot that
+stopped, one that had nothing to stop, one reporting an error beside a payload
+that says the loop stopped, and a driver that returns nothing at all are all left
+alone. The authorization guard still runs first, so reading the verdict does not
+widen who can halt a task.
+
+The three suites that already drive `onEmergencyStop` assert
+`stop_task.assert_called_once()` or `robot.stopped is True` - that the call was
+made, never what it answered - and their robot doubles are `MagicMock`s whose
+`stop_task` returns a `MagicMock`, which carries no verdict to read. That is why
+the discard was invisible.

--- a/strands_robots/device_connect/robot_driver.py
+++ b/strands_robots/device_connect/robot_driver.py
@@ -25,6 +25,59 @@ from strands_robots.mesh.security import is_safe_policy_provider
 logger = logging.getLogger(__name__)
 
 
+def _stop_task_refusal(envelope: object) -> str | None:
+    """Read whether a ``stop_task`` envelope reports a stop that did not happen.
+
+    Two of the robot surfaces :class:`RobotDeviceDriver` can wrap answer a stop
+    with an affirmative "I did not stop", and they spell it differently.
+    ``G1Driver.stop_task`` reports ``status="error"`` and carries ``stopped``
+    in a ``json`` block when its control loop outlasts the join budget, while
+    ``ReachyDriver.stop_task`` reports a daemon that refused the stop through
+    ``_refuse``, whose envelope carries a ``text`` block and no ``stopped`` key
+    at all. So both signals are read: an explicit ``stopped`` flag is
+    authoritative where the driver supplies one, and ``status`` answers for the
+    envelopes that do not.
+
+    ``teleop_mixin._stop_reported_stopped`` asks the same question of a
+    ``stop_teleoperate`` envelope and is deliberately not reused: it returns
+    ``True`` for an envelope with no ``json`` block, which is right there
+    (nothing was teleoperating) and wrong here, because that is the shape a
+    refused ``stop_task`` arrives in.
+
+    Deliberately conservative, for the reason
+    ``mesh.core._peers_that_did_not_stop`` gives: only an envelope that
+    AFFIRMATIVELY reports a failure is flagged. Anything else -- a driver that
+    returns nothing, a test double, a shape this function does not recognise --
+    is left alone, because a false "did not stop" on the safety path trains
+    operators to ignore the warning.
+
+    Args:
+        envelope: Whatever the wrapped robot's ``stop_task`` returned.
+
+    Returns:
+        The reason the robot gave for not stopping, or ``None`` when the stop is
+        accounted for.
+    """
+    if not isinstance(envelope, dict):
+        return None
+    blocks = envelope.get("content")
+    texts: list[str] = []
+    for block in blocks if isinstance(blocks, list) else []:
+        if not isinstance(block, dict):
+            continue
+        payload = block.get("json")
+        if isinstance(payload, dict) and "stopped" in payload:
+            if payload["stopped"]:
+                return None
+            return str(payload.get("reason") or payload)
+        text = block.get("text")
+        if isinstance(text, str):
+            texts.append(text)
+    if envelope.get("status") == "error":
+        return "; ".join(texts) if texts else str(envelope)
+    return None
+
+
 class RobotDeviceDriver(DeviceDriver):
     """Device Connect device driver wrapping a strands-robots Robot instance."""
 
@@ -226,12 +279,29 @@ class RobotDeviceDriver(DeviceDriver):
         Security hardening: only act on emergency-stop events whose source is
         in the emergency-stop allowlist, so a spoofed event from an arbitrary
         device cannot interrupt operations.
+
+        The stop's own verdict is read rather than discarded. ``stop_task`` is
+        written to report a stop that did not happen -- ``G1Driver`` returns
+        ``status="error"`` with ``stopped=False`` precisely "so the caller
+        cannot read 'success' while the payload's own ``running=True`` says the
+        loop is still writing frames" -- and this handler was the caller that
+        read neither field. ``Mesh.emergency_stop`` grades that same verdict for
+        every peer it fans out to and logs one that did not stop at CRITICAL; a
+        stop that arrives over Device Connect rather than over the mesh is the
+        same operator request and gets the same accounting.
         """
         if not is_authorized_caller(device_id, scope="estop"):
             logger.warning("Ignoring emergencyStop from unauthorized source %s", device_id)
             return
         logger.warning("Emergency stop received from %s - stopping task", device_id)
-        self._robot.stop_task()
+        refusal = _stop_task_refusal(self._robot.stop_task())
+        if refusal is not None:
+            logger.critical(
+                "[safety] emergency stop from %s: the robot reported it did NOT stop: %s. "
+                "It may still be executing; use a hardware cutoff.",
+                device_id,
+                refusal,
+            )
 
     # ── Periodic state publishing ─────────────────────────────
 

--- a/tests/test_estop_reports_a_robot_that_did_not_stop.py
+++ b/tests/test_estop_reports_a_robot_that_did_not_stop.py
@@ -1,0 +1,281 @@
+"""An emergency stop that the robot refused is reported, not discarded.
+
+``RobotDeviceDriver.onEmergencyStop`` called ``self._robot.stop_task()`` and
+dropped the envelope. Two of the four robot surfaces the driver can wrap answer
+a stop with an affirmative "I did not stop": ``G1Driver.stop_task`` reports
+``status="error"`` with ``stopped=False`` when its control loop outlasts the
+join budget, and ``ReachyDriver.stop_task`` reports a daemon that refused. So
+an operator's emergency stop was answered by a single WARNING line saying the
+stop was being attempted, while the loop kept writing frames and nothing was
+recorded above WARNING.
+
+``Mesh.emergency_stop`` grades exactly that verdict for every peer it fans out
+to and logs one that did not stop at CRITICAL, quoting a hardware cutoff as the
+remedy. A stop that arrives over Device Connect rather than over the mesh is
+the same operator request, so it gets the same accounting.
+
+Why the existing suites were silent: the three files that drive
+``onEmergencyStop`` assert ``stop_task.assert_called_once()`` or
+``robot.stopped is True`` -- that the CALL WAS MADE, never what it ANSWERED --
+and their robot doubles are ``MagicMock``s whose ``stop_task`` returns a
+``MagicMock``, which carries no verdict to read.
+"""
+
+import ast
+import asyncio
+import inspect
+import logging
+
+import pytest
+
+# The autouse fixture below is what makes this import safe. A sibling test file
+# replaces the device_connect_edge submodules with MagicMocks at import time,
+# and this helper restores the real ones. Importing the helper does NOT bring
+# the sibling's autouse fixture with it -- an autouse fixture is bound to the
+# module that declares it -- so this file declares its own.
+from tests.test_device_connect_hardening import _force_real_device_connect_edge
+
+# The two shapes a real driver produces, stated here rather than imported so a
+# failure names the disagreement instead of inheriting it. The one cell that
+# reads the drivers is the premise below.
+_G1_JOIN_TIMEOUT = {
+    "status": "error",
+    "content": [
+        {
+            "json": {
+                "stopped": False,
+                "running": True,
+                "steps": 4211,
+                "reason": "stop_task: control loop did not join within timeout; policy is likely blocking",
+            }
+        }
+    ],
+}
+_REACHY_DAEMON_REFUSED = {
+    "status": "error",
+    "content": [{"text": "stop_task: daemon refused the stop: connection reset"}],
+}
+_CLEAN_STOP = {
+    "status": "success",
+    "content": [{"json": {"stopped": True, "running": False, "steps": 12}}],
+}
+_NOTHING_TO_STOP = {
+    "status": "success",
+    "content": [{"text": "No task running to stop (current: idle)"}],
+}
+
+_CUTOFF_REMEDY = "hardware cutoff"
+_LOGGER = "strands_robots.device_connect.robot_driver"
+
+
+@pytest.fixture(autouse=True)
+def _real_device_connect(monkeypatch):
+    """Restore the real device_connect_edge and clear the estop allowlist."""
+    _force_real_device_connect_edge()
+    for var in ("DEVICE_CONNECT_RPC_ALLOW", "DEVICE_CONNECT_ESTOP_ALLOW", "DEVICE_CONNECT_ALLOW_INSECURE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _Robot:
+    """A robot whose ``stop_task`` answers with a chosen envelope."""
+
+    tool_name_str = "g1"
+
+    def __init__(self, envelope):
+        self._envelope = envelope
+        self.calls = 0
+
+    def stop_task(self):
+        self.calls += 1
+        return self._envelope
+
+
+def _estop(envelope, caplog, device_id="safety-controller-1"):
+    """Deliver an emergency stop and return (robot, records)."""
+    from strands_robots.device_connect.robot_driver import RobotDeviceDriver
+
+    robot = _Robot(envelope)
+    driver = RobotDeviceDriver(robot)
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        _run(driver.onEmergencyStop(device_id, "emergencyStop", {"reason": "operator pressed"}))
+    return robot, [r for r in caplog.records if r.name == _LOGGER]
+
+
+def _above_warning(records):
+    return [r for r in records if r.levelno >= logging.ERROR]
+
+
+class TestTheRefusalShapesAreReal:
+    """The two envelopes graded below are the ones the drivers actually build.
+
+    Premises: they hold before and after the fix.
+    """
+
+    def test_a_refused_stop_carries_text_and_no_stopped_flag(self):
+        """``_refuse`` is how both drivers report a refusal, and it carries no json block."""
+        from strands_robots.drivers.g1 import _refuse as g1_refuse
+        from strands_robots.drivers.reachy import _refuse as reachy_refuse
+
+        for refuse in (g1_refuse, reachy_refuse):
+            envelope = refuse("stop_task: daemon refused the stop: connection reset")
+            assert envelope["status"] == "error"
+            assert [b for b in envelope["content"] if "json" in b] == [], (
+                "a refusal carries text only, which is why a stopped-flag reader alone misses it"
+            )
+
+    def test_the_g1_stop_reports_the_join_outcome_in_its_payload(self):
+        """G1's ``stop_task`` puts the join outcome under ``stopped``."""
+        from strands_robots.drivers.g1 import G1Driver
+
+        source = inspect.getsource(G1Driver.stop_task)
+        assert '"stopped"' in source, "the graded json shape requires G1 to report a stopped flag"
+
+    def test_the_teleop_reader_alone_would_miss_a_refused_stop(self):
+        """The design reason a ``stop_task`` reader is not the teleop reader.
+
+        ``teleop_mixin._stop_reported_stopped`` answers ``True`` for an envelope
+        with no ``json`` block. That is right for ``stop_teleoperate`` (nothing
+        was teleoperating) and wrong here, because it is the shape a refused
+        ``stop_task`` arrives in.
+        """
+        from strands_robots.teleop_mixin import _stop_reported_stopped
+
+        assert _stop_reported_stopped(_G1_JOIN_TIMEOUT) is False
+        assert _stop_reported_stopped(_REACHY_DAEMON_REFUSED) is True
+
+
+class TestARobotThatDidNotStopIsReported:
+    """The affirmative refusal reaches an operator."""
+
+    @pytest.mark.parametrize(
+        ("label", "envelope"),
+        [("join-timeout", _G1_JOIN_TIMEOUT), ("daemon-refused", _REACHY_DAEMON_REFUSED)],
+    )
+    def test_the_refusal_is_recorded_above_warning(self, label, envelope, caplog):
+        robot, records = _estop(envelope, caplog)
+        assert robot.calls == 1, "the stop is still attempted"
+        assert _above_warning(records), f"a {label} stop was recorded at WARNING or below"
+
+    @pytest.mark.parametrize(
+        ("label", "envelope", "quote"),
+        [
+            ("join-timeout", _G1_JOIN_TIMEOUT, "did not join within timeout"),
+            ("daemon-refused", _REACHY_DAEMON_REFUSED, "daemon refused the stop"),
+        ],
+    )
+    def test_the_report_names_the_reason_the_robot_gave(self, label, envelope, quote, caplog):
+        _robot, records = _estop(envelope, caplog)
+        loud = " ".join(r.getMessage() for r in _above_warning(records))
+        assert quote in loud, f"the {label} report does not carry the robot's own reason"
+
+    def test_the_report_names_the_source_of_the_stop(self, caplog):
+        _robot, records = _estop(_G1_JOIN_TIMEOUT, caplog, device_id="safety-controller-7")
+        loud = " ".join(r.getMessage() for r in _above_warning(records))
+        assert "safety-controller-7" in loud
+
+    def test_the_report_names_the_hardware_cutoff_remedy(self, caplog):
+        """The mesh's own wording: a robot that may still be executing needs a cutoff."""
+        _robot, records = _estop(_G1_JOIN_TIMEOUT, caplog)
+        loud = " ".join(r.getMessage() for r in _above_warning(records))
+        assert _CUTOFF_REMEDY in loud
+
+
+class TestAStopThatHappenedIsQuiet:
+    """Over-reach controls: a false "did not stop" on the safety path is worse than none."""
+
+    @pytest.mark.parametrize(
+        ("label", "envelope"),
+        [("clean stop", _CLEAN_STOP), ("nothing to stop", _NOTHING_TO_STOP)],
+    )
+    def test_an_accounted_stop_records_nothing_above_warning(self, label, envelope, caplog):
+        _robot, records = _estop(envelope, caplog)
+        assert _above_warning(records) == [], f"a {label} must not be reported as a failure"
+
+    def test_an_error_beside_a_successful_stop_is_not_flagged(self, caplog):
+        """An explicit ``stopped=True`` is authoritative over the envelope's status.
+
+        This is why the flag is read ahead of ``status`` rather than instead of
+        it: a driver reporting an error about something else, while its own
+        payload says the loop stopped, has not failed to stop.
+        """
+        envelope = {
+            "status": "error",
+            "content": [{"json": {"stopped": True, "running": False, "note": "zero-torque publish retried"}}],
+        }
+        _robot, records = _estop(envelope, caplog)
+        assert _above_warning(records) == []
+
+    def test_a_return_that_is_not_an_envelope_is_not_flagged(self, caplog):
+        """A driver returning ``None`` reports nothing; it is not an affirmative failure."""
+        _robot, records = _estop(None, caplog)
+        assert _above_warning(records) == []
+
+    def test_a_test_double_that_answers_nothing_is_not_flagged(self, caplog):
+        """The shape the three pre-existing suites hand this handler."""
+        from unittest.mock import MagicMock
+
+        from strands_robots.device_connect.robot_driver import RobotDeviceDriver
+
+        robot = MagicMock()
+        robot.tool_name_str = "so100"
+        driver = RobotDeviceDriver(robot)
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+            _run(driver.onEmergencyStop("safety-1", "emergencyStop", {}))
+        robot.stop_task.assert_called_once()
+        assert _above_warning([r for r in caplog.records if r.name == _LOGGER]) == []
+
+
+class TestTheAuthorizationGuardStillComesFirst:
+    """Reading the verdict must not widen who can trigger a stop."""
+
+    def test_an_unauthorized_source_never_reaches_stop_task(self, caplog, monkeypatch):
+        monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", "safety-controller-1")
+        robot, records = _estop(_G1_JOIN_TIMEOUT, caplog, device_id="rogue-device")
+        assert robot.calls == 0, "a spoofed emergency stop must not halt the task"
+        assert _above_warning(records) == [], "a rejected source is not a robot that did not stop"
+
+    def test_an_authorized_source_still_reaches_stop_task(self, caplog, monkeypatch):
+        monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", "safety-controller-1")
+        robot, _records = _estop(_G1_JOIN_TIMEOUT, caplog)
+        assert robot.calls == 1
+
+
+class TestTheHandlerReadsTheVerdictRatherThanDiscardingIt:
+    """Structural: the call's value is consumed, and the mesh sibling agrees."""
+
+    def test_the_stop_call_is_not_a_bare_statement(self):
+        from strands_robots.device_connect import robot_driver
+
+        tree = ast.parse(inspect.getsource(robot_driver))
+        handler = next(
+            node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef) and node.name == "onEmergencyStop"
+        )
+        discarded = [
+            ast.unparse(node.value)
+            for node in ast.walk(handler)
+            if isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Call)
+            and "stop_task" in ast.unparse(node.value)
+        ]
+        assert discarded == [], f"the stop's verdict is discarded: {discarded}"
+
+    def test_the_mesh_estop_path_flags_the_same_envelope(self):
+        """The in-tree control: one fleet, one envelope, one verdict.
+
+        ``Mesh.emergency_stop`` already reports a peer that did not stop. If the
+        two paths disagreed about the same envelope, an operator's accounting
+        would depend on which transport the stop arrived over.
+        """
+        from strands_robots.mesh.core import _peers_that_did_not_stop
+
+        flagged = _peers_that_did_not_stop([{**_G1_JOIN_TIMEOUT, "responder_id": "g1-01"}])
+        assert flagged == {"g1-01"}
+        assert _peers_that_did_not_stop([{**_CLEAN_STOP, "responder_id": "g1-01"}]) == set()


### PR DESCRIPTION
## The defect

`RobotDeviceDriver.onEmergencyStop` called `self._robot.stop_task()` and dropped the envelope.

Two of the four robot surfaces this driver can wrap answer a stop with an affirmative "I did not stop", and each was written deliberately to do so:

- `G1Driver.stop_task` returns `status="error"` with `stopped=False` when its control loop outlasts the join budget. Its own docstring says why: *"so the caller cannot read 'success' while the payload's own `running=True` says the loop is still writing frames"*, and the inline comment adds *"a caller that reads only `status` cannot count the task as stopped"*.
- `ReachyDriver.stop_task` reports a daemon that refused the stop.

This handler was the caller that read neither field.

## Measured, on a robot that affirmatively refused

Driving `onEmergencyStop` from an authorized source, with the robot answering `{"status": "error", "content": [{"json": {"stopped": false, "running": true, "steps": 4211, "reason": "control loop did not join within timeout"}}]}`:

| | before | after |
|---|---|---|
| `stop_task` called | 1 | 1 |
| handler returned | `None` | `None` |
| records at ERROR or above | **0** | 1 |
| anything naming the refusal | **nothing** | the reason, the source, and the remedy |

Before, the only record was `WARNING  Emergency stop received from safety-controller-1 - stopping task` — the intent, not the outcome. After:

```
CRITICAL [safety] emergency stop from safety-controller-1: the robot reported it did NOT
         stop: stop_task: control loop did not join within timeout; policy is likely
         blocking. It may still be executing; use a hardware cutoff.
```

## The in-tree control: one fleet, one envelope, two answers

`Mesh.emergency_stop` already grades this verdict for every peer it fans out to. Passing the **same envelope** through both paths:

| path | verdict |
|---|---|
| `mesh.core._peers_that_did_not_stop` | `{'g1-01'}` — reports it did not stop |
| `RobotDeviceDriver.onEmergencyStop` | discarded, nothing above WARNING |

`_peers_that_did_not_stop`'s docstring gives the reasoning this change adopts: *"An emergency stop is only as trustworthy as its accounting"*, and it explicitly enumerates *"a hardware stop that failed answers `{"ok": False, "error": "stop_task failed: ..."}`"* as a shape that must not be counted as an acknowledgement. An operator's accounting should not depend on whether the stop arrived over the mesh or over Device Connect.

## Why both signals are read

`teleop_mixin._stop_reported_stopped` asks the same question of a `stop_teleoperate` envelope and is **deliberately not reused**. Measured against the two real `stop_task` failure shapes:

| envelope | `status` | `_stop_reported_stopped` | teleop reader alone |
|---|---|---|---|
| G1 join timeout | `error` | `False` | catches it |
| Reachy daemon refused | `error` | `True` | **misses it** |
| hardware idle | `success` | `True` | correct |
| G1 clean stop | `success` | `True` | correct |

It answers `True` for an envelope with no `json` block, which is right there (nothing was teleoperating) and wrong here, because that is exactly the shape a refused `stop_task` arrives in. So an explicit `stopped` flag is authoritative where a driver supplies one, and the envelope's status answers for the drivers that report through `_refuse`.

## Conservatism

Only an envelope that **affirmatively** reports a failure is flagged, for the reason `_peers_that_did_not_stop` states: a false "did not stop" on the safety path trains operators to ignore the warning. Left alone: a robot that stopped, one that had nothing to stop, one reporting an error beside a payload saying the loop stopped, a driver returning `None`, and a test double. The authorization guard still runs first, so reading the verdict does not widen who can halt a task.

## Why nothing caught it

The three suites that already drive `onEmergencyStop` assert `stop_task.assert_called_once()` or `robot.stopped is True` — that the **call was made**, never what it **answered** — and their robot doubles are `MagicMock`s whose `stop_task` returns a `MagicMock`, which carries no verdict to read. Every mutation below fires **0** of those 175 pre-existing cells except the one that reorders the authorization guard.

## Pre-fix split

`7 failed / 10 passed`, by class:

| class | role | failed / total |
|---|---|---|
| `TestARobotThatDidNotStopIsReported` | regression | **6 / 6** |
| `TestTheHandlerReadsTheVerdictRatherThanDiscardingIt` | structural | 1 / 2 |
| `TestTheRefusalShapesAreReal` | premise | 0 / 3 |
| `TestAStopThatHappenedIsQuiet` | over-reach control | 0 / 4 |
| `TestTheAuthorizationGuardStillComesFirst` | control | 0 / 2 |

The structural class's second cell is the mesh control, which correctly holds both ways.

## Mutation table

11 mutations, control clean, **10 distinct firing sets**, `collected` stable at 18 on every row (so no row hides a deselection). `sib` counts failures in the three pre-existing `onEmergencyStop` suites.

| mutation | fires | sib |
|---|---|---|
| control (no mutation) | 0 | 0 |
| verdict discarded again (the base handler) | 7 | 0 |
| reader always answers "stopped" | 6 | 0 |
| status fallback dropped (the teleop reader's logic) | 2 | 0 |
| `stopped`-flag branch dropped (status only) | 1 | 0 |
| conservatism dropped (no envelope-shape guard) | 1 | 0 |
| reported at WARNING rather than CRITICAL | 6 | 0 |
| hardware-cutoff remedy dropped | 1 | 0 |
| source of the stop dropped | 1 | 0 |
| robot's own reason not carried | 2 | 0 |
| stop read moved ahead of the authorization check | 1 | **2** |
| reader always answers "refused" (inverse) | 5 | 0 |

The rows that carry the design: the status fallback dropped fires exactly the two **daemon-refused** cells, which is the measured argument against reusing the teleop reader; the inverse row fires 5 including three over-reach controls, so that class is load-bearing; and moving the read ahead of the authorization check is the only row that trips a pre-existing test, so the ordering is graded at runtime rather than only in an assertion. Two rows share a firing set for a structural reason — not computing the refusal and not logging it loudly both make it invisible above WARNING.

## Gate

- Paired 550-file selection (everything naming `device_connect`, `stop_task`, `emergencyStop` or the mesh e-stop reader, plus every tree-walking guard), the new file excluded from both trees and every path verified present on both: identical **25175 collected** and `22 failed, 25043 passed, 110 skipped` on each, **22 identical failing ids with `comm` empty in both directions**, distinct rootdirs. All 22 classified: 17 need `awsiot` (declared in the `[mesh-iot]` extra), 3 are lerobot-from-source drift, 2 need `device_connect_agent_tools` (declared in `[device-connect]`).
- `mypy strands_robots tests tests_integ`: **24 == 24**, normalized message sets byte-identical in both directions, **0 attributable** to the changed files.
- `ruff check` and `ruff format --check` clean over 1638 files.

No visual artifact: this is a reporting change on a teardown path, not a policy, simulation, rendering, recording or asset change. The measured log capture above is the evidence.

## Scope

`HardwareRobot.cleanup` also discards a `stop_task` envelope, and is deliberately untouched: `HardwareRobot.stop_task` has no error path at all, so there is no verdict there to read. `SimulationDeviceDriver.onEmergencyStop` clears `policy_running` directly and produces no envelope, so it is a different shape.
