### PR TITLE
fix(docs/policies): the catalogue names an install extra that cannot exist

### DIFF
--- a/changelog.d/2857-catalogue-names-only-real-install-extras.md
+++ b/changelog.d/2857-catalogue-names-only-real-install-extras.md
@@ -1,0 +1,44 @@
+### Fixed: the policy catalogue named an install extra that cannot exist, and the guard for that class could not see the column
+
+``docs/policies/overview.md`` is the page a reader lands on to choose a
+``policy_provider``, and its Providers table gave VERA's install extra as the
+bare name ``vera``. There is no such extra. Three places in the tree already say
+so: ``pyproject.toml`` carries a comment beginning "There is intentionally no
+``vera`` extra", ``docs/policies/vera.md`` repeats it in its install section, and
+the README's VERA row reads "Git-only (not on PyPI, no extra)". The catalogue was
+the one surface that disagreed, and the page's own preamble claimed the table
+"can never silently drift".
+
+pip does not refuse an extra a distribution never declared, and on a current pip
+it does not even warn. Measured on pip 26.0.1 against a throwaway project whose
+only extra is ``real``, both ``pip install --dry-run --no-deps '.[real]'`` and
+the same command for ``'.[nope]'`` answer ``Would install extra-probe-0.0.1`` and
+exit 0, with no mention of the bad name anywhere in the output -- the
+``WARNING: ... does not provide the extra ...`` line older pip printed is gone. So
+a reader following that row installed the base package, received none of VERA's
+client dependencies, and got no signal at all; the only remaining evidence is an
+ImportError met later, somewhere unrelated-looking. The cell now says there is no
+extra and leaves the install to the provider's page, which carries the two
+commands the client actually needs.
+
+``tests/test_dependency_audit`` already owns this rule, and its history section
+records fixing this same name once before -- on the VERA page. It sweeps the
+qualified ``strands-robots[NAME]`` form, and its stated reason for sweeping only
+that form is that a bare ``[wbc]`` in prose is ambiguous with lerobot's own
+extras, which are written identically. That is true of prose and it does not
+survive a table column whose header says what the column holds: a cell under
+``| Install extra |`` in this project's own docs names one of this project's
+extras by construction. The catalogue is exactly such a column, which is why the
+name survived the page fix, so the column becomes the third graded surface
+alongside the written command and the runtime ``require_optional(extra=...)``
+message.
+
+Both cell forms in use are read, because they split the population in half: a
+bare name in the README and policy tables, and the bracket a reader types in the
+architecture and installation matrices. Reading only the bare form left two of
+the four columns ungraded. The sweep covers 4 columns and 46 names, of which the
+one violation was VERA's; the remaining 45 are unchanged, and floors under both
+counts make a scan that stops matching fail rather than report a clean tree. A
+narrowed file walk is caught by those floors, and a narrowed header vocabulary by
+constructed exemplars that grade the reader on markdown built in the test, since
+a clean tree can no longer exercise a rejection.

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -53,9 +53,13 @@ from config:
 
 ## Providers
 
-Every row below is a registered provider (`create_policy("<name>")`). The table
-is kept in sync with `list_providers()` by a regression test
-(`tests/test_docs_policy_coverage.py`), so it can never silently drift.
+Every row below is a registered provider (`create_policy("<name>")`). The
+provider column is kept in sync with `list_providers()` by a regression test
+(`tests/test_docs_policy_coverage.py`), and the install-extra column with
+`[project.optional-dependencies]` by `tests/test_dependency_audit.py`,
+so neither can silently drift. VERA is the one provider with no extra to name:
+its client needs only core deps plus the git-installed `vera` package, so
+[its page](vera.md) carries the install rather than a bracket.
 
 | Provider | Class | Install extra | When to use |
 |----------|-------|---------------|-------------|
@@ -64,7 +68,7 @@ is kept in sync with `list_providers()` by a regression test
 | [`lerobot_local`](lerobot-local.md) | `LerobotLocalPolicy` | `lerobot` | HF LeRobot in-process (ACT, Pi0, SmolVLA, MolmoAct2, ...) |
 | [`lerobot_async`](lerobot-async.md) | `LerobotAsyncPolicy` | `lerobot-async` | Offload a LeRobot policy to a GPU box over lerobot's native async-inference gRPC transport; the robot host stays light. Edge-device inference |
 | [`cosmos3`](cosmos3.md) | `Cosmos3Policy` | `cosmos3-service` | NVIDIA Cosmos 3 omnimodal VLA over WebSocket |
