### PR TITLE
fix(assets): let a caller resolve an asset path without fetching the corpus

### DIFF
--- a/changelog.d/2851-resolve-model-path-can-decline-the-download.md
+++ b/changelog.d/2851-resolve-model-path-can-decline-the-download.md
@@ -33,6 +33,20 @@ fetching the corpus into the temp directory instead of reporting that there was
 nothing to read; the class now confirms all six families where the assets are
 present and skips where they are not, which is what its own docstring said it did.
 
+Declining also declines the `robot_descriptions` discovery fallback, which the
+first version of the keyword did not. The resolver's first statement is a registry
+lookup, and that lookup falls back to `discover_robot` for any name the curated
+registry does not know - so for those names the promise was broken before
+`allow_download` was ever read. The import is the fetch: `robot_descriptions` calls
+`clone_to_cache` at module scope, so consulting a description module clones the
+upstream asset repository. Measured over the nine MJCF-discoverable names this
+registry does not curate, `allow_download=False` returned a path for five of them
+and asked for the Menagerie clone every time, including for `rizon4`, where the
+answer is `None` either way. The gate now lives on the shared lookup and the
+resolver hands its own decision to it, so the keyword also restores the parity its
+docstring claims: `is_robot_asset_present` reads the curated registry alone, and a
+declined resolve now answers over the same names.
+
 Declining changes no answer. The same 58 models compile and the same six families
 are derived either way, and every registry robot still resolves and loads through
 the unchanged default.

--- a/changelog.d/2851-resolve-model-path-can-decline-the-download.md
+++ b/changelog.d/2851-resolve-model-path-can-decline-the-download.md
@@ -1,0 +1,38 @@
+### Fixed: resolving an asset path no longer has to fetch the ones that are absent
+
+`resolve_model_path` downloads whatever it cannot find on disk. That is the right
+default for a caller about to load the model - a path whose meshes are absent is
+useless to MuJoCo, so fetching them is the helpful thing. It is the wrong default
+for a caller that reports on assets rather than loading them, and there was no way
+to ask for the other one: `is_robot_asset_present` answers *whether* an asset is on
+disk without a download, and nothing answered *where* under the same terms.
+
+Two callers wanted it, and both had already noticed. `list_available_robots`
+hand-rolled a guard for the first of the resolver's two download triggers - "Only
+resolve full path when asset is present - avoids download attempts" - and still
+fetched for the second, because a cached XML whose meshes are missing passes the
+presence check. Building a status listing on this machine's cache downloaded 4
+robots. And `tests/registry/test_asset_family_joint_counts.py` re-derives the
+asset-family grouping by walking all 72 registry entries, so it fetched every
+asset the machine did not already have: 63 on a fresh checkout, 58 recorded
+`attempting auto-download` lines and 11 real clones in one CI run, which took it
+past its 120s `pytest-timeout` budget.
+
+`resolve_model_path` now takes a keyword-only `allow_download`, defined as exactly
+a download that declines: an absent XML still returns `None`, and a mesh-less XML
+still returns its first candidate - the two outcomes a failed download already
+produces. It introduces no third outcome, so the 46 existing call sites keep the
+downloading default unchanged, and a caller that only reports can opt out of the
+network entirely.
+
+Both reporting callers now do. The family re-derivation also reads the machine's
+real asset cache rather than the per-test temp directory `tests/registry/conftest.py`
+points `STRANDS_ASSETS_DIR` at for user-registry isolation. Under that directory the
+grouping was unconfirmable on every machine, and the downloading default hid it by
+fetching the corpus into the temp directory instead of reporting that there was
+nothing to read; the class now confirms all six families where the assets are
+present and skips where they are not, which is what its own docstring said it did.
+
+Declining changes no answer. The same 58 models compile and the same six families
+are derived either way, and every registry robot still resolves and loads through
+the unchanged default.

--- a/strands_robots/assets/manager.py
+++ b/strands_robots/assets/manager.py
@@ -32,20 +32,36 @@ except ImportError:
     _auto_download_robot_impl = None  # type: ignore[assignment]
 
 
-def _lookup(name: str) -> dict | None:
+def _lookup(name: str, *, allow_discovery: bool = True) -> dict | None:
     """Resolve a registry entry for *name*, with ``robot_descriptions`` fallback.
 
     A curated ``robots.json`` entry always wins. When a name is unknown to the
     curated registry, fall back to :func:`strands_robots.registry.discovery`,
     which synthesizes an entry for any MJCF-capable ``robot_descriptions`` robot
-    (the long tail: ``go2``, ``spot``, ``h1``, ...). Discovery imports the
+    (the long tail: ``gen3``, ``iiwa14``, ``viper``, ...). Discovery imports the
     description module, which can trigger an asset download on first use, so
     this helper is used only by download-capable resolvers - never by the
     side-effect-free presence check.
+
+    Args:
+        name: Robot name (canonical or alias).
+        allow_discovery: When False, answer from the curated registry alone. A
+                         resolver whose caller declined the download must pass
+                         False: the discovery import *is* the fetch, because
+                         ``robot_descriptions`` calls ``clone_to_cache`` at
+                         module scope, so consulting it would perform the exact
+                         download the caller declined - including on the miss
+                         path, where the answer is ``None`` either way.
+
+    Returns:
+        A registry-style entry, or ``None`` when the name is unknown (and, with
+        ``allow_discovery=False``, when only discovery could have synthesized one).
     """
     info = get_robot(name)
     if info is not None:
         return info
