### PR TITLE
fix(tools/pose_tool): answer for every joint a whole-arm reading was asked for

### DIFF
--- a/changelog.d/2832-whole-arm-reading-names-a-silent-joint.md
+++ b/changelog.d/2832-whole-arm-reading-names-a-silent-joint.md
@@ -1,0 +1,28 @@
+### Fixed: a whole-arm reading answers for every joint it was asked for
+
+`MotorController.read_all_positions` skips a motor whose reply did not verify, so
+it returns a subset of `motor_configs` carrying no record of what fell out. Both
+tool actions that consume it guarded only the all-empty case, so a truthy partial
+reading passed straight through. On a six-joint SO-101 with one dead servo,
+`read_all` reported five positions as "Current robot positions" and `store_pose`
+persisted those five under a name, which every later `load_pose` then drove
+towards while answering "Moved to pose". `validate_pose` checks bounds rather
+than arity, so nothing downstream could notice.
+
+`emergency_stop` had already settled the disposition for a partial result over
+the configured motor set: it answers `status="error"` and names the joints plus
+what that means, because a caller told the whole arm was released when part of it
+is still driven is worse than no stop at all. `read_all` now answers the same way
+and still carries the positions that did arrive, which are what a caller
+diagnosing a dead servo needs. `store_pose` refuses instead, because that one
+persists - `incremental_move` refuses on an unreadable position for the same
+reason, and a stored pose misrepresents itself on every load rather than once.
+
+The gap is derived by one helper shared by both readers, the same way
+`_smooth_move` derives its own: compare what came back against what was
+expected. A bus where nothing answers keeps its own diagnosis, and every motor is
+still attempted - the reported outcome changes, the packets do not.
+
+The two buses already pinned were the extremes, all servos answering and none
+answering, and those are exactly the two on which a partial-drop guard and its
+absence are indistinguishable. The mixed bus is now covered.

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -230,6 +230,30 @@ _DEFAULT_MOTOR_CONFIGS: dict[str, MotorConfig] = {
     "gripper": {"id": 6, "range": (0, 100), "resolution": 4095},
 }
 
+
+def _joints_that_did_not_answer(controller: "MotorController", positions: dict[str, float]) -> list[str]:
+    """Name the configured joints missing from a whole-arm reading.
+
+    :meth:`MotorController.read_all_positions` skips a motor whose reply did
+    not verify, so its result is a subset of ``motor_configs`` and carries no
+    record of what fell out. The gap is derived the same way
+    :meth:`MotorController._smooth_move` derives its own: compare what came
+    back against what was expected.
+
+    One helper for both whole-arm readers, so ``read_all`` and ``store_pose``
+    cannot come to disagree about what a complete reading is.
+
+    Args:
+        controller: The arm whose ``motor_configs`` defines the expected set.
+        positions: The reading returned for that arm.
+
+    Returns:
+        Sorted names of the configured joints absent from ``positions``, empty
+        when every joint answered.
+    """
+    return sorted(set(controller.motor_configs) - set(positions))
+
+
 # The degree-valued target each action reads. An action absent from this map
 # commands no joint and is never refused here.
 _TARGET_OPTION_BY_ACTION: dict[str, str] = {
@@ -1011,6 +1035,27 @@ def pose_tool(
                             for motor, pos in positions.items()
                         ]
                     )
+                    silent = _joints_that_did_not_answer(controller, positions)
+                    if silent:
+                        # Same disposition emergency_stop gives a partial result:
+                        # a reading covering part of the arm is reported as one,
+                        # naming the joints it does not cover. The positions that
+                        # did arrive are still carried -- they are what a caller
+                        # diagnosing a dead servo needs.
+                        return {
+                            "status": "error",
+                            "content": [
+                                {
+                                    "text": (
+                                        f"Read {len(positions)} of "
+                                        f"{len(controller.motor_configs)} joints; no verified "
+                                        f"reply from: {', '.join(silent)}. The positions below "
+                                        f"are the rest of the arm, not its full pose.\n{pos_text}"
+                                    )
+                                },
+                                {"json": {"positions": positions, "unread": silent}},
+                            ],
+                        }
                     return {
                         "status": "success",
                         "content": [
@@ -1035,6 +1080,29 @@ def pose_tool(
                 current_positions = controller.read_all_positions()
                 if not current_positions:
                     return {"status": "error", "content": [{"text": "Failed to read current positions"}]}
+
+                silent = _joints_that_did_not_answer(controller, current_positions)
+                if silent:
+                    # Refuse rather than report, because this one persists. A
+                    # stored pose is a named posture every later load_pose drives
+                    # towards, and validate_pose checks bounds rather than arity,
+                    # so an incomplete pose would misrepresent itself on every
+                    # load with nothing downstream able to notice. incremental_move
+                    # refuses on an unreadable position for the same reason.
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"Not storing '{pose_name}': no verified reply from "
+                                    f"{', '.join(silent)}, so this would persist "
+                                    f"{len(current_positions)} of "
+                                    f"{len(controller.motor_configs)} joints under a name that "
+                                    "promises the whole arm."
+                                )
+                            }
+                        ],
+                    }
 
                 pose = pose_manager.store_pose(pose_name, current_positions, description)
 

