### PR TITLE
fix(training/rl): hold learning_starts to the count domain its relation's other operand uses

### DIFF
--- a/changelog.d/2860-learning-starts-count-domain.md
+++ b/changelog.d/2860-learning-starts-count-domain.md
@@ -1,0 +1,47 @@
+### Fixed: a `learning_starts` that is not a count is refused instead of silently taking zero gradient steps
+
+`learning_starts` is one side of the relation `learning_starts >= batch_size`, and
+that relation was the only thing standing between the field and its two consumers.
+The relation's *other* operand was already asked of `positive_count_error` before
+being compared; this one was not, on the stated grounds that it is "one side of a
+relation rather than a bare count". That reason is about the shape of the *rule*
+and says nothing about whether the value is a count at all, and a comparison is
+not a domain: nothing is greater than `nan` and `inf` is below no integer, so a
+non-finite value made `learning_starts < batch_size` answer `False`, the relation
+passed, and `validate` reported nothing.
+
+Both consumers then read a value that is not a count. `collect_rollout` tests
+`buffer.size < learning_starts` to decide whether to draw a random warmup action,
+and `train` tests `buffer.size >= learning_starts` to decide whether `update()`
+runs at all - so a threshold no buffer can pass disables the whole learning half
+of the loop. Measured on the MuJoCo reach env used by
+`tests/training/test_rl_fast_sac.py` (40 timesteps, `rollout_steps=10`,
+`batch_size=16`, `gradient_steps=2`, one field mutated): `learning_starts=16` gave
+`validate() == []`, `train()` success and **3** `update()` calls, while
+`float("nan")` and `float("inf")` each gave `validate() == []`, `train()` success
+and **0** `update()` calls. The run built the environment, the networks, the
+optimizers and the replay buffer, collected every rollout, wrote a loadable
+checkpoint and reported `status="success"` having taken no gradient step at all.
+That is the outcome `_rl_replay_problems` exists to refuse for `buffer_size` - its
+own docstring records the same "zero gradient updates, yet the run reported
+success" - reached through the field its scope line excluded. `nan` additionally
+skips the random warmup the field exists to provide, so the untrained actor drives
+from the first step.
+
+Both operands of the relation are now asked of the same strict-`int` domain, and
+the relation only of two values that are counts. The relation is preserved rather
+than replaced: a real count below `batch_size` still gets the "must be >=
+batch_size" message, so a value that is merely too small is not reported as a
+non-count. A very large `int` is still accepted, because magnitude is not the axis
+- `10**400` is a count, and a run that has not reached it has genuinely not
+finished warming up. Strict does newly refuse an integral float such as `1000.0`
+and a `numpy` integer, both of which the bare comparison admitted; the field is
+annotated `int`, a relation between a strict count and a loose one is the drift
+this closes, and both are pinned as deliberate consequences.
+
+The field-scoped gate's own scope is unchanged: `_rl_replay_problems` still reports
+nothing about `learning_starts`, because PPO reads neither it nor the three replay
+counts, and the domain is asked in FastSAC's own `validate` beside the relation it
+guards. The two claims in `tests/training/test_rl_replay_domain.py` that read
+otherwise are corrected in place rather than removed - `tau` remains outside the
+count domain entirely, as a coefficient in `(0, 1]`.

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -183,15 +183,26 @@ class FastSacTrainer(BaseRLAlgo):
         problems.extend(self._rl_replay_problems(spec))
         if not 0.0 < spec.tau <= 1.0:
             problems.append(f"tau must be in (0, 1], got {spec.tau}")
