### PR TITLE
fix(policies): escape a line break where an observation-derived value enters a log record

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2228,6 +2228,24 @@ Corrections from code review that apply to all future contributions:
   merge. Identical construct, opposite consequence, separated only by having
   arrived on a branch - and two rounds were spent arguing the idiom rather than
   applying the second bullet. See #1919.
+- **`py/log-injection`'s axis is the line break at interpolation time, not where
+  the value sits in the record.** Two edits look like they clear it and do not.
+  Moving the payload from `LogRecord.msg` into `args` behind a literal `%s` is
+  better logging practice on its own merits - a payload containing `%s` cannot
+  re-enter interpolation - but the break survives interpolation either way, and
+  #2852 measured the cost of assuming otherwise: `Analyze (Python)` re-opened the
+  alert at the rewritten line under a new id, so a merge-gating review thread came
+  back with it and the branch was closed rather than argued. Rendering through
+  `%r` *does* neutralize the break, and three sinks already did, which is why a
+  census of the class has to be read sink by sink: of the eight #2853 counted,
+  three could forge a record and five could not. The five were safe by the shape
+  the value arrived in - inside a list, whose `repr` escapes a `str` element, or
+  after `tolist()` - never by anything at the sink, so a container holding one
+  object with a multi-line `__repr__` walks straight through. Escape at the sink
+  (`strands_robots.policies._log_safety.sanitize_log_value`), grade the property
+  that a record cannot split rather than the record's field layout, and keep the
+  escape to `\r` and `\n`: these messages are read by a human diagnosing a
+  binding, and a broader filter corrupts the diagnosis they exist for.
 - **Dependency Review hard-fails on high/critical CVEs in new deps.** If a PR
   needs a dep with a known critical CVE, the conversation is "do we need this
   dep" not "let's bypass the check."

--- a/changelog.d/2855-policies-log-sink-line-break-escape.md
+++ b/changelog.d/2855-policies-log-sink-line-break-escape.md
@@ -35,3 +35,18 @@ which renders the same bytes `%r` rendered. `tokens.shape` at the tokenizer sink
 is deliberately left unwrapped: it is a shape the policy computed, not anything
 the observation supplied, and wrapping it would state a provenance it does not
 have.
+
+The escape is written as two chained `.replace()` calls with literal arguments
+rather than a loop over a table of pairs, and the spelling is load-bearing rather
+than a style choice. `py/log-injection`'s barrier in CodeQL's Python pack
+(`ReplaceLineBreaksSanitizer` in
+`semmle/python/security/dataflow/LogInjectionCustomizations.qll`) holds only for a
+`.replace` call whose first argument is a *string literal* equal to `"\r\n"` or
+`"\n"`; a name read from a constant satisfies neither conjunct, so a table-driven
+loop escapes the break exactly as well while being recognised as no barrier at
+all. The rendered text is identical either way -- and order-independent, since
+neither escape contains a raw break, so the two replacements cannot overlap -- but
+`"\r"` alone is not in that literal set, so `"\n"` goes last and the value leaving
+the helper is the result of the call the barrier recognises. A cell asserts the
+first arguments are literals, so tidying the function back into a loop fails
+rather than silently restoring the report.

--- a/changelog.d/2855-policies-log-sink-line-break-escape.md
+++ b/changelog.d/2855-policies-log-sink-line-break-escape.md
@@ -1,0 +1,37 @@
+### Fixed: an observation-derived value can no longer split the log record that quotes it
+
+Three of the eight `py/log-injection` sinks issue #2853 counted could forge a log
+record, and five could not, and the difference was not the one the rule reports.
+What decides it is whether the value can still carry a `\r` or `\n` at the moment
+it is interpolated. `_to_lerobot_observation`, `_build_observation_batch` and
+`_resolve_camera_targets` each hand a bare `str` -- a camera name, a language
+instruction slice -- to a bare `%s`, so a line feed in it put the tail of the
+warning on a line of its own, where a `FileHandler` or a shipper that frames on
+`\n` reads it as a record this process never wrote, complete with whatever
+timestamp and level the payload chose to spell.
+
+The other five were escaped, but incidentally rather than by construction: the
+two state-key sinks interpolate their keys inside a *list*, and `repr` escapes a
+`str` element, while the cuRobo and MoveIt2 state sinks reach `%r` only after
+`tolist()` has run. Nothing at those sinks said so, and the property is one
+readability edit away from gone -- render the same keys as `', '.join(keys)`, or
+let a list hold one object whose `__repr__` spans lines, and the break is back on
+the wire with no sink-side change to notice it. That last case is what the two new
+cuRobo/MoveIt2 cells drive, and both fail on the pre-change tree.
+
+So `strands_robots.policies._log_safety.sanitize_log_value` now escapes the two
+break characters at all eight sinks, and the property is stated where the record
+is emitted instead of being inherited from the caller's formatting choice. It
+touches `\r` and `\n` only: a key list, a joint-state repr and a remedy sentence
+are mostly brackets, quotes and commas, and a broader filter would corrupt the
+diagnosis the message exists for. Each break becomes its own visible two-character
+escape rather than being dropped, which is what `repr` would have shown, so a
+joint whose name genuinely contains a newline stays diagnosable. Escaping is
+idempotent on already-escaped text, so the five sinks that were incidentally safe
+render byte-identically to before.
+
+Three sinks changed a format spec from `%r` to `%s` over an explicit `repr()`,
+which renders the same bytes `%r` rendered. `tokens.shape` at the tokenizer sink
+is deliberately left unwrapped: it is a shape the policy computed, not anything
+the observation supplied, and wrapping it would state a provenance it does not
+have.