--- a/tests/tools/test_pose_tool_whole_arm_reading_names_a_silent_joint.py
+++ b/tests/tools/test_pose_tool_whole_arm_reading_names_a_silent_joint.py
@@ -1,0 +1,254 @@
+"""A whole-arm reading answers for every configured joint, or names the gap.
+
+``MotorController.read_all_positions`` skips a motor whose reply did not
+verify, so it returns a subset of ``motor_configs`` carrying no record of what
+fell out. Both tool actions that consume it guarded only the all-empty case, so
+a bus with one dead servo reported a five-of-six reading as the arm's positions
+and persisted it as a named pose.
+
+The two extremes were already pinned - ``test_pose_tool_read_all_formats_every_motor``
+drives a bus where every servo answers and
+``test_pose_tool_read_all_reports_failure_without_responses`` one where none
+does - and those are exactly the two buses on which a partial-drop guard and
+its absence are indistinguishable. The mixed bus below is the discriminating
+one.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+import serial
+
+import strands_robots.tools.pose_tool as pose_tool_module
+from strands_robots.tools.pose_tool import PoseManager, pose_tool
+from tests.tools.conftest import ReadingSerial, position_packet
+
+# wrist_flex, id 4 of the six SO-101 joints. Chosen mid-chain rather than last
+# so the reading it falls out of is not merely shorter than expected.
+SILENT_JOINT = "wrist_flex"
+SILENT_ID = 4
+
+
+class OneSilentMotor(ReadingSerial):
+    """A bus where every servo answers except one - a single dead joint.
+
+    ``ReadingSerial`` answers as whichever motor the outgoing packet addressed,
+    which is what lets exactly one id go quiet while the rest of the arm stays
+    live.
+    """
+
+    def read(self, n: int = 1) -> bytes:
+        asked = self.writes[-1][2] if self.writes else 0x01
+        if asked == SILENT_ID:
+            return b""
+        return position_packet(motor_id=asked)
+
+
+@pytest.fixture
+def one_silent_motor(monkeypatch):
+    """Patch ``serial.Serial`` with a bus whose ``SILENT_ID`` never replies."""
+    instances: list[OneSilentMotor] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> OneSilentMotor:
+        bus = OneSilentMotor(port, baudrate, timeout)
+        instances.append(bus)
+        return bus
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return instances
+
+
+# A second bus, because the order of a one-element gap is not observable and so
+# would leave the helper's sort ungraded.
+TWO_SILENT_JOINTS = ("shoulder_pan", "wrist_flex")
+TWO_SILENT_IDS = (1, 4)
+
+
+class TwoSilentMotors(ReadingSerial):
+    """A bus with two dead joints, one early and one mid-chain."""
+
+    def read(self, n: int = 1) -> bytes:
+        asked = self.writes[-1][2] if self.writes else 0x01
+        if asked in TWO_SILENT_IDS:
+            return b""
+        return position_packet(motor_id=asked)
+
+
+@pytest.fixture
+def two_silent_motors(monkeypatch):
+    """Patch ``serial.Serial`` with a bus whose two ``TWO_SILENT_IDS`` never reply."""
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> TwoSilentMotors:
+        return TwoSilentMotors(port, baudrate, timeout)
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+
+
+def _text(result: dict) -> str:
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _json(result: dict) -> dict | None:
+    return next((block["json"] for block in result["content"] if "json" in block), None)
+
+
+class TestThePremisesTheMixedBusRestsOn:
+    """What the fixture and the arm must be for the cases below to mean anything."""
+
+    def test_the_arm_configures_more_joints_than_the_silent_one(self, one_silent_motor) -> None:
+        """A partial reading is only distinguishable if several joints answer."""
+        controller = pose_tool_module.MotorController("/dev/ttyTEST")
+        assert SILENT_JOINT in controller.motor_configs
+        assert len(controller.motor_configs) > 2
+
+    def test_the_silent_id_is_the_one_the_named_joint_uses(self, one_silent_motor) -> None:
+        """The fixture silences the joint the assertions below name."""
+        controller = pose_tool_module.MotorController("/dev/ttyTEST")
+        assert controller.motor_configs[SILENT_JOINT]["id"] == SILENT_ID
+
+    def test_the_reading_really_loses_exactly_that_joint(self, cwd_tmp, one_silent_motor) -> None:
+        """Every other joint still answers, so the gap is one dead servo."""
+        controller = pose_tool_module.MotorController("/dev/ttyTEST")
+        connected, _ = controller.connect()
+        assert connected
+        positions = controller.read_all_positions()
+        assert set(controller.motor_configs) - set(positions) == {SILENT_JOINT}
+
+
+class TestAnIncompleteReadingIsReportedAsOne:
+    """read_all over a bus with a dead servo does not present a partial arm."""
+
+    def test_read_all_refuses_a_partial_reading(self, cwd_tmp, one_silent_motor) -> None:
+        result = pose_tool(action="read_all", robot_id="hw_arm", port="/dev/ttyTEST")
+        assert result["status"] == "error"
+
+    def test_read_all_names_the_joint_that_did_not_answer(self, cwd_tmp, one_silent_motor) -> None:
+        result = pose_tool(action="read_all", robot_id="hw_arm", port="/dev/ttyTEST")
+        assert SILENT_JOINT in _text(result)
+
+    def test_read_all_reports_how_much_of_the_arm_it_covered(self, cwd_tmp, one_silent_motor) -> None:
+        result = pose_tool(action="read_all", robot_id="hw_arm", port="/dev/ttyTEST")
+        controller = pose_tool_module.MotorController("/dev/ttyTEST")
+        assert f"5 of {len(controller.motor_configs)}" in _text(result)
+
+    def test_several_silent_joints_are_named_in_a_stable_order(self, cwd_tmp, two_silent_motors) -> None:
+        """Sorted, so the report does not reorder between two runs of one fault."""
+        payload = _json(pose_tool(action="read_all", robot_id="hw_arm", port="/dev/ttyTEST"))
+        assert payload is not None
+        assert payload["unread"] == sorted(TWO_SILENT_JOINTS)
+
+    def test_read_all_still_carries_the_positions_that_did_arrive(self, cwd_tmp, one_silent_motor) -> None:
+        """A caller diagnosing a dead servo needs the rest of the arm."""
+        payload = _json(pose_tool(action="read_all", robot_id="hw_arm", port="/dev/ttyTEST"))
+        assert payload is not None
+        assert len(payload["positions"]) == 5
+        assert payload["unread"] == [SILENT_JOINT]
+
+
+class TestAnIncompletePoseIsNotPersisted:
+    """store_pose refuses, because a stored pose is a durable named posture."""
+
+    def test_store_pose_refuses_a_partial_arm(self, cwd_tmp, one_silent_motor) -> None:
+        result = pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        assert result["status"] == "error"
+
+    def test_store_pose_names_the_joint_and_the_consequence(self, cwd_tmp, one_silent_motor) -> None:
+        result = pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        text = _text(result)
+        assert SILENT_JOINT in text
+        assert "promises the whole arm" in text
+
+    def test_several_silent_joints_are_named_in_a_stable_order(self, cwd_tmp, two_silent_motors) -> None:
+        """The refusal lists the joints sorted, matching the reading's own report."""
+        result = pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        assert ", ".join(sorted(TWO_SILENT_JOINTS)) in _text(result)
+
+    def test_nothing_reaches_the_pose_store(self, cwd_tmp, one_silent_motor) -> None:
+        """The durable artifact is what makes this one a refusal rather than a report."""
+        pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        assert PoseManager("hw_arm").get_pose("home") is None
+
+    def test_a_later_load_cannot_find_a_pose_that_was_never_stored(self, cwd_tmp, one_silent_motor) -> None:
+        """Pre-fix this drove five joints and reported the full pose reached."""
+        pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        result = pose_tool(action="load_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        assert result["status"] == "error"
+        assert "Moved to pose" not in _text(result)
+
+
+class TestAHealthyArmIsUnchanged:
+    """Every joint answering must behave exactly as it did before."""
+
+    def test_read_all_still_succeeds_for_the_whole_arm(self, cwd_tmp, reading_serial) -> None:
+        result = pose_tool(action="read_all", robot_id="hw_arm", port="/dev/ttyTEST")
+        assert result["status"] == "success"
+        assert "Current robot positions" in _text(result)
+
+    def test_read_all_carries_no_unread_key_when_nothing_is_unread(self, cwd_tmp, reading_serial) -> None:
+        payload = _json(pose_tool(action="read_all", robot_id="hw_arm", port="/dev/ttyTEST"))
+        assert payload is not None
+        assert "unread" not in payload
+
+    def test_store_pose_still_persists_a_complete_arm(self, cwd_tmp, reading_serial) -> None:
+        controller = pose_tool_module.MotorController("/dev/ttyTEST")
+        result = pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        assert result["status"] == "success"
+        stored = PoseManager("hw_arm").get_pose("home")
+        assert stored is not None
+        assert set(stored.positions) == set(controller.motor_configs)
+
+
+class TestTheAllSilentBusKeepsItsOwnDiagnosis:
+    """A bus where nothing answers is a different fault and reads as one."""
+
+    def test_read_all_reports_the_original_total_failure(self, cwd_tmp, fake_serial) -> None:
+        result = pose_tool(action="read_all", robot_id="hw_arm", port="/dev/ttyTEST")
+        assert result["status"] == "error"
+        assert "Failed to read positions" in _text(result)
+
+    def test_store_pose_reports_the_original_total_failure(self, cwd_tmp, fake_serial) -> None:
+        result = pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        assert result["status"] == "error"
+        assert "Failed to read current positions" in _text(result)
+
+
+class TestBothReadersShareOneAccountOfCompleteness:
+    """Derived, so read_all and store_pose cannot drift apart on what is complete."""
+
+    def test_the_helper_has_exactly_one_definition(self) -> None:
+        source = pathlib.Path(inspect.getfile(pose_tool_module)).read_text()
+        defs = [
+            node.name
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name == "_joints_that_did_not_answer"
+        ]
+        assert defs == ["_joints_that_did_not_answer"]
+
+    def test_every_whole_arm_reader_consults_it(self) -> None:
+        """A reader of read_all_positions that judges completeness must use the helper."""
+        source = pathlib.Path(inspect.getfile(pose_tool_module)).read_text()
+        tool = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name == "pose_tool"
+        )
+        readers = sum(
+            1
+            for node in ast.walk(tool)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "read_all_positions"
+        )
+        consults = sum(
+            1
+            for node in ast.walk(tool)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_joints_that_did_not_answer"
+        )
+        assert readers == 2, readers
+        assert consults == readers, (consults, readers)


