### PR TITLE
fix(policies/motionbricks): refuse a non-finite direction goal and name the key it came from

### DIFF
--- a/changelog.d/2846-motionbricks-direction-goal-domain.md
+++ b/changelog.d/2846-motionbricks-direction-goal-domain.md
@@ -1,0 +1,53 @@
+### Fixed: a non-finite direction goal is refused, and the refusal names the key it came from
+
+`MotionBricksPolicy` resolves two of the issue #300 well-known goal keys -
+`target_velocity` and `target_heading` - through one reader that normalises each
+to a unit direction in the world XY plane. That reader falls back to "walk
+straight ahead" for a command with no direction, and its own docstring gave the
+reason: so an all-zero command "does not produce a NaN direction".
+
+The fallback is a magnitude test, so it could not cover a non-finite component.
+`nan < 1e-6` is `False`, and `inf` divided by its own norm is `nan`, so either
+one fell straight through it and produced exactly the outcome the fallback exists
+to prevent: `target_velocity=[nan, 0.0]` resolved to a `movement_direction` of
+`[nan, nan, nan]`, handed to the generator by a call that reported success. The
+same held for `target_heading` and the `facing_direction` it drives. The
+per-component domain is now the shared `finite_vector_error` the simulation
+setters already hold their own vectors to, so a `nan`/`inf` component, a
+non-numeric element and a `bool` are each refused in the library's own words
+rather than read as `1.0` or surfaced as numpy's `could not convert string to
+float`.
+
+The refusal named neither key. One reader serves both, and both answered
+`direction vector must have 2 or 3 entries`, so a caller passing both could not
+tell which one had been refused. Each call site now passes the key it reads. The
+sibling locomotion family already did this - `WBCPolicy._validate_velocity`
+answers `target_velocity must have at least 3 elements [vx, vy, omega]` - and the
+policy contract's stated reason for leaving the component count out of the goal
+vocabulary is that "each receiver states its own arity and refuses a shape it
+cannot use", which needs the refusal to say which receiver and which key. The
+mesh wire validator defers the count here deliberately ("the component COUNT is
+not checked against any receiver's arity here"), so this reader is the only place
+it is checked at all.
+
+And the message stated a rule the check did not enforce. Five statements in the
+package gave the accepted shape as two or three components - the reader's
+docstring, the module docstring, the constructor's `target_velocity` entry, the
+refusal text itself and `docs/policies/motionbricks.md` - while the check tested
+the lower bound alone. A four-, six- or twenty-component vector was accepted and
+read for its first two entries, so a caller who packed a six-component spatial
+twist got planar motion and no error. The count is now the closed range every
+one of those statements already described.
+
+The constructor's `target_velocity` default went through no domain at all and was
+injected into every call that passed none. It now goes through the same reader,
+so a default that cannot be honoured is reported at construction rather than on
+the first step of a started rollout - the ordering the sibling family's own
+constructor comment gives as its reason.
+
+Nothing caught any of this because the suite stated the property without driving
+the input that violates it. Two shipped cells say so in their own words - "the
+builder rejects it instead of fabricating a NaN/garbage heading", "an all-zero
+command must not yield a NaN direction" - and both pass only the inputs where the
+fallback does fire. Both have been narrowed to the half they grade and now point
+at the new cells for the other.

--- a/docs/policies/motionbricks.md
+++ b/docs/policies/motionbricks.md
@@ -138,15 +138,25 @@ policy = create_policy(
 
 ### Per-call goal kwargs
 
-| kwarg | Meaning |
-| --- | --- |
-| `style` / `mode` | Clip mode - an `int` index or `str` name (e.g. `"walk"`, `"stealth_walk"`, `"walk_boxing"`, `"hand_crawling"`). |
-| `target_velocity` | `[vx, vy]` desired planar movement direction (world frame); only the direction is used. |
-| `target_heading` | `[hx, hy]` facing direction, or `target_heading_angle` (radians). |
+| kwarg | Accepted | Meaning |
+| --- | --- | --- |
+| `style` / `mode` | `int` index or `str` name | Clip mode (e.g. `"walk"`, `"stealth_walk"`, `"walk_boxing"`, `"hand_crawling"`). |
+| `target_velocity` | 2 or 3 entries, every component a finite number | `[vx, vy]` (or `[vx, vy, vz]`) desired planar movement direction (world frame); only the direction is used, and a third entry is projected away. |
+| `target_heading` | 2 or 3 entries, every component a finite number | `[hx, hy]` facing direction, or `target_heading_angle` (radians, any finite float). |
 
 An unknown style or out-of-range index raises `ValueError` listing the
 available modes. A missing `[motionbricks]` install or checkpoint raises
 `RuntimeError` with an install hint - there is no silent fallback.
+
+A direction outside the accepted domain raises `ValueError` naming the key it
+came from, so a call passing both `target_velocity` and `target_heading` is told
+which one was refused. A `nan`/`inf` component is refused rather than normalised:
+the near-zero fallback that turns an all-zero command into "walk straight ahead"
+is a magnitude test, and `nan` does not compare small, so a non-finite component
+would otherwise reach the generator as a `[nan, nan, nan]` direction from a call
+that reported success. The same domain applies to the constructor's
+`target_velocity` default, so a default the reader cannot honour is reported at
+construction rather than on the first step of a started rollout.
 
 ## Driving the gait with the `locomotion_style` goal kwarg
 

--- a/strands_robots/policies/motionbricks/observation.py
+++ b/strands_robots/policies/motionbricks/observation.py
@@ -22,6 +22,8 @@ The well-known goal kwargs a caller passes through ``get_actions`` are:
 * ``target_velocity`` - ``[vx, vy]`` (or ``[vx, vy, vz]``) desired planar
   movement direction in the world frame; only the direction is used (the clip's
   ``avg_root_vel`` sets the speed). Absent -> walk straight ahead (``+x``).
+  Every component must be a finite number; a count outside two or three, a
+  ``nan``/``inf`` component or a ``bool`` is refused by name.
 * ``target_heading`` - facing direction as ``[hx, hy]`` (or an angle in radians
   via ``target_heading_angle``). Absent -> face the movement direction.
 """
@@ -33,8 +35,17 @@ from typing import Any
 
 import numpy as np
 
+from ...utils import finite_vector_error, sequence_length
+
 # Default movement / facing direction: walk straight ahead along +x (world).
 _DEFAULT_DIRECTION = (1.0, 0.0, 0.0)
+
+#: Component counts a planar direction may arrive with: ``[vx, vy]`` or
+#: ``[vx, vy, vz]``. Three is accepted because the world frame is 3-D and a
+#: caller holding a 3-vector should not have to slice it; the third entry is
+#: projected away, since this reader takes a direction in the XY plane.
+_MIN_DIRECTION_ENTRIES = 2
+_MAX_DIRECTION_ENTRIES = 3
 
 # Accepted ``locomotion_style`` vocabulary - the SONIC locomotion style names a
 # caller passes through ``run_policy(policy_kwargs={"locomotion_style": ...})``.
@@ -157,15 +168,65 @@ def resolve_locomotion_style(
     return clip
 
 
-def _unit_direction(vec: Any, default: tuple[float, float, float]) -> list[float]:
+def _unit_direction(vec: Any, default: tuple[float, float, float], *, method: str, param_name: str) -> list[float]:
     """Normalise a 2- or 3-vector to a unit 3-vector in the world XY plane.
 
     A near-zero vector falls back to ``default`` (so an all-zero command does
-    not produce a NaN direction).
+    not produce a NaN direction). That fallback is a magnitude test, so it
+    cannot cover a non-finite component: ``nan < 1e-6`` is ``False``, and
+    ``inf`` divided by its own norm is ``nan``, so either one fell through it and
+    produced exactly the NaN direction the fallback exists to prevent - a
+    ``movement_direction`` of ``[nan, nan, nan]`` handed to the generator, from a
+    call that reported success. The per-component domain is therefore the shared
+    :func:`~strands_robots.utils.finite_vector_error`, which the sim setters
+    already hold their own vectors to: finite, numeric, and a ``bool`` refused by
+    name rather than read as ``1.0``.
+
+    ``method`` and ``param_name`` are what make the refusal legible. This helper
+    reads two of the issue #300 well-known goal keys - ``target_velocity`` and
+    ``target_heading`` - so a message naming only "direction vector" left a
+    caller who passed both unable to tell which one was refused. The sibling
+    locomotion family names its key in every refusal
+    (:meth:`WBCPolicy._validate_velocity` answers ``target_velocity must have at
+    least 3 elements [vx, vy, omega]``), and the ABC's own reason for leaving the
+    component count out of the goal contract is that "each receiver states its
+    own arity and refuses a shape it cannot use" - which requires the refusal to
+    say which receiver and which key.
+
+    The arity is a closed range rather than a floor. Five statements in this
+    package already give the rule as two or three components - this docstring,
+    the module docstring, the policy constructor's ``target_velocity`` entry, the
+    refusal text itself and ``docs/policies/motionbricks.md`` - while the check
+    tested only the lower half, so a four-, six- or twenty-component vector was
+    accepted and silently read for its first two entries. The wire validator
+    defers the count here on purpose ("the component COUNT is not checked against
+    any receiver's arity here", :func:`~strands_robots.mesh.security.validate_command`),
+    so this is the only place it is checked at all.
+
+    Args:
+        vec: The caller's direction, two or three finite numbers.
+        default: Direction to fall back to when ``vec`` is near zero.
+        method: Calling function name, used in the message.
+        param_name: The goal key it came from, used in the message.
+
+    Returns:
+        A unit 3-vector in the world XY plane, as plain floats.
+
+    Raises:
+        ValueError: If a component is non-finite, non-numeric or a ``bool``, or
+            if the count is outside ``[2, 3]``.
     """
+    component_error = finite_vector_error(method, param_name, vec)
+    if component_error is not None:
+        raise ValueError(component_error)
+    count = sequence_length(vec)
+    if count is None or not _MIN_DIRECTION_ENTRIES <= count <= _MAX_DIRECTION_ENTRIES:
+        raise ValueError(
+            f"{method}: {param_name!r} must have "
+            f"{_MIN_DIRECTION_ENTRIES} or {_MAX_DIRECTION_ENTRIES} entries "
+            f"(a planar direction; a third entry is projected away), got {count}"
+        )
     raw = np.asarray(vec, dtype=np.float64).ravel()
-    if raw.shape[0] < 2:
-        raise ValueError(f"direction vector must have 2 or 3 entries, got {raw.shape[0]}")
     # Project onto the world XY plane (ignore any z component).
     planar = np.array([float(raw[0]), float(raw[1]), 0.0], dtype=np.float64)
     norm = float(np.linalg.norm(planar))
@@ -180,7 +241,12 @@ def _heading_to_direction(kwargs: dict[str, Any], movement_direction: list[float
         angle = float(kwargs["target_heading_angle"])
         return [math.cos(angle), math.sin(angle), 0.0]
     if kwargs.get("target_heading") is not None:
-        return _unit_direction(kwargs["target_heading"], tuple(movement_direction))  # type: ignore[arg-type]
+        return _unit_direction(
+            kwargs["target_heading"],
+            tuple(movement_direction),  # type: ignore[arg-type]
+            method="build_control_signals",
+            param_name="target_heading",
+        )
     return list(movement_direction)
 
 
@@ -245,7 +311,12 @@ def build_control_signals(
         JSON-serialisable and torch-independent; the policy wraps it in tensors.
     """
     movement = (
-        _unit_direction(kwargs["target_velocity"], _DEFAULT_DIRECTION)
+        _unit_direction(
+            kwargs["target_velocity"],
+            _DEFAULT_DIRECTION,
+            method="build_control_signals",
+            param_name="target_velocity",
+        )
         if kwargs.get("target_velocity") is not None
         else list(_DEFAULT_DIRECTION)
     )

--- a/strands_robots/policies/motionbricks/policy.py
+++ b/strands_robots/policies/motionbricks/policy.py
@@ -59,7 +59,13 @@ from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS
 from strands_robots.utils import require_optional
 
 from .config import MotionBricksConfig
-from .observation import build_control_signals, resolve_locomotion_style, resolve_mode
+from .observation import (
+    _DEFAULT_DIRECTION,
+    _unit_direction,
+    build_control_signals,
+    resolve_locomotion_style,
+    resolve_mode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -134,8 +140,9 @@ class MotionBricksPolicy(Policy):
             is built from it (plus ``style`` / ``device``).
         style: Default motion style (mode index or name) used when a call does
             not pass ``style`` / ``mode``. Overrides ``config.style``.
-        target_velocity: Optional default movement direction ``[vx, vy]`` used
-            when a call passes none.
+        target_velocity: Optional default movement direction ``[vx, vy]`` (or
+            ``[vx, vy, vz]``) used when a call passes none. Held to the same
+            domain as a per-call value: two or three finite numbers.
         device: Torch device for the generator (when building from ``config``).
         style_map: Optional overrides merged over the built-in
             ``locomotion_style`` -> clip-name map
@@ -171,7 +178,23 @@ class MotionBricksPolicy(Policy):
         self._default_style: int | str = (
             style if style is not None else (self._config.style if self._config is not None else "walk")
         )
-        self._default_velocity = list(target_velocity) if target_velocity is not None else None
+        # Through the same door a per-call ``target_velocity`` goes through, so a
+        # default the reader cannot honor is reported at construction rather than on
+        # the first ``get_actions`` tick of a started rollout. This mirrors the
+        # sibling locomotion family, whose constructor validates its own
+        # ``target_velocity`` default with the guard its per-call path uses.
+        self._default_velocity: list[float] | None = None
+        if target_velocity is not None:
+            # Raises when the default is outside the domain; the returned unit
+            # vector is discarded because the stored default is the caller's own
+            # components, which every call re-normalises against its own fallback.
+            _unit_direction(
+                target_velocity,
+                _DEFAULT_DIRECTION,
+                method="MotionBricksPolicy",
+                param_name="target_velocity",
+            )
+            self._default_velocity = [float(component) for component in target_velocity]
 
         # locomotion_style -> clip-name overrides: config.style_map is the base,
         # the constructor arg takes precedence; both overlay the built-in

--- a/tests/policies/motionbricks/test_direction_goal_keys_are_held_to_one_domain.py
+++ b/tests/policies/motionbricks/test_direction_goal_keys_are_held_to_one_domain.py
@@ -46,6 +46,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 import strands_robots.policies.motionbricks.observation as observation
 import strands_robots.policies.motionbricks.policy as policy_module
@@ -77,10 +78,25 @@ def _direction_for(key: str, value: Any) -> list[float]:
 
 
 class _StubAgent:
-    """Enough of a motion agent to construct the policy; never generates."""
+    """A :class:`MotionAgent` that satisfies the protocol and never generates.
 
-    def generate(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - never called
+    Only the constructor is exercised here, so ``next_qpos`` is never reached;
+    the four class attributes are what make this a ``MotionAgent`` structurally,
+    which is how the shipped stub in ``test_policy.py`` satisfies the same seam.
+    """
+
+    clip_keys: list[str] = ["walk"]
+    clip_token_specs: list[list[int] | None] = [None]
+    min_token: int = 1
+    max_token: int = 1
+
+    def reset(self) -> None:  # pragma: no cover - never called
         return None
+
+    def next_qpos(
+        self, control_signals: dict[str, Any], controller_dt: float
+    ) -> NDArray[np.float64]:  # pragma: no cover - never called
+        raise AssertionError("these cells never step the generator")
 
 
 def _build(**kwargs: Any) -> policy_module.MotionBricksPolicy:

--- a/tests/policies/motionbricks/test_direction_goal_keys_are_held_to_one_domain.py
+++ b/tests/policies/motionbricks/test_direction_goal_keys_are_held_to_one_domain.py
@@ -1,0 +1,371 @@
+"""A planar direction goal is refused by name, and the refusal states the rule.
+
+:func:`~strands_robots.policies.motionbricks.observation._unit_direction` reads two
+of the issue #300 well-known goal keys - ``target_velocity`` and
+``target_heading`` - and normalises each to a unit 3-vector in the world XY
+plane. Three things about that read were not graded anywhere.
+
+The near-zero fallback is a magnitude test, so it cannot cover a non-finite
+component. ``nan < 1e-6`` is ``False`` and ``inf`` divided by its own norm is
+``nan``, so either one fell straight through the fallback and produced a
+``movement_direction`` of ``[nan, nan, nan]`` - handed to the generator, from a
+call that reported success. That is exactly the outcome the fallback exists to
+prevent, and two shipped cells in ``test_policy.py`` say so in their own words
+("instead of fabricating a NaN/garbage heading", "must not yield a NaN
+direction") while driving only the inputs where the fallback does fire. The
+property was stated and the input that violates it was never passed.
+
+The refusal named neither key. One helper serves two documented keys, and both
+answered ``direction vector must have 2 or 3 entries``, so a caller who passed
+both could not tell which one was refused. The sibling locomotion family names
+its key in every refusal - :meth:`WBCPolicy._validate_velocity` answers
+``target_velocity must have at least 3 elements [vx, vy, omega]`` - and the ABC's
+stated reason for leaving the component count out of the goal contract is that
+"each receiver states its own arity and refuses a shape it cannot use", which
+requires the refusal to say which receiver and which key.
+
+And the message stated a rule the check did not enforce. Five statements in the
+package give the rule as two or three components; the check tested ``< 2`` alone,
+so four, six and twenty components were accepted and read for their first two
+entries. The wire validator defers the count here deliberately ("the component
+COUNT is not checked against any receiver's arity here"), so this is the only
+place it is checked at all.
+
+The per-component domain is now the shared
+:func:`~strands_robots.utils.finite_vector_error` the sim setters already use, so
+a ``bool`` is refused by name rather than read as ``1.0`` and the wording matches
+the rest of the library. The cells below drive both keys and both doors: the
+per-call kwarg and the constructor default.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.policies.motionbricks.observation as observation
+import strands_robots.policies.motionbricks.policy as policy_module
+from strands_robots.utils import finite_vector_error
+
+_NAN = float("nan")
+_INF = float("inf")
+
+#: The two well-known goal keys this reader serves. Both must name themselves.
+_DIRECTION_KEYS = ("target_velocity", "target_heading")
+
+#: Counts the message states, stated here rather than read off the module so a
+#: silent widening of the module's own bounds fails a cell instead of following it.
+_ACCEPTED_COUNTS = (2, 3)
+
+
+def _signals(**kwargs: Any) -> dict[str, Any]:
+    """Build one control-signal dict through the public builder."""
+    return observation.build_control_signals(
+        mode_idx=0, clip_token_specs=[None], min_token=1, max_token=1, kwargs=kwargs
+    )
+
+
+def _direction_for(key: str, value: Any) -> list[float]:
+    """The direction ``key`` resolves to, read from the field it drives."""
+    if key == "target_velocity":
+        return list(_signals(target_velocity=value)["movement_direction"])
+    return list(_signals(target_velocity=[1.0, 0.0], target_heading=value)["facing_direction"])
+
+
+class _StubAgent:
+    """Enough of a motion agent to construct the policy; never generates."""
+
+    def generate(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - never called
+        return None
+
+
+def _build(**kwargs: Any) -> policy_module.MotionBricksPolicy:
+    """Construct the policy through its real constructor."""
+    return policy_module.MotionBricksPolicy(motion_agent=_StubAgent(), style="walk", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Regression: a non-finite component is the NaN direction the fallback prevents
+# ---------------------------------------------------------------------------
+class TestANonFiniteComponentIsRefused:
+    """The fallback is a magnitude test, so the domain has to be a domain."""
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param([_NAN, 0.0], id="nan-first"),
+            pytest.param([0.0, _NAN], id="nan-second"),
+            pytest.param([_NAN, _NAN], id="nan-both"),
+            pytest.param([_INF, 0.0], id="inf-first"),
+            pytest.param([_INF, _INF], id="inf-both"),
+            pytest.param([0.0, 0.0, _NAN], id="nan-in-third-entry"),
+        ],
+    )
+    def test_a_non_finite_component_is_refused(self, key: str, value: list[float]) -> None:
+        with pytest.raises(ValueError, match="must contain finite numbers"):
+            _direction_for(key, value)
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    def test_no_direction_a_caller_can_pass_reaches_the_generator_non_finite(self, key: str) -> None:
+        # The harm, stated as the invariant rather than as one input: whatever a
+        # caller passes, the resolved direction is finite or the call refused.
+        for value in ([_NAN, 0.0], [_INF, 0.0], [0.0, _NAN], [_NAN, _NAN, _NAN]):
+            try:
+                resolved = _direction_for(key, value)
+            except ValueError:
+                continue
+            assert all(math.isfinite(component) for component in resolved), (
+                f"{key}={value!r} resolved to {resolved!r}, which the generator would read"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Regression: the refusal names the key it came from
+# ---------------------------------------------------------------------------
+class TestTheRefusalNamesTheKeyItCameFrom:
+    """One helper, two documented keys; a caller who passed both must be told which."""
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param([0.5], id="too-few"),
+            pytest.param([0.5, 0.0, 0.0, 0.0], id="too-many"),
+            pytest.param([_NAN, 0.0], id="non-finite"),
+            pytest.param("abc", id="non-numeric"),
+            pytest.param([True, False], id="bool"),
+        ],
+    )
+    def test_every_refusal_names_the_key(self, key: str, value: Any) -> None:
+        with pytest.raises(ValueError) as caught:
+            _direction_for(key, value)
+        assert key in str(caught.value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param([0.5], id="too-few"),
+            pytest.param([_NAN, 0.0], id="non-finite"),
+        ],
+    )
+    def test_the_two_keys_do_not_share_one_refusal(self, value: Any) -> None:
+        # The same bad shape under each key must produce distinguishable text, or
+        # naming the key has bought nothing.
+        messages = []
+        for key in _DIRECTION_KEYS:
+            with pytest.raises(ValueError) as caught:
+                _direction_for(key, value)
+            messages.append(str(caught.value))
+        assert messages[0] != messages[1]
+        assert "target_heading" not in messages[0]
+        assert "target_velocity" not in messages[1]
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    def test_a_non_numeric_value_is_refused_by_name_not_by_numpy(self, key: str) -> None:
+        # Previously numpy answered "could not convert string to float: 'abc'",
+        # naming neither the key nor the expected shape.
+        with pytest.raises(ValueError) as caught:
+            _direction_for(key, "abc")
+        message = str(caught.value)
+        assert "could not convert string to float" not in message
+        assert "elements must be numbers" in message
+
+
+# ---------------------------------------------------------------------------
+# Regression: the arity the message states is the arity enforced
+# ---------------------------------------------------------------------------
+class TestTheStatedArityIsTheEnforcedArity:
+    """Five statements said two or three; the check tested only the floor."""
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    @pytest.mark.parametrize(
+        "count",
+        [
+            pytest.param(0, id="0"),
+            pytest.param(1, id="1"),
+            pytest.param(4, id="4"),
+            pytest.param(6, id="6-a-spatial-twist"),
+            pytest.param(20, id="20"),
+        ],
+    )
+    def test_a_count_outside_the_stated_range_is_refused(self, key: str, count: int) -> None:
+        value = [1.0] + [0.0] * (count - 1) if count else []
+        with pytest.raises(ValueError, match="must have 2 or 3 entries"):
+            _direction_for(key, value)
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    @pytest.mark.parametrize("count", _ACCEPTED_COUNTS)
+    def test_every_count_the_message_states_is_accepted(self, key: str, count: int) -> None:
+        resolved = _direction_for(key, [1.0] + [0.0] * (count - 1))
+        assert resolved == pytest.approx([1.0, 0.0, 0.0])
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param((component for component in (1.0, 2.0)), id="generator"),
+            pytest.param(5.0, id="bare-scalar"),
+        ],
+    )
+    def test_a_value_with_no_readable_length_is_refused_by_the_component_domain(self, key: str, value: Any) -> None:
+        # The order of the two checks is observable here, which is why it is
+        # pinned. A value whose length cannot be read has no count to compare, so
+        # the arity check running first would answer "got None" - reporting a
+        # domain check that never ran. The component domain owns this verdict and
+        # says what actually happened, which is the rule
+        # ``finite_vector_error`` already applies to its own callers.
+        with pytest.raises(ValueError) as caught:
+            _direction_for(key, value)
+        message = str(caught.value)
+        assert "must be a list/tuple of numbers" in message
+        assert "got None" not in message
+
+    def test_the_module_bounds_are_the_bounds_the_message_states(self) -> None:
+        assert (observation._MIN_DIRECTION_ENTRIES, observation._MAX_DIRECTION_ENTRIES) == (
+            min(_ACCEPTED_COUNTS),
+            max(_ACCEPTED_COUNTS),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression: the constructor default goes through the same door
+# ---------------------------------------------------------------------------
+class TestTheConstructorDefaultIsHeldToTheSameDomain:
+    """A default the reader cannot honor is reported before a rollout starts."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param([_NAN, 0.0], id="non-finite"),
+            pytest.param([_INF, 0.0], id="inf"),
+            pytest.param([0.5], id="too-few"),
+            pytest.param([0.5, 0.0, 0.0, 0.0], id="too-many"),
+            pytest.param([True, False], id="bool"),
+        ],
+    )
+    def test_a_default_outside_the_domain_is_refused_at_construction(self, value: Any) -> None:
+        with pytest.raises(ValueError) as caught:
+            _build(target_velocity=value)
+        assert "target_velocity" in str(caught.value)
+        assert "MotionBricksPolicy" in str(caught.value)
+
+    def test_an_acceptable_default_is_stored_as_the_callers_own_components(self) -> None:
+        # Not the unit vector: every call re-normalises, and the stored default is
+        # what a caller reads back.
+        built = _build(target_velocity=[0.0, 2.0])
+        assert built._default_velocity == [0.0, 2.0]
+
+    def test_omitting_the_default_stores_nothing(self) -> None:
+        assert _build()._default_velocity is None
+
+
+# ---------------------------------------------------------------------------
+# Over-reach controls: everything a caller could legitimately pass still works
+# ---------------------------------------------------------------------------
+class TestWhatIsUnchanged:
+    """Every shape the reader legitimately took still resolves the same way."""
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param([0.5, 0.0], [1.0, 0.0, 0.0], id="two-components"),
+            pytest.param([0.0, 2.0], [0.0, 1.0, 0.0], id="normalised"),
+            pytest.param([0.5, 0.0, 9.0], [1.0, 0.0, 0.0], id="third-entry-projected-away"),
+            pytest.param((0.0, 3.0), [0.0, 1.0, 0.0], id="tuple"),
+            pytest.param([0, 1], [0.0, 1.0, 0.0], id="ints"),
+            pytest.param([np.float64(0.0), np.float32(4.0)], [0.0, 1.0, 0.0], id="numpy-scalars"),
+        ],
+    )
+    def test_an_acceptable_direction_resolves_unchanged(self, key: str, value: Any, expected: list[float]) -> None:
+        assert _direction_for(key, value) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("key", _DIRECTION_KEYS)
+    def test_a_numpy_array_is_still_accepted(self, key: str) -> None:
+        assert _direction_for(key, np.array([0.0, 5.0])) == pytest.approx([0.0, 1.0, 0.0])
+
+    @pytest.mark.parametrize(
+        "value",
+        [pytest.param([0.0, 0.0], id="all-zero"), pytest.param([1e-300, 1e-300], id="near-zero")],
+    )
+    def test_the_near_zero_fallback_still_fires(self, value: list[float]) -> None:
+        # The behaviour the two shipped cells in test_policy.py grade: a command
+        # with no direction walks straight ahead rather than yielding NaN.
+        assert _signals(target_velocity=value)["movement_direction"] == [1.0, 0.0, 0.0]
+
+    def test_omitting_both_keys_still_walks_forward(self) -> None:
+        signals = _signals()
+        assert signals["movement_direction"] == [1.0, 0.0, 0.0]
+        assert signals["facing_direction"] == [1.0, 0.0, 0.0]
+
+    def test_a_heading_angle_is_untouched_by_this_domain(self) -> None:
+        # target_heading_angle is a scalar, not a direction vector, so it does not
+        # go through this reader at all.
+        signals = _signals(target_heading_angle=math.pi / 2)
+        assert signals["facing_direction"] == pytest.approx([0.0, 1.0, 0.0], abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Regression (structural): one reader, one domain, both keys named
+# ---------------------------------------------------------------------------
+class TestTheReaderIsSingleSourced:
+    """The domain is consulted, not restated, and each call site names its key."""
+
+    def test_the_reader_consults_the_shared_domain_rather_than_restating_it(self) -> None:
+        # A local finiteness test here would be a second copy of a rule the
+        # library already owns, and the two could then disagree about a bool or a
+        # numpy scalar.
+        source = inspect.getsource(observation._unit_direction)
+        assert "finite_vector_error(" in source
+        assert "isfinite" not in source
+
+    def test_both_call_sites_pass_the_key_they_read(self) -> None:
+        source = inspect.getsource(observation)
+        for key in _DIRECTION_KEYS:
+            assert f'param_name="{key}"' in source
+
+    def test_the_constructor_default_goes_through_the_same_reader(self) -> None:
+        # Not a second copy of the domain in the policy module: the constructor
+        # calls this reader, so the two doors cannot drift apart.
+        source = inspect.getsource(policy_module.MotionBricksPolicy.__init__)
+        assert "_unit_direction(" in source
+        assert "finite_vector_error(" not in source
+
+
+# ---------------------------------------------------------------------------
+# Premises: the facts the fix rests on
+# ---------------------------------------------------------------------------
+class TestThePremises:
+    """Each of these is a fact the regression cells above depend on."""
+
+    def test_the_fallback_cannot_cover_a_non_finite_magnitude(self) -> None:
+        # Why a magnitude test is not a domain: this is the comparison the
+        # fallback makes, and it is False for nan.
+        assert not (_NAN < 1e-6)
+        assert math.isnan(_INF / _INF)
+
+    def test_the_shared_component_domain_answers_for_these_values(self) -> None:
+        # The regression cells above expect this guard's wording, so the fix must
+        # be consulting it rather than restating it.
+        assert finite_vector_error("m", "p", [_NAN, 0.0]) is not None
+        assert finite_vector_error("m", "p", [True, False]) is not None
+        assert finite_vector_error("m", "p", "abc") is not None
+        assert finite_vector_error("m", "p", [0.5, 0.0]) is None
+        # And it deliberately does not check the count, which is why the arity
+        # check above is separate.
+        assert finite_vector_error("m", "p", [0.5]) is None
+        assert finite_vector_error("m", "p", [0.5, 0.0, 0.0, 0.0]) is None
+
+    def test_the_sibling_locomotion_family_names_its_key_too(self) -> None:
+        # The convention this fix follows, read off the sibling rather than
+        # asserted: wbc's own arity refusal names target_velocity.
+        from strands_robots.policies.wbc.policy import WBCPolicy
+
+        with pytest.raises(ValueError) as caught:
+            WBCPolicy._validate_velocity([0.5, 0.0])
+        assert "target_velocity" in str(caught.value)

--- a/tests/policies/motionbricks/test_policy.py
+++ b/tests/policies/motionbricks/test_policy.py
@@ -242,9 +242,12 @@ def test_allowed_pred_num_tokens_rejects_bad_mode_and_range() -> None:
 
 
 def test_build_control_signals_rejects_short_direction() -> None:
-    # A single-component target_velocity cannot define a planar direction; the
-    # builder rejects it instead of fabricating a NaN/garbage heading.
-    with pytest.raises(ValueError, match="2 or 3 entries"):
+    # A single-component target_velocity cannot define a planar direction, so the
+    # builder rejects it and names the key it came from. This cell grades the
+    # count; a non-finite component is the other way a direction is unusable and
+    # it is graded in test_direction_goal_keys_are_held_to_one_domain.py, because
+    # the near-zero fallback is a magnitude test and cannot cover it.
+    with pytest.raises(ValueError, match="'target_velocity' must have 2 or 3 entries"):
         build_control_signals(
             mode_idx=2,
             clip_token_specs=_CLIP_SPECS,
@@ -255,8 +258,10 @@ def test_build_control_signals_rejects_short_direction() -> None:
 
 
 def test_build_control_signals_zero_velocity_falls_back_to_forward() -> None:
-    # An all-zero command must not yield a NaN direction: it falls back to the
-    # default forward (+x) heading for both movement and facing.
+    # An all-zero command falls back to the default forward (+x) heading for both
+    # movement and facing. That fallback is a magnitude test, so it answers for a
+    # zero vector and not for a nan/inf one - which is refused by the component
+    # domain instead (test_direction_goal_keys_are_held_to_one_domain.py).
     cs = build_control_signals(
         mode_idx=2,
         clip_token_specs=_CLIP_SPECS,


### PR DESCRIPTION
## Problem

`MotionBricksPolicy` resolves two of the issue #300 well-known goal keys — `target_velocity` and `target_heading` — through one reader, `_unit_direction`, which normalises each to a unit direction in the world XY plane. It falls back to "walk straight ahead" for a command with no direction, and its own docstring gave the reason: so an all-zero command "does not produce a NaN direction".

That fallback is a magnitude test, so it could not cover a non-finite component. `nan < 1e-6` is `False`, and `inf` divided by its own norm is `nan`, so either one fell straight through it and produced exactly the outcome the fallback exists to prevent.

Measured on `f35e4f2f`, through the public builder:

| `target_velocity` | main | this branch |
| --- | --- | --- |
| `[0.5, 0.0]` | `movement_direction=[1.0, 0.0, 0.0]` | identical |
| `[0.0, 2.0]` | `[0.0, 1.0, 0.0]` | identical |
| `[0.0, 0.0]` | `[1.0, 0.0, 0.0]` (fallback fires) | identical |
| `[nan, 0.0]` | **`[nan, nan, nan]`**, reported success | refused, names `target_velocity` |
| `[inf, 0.0]` | **`[nan, 0.0, 0.0]`**, reported success | refused, names `target_velocity` |
| `[0.5, 0.0, 0.0, 0.0]` | accepted, read for its first two entries | refused, names `target_velocity` |
| `"abc"` | numpy's `could not convert string to float: 'abc'` | `'target_velocity' elements must be numbers, got 'abc'` |

The same held for `target_heading` and the `facing_direction` it drives.

Two further things about that read were ungraded.

**The refusal named neither key.** One reader serves both, and both answered `direction vector must have 2 or 3 entries`, so a caller passing both could not tell which one had been refused. The sibling locomotion family already names its key in every refusal — `WBCPolicy._validate_velocity` answers `target_velocity must have at least 3 elements [vx, vy, omega]` — and the policy contract's stated reason for leaving the component count out of the goal vocabulary is that "each receiver states its own arity and refuses a shape it cannot use", which needs the refusal to say which receiver and which key. `mesh.security.validate_command` defers the count here deliberately ("the component COUNT is not checked against any receiver's arity here"), so this reader is the only place it is checked at all.

**The message stated a rule the check did not enforce.** Five statements in the package gave the accepted shape as two or three components — the reader's docstring, the module docstring, the constructor's `target_velocity` entry, the refusal text itself and `docs/policies/motionbricks.md` — while the check tested the lower bound alone.

And the constructor's `target_velocity` default went through no domain at all, then was injected into every call that passed none.

## Change

`_unit_direction` now takes the calling `method` and the `param_name` it is reading, consults the shared `utils.finite_vector_error` for the per-component domain, and checks the count against a closed range named by two module constants. Both call sites pass the key they read. The constructor's default goes through the same reader, so a default that cannot be honoured is reported at construction rather than on the first step of a started rollout — the ordering the sibling family's own constructor comment gives as its reason.

Reusing `finite_vector_error` rather than restating the rule is what makes a `bool` refused by name instead of read as `1.0`, and keeps the wording identical to the simulation setters. The ordering of the two checks is observable and is pinned: a value with no readable length has no count to compare, so the arity check running first would answer `got None` — reporting a domain check that never ran — while the component domain says what actually happened.

## Why nothing caught it

The suite stated the property without driving the input that violates it. Two shipped cells say so in their own words:

- `test_build_control_signals_rejects_short_direction` — "the builder rejects it instead of **fabricating a NaN/garbage heading**"
- `test_build_control_signals_zero_velocity_falls_back_to_forward` — "an all-zero command **must not yield a NaN direction**"

Both pass only the inputs where the fallback does fire. Each has been narrowed to the half it grades and now points at the new cells for the other; the first also asserts the key is named, which is why it is the one sibling cell that fails on the pre-fix tree.

## Tests

`tests/policies/motionbricks/test_direction_goal_keys_are_held_to_one_domain.py`, 78 cells over both keys and both doors. Pre-fix split, source reverted and tests kept: **47 failed / 31 passed**.

| class | role | pre-fix |
| --- | --- | --- |
| `TestANonFiniteComponentIsRefused` | regression | 14/14 |
| `TestTheRefusalNamesTheKeyItCameFrom` | regression | 14/14 |
| `TestTheStatedArityIsTheEnforcedArity` | regression | 11/11 |
| `TestTheConstructorDefaultIsHeldToTheSameDomain` | regression | 5/5 |
| `TestTheReaderIsSingleSourced` | regression (structural) | 3/3 |
| `TestWhatIsUnchanged` | over-reach control | **0 of 5** |
| `TestThePremises` | premise | **0 of 3** |

Mutation table, each row against the new file, `collected` stable at 78 and the control clean:

| mutation | fires |
| --- | --- |
| control (nothing changed) | 0 |
| component domain call removed | 31 |
| arity range check removed | 17 |
| both removed (behavioural revert) | 48 |
| arity weakened to a floor only | 9 |
| message drops the key it came from | 7 |
| both call sites pass one key name | 8 |
| constructor default not validated | 6 |
| domain restated locally instead of consulted | 8 |
| arity checked before the components | 4 |
| finiteness narrowed to `nan` only | 15 |

Each half is independently pinned: the two single-half reverts are **disjoint** and their union is exactly the both-halves revert (31 + 17 = 48).

## Gate

- `ruff check` / `ruff format --check` clean over 1597 files.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the merge base, normalized message sets byte-identical in both directions, 0 attributable (`checked 1649` vs `1648`, the one extra file being the new test).
- Paired run, identical 216-file selection (all of `tests/policies/` plus every guard walking the tree, parsing source or reading docstrings, `Args:`, `Raises:`, `__all__` or `docs/`), the new file excluded from both trees: identical **8656 collected**, `8600 passed, 56 skipped, 0 failed` on each, distinct rootdirs.
- `mkdocs build --strict` clean.

## Artifact

`motionbricks` is not installed on this node, so the generator itself cannot be stepped. The quantity the fix governs is the direction vector handed to it, and that is what is rendered — one capture script driving the real reader against both trees, with every claim in the caption asserted from the two captures before anything is drawn.

![target_velocity resolved to movement_direction, main vs this branch](https://github.com/cagataycali/robots/releases/download/artifacts/motionbricks-direction-domain-2846.png)

## Scope

`target_heading_angle` is a scalar rather than a direction vector and does not go through this reader; it is pinned as unchanged. The sibling family's own arity stays as it is — the contract deliberately does not fix a component count across receivers, and this change makes that reason true for this receiver rather than making the two agree.