+    if not allow_discovery:
+        return None
     from strands_robots.registry.discovery import discover_robot
 
     return discover_robot(name)
@@ -187,21 +203,31 @@ def resolve_model_path(
     ``robot_descriptions`` before returning - unless ``allow_download`` declines.
 
     ``allow_download=False`` makes this a pure filesystem lookup: no network, no
-    ``robot_descriptions`` import. It is exactly equivalent to a download that
-    declines, so it cannot change the answer for an asset already on disk - an
-    absent XML still returns ``None`` and a mesh-less XML still returns its first
-    candidate, the same two outcomes a failed download produces today.
+    ``robot_descriptions`` import. Within the curated registry it is exactly
+    equivalent to a download that declines, so it cannot change the answer for an
+    asset already on disk - an absent XML still returns ``None`` and a mesh-less
+    XML still returns its first candidate, the same two outcomes a failed download
+    produces today.
+
+    It declines the discovery fallback too, so a name only
+    :mod:`strands_robots.registry.discovery` could synthesize an entry for reports
+    a miss instead of importing a description module to find out. That import is
+    itself the fetch - ``robot_descriptions`` calls ``clone_to_cache`` at module
+    scope - so consulting discovery clones the upstream asset repository on a cold
+    cache, including on the miss path where the answer is ``None`` either way.
 
     Prefer it in any caller that reports on assets rather than loading them.
-    :func:`is_robot_asset_present` answers *whether* an asset is on disk without
-    a download; this answers *where* under the same terms.
+    :func:`is_robot_asset_present` answers *whether* an asset is on disk without a
+    download; this answers *where* on the same terms and over the same names -
+    both read the curated registry alone.
 
     Args:
         name: Robot name (canonical or alias).
         prefer_scene: If True, return scene XML (with ground/lights)
                       instead of bare model XML.
-        allow_download: When False, never attempt an asset download; resolve
-                        from what is already on disk or report a miss.
+        allow_download: When False, never attempt an asset download and never
+                        consult discovery; resolve from what is already on disk
+                        for a curated name, or report a miss.
 
     Returns:
         Path to the MJCF XML file, or None if not found.
@@ -212,7 +238,7 @@ def resolve_model_path(
         resolve_model_path("so100", prefer_scene=True)  # → .../trs_so_arm100/scene.xml
         resolve_model_path("franka")            # → .../franka_emika_panda/panda.xml
     """
-    info = _lookup(name)
+    info = _lookup(name, allow_discovery=allow_download)
     if not info or "asset" not in info:
         # DEBUG, not WARNING: resolve_model() probes several candidate names
         # (incl. suffix-stripped variants) and handles a None return cleanly,

--- a/strands_robots/assets/manager.py
+++ b/strands_robots/assets/manager.py
@@ -176,18 +176,32 @@ def is_robot_asset_present(name: str) -> bool:
 def resolve_model_path(
     name: str,
     prefer_scene: bool = False,
+    *,
+    allow_download: bool = True,
 ) -> Path | None:
     """Resolve a robot name to its MJCF model XML path.
 
     Looks up the robot in ``registry/robots.json``, then searches
-    the asset directories for the actual file.  If XML is found but
-    mesh files are missing, automatically downloads them via
-    ``robot_descriptions`` before returning.
+    the asset directories for the actual file.  If no XML is found, or XML is
+    found but mesh files are missing, downloads the asset via
+    ``robot_descriptions`` before returning - unless ``allow_download`` declines.
+
+    ``allow_download=False`` makes this a pure filesystem lookup: no network, no
+    ``robot_descriptions`` import. It is exactly equivalent to a download that
+    declines, so it cannot change the answer for an asset already on disk - an
+    absent XML still returns ``None`` and a mesh-less XML still returns its first
+    candidate, the same two outcomes a failed download produces today.
+
+    Prefer it in any caller that reports on assets rather than loading them.
+    :func:`is_robot_asset_present` answers *whether* an asset is on disk without
+    a download; this answers *where* under the same terms.
 
     Args:
         name: Robot name (canonical or alias).
         prefer_scene: If True, return scene XML (with ground/lights)
                       instead of bare model XML.
+        allow_download: When False, never attempt an asset download; resolve
+                        from what is already on disk or report a miss.
 
     Returns:
         Path to the MJCF XML file, or None if not found.
@@ -236,7 +250,7 @@ def resolve_model_path(
     # Search standard paths with traversal protection
     candidates.extend(_resolve_candidates(asset_dir_name, xml_file, name))
 
-    if not candidates:
+    if not candidates and allow_download:
         # No XML found at all - try auto-download, then re-search
         logger.info("No XML found for %s, attempting auto-download...", name)
         if _auto_download_robot(name, info):
@@ -253,15 +267,18 @@ def resolve_model_path(
             logger.debug("Resolved %s -> %s (has meshes)", name, path)
             return Path(path)
 
-    # XML found but no meshes - auto-download and re-check
-    logger.info("XML found for %s but no meshes, attempting auto-download...", name)
-    if _auto_download_robot(name, info):
-        # Re-scan after download (new symlinks may have appeared)
-        refreshed = _resolve_candidates(asset_dir_name, xml_file, name)
-        for path in refreshed:
-            if _has_meshes(path.parent):
-                logger.debug("Resolved %s -> %s (auto-downloaded)", name, path)
-                return Path(path)
+    # XML found but no meshes - auto-download and re-check. Declining the
+    # download leaves the first candidate to the fallback below, which is what a
+    # download that fails already does.
+    if allow_download:
+        logger.info("XML found for %s but no meshes, attempting auto-download...", name)
+        if _auto_download_robot(name, info):
+            # Re-scan after download (new symlinks may have appeared)
+            refreshed = _resolve_candidates(asset_dir_name, xml_file, name)
+            for path in refreshed:
+                if _has_meshes(path.parent):
+                    logger.debug("Resolved %s -> %s (auto-downloaded)", name, path)
+                    return Path(path)
 
     # Final fallback: return first candidate (some robots have no meshes)
     logger.debug("Resolved %s -> %s (no meshes available)", name, candidates[0])
@@ -316,9 +333,11 @@ def get_robot_info(name: str) -> dict | None:
 def list_available_robots() -> list[dict]:
     """List all available robot models with their info.
 
-    Uses :func:`is_robot_asset_present` for a fast filesystem-only check
-    per robot instead of the heavier :func:`resolve_model_path` which can
-    trigger auto-downloads and mesh cache walks.
+    Filesystem-only: :func:`is_robot_asset_present` for the availability flag
+    and ``allow_download=False`` for the path, so listing what is installed never
+    fetches what is not. The presence check alone was not enough - it stops the
+    resolver reaching for an absent XML, but a cached XML whose meshes are missing
+    passes it and was still fetched, once per such robot per listing.
 
     Returns:
         List of dicts with name, description, joints, category, available, path.
@@ -328,8 +347,8 @@ def list_available_robots() -> list[dict]:
         name = r["name"]
         present = is_robot_asset_present(name)
         info = get_robot(name) or {}
-        # Only resolve full path when asset is present - avoids download attempts
-        path = resolve_model_path(name) if present else None
+        # Report where the asset is, never fetch one that is not here.
+        path = resolve_model_path(name, allow_download=False) if present else None
         robots.append(
             {
                 "name": name,

--- a/tests/registry/test_asset_family_joint_counts.py
+++ b/tests/registry/test_asset_family_joint_counts.py
@@ -49,12 +49,19 @@ Two layers, because the oracle is not available everywhere:
   the real compiled models and asserts :data:`_ASSET_FAMILIES` still describes
   them. Without it the frozen table could drift into agreeing with a wrong
   registry, which is the failure a hand-maintained copy always has. It skips
-  where the assets are absent rather than downloading them.
+  where the assets are absent rather than downloading them, which is what
+  ``allow_download=False`` in :func:`_asset_signatures` buys: this walks the
+  whole registry, so the downloading resolver fetches every asset the machine
+  does not already have.
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
 import json
+import textwrap
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -96,9 +103,68 @@ def registry() -> dict[str, Any]:
     return dict(data.get("robots", data))
 
 
+@pytest.fixture
+def host_asset_cache(monkeypatch: Any) -> None:
+    """Let the re-derivation read the machine's real asset cache.
+
+    ``tests/registry/conftest.py`` repoints ``STRANDS_ASSETS_DIR`` at a per-test
+    temp dir, so a developer's user robots cannot leak into registry assertions.
+    That isolation is right for the registry reads it was written for, and it
+    also empties the asset cache - the one input this class needs. Under it the
+    grouping is unconfirmable on every machine, and the resolver's downloading
+    default hid that by fetching the whole corpus into the temp dir instead of
+    reporting that there was nothing to read.
+
+    Restoring the host value for this class alone gives the two honest outcomes
+    the class documents: confirm the table where the assets are present, skip
+    where they are not.
+    """
+    monkeypatch.delenv("STRANDS_ASSETS_DIR", raising=False)
+
+
 def _graded_families() -> tuple[tuple[str, ...], ...]:
     """The families this file requires to agree."""
     return tuple(f for f in _ASSET_FAMILIES if f not in _UNRESOLVED_FAMILIES)
+
+
+def _asset_signatures(names: Iterable[str]) -> dict[str, tuple[Any, ...]]:
+    """Compile each asset already on disk and read its joint/actuator signature.
+
+    ``allow_download=False`` is load-bearing rather than a speed-up. This walks
+    the whole registry, and the resolver downloads any asset it cannot find, so
+    the default fetches every entry a machine does not already have - 63 of the
+    72 on a fresh checkout. Declining is equivalent to a download that fails, so
+    it cannot change the grouping on a machine that has the assets, and leaves it
+    empty on one that does not.
+
+    Args:
+        names: Registry robot names to look for on disk.
+
+    Returns:
+        The signature of every named robot whose asset is present and compiles;
+        robots whose asset is absent or unloadable are simply left out.
+    """
+    mujoco = pytest.importorskip("mujoco")
+    from strands_robots.assets.manager import resolve_model_path
+
+    signatures: dict[str, tuple[Any, ...]] = {}
+    for name in names:
+        try:
+            path = resolve_model_path(name, allow_download=False)
+        except Exception:  # pragma: no cover - a resolver failure is not this test's subject
+            continue
+        if path is None or not Path(path).exists():
+            continue
+        try:
+            model = mujoco.MjModel.from_xml_path(str(path))
+        except Exception:  # pragma: no cover - an unloadable asset is not this test's subject
+            continue
+        signatures[name] = (
+            tuple(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i) for i in range(model.njnt)),
+            tuple(int(model.jnt_type[i]) for i in range(model.njnt)),
+            tuple(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)),
+        )
+    return signatures
 
 
 class TestTheFamilyTableIsUsable:
@@ -184,6 +250,7 @@ class TestEveryAssetFamilyAgrees:
 class TestTheFrozenFamiliesStillMatchTheAssets:
     """Keep :data:`_ASSET_FAMILIES` honest against the compiled models."""
 
+    @pytest.mark.usefixtures("host_asset_cache")
     def test_the_families_are_what_the_assets_say_they_are(self, registry: dict[str, Any]) -> None:
         """Re-derive the grouping; the frozen table must still describe it.
 
@@ -191,26 +258,7 @@ class TestTheFrozenFamiliesStillMatchTheAssets:
         members are not all loadable here cannot be confirmed or refuted, so it
         is neither.
         """
-        mujoco = pytest.importorskip("mujoco")
-        from strands_robots.assets.manager import resolve_model_path
-
-        signatures: dict[str, tuple[Any, ...]] = {}
-        for name in registry:
-            try:
-                path = resolve_model_path(name)
-            except Exception:  # pragma: no cover - a resolver failure is not this test's subject
-                continue
-            if path is None or not Path(path).exists():
-                continue
-            try:
-                model = mujoco.MjModel.from_xml_path(str(path))
-            except Exception:  # pragma: no cover - an unloadable asset is not this test's subject
-                continue
-            signatures[name] = (
-                tuple(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i) for i in range(model.njnt)),
-                tuple(int(model.jnt_type[i]) for i in range(model.njnt)),
-                tuple(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)),
-            )
+        signatures = _asset_signatures(registry)
 
         if len(signatures) < 2:
             pytest.skip("registry assets unavailable, so the grouping cannot be re-derived")
@@ -232,4 +280,81 @@ class TestTheFrozenFamiliesStillMatchTheAssets:
         assert not undeclared, (
             "the assets group these robots identically but no family declares them, "
             f"so their joint counts are ungraded: {undeclared}"
+        )
+
+
+class TestTheRederivationReadsDiskOnly:
+    """Re-deriving the grouping must not fetch an asset the machine lacks.
+
+    :func:`_asset_signatures` walks all 72 registry entries, and the resolver's
+    default is to download whatever it cannot find. That put a network fetch
+    behind 63 of those entries on a fresh checkout - the case where there is no
+    grouping to re-derive in the first place - and took this file past the 120s
+    ``pytest-timeout`` budget.
+
+    Both halves are needed. The behavioural cell reads the download hook, which
+    is also silent on a machine that happens to hold every asset already; the
+    structural cell pins the reason, so a passing run cannot be an accident of
+    what is on disk.
+    """
+
+    @staticmethod
+    def _download_attempts(names: Iterable[str], monkeypatch: Any) -> list[str]:
+        """Names the walk asked the download hook to fetch."""
+        from strands_robots.assets import manager
+
+        attempted: list[str] = []
+
+        def refuse(name: str, info: dict[str, Any]) -> bool:
+            attempted.append(name)
+            return False
+
+        monkeypatch.setattr(manager, "_auto_download_robot", refuse)
+        _asset_signatures(names)
+        return attempted
+
+    def test_no_download_when_the_cache_is_empty(self, registry: dict[str, Any], monkeypatch: Any) -> None:
+        """An empty cache is a skip, not a fetch of the whole corpus.
+
+        This is the state every machine is in under the conftest's asset
+        isolation, and the one a fresh checkout is in for real: no XML anywhere,
+        so the resolver's default reaches for the network 63 times.
+        """
+        pytest.importorskip("mujoco")
+        attempted = self._download_attempts(registry, monkeypatch)
+        assert not attempted, (
+            f"re-deriving the grouping with an empty cache tried to download {len(attempted)} "
+            f"assets (first few: {sorted(attempted)[:6]}). There is no grouping to confirm "
+            "here, so it must skip - pass allow_download=False to resolve_model_path."
+        )
+
+    @pytest.mark.usefixtures("host_asset_cache")
+    def test_no_download_when_the_cache_is_partial(self, registry: dict[str, Any], monkeypatch: Any) -> None:
+        """A cached XML whose meshes are missing is the second fetch trigger.
+
+        Distinct from the empty case: ``is_robot_asset_present`` is true for
+        these, so guarding on presence alone still lets the resolver fetch -
+        including for members of a graded family.
+        """
+        pytest.importorskip("mujoco")
+        attempted = self._download_attempts(registry, monkeypatch)
+        assert not attempted, (
+            f"re-deriving the grouping against the host cache tried to download "
+            f"{len(attempted)} assets (first few: {sorted(attempted)[:6]}); a mesh-less "
+            "cached XML must be left to the caller, not fetched from a test."
+        )
+
+    def test_the_walk_asks_the_resolver_not_to_fetch(self) -> None:
+        """Non-vacuity: the zero above is a refusal, not an absence of work."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(_asset_signatures)))
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "resolve_model_path"
+        ]
+        assert len(calls) == 1, f"expected exactly one resolve_model_path call, found {len(calls)}"
+        declined = {kw.arg: kw.value for kw in calls[0].keywords}.get("allow_download")
+        assert isinstance(declined, ast.Constant) and declined.value is False, (
+            "the registry walk must pass allow_download=False; without it the resolver "
+            "downloads every asset this machine does not have"
         )

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -352,6 +352,214 @@ class TestDownloadCanBeDeclined:
         assert attempts == []
 
 
+class TestDecliningAlsoDeclinesDiscovery:
+    """A declined resolve must not reach ``robot_descriptions`` discovery.
+
+    ``allow_download=False`` promises "no network, no ``robot_descriptions``
+    import", but the resolver's first statement is a registry lookup, and that
+    lookup falls back to :func:`strands_robots.registry.discovery.discover_robot`
+    for any name the curated registry does not know. For those names the promise
+    was broken before ``allow_download`` was ever read.
+
+    The import *is* the fetch. ``robot_descriptions`` calls ``clone_to_cache`` at
+    module scope, so importing a description module clones the upstream asset
+    repository on a cold cache - the exact side effect this keyword exists to
+    decline. Both docstrings say so in advance: ``_lookup`` is "used only by
+    download-capable resolvers" and ``discover_robot`` is "Heavy ... Call only
+    from asset-resolution paths that are allowed to download."
+
+    It costs the same on the miss path, which is what makes it more than a
+    performance note: a name discovery *cannot* resolve still clones the
+    repository and then returns ``None`` - the answer the caller would have had
+    for free.
+
+    The seam these cells drive is the fallback itself rather than
+    ``robot_descriptions``, so they grade the contract on a core install too. The
+    last cell re-asks the question of the real registry as an independent oracle.
+    """
+
+    @staticmethod
+    def _recording_discovery(consulted: list[str], entry: dict | None = None):
+        """Stand in for the discovery fallback, recording every consultation.
+
+        ``_lookup`` imports ``discover_robot`` inside its body, so patching the
+        module attribute is what the call site reads.
+        """
+
+        def discover(name: str) -> dict | None:
+            consulted.append(name)
+            return entry
+
+        return discover
+
+    def _patch_discovery(self, monkeypatch, consulted: list[str], entry: dict | None = None) -> None:
+        from strands_robots.registry import discovery
+
+        discovery.invalidate_cache()
+        monkeypatch.setattr(discovery, "discover_robot", self._recording_discovery(consulted, entry))
+
+    @staticmethod
+    def _synthesizable_asset(assets_dir: Path, name: str = "synthbot") -> dict:
+        """Put an asset on disk that only discovery can name, and return that entry.
+
+        This is the shape the real registry has: ``gen3``'s XML sits in the asset
+        cache under a directory only ``robot_descriptions`` knows the name of, so
+        a resolve that consults discovery *succeeds* while
+        :func:`is_robot_asset_present` - which reads ``get_robot`` alone - reports
+        it absent. Without the file on disk a declined resolve returns ``None``
+        because there was nothing to find, which is not the property under test.
+        """
+        robot_dir = assets_dir / name
+        robot_dir.mkdir(parents=True, exist_ok=True)
+        (robot_dir / f"{name}.xml").write_text(_MINIMAL_MJCF)
+        return {"asset": {"dir": name, "model_xml": f"{name}.xml", "scene_xml": "scene.xml"}}
+
+    # -- the declined path never consults discovery -----------------------
+
+    def test_a_non_curated_name_never_reaches_discovery(self, monkeypatch):
+        """The headline: declining the download declines the clone that finds it."""
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted)
+
+        manager.resolve_model_path("not-in-the-curated-registry", allow_download=False)
+
+        assert consulted == [], (
+            f"a declined resolve consulted discovery, whose import clones the asset repository: {consulted}"
+        )
+
+    def test_a_non_curated_name_reports_the_miss(self, tmp_path, monkeypatch):
+        """Declining answers ``None`` rather than importing to find out.
+
+        The asset is on disk under the name only discovery supplies, so the
+        declined ``None`` is the decision - against a resolve that would
+        otherwise have returned a real path.
+        """
+        entry = self._synthesizable_asset(tmp_path / "assets")
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted, entry=entry)
+        monkeypatch.setattr(manager, "_auto_download_robot", lambda _n, _i: False)
+
+        assert manager.resolve_model_path("synthbot", allow_download=False) is None
+        assert consulted == []
+
+    def test_the_miss_path_declines_too(self, monkeypatch):
+        """Discovery that would answer ``None`` is still not worth a clone."""
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted, entry=None)
+
+        assert manager.resolve_model_path("no-such-robot-anywhere", allow_download=False) is None
+        assert consulted == [], "the clone was paid for an answer that is None either way"
+
+    def test_it_answers_over_the_same_names_as_the_presence_check(self, tmp_path, monkeypatch):
+        """The documented parity with :func:`is_robot_asset_present`.
+
+        The docstring offers this as the *where* to that function's *whether*, on
+        the same terms. That holds only if the two read the same names: the
+        presence check consults ``get_robot`` alone, so a resolver that consults
+        discovery answers about robots its stated companion cannot see.
+        """
+        entry = self._synthesizable_asset(tmp_path / "assets")
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted, entry=entry)
+        monkeypatch.setattr(manager, "_auto_download_robot", lambda _n, _i: False)
+        _register_bot(tmp_path / "assets")
+
+        for name in ("unitbot", "synthbot"):
+            present = manager.is_robot_asset_present(name)
+            resolved = manager.resolve_model_path(name, allow_download=False)
+            assert present is (resolved is not None), (
+                f"{name!r}: presence says {present} and the declined resolve says "
+                f"{resolved!r} - the two do not answer over the same names"
+            )
+
+    # -- structural: the decision is forwarded, not re-derived -------------
+
+    def test_the_resolver_forwards_the_decision_to_the_lookup(self):
+        """The gate belongs to the shared lookup, and the caller must pass it on.
+
+        Reading the keyword's *value* rather than its presence: a forward of
+        ``allow_discovery=True`` spells the same keyword and restores the clone.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(manager.resolve_model_path)))
+        forwards = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_lookup"
+        ]
+        assert len(forwards) == 1, f"expected one _lookup call, found {len(forwards)}"
+        passed = {kw.arg: ast.unparse(kw.value) for kw in forwards[0].keywords if kw.arg is not None}
+        assert passed.get("allow_discovery") == "allow_download", (
+            f"resolve_model_path must hand its own allow_download to the lookup; it passes {passed!r}"
+        )
+
+    # -- over-reach controls: nothing else changes -------------------------
+
+    def test_the_downloading_default_still_consults_discovery(self, monkeypatch):
+        """The long tail still resolves for a caller about to load the model."""
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted)
+
+        manager.resolve_model_path("not-in-the-curated-registry")
+
+        assert consulted == ["not-in-the-curated-registry"]
+
+    @pytest.mark.parametrize("resolver", ["resolve_model_dir", "get_robot_info"])
+    def test_the_sibling_resolvers_still_consult_discovery(self, monkeypatch, resolver):
+        """The lookup's gate defaults open, so its other two callers are untouched."""
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted)
+
+        getattr(manager, resolver)("not-in-the-curated-registry")
+
+        assert consulted == ["not-in-the-curated-registry"]
+
+    def test_a_curated_name_is_unaffected(self, tmp_path, monkeypatch):
+        """Declining changes no answer for a name the curated registry knows."""
+        robot_dir = _register_bot(tmp_path / "assets")
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted)
+
+        assert manager.resolve_model_path("unitbot", allow_download=False) == robot_dir / "unitbot.xml"
+        assert consulted == [], "a curated hit must not reach the fallback at all"
+
+    # -- premise ----------------------------------------------------------
+
+    def test_the_lookup_records_why_discovery_needs_permission(self):
+        """The reason is the helper's own, so the gate is not a new policy."""
+        doc = " ".join((manager._lookup.__doc__ or "").split())
+        assert "download-capable resolvers" in doc
+        assert "asset download" in doc
+
+    # -- second layer: the same question, of the real registry ------------
+
+    def test_a_really_discoverable_name_is_declined(self):
+        """Independent oracle: real registry data, no stand-in.
+
+        A name the curated registry does not carry but ``robot_descriptions``
+        can synthesize is exactly the population the stand-in models. Asserting
+        no description module is imported is the reviewer-suggested check, and
+        it holds against whatever the installed ``robot_descriptions`` ships.
+        """
+        pytest.importorskip("robot_descriptions")
+        import sys
+
+        from strands_robots.registry import get_robot
+        from strands_robots.registry.discovery import list_discoverable
+
+        candidates = [name for name in sorted(list_discoverable()) if get_robot(name) is None]
+        assert candidates, "no discoverable name is outside the curated registry to test with"
+
+        name = candidates[0]
+        before = {m for m in sys.modules if m.startswith("robot_descriptions")}
+        assert manager.resolve_model_path(name, allow_download=False) is None
+        new = {m for m in sys.modules if m.startswith("robot_descriptions")} - before
+        assert new == set(), f"declining {name!r} imported description modules: {sorted(new)}"
+
+
 class TestAutoDownloadUnavailable:
     """When the download module is absent, the delegate is a no-op returning False."""
 

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -149,6 +149,29 @@ class TestListAvailableRobots:
         assert listed["unitbot"]["path"] is None
 
 
