### PR TITLE
fix(hardware): abandon a rollout whose bring-up a shutdown has already cancelled

### DIFF
--- a/changelog.d/2834-a-shutdown-during-bring-up-stops-the-rollout.md
+++ b/changelog.d/2834-a-shutdown-during-bring-up-stops-the-rollout.md
@@ -1,0 +1,59 @@
+### Fixed: a `cleanup()` that lands during bring-up abandons the rollout instead of finishing it
+
+`cleanup()` sets `_shutdown_event` and only then calls `stop_task()`, gated on
+`status == RUNNING`. A teardown arriving while the task is still in `CONNECTING`
+- a motors-bus handshake plus per-camera warmup, seconds on a real arm and
+longer on a multi-camera rig - therefore sets no stop latch at all, and the
+shutdown event is its only record. `_execute_task_async` checks
+`_honor_stop_request()` at each stage boundary and that gate read only the stop
+latch, so both checks passed and the rollout went on to finish the bring-up it
+had just been asked to abandon.
+
+The reported status was already right. `_shutdown_error` refuses a task started
+*after* `cleanup()` rather than merely relabelling it, and its docstring says
+why: "Bring-up is not free of side effects, which is what makes this a refusal
+rather than a cosmetic status fix." It then lists them. The in-flight producer
+reached the same ones, and the terminal-status discriminator - which does read
+both latches - could only correct what the rollout said about itself, not what
+it did. Measured on the two-device double, with `cleanup()` landing while the
+bring-up is parked inside `connect()`:
+
+```
+                                              before      after
+policy-server dial / checkpoint load          1           0
+observation read off the bus and cameras      1           0
+Policy.reset() on the caller's own object     1           0
+cleanup() blocked on that work (start_task)   0.703s      0.402s
+task status / steps                           stopped / 0 stopped / 0
+arm commanded                                 no          no
+```
+
+The reset is the sharpest of them: a caller may drive one policy object through
+several tasks - the documented `run_policy(policy_object=...)` reuse pattern -
+so clearing its action-chunk cache and sampler RNG while backing out of a
+cancelled rollout corrupts a rollout running elsewhere. The sibling producer's
+`reset_calls == 0` was already pinned; this one's was not.
+
+Three readers decide whether the rollout in flight may continue, and they must
+agree: the bring-up gate, the control loop's exit condition, and the terminal
+discriminator. The last two read both latches and the first read one. Asserting
+their values agree cannot see that - two copies of the same disjunction agree up
+to the moment one is edited, which is how the drift arose - so all three now
+read a single `_rollout_stop_latched` predicate, and a test walks the module to
+check the disjunction has exactly one owner.
+
+Widening `cleanup()`'s own `stop_task()` guard to cover `CONNECTING` would also
+stop the side effects, and is ruled out rather than merely disfavoured: it trips
+`test_a_shutdown_during_bring_up_reports_stopped_not_completed`, which asserts
+`_stop_requested.is_set() is False` after that teardown. Reading the latch at
+the gate also covers any setter of `_shutdown_event`, not just that one branch.
+
+Unchanged: an operator `stop_task()` during bring-up behaves exactly as before,
+a healthy rollout still resets its policy once and reads its observations, and
+the terminal discriminator remains the backstop for a shutdown landing after the
+last stage check. Deliberately out of scope and pinned as such: the devices the
+parked `connect()` opens are still open afterwards. That call is already inside
+its blocking handshake when the teardown lands, so it completes either way, and
+for a rollout `cleanup()` did not submit it completes after `_disconnect_devices()`
+has run. Closing them needs `cleanup()` to wait for a rollout running on a
+caller's thread, which is a different fix.

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -50,7 +50,7 @@ robot.cleanup()
 | `start_task(instruction, policy_port, policy_host, policy_provider, duration)` | Async; returns immediately. |
 | `stop_task()` | Halt the current task. Covers a task still in `CONNECTING` (bring-up): the rollout is abandoned before the arm is commanded. |
 | `get_task_status()` | Returns `RobotTaskState` (status, step count, error). |