### PR DESCRIPTION
## What was wrong

`MotorController.read_all_positions` skips a motor whose reply did not verify, so
it returns a subset of `motor_configs` carrying no record of what fell out. Both
tool actions that consume it guarded only the all-empty case (`if positions:`,
`if not current_positions:`), so a truthy partial reading passed straight
through.

Measured on a six-joint SO-101 with one dead servo (`wrist_flex`, id 4, every
other joint answering):

| action | before | after |
|---|---|---|
| `read_all` | `success`, 5 joints, "Current robot positions" | `error`, names `wrist_flex`, still carries the 5 |
| `store_pose` | `success`, **persisted 5 of 6 under the name** | `error`, refuses |
| `show_pose` | `success`, reports it as the pose | not found - never stored |
| `load_pose` | `success`, **"Moved to pose 'home'"** | not found - never stored |

The read layer does log `No verified reply from motor wrist_flex (id 4)`, but the
envelope said success, and `store_pose` turned a transient bus fault into a
durable artifact: a pose named `home` missing a joint, which every later
`load_pose` drives towards while answering "Moved to pose". `validate_pose`
checks bounds rather than arity, so nothing downstream could notice.

## Why this disposition

`emergency_stop` had already settled it for a partial result over the configured
motor set - it answers `status="error"` and names the joints plus what that
means:

