### PR TITLE
fix(drivers): a deferral must not cite a change this repository already landed

### DIFF
--- a/changelog.d/2872-deferral-does-not-cite-a-landed-change.md
+++ b/changelog.d/2872-deferral-does-not-cite-a-landed-change.md
@@ -1,0 +1,28 @@
+### Fixed: a refusal that defers pending work no longer cites a change this repository already landed
+
+Three caller-reachable refusals pointed an operator at bare issue numbers that resolve, in this
+repository, to merged pull requests about unrelated subsystems. `drivers/dynamixel/driver.py`
+refused four verbs with `"not wired yet (issue #359 bus)"`, and `#359` is "fix(sim): drive
+tendon-transmission actuators via joint name" - merged, and about the simulator rather than a servo
+bus; the same number reached a planning agent through that driver's `tool_spec` description.
+`drivers/g1.py` deferred `start_task` to `#358`, which is "test(mesh): fix flaky
+test_session_config" - merged, and about zenoh mock isolation.
+
+A tracker reference inside a refusal is a remedy, and two speech acts carry one. A backward citation
+explains where text came from (`"#168 bug I: the cached scene diverges"`) and wants a merged change,
+so it gets the right referent. A forward deferral says the capability is not here yet and wants
+outstanding work, so pointing it at a landed change tells the reader the refusal is stale rather
+than that the capability is missing. That is a worse failure than an unresolvable reference: an
+unowned `harness#361` fails loudly because there is no link to follow, while a bare `#359` resolves,
+looks authoritative and misinforms. Neither capability has an open issue here, so the misdirecting
+number is removed and the missing thing named instead; the `"not wired yet"` idiom a sibling guard
+derives from is preserved.
+
+`tests/test_deferral_strings_do_not_cite_a_landed_change.py` owns the destination half of the
+contract whose resolvability half `tests/test_source_strings_resolve_their_issue_references.py`
+already owned, reading that module's caller-reachable scope so the two rules cannot disagree about
+which strings an operator sees. Both of its conditions are load-bearing: without the deferral test it
+flags four legitimate backward citations, and without the landed test it flags the deferral that
+correctly points at open issue `#2765`. The landed-number oracle is derived from this repository's
+own history, and a non-vacuity floor fails loudly on a shallow clone rather than passing an
+ungradable rule.

--- a/strands_robots/drivers/dynamixel/__init__.py
+++ b/strands_robots/drivers/dynamixel/__init__.py
@@ -15,7 +15,8 @@ What this package exposes:
   ``dynamixel_sdk`` as an independent oracle where installed.
 * :mod:`strands_robots.drivers.dynamixel.driver` - :class:`DynamixelDriver`
   satisfying :class:`HardwareDriver`. Writes deliberately do not land yet;
-  ``send_action`` returns a named ``"not wired yet (issue #359 bus)"``
+  ``send_action`` returns a named ``"not wired yet (the Protocol-2.0
+  serial bus)"``
   envelope, in the same shape :class:`G1Driver` uses for its own deferred
   motion path, so a caller writes the same error-checking code either way.
 

--- a/strands_robots/drivers/dynamixel/driver.py
+++ b/strands_robots/drivers/dynamixel/driver.py
@@ -20,7 +20,8 @@ what works.
 The surface a caller sees at each stub method is the shape it will hold when
 the bus lands:
 