--- a/strands_robots/policies/_log_safety.py
+++ b/strands_robots/policies/_log_safety.py
@@ -32,14 +32,6 @@ byte the observation offered and a key whose name genuinely contains a newline
 is diagnosable rather than silently reflowed.
 """
 
-# The two characters that can start a new record. A ``\r\n`` pair needs no entry
-# of its own: escaping each half independently already renders it as ``\r\n``,
-# in order, which is what a reader has to see to know which pair was on the wire.
-_LINE_BREAKS: tuple[tuple[str, str], ...] = (
-    ("\r", "\\r"),
-    ("\n", "\\n"),
-)
-
 
 def sanitize_log_value(value: object) -> str:
     r"""Return ``value`` rendered for a log line with its line breaks escaped.
@@ -60,6 +52,16 @@ def sanitize_log_value(value: object) -> str:
         The rendered value, guaranteed to contain no ``\r`` or ``\n``.
     """
     text = value if isinstance(value, str) else str(value)
-    for raw, escaped in _LINE_BREAKS:
-        text = text.replace(raw, escaped)
-    return text
+    # Chained calls with literal arguments, not a loop over a table of pairs: the
+    # spelling is what carries the claim. The py/log-injection barrier in CodeQL's
+    # Python pack (``ReplaceLineBreaksSanitizer``) holds only for a ``.replace``
+    # call whose first argument is a string literal equal to ``"\r\n"`` or
+    # ``"\n"``, so a name read from a constant escapes the break just as well and
+    # is recognised as no barrier at all - which is how an escape can close the
+    # defect and still leave the rule reporting every sink that uses it.
+    #
+    # The rendered text is order-independent (neither escape contains a raw break,
+    # so the two replacements cannot overlap). The order here is chosen because
+    # ``"\r"`` alone is not in that literal set: putting ``"\n"`` last makes the
+    # value leaving this function the result of the call the barrier recognises.
+    return text.replace("\r", "\\r").replace("\n", "\\n")

--- a/strands_robots/policies/_log_safety.py
+++ b/strands_robots/policies/_log_safety.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+r"""Render an observation-derived value into a log line without forging a record.
+
+Every provider in this package emits operator diagnostics that quote values read
+straight out of a live observation: the observation dict's own key names, a
+camera key, a language instruction, a joint-state object. A value carrying a
+carriage return or a line feed splits the emitted record in two the moment it
+reaches a line-oriented consumer - a ``FileHandler``, ``journalctl``, a shipper
+that frames on ``\n`` - and the second half arrives looking like a record this
+process never wrote, free to carry its own timestamp, level and logger name.
+That is the ``py/log-injection`` class, and it is what :func:`sanitize_log_value`
+closes.
+
+Two shapes that look like they close it do not, both measured rather than
+assumed (see issue #2853 for the full eight-alert landscape):
+
+* **Keeping the value in the** ``args`` **tuple with a literal** ``%s`` **format
+  string.** Better logging practice on its own merits, because a payload
+  containing ``%s`` then cannot re-enter interpolation - but the line break
+  survives interpolation either way, so the record still splits.
+* **Rendering through** ``%r``. This one does neutralize the break
+  (``"\n" in ("%r" % "a\nb")`` is ``False``), which is why the three sinks that
+  already did it were never the risk - but it states nothing about the other
+  five, and it is not visible as a decision at the sinks that lack it.
+
+So the escape is applied here, at one named function, and the call sites read
+``%s`` with the value wrapped. What the escape does *not* do is drop content:
+each break becomes its own two-character visible escape, which is what
+:func:`repr` would have shown, so an operator reading the line still sees every
+byte the observation offered and a key whose name genuinely contains a newline
+is diagnosable rather than silently reflowed.
+"""
+
+# The two characters that can start a new record. A ``\r\n`` pair needs no entry
+# of its own: escaping each half independently already renders it as ``\r\n``,
+# in order, which is what a reader has to see to know which pair was on the wire.
+_LINE_BREAKS: tuple[tuple[str, str], ...] = (
+    ("\r", "\\r"),
+    ("\n", "\\n"),
+)
+
+
+def sanitize_log_value(value: object) -> str:
+    r"""Return ``value`` rendered for a log line with its line breaks escaped.
+
+    The only characters this touches are ``\r\n``, ``\r`` and ``\n``, each
+    replaced by its visible two-character escape. Everything else - commas,
+    brackets, quotes, the punctuation a joint-state repr or a key list is made
+    of - is passed through, because these messages are read by a human
+    diagnosing a binding and a broader filter would corrupt the diagnosis.
+
+    Args:
+        value: Any object bound for an operator-facing log message. A non-string
+            is rendered with :func:`str` first; pass ``repr(value)`` explicitly
+            at a site that wants the quoted form (the escape then applies to
+            what ``%r`` would have emitted).
+
+    Returns:
+        The rendered value, guaranteed to contain no ``\r`` or ``\n``.
+    """
+    text = value if isinstance(value, str) else str(value)
+    for raw, escaped in _LINE_BREAKS:
+        text = text.replace(raw, escaped)
+    return text

--- a/strands_robots/policies/curobo/policy.py
+++ b/strands_robots/policies/curobo/policy.py
@@ -70,6 +70,7 @@ import math
 import re
 from typing import Any
 
+from strands_robots.policies._log_safety import sanitize_log_value
 from strands_robots.policies.base import Policy, chunk_count_error
 from strands_robots.utils import name_list_error, require_optional
 
@@ -786,10 +787,13 @@ class CuroboPolicy(Policy):
             self._motion_planner, "update_world", None
         )
         if update_fn is None:
+            shown = sorted(world_update.keys()) if isinstance(world_update, dict) else world_update
             logger.warning(
                 "CuroboPolicy: motion_planner exposes neither update_scene() "
-                "nor update_world(); world_update=%r ignored",
-                sorted(world_update.keys()) if isinstance(world_update, dict) else world_update,
+                "nor update_world(); world_update=%s ignored",
+                # %s over the sanitized repr renders what %r rendered, with the
+                # observation-derived key names' line breaks escaped.
+                sanitize_log_value(repr(shown)),
             )
             return
         update_fn(world_update)
@@ -991,10 +995,10 @@ class CuroboPolicy(Policy):
             return [float(x) for x in state]
         except (TypeError, ValueError) as e:
             logger.warning(
-                "CuroboPolicy: failed to extract joint_state from observation.state=%r (%s); "
+                "CuroboPolicy: failed to extract joint_state from observation.state=%s (%s); "
                 "letting planner use its own retract configuration",
-                state,
-                e,
+                sanitize_log_value(repr(state)),
+                sanitize_log_value(e),
             )
             return None
 

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -22,6 +22,7 @@ import torch
 
 from ...utils import name_list_error, positive_count_error
 from .. import Policy, align_action_values, chunk_count_error
+from .._log_safety import sanitize_log_value
 from .._state_keys import drop_velocity_siblings
 from .embodiment import (
     ZeroActionMonitor,
@@ -2458,7 +2459,7 @@ class LerobotLocalPolicy(Policy):
         # most once per policy so a long rollout is not spammed.
         self.generic_state_keys_used = True
         if not self._state_key_mismatch_warned:
-            logger.warning(msg)
+            logger.warning("%s", sanitize_log_value(msg))
             self._state_key_mismatch_warned = True
         return drop_velocity_siblings(scalar_keys)
 
@@ -2531,7 +2532,7 @@ class LerobotLocalPolicy(Policy):
                 raise ValueError("strict_keys=True: " + msg)
             self.missing_state_keys_used = True
             if not self._state_missing_keys_warned:
-                logger.warning(msg)
+                logger.warning("%s", sanitize_log_value(msg))
                 self._state_missing_keys_warned = True
         return values
 
@@ -2624,8 +2625,8 @@ class LerobotLocalPolicy(Policy):
                 "routing positionally to '%s'. The frame may feed the wrong model "
                 "input - pass camera_key_map to bind cameras explicitly (or "
                 "strict_keys=True to make this an error).",
-                k,
-                feat,
+                sanitize_log_value(k),
+                sanitize_log_value(feat),
             )
             out[feat] = v
             used_feats.add(feat)
@@ -2712,7 +2713,11 @@ class LerobotLocalPolicy(Policy):
                 batch["observation.language.tokens"] = tokens
                 if mask is not None:
                     batch["observation.language.attention_mask"] = mask
-                logger.debug("VLA tokenized instruction: '%s...' -> %s tokens", instruction[:50], tokens.shape)
+                logger.debug(
+                    "VLA tokenized instruction: '%s...' -> %s tokens",
+                    sanitize_log_value(instruction[:50]),
+                    tokens.shape,
+                )
 
         # Fill task key for models that read it directly from the batch
         # (e.g. some VLA models read "task" or "observation.task" from the
@@ -2911,8 +2916,8 @@ class LerobotLocalPolicy(Policy):
                 "Camera '%s' does not match any declared policy image key by name; "
                 "routing positionally to '%s'. Pass camera_key_map to bind cameras "
                 "explicitly and silence this warning.",
-                cam,
-                feat,
+                sanitize_log_value(cam),
+                sanitize_log_value(feat),
             )
             result[cam] = feat
             used.add(feat)

--- a/strands_robots/policies/moveit2/policy.py
+++ b/strands_robots/policies/moveit2/policy.py
@@ -40,6 +40,7 @@ import math
 import os
 from typing import Any
 
+from strands_robots.policies._log_safety import sanitize_log_value
 from strands_robots.policies.base import Policy
 from strands_robots.utils import name_list_error, tcp_port_error
 
@@ -325,10 +326,10 @@ class MoveIt2Policy(Policy):
             return [float(x) for x in state]
         except (TypeError, ValueError) as e:
             logger.warning(
-                "MoveIt2Policy: failed to extract joint_state from observation.state=%r (%s); "
+                "MoveIt2Policy: failed to extract joint_state from observation.state=%s (%s); "
                 "letting sidecar use its own state estimate",
-                state,
-                e,
+                sanitize_log_value(repr(state)),
+                sanitize_log_value(e),
             )
             return None
 

--- a/tests/policies/test_log_sink_sanitizer.py
+++ b/tests/policies/test_log_sink_sanitizer.py
@@ -62,6 +62,7 @@ from typing import Any
 import pytest
 
 import strands_robots.policies as policies_pkg
+import strands_robots.policies._log_safety as log_safety
 from strands_robots.policies._log_safety import sanitize_log_value
 from strands_robots.policies.curobo.policy import CuroboPolicy
 from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
@@ -152,6 +153,42 @@ def test_a_payload_that_already_reads_as_an_escape_is_left_alone() -> None:
     were escaped incidentally render byte-identically after this change."""
     already = "['shoulder\\npan', 'gripper']"
     assert sanitize_log_value(already) == already
+
+
+def test_the_escape_is_written_as_a_literal_replace_call() -> None:
+    r"""The break characters are passed as literals, not read from a table.
+
+        Helper contract. Two spellings escape the break identically and only one of
+        them is recognised as a barrier by the scanner that reports these sinks:
+        ``py/log-injection``'s ``ReplaceLineBreaksSanitizer`` holds for a ``.replace``
+        call whose first argument is a *string literal* equal to ``"
+    "`` or
+        ``"
+    "``, so a loop over a table of pairs closes the defect while reading as
+        no barrier at all. That is not a property a reader can see from the rendered
+        output, which is why it is asserted here rather than left to the next person
+        who tidies the function into a loop.
+    """
+    module = ast.parse(Path(log_safety.__file__).read_text(encoding="utf-8"))
+    function = next(
+        node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "sanitize_log_value"
+    )
+    literals = {
+        node.args[0].value
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "replace"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    }
+    recognised = literals & {"\r\n", "\n"}
+    assert recognised, (
+        "no .replace() call in sanitize_log_value passes a literal '\\r\\n' or "
+        f"'\\n' as its first argument, so the escape is not the barrier the "
+        f"scanner recognises; first arguments found: {sorted(literals)!r}"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/policies/test_log_sink_sanitizer.py
+++ b/tests/policies/test_log_sink_sanitizer.py
@@ -1,0 +1,323 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+r"""A value read out of a live observation cannot split the record that quotes it.
+
+Eight ``py/log-injection`` alerts are open across three policy providers and
+issue #2853 has the census. What the alerts agree on is the taint path: an
+observation dict's own key names, a camera key, a language instruction and a
+joint-state object all reach a logging sink. What they do not distinguish is
+whether the value can still carry a ``\r`` or ``\n`` *by the time it is
+interpolated* - and that is the only thing that splits a record for a
+line-oriented consumer, which is the defect the rule is named for.
+
+Measured on the tree before this module existed, driving each sink with a payload
+whose name carried a line feed:
+
+===== ================================= ==============================================
+alert sink                              raw break in ``LogRecord.getMessage()``
+===== ================================= ==============================================
+715   ``_to_lerobot_observation``       yes - bare ``%s`` on the camera key
+716   ``_build_observation_batch``      yes - bare ``%s`` on the instruction slice
+717   ``_resolve_camera_targets``       yes - bare ``%s`` on the camera name
+949   ``_resolve_state_order``          no - the keys arrive inside a list, and
+                                        ``repr`` escapes a ``str`` element
+714   ``_collect_state_values``         no - same list interpolation
+710   ``_apply_world_update``           no - ``%r`` over a list of keys
+711   cuRobo ``_extract_joint_state``   no - ``tolist()`` runs before the sink, so
+                                        ``%r`` renders a list
+712   MoveIt2 ``_extract_joint_state``  no - same
+===== ================================= ==============================================
+
+So three of the eight could forge a record and five could not. The five are not
+safe *by construction* though - they are safe by the shape the value happens to
+arrive in. Interpolate the same keys as ``', '.join(scalar_keys)`` for
+readability, or hand ``%r`` a list holding one object with a multi-line
+``__repr__`` instead of a list of strings, and the property is gone with nothing
+at the sink to notice. That last case is not hypothetical: it is what cells
+:func:`test_curobo_joint_state_object_with_a_multiline_repr_cannot_split_the_record`
+and its MoveIt2 sibling drive, and both fail on the pre-change tree.
+
+Hence the grading here is split in three, and each cell says which kind it is:
+
+* **Forging cells** - drive a sink with a payload that *did* split the record
+  before, and pin that it no longer does. These fail on the pre-change tree.
+* **Property cells** - drive a sink whose escape was incidental, and pin the
+  property directly so it is stated at the sink rather than inferred from the
+  caller's formatting choice. These pass either way; what they defend is the
+  next refactor of the message, not this change.
+* **The wiring cell** - hold the set of sanitized sinks to exactly the eight the
+  census names, keyed by the function that owns each one because a line number is
+  the part that goes stale. Removing a wrapper fails it. Finding a *new* sink is
+  CodeQL's job, not this file's.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import strands_robots.policies as policies_pkg
+from strands_robots.policies._log_safety import sanitize_log_value
+from strands_robots.policies.curobo.policy import CuroboPolicy
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+from strands_robots.policies.moveit2.policy import MoveIt2Policy
+
+# A payload shaped like the thing an operator would see in a forged line: the
+# second half looks like a record this process never wrote.
+FORGED = "wrist\nWARNING:root:actuators disabled"
+
+
+def _stub(**attributes: object) -> Any:
+    """Return a stand-in ``self`` for driving one sink in isolation.
+
+    Each sink under test reads a handful of attributes and nothing else, so an
+    unbound call against a namespace keeps the cell on its one message instead of
+    standing up a provider with a loaded model and its optional backend. Typed
+    ``Any`` for the same reason the tree casts a deliberate stand-in elsewhere.
+    """
+    return SimpleNamespace(**attributes)
+
+
+def _rendered(caplog: pytest.LogCaptureFixture) -> str:
+    """Return the last captured record's fully interpolated message."""
+    assert caplog.records, "the sink under test emitted no record"
+    return caplog.records[-1].getMessage()
+
+
+def _has_raw_break(text: str) -> bool:
+    """True when ``text`` can start a new line in a line-oriented log consumer."""
+    return "\n" in text or "\r" in text
+
+
+class MultilineRepr:
+    """An ``observation.state`` element whose ``repr`` spans two lines.
+
+    A joint-state object is not obliged to have a single-line ``repr``, and a
+    container's ``repr`` escapes only its ``str`` elements - it calls ``repr``
+    on everything else and passes the result through verbatim. So this is the
+    shape that defeats the incidental escape at the two ``%r`` state sinks.
+    """
+
+    def __repr__(self) -> str:
+        """Return a two-line representation."""
+        return "JointState(\nWARNING:root:actuators disabled)"
+
+
+# --------------------------------------------------------------------------
+# The helper's own contract.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("a\nb", "a\\nb"),
+        ("a\rb", "a\\rb"),
+        ("a\r\nb", "a\\r\\nb"),
+        ("a\n\nb", "a\\n\\nb"),
+        ("\n", "\\n"),
+    ],
+    ids=["lf", "cr", "crlf", "two-lf", "lf-only"],
+)
+def test_every_line_break_spelling_becomes_its_visible_escape(payload: str, expected: str) -> None:
+    """Each break is replaced in place, and a CRLF pair keeps its order."""
+    assert sanitize_log_value(payload) == expected
+    assert not _has_raw_break(sanitize_log_value(payload))
+
+
+def test_a_non_string_is_rendered_before_it_is_escaped() -> None:
+    """A caller may hand over any object; ``str`` runs first."""
+    assert sanitize_log_value([1, 2]) == "[1, 2]"
+    assert sanitize_log_value(MultilineRepr()) == "JointState(\\nWARNING:root:actuators disabled)"
+
+
+def test_nothing_but_the_two_break_characters_is_touched() -> None:
+    """The punctuation these diagnostics are made of survives verbatim.
+
+    An over-broad filter would corrupt the diagnosis the message exists for: a
+    key list, a joint-state repr and a remedy sentence are mostly brackets,
+    quotes, commas and tabs.
+    """
+    intact = "['shoulder_pan', 'gripper'] -> set_robot_state_keys(...) 50% \t|;$`"
+    assert sanitize_log_value(intact) == intact
+
+
+def test_a_payload_that_already_reads_as_an_escape_is_left_alone() -> None:
+    """Escaping is idempotent on already-escaped text, so the five sinks that
+    were escaped incidentally render byte-identically after this change."""
+    already = "['shoulder\\npan', 'gripper']"
+    assert sanitize_log_value(already) == already
+
+
+# --------------------------------------------------------------------------
+# Forging cells: these fail on the pre-change tree.
+# --------------------------------------------------------------------------
+
+
+def test_an_unmatched_camera_name_cannot_split_the_record(caplog: pytest.LogCaptureFixture) -> None:
+    """Alert 717. The camera name reached a bare ``%s``, so a line feed in it
+    put half of the warning on a line of its own."""
+    policy = _stub(
+        _policy_image_keys=lambda: ["observation.images.top"],
+        camera_key_map=None,
+        strict_keys=False,
+        positional_fallback_used=False,
+    )
+    with caplog.at_level(logging.WARNING):
+        LerobotLocalPolicy._resolve_camera_targets(policy, [FORGED])
+
+    rendered = _rendered(caplog)
+    assert not _has_raw_break(rendered), f"record still splits: {rendered!r}"
+    # The name is still readable, and still names the offending camera.
+    assert "wrist\\nWARNING:root:actuators disabled" in rendered
+
+
+def test_curobo_joint_state_object_with_a_multiline_repr_cannot_split_the_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Alert 711. ``%r`` over a list escapes ``str`` elements only, so one
+    element with a multi-line ``repr`` put the break back on the wire."""
+    policy = _stub()
+    with caplog.at_level(logging.WARNING):
+        result = CuroboPolicy._extract_joint_state(policy, {"observation.state": [MultilineRepr()]})
+
+    assert result is None, "the degraded-extraction path is the one under test"
+    rendered = _rendered(caplog)
+    assert not _has_raw_break(rendered), f"record still splits: {rendered!r}"
+    assert "JointState(\\nWARNING:root:actuators disabled)" in rendered
+
+
+def test_moveit2_joint_state_object_with_a_multiline_repr_cannot_split_the_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Alert 712. Same shape as the cuRobo sink, and the same fix, so a
+    provider that grows a third copy of this message is graded here too."""
+    policy = _stub()
+    with caplog.at_level(logging.WARNING):
+        result = MoveIt2Policy._extract_joint_state(policy, {"observation.state": [MultilineRepr()]})
+
+    assert result is None, "the degraded-extraction path is the one under test"
+    rendered = _rendered(caplog)
+    assert not _has_raw_break(rendered), f"record still splits: {rendered!r}"
+    assert "JointState(\\nWARNING:root:actuators disabled)" in rendered
+
+
+# --------------------------------------------------------------------------
+# Property cells: the escape was incidental at these sinks; state it there.
+# --------------------------------------------------------------------------
+
+
+def test_a_state_key_mismatch_names_the_observation_keys_on_one_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Alert 949. Escaped before this change only because the keys arrive as a
+    list; pinned here so a reflowed message cannot lose the property quietly."""
+    policy = _stub(
+        robot_state_keys=["joint_0"],
+        strict_keys=False,
+        generic_state_keys_used=False,
+        _state_key_mismatch_warned=False,
+    )
+    observation = {FORGED: 0.0, "gripper": 1.0}
+    with caplog.at_level(logging.WARNING):
+        LerobotLocalPolicy._resolve_state_order(policy, observation, list(observation))
+
+    rendered = _rendered(caplog)
+    assert not _has_raw_break(rendered), f"record still splits: {rendered!r}"
+    assert "gripper" in rendered, "the observed keys are still named"
+
+
+def test_missing_state_keys_name_the_absent_keys_on_one_record(caplog: pytest.LogCaptureFixture) -> None:
+    """Alert 714. Same list interpolation, same reason to state it at the sink."""
+    configured = [FORGED, "gripper"]
+    policy = _stub(
+        robot_state_keys=configured,
+        strict_keys=False,
+        missing_state_keys_used=False,
+        _state_missing_keys_warned=False,
+    )
+    with caplog.at_level(logging.WARNING):
+        LerobotLocalPolicy._collect_state_values(policy, {"gripper": 1.0}, configured)
+
+    rendered = _rendered(caplog)
+    assert not _has_raw_break(rendered), f"record still splits: {rendered!r}"
+    assert "1 configured robot_state_keys are not present" in rendered
+
+
+def test_an_ignored_world_update_names_its_keys_on_one_record(caplog: pytest.LogCaptureFixture) -> None:
+    """Alert 710. The planner-shim warning quotes the caller's own scene keys."""
+    policy = _stub(_motion_planner=SimpleNamespace())
+    with caplog.at_level(logging.WARNING):
+        CuroboPolicy._apply_world_update(policy, {FORGED: {}})
+
+    rendered = _rendered(caplog)
+    assert not _has_raw_break(rendered), f"record still splits: {rendered!r}"
+    assert "world_update=" in rendered
+
+
+# --------------------------------------------------------------------------
+# The wiring cell.
+# --------------------------------------------------------------------------
+
+# Every sink issue #2853 counted, keyed by the function that owns it, mapped to
+# the argument expressions that must pass through the sanitizer. ``tokens.shape``
+# is deliberately absent from the 716 entry: it is a tensor shape the policy
+# computed, not anything the observation supplied, and wrapping it would state a
+# provenance it does not have.
+_SANITIZED_SINKS: dict[str, dict[str, list[str]]] = {
+    "lerobot_local/policy.py": {
+        "LerobotLocalPolicy._resolve_state_order": ["msg"],
+        "LerobotLocalPolicy._collect_state_values": ["msg"],
+        "LerobotLocalPolicy._to_lerobot_observation": ["feat", "k"],
+        "LerobotLocalPolicy._build_observation_batch": ["instruction[:50]"],
+        "LerobotLocalPolicy._resolve_camera_targets": ["cam", "feat"],
+    },
+    "curobo/policy.py": {
+        "CuroboPolicy._apply_world_update": ["repr(shown)"],
+        "CuroboPolicy._extract_joint_state": ["e", "repr(state)"],
+    },
+    "moveit2/policy.py": {
+        "MoveIt2Policy._extract_joint_state": ["e", "repr(state)"],
+    },
+}
+
+_PACKAGE_DIR = Path(policies_pkg.__file__).parent
+
+
+def _sanitized_arguments(relative_path: str) -> dict[str, list[str]]:
+    """Map ``Class.method`` -> sorted ``sanitize_log_value`` argument sources."""
+    tree = ast.parse((_PACKAGE_DIR / relative_path).read_text(encoding="utf-8"))
+    found: dict[str, list[str]] = {}
+
+    def visit(node: ast.AST, scope: list[str]) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                visit(child, [*scope, child.name])
+                continue
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == "sanitize_log_value"
+                and scope
+            ):
+                found.setdefault(".".join(scope), []).append(ast.unparse(child.args[0]))
+            visit(child, scope)
+
+    visit(tree, [])
+    return {qualname: sorted(args) for qualname, args in found.items()}
+
+
+@pytest.mark.parametrize("relative_path", sorted(_SANITIZED_SINKS), ids=lambda p: p.split("/")[0])
+def test_exactly_the_census_sinks_are_sanitized(relative_path: str) -> None:
+    """The sanitized set is the eight the census names - no more, no fewer.
+
+    A wrapper removed from one of them fails here as well as re-opening its
+    alert, and a wrapper added somewhere new has to be added to the census in
+    the same diff, which is where the argument for it gets written down.
+    """
+    assert _sanitized_arguments(relative_path) == _SANITIZED_SINKS[relative_path]