```
EMERGENCY STOP INCOMPLETE - torque is still enabled on: <joints>.
Those joints are still driven; use the hardware power cutoff.
```

`read_all` now answers the same way and still carries the positions that did
arrive, which are what a caller diagnosing a dead servo needs.

`store_pose` refuses instead, because that one persists. `incremental_move`
refuses on an unreadable position for the same reason, and a stored pose
misrepresents itself on every later load rather than once. The mutation that
reports but persists anyway fires 5 cells, so the refusal is the behavioural
content here rather than the wording.

The gap is derived by one helper both readers share, the same way `_smooth_move`
derives its own (`sorted(set(expected) - set(got))`). Every motor is still
attempted: the reported outcome changes, the packets do not.

## Why nothing caught it

The two buses already pinned are the extremes:

| test | bus |
|---|---|
| `test_pose_tool_read_all_formats_every_motor` | every servo answers |
| `test_pose_tool_read_all_reports_failure_without_responses` | none answers |
| `test_pose_tool_store_pose_captures_current_positions` | every servo answers |
| `test_pose_tool_store_pose_failure_when_no_positions_read` | none answers |

Those are exactly the two buses on which a partial-drop guard and its absence are
indistinguishable. The mixed bus is the discriminating one, and no test drove it.

## Verification

