### PR TITLE
test(drivers/g1): grade the rt/lowcmd wire-frame contract on CI, not only where the SDK is installed

### DIFF
--- a/changelog.d/2847-g1-wire-frame-contract-graded-on-ci.md
+++ b/changelog.d/2847-g1-wire-frame-contract-graded-on-ci.md
@@ -1,0 +1,44 @@
+### Tests: the g1's ``rt/lowcmd`` wire-frame contract is graded in CI, not only where the SDK is installed
+
+Twenty cells in ``tests/drivers/test_g1_driver.py`` covered ``send_action``'s
+write path and the two ``LowCmd_`` builders, and every one of them sat behind
+``skipif(not _HAS_SDK)``. ``unitree-sdk2`` is in no extra and in no core
+dependency, and ``hatch``'s default env resolves ``features = ["all"]``, so
+``call-test-lint`` skipped all twenty: the CRC, the ``mode_machine`` echo,
+``mode_pr`` and the Enable byte -- the four fields the G1 firmware validates,
+and the four a review of the write path asked for by name -- were asserted by
+nothing on the runner that gates a merge. The suite reported ``53 passed, 20
+skipped`` there while reporting ``73 passed`` on a box that happens to carry
+the SDK.
+
+``tests/drivers/test_g1_per_joint_gains`` already states the rule for the same
+builder: a contract asserted only behind ``skipif(not _HAS_SDK)`` is asserted
+by nothing in CI. Four sibling suites act on it by installing a
+``unitree_sdk2py`` stub on ``sys.modules`` and driving the production lane
+against it. This module was the one that skipped instead, and its section
+comment gave the reason as "a missing SDK short-circuits the whole class" --
+true of the driver, and an argument for supplying a ``LowCmd_``-shaped object
+rather than for leaving the contract ungraded.
+
+Eighteen of the twenty need only that shape to write into, so they now take the
+stub ``tests.drivers.test_g1_control_loop`` installs, imported rather than
+copied so every suite grading this builder writes into the same object. The two
+cells that recompute the SDK's own CRC as an independent oracle keep the marker:
+under a stub whose ``Crc`` returns a constant, ``cmd.crc == CRC().Crc(cmd)``
+compares that constant against itself and grades nothing. One added cell takes
+the half of the stop-frame oracle that is not a CRC question -- the Enable bound
+over the 29 named slots and the reserved tail -- so a stop frame that lands as a
+wire-side no-op is refused by CI rather than by a box with the SDK.
+
+The fixture is opt-in per cell rather than autouse because this module also pins
+the SDK-*absent* refusals (``test_ensure_dds_reports_missing_sdk``,
+``test_connect_eagerly_reports_reason_without_sdk``); a module-wide stub would
+have made those unreachable while leaving them green.
+
+On the tree CI runs, seven wire-frame regressions were undetectable before and
+are detected now: a dropped CRC stamp, ``mode_pr = 1`` (which silently remaps
+four ankle indices), a dropped ``mode_machine`` echo, an Enable byte left at
+Disable in either builder, the per-joint gain table collapsed to a scalar, and a
+stop frame that keeps its stiffness. The suite is unchanged where the SDK is
+present (73 passed, now 74 with the added cell) and moves from ``53 passed, 20
+skipped`` to ``72 passed, 2 skipped`` where it is not.

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -9,6 +9,7 @@ that is a class problem, not a robotics problem.
 from __future__ import annotations
 
 import asyncio
+import sys
 import types
 from typing import Any
 
@@ -31,6 +32,7 @@ from strands_robots.tools.g1 import (
 )
 from strands_robots.tools.g1._dds_engine import DDSSubscriberSet
 from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
+from tests.drivers.test_g1_control_loop import _StubCRC, _StubLowCmd
 
 # =========================================================================
 # The seam - Protocol conformance and factory wiring.                     #
@@ -885,9 +887,20 @@ def test_connect_eagerly_reports_reason_without_sdk() -> None:
 # Every test builds a driver that has already passed the gates and installs
 # a recording publisher in ``_pubs``.  The point is the wire capture: which
 # ``motor_cmd`` slots the driver filled, and with which values.  A missing
