### PR TITLE
fix(inference): hold the wire lock across the connect replay

### DIFF
--- a/changelog.d/2843-connect-replay-holds-the-wire-lock.md
+++ b/changelog.d/2843-connect-replay-holds-the-wire-lock.md
@@ -1,0 +1,39 @@
+### Fixed: the remote-policy connect replay holds the wire lock the other callers hold
+
+`RemotePolicy` serialises its WebSocket with one lock, and its wire helper says so
+in the section header above it: "call while holding `self._lock`". Four of
+`_request`'s seven call sites did. The three inside `_connect` did not, and those
+three run *after* `self._ws` is live - the handshake read, then the replay of any
+state keys, control frequency and pending reset that were set before the
+connection existed. The connect sequence is the widest wire user in the class and
+it was the one outside the lock.
+
+A second thread reaching the wire in that window overlapped the read, and
+`websockets` refuses an overlapping read. Measured with a server parked mid-replay
+and a client whose config was set before connecting: `reset(seed=7)` raised
+`ConcurrencyError: cannot call recv while another thread is already running recv
+or recv_streaming` - a report naming the transport's internals rather than
+anything the caller passed, out of a call that never mentions threads. The same
+window is reachable from `set_robot_state_keys` and from `get_actions`.
+
+Two threads on one policy is the ordinary case rather than a contrived one. Every
+policy coroutine resolves through `_async_utils`' reused worker thread, and the
+async-RTC path in `simulation.policy_runner` submits prefetch inference to its own
+`rtc-prefetch` worker while the rollout thread carries on stepping, so a
+first connect and another call on the same policy land on different threads by
+design.
+
+`_ensure_connected` now holds `self._lock` across `_connect`. The unlocked fast
+path stays, with the state re-checked under the lock, so two racing first-callers
+open one connection rather than two; none of its three callers holds the lock, so
+nothing deadlocks. A concurrent wire user waits for the replay and then proceeds,
+which is what the lock was there to do. Reusing that lock rather than adding a
+connect-only one is the point: a dedicated lock would make connects mutually
+exclusive and still leave them racing `reset` and `get_actions`.
+
+The precondition is now graded at runtime rather than by reading the source. A
+witness lock records whether it was held when `_request` ran, so the coverage
+`_connect` inherits from its caller counts, where a lexical scan would report
+those three calls as unlocked either way. The pre-existing suite could not see
+this: its threads run the *server*, and the client is driven from one thread
+throughout.

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -209,8 +209,37 @@ class RemotePolicy(Policy):
             self._reset_pending = False
 
     def _ensure_connected(self) -> None:
-        if self._ws is None:
-            self._connect()
+        """Open the connection if it is not open yet, serialised with the other wire users.
+
+        Holds ``self._lock`` across :meth:`_connect` because the connect
+        sequence is itself a wire user, and the widest one: it reads the
+        handshake and then replays up to three pending-config requests through
+        :meth:`_request`, every one of them after ``self._ws`` is already live.
+        Left unlocked, those sends interleave with a concurrent :meth:`reset`,
+        :meth:`set_robot_state_keys` or :meth:`get_actions` on the same
+        connection, and ``websockets`` refuses the overlapping read with a
+        ``ConcurrencyError`` naming its own internals rather than anything the
+        caller passed - a report no ``RemotePolicy`` caller can act on.
+
+        Two threads on one policy is the ordinary case here, not a contrived
+        one: every policy coroutine resolves through
+        :mod:`strands_robots._async_utils`' reused worker thread, and the
+        async-RTC path in :mod:`strands_robots.simulation.policy_runner`
+        submits prefetch inference to its own ``rtc-prefetch`` worker while the
+        rollout thread carries on stepping.
+
+        The unlocked fast path is a benign double check. A thread that already
+        sees a live connection has nothing to serialise against; one that sees
+        ``None`` re-checks under the lock before connecting, so two racing
+        first-callers open one connection rather than two.
+        """
+        if self._ws is not None:
+            return
+        with self._lock:
+            # Re-checked under the lock: another thread may have connected
+            # while this one waited, and a second connect would leak the first.
+            if self._ws is None:
+                self._connect()
 
     def _apply_metadata(self, metadata: dict[str, Any]) -> None:
         """Mirror the server policy's introspection metadata locally."""

--- a/tests/inference/test_connect_replay_serialises_with_other_wire_users.py
+++ b/tests/inference/test_connect_replay_serialises_with_other_wire_users.py
@@ -150,7 +150,12 @@ class TestAConcurrentWireUserWaitsForTheConnectReplay:
                 else:
                     client.get_actions_sync({"observation.state": [0.0]}, "")
                 outcome["result"] = "returned"