-| [`vera`](vera.md) | `VeraPolicy` | `vera` | MIT VERA video-to-action (DFoT/WAN planner + Jacobian IDM) over a containerized GPU server |
+| [`vera`](vera.md) | `VeraPolicy` | _(none - git-only)_ | MIT VERA video-to-action (DFoT/WAN planner + Jacobian IDM) over a containerized GPU server |
 | [`remote`](remote.md) | `RemotePolicy` | `inference` | Offload a large policy to a GPU box: forward observations to a remote `PolicyServer` over WebSocket, get back action chunks. Edge-device inference |
 | [`curobo`](curobo.md) | `CuroboPolicy` | `curobo` | NVIDIA cuRobo collision-aware motion planning, in-process CUDA (non-VLA) |
 | [`moveit2`](moveit2.md) | `MoveIt2Policy` | `moveit2` | MoveIt2 motion planning over a ROS 2 sidecar (ZMQ), no in-venv ROS 2 deps (non-VLA) |

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -515,21 +515,34 @@ def test_ik_install_hints_name_only_declared_extras() -> None:
 # and ``[sim-libero]`` for what are really ``sim-isaac`` and ``benchmark-libero``.
 #
 # The failure mode is silent in the worst direction: pip does NOT fail on an
-# unknown extra. ``pip install 'strands-robots[vera]'`` exits 0, prints one
-# ``WARNING: strands-robots does not provide the extra 'vera'``, and installs the
-# base package with none of the dependencies the reader was promised. The reader
-# sees a successful install, then hits an ImportError somewhere unrelated-looking
-# with nothing tying it back to the install step. That makes an extra name in an
-# install hint load-bearing, and a typo in one is not cosmetic.
+# unknown extra, and on a current pip it no longer even warns. Measured on pip
+# 26.0.1 against a throwaway project whose only extra is ``real``, both
+# ``pip install --dry-run --no-deps '.[real]'`` and the same command for
+# ``'.[nope]'`` answer ``Would install extra-probe-0.0.1`` and exit 0, with no
+# mention of ``nope`` anywhere in the output. The
+# ``WARNING: ... does not provide the extra ...`` line older pip printed is gone,
+# so the only remaining signal is the ImportError the reader meets later,
+# somewhere unrelated-looking, with nothing tying it back to the install step.
+# That makes an extra name in an install hint load-bearing, and a typo in one is
+# not cosmetic.
 #
-# Two guards, one per surface that hands a name to a user: written instructions,
-# and the runtime ``require_optional(extra=...)`` messages.
+# Three guards, one per surface that hands a name to a user: a written install
+# command, a "which extra do I need" table column, and the runtime
+# ``require_optional(extra=...)`` message.
 # ---------------------------------------------------------------------------
 
 # A qualified mention -- ``strands-robots[NAME]``. Only the qualified form is
-# swept: a bare ``[wbc]`` in prose is ambiguous, because lerobot's own extras
+# swept here: a bare ``[wbc]`` in prose is ambiguous, because lerobot's own extras
 # (``[smolvla]``, ``[pi]``, ``[dataset]``) are written exactly the same way, so
 # requiring the distribution name keeps the sweep free of false positives.
+#
+# That ambiguity is a property of prose, and it does not survive a table column
+# whose header says what the column holds. A cell under ``| Install extra |`` in
+# this project's own docs names one of this project's extras by construction, so
+# the bare spelling is unambiguous there and is swept by
+# ``test_install_extra_table_columns_name_only_declared_extras`` below. The
+# policy catalogue is exactly such a column, and it is where the ``[vera]`` row in
+# the history above survived the page fix.
 _EXTRA_MENTION_RE = re.compile(r"strands[-_]robots\[([^\]\s]+)\]")
 
 # A token that can be an extra name at all. Anything else caught by the mention
