### PR TITLE
fix(assets): let the directory resolver decline the fetch it cannot use

### DIFF
--- a/changelog.d/2868-asset-dir-resolver-can-decline-the-fetch.md
+++ b/changelog.d/2868-asset-dir-resolver-can-decline-the-fetch.md
@@ -1,0 +1,27 @@
+### Fixed: the asset directory resolver can decline the fetch it cannot use
+
+`resolve_model_dir` reads the filesystem. It returns a directory that already exists on a search path
+and never downloads the asset, so the only call in it that can reach the network is the shared
+registry lookup - which falls back to `robot_descriptions` discovery for any name the curated
+registry does not know, and that import *is* the fetch, because `robot_descriptions` calls
+`clone_to_cache` at module scope.
+
+That left the resolver that cannot download as the one whose caller could not decline a download.
+Asking where a discovery-only robot's directory is clones the upstream asset corpus, while the same
+question about a curated robot clones nothing, and the resolver reaches the asset downloader zero
+times where its sibling `resolve_model_path` reaches it once for the same absent robot.
+`discover_robot` is documented "Call only from asset-resolution paths that are allowed to download",
+and this is not one of them.
+
+`resolve_model_dir` now takes `allow_download`, spelled and forwarded exactly as `resolve_model_path`
+has done since the fetch was first made declinable, so `allow_download=False` is a pure filesystem
+lookup with no network and no `robot_descriptions` import. The default stays open, so the long tail
+still resolves for a caller about to load a model and no existing answer changes.
+
+The one in-tree consumer documented the opposite. The cuRobo planner example reported that
+`resolve_model_dir` "triggers the same auto-download the MuJoCo path uses, so a clean box with
+internet populates the cache here too"; it triggers none, so on a cold cache the helper returned no
+URDF and sent the reader back to the manual `--curobo-urdf` flag its own docstring says it removed.
+It now declines the network for its best-effort probe and, on a miss, downloads through the capable
+sibling and re-resolves the directory - rather than taking the model XML's parent, which is not the
+asset directory for the robots that nest their XML in a subdirectory.

--- a/examples/so101_curobo/planner.py
+++ b/examples/so101_curobo/planner.py
@@ -67,18 +67,32 @@ def _so101_cache_urdf() -> tuple[str | None, str]:
 
     Returns ``(urdf_path, asset_path)``; ``urdf_path`` is ``None`` when the
     cache / package isn't available (so callers keep their existing
-    "raise an actionable error" behaviour). ``resolve_model_dir`` triggers the
-    same auto-download the MuJoCo path uses, so a clean box with internet
-    populates the cache here too.
+    "raise an actionable error" behaviour). The directory probe declines the
+    network, because a best-effort helper should not clone an asset repository
+    to answer a question about the local cache. When the cache is cold,
+    ``resolve_model_path`` performs the same auto-download the MuJoCo path uses
+    and the directory is re-resolved from the registry, so a clean box with
+    internet populates the cache here too.
     """
     try:
         import glob
 
-        from strands_robots.assets import resolve_model_dir  # type: ignore[import-not-found]
+        from strands_robots.assets import (  # type: ignore[import-not-found]
+            resolve_model_dir,
+            resolve_model_path,
+        )
     except Exception:  # noqa: BLE001
         return None, ""
     try:
-        model_dir = resolve_model_dir("so101")
+        # The common case is the box the MuJoCo demo already ran on, so ask the
+        # filesystem first and take no side effect for an answer already here.
+        model_dir = resolve_model_dir("so101", allow_download=False)
+        if not model_dir:
+            # Cold cache: this is the call that downloads. Re-resolve the
+            # directory afterwards rather than taking the XML's parent, because
+            # several robots nest their model XML in a subdirectory.
+            if resolve_model_path("so101") is not None:
+                model_dir = resolve_model_dir("so101")
     except Exception:  # noqa: BLE001
         return None, ""
     if not model_dir:

--- a/strands_robots/assets/manager.py
+++ b/strands_robots/assets/manager.py
@@ -311,16 +311,36 @@ def resolve_model_path(
     return Path(candidates[0])
 
 
-def resolve_model_dir(name: str) -> Path | None:
+def resolve_model_dir(name: str, *, allow_download: bool = True) -> Path | None:
     """Resolve a robot name to its asset directory (containing XML + meshes).
