### PR TITLE
docs(security): name the audit-log environment variables the module reads

### DIFF
--- a/changelog.d/2871-audit-env-vars-documented.md
+++ b/changelog.d/2871-audit-env-vars-documented.md
@@ -25,8 +25,8 @@ four variables in the form the page already uses for every other
 configuration knob: whether the variable is required, what it defaults to,
 and what setting it wrong looks like at runtime.  The section also names the
 symlink refusal, because a hardening reader who set `_DIR` to a controlled
-path expects to know that a symlink already sitting at the target is
-refused before the daemon starts writing.
+path expects to know that a symlink already sitting at the target is refused
+rather than written through.
 
 The rule is pinned by
 `tests/mesh/test_docs_audit_env_vars_reference.py`, following the same
@@ -35,8 +35,41 @@ and #2870's `tests/mesh/test_docs_iot_credentials_reference.py`: every
 `STRANDS_MESH_AUDIT_*` name the module reads must appear on the page, all
 must appear under one heading, and that heading must be the "Audit log"
 heading the module docstring references.  A fifth variable added to
-`mesh/audit.py` later is graded on arrival.  This is the first
-scoped-and-shipped answer to the guardrail called for by harness#376
-("~58 `STRANDS_*` vars undocumented"); the same test pattern extends to
-the other groups (TLS, transport, bridge, training, sim) named in that
-issue.
+`mesh/audit.py` later is graded on arrival.  The same test pattern extends to
+the other undocumented `STRANDS_*` groups (TLS, transport, bridge, training,
+sim).
+
+Two of that section's first-draft claims were the inverse of the module they
+document, and both are corrected here.  It promised that a peer which cannot
+open the log "refuses to start the auditor, rather than running with the audit
+trail silently off"; `log_safety_event` documents the opposite - "write errors
+are logged at WARNING and swallowed because an audit-log failure must never
+propagate up into the safety code path" - and its write block ends in
+`except OSError: logger.warning("[audit] failed to write ...")`.  There is no
+eager auditor start at all: `_ensure_paths` runs per write.  Measured over
+three ways to make the destination unusable (an unwritable parent, a symlink
+at the log path, a directory at the log path), three safety events each time
+produced no exception, zero records written, and only WARNING lines - exactly
+the posture the sentence promised could not happen.  An operator following it
+would have concluded that a running mesh implies a written trail and added no
+monitoring for the real signal.
+
+It also named the persisted signature field `hmac`.  The writer assigns
+`record["sig"]`, `verify_audit_integrity` reads `record.get("sig")`, and no
+record carries an `hmac` key.  The field name is part of the on-disk JSONL
+schema, so it is what an external verifier - a SIEM rule, a forensic script -
+greps for; a checker built from the old wording finds nothing on a correctly
+signed fleet and either alarms permanently or concludes tamper-evidence is
+off.  HMAC-the-mechanism was correct throughout; only the field name was
+wrong.
+
+Both survived the guard above because a presence rule is satisfied by a
+bullet that mentions the variable, whatever the bullet asserts.  The test
+file gains the missing axis: the documented signature field is derived from
+the writer's own dataflow (the `record[...]` key the `_sign_record` result is
+assigned to), every field name the section mentions must be one the record
+schema carries, the section may not assert a refusal to start, and every
+`[audit]` log line it tells an operator to monitor for must be a string the
+module emits.  Behavioural cells hold the two claims against the running
+writer, so a rule that stopped deriving is caught by a written record rather
+than by agreeing with itself.

--- a/changelog.d/2871-audit-env-vars-documented.md
+++ b/changelog.d/2871-audit-env-vars-documented.md
@@ -1,0 +1,42 @@
+### Docs: the audit log's environment variables are named on the security page
+
+`strands_robots/mesh/audit.py` reads four `STRANDS_MESH_AUDIT_*` environment
+variables that decide where the mesh's tamper-evident audit trail is written,
+how large it may grow, and whether it carries a per-record HMAC:
+`STRANDS_MESH_AUDIT_DIR`, `STRANDS_MESH_AUDIT_PSK`,
+`STRANDS_MESH_AUDIT_MAX_BYTES`, and `STRANDS_MESH_AUDIT_MAX_FILES`.  None of
+the four appeared anywhere under `docs/`.  An operator who read
+`docs/security.md` believed the transport was hardened and the mesh action
+surface was gated, and never saw the four variables that decide whether the
+log they were relying on to reconstruct fleet-wide actions was itself
+forgeable and where on disk it lived.
+
+The failure was silent by construction: the module wrote the log at
+`~/.strands_robots/mesh_audit.jsonl` whether or not the PSK was configured,
+so `ls` on the default directory showed a well-formed JSONL trail on both
+sides of the tamper-evidence contract.  Only `verify_audit_integrity` could
+tell the two apart, and only if invoked - and the environment variable that
+turned the check on was undocumented, so a reader with a hardening checklist
+had nothing to check.
+
+`docs/security.md` gains an "Audit log" section, sibling to the transport
+posture sections above and to "Credentials and secrets" below, listing all
+four variables in the form the page already uses for every other
+configuration knob: whether the variable is required, what it defaults to,
+and what setting it wrong looks like at runtime.  The section also names the
+symlink refusal, because a hardening reader who set `_DIR` to a controlled
+path expects to know that a symlink already sitting at the target is
+refused before the daemon starts writing.
+
+The rule is pinned by
+`tests/mesh/test_docs_audit_env_vars_reference.py`, following the same
+AST-derived pattern as `tests/test_docs_device_connect_env_reference.py`
+and #2870's `tests/mesh/test_docs_iot_credentials_reference.py`: every
+`STRANDS_MESH_AUDIT_*` name the module reads must appear on the page, all
+must appear under one heading, and that heading must be the "Audit log"
+heading the module docstring references.  A fifth variable added to
+`mesh/audit.py` later is graded on arrival.  This is the first
+scoped-and-shipped answer to the guardrail called for by harness#376
+("~58 `STRANDS_*` vars undocumented"); the same test pattern extends to
+the other groups (TLS, transport, bridge, training, sim) named in that
+issue.