@@ -649,6 +662,164 @@ def test_written_install_hints_name_only_declared_extras() -> None:
         "unknown extra and installs none of the dependencies, so the failure surfaces later and "
         f"misattributed. Declared extras: {sorted(extras)}\n" + "\n".join(offenders)
     )
+
+
+# Headers that mean "the extra you install". A column merely containing the word
+# is not one: ``Extra outputs`` in the Cosmos 3 page lists result keys, and a
+# header whose prose mentions an extra in passing is prose.
+_INSTALL_EXTRA_HEADERS = frozenset({"extra", "extras", "install extra", "install extras"})
+
+
+def _install_extra_cells(text: str) -> list[tuple[int, str]]:
+    """Return ``(line number, extra name)`` for each install-extra table cell.
+
+    Args:
+        text: Markdown source.
+
+    Returns:
+        One entry per backticked name in a column whose header is an
+        install-extra header, in either cell form in use across the tree - a bare
+        name (``sim-mujoco``) or the bracket a reader types (``[sim-mujoco]``).
+        Reading only the bare form would leave the installation and architecture
+        matrices, half the columns, ungraded. Fenced regions are skipped: a table
+        inside a fence is sample output rather than an instruction.
+    """
+    found: list[tuple[int, str]] = []
+    in_fence = False
+    columns: list[int] = []
+    for number, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if not line.startswith("|"):
+            columns = []
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        header = [index for index, cell in enumerate(cells) if cell.lower() in _INSTALL_EXTRA_HEADERS]
+        if header:
+            columns = header
+            continue
+        for index in columns:
+            if index >= len(cells):
+                continue
+            for token in re.findall(r"`([^`]+)`", cells[index]):
+                name = token[1:-1] if token.startswith("[") and token.endswith("]") else token
+                if _EXTRA_NAME_RE.match(name):
+                    found.append((number, name))
+    return found
+
+
+def test_install_extra_table_columns_name_only_declared_extras() -> None:
+    """A cell under ``| Install extra |`` must name an extra that exists.
+
+    This is the third surface: a reader choosing a provider or a feature scans
+    the catalogue column rather than a prose command, and copies the name out of
+    it. The qualified-mention sweep above cannot see that spelling, because the
+    cell carries the bare name - the distribution is named by the header.
+    """
+    extras = _declared_extras()
+    offenders: list[str] = []
+    columns = 0
+    cells = 0
+    for path in _iter_scanned_files():
+        if path.suffix.lower() != ".md":
+            continue
+        found = _install_extra_cells(path.read_text(encoding="utf-8", errors="ignore"))
+        if not found:
+            continue
+        columns += 1
+        cells += len(found)
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        offenders.extend(
+            f"{rel}:{number} names [{name}]" for number, name in found if _normalize_extra(name) not in extras
+        )
+    # A scan that has stopped matching must fail rather than report a clean tree.
+    assert columns >= 3, f"only {columns} file(s) with an install-extra column were read"
+    assert cells >= 20, f"only {cells} extra name(s) were read out of install-extra columns"
+    assert not offenders, (
+        "these table cells tell a reader to install an extra that does not exist. pip exits 0 on "
+        "an unknown extra without a warning, so the reader installs the base package and none of "
+        f"the dependencies the row promised. Declared extras: {sorted(extras)}\n"
+        + "\n".join(offenders)
+        + "\nDeclare the extra, or say in the cell that there is none."
+    )
+
+
+@pytest.mark.parametrize(
+    ("markdown", "expected"),
+    [
+        pytest.param(
+            "| Extra | Pulls in |\n|---|---|\n| `nope` | things |\n",
+            ["nope"],
+            id="bare-cell-form",
+        ),
+        pytest.param(
+            "| Extra | Pulls in |\n|---|---|\n| `[nope]` | things |\n",
+            ["nope"],
+            id="bracket-cell-form",
+        ),
+        pytest.param(
+            "| Provider | Class | Install extra |\n|---|---|---|\n| `p` | `C` | `nope` |\n",
+            ["nope"],
+            id="third-column",
+        ),
+        pytest.param(
+            "| Extra outputs | Meaning |\n|---|---|\n| `last_rollout` | a path |\n",
+            [],
+            id="not-an-install-column",
+        ),
+        pytest.param(
+            "```\n| Extra | Pulls in |\n|---|---|\n| `nope` | things |\n```\n",
+            [],
+            id="fenced-table-is-sample-output",
+        ),
+        pytest.param(
+            "| Extra | Pulls in |\n|---|---|\n| _(none - git-only)_ | nothing |\n",
+            [],
+            id="a-cell-that-names-no-extra",
+        ),
+    ],
+)
+def test_install_extra_cell_reader_reads_install_columns_only(markdown: str, expected: list[str]) -> None:
+    """The cell reader picks up install-extra cells in both forms, and nothing else.
+
+    Graded on constructed markdown because the tree is clean once the catalogue is
+    fixed, so the corpus can no longer exercise a rejection.
+    """
+    assert [name for _, name in _install_extra_cells(markdown)] == expected
+
+
+def test_the_install_extra_cell_rule_can_both_accept_and_reject() -> None:
+    """The rule is not constantly one answer."""
+    extras = _declared_extras()
+    outcomes = {
+        _normalize_extra(name) in extras
+        for _, name in _install_extra_cells("| Extra | Pulls in |\n|---|---|\n| `nope` | x |\n| `lerobot` | y |\n")
+    }
+    assert outcomes == {True, False}
+
+
+def test_the_policy_catalogue_names_no_vera_extra() -> None:
+    """VERA is the provider with no extra, so its row must not name one.
+
+    ``pyproject.toml`` says at length that a ``vera`` extra can never exist - it
+    would need a direct reference to the upstream git repository, which
+    ``test_pyproject_has_no_direct_reference_dependency`` separately forbids.
+    ``vera-sim`` exists and is a different thing: the gymnasium / robosuite
+    evaluation stack, declared in conflict with the lerobot extras, so it is not
+    the provider's install either.
+    """
+    extras = _declared_extras()
+    assert "vera" not in extras
+    assert "vera-sim" in extras
+    overview = (_REPO_ROOT / "docs" / "policies" / "overview.md").read_text(encoding="utf-8")
+    row = next(line for line in overview.splitlines() if line.startswith("| [`vera`]"))
+    cells = [cell.strip() for cell in row.strip("|").split("|")]
+    assert "`vera`" not in cells[2], f"the install-extra cell names an extra: {cells[2]!r}"
+    assert "none" in cells[2].lower(), f"the cell should say there is none: {cells[2]!r}"
 
 
 def test_require_optional_call_sites_name_declared_extras() -> None:


