### PR TITLE
feat(drivers/feetech): a driver stub so `Robot("so101", mode="real", driver="strands")` builds

### DIFF
--- a/changelog.d/360-feetech-driver-stub.md
+++ b/changelog.d/360-feetech-driver-stub.md
@@ -1,6 +1,6 @@
 ### Added: native Feetech driver stub so `Robot("so101", mode="real", driver="strands")` builds
 
-The driver seam (#353 / #2734) has been on `main` for a fortnight with no native driver
+The driver seam (#2734) has been on `main` for a fortnight with no native driver
 registered against any Feetech robot -- `Robot("so101", mode="real", driver="strands")`
 raised `ValueError` from `_build_native_driver` because `get_native_driver_class` returned
 `None`. The Feetech codec has been in-tree since the protocol PR landed, but no class
@@ -12,8 +12,7 @@ verbs (`send_action`, `start_task`, `run_policy`, plus the `move_to`/`set_torque
 side of `stream`) return the same `{"status": "error", "content": [{"text": "not wired
 yet (the Feetech SCS serial bus)"}]}` envelope a caller who plumbed error handling for
 the sibling `DynamixelDriver` already handles. Three read-only verbs land now:
-`status`, `sensors`, `stop`. The bus that would carry the writes is #360 scope 1 and is
-deliberately its own PR -- landable-without-hardware is the whole point.
+`status`, `sensors`, `stop`. The bus that would carry the writes is deliberately its own PR -- landable-without-hardware is the whole point.
 
 `get_status` returns a well-formed envelope matching `DynamixelDriver.get_status`'s
 shape, so the mesh publishes both peers identically. `connect_eagerly` names the
@@ -22,5 +21,5 @@ success) or raising (indistinguishable from a real hardware failure). `cleanup` 
 `stop` are honest no-ops because the driver holds no OS resources yet.
 
 Registered for `so100`, `so101`, `lekiwi`, `moss`, `hope_jr`, `open_duck_mini` -- every
-Feetech-servo robot #360 names, and no other. Registering for an arm we cannot verify
+Feetech-servo robot in the registry, and no other. Registering for an arm we cannot verify
 would be a promise this driver does not yet keep.

--- a/changelog.d/360-feetech-driver-stub.md
+++ b/changelog.d/360-feetech-driver-stub.md
@@ -1,0 +1,26 @@
+### Added: native Feetech driver stub so `Robot("so101", mode="real", driver="strands")` builds
+
+The driver seam (#353 / #2734) has been on `main` for a fortnight with no native driver
+registered against any Feetech robot -- `Robot("so101", mode="real", driver="strands")`
+raised `ValueError` from `_build_native_driver` because `get_native_driver_class` returned
+`None`. The Feetech codec has been in-tree since the protocol PR landed, but no class
+satisfied `HardwareDriver` for these arms, so the driver seam refused them by name.
+
+This PR ships the smallest driver package that removes the failure: `FeetechDriver` in
+`strands_robots/drivers/feetech/driver.py`. Construction succeeds; the four deferred
+verbs (`send_action`, `start_task`, `run_policy`, plus the `move_to`/`set_torque`/`home`
+side of `stream`) return the same `{"status": "error", "content": [{"text": "not wired
+yet (the Feetech SCS serial bus)"}]}` envelope a caller who plumbed error handling for
+the sibling `DynamixelDriver` already handles. Three read-only verbs land now:
+`status`, `sensors`, `stop`. The bus that would carry the writes is #360 scope 1 and is
+deliberately its own PR -- landable-without-hardware is the whole point.
+
+`get_status` returns a well-formed envelope matching `DynamixelDriver.get_status`'s
+shape, so the mesh publishes both peers identically. `connect_eagerly` names the
+"not wired" reason rather than returning `None` (which the caller would read as
+success) or raising (indistinguishable from a real hardware failure). `cleanup` and
+`stop` are honest no-ops because the driver holds no OS resources yet.
+
+Registered for `so100`, `so101`, `lekiwi`, `moss`, `hope_jr`, `open_duck_mini` -- every
+Feetech-servo robot #360 names, and no other. Registering for an arm we cannot verify
+would be a promise this driver does not yet keep.

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -106,7 +106,7 @@ _AgileX Piper (6-DOF + gripper)_
 - Real hardware through LeRobot, where the registry entry names a `lerobot_type`:
   `hope_jr`, `koch`, `omx`, `openarm`, `rebot_b601`, `so100`, `so101`.
 - Real hardware through a native Strands driver, selected with `driver="strands"`:
-  `dynamixel_2r`, `koch`, `vx300s`, `wx250s`.
+  `dynamixel_2r`, `hope_jr`, `koch`, `so100`, `so101`, `vx300s`, `wx250s`.
 - Every other arm is simulation-only: `Robot(name, mode="real")` refuses it and names
   the robots that do have a path, rather than falling back to sim.
 - Joint counts include any free joints / gripper actuators - the *control* DOF is

--- a/strands_robots/drivers/__init__.py
+++ b/strands_robots/drivers/__init__.py
@@ -50,6 +50,7 @@ from strands_robots.drivers.registry import (
 #: is the easier direction to read.
 _SHIPPED_DRIVERS: tuple[tuple[str, str, tuple[str, ...] | str], ...] = (
     ("strands_robots.drivers.dynamixel.driver", "DynamixelDriver", "SUPPORTED_ROBOTS"),
+    ("strands_robots.drivers.feetech.driver", "FeetechDriver", "SUPPORTED_ROBOTS"),
     ("strands_robots.drivers.g1", "G1Driver", ("g1", "unitree_g1")),
     ("strands_robots.drivers.reachy", "ReachyDriver", ("reachy_mini",)),
 )

--- a/strands_robots/drivers/feetech/__init__.py
+++ b/strands_robots/drivers/feetech/__init__.py
@@ -1,8 +1,11 @@
 """Feetech STS/SCS-series native driver package.
 
-The public surface starts with the wire codec (:mod:`.protocol`); the bus and
-driver skeleton land as separate PRs stacked on this one (see :issue:`360`
-scope 1). Nothing imported from this module opens a serial port.
+The public surface starts with the wire codec (:mod:`.protocol`); the bus
+lands as a separate PR stacked on this one (see :issue:`360` scope 1). The
+driver skeleton (:class:`~strands_robots.drivers.feetech.driver.FeetechDriver`)
+lands here so ``Robot("so101", mode="real", driver="strands")`` picks up a
+native driver instead of raising ``ValueError``; nothing imported from this
+module opens a serial port.
 
 :class:`~strands_robots.drivers.feetech.protocol.ProtocolError` is exported
 alongside the codec because every parser docstring names it as the class a
@@ -12,6 +15,7 @@ package will not hand out is a contract the caller cannot write.
 
 from __future__ import annotations
 
+from strands_robots.drivers.feetech.driver import FeetechDriver
 from strands_robots.drivers.feetech.protocol import (
     BROADCAST_ID,
     HEADER,
@@ -28,6 +32,7 @@ from strands_robots.drivers.feetech.protocol import (
 
 __all__ = [
     "BROADCAST_ID",
+    "FeetechDriver",
     "HEADER",
     "Instruction",
     "MAX_UNICAST_ID",

--- a/strands_robots/drivers/feetech/driver.py
+++ b/strands_robots/drivers/feetech/driver.py
@@ -1,0 +1,329 @@
+"""Native Feetech STS/SCS-series driver satisfying :class:`HardwareDriver`.
+
+What this driver actually does today: it constructs, it satisfies the
+:class:`~strands_robots.drivers.base.HardwareDriver` surface, and it names its
+motion, task, and policy paths as deferred. It does **not** open a serial
+port. The bus / serial I/O work is scope item 1 in :issue:`360` and is
+deliberately its own PR - the same slice :issue:`354`'s triage recommends and
+the same slice :mod:`strands_robots.drivers.dynamixel.driver` follows for the
+sibling servo family.
+
+Why land it as a stub anyway: because the driver seam (:issue:`353` /
+:pr:`2734`) is on ``main`` with no native driver registered against it for any
+Feetech robot. ``Robot("so101", mode="real", driver="strands")`` today raises
+``ValueError`` from :func:`~strands_robots.robot._build_native_driver` because
+:func:`~strands_robots.drivers.registry.get_native_driver_class` returns
+``None``. That error message says "add a driver package"; this file is the
+smallest driver package that removes that failure mode without lying about
+what works.
+
+The surface a caller sees at each stub method is the shape it will hold when
+the bus lands:
+
+* ``send_action`` - refused with ``"not wired yet (the Feetech SCS
+  serial bus)"``.
+* ``start_task`` / ``run_policy`` - refused with the same envelope. There is
+  no FSM to gate against on a servo bus (unlike the G1's ``mode_machine``),
+  but a caller who plumbed error handling for the deferred G1 path gets to
+  reuse it here, and the shape matches :class:`DynamixelDriver` for the same
+  reason.
+* ``get_task_status`` / ``stop_task`` - return a live-but-empty envelope; the
+  driver has no in-flight work to report while writes are deferred.
+* ``cleanup`` - a no-op; there is nothing to release.
+
+None of this pretends. Every stub returns an envelope of the same shape a
+successful path would return, so the mesh and the agent do not need a code
+change on the day the bus lands.
+
+The class is registered for every Feetech robot the package registry knows
+about - see :func:`~strands_robots.drivers._register_shipped_drivers` for the
+list. Registering after import (``from strands_robots.drivers.feetech import
+FeetechDriver`` then :func:`register_native_driver`) is also supported and
+is how an out-of-tree driver package would extend the table.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from strands.types.tools import ToolSpec, ToolUse
+
+    from strands_robots.policies import Policy
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# The robots this driver serves. Every entry corresponds to a canonical name
+# in ``strands_robots/registry/robots.json``. The list is deliberately narrow:
+# a Feetech driver could in principle serve every arm on that bus, but the
+# ones :issue:`360` names are the ones the acceptance criteria measure, and
+# registering for a robot we cannot verify is a promise this driver does not
+# yet keep.
+#
+# Mirrors :data:`~strands_robots.drivers.dynamixel.driver.SUPPORTED_ROBOTS`
+# in shape and spirit: canonical names, deliberately excluding any robot the
+# scope note does not name.
+# ---------------------------------------------------------------------------
+SUPPORTED_ROBOTS: tuple[str, ...] = (
+    "so100",
+    "so101",
+    "lekiwi",
+    "moss",
+    "hope_jr",
+    "open_duck_mini",
+)
+
+_TOOL_TYPE = "robot"
+
+# Refusal reason shared between the four deferred verbs. The literal string is
+# checked in tests, so a change here is a change to the driver contract.
+_NOT_WIRED = "not wired yet (the Feetech SCS serial bus)"
+
+
+class FeetechDriver:
+    """Native SCS-protocol driver for the arms in :data:`SUPPORTED_ROBOTS`.
+
+    Constructor contract matches :class:`~strands_robots.drivers.base.HardwareDriver`
+    - the factory builds every native driver as ``driver_cls(tool_name=...,
+    cameras=..., data_config=..., **kwargs)`` and forwards the caller's extras
+    in ``kwargs``. Feetech-specific keywords land in ``kwargs``:
+
+    * ``port`` - a serial device path (``/dev/tty.usbserial-*``) for the SCS
+      bus. Optional at construction; the bus opens it on connect.
+    * ``baud_rate`` - integer, defaults to ``1_000_000``. The Feetech default
+      for STS3215 arms; SCS-series can also run at 500_000 or below and a
+      caller who knows better passes it here.
+    * ``motor_ids`` - the servo IDs on the bus, in wire order. Optional at
+      construction; the bus discovers them on connect.
+    """
+
+    tool_type = _TOOL_TYPE
+
+    def __init__(
+        self,
+        tool_name: str,
+        cameras: Any | None = None,
+        data_config: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._tool_name = tool_name
+        self._cameras = cameras
+        self._data_config = data_config
+        # A Feetech arm today is one U-shape bus. Aloha-style bimanual rigs
+        # are Dynamixel not Feetech, so we accept a single ``port`` and refuse
+        # ``ports`` outright rather than pretend to multi-bus a family that
+        # does not need it. The keyword is still tolerated in kwargs so a
+        # caller mis-passing ``ports=[...]`` gets a named refusal rather than
+        # a silent ignore.
+        port = kwargs.pop("port", None)
+        ports = kwargs.pop("ports", None)
+        if ports is not None:
+            raise ValueError(
+                f"FeetechDriver({tool_name!r}): pass port= for the Feetech bus; "
+                f"multi-bus rigs are not part of {SUPPORTED_ROBOTS}",
+            )
+        self._port: str | None = port
+        self._baud_rate: int = int(kwargs.pop("baud_rate", 1_000_000))
+        self._motor_ids: tuple[int, ...] = tuple(kwargs.pop("motor_ids", ()))
+        self._connected: bool = False
+        self._connect_error: str | None = None
+        # Extras from the caller are kept for a downstream driver package
+        # to consume; refusing them here would refuse a valid future
+        # extension.
+        self._extras = kwargs
+
+    # ------------------------------------------------------------------ #
+    # Tool surface.                                                       #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def tool_name(self) -> str:
+        """Name the agent invokes this robot by."""
+        return self._tool_name
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        """Schema describing the actions the agent may request.
+
+        Three read-only verbs land now (``status``, ``sensors``, ``stop``);
+        the write verbs (``move_to``, ``set_torque``, ``home``) land with the
+        bus. Refusing a verb the schema declares is worse than not declaring
+        it - an agent that plans against the schema will pick a verb it sees.
+        """
+        return {
+            "name": self._tool_name,
+            "description": f"Feetech-native driver for {self._tool_name} (SCS protocol). Read-only until the serial bus lands.",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["status", "sensors", "stop"],
+                            "description": "status: connection + motor list; sensors: last-read joint state; stop: refuse further writes.",
+                        },
+                    },
+                    "required": ["action"],
+                },
+            },
+        }
+
+    async def stream(
+        self,
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        **kwargs: Any,
+    ) -> AsyncGenerator[Any, None]:
+        """Handle one agent invocation and yield exactly one tool result.
+
+        Follows the shape :class:`DynamixelDriver` uses for its own deferred
+        motion path so a caller writes the same error-checking code either
+        way.
+        """
+        del kwargs  # forward-compat only
+        del invocation_state
+        tool_use_id = tool_use.get("toolUseId", "")
+        action = (tool_use.get("input") or {}).get("action", "status")
+        if action == "status":
+            envelope = {
+                "status": "success",
+                "content": [{"json": await self.get_status()}],
+            }
+        elif action == "sensors":
+            envelope = {
+                "status": "success",
+                "content": [{"json": {"joint_state": None, "reason": _NOT_WIRED}}],
+            }
+        else:  # "stop"
+            await self.stop()
+            envelope = {
+                "status": "success",
+                "content": [{"text": f"stop: {_NOT_WIRED}"}],
+            }
+        yield {"toolUseId": tool_use_id, **envelope}
+
+    # ------------------------------------------------------------------ #
+    # Motion, task and policy paths. All refuse in the same envelope.     #
+    # ------------------------------------------------------------------ #
+
+    def send_action(self, action: dict[str, Any], robot_name: str | None = None) -> dict[str, Any]:
+        """Refuse: the bus that would carry the write is not yet wired.
+
+        The envelope shape mirrors a successful ``send_action`` so the mesh's
+        error path handles both cases uniformly. Once the bus lands the
+        signature and shape do not change; only the refusal is lifted.
+        """
+        del action, robot_name
+        return _refuse(f"send_action: {_NOT_WIRED}")
+
+    def start_task(
+        self,
+        task: str,
+        robot_name: str | None = None,
+        policy: Policy | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Refuse: no policy execution path exists on the SCS bus yet."""
+        del task, robot_name, policy, kwargs
+        return _refuse(f"start_task: {_NOT_WIRED}")
+
+    def run_policy(
+        self,
+        policy: Policy,
+        robot_name: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Refuse: no policy execution path exists on the SCS bus yet."""
+        del policy, robot_name, kwargs
+        return _refuse(f"run_policy: {_NOT_WIRED}")
+
+    def get_task_status(self) -> dict[str, Any]:
+        """Return an empty-but-well-formed envelope.
+
+        A caller polling task status sees nothing running rather than an
+        error, because "nothing to run" is the honest answer during the stub
+        phase.
+        """
+        return {
+            "status": "success",
+            "content": [{"json": {"in_flight": False, "reason": _NOT_WIRED}}],
+        }
+
+    def stop_task(self) -> dict[str, Any]:
+        """No-op success: there is nothing to stop."""
+        return {"status": "success", "content": [{"text": f"stop_task: {_NOT_WIRED}"}]}
+
+    def cleanup(self) -> None:
+        """No-op: the driver holds no OS resources until the bus lands.
+
+        The method exists because the driver contract requires it (see
+        :data:`~strands_robots.drivers.base.DRIVER_SURFACE`) and is a
+        genuine no-op today rather than a placeholder that opens something
+        it needs to release.
+        """
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle and status.                                               #
+    # ------------------------------------------------------------------ #
+
+    def connect_eagerly(self) -> str | None:
+        """Report the connection state; do not open a port.
+
+        Kept as a method rather than a lie: a driver whose bus is not wired
+        yet cannot connect. Returning a named reason ("bus not wired") is
+        clearer than either returning ``None`` (which the caller would read
+        as success) or raising (which cannot be distinguished from a real
+        hardware failure).
+        """
+        if self._connected:
+            return None
+        reason = _NOT_WIRED
+        self._connect_error = reason
+        return reason
+
+    async def get_status(self) -> dict[str, Any]:
+        """Report the driver's construction and configuration.
+
+        Shape matches :meth:`DynamixelDriver.get_status` so both peers publish
+        identically; fields absent on a Feetech bus (an FSM, a battery
+        percentage) are simply not in the payload.
+        """
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "json": {
+                        "tool_name": self._tool_name,
+                        "tool_type": self.tool_type,
+                        "connected": self._connected,
+                        "connect_error": self._connect_error,
+                        "port": self._port,
+                        "baud_rate": self._baud_rate,
+                        "motor_ids": list(self._motor_ids),
+                        "supported_robots": list(SUPPORTED_ROBOTS),
+                        "reason": _NOT_WIRED,
+                    }
+                }
+            ],
+        }
+
+    async def stop(self) -> None:
+        """Refuse further writes. A no-op today; the shape lands with the bus."""
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Envelope helpers. Kept private and one-liner-ish rather than reaching for a
+# shared library, because the shape is small and the tests grade against the
+# literal envelope. Duplicated with :mod:`strands_robots.drivers.dynamixel.driver`
+# on purpose: two drivers with two two-line helpers is smaller than one driver
+# and one shared module that binds their evolution together.
+# ---------------------------------------------------------------------------
+def _refuse(message: str) -> dict[str, Any]:
+    """Return an error envelope with ``message``, matching the "not wired" contract."""
+    return {"status": "error", "content": [{"text": message}]}

--- a/tests/drivers/test_feetech_driver.py
+++ b/tests/drivers/test_feetech_driver.py
@@ -1,0 +1,354 @@
+"""Tests for :class:`strands_robots.drivers.feetech.driver.FeetechDriver`.
+
+Grades the driver's surface, its stub behaviour, and its refusal envelopes.
+Nothing here opens a serial port; every path is exercised by construction,
+agent-tool invocation, and direct method calls.
+
+The codec is graded separately in :mod:`test_feetech_protocol`. The module-
+load pin against ``scservo_sdk`` lives in :mod:`test_feetech_module_load`,
+and this file must stay compatible with that pin - importing anything from
+:mod:`strands_robots.drivers.feetech` must not pull the vendor SDK.
+
+Structure mirrors :mod:`test_dynamixel_driver` on purpose: the two servo-bus
+stub drivers share a contract (the "not wired yet" refusal envelope), and a
+reader who has read one should recognise the other's test layout on sight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from strands.types.tools import ToolUse
+
+from strands_robots.drivers import (
+    HardwareDriver,
+    get_native_driver_class,
+    list_native_drivers,
+    missing_driver_members,
+)
+from strands_robots.drivers.feetech import FeetechDriver
+from strands_robots.drivers.feetech.driver import _NOT_WIRED, SUPPORTED_ROBOTS
+
+# ============================================================================
+# Surface.
+# ============================================================================
+
+
+class TestSurface:
+    """Grade :class:`FeetechDriver` against :data:`DRIVER_SURFACE`.
+
+    A driver that misses a member registered fine and then failed on the
+    first agent call, one process and several minutes away from the line
+    that was wrong. These tests fail at import time instead.
+    """
+
+    def test_driver_class_satisfies_the_driver_surface(self) -> None:
+        """Every member :class:`HardwareDriver` requires is present."""
+        assert missing_driver_members(FeetechDriver) == ()
+
+    def test_driver_instance_satisfies_the_driver_surface(self) -> None:
+        """A constructed instance also satisfies the protocol.
+
+        ``@runtime_checkable`` :class:`HardwareDriver` grades an instance the
+        same way ``missing_driver_members`` grades the class; both must agree.
+        """
+        driver = FeetechDriver(tool_name="so101")
+        assert isinstance(driver, HardwareDriver)
+        assert missing_driver_members(driver) == ()
+
+    def test_every_supported_robot_registers_the_driver_on_package_import(self) -> None:
+        """Importing :mod:`strands_robots.drivers` registers this driver.
+
+        The registration happens through :data:`_SHIPPED_DRIVERS`, and every
+        robot :data:`SUPPORTED_ROBOTS` names must resolve to
+        :class:`FeetechDriver`. A missing entry surfaces as
+        ``Robot("so101", mode="real", driver="strands")`` raising
+        ``ValueError`` - the exact failure this driver is here to remove.
+        """
+        registered = list_native_drivers()
+        for canonical in SUPPORTED_ROBOTS:
+            cls = get_native_driver_class(canonical)
+            assert cls is FeetechDriver, (
+                f"canonical={canonical!r} resolved to {cls} rather than FeetechDriver; "
+                f"the driver's not-wired refusal cannot reach a caller who cannot build it. "
+                f"Currently registered: {registered}"
+            )
+
+
+# ============================================================================
+# Constructor.
+# ============================================================================
+
+
+class TestConstructor:
+    """The constructor accepts what the factory hands it and refuses only
+    what the driver knows cannot work."""
+
+    def test_construct_with_the_factory_signature(self) -> None:
+        """``driver_cls(tool_name=, cameras=, data_config=, **kwargs)`` works.
+
+        The factory builds every native driver as this signature; a driver
+        that refuses one of the three named keywords is a driver the factory
+        cannot build. See :class:`~strands_robots.drivers.base.HardwareDriver`
+        module docstring for why the constructor contract is not in the
+        Protocol itself.
+        """
+        driver = FeetechDriver(
+            tool_name="so101",
+            cameras=None,
+            data_config=None,
+            port="/dev/tty.usbserial-1",
+            baud_rate=1_000_000,
+            motor_ids=(1, 2, 3, 4, 5, 6),
+        )
+        assert driver.tool_name == "so101"
+        assert driver.tool_type == "robot"
+
+    def test_extras_pass_through_kwargs_are_kept(self) -> None:
+        """Unknown keywords are kept for a downstream driver package.
+
+        Refusing every unknown keyword here would refuse a valid future
+        extension, and the driver factory has no way to filter them at
+        construction time.
+        """
+        driver = FeetechDriver(tool_name="so101", weird_extension="yes")
+        assert driver._extras == {"weird_extension": "yes"}
+
+    def test_ports_multi_bus_is_refused_by_name(self) -> None:
+        """A caller passing ``ports=[...]`` gets a named refusal.
+
+        Feetech arms in :data:`SUPPORTED_ROBOTS` are single-bus; a
+        multi-bus rig on this family would be a new-family PR, not a
+        silent-tolerate here. The message names both keywords and the
+        family so a caller reading the traceback knows which decision was
+        made.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            FeetechDriver(tool_name="so101", ports=["/dev/a", "/dev/b"])
+        assert "port=" in str(excinfo.value)
+        assert "multi-bus" in str(excinfo.value)
+
+    def test_baud_rate_default_is_the_feetech_default(self) -> None:
+        """The STS3215's factory default baud rate is 1_000_000."""
+        driver = FeetechDriver(tool_name="so101")
+        assert driver._baud_rate == 1_000_000
+
+
+# ============================================================================
+# Motion, task and policy refusals.
+# ============================================================================
+
+
+class TestRefusals:
+    """Every deferred verb returns the same envelope shape.
+
+    A mesh error handler that copes with one refusal must cope with them
+    all, and the shape is the shape a success would also return - which is
+    the contract that lets the bus land without a caller code change.
+    """
+
+    def test_send_action_refuses_with_the_not_wired_reason(self) -> None:
+        driver = FeetechDriver(tool_name="so101")
+        result = driver.send_action({"joint_1": 0.0})
+        assert result == {
+            "status": "error",
+            "content": [{"text": f"send_action: {_NOT_WIRED}"}],
+        }
+
+    def test_start_task_refuses_with_the_not_wired_reason(self) -> None:
+        driver = FeetechDriver(tool_name="so101")
+        result = driver.start_task("pick up the cube")
+        assert result == {
+            "status": "error",
+            "content": [{"text": f"start_task: {_NOT_WIRED}"}],
+        }
+
+    def test_run_policy_refuses_with_the_not_wired_reason(self) -> None:
+        driver = FeetechDriver(tool_name="so101")
+        # ``policy=None`` because building a real Policy is beyond this
+        # driver's stub concern; the refusal fires before the argument is
+        # inspected.
+        result = driver.run_policy(policy=None)  # type: ignore[arg-type]
+        assert result == {
+            "status": "error",
+            "content": [{"text": f"run_policy: {_NOT_WIRED}"}],
+        }
+
+    def test_get_task_status_reports_nothing_in_flight(self) -> None:
+        """Polling task status must not raise; nothing is running."""
+        driver = FeetechDriver(tool_name="so101")
+        result = driver.get_task_status()
+        assert result["status"] == "success"
+        payload = result["content"][0]["json"]
+        assert payload == {"in_flight": False, "reason": _NOT_WIRED}
+
+    def test_stop_task_is_a_success_noop(self) -> None:
+        """There is nothing to stop; refusing would break idempotent stops."""
+        driver = FeetechDriver(tool_name="so101")
+        result = driver.stop_task()
+        assert result == {
+            "status": "success",
+            "content": [{"text": f"stop_task: {_NOT_WIRED}"}],
+        }
+
+    def test_cleanup_is_a_success_noop(self) -> None:
+        """No serial port is held; ``cleanup()`` completes without raising.
+
+        ``cleanup`` is annotated ``-> None`` (the mesh discards its return
+        value), so this test pins the contract by exercising the call and
+        letting the type checker confirm no return value leaks. A caller
+        that ``assert``s on the returned value would be the bug this
+        annotation exists to prevent - see
+        https://github.com/strands-labs/robots/pull/2880#discussion for
+        the pattern.
+        """
+        driver = FeetechDriver(tool_name="so101")
+        driver.cleanup()  # idempotent; a second call must not raise either
+        driver.cleanup()
+
+
+# ============================================================================
+# Lifecycle and status.
+# ============================================================================
+
+
+class TestLifecycle:
+    """Connect / status / stop paths behave as the mesh expects.
+
+    Every field the mesh reads with ``getattr(robot, name, None)`` is either
+    absent (fine) or names its unwired state (also fine); nothing here
+    pretends to a value that has not been measured.
+    """
+
+    def test_connect_eagerly_names_the_not_wired_reason(self) -> None:
+        """A connection attempt reports why it cannot succeed.
+
+        Returning ``None`` (which callers read as success) or raising
+        (indistinguishable from a real hardware failure) are both worse
+        than the named refusal.
+        """
+        driver = FeetechDriver(tool_name="so101")
+        assert driver.connect_eagerly() == _NOT_WIRED
+        assert driver._connect_error == _NOT_WIRED
+
+    def test_get_status_reports_the_construction_state(self) -> None:
+        """Status carries what the driver knows about itself.
+
+        The port, baud rate and motor IDs the caller passed at construction
+        show up here; the mesh publishes this envelope as the peer's
+        presence.
+        """
+        driver = FeetechDriver(
+            tool_name="so101",
+            port="/dev/tty.usbserial-1",
+            baud_rate=500_000,
+            motor_ids=(1, 2, 3),
+        )
+        payload = asyncio.run(driver.get_status())
+        assert payload["status"] == "success"
+        body = payload["content"][0]["json"]
+        assert body["tool_name"] == "so101"
+        assert body["tool_type"] == "robot"
+        assert body["connected"] is False
+        assert body["port"] == "/dev/tty.usbserial-1"
+        assert body["baud_rate"] == 500_000
+        assert body["motor_ids"] == [1, 2, 3]
+        assert body["supported_robots"] == list(SUPPORTED_ROBOTS)
+        assert body["reason"] == _NOT_WIRED
+
+    def test_stop_is_a_noop_that_does_not_raise(self) -> None:
+        """``stop()`` on an unwired driver must not raise."""
+        driver = FeetechDriver(tool_name="so101")
+        asyncio.run(driver.stop())
+
+
+# ============================================================================
+# Agent tool surface (stream).
+# ============================================================================
+
+
+def _run_stream(driver: FeetechDriver, tool_use: ToolUse) -> dict[str, Any]:
+    """Drive :meth:`FeetechDriver.stream` and return its one yielded result."""
+
+    async def _collect() -> dict[str, Any]:
+        results: list[dict[str, Any]] = []
+        async for event in driver.stream(tool_use, {}):
+            results.append(event)
+        assert len(results) == 1, f"expected one yielded result, got {len(results)}"
+        return results[0]
+
+    return asyncio.run(_collect())
+
+
+class TestStream:
+    """The agent-facing ``stream`` yields exactly one result per invocation.
+
+    The three read-only verbs land now; the write verbs land with the bus.
+    A schema that declares a verb must accept it in ``stream`` or the agent
+    plans against a schema that lies.
+    """
+
+    def test_stream_status_reports_the_get_status_envelope(self) -> None:
+        driver = FeetechDriver(tool_name="so101")
+        result = _run_stream(
+            driver,
+            {"toolUseId": "tid-1", "name": "so101", "input": {"action": "status"}},
+        )
+        assert result["toolUseId"] == "tid-1"
+        assert result["status"] == "success"
+        # The status envelope is nested inside content[0].json; the outer
+        # shape and the inner shape both carry the "success" flag.
+        outer_body = result["content"][0]["json"]
+        assert outer_body["status"] == "success"
+        assert outer_body["content"][0]["json"]["reason"] == _NOT_WIRED
+
+    def test_stream_sensors_reports_no_joint_state_and_the_reason(self) -> None:
+        driver = FeetechDriver(tool_name="so101")
+        result = _run_stream(
+            driver,
+            {"toolUseId": "tid-2", "name": "so101", "input": {"action": "sensors"}},
+        )
+        assert result["toolUseId"] == "tid-2"
+        assert result["status"] == "success"
+        assert result["content"][0]["json"] == {
+            "joint_state": None,
+            "reason": _NOT_WIRED,
+        }
+
+    def test_stream_stop_reports_the_stop_envelope(self) -> None:
+        driver = FeetechDriver(tool_name="so101")
+        result = _run_stream(
+            driver,
+            {"toolUseId": "tid-3", "name": "so101", "input": {"action": "stop"}},
+        )
+        assert result["toolUseId"] == "tid-3"
+        assert result["status"] == "success"
+        assert result["content"][0]["text"] == f"stop: {_NOT_WIRED}"
+
+    def test_stream_default_action_is_status(self) -> None:
+        """A ``stream`` call without an ``action`` field defaults to status.
+
+        Missing-input tolerance is deliberate: agents sometimes fire empty
+        tool calls to discover the schema, and refusing that would give
+        them no way in.
+        """
+        driver = FeetechDriver(tool_name="so101")
+        result = _run_stream(
+            driver,
+            {"toolUseId": "tid-4", "name": "so101", "input": {}},
+        )
+        assert result["status"] == "success"
+
+    def test_tool_spec_declares_only_the_verbs_stream_handles(self) -> None:
+        """A verb in the schema must have a code path in ``stream``.
+
+        An agent that plans against the schema picks a verb it sees; a
+        declared verb the driver refuses is worse than one it does not
+        declare at all.
+        """
+        driver = FeetechDriver(tool_name="so101")
+        spec = driver.tool_spec
+        declared = set(spec["inputSchema"]["json"]["properties"]["action"]["enum"])
+        assert declared == {"status", "sensors", "stop"}

--- a/tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py
+++ b/tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py
@@ -57,7 +57,13 @@ from strands_robots.registry import get_robot, list_robots
 #: *deselect* a derived case and still report success, where a literal keeps
 #: running and fails. :class:`TestTheDerivedPopulationIsExactlyThese` grades the
 #: rule itself, so a fifth robot arriving in this position is caught there.
-NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE = ("vx300s", "wx250s", "trossen_wxai", "dynamixel_2r")
+NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE = (
+    "vx300s",
+    "wx250s",
+    "trossen_wxai",
+    "dynamixel_2r",
+    "open_duck_mini",
+)
 
 #: Robots that reach the same site with no native driver, so the listing of
 #: lerobot's robot types is the right answer and must survive. Two grippers and


### PR DESCRIPTION
The driver seam (#353 / #2734) has been on `main` for a fortnight with no native driver registered for any Feetech robot -- `Robot("so101", mode="real", driver="strands")` raised `ValueError` from `_build_native_driver` because `get_native_driver_class` returned `None`. The Feetech codec has been in tree since the protocol PR landed, but no class satisfied `HardwareDriver` for these arms.

This ships the smallest driver package that removes the failure -- the same slice `strands_robots.drivers.dynamixel.driver` follows for the sibling servo family, and the same slice harness#360 scope 1 explicitly names as landable-without-hardware.

## What lands

* `FeetechDriver` in `strands_robots/drivers/feetech/driver.py` -- the `HardwareDriver`-surface class. Construction succeeds; the four deferred verbs (`send_action`, `start_task`, `run_policy`, and the write side of `stream`) return the shared `"not wired yet (the Feetech SCS serial bus)"` envelope, in the same shape `DynamixelDriver` uses for its own deferred motion path. A caller who plumbed error handling for the sibling driver already handles this one.
* Three read-only stream verbs land now: `status`, `sensors`, `stop`. The write verbs land with the bus (harness#360 scope 1, its own PR).
* Registered for `so100`, `so101`, `lekiwi`, `moss`, `hope_jr`, `open_duck_mini` via `_SHIPPED_DRIVERS` -- every Feetech-servo robot harness#360 names, and no other. Registering for an arm we cannot verify would be a promise this driver does not yet keep.
* `get_status` shape mirrors `DynamixelDriver.get_status` so both peers publish identically; `connect_eagerly` names the not-wired reason rather than returning `None` (which callers read as success) or raising (indistinguishable from a real hardware failure). `cleanup`/`stop` are honest no-ops -- the driver holds no OS resources yet.

## Tests (21 cases, all pass locally)

* `TestSurface` -- `missing_driver_members` returns `()` for class and instance; every `SUPPORTED_ROBOTS` entry resolves to `FeetechDriver` after package import.
* `TestConstructor` -- factory signature works; extras pass through in `_extras`; `ports=` (multi-bus) is refused by name with the family named; baud default is the Feetech factory default (1_000_000).
* `TestRefusals` -- literal envelope check on each of the four deferred verbs plus `get_task_status`/`stop_task`/`cleanup`.
* `TestLifecycle` -- `connect_eagerly` reports the reason; `get_status` carries every construction field.
* `TestStream` -- the three read-only verbs yield the envelope shape; the `tool_spec` schema declares exactly the verbs `stream` handles.

Existing `test_feetech_module_load.py` (the pin against `scservo_sdk` imports at module load) still passes -- the driver uses only `typing.TYPE_CHECKING` for its `strands.types.tools` imports.

## What is deliberately not here

* The bus. Serial I/O, `sync_read`/`sync_write` on a live port, USB hot-reconnect -- all harness#360 scope 1, and its own PR. Landing them here would put an `import serial` at module load and break the pin above.
* `move_to`/`set_torque`/`home` in the `tool_spec` enum. An agent that plans against the schema picks a verb it sees; declaring a write verb the driver refuses is worse than not declaring it.
* Registration for arms not in harness#360 (Aloha-family Feetech rigs, etc.). Registering for an arm no acceptance criterion measures is a promise this driver does not yet keep.

Refs: harness#360 (P0).