### PR DESCRIPTION
## The problem

`py/log-injection` has eight open alerts across three policy providers, and issue #2853 has the census. The rule reports a taint path and every one of the eight is real: an observation dict's own key names, a camera key, a language instruction and a joint-state object all reach a logging sink. What the rule does not distinguish is the thing that decides whether a record can actually be forged - whether the value still carries a `\r` or `\n` *at the moment it is interpolated*. That is the only property that splits a record for a line-oriented consumer, which is the defect the rule is named for.

So I measured it, driving each sink with a payload whose name carried a line feed and reading `LogRecord.getMessage()`:

| alert | sink | raw break in the rendered record | why |
|---|---|---|---|
| 715 | `_to_lerobot_observation` | **yes** | bare `%s` on the camera key |
| 716 | `_build_observation_batch` | **yes** | bare `%s` on the instruction slice |
| 717 | `_resolve_camera_targets` | **yes** | bare `%s` on the camera name |
| 949 | `_resolve_state_order` | no | keys arrive inside a list, and `repr` escapes a `str` element |
| 714 | `_collect_state_values` | no | same list interpolation |
| 710 | `_apply_world_update` | no | `%r` over a list of keys |
| 711 | cuRobo `_extract_joint_state` | no | `tolist()` runs before the sink, so `%r` renders a list |
| 712 | MoveIt2 `_extract_joint_state` | no | same |

