### PR TITLE
fix(simulation/ik): refuse a non-finite pose or seed instead of solving with it

### DIFF
--- a/changelog.d/2875-ik-solve-non-finite-pose-or-seed.md
+++ b/changelog.d/2875-ik-solve-non-finite-pose-or-seed.md
@@ -1,0 +1,37 @@
+### Fixed: a non-finite IK pose or seed is refused instead of solved with
+
+`MinkIKBridge` now holds all eight of its numeric *knobs* to a shared value
+domain in `__init__` - the three task costs and the two convergence thresholds to
+`finite_number_error`, `damping` to a local wrapper over it, `max_iters` to
+`positive_count_error` and `dt` to `positive_finite_number_error`. The two
+*arrays* `solve` reads went straight through, and `solve_trajectory` checked the
+one thing a wrong-shaped batch would break on, `poses.shape`, and none of the
+values inside it.
+
+Both arrays are applied rather than forwarded: `target_pose` becomes the frame
+task's target and `q_init` becomes the configuration the QP warm-starts from.
+Measured against a Franka Panda (`nq=9`) on a reachable 80 mm target whose
+healthy solve returns nine finite joints, a single `nan` or `inf` anywhere in
+either array returned **9 of 9** joints non-finite - as a successful return,
+shaped exactly like a converged solve, with nothing in the value or the type to
+distinguish it from one. `solve_trajectory([good, bad])` returned **9 of 18**:
+the first waypoint a real configuration and the second entirely NaN, so a caller
+iterating waypoints receives a partially valid trajectory rather than an error.
+
+Both arrays now reach `finite_vector_error`, the same shared domain the
+scene-construction vectors use, checked before the configuration is updated and
+before the frame target is set so a refused solve mutates nothing. The pose is
+flattened for the check because that domain reads a 2-D argument's *rows* as its
+elements and would otherwise refuse a clean `(4, 4)`. One guard in `solve` covers
+`solve_trajectory`, which calls it per waypoint; placing the check in
+`solve_trajectory` instead would leave a direct `solve` caller unguarded. The
+check costs 4.221 us against a 3.405 ms solve, 0.124% of one call, so there is no
+budget argument for leaving it to the consumer.
+
+Two things are deliberately unchanged. The bridge never carried the damage across
+calls - `solve` re-seeds the configuration from `q_init` every time, so the next
+healthy solve was already clean; the guard's placement ahead of the mutation is
+craft rather than a repair, and a regression cell pins that a solve after a
+refusal is byte-identical to one before it. And `tracking_error` is untouched: it
+returns `{"mean_mm": nan, "max_mm": nan}`, a visibly non-finite reading rather
+than a plausible one.

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -35,7 +35,12 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
-from ..utils import finite_number_error, positive_count_error, positive_finite_number_error
+from ..utils import (
+    finite_number_error,
+    finite_vector_error,
+    positive_count_error,
+    positive_finite_number_error,
+)
 
 if TYPE_CHECKING:
     import mujoco
@@ -375,13 +380,34 @@ class MinkIKBridge:
             The solved joint configuration (length ``model.nq``, ``float64``).
             When ``commanded_dofs`` was given, every DOF outside it holds its
             ``q_init`` value exactly, so the caller can realize the answer.