-# SDK short-circuits the whole class (the driver refuses with the SDK's own
-# reason before it would build a LowCmd_) so a skip-marker keeps the suite
-# green on machines without the SDK.
+# SDK short-circuits the driver (it refuses with the SDK's own reason before
+# it would build a LowCmd_), so these cells need a LowCmd_-shaped object to
+# write into.  They take one from the stub :mod:`tests.drivers.test_g1_control_loop`
+# installs rather than a skip-marker: ``unitree-sdk2`` is not a declared
+# dependency of this project, so a contract asserted only behind
+# ``skipif(not _HAS_SDK)`` is asserted by nothing in ``call-test-lint`` - the
+# rule :mod:`tests.drivers.test_g1_per_joint_gains` states for the same
+# builder.  The two cells that recompute the SDK's own CRC as an independent
+# oracle keep the marker: a stub CRC would compare a constant against itself.
+#
+# The fixture is opt-in per cell rather than autouse because this module also
+# pins the SDK-*absent* refusals (``test_ensure_dds_reports_missing_sdk``,
+# ``test_connect_eagerly_reports_reason_without_sdk``), which a module-wide
+# stub would quietly make unreachable.
 
 
 _HAS_SDK: bool
@@ -946,7 +959,49 @@ def _gated_driver() -> tuple[G1Driver, _RecordingPublisher]:
     return driver, pub
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.fixture
+def _stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a ``unitree_sdk2py`` stub for the duration of one test.
+
+    ``_build_lowcmd_from_action`` imports ``unitree_sdk2py.idl.default`` and
+    ``unitree_sdk2py.utils.crc`` inside its body, and ``send_action`` imports
+    ``unitree_sdk2py.idl.unitree_hg.msg.dds_``.  Registering each on
+    :mod:`sys.modules` lets the cells below drive the same production lane
+    hardware drives, on a box where the SDK is not installed.
+
+    The stub classes come from :mod:`tests.drivers.test_g1_control_loop`
+    rather than a fifth copy, so every suite that grades this builder writes
+    into the same ``LowCmd_`` shape.  ``monkeypatch.setitem`` restores the
+    previous entries - typically absent - on teardown, per AGENTS.md >
+    Testing Patterns > Restore a sys.modules entry you remove.
+    """
+    root = types.ModuleType("unitree_sdk2py")
+    idl = types.ModuleType("unitree_sdk2py.idl")
+    default = types.ModuleType("unitree_sdk2py.idl.default")
+    unitree_hg = types.ModuleType("unitree_sdk2py.idl.unitree_hg")
+    unitree_hg_msg = types.ModuleType("unitree_sdk2py.idl.unitree_hg.msg")
+    dds_ = types.ModuleType("unitree_sdk2py.idl.unitree_hg.msg.dds_")
+    utils = types.ModuleType("unitree_sdk2py.utils")
+    crc = types.ModuleType("unitree_sdk2py.utils.crc")
+
+    default.unitree_hg_msg_dds__LowCmd_ = _StubLowCmd  # type: ignore[attr-defined]
+    dds_.LowCmd_ = _StubLowCmd  # type: ignore[attr-defined]
+    crc.CRC = _StubCRC  # type: ignore[attr-defined]
+
+    for name, mod in [
+        ("unitree_sdk2py", root),
+        ("unitree_sdk2py.idl", idl),
+        ("unitree_sdk2py.idl.default", default),
+        ("unitree_sdk2py.idl.unitree_hg", unitree_hg),
+        ("unitree_sdk2py.idl.unitree_hg.msg", unitree_hg_msg),
+        ("unitree_sdk2py.idl.unitree_hg.msg.dds_", dds_),
+        ("unitree_sdk2py.utils", utils),
+        ("unitree_sdk2py.utils.crc", crc),
+    ]:
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_writes_to_lowcmd_topic_when_gates_pass() -> None:
     """A gated action publishes exactly one frame to ``rt/lowcmd``.
 
