### PR TITLE
fix(isaac): refuse a non-finite mesh scale wherever it is carried, not only where it is measured

### DIFF
--- a/changelog.d/2845-mesh-scale-refused-wherever-it-is-carried.md
+++ b/changelog.d/2845-mesh-scale-refused-wherever-it-is-carried.md
@@ -1,0 +1,27 @@
+### Fixed: a non-finite MJCF mesh scale is refused on every body that carries it
+
+`mesh_aabb` refuses a `<mesh scale=...>` whose components are not all finite,
+because it measures `vertex * scale` and `min`/`max` order a NaN as neither
+smaller nor larger than anything. `load_mjcf_scene_objects` reaches that
+measurement only on the branch where no collidable analytic geom supplied the
+bound - yet it carries the scale onto the `SceneObject` on every branch, and the
+Isaac realization applies it to the visual prim's xform.
+
+So a body declaring both a collidable geom and a visual mesh took its bound from
+the geom, never measured, and reported `mesh_scale=(nan, 1.0, 1.0)` under
+`success`. `position`, `size` and `offset` all stayed finite and correct, because
+the collidable geom supplied them, so every field a consumer would screen for a
+non-finite value was healthy. 53 of the 63 mesh-carrying bodies in the shipped
+registry are in that shape.
+
+The value lands in one `_author_local_xform(translate=..., orient_wxyz=...,
+scale=...)` call whose other two arguments come from `mesh_pos` and `mesh_quat`,
+both already refused when they are not finite. The finiteness test now lives in
+`refuse_non_finite_scale`, the single owner both consumers call, and the loader
+reaches it where the scale is read - beside the missing-file contract, for the
+same reason: an asset declaration a body reaches has to be usable. The refusal's
+wording gains the xform consequence alongside the sizing one.
+
+A finite scale is untouched, including the 250 non-unit and the negative and zero
+ones the shipped corpus declares. All 60 resolvable registry models still load,
+and none declares a non-finite scale anywhere.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -2248,7 +2248,12 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
         measured around one reports a collision bound for geometry the scene
         does not declare, so it is refused rather than approximated).
     """
-    from strands_robots.simulation.isaac.mesh_assets import MESH_EXTENSIONS, USD_EXTENSIONS, mesh_aabb
+    from strands_robots.simulation.isaac.mesh_assets import (
+        MESH_EXTENSIONS,
+        USD_EXTENSIONS,
+        mesh_aabb,
+        refuse_non_finite_scale,
+    )
 
     _require_existing_file(path, "MJCF scene")
     root = _parse_xml(path, "MJCF scene")
@@ -2307,6 +2312,15 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
             asset = mesh_registry.get(mesh_name)
             if asset is not None:
                 candidate_path, mesh_scale = asset
+                # Refused here rather than at the measurement below, because the
+                # scale rides onto the scene object whichever branch supplies the
+                # bound: a body with collidable geometry takes the analytic bound
+                # and never measures, yet the realization still applies this scale
+                # to the visual prim's xform, beside the mesh geom's position and
+                # orientation - which are already refused when they are not
+                # finite. Placed beside the missing-file contract for the same
+                # reason: an asset declaration a body reaches has to be usable.
+                refuse_non_finite_scale(candidate_path, mesh_scale)
                 ext = os.path.splitext(candidate_path)[1].lower()
                 if ext in MESH_EXTENSIONS or ext in USD_EXTENSIONS:
                     if not os.path.isfile(candidate_path):

--- a/strands_robots/simulation/isaac/mesh_assets.py
+++ b/strands_robots/simulation/isaac/mesh_assets.py
@@ -56,6 +56,7 @@ __all__ = [
     "load_mesh_geometry",
     "mesh_aabb",
     "mesh_usd_cache_dir",
+    "refuse_non_finite_scale",
     "convert_mesh_to_usd",
 ]
 
@@ -137,6 +138,16 @@ def _non_finite_scale_error(mesh_path: str, scale: tuple[float, float, float]) -
     finite is therefore not enough: the transform applied to them has to be
     finite too, and it arrives from the caller rather than from the file.
 
+    The scale has two consumers and only one of them measures. :func:`mesh_aabb`
+    measures through it, and
+    :func:`~strands_robots.simulation.isaac.loaders.load_mjcf_scene_objects`
+    also *carries* it onto the scene object it builds, where the Isaac
+    realization applies it to the visual prim's xform alongside the mesh geom's
+    position and orientation. Those two siblings are already refused when they
+    are not finite, and all three are arguments of the same
+    ``_author_local_xform`` call, so the scale is held to the same test as the
+    values it travels with rather than to the reach of the measurement.
+
     The two components fail differently and neither is screenable:
 
     * A NaN axis reports a centre of NaN and, because the reported extent is
@@ -154,9 +165,35 @@ def _non_finite_scale_error(mesh_path: str, scale: tuple[float, float, float]) -
     """
     return ValueError(
         f"mesh {mesh_path}: scale has a component that is not finite ({scale!r}) - a mesh measured "
-        f"through it reports a centre that is not a position and an extent floored at 1e-4, so the "
-        f"asset is refused instead of being sized"
+        f"through it reports a centre that is not a position and an extent floored at 1e-4, and a "
+        f"visual prim authored with it is scaled by a value that is not a length, so the asset is "
+        f"refused instead of being carried"
     )
