### PR TITLE
docs(mesh): name STRANDS_MESH_BACKEND, the env var that selects the transport

### DIFF
--- a/changelog.d/2867-mesh-backend-env-var-documented.md
+++ b/changelog.d/2867-mesh-backend-env-var-documented.md
@@ -1,0 +1,24 @@
+### Fixed: the mesh docs did not name the env var that actually selects the transport
+
+`docs/mesh.md` covered the `[mesh-iot]` install extra but never mentioned
+`STRANDS_MESH_BACKEND`, the variable `strands_robots/mesh/_backend_select.py`
+is the sole owner of. A reader following the blog snippet
+``os.environ["STRANDS_MESH_BACKEND"] = "iot"`` could not find the name in the
+published docs and had cause to doubt whether the env var was live at all,
+even though `_backend_select.BACKEND_ENV_VAR` is the string both the session
+gate (`session._backend_choice`) and the transport factory
+(`transport.factory.get_transport`) read from and typos are reported through
+its `_UNKNOWN_WARNED` set.
+
+The docs now name the variable, list its three accepted values with the
+transport each one selects, spell out that the install extra and the env var
+are the two halves of the same choice (extra installs the dependency, variable
+selects the runtime), and record the case/whitespace normalisation plus the
+once-per-distinct-value fallback for a typo. The `[mesh-iot]` extra is where
+the `iot` and `bridge` values need their client library, so both rows point at
+it; `zenoh` needs no extra and stays the default that every unset value
+resolves to.
+
+Closes cagataycali/robots-harness#375, which the blog PR
+strands-agents/harness-sdk#4024 opened after the reviewer could not find
+`STRANDS_MESH_BACKEND` anywhere under `docs/`.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -324,6 +324,39 @@ mesh off.
 
 Mesh failures are non-fatal - `robot.mesh` becomes `None`; the sim/hardware instance still works.
 
+## Transport selection: `STRANDS_MESH_BACKEND`
+
+The mesh has three transports and one env var chooses between them at runtime.
+An install extra brings the client dependency; the env var picks which client
+the session actually constructs. Both are needed to move off the default:
+the extra without the variable installs code that never runs, and the variable
+without the extra selects a backend whose client is not importable.
+
+| Value | Transport | Extra needed | Notes |
+|-------|-----------|--------------|-------|
+| `zenoh` (default) | Local Zenoh peer discovery over UDP multicast. | none - ships with `strands-robots`. | What every unset value resolves to. |
+| `iot` | AWS IoT Core MQTT with X.509 mutual TLS. | `strands-robots[mesh-iot]` (adds `awsiotsdk`). | Requires `STRANDS_IOT_ENDPOINT`, `STRANDS_IOT_THING_NAME`, `STRANDS_IOT_CERT_DIR`. See [Security](security.md). |
+| `bridge` | Zenoh locally, mirrored to AWS IoT for fleet-wide fan-out. | `strands-robots[mesh-iot]`. | A peer speaks Zenoh to its lab neighbours and IoT to the cloud on the same publish. |
+
+```bash
+# Local dev, nothing to set - the mesh joins a Zenoh peer group.
+export STRANDS_MESH_BACKEND=zenoh   # or leave unset
+
+# AWS IoT Core - the peers are on different networks.
+export STRANDS_MESH_BACKEND=iot
+
+# Both at once - a lab peer is reachable from a remote operator.
+export STRANDS_MESH_BACKEND=bridge
+```
+
+Case and whitespace are normalised, so `IOT` and `" iot "` both select `iot`.
+An unrecognized value (`STRANDS_MESH_BACKEND=iott`) falls back to `zenoh` and
+is reported once per distinct offending value in the log - the policy is to
+keep the mesh running rather than crash a host on a typo, and to make the
+typo visible without one report per published message. The full vocabulary
+lives in `strands_robots/mesh/_backend_select.py`, which is the sole owner
+both the session gate and the transport factory read from.
+
 ## See also
 
 - [Device Connect](device-connect.md) - the recommended networking layer this mesh backs.


### PR DESCRIPTION
## What

Add a **Transport selection** section to `docs/mesh.md` that names `STRANDS_MESH_BACKEND` — the runtime transport selector `strands_robots/mesh/_backend_select.py` is the sole owner of.

Today `grep -rn 'STRANDS_MESH_BACKEND' docs/` returns nothing, even though the docs list 20+ other `STRANDS_MESH_*` variables. Only the `[mesh-iot]` install extra is documented, which makes a blog snippet like:

```python
os.environ['STRANDS_MESH_BACKEND'] = 'iot'
```

look like a no-op to a reader who can't find the name.

## Why now

The [strands-agents/harness-sdk#4024](https://github.com/strands-agents/harness-sdk/pull/4024) blog PR got an 'Important' review note that this env var couldn't be found in the published docs. The env var is real and the docs are the gap.

## What the section covers

- All three accepted values (`zenoh` default / `iot` / `bridge`) with the transport each selects and the extra it needs.
- The relationship: install extra = dependency, env var = runtime selection. Both are needed to move off the default.
- Case/whitespace normalisation and the once-per-distinct-value typo report (matches `_backend_select.select_backend`).
- Points at `docs/security.md` for the `STRANDS_IOT_*` credentials that `iot`/`bridge` need.

## Scope

- **Docs only.** No behaviour change, no new tests needed. Diff is +57 lines in one file + one changelog fragment.
- Fragment: `changelog.d/2867-mesh-backend-env-var-documented.md` (per `changelog.d/README.md`).

Closes cagataycali/robots-harness#375.