### PR TITLE
docs(security): name the IoT credentials the transport reads

### DIFF
--- a/changelog.d/2870-iot-credentials-documented.md
+++ b/changelog.d/2870-iot-credentials-documented.md
@@ -1,0 +1,24 @@
+### Fixed: the security reference names the IoT credentials the transport reads
+
+`docs/security.md`'s cross-network fleet section is where an operator configures the AWS IoT Core
+path. It told the reader that the IoT device certificates and provisioning material are production
+secrets and to provision, scope and rotate them, and it never named a variable. All four the
+transport reads -- `STRANDS_IOT_THING_NAME`, `STRANDS_IOT_ENDPOINT`, `STRANDS_IOT_CERT_DIR` and
+`STRANDS_IOT_CA_FILE` -- appeared nowhere in `docs/` or `README.md`, while
+`mesh.iot.provision.ProvisionedThing.env_vars` hands the first three back to the operator after
+provisioning and both the `iot` and `bridge` backends construct `IotMqttTransport` with no
+arguments, so those variables are the whole of its configuration.
+
+The failure mode is a silent one by design: with a credential unset, `connect()` logs at ERROR and
+returns `False` so the mesh stays off rather than crash the host, which means the symptom is a peer
+that never appears on the fleet. The names were reachable only one refusal at a time -- unset gives
+`STRANDS_IOT_THING_NAME is required for IoT transport`, setting that gives
+`STRANDS_IOT_ENDPOINT is required for IoT transport`, and setting both reports the certificate path
+that `STRANDS_IOT_CERT_DIR` resolves, along with the three filenames it must contain.
+
+The section now documents the four as bullets, the form this page already uses for every other
+variable, and states which two are required and what the other two default to. The guard derives
+the credential set from the transport's own literal environment reads and from the provisioner's
+export list rather than from a list kept beside them, so a variable added to either surface is
+graded on arrival; it also holds them to one section, because they configure a single channel and a
+reader who finds only some of them configures half a connection.

--- a/docs/security.md
+++ b/docs/security.md
@@ -80,6 +80,13 @@ mTLS alone is not sufficient - pair it with an access-control list:
 
 Two steps route traffic through AWS IoT Core (MQTT5 with mTLS): the `[mesh-iot]` extra installs the dependency, and `STRANDS_MESH_BACKEND=iot` selects the transport. The extra alone changes nothing - the fleet stays on Zenoh - so set both. `STRANDS_MESH_BACKEND=bridge` selects a `BridgeTransport` instead, which keeps high-rate topics local while bridging presence, health, and safety to the cloud. When you use this path, the IoT device certificates and provisioning material become production secrets - provision them per-device, scope their IoT policies to the minimum topic set, and rotate/revoke them like any other fleet credential.
 
+Both `iot` and `bridge` construct that transport with no arguments, so four environment variables are the whole of its configuration - `ProvisionedThing.env_vars()` hands the first three back after provisioning. With either required variable unset, `connect()` logs at ERROR and returns `False`: the mesh stays off rather than crash the host, so the symptom is a peer that never appears on the fleet.
+
+- `STRANDS_IOT_THING_NAME` - required. The AWS IoT Thing name, sent as the MQTT `client_id`, so it must match both the certificate's CN and the Thing your IoT policy authorises through `${iot:Connection.Thing.ThingName}`. The trust model ties it to the `Mesh` peer id, because a peer publishes under `strands/{peer}/...`.
+- `STRANDS_IOT_ENDPOINT` - required. The account's ATS endpoint, e.g. `a2acz9p1ge6619-ats.iot.us-west-2.amazonaws.com`.
+- `STRANDS_IOT_CERT_DIR` - optional; defaults to `~/.strands_robots/iot`. The directory holding `{thing}.cert.pem`, `{thing}.private.key`, and `AmazonRootCA1.pem` - the production secrets named above. A missing file is reported by path.
+- `STRANDS_IOT_CA_FILE` - optional; defaults to `AmazonRootCA1.pem` inside `STRANDS_IOT_CERT_DIR`. Overrides the root CA path.
+
 Reference: `strands_robots.mesh.session`, `strands_robots.mesh._acl_config`, `strands_robots.mesh.transport.iot_transport`.
 
 ## Operator approval for fleet-wide actions