@@ -966,7 +1021,7 @@ def test_send_action_writes_to_lowcmd_topic_when_gates_pass() -> None:
     assert isinstance(message, LowCmd_)
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_fills_the_named_slot_and_leaves_the_rest_alone() -> None:
     """A caller who names one joint sets exactly one slot's ``q``.
 
@@ -990,7 +1045,7 @@ def test_send_action_fills_the_named_slot_and_leaves_the_rest_alone() -> None:
         assert motor.q == pytest.approx(0.0)
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_applies_default_gains_for_scalar_targets() -> None:
     """A scalar target lands that slot's reference gains on the wire.
 
@@ -1021,7 +1076,7 @@ def test_send_action_applies_default_gains_for_scalar_targets() -> None:
     assert m.tau == pytest.approx(0.0)
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_accepts_per_joint_gains_and_feedforward() -> None:
     """A dict target lands every field the caller supplied.
 
@@ -1047,7 +1102,7 @@ def test_send_action_accepts_per_joint_gains_and_feedforward() -> None:
     assert m.tau == pytest.approx(0.05)
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_refuses_unknown_joint_name() -> None:
     """An unknown joint name refuses the whole action - no partial writes.
 
@@ -1063,7 +1118,7 @@ def test_send_action_refuses_unknown_joint_name() -> None:
     assert pub.writes == []  # no partial writes
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_refuses_per_joint_dict_missing_q() -> None:
     """A per-joint dict without ``q`` is refused; no default target is invented.
 
@@ -1077,7 +1132,7 @@ def test_send_action_refuses_per_joint_dict_missing_q() -> None:
     assert pub.writes == []
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_refuses_unknown_per_joint_key() -> None:
     """An unknown inner key refuses the action - same reason as an unknown joint name.
 
@@ -1092,7 +1147,7 @@ def test_send_action_refuses_unknown_per_joint_key() -> None:
     assert pub.writes == []
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_refuses_non_numeric_target() -> None:
     """A non-numeric target is refused with the joint name in the reason."""
     driver, pub = _gated_driver()
@@ -1103,7 +1158,7 @@ def test_send_action_refuses_non_numeric_target() -> None:
     assert pub.writes == []
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_refuses_empty_action() -> None:
     """An empty action dict is refused - "nothing to command" is not a write."""
     driver, pub = _gated_driver()
@@ -1113,7 +1168,7 @@ def test_send_action_refuses_empty_action() -> None:
     assert pub.writes == []
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_surfaces_publisher_error() -> None:
     """A publisher that returns a reason surfaces that reason in the envelope.
 
@@ -1128,7 +1183,7 @@ def test_send_action_surfaces_publisher_error() -> None:
     assert "bus is down" in result["content"][0]["text"]
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_refuses_when_pubs_is_missing() -> None:
     """A gated driver whose ``_pubs`` was never set refuses with a named reason.
 
@@ -1147,7 +1202,7 @@ def test_send_action_refuses_when_pubs_is_missing() -> None:
     assert "publisher not initialised" in result["content"][0]["text"]
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_returns_success_envelope_with_joints_and_topic() -> None:
     """The success envelope carries the topic and every joint it commanded.
 
@@ -1188,7 +1243,7 @@ def test_send_action_still_refuses_before_fsm_gate_regardless_of_wire() -> None:
 # =========================================================================
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_build_lowcmd_scalar_and_dict_land_on_the_same_slot() -> None:
     """Scalar and dict forms land ``q`` on the same slot for the same joint.
 
@@ -1208,7 +1263,7 @@ def test_build_lowcmd_scalar_and_dict_land_on_the_same_slot() -> None:
     assert cmd_scalar.motor_cmd[slot].q == pytest.approx(cmd_dict.motor_cmd[slot].q)
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_build_lowcmd_from_action_rejects_non_dict_input() -> None:
     """A non-dict action is refused with the type it actually was."""
     from strands_robots.drivers.g1 import _build_lowcmd_from_action
@@ -1220,7 +1275,7 @@ def test_build_lowcmd_from_action_rejects_non_dict_input() -> None:
     assert "list" in err
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_build_zero_torque_lowcmd_zeroes_every_motor_field() -> None:
     """Every motor in the zero-torque envelope has kp=kd=tau=q=dq=0.
 
@@ -1272,7 +1327,7 @@ def test_build_lowcmd_sets_a_matching_crc_the_firmware_will_accept() -> None:
     assert cmd.crc != 0
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_build_lowcmd_echoes_mode_machine_and_pins_mode_pr_to_zero() -> None:
     """``mode_machine`` mirrors ``LowState``; ``mode_pr`` stays PR.
 
