### PR TITLE
fix(training/rl): hold num_envs to the shared count domain on both backends

### DIFF
--- a/changelog.d/2849-rl-env-count-is-a-count-on-every-backend.md
+++ b/changelog.d/2849-rl-env-count-is-a-count-on-every-backend.md
@@ -1,0 +1,59 @@
+### Fixed: `num_envs` is held to the shared count domain on both RL backends
+
+`RLTrainSpec.num_envs` is the third caller-supplied factor of the one loop bound
+every RL backend derives, `max(1, total_timesteps // (rollout_steps * num_envs))`
+iterated as `range()`. Its two siblings are held to
+`strands_robots.utils.positive_count_error` by `rl_run_size_problems`, whose own
+docstring works through why a bare `value <= 0` test on a *derived* bound is
+weaker than the same test on a field read straight off the spec: the `max(1, ...)`
+clamp turns every value that survives the comparison but cannot divide into a
+silent wrong-length run.
+
+`num_envs` was deliberately left out of that gate, for a reason that holds: which
+*counts* are usable genuinely differs per backend - PPO parallelizes over any
+positive count where the MuJoCo-backed FastSAC is single-env and requires exactly
+`1` - so that half is not one shared rule, and each backend stated its own with a
+bare comparison. What the reason does not cover is whether the value is a count
+at all. That half is identical on both backends and was stated by neither, so the
+third factor of this product sat outside the domain its two siblings are held to.
+
+Measured over `total_timesteps=1000` and `rollout_steps=64`, which asks for 15
+iterations of 64 steps:
+
+- `nan` passed PPO's `< 1`. `64 * nan` is `nan`, `max(1, nan)` keeps the `1`, and
+  `1000 // 1` is `1000`: the run reported `success` and announced `"1000
+  iterations x 1 steps complete"` while each of those 1000 iterations collected
+  `rollout_steps` steps - 66x the requested budget, under a message that
+  misdescribes both factors.
+- `inf` passed the same test and ran **one** iteration, announcing `"1 iterations
+  x inf steps complete"`.
+- `1.0` and `2.5` kept the bound a float, which raises `TypeError: 'float' object
+  cannot be interpreted as an integer` out of `range()` - after `setup` had built
+  the environment, the networks and the optimizers, which is the cost a read-only
+  preflight exists to precede. `1.0` reached that through FastSAC's `!= 1` as
+  well. A large float does not: `100.5` makes `1000 // 6432.0` the float `0.0`,
+  which the clamp replaces with the int `1`, so it runs one iteration instead.
+- `True` passed both backends - it satisfies `< 1` being false and `!= 1` being
+  false - and is numerically `1`, so the run length was right and what was wrong
+  is that a value reading as a flag was accepted as a count. That is the reason
+  the shared domain refuses a `bool` rather than testing a bound.
+- `"4"` and `None` raised `TypeError: '<' not supported between instances of
+  'str' and 'int'` out of PPO's comparison itself, from a `Trainer.validate`
+  documented to *return* problems.
+
+Both backends now consult the shared domain first and ask their own count rule
+only of a count, matching the idiom each already uses one statement later for a
+relation between two counts. The per-backend line is unchanged and pinned: `4` is
+still usable for the parallel backend and still refused as single-env by the
+other, and a non-count is no longer reported as the wrong *number* of
+environments. PPO keeps no second comparison, because over the values the domain
+accepts every positive `int` parallelizes, so a `< 1` branch there would be
+unreachable - and the refusal now names the backend that refused, which the bare
+comparison's message did not.
+
+The scope paragraph in `rl_run_size_problems` said the whole field was excluded;
+it now says which half, so the next reader is not invited to leave the shared half
+open again. `TestNumEnvsIsNotInTheSharedDomain`'s non-vacuity test asserted that
+"excluding it from the domain did not leave it unchecked" while driving only `0` -
+the one unusable value a bare comparison already caught - and is widened to the
+values that survive one.

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -289,10 +289,18 @@ def rl_run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
     ``range()`` bounds.
 
     ``num_envs``, the third factor of ``steps_per_iter``, is deliberately not
