### PR TITLE
fix(drivers/g1): a docstring deferral must not cite a landed change

### DIFF
--- a/changelog.d/2877-docstring-deferral-cites-a-landed-change.md
+++ b/changelog.d/2877-docstring-deferral-cites-a-landed-change.md
@@ -1,0 +1,27 @@
+### Fixed: a docstring that defers pending work no longer cites a change this repository already landed
+
+The regression guard added for the caller-reachable half of this contract scoped
+itself to strings, on the grounds that a developer-facing docstring legitimately
+cites historical work and a maintainer reading one has the git history to hand.
+That reason describes a *backward citation*. It does not describe a *forward
+deferral*, which the same module identifies as the opposite speech act: a
+deferral tells the next contributor a capability is still outstanding and where
+to watch for it, and git history cannot answer "when will this land".
+
+Seven docstring sentences in `strands_robots/drivers/g1.py` deferred to `#358`
+and `#361`. Both resolve, in this repository, to merged pull requests about
+unrelated subsystems, so a reader following one found a landed change and could
+not tell whether the capability was missing or the note was stale. One sentence
+was worse than misdirecting: `send_action` said "the loop lands in the follow-up
+PR that closes issue #361 in full" while `_ControlLoop` ships in the same
+module, describing shipped code as future work.
+
+The two conditions now also grade docstring sentences. The scope is the sentence
+rather than the docstring, because one paragraph routinely carries a deferral and
+a backward citation and a paragraph-wide read blames the deferral for the
+credit's reference. The deferral vocabulary gains "lands in" and "future work",
+which - measured across the package - adds no caller-reachable offender and takes
+the docstring rule from two of the seven sentences to all seven. Each fixed
+sentence names the missing capability instead of a tracker number, matching the
+remedy the string half already applies. `#` comments stay out of scope: a comment
+is neither read by a caller nor part of the rendered API surface.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -26,11 +26,11 @@ What the driver actually does:
   on a dedicated 500 Hz thread (per-step FSM re-gate, zero-torque frame on
   exit); :meth:`stop_task` halts that loop and reports the join outcome;
   :meth:`get_task_status` reports the loop's snapshot or the last exit
-  reason.  :meth:`start_task` still refuses with a named message pointing
-  at issue #358 because the provider registry (Groot/ACT/Diffusion clients)
-  is not yet plumbed here - a caller with an already-built policy uses
-  :meth:`run_policy` today.  Locomotion and arm-SDK-shaped verbs land in
-  issue #358; the driver's job in issue #354 was the transport, and the
+  reason.  :meth:`start_task` still refuses with a named message because
+  the provider registry (Groot/ACT/Diffusion clients) is not yet plumbed
+  here - a caller with an already-built policy uses :meth:`run_policy`
+  today.  Locomotion and arm-SDK-shaped verbs arrive with the ``g1_tools``
+  motion verbs; the driver's job in issue #354 was the transport, and the
   control loop that closes issue #361 lives here now.
 
 Nothing in this module imports ``unitree_sdk2py`` at module load. Every SDK
