### PR TITLE
fix(drivers/g1): the write refusal cites a resolvable issue, and the soft-stop helper documents its call site

### DIFF
--- a/changelog.d/2865-g1-refusal-cites-a-resolvable-issue.md
+++ b/changelog.d/2865-g1-refusal-cites-a-resolvable-issue.md
@@ -1,0 +1,69 @@
+### Fixed: the G1 write refusal pointed the operator at a repository with no owner, and the soft-stop helper documented itself as dead code
+
+`G1Driver.send_action` refuses every write until the motion-switcher source that
+feeds `_fsm_id` is wired, and the message it returns carried two tracker
+references: a bare `#2765`, and `harness#361 PR-C`. The second one resolves to
+nothing. It names a repository without an owner, so there is no coordinate for
+the reader to open - not a link, not a path, not a search that lands anywhere.
+The refusal it sat in is not a rare one either: `_fsm_id` has exactly one
+assignment in the driver and it is the `None` initialiser, so this is the message
+every real driver produces for every write, which made the unresolvable half the
+most-read tracker reference in the package. Driven against the real driver with
+`_connected` set, `rt/lowstate` delivered and a 92 percent pack, `send_action`
+answered:
+
+```
+FSM id unknown - motion-switcher source has not been wired (harness#361 PR-C); see #2765 for the wire-side decision
+```
+
+and now answers:
+
+```
+FSM id unknown - motion-switcher source has not been wired; see issue #2765 for the wire-side decision
+```
+
+The verdict is unchanged - the gate still refuses, for the same reason - and both
+phrases the existing tests pin (`FSM id unknown` and `motion-switcher`) survive.
+What changes is that the remedy the message advertises can be followed. This also
+brings the refusal into line with every sibling: the Dynamixel driver's
+`_NOT_WIRED` constant and the G1's own `start_task` both cite an in-repo issue
+(`issue #359 bus`, `issue #358`), and this was the one that did not.
+
+`_build_zero_torque_lowcmd` had the complementary problem: its docstring
+described a state the code left behind. It read "This helper is defined but not
+yet wired: `G1Driver.stop` and `stop_task` currently return refusal envelopes
+rather than publishing a frame, and no other call site exists." Every clause of
+that is now false. `_ControlLoop._emit_zero_torque` calls the helper from the
+loop's `finally`, on every exit path except one where the wire itself just
+refused a publish, and `G1Driver.stop_task`'s own docstring 370 lines above
+already said as much ("the loop publishes `_build_zero_torque_lowcmd` on the way
+out"). Two docstrings in one module contradicting each other is worse than either
+being vague: a reader who meets the helper first is told the soft-stop path does
+not exist, and the reasonable conclusion is that one still has to be built beside
+it. The paragraph now describes the call site and why the helper stays separate
+from the loop.
+
+Two guards hold the classes out, with scopes chosen by measurement rather than by
+taste. The first sweeps every string a *caller* can receive across the package
+and requires any tracker reference in it to be resolvable: a bare `#NNNN` for an
+issue here, or an owner-qualified `owner/repo#NNNN` for a sibling. Both spellings
+are pinned as accepted so the rule is not blanket strictness, and the predicate is
+graded on constructed exemplars because a clean tree can no longer exercise a
+rejection. Docstrings are deliberately excluded and a boundary test records why:
+over twenty `robots-sim#NN` references sit in developer-facing prose in
+`simulation/isaac`, `strands-labs/robots-sim` is a real repository, and a
+maintainer reading a docstring has the sibling checkout that an operator holding
+a refusal envelope does not. That test fails if the docstring population ever
+empties, at which point widening the scan is free. Across the whole package
+exactly one caller-reachable string violated the rule, and it was this refusal.
+
+The second guard is scoped to the G1 module and to its module-private functions,
+and requires that a helper the module calls does not document itself as uncalled.
+That scope is the one in which matching a call by name is sound, because a
+leading-underscore module-level function is called by its bare name inside its own
+module. The same rule package-wide is unsound and is not shipped: a public method
+name such as `send_action` is declared on several unrelated classes, so counting
+calls by name would attribute every `robot.send_action` in the tree to whichever
+driver happened to declare it, and the Dynamixel driver - which legitimately
+documents its own bus as not yet wired - would be reported as drifting when it is
+not.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -20,7 +20,7 @@ What the driver actually does:
   FSM state from the motion-switcher API) rather than :attr:`_mode_machine`
   (the uint8 hardware-layout id from ``LowState``); those two fields have
   disjoint value ranges and must not be conflated.  Until the