+
+
+def refuse_non_finite_scale(mesh_path: str, scale: tuple[float, float, float]) -> None:
+    """Refuse a mesh scale that parsed but is not finite.
+
+    The single owner of the scale finiteness test, so the measurement and the
+    passthrough cannot drift into tolerating what the other refuses.
+    :func:`mesh_aabb` reaches it because it measures ``vertex * scale``;
+    :func:`~strands_robots.simulation.isaac.loaders.load_mjcf_scene_objects`
+    reaches it because it carries the scale onto the scene object whether or not
+    it measures through it - a body whose bound comes from its collidable
+    geometry never calls the measurement, so a check that lived only there
+    covered the minority of the bodies that carry a scale.
+
+    Args:
+        mesh_path: The asset at fault, named in the refusal.
+        scale: The parsed per-axis scale components.
+
+    Raises:
+        ValueError: If any component of ``scale`` is not finite
+            (:func:`_non_finite_scale_error`).
+    """
+    if all(map(math.isfinite, scale)):
+        return
+    raise _non_finite_scale_error(mesh_path, scale)
 
 
 def load_mesh_geometry(
@@ -448,8 +485,7 @@ def mesh_aabb(
         reported extent's ``1e-4`` floor makes a NaN axis look like a
         plausible sub-millimetre asset rather than a failure.
     """
-    if not all(map(math.isfinite, scale)):
-        raise _non_finite_scale_error(mesh_path, scale)
+    refuse_non_finite_scale(mesh_path, scale)
     points, _counts, _indices = load_mesh_geometry(mesh_path)
     mins = [float("inf")] * 3
     maxs = [float("-inf")] * 3

--- a/tests/simulation/isaac/test_mesh_asset_scale_is_refused_wherever_it_is_carried.py
+++ b/tests/simulation/isaac/test_mesh_asset_scale_is_refused_wherever_it_is_carried.py
@@ -1,0 +1,257 @@
+"""A non-finite mesh scale is refused on every body that carries it, not only where it is measured.
+
+:func:`~strands_robots.simulation.isaac.mesh_assets.mesh_aabb` refuses a scale
+whose components are not all finite, because it measures ``vertex * scale`` and
+``min``/``max`` order a NaN as neither smaller nor larger than anything, so the
+running comparison drops every vertex on that axis.
+
+The scale has a *second* consumer.
+:func:`~strands_robots.simulation.isaac.loaders.load_mjcf_scene_objects` carries
+it onto the :class:`~strands_robots.simulation.isaac.loaders.SceneObject` it
+builds, and the Isaac realization applies it to the visual prim's xform. That
+happens on every body that declares a mesh, while the *measurement* happens only
+on the branch where no collidable analytic geom supplied the bound - so a check
+that lived only at the measurement covered the minority of the bodies that carry
+a scale.
+
+The reason to hold the scale to the same test is the call it lands in. The
+realization authors the visual prim with one
+``_author_local_xform(translate=..., orient_wxyz=..., scale=...)``, whose three
+arguments come from ``mesh_pos``, ``mesh_quat`` and ``mesh_scale``. The first two
+are already refused when they are not finite. On a body with a collidable box,
+``pos="nan 0 0"`` on the mesh geom and ``quat="nan 1 0 0"`` on the mesh geom were
+both refused while ``scale="nan 1 1"`` on the asset it references was reported as
+``mesh_scale=(nan, 1.0, 1.0)`` under ``success`` - and ``position``, ``size`` and
+``offset`` all stayed finite and correct, because the collidable geom supplied
+them. Every field a consumer would screen for a non-finite value was healthy.
+
+The classes below pin, in order: the refusal on both templates for both values on
+every axis; that the two siblings of the same xform call were already refused,
+which is the reason this one is too; that a finite scale - negative, zero and
+non-unit included - is unchanged on both templates; the premises that make the
+refusal necessary (MuJoCo compiles the model, and the collidable body really does
+take its bound from its geom rather than from the measurement); and that the
+finiteness test has a single owner both consumers reach.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+from pathlib import Path
+
+import pytest
+
+from strands_robots.simulation.isaac import loaders, mesh_assets
+from strands_robots.simulation.isaac.loaders import load_mjcf_scene_objects
+from strands_robots.simulation.isaac.mesh_assets import mesh_aabb, refuse_non_finite_scale
+from tests.simulation.isaac.test_mesh_asset_scale_must_be_finite import (
+    _MESH_ONLY,
+    _WITH_COLLISION,
+    AXES,
+    NAN,
+    NON_FINITE,
+    REFUSAL,
+    _asset,
+    _scale,
+    _scene,
+    _widget,
+)
+
+#: Both body shapes, named by which branch supplies the reported bound. The
+#: measurement is reached only by the first; the carry happens on both.
+TEMPLATES = (("mesh-only", _MESH_ONLY), ("with-collision", _WITH_COLLISION))
+
+#: A finite scale that is not unit, so a control cannot pass by the value
+#: happening to be the default.
+FINITE_NON_UNIT = "3 3 3"
+
+
+def _spell(scale: tuple[float, float, float]) -> str:
+    return " ".join(repr(component) for component in scale)
+
+
+class TestTheScaleIsRefusedOnEveryBodyThatCarriesIt:
+    """Both templates, both non-finite values, every axis.
+
+    The mesh-only rows were already refused at the measurement; the
+    with-collision rows are the ones that reported success while carrying the
+    value onto the scene object.
+    """
+
+    @pytest.mark.parametrize("shape,template", TEMPLATES, ids=[name for name, _ in TEMPLATES])
+    @pytest.mark.parametrize("axis", AXES)
+    @pytest.mark.parametrize("value", NON_FINITE, ids=["nan", "inf", "-inf"])
+    def test_the_scene_is_refused(self, tmp_path: Path, shape: str, template: str, axis: int, value: float) -> None:
+        scene = _scene(tmp_path, template, _spell(_scale(axis, value)))
+        with pytest.raises(ValueError, match=REFUSAL):
+            load_mjcf_scene_objects(scene)
+
+    def test_the_refusal_names_the_asset_and_the_value(self, tmp_path: Path) -> None:
+        scene = _scene(tmp_path, _WITH_COLLISION, "nan 1 1")
+        with pytest.raises(ValueError) as caught:
+            load_mjcf_scene_objects(scene)
+        text = str(caught.value)
+        assert "asset.stl" in text, text
+        assert "nan" in text.lower(), text
+
+    def test_the_refusal_names_the_visual_xform_as_well_as_the_measurement(self, tmp_path: Path) -> None:
+        # The value reaches the xform on a body that never measures, so a
+        # message about sizing alone would describe the wrong consumer.
+        scene = _scene(tmp_path, _WITH_COLLISION, "nan 1 1")
+        with pytest.raises(ValueError) as caught:
+            load_mjcf_scene_objects(scene)
+        text = str(caught.value)
+        assert "visual prim" in text, text
+        assert "extent floored at 1e-4" in text, text
+
+
+class TestTheSiblingsOfTheSameXformCallWereAlreadyRefused:
+    """Why this value is held to the same test: it travels with two that are.
+
+    ``mesh_pos``, ``mesh_quat`` and ``mesh_scale`` are the three arguments of one
+    ``_author_local_xform`` call in the Isaac realization. These pin that the
+    first two are refused on a body whose bound comes from its collidable geom -
+    the shape where the scale used to be carried unchecked.
+    """
+
+    def test_a_non_finite_mesh_geom_position_is_refused(self, tmp_path: Path) -> None:
+        _asset(tmp_path)
+        scene = tmp_path / "scene.xml"
+        scene.write_text(_WITH_COLLISION.format(scale="1 1 1").replace('mesh="m"', 'mesh="m" pos="nan 0 0"'))
+        with pytest.raises(ValueError, match="pos has a component that is not finite"):
+            load_mjcf_scene_objects(str(scene))
+
+    def test_a_non_finite_mesh_geom_orientation_is_refused(self, tmp_path: Path) -> None:
+        _asset(tmp_path)
+        scene = tmp_path / "scene.xml"
+        scene.write_text(_WITH_COLLISION.format(scale="1 1 1").replace('mesh="m"', 'mesh="m" quat="nan 1 0 0"'))
+        with pytest.raises(ValueError, match="quat has a component that is not finite"):
+            load_mjcf_scene_objects(str(scene))
+
+    def test_the_realization_applies_all_three_in_one_xform_call(self) -> None:
+        # Derived, so the premise cannot rot into naming a call the realization
+        # no longer makes. The three fields must be arguments of one call.
+        source = inspect.getsource(loaders)
+        assert "mesh_scale" in source, "the loader no longer carries a mesh scale"
+        simulation = inspect.getsource(__import__("strands_robots.simulation.isaac.simulation", fromlist=["x"]))
+        tree = ast.parse(simulation)
+        together = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and {kw.arg for kw in node.keywords} >= {"translate", "orient_wxyz", "scale"}
+        ]
+        assert together, "no xform call takes the three fields together any more"
+        rendered = {ast.unparse(node) for node in together}
+        assert any("mesh_scale" in text and "mesh_quat" in text for text in rendered), rendered
+
+
+class TestAFiniteScaleIsUnchanged:
+    """Negative, zero and non-unit scales still load, on both templates.
+
+    250 of the 1746 mesh assets the shipped registry declares carry a finite
+    non-unit scale, so this is the population the guard must not touch.
+    """
+
+    @pytest.mark.parametrize("shape,template", TEMPLATES, ids=[name for name, _ in TEMPLATES])
+    @pytest.mark.parametrize("scale", ("1 1 1", "3 3 3", "-1 2 1", "0 1 1"))
+    def test_the_scene_loads(self, tmp_path: Path, shape: str, template: str, scale: str) -> None:
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, template, scale)))
+        assert all(math.isfinite(component) for component in widget.mesh_scale)
+        assert all(math.isfinite(component) for component in widget.size)
+
+    def test_the_declared_scale_still_reaches_the_scene_object(self, tmp_path: Path) -> None:
+        # The guard refuses a value; it must not stop a usable one being carried.
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _WITH_COLLISION, FINITE_NON_UNIT)))
+        assert widget.mesh_scale == pytest.approx((3.0, 3.0, 3.0))
+
+
+class TestThePremisesThatMakeTheRefusalNecessary:
+    """MuJoCo compiles it, and the collidable body really never measures."""
+
+    @pytest.mark.parametrize("shape,template", TEMPLATES, ids=[name for name, _ in TEMPLATES])
+    def test_mujoco_compiles_the_model(self, tmp_path: Path, shape: str, template: str) -> None:
+        # The compiler only warns, so the reader cannot defer the question to it.
+        mujoco = pytest.importorskip("mujoco")
+        scene = _scene(tmp_path, template, "nan 1 1")
+        assert mujoco.MjModel.from_xml_path(scene) is not None
+
+    def test_the_collidable_body_takes_its_bound_from_its_geom(self, tmp_path: Path) -> None:
+        # A 3x scale would give the mesh a 0.6 m bound; the box is what is
+        # reported, which is what makes the measurement unreachable here.
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _WITH_COLLISION, FINITE_NON_UNIT)))
+        assert widget.size == pytest.approx((0.2, 0.2, 0.1))
+
+    def test_the_mesh_only_body_does_measure_through_the_scale(self, tmp_path: Path) -> None:
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _MESH_ONLY, FINITE_NON_UNIT)))
+        assert widget.size[0] == pytest.approx(0.6, abs=1e-3)
+
+
+class TestTheFinitenessTestHasOneOwnerBothConsumersReach:
+    """One test for the scale, so the two consumers cannot drift apart.
+
+    Derived over the module rather than listed, so a third consumer is held to
+    the same rule the hour it lands.
+    """
+
+    def test_only_the_owner_tests_the_scale_for_finiteness(self) -> None:
+        tree = ast.parse(inspect.getsource(mesh_assets))
+        owners: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Attribute) and inner.attr == "isfinite":
+                    owners.add(node.name)
+        assert owners, "the scan found no finiteness test at all - it is looking in the wrong place"
+        assert owners == {"load_mesh_geometry", "refuse_non_finite_scale"}, owners
+
+    def test_the_measurement_reaches_the_owner(self) -> None:
+        called = {
+            node.func.id
+            for node in ast.walk(ast.parse(inspect.getsource(mesh_aabb).strip()))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "refuse_non_finite_scale" in called, called
+
+    def test_the_loader_reaches_the_owner(self) -> None:
+        called = {
+            node.func.id
+            for node in ast.walk(ast.parse(inspect.getsource(loaders.load_mjcf_scene_objects).strip()))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "refuse_non_finite_scale" in called, called
+
+    def test_the_owner_is_reached_before_the_bound_is_built(self) -> None:
+        # Refusing after the object is appended would report a scene the caller
+        # cannot use; refusing after the measurement would keep the old hole.
+        tree = ast.parse(inspect.getsource(loaders.load_mjcf_scene_objects).strip())
+        guard = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "refuse_non_finite_scale"
+        ]
+        built = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "SceneObject"
+        ]
+        measured = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "mesh_aabb"
+        ]
+        assert len(guard) == 1, guard
+        assert built and measured, (built, measured)
+        assert guard[0] < min(measured), (guard, measured)
+        assert guard[0] < min(built), (guard, built)
+
+    def test_the_owner_accepts_a_finite_scale_and_refuses_a_non_finite_one(self) -> None:
+        # Only the raising half is asserted: the owner is annotated ``-> None``,
+        # so "it returns nothing" is a static fact rather than a runtime one.
+        refuse_non_finite_scale("m.stl", (-1.0, 0.0, 3.0))
+        with pytest.raises(ValueError, match=REFUSAL):
+            refuse_non_finite_scale("m.stl", (NAN, 1.0, 1.0))

