### PR TITLE
test(policies): read the log-escape's shape off the value the caller receives

### DIFF
--- a/changelog.d/2859-log-escape-shape-read-off-the-returned-value.md
+++ b/changelog.d/2859-log-escape-shape-read-off-the-returned-value.md
@@ -1,0 +1,32 @@
+### Tests: the log-escape's shape is read off the value the caller receives
+
+`strands_robots.policies._log_safety.sanitize_log_value` escapes the two line-break
+characters as chained `.replace` calls with literal arguments rather than a loop over
+a table of pairs, and the spelling is load-bearing: `py/log-injection`'s only barrier
+reads the call site rather than its effect, holding for a `.replace` whose first
+argument is a *string literal* equal to `"\r\n"` or `"\n"`. A cell holds that shape so
+tidying the function back into a loop fails rather than silently restoring the report
+on every sink the helper is the only escape for.
+
+That cell walked the whole function body for such a call, which is satisfied by an
+escape whose result never leaves the helper. Computing the chain into a local and
+returning the raw text passes it while the record still splits, so the cell reported
+true about a shape that was false; the forging cells caught the mutation, but under
+names that describe a split record rather than the shape the cell exists to hold.
+Reading the calls off the single `return` makes the cell's own name true.
+
+Two cells sit beside it. A premise states the accepted set the rule reads and that
+`"\r"` is not in it, which is what makes the second link in the chain a decision
+rather than a leftover -- a payload can arrive carrying a bare carriage return, so the
+escape has to cover a spelling the rule does not recognise. An over-reach control
+holds the rendered text against the table loop the chain replaced, exhaustively over
+every string up to four characters drawn from `\r`, `\n`, a backslash and an ordinary
+letter, so "the two forms render identically" is measured rather than asserted; a link
+that keeps its literal argument and renders the wrong escape fails it while the shape
+cells stay green.
+
+The shape cell's docstring carried real line breaks inside the inline-code spans where
+those two spellings belonged, so the sentence naming them rendered with the spellings
+invisible -- in a module whose whole subject is that substitution. They are written as
+escapes now, and the docstring body is de-indented to the level the rest of the file
+uses.

--- a/tests/policies/test_log_sink_sanitizer.py
+++ b/tests/policies/test_log_sink_sanitizer.py
@@ -54,6 +54,7 @@ Hence the grading here is split in three, and each cell says which kind it is:
 from __future__ import annotations
 
 import ast
+import itertools
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -155,40 +156,104 @@ def test_a_payload_that_already_reads_as_an_escape_is_left_alone() -> None:
     assert sanitize_log_value(already) == already
 
 