--- a/docs/security.md
+++ b/docs/security.md
@@ -184,16 +184,22 @@ that hides.  The variables:
 - **`STRANDS_MESH_AUDIT_DIR`** *(optional; default: `~/.strands_robots/`,
   under which `mesh_audit.jsonl` is written)*.  Overrides the write path for
   the JSONL file.  The directory must be writable by the process that hosts
-  the mesh; a peer whose process cannot open the file refuses to start the
-  auditor, rather than running with the audit trail silently off.  A symlink
-  at the log path is refused - the audit log must be a regular file at the
-  canonical location, so an attacker cannot redirect writes to `/dev/null`
-  or a file owned by another process.
+  the mesh, and an unusable destination does **not** stop the peer: a write
+  error is logged at WARNING and swallowed, because an audit-log failure must
+  never propagate into the safety code path that emitted the event.  So the
+  posture to plan for when relocating this variable is a peer that keeps
+  running with the audit trail off, emitting one `[audit]` WARNING per dropped
+  record - `[audit] failed to write` from the write itself.  Monitor that
+  line; a running mesh does not imply a written trail.  A symlink at the log
+  path is refused - the audit log must be a regular file at the canonical
+  location, so an attacker cannot redirect writes to `/dev/null` or a file
+  owned by another process - and that refusal reaches the operator through the
+  same swallowed WARNING, not as a failure to start.
 - **`STRANDS_MESH_AUDIT_PSK`** *(optional; when set, per-record HMAC is on)*.
   A pre-shared key that keys the SHA-256 HMAC written into each record's
-  `hmac` field.  With the PSK set, `verify_audit_integrity` refuses a record
+  `sig` field.  With the PSK set, `verify_audit_integrity` refuses a record
   whose HMAC does not match the running key, and refuses the whole log if the
-  PSK changes between records.  Without the PSK the `hmac` field is absent
+  PSK changes between records.  Without the PSK the `sig` field is absent
   and the check step trusts the file: an attacker with write access to
   `STRANDS_MESH_AUDIT_DIR` could edit a record and leave no HMAC to fail
   against.  Set the PSK on every peer that writes to the same directory.

--- a/docs/security.md
+++ b/docs/security.md
@@ -171,6 +171,52 @@ Reference: `strands_robots.tools.gr00t_inference`.
 - **Agent-side command gate (`use_ros`).** The bridge protections above harden the *inbound* surface a robot exposes. The three graph tools - `use_ros`, `use_rtps` and `use_rosbridge` - are the other direction, an agent publishing onto someone else's graph, and each gates the safety-critical surfaces behind an operator interrupt, keyed on the surface name so a topic publish, a service call and an action goal are all covered. One shared blocklist serves all three, so a surface refused on one transport cannot be sent on another. `RosBridgedRobot`, `AckermannRosRobot` and `RtpsRobot` all forward the operator context into it, so an agent-driven robot prompts whichever transport carries the command, while a programmatic `robot.drive(...)`/`stop()` needs the surface pre-approved. Pre-approve surfaces with `STRANDS_ROS2_COMMAND_ALLOW` - matched by base name as well as exactly, so a `/cmd_vel` entry lifts the gate on every namespaced `cmd_vel` and not only the robot being driven; name the namespace to scope it to one - or bypass with `BYPASS_TOOL_CONSENT=true`; with neither set and no interrupt reachable it fails closed. See [safety-critical command surfaces](ros2-integration.md#safety-critical-command-surfaces-need-operator-approval).
 - **Telemetry-only is ungated.** `ros2_commands=False` is publish-only (no inbound surface) and needs no security config. That posture is only as good as how the flag is read, so `ros2_bridge` / `ros2_commands` (and `enable_commands` on either bridge class directly) are **checked** against the shared boolean domain rather than read by truthiness: a non-boolean is refused at construction, so a deployment config that spells the flag `"false"` cannot select the surface it asks to close.
 
