### PR TITLE
fix(policies/wbc): hold every observation dimension to the shared count domain

### DIFF
--- a/changelog.d/2858-wbc-dimensions-on-the-shared-count-domain.md
+++ b/changelog.d/2858-wbc-dimensions-on-the-shared-count-domain.md
@@ -1,0 +1,50 @@
+### Fixed: every WBC observation dimension is held to the shared count domain
+
+`WBCConfig` carries five discrete dimensions - `num_actions`, `obs_history_len`,
+`single_obs_dim`, `command_dim` and `n_obs_joints` - and each is consumed as a
+`deque` maxlen, a `range()` bound, a slice index or an `np.zeros` width. Every
+scalar in the same `__post_init__` already went through a shared numeric domain,
+under a comment explaining why: each is "read verbatim into either the PD law
+that writes `data.ctrl` or the observation the network sees", so a non-real value
+"surfaces as a bare `TypeError` from its `float()` after the ONNX sessions have
+loaded and the rollout has started - the mid-rollout failure this module exists
+to convert into a construction-time message". The dimensions above them were
+checked with bare comparisons (`< 1`, and `< 3` for the command block), which
+decide a floor and cannot decide whether the value is an integer at all.
+
+Two spellings got through, and `positive_count_error` - the shared domain for
+exactly this kind of value - names the first of them in its own docstring:
+"`bool` is rejected explicitly. It is an `int` subclass, so a bare `value < 1`
+test lets `True` through as a silent count of 1."
+
+Measured against the shipped 86-wide GEAR-SONIC layout stacked over six frames:
+
+| `obs_history_len` | before | after |
+| --- | --- | --- |
+| `6` (default) | 6 frames, 516-wide input | unchanged |
+| `True` | **1 frame, 86-wide input, no error** | refused, names the field |
+| `nan` | accepted; bare numpy `TypeError` at the first frame | refused, names the field |
+| `2.5` | accepted; bare `TypeError: an integer is required` | refused, names the field |
+
+The `True` row is the one that produced no error at all. `ObservationHistory`
+took `maxlen=1`, `num_obs` became `86 * True == 86`, and `push` returned an
+86-wide vector for a checkpoint expecting 516 - a stacked observation five frames
+short, reported as healthy. `nan` is below nothing, so it passed all five
+comparisons and reached the observation builder, which is the mid-rollout failure
+the value checks below it exist to prevent. Across the five fields and thirteen
+spellings, sixty cells were accepted or raised an unnamed error; all sixty are
+now refused at construction with the field named.
+
+The three `>= 1` floors are exactly what the shared domain decides, so they are
+gone rather than restated. The command block's floor of three and the
+`n_obs_joints >= num_actions` relation are not, and survive with their own
+messages, asked of values the domain accepted - so `command_dim=2` still reports
+"must be >= 3 (vx, vy, omega)" while `command_dim=True` now reports that a flag
+is not a count, rather than a width slightly too small.
+
+The domain is strict-`int` rather than any-integral-real because these values
+reach a C-level API: `deque(maxlen=np.int64(6))` and `np.zeros(86.5)` both raise,
+so a domain accepting an integral float or a NumPy integer would hand the caller
+a value the next call cannot use. Not changed here: that domain accepts an
+arbitrarily large `int`, which `deque` then refuses with an `OverflowError` naming
+nothing - a property of a guard with fifty-one callers rather than of this config.

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from strands_robots.utils import (
     finite_number_error,
+    positive_count_error,
     positive_finite_number_error,
     require_optional,
     sequence_length,
@@ -151,9 +152,12 @@ class WBCConfig:
             (upstream ``rpy_cmd = [0, 0, 0]``). Overridable per call via the
             ``target_orientation`` kwarg.
         single_obs_dim: Width of one observation frame (before history
-            stacking). Default 86 (upstream GEAR-SONIC).
+            stacking). Default 86 (upstream GEAR-SONIC). A positive integer:
+            it is an ``np.zeros`` width, so an integral float raises there
+            rather than being coerced.
         obs_history_len: Number of frames stacked into the network input.
-            Default 6 (upstream num_obs = 86 * 6 = 516).
+            Default 6 (upstream num_obs = 86 * 6 = 516). A positive integer:
+            it is the history ``deque``'s maxlen and a ``range()`` bound.
         num_actions: Number of controllable joints (legs + waist). Default 15.
         command_dim: Width of the command sub-vector at the head of the
             observation. Default 7 (velocity[3] + height[1] + rpy[3]).