Pre-fix split, source at the base with the new tests kept - **12 failed / 8
passed**:

| class | role | failed / total |
|---|---|---|
| `TestThePremisesTheMixedBusRestsOn` | premise | **0 / 3** |
| `TestAnIncompleteReadingIsReportedAsOne` | regression | 5 / 5 |
| `TestAnIncompletePoseIsNotPersisted` | regression | 5 / 5 |
| `TestBothReadersShareOneAccountOfCompleteness` | structural | 2 / 2 |
| `TestAHealthyArmIsUnchanged` | control | **0 / 3** |
| `TestTheAllSilentBusKeepsItsOwnDiagnosis` | over-reach | **0 / 2** |

Mutations, all against the 20 cells plus the four pre-existing `pose_tool`
suites, `collected` stable at 20 on every row:

| mutation | fires | sib |
|---|---|---|
| control (none) | 0 | 0 |
| `read_all` guard removed | 6 | 0 |
| `store_pose` guard removed | 6 | 0 |
| both guards removed | 11 | 0 |
| helper compares the reading against itself | 10 | 0 |
| `read_all` reports but keeps `status="success"` | 1 | 0 |
| `store_pose` reports but persists anyway | 5 | 0 |
| helper returns an unsorted set | 0 (see below) | 0 |
| `read_all` drops the `unread` key | 2 | 0 |
| `store_pose` message drops the joint names | 2 | 0 |
| each site re-derives the gap inline (drift) | 1 | 0 |
| over-reach: all-silent routed to the new message | 1 | **1** |

`b1 | b2 == b3` holds, and the two halves share exactly one cell - the structural
one, which either half correctly fires - so 6 + 6 - 1 = 11 exactly.

The over-reach row is the only one that trips a pre-existing test, which is what
pins the all-silent bus keeping its own diagnosis rather than being folded into
the new message.

The unsorted-set row is reported honestly as intermittent rather than as a gap:
`list(set(names))` can coincide with `sorted(names)`, and measuring across eight
hash seeds it does so on 4 of 8 for a two-name gap. The shipped assertion is
deterministic on correct code; only the mutation's detection depends on the
process hash seed. The sort is kept because it matches `_smooth_move`'s form and
costs nothing.

Gate: `ruff check` and `ruff format --check` clean over 1640 files. mypy
**24 == 24** against a pristine worktree of the same base, normalized message
sets byte-identical in both directions, **0 attributable**. Paired run over an
identical 233-file selection with the new file excluded from both trees:
identical **10084 collected** and `10019 passed, 65 skipped, 0 failed` on each,
distinct rootdirs. Rebased onto `49eec31f` after #2826 and #2830 landed, then
re-ran my files together with the two guard files main added (358 passed).

No visual artifact: this changes what a hardware tool reports, not a policy,
simulation, render, recording or asset. The measured before/after table above is
the evidence.

## Deliberately out of scope

A pose already on disk that is incomplete - written before this change, or by
hand - still loads and drives the joints it names. `validate_pose` could check
arity, but that is a third decision about what an existing stored pose means, and
`store_pose` refusing is what stops new ones being created.