@@ -1290,7 +1345,7 @@ def test_build_lowcmd_echoes_mode_machine_and_pins_mode_pr_to_zero() -> None:
     assert cmd.mode_pr == 0
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_build_lowcmd_enables_the_touched_slot_and_leaves_the_rest_disabled() -> None:
     """Only commanded slots carry ``motor.mode = 1``; the others stay 0.
 
@@ -1352,7 +1407,34 @@ def test_build_zero_torque_stamps_crc_and_enables_every_named_slot() -> None:
         )
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
+def test_build_zero_torque_enables_every_named_slot_and_leaves_the_tail() -> None:
+    """The stop frame's Enable bound, graded without the SDK.
+
+    The cell above grades this too, but only where ``unitree_sdk2py`` is
+    installed, because it recomputes the SDK's own CRC as an independent
+    oracle.  The Enable bound is not a CRC question: a stop frame whose
+    named slots carry ``mode = 0`` is a wire-side no-op and the arm falls
+    freely, and that is decidable against any ``LowCmd_``-shaped object.
+    Graded here so ``call-test-lint`` refuses the regression rather than
+    only a box that happens to carry the SDK.
+    """
+    from strands_robots.drivers.g1 import _G1_NAMED_JOINTS, _build_zero_torque_lowcmd
+
+    cmd, err = _build_zero_torque_lowcmd(mode_machine=7)
+    assert err is None and cmd is not None
+    assert cmd.mode_machine == 7
+    assert cmd.mode_pr == 0
+    for i in range(_G1_NAMED_JOINTS):
+        assert cmd.motor_cmd[i].mode == 1, f"named slot {i} is not Enable on the stop frame"
+    for i in range(_G1_NAMED_JOINTS, len(cmd.motor_cmd)):
+        assert cmd.motor_cmd[i].mode == 0, (
+            f"reserved slot {i} was enabled; the SDK reference bounds "
+            f"Enable by G1_NUM_MOTOR (29), not by the array width"
+        )
+
+
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 def test_send_action_echoes_cached_mode_machine_not_fsm_id() -> None:
     """``send_action`` echoes ``_mode_machine`` (uint8) onto the wire, not ``_fsm_id``.
 


### PR DESCRIPTION
## The wire-frame contract was graded by nothing in CI

`tests/drivers/test_g1_driver.py` covers `send_action`'s write path and the two `LowCmd_` builders in 20 cells, and every one of them sat behind `skipif(not _HAS_SDK)`.

`unitree-sdk2` is in no extra and in no core dependency, and `hatch`'s default env resolves `features = ["all"]`, so `_HAS_SDK` is False on the runner that gates a merge. Modelling that (both layers a suite can consult: `find_spec` returns `None`, and a real import raises `ModuleNotFoundError`), the suite reads:

| suite | SDK present | SDK hidden, i.e. `call-test-lint` |
|---|---|---|
| `test_g1_driver.py` | 73 passed | **53 passed, 20 skipped** |
| `test_g1_control_loop.py` | 35 passed | 35 passed, 0 skipped |

Same 73 collected either way, so the cells exist and their disposition moves. Among the 20 CI never runs are the four fields the G1 firmware validates:

- `test_build_lowcmd_sets_a_matching_crc_the_firmware_will_accept`
- `test_build_lowcmd_echoes_mode_machine_and_pins_mode_pr_to_zero`
- `test_build_lowcmd_enables_the_touched_slot_and_leaves_the_rest_disabled`
- `test_build_zero_torque_stamps_crc_and_enables_every_named_slot`

A frame with a wrong CRC, a wrong `mode_machine`, `mode_pr = 1` or a Disable byte is one the robot silently ignores or acts on with the wrong physical meaning, and `send_action` reports `success` either way. Those are the regressions the required check could not see.

## The rule is already stated in-tree, for the same builder

`tests/drivers/test_g1_per_joint_gains` grades `_build_lowcmd_from_action` and writes its layering down:

> The contract cells need no `unitree_sdk2py`, so `call-test-lint` grades them in CI, where the SDK is not installed. `unitree-sdk2` is not a declared dependency of this project, so a contract asserted only behind `skipif(not _HAS_SDK)` is asserted by nothing in CI.
> The wire cells, which do need the SDK to build a real `LowCmd_`, confirm the contract cells describe what actually lands on the topic.

Four sibling suites act on it by installing a `unitree_sdk2py` stub on `sys.modules` and driving the production lane against it. Across the 12 g1 suites, 8 run fully in CI; this module loses the most (20 of 73).

Its section comment gave the reason for skipping instead: "a missing SDK short-circuits the whole class (the driver refuses with the SDK's own reason before it would build a LowCmd_)". That is true of the driver, and it is an argument for supplying a `LowCmd_`-shaped object -- which is what the siblings do -- rather than for leaving the contract ungraded.

## The change

Eighteen of the twenty need only that shape to write into. They now take the stub `tests.drivers.test_g1_control_loop` installs, imported rather than copied (the idiom `test_g1_cleanup_reads_the_loop_halt_outcome` already uses) so every suite grading this builder writes into the same object.

Two cells keep the marker, and this is the split the sibling names: they recompute the SDK's own CRC as an independent oracle, and under a stub whose `Crc` returns a constant, `cmd.crc == CRC().Crc(cmd)` compares that constant against itself and grades nothing.

One cell is added. `test_build_zero_torque_stamps_crc_and_enables_every_named_slot` does four jobs and only one is a CRC question; the Enable bound over the 29 named slots and the reserved tail is decidable against any `LowCmd_`-shaped object. The break table below found that gap -- without the new cell, a stop frame left at Disable was still undetectable in CI.

The fixture is **opt-in per cell rather than autouse**, because this module also pins the SDK-*absent* refusals (`test_ensure_dds_reports_missing_sdk`, `test_connect_eagerly_reports_reason_without_sdk`). A module-wide stub would have made those unreachable while leaving them green. Both pass in both dependency modes here.

No production code changes.

## What CI can now detect

Each mutation is a real wire-frame regression, applied to `strands_robots/drivers/g1.py` and run with the SDK hidden -- the tree `call-test-lint` sees. `collected` is stable at 73 (base) and 74 (branch) on every row, so no row hides a deselection.

| mutation | before | after | cell that catches it |
|---|---|---|---|
| control, no mutation | 0 | 0 | - |
| CRC never stamped | **0** | 1 | `..._echoes_cached_mode_machine_not_fsm_id` (`crc != 0`) |
| `mode_pr = 1` (remaps four ankle indices) | **0** | 2 | `..._echoes_mode_machine_and_pins_mode_pr_to_zero` |
| `mode_machine` not echoed | **0** | 2 | `..._echoes_mode_machine_and_pins_mode_pr_to_zero` |
| Enable byte left Disable | **0** | 1 | `..._enables_the_touched_slot_and_leaves_the_rest_disabled` |
| per-joint gains collapsed to a scalar | **0** | 1 | `..._applies_default_gains_for_scalar_targets` |
| stop frame keeps its stiffness | **0** | 1 | `..._zero_torque_lowcmd_zeroes_every_motor_field` |
| stop frame slot left Disable | **0** | 1 | `..._zero_torque_enables_every_named_slot_and_leaves_the_tail` (added) |

Seven regressions, undetectable before, detected after. The source was restored byte-identically after every row.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1650 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine worktree of the merge-base, normalized message sets byte-identical in both directions, 0 attributable to the changed file.
- Paired gate, identical 196-file selection (all of `tests/drivers/` plus every suite that walks the tree, parses source, or reads docstrings), the changed file excluded from both trees, every path verified present on both: identical **7811 collected** and `7745 passed, 66 skipped, 0 failed` on each, distinct rootdirs.
- `tests/drivers/` on the rebased tree, with the guard `main` added since: **699 passed, 3 skipped**.
- The suite itself: unchanged at 73 passed where the SDK is present (74 with the added cell), and `53 passed, 20 skipped` becomes `72 passed, 2 skipped` where it is not.

No visual artifact: this is a test-visibility change with no rendering, recording, policy or asset behaviour. The break table is the evidence.