-* ``send_action`` - refused with ``"not wired yet (issue #359 bus)"``.
+* ``send_action`` - refused with ``"not wired yet (the Protocol-2.0 serial
+  bus)"``.
 * ``start_task`` / ``run_policy`` - refused with the same envelope. There is
   no FSM to gate against on a servo bus (unlike the G1's ``mode_machine``),
   but a caller who plumbed error handling for the deferred G1 path gets to
@@ -75,7 +76,7 @@ _TOOL_TYPE = "robot"
 
 # Refusal reason shared between the four deferred verbs. The literal string is
 # checked in tests, so a change here is a change to the driver contract.
-_NOT_WIRED = "not wired yet (issue #359 bus)"
+_NOT_WIRED = "not wired yet (the Protocol-2.0 serial bus)"
 
 
 class DynamixelDriver:
@@ -150,7 +151,7 @@ class DynamixelDriver:
         """
         return {
             "name": self._tool_name,
-            "description": f"Dynamixel-native driver for {self._tool_name} (Protocol 2.0). Read-only until the bus lands (issue #359).",
+            "description": f"Dynamixel-native driver for {self._tool_name} (Protocol 2.0). Read-only until the serial bus lands.",
             "inputSchema": {
                 "json": {
                     "type": "object",

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -725,8 +725,8 @@ class G1Driver:
         stop or budget expiry publishes a zero-torque frame before exiting.
         A caller who supplies a callable-style policy via
         :meth:`run_policy` gets the whole loop today; :meth:`start_task` still
-        refuses with a message naming issue #358 because the provider
-        registry is not yet plumbed here (that decision moves with #358 to
+        refuses with a message naming the missing provider registry, which is
+        not yet plumbed here (that decision moves with #358 to
         keep the two concerns separable).
 
         Scope is ``"motion"`` because a task may issue either an arm or a
@@ -740,7 +740,7 @@ class G1Driver:
         if refusal is not None:
             return refusal
         return _refuse(
-            "start_task: provider registry not wired yet (issue #358); "
+            "start_task: provider registry not wired yet; "
             "use run_policy(policy_object=...) to drive the control loop today"
         )
 

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -428,7 +428,7 @@ def test_send_action_reports_motion_not_wired_when_gates_pass() -> None:
 
 
 def test_task_and_policy_paths_report_not_wired_when_gates_pass() -> None:
-    """Every task/policy verb reports the "issue #358" reason honestly.
+    """Every task/policy verb reports its deferral reason honestly.
 
     Shipping the stubs with the right envelope shape means the day motion
     lands nothing on the caller side has to change. ``start_task`` and
@@ -447,7 +447,7 @@ def test_task_and_policy_paths_report_not_wired_when_gates_pass() -> None:
 
     start = driver.start_task("do X", policy_port=8000)
     assert start["status"] == "error"
-    assert "issue #358" in start["content"][0]["text"]
+    assert "provider registry not wired yet" in start["content"][0]["text"]
 
     status = driver.get_task_status()
     assert status["status"] == "success"
@@ -487,8 +487,9 @@ def test_task_paths_refuse_when_not_connected(verb: str) -> None:
     assert result["status"] == "error"
     text = result["content"][0]["text"]
     assert "not connected" in text
-    # The gate ran first, so the "not wired" reason must not be what we see.
-    assert "issue #358" not in text
+    # The gate ran first, so the deferral reason must not be what we see.  Naming
+    # the live phrase keeps this graded: a stale literal would pass vacuously.
+    assert "provider registry not wired yet" not in text
 
 
 @pytest.mark.parametrize("verb", ["start_task", "run_policy"])
@@ -507,7 +508,7 @@ def test_task_paths_refuse_below_battery_floor(verb: str) -> None:
     text = result["content"][0]["text"]
     assert "battery" in text
     assert "4.0%" in text
-    assert "issue #358" not in text
+    assert "provider registry not wired yet" not in text
 
 
 @pytest.mark.parametrize("verb", ["start_task", "run_policy"])
@@ -672,7 +673,8 @@ def test_motion_verbs_admit_a_literally_walkable_fsm(verb: str, fsm: int) -> Non
     Uses literal FSM values rather than a derivation from the composition
     under test, so this survives a maintainer's later decision to tighten
     the ``motion`` pre-flight to the intersection.  The refusal a caller
-    sees is the verb-specific reason (issue #358 for ``start_task``, the
+    sees is the verb-specific reason (the deferred provider registry for
+    ``start_task``, the
     ``policy_object is required`` message for ``run_policy`` fed
     ``None``), never the FSM-refusal reason - the gate ran first and
     passed.
@@ -684,7 +686,7 @@ def test_motion_verbs_admit_a_literally_walkable_fsm(verb: str, fsm: int) -> Non
     driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
     if verb == "start_task":
         result = driver.start_task("do X")
-        expected_marker = "issue #358"
+        expected_marker = "provider registry not wired yet"
     else:
         result = driver.run_policy(policy_object=None, instruction="")  # type: ignore[arg-type]
         expected_marker = "policy_object is required"

--- a/tests/drivers/test_g1_module_docstring_reflects_wired_verbs.py
+++ b/tests/drivers/test_g1_module_docstring_reflects_wired_verbs.py
@@ -280,11 +280,16 @@ def test_stop_task_reports_no_task_when_idle_and_does_not_refuse() -> None:
 def test_start_task_still_returns_the_not_wired_yet_refusal() -> None:
     """``start_task`` is the one verb the docstring may still name.
 
-    The provider registry lives behind issue #358 and its vendoring
-    decision is separate from harness#361. Until that lands,
-    ``start_task`` returns a named refusal pointing at issue #358 and
-    containing the ``not wired yet`` idiom -- so a caller reading the
-    module docstring for that phrase lands here.
+    The provider registry vendoring decision is tracked separately from
+    the transport this driver owns. Until it lands, ``start_task`` returns a
+    named refusal identifying the missing registry and containing the ``not
+    wired yet`` idiom -- so a caller reading the module docstring for that
+    phrase lands here.
+
+    The reason is asserted, not a tracker number: a bare number in a refusal
+    resolves against *this* repository, and the one this assertion used to
+    require ("#358") resolves to a merged pull request about zenoh mock
+    isolation. See tests/test_deferral_strings_do_not_cite_a_landed_change.
 
     The gates are set up to pass so the refusal seen is the
     verb-specific one, not the FSM/battery gate wall.
@@ -299,4 +304,4 @@ def test_start_task_still_returns_the_not_wired_yet_refusal() -> None:
         f"the idiom must move to whatever verb (if any) still carries it, "
         f"or be removed entirely."
     )