### PR DESCRIPTION
## What is wrong

`docs/policies/overview.md` is the page a reader lands on to choose a `policy_provider`. Its Providers table gave VERA's install extra as the bare name `vera`. There is no such extra, and three places in the tree already say so:

| Source | What it says |
|---|---|
| `pyproject.toml:463` | "NOTE: There is intentionally no `vera` extra. VERA is only distributed as a ... git repository, which no extra can pull" |
| `docs/policies/vera.md:260` | "There is no `vera` extra: the provider needs only a ... repository, which no extra can pull" |
| `README.md:608` | "**Git-only** (not on PyPI, no extra)" |

The catalogue was the one surface that disagreed. `docs/getting-started/installation.md`, the extras matrix, does not mention VERA at all.

## Why it is silent

pip does not refuse an extra a distribution never declared, and on a current pip it does not even warn. Measured against a throwaway project whose only extra is `real`, with the real extra as the control:

| Command | Result | Exit |
|---|---|---|
| `pip install --dry-run --no-deps '.[real]'` | `Would install extra-probe-0.0.1` | 0 |
| `pip install --dry-run --no-deps '.[nope]'` | `Would install extra-probe-0.0.1` | 0 |

pip 26.0.1, and a grep of the full output for `warn`, `extra` and `nope` returns only the `Would install` line. The `WARNING: ... does not provide the extra ...` that older pip printed is gone, so a reader following that row installed the base package, received none of VERA's client dependencies, and got no signal at all. The remaining evidence is an `ImportError` met later, somewhere unrelated-looking.

The cell now says there is no extra. The row already links to `vera.md`, which carries the two commands the client actually needs (`websockets msgpack numpy`, plus the git-installed `vera` package for the server). `vera-sim` is deliberately not offered instead: it is the gymnasium / robosuite evaluation stack, and `pyproject.toml` declares it in conflict with the lerobot extras, so it is not the provider's install.