+
+    This resolver reads the filesystem. It returns a directory that already
+    exists on a search path and never downloads the asset itself, so the only
+    call here that can reach the network is the registry lookup: :func:`_lookup`
+    falls back to ``robot_descriptions`` discovery for a name the curated
+    registry does not know, and that import *is* the fetch.
+
+    That left this resolver holding the side effect without the capability.
+    ``discover_robot`` is documented "Call only from asset-resolution paths that
+    are allowed to download", and this path downloads nothing, yet its caller had
+    no way to decline the clone the way :func:`resolve_model_path`'s caller can.
+    ``allow_download=False`` closes that gap and makes this a pure filesystem
+    lookup - no network, no ``robot_descriptions`` import.
+
+    The default stays open, so the long tail still resolves for a caller about to
+    load a model. Declining costs the answer only for a robot that discovery
+    alone can name; a curated robot never reaches the fallback either way.
 
     Args:
         name: Robot name (canonical or alias).
+        allow_download: When False, answer from the curated registry alone
+            rather than letting the discovery fallback clone the upstream asset
+            repository.
 
     Returns:
         Path to the robot's asset directory, or None if not found.
     """
-    info = _lookup(name)
+    info = _lookup(name, allow_discovery=allow_download)
     if not info or "asset" not in info:
         return None
 

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -666,3 +666,185 @@ class TestResolveModelDirEdges:
             lambda _name: {"asset": {"dir": "ghostbot", "model_xml": "ghost.xml"}},
         )
         assert manager.resolve_model_dir("ghost") is None
+
+
+class TestTheDirectoryResolverCanDeclineTheSameFetch:
+    """The directory resolver holds the side effect without the capability.
+
+    :func:`~strands_robots.assets.manager.resolve_model_dir` reads the
+    filesystem: it returns a directory that already exists on a search path and
+    never downloads the asset. Its first statement is the shared registry
+    lookup, though, which falls back to ``robot_descriptions`` discovery for any
+    name the curated registry does not know - and that import *is* the fetch,
+    because ``robot_descriptions`` calls ``clone_to_cache`` at module scope.
+
+    So the resolver that cannot download was the one whose caller could not
+    decline a download. ``discover_robot`` is documented "Call only from
+    asset-resolution paths that are allowed to download"; this path is not one.
+    Its sibling :func:`resolve_model_path` has offered ``allow_download`` since
+    the fetch was first made declinable, and it hands that keyword to the lookup.
+
+    The default stays open, so ``test_the_sibling_resolvers_still_consult_discovery``
+    above - the control that pinned these callers as untouched - keeps passing.
+    """
+
+    @staticmethod
+    def _recording_discovery(consulted: list[str], entry: dict | None = None):
+        """Stand in for the discovery fallback, recording every consultation."""
+
+        def discover(name: str) -> dict | None:
+            consulted.append(name)
+            return entry
+
+        return discover
+
+    def _patch_discovery(self, monkeypatch, consulted: list[str], entry: dict | None = None) -> None:
+        from strands_robots.registry import discovery
+
+        discovery.invalidate_cache()
+        monkeypatch.setattr(discovery, "discover_robot", self._recording_discovery(consulted, entry))
+
+    # -- premise: the resolver has no capability to justify the side effect --
+
+    def test_the_directory_resolver_downloads_nothing(self, tmp_path, monkeypatch):
+        """It never reaches the downloader, while its sibling does.
+
+        This is what makes the unavoidable clone a defect rather than a cost of
+        doing business: the fetch it could not decline is one it cannot use.
+        """
+        robot_dir = _register_bot(tmp_path / "assets")
+        (robot_dir / "unitbot.xml").unlink()  # absent asset: the downloading trigger
+        _invalidate_cache()
+        attempts: list[str] = []
+        monkeypatch.setattr(manager, "_auto_download_robot", lambda n, _i: attempts.append(n) or False)
+
+        # The directory is still here; only the model XML is gone. The resolver
+        # answers from the filesystem and takes no side effect for the absence.
+        assert manager.resolve_model_dir("unitbot") == robot_dir
+        assert attempts == [], "resolve_model_dir must not download; it only reads the filesystem"
+
+        manager.resolve_model_path("unitbot")
+        assert attempts == ["unitbot"], "resolve_model_path is the download-capable sibling"
+
+    # -- regression --------------------------------------------------------
+
+    def test_declining_skips_the_discovery_fallback(self, monkeypatch):
+        """``allow_download=False`` answers from the curated registry alone."""
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted)
+
+        assert manager.resolve_model_dir("not-in-the-curated-registry", allow_download=False) is None
+        assert consulted == [], f"a declined directory resolve reached discovery: {consulted!r}"
+
+    def test_the_resolver_hands_its_own_flag_to_the_lookup(self):
+        """Read the keyword's value, not its presence.
+
+        Forwarding ``allow_discovery=True`` spells the same keyword and restores
+        the clone, so a scan for the name alone would pass on the defect.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(manager.resolve_model_dir)))
+        forwards = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_lookup"
+        ]
+        assert len(forwards) == 1, f"expected one _lookup call, found {len(forwards)}"
+        passed = {kw.arg: ast.unparse(kw.value) for kw in forwards[0].keywords if kw.arg is not None}
+        assert passed.get("allow_discovery") == "allow_download", (
+            f"resolve_model_dir must hand its own allow_download to the lookup; it passes {passed!r}"
+        )
+
+    # -- over-reach controls: nothing else changes -------------------------
+
+    def test_the_default_still_consults_discovery(self, monkeypatch):
+        """The long tail still resolves for a caller about to load a model."""
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted)
+
+        manager.resolve_model_dir("not-in-the-curated-registry")
+
+        assert consulted == ["not-in-the-curated-registry"]
+
+    def test_a_curated_name_is_unaffected(self, tmp_path, monkeypatch):
+        """Declining changes no answer for a name the curated registry knows."""
+        robot_dir = _register_bot(tmp_path / "assets")
+        consulted: list[str] = []
+        self._patch_discovery(monkeypatch, consulted)
+
+        assert manager.resolve_model_dir("unitbot", allow_download=False) == robot_dir
+        assert consulted == [], "a curated hit must not reach the fallback at all"
+
+    # -- second layer: the same question, of the real registry ------------
+
+    def test_a_really_discoverable_name_is_declined(self):
+        """Independent oracle: real registry data, no stand-in."""
+        pytest.importorskip("robot_descriptions")
+        import sys
+
+        from strands_robots.registry import get_robot
+        from strands_robots.registry.discovery import list_discoverable
+
+        candidates = [name for name in sorted(list_discoverable()) if get_robot(name) is None]
+        assert candidates, "no discoverable name is outside the curated registry to test with"
+
+        name = candidates[0]
+        before = {m for m in sys.modules if m.startswith("robot_descriptions")}
+        assert manager.resolve_model_dir(name, allow_download=False) is None
+        new = {m for m in sys.modules if m.startswith("robot_descriptions")} - before
+        assert new == set(), f"declining {name!r} imported description modules: {sorted(new)}"
+
+    # -- the consumer -----------------------------------------------------
+
+    def test_the_curobo_helper_reaches_the_resolver_that_can_download(self):
+        """The example's docstring promises a download; only one resolver does one.
+
+        It reported that this helper "triggers the same auto-download the MuJoCo
+        path uses" while calling the resolver measured above to download nothing,
+        so on a cold cache it returned no URDF and sent the reader back to the
+        manual flag its own docstring says it removed.
+        """
+        import ast
+
+        source = Path("examples/so101_curobo/planner.py").read_text()
+        helper = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name == "_so101_cache_urdf"
+        )
+        called = {
+            node.func.id for node in ast.walk(helper) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "resolve_model_path" in called, (
+            "the helper documents an auto-download, so it must reach the resolver that performs one"
+        )
+        declined = [
+            node
+            for node in ast.walk(helper)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "resolve_model_dir"
+            and any(kw.arg == "allow_download" and kw.value.value is False for kw in node.keywords)
+        ]
+        assert declined, "the best-effort probe must decline the network rather than clone a corpus"
+
+    def test_the_xml_parent_is_not_the_asset_directory(self, tmp_path):
+        """Why the helper re-resolves instead of taking the model XML's parent.
+
+        A robot may nest its model XML in a subdirectory, and several shipped
+        ones do, so the parent of a resolved XML is not the asset directory for
+        them - a shortcut that would have looked right on the robots that do not.
+        """
+        assets = tmp_path / "assets"
+        (assets / "nestbot" / "xml").mkdir(parents=True, exist_ok=True)
+        robot_dir = _register_bot(assets, name="nestbot", xml_name="xml/nestbot.xml")
+
+        path = manager.resolve_model_path("nestbot", allow_download=False)
+        directory = manager.resolve_model_dir("nestbot", allow_download=False)
+
+        assert path == robot_dir / "xml" / "nestbot.xml"
+        assert directory == robot_dir
+        assert path.parent != directory, "a nested XML's parent is not the asset directory"


### PR DESCRIPTION
## Problem

`resolve_model_dir` reads the filesystem. It returns a directory that already exists on a search
path and never downloads the asset, so the only call in it that can reach the network is the shared
registry lookup - and `_lookup` falls back to `robot_descriptions` discovery for any name the curated
registry does not know. That import *is* the fetch, because `robot_descriptions` calls
`clone_to_cache` at module scope.

So the resolver that cannot download was the one whose caller could not decline a download. Measured
on this tree, with `clone_to_cache` and the asset downloader replaced by recording stand-ins:

| call | returns | `clone_to_cache` calls | asset-downloader calls |
|---|---|---|---|
| `resolve_model_dir("gen3")` | (clone blocked by the spy) | **1** (`mujoco_menagerie`) | - |
| `resolve_model_dir("rizon4")` | (clone blocked by the spy) | **1** (`mujoco_menagerie`) | - |
| `resolve_model_dir("so101")` (curated, control) | a real path | **0** | - |
| `resolve_model_path("gen3", allow_download=False)` (sibling) | `None` | **0** | - |
| `resolve_model_dir(<absent curated robot>)` | the directory | - | **0** |
| `resolve_model_path(<the same robot>)` | `None` | - | **1** |

The last two rows are what make the unavoidable clone a defect rather than a cost of doing business:
the fetch the caller could not decline is one this resolver cannot use. `discover_robot` is
documented "Call only from asset-resolution paths that are allowed to download", and `_lookup`'s own
docstring says it is "used only by download-capable resolvers"; this path downloads nothing.

Nine names in the installed registry are reachable only through discovery (`gen3`, `iiwa14`,
`mujoco_humanoid`, `n1`, `openarm_v1`, `rizon4`, `so_arm101`, `viper`, `widow`), so asking where any
of their directories is clones the upstream asset repository.

## Fix

`resolve_model_dir` takes `allow_download`, spelled and forwarded exactly as `resolve_model_path`
has since the fetch was first made declinable, so `allow_download=False` is a pure filesystem lookup
with no network and no `robot_descriptions` import.

The default stays open. `test_the_sibling_resolvers_still_consult_discovery[resolve_model_dir]` - the
control added with `allow_download` to pin this caller as untouched - keeps passing, and the long
tail still resolves for a caller about to load a model. A discovery-only robot's asset genuinely can
be on disk, because `auto_download_robot` takes the entry as an argument and writes into
`get_assets_dir()`, so closing discovery unconditionally would have cost that answer.

`get_robot_info` is deliberately unchanged: it calls `resolve_model_path(name)` with downloads
enabled, so it is a download-capable resolver and the keyword would have nothing to decline.

## The consumer documented the opposite

`examples/so101_curobo/planner.py` reported that `resolve_model_dir` "triggers the same auto-download
the MuJoCo path uses, so a clean box with internet populates the cache here too". It triggers none -
zero downloader calls above - so on a cold cache that helper returned no URDF and sent the reader
back to the manual `--curobo-urdf` flag its own docstring says it removed.

It now declines the network for the best-effort probe, and on a miss downloads through the capable
sibling and re-resolves the directory. It does **not** take the resolved XML's parent: that is not
the asset directory for 6 of the 61 robots installed here (`aliengo`, `asimov_v0`, `jvrc`, `lekiwi`,
`reachy_mini`, `unitree_a1`), which nest their model XML in a subdirectory - a shortcut that would
have looked right on the 55 that do not.

## Why nothing caught it

The control that covers these callers asserts only that the lookup's gate "defaults open, so its
other two callers are untouched" - a no-regression claim about the change that introduced the
keyword, silent on whether a caller of this resolver should be able to decline at all.

## Tests

Nine cells in `tests/test_asset_manager.py`, mirroring the sibling class's stand-in and its
value-reading AST check. Behavioural revert (signature kept, only the forwarding undone): **3
failed**. Raw revert of both halves: **6 failed**, of which 2 fail as signature artifacts because
they pass the new keyword.

| mutation | collected | fires |
|---|---|---|
| control (fix in place) | 56 | 0 |
| resolver half reverted | 56 | 5 |
| example half reverted | 56 | 1 |
| both reverted (raw) | 56 | 6 |
| forwards `allow_discovery=True` (keyword present, value wrong) | 56 | 3 |
| keyword accepted, never forwarded | 56 | 3 |

`b1 | b2 == b3` exactly, with an **empty** intersection, so each half is independently pinned. The
last two rows share a firing set for a structural reason - both mean discovery is consulted whatever
the caller asked - and they are why the AST cell reads the keyword's *value* rather than its
presence. Source restored byte-identical after the table.

Over-reach controls that hold both ways: the default still consults discovery, a curated name never
reaches the fallback, and the resolver still downloads nothing.

## Gate

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `examples`
clean too. mypy: 5 errors in 4 files, the standing baseline on this tree, **0 attributable** to the
changed files.

Paired run over a 417-file selection (every suite that walks the tree, parses source, reads
docstrings, or names assets/registry/discovery/examples), identical on both trees with the changed
test file excluded from each: **20042 collected, 19 failed, 19955 passed, 68 skipped on both**, 19
identical failing ids, `comm` empty in both directions, distinct rootdirs. Of the 19, 17 need
`awsiot` (absent here, declared in the `mesh-iot` extra that CI installs) and 2 are the
lerobot-from-source `encode()` drift; all 19 reproduce on the base alone. The changed test file runs
separately: **56 passed, 0 skipped**.

No visual artifact: nothing rendered or recorded changes. The measured clone and downloader counts
above are the evidence.