-  motion-switcher source is wired (harness#361 PR-C, #2765), the gate
+  motion-switcher source is wired (issue #2765), the gate
   refuses honestly rather than silently rejecting every real frame.
 * Task and policy paths (``start_task``, ``run_policy``, ``stop_task``,
   ``get_task_status``) return a named "not wired yet" envelope. Locomotion
@@ -610,8 +610,7 @@ class G1Driver:
             # frame silently reach a gate whose intersection with the echo's
             # value range is empty.
             return _refuse(
-                "FSM id unknown - motion-switcher source has not been wired "
-                "(harness#361 PR-C); see #2765 for the wire-side decision"
+                "FSM id unknown - motion-switcher source has not been wired; see issue #2765 for the wire-side decision"
             )
         if scope == "arm":
             allowed, kind = HANDSHAKE_FSMS, "arm writes"
@@ -713,7 +712,7 @@ class G1Driver:
         ``g1_tools`` motion verbs (issue #358) so the loop has something to
         command with joint-name semantics.
 
-        This driver's role for harness#361 PR-C is the **transport primitive**:
+        This driver's role is the **transport primitive**:
         a background thread that spins at 500 Hz, gates every step against the
         FSM and battery, publishes ``LowCmd_`` frames on ``rt/lowcmd``, and on
         stop or budget expiry publishes a zero-torque frame before exiting.
@@ -1232,12 +1231,15 @@ def _build_zero_torque_lowcmd(
     helper; no production path in this driver can reach the raise because
     ``G1Driver._on_lowstate`` binds ``_mode_machine`` from a uint8 IDL field.
 
-    This helper is defined but not yet wired: ``G1Driver.stop`` and
-    ``stop_task`` currently return refusal envelopes rather than publishing
-    a frame, and no other call site exists.  The 500 Hz control-loop PR
-    (harness#361 PR-C) is where the wiring lands; the helper is defined
-    here so the loop's shutdown path composes on a tested, CRC-correct
-    frame rather than one hand-rolled next to it.
+    The control loop publishes this frame on its way out:
+    :meth:`_ControlLoop._emit_zero_torque` calls it from the loop's
+    ``finally``, on every exit path except one where the wire itself just
+    refused a publish - clobbering that reason with a fresh publish error
+    is worse than not stamping a stop frame the wire cannot carry anyway.
+    That is what makes :meth:`G1Driver.stop_task` a soft *controlled* stop
+    rather than a Disable that would let the named joints fall freely.  The
+    helper stays separate from the loop so that shutdown path composes on a
+    tested, CRC-correct frame rather than one hand-rolled next to it.
     """
     try:
         from unitree_sdk2py.idl.default import unitree_hg_msg_dds__LowCmd_ as _default_lowcmd

--- a/tests/drivers/test_g1_zero_torque_docstring_matches_its_call_site.py
+++ b/tests/drivers/test_g1_zero_torque_docstring_matches_its_call_site.py
@@ -1,0 +1,116 @@
+"""Regression: a G1 module-private helper may not document itself as uncalled
+while the module calls it.
+
+``_build_zero_torque_lowcmd`` builds the soft-stop frame the control loop
+publishes on its way out. Its docstring said the opposite:
+
+    This helper is defined but not yet wired: ``G1Driver.stop`` and
+    ``stop_task`` currently return refusal envelopes rather than publishing
+    a frame, and no other call site exists.
+
+Every clause of that was false once the 500 Hz loop landed. ``_ControlLoop``
+calls the helper from its ``finally``, and ``G1Driver.stop_task``'s own
+docstring - 370 lines above in the same module - already said so ("the loop
+publishes :func:`_build_zero_torque_lowcmd` on the way out"). Two docstrings in
+one module directly contradicting each other is worse than either being vague:
+a reader who finds the helper first is told the shutdown path does not exist,
+and the natural conclusion is that a soft stop still has to be built.
+
+The scan is deliberately scoped to this one module and to its *module-private*
+functions, because that is the scope in which matching a call by name is sound:
+a leading-underscore module-level function is called by its bare name inside its
+own module. The same rule package-wide is not sound and is not shipped - a
+public method name such as ``send_action`` is defined on several unrelated
+classes, so counting calls by name would attribute every ``robot.send_action``
+in the tree to whichever driver happened to declare it, and a driver that
+legitimately documents its own bus as unwired would be reported as drifting.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.drivers.g1 as g1_module
+
+# Prose that claims the function the reader is looking at has no caller. Each
+# alternative is a claim about *wiring*, which the module's own call graph
+# either bears out or contradicts.
+_UNCALLED_CLAIM = re.compile(r"not yet wired|no other call site|no call sites?\b", re.IGNORECASE)
+
+_G1_SOURCE = Path(g1_module.__file__).resolve()
+
+
+def _module_tree() -> ast.Module:
+    return ast.parse(_G1_SOURCE.read_text(encoding="utf-8"))
+
+
+def _module_private_functions(tree: ast.Module) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Module-level functions whose name marks them private to this module."""
+    return {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("_")
+    }
+
+
+def _bare_name_call_lines(tree: ast.Module, name: str) -> list[int]:
+    """Lines in the module that call ``name`` by its bare name."""
+    return sorted(
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == name
+    )
+
+
+def _claims_it_is_uncalled(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Whether the function's docstring tells the reader nothing calls it."""
+    doc = ast.get_docstring(node) or ""
+    return bool(_UNCALLED_CLAIM.search(" ".join(doc.split())))
+
+
+def test_the_soft_stop_helper_has_a_production_call_site() -> None:
+    """Premise: the wiring this test grades exists, so it cannot pass vacuously."""
+    tree = _module_tree()
+    assert "_build_zero_torque_lowcmd" in _module_private_functions(tree)
+    call_lines = _bare_name_call_lines(tree, "_build_zero_torque_lowcmd")
+    assert call_lines, "the soft-stop helper is no longer called; this test's premise is gone"
+
+
+def test_no_called_module_private_helper_documents_itself_as_uncalled() -> None:
+    """A helper the module calls must not tell the reader it has no caller."""
+    tree = _module_tree()
+    offenders: list[str] = []
+    for name, node in _module_private_functions(tree).items():
+        call_lines = _bare_name_call_lines(tree, name)
+        if call_lines and _claims_it_is_uncalled(node):
+            offenders.append(f"{name}() at line {node.lineno} claims it is unwired, but is called at {call_lines}")
+    assert not offenders, (
+        "A module-private helper documents itself as unwired while this module "
+        "calls it. Describe the call site instead - a reader who believes the "
+        "helper is dead will build a second one:\n" + "\n".join(offenders)
+    )
+
+
+def test_the_derivation_reaches_the_helpers_it_grades() -> None:
+    """Non-vacuity: the scan found a real population, not an empty one."""
+    tree = _module_tree()
+    private = _module_private_functions(tree)
+    assert len(private) > 3, f"only {len(private)} module-private functions found"
+    called = [name for name in private if _bare_name_call_lines(tree, name)]
+    assert "_build_zero_torque_lowcmd" in called
+
+
+def test_the_claim_predicate_separates_the_two_shapes() -> None:
+    """The predicate answers both ways, so the rule is not trivially satisfied."""
+    module = ast.parse(
+        "def _drifted():\n"
+        '    """Defined but not yet wired: no other call site exists."""\n'
+        "\n"
+        "def _accurate():\n"
+        '    """The control loop publishes this frame from its finally."""\n'
+    )
+    functions = _module_private_functions(module)
+    assert _claims_it_is_uncalled(functions["_drifted"]) is True
+    assert _claims_it_is_uncalled(functions["_accurate"]) is False

--- a/tests/test_source_strings_resolve_their_issue_references.py
+++ b/tests/test_source_strings_resolve_their_issue_references.py
@@ -1,0 +1,162 @@
+"""Regression: no caller-reachable string may cite an issue in a repository the
+reader cannot resolve.
+
+A refusal envelope, a log line or a help string is read by an operator, and the
+tracker reference it carries is a *remedy*: the reader follows it to find out
+what is missing and when it lands. Two spellings resolve for that reader - a
+bare ``#2765`` (an issue in this repository, which every tracker and IDE turns
+into a link) and an owner-qualified ``strands-labs/robots-sim#46`` (a complete
+coordinate). A bare ``<slug>#361`` resolves to nothing: it names a repository
+without an owner, so the reader has no path to open and the message advertises a
+remedy that cannot be followed.
+
+The scan walks every module under the ``strands_robots`` package, parses it, and
+inspects only string constants a *caller* can receive - runtime literals, with
+module, class and function docstrings excluded. That boundary is deliberate and
+narrow. Developer-facing prose legitimately cites the sibling repositories this
+package grew out of (over twenty ``robots-sim#NN`` references sit in
+``simulation/isaac`` comments and docstrings, and ``strands-labs/robots-sim`` is
+a real repository), and a maintainer reading a docstring has the git history and
+the sibling checkouts to hand. An operator holding a refusal envelope has
+neither, so the rule applies where the text reaches them.
+
+It would have failed while ``G1Driver._check_motion_gates`` refused every write
+with "FSM id unknown - motion-switcher source has not been wired (harness#361
+PR-C); see #2765 for the wire-side decision". That refusal is the one every real
+driver hits - ``_fsm_id`` has a single assignment, its ``None`` initialiser - so
+the unresolvable half was the most-read tracker reference in the package, sitting
+beside a bare ``#2765`` that already carried the same information.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots
+
+# A tracker reference qualified by a repository name: the slug, ``#``, a number.
+# A bare ``#2765`` does not match (no leading slug) and needs no owner - it is
+# an issue in this repository. A slug carrying ``/`` is owner-qualified and
+# resolves on its own; a slug without one names a repository with no owner.
+_QUALIFIED_ISSUE_REF = re.compile(r"([A-Za-z][A-Za-z0-9_.\-/]*)#(\d+)")
+
+_PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for p in _PACKAGE_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _docstring_constant_ids(tree: ast.Module) -> set[int]:
+    """Identify the docstring node of every module, class and function."""
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) and isinstance(first.value.value, str):
+            ids.add(id(first.value))
+    return ids
+
+
+def _caller_reachable_literals(path: Path) -> list[tuple[int, str]]:
+    """Every string constant a caller can receive, paired with its line number.
+
+    Docstrings are excluded: they are read by a maintainer with the repository
+    checked out, not returned to a caller.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    docstrings = _docstring_constant_ids(tree)
+    return [
+        (node.lineno, node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and id(node) not in docstrings
+    ]
+
+
+def _unresolvable_references(text: str) -> list[str]:
+    """Tracker references in ``text`` that name a repository with no owner."""
+    return [f"{slug}#{number}" for slug, number in _QUALIFIED_ISSUE_REF.findall(text) if "/" not in slug]
+
+
+def test_package_sources_discovered() -> None:
+    """Guard: the scan walked the whole package, not one subtree."""
+    sources = _python_sources()
+    assert len(sources) > 50
+    rel_dirs = {p.relative_to(_PACKAGE_DIR).parts[0] for p in sources if p.parent != _PACKAGE_DIR}
+    assert {"drivers", "simulation", "tools", "policies"} <= rel_dirs
+
+
+def test_caller_reachable_literals_discovered() -> None:
+    """Guard: excluding docstrings did not empty the population being scanned."""
+    total = sum(len(_caller_reachable_literals(path)) for path in _python_sources())
+    assert total > 1000, f"only {total} caller-reachable literals found; the extraction is too narrow"
+
+
+def test_no_caller_reachable_string_cites_an_unresolvable_repository() -> None:
+    """A string a caller receives must not cite an issue in an unowned repository."""
+    offenders: list[str] = []
+    for path in _python_sources():
+        for lineno, literal in _caller_reachable_literals(path):
+            for reference in _unresolvable_references(literal):
+                offenders.append(f"{path.relative_to(_PACKAGE_DIR.parent)}:{lineno}: {reference}")
+    assert not offenders, (
+        "A string a caller can receive cites an issue in a repository the reader "
+        "cannot resolve. Use a bare '#2765' for an issue in this repository, or "
+        "an owner-qualified 'strands-labs/robots-sim#46' for a sibling - an "
+        "unowned slug advertises a remedy the reader has no path to open:\n" + "\n".join(offenders)
+    )
+
+
+def test_an_unowned_slug_reference_is_flagged() -> None:
+    """The predicate flags the shape this guard exists to keep out."""
+    refused = "FSM id unknown - motion-switcher source has not been wired (harness#361 PR-C)"
+    assert _unresolvable_references(refused) == ["harness#361"]
+
+
+def test_bare_and_owner_qualified_references_are_not_flagged() -> None:
+    """Both resolvable spellings must pass, or the rule is blanket strictness."""
+    accepted = [
+        "see issue #2765 for the wire-side decision",  # bare: this repository
+        "start_task: provider registry not wired yet (issue #358)",  # the sibling convention
+        "tracked in strands-labs/robots-sim#46",  # owner-qualified sibling repository
+        "see strands-labs/robots#708 for the root-cause analysis",
+        "not wired yet (issue #359 bus)",
+    ]
+    for text in accepted:
+        assert _unresolvable_references(text) == [], f"should not be flagged: {text!r}"
+
+
+def test_the_predicate_separates_the_two_shapes() -> None:
+    """Non-vacuity: the predicate answers both ways over the exemplars."""
+    outcomes = {
+        bool(_unresolvable_references(text))
+        for text in ("harness#361 PR-C", "issue #2765", "strands-labs/robots-sim#46")
+    }
+    assert outcomes == {True, False}
+
+
+def test_developer_facing_docstrings_are_deliberately_out_of_scope() -> None:
+    """The scope boundary is a measurement, not an oversight.
+
+    Docstrings and comments in this package do carry unowned sibling-repository
+    references today. They are excluded because a maintainer reading them has
+    the sibling checkout; an operator holding a refusal envelope does not. If
+    that population ever empties, widening the scan becomes a free tightening.
+    """
+    in_docstrings = 0
+    for path in _python_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        docstrings = _docstring_constant_ids(tree)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) and id(node) in docstrings:
+                in_docstrings += len(_unresolvable_references(node.value))
+    assert in_docstrings > 0, (
+        "no docstring cites an unowned sibling repository any more; the scan can "
+        "be widened to docstrings and this boundary test removed"
+    )


### PR DESCRIPTION
## Problem

`G1Driver.send_action` refuses every write until the motion-switcher source that
feeds `_fsm_id` is wired, and the message it handed back carried two tracker
references. One of them resolves to nothing:

```
FSM id unknown - motion-switcher source has not been wired (harness#361 PR-C); see #2765 for the wire-side decision
```

`harness#361` names a repository with no owner, so an operator following it has
no coordinate to open. That would be a small thing in a rare message, and this is
not a rare message: `_fsm_id` has exactly one assignment in the driver and it is
the `None` initialiser, so this is the refusal **every** real driver produces for
**every** write. It was the most-read tracker reference in the package, and it sat
beside a bare `#2765` that already carried the same information.

It is also the only refusal of its kind that does this. Every sibling cites an
in-repo issue: `drivers/dynamixel/driver.py`'s `_NOT_WIRED` constant reads
`"not wired yet (issue #359 bus)"`, and the G1's own `start_task` reads
`"provider registry not wired yet (issue #358)"`.

A second, complementary defect in the same module: `_build_zero_torque_lowcmd`
documented itself as dead code.

```
This helper is defined but not yet wired: ``G1Driver.stop`` and
``stop_task`` currently return refusal envelopes rather than publishing
a frame, and no other call site exists.
```

Every clause of that is false. `_ControlLoop._emit_zero_torque` calls it from the
loop's `finally` (`g1.py:1537`), and `G1Driver.stop_task`'s own docstring 370
lines above already said so: "the loop publishes `_build_zero_torque_lowcmd` on
the way out". Two docstrings in one module contradicting each other is worse than
either being vague, because a reader who meets the helper first is told the
soft-stop path does not exist and the reasonable conclusion is to build a second
one beside it.

## Change

The refusal drops the unresolvable half and keeps the issue that was already
there. Driven against the real driver with `_connected` set, `rt/lowstate`
delivered and a 92 percent pack:

| | `status` | text an operator receives |
|---|---|---|
| before (`2a0c03e3`) | `error` | `FSM id unknown - motion-switcher source has not been wired (harness#361 PR-C); see #2765 for the wire-side decision` |
| after | `error` | `FSM id unknown - motion-switcher source has not been wired; see issue #2765 for the wire-side decision` |

The verdict is unchanged and both phrases the existing tests pin (`FSM id unknown`
and `motion-switcher`) survive. The helper's paragraph now describes its call site.
The two remaining occurrences of the same unresolvable slug in this module's
docstrings go with them, since the slug resolves nowhere regardless of who reads it.

## Guards

Two, with scopes chosen by measurement rather than taste.

`tests/test_source_strings_resolve_their_issue_references.py` sweeps every string
a **caller** can receive across the package and requires each tracker reference in
it to be resolvable: a bare `#NNNN` for an issue here, or an owner-qualified
`owner/repo#NNNN` for a sibling. Both accepted spellings are pinned so the rule is
not blanket strictness, and the predicate is graded on constructed exemplars
because a clean tree can no longer exercise a rejection. Docstrings are excluded
and a boundary test records why: over twenty `robots-sim#NN` references sit in
developer-facing prose under `simulation/isaac`, `strands-labs/robots-sim` is a
real repository, and a maintainer reading a docstring has the sibling checkout an
operator holding a refusal envelope does not. That test fails if the docstring
population ever empties, at which point widening the scan is free. **Across the
whole package exactly one caller-reachable string violated the rule, and it was
this refusal.**

`tests/drivers/test_g1_zero_torque_docstring_matches_its_call_site.py` is scoped
to this module and to its module-private functions, which is the scope in which
matching a call by name is sound: a leading-underscore module-level function is
called by its bare name inside its own module. The same rule package-wide is
unsound and is deliberately not shipped, and the test says so - a public method
name like `send_action` is declared on several unrelated classes, so counting calls
by name would attribute every `robot.send_action` in the tree to whichever driver
declared it, and the Dynamixel driver, which legitimately documents its own bus as
not yet wired, would be reported as drifting when it is not.

## Verification

Pre-fix split, with the source reverted and both new test files kept:

```
2 failed, 9 passed
```

The two failures are the two regression cells, each naming the defect:

```
strands_robots/drivers/g1.py:613: harness#361
_build_zero_torque_lowcmd() at line 1194 claims it is unwired, but is called at [1537]
```

The 9 that pass are the premise, non-vacuity, exemplar and scope-boundary cells,
so no control is dirty. Post-fix all 11 pass.

* `ruff check strands_robots tests tests_integ` clean; `ruff format --check` clean over 1663 files.
* `mypy strands_robots tests tests_integ`: `Success: no issues found in 1659 source files`.
* `tests/drivers/` plus the whole source-strings and docstring guard family: `708 passed, 10 skipped`.
* A 440-file selection of every test that walks the tree, parses source or reads docstrings: `5 failed, 20706 passed, 87 skipped`. Those 5 are environmental and reproduce identically on a pristine `upstream/main` worktree at `2a0c03e3` (they assert `rclpy` is absent; it resolves on this machine). **0 introduced failures.**
* Rebased onto `5ded625b` and re-run: `1076 passed, 10 skipped`, lint clean.
* Cross-checked against the in-flight #2861, which asserts on this refusal: its tests are `2 passed, 1 xfailed` against the new text.

No documentation change: `grep -rniE 'harness#[0-9]+' docs/ *.md` is empty.