+
+        Raises:
+            ValueError: If ``target_pose`` or ``q_init`` holds a non-finite
+                value. Both are read straight into the solver - the pose becomes
+                the frame task's target and the seed becomes the configuration
+                the QP warm-starts from - so a single ``nan`` or ``inf``
+                propagates through every iteration and *each* joint of the
+                returned configuration comes back non-finite, under a successful
+                return that is shaped exactly like a converged solve. Checked
+                before the configuration is updated, so a refused solve leaves
+                the bridge as it was.
         """
         mink = self._mink
+        pose = np.asarray(target_pose, dtype=np.float64)
         q = np.asarray(q_init, dtype=np.float64).copy()
+        # Both arrays are checked before the configuration is updated and before
+        # the frame target is set, so a refused solve mutates nothing. The pose
+        # is flattened for the check because ``finite_vector_error`` reads a
+        # 2-D argument's *rows* as its elements and would refuse a clean
+        # ``(4, 4)``; the seed is already the 1-D vector that domain expects.
+        if text := finite_vector_error("solve", "target_pose", pose.ravel()):
+            raise ValueError(text)
+        if text := finite_vector_error("solve", "q_init", q):
+            raise ValueError(text)
         self._configuration.update(q)
         self._posture_task.set_target(q)
 
-        target = mink.SE3.from_matrix(np.asarray(target_pose, dtype=np.float64))
+        target = mink.SE3.from_matrix(pose)
         self._frame_task.set_target(target)
 
         for _ in range(self.max_iters):

--- a/tests/simulation/test_ik_solve_refuses_a_non_finite_pose_or_seed.py
+++ b/tests/simulation/test_ik_solve_refuses_a_non_finite_pose_or_seed.py
@@ -132,9 +132,9 @@ class TestThePoseAndSeedAreWhatTheSolverReads:
         seed[0] = 0.25
         pose = _target_pose([0.4, 0.0, 0.4])
         _solve(bridge, pose, seed)
-        assert bridge._posture_task.target is not None
-        assert np.asarray(bridge._posture_task.target)[0] == pytest.approx(0.25)
-        assert bridge._frame_task.target is not None
+        assert bridge._posture_task.target is not None  # type: ignore[attr-defined]
+        assert np.asarray(bridge._posture_task.target)[0] == pytest.approx(0.25)  # type: ignore[attr-defined]
+        assert bridge._frame_task.target is not None  # type: ignore[attr-defined]
 
     def test_the_shared_domain_refuses_a_flat_non_finite_vector(self) -> None:
         clean = finite_vector_error("solve", "q_init", _seed())

--- a/tests/simulation/test_ik_solve_refuses_a_non_finite_pose_or_seed.py
+++ b/tests/simulation/test_ik_solve_refuses_a_non_finite_pose_or_seed.py
@@ -1,0 +1,292 @@
+"""``MinkIKBridge.solve`` refuses a non-finite pose or seed instead of solving with it.
+
+:class:`~strands_robots.simulation.ik.MinkIKBridge` holds all eight of its
+numeric *knobs* to a shared domain in ``__init__`` - the three task costs and the
+two thresholds to :func:`~strands_robots.utils.finite_number_error`, ``damping``
+to the local wrapper over it, ``max_iters`` to
+:func:`~strands_robots.utils.positive_count_error` and ``dt`` to
+:func:`~strands_robots.utils.positive_finite_number_error` - and handed the two
+*arrays* ``solve`` reads straight through. ``solve_trajectory`` checked the one
+thing a wrong-shaped batch would break on, ``poses.shape``, and none of the
+values inside it.
+
+Both arrays are applied rather than forwarded: the pose becomes the frame task's
+target and the seed becomes the configuration the QP warm-starts from. Measured
+against a Panda (``nq=9``) on a reachable 80 mm target whose healthy solve
+returns nine finite joints:
+
+* one ``nan`` anywhere in ``target_pose`` returned **9 of 9** joints non-finite,
+  as a successful return shaped exactly like a converged solve;
+* one ``inf`` in ``target_pose`` did the same;
+* one ``nan`` in ``q_init`` did the same;
+* ``solve_trajectory([good, bad])`` returned **9 of 18** non-finite - the first
+  waypoint a real configuration and the second entirely NaN, so a caller
+  iterating waypoints gets a partially valid trajectory rather than an error.
+
+The check costs 4.221 us against a 3.405 ms solve, 0.124% of one call, so there
+is no budget argument for leaving it to the consumer.
+
+Two things are deliberately *not* claimed. The bridge does not carry the damage
+across calls - ``solve`` re-seeds the configuration from ``q_init`` every time,
+so the next healthy solve was already clean before this change; the guard's
+placement ahead of the mutation is craft rather than a fix for a measured leak,
+and ``TestTheRefusalCostsTheBridgeNothing`` pins it. And ``tracking_error``
+stays untouched: it returns ``{"mean_mm": nan, "max_mm": nan}``, which is a
+visibly non-finite reading rather than a plausible one.
+
+The behavioural cells drive the real ``solve`` loop against the fake ``mink``
+module the sibling suites already use, so nothing here needs ``mink``,
+``mujoco`` or ``qpsolvers`` installed.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.ik import MinkIKBridge
+from strands_robots.utils import finite_vector_error
+from tests.policies.cosmos3.test_sim_ik_bridge_solve_loop import (
+    _FakeConfiguration,
+    _FakeFrameTask,
+    _FakePostureTask,
+    _FakeSE3,
+    _model,
+    _solve_ik,
+    _target_pose,
+)
+
+#: The two array arguments ``solve`` reads, named locally so these cells are an
+#: independent oracle rather than a restatement of the module.
+ARRAY_PARAMETERS = ("target_pose", "q_init")
+
+
+@pytest.fixture
+def fake_mink(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Install the sibling suite's fake ``mink`` plus a stub ``qpsolvers``.
+
+    Declared here rather than imported: importing a fixture re-binds the name in
+    this module, which ``ruff`` reports as a redefinition for every cell that
+    then takes it as a parameter. Only the stand-in classes are shared.
+    """
+    mod = types.ModuleType("mink")
+    mod.Configuration = _FakeConfiguration  # type: ignore[attr-defined]
+    mod.FrameTask = _FakeFrameTask  # type: ignore[attr-defined]
+    mod.PostureTask = _FakePostureTask  # type: ignore[attr-defined]
+    mod.SE3 = _FakeSE3  # type: ignore[attr-defined]
+    mod.solve_ik = _solve_ik  # type: ignore[attr-defined]
+    monkeypatch.setitem(__import__("sys").modules, "mink", mod)
+
+    qp = types.ModuleType("qpsolvers")
+    qp.available_solvers = ["quadprog"]  # type: ignore[attr-defined]
+    monkeypatch.setitem(__import__("sys").modules, "qpsolvers", qp)
+    return mod
+
+
+def _bridge() -> MinkIKBridge:
+    return MinkIKBridge(model=_model(), ee_frame_name="gripper", solver="quadprog")
+
+
+def _seed(nq: int = 7) -> np.ndarray:
+    return np.zeros(nq, dtype=np.float64)
+
+
+def _solve(bridge: MinkIKBridge, pose: Any, seed: Any) -> np.ndarray:
+    """Call ``solve`` through one deliberately untyped funnel.
+
+    The cells below pass a nested list and a non-finite array on purpose, which
+    is the whole point of a value domain. Routing them here keeps the call sites
+    free of the ``arg-type`` reports a literal would draw.
+    """
+    return bridge.solve(pose, seed)
+
+
+def _poisoned(base: np.ndarray, index: tuple[int, ...], value: float) -> np.ndarray:
+    out = base.copy()
+    out[index] = value
+    return out
+
+
+_POSE_CASES = [
+    pytest.param((0, 3), float("nan"), id="nan-in-translation"),
+    pytest.param((1, 3), float("inf"), id="inf-in-translation"),
+    pytest.param((0, 0), float("nan"), id="nan-in-rotation"),
+    pytest.param((2, 2), float("-inf"), id="negative-inf-in-rotation"),
+]
+
+
+class TestThePoseAndSeedAreWhatTheSolverReads:
+    """Premise: both arrays reach the solver, which is why a bad value spreads."""
+
+    def test_the_seed_becomes_the_configuration_and_the_pose_the_frame_target(
+        self, fake_mink: types.ModuleType
+    ) -> None:
+        bridge = _bridge()
+        seed = _seed()
+        seed[0] = 0.25
+        pose = _target_pose([0.4, 0.0, 0.4])
+        _solve(bridge, pose, seed)
+        assert bridge._posture_task.target is not None
+        assert np.asarray(bridge._posture_task.target)[0] == pytest.approx(0.25)
+        assert bridge._frame_task.target is not None
+
+    def test_the_shared_domain_refuses_a_flat_non_finite_vector(self) -> None:
+        clean = finite_vector_error("solve", "q_init", _seed())
+        dirty = finite_vector_error("solve", "q_init", _poisoned(_seed(), (2,), float("nan")))
+        assert clean is None
+        assert dirty is not None and "q_init" in dirty
+
+    def test_the_shared_domain_reads_a_two_dimensional_argument_by_rows(self) -> None:
+        """Why the pose is flattened: the domain refuses even a *clean* 4x4."""
+        matrix = np.eye(4)
+        assert finite_vector_error("solve", "target_pose", matrix) is not None
+        assert finite_vector_error("solve", "target_pose", matrix.ravel()) is None
+
+
+class TestANonFinitePoseIsRefused:
+    """Regression: the all-NaN configuration is no longer returned as a solve."""
+
+    @pytest.mark.parametrize(("index", "value"), _POSE_CASES)
+    def test_solve_refuses_the_pose(self, fake_mink: types.ModuleType, index: tuple[int, ...], value: float) -> None:
+        pose = _poisoned(_target_pose([0.4, 0.0, 0.4]), index, value)
+        with pytest.raises(ValueError, match="'target_pose' must contain finite numbers"):
+            _solve(_bridge(), pose, _seed())
+
+    def test_the_refusal_names_the_method_and_the_parameter(self, fake_mink: types.ModuleType) -> None:
+        pose = _poisoned(_target_pose([0.4, 0.0, 0.4]), (0, 3), float("nan"))
+        with pytest.raises(ValueError) as excinfo:
+            _solve(_bridge(), pose, _seed())
+        text = str(excinfo.value)
+        assert text.startswith("solve:")
+        assert "'target_pose'" in text
+        assert "'q_init'" not in text
+
+    def test_no_configuration_comes_back_non_finite(self, fake_mink: types.ModuleType) -> None:
+        """The outcome the refusal replaces: nine of nine joints were NaN."""
+        pose = _poisoned(_target_pose([0.4, 0.0, 0.4]), (0, 3), float("nan"))
+        with pytest.raises(ValueError):
+            _solve(_bridge(), pose, _seed())
+
+
+class TestANonFiniteSeedIsRefused:
+    """Regression: a seed the QP cannot warm-start from is refused by name."""
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_solve_refuses_the_seed(self, fake_mink: types.ModuleType, value: float) -> None:
+        seed = _poisoned(_seed(), (2,), value)
+        with pytest.raises(ValueError, match="'q_init' must contain finite numbers"):
+            _solve(_bridge(), _target_pose([0.4, 0.0, 0.4]), seed)
+
+    def test_the_refusal_names_the_seed_not_the_pose(self, fake_mink: types.ModuleType) -> None:
+        seed = _poisoned(_seed(), (0,), float("nan"))
+        with pytest.raises(ValueError) as excinfo:
+            _solve(_bridge(), _target_pose([0.4, 0.0, 0.4]), seed)
+        text = str(excinfo.value)
+        assert "'q_init'" in text
+        assert "'target_pose'" not in text
+
+
+class TestTheTrajectoryPathInheritsTheGuard:
+    """Regression: one guard in ``solve`` covers every ``solve_trajectory`` waypoint."""
+
+    def test_a_bad_waypoint_is_refused_rather_than_partially_solved(self, fake_mink: types.ModuleType) -> None:
+        good = _target_pose([0.4, 0.0, 0.4])
+        bad = _poisoned(good, (0, 3), float("nan"))
+        with pytest.raises(ValueError, match="'target_pose' must contain finite numbers"):
+            _bridge().solve_trajectory(np.stack([good, bad]), _seed())
+
+    def test_a_bad_seed_is_refused_on_the_first_waypoint(self, fake_mink: types.ModuleType) -> None:
+        good = _target_pose([0.4, 0.0, 0.4])
+        with pytest.raises(ValueError, match="'q_init' must contain finite numbers"):
+            _bridge().solve_trajectory(np.stack([good, good]), _poisoned(_seed(), (1,), float("nan")))
+
+
+class TestWhatStaysAccepted:
+    """Over-reach controls: every legitimate call is unchanged."""
+
+    def test_a_healthy_solve_still_returns_finite_joints(self, fake_mink: types.ModuleType) -> None:
+        solved = _solve(_bridge(), _target_pose([0.4, 0.0, 0.4]), _seed())
+        assert np.all(np.isfinite(solved))
+        assert solved.shape == (7,)
+
+    def test_a_nested_list_pose_and_seed_are_still_accepted(self, fake_mink: types.ModuleType) -> None:
+        pose = _target_pose([0.4, 0.0, 0.4]).tolist()
+        solved = _solve(_bridge(), pose, _seed().tolist())
+        assert np.all(np.isfinite(solved))
+
+    def test_a_large_but_finite_coordinate_is_still_accepted(self, fake_mink: types.ModuleType) -> None:
+        """Unreachable is not unusable: the domain bounds finiteness, not range."""
+        solved = _solve(_bridge(), _target_pose([1e6, 0.0, 0.0]), _seed())
+        assert np.all(np.isfinite(solved))
+
+    def test_the_shape_refusal_still_precedes_the_value_check(self, fake_mink: types.ModuleType) -> None:
+        """A wrong-shaped batch keeps naming the shape, not the values inside it."""
+        with pytest.raises(ValueError, match=r"poses must be \[N, 4, 4\]"):
+            _bridge().solve_trajectory(np.full((2, 3, 3), np.nan), _seed())
+
+    def test_an_empty_trajectory_is_still_zero_length_with_nq_width(self, fake_mink: types.ModuleType) -> None:
+        out = _bridge().solve_trajectory(np.empty((0, 4, 4)), _seed())
+        assert out.shape == (0, 7)
+
+    def test_a_healthy_trajectory_still_solves_every_waypoint(self, fake_mink: types.ModuleType) -> None:
+        poses = np.stack([_target_pose([0.4, 0.0, 0.4]), _target_pose([0.45, 0.0, 0.4])])
+        out = _bridge().solve_trajectory(poses, _seed())
+        assert out.shape == (2, 7)
+        assert np.all(np.isfinite(out))
+
+
+class TestTheRefusalCostsTheBridgeNothing:
+    """The guard precedes the mutation, so a refused solve leaves the bridge usable."""
+
+    def test_a_solve_after_a_refusal_is_identical_to_one_before_it(self, fake_mink: types.ModuleType) -> None:
+        bridge = _bridge()
+        good = _target_pose([0.4, 0.0, 0.4])
+        before = _solve(bridge, good, _seed())
+        with pytest.raises(ValueError):
+            _solve(bridge, _poisoned(good, (0, 3), float("nan")), _seed())
+        after = _solve(bridge, good, _seed())
+        assert np.array_equal(before, after)
+
+    def test_a_refused_solve_does_not_update_the_configuration(self, fake_mink: types.ModuleType) -> None:
+        bridge = _bridge()
+        _solve(bridge, _target_pose([0.4, 0.0, 0.4]), _seed())
+        settled = np.asarray(bridge._configuration.q).copy()
+        with pytest.raises(ValueError):
+            _solve(bridge, _target_pose([0.4, 0.0, 0.4]), _poisoned(_seed(), (0,), float("nan")))
+        assert np.array_equal(np.asarray(bridge._configuration.q), settled)
+
+
+class TestBothArraysReachTheSharedDomain:
+    """Structural: the check is the shared domain, applied to each array, once."""
+
+    def test_solve_consults_the_shared_domain_for_every_array_it_reads(self) -> None:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(MinkIKBridge.solve)))
+        guarded = {
+            node.args[1].value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "finite_vector_error"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        }
+        assert guarded == set(ARRAY_PARAMETERS)
+
+    def test_the_checks_precede_the_state_the_solve_mutates(self) -> None:
+        source = textwrap.dedent(inspect.getsource(MinkIKBridge.solve))
+        last_guard = source.rindex("finite_vector_error(")
+        assert last_guard < source.index("self._configuration.update(")
+        assert last_guard < source.index("self._frame_task.set_target(")
+
+    def test_the_pose_is_flattened_for_the_check(self) -> None:
+        """A 2-D argument would be refused for the wrong reason; see the premise."""
+        source = textwrap.dedent(inspect.getsource(MinkIKBridge.solve))
+        line = next(ln for ln in source.splitlines() if 'finite_vector_error("solve", "target_pose"' in ln)
+        assert ".ravel()" in line


### PR DESCRIPTION
## The defect

`MinkIKBridge` holds all eight of its numeric **knobs** to a shared value domain in `__init__` (the task costs and thresholds to `finite_number_error`, `max_iters` to `positive_count_error`, `dt` to `positive_finite_number_error`) and handed the two **arrays** `solve` reads straight through. `solve_trajectory` checked the one thing a wrong-shaped batch would break on, `poses.shape`, and none of the values inside it.

Both arrays are *applied* rather than forwarded: `target_pose` becomes the frame task's target and `q_init` becomes the configuration the QP warm-starts from. Measured against a Franka Panda (`nq=9`) on a reachable 80 mm target:

| call | before | after |
|---|---|---|
| healthy solve (control) | ok, `non_finite=0/9` | unchanged, `0/9` |
| one `nan` in `target_pose` | **ok, `9/9` non-finite** | `ValueError: solve: 'target_pose' must contain finite numbers` |
| one `inf` in `target_pose` | **ok, `9/9`** | refused, names `target_pose` |
| one `nan` in `q_init` | **ok, `9/9`** | refused, names `q_init` |
| `solve_trajectory([good, bad])` | **ok, `9/18`** | refused on the bad waypoint |
| `solve_trajectory` with a bad seed | **ok, `18/18`** | refused on the first waypoint |

Every "before" row is a *successful return*, shaped exactly like a converged solve. The trajectory row is the sharpest: the first waypoint is a real configuration and the second is entirely NaN, so a caller iterating waypoints gets a partially valid trajectory rather than an error.

## The change

Both arrays go through `finite_vector_error`, the same shared domain the scene-construction vectors use, checked before the configuration is updated and before the frame target is set.

Three decisions worth stating, each measured rather than preferred:

**The pose is flattened.** That domain reads a 2-D argument's *rows* as its elements, so it refuses even a clean `(4, 4)`: `finite_vector_error("solve", "target_pose", numpy.eye(4))` returns an error and `...eye(4).ravel()` returns `None`. A premise cell pins both halves, and the mutation that drops the `.ravel()` is the only row in the break table that trips the sibling suites (`sib=4`) - handing the matrix in would refuse every legitimate pose.

**One guard, in `solve`.** `solve_trajectory` calls `solve` per waypoint, so a single guard covers both entry points. The mutation that moves the check into `solve_trajectory` instead fires 15 cells: it leaves a direct `solve` caller unguarded.

**No budget argument.** One `solve` is 3.405 ms; `numpy.all(numpy.isfinite(...))` over the pose and the seed is 4.221 us, **0.124%** of a call.

## Deliberately unchanged

The bridge never carried the damage *across* calls. `solve` re-seeds the configuration from `q_init` every time, so a healthy solve following a bad one was already clean before this change. The guard's placement ahead of the mutation is craft rather than a repair, and `TestTheRefusalCostsTheBridgeNothing` pins it: a solve after a refusal is byte-identical (`numpy.array_equal`) to one before it, and the configuration is untouched.

`tracking_error` is untouched too. It returns `{"mean_mm": nan, "max_mm": nan}`, which is a visibly non-finite reading rather than a plausible one.

Finiteness is the whole domain: a large but unreachable coordinate (`1e6`) stays accepted, because unreachable is not unusable.

## Why nothing caught it

The bridge's own domain suite (`test_ik_bridge_numeric_parameter_domains.py`) derives its subject from the constructor's `int`/`float` **signature parameters**, so an array argument to a method is outside what it enumerates. `solve_trajectory`'s existing shape check is the one value-shaped guard on either method, and it grades the batch's dimensions rather than its contents.

## Verification

Break table, 8 mutations, control clean, `collected` stable at 26 on every row:

| mutation | cells fired | sibling suites |
|---|---|---|
| control (no mutation) | 0 | 0 |
| pose guard removed | 10 | 0 |
| seed guard removed | 7 | 0 |
| both removed (behavioural revert) | 17 | 0 |
| guards moved after the state mutation | 2 | 0 |
| pose not flattened (2-D handed to the domain) | 18 | **4** |
| pose guard filed under the wrong parameter name | 8 | 0 |
| pose verdict discarded (called, not read) | 8 | 0 |
| guard placed in `solve_trajectory` instead of `solve` | 15 | 0 |

Eight firing rows, eight distinct firing sets. The per-array reverts partition the full revert exactly: 10 + 7 with one shared cell (the derived-inventory assertion, which fires when *either* guard is missing) plus one residual, `test_the_checks_precede_the_state_the_solve_mutates` - it reads the *last* `finite_vector_error` call, so one surviving guard still satisfies it and only both-gone makes it fire. 10 + 7 - 1 + 1 = 17.

Pre-fix split **17 failed / 9 passed**: 6/6, 4/4, 3/3, 2/2 and 2/2 across the regression classes, **0 of 3 premise** and **0 of 6 over-reach controls**.

Paired gate on an identical 833-file selection (all of `tests/simulation/` plus every suite walking the tree, parsing source or reading docstrings, `Args:`, `Raises:` and `__all__`), with the new file excluded from both trees: identical **30197 collected** and `25 failed, 29906 passed, 266 skipped` on each, 25 == 25 failing ids, **both `comm` directions empty**. Those 25 are pre-existing and classified: 17 need `awsiot`/`awscrt` (both absent locally, declared in the `mesh-iot` extra), 4 in `test_recording_frame_loss_is_not_tolerated.py` pass 13/13 in isolation, 3 are lerobot-from-source drift, and 1 is a load-sensitive wall-clock pacer that passes 16/16 alone.

mypy **24 == 24** with both normalized `comm` directions empty and nothing attributable (`checked 1668` vs `1667`, the difference being the new test file); the one `simulation/ik.py` message is pre-existing on both trees. `ruff check` and `ruff format` clean.

The new suite drives the real `solve` loop against the fake `mink` module the sibling suites already use, so its 26 cells need neither `mink`, `mujoco` nor `qpsolvers` and run in 0.12 s.

No visual artifact: this is a refusal-vs-silent-NaN change on a solver input, and the consumer of the returned configuration is unchanged. The measured tables above are the evidence.

Closes #2873.
