### PR TITLE
fix(mesh): report a timed drive whose trailing stop was refused

### DIFF
--- a/changelog.d/2839-drive-reports-a-refused-trailing-stop.md
+++ b/changelog.d/2839-drive-reports-a-refused-trailing-stop.md
@@ -1,0 +1,36 @@
+### Fixed: a timed drive whose trailing stop was refused reports it
+
+A timed or repeated `drive` owns its own stop: `MobileBaseRobot`, `RosbridgeRobot`
+and `AckermannRosRobot` all follow a non-zero command with a single zero one from
+`finally`, so the zero goes out even when the main publish raised. Sending it is
+not the same as landing it. That zero is a second command over the same
+transport, and every shipped graph tool reports a refusal - a declined operator
+approval, a rate limit, a transport failure - as an error envelope rather than by
+raising, so the refusal was a value that had to be read. Three of the four
+drive-owning classes dropped it inside the `finally` and returned the hold's own
+success.
+
+Measured against the real `use_rosbridge` gate with an operator who approves the
+hold and declines the stop, on a blocklisted `/cmd_vel`: `drive(linear=1.0,
+duration=1.0)` answered `status="success"` with "published 2 message(s)", two
+messages reached the wire, the last of them `linear.x = 1.0`, and no zero
+followed. The robot is left moving at the commanded velocity and the caller is
+told the drive succeeded - and the agent-facing tool description promises a timed
+command "stops automatically afterwards", so a caller reading `success` never
+issues `stop`. The gate prompts once per publish, so approving a hold and
+declining its stop is an ordinary pair of operator decisions. `RtpsRobot` and
+`RosBridgedRobot` reproduced it through the shared base.
+
+`AckermannRosRobot` already kept the verdict and compared it against the hold's
+own result, which is why this is a consolidation rather than a new rule - its
+docstring claimed the "same contract as `RosBridgedRobot.drive`", which was the
+reverse of the truth. The rule now lives once as
+`_mobile_base.failed_halt_error`, beside the drive contract it belongs to, and
+the car's message is unchanged. A hold that failed is still the cause, because a
+stop it never got to undo is a consequence of it; a single-shot command owes no
+stop, so no verdict is read and it latches by contract as before.
+
+The shared safety contract stated the guarantee as fact - "a timed drive cannot
+leave a robot with a live velocity latched" - so it now says that the stop's
+verdict is read rather than dropped, and `docs/rosbridge-integration.md` says the
+same where a reader learns the fleet contract.

--- a/docs/rosbridge-integration.md
+++ b/docs/rosbridge-integration.md
@@ -161,9 +161,12 @@ scan = robot.get_scan()  # read one laser scan (error if no scan_topic)
 - **Timed-command trailing zero**: every drive with a `duration` argument and a
   non-zero command (or multi-message publish) automatically publishes a single
   zero Twist afterwards - even if the main publish failed - so a timed drive
-  cannot leave the robot with a live velocity. This was previously this bridge's
-  alone; the ROS 2 and RTPS bridges inherit it from the shared mobile base now,
-  so a timed drive self-stops on all three.
+  does not leave the robot with a live velocity. That zero is itself a gated
+  command, so when it is the call that fails - a declined approval, a rate limit,
+  a transport error - `drive` returns that failure instead of the hold's success,
+  naming the still-live topic and telling you to halt with `stop`. This was
+  previously this bridge's alone; the ROS 2 and RTPS bridges inherit it from the
+  shared mobile base now, so a timed drive self-stops on all three.
 - **stop() needs no prior state**: the stop method publishes a zero Twist
   regardless of whether an earlier command succeeded, and there is no enable
   handshake to satisfy first. It is *not* exempt from the operator gate: that

--- a/strands_robots/mesh/_mobile_base.py
+++ b/strands_robots/mesh/_mobile_base.py
@@ -38,7 +38,13 @@ Safety semantics, stated once because they are now implemented once:
   means "this platform declares no limit", not "zero".
 - Every timed or multi-message non-zero command is followed by a single zero
   command through ``try``/``finally`` - *even when the main publish raised* - so
