### PR TITLE
test(drivers/g1): the harness#361 XPASS marker cites the refusal the driver actually returns

### DIFF
--- a/changelog.d/2873-xpass-reason-matches-shipped-refusal.md
+++ b/changelog.d/2873-xpass-reason-matches-shipped-refusal.md
@@ -1,0 +1,32 @@
+### Tests: the harness#361 XPASS marker cites the refusal the driver actually returns
+
+The strict-xfail cell in
+`tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py`
+documented its deferral by quoting the shipped refusal.  When #2865 tightened
+that refusal (dropping the parenthetical `(harness#361 PR-C)` because the PR
+had landed and the issue reference alone is the resolvable pointer), the test
+file - which merged two hours later as #2861 - kept the older wording.  Pytest
+treats an `xfail` `reason` as descriptive prose and never asserts it, so the
+drift was silent: a reader following the marker to the shipped refusal would
+find a substring that no longer appears.
+
+Two changes hold the citation in place:
+
+1. The docstring header and the `pytest.mark.xfail(reason=...)` argument are
+   rewritten to the current refusal text
+   (`"FSM id unknown - motion-switcher source has not been wired; see issue
+   #2765 for the wire-side decision"`).  The XPASS trigger is unchanged - it
+   still fires when a motion-switcher decoder gives `_fsm_id` a producer -
+   only the human-readable citation is corrected.
+2. A new cell,
+   `test_the_xfail_reason_quotes_the_shipped_refusal_verbatim`, reads the
+   marker's `reason` off the test object and requires the driver's actual
+   refusal text to appear verbatim inside it.  A future wording change on
+   either side now breaks a cell rather than remaining silent, matching the
+   pattern #2872 established for driver-docstring deferral citations.
+
+On the wired-FSM day the refusal disappears; the XPASS cell fails
+(`strict=True`), `test_the_current_refusal_still_names_the_fsm_and_the_motion_switcher`
+fails on the missing-refusal side, and the new grading cell also fails
+because `refusal["status"]` is no longer `"error"`.  All three point the
+author of the wiring commit at the marker in the same run.

--- a/tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py
+++ b/tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py
@@ -356,7 +356,7 @@ def test_the_xfail_reason_quotes_the_shipped_refusal_verbatim() -> None:
     """
     marker = next(
         m
-        for m in test_send_action_returns_success_on_a_healthy_driver_that_has_a_decoded_lowstate.pytestmark
+        for m in test_send_action_returns_success_on_a_healthy_driver_that_has_a_decoded_lowstate.pytestmark  # type: ignore[attr-defined]
         if m.name == "xfail"
     )
     reason = marker.kwargs["reason"]

--- a/tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py
+++ b/tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py
@@ -330,7 +330,6 @@ def test_the_publisher_is_populated_and_the_driver_is_otherwise_healthy() -> Non
     assert "battery" not in text
 
 
-
 def test_the_xfail_reason_quotes_the_shipped_refusal_verbatim() -> None:
     """The xfail marker's ``reason`` cites the refusal text; hold the citation.
 
@@ -374,4 +373,3 @@ def test_the_xfail_reason_quotes_the_shipped_refusal_verbatim() -> None:
         "the wired-FSM day has arrived and this file's marker is due for "
         "removal alongside its cells."
     )
-

--- a/tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py
+++ b/tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py
@@ -22,10 +22,9 @@ This file adds the positive-outcome cell as an :func:`pytest.mark.xfail` with
 one:
 
 1. Today it xfails, and the recorded reason is exactly the shipped refusal
-   text: ``FSM id unknown - motion-switcher source has not been wired
-   (harness#361 PR-C); see #2765 for the wire-side decision``. So the file
-   is not adding a red cell to CI; it is adding a documented deferral that
-   CI grades.
+   text: ``FSM id unknown - motion-switcher source has not been wired;
+   see issue #2765 for the wire-side decision``. So the file is not adding
+   a red cell to CI; it is adding a documented deferral that CI grades.
 
 2. The day a motion-switcher decoder gives ``_fsm_id`` a producer, this
    cell passes -- and because ``strict=True`` an xfail that passes is a
@@ -197,8 +196,8 @@ def _healthy_driver() -> G1Driver:
         "harness#361 acceptance criterion: send_action returns success on a "
         "connected driver with a decoded LowState_ and a healthy pack.  Today "
         "the driver refuses with 'FSM id unknown - motion-switcher source "
-        "has not been wired (harness#361 PR-C); see #2765 for the wire-side "
-        "decision'.  When a motion-switcher decoder gives _fsm_id a producer, "
+        "has not been wired; see issue #2765 for the wire-side decision'.  "
+        "When a motion-switcher decoder gives _fsm_id a producer, "
         "this cell passes and (strict=True) fires an XPASS failure so the "
         "author of that change deletes the marker in the same commit."
     ),
@@ -329,3 +328,50 @@ def test_the_publisher_is_populated_and_the_driver_is_otherwise_healthy() -> Non
     assert "not connected" not in text
     assert "mode_machine unknown" not in text
     assert "battery" not in text
