### PR TITLE
fix(simulation): fill the undriven state columns of a synchronized rollout too

### DIFF
--- a/changelog.d/2844-synchronized-rollout-fills-the-undriven-columns.md
+++ b/changelog.d/2844-synchronized-rollout-fills-the-undriven-columns.md
@@ -1,0 +1,46 @@
+### Fixed: a synchronized rollout that drives a subset of the scene records the rest as measurements
+
+`start_recording` declares `observation.state` over EVERY robot in the scene,
+prefixing each column with its robot's name (`alice__shoulder_pan`). A rollout's
+recording hook supplies only the observation of the robots it drives, so every
+column belonging to another robot is absent from the frame and
+`DatasetRecorder.add_frame` writes it as `0.0` - in the same column, with the
+same dtype, as a measurement, for every frame of the episode, under
+`status="success"`. Nothing downstream can tell that zero from a real reading: a
+policy trained on the dataset learns the other robot is permanently at its zero
+pose. `undriven_robot_state` exists to fill those columns from the engine
+instead, and the three single-policy recording hooks went through it.
+
+`run_multi_policy` did not. Its merge loop iterates the keys of `policies`, and
+`SimEngine.run_multi_policy` requires each key to name a robot in the scene
+without requiring the keys to cover it - the constraint runs one way only. So a
+synchronized call that drives a subset of the scene left every other robot to
+the fill, exactly as a single-policy hook did before the helper existed. The
+helper's own docstring credited the synchronized loop with already having the
+guarantee, on the strength of its merging every robot *it drives*.
+
+Measured on a two-robot MuJoCo scene with `bob` parked at `shoulder_pan 0.9`,
+`elbow -0.7` and `policies={"alice": MockPolicy()}`: the schema declared
+`bob__shoulder_pan` and `bob__elbow`, the rollout reported `status="success"`
+with 6 frames and a written MP4, and both of `bob`'s columns were `0.0` in every
+frame - the largest reading the fill replaced being 2.2629 rad. Reading the same
+dataset back after the fix, `bob__shoulder_pan` holds `0.9` across the episode
+and `bob__elbow` traces the 2.52 rad of gravity swing the joint really performed,
+agreeing with the engine's own reading to within 1e-3 rad. The driven robot's
+columns are bit-identical across the two recordings.
+
+The helper now takes the collection of robots a frame drives rather than a single
+name, and both `run_multi_policy` implementations (MuJoCo and Isaac) merge its
+result before their own driven columns, so driven keys still win any collision.
+A bare `str` is refused rather than accepted: a string is iterable per character,
+which would turn the skip into a substring test and drop a robot named `ali` as
+though `alice` drove it - the very fill the helper exists to avoid.
+
+The *action* half of the same frame is unchanged and deliberately so. No command
+was issued to a robot this call does not drive, so its action columns have no
+truthful value to write, and they are left where #1715 left them. The structural
+survey that held each recording entry point to the shared helper covered only the
+single-policy hooks; it is now derived from the backend registry
+`create_simulation` itself resolves and covers `run_multi_policy` for every
+backend that implements one, so Isaac's half of the fix is graded on a machine
+that cannot run Isaac Sim.

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -624,7 +624,7 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 # are filled from the engine at this step rather than left to
                 # add_frame's 0.0 fill, which records them as a zero pose the
                 # robot is not in. Driven keys win any collision.
-                obs = undriven_robot_state(self, robot_name, self._robots)
+                obs = undriven_robot_state(self, (robot_name,), self._robots)
                 obs.update({f"{robot_name}__{k}": v for k, v in scalars.items()})
                 obs.update(images)
                 act = {f"{robot_name}__{k}": v for k, v in action.items()}

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -43,6 +43,7 @@ from strands_robots.simulation.isaac.joint_names import demangle_usd_joint_names
 from strands_robots.simulation.isaac.motion_primitives import IsaacMotionPrimitivesMixin
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
 from strands_robots.simulation.models import registered, registry_entry
+from strands_robots.simulation.recording import undriven_robot_state
 from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
@@ -4321,6 +4322,14 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 if recording and recorder is not None:
                     merged_obs: dict[str, Any] = {}
                     merged_act: dict[str, Any] = {}