-| `cleanup()` | Stop tasks, disconnect the robot (motors bus + every camera), stop mesh. Terminal - see below. |
+| `cleanup()` | Stop tasks, disconnect the robot (motors bus + every camera), stop mesh. Abandons a task still in `CONNECTING` at its next stage check, like `stop_task()`. Terminal - see below. |
 | `stop()` | Async spelling of `cleanup()`; delegates to it off the event loop. Terminal. |
 
 One rollout at a time: the arm has a single command bus, so `start_task` /
@@ -91,8 +91,11 @@ construct a new `Robot` - work without exiting the process. There is no
 name the shutdown, rather than admitting a rollout that would command the arm
 zero times. A rollout already in flight when the shutdown lands is reported
 `STOPPED`, not `COMPLETED` - a shutdown truncates a task exactly as
-`stop_task()` does, so its step count is a partial one. Construct a new `Robot`
-to run another task.
+`stop_task()` does, so its step count is a partial one. That equivalence covers
+the work as well as the report: a task still in `CONNECTING` is abandoned at its
+next stage check, so the shutdown is not followed by the policy-server dial, the
+observation read and the `Policy.reset()` that the rest of that bring-up would
+have performed. Construct a new `Robot` to run another task.
 
 ## AgentTool actions
 

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1538,19 +1538,58 @@ class Robot(TeleopMixin, AgentTool):
             logger.error(f"Failed to initialize policy: {e}")
             return False
 
+    @property
+    def _rollout_stop_latched(self) -> bool:
+        """Whether either latch says the rollout in flight must not go on.
+
+        Two independent events end a rollout, and a reader that consults one of
+        them lets the stage it guards run on after the robot has been asked to
+        stop:
+
+        * ``_stop_requested`` -- an operator or fleet stop, set by
+          :meth:`stop_task` for a task in ``RUNNING`` or ``CONNECTING``.
+        * ``_shutdown_event`` -- a terminal teardown, set by :meth:`cleanup`
+          before it does anything else.
+
+        The shutdown latch is the one a reader is apt to miss, because it is the
+        only record of a teardown that lands mid-bring-up: ``cleanup()`` gates
+        its ``stop_task()`` call on ``status == RUNNING``, so a task still in
+        ``CONNECTING`` gets no stop latch at all.
+
+        Three readers ask this question -- this gate, the control loop's exit
+        condition and the terminal-status discriminator -- so they read one
+        predicate rather than three copies that can drift apart.
+        """
+        return self._stop_requested.is_set() or self._shutdown_event.is_set()
+
     def _honor_stop_request(self) -> bool:
-        """Record a latched stop request as the task's terminal state.
+        """Record a latched stop or shutdown as the task's terminal state.
 
         Called at each point in ``_execute_task_async`` where the task is about
-        to move on to a stage that commands the arm. ``stop_task`` sets the
-        latch unconditionally, so this is the only thing that has to run for a
-        stop pressed at any point during bring-up to be honored.
+        to move on to a stage with effects of its own -- a policy-server dial or
+        checkpoint load, an observation read, and finally commanding the arm.
+        Reads :attr:`_rollout_stop_latched`, so this is the only thing that has
+        to run for either latch to be honored during bring-up.
+
+        Reading only ``_stop_requested`` was not enough, and the gap was not the
+        reported status -- the terminal block below already discriminates on
+        both latches -- but the bring-up that ran after the robot had been told
+        to shut down. ``cleanup()`` sets the shutdown latch and only then calls
+        ``stop_task()``, gated on ``status == RUNNING``, so a teardown arriving
+        while the task was still in ``CONNECTING`` set no stop latch, both stage
+        checks passed, and the rollout finished the bring-up it had just been
+        asked to abandon. Measured on the two-device double, with the shutdown
+        latch already set: the motors bus opened and every camera warmed, one
+        observation read off them, and ``Policy.reset()`` called on a policy
+        object the caller may still be driving elsewhere -- the documented
+        ``policy_object=`` reuse pattern, and the same side effects
+        :meth:`_shutdown_error` refuses a *new* task for.
 
         Returns:
-            ``True`` when a stop was requested and the caller must abandon the
-            rollout, ``False`` when the task may proceed.
+            ``True`` when a stop or a shutdown was latched and the caller must
+            abandon the rollout, ``False`` when the task may proceed.
         """
-        if not self._stop_requested.is_set():
+        if not self._rollout_stop_latched:
             return False
         self._task_state.status = TaskStatus.STOPPED
         logger.info(
@@ -1688,8 +1727,7 @@ class Robot(TeleopMixin, AgentTool):
                 time.monotonic() - start_mono < duration
                 and (n_steps is None or self._task_state.step_count < n_steps)
                 and self._task_state.status == TaskStatus.RUNNING
-                and not self._stop_requested.is_set()
-                and not self._shutdown_event.is_set()
+                and not self._rollout_stop_latched
             ):
                 # Get observation from robot
                 observation = await asyncio.to_thread(read_observation, self.robot)
@@ -1760,15 +1798,18 @@ class Robot(TeleopMixin, AgentTool):
                 # is what decides here - otherwise an interrupted task reports
                 # itself completed.
                 #
-                # ``_shutdown_event`` is the other latch that ends the loop, and
-                # it needs the same treatment for a reason no entry-point guard
+                # ``_shutdown_event`` is the other latch that ends the loop and
+                # it needs the same treatment, for a reason no entry-point guard
                 # can cover: ``cleanup()`` sets it and only then calls
-                # ``stop_task()``, gated on ``status == RUNNING``. A shutdown
-                # landing while this task is still in ``CONNECTING`` therefore
-                # sets no stop latch, and the rollout goes on to finish bring-up
-                # and exit the loop on its first evaluation - reported as
-                # ``completed`` with 0 steps.
-                if self._stop_requested.is_set() or self._shutdown_event.is_set():
+                # ``stop_task()``, gated on ``status == RUNNING``, so a shutdown
+                # landing after this task's last stage check sets no stop latch.
+                # Without it such a rollout exits the loop on its first
+                # evaluation and reports ``completed`` with 0 steps.
+                #
+                # Both are read through ``_rollout_stop_latched`` -- the one
+                # predicate the bring-up gate and the loop condition above also
+                # read, so the three cannot drift apart.
+                if self._rollout_stop_latched:
                     self._task_state.status = TaskStatus.STOPPED
                     logger.info(f"Task stopped: '{instruction}' after {self._task_state.step_count} steps")
                 else:
@@ -2689,7 +2730,9 @@ class Robot(TeleopMixin, AgentTool):
         ``run_policy`` / ``start_task`` / the ``execute`` action refuse
         permanently afterwards rather than admit a rollout that would command
         the arm zero times, and a rollout still in flight when this runs is
-        reported ``STOPPED`` rather than ``COMPLETED``. Construct a new
+        abandoned at its next stage check -- rather than finishing a bring-up
+        this teardown has already made pointless -- and reported ``STOPPED``
+        rather than ``COMPLETED``. Construct a new
         ``Robot`` to run another task.
         """
         try:

--- a/tests/test_hardware_after_shutdown.py
+++ b/tests/test_hardware_after_shutdown.py
@@ -54,7 +54,18 @@ first evaluation::
     task status / steps       : completed / 0
 
 so the terminal block has to treat ``_shutdown_event`` the way it already