--- a/tests/simulation/isaac/test_mesh_asset_scale_must_be_finite.py
+++ b/tests/simulation/isaac/test_mesh_asset_scale_must_be_finite.py
@@ -38,9 +38,11 @@ that reaches the measurement; the premises that make the refusal necessary
 (MuJoCo compiles it, the asset's own vertices are finite, and the extent
 floor is what made the NaN case unscreenable); that a finite scale -
 including the negative and zero ones - measures exactly what it did before;
-that a body carrying collidable geometry never reaches the measurement and
-is deliberately unchanged; that the wording has one owner per cause; and
-that the guard precedes the parse.
+that a body carrying collidable geometry takes its bound from that geometry
+and never reaches the measurement - which is why the refusal for the value it
+still carries lives at the read rather than here, pinned in
+``test_mesh_asset_scale_is_refused_wherever_it_is_carried``; that the wording
+has one owner per cause; and that the guard precedes the parse.
 """
 
 from __future__ import annotations
@@ -283,23 +285,32 @@ class TestAFiniteScaleIsUnchanged:
         assert mesh_aabb(_asset(tmp_path)) == (UNIT_CENTER, UNIT_SIZE)
 
 
-class TestABodyWithCollidableGeometryIsDeliberatelyUnchanged:
+class TestABodyWithCollidableGeometryTakesItsBoundFromItsGeom:
     """The analytic bound wins, so such a body never reaches the measurement.
 