+                    # The schema declares a state column for every robot in the
+                    # scene, and ``policies`` need only name robots that exist -
+                    # not all of them. A robot this call does not drive is a
+                    # readable measurement, so its columns are filled from the
+                    # engine at this step rather than left to add_frame's 0.0
+                    # fill, which records them as a zero pose the robot is not
+                    # in. Merged first, so driven keys win any collision.
+                    merged_obs.update(undriven_robot_state(self, policies, self._robots))
                     for rname in policies:
                         if multi_robot:
                             for k, v in per_robot_obs[rname].items():

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5279,7 +5279,7 @@ class MuJoCoSimEngine(
                             # are filled from the engine at this step rather than left to
                             # add_frame's 0.0 fill, which records them as a zero pose the
                             # robot is not in. Driven keys win any collision.
-                            obs_keyed = undriven_robot_state(self, robot_name, world.robots)
+                            obs_keyed = undriven_robot_state(self, (robot_name,), world.robots)
                             obs_keyed.update(
                                 {
                                     (k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v
@@ -5661,6 +5661,14 @@ class MuJoCoSimEngine(
                 if recording and recorder is not None:
                     merged_obs: dict[str, Any] = {}
                     merged_act: dict[str, Any] = {}
+                    # The schema declares a state column for every robot in the
+                    # scene, and ``policies`` need only name robots that exist -
+                    # not all of them. A robot this call does not drive is a
+                    # readable measurement, so its columns are filled from the
+                    # engine at this step rather than left to add_frame's 0.0
+                    # fill, which records them as a zero pose the robot is not
+                    # in. Merged first, so driven keys win any collision.
+                    merged_obs.update(undriven_robot_state(self, policies, self._world.robots))
                     for rname in policies:
                         if multi_robot:
                             for k, v in per_robot_obs[rname].items():

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -541,7 +541,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 # add_frame's 0.0 fill, which records them as a zero pose the
                 # robot is not in. Driven keys win any collision.
                 driven = {(k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v for k, v in obs.items()}
-                obs = undriven_robot_state(self, robot_name, world.robots)
+                obs = undriven_robot_state(self, (robot_name,), world.robots)
                 obs.update(driven)
                 act = {f"{robot_name}__{k}": v for k, v in action.items()}
                 rec.add_frame(

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -30,7 +30,7 @@ import logging
 import math
 import numbers
 import shutil
-from collections.abc import Iterable, Mapping
+from collections.abc import Collection, Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -555,13 +555,13 @@ def _resume_schema_error(diffs: list[str]) -> str:
     )
 
 
-def undriven_robot_state(engine: Any, driven_robot: str, robot_names: Iterable[str]) -> dict[str, Any]:
+def undriven_robot_state(engine: Any, driven_robots: Collection[str], robot_names: Iterable[str]) -> dict[str, Any]:
     """Read the scalar state of every robot a recorded frame does not drive.
 
     ``start_recording`` declares ``observation.state`` over EVERY robot in the
     scene, prefixing each column with its robot's name
-    (``alice__shoulder_pan``). A single-policy rollout's recording hook supplies
-    only the driven robot's observation, so every column belonging to another
+    (``alice__shoulder_pan``). A rollout's recording hook supplies only the
+    observation of the robots it drives, so every column belonging to another
     robot is absent from the frame and
     :meth:`~strands_robots.dataset_recorder.DatasetRecorder.add_frame` writes it
     as ``0.0`` - under ``status="success"``, for every frame of the episode.
@@ -584,14 +584,20 @@ def undriven_robot_state(engine: Any, driven_robot: str, robot_names: Iterable[s
     robot's own columns come from. So the undriven columns are filled with the
     measurement rather than left to the ``0.0`` fill.
 
-    This is the behaviour ``run_multi_policy``'s synchronized loop already has -
-    it builds one merged observation per step covering every robot it drives and
-    hands that to ``add_frame``. This helper is that same guarantee for the
-    three single-policy hooks, so which rollout entry point recorded an episode
-    stops changing whether its state columns are measurements.
+    Every recording entry point needs this, because each one declares the
+    schema over the whole scene and then supplies a frame covering only the
+    robots it drives. That is the three single-policy hooks, whose frame
+    carries one robot, and ``run_multi_policy``'s synchronized loop, whose
+    merged frame carries the keys of its ``policies`` mapping - which
+    :meth:`~strands_robots.simulation.base.SimEngine.run_multi_policy`
+    requires to name robots in the scene but never requires to name all of
+    them. A synchronized call that drives a subset therefore leaves the rest
+    to the fill exactly as a single-policy hook does, so both go through here
+    and which rollout entry point recorded an episode does not change whether
+    its state columns are measurements.
 
     Images are deliberately not collected. A camera array is keyed by the
-    camera's own name rather than a robot's, and the recording hooks scope
+    camera's own name rather than a robot's, and the recording paths scope
     cameras through ``start_recording(cameras=...)``, so an undriven robot
     contributes no image column. Only scalars are returned, prefixed exactly as
     the hooks prefix the driven robot's.
@@ -599,19 +605,34 @@ def undriven_robot_state(engine: Any, driven_robot: str, robot_names: Iterable[s
     Args:
         engine: The simulation engine, read through its public
             ``get_observation(robot_name=..., skip_images=True)``.
-        driven_robot: The robot this frame drives; its columns are supplied by
-            the hook itself and are not re-read here.
+        driven_robots: The robots this frame drives; their columns are
+            supplied by the caller and are not re-read here. Pass ``(name,)``
+            from a single-policy hook and the ``policies`` mapping from a
+            synchronized multi-robot loop.
         robot_names: Every robot the dataset schema declares columns for.
 
     Returns:
         ``{"<robot>__<joint>": value}`` for each scalar observation of each
-        robot other than ``driven_robot``. Empty when the scene holds only the
-        driven robot, which is the single-robot case where the schema is not
-        prefixed at all.
+        robot outside ``driven_robots``. Empty when every robot in the scene
+        is driven, which includes the single-robot case where the schema is
+        not prefixed at all.
+
+    Raises:
+        TypeError: ``driven_robots`` is a bare ``str``. A string is iterable
+            per character, so it would make the skip below a substring test:
+            a robot named ``ali`` satisfies ``"ali" in "alice"`` and would be
+            skipped as though it were driven, dropping its columns to the
+            very fill this helper exists to avoid.
     """
+    if isinstance(driven_robots, str):
+        raise TypeError(
+            "undriven_robot_state: 'driven_robots' must be a collection of robot names, "
+            f"not the bare string {driven_robots!r}. Pass ({driven_robots!r},) to name one."
+        )
+    driven = frozenset(driven_robots)
     merged: dict[str, Any] = {}
     for name in robot_names:
-        if name == driven_robot:
+        if name in driven:
             continue
         try:
             observation = engine.get_observation(robot_name=name, skip_images=True)

--- a/tests/simulation/test_recorded_undriven_robot_state.py
+++ b/tests/simulation/test_recorded_undriven_robot_state.py
@@ -17,14 +17,20 @@ touched here - no command was issued to a robot this rollout does not drive, so
 there is no truthful value to write (#1715). A state column has one: the robot
 is in the scene and its joint positions are readable at that instant.
 
-``run_multi_policy``'s synchronized loop already merged every robot's state into
-one frame per step, so this was the three single-policy hooks disagreeing with
-the one path that had it right.
+Every recording entry point declares the schema over the whole scene and then
+supplies a frame covering only the robots it drives, so each one needs the same
+fill. That is the three single-policy hooks, whose frame carries one robot, and
+``run_multi_policy``'s synchronized loop, whose merged frame carries the keys of
+its ``policies`` mapping - a mapping the contract requires to name robots in the
+scene, but never requires to name all of them. A synchronized call that drives a
+subset of the scene therefore leaves the rest to the fill exactly as a
+single-policy hook does.
 """
 
 from __future__ import annotations
 
 import ast
+import importlib
 import inspect
 import json
 import pathlib
@@ -37,6 +43,7 @@ import pytest
 pytest.importorskip("mujoco")
 pytest.importorskip("lerobot")
 
+from strands_robots.simulation.base import SimEngine  # noqa: E402
 from strands_robots.simulation.recording import undriven_robot_state  # noqa: E402
 
 _ROBOT_XML = """
@@ -87,8 +94,8 @@ def two_robot_recording(tmp_path: pathlib.Path) -> Any:
     return sim
 
 
-def _record_one_episode(sim: Any, root: pathlib.Path) -> dict[str, Any]:
-    """Drive ``alice`` for a few steps with a recording open, then read the parquet."""
+def _open_recording(sim: Any, root: pathlib.Path) -> None:
+    """Declare the dataset schema over the whole scene."""
     assert (
         sim.start_recording(
             repo_id="local/undriven_state_probe",
@@ -100,6 +107,34 @@ def _record_one_episode(sim: Any, root: pathlib.Path) -> dict[str, Any]:
         )["status"]
         == "success"
     )
+
+
+def _read_back(root: pathlib.Path) -> dict[str, Any]:
+    """Reopen the recorded dataset and return its declared names and columns.
+
+    Read through the public reader rather than the parquet, so this is the round
+    trip a consumer of the dataset actually performs.
+    """
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    info = json.loads((root / "meta" / "info.json").read_text(encoding="utf-8"))
+    dataset = LeRobotDataset("local/undriven_state_probe", root=str(root))
+    assert len(dataset) > 0, f"reopened dataset at {root} is empty"
+
+    def _column(key: str) -> Any:
+        return np.stack([np.asarray(dataset[i][key], dtype=np.float64) for i in range(len(dataset))])
+
+    return {
+        "names": info["features"]["observation.state"]["names"],
+        "state": _column("observation.state"),
+        "action_names": info["features"]["action"]["names"],
+        "action": _column("action"),
+    }
+
+
+def _record_one_episode(sim: Any, root: pathlib.Path) -> dict[str, Any]:
+    """Drive ``alice`` through the single-policy hook, then read the dataset."""
+    _open_recording(sim, root)
     assert (
         sim.run_policy(
             robot_name="alice",
@@ -112,17 +147,64 @@ def _record_one_episode(sim: Any, root: pathlib.Path) -> dict[str, Any]:
         == "success"
     )
     assert sim.stop_recording()["status"] == "success"
+    return _read_back(root)
 
-    # Read back through the public reader rather than the parquet, so this is
-    # the round trip a consumer of the dataset actually performs.
-    from lerobot.datasets.lerobot_dataset import LeRobotDataset
 
-    info = json.loads((root / "meta" / "info.json").read_text(encoding="utf-8"))
-    names = info["features"]["observation.state"]["names"]
-    dataset = LeRobotDataset("local/undriven_state_probe", root=str(root))
-    assert len(dataset) > 0, f"reopened dataset at {root} is empty"
-    state = np.stack([np.asarray(dataset[i]["observation.state"], dtype=np.float64) for i in range(len(dataset))])
-    return {"names": names, "state": state}
+def _record_one_synchronized_episode(sim: Any, root: pathlib.Path) -> dict[str, Any]:
+    """Drive ``alice`` alone through ``run_multi_policy``, then read the dataset.
+
+    ``bob`` is in the scene and so has declared columns, but is absent from
+    ``policies`` - the subset case the contract permits.
+    """
+    from strands_robots.policies import MockPolicy
+
+    _open_recording(sim, root)
+    assert (
+        sim.run_multi_policy(
+            policies={"alice": MockPolicy()},
+            instructions="probe",
+            n_steps=5,
+            control_frequency=10.0,
+        )["status"]
+        == "success"
+    )
+    assert sim.stop_recording()["status"] == "success"
+    return _read_back(root)
+
+
+def _backend_engines() -> list[tuple[str, Any]]:
+    """Every built-in backend engine class, read from the registry.
+
+    Derived rather than listed so a backend added later is surveyed without a
+    second edit. Every engine module imports without its heavy simulator, which
+    is what lets this run on a machine that has only one backend installed.
+    """
+    from strands_robots.simulation.factory import _BUILTIN_BACKENDS
+
+    return [
+        (backend, getattr(importlib.import_module(module_name), attr))
+        for backend, (module_name, attr) in sorted(_BUILTIN_BACKENDS.items())
+    ]
+
+
+#: ``(backend, engine class)`` for every built-in backend.
+_BACKEND_ENGINES = _backend_engines()
+
+#: The subset that implements its own ``run_multi_policy`` rather than
+#: inheriting the base contract, so only those have a merge loop to survey.
+_SYNCHRONIZED_ENGINES = [
+    (backend, engine)
+    for backend, engine in _BACKEND_ENGINES
+    if engine.run_multi_policy is not SimEngine.run_multi_policy
+]
+
+
+def _calls_the_shared_owner(func: Any) -> bool:
+    """Whether ``func``'s source calls ``undriven_robot_state`` by name."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    return "undriven_robot_state" in {
+        node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
 
 
 class TestAnUndrivenRobotsStateIsRecordedAsMeasured:
@@ -193,7 +275,10 @@ class TestAnUndrivenRobotsStateIsRecordedAsMeasured:
         monkeypatch.setattr(
             mujoco_sim,
             "undriven_robot_state",
-            lambda engine, driven, names: {f"{driven}__shoulder_pan": sentinel, "bob__shoulder_pan": sentinel},
+            lambda engine, driven, names: {
+                **{f"{name}__shoulder_pan": sentinel for name in driven},
+                "bob__shoulder_pan": sentinel,
+            },
         )
         recorded = _record_one_episode(two_robot_recording, tmp_path / "ds_precedence")
         driven = recorded["names"].index("alice__shoulder_pan")
@@ -225,59 +310,162 @@ class TestTheHelperReadsOnlyWhatItShould:
     def test_the_driven_robot_is_not_re_read(self) -> None:
         """The hook already carries the driven robot's own observation."""
         engine = self._Engine({"alice": {"j": 1.0}, "bob": {"j": 2.0}})
-        assert undriven_robot_state(engine, "alice", ["alice", "bob"]) == {"bob__j": 2.0}
+        assert undriven_robot_state(engine, ("alice",), ["alice", "bob"]) == {"bob__j": 2.0}
         assert engine.asked == ["bob"]
 
     def test_a_single_robot_scene_yields_nothing(self) -> None:
         """A one-robot schema is not prefixed, so there is nothing to fill."""
         engine = self._Engine({"alice": {"j": 1.0}})
-        assert undriven_robot_state(engine, "alice", ["alice"]) == {}
+        assert undriven_robot_state(engine, ("alice",), ["alice"]) == {}
         assert engine.asked == []
 
     def test_array_values_are_left_out(self) -> None:
         """A camera frame is keyed by the camera, never by a robot."""
         engine = self._Engine({"bob": {"j": 2.0, "wrist": np.zeros((2, 2, 3), dtype=np.uint8)}})
-        assert undriven_robot_state(engine, "alice", ["alice", "bob"]) == {"bob__j": 2.0}
+        assert undriven_robot_state(engine, ("alice",), ["alice", "bob"]) == {"bob__j": 2.0}
 
     def test_a_failed_read_does_not_lose_the_episode(self) -> None:
         """The driven robot's columns are the rollout's primary product."""
         engine = self._Engine({"bob": {"j": 2.0}, "carol": {"j": 3.0}}, raises={"bob"})
-        assert undriven_robot_state(engine, "alice", ["alice", "bob", "carol"]) == {"carol__j": 3.0}
+        assert undriven_robot_state(engine, ("alice",), ["alice", "bob", "carol"]) == {"carol__j": 3.0}
+
+    def test_every_driven_robot_is_skipped_not_only_the_first(self) -> None:
+        """A synchronized loop drives several robots, so the skip is a set test."""
+        engine = self._Engine({"alice": {"j": 1.0}, "bob": {"j": 2.0}, "carol": {"j": 3.0}})
+        assert undriven_robot_state(engine, ("alice", "bob"), ["alice", "bob", "carol"]) == {"carol__j": 3.0}
+        assert engine.asked == ["carol"]
+
+    def test_a_bare_string_is_refused(self) -> None:
+        """A string is iterable per character, so it would skip by substring.
+
+        A robot named ``ali`` satisfies ``"ali" in "alice"`` and would be
+        skipped as though it were driven - dropping its columns to the very
+        fill this helper exists to avoid.
+        """
+        engine = self._Engine({"ali": {"j": 1.0}})
+        with pytest.raises(TypeError, match="must be a collection of robot names"):
+            undriven_robot_state(engine, "alice", ["alice", "ali"])
+        assert engine.asked == [], "the refusal must precede any read"
 
 
-class TestEverySinglePolicyHookConsultsTheSharedOwner:
-    """A fourth backend cannot reintroduce the fill by forgetting the helper."""
+class TestEveryRecordingEntryPointConsultsTheSharedOwner:
+    """A backend cannot reintroduce the fill by forgetting the helper.
 
-    #: Each backend's single-policy recording hook, as ``(module, attribute)``.
-    HOOKS = [
-        ("strands_robots.simulation.mujoco.simulation", "MuJoCoSimEngine"),
-        ("strands_robots.simulation.isaac.recording", "IsaacRecordingMixin"),
-        ("strands_robots.simulation.newton.recording", "NewtonRecordingMixin"),
-    ]
+    Both kinds of entry point declare the schema over the whole scene and then
+    supply a frame covering only what they drive, so both are surveyed: the
+    single-policy hook every backend has, and ``run_multi_policy`` for each
+    backend that implements its own. The population is read from the backend
+    registry :func:`~strands_robots.simulation.create_simulation` itself
+    resolves, rather than listed here, so a backend added later is held to this
+    the hour it lands.
+    """
 
-    def _hook_source(self, module_name: str, attr: str) -> str:
-        import importlib
+    def test_the_survey_reaches_every_known_backend(self) -> None:
+        """Premise: a narrowed survey would make every check below vacuous."""
+        surveyed = {backend for backend, _ in _BACKEND_ENGINES}
+        assert {"mujoco", "newton", "isaac"} <= surveyed, (
+            f"the backend registry no longer resolves every known backend: {sorted(surveyed)}"
+        )
 
-        module = importlib.import_module(module_name)
-        owner = getattr(module, attr)
-        return inspect.getsource(owner._make_run_policy_hook)
+    def test_the_synchronized_survey_is_not_empty(self) -> None:
+        """Premise: the backends that implement the synchronized loop are graded.
 
-    def test_the_hooks_under_survey_all_exist(self) -> None:
-        """Premise: a renamed backend would make every check below vacuous."""
-        for module_name, attr in self.HOOKS:
-            assert self._hook_source(module_name, attr), f"{module_name}.{attr} has no readable hook source"
+        ``run_multi_policy`` is optional - a backend that inherits the base
+        contract without implementing it has no merge loop to survey - so this
+        pins that the two which do implement it are still reached.
+        """
+        assert {"mujoco", "isaac"} <= {backend for backend, _ in _SYNCHRONIZED_ENGINES}
 
-    @pytest.mark.parametrize(("module_name", "attr"), HOOKS)
-    def test_the_hook_fills_undriven_columns_from_the_shared_owner(self, module_name: str, attr: str) -> None:
-        """Each hook resolves the undriven columns through the one helper."""
-        source = self._hook_source(module_name, attr)
-        called = {
-            node.func.id
-            for node in ast.walk(ast.parse(textwrap.dedent(source)))
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-        }
-        assert "undriven_robot_state" in called, (
-            f"{module_name}.{attr}._make_run_policy_hook does not call undriven_robot_state, so a "
+    @pytest.mark.parametrize(("backend", "engine"), _BACKEND_ENGINES, ids=[backend for backend, _ in _BACKEND_ENGINES])
+    def test_the_single_policy_hook_fills_undriven_columns(self, backend: str, engine: Any) -> None:
+        """Each backend's per-step hook resolves the undriven columns here."""
+        assert _calls_the_shared_owner(engine._make_run_policy_hook), (
+            f"{backend}'s _make_run_policy_hook does not call undriven_robot_state, so a "
             "multi-robot recording made through it writes the other robots' declared "
             "observation.state columns as add_frame's 0.0 fill"
         )
+
+    @pytest.mark.parametrize(
+        ("backend", "engine"),
+        _SYNCHRONIZED_ENGINES,
+        ids=[backend for backend, _ in _SYNCHRONIZED_ENGINES],
+    )
+    def test_the_synchronized_loop_fills_undriven_columns(self, backend: str, engine: Any) -> None:
+        """Each backend's ``run_multi_policy`` merge resolves them here too."""
+        assert _calls_the_shared_owner(engine.run_multi_policy), (
+            f"{backend}'s run_multi_policy does not call undriven_robot_state, so a "
+            "synchronized rollout that drives a subset of the scene writes the robots it "
+            "does not drive as add_frame's 0.0 fill"
+        )
+
+
+class TestASynchronizedLoopThatDrivesASubsetFillsTheRest:
+    """The regression: ``run_multi_policy`` need not name every robot in the scene."""
+
+    def test_the_contract_permits_driving_a_subset(self) -> None:
+        """Premise: the mapping constraint runs one way only.
+
+        Every key must name a robot in the scene, and nothing requires the keys
+        to cover it - which is what leaves a bystander's declared columns to the
+        fill.
+        """
+        contract = " ".join((SimEngine.run_multi_policy.__doc__ or "").split())
+        assert "Every key must name a robot in the scene" in contract
+
+    def test_the_schema_declares_the_undriven_robots_columns(self, two_robot_recording: Any, tmp_path: Any) -> None:
+        """Premise: without declared ``bob__*`` columns there is nothing to fill."""
+        recorded = _record_one_synchronized_episode(two_robot_recording, tmp_path / "sync_schema")
+        assert [n for n in recorded["names"] if n.startswith("bob__")] == ["bob__shoulder_pan", "bob__elbow"]
+
+    def test_the_undriven_robots_columns_are_not_the_zero_fill(self, two_robot_recording: Any, tmp_path: Any) -> None:
+        """The defect: driving a subset used to record the rest as ``0.0``."""
+        recorded = _record_one_synchronized_episode(two_robot_recording, tmp_path / "sync_zero")
+        idx = [i for i, n in enumerate(recorded["names"]) if n.startswith("bob__")]
+        column = recorded["state"][:, idx]
+        assert not np.allclose(column, 0.0), (
+            "run_multi_policy recorded every declared observation.state column of 'bob' - a robot "
+            f"in the scene but absent from policies - as the 0.0 fill while it is parked at "
+            f"{_PARKED}: {column.tolist()}"
+        )
+
+    def test_the_undriven_robots_columns_match_the_engines_own_reading(
+        self, two_robot_recording: Any, tmp_path: Any
+    ) -> None:
+        """The recorded value is the measurement, not merely non-zero."""
+        sim = two_robot_recording
+        recorded = _record_one_synchronized_episode(sim, tmp_path / "sync_match")
+        truth = sim.get_observation(robot_name="bob", skip_images=True)
+        for i, name in enumerate(recorded["names"]):
+            if not name.startswith("bob__"):
+                continue
+            joint = name.removeprefix("bob__")
+            assert float(recorded["state"][-1][i]) == pytest.approx(float(truth[joint]), abs=1e-3), (
+                f"{name} on disk disagrees with the engine's own reading of bob's {joint}"
+            )
+
+    def test_the_driven_robots_columns_still_track_a_real_trajectory(
+        self, two_robot_recording: Any, tmp_path: Any
+    ) -> None:
+        """Control: filling the undriven columns must not flatten the driven ones."""
+        recorded = _record_one_synchronized_episode(two_robot_recording, tmp_path / "sync_driven")
+        idx = [i for i, n in enumerate(recorded["names"]) if n.startswith("alice__")]
+        assert idx, "premise: the driven robot must have declared columns too"
+        column = recorded["state"][:, idx]
+        assert np.ptp(column, axis=0).max() > 1e-4, (
+            f"the driven robot's own columns no longer vary across the episode: {column.tolist()}"
+        )
+
+    def test_the_undriven_robots_action_columns_are_left_to_the_fill(
+        self, two_robot_recording: Any, tmp_path: Any
+    ) -> None:
+        """The boundary: only the *state* half is filled, deliberately.
+
+        No command was issued to a robot this call does not drive, so its action
+        columns have no truthful value to write and are left where #1715 left
+        them. Pinned so widening the fill to the action half is a visible
+        decision rather than a side effect.
+        """
+        recorded = _record_one_synchronized_episode(two_robot_recording, tmp_path / "sync_action")
+        idx = [i for i, n in enumerate(recorded["action_names"]) if n.startswith("bob__")]
+        assert idx, "premise: the schema declares action columns for the undriven robot"
+        assert np.allclose(recorded["action"][:, idx], 0.0)


### PR DESCRIPTION
## Problem

`start_recording` declares `observation.state` over **every** robot in the scene, prefixing each column with its robot's name (`alice__shoulder_pan`). A rollout's recording hook supplies only the observation of the robots it drives, so every column belonging to another robot is absent from the frame and `DatasetRecorder.add_frame` writes it as `0.0` — in the same column, with the same dtype, as a measurement, for every frame, under `status="success"`. Nothing downstream can tell that zero from a real reading.

`undriven_robot_state` exists to fill those columns from the engine instead, and the three single-policy recording hooks go through it. `run_multi_policy` does not. Its merge loop iterates the keys of `policies`:

```python
for rname in policies:
    if multi_robot:
        for k, v in per_robot_obs[rname].items():
            merged_obs[f"{rname}__{k}"] = v
```

and `SimEngine.run_multi_policy` requires each key to name a robot in the scene *without* requiring the keys to cover it — the constraint runs one way only. Meanwhile `multi_robot = len(self._world.robots) > 1` is computed over the whole scene, so the schema is prefixed for a bystander whose columns the merge never produces. A synchronized call that drives a subset therefore left every other robot to the fill, exactly as a single-policy hook did before the helper existed.

The helper's own docstring credited the synchronized loop with already having the guarantee, on the strength of its merging every robot *it drives*.

## Measured

Two-robot MuJoCo scene, `bob` parked at `shoulder_pan 0.9` / `elbow -0.7`, `policies={"alice": MockPolicy()}`, read back through `LeRobotDataset`:

| | before | after |
|---|---|---|
| declared columns | `alice__shoulder_pan, alice__elbow, bob__shoulder_pan, bob__elbow` | same |
| reported | `status="success"`, 6 frames, MP4 written | same |
| `bob__shoulder_pan` | `0.0` every frame | `0.9000` every frame |
| `bob__elbow` | `0.0` every frame | traces 2.52 rad of real gravity swing |
| largest reading the fill replaced | 2.2629 rad | — |
| last frame vs the engine's own reading | disagrees | agrees to within 1e-3 rad |
| driven robot's columns | — | bit-identical to before |

## Change

`undriven_robot_state` now takes the collection of robots a frame drives rather than a single name; both `run_multi_policy` implementations (MuJoCo and Isaac) merge its result **before** their own driven columns, so driven keys still win any collision. A bare `str` is refused: a string is iterable per character, which would turn the skip into a substring test and drop a robot named `ali` as though `alice` drove it — the very fill the helper exists to avoid.

The **action** half of the same frame is unchanged and deliberately so: no command was issued to a robot this call does not drive, so its action columns have no truthful value to write. Pinned, so widening the fill there is a visible decision rather than a side effect.

## Tests

Added beside the single-policy cells that pin the same property, so the parity is visible. Behavioural pre-fix split **4 failed / 21 passed**, with 0 failures in every premise, control, boundary and pre-existing class. The whole defect fires **0** of 233 pre-existing cells in the surrounding `run_multi_policy` and recording suites — nothing else could see it.

The structural survey that held each recording entry point to the shared helper covered only the single-policy hooks. It is now derived from the backend registry `create_simulation` itself resolves, and covers `run_multi_policy` for each backend that implements one, so **Isaac's half of the fix is graded on a machine that cannot run Isaac Sim**.

| mutation | fires | collected | note |
|---|---|---|---|
| control | 0 | 25 | |
| both synchronized fills dropped | 4 | 25 | the defect |
| MuJoCo fill only | 3 | 25 | 2 behavioural + structural[mujoco] |
| Isaac fill only | 1 | 25 | structural[isaac] alone |
| bare-`str` refusal dropped | 1 | 25 | |
| skip reverted to equality against the collection | 3 | 25 | |
| fill merged after the driven loop | 0 | 25 | measured no-op: the two key sets are disjoint by construction |
| Isaac fill dropped **and** the survey narrowed to the hooks | 0 | 22 | Isaac's defect is silent without the derived survey |
| the survey narrowed, no defect | 0 | 22 | the narrowing alone fires nothing |
| both fills dropped **and** the survey narrowed | 2 | 22 | only the MuJoCo-reachable behavioural cells |

`MuJoCo fill only` and `Isaac fill only` are disjoint and their union is exactly the full defect, so each backend's half is independently pinned.

## Gate

- `ruff check` / `ruff format --check` clean over 1648 files.
- `mypy` **24 == 24** against a pristine base worktree, normalized message sets byte-identical both directions, **0** attributable to the changed files.
- Paired run over an identical 600-file selection (all of `tests/simulation/` plus every tree-walking, source-parsing and docstring guard), the changed test file excluded from both trees: identical **20713 collected** and `5 failed, 20461 passed, 247 skipped` on each, failing-ID sets identical with `comm` empty both directions. All 5 pass **29/29 in isolation** — a large-selection module-caching artifact in `test_recording_frame_loss_is_not_tolerated.py` plus one wall-clock pacer, present on both trees.

## Artifact

One synchronized episode recorded twice from an identical scene, MuJoCo headless (EGL). Every number in the figure is asserted from the two captures before it is drawn.

![undriven state columns of a synchronized rollout](https://github.com/cagataycali/robots/releases/download/artifacts/pr2844-undriven-columns.png)