-def test_the_escape_is_written_as_a_literal_replace_call() -> None:
-    r"""The break characters are passed as literals, not read from a table.
+# The two spellings ``py/log-injection`` accepts as the first argument of the
+# ``.replace`` call it treats as a barrier. Stated here rather than read from the
+# module under test so these cells are an independent oracle for the rule's own
+# condition, which is:
+#
+#     this.getFunction().(DataFlow::AttrRead).getAttributeName() = "replace" and
+#     this.getArg(0).asExpr().(StringLiteral).getText() in ["\r\n", "\n"]
+_BARRIER_FIRST_ARGUMENTS = frozenset({"\r\n", "\n"})
 
-        Helper contract. Two spellings escape the break identically and only one of
-        them is recognised as a barrier by the scanner that reports these sinks:
-        ``py/log-injection``'s ``ReplaceLineBreaksSanitizer`` holds for a ``.replace``
-        call whose first argument is a *string literal* equal to ``"
-    "`` or
-        ``"
-    "``, so a loop over a table of pairs closes the defect while reading as
-        no barrier at all. That is not a property a reader can see from the rendered
-        output, which is why it is asserted here rather than left to the next person
-        who tidies the function into a loop.
+
+def _returned_replace_chain() -> list[ast.Call]:
+    """Return the ``.replace`` calls the escape's returned expression is built from.
+
+    Outermost first, walking inward through each receiver, and empty when the
+    escape does not return such a chain at all - which is the shape a loop leaves
+    behind, the returned name carrying text no call on the path produced. Anchored
+    on the ``return`` rather than on the function body because a ``.replace`` whose
+    result is discarded escapes nothing the caller receives.
     """
     module = ast.parse(Path(log_safety.__file__).read_text(encoding="utf-8"))
     function = next(
         node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "sanitize_log_value"
     )
-    literals = {
-        node.args[0].value
-        for node in ast.walk(function)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "replace"
-        and node.args
-        and isinstance(node.args[0], ast.Constant)
-        and isinstance(node.args[0].value, str)
-    }
-    recognised = literals & {"\r\n", "\n"}
-    assert recognised, (
-        "no .replace() call in sanitize_log_value passes a literal '\\r\\n' or "
-        f"'\\n' as its first argument, so the escape is not the barrier the "
-        f"scanner recognises; first arguments found: {sorted(literals)!r}"
+    returns = [node for node in ast.walk(function) if isinstance(node, ast.Return)]
+    assert len(returns) == 1, "sanitize_log_value returns from exactly one place"
+    chain: list[ast.Call] = []
+    node: ast.expr | None = returns[0].value
+    while isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "replace":
+        chain.append(node)
+        node = node.func.value
+    return chain
+
+
+def _literal_first_argument(call: ast.Call) -> str | None:
+    """Return the call's first argument when it is a string literal, else ``None``."""
+    if not call.args:
+        return None
+    first = call.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    return None
+
+
+def test_the_escape_is_written_as_a_literal_replace_call() -> None:
+    r"""The break characters are passed as literals, not read from a table.
+
+    Helper contract. Two spellings escape the break identically and only one of
+    them is recognised as a barrier by the scanner that reports these sinks:
+    ``py/log-injection``'s ``ReplaceLineBreaksSanitizer`` holds for a ``.replace``
+    call whose first argument is a *string literal* equal to ``"\r\n"`` or ``"\n"``,
+    so a loop over a table of pairs closes the defect while reading as no barrier
+    at all. That is not a property a reader can see from the rendered output, which
+    is why it is asserted here rather than left to the next person who tidies the
+    function into a loop.
+    """
+    chain = _returned_replace_chain()
+    assert chain, "the escape must return a chain of .replace calls, not a name a loop rebound"
+    literals = {_literal_first_argument(call) for call in chain}
+    assert None not in literals, (
+        "every .replace in the escape must name its break as a string literal: a spelling "
+        "read from a constant escapes the break just as well and is recognised as no barrier"
     )
+    assert literals & _BARRIER_FIRST_ARGUMENTS, (
+        f"the escape replaces {sorted(spelling for spelling in literals if spelling)!r}, none of "
+        f"which is one of the {sorted(_BARRIER_FIRST_ARGUMENTS)!r} the scanner recognises"
+    )
+
+
+def test_a_lone_carriage_return_is_not_one_of_the_barrier_spellings() -> None:
+    r"""Premise: the accepted set is those two spellings, and ``"\r"`` is not one.
+
+    Which is why the chain carries a link the barrier does not need. A payload can
+    arrive with a bare carriage return, and an escape covering only what the rule
+    reads would leave it on the wire.
+    """
+    assert _BARRIER_FIRST_ARGUMENTS == {"\r\n", "\n"}
+    assert "\r" not in _BARRIER_FIRST_ARGUMENTS
+
+
+@pytest.mark.parametrize("length", [0, 1, 2, 3, 4], ids=lambda n: f"len-{n}")
+def test_the_chain_renders_exactly_what_the_table_loop_rendered(length: int) -> None:
+    r"""Over-reach control: rewriting the escape's shape changed none of its output.
+
+    Exhaustive over every string of this length drawn from the two break
+    characters, a backslash and an ordinary letter - the alphabet that can tell the
+    two forms apart if anything can - compared against the table loop the chain
+    replaced.
+    """
+
+    def table_loop(text: str) -> str:
+        for raw, visible in (("\r", "\\r"), ("\n", "\\n")):
+            text = text.replace(raw, visible)
+        return text
+
+    for letters in itertools.product("\r\na\\", repeat=length):
+        payload = "".join(letters)
+        assert sanitize_log_value(payload) == table_loop(payload), repr(payload)
+        assert not _has_raw_break(sanitize_log_value(payload))
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What this holds