--- a/tests/mesh/test_docs_iot_credentials_reference.py
+++ b/tests/mesh/test_docs_iot_credentials_reference.py
@@ -1,0 +1,255 @@
+"""Grade the AWS IoT credential reference against the transport's env surface.
+
+``docs/security.md`` owns the cross-network fleet section, and that section is
+where an operator configures the AWS IoT Core path. Three properties are graded
+here, each derived from the package rather than from a list kept beside it, so a
+variable added later is graded on arrival:
+
+- **Every variable the transport reads is documented.** Both the ``iot`` and
+  ``bridge`` backends construct :class:`IotMqttTransport` with no arguments, so
+  these variables are the whole of its configuration. A variable the code
+  honours and the page omits is a setting nobody can find: all four were
+  undocumented across ``docs/`` and ``README.md`` while this very section told
+  the reader to provision, scope and rotate the credentials they point at.
+- **The credentials of one link are documented in one place.** They configure a
+  single channel - one names the Thing, one the broker, two locate the
+  certificate material - so a reader configuring that link should find them
+  together rather than assemble it from two sections.
+- **The provisioner and the page agree.** ``ProvisionedThing.env_vars`` is the
+  package's own answer to "what must an operator export", so a name it hands out
+  and the page does not explain is a gap between two in-tree surfaces.
+
+The behaviour that makes the omission matter is asserted directly too: with the
+credentials unset, ``connect()`` returns ``False`` and reports the missing
+variable by name. That is a fact about the code, true on both sides of this
+documentation change - it is why a reader who cannot find the names discovers
+them one ERROR at a time, and why the peer is simply absent from the fleet until
+they do.
+
+Scope: the selector that chooses this transport, ``STRANDS_MESH_BACKEND``, is
+documented by the change that names it and is deliberately not graded here.
+These rules cover the credentials the selected transport then reads.
+"""
+
+import ast
+import logging
+import pathlib
+import re
+
+import pytest
+
+import strands_robots
+
+_PACKAGE = pathlib.Path(strands_robots.__file__).parent
+_PAGE = _PACKAGE.parent / "docs" / "security.md"
+
+#: The module that owns the AWS IoT broker link. Its variables configure one
+#: channel, so the reference documents them together.
+_TRANSPORT = _PACKAGE / "mesh" / "transport" / "iot_transport.py"
+
+#: The credential prefix this reference covers.
+_CREDENTIAL = re.compile(r"STRANDS_IOT_[A-Z0-9_]*")
+
+#: A documented bullet's variable: ``- `VAR` - ...`` or ``- `VAR=value` - ...``,
+#: which is how every environment variable on this page is already written.
+_BULLET_VAR = re.compile(r"^-\s+`([A-Z][A-Z0-9_]*)(?:=[^`]*)?`")
+
+#: Floors so a scan that silently reads nothing fails instead of passing.
+_MINIMUM_CREDENTIALS = 3
+_MINIMUM_DOCUMENTED_BULLETS = 4
+
+
+def _literal_env_reads(path: pathlib.Path) -> set[str]:
+    """Return every literal environment variable *path* reads.
+
+    Args:
+        path: The module to scan.
+
+    Returns:
+        The variable names read through ``os.getenv`` / ``os.environ.get`` /
+        ``os.environ[...]`` with a literal key.
+    """
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        name = None
+        if isinstance(node, ast.Call) and ast.unparse(node.func) in (
+            "os.getenv",
+            "os.environ.get",
+        ):
+            if node.args and isinstance(node.args[0], ast.Constant):
+                name = node.args[0].value
+        elif isinstance(node, ast.Subscript) and ast.unparse(node.value) == "os.environ":
+            if isinstance(node.slice, ast.Constant):
+                name = node.slice.value
+        if isinstance(name, str) and re.fullmatch(r"[A-Z][A-Z0-9_]*", name):
+            found.add(name)
+    return found
+
+
+def _credentials_read() -> set[str]:
+    """Return the IoT credentials the transport reads from the environment."""
+    return {var for var in _literal_env_reads(_TRANSPORT) if _CREDENTIAL.fullmatch(var)}
+
+
+def _provisioner_exports() -> set[str]:
+    """Return the IoT credentials the provisioner tells an operator to export."""
+    from strands_robots.mesh.iot.provision import ProvisionedThing
+
+    provisioned = ProvisionedThing(
+        thing_name="probe-thing",
+        thing_arn="arn:aws:iot:us-west-2:000000000000:thing/probe-thing",
+        cert_arn="arn:aws:iot:us-west-2:000000000000:cert/probe",
+        cert_id="probe",
+        cert_path=pathlib.Path("/probe/certs/probe-thing.cert.pem"),
+        key_path=pathlib.Path("/probe/certs/probe-thing.private.key"),
+        ca_path=pathlib.Path("/probe/certs/AmazonRootCA1.pem"),
+        endpoint="probe-ats.iot.us-west-2.amazonaws.com",
+        policy_name="probe-policy",
+        region="us-west-2",
+    )
+    return {var for var in provisioned.env_vars() if _CREDENTIAL.fullmatch(var)}
+
+
+def _documented_bullets(page: str) -> dict[str, str]:
+    """Map each variable the page documents to the heading it sits under.
+
+    Args:
+        page: The markdown source to read.
+
+    Returns:
+        ``{"VAR": "heading text"}`` for every bullet naming a variable.
+    """
+    bullets: dict[str, str] = {}
+    heading = ""
+    for line in page.splitlines():
+        if line.startswith("#"):
+            heading = line.lstrip("#").strip()
+            continue
+        match = _BULLET_VAR.match(line)
+        if match:
+            bullets.setdefault(match.group(1), heading)
+    return bullets
+
+
+def _credential_sections(page: str) -> dict[str, str]:
+    """Return the heading each credential is documented under.
+
+    A credential the page omits entirely maps to ``""``, so the caller sees one
+    verdict for "documented elsewhere" and "not documented at all".
+    """
+    bullets = _documented_bullets(page)
+    return {var: bullets.get(var, "") for var in sorted(_credentials_read())}
+
+
+@pytest.fixture
+def page() -> str:
+    """The shipped security reference."""
+    return _PAGE.read_text(encoding="utf-8")
+
+
+class TestTheScanReachesTheSurface:
+    """The derivations read something, so a clean result is not a silent zero."""
+
+    def test_the_transport_scan_finds_the_credentials(self) -> None:
+        """A scan that read no credential would pass every rule below."""
+        found = _credentials_read()
+        assert len(found) >= _MINIMUM_CREDENTIALS, (
+            f"expected at least {_MINIMUM_CREDENTIALS} IoT credentials read by "
+            f"{_TRANSPORT.name}, found {sorted(found)}. A scan that reads nothing "
+            "reports the same clean result as a fully documented page."
+        )
+
+    def test_the_page_documents_variables_as_bullets(self, page: str) -> None:
+        """The bullet form is how this page already writes its variables."""
+        bullets = _documented_bullets(page)
+        assert len(bullets) >= _MINIMUM_DOCUMENTED_BULLETS, (
+            f"expected at least {_MINIMUM_DOCUMENTED_BULLETS} documented variables "
+            f"on {_PAGE.name}, parsed {sorted(bullets)}. A parser that matches no "
+            "bullet cannot tell a documented variable from an omitted one."
+        )
+
+    def test_the_provisioner_hands_out_credentials(self) -> None:
+        """The export list is the operator-facing set the page must explain."""
+        exported = _provisioner_exports()
+        assert len(exported) >= _MINIMUM_CREDENTIALS, (
+            f"expected at least {_MINIMUM_CREDENTIALS} IoT credentials from "
+            f"ProvisionedThing.env_vars, found {sorted(exported)}."
+        )
+
+
+class TestTheReferenceCoversTheCredentials:
+    """Every credential the code honours is documented, and one link reads as one."""
+
+    def test_every_credential_the_transport_reads_is_documented(self, page: str) -> None:
+        """A credential the transport reads but the page omits is unreachable config."""
+        missing = sorted(_credentials_read() - set(_documented_bullets(page)))
+        assert not missing, (
+            f"docs/security.md documents no bullet for IoT credentials the transport "
+            f"reads: {missing}. Both the iot and bridge backends construct "
+            "IotMqttTransport with no arguments, so a variable the code honours and "
+            "the page omits is the whole of a setting the operator cannot find - "
+            "connect() then returns False and the peer never appears on the fleet."
+        )
+
+    def test_every_credential_the_provisioner_exports_is_documented(self, page: str) -> None:
+        """The page and the provisioner cannot disagree about the operator's set."""
+        missing = sorted(_provisioner_exports() - set(_documented_bullets(page)))
+        assert not missing, (
+            f"ProvisionedThing.env_vars tells an operator to export {missing}, which "
+            "docs/security.md does not explain. The provisioner's export list is the "
+            "package's own answer to what must be set, so the page has to name it."
+        )
+
+    def test_the_credentials_are_documented_in_one_section(self, page: str) -> None:
+        """The variables of one link belong under one heading."""
+        sections = _credential_sections(page)
+        assert len(set(sections.values())) == 1, (
+            "the credentials that configure the AWS IoT broker link are documented "
+            f"under different headings (empty = not documented at all): {sections}. "
+            "One link's variables belong in one place: two name the broker and the "
+            "Thing, two locate the certificate material, so a reader who finds only "
+            "some of them configures half a connection."
+        )
+
+
+class TestTheSilentOffIsWhyTheOmissionMatters:
+    """Facts about the code, true on both sides of this documentation change."""
+
+    def test_a_missing_thing_name_is_reported_by_name_and_the_mesh_stays_off(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """With nothing set, the operator learns the first name from a log line."""
+        pytest.importorskip("awsiot")
+        from strands_robots.mesh.transport import iot_transport
+
+        for var in _credentials_read():
+            monkeypatch.delenv(var, raising=False)
+        transport = iot_transport.IotMqttTransport()
+
+        with caplog.at_level(logging.ERROR, logger=iot_transport.__name__):
+            assert transport.connect() is False
+
+        assert any("STRANDS_IOT_THING_NAME" in record.getMessage() for record in caplog.records), (
+            f"connect() refused without naming the missing credential: "
+            f"{[record.getMessage() for record in caplog.records]}"
+        )
+
+    def test_a_missing_endpoint_is_reported_by_name(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Each credential is discovered separately, one refusal at a time."""
+        pytest.importorskip("awsiot")
+        from strands_robots.mesh.transport import iot_transport
+
+        for var in _credentials_read():
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("STRANDS_IOT_THING_NAME", "probe-thing")
+        transport = iot_transport.IotMqttTransport()
+
+        with caplog.at_level(logging.ERROR, logger=iot_transport.__name__):
+            assert transport.connect() is False
+
+        assert any("STRANDS_IOT_ENDPOINT" in record.getMessage() for record in caplog.records), (
+            f"connect() refused without naming the missing endpoint: "
+            f"{[record.getMessage() for record in caplog.records]}"
+        )


### PR DESCRIPTION
## Problem

`docs/security.md`'s "Cross-network fleets (AWS IoT Core)" section is where an operator configures the AWS IoT Core path. It tells the reader that the IoT device certificates and provisioning material "become production secrets - provision them per-device, scope their IoT policies to the minimum topic set, and rotate/revoke them like any other fleet credential", and it names no variable at all.

Every credential `IotMqttTransport` reads was undocumented across the whole of `docs/` and `README.md`:

| Variable | Required | Read by | Handed out by the provisioner | Occurrences in `docs/` + `README.md` |
|---|---|---|---|---|
| `STRANDS_IOT_THING_NAME` | yes | `mesh/transport/iot_transport.py:348` | yes | 0 |
| `STRANDS_IOT_ENDPOINT` | yes | `iot_transport.py:349` | yes | 0 |
| `STRANDS_IOT_CERT_DIR` | no, defaults to `~/.strands_robots/iot` | `iot_transport.py:350` | yes | 0 |
| `STRANDS_IOT_CA_FILE` | no, defaults to `AmazonRootCA1.pem` in the cert dir | `iot_transport.py:351` | no | 0 |

`transport.factory.get_transport` and `BridgeTransport.__init__` both construct `IotMqttTransport()` with no arguments, so for both the `iot` and `bridge` backends these four variables are the whole of its configuration. `mesh.iot.provision.ProvisionedThing.env_vars` returns three of them plus `STRANDS_MESH_BACKEND`, which is the package's own answer to what an operator must export - and until #2864 and #2867 landed, the page explained none of the four.

## Why it matters

The failure is silent by design: the module docstring states that a missing credential leaves the mesh off "rather than crash the host". So the symptom is a peer that never appears on the fleet, and the names were reachable only one refusal at a time. Measured with `awsiotsdk` present, one credential added per row:

| Environment | `connect()` | ERROR logged |
|---|---|---|
| nothing set | `False` | `STRANDS_IOT_THING_NAME is required for IoT transport (must match the AWS IoT Thing name attached to the cert)` |
| `THING_NAME` set | `False` | `STRANDS_IOT_ENDPOINT is required for IoT transport` |
| both set | `False` | `IoT certificate not found: ~/.strands_robots/iot/<thing>.cert.pem` |
| `CERT_DIR` set to an empty directory | `False` | `IoT certificate not found: <dir>/<thing>.cert.pem` |

The transport names the variable it wants at runtime; the page an operator reads beforehand did not.

## Change

The section gains a paragraph and four bullets - the form this page already uses for every other environment variable, and it has no tables. Each bullet states whether the variable is required, what it defaults to, and what the value has to match: the Thing name is sent as the MQTT `client_id`, so it must match both the certificate's CN and the Thing the IoT policy authorises through `${iot:Connection.Thing.ThingName}`, and the cert directory must hold `{thing}.cert.pem`, `{thing}.private.key` and `AmazonRootCA1.pem`.

`tests/mesh/test_docs_iot_credentials_reference.py` grades three properties, each derived from the package rather than from a list kept beside it, following `tests/test_docs_device_connect_env_reference.py` - the guard that exists because `REACHY_DAEMON_TLS` stayed undocumented the same way:

- every credential the transport reads has a documented bullet;
- every credential the provisioner exports has one, so the page and `env_vars` cannot drift;
- they are documented under one heading, because they configure a single channel.

The behavioural facts above are asserted too, gated on `awsiot`, which `[all]` installs.

## Verification

Pre-fix, with the documentation reverted and the guard kept: **2 failed, 6 passed**. Both regression cells fire and name the omission - `['STRANDS_IOT_CA_FILE', 'STRANDS_IOT_CERT_DIR', 'STRANDS_IOT_ENDPOINT', 'STRANDS_IOT_THING_NAME']` from the transport rule and the three exported names from the provisioner rule. The four control and floor cells stay clean.

Mutation table, `collected` stable at 8 on every row and `sib` measured over `tests/mesh/test_transport.py`, `tests/mesh/test_iot_provision.py`, `tests/test_docs_device_connect_env_reference.py` and `tests/test_dependency_audit.py`:

| Mutation | Guard fires | sib | Cells |
|---|---|---|---|
| control | 0 | 0 | - |
| all four bullets removed | 2 | 0 | transport rule, provisioner rule |
| only the optional `CA_FILE` bullet removed | 2 | 0 | transport rule, one-section rule |
| only the required `THING_NAME` bullet removed | 3 | 0 | all three documentation rules |
| two bullets moved to another section | 1 | 0 | one-section rule alone |
| credential scan hardcoded to three names, `CA_FILE` bullet removed | **0** | 0 | - |
| credential scan hardcoded, page intact | 0 | 0 | - |
| bullet parser matches nothing | 3 | 0 | both rules plus the floor |
| transport refusal stops naming `THING_NAME` | 1 | 0 | behavioural cell |

The two zero rows are the point of deriving the set: hardcoding the scan to today's three exported names lets the fourth credential go undocumented in silence, where the AST-derived scan reports it. The last row is why the behavioural cells exist - the refusal text is the operator's only other route to the name, so it is pinned.

Skip arithmetic, same 8 collected either way: `6 passed, 2 skipped` without `awsiot`, `8 passed` with it, so nothing is hidden on an install that has the extra.

Lint: `ruff check` clean, `ruff format --check` 1663 files already formatted, `mypy strands_robots tests tests_integ` 24 errors in 9 files against 24 on the base with byte-identical normalised message sets in both directions and 0 attributable, `mkdocs build --strict` builds in 1.67s.

Paired suite over a 566-file selection - every test that walks the tree, parses source, or reads `docs/`, `README.md` or `pyproject.toml`, plus all of `tests/mesh/`, with the new file excluded from both sides: identical **23087 collected** and `23 failed, 22967 passed, 73 skipped, 24 errors` on each, 47 identical failing ids, both `comm` directions empty. Of those 47, 45 need `awsiot`/`awscrt` (declared in `[mesh-iot]`, absent on this machine, installed in CI through `[all]`) and 2 are the existing lerobot-from-source drift in `tests/training/test_lerobot.py`.

Composed against #2864 and #2867 before they merged - all three touch this documentation area and #2864 edits the same file - the merge was conflict-free and both guards passed together, 33 cells. After rebasing onto them the section reads as one sequence: the two-step extra-and-selector paragraph, then the credentials the selected transport reads.

No visual artifact: this is a documentation and test change, with no policy, simulation, rendering, recording or asset behaviour to render.