@@ -188,12 +192,29 @@ class WBCConfig:
         # Dimensions first, then values: a wrong length is the likelier root
         # cause (a config paired with the wrong checkpoint) and naming it first
         # keeps its message the one a mismatched pair reports.
-        if self.num_actions < 1:
-            raise ValueError(f"WBCConfig.num_actions must be >= 1, got {self.num_actions}")
-        if self.obs_history_len < 1:
-            raise ValueError(f"WBCConfig.obs_history_len must be >= 1, got {self.obs_history_len}")
-        if self.single_obs_dim < 1:
-            raise ValueError(f"WBCConfig.single_obs_dim must be >= 1, got {self.single_obs_dim}")
+        #
+        # Every dimension goes through the shared count domain rather than a bare
+        # ``< 1`` test, because each is consumed as a ``deque`` maxlen, a
+        # ``range()`` bound, a slice index or an ``np.zeros`` width - the uses
+        # positive_count_error documents itself for, where an integral float
+        # raises rather than being coerced. A bare comparison cannot decide
+        # integer-ness, and both ways it fails are reachable from a config file:
+        # ``bool`` is an ``int`` subclass, so ``True`` passed ``obs_history_len
+        # < 1`` and ObservationHistory then stacked ONE frame into an 86-wide
+        # network input where the checkpoint expects 516 - no error, just the
+        # wrong observation; and ``nan`` is below nothing, so it passed every one
+        # of these tests and surfaced as a bare numpy ``TypeError`` from the
+        # observation builder after the ONNX sessions had loaded and the rollout
+        # had started - the mid-rollout failure the value checks below exist to
+        # convert into a construction-time message naming the field.
+        for dimension_name in ("num_actions", "obs_history_len", "single_obs_dim", "command_dim", "n_obs_joints"):
+            if error := positive_count_error(getattr(self, dimension_name), dimension_name, "WBCConfig"):
+                raise ValueError(error)
+        # The per-field floor and the cross-field relation, reached only with
+        # values the loop above accepted, so each is asked of a positive integer.
+        # The ``>= 1`` floors the three widths used to carry are exactly what the
+        # shared domain decides, so they are gone rather than restated; the
+        # command floor is 3, which it does not decide, so only that is kept.
         if self.command_dim < 3:
             # Need at least [vx, vy, omega].
             raise ValueError(f"WBCConfig.command_dim must be >= 3 (vx, vy, omega), got {self.command_dim}")

--- a/tests/policies/wbc/test_wbc_config_validation.py
+++ b/tests/policies/wbc/test_wbc_config_validation.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -21,19 +22,25 @@ from strands_robots.policies.wbc import WBCConfig
 
 
 class TestDimensionFailFast:
-    """__post_init__ rejects sub-minimal dimensions with an actionable message."""
+    """__post_init__ rejects sub-minimal dimensions with an actionable message.
 
-    def test_num_actions_below_one_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match=r"num_actions must be >= 1"):
-            WBCConfig(policy_path="p.onnx", num_actions=0)
+    Widened from three fields to all five when the dimensions moved onto the
+    shared count domain: ``command_dim`` and ``n_obs_joints`` were refused at
+    zero only as a side effect of their own floor and relation, so neither had
+    a cell of its own here. The message is the shared domain's, which names the
+    field - a zero is not a small count, it is not a count at all.
+    """
 
-    def test_obs_history_len_below_one_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match=r"obs_history_len must be >= 1"):
-            WBCConfig(policy_path="p.onnx", obs_history_len=0)
-
-    def test_single_obs_dim_below_one_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match=r"single_obs_dim must be >= 1"):
-            WBCConfig(policy_path="p.onnx", single_obs_dim=0)
+    @pytest.mark.parametrize(
+        "dimension_name",
+        ["num_actions", "obs_history_len", "single_obs_dim", "command_dim", "n_obs_joints"],
+    )
+    def test_a_dimension_of_zero_is_rejected(self, dimension_name: str) -> None:
+        # Typed Any: the dataclass mixes field types, so a homogeneous splat is
+        # an [arg-type] against whichever field mypy resolves the mapping to.
+        override: dict[str, Any] = {dimension_name: 0}
+        with pytest.raises(ValueError, match=rf"{dimension_name} must be a positive integer"):
+            WBCConfig(policy_path="p.onnx", **override)
 
 
 class TestFromFileErrorPaths:

--- a/tests/policies/wbc/test_wbc_dimension_count_domain.py
+++ b/tests/policies/wbc/test_wbc_dimension_count_domain.py
@@ -1,0 +1,227 @@
+"""Every WBC observation dimension is held to the shared positive-count domain.
+
+:class:`~strands_robots.policies.wbc.config.WBCConfig` carries five discrete
+dimensions - ``num_actions``, ``obs_history_len``, ``single_obs_dim``,
+``command_dim`` and ``n_obs_joints`` - and each is consumed as a ``deque``
+maxlen, a ``range()`` bound, a slice index or an ``np.zeros`` width. Each used
+to be checked with a bare comparison (``< 1``, or ``< 3`` for the command
+block), which decides a floor and cannot decide whether the value is an integer
+at all. Two spellings got through, and the shared domain's own docstring names
+the first of them:
+
+* ``True`` is an ``int`` subclass, so it passed ``obs_history_len < 1`` and
+  :class:`~strands_robots.policies.wbc.observation.ObservationHistory` stacked
+  ONE frame into an 86-wide network input where the checkpoint expects 516. No
+  exception, no warning - just the wrong observation, at the wrong width.
+* ``nan`` is below nothing, so it passed every one of the five tests and
+  surfaced as a bare numpy ``TypeError`` from the observation builder, after the
+  ONNX sessions had loaded and the rollout had started. That is the mid-rollout
+  failure the value checks in the same ``__post_init__`` exist to convert into a
+  construction-time message naming the field.
+
+The scalars in that same method already went through the shared numeric domains;
+only the dimensions did not. These cells pin the fields onto
+:func:`~strands_robots.utils.positive_count_error`, and pin what that domain
+does NOT decide: the command block's floor of three and the relation between
+``n_obs_joints`` and ``num_actions`` are per-field rules that survive it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from collections import deque
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc.config import WBCConfig
+from strands_robots.policies.wbc.observation import ObservationHistory
+from strands_robots.utils import positive_count_error
+
+_POLICY = "p.onnx"
+
+# The five discrete dimensions, named locally so these cells are an independent
+# oracle rather than a restatement of the tuple the config iterates.
+_DIMENSIONS = ("num_actions", "obs_history_len", "single_obs_dim", "command_dim", "n_obs_joints")
+
+# Spellings a bare ``< 1`` comparison cannot refuse, plus the ones it could.
+_REFUSED = [
+    pytest.param(True, id="bool-true"),
+    pytest.param(False, id="bool-false"),
+    pytest.param(2.5, id="fractional-float"),
+    pytest.param(86.0, id="integral-float"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param("86", id="numeric-string"),
+    pytest.param(None, id="none"),
+    pytest.param([86], id="list"),
+    pytest.param(np.int64(86), id="numpy-int"),
+    pytest.param(np.float64(86), id="numpy-float"),
+    pytest.param(0, id="zero"),
+    pytest.param(-1, id="negative"),
+]
+
+
+def _config(**overrides: Any) -> WBCConfig:
+    """Build a config, letting every dimension default unless overridden."""
+    return WBCConfig(policy_path=_POLICY, **overrides)
+
+
+class TestTheConsumersNeedThisExactDomain:
+    """Premise: the dimension consumers refuse what a bare comparison accepts.
+
+    The domain is strict-``int`` rather than any-integral-real because these
+    values reach a C-level API. Asserting that here is what makes the choice a
+    measurement rather than a preference: an integral float and a NumPy integer
+    are both refused by the consumer, so a domain that accepted them would hand
+    the caller a value the next call cannot use.
+    """
+
+    def test_the_history_deque_refuses_a_numpy_integer_maxlen(self) -> None:
+        # Each value below is typed Any deliberately: mypy states the same
+        # refusal statically, which is why the domain is strict-int, and an
+        # annotated local keeps the runtime assertion without an ignore code.
+        numpy_integer: Any = np.int64(6)
+        with pytest.raises(TypeError):
+            deque(maxlen=numpy_integer)
+
+    def test_a_frame_width_refuses_a_fractional_float(self) -> None:
+        fractional: Any = 86.5
+        with pytest.raises(TypeError):
+            np.zeros(fractional, dtype=np.float64)
+
+    def test_a_range_bound_refuses_a_non_integer(self) -> None:
+        fractional: Any = 2.5
+        with pytest.raises(TypeError):
+            range(fractional)
+
+    def test_nan_is_below_nothing_so_a_bare_floor_cannot_refuse_it(self) -> None:
+        """The arithmetic the old checks rested on, stated once."""
+        assert not (math.nan < 1)
+        assert not (math.nan < 3)
+        assert not (math.nan < 15)
+
+
+class TestEveryDimensionIsHeldToTheDomain:
+    """Regression: each of the five dimensions refuses each unusable spelling."""
+
+    @pytest.mark.parametrize("dimension_name", _DIMENSIONS)
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_the_dimension_is_refused_at_construction(self, dimension_name: str, value: Any) -> None:
+        with pytest.raises(ValueError) as caught:
+            _config(**{dimension_name: value})
+        assert dimension_name in str(caught.value)
+
+    @pytest.mark.parametrize("dimension_name", _DIMENSIONS)
+    def test_the_refusal_names_the_field_and_the_domain(self, dimension_name: str) -> None:
+        with pytest.raises(ValueError, match=rf"{dimension_name} must be a positive integer"):
+            _config(**{dimension_name: float("nan")})
+
+    @pytest.mark.parametrize("dimension_name", _DIMENSIONS)
+    def test_the_refusal_carries_the_value_the_caller_supplied(self, dimension_name: str) -> None:
+        with pytest.raises(ValueError, match=r"got 2\.5"):
+            _config(**{dimension_name: 2.5})
+
+
+class TestTheHistoryIsNoLongerSilentlyTruncated:
+    """The headline: a flag read as a history length built the wrong input.
+
+    ``obs_history_len=True`` is the one spelling that produced no error at all.
+    The deque took ``maxlen=1`` (``True`` is ``1``), ``num_obs`` became ``86 *
+    True == 86``, and ``push`` returned an 86-wide vector for a checkpoint
+    expecting 516 - a stacked observation five frames short, reported as
+    healthy.
+    """
+
+    def test_a_true_history_length_is_refused_rather_than_read_as_one(self) -> None:
+        with pytest.raises(ValueError, match=r"obs_history_len must be a positive integer"):
+            _config(obs_history_len=True)
+
+    def test_a_healthy_history_still_stacks_the_full_network_input(self) -> None:
+        history = ObservationHistory(_config())
+        stacked = history.push(np.ones(86, dtype=np.float64))
+        assert len(history) == 6
+        assert stacked.shape[0] == 516
+
+    def test_a_non_real_width_no_longer_reaches_the_frame_allocation(self) -> None:
+        """``nan`` used to arrive at ``np.zeros`` as a bare ``TypeError``."""
+        with pytest.raises(ValueError, match=r"single_obs_dim must be a positive integer"):
+            _config(single_obs_dim=float("nan"))
+
+
+class TestTheDomainIsWiredForEveryDiscreteField:
+    """Derived: every ``int``-annotated field of the config goes through it.
+
+    Read off the dataclass rather than a list, so a sixth discrete dimension
+    added later is held to the same domain the hour it lands instead of
+    inheriting an exemption by being absent from a tuple.
+    """
+
+    @staticmethod
+    def _integer_fields() -> tuple[str, ...]:
+        return tuple(f.name for f in dataclasses.fields(WBCConfig) if f.type in ("int", int))
+
+    def test_the_derived_set_covers_the_dimensions_these_cells_name(self) -> None:
+        """Non-vacuity: the scan really finds the fields, and misses none."""
+        derived = self._integer_fields()
+        assert set(_DIMENSIONS) <= set(derived), (
+            f"the config's int-annotated fields are {derived}, which does not cover {_DIMENSIONS}"
+        )
+
+    @pytest.mark.parametrize("value", [True, float("nan"), 2.5])
+    def test_every_derived_field_refuses_the_spellings_a_floor_cannot(self, value: Any) -> None:
+        for dimension_name in self._integer_fields():
+            with pytest.raises(ValueError, match=rf"{dimension_name} must be a positive integer"):
+                _config(**{dimension_name: value})
+
+    def test_the_shared_domain_agrees_with_these_cells(self) -> None:
+        """The refusals come from the shared domain, not a local restatement."""
+        for value in (True, float("nan"), 2.5, np.int64(6), 0):
+            assert positive_count_error(value, "d", "C") is not None
+        assert positive_count_error(6, "d", "C") is None
+
+
+class TestWhatTheCountDomainDoesNotDecide:
+    """Controls: the per-field floor and the cross-field relation survive it.
+
+    The domain decides positive-integer-ness. It does not decide that the
+    command block needs three entries, nor that a controller cannot drive more
+    joints than it observes. Both rules are still asked, of values the domain
+    accepted, and both keep their own message.
+    """
+
+    def test_the_command_block_still_needs_three_entries(self) -> None:
+        with pytest.raises(ValueError, match=r"command_dim must be >= 3 \(vx, vy, omega\)"):
+            _config(command_dim=2)
+
+    def test_observing_fewer_joints_than_are_driven_is_still_refused(self) -> None:
+        with pytest.raises(ValueError, match=r"n_obs_joints \(4\) must be >= num_actions \(5\)"):
+            _config(num_actions=5, n_obs_joints=4)
+
+    def test_a_usable_dimension_set_is_still_accepted(self) -> None:
+        config = _config(single_obs_dim=95, command_dim=8, num_actions=15, n_obs_joints=29, obs_history_len=6)
+        assert config.num_obs == 95 * 6
+
+    def test_the_defaults_are_unchanged(self) -> None:
+        config = _config()
+        assert (config.single_obs_dim, config.obs_history_len, config.num_obs) == (86, 6, 516)
+        assert (config.num_actions, config.n_obs_joints, config.command_dim) == (15, 29, 7)
+
+    def test_a_command_block_of_three_is_the_boundary_and_is_accepted(self) -> None:
+        assert _config(command_dim=3).command_dim == 3
+
+    def test_the_domain_answers_before_the_floor_does(self) -> None:
+        """A non-count gets the domain's diagnosis, not the floor's.
+
+        ``True`` is below three, so a floor asked first would answer
+        "command_dim must be >= 3, got True" - which reads as a value slightly
+        too small when the truth is that a flag is not a width at all. The
+        domain is asked first so the message names the real fault, and the floor
+        keeps its own wording for a value that genuinely is a count below three.
+        """
+        with pytest.raises(ValueError, match=r"command_dim must be a positive integer"):
+            _config(command_dim=True)
+        with pytest.raises(ValueError, match=r"command_dim must be >= 3"):
+            _config(command_dim=2)


### PR DESCRIPTION
## Problem

`WBCConfig` carries five discrete dimensions - `num_actions`, `obs_history_len`, `single_obs_dim`, `command_dim` and `n_obs_joints` - and each is consumed as a `deque` maxlen, a `range()` bound, a slice index or an `np.zeros` width.

Every **scalar** in the same `__post_init__` already went through a shared numeric domain, under a comment explaining why: each is "read verbatim into either the PD law that writes `data.ctrl` or the observation the network sees", so a non-real value "surfaces as a bare `TypeError` from its `float()` after the ONNX sessions have loaded and the rollout has started - the mid-rollout failure this module exists to convert into a construction-time message".

The **dimensions** above them were checked with bare comparisons (`< 1`, and `< 3` for the command block). A floor cannot decide whether a value is an integer at all, and two spellings got through. `positive_count_error` names the first in its own docstring:

> `bool` is rejected explicitly. It is an `int` subclass, so a bare `value < 1` test lets `True` through as a silent count of 1.

Measured against the shipped 86-wide GEAR-SONIC layout stacked over six frames:

| `obs_history_len` | before | after |
| --- | --- | --- |
| `6` (default) | 6 frames, 516-wide input | unchanged |
| `True` | **1 frame, 86-wide input, no error** | refused, names the field |
| `nan` | accepted; bare numpy `TypeError` at the first frame | refused, names the field |
| `2.5` | accepted; bare `TypeError: an integer is required` | refused, names the field |

The `True` row produced no error at all. `ObservationHistory` took `maxlen=1`, `num_obs` became `86 * True == 86`, and `push` returned an 86-wide vector for a checkpoint expecting 516 - a stacked observation five frames short, reported as healthy. `nan` is below nothing, so it passed all five comparisons and reached the observation builder.

Across the five fields and thirteen spellings, **sixty cells** were accepted or raised an unnamed error. All sixty are now refused at construction with the field named. The healthy path is unchanged: `num_obs == 516`, a six-frame buffer, a 516-wide stacked input.

## Why nothing caught it

`tests/policies/wbc/test_wbc_config_validation.py` exists for this contract - its module docstring says a bad dimension "would destabilise the robot at runtime" so `__post_init__` "rejects impossible dimensions at construction rather than warn-and-continue". Its three cells drove `0`, the one unusable value a bare comparison does catch. `command_dim` and `n_obs_joints` had no zero cell of their own; both were refused only as a side effect of their own floor and relation.

That class is widened here from three cells to five parametrized over all five fields, so the two that were covered incidentally are covered on purpose.

## Change

`positive_count_error` for all five dimensions, then the rules the domain does not decide, asked of values it accepted.

The three `>= 1` floors are exactly what the shared domain decides, so they are **gone rather than restated**. The command block's floor of three and the `n_obs_joints >= num_actions` relation are not, and keep their own messages - `command_dim=2` still reports "must be >= 3 (vx, vy, omega)", while `command_dim=True` now reports that a flag is not a count rather than a width slightly too small.

The domain is strict-`int` rather than any-integral-real because these values reach a C-level API: `deque(maxlen=np.int64(6))` and `np.zeros(86.5)` both raise, so a domain accepting an integral float or a NumPy integer would hand the caller a value the next call cannot use. Pinned as premise cells.

## Mutation table

13 rows, control clean, `collected` stable at 93 on every row, source restored byte-identical. `sib` is the four pre-existing wbc suites.

| # | mutation | new file | sib |
| --- | --- | --- | --- |
| b0 | control | 0 | 0 |
| b1 | whole fix reverted | 57 | 5 |
| b2 | domain loop dropped | 66 | 5 |
| b3 | loop narrowed to the 3 originally-floored fields | 23 | 2 |
| b4 | wrong domain (`positive_whole_number_error`) | 23 | 5 |
| b5 | command floor of 3 deleted | 2 | 1 |
| b6 | `n_obs_joints` relation deleted | 1 | 1 |
| b7 | domain verdict discarded | 66 | 5 |
| b8 | domain told the wrong field name | 62 | 4 |
| b9 | loop moved after the command floor | 6 | 1 |
| b10 | plant a 6th `int` field, scan **derived** | 3 | 0 |
| b11 | same plant, scan **hardcoded** to today's five | **0** | 0 |
| b12 | scan hardcoded, no plant | 0 | 0 |

10 distinct firing sets of 13. The one collision is b2 == b7 (66 ids): a discarded verdict and a deleted loop are the same thing - no refusal happens.

Rows worth reading:

- **b3** is the completeness proof: narrowing the loop to the three fields that previously had a floor leaves `command_dim` and `n_obs_joints` unguarded again.
- **b4** is the domain-choice proof: the any-integral-real sibling accepts `86.0`, `np.int64` and `np.float64`, which the consumers refuse.
- **b5/b6** are the scope proof - each fires a control *and* a pre-existing test, so neither surviving rule was absorbed.
- **b9** was initially 0 because my mutation re-inserted the loop in its original position. Re-aimed, it fires 6: the ordering cell plus three where a string, `None` or a list reaches the floor's `<` as a bare `TypeError`. Fixing my own mutation, not the test.
- **b10/b11/b12** are the derived-inventory trio. A sixth `int` field planted on the dataclass is caught when the scan reads `dataclasses.fields`, and is **completely silent** when the same scan is hardcoded to today's five names.

## Gate

- Pre-fix split **57 failed / 36 passed**: 0 of 4 premise cells, 0 of 5 control cells.
- Paired selection, 316 files identical on both trees, new file excluded from both (1 exclusion, printed): branch **9750 collected, 9693 passed, 57 skipped, 0 failed**; base **9748 / 9691 / 57 / 0 failed**. Distinct rootdirs. The `+2` localises entirely to the widened sibling file.
- `mypy strands_robots tests tests_integ`: **5 == 5**, normalized message sets byte-identical both directions, 0 attributable.
- `ruff check` and `ruff format --check` clean over 1656 files.
- Whole `tests/policies/wbc/`: **631 passed** (536 before, plus 93 new cells and 2 from the widening).

No visual artifact: this is a value-domain and refusal-text change, not a policy, simulation, rendering, recording or asset change. The measured before/after tables are the evidence.