## Why nothing caught it

`tests/test_dependency_audit` already owns this rule, and its history section records fixing **this same name** once before, on the VERA page. It sweeps the qualified `strands-robots[NAME]` form, and its stated reason for sweeping only that form is:

> Only the qualified form is swept: a bare `[wbc]` in prose is ambiguous, because lerobot's own extras (`[smolvla]`, `[pi]`, `[dataset]`) are written exactly the same way, so requiring the distribution name keeps the sweep free of false positives.

That ambiguity is a property of prose. It does not survive a table column whose header says what the column holds: a cell under `| Install extra |` in this project's own docs names one of this project's extras by construction. The catalogue is exactly such a column, which is why the name survived the page fix. The page's own preamble also claimed the table "can never silently drift"; the guard beside it ties the provider column to the registry and reads no other column, and the registry carries an `extra` key for 1 of its 14 providers, so that column had no registry to be matched against.

## The change

The column becomes the third graded surface in the same owner, alongside the written command and the runtime `require_optional(extra=...)` message. Both cell forms in use are read, because they split the population in half:

| Column | Cell form | Names read |
|---|---|---|
| `README.md:161` | bare (`sim-mujoco`) | 17 |
| `docs/architecture.md:104` | bracket (`[sim-mujoco]`) | 7 |
| `docs/getting-started/installation.md:11` | bracket (`[sim]`) | 10 |
| `docs/policies/overview.md:60` | bare (`groot-service`) | 12 |

Reading only the bare form left two of the four columns ungraded. 4 columns, 46 names, one violation (VERA's); the other 45 are unchanged. Floors under both counts make a scan that stops matching fail rather than report a clean tree.

## Measurements

Pre-fix split, with the cell put back: **2 fired**, and they are complementary rather than redundant.

| Row | Fires | Which |
|---|---|---|
| b0 control, fix present | 0 | - |
| b1 defect present | 2 | the column rule + the VERA-row pin |
| b2 defect, column rule's assert disabled | 1 | the VERA-row pin alone |
| b3 defect, VERA-row pin removed | 1 | the column rule alone (`collected` 63 -> 62) |
| b4 bracket cell form unread | 3 | + the bracket exemplar |
| b5 header vocabulary narrowed to `install extra` | 5 | exemplars + both-answers |
| b6 fence skip removed | 3 | + the fenced-table exemplar |
| b7 any header containing the word accepted | 3 | + the not-an-install-column exemplar |
| b8 vocabulary narrowed and floors removed | 5 | identical set to b5 |
| b9 vocabulary narrowed, exemplars off, floors on | 3 | floor: "only 1 file(s) ... were read" |
| b11 file walk narrowed, defect absent | 1 | floor alone |

`b2 | b3 == b1` exactly and `b2 & b3` is empty, so each half independently catches it. `b5 == b8` as id sets, so for a narrowed *vocabulary* the floors add diagnosis rather than detection - the exemplars and the both-answers cell catch that. b11 is where a floor is the only catch: a narrowed *file walk* leaves the exemplars untouched. Control clean, `collected` stable at 63 except where a row removes a test, both files restored byte-identical.

Also corrected in the guard's own comment: it stated that pip "prints one `WARNING: ... does not provide the extra`". That line no longer appears, which makes the harm worse than documented, so the comment now carries the measurement above.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1655 files).
- `mypy strands_robots tests tests_integ`: 24 errors, the standing baseline, 0 in the changed files.
- Paired against the merge-base on an identical 430-file selection (every test reading `docs/`, `README.md`, `pyproject.toml` or `mkdocs.yml`, plus every tree-walking guard), the changed test file excluded from both: identical **19791 collected** and `17 failed, 19709 passed, 65 skipped` on each tree, 17 identical failing ids, `comm` empty in both directions, distinct rootdirs. All 17 are `tests/mesh/test_iot_*` needing `awsiot`/`awscrt`, both absent here and declared in the `[mesh-iot]` extra.
- `tests/test_dependency_audit.py`: 62 passed, 1 skipped. Changelog fragment guards: 30 passed.

No visual artifact: this changes a documented name and a repo guard, not a policy, a simulation, a render, a recording or an asset. The measured pip table is the evidence.