-  a timed drive cannot leave a robot with a live velocity latched.
+  a timed drive does not leave a robot with a live velocity latched. Sending it
+  is not the same as landing it: that stop is a second command over the same
+  transport, and the tool it goes through reports a refusal as an error envelope
+  rather than by raising. Its verdict is therefore read, not dropped - a hold
+  that succeeded over a stop that was refused is reported as the error, because
+  the robot is still moving and a caller reading ``success`` never issues
+  :meth:`MobileBaseRobot.stop`.
 - A bare single-shot ``drive()`` latches until :meth:`stop`, matching a raw
   ``cmd_vel`` publish. This is disclosed in the agent-facing tool description
   rather than papered over.
@@ -180,6 +186,54 @@ def positive_finite(label: str, value: Any, context: str = "MobileBaseRobot") ->
     if error := positive_finite_number_error(value, label, context):
         raise ValueError(error)
     return float(value)
+
+
+#: What is still moving when a velocity command outlived the stop that ends it.
+#: Shared by every ``Twist`` bridge so the two that own their own ``drive`` say
+#: the same thing about the same failure.
+LATCHED_VELOCITY = "the robot may still be moving at the commanded velocity"
+
+
+def failed_halt_error(
+    result: dict[str, Any],
+    halt: dict[str, Any] | None,
+    *,
+    topic: str,
+    subject: str,
+) -> str | None:
+    """Report a trailing stop that failed under a command that succeeded.
+
+    A timed or repeated drive owns its own stop, and that stop is a second
+    command over the same transport: the tool it goes through reports a refusal
+    - a declined operator approval, a rate limit, a transport failure - as an
+    error envelope rather than by raising. Returning the hold's success after
+    that refusal presents a robot still moving at the commanded velocity as a
+    drive that stopped itself, and a caller reading ``success`` never issues the
+    ``stop`` that would end it.
+
+    The hold's own failure wins when both failed: that is the cause, and a stop
+    it never got to undo is a consequence of it. ``None`` for ``halt`` means no
+    stop was owed - a single-shot command latches by contract - so there is no
+    verdict to read and a queued failure from some later call cannot be
+    misattributed to this one.
+
+    Args:
+        result: The hold's own publish envelope.
+        halt: The trailing stop's envelope, or ``None`` when none was sent.
+        topic: Command topic, named so the caller knows what is still live.
+        subject: What is still moving, in the platform's own vocabulary.
+
+    Returns:
+        The error text, or ``None`` when there is nothing to report.
+    """
+    if halt is None or halt.get("status") == "success" or result.get("status") != "success":
+        return None
+    cause = " ".join(block.get("text", "") for block in halt.get("content", []) if isinstance(block, dict)).strip()
+    return (
+        f"drive: the command was published to {topic}, but the trailing stop "
+        f"failed - {subject}. Halt it with stop. "
+        f"Halt failure: {cause or 'no detail reported'}"
+    )
 
 
 class MobileBaseRobot:
@@ -431,9 +485,12 @@ class MobileBaseRobot:
 
         Returns:
             The transport's publish result, or a structured error when the
-            request was refused. The module docstring states the full safety
-            contract; the order here is deliberate and pinned by tests -
-            finite check, then ``duration``, then the handshake, then publish.
+            request was refused - or when the command was published and the
+            trailing stop that ends it was not, which names the still-live
+            topic and the stop's own cause. The module docstring states the
+            full safety contract; the order here is deliberate and pinned by
+            tests - finite check, then ``duration``, then the handshake, then
+            publish.
         """
         # One domain rule per parameter, taken from the shared guards rather than
         # restated here, so the accepted set cannot drift between this base and
@@ -473,15 +530,21 @@ class MobileBaseRobot:
             else max(-self.max_angular, min(self.max_angular, float(angular)))
         )
         n = max(1, round(duration * self.publish_rate)) if duration is not None else count
+        # The trailing stop runs from ``finally`` so it goes out even when the
+        # main publish raised, and its verdict is kept rather than dropped -
+        # see :func:`failed_halt_error`.
+        halt: dict[str, Any] | None = None
         try:
-            return self._publish_cmd(v, w, count=n, tool_context=tool_context)
+            result = self._publish_cmd(v, w, count=n, tool_context=tool_context)
         finally:
             # A timed or repeated command owns its own stop. Skipped for a
             # command that was already zero - there is nothing to undo. Carries
             # the same context as the command it undoes: a trailing zero that
             # could not reach the gate would leave the robot latched at speed.
             if (duration is not None or n > 1) and (v or w):
-                self._publish_cmd(0.0, 0.0, count=1, tool_context=tool_context)
+                halt = self._publish_cmd(0.0, 0.0, count=1, tool_context=tool_context)
+        latched = failed_halt_error(result, halt, topic=self.cmd_vel_topic, subject=LATCHED_VELOCITY)
+        return self._error(latched) if latched else result
 
     def stop(self, tool_context: ToolContext | None = None) -> dict[str, Any]:
         """Publish a single zero-velocity command.