Three of eight could forge a record. Measured, not asserted - the 717 row is what a forged line looks like today:

```
Camera 'wrist
WARNING:root:actuators disabled' does not match any declared policy image key by name; ...
```

The five that could not were **safe by the shape the value arrived in, never by anything at the sink**. That distinction is the whole point of this PR: interpolate the same keys as `', '.join(scalar_keys)` for readability, or hand `%r` a list holding one object with a multi-line `__repr__` instead of a list of strings, and the property is gone with nothing at the sink to notice. The second case is not hypothetical - it is what two of the new cells drive, and both fail on the pre-change tree:

```
CuroboPolicy: failed to extract joint_state from observation.state=[JointState(
WARNING:root:actuators disabled)] (float() argument must be ...)
```

## The change

`strands_robots/policies/_log_safety.py` - one function, `sanitize_log_value`, applied at all eight sinks so the property is stated where the record is emitted rather than inherited from the caller's formatting choice.

It escapes `\r` and `\n` and nothing else. Not a wider filter: a key list, a joint-state repr and a remedy sentence are mostly brackets, quotes, commas and tabs, and these messages are read by a human diagnosing a binding, so a broader filter would corrupt the diagnosis the message exists for. Each break becomes its own visible two-character escape rather than being dropped - which is what `repr` would have shown - so a joint whose name genuinely does contain a newline stays diagnosable instead of being silently reflowed.