-            except BaseException as exc:  # noqa: BLE001 - the failure is the subject
+            except Exception as exc:  # noqa: BLE001 - the failure is the subject
+                # Not ``BaseException``: the failure under test is a
+                # ``websockets`` ``ConcurrencyError`` (a ``RuntimeError``), and a
+                # non-reraising ``BaseException`` handler is its own CodeQL alert
+                # whose review thread gates a merge - see the census in
+                # ``tests/test_codeql_query_filters.py``.
                 outcome["result"] = f"{type(exc).__name__}: {exc}"
 
         second = threading.Thread(target=drive, daemon=True)
@@ -177,7 +182,7 @@ class TestAConcurrentWireUserWaitsForTheConnectReplay:
         def drive() -> None:
             try:
                 client.reset(seed=1)
-            except BaseException as exc:  # noqa: BLE001 - the failure is the subject
+            except Exception as exc:  # noqa: BLE001 - the failure is the subject
                 errors.append(f"{type(exc).__name__}: {exc}")
 
         second = threading.Thread(target=drive, daemon=True)

--- a/tests/inference/test_connect_replay_serialises_with_other_wire_users.py
+++ b/tests/inference/test_connect_replay_serialises_with_other_wire_users.py
@@ -1,0 +1,290 @@
+"""The connect sequence is a wire user, so it holds the lock the others hold.
+
+``RemotePolicy._request`` documents its precondition in the section header
+above it: "call while holding ``self._lock``". Four of its call sites did;
+the three inside :meth:`~strands_robots.inference.client.RemotePolicy._connect`
+did not, and those three run *after* ``self._ws`` is live - the handshake read
+plus the replay of any config set before the connection existed. A second
+thread reaching the wire in that window overlapped the read, and ``websockets``
+refused it with a ``ConcurrencyError`` naming its own internals.
+
+Two threads on one policy is the ordinary case: every policy coroutine resolves
+through :mod:`strands_robots._async_utils`' reused worker thread, and the
+async-RTC path in :mod:`strands_robots.simulation.policy_runner` submits
+prefetch inference to its own ``rtc-prefetch`` worker while the rollout thread
+carries on. The pre-existing suite could not see it - its threads run the
+*server*, and the client is driven from one thread throughout.
+
+The precondition is graded at runtime rather than by reading the source: a
+witness lock records whether it was held when ``_request`` ran, which follows
+the coverage ``_connect`` gets from its caller. A lexical scan would report
+``_connect``'s calls as unlocked either way.
+"""
+
+import ast
+import inspect
+import textwrap
+import threading
+from typing import Any
+
+import pytest
+
+from strands_robots.inference import PolicyServer, RemotePolicy
+from strands_robots.policies import MockPolicy
+
+pytest.importorskip("websockets")
+
+
+class ParkingPolicy(MockPolicy):  # type: ignore[misc]
+    """Server-side policy that parks inside ``set_robot_state_keys``.
+
+    Parking there holds the client's connect replay open at a known point -
+    after ``self._ws`` is live, mid-``_request`` - so a second thread can be
+    pointed at the same connection deterministically instead of by sleeping.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.entered.set()
+        self.release.wait(timeout=10.0)
+        super().set_robot_state_keys(robot_state_keys)
+
+
+class WitnessLock:
+    """A lock that records whether it is currently held.
+
+    Stands in for ``RemotePolicy._lock`` so a test can assert the wire
+    helper's documented precondition at the moment it runs, wherever the
+    coverage came from.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.held = False
+
+    def __enter__(self) -> "WitnessLock":
+        self._lock.acquire()
+        self.held = True
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.held = False
+        self._lock.release()
+
+    def acquire(self, *args: Any, **kwargs: Any) -> bool:
+        return self._lock.acquire(*args, **kwargs)
+
+    def release(self) -> None:
+        self._lock.release()
+
+
+@pytest.fixture
+def parked() -> Any:
+    """A live server whose policy parks on the connect replay, plus its client.
+
+    The client is handed config *before* connecting, so the replay has
+    something to send and the window is a real one rather than a bare
+    handshake.
+    """
+    policy = ParkingPolicy()
+    server = PolicyServer(policy=policy, host="127.0.0.1", port=0).start()
+    client = RemotePolicy(host="127.0.0.1", port=server.port, connect_timeout=10.0, request_timeout=10.0)
+    client.set_robot_state_keys(["shoulder_pan", "elbow_flex"])
+    client.set_control_frequency(50.0)
+    try:
+        yield policy, server, client
+    finally:
+        policy.release.set()
+        client.close()
+        server.stop()
+
+
+def _open_the_window(policy: ParkingPolicy, client: RemotePolicy) -> threading.Thread:
+    """Start a connect in its own thread and return once it is parked mid-replay."""
+    thread = threading.Thread(target=lambda: client.requires_images, daemon=True)
+    thread.start()
+    assert policy.entered.wait(timeout=10.0), "the server never reached the parked replay"
+    return thread
+
+
+class TestTheConnectReplayIsAWireUser:
+    """Premise: there is something in the connect sequence to serialise."""
+
+    def test_the_connect_sequence_sends_requests_of_its_own(self) -> None:
+        source = inspect.getsource(RemotePolicy._connect)
+        calls = [
+            node
+            for node in ast.walk(ast.parse(textwrap.dedent(source)))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "_request"
+        ]
+        assert calls, "_connect no longer replays config; this contract needs re-deriving"
+
+    def test_the_connection_is_live_while_the_replay_runs(self, parked: Any) -> None:
+        policy, _server, client = parked
+        thread = _open_the_window(policy, client)
+        assert client._ws is not None, "the replay runs before the connection is usable"
+        policy.release.set()
+        thread.join(timeout=10.0)
+
+
+class TestAConcurrentWireUserWaitsForTheConnectReplay:
+    """Regression: a second thread is serialised, not refused."""
+
+    @pytest.mark.parametrize("caller", ["reset", "set_robot_state_keys", "get_actions"])
+    def test_a_second_thread_is_not_refused_mid_replay(self, parked: Any, caller: str) -> None:
+        policy, _server, client = parked
+        connecting = _open_the_window(policy, client)
+
+        outcome: dict[str, Any] = {}
+
+        def drive() -> None:
+            try:
+                if caller == "reset":
+                    client.reset(seed=7)
+                elif caller == "set_robot_state_keys":
+                    client.set_robot_state_keys(["j0", "j1"])
+                else:
+                    client.get_actions_sync({"observation.state": [0.0]}, "")
+                outcome["result"] = "returned"
+            except BaseException as exc:  # noqa: BLE001 - the failure is the subject
+                outcome["result"] = f"{type(exc).__name__}: {exc}"
+
+        second = threading.Thread(target=drive, daemon=True)
+        second.start()
+        # The second caller must be waiting, not racing the replay onto the wire.
+        second.join(timeout=0.5)
+        assert second.is_alive(), "the second wire user did not wait for the replay"
+
+        policy.release.set()
+        second.join(timeout=10.0)
+        connecting.join(timeout=10.0)
+        assert outcome["result"] == "returned", outcome["result"]
+
+    def test_the_refusal_that_used_to_surface_names_nothing_the_caller_passed(self, parked: Any) -> None:
+        """The old failure was a ``websockets`` concurrency error, not a domain refusal.
+
+        Pinned so a future change cannot re-route this window into an error
+        whose text is about the transport rather than about the call.
+        """
+        policy, _server, client = parked
+        connecting = _open_the_window(policy, client)
+        errors: list[str] = []
+
+        def drive() -> None:
+            try:
+                client.reset(seed=1)
+            except BaseException as exc:  # noqa: BLE001 - the failure is the subject
+                errors.append(f"{type(exc).__name__}: {exc}")
+
+        second = threading.Thread(target=drive, daemon=True)
+        second.start()
+        policy.release.set()
+        second.join(timeout=10.0)
+        connecting.join(timeout=10.0)
+        assert errors == [], errors
+
+
+class TestTwoRacingFirstCallersOpenOneConnection:
+    """Regression: the double check under the lock, not just the serialising."""
+
+    def test_one_connection_is_opened_for_two_racing_first_callers(self, parked: Any) -> None:
+        policy, _server, client = parked
+        policy.release.set()
+        opened: list[object] = []
+        real_connect = client._connect
+
+        def counting() -> None:
+            real_connect()
+            opened.append(client._ws)
+
+        client._connect = counting  # type: ignore[method-assign]
+        # A barrier so every caller reaches the guard together. The window is
+        # the connect handshake itself, so staggered starts let the GIL
+        # serialise them by luck and the race goes unobserved.
+        racers = 8
+        gate = threading.Barrier(racers)
+
+        def race() -> None:
+            gate.wait(timeout=10.0)
+            client.requires_images  # noqa: B018 - the property is what connects
+
+        threads = [threading.Thread(target=race, daemon=True) for _ in range(racers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10.0)
+        assert len(opened) == 1, f"opened {len(opened)} connections for one policy"
+
+
+class TestEveryWireRequestRunsUnderTheLock:
+    """The documented precondition, graded at runtime over every wire path."""
+
+    def test_no_request_reaches_the_wire_without_the_lock(self, parked: Any) -> None:
+        policy, _server, client = parked
+        policy.release.set()  # this one drives the paths, it does not need the window
+
+        witness = WitnessLock()
+        client._lock = witness  # type: ignore[assignment]
+        seen: list[tuple[str, bool]] = []
+        real_request = client._request
+
+        def recording(message: dict[str, Any]) -> dict[str, Any]:
+            seen.append((str(message.get("type")), witness.held))
+            return real_request(message)
+
+        client._request = recording  # type: ignore[method-assign]
+
+        # Drive every public path that reaches the wire, connect included.
+        assert client.requires_images in (True, False)
+        client.set_robot_state_keys(["j0", "j1"])
+        client.set_control_frequency(25.0)
+        client.reset(seed=3)
+        client.get_actions_sync({"observation.state": [0.0]}, "")
+
+        assert seen, "no request reached the wire; this contract would pass vacuously"
+        unlocked = [message_type for message_type, held in seen if not held]
+        assert unlocked == [], f"reached the wire without the lock: {unlocked}"
+
+    def test_the_connect_replay_is_among_the_paths_graded(self, parked: Any) -> None:
+        """Non-vacuity: the replay's own requests are in the graded set.
+
+        Without this, narrowing the drive above to the already-connected paths
+        would still report a clean result.
+        """
+        policy, _server, client = parked
+        policy.release.set()
+
+        seen: list[str] = []
+        real_request = client._request
+
+        def recording(message: dict[str, Any]) -> dict[str, Any]:
+            seen.append(str(message.get("type")))
+            return real_request(message)
+
+        client._request = recording  # type: ignore[method-assign]
+        assert client.requires_images in (True, False)  # connect + replay only
+        assert "set_state_keys" in seen, seen
+        assert "set_control_frequency" in seen, seen
+
+
+class TestWhatIsUnchanged:
+    """Serialising the connect must not cost the behaviour around it."""
+
+    def test_the_pending_config_still_reaches_the_server(self, parked: Any) -> None:
+        policy, _server, client = parked
+        policy.release.set()
+        assert client.requires_images in (True, False)
+        assert policy.robot_state_keys == ["shoulder_pan", "elbow_flex"]
+
+    def test_close_still_returns_after_a_connect(self, parked: Any) -> None:
+        policy, _server, client = parked
+        policy.release.set()
+        assert client.requires_images in (True, False)
+        client.close()
+        assert client._ws is None
+        client.close()  # idempotent
+        assert client._ws is None


### PR DESCRIPTION
## Problem

`RemotePolicy` serialises its single WebSocket with one lock, and the wire helper
states the precondition in the section header directly above it:

```python
# -- wire helpers (call while holding ``self._lock``) ---------------------

def _request(self, message: dict[str, Any]) -> dict[str, Any]:
```

Four of `_request`'s seven call sites held it. The three inside `_connect` did
not, and those three run *after* `self._ws` is live: the handshake read, then the
replay of any state keys, control frequency and pending reset set before the
connection existed. `_get_actions_blocking` even calls `_ensure_connected()`
*outside* the lock and takes it only for its own request, so the connect sequence
ran its whole replay unlocked on an already-usable connection.

| `_request` call site | lock held |
|---|---|
| `_connect` (state-keys replay) | no |
| `_connect` (control-frequency replay) | no |
| `_connect` (pending-reset replay) | no |
| `set_robot_state_keys` | yes |
| `set_control_frequency` | yes |
| `reset` | yes |
| `_get_actions_blocking` | yes |

## Measured consequence

A server parked inside the replay, a client whose config was set before
connecting, and a second thread on the same policy:

| | before | after |
|---|---|---|
| `self._ws` during the replay | live | live |
| second thread's `reset(seed=7)` | `ConcurrencyError: cannot call recv while another thread is already running recv or recv_streaming` | returns |
| second thread while the replay is open | raised | waiting on the lock |
| connections opened by 8 racing first-callers | up to 8 | 1 |

The report names the transport's internals, out of a call that never mentions
threads, and nothing a caller passed is wrong. The same window is reachable from
`set_robot_state_keys` and from `get_actions`.

## Reachability

Two threads on one policy is the ordinary case here rather than a contrived one.
Every policy coroutine resolves through `_async_utils`' reused worker thread, and
the async-RTC path in `simulation.policy_runner` submits prefetch inference to
its own `rtc-prefetch` worker while the rollout thread carries on stepping - so a
first connect and another call on the same policy land on different threads by
design.

## Why nothing caught it

`tests/inference/` does use threads, but on the *server*: every existing test
runs `PolicyServer` in a background thread and drives the client from one thread
throughout. No test drives the client concurrently, so the suite structurally
could not observe an overlap on the client's own connection.

## Change

`_ensure_connected` holds `self._lock` across `_connect`, with the unlocked fast
path kept and the state re-checked under the lock. None of its three callers
holds the lock, so nothing deadlocks; a concurrent wire user waits for the replay
and then proceeds, which is what the lock was there to do.

Reusing that lock rather than adding a connect-only one is the point, and it is
the row below that measures it: a dedicated lock makes connects mutually
exclusive and still leaves them racing `reset` and `get_actions`.

The precondition is graded at runtime rather than by reading the source. A
witness lock records whether it was held when `_request` ran, so the coverage
`_connect` inherits from its caller counts - a lexical scan would report those
three calls as unlocked either way.

## Mutation table

Every row against the new file (`mine`) and the rest of `tests/inference/` with
it deselected (`sib`); `coll` is the collected count, stable throughout, so no
row hides a deselection.

| id | mutation | mine | coll | sib | firing |
|---|---|---|---|---|---|
| b0 | control, no mutation | 0 | 11 | 0 | - |
| b1 | fix reverted (the shipped defect) | 6 | 11 | 0 | serialisation + precondition + racing |
| b2 | lock held, inner re-check dropped | 1 | 11 | 0 | racing only |
| b3 | lock taken then released before connect | 5-6 | 11 | 0 | serialisation + precondition (+ racing) |
| b4 | unlocked fast path dropped, always acquire | 0 | 11 | 0 | - |
| b5 | a separate `_connect_lock`, not the wire lock | 5 | 11 | 0 | serialisation + precondition |

`b2 | b3 == b1` and b2/b3 are disjoint: the double check and the lock coverage
are independently pinned.

b4 is a measured no-op with a reason - always acquiring is behaviourally
identical to the fast path, only slower - and is reported rather than dropped.

b5 fires b3's set because a connect-only lock serialises connects (so the racing
cell passes) and not the other wire users. That is the distinction between "a
lock" and "the lock", and it is why the fix reuses `self._lock`.