+## Audit log
+
+Every fleet action the mesh accepts is appended to a JSONL audit log.  The log
+lives on disk, and four environment variables configure where it is written,
+how large it may grow, and whether records carry a per-record HMAC that lets a
+downstream verifier reject a forged entry.  Without the PSK, the log is still
+written and still verifiable for order and sequence continuity, but a
+tamper-evidence step is off: the mode is a deliberate posture, not a default
+that hides.  The variables:
+
+- **`STRANDS_MESH_AUDIT_DIR`** *(optional; default: `~/.strands_robots/`,
+  under which `mesh_audit.jsonl` is written)*.  Overrides the write path for
+  the JSONL file.  The directory must be writable by the process that hosts
+  the mesh; a peer whose process cannot open the file refuses to start the
+  auditor, rather than running with the audit trail silently off.  A symlink
+  at the log path is refused - the audit log must be a regular file at the
+  canonical location, so an attacker cannot redirect writes to `/dev/null`
+  or a file owned by another process.
+- **`STRANDS_MESH_AUDIT_PSK`** *(optional; when set, per-record HMAC is on)*.
+  A pre-shared key that keys the SHA-256 HMAC written into each record's
+  `hmac` field.  With the PSK set, `verify_audit_integrity` refuses a record
+  whose HMAC does not match the running key, and refuses the whole log if the
+  PSK changes between records.  Without the PSK the `hmac` field is absent
+  and the check step trusts the file: an attacker with write access to
+  `STRANDS_MESH_AUDIT_DIR` could edit a record and leave no HMAC to fail
+  against.  Set the PSK on every peer that writes to the same directory.
+- **`STRANDS_MESH_AUDIT_MAX_BYTES`** *(optional; default: 100 MiB per file;
+  hard upper cap: 10 GiB)*.  Rotates the JSONL file when the active file
+  crosses the cap.  Values above the hard cap are clamped and logged;
+  non-integer, zero, or negative values fall back to the default with a
+  warning, so a misconfiguration cannot disable rotation by silently reading
+  as zero.
+- **`STRANDS_MESH_AUDIT_MAX_FILES`** *(optional; default: 5 rotated files;
+  hard upper cap: 100)*.  The number of rotated `mesh_audit.jsonl.N` files
+  kept alongside the active file.  Older rotations are deleted as new ones
+  arrive; total disk use is bounded by `_MAX_BYTES × _MAX_FILES` (default
+  500 MiB).  The same clamping and warning behaviour applies as for
+  `_MAX_BYTES`.
+
+The audit log records what the mesh accepted; the *inbound* command surface
+that decides what to accept is configured under [Robot mesh authentication](#robot-mesh-authentication)
+above, and the *outbound* subscribe surface that decides what leaves the peer
+is under [Telemetry exposure to the agent context](#telemetry-exposure-to-the-agent-context)
+below.  A production posture pairs the auth mode with the PSK - without both,
+one class of forgery is unprotected.
+
 ## Credentials and secrets
 
 The product touches several classes of secret. Handle each per least-privilege:

--- a/tests/mesh/test_docs_audit_env_vars_reference.py
+++ b/tests/mesh/test_docs_audit_env_vars_reference.py
@@ -1,0 +1,186 @@
+"""Grade the mesh audit log environment reference against the code's env surface.
+
+``docs/security.md`` names the credentials operators must configure to secure a
+fleet: the transport TLS material, the IoT credentials the AWS backend reads,
+and the mesh subscribe allow-list.  It does not, until this file's companion
+change, name the environment variables that configure the *audit log itself* -
+the JSONL write path, the size and file caps that bound disk use, and the PSK
+that turns the log's per-record HMAC on.  A reader who followed the page
+believed the transport was hardened and the actions surface was gated, and
+never saw the four variables that decide where the audit trail lives and
+whether it can be forged.
+
+Two properties are graded here, both derived from the package rather than from
+a list kept alongside it - so a variable added to ``mesh/audit.py`` later is
+graded on arrival:
+
+- **Every audit variable the module reads is documented.** A variable the
+  audit surface honours but the page omits is a setting nobody configuring an
+  audited fleet can find. That is the pattern harness#376 tracks across ~58
+  ``STRANDS_*`` names; this file pins the four that touch the audit log.
+- **The audit variables are documented under one heading.** The four names
+  configure one channel (the audit log file) and its integrity check (the
+  PSK), so an operator turning on tamper-evidence should find them together,
+  not split between "Credentials and secrets" and "Telemetry exposure".
+
+The behavioural fact the rule exists to make discoverable is asserted too:
+with the PSK unset, the audit log accepts a record and re-reads it as-is; the
+HMAC field is absent and the sequence-restore step trusts the file.  That is
+the failure mode - an operator who never saw ``STRANDS_MESH_AUDIT_PSK`` cannot
+know the tamper-evidence contract is off - and it holds on both sides of this
+change, so it is what the four documentation bullets exist to name.
+"""
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+import strands_robots
+
+_AUDIT_MODULE = pathlib.Path(strands_robots.__file__).parent / "mesh" / "audit.py"
+_PAGE = pathlib.Path(strands_robots.__file__).parent.parent / "docs" / "security.md"
+
+#: The prefix every audit-log env var shares.  Reading the module for the
+#: literal names lets a fifth variable added later fail this file on arrival.
+_AUDIT_PREFIX = "STRANDS_MESH_AUDIT_"
+
+#: The heading the four bullets sit under.  A single heading is the point of
+#: rule two: a reader turning on audit-log tamper-evidence finds the file
+#: location, the size caps, and the PSK together.
+_AUDIT_HEADING = "Audit log"
+
+
+def _audit_env_reads() -> set[str]:
+    """The set of ``STRANDS_MESH_AUDIT_*`` env vars ``mesh/audit.py`` reads.
+
+    Returns:
+        Every literal ``os.getenv`` / ``os.environ.get`` / ``os.environ[...]``
+        key in ``mesh/audit.py`` that starts with ``STRANDS_MESH_AUDIT_``.
+    """
+    found: set[str] = set()
+    tree = ast.parse(_AUDIT_MODULE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        name: str | None = None
+        if isinstance(node, ast.Call) and ast.unparse(node.func) in (
+            "os.getenv",
+            "os.environ.get",
+        ):
+            if node.args and isinstance(node.args[0], ast.Constant):
+                name = node.args[0].value
+        elif isinstance(node, ast.Subscript) and ast.unparse(node.value) == "os.environ":
+            if isinstance(node.slice, ast.Constant):
+                name = node.slice.value
+        if isinstance(name, str) and name.startswith(_AUDIT_PREFIX):
+            found.add(name)
+    return found
+
+
+def _documented_audit_vars() -> dict[str, str]:
+    """Map each documented ``STRANDS_MESH_AUDIT_*`` var to its section heading.
+
+    Returns:
+        ``{"VAR": "heading text"}`` for every backticked ``STRANDS_MESH_AUDIT_*``
+        token that appears in ``docs/security.md``, keyed to the nearest
+        preceding ``## `` or ``### `` heading.  A variable named twice under
+        different headings takes its first mention, because that is the entry
+        the reader lands on when they follow the page top to bottom.
+    """
+    text = _PAGE.read_text(encoding="utf-8")
+    mapping: dict[str, str] = {}
+    current = ""
+    var_pattern = re.compile(r"`(" + re.escape(_AUDIT_PREFIX) + r"[A-Z0-9_]+)`")
+    for line in text.splitlines():
+        heading = re.match(r"^#{2,3}\s+(.+?)\s*$", line)
+        if heading:
+            current = heading.group(1).strip()
+            continue
+        for match in var_pattern.finditer(line):
+            name = match.group(1)
+            mapping.setdefault(name, current)
+    return mapping
+
+
+def test_every_audit_env_var_is_documented():
+    """Every ``STRANDS_MESH_AUDIT_*`` var the module reads has a docs entry.
+
+    This is the rule that fires when a knob lands in ``mesh/audit.py`` without
+    a corresponding mention in ``docs/security.md``.  It reads the module's AST
+    for the literal keys rather than trusting an authored list, so no future
+    variable is silently omitted.
+    """
+    read = _audit_env_reads()
+    documented = _documented_audit_vars()
+    missing = sorted(read - documented.keys())
+    assert not missing, (
+        f"``mesh/audit.py`` reads {sorted(read)} but ``docs/security.md`` "
+        f"names {sorted(documented)}. Undocumented: {missing}. "
+        f"Add a bullet under the ``{_AUDIT_HEADING}`` heading naming each."
+    )
+
+
+def test_audit_env_vars_are_documented_together():
+    """All documented ``STRANDS_MESH_AUDIT_*`` vars sit under one heading.
+
+    Rule two: the four names configure one channel.  Splitting them across
+    sections is what let ``REACHY_DAEMON_TLS`` sit under a different heading
+    from the token it carried, leaving a reader who configured half a posture.
+    The audit log is one channel and its variables belong together.
+    """
+    documented = _documented_audit_vars()
+    if not documented:
+        pytest.fail(
+            f"No ``STRANDS_MESH_AUDIT_*`` variables are documented in "
+            f"``docs/security.md``. Expected an ``{_AUDIT_HEADING}`` section."
+        )
+    headings = {heading for heading in documented.values() if heading}
+    assert len(headings) == 1, (
+        f"``STRANDS_MESH_AUDIT_*`` variables are split across headings "
+        f"{sorted(headings)}. An operator turning on the audit log expects "
+        f"one section listing every knob; splitting them lets a reader who "
+        f"followed the page configure a partial posture."
+    )
+
+
+def test_audit_env_vars_sit_under_the_named_heading():
+    """The one heading is the ``{_AUDIT_HEADING}`` heading.
+
+    Naming the heading pins the section anchor: a reader following a link,
+    a search, or a table of contents lands on the same title the module's
+    module-level docstring references.  Without this pin, rules one and two
+    could be satisfied by a section titled "Notes" that the page does not
+    otherwise treat as the audit-log reference.
+    """
+    documented = _documented_audit_vars()
+    if not documented:
+        pytest.skip("no audit vars documented yet; rule one names the omission")
+    headings = {heading for heading in documented.values() if heading}
+    assert _AUDIT_HEADING in headings, (
+        f"``STRANDS_MESH_AUDIT_*`` variables sit under {sorted(headings)}, "
+        f"not under a heading named ``{_AUDIT_HEADING}``. The module's "
+        f"docstring references the audit log as a discrete channel; the "
+        f"page's heading should match."
+    )
+
+
+def test_audit_variables_the_module_reads_include_the_four_known_names():
+    """Pin the four names ``mesh/audit.py`` reads today.
+
+    A premise cell: if this fails, the audit module stopped reading one of the
+    four names the docstring narrates, and the documentation rule above may
+    now name a variable the code no longer reads.  Splitting the premise from
+    the rule keeps a passing rule from resting on a stale assumption.
+    """
+    read = _audit_env_reads()
+    known = {
+        "STRANDS_MESH_AUDIT_DIR",
+        "STRANDS_MESH_AUDIT_PSK",
+        "STRANDS_MESH_AUDIT_MAX_BYTES",
+        "STRANDS_MESH_AUDIT_MAX_FILES",
+    }
+    missing = sorted(known - read)
+    assert not missing, (
+        f"``mesh/audit.py`` no longer reads {missing}. Update this test's "
+        f"``known`` set and the docstrings in ``docs/security.md`` accordingly."
+    )

--- a/tests/mesh/test_docs_audit_env_vars_reference.py
+++ b/tests/mesh/test_docs_audit_env_vars_reference.py
@@ -32,12 +32,14 @@ change, so it is what the four documentation bullets exist to name.
 """
 
 import ast
+import logging
 import pathlib
 import re
 
 import pytest
 
 import strands_robots
+from strands_robots.mesh import audit
 
 _AUDIT_MODULE = pathlib.Path(strands_robots.__file__).parent / "mesh" / "audit.py"
 _PAGE = pathlib.Path(strands_robots.__file__).parent.parent / "docs" / "security.md"
@@ -187,4 +189,397 @@ def test_audit_variables_the_module_reads_include_the_four_known_names():
     assert not missing, (
         f"``mesh/audit.py`` no longer reads {missing}. Update this test's "
         f"``known`` set and the docstrings in ``docs/security.md`` accordingly."
+    )
+
+
+# --- The claims the section makes, graded against the module ----------------
+#
+# The four rules above grade whether each variable is *named*.  They cannot see
+# whether what the page says *about* a variable is true, and two of the first
+# section's claims were not: it promised that a process which cannot open the
+# log "refuses to start the auditor, rather than running with the audit trail
+# silently off" (the inverse of ``log_safety_event``'s documented fail-soft
+# contract), and it named the persisted HMAC field ``hmac`` (the module writes
+# ``sig``).  Both survived a green suite because a presence rule is satisfied by
+# a bullet that mentions the variable, whatever the bullet asserts.
+#
+# The rules below close that gap on the two axes an operator or an external
+# verifier actually builds against:
+#
+# - **the persisted record schema**, derived from the module's own dataflow, so
+#   a field name in the page that no record carries fails here rather than in
+#   somebody's SIEM rule; and
+# - **the failure posture**, so the page cannot promise fail-closed behaviour
+#   for a writer whose contract is fail-soft.
+#
+# The posture rules are scoped to this one section deliberately: ``refuses to
+# start`` appears twice elsewhere in ``docs/security.md`` and once in
+# ``docs/rtps-integration.md`` about ``HardwareRtpsBridge``, where it is
+# accurate - that bridge really does refuse to construct without DDS Security
+# material.  A page-wide phrase rule would flag those true claims, so the
+# scope is the audit section and the derivation is the audit writer.
+
+#: Refusal-to-start phrasings.  The negative rule catches the specific false
+#: assurance; the positive rule (the section must describe the swallow) is the
+#: half that survives a rewording, since a bullet reinstating a fail-closed
+#: claim has to delete the swallow sentence to be coherent.
+_REFUSAL_TO_START_PATTERNS = (
+    r"refus\w*\s+to\s+start",
+    r"refus\w*\s+to\s+begin",
+    r"(?:will|does|would)\s+not\s+start",
+)
+
+
+def _audit_section() -> str:
+    """Return the text of the ``Audit log`` section of ``docs/security.md``.
+
+    Returns:
+        Every line from the ``## Audit log`` heading up to the next ``## ``
+        heading.  Scoping the posture rules to this slice keeps them from
+        flagging the accurate ``refuses to start`` claims the same page makes
+        about the RTPS bridge.
+    """
+    lines = _PAGE.read_text(encoding="utf-8").splitlines()
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        if re.match(r"^##\s+", line):
+            if inside:
+                break
+            inside = line.strip() == f"## {_AUDIT_HEADING}"
+            continue
+        if inside:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _log_safety_event_ast() -> ast.FunctionDef:
+    """Return the ``log_safety_event`` definition from ``mesh/audit.py``.
+
+    Returns:
+        The :class:`ast.FunctionDef` for the audit writer, which is the single
+        function that decides both the persisted record schema and what happens
+        when the destination cannot be written.
+    """
+    tree = ast.parse(_AUDIT_MODULE.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "log_safety_event":
+            return node
+    raise AssertionError("mesh/audit.py no longer defines log_safety_event")
+
+
+def _record_field_names() -> set[str]:
+    """Every literal field name the audit writer puts into a record.
+
+    Returns:
+        The keys of the ``record`` dict literal plus every literal key assigned
+        through ``record[...] = ...``, which together are the persisted JSONL
+        schema an external verifier reads.
+    """
+    found: set[str] = set()
+    for node in ast.walk(_log_safety_event_ast()):
+        # ``record: dict[str, Any] = {...}`` is an AnnAssign, so a walk that
+        # only reads Assign finds the ``record[...] = ...`` additions and none
+        # of the envelope the writer starts from.
+        if isinstance(node, ast.AnnAssign):
+            targets: list[ast.expr] = [node.target]
+        elif isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        else:
+            continue
+        if isinstance(node.value, ast.Dict):
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id == "record":
+                    for key in node.value.keys:
+                        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                            found.add(key.value)
+        for target in targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "record"
+                and isinstance(target.slice, ast.Constant)
+                and isinstance(target.slice.value, str)
+            ):
+                found.add(target.slice.value)
+    return found
+
+
+def _signature_field_name() -> str:
+    """Return the record field the per-record HMAC is written into.
+
+    Derived by dataflow rather than by name: find the local the
+    ``_sign_record`` call binds, then the ``record[...]`` key that local is
+    assigned to.  Renaming the field in ``mesh/audit.py`` therefore moves this
+    answer, and the documentation rule below follows it.
+
+    Returns:
+        The field name, e.g. ``"sig"``.
+    """
+    fn = _log_safety_event_ast()
+    signed_locals: set[str] = set()
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and ast.unparse(node.value.func) == "_sign_record"
+        ):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    signed_locals.add(target.id)
+    assert signed_locals, "mesh/audit.py no longer binds the result of _sign_record"
+
+    fields: set[str] = set()
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (isinstance(node.value, ast.Name) and node.value.id in signed_locals):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "record"
+                and isinstance(target.slice, ast.Constant)
+            ):
+                fields.add(str(target.slice.value))
+    assert len(fields) == 1, f"expected exactly one record field assigned from _sign_record, found {sorted(fields)}"
+    return fields.pop()
+
+
+def _fields_the_section_names() -> set[str]:
+    """Field names the audit section claims a record carries.
+
+    Returns:
+        Every backticked token the section describes as a ``field``, e.g. the
+        ``sig`` in "each record's ``sig`` field".
+    """
+    return set(re.findall(r"`([a-z_][a-z0-9_]*)`\s+field", _audit_section()))
+
+
+def _audit_log_lines_the_section_quotes() -> set[str]:
+    """Log-line fragments the section tells an operator to monitor for.
+
+    Returns:
+        Every backticked token in the section that starts with the module's
+        ``[audit]`` log prefix.
+    """
+    return set(re.findall(r"`(\[audit\][^`]*)`", _audit_section()))
+
+
+@pytest.fixture
+def isolated_audit(monkeypatch, tmp_path):
+    """Point the audit writer at a scratch directory with no PSK.
+
+    Mirrors the isolation fixture in ``tests/mesh/test_audit_integrity.py``:
+    the sequence counters and the per-run PSK fingerprint snapshot are process
+    globals, so a behavioural cell that does not reset them inherits whatever
+    an earlier test left behind.  Deliberately opt-in rather than autouse - the
+    documentation rules above must read the page, not a patched environment.
+    """
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path))
+    monkeypatch.delenv("STRANDS_MESH_AUDIT_PSK", raising=False)
+    audit._SEQ_COUNTERS.clear()
+    audit._AUDIT_STATE.seq_loaded = False
+    audit._AUDIT_STATE.audit_log_seeded = False
+    audit._AUDIT_STATE.psk_fingerprint = None
+    yield tmp_path
+    audit._SEQ_COUNTERS.clear()
+    audit._AUDIT_STATE.seq_loaded = False
+    audit._AUDIT_STATE.audit_log_seeded = False
+    audit._AUDIT_STATE.psk_fingerprint = None
+
+
+def test_the_section_names_the_field_the_signature_is_written_into():
+    """The documented HMAC field is the one the writer assigns the signature to.
+
+    The field name is part of the persisted JSONL schema, so it is what a SIEM
+    rule or a forensic script greps for.  The page named ``hmac``; the writer
+    assigns ``record["sig"]``.  A checker built from the old wording finds no
+    match on a correctly-signed fleet and either alarms forever or concludes
+    tamper-evidence is off.
+    """
+    field = _signature_field_name()
+    named = _fields_the_section_names()
+    assert field in named, (
+        f"``mesh/audit.py`` writes the per-record HMAC into ``record[{field!r}]`` "
+        f"but the ``{_AUDIT_HEADING}`` section names {sorted(named)} as record "
+        f"fields. Name ``{field}`` where the PSK bullet describes the signature."
+    )
+
+
+def test_every_field_the_section_names_is_one_a_record_carries():
+    """No documented field name is absent from the persisted schema.
+
+    The complement of the rule above: naming the right field is not enough if
+    the page also names one no record has.  Both halves are needed because the
+    page describes the signed and unsigned postures in separate sentences, and
+    only one of them has to be wrong to send a verifier looking for a key that
+    never appears.
+    """
+    schema = _record_field_names()
+    named = _fields_the_section_names()
+    unknown = sorted(named - schema)
+    assert not unknown, (
+        f"The ``{_AUDIT_HEADING}`` section names {unknown} as record field(s), "
+        f"but ``log_safety_event`` writes {sorted(schema)}. A verifier built "
+        f"from this page would look for a key no record carries."
+    )
+
+
+def test_the_section_does_not_promise_a_refusal_to_start():
+    """The page must not offer fail-closed assurance for a fail-soft writer.
+
+    ``log_safety_event`` swallows write errors by contract, so there is no
+    startup refusal to promise: an unusable destination yields a running peer
+    with the audit trail off.  Scoped to this section because the same page
+    accurately says ``refuses to start`` about the RTPS bridge.
+    """
+    section = _audit_section()
+    hits = [pattern for pattern in _REFUSAL_TO_START_PATTERNS if re.search(pattern, section, re.IGNORECASE)]
+    assert not hits, (
+        f"The ``{_AUDIT_HEADING}`` section asserts a refusal to start "
+        f"(matched {hits}), but ``log_safety_event`` logs write errors at "
+        f"WARNING and swallows them - the peer keeps running with the audit "
+        f"trail off. Describe that posture instead."
+    )
+
+
+def test_the_section_describes_the_swallowed_write_error():
+    """The page states the posture an operator has to plan for.
+
+    The positive half of the rule above, and the half that survives a
+    rewording: a bullet that reinstates a fail-closed claim has to remove this
+    description to read coherently, so this cell fires on the rewrite even if
+    the phrasing dodges the negative patterns.
+    """
+    section = _audit_section().lower()
+    assert "warning" in section, (
+        f"The ``{_AUDIT_HEADING}`` section does not mention the WARNING level "
+        f"that an audit write failure is reported at, so a reader cannot know "
+        f"which signal to monitor for."
+    )
+    assert "swallow" in section, (
+        f"The ``{_AUDIT_HEADING}`` section does not say that audit write "
+        f"errors are swallowed, which is the posture ``log_safety_event`` "
+        f"documents and the reason a running mesh does not imply a trail."
+    )
+
+
+def test_every_log_line_the_section_quotes_is_one_the_module_emits():
+    """A monitoring instruction must name a string the module actually logs.
+
+    The section tells an operator which line to alert on.  If that literal
+    drifts from the module's format string, the alert silently never fires -
+    the same class of failure as the wrong field name, one layer out.
+    """
+    quoted = _audit_log_lines_the_section_quotes()
+    assert quoted, (
+        f"The ``{_AUDIT_HEADING}`` section quotes no ``[audit]`` log line, so "
+        f"it tells an operator to monitor for a signal it does not name."
+    )
+    source = _AUDIT_MODULE.read_text(encoding="utf-8")
+    missing = sorted(fragment for fragment in quoted if fragment not in source)
+    assert not missing, (
+        f"The ``{_AUDIT_HEADING}`` section quotes {missing}, which do not "
+        f"appear in ``mesh/audit.py``. An alert built on a line the module "
+        f"never emits never fires."
+    )
+
+
+@pytest.mark.parametrize("destination", ["unwritable-parent", "symlink-at-log-path", "log-path-is-a-directory"])
+def test_an_unusable_destination_leaves_the_peer_running_with_the_trail_off(
+    isolated_audit, monkeypatch, tmp_path, destination, caplog
+):
+    """The behavioural fact the corrected wording describes.
+
+    Three ways to make the destination unusable, all of which survive the
+    writer's own hardening (``_ensure_paths`` re-chmods the parent to 0o700 on
+    every call, so merely dropping the write bit is undone).  In each, three
+    safety events are issued: nothing raises, nothing is recorded, and the only
+    signal is a WARNING per attempt.
+    """
+    root = tmp_path / destination
+    root.mkdir()
+    if destination == "unwritable-parent":
+        target = root / "auditdir"
+    else:
+        target = root / "d"
+        target.mkdir()
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(target))
+    log_path = audit.audit_log_path()
+    if destination == "symlink-at-log-path":
+        log_path.symlink_to("/dev/null")
+    elif destination == "log-path-is-a-directory":
+        log_path.mkdir()
+    else:
+        root.chmod(0o500)
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.audit"):
+            for index in range(3):
+                audit.log_safety_event("emergency_stop", "peer-a", {"index": index})
+    finally:
+        root.chmod(0o700)
+
+    written = [line for line in log_path.read_text().splitlines() if line.strip()] if log_path.is_file() else []
+    assert written == [], (
+        f"an unusable audit destination ({destination}) wrote {len(written)} "
+        f"record(s); the point of this cell is that it writes none"
+    )
+    assert caplog.records, (
+        f"an unusable audit destination ({destination}) recorded nothing at "
+        f"WARNING, so the peer would run with the audit trail off and no signal"
+    )
+
+
+def test_a_signed_record_carries_the_documented_field_and_not_the_old_name(isolated_audit, monkeypatch):
+    """A written record confirms the schema the derivation reads off the AST.
+
+    With the PSK set from the process's first signed write, the persisted
+    record gains exactly the field the page now names - and does not gain the
+    name the page used to claim.
+    """
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_PSK", "docs-reference-psk")
+    audit.log_safety_event("emergency_stop", "peer-b", {"reason": "docs reference"})
+    records = audit.read_audit_log()
+    assert len(records) == 1, f"expected one audit record, got {len(records)}"
+    field = _signature_field_name()
+    assert field in records[0], f"signed record {sorted(records[0])} carries no {field!r} field"
+    assert len(str(records[0][field])) == 64, "the signature is a SHA-256 hex digest"
+    assert "hmac" not in records[0], (
+        "a signed record carries no ``hmac`` field; that name was the "
+        "documentation error this file's companion change corrects"
+    )
+
+
+def test_the_writer_documents_the_fail_soft_contract_the_section_mirrors():
+    """Premise: the swallow the page describes is the module's stated contract.
+
+    If ``log_safety_event`` ever raises on a write failure, the corrected
+    wording becomes wrong in the other direction and this cell says so, rather
+    than letting the posture rules pin prose against a contract that moved.
+    """
+    doc = " ".join((audit.log_safety_event.__doc__ or "").split())
+    assert "WARNING" in doc and "swallowed" in doc, (
+        "``log_safety_event`` no longer documents write errors as logged at "
+        "WARNING and swallowed; the audit-log section's posture wording and "
+        "the rules above need to be revisited against the new contract."
+    )
+
+
+def test_the_record_schema_derivation_finds_the_documented_envelope():
+    """Premise: the AST derivation reads a plausible record schema.
+
+    A derivation that silently returned an empty set would satisfy the
+    "no unknown field" rule vacuously, so pin the envelope fields the module
+    header narrates.
+    """
+    schema = _record_field_names()
+    expected = {"ts", "event", "peer_id", "payload", "seq"}
+    missing = sorted(expected - schema)
+    assert not missing, (
+        f"the record-schema derivation found {sorted(schema)} and is missing "
+        f"{missing}; ``log_safety_event`` may no longer build the record as a "
+        f"dict literal, which would make the field rules vacuous"
     )

--- a/tests/mesh/test_docs_audit_env_vars_reference.py
+++ b/tests/mesh/test_docs_audit_env_vars_reference.py
@@ -68,10 +68,14 @@ def _audit_env_reads() -> set[str]:
             "os.environ.get",
         ):
             if node.args and isinstance(node.args[0], ast.Constant):
-                name = node.args[0].value
+                value = node.args[0].value
+                if isinstance(value, str):
+                    name = value
         elif isinstance(node, ast.Subscript) and ast.unparse(node.value) == "os.environ":
             if isinstance(node.slice, ast.Constant):
-                name = node.slice.value
+                value = node.slice.value
+                if isinstance(value, str):
+                    name = value
         if isinstance(name, str) and name.startswith(_AUDIT_PREFIX):
             found.add(name)
     return found


### PR DESCRIPTION
## Problem

`strands_robots/mesh/audit.py` reads four `STRANDS_MESH_AUDIT_*` environment variables that decide where the mesh audit trail is written, how large it may grow, and whether it carries a per-record HMAC:

| Variable | Required | Read at | Default |
|---|---|---|---|
| `STRANDS_MESH_AUDIT_DIR` | no | `mesh/audit.py:946` | `~/.strands_robots/` |
| `STRANDS_MESH_AUDIT_PSK` | no (recommended for production) | `mesh/audit.py:250` | unset -- HMAC off |
| `STRANDS_MESH_AUDIT_MAX_BYTES` | no | `mesh/audit.py:264` | 100 MiB |
| `STRANDS_MESH_AUDIT_MAX_FILES` | no | `mesh/audit.py:286` | 5 |

**None of the four appeared anywhere under `docs/` or `README.md`.** An operator hardening a fleet believed the transport was gated and the mesh action surface was auth-guarded, and never saw the switch (`_PSK`) that turns tamper-evidence *on* -- the log was written whether or not the PSK was configured, and `ls` on the default directory showed a well-formed JSONL trail on both sides of the contract. Only `verify_audit_integrity` could distinguish the two, and only if invoked; the env var that turned the check on was undocumented, so a hardening checklist had nothing to check.

## Why it matters

The PSK is the switch. Without it:

- Records are written with **no `sig` field**;
- `verify_audit_integrity` cannot fail on a forged record (nothing to compare);
- An attacker with write access to `STRANDS_MESH_AUDIT_DIR` can rewrite a record and leave no evidence.

With it, the same attacker fails the integrity check on the tampered record, and the check refuses the whole log if the PSK ever changes between records. This is the operator-facing posture the module exists to enforce, and it was reachable only by reading the source.

## Change

`docs/security.md` gains an **Audit log** section, sibling to the existing transport and IoT sections above, listing all four variables in the form the page already uses for every other configuration knob: required/default, what the value has to be, and what setting it wrong looks like at runtime.

`tests/mesh/test_docs_audit_env_vars_reference.py` grades the reference against the module. Four rules cover which variables are *named* -- every `STRANDS_MESH_AUDIT_*` name the module reads is documented, all under one heading, and that heading is the `Audit log` heading the module docstring references, with a premise cell pinning the four names the module reads today. Five further rules cover whether what the page says *about* them is true, described below.

## The section's first form asserted two things the module contradicts

A presence rule is satisfied by a bullet that *mentions* a variable, whatever the bullet asserts, so both of the following passed the four rules above. Both are corrected here, and both now have a rule that would have caught them.

**1. The failure posture was inverted.** The page promised that a peer which cannot open the log "refuses to start the auditor, rather than running with the audit trail silently off". `log_safety_event` documents the opposite -- *"write errors are logged at WARNING and swallowed because an audit-log failure must never propagate up into the safety code path"* -- and its write block ends in `except OSError: logger.warning("[audit] failed to write %s: %s", ...)`. There is no eager auditor start at all: `_ensure_paths` runs per write, inside that block.

Measured by issuing three safety events against each destination. `_ensure_paths` re-chmods the parent to `0o700` on every call, so merely dropping the write bit is undone by the writer's own hardening; these three survive it:

| Audit destination | `log_safety_event` raised | Records written | WARNING lines |
|---|---|---|---|
| healthy control | none | 3 | 0 |
| unwritable parent directory | none | **0** | 6 |
| symlink at the log path | none | **0** | 4 |
| directory at the log path | none | **0** | 3 |

That is exactly the posture the sentence said could not happen. An operator following it would have concluded a running mesh implies a written trail and added no monitoring for the real signal. The bullet now describes the swallow and names the `[audit]` line to alert on. The symlink refusal is real -- `_ensure_paths` raises on `path.is_symlink()` -- but it reaches the operator through the same swallowed WARNING, which the bullet now says.

**2. The persisted signature field was misnamed.** The page called it `hmac`. The writer assigns `record["sig"]`, `verify_audit_integrity` reads `record.get("sig")`, and `"hmac"` appears zero times as a field name in the module -- only as the stdlib import and the mechanism. Driving a signed write:

| | Signed record (PSK set) | Unsigned record |
|---|---|---|
| keys | `event, payload, peer_id, seq, sig, ts` | `event, payload, peer_id, seq, ts` |
| `sig` present | yes, 64-char SHA-256 hex | no |
| `hmac` present | **no** | no |

The field name is part of the on-disk JSONL schema, so it is what an external verifier -- a SIEM rule, a forensic script -- greps for. A checker built from the old wording finds nothing on a correctly signed fleet and either alarms permanently or concludes tamper-evidence is off. HMAC-the-mechanism was accurate throughout; only the field name was wrong. Corrected in both mentions.

## The rules that close the gap

The four original rules grade *presence*. These five grade the *claims*, on the two axes an operator or an external verifier builds against:

- **The documented signature field is the one the writer assigns it to**, derived by dataflow: find the local the `_sign_record` call binds, then the `record[...]` key that local is assigned to. Renaming the field in `mesh/audit.py` moves the expectation.
- **Every field name the section mentions is one the record schema carries**, where the schema is the `record` dict literal's keys plus every literal `record[...] = ...` key in the writer.
- **The section may not assert a refusal to start**, and **must describe the swallow** -- the negative half catches the specific false assurance, the positive half is what survives a rewording, since a bullet reinstating a fail-closed claim has to delete the swallow sentence to read coherently.
- **Every `[audit]` log line the section tells an operator to monitor for is a string the module emits**, so a monitoring instruction cannot drift into an alert that never fires.

Two behavioural cells hold both claims against the running writer (the three unusable destinations above, and a signed record's keys), so a rule that stopped deriving is caught by a written record rather than by agreeing with itself.

The posture rules are scoped to this one section deliberately. `refuses to start` appears twice elsewhere on this page and once in `docs/rtps-integration.md` about `HardwareRtpsBridge`, where it is accurate -- that bridge really does refuse to construct without DDS Security material. Dropping the scope makes the rule flag those true claims; that is a measured row in the table below.

## Verification

Derived values on this branch:

```
record schema (AST)      : event, payload, payload_error, peer_id, psk_degraded,
                           seq, seq_lock_degraded, sig, sign_error, ts
signature field (dataflow): sig
fields the section names : sig
[audit] lines quoted     : "[audit]", "[audit] failed to write"   (both in the module)
```

Pre-fix split, docs reverted and the tests kept: **5 failed / 10 passed.** The five are exactly the new claim rules; the four presence rules and every behavioural and premise cell pass either way, because they grade the code rather than the prose.

Mutation table. `fires` is against this file, `sib` against the other 24 `tests/mesh/test_*audit*.py` files (471 cells). `collected` was 15 on every row, so no row hid a deselection, and all three files restored byte-identically afterwards.

| Mutation | fires | sib | Cells |
|---|---|---|---|
| control | 0 | 0 | -- |
| both docs claims reverted | 5 | 0 | all five claim rules |
| field name reverted only | 2 | 0 | the two schema rules |
| `_DIR` posture sentence reverted only | 2 | 0 | refusal + log-line rules |
| module renames the field, rule stays dataflow-derived | 1 | 12 | the field rule names the drift |
| module renames the field, rule hardcoded to `sig` | 1 | 12 | docs rule goes silent; the **behavioural** cell catches it |
| schema derivation drops `AnnAssign` | 1 | 0 | the premise cell |
| section scope dropped (page-wide) | 1 | 0 | flags the true `HardwareRtpsBridge` claim |
| section quotes a line the module never emits | 1 | 0 | the log-line rule |
| ...and the module-membership half dropped | **0** | 0 | silent -- that half is load-bearing |

`b2` and `b3` are disjoint and together account for four of `b1`'s five; the fifth is the swallow cell, which fires only once the swallow description is fully gone (`b3` is a partial revert that leaves the symlink sentence's clause intact). The dataflow/hardcoded pair is the two-layer result: with the derivation intact the documentation rule names the drift, and with it hardcoded the documentation rule goes silent and the written-record cell is what fails. `sib=12` on those two rows is the field name being load-bearing across the audit suite.

Gate, against pristine `main` (`416a5ed8`, which this branch now contains) on an identical 389-file selection -- all of `tests/mesh/` plus every guard that walks the tree, parses source, or reads `docs/`, with this PR's own new test file excluded from both trees:

```
branch : 11706 collected, 21 failed, 11595 passed, 66 skipped, 24 errors
base   : 11706 collected, 21 failed, 11595 passed, 66 skipped, 24 errors
failing/erroring ids: 45 == 45, comm empty in both directions
```

All 45 are `tests/mesh/test_iot_*` needing `awsiot`/`awscrt` (`find_spec` False for both here; both declared in the `mesh-iot` extra, which CI installs). `tests/mesh/test_zenoh_transport_security.py` is excluded from the pair and verified alone: 9 passed / 2 skipped on both trees.

`ruff check` and `ruff format --check` clean over 1671 files. `mypy strands_robots tests tests_integ`: 24 errors in 9 files, the standing baseline, with **0 attributable** to either changed file. `mkdocs build --strict` clean. The changelog, docs-link and docstring-xref guards: 284 passed, 2 skipped.

## No visual artifact

Documentation and test-only change; no policy, simulation, rendering, recording, or asset behaviour renders. The measured tables above are the evidence.