+class TestListingInstalledAssetsNeverFetches:
+    """A status listing reports what is here; it does not go and get the rest.
+
+    :func:`list_available_robots` gated the resolver on
+    :func:`is_robot_asset_present`, which stops it reaching for an absent XML but
+    not for a cached XML whose meshes are missing - that passes the presence check
+    and was fetched, once per such robot, every time the listing was built.
+    """
+
+    def test_a_mesh_less_cached_asset_is_listed_without_being_fetched(self, tmp_path, monkeypatch):
+        """The row still reports the path; nothing is downloaded to produce it."""
+        robot_dir = _register_bot(tmp_path / "assets")  # XML present, no meshes
+        assert manager.is_robot_asset_present("unitbot") is True, "presence alone would not gate this"
+
+        attempts: list[str] = []
+        monkeypatch.setattr(manager, "_auto_download_robot", lambda n, _i: attempts.append(n) or True)
+
+        rows = {r["name"]: r for r in manager.list_available_robots()}
+        assert attempts == [], f"building the listing downloaded {attempts}"
+        assert rows["unitbot"]["available"] is True
+        assert rows["unitbot"]["path"] == str(robot_dir / "unitbot.xml")
+
+
 class TestPathTraversalProtection:
     """Registry-sourced path components must never escape the search dirs."""
 
