### PR TITLE
fix(simulation/ik): refuse an IK knob that cannot be honored instead of solving with it

### DIFF
--- a/changelog.d/2869-ik-bridge-numeric-parameter-domains.md
+++ b/changelog.d/2869-ik-bridge-numeric-parameter-domains.md
@@ -1,0 +1,41 @@
+### Fixed: an IK knob that cannot be honored is refused instead of solved with
+
+`MinkIKBridge` is the one home for the mink differential-IK solve, re-exported as
+the public `MinkIKBridge` of the `cosmos3` and `vera` providers and documented as
+a constructor a caller builds directly. It validated two of its arguments
+thoroughly - `commanded_dofs` per element, with `bool` rejected by name and every
+index range-checked, and `solver` through `resolve_qp_solver` - and handed its
+eight numeric knobs straight through to mink.
+
+Every one of those knobs is *applied* rather than forwarded: `max_iters` bounds
+the `range` the solve loop iterates, `dt` integrates the joint velocity, `damping`
+and the three task costs weight the QP, and the two thresholds decide when the
+loop breaks. So an unusable value produced a plausible-looking joint
+configuration rather than an error. Measured on a Franka Panda asked to move its
+hand 80 mm, a move whose converged residual is 0.761 mm: `max_iters=0` (also
+`False`, also a negative count) made `range` empty, so `solve` ran the solver
+**zero times** and returned `q_init` unchanged with the whole 80 mm still to go -
+a solve that never happened, handed back as one. `max_iters=True` ran exactly one
+iteration (14.147 mm). Both convergence thresholds infinite made the *first*
+iteration count as converged, byte-identical to `max_iters=1`. A `dt` of `0.0`,
+`nan` or `inf`, a `damping` of `nan`, and any infinite task cost each returned an
+all-NaN configuration; `damping=inf` produced no joint motion at all.
+
+The remaining spellings failed *late* instead: a fractional, whole-float,
+non-finite, string or `None` `max_iters` raised `TypeError` from `range` inside
+`solve`, and a negative `damping` raised `qpsolvers`' "matrix P is not positive
+definite" - all after the QP backend was resolved, both mink tasks were built and
+the bridge had logged that it was ready.
+
+Each knob now reaches the domain its consumer implies, ahead of every side
+effect. `max_iters` takes `positive_count_error`, the strict-integer domain, which
+is what `range` accepts - the looser whole-number sibling admits `20.0`, and
+`range(20.0)` raises. `dt` takes `positive_finite_number_error`. `damping` takes a
+local helper composing the shared finiteness domain with the QP's own `>= 0`
+floor, so `0.0` stays legal as the undamped solve. The three task costs take
+`finite_number_error` only, because mink already refuses a negative cost by name
+at task construction and `orientation_cost=0.0` is the documented position-only
+solve for arms with fewer than six DOF. The two convergence thresholds likewise
+take finiteness only: a threshold no residual can reach means "never break
+early", which runs the full budget and is the idiom both solve-loop suites use to
+exercise it, so only an infinite one is refused.

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -35,6 +35,8 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
+from ..utils import finite_number_error, positive_count_error, positive_finite_number_error
+
 if TYPE_CHECKING:
     import mujoco
 
@@ -56,6 +58,39 @@ _DEFAULT_NO_BACKEND_MSG = (
     "(e.g. 'daqp' or 'quadprog'). Install the sim extra: "
     "uv pip install 'strands-robots[sim-mujoco]'."
 )