-treats the stop latch.
+treats the stop latch. That fixes what the rollout *reports*. It does not stop
+the bring-up: an entry-point guard cannot cover this producer, but the
+in-flight stage gate can, and it read only the stop latch. With the status
+already correct, the same side effects listed above still ran after the
+teardown was latched::
+
+    Policy.reset() on the caller's object : 1   <- 0 for the other producer
+    observation reads off bus + cameras   : 1
+    policy-server dial / checkpoint load  : 1
+
+Both producers now stop before the next effect, which is why the two are
+asserted side by side here.
 
 No serial port is opened and no arm is commanded: an in-memory double stands in
 for the driver, and the bring-up window is opened by the test rather than slept
@@ -63,12 +74,16 @@ through, so every assertion here is deterministic.
 
 from __future__ import annotations
 
+import ast
+import pathlib
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import pytest
 
+from strands_robots import hardware_robot
 from strands_robots.hardware_robot import Robot as HwRobot
 from strands_robots.hardware_robot import RobotTaskState, TaskStatus
 from strands_robots.policies.base import Policy
@@ -116,6 +131,7 @@ class Bus:
         self.commands: list[dict[str, Any]] = []
         self.connect_entered = threading.Event()
         self.connect_gate: threading.Event | None = None
+        self.observation_reads = 0
 
     @property
     def is_connected(self) -> bool:
@@ -137,6 +153,7 @@ class Bus:
         self._connected = False
 
     def get_observation(self) -> dict[str, Any]:
+        self.observation_reads += 1
         return {"gripper.pos": 0.0}
 
     def send_action(self, action: dict[str, Any]) -> None:
@@ -383,3 +400,257 @@ class TestAHealthyRolloutIsUnaffected:
 
         assert result["status"] == "success"
         assert "Task started" in _text(result)