@@ -330,7 +330,7 @@ class G1Driver:
         """A minimal agent-facing spec.
 
         The rich verb set (``arm``, ``walk``, ``posture``, ``speak``,
-        ``lidar_snapshot``) lands in issue #358 as vendored neon tools that
+        ``lidar_snapshot``) arrives with the vendored neon tools that
         the agent gets in addition to the driver-as-tool. Here we ship the
         universal ``status``/``stop`` verbs and a ``sensors`` read-out so a
         Strands agent can already introspect the robot the day the driver
@@ -381,7 +381,7 @@ class G1Driver:
         the loop publishes a zero-torque frame on the way out, and the
         returned envelope reports whether the thread actually joined.  The
         rich motion verb set (``arm``, ``walk``, ``posture``, ``speak``,
-        ``lidar_snapshot``) lands in issue #358 as vendored neon tools that
+        ``lidar_snapshot``) arrives with the vendored neon tools that
         the agent gets in addition to the driver-as-tool; the transport
         primitive those verbs will call - :meth:`send_action` publishing on
         ``rt/lowcmd`` - already ships (issue #361).
@@ -590,7 +590,7 @@ class G1Driver:
         Two FSM sets are enforced separately because the G1 documents them
         separately: :data:`HANDSHAKE_FSMS` covers arm-SDK-shaped writes (which
         the driver publishes on ``rt/lowcmd`` today; the ``rt/armsdk`` topic
-        is future work for the ``g1_tools`` client in issue #358) and
+        is future work for the ``g1_tools`` client) and
         :data:`WALK_FSMS` is narrower - sitting (500) accepts arm gestures
         but not walking. ``scope`` is the caller's declared kind of write:
 
@@ -656,7 +656,7 @@ class G1Driver:
 
         1. A control loop.  A caller who wants 500 Hz calls this on their own
            timer; the driver's job here is one wire frame, not a schedule.
-           The loop lands in the follow-up PR that closes issue #361 in full.
+           :meth:`run_policy` owns that loop today; this method is one frame.
         2. A safety filter.  The FSM and battery gates are the safety
            envelope; command-magnitude limits are the arm-SDK client's job.
 
@@ -716,8 +716,8 @@ class G1Driver:
         The lerobot driver runs its ``start_task`` through a policy provider
         registry.  Providers live in :mod:`strands_robots.policies`; wiring a
         concrete inference client (Groot, ACT, Diffusion) here needs the
-        ``g1_tools`` motion verbs (issue #358) so the loop has something to
-        command with joint-name semantics.
+        ``g1_tools`` motion verbs so the loop has something to command with
+        joint-name semantics.
 
         This driver's role is the **transport primitive**:
         a background thread that spins at 500 Hz, gates every step against the
@@ -726,7 +726,7 @@ class G1Driver:
         A caller who supplies a callable-style policy via
         :meth:`run_policy` gets the whole loop today; :meth:`start_task` still
         refuses with a message naming the missing provider registry, which is
-        not yet plumbed here (that decision moves with #358 to
+        not yet plumbed here (that decision moves with the motion verbs to
         keep the two concerns separable).
 
         Scope is ``"motion"`` because a task may issue either an arm or a

--- a/tests/test_deferral_strings_do_not_cite_a_landed_change.py
+++ b/tests/test_deferral_strings_do_not_cite_a_landed_change.py
@@ -40,13 +40,32 @@ conditions: dropping the deferral test would flag the four legitimate backward
 citations, and dropping the landed test would flag every deferral including the
 one that correctly points at open issue ``#2765``.
 
-Scope: caller-reachable literals only, matching the sibling module's boundary.
-Developer-facing docstrings legitimately cite historical work, and a maintainer
-reading one has the git history to hand.
+Scope: both caller-reachable literals and docstrings, split by *speech act*
+rather than by audience.  A docstring may name a merged change freely when it
+is explaining where text came from - that is the backward citation above, and a
+maintainer reading it has the git history to hand.  A docstring that *defers*
+is a different claim: it tells the next contributor a capability is still
+outstanding and where to watch for it, and git history cannot answer "when will
+this land".  So the same two conditions apply to a docstring sentence, and the
+scope is the sentence rather than the whole docstring - one paragraph routinely
+carries a deferral and a backward citation, and only the deferral's own
+sentence is graded.
+
+It would have failed while seven docstring sentences in
+``strands_robots/drivers/g1.py`` deferred to ``#358`` and ``#361``, both merged
+pull requests about unrelated subsystems.  One of them was worse than
+misdirecting: ``send_action`` told the reader "the loop lands in the follow-up
+PR that closes issue #361 in full" after that loop had shipped, so a
+contributor was told a capability the module already provides was future work.
+
+Out of scope: ``#`` comments.  A comment is neither read by a caller nor part
+of the rendered API surface, and the extraction the two rules share does not
+collect them.
 """
 
 from __future__ import annotations
 