-    Its ``mesh_scale`` still rides into the scene object, because that field is
-    applied by the realization rather than measured here. Refusing it would be
-    a claim about a consumer this reader does not own, so the boundary is
-    pinned rather than moved.
+    That is why the measurement is the wrong place to hold the scale, not a
+    reason to leave it unheld: the scale rides onto the scene object from this
+    branch too, and the realization applies it to the visual prim's xform
+    beside the mesh geom's position and orientation - two values the reader
+    already refuses when they are not finite. The refusal for the third now
+    lives where the scale is read rather than where it is measured, pinned in
+    ``test_mesh_asset_scale_is_refused_wherever_it_is_carried``.
+
+    A finite non-unit scale is used here so the claim is about which branch
+    supplies the bound: at ``3 3 3`` the mesh would measure 0.6 m and the box
+    is what is reported.
     """
 
     def test_the_reported_bound_comes_from_the_collidable_geom(self, tmp_path: Path) -> None:
-        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _WITH_COLLISION, "nan 1 1")))
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _WITH_COLLISION, "3 3 3")))
         assert widget.position == pytest.approx((0.0, 0.0, 0.5))
         assert widget.size == pytest.approx((0.2, 0.2, 0.1))
 
-    def test_the_declared_scale_still_rides_along(self, tmp_path: Path) -> None:
-        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _WITH_COLLISION, "nan 1 1")))
-        assert math.isnan(widget.mesh_scale[0])
+    def test_the_declared_scale_still_rides_along_when_it_is_usable(self, tmp_path: Path) -> None:
+        # The carry is what made the unchecked value reachable; it must survive
+        # for a scale the guard accepts.
+        widget = _widget(load_mjcf_scene_objects(_scene(tmp_path, _WITH_COLLISION, "3 3 3")))
+        assert widget.mesh_scale == pytest.approx((3.0, 3.0, 3.0))
 
 
 class TestOneOwnerForEachWording:
@@ -332,14 +343,31 @@ class TestOneOwnerForEachWording:
         assert "scale" in str(scale)
         assert str(vertex) != str(scale)
 
-    def test_the_scale_factory_is_reached_from_the_measurement(self) -> None:
-        source = inspect.getsource(mesh_aabb)
+    def test_the_scale_factory_is_raised_only_by_the_shared_owner(self) -> None:
+        # Two consumers reach it now - the measurement and the loader's
+        # passthrough - so the factory is raised from one owner they both call
+        # rather than from each of them.
+        raisers: set[str] = set()
+        for node in ast.walk(ast.parse(inspect.getsource(mesh_assets))):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.Raise)
+                    and isinstance(inner.exc, ast.Call)
+                    and isinstance(inner.exc.func, ast.Name)
+                    and inner.exc.func.id == "_non_finite_scale_error"
+                ):
+                    raisers.add(node.name)
+        assert raisers == {"refuse_non_finite_scale"}, raisers
+
+    def test_the_measurement_reaches_that_owner(self) -> None:
         called = {
             node.func.id
-            for node in ast.walk(ast.parse(source.strip()))
+            for node in ast.walk(ast.parse(inspect.getsource(mesh_aabb).strip()))
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
         }
-        assert "_non_finite_scale_error" in called, called
+        assert "refuse_non_finite_scale" in called, called
 
 
 class TestTheGuardPrecedesTheParse:
@@ -367,6 +395,6 @@ class TestTheGuardPrecedesTheParse:
             for node in ast.walk(tree)
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
         }
-        assert "_non_finite_scale_error" in lines, lines
+        assert "refuse_non_finite_scale" in lines, lines
         assert "load_mesh_geometry" in lines, lines
-        assert lines["_non_finite_scale_error"] < lines["load_mesh_geometry"]
+        assert lines["refuse_non_finite_scale"] < lines["load_mesh_geometry"]


### PR DESCRIPTION
## The defect

`mesh_aabb` refuses a `<mesh scale=...>` whose components are not all finite (#2838), because it measures `vertex * scale` and `min`/`max` order a NaN as neither smaller nor larger than anything.

`load_mjcf_scene_objects` reaches that measurement on **one** of its three branches - the `elif mesh_path is not None` fallback for a body with no collidable analytic geom. It carries the scale onto the `SceneObject` on **all** of them, and the Isaac realization applies it to the visual prim's xform.

So a body declaring both a collidable geom and a visual mesh took its bound from the geom, never measured, and reported the scale unchecked:

| `<mesh scale>` | body has a collidable geom | MuJoCo | loader before | loader after |
|---|---|---|---|---|
| `1 1 1` | no | compiles | success, `(1.0, 1.0, 1.0)` | unchanged |
| `1 1 1` | yes | compiles | success, `(1.0, 1.0, 1.0)` | unchanged |
| `nan 1 1` | no | compiles | refused (#2838) | refused |
| `nan 1 1` | **yes** | compiles | **success, `mesh_scale=(nan, 1.0, 1.0)`** | refused |
| `inf 1 1` | **yes** | compiles | **success, `mesh_scale=(inf, 1.0, 1.0)`** | refused |

In the leaking rows `position`, `size` and `offset` were all finite and correct, because the collidable geom supplied them - `size=(0.2, 0.2, 0.1)`, the box. Every field a consumer would screen for a non-finite value was healthy, and the only bad one was the field nothing measures.

**53 of the 63** mesh-carrying bodies in the shipped registry are in that shape (`mesh_aabb` is called for 10 of them), so the measurement covered the minority.

## Why the scale belongs to the same test as its two neighbours

The realization authors the visual prim with one call:

```python
self._author_local_xform(
    stage.GetPrimAtPath(visual_path),
    translate=local_pos,      # from mesh_pos
    orient_wxyz=obj.mesh_quat,
    scale=obj.mesh_scale,
)
```

Two of those three arguments are already refused when they are not finite. Measured on the same body with a collidable box:

| xform argument | from field | non-finite spelling | before |
|---|---|---|---|
| `translate=` | `mesh_pos` | `<geom mesh pos="nan 0 0">` | refused |
| `orient_wxyz=` | `mesh_quat` | `<geom mesh quat="nan 1 0 0">` | refused |
| `scale=` | `mesh_scale` | `<mesh scale="nan 1 1">` | **success, `(nan, 1.0, 1.0)`** |

#2838 pinned the boundary with the reason "refusing it would be a claim about a consumer this reader does not own". That reason covers the *measurement*, and the reader already refuses two arguments of that consumer's own call for exactly this property - so the third is held to the same test rather than to the reach of the measurement. #2838's class is repaired rather than deleted: the claim it gets right (the bound comes from the collidable geom) is kept and strengthened to a finite non-unit scale, where the mesh would measure 0.6 m and the box is what is reported.

## The change

`refuse_non_finite_scale` becomes the single owner of the scale finiteness test in `mesh_assets`; `mesh_aabb` delegates to it, and the loader reaches it where the scale is read - beside the missing-file contract, for the same reason that check sits there: an asset declaration a body reaches has to be usable. The refusal's wording gains the xform consequence alongside the sizing one.

## What is unchanged

A finite scale is untouched on both body shapes, including the negative, zero and non-unit ones. Across the shipped registry: **1746 mesh assets declared, 0 non-finite, 250 finite non-unit** - the population the guard must not touch. After the change all **60** resolvable registry models still load, 0 failures, every reported `mesh_scale` finite. The defect is latent on shipped assets; what it changes is which declarations a scene may be built from.

## Why nothing caught it

`_MESH_ONLY` and `_WITH_COLLISION` templates both existed, and the with-collision one was driven only to assert that the bound came from the geom and that the scale rode along - the second of which is the defect, pinned as intended behaviour.

## Tests

New `tests/simulation/isaac/test_mesh_asset_scale_is_refused_wherever_it_is_carried.py`, 41 cases: the refusal on both templates for both non-finite values on every axis; that the two siblings of the same xform call were already refused; that a finite scale is unchanged on both templates; the premises (MuJoCo compiles the model, the collidable body really takes its bound from its geom, the mesh-only body really measures through the scale); and that the finiteness test has one owner both consumers reach, ahead of both the measurement and the object.

Pre-fix behavioural split (the owner kept importable, the loader's call site undone): **13 failed / 68 passed** - 11 regression (the 9 with-collision refusal cells plus the 2 message cells; the 9 mesh-only cells correctly pass, #2838 already covered them) and 2 structural, with **0** in the premise, control, sibling-xform and repaired classes. A raw revert is a collection error, since the tests import the new owner.

### Mutation table

`mine` is the two scale suites, `sib` is the seven pre-existing isaac mesh and finiteness suites.

| mutation | mine | collected | sib |
|---|---|---|---|
| control | 0 | 81 | 0 |
| loader call site removed (the defect) | 13 | 81 | 0 |
| `mesh_aabb` delegation removed | 16 | 81 | 0 |
| both consumers stop reaching the owner | 43 | 81 | 0 |
| guard moved to the measurement branch | 11 | 81 | 0 |
| owner accepts if **any** component is finite | 37 | 81 | 0 |
| owner checks the first axis only | 20 | 81 | 0 |
| message drops the visual-xform clause | 1 | 81 | 0 |
| owner returns instead of raising | 41 | 81 | 0 |
| two copies of the test instead of one owner | 9 | 81 | 0 |

Ten mutations, nine firing, **nine distinct firing sets**, control clean, `collected` stable at 81 on every row, source restored byte-identical.

The two per-consumer reverts are **disjoint** and their union is a strict subset of the both-consumers revert (13 + 16 = 29 against 43). The 14 cells that need both gone are the mesh-only rows, which either guard alone still catches - the redundancy the belt-and-braces design intends - while the with-collision rows are reachable only through the loader.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1649 files).
- `mypy strands_robots tests tests_integ`: **branch-only message set empty**, 0 attributable. (Raw counts differ only by the cold-cache `examples/isaac_gs/` artifact in the base worktree.)
- Paired 288-file selection - all of `tests/simulation/isaac/` plus every suite walking the tree, parsing source or reading docstrings, `Args:`/`Raises:` and `__all__` - identical on both trees with the new file excluded from each: **0 failures on either side**, both failing-ID sets empty, distinct rootdirs. Collected 14082 against 14081; the `+1` localises to `test_mesh_asset_scale_must_be_finite.py` (39 -> 40), where one test was split into two.
- `tests/simulation/isaac/` alone: **1921 passed, 5 skipped**.

No visual artifact: the consumer this value reaches is Isaac Sim's xform authoring, which needs the `sim-isaac` extra, and MuJoCo compiles the declaration with only a warning rather than rendering a refusal. The measured refusal and corpus tables above are the evidence.