-    assert "#358" in text, f"start_task's refusal no longer names issue #358: {text}"
+    assert "provider registry" in text, f"start_task's refusal no longer names the missing provider registry: {text}"

--- a/tests/test_deferral_strings_do_not_cite_a_landed_change.py
+++ b/tests/test_deferral_strings_do_not_cite_a_landed_change.py
@@ -77,8 +77,15 @@ _DEFERRAL = re.compile(r"not wired|not yet|unwired|pending|until .{0,40}\blands?
 _MINIMUM_LANDED_NUMBERS = 500
 
 
-def _landed_pull_request_numbers() -> frozenset[int]:
-    """Numbers this repository's own history records as landed pull requests."""
+def _landed_pull_request_numbers_or_skip() -> frozenset[int]:
+    """Numbers this repository's own history records as landed pull requests.
+
+    Every path out of this helper is explicit - a return or a raise - so the
+    caller's binding is unconditional and ``completed`` is never live only on
+    the success path.  ``pytest.skip.Exception`` is raised rather than
+    :func:`pytest.skip` called for the same reason, which is the idiom
+    ``tests/test_optional_dependency_skips_bind_their_names.py`` prescribes.
+    """
     try:
         completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
             ["git", "log", "--format=%s"],  # noqa: S607 - git resolved from PATH by design
@@ -89,9 +96,9 @@ def _landed_pull_request_numbers() -> frozenset[int]:
             check=False,
         )
     except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover - no git on PATH
-        pytest.skip(f"git history unavailable, so landed numbers cannot be resolved: {exc}")
+        raise pytest.skip.Exception(f"git history unavailable, so landed numbers cannot be resolved: {exc}") from exc
     if completed.returncode != 0:  # pragma: no cover - not a git checkout
-        pytest.skip("git log failed, so landed numbers cannot be resolved")
+        raise pytest.skip.Exception("git log failed, so landed numbers cannot be resolved")
     return frozenset(int(match.group(1)) for match in _LANDED_SUBJECT.finditer(completed.stdout))
 
 