+import ast
 import re
 import subprocess
 from pathlib import Path
@@ -69,8 +88,15 @@ _BARE_ISSUE_REF = re.compile(r"(?<![A-Za-z0-9_.\-/])#(\d+)\b")
 # historical subject carries shell quoting around the number.
 _LANDED_SUBJECT = re.compile(r"\(#'?(\d+)'?\)\s*$", re.MULTILINE)
 
-# A forward deferral: the text says the capability is still outstanding.
-_DEFERRAL = re.compile(r"not wired|not yet|unwired|pending|until .{0,40}\blands?\b", re.IGNORECASE)
+# A forward deferral: the text says the capability is still outstanding.  The
+# last two alternatives were added with the docstring rule below; measured
+# against the whole package they add no caller-reachable offender, so the
+# widening costs the string rule nothing and lets the docstring rule reach five
+# sentences the original vocabulary walked past.
+_DEFERRAL = re.compile(
+    r"not wired|not yet|unwired|pending|until .{0,40}\blands?\b|\blands? in\b|future work",
+    re.IGNORECASE,
+)
 
 # A shallow clone carries one commit, which would make the oracle empty and the
 # rule vacuous.  The history held 2108 landed numbers when this landed.
@@ -243,3 +269,117 @@ def test_both_conditions_are_load_bearing() -> None:
     # Landed test dropped: every deferral would be flagged.
     assert _DEFERRAL.search(open_deferral) is not None
     assert _landed_citations(open_deferral, landed) == []