@@ -248,6 +271,85 @@ class TestAutoDownloadFallback:
         _invalidate_cache()
         monkeypatch.setattr(manager, "_auto_download_robot", lambda _n, _i: False)
         assert manager.resolve_model_path("unitbot") is None
+
+
+class TestDownloadCanBeDeclined:
+    """``allow_download=False`` resolves from disk and never reaches the network.
+
+    The downloading default is right for a caller about to load the model: a path
+    whose meshes are absent is useless to MuJoCo, so fetching them is the helpful
+    thing. It is wrong for a caller that *reports* on assets rather than loading
+    them - there it turns a read of what is on disk into a fetch of what is not,
+    once per robot.
+
+    Declining is defined as exactly a download that fails, so it cannot change
+    the answer for an asset already present. Both triggers are covered, because
+    guarding on :func:`is_robot_asset_present` alone stops only the first:
+    a cached XML whose meshes are missing passes that check and still fetches.
+    """
+
+    @staticmethod
+    def _recording_downloader(attempts: list[str]):
+        """A downloader that reports success without touching the network."""
+
+        def download(name: str, _info: dict) -> bool:
+            attempts.append(name)
+            return True
+
+        return download
+
+    def test_absent_xml_reports_a_miss_without_attempting(self, tmp_path, monkeypatch):
+        """First trigger: no XML anywhere. Declining gives the same None."""
+        robot_dir = _register_bot(tmp_path / "assets")
+        (robot_dir / "unitbot.xml").unlink()
+        _invalidate_cache()
+        attempts: list[str] = []
+        monkeypatch.setattr(manager, "_auto_download_robot", self._recording_downloader(attempts))
+
+        assert manager.resolve_model_path("unitbot", allow_download=False) is None
+        assert attempts == []
+
+    def test_missing_meshes_return_the_xml_without_attempting(self, tmp_path, monkeypatch):
+        """Second trigger: XML present, meshes absent. Declining keeps the XML."""
+        robot_dir = _register_bot(tmp_path / "assets")  # registered with no meshes
+        assert manager.is_robot_asset_present("unitbot") is True, "presence alone would not gate this"
+        attempts: list[str] = []
+        monkeypatch.setattr(manager, "_auto_download_robot", self._recording_downloader(attempts))
+
+        assert manager.resolve_model_path("unitbot", allow_download=False) == robot_dir / "unitbot.xml"
+        assert attempts == []
+
+    def test_the_downloading_default_is_unchanged(self, tmp_path, monkeypatch):
+        """Over-reach control: adding the knob must not stop the default fetching."""
+        _register_bot(tmp_path / "assets")  # no meshes -> the default reaches for them
+        attempts: list[str] = []
+        monkeypatch.setattr(manager, "_auto_download_robot", self._recording_downloader(attempts))
+
+        manager.resolve_model_path("unitbot")
+        assert attempts == ["unitbot"], "the default must still attempt a download"
+
+    @pytest.mark.parametrize("delete_xml", [True, False], ids=["absent-xml", "missing-meshes"])
+    def test_declining_matches_a_download_that_fails(self, tmp_path, monkeypatch, delete_xml):
+        """The documented equivalence, on both triggers.
+
+        This is what makes the knob safe to add to a resolver 46 call sites
+        already use: it introduces no third outcome.
+        """
+        robot_dir = _register_bot(tmp_path / "assets")
+        if delete_xml:
+            (robot_dir / "unitbot.xml").unlink()
+            _invalidate_cache()
+
+        monkeypatch.setattr(manager, "_auto_download_robot", lambda _n, _i: False)
+        failed_download = manager.resolve_model_path("unitbot")
+        manager._MESH_CACHE.clear()
+
+        attempts: list[str] = []
+        monkeypatch.setattr(manager, "_auto_download_robot", self._recording_downloader(attempts))
+        declined = manager.resolve_model_path("unitbot", allow_download=False)
+
+        assert declined == failed_download
+        assert attempts == []
 
 
 class TestAutoDownloadUnavailable:


### PR DESCRIPTION
## The problem

`resolve_model_path` downloads whatever it cannot find on disk. That is the right
default for a caller about to load the model — a path whose meshes are absent is
useless to MuJoCo, so fetching them is the helpful thing.

It is the wrong default for a caller that *reports* on assets rather than loading
them, and there was no way to ask for the other one. `is_robot_asset_present`
answers **whether** an asset is on disk without a download; nothing answered
**where** under the same terms.

Two callers wanted it, and both had already noticed:

**`list_available_robots`** hand-rolled a guard for the first of the resolver's two
download triggers — `# Only resolve full path when asset is present - avoids
download attempts` — and still fetched for the second. A cached XML whose meshes
are missing passes the presence check, so building a status listing downloaded
once per such robot:

```
list_available_robots(), 63 rows, download hook instrumented
  empty cache  -> 0 attempts   (the presence check does stop this one)
  this cache   -> 4 attempts   aliengo, asimov_v0, jvrc, unitree_a1
```

**`tests/registry/test_asset_family_joint_counts.py`** re-derives the asset-family
grouping by walking all 72 registry entries, so it fetched every asset the machine
did not already have — which is exactly the case where there is no grouping to
re-derive:

```
_auto_download_robot attempts over the registry walk
  empty cache  -> 63 of 72
  this cache   ->  7
```