Two consequences worth stating because they bound the blast radius:

- **The five incidentally-safe sinks render byte-identically.** Escaping is idempotent on already-escaped text, and what reaches those sinks is already the two characters `\` + `n`, not a raw break. Cell `test_a_payload_that_already_reads_as_an_escape_is_left_alone` pins it.
- **The three `%r` -> `%s` conversions render the same bytes.** `"%r" % x` and `"%s" % repr(x)` are the same string; the escape then applies to what `%r` would have emitted.

`tokens.shape` at the tokenizer sink is deliberately left unwrapped: it is a tensor shape the policy computed, not anything the observation supplied, and wrapping it would state a provenance it does not have. The wiring cell's expected set records that decision rather than leaving it to be re-derived.

## Tests

`tests/policies/test_log_sink_sanitizer.py`, 17 cells, graded in three kinds - each cell's docstring says which kind it is, because they defend different things:

- **Forging cells (3).** Drive a sink with a payload that did split the record, pin that it no longer does. These are the regression graders and they fail pre-change: the camera-name sink, and the cuRobo/MoveIt2 state sinks via a list element whose `__repr__` spans lines.
- **Property cells (3).** Drive the sinks whose escape was incidental (949, 714, 710) and pin the invariant at the sink. These pass either way, and I am not claiming otherwise - what they defend is the *next* refactor of those messages, not this change.
- **Helper contract (10 incl. parametrization).** Every break spelling including a CRLF pair keeping its order, non-string rendering, idempotence on escaped text, and an over-reach control pinning that brackets/quotes/commas/tabs/`%`/`;`/`$` survive verbatim.
- **The wiring cell (1, parametrized per module).** Holds the sanitized set to exactly the eight the census names, keyed by the function that owns each - not by line number, which is the part that goes stale. A wrapper removed from any sink fails it; a wrapper added somewhere new has to be added to the census in the same diff, which is where the argument for it gets written down. Finding a *new* sink is CodeQL's job, and this file says so rather than pretending to do it.

### Pre-change baseline (verified locally)

Helper module present, the eight sinks left unwired - so the suite grades the wiring rather than an import error:

```
6 failed, 11 passed
  test_an_unmatched_camera_name_cannot_split_the_record                              FAILED
  test_curobo_joint_state_object_with_a_multiline_repr_cannot_split_the_record       FAILED
  test_moveit2_joint_state_object_with_a_multiline_repr_cannot_split_the_record      FAILED
  test_exactly_the_census_sinks_are_sanitized[lerobot_local|curobo|moveit2]          FAILED (3)
