### PR TITLE
test(drivers/g1): grade the per-joint gain wire cells in CI, and hold the gating rule to itself

### DIFF
--- a/changelog.d/2850-g1-gain-wire-cells-graded-in-ci.md
+++ b/changelog.d/2850-g1-gain-wire-cells-graded-in-ci.md
@@ -1,0 +1,41 @@
+### Tests: the g1 per-joint gain wire cells are graded in CI, and the gating rule now holds for the module that states it
+
+``tests/drivers/test_g1_per_joint_gains`` is where this project writes the rule
+down: ``unitree-sdk2`` is not a declared dependency, so a contract asserted only
+behind ``skipif(not _HAS_SDK)`` is asserted by nothing in CI. Five of that
+module's own cells sat behind that marker, and they are the whole wire half of
+the gain contract -- every slot's gains on a full frame, a knee and an arm
+carrying different gains in one frame, the partial fallback where a caller tunes
+``kp`` and leaves ``kd``, a supplied gain overriding the table, and the stop
+frame staying soft. The module reported ``35 passed, 5 skipped`` where the SDK is
+absent, which is every runner ``call-test-lint`` uses, against ``40 passed``
+where it happens to be present.
+
+None of the five needs the real SDK. The module's own layering note explains why:
+the vendor gains are stated locally there precisely so the value cells are an
+independent oracle rather than a tautology, so what the cells read back is
+compared against those local tuples and not against anything the SDK computes.
+What they need is a ``LowCmd_``-*shaped* object to write into. They now take that
+shape from the stub ``tests.drivers.test_g1_control_loop`` installs, which is
+what puts them in front of CI. The fixture is opt-in per class rather than
+autouse, so an SDK-absent refusal cell added to this module later is not quietly
+made unreachable.
+
+The class had been closed one file at a time twice, so a derived guard is added
+beside the cells: every node gated on the SDK probe has to import the SDK inside
+itself. That is what an independent-oracle cell does to obtain its reference
+value, so the import is the evidence the marker is load-bearing rather than
+inherited. The two ``crc`` cells in ``tests/drivers/test_g1_driver`` keep their
+marker and satisfy the rule -- a stub whose ``Crc`` returns a constant would
+compare that constant against itself. The scan walks every suite, so the next
+gated cell is graded wherever it lands.
+
+Five real gain regressions were measured against the tree CI runs. Three of them
+were previously undetectable there: both tables read one slot's gains for every
+joint (the flat-default failure mode, which keeps the subscript syntax the
+source-reading contract cell looks for), the gain table leaking into the
+zero-torque stop frame so a stop lands stiff, and a supplied ``kp`` no longer
+winning over the table. The other two -- ``kp`` and ``kd`` each collapsed to a
+single value -- went from one cell to three. The firmware validates ``crc``,
+``mode_machine`` and the Enable byte, not gains, so each of those publishes with
+a success envelope and leaves the joints at whatever stiffness was sent.

--- a/tests/drivers/test_g1_per_joint_gains.py
+++ b/tests/drivers/test_g1_per_joint_gains.py
@@ -26,14 +26,23 @@ Layering, and why it is this way:
   them in CI, where the SDK is not installed.  ``unitree-sdk2`` is not a
   declared dependency of this project, so a contract asserted only behind
   ``skipif(not _HAS_SDK)`` is asserted by nothing in CI.