The racing cell detects probabilistically pre-fix: the window is the connect
handshake itself, so staggered starts let the GIL serialise the callers by luck.
With a barrier so all eight arrive together it detects 6 of 8 runs pre-fix and
passes 8 of 8 post-fix; the barrier is in the test for that reason.

## Pre-fix split

6 failed / 5 passed, with roles kept honest:

| class | role | pre-fix |
|---|---|---|
| `TestAConcurrentWireUserWaitsForTheConnectReplay` | regression | 4 of 4 fail |
| `TestEveryWireRequestRunsUnderTheLock` | regression + non-vacuity | 1 of 2 fails |
| `TestTwoRacingFirstCallersOpenOneConnection` | regression | 1 of 1 fails |
| `TestTheConnectReplayIsAWireUser` | premise | 0 of 2 |
| `TestWhatIsUnchanged` | control | 0 of 2 |

The one cell in `TestEveryWireRequestRunsUnderTheLock` that passes both ways is
its non-vacuity half: it asserts the replay's own requests are in the graded set,
which holds either way and is what stops the precondition test passing over a
narrowed drive.

## Gate

* `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean, 1649 files.
* `mypy strands_robots tests tests_integ`: 24 errors in 9 files, the same count as the merge base, 0 in either changed file.
* Paired run over an identical 543-file selection (all of `tests/inference/` plus every guard that walks the tree, parses source, or reads docstrings and `changelog.d`), the new file excluded from both trees, every path verified present on both: identical **24888 collected**, **20 failed on each**, failing-id sets identical, `comm` empty in both directions, distinct rootdirs. The 20 are pre-existing and environmental - 17 need `awsiot`/`awscrt` (declared in the `mesh-iot` extra, absent locally) and 3 are the lerobot-from-source drift in `tests/training/test_lerobot*`.
* `tests/inference/` whole: 135 passed.

The first branch-side run of that selection reported 23, and the three extra were
`tests/test_codeql_query_filters.py`'s derived census of non-reraising
`except BaseException` handlers - the new file added two. They are narrowed to
`except Exception` in the third commit (the failure under test is a
`ConcurrencyError`, a `RuntimeError`), which is what the 20-vs-20 run above
measures.

No visual artifact: this changes when a lock is held and what a concurrent caller
is told, not a policy, simulation, rendering, recording or asset.
