### PR TITLE
test(simulation/ik): read the solve premise off the returned configuration

### DIFF
--- a/changelog.d/2875-ik-solve-non-finite-pose-or-seed.md
+++ b/changelog.d/2875-ik-solve-non-finite-pose-or-seed.md
@@ -17,6 +17,11 @@ shaped exactly like a converged solve, with nothing in the value or the type to
 distinguish it from one. `solve_trajectory([good, bad])` returned **9 of 18**:
 the first waypoint a real configuration and the second entirely NaN, so a caller
 iterating waypoints receives a partially valid trajectory rather than an error.
+One spelling did not come back at all: an `inf` in `q_init` left the QP backend
+unable to solve, raising `mink.exceptions.NoSolutionFound` out of a third-party
+module rather than the `ValueError` the method documents. The same class of bad
+value therefore had two exits, one silent and one naming neither the method nor
+the parameter.
 
 Both arrays now reach `finite_vector_error`, the same shared domain the
 scene-construction vectors use, checked before the configuration is updated and
@@ -25,8 +30,8 @@ flattened for the check because that domain reads a 2-D argument's *rows* as its
 elements and would otherwise refuse a clean `(4, 4)`. One guard in `solve` covers
 `solve_trajectory`, which calls it per waypoint; placing the check in
 `solve_trajectory` instead would leave a direct `solve` caller unguarded. The
-check costs 4.221 us against a 3.405 ms solve, 0.124% of one call, so there is no
-budget argument for leaving it to the consumer.
+two checks together cost 45.8 us against a 7.6 ms solve on that same Panda, 0.60%
+of one call, so there is no budget argument for leaving them to the consumer.
 
 Two things are deliberately unchanged. The bridge never carried the damage across
 calls - `solve` re-seeds the configuration from `q_init` every time, so the next

--- a/tests/simulation/test_ik_solve_refuses_a_non_finite_pose_or_seed.py
+++ b/tests/simulation/test_ik_solve_refuses_a_non_finite_pose_or_seed.py
@@ -19,12 +19,20 @@ returns nine finite joints:
   as a successful return shaped exactly like a converged solve;
 * one ``inf`` in ``target_pose`` did the same;
 * one ``nan`` in ``q_init`` did the same;
+* one ``inf`` in ``q_init`` did *not* come back at all - it left the QP backend
+  itself unable to solve, so the call raised ``mink.exceptions.NoSolutionFound``
+  out of a third-party module rather than the ``ValueError`` this method
+  documents. The same class of bad value therefore had two exits, one silent and
+  one naming neither the method nor the parameter;
 * ``solve_trajectory([good, bad])`` returned **9 of 18** non-finite - the first
   waypoint a real configuration and the second entirely NaN, so a caller
   iterating waypoints gets a partially valid trajectory rather than an error.
 
-The check costs 4.221 us against a 3.405 ms solve, 0.124% of one call, so there
-is no budget argument for leaving it to the consumer.
+Both checks together cost 45.8 us against a 7.6 ms solve on that same Panda -
+0.60% of one call - so there is no budget argument for leaving them to the
+consumer. That is the shipped guard's own cost: :func:`finite_vector_error`
+reads each component rather than vectorising the scan, so it is roughly linear
+in the array and the pose's sixteen elements dominate the seed's nine.
 
 Two things are deliberately *not* claimed. The bridge does not carry the damage
 across calls - ``solve`` re-seeds the configuration from ``q_init`` every time,