```

Each failure names the record it still split. Post-change: **17 passed**.

### Regression check

`tests/policies` (incl. `lerobot_local`, `curobo`, `moveit2`, the docstring/xref guards): **950 passed, 67 skipped**, unchanged from base. Six pre-existing failures in `test_molmoact2` / `test_norm_stats_fallback` are `huggingface_hub` not being installed locally and reproduce identically on `main`. `ruff check`, `ruff format --check` and `mypy` clean on every file this touches (`mypy`'s 74 other findings are missing optional backends locally and are identical on base).

## Not shipped, and why

- **No claim that this clears the eight alerts.** It closes the defect they point at, which is not the same statement, and #2853's second half - what to do if `Analyze (Python)` still opens a thread - stays a maintainer call rather than something I guess at here. That is why this says `Refs`, not `Fixes`. The measurement either way is on this branch's own run, and it came back: see the section below.
- **`.github/codeql/codeql-config.yml` untouched.** Its scope test is that *every* instance in the tree is an idiom the codebase is obliged to use, and a sanitizer existing is a standing counter-example. `tests/test_codeql_query_filters.py` still passes on the two-id set.
- **The other 44 non-literal logger arguments in these three modules are left alone.** Wrapping all of them would be a 57-site diff stating a provenance most of them do not have (`elapsed`, `tokens.shape`, `type(self._policy).__name__`). The eight are the ones a value from the observation reaches.

## AGENTS.md

One bullet in the CI Security Baseline, recording the axis and the two edits that look like they clear this rule and do not - the `msg`-to-`args` move (#2852 measured its cost: the alert re-opened at the rewritten line under a new id) and `%r` rendering. It is the trap that costs a round if it is re-derived per site.

## Measured on this branch: the spelling was the barrier, and it now holds

An earlier revision of this branch escaped the break inside a loop over a table of
pairs and `Analyze (Python)` re-opened five alerts (1106-1110) at the wrapped lines,
which I read as `str.replace` not being a barrier at all. That reading was wrong,
and the query source says why. `LogInjectionQuery.qll` is
`isBarrier(node) { node instanceof Sanitizer }`, and the Python pack's
`LogInjectionCustomizations.qll` defines one for this exact case:

```ql
class ReplaceLineBreaksSanitizer extends Sanitizer, DataFlow::CallCfgNode {
  ReplaceLineBreaksSanitizer() {
    this.getFunction().(DataFlow::AttrRead).getAttributeName() = "replace" and
    this.getArg(0).asExpr().(StringLiteral).getText() in ["\r\n", "\n"]
  }
}
```

Two conjuncts. `text.replace(raw, escaped)` satisfies the first and fails the
second: `getArg(0)` is a `Name` read from `_LINE_BREAKS`, not a `StringLiteral`. So
the loop escaped the break exactly as well and was recognised as no barrier, which
is the whole of the third row below. `78b00b89` writes the same two replacements as
chained calls with literal arguments, byte-identical on 22 probes.

| attempt | where | result |
|---|---|---|
| payload into `args` behind a literal `%s` | #2852 | never touched a barrier; alerts re-opened (1104, 1105) |
| `%r` rendering | already at 710/711/712 on `main` | not a barrier either; alerts open, never cleared |
| escaping helper, break characters read from a constant | this branch, `b20e96d9` | escapes the break, fails the literal conjunct (1106-1110) |
| escaping helper, break characters written as literals | this branch, `78b00b89` | **0 open alerts on the PR ref** |

Measured on `78b00b89` with `Analyze (Python)` `SUCCESS`: open `py/log-injection`
on `refs/pull/2855/merge` went 5 to **0**, total open alerts on the PR ref 5 to
**0**, the `CodeQL` check-run `FAILURE` to **`NEUTRAL`**, and all five review
threads auto-resolved. `main` still reports 8, so this is the branch clearing them
rather than the census moving.

Nothing was dismissed and `.github/codeql/codeql-config.yml` is still untouched, so
the scope discipline stands and #2853's second half does not need an answer for this
class. The order of the two replacements is immaterial to the rendered text
(measured over 10 probes; neither escape contains a raw break, so they cannot
overlap) but `"\r"` alone is not in the barrier's literal set, so `"\n"` goes last
and the value leaving the helper is the result of the recognised call.
`test_the_escape_is_written_as_a_literal_replace_call` pins that: reverting to the
loop fails it and nothing else, and with the cell absent the suite cannot tell the
two spellings apart.

One consequence worth stating: the push that carried this dismissed the approval
under `dismiss_stale_reviews_on_push`, so this needs one fresh approval from a
non-pusher. The reviewed substance is unchanged - one `return` statement, one
deleted constant, one test cell, one changelog paragraph.

## Gate

The changelog fragment name (`2855-...`) is a best-effort predictor and matched the number this landed as, so nothing to rename.

Refs #2853. Supersedes #2852, closed with the measurement rather than another round.