+
+
+def _damping_error(value: Any, context: str) -> str | None:
+    """Error text when ``value`` is not a usable Levenberg-Marquardt damping.
+
+    ``damping`` is added to the diagonal of the QP's cost matrix by
+    ``mink.solve_ik``. It must be a finite number ``>= 0``: ``0.0`` is the
+    undamped least-squares solve and is legal, a negative value makes the
+    matrix indefinite (``qpsolvers`` refuses it mid-solve with "matrix P is not
+    positive definite"), and a non-finite value poisons the matrix so the solve
+    returns an all-NaN configuration rather than raising.
+
+    The finiteness half is the shared
+    :func:`~strands_robots.utils.finite_number_error` domain, so a bool, a
+    string and a non-finite number are refused with the library's wording; only
+    the floor is stated here, because it is the QP's rule rather than a
+    property of the number.
+
+    Args:
+        value: The caller-supplied damping.
+        context: The class name to name in the message.
+
+    Returns:
+        The error text, or ``None`` when ``value`` can be honored.
+    """
+    if text := finite_number_error(value, "damping", context):
+        return text
+    if float(value) < 0.0:
+        return (
+            f"{context}: damping must be >= 0 (0.0 is the undamped solve); a negative value makes the "
+            f"QP cost matrix indefinite, got {value!r}."
+        )
+    return None
 
 
 def resolve_qp_solver(
@@ -117,22 +152,38 @@ class MinkIKBridge:
             Cartesian task tracks (e.g. ``"hand"`` for a Franka/Panda).
         ee_frame_type: ``"body"`` (default), ``"site"``, or ``"geom"`` - the
             ``mink.FrameTask`` frame type for ``ee_frame_name``.
-        position_cost: Cartesian position task weight.
+        position_cost: Cartesian position task weight. A finite number;
+            ``mink`` refuses a negative one by name at task construction, and a
+            non-finite one poisoned the QP so the solve returned an all-NaN
+            configuration.
         orientation_cost: Cartesian orientation task weight (``0.0`` yields a
             position-only solve - important for arms with fewer than 6 DOF).
+            A finite number, on the same terms as ``position_cost``.
         posture_cost: Posture (joint-regularizer) task weight - keeps the solve
             near the current configuration so it stays smooth and avoids
-            flipping between IK branches.
+            flipping between IK branches. A finite number, on the same terms as
+            ``position_cost``.
         solver: ``qpsolvers`` backend name passed to ``mink.solve_ik``.
             ``None`` (default) auto-selects an installed backend - preferring
             ``"daqp"`` (what ``mink`` pins), then ``"quadprog"``, then whatever
             ``qpsolvers.available_solvers`` reports. Pass an explicit name to
             force one.
-        damping: Levenberg-Marquardt damping for ``solve_ik``.
-        max_iters: Max differential-IK iterations per target pose.
-        dt: Integration timestep for each IK iteration (s).
-        pos_threshold: Convergence threshold on position error (m).
-        ori_threshold: Convergence threshold on orientation error (rad).
+        damping: Levenberg-Marquardt damping for ``solve_ik``. A finite number
+            ``>= 0`` (``0.0`` is the undamped solve).
+        max_iters: Max differential-IK iterations per target pose. A positive
+            whole number: it bounds the ``range`` :meth:`solve` iterates over,
+            so ``0`` ran the solver zero times and handed back ``q_init``
+            unchanged as though it had solved.
+        dt: Integration timestep for each IK iteration (s). A positive finite
+            number: ``0.0`` and a non-finite value both produced an all-NaN
+            configuration.
+        pos_threshold: Convergence threshold on position error (m). A finite
+            number: an infinite threshold is met by every residual, so it made
+            the *first* iteration count as converged. A threshold no residual
+            can reach (zero or negative) is left accepted - it means "never
+            break early", which runs the full ``max_iters`` budget.
+        ori_threshold: Convergence threshold on orientation error (rad), on the
+            same terms as ``pos_threshold``.
         commanded_dofs: Velocity-space (``nv``) indices of the ONLY degrees of
             freedom the caller can command, or ``None`` (default) to leave the
             whole model free. ``mink`` optimizes over every DOF in ``model``,
@@ -148,6 +199,14 @@ class MinkIKBridge:
     Raises:
         ImportError: If ``mink``/``mujoco`` are not importable (with an
             actionable install hint).
+        ValueError: If any numeric knob cannot be honored - a ``max_iters``
+            that is not a positive whole number, a ``dt`` that is not a
+            positive finite number, a non-finite convergence threshold, a
+            ``damping`` that is not a finite number ``>= 0``, or a non-finite
+            task cost. Each is applied rather than forwarded, so an
+            unusable value produced a plausible-looking configuration instead
+            of an error; the refusal happens before the QP backend is resolved
+            and before any task is built.
         ValueError: If ``commanded_dofs`` is empty or names an index outside
             ``range(model.nv)`` - a solve that may move nothing, or a mask
             built against a different model, is a caller bug rather than a
@@ -181,6 +240,42 @@ class MinkIKBridge:
             import mink
         except ImportError as e:
             raise ImportError(self._INSTALL_HINT) from e
+
+        # Every numeric knob is checked here, before the QP backend is resolved,
+        # before the DOF mask reads the model, before the Configuration and the
+        # two tasks are constructed and before the ready log line. Each one is
+        # *applied* rather than forwarded - the iteration count bounds a
+        # ``range``, the timestep integrates a velocity, the damping and the
+        # costs weight a QP - so an unusable value produces a plausible-looking
+        # configuration instead of an error. See the per-parameter notes in the
+        # class docstring for what each unchecked value did.
+        label = type(self).__name__
+        for _cost_param, _cost in (
+            ("position_cost", position_cost),
+            ("orientation_cost", orientation_cost),
+            ("posture_cost", posture_cost),
+        ):
+            # ``mink`` already refuses a negative cost by name at task
+            # construction, so only the kind is checked here; ``0.0`` stays
+            # legal because an ``orientation_cost`` of zero is the documented
+            # position-only solve.
+            if text := finite_number_error(_cost, _cost_param, label):
+                raise ValueError(text)
+        if text := _damping_error(damping, label):
+            raise ValueError(text)
+        if text := positive_count_error(max_iters, "max_iters", label):
+            raise ValueError(text)
+        if text := positive_finite_number_error(dt, "dt", label):
+            raise ValueError(text)
+        for _threshold_param, _threshold in (("pos_threshold", pos_threshold), ("ori_threshold", ori_threshold)):
+            # Finiteness only, not a positive floor: a threshold no residual can
+            # meet (zero, or a negative distance) means "never break early", so
+            # the loop runs its whole budget - the conservative direction, and
+            # the idiom the solve-loop suites use to exercise it. An *infinite*
+            # threshold is the damaging one, because every residual satisfies it
+            # and the first iteration counts as converged.
+            if text := finite_number_error(_threshold, _threshold_param, label):
+                raise ValueError(text)
 
         self._mink = mink
         self.model = model

--- a/tests/simulation/test_ik_bridge_numeric_parameter_domains.py
+++ b/tests/simulation/test_ik_bridge_numeric_parameter_domains.py
@@ -1,0 +1,444 @@
+"""Every numeric knob on the shared IK bridge is refused when it cannot be honored.
+
+:class:`~strands_robots.simulation.ik.MinkIKBridge` is the one home for the mink
+differential-IK solve, re-exported as the public ``MinkIKBridge`` of the
+``cosmos3`` and ``vera`` providers and documented as a constructor a caller
+builds directly (``docs/policies/cosmos3.md``). It validated two of its
+arguments thoroughly - ``commanded_dofs`` per element, with ``bool`` rejected by
+name and every index range-checked, and ``solver`` through
+:func:`~strands_robots.simulation.ik.resolve_qp_solver` - and handed its eight
+numeric knobs straight through.
+
+Every one of those knobs is *applied* rather than forwarded: ``max_iters``
+bounds the ``range`` the solve loop iterates, ``dt`` integrates the joint
+velocity, ``damping`` and the three task costs weight the QP, and the two
+thresholds decide when the loop breaks. So an unusable value produced a
+plausible-looking joint configuration rather than an error. Measured against a
+Panda on a reachable 80 mm target whose converged residual is 0.761 mm:
+
+* ``max_iters=0`` (also ``False``, also a negative count) made ``range`` empty,
+  so ``solve`` ran the solver zero times and returned ``q_init`` unchanged with
+  the full 80 mm still to go - a solve that never happened, reported as one.
+* ``max_iters=True`` ran exactly one iteration: 14.147 mm.
+* ``pos_threshold`` and ``ori_threshold`` both infinite (also both ``True``)
+  made the *first* iteration count as converged - 14.147 mm, byte-identical to
+  ``max_iters=1``.
+* ``dt`` of ``0.0``, ``nan`` or ``inf``, ``damping`` of ``nan``, and any
+  infinite task cost each returned an all-NaN configuration.
+* ``damping=inf`` produced no joint motion at all - again the full 80 mm, and
+  ``damping=True`` weighted the QP a thousandfold heavier than the ``1e-3``
+  default for a residual of 29.673 mm.
+
+The remaining spellings failed *late* instead: a fractional, non-finite, string
+or ``None`` ``max_iters`` raised ``TypeError`` from ``range`` inside ``solve``,
+and a negative ``damping`` raised ``qpsolvers``' "matrix P is not positive
+definite" mid-solve - both after the QP backend was resolved, both tasks were
+built and the bridge had logged that it was ready.
+
+The behavioural classes drive the real constructor and the real solve loop
+against the fake ``mink`` module the sibling suite already uses, so nothing here
+needs ``mink``, ``mujoco`` or ``qpsolvers`` installed.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import math
+import textwrap
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation import ik as ik_mod
+from strands_robots.simulation.ik import MinkIKBridge
+from strands_robots.utils import finite_number_error
+from tests.policies.cosmos3.test_sim_ik_bridge_solve_loop import (
+    _FakeConfiguration,
+    _FakeFrameTask,
+    _FakePostureTask,
+    _FakeSE3,
+    _model,
+    _solve_ik,
+    _target_pose,
+)
+
+#: The domain helper each numeric knob is held to, stated here rather than read
+#: off the module so these cells are an independent oracle instead of a
+#: restatement of the code under test.
+EXPECTED_DOMAINS: dict[str, str] = {
+    "position_cost": "finite_number_error",
+    "orientation_cost": "finite_number_error",
+    "posture_cost": "finite_number_error",
+    "damping": "_damping_error",
+    "max_iters": "positive_count_error",
+    "dt": "positive_finite_number_error",
+    "pos_threshold": "finite_number_error",
+    "ori_threshold": "finite_number_error",
+}
+
+#: Spellings the bridge accepted and then answered with the wrong configuration:
+#: no solve at all, one iteration where twenty were asked for, or all-NaN joints.
+SILENTLY_WRONG: list[tuple[str, dict[str, Any]]] = [
+    ("max_iters-zero-runs-the-solver-never", {"max_iters": 0}),
+    ("max_iters-False-runs-the-solver-never", {"max_iters": False}),
+    ("max_iters-negative-runs-the-solver-never", {"max_iters": -5}),
+    ("max_iters-True-runs-one-iteration", {"max_iters": True}),
+    ("dt-zero-yields-nan-joints", {"dt": 0.0}),
+    ("dt-nan-yields-nan-joints", {"dt": float("nan")}),
+    ("dt-inf-yields-nan-joints", {"dt": float("inf")}),
+    ("damping-nan-yields-nan-joints", {"damping": float("nan")}),
+    ("damping-inf-freezes-the-arm", {"damping": float("inf")}),
+    ("damping-True-is-a-thousandfold-heavier-solve", {"damping": True}),
+    ("position_cost-inf-yields-nan-joints", {"position_cost": float("inf")}),
+    ("orientation_cost-inf-yields-nan-joints", {"orientation_cost": float("inf")}),
+    ("posture_cost-inf-yields-nan-joints", {"posture_cost": float("inf")}),
+    ("posture_cost-True-overwhelms-the-frame-task", {"posture_cost": True}),
+    (
+        "both-thresholds-inf-converge-on-iteration-one",
+        {"pos_threshold": float("inf"), "ori_threshold": float("inf")},
+    ),
+    ("both-thresholds-True-converge-on-iteration-one", {"pos_threshold": True, "ori_threshold": True}),
+]
+
+#: Spellings that raised from inside ``solve``, after the bridge reported ready.
+LATE_FAILURES: list[tuple[str, dict[str, Any]]] = [
+    ("max_iters-fractional-breaks-range", {"max_iters": 2.5}),
+    ("max_iters-whole-float-breaks-range", {"max_iters": 20.0}),
+    ("max_iters-nan-breaks-range", {"max_iters": float("nan")}),
+    ("max_iters-inf-breaks-range", {"max_iters": float("inf")}),
+    ("max_iters-str-breaks-range", {"max_iters": "20"}),
+    ("max_iters-None-breaks-range", {"max_iters": None}),
+    ("damping-negative-makes-the-qp-indefinite", {"damping": -1.0}),
+]
+
+#: Values a caller can legitimately mean, which must keep reaching the solve.
+STAYS_ACCEPTED: list[tuple[str, dict[str, Any]]] = [
+    ("the-documented-defaults", {}),
+    ("a-raised-iteration-budget", {"max_iters": 200}),
+    ("orientation_cost-zero-is-the-position-only-solve", {"orientation_cost": 0.0}),
+    ("posture_cost-zero-drops-the-regularizer", {"posture_cost": 0.0}),
+    ("damping-zero-is-the-undamped-solve", {"damping": 0.0}),
+    ("a-numpy-float-timestep", {"dt": np.float64(1e-2)}),
+    ("a-tighter-position-threshold", {"pos_threshold": 1e-4}),
+    ("an-unreachable-threshold-runs-the-whole-budget", {"pos_threshold": -1.0}),
+    ("a-zero-threshold-runs-the-whole-budget", {"pos_threshold": 0.0}),
+]
+
+
+def _ids(rows: list[tuple[str, dict[str, Any]]]) -> list[str]:
+    return [row[0] for row in rows]
+
+
+@pytest.fixture
+def fake_mink(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Install the sibling suite's fake ``mink`` plus a stub ``qpsolvers``.
+
+    Declared here rather than imported: importing a fixture re-binds the name in
+    this module, which ``ruff`` reports as a redefinition for every cell that
+    then takes it as a parameter. Only the stand-in classes are shared.
+    """
+    mod = types.ModuleType("mink")
+    mod.Configuration = _FakeConfiguration  # type: ignore[attr-defined]
+    mod.FrameTask = _FakeFrameTask  # type: ignore[attr-defined]
+    mod.PostureTask = _FakePostureTask  # type: ignore[attr-defined]
+    mod.SE3 = _FakeSE3  # type: ignore[attr-defined]
+    mod.solve_ik = _solve_ik  # type: ignore[attr-defined]
+    monkeypatch.setitem(__import__("sys").modules, "mink", mod)
+
+    qp = types.ModuleType("qpsolvers")
+    qp.available_solvers = ["quadprog"]  # type: ignore[attr-defined]
+    monkeypatch.setitem(__import__("sys").modules, "qpsolvers", qp)
+    return mod
+
+
+def _build(**overrides: Any) -> MinkIKBridge:
+    """Build the bridge through one deliberately untyped funnel.
+
+    The cells below supply values that are off-type on purpose - a string
+    iteration count, a ``None`` timestep - which is the whole point of a domain.
+    Routing them through ``**overrides`` keeps the call sites free of the
+    ``arg-type`` reports a literal would draw.
+    """
+    return MinkIKBridge(model=_model(), ee_frame_name="gripper", solver="quadprog", **overrides)
+
+
+def _init_source() -> str:
+    return textwrap.dedent(inspect.getsource(MinkIKBridge.__init__))
+
+
+def _numeric_parameters() -> dict[str, str]:
+    """The constructor's ``int`` / ``float`` parameters, read off its signature.
+
+    Derived rather than listed so a ninth numeric knob added later is graded on
+    arrival instead of inheriting an exemption by being absent from a tuple.
+    """
+    found: dict[str, str] = {}
+    for name, param in inspect.signature(MinkIKBridge.__init__).parameters.items():
+        annotation = param.annotation
+        if isinstance(annotation, str) and annotation.replace(" ", "") in {"int", "float"}:
+            found[name] = annotation
+    return found
+
+
+def _domained_parameters() -> dict[str, set[str]]:
+    """Map each parameter named in a domain call inside ``__init__`` to its domains.
+
+    Reads both spellings the constructor uses: a direct
+    ``some_error(value, "name", label)`` call, and a ``for (name, value) in
+    ((literal, Name), ...)`` sweep whose loop variable is passed instead.
+    """
+    tree = ast.parse(_init_source())
+    fn = tree.body[0]
+    assert isinstance(fn, ast.FunctionDef)
+
+    # Loop variable -> the parameter names that flow through it.
+    via_loop: dict[str, set[str]] = {}
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.For) or not isinstance(node.iter, ast.Tuple):
+            continue
+        if not isinstance(node.target, ast.Tuple) or len(node.target.elts) != 2:
+            continue
+        value_var = node.target.elts[1]
+        if not isinstance(value_var, ast.Name):
+            continue
+        for pair in node.iter.elts:
+            if isinstance(pair, ast.Tuple) and len(pair.elts) == 2 and isinstance(pair.elts[1], ast.Name):
+                via_loop.setdefault(value_var.id, set()).add(pair.elts[1].id)
+
+    domains: dict[str, set[str]] = {}
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        name = node.func.id if isinstance(node.func, ast.Name) else None
+        if name is None or not (name.endswith("_error") or name.endswith("_problems")):
+            continue
+        first = node.args[0]
+        if not isinstance(first, ast.Name):
+            continue
+        for param in via_loop.get(first.id, {first.id}):
+            domains.setdefault(param, set()).add(name)
+    return domains
+
+
+class TestWhatMadeEachValueUnusable:
+    """The arithmetic and the loop shape the domains were chosen from.
+
+    Holds on the code either way: these are properties of ``range``, of
+    floating-point comparison and of the solve loop, not of the guards.
+    """
+
+    def test_an_empty_range_runs_the_solver_never(self) -> None:
+        """``0``, ``False`` and a negative count all make the loop body unreachable."""
+        assert len(range(0)) == 0
+        assert len(range(False)) == 0
+        assert len(range(-5)) == 0
+
+    def test_a_true_iteration_budget_is_a_single_iteration(self) -> None:
+        """``bool`` is an ``int`` subclass, so ``True`` is a silent budget of one."""
+        assert len(range(True)) == 1
+
+    def test_an_infinite_threshold_is_met_by_any_error(self) -> None:
+        """So the convergence break fires on the first iteration."""
+        residual = 0.08  # metres still to go after one iteration of an 80 mm move.
+        for threshold in (float("inf"), True):
+            assert residual <= threshold
+
+    def test_an_unreachable_threshold_means_never_break_early(self) -> None:
+        """Zero and negative thresholds are the *conservative* direction.
+
+        No residual satisfies them, so the loop runs its whole budget rather
+        than stopping short - which is why they are held only to finiteness.
+        """
+        smallest_residual = 1e-12
+        for threshold in (0.0, -1.0):
+            assert not smallest_residual <= threshold
+
+    def test_the_solve_loop_reads_the_iteration_budget_and_both_thresholds(self) -> None:
+        """The three consumers the domains are chosen from, read off the source."""
+        source = textwrap.dedent(inspect.getsource(MinkIKBridge.solve))
+        assert "range(self.max_iters)" in source
+        assert "self.pos_threshold" in source
+        assert "self.ori_threshold" in source
+
+    def test_the_neighbouring_arguments_were_already_checked_thoroughly(self) -> None:
+        """``commanded_dofs`` is validated per element, and ``solver`` is resolved.
+
+        The contrast is the finding: two arguments checked exhaustively, eight
+        numbers handed through.
+        """
+        mask_source = textwrap.dedent(inspect.getsource(MinkIKBridge._build_dof_mask))
+        assert "isinstance(index, bool)" in mask_source
+        assert "range(model.nv)" in mask_source or "nv" in mask_source
+        assert "resolve_qp_solver(" in _init_source()
+
+
+class TestTheSilentlyWrongSolvesAreRefused:
+    """Each value that produced a wrong configuration is refused at construction."""
+
+    @pytest.mark.parametrize(("label", "overrides"), SILENTLY_WRONG, ids=_ids(SILENTLY_WRONG))
+    def test_the_bridge_refuses_the_value(self, fake_mink: types.ModuleType, label: str, overrides: dict) -> None:
+        """A ``ValueError`` naming the parameter, instead of a plausible solve."""
+        with pytest.raises(ValueError) as excinfo:
+            _build(**overrides)
+
+        text = str(excinfo.value)
+        assert "MinkIKBridge" in text
+        assert any(param in text for param in overrides), f"{label}: {text!r} names no supplied parameter"
+
+    def test_a_zero_iteration_budget_no_longer_hands_back_the_seed(self, fake_mink: types.ModuleType) -> None:
+        """The headline case: ``solve`` ran the solver zero times and reported it.
+
+        Pre-fix the bridge built, ``solve`` iterated an empty ``range``, and the
+        caller received ``q_init`` untouched - the full requested displacement
+        still to go, with nothing to distinguish it from a converged solve.
+        """
+        with pytest.raises(ValueError, match=r"max_iters must be a positive integer"):
+            _build(max_iters=0)
+
+    def test_a_non_finite_timestep_no_longer_yields_nan_joints(self, fake_mink: types.ModuleType) -> None:
+        """``dt`` scales the integrated velocity, so a non-finite one poisons every joint."""
+        with pytest.raises(ValueError, match=r"dt must be > 0"):
+            _build(dt=float("nan"))
+
+
+class TestTheLateFailuresBecomeConstructionRefusals:
+    """Values that raised from inside ``solve`` are refused before the tasks exist."""
+
+    @pytest.mark.parametrize(("label", "overrides"), LATE_FAILURES, ids=_ids(LATE_FAILURES))
+    def test_the_bridge_refuses_the_value(self, fake_mink: types.ModuleType, label: str, overrides: dict) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _build(**overrides)
+
+        assert any(param in str(excinfo.value) for param in overrides)
+
+    def test_a_negative_damping_names_the_qp_rule_it_breaks(self, fake_mink: types.ModuleType) -> None:
+        """Rather than surfacing as "matrix P is not positive definite" mid-solve."""
+        with pytest.raises(ValueError, match=r"damping must be >= 0"):
+            _build(damping=-1.0)
+
+
+class TestEveryNumericParameterReachesADomain:
+    """The drift guard: a knob added later cannot skip the check.
+
+    Derived from the constructor's own signature, so this fires on a ninth
+    numeric parameter the hour it lands rather than when someone remembers.
+    """
+
+    def test_the_signature_still_carries_the_eight_numeric_knobs(self) -> None:
+        """Non-vacuity: the derivation reads real parameters off a real signature."""
+        assert set(_numeric_parameters()) == set(EXPECTED_DOMAINS)
+
+    def test_every_numeric_parameter_is_asked_of_a_domain(self) -> None:
+        domained = _domained_parameters()
+        missing = sorted(set(_numeric_parameters()) - set(domained))
+        assert not missing, f"numeric parameters reaching no domain: {missing}"
+
+    @pytest.mark.parametrize(("param", "domain"), sorted(EXPECTED_DOMAINS.items()))
+    def test_the_parameter_is_held_to_the_domain_its_consumer_needs(self, param: str, domain: str) -> None:
+        """Each knob's domain is the one its consumer's accepted set implies."""
+        assert domain in _domained_parameters().get(param, set())
+
+
+class TestTheRefusalPrecedesEverySideEffect:
+    """A refused value is reported before anything is resolved, built or logged."""
+
+    def test_the_checks_run_before_the_solver_resolution_and_the_tasks(self) -> None:
+        """Read off the constructor's own statement order."""
+        source = _init_source()
+        first_check = min(
+            source.index(f"{domain}(") for domain in set(EXPECTED_DOMAINS.values()) if f"{domain}(" in source
+        )
+        for later in (
+            "resolve_qp_solver(",
+            "_build_dof_mask(",
+            "mink.Configuration(",
+            "mink.FrameTask(",
+            "logger.info(",
+        ):
+            assert first_check < source.index(later), f"{later} runs before the value checks"
+
+    def test_a_refused_value_logs_no_ready_line(
+        self, fake_mink: types.ModuleType, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The bridge must not announce itself ready and then be unusable."""
+        with caplog.at_level(logging.INFO, logger=ik_mod.__name__), pytest.raises(ValueError):
+            _build(max_iters=0)
+
+        assert [record.getMessage() for record in caplog.records] == []
+
+
+class TestWhatStaysAccepted:
+    """Over-reach controls: nothing a caller can legitimately mean is refused."""
+
+    @pytest.mark.parametrize(("label", "overrides"), STAYS_ACCEPTED, ids=_ids(STAYS_ACCEPTED))
+    def test_the_bridge_accepts_the_value(self, fake_mink: types.ModuleType, label: str, overrides: dict) -> None:
+        bridge = _build(**overrides)
+
+        assert bridge.solver == "quadprog"
+
+    def test_an_accepted_bridge_still_solves_to_the_target(self, fake_mink: types.ModuleType) -> None:
+        """The guards check and pass the value on; they do not reshape the solve."""
+        bridge = _build(max_iters=20)
+        target = _target_pose([0.4, -0.1, 0.25])
+
+        solved = bridge.solve(target, np.zeros(7, dtype=float))
+
+        np.testing.assert_allclose(solved[:3], [0.4, -0.1, 0.25], atol=1e-6)
+
+    def test_the_position_only_solve_is_still_reachable(self, fake_mink: types.ModuleType) -> None:
+        """``orientation_cost=0.0`` is documented for arms with fewer than 6 DOF.
+
+        The costs are held to finiteness rather than to a positive floor for
+        exactly this reason.
+        """
+        bridge = _build(orientation_cost=0.0)
+
+        assert bridge._frame_task is not None
+
+
+class TestKnobsDeliberatelyLeftToTheirConsumer:
+    """What the constructor does not restate, and why.
+
+    ``mink`` refuses a negative task cost by name at task construction, which is
+    already a loud refusal from the layer that owns the rule, so only the kind of
+    the three costs is checked here. Recording it keeps the next reader from
+    reading the asymmetry as an oversight.
+    """
+
+    def test_the_costs_are_held_to_finiteness_rather_than_to_a_floor(self) -> None:
+        assert _domained_parameters()["position_cost"] == {"finite_number_error"}
+        assert math.isfinite(-1.0)  # so the shared domain accepts it and mink refuses it.
+
+    def test_the_thresholds_are_held_to_finiteness_rather_than_to_a_floor(self) -> None:
+        """An unreachable threshold is a documented way to force the full budget.
+
+        ``tests/policies/cosmos3/test_sim_ik_bridge_solve_loop.py`` and its
+        ``vera`` twin both pass ``pos_threshold=-1.0`` to assert the loop burns
+        its whole ``max_iters`` budget when the break never fires. A positive
+        floor here would refuse that, and would refuse it for a value that
+        cannot produce a wrong answer.
+        """
+        assert _domained_parameters()["pos_threshold"] == {"finite_number_error"}
+        assert _domained_parameters()["ori_threshold"] == {"finite_number_error"}
+
+    def test_the_damping_floor_is_stated_once(self) -> None:
+        """One helper owns the ``>= 0`` rule, so the two halves cannot drift."""
+        module_source = inspect.getsource(ik_mod)
+        assert module_source.count("def _damping_error(") == 1
+        assert _domained_parameters()["damping"] == {"_damping_error"}
+
+    def test_the_damping_helper_delegates_the_boolean_refusal(self) -> None:
+        """Its bare ``float()`` is reached only for a value the shared domain took.
+
+        ``tests/simulation/test_input_validators_refuse_a_boolean.py`` exempts
+        ``_damping_error`` from the boolean census on exactly that basis, and
+        names this file as where the delegation is pinned behaviourally. The
+        ``damping-True`` cell above is that pin; this one holds the shared
+        domain's own refusal it rests on.
+        """
+        assert finite_number_error(True, "damping", "Ctx") is not None
+        assert "finite_number_error(value" in textwrap.dedent(inspect.getsource(ik_mod._damping_error))

--- a/tests/simulation/test_input_validators_refuse_a_boolean.py
+++ b/tests/simulation/test_input_validators_refuse_a_boolean.py
@@ -531,6 +531,14 @@ _NOT_AN_INPUT_DOMAIN = {
     # tests/simulation/test_predicate_tolerance_sign_domain.py fails when the
     # delegation is dropped or the shared domain stops refusing a boolean.
     "_kwarg_domain_error": "coerces only a value finite_number_error accepted",
+    # Same shape one module over: the float() states the Levenberg-Marquardt
+    # floor for a value finite_number_error has already accepted, and that
+    # shared domain refuses bool and numpy.bool_ by name, so a boolean is
+    # answered with its own reason and never reaches the coercion. Pinned
+    # behaviourally rather than only claimed here:
+    # tests/simulation/test_ik_bridge_numeric_parameter_domains.py fails when
+    # the delegation is dropped or the shared domain stops refusing a boolean.
+    "_damping_error": "coerces only a value finite_number_error accepted",
 }
 
 _GUARDED_VALIDATORS = {


### PR DESCRIPTION
## The problem

`MinkIKBridge` (`strands_robots/simulation/ik.py`) is the one home for the mink differential-IK solve. It is re-exported as the public `MinkIKBridge` of the `cosmos3` and `vera` providers, is in `strands_robots.policies.cosmos3.__all__`, and `docs/policies/cosmos3.md` documents constructing it directly.

It validated two of its arguments thoroughly:

- `commanded_dofs` per element, with `bool` rejected by name and every index checked against `range(model.nv)`, under a five-line `Raises:` paragraph;
- `solver` through `resolve_qp_solver`, which raises for an uninstalled backend.

And it handed its **eight numeric knobs** straight through to mink.

Every one of those knobs is *applied* rather than forwarded. `max_iters` bounds the `range` the solve loop iterates, `dt` integrates the joint velocity, `damping` and the three task costs weight the QP, and the two thresholds decide when the loop breaks. So an unusable value produced a plausible-looking joint configuration instead of an error.

## Measured

A Franka Panda seated at `[0, -0.3, 0, -2.2, 0, 2.0, 0.79]`, asked to move the hand 80 mm in +x. That move converges to a **0.761 mm** end-effector residual on the defaults. One knob changed per row:

| value | outcome | EE residual | joint motion |
|---|---|---|---|
| defaults | converged | 0.761 mm | 0.353 |
| `max_iters=0` | accepted, **solver ran zero times**, `q_init` returned | **80.000 mm** | **0.000000** |
| `max_iters=False` | same as `0` | 80.000 mm | 0.000000 |
| `max_iters=-5` | same as `0` | 80.000 mm | 0.000000 |
| `max_iters=True` | accepted, exactly one iteration | 14.147 mm | 0.298 |
| `pos_threshold=inf, ori_threshold=inf` | accepted, first iteration counted as converged | 14.147 mm | 0.298 |
| both thresholds `True` | same as above (1.0 m / 1.0 rad) | 14.147 mm | 0.298 |
| `dt=0.0` | accepted, all-NaN configuration | `nan` | `nan` |
| `dt=nan` / `dt=inf` | accepted, all-NaN configuration | `nan` | `nan` |
| `damping=nan` | accepted, all-NaN configuration | `nan` | `nan` |
| `damping=inf` | accepted, no joint motion at all | 80.000 mm | 0.000000 |
| `damping=True` | accepted, QP weighted 1000x the default | 29.673 mm | 0.215 |
| `position_cost=inf` (also orientation, posture) | accepted, all-NaN configuration | `nan` | `nan` |
| `posture_cost=True` | accepted, regularizer overwhelms the frame task | 75.335 mm | 0.019 |

`max_iters=0` is the headline: `range(0)` is empty, so `solve` never entered its body, returned the seed configuration untouched, and the caller received the pose it started at with the entire requested displacement still to go - indistinguishable from a converged solve.

The remaining spellings failed *late* rather than silently:

| value | failure |
|---|---|
| `max_iters=2.5` / `20.0` / `nan` / `inf` / `"20"` / `None` | `TypeError` from `range` inside `solve` |
| `damping=-1.0` | `qpsolvers` `ProblemError: matrix P is not positive definite` |

Both land after the QP backend has been resolved, after both mink tasks have been constructed, and after the bridge has logged that it is ready.

## The change

Each knob is now asked of the domain its consumer implies, before any side effect:

| knob | domain | why that one |
|---|---|---|
| `max_iters` | `positive_count_error` | It bounds a `range`. The strict-integer domain is what `range` accepts; the looser whole-number sibling admits `20.0`, and `range(20.0)` raises. |
| `dt` | `positive_finite_number_error` | `0.0` and non-finite both produced NaN joints. |
| `damping` | local `_damping_error` | Composes shared finiteness with the QP's own `>= 0` floor. `0.0` stays legal - it is the undamped least-squares solve. |
| `position_cost`, `orientation_cost`, `posture_cost` | `finite_number_error` | mink already refuses a negative cost **by name** at task construction, so only the kind is stated here. `orientation_cost=0.0` is the documented position-only solve and must stay accepted. |
| `pos_threshold`, `ori_threshold` | `finite_number_error` | Finiteness only. An *infinite* threshold is met by every residual, so it collapses the loop to one iteration - that is the damaging one. A threshold no residual can reach (zero, or negative) means "never break early", which runs the full budget: the conservative direction, and the idiom both solve-loop suites use to exercise it. |

The refusal precedes `resolve_qp_solver`, the DOF-mask read of the model, the `Configuration` build, both task constructions and the ready log line - pinned by an AST ordering assertion and by a cell asserting no log record is emitted for a refused value.

## Visual

The same 80 mm request through the same bridge, rendered headless (MuJoCo EGL) with the same camera and the same lighting. The orange sphere is the requested end-effector position; the arm is the configuration `solve()` returned for it.

![An IK iteration budget of zero is refused, not solved with](https://github.com/cagataycali/robots/releases/download/artifacts/ik_knob_refusal.png)

The converged hand sits *on* the marker and hides it (0 marker pixels left); the zero-budget arm never moved, so the marker is fully exposed 490 px 80 mm away. The two renders differ by 58929 px.

## Tests

`tests/simulation/test_ik_bridge_numeric_parameter_domains.py`, 59 cells (40 of which fail pre-fix), driving the real constructor and the real solve loop against the fake `mink` module the sibling solve-loop suite already ships - so nothing here needs `mink`, `mujoco` or `qpsolvers` installed.

Pre-fix split: **40 failed / 19 passed**.

| class | role | failed / total |
|---|---|---|
| `TestWhatMadeEachValueUnusable` | premise (holds either way) | 0 / 6 |
| `TestTheSilentlyWrongSolvesAreRefused` | regression | 18 / 18 |
| `TestTheLateFailuresBecomeConstructionRefusals` | regression | 8 / 8 |
| `TestEveryNumericParameterReachesADomain` | derived drift guard | 9 / 10 |
| `TestTheRefusalPrecedesEverySideEffect` | placement | 2 / 2 |
| `TestWhatStaysAccepted` | over-reach control | 0 / 11 |
| `TestKnobsDeliberatelyLeftToTheirConsumer` | scope boundary | 3 / 4 |

Nothing in the premise or over-reach classes fires, which is the point: the change refuses only values that produced a wrong answer or a late crash.

## Mutation table

Each row mutates the source and reports the cells that fire in the new file, plus the cells that fire in the surrounding IK suites (`sib`: `tests/policies/cosmos3/`, `tests/policies/vera/`, and the three `move_to` / EE-frame suites, 1187 cells).

| row | mutation | fires | sib |
|---|---|---|---|
| b0 | control | 0 | 0 |
| b1 | every check removed (the pre-fix constructor) | 40 | 0 |
| b2 | `max_iters` check removed | 14 | 0 |
| b3 | `dt` check removed | 6 | 0 |
| b4 | both threshold checks removed | 6 | 0 |
| b5 | three cost checks removed | 9 | 0 |
| b6 | `damping` check removed | 8 | 0 |
| b7 | `max_iters` takes the loose whole-number domain (admits `20.0`) | 3 | 0 |
| b8 | `dt` takes signed finiteness (admits `0.0`) | 3 | 0 |
| b9 | thresholds demand a positive floor | 5 | **2** |
| b10 | costs demand a positive floor | 7 | **15** |
| b11 | `damping` floor dropped (finiteness only) | 2 | 0 |
| b12 | checks moved after the solver resolve and both tasks | 1 | 0 |
| b13 | checks moved after the ready log line | 2 | 0 |
| b14 | `_damping_error` stops delegating to the shared domain | 4 | 0 |
| d1 | a ninth numeric knob planted, scan **derived** | 2 (names the plant) | - |
| d2 | the same plant, scan **hardcoded** to today's eight | **0 (silent)** | - |
| d3 | scan hardcoded, no plant (d2's control) | 0 | - |

15 mutations, 14 distinct firing sets, control clean, source restored byte-identically.

The two rows that decided the scope are b9 and b10 - both are the *tighter* domain, and both trip pre-existing tests. b9 fires `test_solve_runs_full_iteration_budget_when_never_converged` in both solve-loop suites, which pass `pos_threshold=-1.0` deliberately to assert the loop burns its whole budget; b10 fires 15 cells that rely on `orientation_cost=0.0`. The first draft of this change used `positive_finite_number_error` for the thresholds and the control row's `sib` column caught it.

The five per-check reverts (b2-b6) partition b1's 40 cells exactly, with one cell left over - `test_the_checks_run_before_the_solver_resolution_and_the_tasks`, which needs at least one check to exist before it can order anything - and a single shared cell across every pair, the derived "every numeric parameter reaches a domain" assertion.

d1/d2/d3 are the derived-inventory proof: a ninth numeric parameter added to the signature with no domain is named by the scan when it reads `inspect.signature`, and is completely invisible when the same scan is hardcoded to today's eight names.

## Two guards the broad gate caught

`_damping_error` returns a reason and coerces with a bare `float()`, so `tests/simulation/test_input_validators_refuse_a_boolean.py` discovered it and required an accounting. It is listed in `_NOT_AN_INPUT_DOMAIN` on the same basis as `_kwarg_domain_error` one module over - its `float()` is reached only for a value `finite_number_error` has already accepted, and that domain refuses `bool` and `numpy.bool_` by name. That exemption is now pinned behaviourally by the `damping-True` regression cell and by b14, exactly as the `_kwarg_domain_error` entry does.

Two premise assertions compared literals on both sides, which `tests/test_no_vacuous_comparisons.py` refuses; the compared values are named locals now, which is stronger anyway.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1668 files).
- `mypy strands_robots tests tests_integ`: 24 errors on both trees, normalized message sets byte-identical in both directions, 0 attributable to the changed files.
- Paired run over an identical 864-file selection - all of `tests/simulation/`, `tests/policies/cosmos3/`, `tests/policies/vera/`, plus every suite that walks the tree, parses source or reads docstrings - with the new file excluded from both: 30930 collected on each side, and after the two guard fixes above the branch-only and base-only failing-ID sets are both empty.
- The changed files plus the six suites `main` added since the branch point: 1470 passed.