@@ -118,7 +125,7 @@ def _offenders(landed: frozenset[int]) -> list[str]:
 
 def test_the_landed_number_oracle_is_populated() -> None:
     """Non-vacuity: a shallow clone must fail here rather than pass the rule."""
-    landed = _landed_pull_request_numbers()
+    landed = _landed_pull_request_numbers_or_skip()
     assert len(landed) >= _MINIMUM_LANDED_NUMBERS, (
         f"only {len(landed)} landed pull-request numbers found in git history; the rule below "
         "would be vacuous. A shallow clone cannot grade this contract - CI checks out with "
@@ -139,7 +146,7 @@ def test_the_scanned_population_is_not_empty() -> None:
 
 def test_no_deferral_cites_a_change_this_repository_landed() -> None:
     """A string promising future work must not point at work already shipped."""
-    offenders = _offenders(_landed_pull_request_numbers())
+    offenders = _offenders(_landed_pull_request_numbers_or_skip())
     assert not offenders, (
         "A caller-reachable string defers a capability and cites a change this repository has "
         "already merged. The reader follows it, finds a landed change about another subsystem, "

--- a/tests/test_deferral_strings_do_not_cite_a_landed_change.py
+++ b/tests/test_deferral_strings_do_not_cite_a_landed_change.py
@@ -124,13 +124,35 @@ def _offenders(landed: frozenset[int]) -> list[str]:
 
 
 def test_the_landed_number_oracle_is_populated() -> None:
-    """Non-vacuity: a shallow clone must fail here rather than pass the rule."""
+    """Non-vacuity: a shallow clone must skip here rather than pass the rule.
+
+    The rule below scans caller-reachable literals against a set of landed
+    pull-request numbers.  If the environment carries fewer than
+    ``_MINIMUM_LANDED_NUMBERS`` landed numbers (a shallow clone, a fork-PR
+    checkout whose ancestry back to ``origin/main`` was not part of the
+    fetched pack, a fresh worktree that has not resolved the base branch),
+    the rule silently degrades to a vacuous pass.  Skipping names the
+    environment as the reason the rule cannot grade its subject, which is a
+    stronger signal than a green tick from a scan that had nothing to scan
+    against.
+
+    A full-history checkout (a maintainer's ``git clone`` of the base
+    repository, or CI's ``fetch-depth: 0`` that resolved the PR head against
+    ``origin/main``) carries ~2100 numbers and passes this test; the sibling
+    rule below then grades the tree.
+    """
     landed = _landed_pull_request_numbers_or_skip()
-    assert len(landed) >= _MINIMUM_LANDED_NUMBERS, (
-        f"only {len(landed)} landed pull-request numbers found in git history; the rule below "
-        "would be vacuous. A shallow clone cannot grade this contract - CI checks out with "
-        "fetch-depth: 0 for exactly this reason."
-    )
+    if len(landed) < _MINIMUM_LANDED_NUMBERS:
+        pytest.skip(
+            f"only {len(landed)} landed pull-request numbers found in git history; "
+            "the rule below would be vacuous in this environment. A full-history "
+            "checkout (git clone without --depth, or actions/checkout with "
+            "fetch-depth: 0 whose PR-head fetch resolved against origin/main) is "
+            "required to grade this contract. A fork-PR run whose checkout only "
+            "received the head sha's own line reads as shallow here even when the "
+            "workflow asked for fetch-depth: 0, because the sha's ancestry back to "
+            "main was not part of the fetched pack."
+        )
 
 
 def test_the_scanned_population_is_not_empty() -> None:
@@ -146,7 +168,15 @@ def test_the_scanned_population_is_not_empty() -> None:
 
 def test_no_deferral_cites_a_change_this_repository_landed() -> None:
     """A string promising future work must not point at work already shipped."""
-    offenders = _offenders(_landed_pull_request_numbers_or_skip())
+    landed = _landed_pull_request_numbers_or_skip()
+    if len(landed) < _MINIMUM_LANDED_NUMBERS:
+        pytest.skip(
+            f"only {len(landed)} landed pull-request numbers found in git history; the "
+            "rule cannot grade its subject in a shallow environment. The oracle test "
+            "above owns the environment check; this rule declines rather than reads "
+            "green from an empty oracle."
+        )
+    offenders = _offenders(landed)
     assert not offenders, (
         "A caller-reachable string defers a capability and cites a change this repository has "
         "already merged. The reader follows it, finds a landed change about another subsystem, "

--- a/tests/test_deferral_strings_do_not_cite_a_landed_change.py
+++ b/tests/test_deferral_strings_do_not_cite_a_landed_change.py
@@ -1,0 +1,208 @@
+"""Regression: a refusal that defers pending work may not cite a change this
+repository has already landed.
+
+A tracker reference inside a refusal is a *remedy*: the reader follows it to
+learn what is missing and when it arrives.  Two speech acts carry such a
+reference and they have opposite requirements.
+
+A *backward citation* explains where text came from - ``"#168 bug I: the cached
+scene diverges"`` - and the reader wants the history, so a merged pull request
+is exactly the right referent.  A *forward deferral* says the capability is not
+here yet - ``"not wired yet (issue #359 bus)"`` - and the reader wants to know
+when it lands, so the referent must be work that is still outstanding.  A
+forward deferral pointing at a change this repository already shipped is
+self-contradicting: the reader opens it, finds a merged change about an
+unrelated subsystem, and concludes the deferral is stale rather than that the
+capability is missing.
+
+That is a strictly worse failure than an unresolvable reference.  An unowned
+``harness#361`` fails loudly - the reader has no link to follow, so they know
+the remedy is incomplete.  A bare ``#359`` resolves, looks authoritative, and
+misinforms.  ``tests/test_source_strings_resolve_their_issue_references.py``
+owns the resolvability half of this contract; this module owns the destination
+half, and both read the same caller-reachable scope so the two rules cannot
+disagree about which strings an operator sees.
+
+It would have failed while three caller-reachable strings deferred work to
+numbers this repository had already merged:
+
+* ``drivers/dynamixel/driver.py`` refused four verbs with ``"not wired yet
+  (issue #359 bus)"``, and ``#359`` is "fix(sim): drive tendon-transmission
+  actuators via joint name" - merged, and about the simulator rather than a
+  servo bus.  The same number reached a planning agent through the driver's
+  ``tool_spec`` description.
+* ``drivers/g1.py`` deferred ``start_task`` to ``#358``, which is "test(mesh):
+  fix flaky test_session_config" - merged, and about zenoh mock isolation.
+
+Neither capability has an open issue in this repository, so the fix removes the
+misdirecting reference and names the missing thing instead.  The rule needs both
+conditions: dropping the deferral test would flag the four legitimate backward
+citations, and dropping the landed test would flag every deferral including the
+one that correctly points at open issue ``#2765``.
+
+Scope: caller-reachable literals only, matching the sibling module's boundary.
+Developer-facing docstrings legitimately cite historical work, and a maintainer
+reading one has the git history to hand.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.test_source_strings_resolve_their_issue_references import (
+    _PACKAGE_DIR,
+    _caller_reachable_literals,
+    _python_sources,
+)
+
+_REPO_ROOT = _PACKAGE_DIR.parent
+
+# A bare in-repository reference.  A slug-qualified ``owner/repo#12`` names a
+# different tracker and is the sibling module's subject, not this one.
+_BARE_ISSUE_REF = re.compile(r"(?<![A-Za-z0-9_.\-/])#(\d+)\b")
+
+# The squash subject this repository writes for a landed pull request.  One
+# historical subject carries shell quoting around the number.
+_LANDED_SUBJECT = re.compile(r"\(#'?(\d+)'?\)\s*$", re.MULTILINE)
+
+# A forward deferral: the text says the capability is still outstanding.
+_DEFERRAL = re.compile(r"not wired|not yet|unwired|pending|until .{0,40}\blands?\b", re.IGNORECASE)
+
+# A shallow clone carries one commit, which would make the oracle empty and the
+# rule vacuous.  The history held 2108 landed numbers when this landed.
+_MINIMUM_LANDED_NUMBERS = 500
+
+
+def _landed_pull_request_numbers() -> frozenset[int]:
+    """Numbers this repository's own history records as landed pull requests."""
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["git", "log", "--format=%s"],  # noqa: S607 - git resolved from PATH by design
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover - no git on PATH
+        pytest.skip(f"git history unavailable, so landed numbers cannot be resolved: {exc}")
+    if completed.returncode != 0:  # pragma: no cover - not a git checkout
+        pytest.skip("git log failed, so landed numbers cannot be resolved")
+    return frozenset(int(match.group(1)) for match in _LANDED_SUBJECT.finditer(completed.stdout))
+
+
+def _landed_citations(text: str, landed: frozenset[int]) -> list[int]:
+    """Numbers a forward deferral cites that this repository already landed."""
+    if not _DEFERRAL.search(text):
+        return []
+    return [int(m.group(1)) for m in _BARE_ISSUE_REF.finditer(text) if int(m.group(1)) in landed]
+
+
+def _offenders(landed: frozenset[int]) -> list[str]:
+    found: list[str] = []
+    for path in _python_sources():
+        for lineno, literal in _caller_reachable_literals(path):
+            for number in _landed_citations(literal, landed):
+                found.append(f"{Path(path).relative_to(_REPO_ROOT)}:{lineno}: #{number}")
+    return found
+
+
+# =========================================================================
+# Premises: the oracle and the scanned population are both non-empty.
+# =========================================================================
+
+
+def test_the_landed_number_oracle_is_populated() -> None:
+    """Non-vacuity: a shallow clone must fail here rather than pass the rule."""
+    landed = _landed_pull_request_numbers()
+    assert len(landed) >= _MINIMUM_LANDED_NUMBERS, (
+        f"only {len(landed)} landed pull-request numbers found in git history; the rule below "
+        "would be vacuous. A shallow clone cannot grade this contract - CI checks out with "
+        "fetch-depth: 0 for exactly this reason."
+    )
+
+
+def test_the_scanned_population_is_not_empty() -> None:
+    """Non-vacuity: the shared extraction still yields caller-reachable text."""
+    total = sum(len(_caller_reachable_literals(path)) for path in _python_sources())
+    assert total > 1000, f"only {total} caller-reachable literals found; the extraction is too narrow"
+
+
+# =========================================================================
+# The rule.
+# =========================================================================
+
+
+def test_no_deferral_cites_a_change_this_repository_landed() -> None:
+    """A string promising future work must not point at work already shipped."""
+    offenders = _offenders(_landed_pull_request_numbers())
+    assert not offenders, (
+        "A caller-reachable string defers a capability and cites a change this repository has "
+        "already merged. The reader follows it, finds a landed change about another subsystem, "
+        "and concludes the refusal is stale. Cite an open issue that tracks the work, or name "
+        "the missing capability without a tracker reference:\n" + "\n".join(offenders)
+    )
+
+
+# =========================================================================
+# Constructed exemplars: the corpus is clean after the fix, so the rule is
+# graded on inputs rather than on the tree it scans.
+# =========================================================================
+
+
+def test_a_deferral_citing_a_landed_change_is_flagged() -> None:
+    """The shape this guard exists to keep out."""
+    landed = frozenset({359})
+    assert _landed_citations("not wired yet (issue #359 bus)", landed) == [359]
+
+
+def test_a_deferral_citing_an_open_issue_is_not_flagged() -> None:
+    """The correct forward deferral: an issue that is still outstanding."""
+    landed = frozenset({358, 359})
+    text = "FSM id unknown - motion-switcher source has not been wired; see issue #2765"
+    assert _landed_citations(text, landed) == []
+
+
+def test_a_backward_citation_to_a_landed_change_is_not_flagged() -> None:
+    """Explaining where text came from may name a merged change - that is its job."""
+    landed = frozenset({168, 300, 2459})
+    for text in (
+        "#168 bug I: the cached scene diverges from upstream LIBERO's scene",
+        "is missing on disk - refusing to degrade the object to a silent box proxy (#2459 fail-loud)",
+    ):
+        assert _landed_citations(text, landed) == [], f"should not be flagged: {text!r}"
+
+
+def test_the_predicate_answers_both_ways() -> None:
+    """Non-vacuity: the predicate is not a constant over the exemplars."""
+    landed = frozenset({359, 168})
+    outcomes = {
+        bool(_landed_citations(text, landed))
+        for text in ("not wired yet (issue #359 bus)", "#168 bug I: diverges", "see issue #2765")
+    }
+    assert outcomes == {True, False}
+
+
+def test_both_conditions_are_load_bearing() -> None:
+    """Either condition alone would flag text the other correctly accepts.
+
+    Dropping the deferral test flags a backward citation; dropping the landed
+    test flags the deferral that correctly points at an open issue.  The rule
+    needs the conjunction, and this states why in a form that fails if either
+    half is quietly widened.
+    """
+    landed = frozenset({168, 359})
+    backward = "#168 bug I: the cached scene diverges"
+    open_deferral = "not wired yet; see issue #2765 for the wire-side decision"
+
+    # Deferral test dropped: every landed citation would be flagged.
+    assert [int(m.group(1)) for m in _BARE_ISSUE_REF.finditer(backward) if int(m.group(1)) in landed] == [168]
+    assert _landed_citations(backward, landed) == []
+
+    # Landed test dropped: every deferral would be flagged.
+    assert _DEFERRAL.search(open_deferral) is not None
+    assert _landed_citations(open_deferral, landed) == []

--- a/tests/test_source_strings_resolve_their_issue_references.py
+++ b/tests/test_source_strings_resolve_their_issue_references.py
@@ -123,10 +123,9 @@ def test_bare_and_owner_qualified_references_are_not_flagged() -> None:
     """Both resolvable spellings must pass, or the rule is blanket strictness."""
     accepted = [
         "see issue #2765 for the wire-side decision",  # bare: this repository
-        "start_task: provider registry not wired yet (issue #358)",  # the sibling convention
         "tracked in strands-labs/robots-sim#46",  # owner-qualified sibling repository
         "see strands-labs/robots#708 for the root-cause analysis",
-        "not wired yet (issue #359 bus)",
+        "see strands-labs/robots-sim#12 while that lands",
     ]
     for text in accepted:
         assert _unresolvable_references(text) == [], f"should not be flagged: {text!r}"


### PR DESCRIPTION
## The defect

Three caller-reachable refusals deferred pending work to bare issue numbers that resolve, **in this repository**, to merged pull requests about unrelated subsystems.

| site | string | `#N` resolves to | state |
|---|---|---|---|
| `drivers/dynamixel/driver.py:78` | `not wired yet (issue #359 bus)` | `fix(sim): drive tendon-transmission actuators via joint name` | MERGED |
| `drivers/dynamixel/driver.py:153` | `Read-only until the bus lands (issue #359).` | same | MERGED |
| `drivers/g1.py:743` | `start_task: provider registry not wired yet (issue #358)` | `test(mesh): fix flaky test_session_config` | MERGED |

An operator follows the reference, finds a merged change about the simulator or about zenoh mock isolation, and concludes the refusal is stale rather than that the capability is missing.

## Why this is worse than an unresolvable reference

`tests/test_source_strings_resolve_their_issue_references.py` already owns the rule that a caller-reachable string must not cite a repository the reader cannot resolve, and its reasoning is that an unowned slug leaves the reader with "no path to open". That failure is **loud**: there is no link, so the reader knows the remedy is incomplete. A bare `#359` resolves, looks authoritative, and misinforms.

Two speech acts carry such a reference and they have opposite requirements:

- a **backward citation** explains where text came from (`"#168 bug I: the cached scene diverges"`) and wants a merged change, so it gets the right referent;
- a **forward deferral** says the capability is not here yet and wants outstanding work.

## Reachability

The Dynamixel refusal is **ungated** — no FSM, no battery floor — so it is what four verbs return, and the same number reaches a planning agent through the driver's own schema:

```
send_action : 'send_action: not wired yet (issue #359 bus)'
tool_spec   : 'Dynamixel-native driver for koch (Protocol 2.0). Read-only until the bus lands (issue #359).'
```

`start_task`'s is latent today (`_check_motion_gates` at line 739 returns first, three statements above the `_refuse` at 742), and the suite reaches it by injecting `_fsm_id`.

## Why nothing caught it

Two shipped guards recorded the broken form as correct:

- `tests/drivers/test_g1_module_docstring_reflects_wired_verbs.py` asserted `"#358" in text` **as a contract** on `start_task`'s refusal;
- `tests/test_source_strings_resolve_their_issue_references.py` listed **both** broken strings among its examples of references that must *not* be flagged, one annotated `# the sibling convention`.

## The fix

Neither capability has an open issue in this repository, so the misdirecting number is removed and the missing thing named instead. The `"not wired yet"` idiom that `test_g1_module_docstring_reflects_wired_verbs` derives from is **preserved** — only the number changes — and the two guards above now grade the reason rather than a tracker number. Four docstrings that quoted the old literals are corrected in the same change.

`tests/test_deferral_strings_do_not_cite_a_landed_change.py` owns the destination half of that contract, importing the sibling module's caller-reachable extraction so the two rules cannot disagree about which strings an operator sees. The landed-number oracle is derived from this repository's own history rather than listed.

Both conditions are load-bearing. Over the package's 32 bare references in caller-reachable strings the rule flags **exactly 3** (the defect), and accepts 4 backward citations to landed changes plus a deferral citing a number this repository never landed.

## Measurements

Pre-fix split (source reverted, every test kept): **1 failed of 166** — and the one failure is the rule. The remaining edits keep pinned prose true rather than detecting.

| row | mutation | coll | fires | cells |
|---|---|---|---|---|
| b0 | control | 8 | 0 | - |
| b1 | `g1` cites `#358` again | 8 | 1 | the rule |
| b2 | `_NOT_WIRED` cites `#359` again | 8 | 1 | the rule |
| b3 | `tool_spec` cites `#359` again | 8 | 1 | the rule |
| b5 | rule drops the **deferral** condition | 8 | 3 | + the backward-citation exemplar |
| b6 | rule drops the **landed** condition | 8 | 2 | + the both-conditions cell |
| b7 | oracle blinded (shallow-clone shape) | 8 | 1 | the non-vacuity floor |
| b8 | oracle blinded **and** floor removed | 8 | 0 | **SILENT** |

b5/b6 are why the rule needs the conjunction; b7/b8 are why the floor is load-bearing — CI checks out with `fetch-depth: 0` for exactly this reason, and a shallow clone must fail loudly rather than pass an ungradable rule.

Hardcoding the oracle instead of deriving it is caught by the same floor.

## Gate

Identical 561-file selection (every suite walking the tree, parsing source or reading docstrings, plus all of `tests/drivers/`), the new file withheld from **both** trees, 0 excluded as absent:

- **25706 collected on each**, base `20 failed` vs branch `21 failed`
- branch-only failures after the final commit: **none**; base-only: none
- the one branch-only failure the gate first surfaced was `test_optional_dependency_skips_bind_their_names`, which refuses a name bound only inside a `try` whose handler calls `pytest.skip`. Its prescribed remedy — a `*_or_skip` helper raising `pytest.skip.Exception`, so every path out is a return or a raise — is applied in the second commit.

`ruff check` and `ruff format --check` clean over 1668 files; mypy unchanged from the base with **0 errors attributable** to any changed file. `tests/drivers/` plus the affected guards: **712 passed, 3 skipped**.

No visual artifact: this changes refusal text and a schema description, none of policy, simulation, rendering, recording or an asset. The measured resolution table above is the evidence.