+
+
+# =========================================================================
+# The same rule over docstrings, scoped to the sentence that defers.
+# =========================================================================
+
+# A docstring paragraph routinely carries a deferral and a backward citation
+# in adjacent sentences, so the reference must sit in the deferring sentence
+# to be graded.  Splitting is deliberately eager: an abbreviation splits a
+# sentence in two, which can only narrow what the rule reads, and a narrower
+# read declines to flag rather than flagging text it should not.
+_SENTENCE_BREAK = re.compile(r"(?<=[.:;])\s+")
+
+_DOCUMENTED_NODES = (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+
+def _docstring_sentences(path: Path) -> list[tuple[int, str, str]]:
+    """Every ``(lineno, owner, sentence)`` triple in a module's docstrings.
+
+    ``clean=False`` keeps the text as written; the sentence is whitespace-
+    normalised so a reference wrapped across two source lines is still one
+    token to the reference pattern.
+    """
+    found: list[tuple[int, str, str]] = []
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if not isinstance(node, _DOCUMENTED_NODES):
+            continue
+        docstring = ast.get_docstring(node, clean=False)
+        if not docstring:
+            continue
+        owner = getattr(node, "name", "<module>")
+        lineno = getattr(node, "lineno", 1)
+        for sentence in _SENTENCE_BREAK.split(" ".join(docstring.split())):
+            found.append((lineno, owner, sentence))
+    return found
+
+
+def _docstring_offenders(landed: frozenset[int]) -> list[str]:
+    found: list[str] = []
+    for path in _python_sources():
+        for lineno, owner, sentence in _docstring_sentences(path):
+            for number in _landed_citations(sentence, landed):
+                found.append(f"{Path(path).relative_to(_REPO_ROOT)}:{lineno} ({owner}): #{number}")
+    return found
+
+
+def test_the_docstring_population_is_not_empty() -> None:
+    """Non-vacuity: the docstring walk still yields sentences to grade."""
+    total = sum(len(_docstring_sentences(path)) for path in _python_sources())
+    assert total > 1000, f"only {total} docstring sentences found; the walk is too narrow"
+
+
+def test_no_docstring_deferral_cites_a_change_this_repository_landed() -> None:
+    """A docstring promising future work must not point at work already shipped."""
+    landed = _landed_pull_request_numbers_or_skip()
+    if len(landed) < _MINIMUM_LANDED_NUMBERS:
+        pytest.skip(
+            f"only {len(landed)} landed pull-request numbers found in git history; the "
+            "rule cannot grade its subject in a shallow environment. The oracle test "
+            "above owns the environment check; this rule declines rather than reads "
+            "green from an empty oracle."
+        )
+    offenders = _docstring_offenders(landed)
+    assert not offenders, (
+        "A docstring defers a capability and cites a change this repository has already "
+        "merged. The next contributor follows it, finds a landed change about another "
+        "subsystem, and cannot tell whether the capability is missing or the note is "
+        "stale. Cite an open issue that tracks the work, or name the missing capability "
+        "without a tracker reference:\n" + "\n".join(offenders)
+    )
+
+
+def test_a_deferral_and_a_backward_citation_in_one_paragraph_are_graded_apart() -> None:
+    """Sentence scope: the landed number must sit in the deferring sentence.
+
+    This is the shape the whole-docstring reading got wrong.  ``g1.py``'s module
+    docstring defers in one sentence and credits merged work in the next, and a
+    paragraph-wide read blamed the deferral for the credit's reference.
+    """
+    landed = frozenset({354, 358})
+    paragraph = "The provider registry is not yet plumbed here. The driver's job in issue #354 was the transport."
+    sentences = _SENTENCE_BREAK.split(paragraph)
+    assert len(sentences) == 2, sentences
+    assert [n for s in sentences for n in _landed_citations(s, landed)] == []
+    assert _landed_citations(paragraph, landed) == [354], "the paragraph-wide read is the defect"
+
+
+def test_a_docstring_deferral_citing_a_landed_change_is_flagged() -> None:
+    """The shape this half of the guard exists to keep out."""
+    landed = frozenset({361})
+    text = "The loop lands in the follow-up PR that closes issue #361 in full."
+    assert _landed_citations(text, landed) == [361]
+
+
+def test_a_docstring_deferral_citing_an_open_issue_is_not_flagged() -> None:
+    """Deferring to outstanding work is what a deferral is for."""
+    landed = frozenset({358, 361})
+    text = "Until the motion-switcher source is wired (issue #2765), the gate refuses honestly."
+    assert _landed_citations(text, landed) == []
+
+
+def test_the_widened_vocabulary_reaches_the_sentences_it_was_added_for() -> None:
+    """Non-vacuity of the widening: the two added phrases are load-bearing.
+
+    Without them the docstring rule reads five of the seven ``g1.py`` sentences
+    as prose rather than as deferrals, so the widening is what makes the rule
+    cover the class instead of two instances of it.
+    """
+    landed = frozenset({358, 361})
+    for text in (
+        "The rich verb set lands in issue #358 as vendored neon tools.",
+        "The rt/armsdk topic is future work for the g1_tools client in issue #358.",
+    ):
+        assert _landed_citations(text, landed), f"widened vocabulary should reach: {text!r}"


### PR DESCRIPTION
## The defect

`tests/test_deferral_strings_do_not_cite_a_landed_change.py` grades caller-reachable literals only. Its scope paragraph justified the exclusion this way:

> Developer-facing docstrings legitimately cite historical work, and a maintainer reading one has the git history to hand.

That reason describes a **backward citation** — and the same module's opening paragraphs argue at length that the two speech acts have *opposite* requirements. A **forward deferral** tells the next contributor a capability is still outstanding and where to watch for it; git history cannot answer "when will this land". So the stated reason covers one half of what it excluded.

Seven docstring sentences in `strands_robots/drivers/g1.py` were forward deferrals citing `#358` and `#361`:

| site | text | referent |
|---|---|---|
| module docstring | `start_task` "refuses ... at issue #358 because the provider registry ... **is not yet plumbed**" | `#358` merged 2026-06-07 |
| module docstring | "Locomotion and arm-SDK-shaped verbs **land in** issue #358" | same |
| `tool_spec` | "the rich verb set ... **lands in** issue #358 as vendored neon tools" | same |
| `stream` | same sentence, second surface | same |
| `_check_motion_gates` | "the `rt/armsdk` topic is **future work** for the `g1_tools` client in issue #358" | same |
| `send_action` | "The loop **lands in** the follow-up PR that closes issue #361 in full" | `#361` merged |
| `start_task` | "not yet plumbed here (that decision **moves with** #358 ...)" | `#358` |

`#358` is `test(mesh): fix flaky test_session_config (leaked zenoh MagicMock isolation)`. A reader follows it, finds a merged change about zenoh mock isolation, and cannot tell whether the capability is missing or the note is stale — the module's own argument for why this is worse than an unresolvable reference.

The `send_action` row is worse than misdirecting. `_ControlLoop` ships in the same module, so that sentence told a contributor a capability the module already provides was future work.

## The rule

The same two conditions, over docstring sentences.

**Sentence scope, not paragraph scope.** `g1.py`'s module docstring defers in one sentence and credits merged work in the next ("the driver's job in issue #354 **was** the transport"). A paragraph-wide read blames the deferral for the credit's reference — measured, that reading reports 5 offenders on a *corrected* tree, so it is a false-positive generator rather than a stricter rule.

**Two phrases added to the deferral vocabulary** (`lands in`, `future work`). Measured across the whole package this adds **no** caller-reachable offender, so the widening costs the existing string rule nothing, and it takes the docstring rule from 2 of the 7 sentences to all 7.

**`#` comments stay out of scope**, stated in the module docstring: a comment is neither read by a caller nor part of the rendered API surface, and the extraction the two rules share does not collect them. One remains in `g1.py` (line 67).

Each fixed sentence names the missing capability instead of a number, matching the remedy the string half already applies.

## Measurements

Pre-fix split, guard present and `g1.py` reverted: **1 failed / 13 passed**. The failure lists all seven offenders with file, line and owning definition. 0 of the 13 premise/exemplar cells fail, which is correct — they are graded on constructed inputs rather than on the tree.

| row | collected | fires | reading |
|---|---|---|---|
| control (as shipped) | 14 | 0 | — |
| `g1.py` reverted (the defect) | 14 | 1 | the rule catches it |
| whole-docstring scope, `g1.py` **fixed** | 14 | 2 | paragraph scope flags a correct tree |
| original vocabulary, `g1.py` reverted | 14 | 3 | the two added phrases are load-bearing |
| guard **and** `g1.py` reverted (`main` today) | **8** | 0 | silent, and the collected count drops |
| docstring walk narrowed to nothing, floor removed | 14 | 0 | a degenerate walk reads green |
| same, floor present | 14 | 1 | the non-vacuity floor names it |

The fifth row is the point: on `main` the drift is silent. The last pair is why the population floor is there rather than only a violations assertion.

## Gate

- `ruff check` clean, `ruff format --check` 1672 files already formatted.
- `mypy strands_robots tests tests_integ`: **24 == 24** against the same tree with both files reverted, normalized message sets byte-identical in both directions, **0 attributable** to either changed file.
- Paired run over a 469-file selection (every suite that walks the tree, parses source, or reads docstrings, plus all of `tests/drivers/` and `tests/tools/g1/`), the changed test file excluded from both sides: identical **21840 collected** and `20 failed, 21744 passed, 75 skipped, 1 xfailed` on each, **20 == 20 failing ids with both `comm` directions empty**. Of the 20, 17 are `tests/mesh/test_iot_*` needing `awsiot`/`awscrt` (both absent locally, both declared in the `mesh-iot` extra CI installs) and 3 are the lerobot-from-source `encode()` drift.
- The changed guard file alone: 14 passed.

No visual artifact: this changes docstring prose and a test. Nothing about a policy, a simulation, a render, a recording or an asset moves, and the refusal strings a caller sees are byte-identical before and after.

## Deliberately unchanged

`#354` and `#361` remain in three `g1.py` docstring sentences as backward citations ("was the transport", "already ships", "follow-up"). They are the speech act the excluded-scope reason genuinely covers, and the rule accepts them — which is the over-reach control for sentence scope.
