### PR TITLE
fix(isaac): refuse a non-finite mesh scale instead of measuring through it

### DIFF
--- a/strands_robots/simulation/isaac/mesh_assets.py
+++ b/strands_robots/simulation/isaac/mesh_assets.py
@@ -123,6 +123,42 @@ def _non_finite_vertex_error(mesh_path: str, index: int, vertex: tuple[float, fl
     )
 
 
+def _non_finite_scale_error(mesh_path: str, scale: tuple[float, float, float]) -> ValueError:
+    """The refusal for a mesh scale whose components are not all finite.
+
+    :func:`load_mesh_geometry` already refuses a vertex that is not finite,
+    for the reason :func:`_non_finite_vertex_error` states: ``min``/``max``
+    order a NaN as neither smaller nor larger than anything, so the running
+    comparison drops it and reports the bounds of what remains. ``scale``
+    reaches that same comparison - :func:`mesh_aabb` measures
+    ``vertex * scale`` - so a non-finite component there poisons every
+    vertex on that axis and the comparison drops all of them, leaving the
+    axis at its ``inf``/``-inf`` seed. The asset's own coordinates being
+    finite is therefore not enough: the transform applied to them has to be
+    finite too, and it arrives from the caller rather than from the file.
+
+    The two components fail differently and neither is screenable:
+
+    * A NaN axis reports a centre of NaN and, because the reported extent is
+      floored at ``1e-4``, a **finite** size of 0.1 mm. A consumer that
+      screens the reported fields for non-finite values catches the centre
+      and not the size, so a metre-scale asset passes that screen as a
+      plausible sub-millimetre one.
+    * An infinite axis reports an infinite centre and a size of NaN, because
+      the extent is ``inf - inf``.
+
+    A scale of ``0.0`` stays accepted: it is a finite request to flatten the
+    asset on that axis, and the ``1e-4`` floor is doing the job it is there
+    for. A negative scale stays accepted too - it mirrors the asset, and the
+    running comparison is order-independent, so the bound is right.
+    """
+    return ValueError(
+        f"mesh {mesh_path}: scale has a component that is not finite ({scale!r}) - a mesh measured "
+        f"through it reports a centre that is not a position and an extent floored at 1e-4, so the "
+        f"asset is refused instead of being sized"
+    )
+
+
 def load_mesh_geometry(
     mesh_path: str,
 ) -> tuple[list[tuple[float, float, float]], list[int], list[int]]:
@@ -391,7 +427,10 @@ def mesh_aabb(
         Filesystem path to a ``.obj``, ``.stl`` or ``.msh`` (legacy MuJoCo binary mesh) file.
     scale : tuple[float, float, float]
         Per-axis scale applied to the vertices before measuring (an MJCF
-        ``<mesh scale=...>``). Defaults to unit scale.
+        ``<mesh scale=...>``). Defaults to unit scale. Every component must
+        be finite; it is checked before the asset is parsed, because a
+        transform that can never be applied is not worth reading a mesh
+        for, and the check needs nothing from the file.
 
     Returns
     -------
@@ -402,8 +441,15 @@ def mesh_aabb(
     Raises
     ------
     FileNotFoundError / ValueError
-        Same contract as :func:`load_mesh_geometry`.
+        Same contract as :func:`load_mesh_geometry`, plus
+        :func:`_non_finite_scale_error` when a ``scale`` component is not
+        finite. The asset's vertices being finite does not make the bound
+        finite: ``scale`` reaches the same running comparison, and the
+        reported extent's ``1e-4`` floor makes a NaN axis look like a
+        plausible sub-millimetre asset rather than a failure.
     """
+    if not all(map(math.isfinite, scale)):
+        raise _non_finite_scale_error(mesh_path, scale)
     points, _counts, _indices = load_mesh_geometry(mesh_path)
     mins = [float("inf")] * 3
     maxs = [float("-inf")] * 3

--- a/tests/simulation/isaac/test_mesh_asset_scale_must_be_finite.py
+++ b/tests/simulation/isaac/test_mesh_asset_scale_must_be_finite.py
@@ -1,0 +1,372 @@
+"""A mesh asset whose declared ``scale`` is not finite is refused, not measured.
+
+:func:`~strands_robots.simulation.isaac.mesh_assets.load_mesh_geometry`
+already refuses a vertex coordinate that is not finite, and
+:func:`~strands_robots.simulation.isaac.mesh_assets._non_finite_vertex_error`
+states why: ``min``/``max`` order a NaN as neither smaller nor larger than
+anything, so the running comparison
+:func:`~strands_robots.simulation.isaac.mesh_assets.mesh_aabb` uses drops it
+and reports the bounds of the coordinates that *are* finite - "the same
+numbers a mesh declaring only those would produce, under no error at all".
+
+``scale`` reaches that same comparison. ``mesh_aabb`` measures
+``vertex * scale``, so a non-finite component poisons every vertex on that
+axis and the comparison drops all of them, leaving the axis at its
+``inf``/``-inf`` seed. The asset's own coordinates being finite is not
+enough: the transform applied to them arrives from the caller, and it was
+unchecked.
+
+The reachable route is an MJCF ``<asset><mesh scale=...>``. MuJoCo compiles
+such a model, so the reader cannot defer the question to the compiler, and
+:func:`~strands_robots.simulation.isaac.loaders.load_mjcf_scene_objects`
+measures the mesh's own bounds for a *mesh-only* body - one with no
+collidable analytic geom - which is the branch the loader's own comment says
+exists "so a mesh-only body can fall back to the mesh's own bounds".
+
+Neither failure is screenable from the reported fields:
+
+* A NaN axis gives a centre of NaN and, because the reported extent is
+  floored at ``1e-4``, a **finite** size of 0.1 mm. A consumer screening the
+  reported fields for non-finite values catches the centre and not the size,
+  so a 0.2 m asset passes that screen as a plausible sub-millimetre one.
+* An infinite axis gives an infinite centre and a size of NaN, because the
+  extent is ``inf - inf``.
+
+The classes below pin, in order: the refusal for both non-finite values on
+every axis; that the MJCF loader refuses it end to end on the mesh-only body
+that reaches the measurement; the premises that make the refusal necessary
+(MuJoCo compiles it, the asset's own vertices are finite, and the extent
+floor is what made the NaN case unscreenable); that a finite scale -
+including the negative and zero ones - measures exactly what it did before;
+that a body carrying collidable geometry never reaches the measurement and
+is deliberately unchanged; that the wording has one owner per cause; and
+that the guard precedes the parse.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import struct
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.isaac import mesh_assets
+from strands_robots.simulation.isaac.loaders import (
+    _parse_axis,
+    _parse_mjcf_mesh_assets,
+    load_mjcf_scene_objects,
+)
+from strands_robots.simulation.isaac.mesh_assets import mesh_aabb
+
+NAN = float("nan")
+POS_INF = float("inf")
+NEG_INF = float("-inf")
+
+#: The refusal's stable phrase, shared by every axis and both values.
+REFUSAL = "scale has a component that is not finite"
+
+#: A closed tetrahedron with a 0.2 m extent on every axis. Four distinct
+#: vertices is MuJoCo's own minimum for a mesh, so the same asset serves the
+#: reader here and the compiler in the premise class.
+TETRA: tuple[tuple[float, float, float], ...] = (
+    (0.0, 0.0, 0.0),
+    (0.2, 0.0, 0.0),
+    (0.0, 0.2, 0.0),
+    (0.0, 0.0, 0.2),
+)
+FACES: tuple[tuple[int, int, int], ...] = ((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))
+
+#: What ``mesh_aabb`` measures from :data:`TETRA` at unit scale. Float32 on
+#: disk, so the values are the binary-STL round trip rather than exact.
+UNIT_CENTER = (0.10000000149011612,) * 3
+UNIT_SIZE = (0.20000000298023224,) * 3
+
+#: Every axis, so a guard that checks only the first cannot pass.
+AXES = (0, 1, 2)
+
+#: Both non-finite values, which fail *differently*: NaN leaves the reported
+#: size finite (floored), infinity does not.
+NON_FINITE = (NAN, POS_INF, NEG_INF)
+
+
+def _binary_stl(verts: tuple[tuple[float, float, float], ...]) -> bytes:
+    out = [b"\0" * 80, struct.pack("<I", len(FACES))]
+    for tri in FACES:
+        out.append(struct.pack("<3f", 0.0, 0.0, 1.0))
+        for idx in tri:
+            out.append(struct.pack("<3f", *verts[idx]))
+        out.append(struct.pack("<H", 0))
+    return b"".join(out)
+
+
+def _asset(tmp_path: Path, name: str = "asset") -> str:
+    path = tmp_path / f"{name}.stl"
+    path.write_bytes(_binary_stl(TETRA))
+    return str(path)
+
+
+def _scale(axis: int, value: float) -> tuple[float, float, float]:
+    out = [1.0, 1.0, 1.0]
+    out[axis] = value
+    return (out[0], out[1], out[2])
+
+
+#: A body with a mesh geom and *no* collidable analytic geom, so
+#: ``load_mjcf_scene_objects`` falls through to ``mesh_aabb``.
+_MESH_ONLY = """<mujoco model="probe">
+  <asset><mesh name="m" file="asset.stl" scale="{scale}"/></asset>
+  <worldbody>
+    <geom name="floor" type="plane" size="2 2 0.1"/>
+    <body name="widget" pos="0 0 0.5"><geom name="w_vis" type="mesh" mesh="m"/></body>
+  </worldbody>
+</mujoco>
+"""
+
+#: The same declaration on a body that *does* carry a collidable box. The
+#: analytic bound wins, so the measurement is never reached.
+_WITH_COLLISION = """<mujoco model="probe">
+  <asset><mesh name="m" file="asset.stl" scale="{scale}"/></asset>
+  <worldbody>
+    <geom name="floor" type="plane" size="2 2 0.1"/>
+    <body name="widget" pos="0 0 0.5">
+      <geom name="w_col" type="box" size="0.1 0.1 0.05"/>
+      <geom name="w_vis" type="mesh" mesh="m" contype="0" conaffinity="0"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _scene(tmp_path: Path, template: str, scale: str) -> str:
+    _asset(tmp_path)
+    path = tmp_path / "scene.xml"
+    path.write_text(template.format(scale=scale))
+    return str(path)
+
+
+def _widget(objects: list[Any]) -> Any:
+    return next(obj for obj in objects if obj.name == "widget")
+
+
+class TestANonFiniteScaleIsRefused:
+    """Every axis, both values. A NaN or infinite scale is not a transform."""
+
+    @pytest.mark.parametrize("axis", AXES)
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_mesh_aabb_refuses_instead_of_reporting_bounds(self, tmp_path: Path, axis: int, value: float) -> None:
+        with pytest.raises(ValueError, match=REFUSAL):
+            mesh_aabb(_asset(tmp_path), _scale(axis, value))
+
+    def test_a_scale_that_is_non_finite_on_every_axis_is_refused(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match=REFUSAL):
+            mesh_aabb(_asset(tmp_path), (NAN, NAN, NAN))
+
+    def test_the_refusal_names_the_asset_and_the_scale(self, tmp_path: Path) -> None:
+        asset = _asset(tmp_path)
+        with pytest.raises(ValueError) as excinfo:
+            mesh_aabb(asset, (NAN, 1.0, 1.0))
+        message = str(excinfo.value)
+        assert asset in message
+        assert "nan" in message.lower()
+
+    def test_the_refusal_names_the_consequence_it_prevents(self, tmp_path: Path) -> None:
+        # The reported extent's floor is why the NaN case was unscreenable, so
+        # the message says so rather than only naming the offending value.
+        with pytest.raises(ValueError, match=r"1e-4"):
+            mesh_aabb(_asset(tmp_path), (NAN, 1.0, 1.0))
+
+
+class TestTheMjcfSceneLoaderRefusesIt:
+    """The reachable route: an ``<asset><mesh scale=...>`` on a mesh-only body."""
+
+    @pytest.mark.parametrize("declared", ["nan 1 1", "1 nan 1", "1 1 nan", "nan nan nan", "inf 1 1"])
+    def test_a_mesh_only_body_is_refused(self, tmp_path: Path, declared: str) -> None:
+        with pytest.raises(ValueError, match=REFUSAL):
+            load_mjcf_scene_objects(_scene(tmp_path, _MESH_ONLY, declared))
+
+    def test_a_finite_declaration_is_measured_as_before(self, tmp_path: Path) -> None:
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _MESH_ONLY, "1 1 1")))
+        assert widget.size == UNIT_SIZE
+        assert widget.position == pytest.approx((0.1, 0.1, 0.6))
+
+    def test_the_declaration_reaches_the_measurement_through_the_registry(self, tmp_path: Path) -> None:
+        # Premise for the route above: the scale the loader hands ``mesh_aabb``
+        # is the one the ``<asset>`` element declared, parsed as three floats.
+        path = _scene(tmp_path, _MESH_ONLY, "nan 1 1")
+        registry = _parse_mjcf_mesh_assets(ET.parse(path).getroot(), str(tmp_path))
+        _resolved, scale = registry["m"]
+        assert math.isnan(scale[0])
+        assert scale[1:] == (1.0, 1.0)
+
+
+class TestThePremisesThatMakeTheRefusalNecessary:
+    """Why the reader has to check: nobody upstream does, and nothing downstream can see it."""
+
+    @pytest.mark.parametrize("declared", ["nan 1 1", "inf 1 1", "nan nan nan"])
+    def test_mujoco_compiles_the_model_the_reader_must_refuse(self, tmp_path: Path, declared: str) -> None:
+        # The reader cannot defer the question to the format's owner.
+        mujoco = pytest.importorskip("mujoco")
+        model = mujoco.MjModel.from_xml_path(_scene(tmp_path, _MESH_ONLY, declared))
+        assert model.nmesh == 1
+
+    def test_the_assets_own_coordinates_are_finite(self, tmp_path: Path) -> None:
+        # So the vertex guard that already exists cannot catch this: the file
+        # is clean and the transform is not.
+        points, _counts, _indices = mesh_assets.load_mesh_geometry(_asset(tmp_path))
+        assert all(math.isfinite(v) for point in points for v in point)
+
+    def test_the_extent_floor_is_what_made_the_nan_case_unscreenable(self, tmp_path: Path) -> None:
+        # ``zero`` is a finite, legitimate request to flatten an axis, and it
+        # reports the same floored 1e-4 extent a NaN axis used to. That floor
+        # is why screening the reported fields for non-finite values caught the
+        # centre and not the size.
+        center, size = mesh_aabb(_asset(tmp_path), (0.0, 1.0, 1.0))
+        assert size[0] == 1e-4
+        assert all(map(math.isfinite, center))
+        assert all(map(math.isfinite, size))
+
+    def test_the_mjcf_route_can_declare_exactly_these_two_values(self) -> None:
+        # A malformed or wrong-arity ``scale`` falls back to unit scale, so
+        # ``nan`` and ``inf`` are the only non-finite values the format's own
+        # parse can hand the measurement.
+        unit = (1.0, 1.0, 1.0)
+        assert _parse_axis("garbage", default=unit) == unit
+        assert _parse_axis("1 1", default=unit) == unit
+        parsed = _parse_axis("nan inf -inf", default=unit)
+        assert math.isnan(parsed[0])
+        assert parsed[1] == POS_INF
+        assert parsed[2] == NEG_INF
+
+
+class TestAFiniteScaleIsUnchanged:
+    """Every finite spelling measures exactly what it measured before."""
+
+    @pytest.mark.parametrize(
+        ("scale", "center", "size"),
+        [
+            ((1.0, 1.0, 1.0), UNIT_CENTER, UNIT_SIZE),
+            (
+                (2.0, 1.0, 0.5),
+                (0.20000000298023224, 0.10000000149011612, 0.05000000074505806),
+                (0.4000000059604645, 0.20000000298023224, 0.10000000149011612),
+            ),
+            ((-1.0, 1.0, 1.0), (-0.10000000149011612, 0.10000000149011612, 0.10000000149011612), UNIT_SIZE),
+            (
+                (0.0, 1.0, 1.0),
+                (0.0, 0.10000000149011612, 0.10000000149011612),
+                (1e-4, 0.20000000298023224, 0.20000000298023224),
+            ),
+        ],
+        ids=["unit", "non-uniform", "mirrored", "flattened"],
+    )
+    def test_the_measured_bound_is_untouched(
+        self,
+        tmp_path: Path,
+        scale: tuple[float, float, float],
+        center: tuple[float, float, float],
+        size: tuple[float, float, float],
+    ) -> None:
+        assert mesh_aabb(_asset(tmp_path), scale) == (center, size)
+
+    def test_a_millimetre_asset_still_measures_a_millimetre_bound(self, tmp_path: Path) -> None:
+        # The idiom the registry's own docstring names, and the one a finiteness
+        # guard must not mistake for a degenerate value.
+        _center, size = mesh_aabb(_asset(tmp_path), (0.001, 0.001, 0.001))
+        assert size == pytest.approx((0.0002, 0.0002, 0.0002))
+
+    def test_the_default_scale_is_still_unit(self, tmp_path: Path) -> None:
+        assert mesh_aabb(_asset(tmp_path)) == (UNIT_CENTER, UNIT_SIZE)
+
+
+class TestABodyWithCollidableGeometryIsDeliberatelyUnchanged:
+    """The analytic bound wins, so such a body never reaches the measurement.
+
+    Its ``mesh_scale`` still rides into the scene object, because that field is
+    applied by the realization rather than measured here. Refusing it would be
+    a claim about a consumer this reader does not own, so the boundary is
+    pinned rather than moved.
+    """
+
+    def test_the_reported_bound_comes_from_the_collidable_geom(self, tmp_path: Path) -> None:
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _WITH_COLLISION, "nan 1 1")))
+        assert widget.position == pytest.approx((0.0, 0.0, 0.5))
+        assert widget.size == pytest.approx((0.2, 0.2, 0.1))
+
+    def test_the_declared_scale_still_rides_along(self, tmp_path: Path) -> None:
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _WITH_COLLISION, "nan 1 1")))
+        assert math.isnan(widget.mesh_scale[0])
+
+
+class TestOneOwnerForEachWording:
+    """Every finiteness refusal in the module is raised from a named factory.
+
+    Derived rather than listed, so a third non-finite cause is held to the same
+    rule the hour it lands instead of inheriting an exemption by being absent
+    from a tuple.
+    """
+
+    def test_every_finiteness_refusal_is_raised_from_a_factory(self) -> None:
+        tree = ast.parse(inspect.getsource(mesh_assets))
+        raised: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Raise) or node.exc is None:
+                continue
+            call = node.exc
+            if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
+                continue
+            if "_non_finite" in call.func.id:
+                raised.add(call.func.id)
+        assert raised == {"_non_finite_vertex_error", "_non_finite_scale_error"}, raised
+
+    def test_each_factory_carries_its_own_cause(self) -> None:
+        # The two causes fail differently - a bad coordinate in the file versus
+        # a bad transform from the caller - so they are two wordings, not one.
+        vertex = mesh_assets._non_finite_vertex_error("m.stl", 0, (NAN, 0.0, 0.0))
+        scale = mesh_assets._non_finite_scale_error("m.stl", (NAN, 1.0, 1.0))
+        assert "vertex" in str(vertex)
+        assert "scale" in str(scale)
+        assert str(vertex) != str(scale)
+
+    def test_the_scale_factory_is_reached_from_the_measurement(self) -> None:
+        source = inspect.getsource(mesh_aabb)
+        called = {
+            node.func.id
+            for node in ast.walk(ast.parse(source.strip()))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "_non_finite_scale_error" in called, called
+
+
+class TestTheGuardPrecedesTheParse:
+    """A transform that can never be applied is not worth reading a mesh for."""
+
+    def test_a_missing_asset_is_still_named_by_its_own_message(self, tmp_path: Path) -> None:
+        # The scale guard must not shadow the file contract for a caller whose
+        # path is wrong and whose scale is fine.
+        with pytest.raises(FileNotFoundError):
+            mesh_aabb(str(tmp_path / "absent.stl"), (1.0, 1.0, 1.0))
+
+    def test_the_scale_is_refused_without_reading_the_file(self, tmp_path: Path) -> None:
+        # No asset on disk at all, so only a check that precedes the parse can
+        # produce the scale refusal.
+        with pytest.raises(ValueError, match=REFUSAL):
+            mesh_aabb(str(tmp_path / "absent.stl"), (NAN, 1.0, 1.0))
+
+    def test_the_guard_precedes_the_parse_call(self) -> None:
+        # Graded on the calls rather than on the text: the docstring names
+        # ``load_mesh_geometry`` before either statement runs, so a string
+        # search finds the reference and not the ordering.
+        tree = ast.parse(inspect.getsource(mesh_aabb).strip())
+        lines = {
+            node.func.id: node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "_non_finite_scale_error" in lines, lines
+        assert "load_mesh_geometry" in lines, lines
+        assert lines["_non_finite_scale_error"] < lines["load_mesh_geometry"]


### PR DESCRIPTION
## Problem

`load_mesh_geometry` already refuses a vertex coordinate that is not finite, and `_non_finite_vertex_error` states exactly why: `min`/`max` order a NaN as neither smaller nor larger than anything, so the running comparison `mesh_aabb` uses "drops it and returns the bounds of the vertices that are finite - the same numbers a mesh declaring only those would produce, under no error at all". That rule was applied where the four parse paths meet.

`scale` reaches the same comparison and did not go through it. `mesh_aabb` measures `vertex * scale`, so a non-finite component poisons every vertex on that axis and the comparison drops all of them, leaving the axis at its `inf`/`-inf` seed. One function, two inputs: the coordinates it reads from disk were checked, the transform it applies to them was not - and that one arrives from the caller.

The reachable route is an MJCF `<asset><mesh scale=...>`. `_parse_mjcf_mesh_assets` reads it through `_parse_axis`, which returns three floats, so `nan` and `inf` pass. MuJoCo compiles such a model, so the reader cannot defer the question to the format's owner. `load_mjcf_scene_objects` then measures the mesh's own bounds for a **mesh-only** body - the `elif mesh_path is not None` branch whose own comment says it exists "so a mesh-only body can fall back to the mesh's own bounds".

## Measured

A 0.2 m mesh on a mesh-only body, `MUJOCO_GL=egl`:

| declared scale | MuJoCo | reported `position` | reported `size` | non-finite reported fields |
|---|---|---|---|---|
| `1 1 1` | compiles | `(0.1, 0.1, 0.6)` | `(0.2, 0.2, 0.2)` | none |
| `nan 1 1` | compiles | `(nan, 0.1, 0.6)` | `(0.0001, 0.2, 0.2)` | `position` |
| `nan nan nan` | compiles | `(nan, nan, nan)` | `(0.0001, 0.0001, 0.0001)` | `position` |
| `inf 1 1` | compiles | `(inf, 0.1, 0.6)` | `(nan, 0.2, 0.2)` | `position`, `size` |

The NaN row is the worse half, and it is the one a consumer cannot screen for. Because the reported extent is floored at `1e-4`, a NaN axis leaves the **size finite** - a plausible 0.1 mm, 2000x smaller per axis than the asset - so screening the reported fields for non-finite values catches the centre and not the size.

The in-scene control is the same declaration on a body that also carries a collidable box: the analytic bound wins, the measurement is never reached, and `position`/`size` are correct. The leak was specific to the branch that exists to prefer the asset itself.

## Change

`mesh_aabb` refuses a non-finite `scale` through `_non_finite_scale_error` - a sibling to the vertex wording rather than a reuse of it, because a bad coordinate in the file and a bad transform from the caller are two causes and so two messages. The check precedes the parse: it needs nothing from the file, and a transform that can never be applied is not worth reading a mesh for. A caller whose path is wrong and whose scale is fine still gets the file contract's own message.

A finite scale is untouched, including the two spellings that look degenerate and are not. `0.0` is a finite request to flatten an axis, where the `1e-4` floor is doing the job it is there for; a negative scale mirrors the asset, where the running comparison is order-independent and the bound is already right.

Both of those are real rather than hypothetical. Across the 811 MJCF models cached on the measuring machine there are **17322** `<mesh>` registry entries, **1631** declare a non-unit scale, and those include `(-1, -1, -1)`, `(-0.001, 0.001, 0.001)` and millimetre scales - so the accepted boundary is what the shipped corpus actually uses.

## Safety

**0** of the 17322 entries is non-finite, so the defect is latent. **9** of the 59 loadable registry robots reach this measurement, one of them through a millimetre scale, so the branch is live. All **60** loadable registry scenes report byte-identical objects before and after (`md5 e64a4b72b6de6e8e325e161d9ba1cd87` on both trees, 0 scenes changed).

## Tests

`tests/simulation/isaac/test_mesh_asset_scale_must_be_finite.py`, 39 cases. Pre-fix **22 failed / 17 passed**, with **0 of 6 premise, 0 of 6 control and 0 of 2 boundary cells** failing - the premises (MuJoCo compiles the model; the asset's own vertices are finite; the extent floor is what made the NaN case unscreenable) and the accepted-scale controls hold either way, which is what makes them premises and controls.

11 mutations, 10 detected, **10 distinct firing sets**, control clean, `collected` stable at 39 on every row, and **0 failures in 6 pre-existing suites** on every row:

| mutation | fires | note |
|---|---|---|
| guard removed | 21 | the behavioural revert |
| checks `scale[0]` only | 8 | the axis-1 and axis-2 cells |
| `all` -> `not any` | 16 | refuses only an all-non-finite scale |
| guard moved after the parse | 2 | the ordering |
| over-reach: `0.0` refused too | 2 | fires the flattened control and a premise |
| over-reach: negative refused | 3 | fires the mirrored control and a premise |
| message drops the asset path | 1 | |
| message drops the `1e-4` cause | 1 | |
| raises inline, not via the factory | 3 | structural |
| reuses the vertex wording | 20 | one owner per cause |

The two over-reach rows are the ones that make the accepted boundary load-bearing: a guard that also refused `0.0` or a negative scale would break spellings 1631 shipped `<mesh>` entries use.

The structural class derives its universe from the module rather than listing it, so a third non-finite cause is held to the same rule when it lands instead of inheriting an exemption by being absent from a tuple.

## Gate

`ruff check` and `ruff format --check` clean over 1646 files. `mypy strands_robots tests tests_integ`: `Success: no issues found in 1643 source files`. Paired run over an identical 571-file selection (all of `tests/simulation/isaac/` plus every suite that walks the tree, parses source, or reads docstrings) with the new file excluded from both trees: **25792 collected and `7 failed, 25667 passed, 118 skipped` on each**, the same 7 ids, both `comm` directions empty. Those 7 are the measuring machine's own environment - 5 assert `rclpy` is absent where it resolves from a system install, and 2 need `docker`.

## Visual

Rendered from one MJCF scene, `MUJOCO_GL=egl`, one camera and one light for all panels. Masks come from separate segmentation passes per geom group, so the proxy's transparency cannot affect a pixel count.

![non-finite mesh scale](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-asset-scale-finite/docs/assets/mesh-scale-finite.png)

At unit scale the reported proxy encloses the asset: **0** of its 15294 pixels fall outside its own bound. For `scale="nan nan nan"` the reported bound occupies **0 pixels** and **all 15294** asset pixels fall outside it. The reported centre is NaN and a renderer cannot place it, so panel 2 draws the bound at the asset's own centre - a declared substitution, with only the extent being the measurement.