-* The wire cells, which do need the SDK to build a real ``LowCmd_``, confirm the
-  contract cells describe what actually lands on the topic.
+* The wire cells confirm the contract cells describe what actually lands on the
+  topic.  They need a ``LowCmd_``-*shaped* object to write into, which is not
+  the same as needing the SDK: the gains they read back are compared against the
+  vendor tuples stated locally below, so the oracle is those tuples rather than
+  anything the SDK computes.  They take the shape from the stub
+  :mod:`tests.drivers.test_g1_control_loop` installs, so the rule in the bullet
+  above covers them too.  A cell that recomputes an SDK value as an independent
+  oracle - the ``crc`` cells in :mod:`tests.drivers.test_g1_driver` - keeps the
+  marker instead, because a stub CRC would compare a constant against itself.
 """
 
 from __future__ import annotations
 
 import ast
 import inspect
+import sys
+import types
 from typing import Any
 
 import pytest
@@ -46,6 +55,7 @@ from strands_robots.drivers.g1 import (
     _build_lowcmd_from_action,
     _build_zero_torque_lowcmd,
 )
+from tests.drivers.test_g1_control_loop import _StubCRC, _StubLowCmd
 
 # The vendor's gain lists for this robot, transcribed from the module scope of
 # ``unitree_sdk2_python/example/g1/low_level/g1_low_level_example.py``.  Stated
@@ -117,12 +127,51 @@ VENDOR_KD: tuple[float, ...] = (
 _KNEE_SLOTS = (3, 9)
 _SLOT_NAME = {slot: name for name, slot in _G1_JOINT_INDEX.items()}
 
-try:  # pragma: no cover - environment probe
-    import unitree_sdk2py.idl.default as _sdk_default
 
-    _HAS_SDK = _sdk_default is not None
-except Exception:  # pragma: no cover - environment probe
-    _HAS_SDK = False
+@pytest.fixture
+def _stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a ``unitree_sdk2py`` stub for the duration of one test.
+
+    ``_build_lowcmd_from_action`` and ``_build_zero_torque_lowcmd`` import
+    ``unitree_sdk2py.idl.default`` and ``unitree_sdk2py.utils.crc`` inside
+    their bodies.  Registering each name on :mod:`sys.modules` lets the wire
+    cells drive the same production lane hardware drives, on a box where the
+    SDK is not installed - which is every box ``call-test-lint`` runs on.
+
+    The stub classes come from :mod:`tests.drivers.test_g1_control_loop`
+    rather than another copy, so every suite grading this builder writes into
+    the same ``LowCmd_`` shape.  ``monkeypatch.setitem`` restores the previous
+    entries - typically absent - on teardown, per AGENTS.md > Testing Patterns
+    > Restore a sys.modules entry you remove.
+
+    Opt-in per class rather than autouse: a module-wide stub would quietly
+    make an SDK-*absent* refusal cell unreachable if one is added here later,
+    the way it would in :mod:`tests.drivers.test_g1_driver`.
+    """
+    root = types.ModuleType("unitree_sdk2py")
+    idl = types.ModuleType("unitree_sdk2py.idl")
+    default = types.ModuleType("unitree_sdk2py.idl.default")
+    unitree_hg = types.ModuleType("unitree_sdk2py.idl.unitree_hg")
+    unitree_hg_msg = types.ModuleType("unitree_sdk2py.idl.unitree_hg.msg")
+    dds_ = types.ModuleType("unitree_sdk2py.idl.unitree_hg.msg.dds_")
+    utils = types.ModuleType("unitree_sdk2py.utils")
+    crc = types.ModuleType("unitree_sdk2py.utils.crc")
+
+    default.unitree_hg_msg_dds__LowCmd_ = _StubLowCmd  # type: ignore[attr-defined]
+    dds_.LowCmd_ = _StubLowCmd  # type: ignore[attr-defined]
+    crc.CRC = _StubCRC  # type: ignore[attr-defined]
+
+    for name, mod in [
+        ("unitree_sdk2py", root),
+        ("unitree_sdk2py.idl", idl),
+        ("unitree_sdk2py.idl.default", default),
+        ("unitree_sdk2py.idl.unitree_hg", unitree_hg),
+        ("unitree_sdk2py.idl.unitree_hg.msg", unitree_hg_msg),
+        ("unitree_sdk2py.idl.unitree_hg.msg.dds_", dds_),
+        ("unitree_sdk2py.utils", utils),
+        ("unitree_sdk2py.utils.crc", crc),
+    ]:
+        monkeypatch.setitem(sys.modules, name, mod)
 
 
 def _slot_ids() -> list[str]:
@@ -218,7 +267,7 @@ class TestTheBuilderIndexesTheTablePerSlot:
         assert "_SDK_KD" in subscripted, "kd default is not indexed by slot"
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 class TestTheWireFrameCarriesTheSlotsOwnGains:
     """The frame that reaches ``rt/lowcmd`` carries each slot's own gains."""
 
@@ -260,7 +309,7 @@ class TestTheWireFrameCarriesTheSlotsOwnGains:
         assert motor.kd == pytest.approx(VENDOR_KD[_G1_JOINT_INDEX["left_knee"]])
 
 
