### PR TITLE
fix(drivers/g1): FSM-set docstrings name the topic send_action actually writes

### DIFF
--- a/changelog.d/2866-g1-handshake-fsms-docstring-names-lowcmd.md
+++ b/changelog.d/2866-g1-handshake-fsms-docstring-names-lowcmd.md
@@ -1,0 +1,27 @@
+### Fixed: the FSM-set docstrings name the topic ``send_action`` actually writes
+
+Two docstrings said :data:`HANDSHAKE_FSMS` gated writes to ``rt/armsdk``:
+the ``#:`` block above ``HANDSHAKE_FSMS`` in ``strands_robots/tools/g1/_g1_common.py``
+and the ``_check_motion_gates`` docstring in ``strands_robots/drivers/g1.py``.
+Since #2767 landed, ``G1Driver.send_action`` publishes on ``rt/lowcmd`` -
+``_TOPIC_LOWCMD = "rt/lowcmd"`` and ``_pubs.publish(_TOPIC_LOWCMD, LowCmd_, cmd)``
+is the one write site.  The 500 Hz control loop wired by #2779 writes the same
+topic on every step and on stop.  A reader following ``HANDSHAKE_FSMS`` from
+either docstring was pointed at a topic string this file does not appear in and
+could not confirm by grep, and the two mentions of the real topic in the same
+module (``send_action``'s own docstring and its scope classification) already
+said "``rt/lowcmd``" - so the module contradicted itself.
+
+The arm-SDK-*shape* (the FSM set) and the arm-SDK-*topic* (``rt/armsdk``, which
+the ``g1_tools`` client for issue #358 will write) are not the same thing.  The
+docstrings now name the FSM set on its own terms (motion-switcher state) and
+cite ``rt/lowcmd`` as the topic the driver writes today; the ``rt/armsdk`` topic
+name is left where it belongs - inside the SDK error-code table for firmware
+response 7400, which is out of scope.
+
+The rule is pinned by
+``tests/drivers/test_g1_handshake_fsms_docstring_names_the_topic_it_gates``:
+two defect cells, both failed on ``main @ 5ded625b`` and pass on this branch;
+two premise cells (the constant is still declared, the write site still reads
+``_TOPIC_LOWCMD``); and one scope-boundary cell that pins the SDK error-table
+mention as legitimate so the rule cannot creep to a blanket ban.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -583,8 +583,10 @@ class G1Driver:
         """Return a refusal envelope if a motion write is not safe, else ``None``.
 
         Two FSM sets are enforced separately because the G1 documents them
-        separately: :data:`HANDSHAKE_FSMS` covers arm-SDK writes (``rt/armsdk``)
-        and :data:`WALK_FSMS` is narrower - sitting (500) accepts arm gestures
+        separately: :data:`HANDSHAKE_FSMS` covers arm-SDK-shaped writes (which
+        the driver publishes on ``rt/lowcmd`` today; the ``rt/armsdk`` topic
+        is future work for the ``g1_tools`` client in issue #358) and
+        :data:`WALK_FSMS` is narrower - sitting (500) accepts arm gestures
         but not walking. ``scope`` is the caller's declared kind of write:
 
         * ``"arm"`` - test :data:`HANDSHAKE_FSMS` and phrase the refusal as

--- a/strands_robots/tools/g1/_g1_common.py
+++ b/strands_robots/tools/g1/_g1_common.py
@@ -51,9 +51,13 @@ ERR_CODES: dict[int, str] = {
     7404: "Invalid FSM id - need FSM in {500, 501, 801}",
 }
 
-#: FSM ids where arm-SDK commands are honoured. Outside this set the arm
-#: refuses to move at all - so :meth:`~strands_robots.drivers.g1.G1Driver.send_action`
-#: checks membership before writing ``rt/armsdk``.
+#: FSM ids where arm-SDK-shaped commands are honoured. Outside this set the
+#: arm refuses to move at all - so
+#: :meth:`~strands_robots.drivers.g1.G1Driver.send_action` checks membership
+#: before publishing its ``LowCmd_`` on ``rt/lowcmd``. The set is defined
+#: against the motion-switcher FSM (arm-SDK, sit, sit-down), not against a
+#: topic name; the ``rt/armsdk`` topic itself is future work for the
+#: ``g1_tools`` client (issue #358) and this driver does not write it.
 HANDSHAKE_FSMS: frozenset[int] = frozenset({500, 501, 801})
 
 #: FSM ids where locomotion velocity commands are honoured. Narrower than

--- a/tests/drivers/test_g1_handshake_fsms_docstring_names_the_topic_it_gates.py
+++ b/tests/drivers/test_g1_handshake_fsms_docstring_names_the_topic_it_gates.py
@@ -1,0 +1,191 @@
+"""Regression: the FSM-set docstrings do not name a topic ``send_action`` does not write.
+
+Two docstrings in this driver claimed :data:`HANDSHAKE_FSMS` gates writes to
+``rt/armsdk``:
+
+* ``strands_robots/tools/g1/_g1_common.py`` on the ``HANDSHAKE_FSMS`` constant
+  itself: "so :meth:`~strands_robots.drivers.g1.G1Driver.send_action` checks
+  membership before writing ``rt/armsdk``".
+* ``strands_robots/drivers/g1.py`` on ``_check_motion_gates``: ":data:`HANDSHAKE_FSMS`
+  covers arm-SDK writes (``rt/armsdk``)".
+
+Neither is what the shipped driver does.  Since #2767 landed (2026-08-24)
+``G1Driver.send_action`` publishes on ``rt/lowcmd`` -- ``_TOPIC_LOWCMD`` is
+`"rt/lowcmd"` and ``_pubs.publish(_TOPIC_LOWCMD, LowCmd_, cmd)`` is the one
+write site.  The control loop wired by #2779 writes the same topic on every
+step and on stop.  The reader following ``HANDSHAKE_FSMS`` from either docstring
+was pointed at a topic string this file does not appear in and could not confirm
+by grep, and the two mentions of the real topic in the same module
+(``send_action``'s own docstring at line 635 and its scope classification at
+line 657) already say "``rt/lowcmd``" -- so the module contradicted itself.
+
+The confusion is worth naming: the arm-SDK-*shape* (the client that talks
+:data:`HANDSHAKE_FSMS` at the FSM level) and the arm-SDK-*topic* (``rt/armsdk``,
+which the ``g1_tools`` client for issue #358 will write) are not the same
+thing.  ``HANDSHAKE_FSMS`` is a set of FSM ids on the motion-switcher rail; the
+G1 driver's write for that shape lands on ``rt/lowcmd`` today, and the
+``rt/armsdk`` topic name appears in this package only inside the SDK error
+table (code 7400 says "``rt/armsdk`` topic is occupied", which is the
+firmware's own text and out of scope for this rule) and inside forward-looking
+docstrings for the issue #358 tools that do not exist yet.
+
+## Scope
+
+This test grades the two named docstrings only.  The rule is *not* a blanket
+ban on the ``rt/armsdk`` substring (which would fire on the SDK error table
+for firmware response 7400 and on forward-looking references to the
+``g1_tools`` client of issue #358); it is that where either docstring names a
+topic in the context of a currently-gated write, ``rt/lowcmd`` must appear.
+A docstring that mentions ``rt/armsdk`` alongside ``rt/lowcmd`` (naming
+future work explicitly) satisfies the rule; naming only ``rt/armsdk`` does
+not.
+
+## Fires on the defect, passes on the fix
+
+Both defect cells fail on ``main @ 5ded625b`` (where ``rt/armsdk`` is the only
+topic named beside :data:`HANDSHAKE_FSMS`) and pass after the fix (where
+``rt/lowcmd`` is named as today's write and ``rt/armsdk`` is optional
+context).  The two premise cells fail vacuously if a future refactor renames
+the constant or the write topic, at which point the pin has to move with it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import strands_robots
+from strands_robots.tools.g1 import _g1_common
+
+_PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
+
+
+def _read(rel: str) -> str:
+    return (_PACKAGE_DIR / rel).read_text(encoding="utf-8")
+
+
+def _handshake_docstring_in_common() -> str:
+    """The ``#:``-prefixed docstring above ``HANDSHAKE_FSMS`` in ``_g1_common``.
+
+    Sphinx renders ``#:`` lines that precede a module-level assignment as the
+    docstring for the assigned name, so the reader who follows
+    :data:`HANDSHAKE_FSMS` sees exactly this block.  The scan collects the
+    contiguous run of ``#:`` lines immediately above the assignment.
+    """
+    text = _read("tools/g1/_g1_common.py")
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        if line.startswith("HANDSHAKE_FSMS"):
+            # Walk backwards to the top of the contiguous ``#:`` block.
+            top = idx
+            while top > 0 and lines[top - 1].lstrip().startswith("#:"):
+                top -= 1
+            return "\n".join(lines[top:idx])
+    raise AssertionError("HANDSHAKE_FSMS assignment not found in _g1_common.py")
+
+
+def _check_motion_gates_docstring() -> str:
+    """The docstring on ``G1Driver._check_motion_gates``.
+
+    Extracted textually so the test does not have to import ``G1Driver`` (which
+    binds a DDS interface at construction time).  The scan captures from the
+    ``def _check_motion_gates`` line to the closing ``\"\"\"`` that follows the
+    first ``\"\"\"`` opening on the next line.
+    """
+    text = _read("drivers/g1.py")
+    match = re.search(
+        r'def _check_motion_gates\(.*?\n\s+"""(.*?)"""',
+        text,
+        flags=re.DOTALL,
+    )
+    assert match is not None, "_check_motion_gates docstring not found in drivers/g1.py"
+    return match.group(1)
+
+
+# ---------------------------------------------------------------------------
+# Premise cells -- exist so a rename can never make the defect cells vacuous.
+# ---------------------------------------------------------------------------
+
+
+def test_premise_handshake_fsms_still_declared_in_g1_common() -> None:
+    """The constant this file grades is at the location it grades."""
+    assert isinstance(_g1_common.HANDSHAKE_FSMS, frozenset)
+    assert _g1_common.HANDSHAKE_FSMS == frozenset({500, 501, 801})
+
+
+def test_premise_send_action_writes_rt_lowcmd() -> None:
+    """The topic the docstrings must name is the one the driver writes.
+
+    Read out of the module source (not out of an import that would touch the
+    SDK).  If ``_TOPIC_LOWCMD`` moves or is renamed, this cell fires before the
+    defect cell it supports so a reader is not left grading the wrong site.
+    """
+    text = _read("drivers/g1.py")
+    assert '_TOPIC_LOWCMD = "rt/lowcmd"' in text
+    # And the one write site in ``send_action`` reads that constant.
+    assert "_pubs.publish(_TOPIC_LOWCMD, LowCmd_, cmd)" in text
+
+
+# ---------------------------------------------------------------------------
+# Defect cells -- both fire on main, both pass after the fix.
+# ---------------------------------------------------------------------------
+
+
+def test_handshake_fsms_docstring_does_not_name_a_topic_send_action_does_not_write() -> None:
+    """The ``HANDSHAKE_FSMS`` docstring in ``_g1_common`` cites ``rt/lowcmd`` where it names a topic.
+
+    The defect was a docstring that said :meth:`send_action` writes ``rt/armsdk``.
+    The fix does not have to strip every mention of ``rt/armsdk`` - it may
+    legitimately distinguish today (``rt/lowcmd``) from future work
+    (``rt/armsdk``, issue #358) - but a docstring that mentions ``rt/armsdk``
+    without also naming ``rt/lowcmd`` in the same block is naming only the
+    wrong topic.  The rule is *not* "must never say ``rt/armsdk``"; it is
+    "if the reader is told a topic name in the ``send_action`` neighbourhood,
+    ``rt/lowcmd`` must be one of them."
+    """
+    doc = _handshake_docstring_in_common()
+    if "send_action" not in doc:
+        return  # the docstring may have been rewritten to omit send_action entirely
+    if "rt/armsdk" in doc:
+        assert "rt/lowcmd" in doc, (
+            "HANDSHAKE_FSMS docstring names rt/armsdk in a send_action context "
+            "without also naming rt/lowcmd; the shipped driver writes rt/lowcmd (#2767) "
+            "and the reader must be told which one send_action writes today."
+        )
+
+
+def test_check_motion_gates_docstring_does_not_conflate_the_arm_shape_with_the_armsdk_topic() -> None:
+    """The ``_check_motion_gates`` docstring must not tie ``HANDSHAKE_FSMS`` to ``rt/armsdk`` alone.
+
+    The original phrasing was ":data:`HANDSHAKE_FSMS` covers arm-SDK writes
+    (``rt/armsdk``)".  ``HANDSHAKE_FSMS`` gates the FSM shape, and the write
+    that shape produces today lands on ``rt/lowcmd``; the ``rt/armsdk`` topic
+    is future work for issue #358's ``g1_tools`` client.  A docstring naming
+    ``rt/armsdk`` without also naming ``rt/lowcmd`` reads as an authoritative
+    statement of what ``send_action`` does today, which is wrong.
+    """
+    doc = _check_motion_gates_docstring()
+    if "rt/armsdk" in doc:
+        assert "rt/lowcmd" in doc, (
+            "_check_motion_gates docstring names rt/armsdk without naming rt/lowcmd; "
+            "the driver's arm write goes to rt/lowcmd today (#2767) and the reader "
+            "must be able to see that from this docstring."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scope-boundary cell -- keeps the rule from creeping.
+# ---------------------------------------------------------------------------
+
+
+def test_scope_the_sdk_error_table_still_names_rt_armsdk_because_that_is_the_sdks_text() -> None:
+    """The error-code table quotes SDK text: ``rt/armsdk topic is occupied``.
+
+    That is not a claim about what this driver writes; it is the firmware's
+    own error string for response code 7400 and must survive unchanged so a
+    real error surfaces with the same text the SDK sends.  If the rule ever
+    grew to blanket-ban the substring, it would fire here and this file's
+    scope would need re-stating.
+    """
+    text = _read("tools/g1/_g1_common.py")
+    assert "rt/armsdk topic is occupied" in text


### PR DESCRIPTION
## Problem

Two docstrings said :data:`HANDSHAKE_FSMS` gates writes to `rt/armsdk`:

1. The `#:` docstring above `HANDSHAKE_FSMS` in `strands_robots/tools/g1/_g1_common.py`:
   > "so `G1Driver.send_action` checks membership before writing `rt/armsdk`"
2. The `_check_motion_gates` docstring in `strands_robots/drivers/g1.py`:
   > "`HANDSHAKE_FSMS` covers arm-SDK writes (`rt/armsdk`)"

Neither is what the shipped driver does. Since **#2767 landed on 2026-08-24**, `G1Driver.send_action` publishes on `rt/lowcmd`:

```python
_TOPIC_LOWCMD = "rt/lowcmd"
# ...
pub_err = self._pubs.publish(_TOPIC_LOWCMD, LowCmd_, cmd)
```

That is the **one write site** in `send_action`, and the 500 Hz control loop wired by **#2779** writes the same topic on every step and on stop. Two other mentions of the write topic in the same module (`send_action`'s own docstring at L635 and its scope classification at L657) already said `rt/lowcmd`, so the module contradicted itself.

## The confusion, named

The arm-SDK **shape** (the client that talks `HANDSHAKE_FSMS`-space at the FSM level) and the arm-SDK **topic** (`rt/armsdk`, which the `g1_tools` client for issue #358 will write) are not the same thing. `HANDSHAKE_FSMS` is a set of FSM ids on the motion-switcher rail; the G1 driver's write for that shape lands on `rt/lowcmd` today.

The `rt/armsdk` string appears in this package only inside:
- the SDK error-code table (code 7400: `"rt/armsdk topic is occupied"`, which is firmware text — out of scope), and
- the `strands_robots.tools.g1` package docstring, which lists topics that package will **carry** including future ones.

Neither of those is the defect; both are legitimate.

## Change

- `_g1_common.py` `HANDSHAKE_FSMS` docstring: names the FSM set on its own terms (motion-switcher FSM: arm-SDK, sit, sit-down), cites `rt/lowcmd` as where `send_action` publishes today, and explicitly notes the `rt/armsdk` topic is future work for issue #358.
- `drivers/g1.py` `_check_motion_gates` docstring: same fix — arm-SDK-shaped writes go to `rt/lowcmd` today; `rt/armsdk` is future work.

## Guard: `tests/drivers/test_g1_handshake_fsms_docstring_names_the_topic_it_gates.py`

Five cells:

| Cell | Kind | On main (defect) | On fix |
|---|---|---|---|
| `test_premise_handshake_fsms_still_declared_in_g1_common` | premise | PASS | PASS |
| `test_premise_send_action_writes_rt_lowcmd` | premise | PASS | PASS |
| `test_handshake_fsms_docstring_does_not_name_a_topic_send_action_does_not_write` | **defect** | **FAIL** | PASS |
| `test_check_motion_gates_docstring_does_not_conflate_the_arm_shape_with_the_armsdk_topic` | **defect** | **FAIL** | PASS |
| `test_scope_the_sdk_error_table_still_names_rt_armsdk_because_that_is_the_sdks_text` | scope-boundary | PASS | PASS |

The rule is **not** "must never say `rt/armsdk`" (that would fire on the SDK error table and on the forward-looking package docstring — neither is the defect). It is **"where either named docstring cites a topic, `rt/lowcmd` must appear."** A docstring that mentions `rt/armsdk` alongside `rt/lowcmd` (naming future work explicitly) satisfies the rule; naming only `rt/armsdk` does not.

The premise cells guard the defect cells from silent vacuity: if `HANDSHAKE_FSMS` is renamed or `_TOPIC_LOWCMD` moves, the premise cells fire first so a reader is not left grading the wrong site. The scope-boundary cell keeps the rule from creeping to a blanket ban.

## Break table

Both defect cells were driven against both trees before the source change was written:

| tree | defect cells fired | scope-boundary held |
|---|---|---|
| `main @ 5ded625b` (defect present) | 2 of 2 | yes |
| fix branch | 0 of 2 | yes |
| premise-only revert (only rename premise) | 0 of 2 vacuously — premise cells fire first | — |

## Verification

- `pytest tests/drivers/test_g1_handshake_fsms_docstring_names_the_topic_it_gates.py`: **5 passed** on fix; **2 failed, 3 passed** on main (defect cells fire; premise + scope-boundary hold).
- `pytest tests/drivers/test_g1_driver.py tests/drivers/test_g1_control_loop.py tests/drivers/test_g1_battery_floor_is_gated_behind_the_unwired_fsm.py tests/tools/g1/ tests/drivers/test_g1_handshake_fsms_docstring_names_the_topic_it_gates.py`: **189 passed, 9 skipped** (SDK-gated cells, no runner has the SDK).
- `pytest tests/test_source_strings_no_review_archaeology.py tests/test_source_strings_no_internal_file_paths.py tests/test_source_strings_no_unicode_dashes.py tests/test_source_strings_no_emoji.py`: **14 passed** (source-string family unaffected).
- `ruff check strands_robots tests`: clean.
- `ruff format --check strands_robots tests`: `1608 files already formatted`.
- **Module-load hygiene**: `import strands_robots.drivers.g1; import strands_robots.tools.g1._g1_common` — `unitree_sdk2py` in `sys.modules`: `[]`. The test file itself imports zero `unitree_*` modules.

## Refs

- **#2767** — feat(g1): wire send_action to publish LowCmd_ on rt/lowcmd (issue #361, PR-B)
- **#2779** — feat(g1): wire the 500 Hz control loop (issue #361, PR-C)
- **#358** — the future `g1_tools` client that will write `rt/armsdk`
- harness#361

Size: 4 files, 229 insertions, 5 deletions. Docs-heavy (test file is the argument; source change is 8 modified lines).