+
+
+def _wait_until(predicate: Any, timeout: float = DEADLINE) -> bool:
+    """Wait for ``predicate()`` without racing the thread that satisfies it."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.001)
+    return False
+
+
+def _interrupted_bring_up(
+    hw: HwRobot,
+    bus: Bus,
+    *,
+    policy: CountingPolicy | None = None,
+    **run_kwargs: Any,
+) -> dict[str, Any]:
+    """Land ``cleanup()`` while the rollout is still in ``CONNECTING``.
+
+    The bring-up is parked inside ``connect()`` -- the motors-bus handshake plus
+    per-camera warmup, seconds on a real arm -- so the teardown lands in the one
+    window ``cleanup()`` sets no stop latch for. The gate is opened only after
+    ``cleanup()`` has returned, so whatever the rollout does next, it does with
+    the shutdown already latched.
+    """
+    bus.connect_gate = threading.Event()
+    out: dict[str, Any] = {}
+    kwargs: dict[str, Any] = {"instruction": "interrupted", "n_steps": 6, **run_kwargs}
+    if policy is not None:
+        kwargs["policy_object"] = policy
+    thread = threading.Thread(
+        target=lambda: out.__setitem__("result", hw.run_policy(**kwargs)),
+        daemon=True,
+    )
+    thread.start()
+    assert bus.connect_entered.wait(DEADLINE), "rollout never reached connect()"
+    assert hw._task_state.status is TaskStatus.CONNECTING
+
+    hw.cleanup()
+    # The premise the gate exists for: this teardown gated its ``stop_task()``
+    # call on ``status == RUNNING``, so the shutdown event is its only record.
+    assert hw._stop_requested.is_set() is False
+    assert hw._shutdown_event.is_set() is True
+
+    bus.connect_gate.set()
+    thread.join(DEADLINE)
+    assert not thread.is_alive(), "rollout never finished"
+    return out["result"]
+
+
+class TestAShutdownDuringBringUpStopsBeforeTheNextEffect:
+    """The in-flight producer reaches no further than the one started later.
+
+    ``TestRefusalHappensBeforeAnyDeviceEffect`` above pins these properties for
+    a task started *after* ``cleanup()``. These pin them for a task already in
+    bring-up when the teardown lands: the producer no entry-point guard can
+    reach, and the one whose stage gate read only the stop latch.
+    """
+
+    def test_a_reusable_policy_keeps_its_episode_state(self, hw: HwRobot, bus: Bus):
+        """``Policy.reset()`` must not fire for a rollout being abandoned.
+
+        The mirror of the cell above: a caller may drive one policy object
+        through several tasks, so clearing its action-chunk cache / sampler RNG
+        while backing out of a rollout this teardown has cancelled would corrupt
+        a rollout running elsewhere.
+        """
+        policy = CountingPolicy()
+
+        _interrupted_bring_up(hw, bus, policy=policy)
+
+        assert policy.reset_calls == 0
+        assert policy.get_actions_calls == 0
+
+    def test_nothing_is_read_off_the_devices(self, hw: HwRobot, bus: Bus):
+        """No observation is taken from the bus or the cameras.
+
+        ``_initialize_policy`` reads one to derive the policy's state keys. That
+        read goes through ``read_observation``, which takes the bus lock, so on
+        a real arm it is a serial exchange performed for a rollout the caller
+        has already torn the robot down for.
+        """
+        _interrupted_bring_up(hw, bus, policy=CountingPolicy())
+
+        assert bus.observation_reads == 0
+
+    def test_no_policy_is_built_for_the_abandoned_rollout(self, hw: HwRobot, bus: Bus, monkeypatch: pytest.MonkeyPatch):
+        """The most expensive effect: a policy-server dial or a checkpoint load.
+
+        Driven through ``start_task`` and a provider, because that is the path
+        where the build is remote work -- and the path where ``cleanup()`` pays
+        for it directly, since the rollout is on the executor it joins.
+        """
+        dials: list[int | None] = []
+
+        async def recording_get_policy(
+            policy_port: int | None = None,
+            policy_host: str = "localhost",
+            policy_provider: str = "groot",
+            **kwargs: Any,
+        ) -> Any:
+            # The real one is called positionally, so the stand-in has to accept
+            # the same three: a narrower one raises and the task reports ERROR,
+            # which would leave ``dials`` empty for the wrong reason.
+            dials.append(policy_port)
+            return CountingPolicy()
+
+        monkeypatch.setattr(hw, "_get_policy", recording_get_policy)
+        bus.connect_gate = threading.Event()
+
+        started = hw.start_task("interrupted", policy_port=5555, n_steps=6)
+        assert started["status"] == "success"
+        assert bus.connect_entered.wait(DEADLINE), "rollout never reached connect()"
+        assert hw._task_state.status is TaskStatus.CONNECTING
+
+        # ``cleanup()`` joins the executor, so it cannot return while the
+        # bring-up is parked. Release the bring-up only once the shutdown latch
+        # is on record -- the first thing ``cleanup()`` sets -- so the rollout
+        # resumes into a teardown that has already happened.
+        teardown = threading.Thread(target=hw.cleanup, daemon=True)
+        teardown.start()
+        assert _wait_until(hw._shutdown_event.is_set), "cleanup() never latched the shutdown"
+        assert hw._stop_requested.is_set() is False
+        bus.connect_gate.set()
+        teardown.join(DEADLINE)
+        assert not teardown.is_alive(), "cleanup() never returned"
+
+        assert dials == []
+        assert bus.observation_reads == 0
+        # The rollout was abandoned, not derailed: an ERROR here would mean the
+        # stand-in raised and the empty ``dials`` proved nothing.
+        assert hw._task_state.status is TaskStatus.STOPPED
+
+
+class TestBothProducersStopBeforeTheSameEffects:
+    """One rule for the two ways a shutdown can meet a rollout."""
+
+    @pytest.mark.parametrize("producer", ["started-after-cleanup", "cleanup-during-bring-up"])
+    def test_neither_reaches_a_policy_reset_or_a_device_read(self, hw: HwRobot, bus: Bus, producer: str):
+        policy = CountingPolicy()
+
+        if producer == "started-after-cleanup":
+            _shut_down(hw)
+            hw.run_policy(policy_object=policy, instruction="after shutdown", n_steps=6)
+        else:
+            _interrupted_bring_up(hw, bus, policy=policy)
+
+        assert policy.reset_calls == 0
+        assert bus.observation_reads == 0
+
+
+class TestWhatAnInterruptedBringUpStillReports:
+    """Held before the gate read the shutdown latch, and still held after it.
+
+    The terminal-status discriminator already covered the report, which is why
+    reading the shutdown latch earlier had to leave every one of these alone:
+    the gap was the work the rollout did, not what it said about it.
+    """
+
+    def test_it_reports_stopped_with_no_steps_and_no_commands(self, hw: HwRobot, bus: Bus):
+        result = _interrupted_bring_up(hw, bus, policy=CountingPolicy())
+
+        assert result["status"] == "error"
+        assert hw._task_state.status is TaskStatus.STOPPED
+        assert hw._task_state.step_count == 0
+        assert bus.commands == []
+
+    def test_the_devices_the_parked_bring_up_opens_are_still_left_open(self, hw: HwRobot, bus: Bus):
+        """The boundary this gate does not move, stated so it is not assumed.
+
+        ``connect()`` is already inside its blocking handshake when the teardown
+        lands, so it finishes either way -- and ``cleanup()`` disconnects the
+        robot before it returns, which for a rollout it did not submit is before
+        that handshake completes. The devices are therefore open afterwards, on
+        both sides of this change. Closing them needs ``cleanup()`` to wait for
+        a rollout running on a caller's thread, which is a different fix.
+        """
+        _interrupted_bring_up(hw, bus, policy=CountingPolicy())
+
+        assert bus.connect_calls == 1
+        assert bus.cameras["wrist"].connect_calls == 1
+        assert bus.is_connected is True
+        assert bus.disconnect_calls == 0
+
+
+def _rollout_module_ast() -> ast.Module:
+    """Parse the hardware-robot module the three readers live in."""
+    source = pathlib.Path(hardware_robot.__file__).read_text(encoding="utf-8")
+    return ast.parse(source)
+
+
+def _function_named(tree: ast.Module, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} is no longer defined in {hardware_robot.__name__}")
+
+
+_PREDICATE = "_rollout_stop_latched"
+
+
+class TestTheThreeReadersShareOnePredicate:
+    """Structural, because equal copies are what the drift looked like before.
+
+    Three places ask whether the rollout in flight must stop, and the answer has
+    to be the same in all three. Asserting the values agree cannot see that: two
+    copies of the same disjunction agree right up to the moment one of them is
+    edited, which is how the bring-up gate came to read one latch while the loop
+    condition and the terminal discriminator read both.
+    """
+
+    def test_the_disjunction_has_exactly_one_owner(self):
+        """No reader re-derives ``stop or shutdown`` for itself."""
+        wanted = {"self._stop_requested.is_set()", "self._shutdown_event.is_set()"}
+        owners: list[str] = []
+        tree = _rollout_module_ast()
+        for parent in ast.walk(tree):
+            if not isinstance(parent, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for node in ast.walk(parent):
+                if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or):
+                    if wanted <= {ast.unparse(value) for value in node.values}:
+                        owners.append(parent.name)
+
+        assert owners == [_PREDICATE], f"the two latches are OR-ed together in {owners}"
+
+    def test_the_bring_up_gate_reads_it(self):
+        gate = _function_named(_rollout_module_ast(), "_honor_stop_request")
+
+        assert _PREDICATE in ast.unparse(gate), "the bring-up gate does not read the shared predicate"
+
+    def test_the_control_loop_exit_condition_reads_it(self):
+        rollout = _function_named(_rollout_module_ast(), "_execute_task_async")
+        loops = [
+            node
+            for node in ast.walk(rollout)
+            if isinstance(node, ast.While) and "TaskStatus.RUNNING" in ast.unparse(node.test)
+        ]
+
+        assert len(loops) == 1, "the rollout's control loop is no longer recognisable"
+        assert _PREDICATE in ast.unparse(loops[0].test)
+
+    def test_the_terminal_status_discriminator_reads_it(self):
+        rollout = _function_named(_rollout_module_ast(), "_execute_task_async")
+        discriminators = [
+            node
+            for node in ast.walk(rollout)
+            if isinstance(node, ast.If) and "TaskStatus.STOPPED" in ast.unparse(node.body)
+        ]
+
+        assert discriminators, "nothing in the rollout writes STOPPED as a terminal status"
+        assert any(_PREDICATE in ast.unparse(node.test) for node in discriminators)


### PR DESCRIPTION
## Problem

`cleanup()` sets `_shutdown_event` and only then calls `stop_task()`, gated on
`status == RUNNING`. A teardown that lands while a task is still in `CONNECTING`
— a motors-bus handshake plus per-camera warmup, seconds on a real arm and
longer on a multi-camera rig — therefore sets **no stop latch at all**, and the
shutdown event is the only record of it.

`_execute_task_async` calls `_honor_stop_request()` at each stage boundary, and
that gate read only `_stop_requested`. So both stage checks passed and the
rollout went on to finish the bring-up it had just been asked to abandon.

Three places decide whether the rollout in flight may continue. Two of them read
both latches; the bring-up gate read one:

| reader | `_stop_requested` | `_shutdown_event` |
|---|---|---|
| control loop exit condition | yes | yes |
| terminal-status discriminator | yes | yes |
| `_honor_stop_request()` (bring-up gate) | yes | **no** |

## Why this is a defect and not a cosmetic status issue

The reported status was already correct — the terminal discriminator reads both
latches, so such a rollout reports `STOPPED` with 0 steps and never commands the
arm. What ran anyway was the rest of the bring-up.

`_shutdown_error` refuses a task started *after* `cleanup()` rather than merely
relabelling it, and its docstring states the reason: *"Bring-up is not free of
side effects, which is what makes this a refusal rather than a cosmetic status
fix."* It then lists them. The in-flight producer reached the same ones.

Measured on the existing two-device double, with `cleanup()` landing while the
bring-up is parked inside `connect()`:

| | before | after |
|---|---|---|
| policy-server dial / checkpoint load | 1 | **0** |
| observation read off the bus and cameras | 1 | **0** |
| `Policy.reset()` on the caller's own object | 1 | **0** |
| `cleanup()` blocked on that work (`start_task` path) | 0.703 s | **0.402 s** |
| task status / steps | stopped / 0 | stopped / 0 |
| arm commanded | no | no |

The reset is the sharpest: a caller may drive one policy object through several
tasks — the documented `run_policy(policy_object=...)` reuse pattern — so
clearing its action-chunk cache and sampler RNG while backing out of a cancelled
rollout corrupts a rollout running elsewhere.

## Why nothing caught it

`tests/test_hardware_after_shutdown.py` already frames both producers, and its
docstring concluded *"so the terminal block has to treat `_shutdown_event` the
way it already treats the stop latch."* That is true and it fixes the report. An
entry-point guard genuinely cannot cover this producer, but the **in-flight stage
gate** can, and it was reading one latch.

Three producers ask the rollout to stop. Only one had these properties ungraded:

| producer | reached the dial / read / reset | pinned by |
|---|---|---|
| operator `stop_task()` during `CONNECTING` | no | `test_hardware_stop_during_connect.py::TestStopWhileConnecting::test_the_policy_is_never_initialized` |
| task started after `cleanup()` | no | `test_hardware_after_shutdown.py::TestRefusalHappensBeforeAnyDeviceEffect` |
| `cleanup()` during `CONNECTING` | **yes** | nothing |

## Change

`_rollout_stop_latched` becomes the single predicate all three readers consult.
Rewriting the loop condition and the terminal discriminator in its terms is a
provable no-op (De Morgan on the same two latches); the behavioural content is
the gate. A test walks the module to check the disjunction has exactly one
owner, because asserting the values agree cannot see this class of drift — two
copies of one disjunction agree right up to the moment one of them is edited.

Docstrings corrected where they now understate or overstate: the gate's claim
that it is "the only thing that has to run for a stop pressed at any point
during bring-up to be honored", `cleanup()`'s summary, and the terminal block's
comment. `docs/hardware/robot-control.md` already claimed *"a shutdown truncates
a task exactly as `stop_task()` does"* — true of the report, and now true of the
work as well.

## Tests

Pre-fix split on the changed suite: **8 failed / 17 passed** — 4 behavioural
regression cells and 4 structural, with 0 failures in the premise, control,
boundary and pre-existing classes.

Mutation table, 9 rows, control clean, **8 distinct firing sets**, `collected`
stable at 25 on every row, source restored byte-identically. `sib` counts the
seven sibling hardware suites:

| mutation | fires (suite) | sib |
|---|---|---|
| b0 control | 0 | 0 |
| b1 gate reads only the stop latch (the defect) | 4 | 0 |
| b2 shared predicate returns only the stop latch | 7 | 0 |
| b3 shared predicate returns only the shutdown latch | 1 | **7** |
| b4 shared predicate ANDs instead of ORs | 7 | 7 |
| b5 loop condition re-derives it inline | 1 | 0 |
| b6 terminal discriminator re-derives it inline | 2 | 0 |
| b7 gate moved after the policy build | 1 | 27 |
| b8 instead: `cleanup()` widens its own `stop_task` guard | 7 | 0 |

- **b3** is the scope row: dropping the *stop* latch fires six cells in
  `test_hardware_stop_during_connect.py`, so that half is load-bearing and
  pinned elsewhere.
- **b5** is behaviourally a no-op and is caught only structurally — which is
  exactly what the drift looked like before it drifted.
- **b8** rules out the alternative fix by measurement rather than preference: it
  trips the pre-existing
  `TestNoFalseTerminalStatus::test_a_shutdown_during_bring_up_reports_stopped_not_completed`,
  which asserts `_stop_requested.is_set() is False` after that teardown.
  Reading the latch at the gate also covers any setter of `_shutdown_event`, not
  just `cleanup()`'s one branch.

## Scope

Unchanged: an operator `stop_task()` during bring-up behaves exactly as before, a
healthy rollout still resets its policy once and reads its observations, and the
terminal discriminator remains the backstop for a shutdown landing after the last
stage check.

Deliberately out of scope, and pinned as such by
`test_the_devices_the_parked_bring_up_opens_are_still_left_open`: the devices the
parked `connect()` opens are still open afterwards. That call is already inside
its blocking handshake when the teardown lands, so it completes either way, and
for a rollout `cleanup()` did not submit it completes after
`_disconnect_devices()` has run. Closing them needs `cleanup()` to wait for a
rollout running on a caller's thread, which is a different fix.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1641 files).
- `mypy` **24 == 24** against a worktree of the merge-base, normalized message
  sets byte-identical in both directions, **0 attributable** to the changed files.
- Paired suite over an identical 774-file selection (everything naming the
  hardware robot, the task lifecycle, the latches or teleop, plus every guard
  that walks the tree, parses source or reads docstrings and `docs/`), with the
  changed test file deselected from both trees: **36 failed, 29766 passed, 167
  skipped on each**, 29967 collected on each, **36 == 36 identical failing IDs,
  `comm` empty in both directions**. 17 need `awsiot`/`awscrt` (absent locally,
  declared in the `[mesh-iot]` extra); 4 pass 13/13 in isolation on both trees;
  the rest are the lerobot-from-source `encode()` drift and HF-hub reachability.
- Changed suite plus the seven sibling hardware suites and the four guards main
  gained since the merge-base: **308 passed**.
- `mkdocs build --strict` clean.

No visual artifact: this changes teardown control flow, not a policy, a
simulation behaviour, rendering, recording or a robot asset. The measured
side-effect table above is the evidence.