-    here. Its accepted set differs between the backends - PPO parallelizes and
-    accepts any count ``>= 1``, while the MuJoCo-backed FastSAC is single-env and
-    requires exactly ``1`` - so it is not one shared domain, and each backend
-    keeps the rule only it can state.
+    here, and the reason is narrower than the whole field: which *counts* are
+    usable differs between the backends - PPO parallelizes and accepts any
+    positive count, while the MuJoCo-backed FastSAC is single-env and requires
+    exactly ``1`` - so that half is not one shared rule and each backend keeps it.
+    That the value must be a count *at all* is not per-backend, and it is this
+    same domain, so both backends consult it before asking their own count rule.
+    Excluding the whole field would have left the third factor of this very
+    product outside the domain its two siblings are held to, which is what a bare
+    per-backend comparison could not carry: it read ``nan`` and ``inf`` as usable
+    and the ``max(1, ...)`` clamp turned them into a 1000-iteration and a
+    one-iteration run under ``status="success"``, and ``True`` into a count of one
+    from a value that reads as a flag.
 
     Args:
         spec: The spec to check.

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -156,10 +156,20 @@ class FastSacTrainer(BaseRLAlgo):
         # it reads True, a fraction below one iteration, nan and inf as a single
         # iteration under a successful run.
         problems.extend(self._rl_run_size_problems(spec))
-        # num_envs is the third factor and is NOT part of that shared domain: this
-        # backend is single-env, so only 1 is usable here while PPO parallelizes
-        # and accepts any count >= 1. Only this backend can state it.
-        if spec.num_envs != 1:
+        # num_envs is the third factor of that same product. Which *count* is
+        # usable is per-backend - this one is single-env, so only 1 is, while PPO
+        # parallelizes and accepts any positive count - but that a count is what
+        # the field must hold is not, and it is the same ``positive_count_error``
+        # domain the two factors above use. A bare ``!= 1`` test cannot carry that
+        # half: ``True`` and ``1.0`` both satisfy it, so a value that reads as a
+        # flag landed as the required single env, and ``rollout_steps * 1.0`` made
+        # ``num_iters`` a float that raised out of ``range()`` after setup had
+        # built the env, the networks, the optimizers and the replay buffer. The
+        # count rule is asked only of a count, so a non-count is reported as one
+        # rather than as the wrong number of envs.
+        if (error := positive_count_error(spec.num_envs, "num_envs", self.provider_name)) is not None:
+            problems.append(error)
+        elif spec.num_envs != 1:
             problems.append(f"the MuJoCo backend is single-env (num_envs must be 1), got {spec.num_envs}")
         # buffer_size, batch_size and gradient_steps are the replay loop's three
         # caller-supplied counts: the buffer capacity, the transitions sampled

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -180,11 +180,25 @@ class PpoTrainer(BaseRLAlgo):
         # it reads True, a fraction below one iteration, nan and inf as a single
         # iteration under a successful run.
         problems.extend(self._rl_run_size_problems(spec))
-        # num_envs is the third factor and is NOT part of that shared domain: this
-        # backend parallelizes, so any count >= 1 is usable here while the
-        # single-env FastSAC requires exactly 1. Only this backend can state it.
-        if spec.num_envs < 1:
-            problems.append(f"num_envs must be >= 1, got {spec.num_envs}")
+        # num_envs is the third factor of that same product. Which *counts* are
+        # usable is per-backend - this one parallelizes, so any positive count is,
+        # while the single-env FastSAC requires exactly 1 - but that a count is
+        # what the field must hold is not, and it is the same
+        # ``positive_count_error`` domain the two factors above use, for the same
+        # reason: it is a factor of a ``range()`` bound. A bare ``< 1`` test
+        # cannot carry that half. It read ``nan`` as usable and the clamp turned
+        # ``rollout_steps * nan`` into one step, so a 1000-step budget over 64
+        # rollout steps ran 1000 iterations instead of 15 and announced "1000
+        # iterations x 1 steps complete"; ``inf`` ran one; an integral float made
+        # ``num_iters`` a float and raised out of ``range()`` after setup had
+        # built the env, the networks and the optimizers; ``True`` landed as a
+        # count of one from a value that reads as a flag; and a str / None raised
+        # ``TypeError`` out of the comparison itself, from a ``validate``
+        # documented to return problems. For this backend the domain is the whole
+        # rule: over the values it accepts, every positive ``int`` parallelizes,
+        # so there is no further count to test here.
+        if (error := positive_count_error(spec.num_envs, "num_envs", self.provider_name)) is not None:
+            problems.append(error)
         # num_mini_batches splits the rollout batch, so this is a relation BETWEEN
         # two counts and can only be asked once rollout_steps is one: a str reaches
         # ``%`` as string formatting (TypeError, out of a method documented to