`strands_robots.policies._log_safety.sanitize_log_value` escapes the two line-break
characters as chained `.replace` calls with literal arguments rather than a loop over a
table of pairs, and the spelling is load-bearing rather than a style choice.
`py/log-injection`'s only barrier reads the call site rather than its effect:

```ql
class ReplaceLineBreaksSanitizer extends Sanitizer, DataFlow::CallCfgNode {
  ReplaceLineBreaksSanitizer() {
    this.getFunction().(DataFlow::AttrRead).getAttributeName() = "replace" and
    this.getArg(0).asExpr().(StringLiteral).getText() in ["\r\n", "\n"]
  }
}
```

A loop hands `.replace` a loop variable, which satisfies neither conjunct, so the escape
runs and the rule still reports every sink the helper is the only escape for. That is not
hypothetical: with the escape written as a loop, five of the eight sinks stayed reported -
exactly the five whose value does not additionally pass through `repr()`. With it written
as the chain, `py/log-injection` on `main` reads **0 open, down from 8**
(`Analyze (Python)` completed on `50177d51`).

A cell already holds that shape. It walked the whole function body for a `.replace` with a
literal break argument, and that is satisfied by an escape whose result never leaves the
helper: compute the chain into a local, return the raw text, and the cell passes while the
record still splits. Reading the calls off the single `return` instead makes the cell's own
name true.

## Measured

Each mutation applied to the escape, run against the cells as they stand on `main` and
against this branch. `main` collects 18 cells in the file, this branch 24.

| mutation | `main` | here | only this branch catches |
| --- | --- | --- | --- |
| control | 0 | 0 | - |
| the table loop restored | 1 | 1 | - |
| escape computed into a local, raw text returned | 9 | 14 | the shape cell itself, + the render control |
| first arguments read from module constants | 1 | 1 | - |
| a link renders the wrong escape, literal intact | 8 | 12 | the render control |

The two rows where the counts are equal are the shapes the existing cell already covers,
and they are the ones that matter most day to day - a loop, and literals factored into
constants. The two rows where they differ are the ones its body-wide walk could not see: on
the third, the cell reported true about a shape that was false, and the mutation was caught
only under names that describe a split record rather than the shape the cell exists to
hold. Source restored byte-identically after every row; `collected` stable at 18 and 24.

## The two cells beside it

A **premise** states the accepted set the rule reads and that `"\r"` is not in it. That is
what makes the second link in the chain a decision rather than a leftover: a payload can
arrive carrying a bare carriage return, so the escape has to cover a spelling the rule does
not recognise.

An **over-reach control** holds the rendered text against the table loop the chain replaced,
exhaustively over every string up to four characters drawn from `\r`, `\n`, a backslash and
an ordinary letter - 341 payloads, 0 divergences. "The two forms render identically" was
prose; it is now measured, and the last row of the table is a link that keeps its literal
argument while rendering the wrong escape, which the shape cells cannot see and this one
does. It does not subsume the existing `nothing but the two break characters is touched`
cell, which catches a widening to a character outside that alphabet; the two are
complementary.

## The docstring

The shape cell's docstring carried real line breaks inside the inline-code spans where the
two spellings belonged, so the sentence naming them rendered as ``equal to `` `"` `` or
`` `"` ``, with the spellings invisible - in a module whose whole subject is that
substitution. They are written as escapes now, and the body is de-indented to the level the
rest of the file uses.

## Gate

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1657
files). `mypy` 24 == 24 against a worktree of the base, normalized message sets identical
in both directions, 0 attributable. A 670-file paired selection - all of `tests/policies/`
plus every suite that walks the tree, parses source, or reads docstrings, `Args:`,
`Raises:` or `changelog.d/` - is byte-identical: 28030 collected, `20 failed, 27907 passed,
103 skipped` on both sides, the same 20 ids, `comm` empty both ways. Of those 20, 17 need
`awsiot`/`awscrt` from the `mesh-iot` extra and 3 are lerobot-from-source drift; all 20
reproduce on the base alone.

No visual artifact: this changes no policy, simulation, rendering, recording or asset
behaviour. The measured tables are the evidence.