+
+
+
+def test_the_xfail_reason_quotes_the_shipped_refusal_verbatim() -> None:
+    """The xfail marker's ``reason`` cites the refusal text; hold the citation.
+
+    The marker on
+    :func:`test_send_action_returns_success_on_a_healthy_driver_that_has_a_decoded_lowstate`
+    documents the deferral by quoting the shipped refusal.  Pytest treats the
+    ``reason`` as descriptive prose - it never asserts the text - so a drift
+    between the quoted refusal and the one the driver actually returns is
+    invisible until a reader compares them by hand.  The precedent for grading
+    this drift is :func:`test_deferrals_do_not_cite_a_landed_change` (PR
+    :issue:`#2872`), which pins the same class of citation drift on the
+    driver docstrings; this cell extends the same guard to the test file's
+    own xfail reason so a wording change on either side breaks a cell rather
+    than remaining silent.
+
+    The measurement is direct: read the marker's ``reason`` off the test
+    object, read the refusal off the driver, and require the refusal text to
+    appear verbatim inside the reason string.  ``in`` (rather than equality)
+    is deliberate: the reason wraps the quoted refusal in surrounding prose,
+    so an equality check would fail on the prose while the citation stayed
+    correct.  On the wired-FSM day the refusal is gone and this cell fails
+    alongside the XPASS - both halves of the deferral turn over in the same
+    commit, exactly like the ``strict=True`` marker itself.
+    """
+    marker = next(
+        m
+        for m in test_send_action_returns_success_on_a_healthy_driver_that_has_a_decoded_lowstate.pytestmark
+        if m.name == "xfail"
+    )
+    reason = marker.kwargs["reason"]
+
+    driver = _healthy_driver()
+    refusal = driver.send_action({"left_shoulder_pitch": 0.0})
+    assert refusal["status"] == "error"
+    refusal_text = refusal["content"][0]["text"]
+
+    assert refusal_text in reason, (
+        "The xfail reason no longer quotes the shipped refusal verbatim. "
+        f"Refusal is: {refusal_text!r}. Reason is: {reason!r}. "
+        "Update the reason string to match, or (if the refusal is gone) "
+        "the wired-FSM day has arrived and this file's marker is due for "
+        "removal alongside its cells."
+    )
+


### PR DESCRIPTION
## Context

The strict-xfail cell in `tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py` documented its deferral by quoting the shipped refusal. When #2865 tightened that refusal (dropping `(harness#361 PR-C)` because the PR had landed and the issue reference alone is the resolvable pointer), the test file - which merged two hours later as #2861 - kept the older wording.

Pytest treats an `xfail` `reason` as descriptive prose and never asserts it, so the drift was silent: a reader following the marker to the shipped refusal would find a substring that no longer appears there.

## Change

1. **Rewrite docstring and `pytest.mark.xfail(reason=...)`** to quote the current refusal:
   `"FSM id unknown - motion-switcher source has not been wired; see issue #2765 for the wire-side decision"`

   The XPASS trigger is unchanged - it still fires when a motion-switcher decoder gives `_fsm_id` a producer. Only the human-readable citation is corrected.

2. **Add `test_the_xfail_reason_quotes_the_shipped_refusal_verbatim`** - a grading cell that reads the marker's `reason` off the test object at runtime and requires the driver's actual refusal text to appear verbatim inside it. A future wording change on either side breaks a cell rather than remaining silent.

   This extends the pattern PR #2872 established for driver-docstring deferral citations ("a deferral must not cite a change this repository already landed") to the test file's own xfail reason.

## Wired-FSM day

Three cells fail in one run, all pointing at the marker:

- The XPASS cell fails (`strict=True`, expected refusal, got success)
- `test_the_current_refusal_still_names_the_fsm_and_the_motion_switcher` fails on the missing-refusal side
- `test_the_xfail_reason_quotes_the_shipped_refusal_verbatim` fails because `status` is no longer `"error"`

The author of the wiring commit deletes all three plus the marker.

## Local test

```
tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py::test_send_action_returns_success_on_a_healthy_driver_that_has_a_decoded_lowstate XFAIL
tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py::test_the_fsm_id_is_still_unwritten_on_a_healthy_driver PASSED
tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py::test_the_current_refusal_still_names_the_fsm_and_the_motion_switcher PASSED
tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py::test_the_publisher_is_populated_and_the_driver_is_otherwise_healthy PASSED
tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py::test_the_xfail_reason_quotes_the_shipped_refusal_verbatim PASSED
====================== 4 passed, 1 xfailed in 1.80s ======================
```

## Hygiene

- Changelog fragment: `changelog.d/2873-xpass-reason-matches-shipped-refusal.md`
- No `unitree_sdk2py` at module load (test imports duck-typed `SimpleNamespace`)
- Test-only change; driver behavior unchanged
- 58 LOC test additions + 32 LOC changelog