-@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+@pytest.mark.usefixtures("_stub_unitree_sdk")
 class TestWhatTheTableDoesNotChange:
     """Over-reach guards: the table is a default, and only a default.
 

--- a/tests/drivers/test_sdk_gated_cells_carry_their_own_oracle.py
+++ b/tests/drivers/test_sdk_gated_cells_carry_their_own_oracle.py
@@ -1,0 +1,152 @@
+"""Guard: a cell gated on the vendor SDK has to say why it needs the real one.
+
+``unitree-sdk2`` is not a declared dependency of this project - it is not on
+PyPI under a name ``call-test-lint`` can install, and the hatch test env is
+built from ``features = ["all"]``, which does not reach it.  So a cell behind
+``skipif(not _HAS_SDK)`` is graded by nothing on the runner that decides
+whether a pull request may merge.  It runs here, on a box where the SDK
+happens to be installed, and nowhere else.
+
+That is only acceptable when the cell needs the *real* SDK: one that recomputes
+an SDK-computed value as an independent oracle cannot use a stub, because a stub
+would compare a constant against itself.  A cell that needs a ``LowCmd_``-shaped
+object to write into needs a *shape*, not the SDK, and can take one from the
+stub :mod:`tests.drivers.test_g1_control_loop` installs - which is what puts it
+in front of CI.
+
+The distinction is decidable from the cell: an independent-oracle cell has to
+import the SDK to obtain the reference value, so the rule below is that a gated
+node imports the SDK inside itself.  A gated node that imports nothing is
+asserting a contract CI never reads, and the remedy is the stub rather than the
+marker.
+
+Scope: the rule reads gating, not skipping.  A cell that skips on an optional
+dependency this project *does* declare is outside it, because CI installs that
+dependency and grades the cell.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+_SDK_ROOT = "unitree_sdk2py"
+_TESTS = pathlib.Path(__file__).resolve().parent.parent
+_GATE_NAME = "_HAS_SDK"
+
+# The population is small and lives in one directory today, but the scan walks
+# every suite: the next gated cell is graded the hour it lands, wherever it
+# lands.
+_MINIMUM_GATED_NODES = 2
+
+
+def _imports_the_sdk(node: ast.AST) -> bool:
+    """Whether ``node``'s own subtree imports the vendor SDK.
+
+    An independent-oracle cell reaches for the SDK to obtain the reference
+    value it grades against, so the import is the evidence that the marker is
+    load-bearing rather than inherited.
+    """
+    for child in ast.walk(node):
+        if isinstance(child, ast.ImportFrom) and (child.module or "").startswith(_SDK_ROOT):
+            return True
+        if isinstance(child, ast.Import) and any(alias.name.startswith(_SDK_ROOT) for alias in child.names):
+            return True
+    return False
+
+
+def _gated_nodes(tree: ast.AST, path: str) -> list[tuple[str, int, bool]]:
+    """Every node gated on the SDK probe, with whether it imports the SDK."""
+    found: list[tuple[str, int, bool]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        gated = any(_GATE_NAME in ast.unparse(decorator) for decorator in node.decorator_list)
+        if gated:
+            found.append((f"{path}::{node.name}", node.lineno, _imports_the_sdk(node)))
+    return found
+
+
+def _scan_the_suites() -> list[tuple[str, int, bool]]:
+    """Walk every test module and collect the gated nodes."""
+    rows: list[tuple[str, int, bool]] = []
+    for module in sorted(_TESTS.rglob("test_*.py")):
+        source = module.read_text(encoding="utf-8")
+        if _GATE_NAME not in source:
+            continue
+        rows.extend(_gated_nodes(ast.parse(source), str(module.relative_to(_TESTS.parent))))
+    return rows
+
+
+class TestEveryGatedCellNeedsTheRealSdk:
+    """A cell CI cannot run has to be one a stub could not serve."""
+
+    def test_no_gated_node_is_missing_its_oracle(self) -> None:
+        """Each gated node imports the SDK, so its marker is load-bearing."""
+        inherited = [f"{name} (line {line})" for name, line, imports in _scan_the_suites() if not imports]
+        assert not inherited, (
+            "these nodes are gated on the vendor SDK but import nothing from it, so the "
+            "contract they assert is graded by nothing in CI: "
+            f"{inherited}.  Either drive them through the stub "
+            "tests.drivers.test_g1_control_loop installs and drop the marker, or import "
+            "the SDK value the cell grades against so the marker is load-bearing."
+        )
+
+    def test_the_scan_finds_the_gated_nodes_it_grades(self) -> None:
+        """Non-vacuity: an empty scan would pass the rule above for free."""
+        rows = _scan_the_suites()
+        assert len(rows) >= _MINIMUM_GATED_NODES, (
+            f"expected at least {_MINIMUM_GATED_NODES} SDK-gated nodes to grade, found {rows}"
+        )
+
+
+class TestTheRuleReadsTheCellRatherThanItsName:
+    """Constructed exemplars, because the shipped suites satisfy the rule.
+
+    With no violator left in the tree the scan cannot exercise its own failing
+    branch, so the two outcomes are graded on source built here.
+    """
+
+    _WITH_ORACLE = """
+@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+def test_recomputes_the_vendor_value() -> None:
+    from unitree_sdk2py.utils.crc import CRC
+
+    assert CRC().Crc(object()) is not None
+"""
+
+    _WITHOUT_ORACLE = """
+@pytest.mark.skipif(not _HAS_SDK, reason="unitree_sdk2py not installed")
+def test_reads_back_a_field_it_wrote() -> None:
+    cmd, err = _build_lowcmd_from_action({"left_knee": 0.2}, mode_machine=9)
+    assert cmd.motor_cmd[3].kp == 100.0
+"""
+
+    _UNGATED = """
+def test_needs_no_sdk() -> None:
+    from unitree_sdk2py.utils.crc import CRC
+
+    assert CRC is not None
+"""
+
+    @pytest.mark.parametrize(
+        ("label", "source", "expected"),
+        [
+            pytest.param("gated-and-imports-the-sdk", _WITH_ORACLE, [True], id="gated-with-oracle"),
+            pytest.param("gated-and-imports-nothing", _WITHOUT_ORACLE, [False], id="gated-without-oracle"),
+            pytest.param("not-gated-at-all", _UNGATED, [], id="not-gated"),
+        ],
+    )
+    def test_the_rule_classifies_a_constructed_cell(self, label: str, source: str, expected: list[bool]) -> None:
+        """The scan reads the cell's imports, not its name or its reason."""
+        rows = _gated_nodes(ast.parse(source), "exemplar.py")
+        assert [imports for _name, _line, imports in rows] == expected, label
+
+    def test_both_outcomes_are_reachable(self) -> None:
+        """Meta: the exemplars really do land on both sides of the rule."""
+        outcomes: set[bool] = set()
+        for source in (self._WITH_ORACLE, self._WITHOUT_ORACLE):
+            outcomes.update(imports for _n, _l, imports in _gated_nodes(ast.parse(source), "exemplar.py"))
+        assert outcomes == {True, False}


### PR DESCRIPTION
## What this changes

`tests/drivers/test_g1_per_joint_gains` is the module that writes the rule down:

> `unitree-sdk2` is not a declared dependency of this project, so a contract asserted only behind `skipif(not _HAS_SDK)` is asserted by nothing in CI.

Five of its own cells sat behind that marker. They are the whole wire half of the per-joint gain contract, and none of them needs the real SDK.

| where | SDK present | SDK absent (every `call-test-lint` runner) |
|---|---|---|
| `test_g1_per_joint_gains.py`, before | 40 passed, 0 skipped | **35 passed, 5 skipped** |
| `test_g1_per_joint_gains.py`, after | 40 passed, 0 skipped | **40 passed, 0 skipped** |

`35 + 5 == 40 + 0` on the same 40 collected, so the same cells are collected either way and only their disposition moves.

The five: every slot's gains on a full frame, a knee and an arm carrying different gains in one frame, the partial fallback where a caller tunes `kp` and leaves `kd`, a supplied gain overriding the table, and the stop frame staying soft.

## Why the marker was not the right tool for them

The module's own layering note explains it: the vendor gain tuples are stated locally there *precisely* so the value cells are an independent oracle rather than a tautology. So the oracle is those tuples, not anything the SDK computes, and what the cells need is a `LowCmd_`-**shaped** object to write into. `_StubLowCmd` already carries a 35-slot `motor_cmd` whose entries have `kp`/`kd`, so they now take the shape from the stub `tests.drivers.test_g1_control_loop` installs.

An AST read of the whole test tree separates the two kinds with no judgement calls:

| gated node | cells | imports the SDK inside itself |
|---|---|---|
| `test_g1_driver.py::test_build_lowcmd_sets_a_matching_crc_the_firmware_will_accept` | 1 | yes, `unitree_sdk2py.utils.crc` |
| `test_g1_driver.py::test_build_zero_torque_stamps_crc_and_enables_every_named_slot` | 1 | yes, `unitree_sdk2py.utils.crc` |
| `test_g1_per_joint_gains.py::TestTheWireFrameCarriesTheSlotsOwnGains` | 3 | no |
| `test_g1_per_joint_gains.py::TestWhatTheTableDoesNotChange` | 2 | no |

The two that import the SDK recompute a value it computes, so a stub `Crc` returning a constant would compare that constant against itself. They keep the marker.

The fixture is opt-in per class rather than autouse: a module-wide stub would quietly make an SDK-*absent* refusal cell unreachable if one is added here later, the way it would in `test_g1_driver`.

## What CI can now catch

Real gain regressions in `strands_robots/drivers/g1.py`, measured with the SDK hidden, against the module before and after. `collected` is 40 on every row and the control is clean both ways.

| # | regression | before | after |
|---|---|---|---|
| b0 | control, nothing changed | 0 | 0 |
| b1 | `kp` default collapsed to one value for all 29 slots | 1 | 3 |
| b2 | `kd` default collapsed to one value for all 29 slots | 1 | 3 |
| b3 | both tables read slot 0 instead of the joint's own slot | **0** | 3 |
| b4 | the gain table leaks into the zero-torque stop frame | **0** | 1 |
| b5 | a supplied `kp` no longer wins over the table | **0** | 2 |

b3 is the sharpest of the three that were invisible: it keeps the `_SDK_KP[...]` subscript the source-reading contract cell looks for, and changes only which slot's gains land on the wire. b4 makes a *stop* frame stiff. The firmware validates `crc`, `mode_machine` and the Enable byte, not gains, so each of these publishes with a success envelope and leaves every joint at whatever stiffness was sent.

## The derived guard

This class has now been closed one file at a time twice, so `tests/drivers/test_sdk_gated_cells_carry_their_own_oracle.py` states it once: a node gated on the SDK probe has to import the SDK inside itself. The scan walks every suite, so the next gated cell is graded wherever it lands.

| # | mutation | fires | collected |
|---|---|---|---|
| g0 | control | 0 | 6 |
| g1 | the gain module's markers restored, scan derived | **1**, naming both classes | 6 |
| g2 | markers restored **and** the scan's universe hardcoded to today's modules | **0, silent** | 6 |
| g3 | scan hardcoded, markers not restored (g2's control) | 0 | 6 |
| g4 | the oracle test always answers yes, so the rule accepts anything | 2 | 6 |
| g5 | the scan narrowed until it finds nothing | **1**, the non-vacuity cell | 6 |
| g6 | the scan narrowed **and** the non-vacuity floor removed | **0, silent** | 6 |

g1/g2/g3 are the reason the inventory is derived rather than listed: a hardcoded list equal to today's set finds nothing and still looks like a working test. g5/g6 are the same argument for the non-vacuity floor. Because the tree has no violator left, the rule's own two outcomes are graded on constructed exemplars rather than on the corpus, with a meta-cell asserting both outcomes are reached.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1653 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree of the merge base, normalized message sets identical in both directions, 0 attributable to either changed file.
- Paired run over an identical 451-file selection (all of `tests/drivers/`, all of `tests/tools/g1/`, and every suite that walks the tree, parses source, or reads docstrings), with the new file excluded from both trees: identical **21301 collected** and `20 failed, 21208 passed, 73 skipped` on each, the same 20 failing ids, `comm` empty in both directions. Of the 20, 17 need `awsiot`/`awscrt` (`find_spec` is `None` for both; declared in the `mesh-iot` extra, which CI installs) and 3 are the `lerobot`-from-source drift in `tests/training/test_lerobot*`.
- `tests/drivers/` whole directory: 658 passed / 3 skipped with the SDK present, 651 passed / 10 skipped with it hidden, 661 collected either way.
- No visual artifact: this changes which box grades an existing contract, and adds no policy, simulation, rendering, recording or asset behaviour. The measured tables above are the evidence.

## Follow-up, not in scope here

Four modules in `tests/drivers/` now need the stub and there is no `conftest.py`, so the registration list exists in two copies (`test_g1_control_loop` autouse, `test_g1_driver` opt-in) and this adds a third. Consolidating it is a refactor with no behaviour change, and it has to keep the opt-in shape, because two suites in that directory pin SDK-*absent* refusals that a directory-wide autouse fixture would make unreachable.