That is what exceeded the file's `120s` `pytest-timeout` budget on `5d64a915`.
That run's log records `58` × `attempting auto-download` and `11` real `Cloning`
operations, and the file's docstring claimed the opposite: *"It skips where the
assets are absent rather than downloading them."*

The two commits after it passed, so this is a latent timeout rather than a
permanent one - it fires whenever the fetches are slow enough. It is worth being
precise about what those green runs do and do not show: pytest only dumps a
captured log for a test that **fails**, and the download lines in the red run sit
inside its `Captured log call` section. A passing run therefore prints none of
them whether or not it fetched, so it is no evidence that it did not. What is
measurable either way is that the walk asks for the corpus, and how long that
takes is the network's business rather than the test's.

## The change

`resolve_model_path` takes a keyword-only `allow_download`, defined as **exactly a
download that declines**: an absent XML still returns `None`, and a mesh-less XML
still returns its first candidate — the two outcomes a failed download already
produces. It introduces no third outcome, so the 46 existing call sites keep the
downloading default unchanged, and a caller that only reports can opt out of the
network entirely. A parametrized test pins that equivalence on both triggers.

Both reporting callers now use it.

## A second finding, in the same test

The re-derivation never saw the real assets. `tests/registry/conftest.py` repoints
`STRANDS_ASSETS_DIR` at a per-test temp directory — correctly, so a developer's
user robots cannot leak into registry assertions — and that also empties the asset
cache, the one input this class needs. Under it the grouping was unconfirmable on
every machine, and the downloading default hid that by fetching the corpus *into
the temp directory* to build the oracle instead of reporting that there was nothing
to read.