--- a/strands_robots/mesh/ackermann_robot.py
+++ b/strands_robots/mesh/ackermann_robot.py
@@ -65,6 +65,7 @@ from typing import Any
 from strands import tool
 from strands.types.tools import AgentTool, ToolContext
 
+from strands_robots.mesh._mobile_base import failed_halt_error
 from strands_robots.mesh.ros_bridge import _check_topic
 from strands_robots.tools.use_ros import use_ros
 from strands_robots.utils import (
@@ -339,16 +340,16 @@ class AckermannRosRobot:
         finally:
             if (duration is not None or n > 1) and (angle or throttle):
                 halt = self._publish_servo(0.0, 0.0, count=1, tool_context=tool_context)
-        if halt is not None and halt.get("status") != "success" and result.get("status") == "success":
-            cause = " ".join(
-                block.get("text", "") for block in halt.get("content", []) if isinstance(block, dict)
-            ).strip()
-            return self._error(
-                f"drive: the command was published to {self.servo_topic}, but the trailing stop "
-                f"failed - the car may still be holding the commanded throttle. Halt it with stop. "
-                f"Halt failure: {cause or 'no detail reported'}"
-            )
-        return result
+        # The rule is the sibling bridges' too, so it lives with the shared drive
+        # contract rather than in a third copy of it. Only the subject differs: a
+        # car holds a throttle where a differential-drive base holds a velocity.
+        latched = failed_halt_error(
+            result,
+            halt,
+            topic=self.servo_topic,
+            subject="the car may still be holding the commanded throttle",
+        )
+        return self._error(latched) if latched else result
 
     def _publish_servo(
         self,

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -34,6 +34,7 @@ from typing import Any
 from strands import tool
 from strands.types.tools import AgentTool, ToolContext
 
+from strands_robots.mesh._mobile_base import LATCHED_VELOCITY, failed_halt_error
 from strands_robots.mesh.ros_bridge import _check_topic
 from strands_robots.tools.use_rosbridge import _HOST_RE, _transport_port_error, use_rosbridge
 from strands_robots.utils import (
@@ -213,7 +214,9 @@ class RosbridgeRobot:
         bare single-shot command latches until :meth:`stop`, like any raw
         cmd_vel publish, and every timed or multi-message non-zero command is
         followed by a single zero Twist - even if the main publish failed - so a
-        timed drive cannot leave the robot with a live velocity. The trailing
+        timed drive does not leave the robot with a live velocity. That zero is a
+        gated command in its own right, so when it is the call that fails the
+        result says so rather than reporting the hold's success. The trailing
         zero was this bridge's alone until the shared mobile base took over the
         drive contract; the other two inherit it now, so a timed drive
         self-stops wherever it is issued.
@@ -293,14 +296,20 @@ class RosbridgeRobot:
         # rule and not a substitute for validation: a hold shorter than one
         # publish period still means "send the command once".
         n = max(1, round(duration * self.publish_rate)) if duration is not None else count
+        # The trailing stop goes out from ``finally`` even when the main publish
+        # raised, and its verdict is kept rather than dropped - see
+        # :func:`~strands_robots.mesh._mobile_base.failed_halt_error`.
+        halt: dict[str, Any] | None = None
         try:
-            return self._publish_twist(v, w, count=n, tool_context=tool_context)
+            result = self._publish_twist(v, w, count=n, tool_context=tool_context)
         finally:
             # The trailing zero carries the same context as the command it
             # undoes: one that could not reach the gate would be refused on its
             # own and leave the robot latched at the speed of an approved hold.
             if (duration is not None or n > 1) and (v or w):
-                self._publish_twist(0.0, 0.0, count=1, tool_context=tool_context)
+                halt = self._publish_twist(0.0, 0.0, count=1, tool_context=tool_context)
+        latched = failed_halt_error(result, halt, topic=self.cmd_vel_topic, subject=LATCHED_VELOCITY)
+        return self._error(latched) if latched else result
 
     def stop(self, tool_context: ToolContext | None = None) -> dict[str, Any]:
         """Publish a single zero Twist.

--- a/tests/mesh/test_drive_reports_a_refused_trailing_stop.py
+++ b/tests/mesh/test_drive_reports_a_refused_trailing_stop.py
@@ -1,0 +1,300 @@
+"""A ``drive`` whose trailing stop was refused reports it, rather than the hold.
+
+A timed or repeated ``drive`` owns its own stop: the shared mobile base and the
+two bridges that own their own ``drive`` all follow a non-zero command with a
+single zero one, from ``finally``, so the zero goes out even when the main
+publish raised. Sending it is not the same as landing it. That zero is a second
+command over the same transport, and every shipped graph tool reports a refusal
+- a declined operator approval, a rate limit, a transport failure - as an error
+envelope rather than by raising, so the refusal was a value that had to be read.
+Three of the four drive-owning classes dropped it on the floor inside the
+``finally`` and returned the hold's own success.
+
+Measured against the real ``use_rosbridge`` gate with an operator who approves
+the hold and declines the stop, on the blocklisted ``/turtle1/cmd_vel``::
+
+    drive(linear=1.0, duration=1.0) -> status="success",
+                                       "published 2 message(s) to /turtle1/cmd_vel"
+    messages on the wire            -> 2, the last one linear.x = 1.0
+    trailing zero                   -> never published
+
+The robot is left moving at the commanded velocity and the caller is told the
+drive succeeded - and the agent-facing tool description promises a timed command
+"stops automatically afterwards", so a caller reading ``success`` never issues
+``stop``. ``RtpsRobot`` reproduces it through the shared base for the same
+reason.
+
+``AckermannRosRobot`` already read the verdict and is the reason this is a
+consolidation rather than a new rule: it kept ``halt``, compared it against the
+hold's own result and returned an error naming the still-live topic. Its own
+docstring claims the "same contract as ``RosBridgedRobot.drive``", which was the
+reverse of the truth. The rule now lives once, beside the drive contract it
+belongs to, and the car's message is unchanged - which is what its three
+existing tests in ``tests/mesh/test_ackermann_robot.py`` measure.
+
+Hermetic: the roslibpy WebSocket client and the RTPS writer bundle are doubled
+beneath the real tools, so the operator gate and the transport wiring both run
+unmodified while nothing reaches a real server.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh._mobile_base import LATCHED_VELOCITY, failed_halt_error
+from tests.mesh.test_drive_contract_fleet_scope import _drive_owning_mesh_classes
+from tests.mesh.test_rosbridge_robot_command_gate import (
+    _BLOCKED_CMD_VEL,
+    _ZERO_TWIST,
+    _published,
+    _texts,
+    _tool,
+    _turtle,
+)
+from tests.mesh.test_rosbridge_robot_command_gate import (
+    _install_doubles as _install_rosbridge_doubles,
+)
+from tests.mesh.test_rtps_robot_command_gate import (
+    _install_doubles as _install_rtps_doubles,
+)
+from tests.mesh.test_rtps_robot_command_gate import (
+    _turtle as _rtps_turtle,
+)
+
+#: An operator who approves the hold and then declines the stop that ends it.
+#: The gate prompts once per publish - pinned by
+#: ``test_the_trailing_zero_of_a_timed_drive_reaches_the_same_operator`` in the
+#: rosbridge gate suite - so this is an ordinary sequence of two decisions and
+#: not a contrived one.
+_APPROVE_THEN_DECLINE = ["y", "n"]
+
+_SUCCESS = {"status": "success", "content": [{"text": "published 20 message(s)"}]}
+_FAILURE = {"status": "error", "content": [{"text": "use_ros: publish failed"}]}
+
+
+def _drive_definers() -> dict[str, str]:
+    """Each drive-owning class, mapped to the module file that defines its ``drive``.
+
+    ``_drive_owning_mesh_classes`` is annotated ``dict[str, type]`` and ``drive``
+    is not an attribute of a bare ``type``, so the widening happens here once
+    instead of at every read.
+    """
+    owners: dict[str, Any] = dict(_drive_owning_mesh_classes())
+    return {name: pathlib.Path(inspect.getsourcefile(cls.drive) or "").name for name, cls in owners.items()}
+
+
+def _drive_source(module_name: str) -> str:
+    """The ``drive`` body defined by ``module_name``."""
+    owners: dict[str, Any] = dict(_drive_owning_mesh_classes())
+    for cls in owners.values():
+        if pathlib.Path(inspect.getsourcefile(cls.drive) or "").name == module_name:
+            return inspect.getsource(cls.drive)
+    raise AssertionError(f"no drive owner is defined in {module_name}")
+
+
+def _decides(*answers: str) -> MagicMock:
+    context = MagicMock()
+    context.interrupt.side_effect = list(answers)
+    return context
+
+
+class TestAnApprovedHoldOverARefusedStopIsReported:
+    """The regression: the drive that could not stop itself says so."""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_rosbridge_doubles(monkeypatch)
+
+    def test_the_verdict_is_the_refused_stop_not_the_published_hold(self) -> None:
+        context = _decides(*_APPROVE_THEN_DECLINE)
+        robot = _turtle(publish_rate=2.0)
+        result = _tool(robot, "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        assert context.interrupt.call_count == 2, "the stop never reached the operator"
+        assert result["status"] == "error"
+
+    def test_the_refusal_names_the_topic_that_is_still_live(self) -> None:
+        """Named where only the refusal can name it.
+
+        The hold's own success text is ``"published N message(s) to <topic>"``,
+        so a bare ``topic in text`` passes on the discarding code too - it reads
+        the success it is meant to refute. The topic is pinned in the clause the
+        refusal builds around it instead.
+        """
+        context = _decides(*_APPROVE_THEN_DECLINE)
+        result = _tool(_turtle(publish_rate=2.0), "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        assert f"{_BLOCKED_CMD_VEL}, but the trailing stop" in _texts(result)
+
+    def test_the_refusal_names_the_action_the_caller_has_to_take_next(self) -> None:
+        """The imperative, not just the word.
+
+        ``"stop"`` also appears in the refusal's own subject ("the trailing stop
+        failed"), so a bare ``"stop" in text`` still passes with the instruction
+        removed. The clause that tells the caller what to do is what is pinned.
+        """
+        context = _decides(*_APPROVE_THEN_DECLINE)
+        result = _tool(_turtle(publish_rate=2.0), "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        assert "Halt it with stop" in _texts(result)
+
+    def test_the_stops_own_cause_survives_into_the_report(self) -> None:
+        """The operator's decision is the cause, and it is what a reader needs."""
+        context = _decides(*_APPROVE_THEN_DECLINE)
+        result = _tool(_turtle(publish_rate=2.0), "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        assert "declined by the operator" in _texts(result)
+
+
+class TestTheRobotReallyIsStillMoving:
+    """Premise: holds either way, and is why the error is the honest verdict.
+
+    A refused stop is not a bookkeeping detail - the velocity the operator
+    approved is still the last thing on the wire. Recorded separately because it
+    is true of the discarding code as well: what changed is whether the caller
+    is told.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _hermetic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_rosbridge_doubles(monkeypatch)
+
+    def test_the_commanded_velocity_is_the_last_thing_on_the_wire(self) -> None:
+        context = _decides(*_APPROVE_THEN_DECLINE)
+        _tool(_turtle(publish_rate=2.0), "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        published = _published()
+        assert published, "the hold was never published, so there is nothing latched"
+        assert published[-1][1] != _ZERO_TWIST, "a zero reached the wire after all"
+        assert published[-1][1]["linear"]["x"] == 1.0
+
+
+class TestTheSharedBaseReportsItToo:
+    """``RtpsRobot`` reaches the same code through ``MobileBaseRobot.drive``."""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_rtps_doubles(monkeypatch)
+
+    def test_a_repeated_command_over_a_refused_stop_is_reported(self) -> None:
+        context = _decides(*_APPROVE_THEN_DECLINE)
+        result = _rtps_turtle().drive(linear=1.0, count=2, tool_context=context)
+        assert context.interrupt.call_count == 2
+        assert result["status"] == "error"
+        text = " ".join(block.get("text", "") for block in result["content"])
+        assert "/turtle1/cmd_vel" in text and "stop" in text
+
+
+class TestTheRuleItself:
+    """The shared verdict-reader, driven directly over every input shape."""
+
+    def test_a_refused_stop_under_a_published_hold_is_reported(self) -> None:
+        text = failed_halt_error(_SUCCESS, _FAILURE, topic="/cmd_vel", subject=LATCHED_VELOCITY)
+        assert text is not None
+        assert "/cmd_vel, but the trailing stop" in text
+        assert "Halt it with stop" in text
+        assert "use_ros: publish failed" in text
+
+    def test_a_stop_that_landed_reports_nothing(self) -> None:
+        assert failed_halt_error(_SUCCESS, _SUCCESS, topic="/cmd_vel", subject=LATCHED_VELOCITY) is None
+
+    def test_no_stop_was_owed_so_there_is_no_verdict_to_read(self) -> None:
+        """``None`` is a single-shot command, which latches by contract."""
+        assert failed_halt_error(_SUCCESS, None, topic="/cmd_vel", subject=LATCHED_VELOCITY) is None
+
+    def test_a_hold_that_failed_is_the_cause_not_the_stop_it_never_undid(self) -> None:
+        assert failed_halt_error(_FAILURE, _FAILURE, topic="/cmd_vel", subject=LATCHED_VELOCITY) is None
+
+    def test_a_stop_that_reported_no_detail_still_reports_the_latch(self) -> None:
+        """The latch is the finding; the missing cause must not swallow it."""
+        text = failed_halt_error(
+            _SUCCESS, {"status": "error", "content": []}, topic="/cmd_vel", subject=LATCHED_VELOCITY
+        )
+        assert text is not None and "no detail reported" in text
+
+    def test_the_subject_is_the_platforms_own_vocabulary(self) -> None:
+        """A car holds a throttle where a differential-drive base holds a velocity."""
+        car = failed_halt_error(_SUCCESS, _FAILURE, topic="/servo", subject="the car may still be holding")
+        assert car is not None and "the car may still be holding" in car
+        assert LATCHED_VELOCITY not in car
+
+
+class TestWhatIsUnchanged:
+    """Controls: every outcome the pre-fix code already got right."""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_rosbridge_doubles(monkeypatch)
+
+    def test_a_hold_and_a_stop_the_operator_both_approve_still_succeeds(self) -> None:
+        context = _decides("y", "y")
+        result = _tool(_turtle(publish_rate=2.0), "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        assert result["status"] == "success"
+        assert _published()[-1] == (_BLOCKED_CMD_VEL, _ZERO_TWIST)
+
+    def test_a_declined_hold_still_reports_the_hold(self) -> None:
+        """Refusing the hold refuses the motion, so its undo has nothing to undo."""
+        result = _tool(_turtle(publish_rate=2.0), "drive_turtlesim")(
+            linear=1.0, duration=1.0, tool_context=_decides("n", "n")
+        )
+        assert result["status"] == "error"
+        assert "declined by the operator" in _texts(result)
+        assert _published() == []
+
+    def test_a_single_shot_command_is_not_reinterpreted(self) -> None:
+        """No stop is owed, so no verdict exists that could turn success into error."""
+        result = _tool(_turtle(), "drive_turtlesim")(linear=1.0, tool_context=_decides("y"))
+        assert result["status"] == "success"
+        assert _published() == [(_BLOCKED_CMD_VEL, {"linear": {"x": 1.0}, "angular": {"z": 0.0}})]
+
+    def test_the_stop_still_goes_out_when_the_hold_itself_failed(self) -> None:
+        """The ``finally`` guarantee is untouched: a failed hold still gets its zero."""
+        context = _decides("n", "y")
+        _tool(_turtle(publish_rate=2.0), "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        assert _published() == [(_BLOCKED_CMD_VEL, _ZERO_TWIST)]
+
+
+class TestOneOwnerForTheRule:
+    """Every class that defines ``drive`` consults the one verdict-reader.
+
+    Derived rather than listed: the defect was three independent implementations
+    of one safety rule, two of which had dropped it, so a fifth bridge that
+    defines its own ``drive`` has to answer this on arrival instead of shipping
+    with the hold's success in place of the stop's refusal.
+    """
+
+    def test_every_module_that_defines_drive_reads_the_stops_verdict(self) -> None:
+        definers = _drive_definers()
+        assert definers, "the drive-owner inventory came back empty"
+        for module_name in sorted(set(definers.values())):
+            assert "failed_halt_error(" in _drive_source(module_name), (
+                f"{module_name} defines drive and does not consult failed_halt_error, "
+                "so a refused trailing stop is reported as the hold's success"
+            )
+
+    def test_the_rule_is_written_once(self) -> None:
+        """One owner, so the platforms cannot drift apart again."""
+        package = pathlib.Path(inspect.getfile(failed_halt_error)).parent
+        definitions = [
+            path.name for path in sorted(package.glob("*.py")) if "def failed_halt_error(" in path.read_text()
+        ]
+        assert definitions == ["_mobile_base.py"], definitions
+
+    def test_the_inventory_covers_more_than_the_shared_base(self) -> None:
+        """Non-vacuity: the survey reaches the classes that own their own drive."""
+        definers = set(_drive_definers().values())
+        assert {"_mobile_base.py", "rosbridge_robot.py", "ackermann_robot.py"} <= definers, definers
+
+
+class TestTheProseMatchesTheMeasurement:
+    """The guarantee is stated where a reader learns the contract."""
+
+    def test_the_shared_safety_contract_says_the_verdict_is_read(self) -> None:
+        import strands_robots.mesh._mobile_base as base
+
+        doc = " ".join((base.__doc__ or "").split())
+        assert "verdict is therefore read, not dropped" in doc
+
+    def test_the_helper_states_why_a_refusal_is_a_value_and_not_a_raise(self) -> None:
+        doc = " ".join((failed_halt_error.__doc__ or "").split())
+        assert "error envelope rather than by raising" in doc


### PR DESCRIPTION
## Problem

A timed or repeated `drive` owns its own stop. `MobileBaseRobot`, `RosbridgeRobot` and `AckermannRosRobot` all follow a non-zero command with a single zero one from `finally`, so the zero goes out even when the main publish raised.

Sending it is not the same as landing it. That zero is a second command over the same transport, and every shipped graph tool reports a refusal - a declined operator approval, a rate limit, a transport failure - as an error envelope rather than by raising. So the refusal was a value that had to be read, and three of the four drive-owning classes dropped it inside the `finally` and returned the hold's own success.

Both discarding sites carried a comment naming the exact consequence:

> Carries the same context as the command it undoes: a trailing zero that could not reach the gate would leave the robot latched at speed.

## Measurement

Against the real `use_rosbridge` gate, with an operator who approves the hold and declines the stop, on a blocklisted `/cmd_vel`:

| | before | after |
|---|---|---|
| operator prompts | 2 | 2 |
| `drive()` status | **`success`** | `error` |
| `drive()` text | `published 2 message(s) to /turtle1/cmd_vel` | names the topic, the still-live velocity, `Halt it with stop`, and the operator's decision |
| messages on the wire | 2 | 2 |
| last message | **`linear.x = 1.0`** | `linear.x = 1.0` |
| trailing zero sent | no | no |

The robot is left moving at the commanded velocity and the caller is told the drive succeeded. The `drive_<node>` tool description promises a timed command "stops automatically afterwards", so a caller reading `success` never issues `stop`. The gate prompts once per publish - pinned by `test_the_trailing_zero_of_a_timed_drive_reaches_the_same_operator` - so approving a hold and declining its stop is an ordinary pair of decisions rather than a contrived input.

`RtpsRobot` reproduces it through the shared base: `drive(linear=1.0, count=2)` with the same two decisions answered `success` / `published 2 message(s)`.

## Change

`AckermannRosRobot` already kept the verdict and compared it against the hold's own result, which is why this is a consolidation rather than a new rule. Its docstring claims the "same contract as `RosBridgedRobot.drive`" - the reverse of the truth.

The rule now lives once as `_mobile_base.failed_halt_error`, beside the drive contract it belongs to, and all three drive owners consult it. The car's message is byte-identical, which is what its 61 existing tests measure. Two decisions carry across from the exemplar: a hold that failed is still the cause, because a stop it never got to undo is a consequence of it; and a single-shot command owes no stop, so no verdict is read and it latches by contract as before.

Prose corrected where a reader learns the contract. The shared safety contract stated the guarantee as fact - "a timed drive cannot leave a robot with a live velocity latched" - and now says the stop's verdict is read rather than dropped. `docs/rosbridge-integration.md` says the same.

## Why nothing caught it

The rosbridge gate suite covers *approve both* (`test_the_trailing_zero_of_a_timed_drive_reaches_the_same_operator`) and *decline the hold* (`test_a_declined_hold_never_latches_a_velocity`). Approve the hold and decline the stop - the case that test's own docstring names, "one that could not reach the gate would leave the robot latched at the speed of a hold the operator did approve" - had no cell.

## Tests

`tests/mesh/test_drive_reports_a_refused_trailing_stop.py`, 21 cases. Pre-fix split, with the helper and prose kept and only the three call sites reverted to discarding: **6 failed / 15 passed** - 4 of 4 in the regression class, 1 of 1 on the shared base, 1 of 3 structural, and **0 of 4 controls, 0 of 1 premise, 0 of 6 rule-level, 0 of 2 prose**. A raw revert is a collection error, since the helper does not exist on the base.

Mutation table, `mine` = this file, `sib` = the 13 pre-existing mesh drive and gate suites:

| row | mutation | mine | coll | sib |
|---|---|---|---|---|
| b0 | control | 0 | 21 | 0 |
| b1 | shared base discards the verdict again | 2 | 21 | 0 |
| b2 | rosbridge discards it again | 5 | 21 | 0 |
| b3 | ackermann discards it again | 1 | 21 | **1** |
| b4 | precedence dropped: a failed hold no longer wins | 1 | 21 | **1** |
| b5 | no-stop-owed guard dropped (a single-shot is judged) | 2 | 21 | **72** |
| b6 | a landed stop is reported as failed too | 2 | 21 | **12** |
| b8 | message drops the topic | 2 | 21 | 0 |
| b9 | message drops the imperative | 2 | 21 | 0 |
| b10 | message drops the stop's own cause | 3 | 21 | 0 |
| b11 | subject hardcoded, ignoring the platform | 1 | 21 | 0 |
| b12 | no-detail fallback dropped | 1 | 21 | 0 |

Every mutation is detected and the control is clean. b3 and b4 trip the Ackermann car's own pre-existing tests, which is the evidence the consolidation preserved its contract; b5 and b6 trip 72 and 12 sibling cases, which is what makes the two guards load-bearing fleet-wide rather than defensive.

Two cells were found vacuous by the table and tightened: the hold's success text is `published N message(s) to <topic>`, so `topic in text` passed on the discarding code, and `"stop"` also appears in the refusal's own subject ("the trailing stop failed"), so a bare `"stop" in text` survived the imperative being removed. Both now pin the clause only the refusal builds.

The structural inventory is derived, not listed, so a fifth bridge answers on arrival. Composed proof that this matters: revert rosbridge with the inventory derived, 5 cells fire including the structural one; revert rosbridge with the inventory hardcoded to `_mobile_base.py`, 4 fire and the structural cell goes silent; hardcode with nothing reverted, 0.

## Gate

- `ruff check` and `ruff format --check` clean over 1646 files.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the merge-base, normalized message sets identical in both directions, 0 attributable.
- Paired run over an identical 535-file selection (all of `tests/mesh` plus every suite that walks the tree, parses source, or reads docstrings and `docs/`), this file excluded from both trees: identical **22401 collected** and `24 failed, 22282 passed, 71 skipped, 24 errors` on each, **48 identical failing ids with both `comm` directions empty**, distinct rootdirs. Of the 48, 45 need `awsiot`/`awscrt` (both absent locally, declared in the `[mesh-iot]` extra) and 3 are the lerobot-from-source `encode()` drift. `tests/mesh/test_zenoh_transport_security.py` is excluded from the pair and verified alone: 9 passed, 2 skipped on both.
- Rebased onto `2d151363` and re-verified there, including the two guard files the base added: 471 passed, 6 skipped.

No visual artifact: this changes what a refusal reports, not a policy, simulation, render, recording or asset. The measured before/after table is the evidence.