--- a/tests/training/test_rl_env_count_domain.py
+++ b/tests/training/test_rl_env_count_domain.py
@@ -1,0 +1,309 @@
+"""``RLTrainSpec.num_envs`` is a count on every backend, whatever count each wants.
+
+``num_envs`` is the third caller-supplied factor of the one loop bound every RL
+backend derives::
+
+    steps_per_iter = rollout_steps * num_envs
+    num_iters = max(1, total_timesteps // steps_per_iter)
+    for it in range(num_iters):  # collect, update
+
+Its two siblings are held to :func:`~strands_robots.utils.positive_count_error`
+by :func:`~strands_robots.training._validate.rl_run_size_problems`, whose own
+docstring works through why a bare ``value <= 0`` test on a *derived* bound is
+weaker than the same test on a field read straight off the spec. ``num_envs`` was
+left out of that gate for a real reason - which counts are usable genuinely
+differs per backend, PPO parallelizing over any positive count where the
+MuJoCo-backed FastSAC requires exactly ``1`` - and each backend stated its own
+rule with a bare comparison.
+
+That reason covers which *counts* are usable. It does not cover whether the value
+is a count, which is the same on both backends and was stated by neither.
+Measured before this gate existed, over ``total_timesteps=1000`` and
+``rollout_steps=64`` (intended: 15 iterations of 64 steps):
+
+* ``nan`` passed PPO's ``< 1`` test. ``64 * nan`` is ``nan``, ``max(1, nan)``
+  keeps ``1``, and ``1000 // 1`` is ``1000``: the run reported ``success`` and
+  announced ``"1000 iterations x 1 steps complete"`` while each of those 1000
+  iterations collected ``rollout_steps`` steps - 66x the requested budget, under a
+  message that misdescribes both factors.
+* ``inf`` passed the same test and ran **one** iteration, announcing
+  ``"1 iterations x inf steps complete"``.
+* ``2.5`` passed and made ``num_iters`` the float ``6.0``, which raises
+  ``TypeError: 'float' object cannot be interpreted as an integer`` out of
+  ``range()`` - after ``setup`` had built the environment, the networks and the
+  optimizers, which is the cost a read-only preflight exists to precede. ``1.0``
+  passed FastSAC's ``!= 1`` as well and raised the same way from ``15.0``. A
+  *large* float does not: ``100.5`` makes ``1000 // 6432.0`` the float ``0.0``,
+  which the clamp replaces with the int ``1``, so it runs one iteration instead.
+* ``True`` passed both backends - it satisfies ``< 1`` being false and ``!= 1``
+  being false - and is numerically ``1``, so the run length is right and what is
+  wrong is that a value reading as a flag was accepted as a count. That is the
+  reason the shared domain refuses a ``bool`` rather than testing a bound.
+* ``"4"`` and ``None`` raised ``TypeError: '<' not supported between instances of
+  'str' and 'int'`` out of PPO's comparison itself - from a
+  :meth:`~strands_robots.training.base.Trainer.validate` documented to *return*
+  problems.
+
+So each backend now consults the shared domain first and asks its own count rule
+only of a count. The scope line the exclusion draws is unchanged and is pinned
+here too: ``4`` is usable for the parallel backend and refused by the single-env
+one, on both trees.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import textwrap
+from typing import Any
+
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import rl_run_size_problems
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+from strands_robots.training.rl.fast_sac import FastSacTrainer
+from strands_robots.training.rl.ppo import PpoTrainer
+from strands_robots.utils import positive_count_error
+
+# The backends that derive a loop bound from this factor.
+RL_BACKENDS = ("ppo", "fast_sac")
+
+# Values that survive a bare per-backend comparison and cannot bound the loop.
+# ``True`` / ``1.0`` survive *both* comparisons; the rest survive PPO's ``< 1``.
+NOT_A_COUNT: list[Any] = [True, False, 1.0, 2.5, 100.5, float("nan"), float("inf"), "4", None, [1], {"n": 1}]
+
+# The subset a bare comparison could not even report on: it raises instead.
+RAISED_OUT_OF_THE_COMPARISON: list[Any] = ["4", None, [1], {"n": 1}]
+
+# The values that SURVIVED a bare comparison, classified by what each did to the
+# derived bound. Every other value in ``NOT_A_COUNT`` was already refused by one
+# comparison or the other, so it is graded above but carries no harm of its own.
+#
+# ``max(1, ...)`` reads ``nan`` as ``1`` (nan compares false against everything)
+# and ``inf`` as ``inf``, so the two land on opposite sides of the intended count.
+WRONG_RUN_LENGTH: dict[Any, int] = {float("nan"): 1000, float("inf"): 1}
+
+# An integral or fractional float keeps the bound a float, but only while
+# ``total_timesteps // steps_per_iter`` is at least one - a large enough float is
+# clamped back to the int ``1`` and lands in ``WRONG_RUN_LENGTH``'s territory
+# instead. These two are the reachable float-bound cases at this run size.
+FLOAT_BOUND: list[float] = [1.0, 2.5]
+
+# ``True`` is numerically ``1``, so it does not change the run length at all: the
+# harm is that a value which reads as a flag is accepted as a count of one, the
+# same reason the shared domain refuses a ``bool`` everywhere else.
+READS_AS_ONE: list[Any] = [True]
+
+# A positive ``int`` is the whole shared half.
+A_COUNT: list[Any] = [1, 2, 4, 1024]
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """A spec whose every other field is usable, so only ``num_envs`` is in doubt."""
+    return RLTrainSpec(
+        output_dir="/tmp/strands-rl-env-count",
+        env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+        total_timesteps=1000,
+        rollout_steps=64,
+    )
+
+
+def _num_envs_problems(provider: str, spec: RLTrainSpec, value: Any) -> list[str]:
+    """The problems ``provider``'s real ``validate`` reports about ``num_envs``."""
+    spec.num_envs = value
+    return [p for p in create_trainer(provider).validate(spec) if "num_envs" in p]
+
+
+class TestEveryBackendRefusesANonCount:
+    """The shared half, through the real ``validate`` entry point."""
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", NOT_A_COUNT)
+    def test_a_non_count_is_refused(self, provider: str, spec: RLTrainSpec, value: Any) -> None:
+        assert _num_envs_problems(provider, spec, value)
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", NOT_A_COUNT)
+    def test_the_refusal_names_the_field_and_the_domain(self, provider: str, spec: RLTrainSpec, value: Any) -> None:
+        """A caller fixes a field it can name, against a rule it can read."""
+        problems = _num_envs_problems(provider, spec, value)
+        assert any("num_envs must be a positive integer" in p for p in problems), problems
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", NOT_A_COUNT)
+    def test_the_refusal_names_the_backend_that_refused(self, provider: str, spec: RLTrainSpec, value: Any) -> None:
+        """The shared domain carries the caller's own identity into the message."""
+        trainer = create_trainer(provider)
+        problems = _num_envs_problems(provider, spec, value)
+        assert any(p.startswith(f"{trainer.provider_name}: num_envs") for p in problems), problems
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", RAISED_OUT_OF_THE_COMPARISON)
+    def test_a_non_numeric_value_is_returned_rather_than_raised(
+        self, provider: str, spec: RLTrainSpec, value: Any
+    ) -> None:
+        """``validate`` is documented to return problems, so it must not raise here."""
+        spec.num_envs = value
+        problems = create_trainer(provider).validate(spec)  # must not raise
+        assert any("num_envs" in p for p in problems), problems
+
+
+class TestTheHarmTheDomainReplaces:
+    """The arithmetic that made a surviving non-count a wrong-length run.
+
+    These read the derived bound rather than the trainers, because the values are
+    refused now - the point is what they *would* do to the loop, which is why
+    refusing them at a read-only preflight is the fix.
+    """
+
+    @pytest.mark.parametrize(("value", "expected"), list(WRONG_RUN_LENGTH.items()))
+    def test_a_surviving_non_count_changes_the_run_length(self, value: Any, expected: int) -> None:
+        """And by how much, in each direction, so a wrong number here fails loudly."""
+        intended = max(1, 1000 // max(1, 64 * 1))
+        assert intended == 15
+        got = max(1, 1000 // max(1, 64 * value))
+        assert got == expected != intended, (value, got, expected, intended)
+
+    def test_nan_lengthens_the_run_where_inf_shortens_it(self) -> None:
+        """The clamp, not the value, decides the direction - which is why it is silent.
+
+        ``nan`` compares false against everything, so ``max(1, nan)`` keeps the
+        ``1`` and the budget divides by a single step; ``inf`` survives the clamp
+        and swallows the whole budget in one iteration.
+        """
+        assert math.isnan(64 * float("nan"))
+        assert max(1, 64 * float("nan")) == 1
+        assert max(1, 64 * float("inf")) == float("inf")
+
+    @pytest.mark.parametrize("value", FLOAT_BOUND)
+    def test_a_float_makes_the_loop_bound_unusable_as_a_range(self, value: float) -> None:
+        num_iters = max(1, 1000 // max(1, 64 * value))
+        assert isinstance(num_iters, float), (value, num_iters)
+        with pytest.raises(TypeError, match="cannot be interpreted as an integer"):
+            range(num_iters)  # type: ignore[call-overload]
+
+    def test_a_large_float_is_clamped_back_to_a_usable_bound_and_is_still_wrong(self) -> None:
+        """The float-bound harm has a boundary; past it the harm is the length again.
+
+        ``100.5`` makes ``1000 // 6432.0`` the float ``0.0``, which the clamp
+        replaces with the int ``1`` - so ``range()`` is happy and the run is one
+        iteration instead of fifteen. Recorded so the two harms are not conflated:
+        a float is not always a float bound.
+        """
+        num_iters = max(1, 1000 // max(1, 64 * 100.5))
+        assert num_iters == 1
+        assert isinstance(num_iters, int)
+        assert range(num_iters) is not None
+
+    @pytest.mark.parametrize("value", READS_AS_ONE)
+    def test_a_flag_is_numerically_one_so_the_length_is_not_the_harm(self, value: Any) -> None:
+        """``True`` runs the intended length; what it changes is what the field means.
+
+        This is the whole reason the shared domain refuses a ``bool`` rather than
+        testing a bound: the arithmetic cannot tell a flag from the count ``1``.
+        """
+        assert max(1, 1000 // max(1, 64 * value)) == max(1, 1000 // max(1, 64 * 1))
+        assert positive_count_error(value, "num_envs", "x") is not None
+
+
+class TestTheDomainIsConsultedBeforeTheCountRule:
+    """Ordering, structurally: a non-count is reported as one, not as a wrong count."""
+
+    @pytest.mark.parametrize(("provider", "trainer_class"), [("ppo", PpoTrainer), ("fast_sac", FastSacTrainer)])
+    def test_the_domain_call_precedes_any_local_comparison(self, provider: str, trainer_class: type[Trainer]) -> None:
+        # ``inspect.getsource`` of a method is indented; ``ast.parse`` is not.
+        tree = ast.parse(textwrap.dedent(inspect.getsource(trainer_class.validate)))
+        domain_lines = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "positive_count_error"
+            and any(_names_num_envs(arg) for arg in node.args)
+        ]
+        comparison_lines = [
+            node.lineno for node in ast.walk(tree) if isinstance(node, ast.Compare) and _names_num_envs(node.left)
+        ]
+        assert len(domain_lines) == 1, (provider, domain_lines)
+        assert all(domain_lines[0] < line for line in comparison_lines), (
+            provider,
+            domain_lines,
+            comparison_lines,
+        )
+
+    def test_the_single_env_message_is_reserved_for_a_real_count(self, spec: RLTrainSpec) -> None:
+        """A non-count is not reported as the wrong number of environments."""
+        problems = _num_envs_problems("fast_sac", spec, float("nan"))
+        assert not any("single-env" in p for p in problems), problems
+
+
+class TestThePerBackendCountRuleIsUnchanged:
+    """The scope line the exclusion draws, pinned on this tree too."""
+
+    @pytest.mark.parametrize("value", A_COUNT)
+    def test_the_parallel_backend_accepts_any_positive_count(self, spec: RLTrainSpec, value: int) -> None:
+        assert _num_envs_problems("ppo", spec, value) == []
+
+    def test_the_single_env_backend_accepts_exactly_one(self, spec: RLTrainSpec) -> None:
+        assert _num_envs_problems("fast_sac", spec, 1) == []
+
+    @pytest.mark.parametrize("value", [2, 4, 1024])
+    def test_the_single_env_backend_still_refuses_a_larger_count(self, spec: RLTrainSpec, value: int) -> None:
+        problems = _num_envs_problems("fast_sac", spec, value)
+        assert any("single-env" in p for p in problems), problems
+
+    def test_the_backends_still_disagree_about_the_same_count(self, spec: RLTrainSpec) -> None:
+        """Two envs: usable for the parallel backend, refused by the single-env one."""
+        assert _num_envs_problems("ppo", spec, 2) == []
+        assert _num_envs_problems("fast_sac", spec, 2)
+
+
+class TestThePremises:
+    """What the fix rests on, so a change to any of it fails here rather than silently."""
+
+    def test_the_shared_domain_refuses_every_probe_value(self) -> None:
+        """Non-vacuity: the domain is what does the refusing, for all of them."""
+        for value in NOT_A_COUNT:
+            assert positive_count_error(value, "num_envs", "x") is not None, value
+
+    def test_the_shared_domain_accepts_every_count(self) -> None:
+        for value in A_COUNT:
+            assert positive_count_error(value, "num_envs", "x") is None, value
+
+    def test_the_domain_is_exactly_the_parallel_backends_own_rule(self) -> None:
+        """Why PPO keeps no second comparison: over the accepted set, ``>= 1`` holds.
+
+        A ``< 1`` branch after this domain would be unreachable, and dead code
+        that reads as a rule is worse than none.
+        """
+        for value in A_COUNT:
+            assert value >= 1, value
+
+    def test_the_shared_gate_says_which_half_of_the_field_it_excludes(self) -> None:
+        """The exclusion is documented as covering the count rule, not the field.
+
+        The gate's docstring is where a contributor reads why ``num_envs`` is not
+        in it. Left saying the whole field is out, it invites the next reader to
+        leave the shared half open again - which is exactly how it was open.
+        """
+        doc = " ".join((rl_run_size_problems.__doc__ or "").split())
+        assert "num_envs" in doc
+        assert "which *counts* are usable differs between the backends" in doc
+        assert "count *at all* is not per-backend" in doc
+
+    def test_the_two_sibling_factors_are_held_to_the_same_domain(self, spec: RLTrainSpec) -> None:
+        """The domain is shared with the two factors this one is multiplied by."""
+        for field in ("total_timesteps", "rollout_steps"):
+            setattr(spec, field, 0)
+            problems = [p for p in create_trainer("ppo").validate(spec) if field in p]
+            assert any("must be a positive integer" in p for p in problems), (field, problems)
+            setattr(spec, field, 64)
+
+
+def _names_num_envs(node: ast.AST) -> bool:
+    """Whether ``node`` is the ``spec.num_envs`` attribute read."""
+    return isinstance(node, ast.Attribute) and node.attr == "num_envs"

--- a/tests/training/test_rl_ppo.py
+++ b/tests/training/test_rl_ppo.py
@@ -95,7 +95,7 @@ def test_validate_rejects_bad_specs() -> None:
     assert not any("num_envs" in p for p in problems), problems
     # But num_envs < 1 is still invalid.
     problems = trainer.validate(RLTrainSpec(output_dir="/tmp/x", env_factory=lambda: None, num_envs=0))  # type: ignore[arg-type,return-value]
-    assert any("num_envs must be >= 1" in p for p in problems)
+    assert any("num_envs must be a positive integer" in p for p in problems)
 
     # rollout_steps must divide into num_mini_batches.
     problems = trainer.validate(RLTrainSpec(output_dir="/tmp/x", rollout_steps=10, num_mini_batches=3))
@@ -109,7 +109,7 @@ def test_validate_rejects_bad_specs() -> None:
         ({"total_timesteps": 0}, "total_timesteps must be a positive integer"),
         ({"total_timesteps": -1}, "total_timesteps must be a positive integer"),
         ({"rollout_steps": 0}, "rollout_steps must be a positive integer"),
-        ({"num_envs": 0}, "num_envs must be >= 1"),
+        ({"num_envs": 0}, "num_envs must be a positive integer"),
         ({"rollout_steps": 10, "num_mini_batches": 3}, "divisible"),
         ({"num_mini_batches": 0}, "divisible"),
     ],

--- a/tests/training/test_rl_run_size_domain.py
+++ b/tests/training/test_rl_run_size_domain.py
@@ -22,11 +22,14 @@ to *return* problems. ``rollout_steps=True`` was worse than a short run: FastSAC
 ran 16 single-step iterations instead of 4 of 4, and PPO normalized advantages
 over a length-one batch and died inside torch's ``Normal`` constraint.
 
-``num_envs``, the third factor of ``steps_per_iter``, is deliberately outside the
-shared domain because its accepted set differs per backend - PPO parallelizes and
-accepts any count ``>= 1``, the MuJoCo-backed FastSAC requires exactly ``1`` - so
-it is not one shared rule. :class:`TestNumEnvsIsNotInTheSharedDomain` pins that
-scope line rather than leaving it to prose.
+``num_envs``, the third factor of ``steps_per_iter``, is outside this gate because
+which *counts* are usable differs per backend - PPO parallelizes and accepts any
+positive count, the MuJoCo-backed FastSAC requires exactly ``1`` - so that half is
+not one shared rule. It is only that half: whether the value is a count at all is
+the same domain, and each backend consults it before asking its own count rule, so
+the third factor of this product is held to what its two siblings are held to.
+:class:`TestNumEnvsIsNotInTheSharedDomain` pins the scope line;
+``test_rl_env_count_domain.py`` pins the shared half.
 
 Every domain test here reaches the real ``validate`` entry point, so it covers
 the wiring as well as the domain.
@@ -290,8 +293,25 @@ class TestNumEnvsIsNotInTheSharedDomain:
 
     @pytest.mark.parametrize("provider", RL_BACKENDS)
     def test_each_backend_still_refuses_a_non_positive_count(self, provider: str, spec: RLTrainSpec) -> None:
-        """Non-vacuity: excluding it from the domain did not leave it unchecked."""
+        """Non-vacuity: excluding the count rule did not leave the field unchecked.
+
+        ``0`` is the one unusable value a bare comparison already caught, so it
+        cannot carry this claim on its own - the values that survive such a
+        comparison are graded in ``test_rl_env_count_domain.py``, which is where
+        this class's scope line stops.
+        """
         spec.num_envs = 0
+        assert [p for p in create_trainer(provider).validate(spec) if "num_envs" in p]
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", NOT_A_COUNT)
+    def test_the_shared_half_reaches_it_on_both_backends(self, provider: str, value: Any, spec: RLTrainSpec) -> None:
+        """The half that IS shared: a non-count is refused wherever it is read.
+
+        The per-backend line is about which counts are usable. It is not about
+        whether the value is a count, so no backend gets to leave that open.
+        """
+        spec.num_envs = value
         assert [p for p in create_trainer(provider).validate(spec) if "num_envs" in p]
 
 


### PR DESCRIPTION
## What is wrong

`RLTrainSpec.num_envs` is the third caller-supplied factor of the one loop bound every RL backend derives:

```
steps_per_iter = rollout_steps * num_envs
num_iters      = max(1, total_timesteps // steps_per_iter)
for it in range(num_iters):   # collect, update
```

Its two siblings go through `positive_count_error` in `rl_run_size_problems`, whose docstring works through why a bare `value <= 0` test on a *derived* bound is weaker than the same test on a field read straight off the spec.

`num_envs` was deliberately left out of that gate, and the reason holds: which **counts** are usable differs per backend - PPO parallelizes over any positive count, the MuJoCo-backed FastSAC is single-env and requires exactly `1` - so that half is not one shared rule, and each backend stated its own with a bare comparison (`< 1`, `!= 1`).

What the reason does not cover is whether the value is a count at all. That half is identical on both backends and was stated by neither, so the third factor of this product sat outside the domain its two siblings are held to.

## Measured

`total_timesteps=1000`, `rollout_steps=64` - which asks for 15 iterations of 64 steps.

| `num_envs` | PPO `< 1` | FastSAC `!= 1` | `num_iters` | consequence |
|---|---|---|---|---|
| `nan` | accepted | refused | **1000** | `success`, announced `"1000 iterations x 1 steps complete"` while each iteration collected 64 steps - 66x the budget, and the message misdescribes both factors |
| `inf` | accepted | refused | **1** | `success`, announced `"1 iterations x inf steps complete"` |
| `2.5` | accepted | refused | `6.0` | `TypeError: 'float' object cannot be interpreted as an integer` out of `range()`, after `setup` built the env, networks and optimizers |
| `1.0` | accepted | **accepted** | `15.0` | same raise, same depth |
| `True` | accepted | **accepted** | 15 | length is right; a value reading as a flag was accepted as a count of one |
| `"4"` / `None` | **raises** | refused | - | `TypeError: '<' not supported between instances of 'str' and 'int'` out of a `Trainer.validate` documented to *return* problems |
| `4` | accepted | refused | 3 | the per-backend line, and it is unchanged |

`100.5` is worth separating from the float-bound row: `1000 // 6432.0` is `0.0`, which the clamp replaces with the int `1`, so `range()` is happy and the run is one iteration instead of fifteen. A float is not always a float bound, and the two harms are pinned separately.

## The change

Both backends consult the shared domain first and ask their own count rule only of a count - the idiom each already uses one statement later for a relation between two counts (`positive_count_error(spec.rollout_steps, ...) is None and <relation>` in PPO, the same for `batch_size` in FastSAC), with the same stated reason: it holds wherever in the preflight it sits.

- The per-backend line is unchanged: `4` is usable for the parallel backend, refused as single-env by the other.
- A non-count is no longer reported as the wrong *number* of environments.
- The refusal names the backend that refused, which the bare comparison's message did not.
- PPO keeps no second comparison: over the values the domain accepts, every positive `int` parallelizes, so a `< 1` branch there would be unreachable, and dead code that reads as a rule is worse than none. This changes PPO's message for `0` / `-1` from `num_envs must be >= 1` to `ppo: num_envs must be a positive integer`, so the two pins of the old wording in `test_rl_ppo.py` move with it - and in that file's own parametrized table `num_envs` now reads the same way its two sibling factors already did.

Two prose corrections in the same change, because both invited the gap to stay open:

- `rl_run_size_problems`' scope paragraph said the whole field was excluded. It now says which half.
- `TestNumEnvsIsNotInTheSharedDomain`'s non-vacuity test claimed "excluding it from the domain did not leave it unchecked" and drove only `0` - the one unusable value a bare comparison already caught. It is widened to the values that survive one, on both backends.

## Why nothing caught it

The gate's own docstring enumerates, with measurements, exactly the values a bare comparison lets through for the two sibling factors - `True`, a fraction, `nan`, `inf`, a non-numeric - and `num_envs` is guarded by a bare comparison one statement after the sentence that condemns one. The non-vacuity test that exists to say the excluded field is still checked graded the single value the comparison does catch.

## Verification

Pre-fix split over the three touched test files: **75 failed / 367 passed**, with 0 in every control and premise class - `TestTheHarmTheDomainReplaces` 0/7, `TestThePerBackendCountRuleIsUnchanged` 0/9, `TestThePremises` 0/4, and 0 in each of the 8 unrelated classes in `test_rl_run_size_domain.py` (156, 48, 32, 29, 10, 6, 4 cases) and in `test_rl_fast_sac.py` (0/17).

Mutation table, `collected` stable at 426 on every row and 0 collection errors:

| row | mine | sib | mutation |
|---|---|---|---|
| b0 | 0 | 0 | control |
| b1 | 48 | 0 | ppo: shared domain dropped, bare `< 1` restored |
| b2 | 27 | 0 | fast_sac: shared domain dropped, bare `!= 1` restored |
| b3 | 75 | 0 | both dropped (the full revert) |
| b4 | 20 | 0 | fast_sac: count rule asked first, domain after |
| b5 | 1 | 0 | fast_sac: `elif` becomes `if` (both complaints for a non-count) |
| b6 | 24 | 0 | ppo: weaker domain (`finite_number_error`, accepts a float) |
| b7 | 51 | 0 | ppo: verdict computed and discarded |
| b8 | 51 | 0 | ppo: domain told the wrong field name |
| b9 | 11 | 0 | ppo: domain told a literal context, not the backend |
| b10 | 5 | **1** | over-reach: fast_sac drops its OWN single-env count rule |
| b11 | 1 | 0 | the scope paragraph reverted (prose only) |

11 distinct firing sets of 12. b7 and b8 share one for a structural reason - both make PPO silent about `num_envs`, one by dropping the verdict and one by putting it under another name. **b1 and b2 are disjoint and `b1 | b2 == b3` exactly** (48 + 27 = 75), so each backend's half is independently pinned. b10 is the only row that trips a sibling suite, which is where `test_rl_fast_sac.py` pins the single-env message - the boundary this change must not cross.

Paired gate, 259-file identical selection (all of `tests/training/` plus every suite walking the tree, parsing source, or reading docstrings / `Args:` / `Raises:` / `changelog.d`, plus everything naming `num_envs` / `positive_count_error` / `steps_per_iter`), the new file excluded from both trees:

- branch `3 failed, 13557 passed, 61 skipped` (13621 collected); base `3 failed, 13535 passed, 61 skipped` (13599 collected)
- identical failing ids, **both `comm` directions empty**, distinct rootdirs
- `+22 collected` is exactly the widened `TestNumEnvsIsNotInTheSharedDomain` cells
- the 3 are the lerobot-from-source `TypeError: encode() takes 1 positional argument` drift, reproduced on a pristine base worktree alone

`tests/training/` whole: base `3 failed, 3519 passed`, branch `3 failed, 3638 passed` - `+119` = the 97 new cells plus the 22 widened ones.

`ruff check` and `ruff format --check` clean over 1652 files. mypy **24 == 24** against a pristine worktree of the same base, normalized message sets byte-identical in both directions, 0 attributable.

No visual artifact: this is a read-only preflight over a spec field, not a policy, simulation, rendering, recording or asset change. The measured tables above are the evidence.