-        # learning_starts >= batch_size is a relation between two counts, so it can
-        # only be asked once batch_size is one: a str / None reaches ``<`` and
-        # raises (out of a method documented to return problems), and a bool /
-        # float would compare nonsensically. batch_size is graded by the shared
-        # gate above; this consults the same domain rather than relying on that
-        # call having run, so it holds wherever it sits. learning_starts is not in
-        # that domain, so a non-count there still raises here as it did before - a
-        # separate field on a separate axis.
-        if (
+        # learning_starts >= batch_size is a relation between two counts, so BOTH
+        # operands are asked of the shared count domain and the relation only of
+        # two values that are counts. Asking it of batch_size alone was not
+        # enough: a non-finite learning_starts makes ``<`` answer False (every
+        # comparison against nan is False, and inf is below no int), so the
+        # relation passed and both consumers then read a value that is not a
+        # count. ``collect_rollout`` tests ``buffer.size < learning_starts`` to
+        # decide the random warmup and ``train`` tests ``buffer.size >=
+        # learning_starts`` to decide whether ``update()`` runs at all, so nan
+        # skips the warmup and takes zero gradient steps while inf warms up
+        # forever and takes zero gradient steps - a run that reports success
+        # having learned nothing, which is the outcome _rl_replay_problems exists
+        # to refuse for buffer_size. The domain is the strict count one its
+        # sibling operand already uses, so the relation compares two values drawn
+        # from one domain rather than one count against whatever the other side
+        # happened to be.
+        learning_starts_error = positive_count_error(spec.learning_starts, "learning_starts", self.provider_name)
+        if learning_starts_error is not None:
+            problems.append(learning_starts_error)
+        elif (
             positive_count_error(spec.batch_size, "batch_size", self.provider_name) is None
             and spec.learning_starts < spec.batch_size
         ):

--- a/tests/training/test_learning_starts_count_domain.py
+++ b/tests/training/test_learning_starts_count_domain.py
@@ -1,0 +1,270 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``learning_starts`` is a count, so FastSAC asks it of the count domain.
+
+``learning_starts`` is one side of the relation ``learning_starts >= batch_size``,
+and that relation was the only thing standing between the field and its two
+consumers. The relation's *other* operand was already asked of
+:func:`~strands_robots.utils.positive_count_error` before being compared; this
+one was not, on the stated grounds that it is "one side of a relation rather than
+a bare count". That reason is about the shape of the *rule* and says nothing
+about whether the value is a count at all, and a comparison is not a domain: a
+non-finite value compares False against every ``int`` (nothing is greater than
+``nan``, and ``inf`` is below no integer), so the relation passed and reported
+nothing.
+
+Both consumers then read a value that is not a count.
+:meth:`~strands_robots.training.rl.fast_sac.FastSacTrainer.collect_rollout` tests
+``buffer.size < learning_starts`` to decide whether to draw a random warmup
+action, and ``train`` tests ``buffer.size >= learning_starts`` to decide whether
+``update()`` runs at all. Measured on the MuJoCo reach env used by
+``tests/training/test_rl_fast_sac.py`` (40 timesteps, ``rollout_steps=10``,
+``batch_size=16``, ``gradient_steps=2``, one field mutated):
+
+=========================  ==========  ========  =====================
+``learning_starts``        ``validate``  ``train``  ``update()`` calls
+=========================  ==========  ========  =====================
+``16`` (a real count)      ``[]``      success   3
+``float("nan")``           ``[]``      success   **0**
+``float("inf")``           ``[]``      success   **0**
+=========================  ==========  ========  =====================
+
+So the run built the environment, the networks, the optimizers and the replay
+buffer, collected every rollout, wrote a checkpoint and reported
+``status="success"`` having taken no gradient step at all. That is the outcome
+``_rl_replay_problems`` exists to refuse for ``buffer_size`` - its docstring
+records the same "zero gradient updates, yet the run reported success" - reached
+through the field its scope line excluded. ``nan`` additionally skips the random
+warmup the field exists to provide, so the untrained actor drives from step one.
+
+The domain applied here is the strict-``int``
+:func:`~strands_robots.utils.positive_count_error` the relation's other operand
+already uses, so the relation now compares two values drawn from one domain. Two
+consequences of *strict*, both deliberate and pinned below: an integral float
+such as ``1000.0`` and a ``numpy`` integer are now refused although the bare
+comparison accepted them, because the field is annotated ``int`` and a relation
+between a strict count and a loose one is the drift this closes; and a very large
+``int`` is still accepted, because magnitude is not the axis - ``10**400`` is a
+count, and a run that has not reached it has genuinely not finished warming up.
+
+The scope of the *gate* is unchanged: ``_rl_replay_problems`` still reports
+nothing about this field, because PPO reads neither it nor the three replay
+counts. ``tests/training/test_rl_replay_domain.py`` pins that, and this file
+grades the domain FastSAC asks of the field in its own ``validate``.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import rl_replay_problems
+from strands_robots.training.rl import RLTrainSpec
+from strands_robots.training.rl.fast_sac import FastSacTrainer
+from strands_robots.utils import positive_count_error
+
+#: The batch size every case below pairs with, so the relation has a real operand.
+BATCH_SIZE = 256
+
+#: A count comfortably above :data:`BATCH_SIZE`, so the relation is satisfied and
+#: only the domain can refuse.
+VALID = 1_000
+
+#: Values a bare ``learning_starts < batch_size`` accepted while being unusable as
+#: a count. These are the silent half: ``validate`` reported nothing at all.
+SILENTLY_ACCEPTED: list[Any] = [float("nan"), float("inf"), 1_000.0]
+
+#: Values the bare comparison already rejected, but as a *relation* failure -
+#: "must be >= batch_size" invites raising the value, when the value is not a
+#: count in the first place.
+MISDESCRIBED: list[Any] = [True, False, 0.5, -1.0, 0, -5, -1_000]
+
+#: Values that reached ``<`` and raised out of a ``validate`` documented to
+#: *return* its problems.
+RAISED_OUT_OF_VALIDATE: list[Any] = ["1000", None, [1000]]
+
+#: Every spelling that is not a usable count, however it failed before.
+NOT_A_COUNT: list[Any] = [*SILENTLY_ACCEPTED, *MISDESCRIBED, *RAISED_OUT_OF_VALIDATE]
+
+
+def _spec(**overrides: Any) -> RLTrainSpec:
+    return RLTrainSpec(batch_size=BATCH_SIZE, **overrides)
+
+
+def _problems(value: Any) -> list[str]:
+    return create_trainer("fast_sac").validate(_spec(learning_starts=value))
+
+
+def _about_learning_starts(value: Any) -> list[str]:
+    return [p for p in _problems(value) if "learning_starts" in p]
+
+
+class TestFastSacRefusesALearningStartsThatIsNotACount:
+    """The regression: every unusable spelling is reported, none reaches a run."""
+
+    @pytest.mark.parametrize("value", NOT_A_COUNT, ids=repr)
+    def test_it_is_reported_as_a_problem(self, value: Any) -> None:
+        assert _about_learning_starts(value)
+
+    @pytest.mark.parametrize("value", NOT_A_COUNT, ids=repr)
+    def test_validate_returns_rather_than_raising(self, value: Any) -> None:
+        """A ``validate`` documented to return problems must not raise one."""
+        assert isinstance(_problems(value), list)
+
+    @pytest.mark.parametrize("value", NOT_A_COUNT, ids=repr)
+    def test_the_message_names_the_field_and_the_domain(self, value: Any) -> None:
+        problem = _about_learning_starts(value)[0]
+        assert "learning_starts" in problem
+        assert "positive integer" in problem
+
+    @pytest.mark.parametrize("value", NOT_A_COUNT, ids=repr)
+    def test_the_message_is_the_shared_domain_one_verbatim(self, value: Any) -> None:
+        """The wording is the shared rule's, so the two cannot drift apart."""
+        expected = positive_count_error(value, "learning_starts", "fast_sac")
+        assert expected is not None
+        assert expected in _about_learning_starts(value)
+
+    @pytest.mark.parametrize("value", NOT_A_COUNT, ids=repr)
+    def test_the_refusal_names_the_backend(self, value: Any) -> None:
+        assert _about_learning_starts(value)[0].startswith("fast_sac:")
+
+
+class TestTheHarmTheRelationCouldNotSee:
+    """Why a comparison is not a domain, as arithmetic rather than as prose.
+
+    These hold on any tree - they are properties of IEEE comparison, not of the
+    fix - and they are what makes the refusal necessary: both consumers read one
+    of these two comparisons to decide what the run does.
+    """
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf")])
+    def test_the_relation_could_not_reject_it(self, value: float) -> None:
+        """``learning_starts < batch_size`` is False, so the relation passed."""
+        assert not value < BATCH_SIZE
+
+    def test_a_nan_threshold_skips_the_warmup_the_field_exists_for(self) -> None:
+        """``collect_rollout`` draws a random action while ``size < threshold``."""
+        assert not 0 < float("nan")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf")])
+    def test_no_buffer_ever_passes_the_threshold(self, value: float) -> None:
+        """``train`` runs ``update()`` only while ``size >= threshold``."""
+        assert not 10**9 >= value
+
+    def test_the_gate_that_names_this_outcome_is_the_replay_one(self) -> None:
+        """The sibling gate's docstring records the same zero-update success."""
+        doc = " ".join((rl_replay_problems.__doc__ or "").split())
+        assert "zero" in doc and "gradient" in doc
+
+
+class TestTheUsableDomainIsUntouched:
+    """A real count is accepted and the relation still does its own job."""
+
+    def test_a_positive_integer_above_the_batch_is_accepted(self) -> None:
+        assert not _about_learning_starts(VALID)
+
+    def test_the_shipped_default_is_accepted(self) -> None:
+        default = RLTrainSpec().learning_starts
+        assert not _about_learning_starts(default)
+
+    def test_a_count_below_the_batch_still_fails_the_relation(self) -> None:
+        """The relation is preserved, not replaced: 1 is a count and still wrong."""
+        problem = _about_learning_starts(1)[0]
+        assert "must be >= batch_size" in problem
+
+    def test_the_relation_message_is_not_the_domain_message(self) -> None:
+        """A count that is merely too small must not be called a non-count."""
+        assert "positive integer" not in _about_learning_starts(1)[0]
+
+    def test_a_very_large_count_is_still_a_count(self) -> None:
+        """Magnitude is not the axis: an enormous warmup is a warmup."""
+        assert not _about_learning_starts(10**400)
+
+
+class TestWhatStrictNewlyRefuses:
+    """Two consequences of using the sibling operand's strict domain.
+
+    Both were accepted by the bare comparison and both are refused now. They are
+    recorded here rather than left to be discovered, because they are the price
+    of the two operands sharing one domain.
+    """
+
+    @pytest.mark.parametrize("value", [1_000.0, np.int64(1_000)], ids=["integral-float", "numpy-int"])
+    def test_it_is_refused_although_the_comparison_accepted_it(self, value: Any) -> None:
+        assert _about_learning_starts(value)
+
+    @pytest.mark.parametrize("value", [1_000.0, np.int64(1_000)], ids=["integral-float", "numpy-int"])
+    def test_the_comparison_alone_would_have_admitted_it(self, value: Any) -> None:
+        """Non-vacuity: these are refused by the domain, not by the relation."""
+        assert not value < BATCH_SIZE
+
+    def test_the_field_is_annotated_as_an_integer(self) -> None:
+        """Which is why strict is the honest reading of the contract."""
+        assert RLTrainSpec.__annotations__["learning_starts"] == "int"
+
+
+class TestTheGateStillReportsNothingAboutIt:
+    """The field-scoped gate's own scope is unchanged by this fix."""
+
+    @pytest.mark.parametrize("value", NOT_A_COUNT, ids=repr)
+    def test_the_replay_gate_stays_silent(self, value: Any) -> None:
+        spec = _spec(learning_starts=value)
+        assert not [p for p in rl_replay_problems(spec, context="fast_sac") if "learning_starts" in p]
+
+    @pytest.mark.parametrize("provider", ["ppo", "mock"])
+    def test_a_backend_that_does_not_read_it_stays_quiet(self, provider: str) -> None:
+        """PPO has no replay warmup, so an SAC-only value is not its business."""
+        spec = _spec(learning_starts=float("nan"))
+        assert not [p for p in create_trainer(provider).validate(spec) if "learning_starts" in p]
+
+    def test_tau_is_still_refused_on_its_own_axis(self) -> None:
+        """The neighbouring exclusion is untouched: a coefficient is not a count."""
+        problems = create_trainer("fast_sac").validate(_spec(learning_starts=VALID, tau=2.0))
+        assert [p for p in problems if "tau" in p]
+        assert not [p for p in problems if "positive integer" in p]
+
+
+class TestBothOperandsOfTheRelationShareOneDomain:
+    """The structural claim, read off the source rather than asserted in prose."""
+
+    @staticmethod
+    def _validate_source() -> str:
+        return inspect.getsource(FastSacTrainer.validate)
+
+    def test_the_relation_reads_both_fields(self) -> None:
+        """Premise: this is the statement the two operands meet in."""
+        assert "spec.learning_starts < spec.batch_size" in self._validate_source()
+
+    def test_each_operand_is_asked_of_the_shared_domain(self) -> None:
+        source = self._validate_source()
+        asked = {
+            call.args[1].value
+            for call in ast.walk(ast.parse(textwrap.dedent(source)))
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "positive_count_error"
+            and len(call.args) > 1
+            and isinstance(call.args[1], ast.Constant)
+        }
+        assert {"learning_starts", "batch_size"} <= asked
+
+    def test_the_domain_is_asked_before_the_relation(self) -> None:
+        """A guard after the comparison would not stop the comparison."""
+        source = self._validate_source()
+        domain_at = source.index('positive_count_error(spec.learning_starts, "learning_starts"')
+        relation_at = source.index("spec.learning_starts < spec.batch_size")
+        assert domain_at < relation_at
+
+    def test_the_domain_is_not_restated_locally(self) -> None:
+        """One owner: no hand-rolled isfinite / isinstance beside the shared call."""
+        source = self._validate_source()
+        assert "math.isfinite" not in source
+        assert "isinstance(spec.learning_starts" not in source
+        assert math.isfinite(1.0)  # the module imports math only for this premise

--- a/tests/training/test_rl_replay_domain.py
+++ b/tests/training/test_rl_replay_domain.py
@@ -26,10 +26,17 @@ the networks, the optimizers and the replay buffer had been built - and ``"256"`
 Only FastSAC reads these three fields. PPO sizes its minibatches from
 ``num_mini_batches`` and never reads them, so it must stay quiet about them, as
 must every supervised backend; :class:`TestABackendThatDoesNotReadThemStaysQuiet`
-pins that. ``learning_starts`` and ``tau`` are deliberately outside this domain -
-the first is one side of a relation (``>= batch_size``), the second a coefficient
-in ``(0, 1]`` - and :class:`TestTauAndLearningStartsAreNotInThisDomain` pins that
-scope line rather than leaving it to prose.
+pins that. ``learning_starts`` and ``tau`` are outside this gate's field set, and
+:class:`TestTauAndLearningStartsAreNotInThisDomain` pins that scope line rather
+than leaving it to prose. ``tau`` is a coefficient in ``(0, 1]`` and so shares no
+part of this domain. ``learning_starts`` is one side of a relation
+(``>= batch_size``) and *does* share the domain: FastSAC asks it of the same
+strict-``int`` rule as the relation's other operand, in its own ``validate``
+rather than through this gate, because PPO reads neither field. That is graded in
+``tests/training/test_learning_starts_count_domain.py``, which measured the cost
+of leaving it to the relation alone - a non-finite value compares False against
+every ``int``, so the relation passed and the run took zero gradient steps while
+reporting success, the same outcome ``buffer_size=True`` produces above.
 
 Every domain test here reaches the real ``validate`` entry point, so it covers
 the wiring as well as the domain.
@@ -253,11 +260,16 @@ class TestTheCountsAreConsumedDirectlyAsCounts:
 
 
 class TestTauAndLearningStartsAreNotInThisDomain:
-    """The scope line, pinned: two SAC fields are checked, but not as counts.
+    """The scope line, pinned: two SAC fields this gate does not carry.
 
-    ``tau`` is a coefficient in ``(0, 1]`` and ``learning_starts`` is one side of
-    a relation (``>= batch_size``), so neither is one of the shared counts. The
-    gate must stay silent about them, and FastSAC must still refuse them itself.
+    Neither is one of the three replay counts, so the gate must stay silent about
+    both and FastSAC must still refuse them itself. What that refusal rests on
+    differs: ``tau`` is a coefficient in ``(0, 1]`` and shares no part of the
+    count domain, while ``learning_starts`` is one side of a relation
+    (``>= batch_size``) whose *other* operand is already asked of the shared
+    count rule - so FastSAC asks it of that rule too, in its own ``validate``.
+    ``tests/training/test_learning_starts_count_domain.py`` grades that; here the
+    claim is only that this gate reports nothing about either field.
     """
 
     @pytest.mark.parametrize("field", ["tau", "learning_starts"])


### PR DESCRIPTION
## The defect

`learning_starts` is one side of the relation `learning_starts >= batch_size`, and that
relation was the only thing standing between the field and its two consumers. The
relation's **other** operand was already asked of `positive_count_error` before being
compared; this one was not, on the stated grounds that it is *"one side of a relation
rather than a bare count"*.

That reason is about the shape of the **rule** and says nothing about whether the value
is a count at all. A comparison is not a domain: nothing is greater than `nan`, and
`inf` is below no integer, so a non-finite value made `learning_starts < batch_size`
answer `False`, the relation passed, and `validate` reported nothing.

## What the consumers then do

`collect_rollout` tests `buffer.size < learning_starts` to decide whether to draw a
random warmup action. `train` tests `buffer.size >= learning_starts` to decide whether
`update()` runs at all. So a threshold no buffer can pass disables the learning half of
the loop entirely.

Measured on the MuJoCo reach env used by `tests/training/test_rl_fast_sac.py`
(40 timesteps, `rollout_steps=10`, `batch_size=16`, `gradient_steps=2`, one field mutated):

| `learning_starts` | `validate()` | `train()` | `update()` calls |
|---|---|---|---|
| `16` (a real count) | `[]` | success | 3 |
| `float("nan")` | `[]` | success | **0** |
| `float("inf")` | `[]` | success | **0** |

The run built the environment, the networks, the optimizers and the replay buffer,
collected every rollout, wrote a loadable checkpoint and reported `status="success"`
having taken no gradient step at all. That is the outcome `_rl_replay_problems` exists to
refuse for `buffer_size` - its own docstring records the same *"zero gradient updates,
yet the run reported success"* - reached through the field its scope line excluded. `nan`
additionally skips the random warmup the field exists to provide, so the untrained actor
drives from the first step.

## The change

Both operands of the relation are now asked of the same strict-`int` domain, and the
relation only of two values that are counts.

| `learning_starts` | before | after |
|---|---|---|
| `1000` | accepted | accepted |
| `10**400` | accepted | accepted (magnitude is not the axis) |
| `1` | relation message | relation message (unchanged) |
| `nan`, `inf` | **accepted** | `learning_starts must be a positive integer` |
| `True`, `0.5`, `0`, `-5` | relation message | domain message (the accurate one) |
| `"1000"`, `None` | **raised `TypeError`** | reported |
| `1000.0`, `np.int64(1000)` | accepted | refused (see below) |

The relation is preserved rather than replaced: a count that is merely too small still
gets `must be >= batch_size`, so it is not reported as a non-count.

### Why strict, and what strict costs

The domain is the one the relation's other operand already uses, so the relation compares
two values drawn from one domain rather than one count against whatever the other side
happened to be. Measured against the looser sibling `positive_whole_number_error`:

| value | `positive_count_error` | `positive_whole_number_error` |
|---|---|---|
| `1000.0` | refuse | accept |
| `10**400` | **accept** | refuse (outside 64-bit float range) |

Strict is the right member here: `10**400` is a count and a run that has not reached it
has genuinely not finished warming up, whereas the loose domain refuses it for a
float-range reason that does not apply to an `int` threshold. The price is that an
integral float and a `numpy` integer are newly refused although the bare comparison
admitted them - the field is annotated `int`, and both are pinned as deliberate
consequences in `TestWhatStrictNewlyRefuses`.

### Scope

The field-scoped gate is unchanged: `_rl_replay_problems` still reports nothing about
`learning_starts`, because PPO reads neither it nor the three replay counts. The domain is
asked in FastSAC's own `validate`, beside the relation it guards. `tau` remains outside the
count domain entirely, as a coefficient in `(0, 1]` whose own comparison does catch a
non-finite value.

Two claims in `tests/training/test_rl_replay_domain.py` said learning_starts "is not one of
the shared counts"; both are corrected in place rather than removed, keeping the half that
is still true (neither field is one of this gate's three).

## Why nothing caught it

`TestTauAndLearningStartsAreNotInThisDomain` exists to keep the exclusion honest, and its
non-vacuity cell sets `learning_starts = 1` - the one value a bare comparison **does**
catch. The values a comparison cannot catch are structurally absent from it.

## Verification

- **Pre-fix split**: 52 failed / 49 passed. 48/65 regression, 2/4 structural, 2/5
  deliberate-consequence; **0 of 16** gate-scope controls, **0 of 6** premises,
  **0 of 5** usable-domain controls.
- **Break table**: 8 mutations, **8 distinct firing sets**, control 0, `collected` stable
  at 101 on every row, `sib` 0 across the four sibling suites, source restored
  byte-identical. Rows include the guard placed *after* the relation (30), the verdict
  computed then discarded (54), `elif` widened to `if` (15), the loose domain substituted
  (33), and the domain told the wrong field name (56) or asked of the wrong operand (51).
- **Paired gate**: identical 246-file selection (all of `tests/training/` plus every suite
  walking the tree, parsing source or reading docstrings, plus everything naming the shared
  domain or this backend), new file excluded from both trees, 1 exclusion printed ->
  identical **12885 collected** and `3 failed, 12822 passed, 60 skipped` on each,
  **3 == 3 identical failing ids, `comm` empty both directions**, distinct rootdirs. The 3
  are the lerobot-from-source `TypeError: encode() takes 1 positional argument` drift,
  reproduced on a pristine base worktree alone.
- **mypy** `24 == 24`, normalized message sets byte-identical both directions, **0
  attributable**, `checked 1655` vs `1654` (+1 = the new test file).
- **ruff** check and format clean over 1658 files.
- Changed files pass together: 425 cases across the new file and the three sibling suites.

No visual artifact: this is a validation-message change, not a policy, simulation,
rendering, recording or asset change. The measured `update()`-call table is the evidence.