@@ -65,6 +73,11 @@ from tests.policies.cosmos3.test_sim_ik_bridge_solve_loop import (
 #: The two array arguments ``solve`` reads, named locally so these cells are an
 #: independent oracle rather than a restatement of the module.
 ARRAY_PARAMETERS = ("target_pose", "q_init")
+
+#: A joint the stand-in solver never drives - it moves only ``q[:3]`` onto the
+#: frame target - so a seed value here survives the solve and is what shows the
+#: seed became the warm-start configuration.
+UNDRIVEN_DOF = 4
 
 
 @pytest.fixture
@@ -127,14 +140,28 @@ class TestThePoseAndSeedAreWhatTheSolverReads:
     def test_the_seed_becomes_the_configuration_and_the_pose_the_frame_target(
         self, fake_mink: types.ModuleType
     ) -> None:
+        """Both arrays are read through the *solve*, not merely stored.
+
+        Asserted on the returned configuration rather than on either task's
+        stored target. ``mink`` names that storage ``PostureTask.target_q`` and
+        ``FrameTask.transform_target_to_world`` while the stand-in keeps a
+        single ``target``, so reading it would pin the fake's own convention
+        rather than the library's. The returned configuration is the surface
+        both agree on, and it shows each array *propagating* through the solve
+        instead of merely arriving at a setter - which is the premise this
+        class exists for.
+        """
         bridge = _bridge()
         seed = _seed()
-        seed[0] = 0.25
-        pose = _target_pose([0.4, 0.0, 0.4])
-        _solve(bridge, pose, seed)
-        assert bridge._posture_task.target is not None  # type: ignore[attr-defined]
-        assert np.asarray(bridge._posture_task.target)[0] == pytest.approx(0.25)  # type: ignore[attr-defined]
-        assert bridge._frame_task.target is not None  # type: ignore[attr-defined]
+        seed[UNDRIVEN_DOF] = 0.25
+        translation = [0.4, 0.0, 0.4]
+        solved = _solve(bridge, _target_pose(translation), seed)
+        # The pose became the frame target: the solver drives the first three
+        # joints onto its translation.
+        assert solved[:3] == pytest.approx(translation)
+        # The seed became the warm-start configuration: a value on a joint the
+        # solver never drives survives into the answer.
+        assert solved[UNDRIVEN_DOF] == pytest.approx(0.25)
 
     def test_the_shared_domain_refuses_a_flat_non_finite_vector(self) -> None:
         clean = finite_vector_error("solve", "q_init", _seed())


### PR DESCRIPTION
## What

`TestThePoseAndSeedAreWhatTheSolverReads` carries the premise the rest of
`test_ik_solve_refuses_a_non_finite_pose_or_seed.py` rests on: that `solve`
*applies* both of its arrays rather than forwarding them, which is why one
non-finite value spreads to every joint. As merged in #2875 it reads that off
`_posture_task.target` and `_frame_task.target` behind three
`# type: ignore[attr-defined]`.

The reports were correct. `mink` names that storage `PostureTask.target_q` and
`FrameTask.transform_target_to_world`; only the stand-in the dependency-free
cells run against spells it `target`, and `MinkIKBridge`'s attributes are
annotated with the real classes. The cell was pinning the stand-in's own storage
convention rather than the library's, and the suppressions are what allowed it.

This asserts on the **returned configuration** instead, the one surface the
stand-in and `mink` agree on: the solver drives the first three joints onto the
pose's translation, and a seed value on a joint it never drives survives into the
answer. The cell now shows each array propagating *through* the solve rather than
merely arriving at a setter, and the three suppressions go with it. The six that
remain are the fixture's module-attribute writes and are unrelated.

`strands_robots/` is untouched - this is the test and the pending fragment only.

## It is also strictly more detection

Seeding the configuration from zeros instead of `q_init` is a dropped warm start,
which is precisely what the cell's name claims to establish. The suppressed form
cannot see it:

| `solve` seeds the configuration from zeros, not `q_init` | collected | fires |
| --- | --- | --- |
| `main` 08a37b04 (three `type: ignore`) | 26 | 0 |
| this change (returned configuration) | 26 | 1 |
| control, unmutated, this change | 26 | 0 |

Equal collection either way, so nothing is deselected, and the single fire is
`test_the_seed_becomes_the_configuration_and_the_pose_the_frame_target` naming
itself.

## Two figures corrected against the real solver

Both the module docstring and the pending fragment stated a cost. Re-measured
against real `mink` + `mujoco` + `qpsolvers` on the same Franka Panda (`nq=9`,
`daqp` backend) the docstring already cites, rather than restated:

| | stated | measured |
| --- | --- | --- |
| one solve | 3.405 ms | 7.615 ms |
| both checks | 4.221 us | 45.8 us |
| share of one call | 0.124% | 0.60% |

`finite_vector_error` reads each component rather than vectorising the scan, so
it scales with the array and the pose's sixteen elements dominate the seed's nine
- 27.7 us against 18.0 us. The conclusion is unchanged, well under one percent,
but the number now describes the guard as written.

The same run recorded a fifth spelling the pre-fix measurement missed. Driving
`solve` against that Panda with the guard reverted:

| input | pre-fix | post-fix |
| --- | --- | --- |
| clean pose and seed | returns, 0 of 9 non-finite | returns, 0 of 9 non-finite |
| `nan` in pose translation | returns, 9 of 9 non-finite | refused, names `target_pose` |
| `inf` in pose translation | returns, 9 of 9 non-finite | refused, names `target_pose` |
| `nan` in pose rotation | returns, 9 of 9 non-finite | refused, names `target_pose` |
| `nan` in `q_init` | returns, 9 of 9 non-finite | refused, names `q_init` |
| `inf` in `q_init` | raises `mink.exceptions.NoSolutionFound` | refused, names `q_init` |

So the same class of bad value had two exits, one silent and one naming neither
the method nor the parameter. An existing cell already pins that it is refused;
only the record of what it used to do was incomplete, and the fragment now says
so.

## Gate

`ruff check` clean, `ruff format --check` 1672 files already formatted, and
`mypy strands_robots tests tests_integ` reports `Success: no issues found in 1669
source files` - the three `attr-defined` reports are gone without a suppression.

156 passed across the changed file, `test_ik_bridge_numeric_parameter_domains`,
both `test_sim_ik_bridge_solve_loop` suites, `test_vera_sim_ik_solver`, the two
changelog gates and the two docstring-reference guards.

A 828-file selection of every suite that walks the tree, parses source or reads
docstrings, plus all of `tests/simulation`, gives `6 failed, 29937 passed, 94
skipped` of 30037 collected. All six reproduce byte-identically on a pristine
worktree of the merge base: five assert `rclpy` is absent where it resolves in
this environment, and one is a pre-existing wording mismatch in
`newton/test_multi_camera.py`. No branch-only failures.