Declining alone would therefore have traded a red test for a permanently skipping
one, silently deleting the protection the class exists for. It now reads the host
cache, so it gets the two outcomes its docstring describes: confirm where the
assets are present, skip where they are not. On a machine with the assets it
confirms all six families — coverage it never actually had.

## Declining changes no answer

Same walk, downloads allowed vs declined:

```
signatures compiled : 58  vs  58
derived families    :  6  vs   6      IDENTICAL: True
lost from signatures: none
```

All six declared families are still re-derived. Every registry robot still
resolves and loads through the unchanged default: `resolve_model_path("so101")`
returns a byte-identical path either way, and `Robot("so101", mode="sim")` builds a
`MuJoCoSimEngine`, runs a 60-step SmolVLA rollout (7.722 rad of joint travel) and
records a LeRobot dataset that reopens with all three
`observation.images.camera{1,2,3}` streams at `[3, 256, 256]`, 60 frames, 0 frozen
and 0 black frames.

## Tests

Each new cell fails before the change and passes after. Reverting only the two
gates (keeping the signature, so the failures are the behaviour rather than a
`TypeError`):

```
tests/registry/test_asset_family_joint_counts.py::TestTheRederivationReadsDiskOnly
  test_no_download_when_the_cache_is_empty     FAILED  tried to download 63 assets
  test_no_download_when_the_cache_is_partial   FAILED  tried to download 7 assets
  test_the_walk_asks_the_resolver_not_to_fetch PASSED  (grades the caller's source)

tests/test_asset_manager.py::TestDownloadCanBeDeclined
  test_absent_xml_reports_a_miss_without_attempting     FAILED  ['unitbot'] == []
  test_missing_meshes_return_the_xml_without_attempting FAILED  ['unitbot'] == []
  test_declining_matches_a_download_that_fails[both]    FAILED  ['unitbot'] == []
  test_the_downloading_default_is_unchanged             PASSED  (over-reach control)
```

Both download triggers are graded separately, because guarding on
`is_robot_asset_present` alone stops only the first — and the robots it leaves
fetchable include members of a graded family. The over-reach control pins that the
default still downloads, and the structural cell pins *why* the count is zero, so
a passing run cannot be an accident of what happens to be on disk.

## Gate

`ruff check` and `ruff format --check` clean over 1653 files. `mypy strands_robots
tests tests_integ` — `Success: no issues found in 1650 source files`.
`tests/test_asset_manager.py` + `tests/registry/` — 851 passed. A 501-file
selection of every guard that walks the tree, parses source, reads docstrings or
names the resolver — 24149 passed, 5 failed; those 5 assert `rclpy` is absent and
reproduce identically on a pristine `main` worktree on this machine, where it
resolves.

The re-derivation itself goes from a `>120s` timeout to 19 passed in 23s, with no
skips and no network - so its cost stops depending on how fast 63 fetches happen
to be.
