### PR TITLE
fix(simulation/ik): refuse a wrong-shaped pose or seed instead of letting the consumer break on it

### DIFF
--- a/changelog.d/2881-ik-pose-shape-and-seed-length-contracts.md
+++ b/changelog.d/2881-ik-pose-shape-and-seed-length-contracts.md
@@ -27,25 +27,28 @@ depending on which entry point a caller used.
 Each documented contract now has exactly one owner. `solve` refuses a pose that
 is not `(4, 4)` and holds `q_init` to `model.nq` through `pose_vector_error`,
 the shared fixed-length domain, which also subsumes the per-component
-finiteness check it replaces. `ee_pose` holds `qpos` to the same length.
+finiteness check it replaces. `ee_pose` holds `qpos` through the same member.
 `solve_trajectory` and `tracking_error` inherit both refusals, because they
 solve and read forward through those two methods - putting the checks in the
 callers instead would leave a direct `solve` or `ee_pose` caller unguarded.
 `tracking_error`'s `qpos_traj` is a caller's own array, and every row of it is
 read back through `ee_pose`.
 
-Two scope decisions are measured rather than assumed. The pose's shape cannot be
-delegated to the shared fixed-length domain: `pose_vector_error(..., 16)`
+One scope decision is measured rather than assumed: the pose's shape cannot be
+delegated to the shared fixed-length domain. `pose_vector_error(..., 16)`
 accepts a `(2, 8)` array, because sixteen components is what it counts and that
 is not what `matrix[:3, :3]` / `matrix[:3, 3]` slicing needs, so the shape is a
-local check and the component domain still owns the values. And `ee_pose` gets
-the length **only**, while `solve` keeps the full per-component domain: a
-non-finite seed in `ee_pose` is already a *visible* reading - twelve of the
-returned pose's sixteen entries come back non-finite and `tracking_error`
-reports `{"mean_mm": nan, "max_mm": nan}` - whereas in `solve` it is not. The
-cost splits the same way. The per-component domain reads each element in Python,
-which is 8.44 us against a 22.9 us `ee_pose`, 37% of the call it would guard,
-and 0.25% of `solve`'s 3.4 ms; the length comparison is 0.095 us.
+local check and the component domain still owns the values.
+
+The seed and the configuration need no such decision, because one member covers
+both halves of what they document. `finite_vector_error("ee_pose", "qpos",
+np.zeros(6))` returns `None` on a nine-joint model, so the component domain
+alone would have accepted a wrong length; `pose_vector_error` is the
+fixed-length wrapper over that same domain, so "`model.nq` finite numbers" is
+checked once rather than as two spellings of half of it. The cost is 8.44 us
+against `solve`'s 3.4 ms - 0.25% of a call, and 0.224% of a closed-loop step by
+#2879's own measurement, since every `ee_pose` consumer pairs it with a solve or
+a norm.
 
 No shipped caller is affected: `move_to` builds its target as `np.eye(4)` and
 seeds from `data.qpos`, and the VERA action path builds its seed from

--- a/changelog.d/2881-ik-pose-shape-and-seed-length-contracts.md
+++ b/changelog.d/2881-ik-pose-shape-and-seed-length-contracts.md
@@ -1,0 +1,52 @@
+### Fixed: a wrong-shaped IK pose or seed is refused instead of breaking the consumer
+
+`MinkIKBridge` documents a shape on three methods and checked it on none. `solve`
+documents `target_pose` as a `(4, 4)` homogeneous pose and `q_init` as "length
+`model.nq`"; `ee_pose` documents `qpos` the same way. Every wrong shape did
+raise - the defect was *what* it raised.
+
+Measured against a Franka Panda (`nq=9`), a pose that is not `(4, 4)` reached
+`mink.SE3.from_matrix`, whose entire shape check is a bare `assert`, so the
+caller received an `AssertionError` carrying **no message at all** - for a
+`(3, 3)`, for a flat sixteen-vector and for a `(2, 4, 4)` batch alike. Under
+`python -O`, where that assertion is stripped, the same three calls raised
+`IndexError` ("index 3 is out of bounds for axis 1 with size 3") or `TypeError`
+out of `mju_mat2Quat` instead, so the exception *type* depended on an
+interpreter flag. A wrong-length `q_init` raised `ValueError: could not
+broadcast input array from shape (6,) into shape (9,)` from the numpy
+assignment inside `mink.Configuration.update`, naming neither the parameter nor
+the class, and a length-one seed raised `mink.exceptions.InvalidTarget` - a
+third type for one class of caller error. None of those is the `ValueError`
+channel these methods document.
+
+`solve_trajectory` meanwhile already refused a wrong-shaped `poses` batch **by
+name** (`poses must be [N, 4, 4]; got (1, 3, 3)`) and then delegated to `solve`
+per waypoint, so one wrong pose was reported two entirely different ways
+depending on which entry point a caller used.
+
+Each documented contract now has exactly one owner. `solve` refuses a pose that
+is not `(4, 4)` and holds `q_init` to `model.nq` through `pose_vector_error`,
+the shared fixed-length domain, which also subsumes the per-component
+finiteness check it replaces. `ee_pose` holds `qpos` to the same length.
+`solve_trajectory` and `tracking_error` inherit both refusals, because they
+solve and read forward through those two methods - putting the checks in the
+callers instead would leave a direct `solve` or `ee_pose` caller unguarded.
+`tracking_error`'s `qpos_traj` is a caller's own array, and every row of it is
+read back through `ee_pose`.
+
+Two scope decisions are measured rather than assumed. The pose's shape cannot be
+delegated to the shared fixed-length domain: `pose_vector_error(..., 16)`
+accepts a `(2, 8)` array, because sixteen components is what it counts and that
+is not what `matrix[:3, :3]` / `matrix[:3, 3]` slicing needs, so the shape is a
+local check and the component domain still owns the values. And `ee_pose` gets
+the length **only**, while `solve` keeps the full per-component domain: a
+non-finite seed in `ee_pose` is already a *visible* reading - twelve of the
+returned pose's sixteen entries come back non-finite and `tracking_error`
+reports `{"mean_mm": nan, "max_mm": nan}` - whereas in `solve` it is not. The
+cost splits the same way. The per-component domain reads each element in Python,
+which is 8.44 us against a 22.9 us `ee_pose`, 37% of the call it would guard,
+and 0.25% of `solve`'s 3.4 ms; the length comparison is 0.095 us.
+
+No shipped caller is affected: `move_to` builds its target as `np.eye(4)` and
+seeds from `data.qpos`, and the VERA action path builds its seed from
+`model.qpos0`, so every internal caller already constructed a correct shape.

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -38,6 +38,7 @@ import numpy as np
 from ..utils import (
     finite_number_error,
     finite_vector_error,
+    pose_vector_error,
     positive_count_error,
     positive_finite_number_error,
 )
@@ -63,6 +64,31 @@ _DEFAULT_NO_BACKEND_MSG = (
     "(e.g. 'daqp' or 'quadprog'). Install the sim extra: "
     "uv pip install 'strands-robots[sim-mujoco]'."
 )
+
+
+def _homogeneous_pose_error(method: str, param_name: str, pose: np.ndarray) -> str | None:
+    """Return an error message if ``pose`` is not a ``(4, 4)`` matrix.
+
+    Local because the shared pose domains are flat-vector shaped:
+    :func:`~strands_robots.utils.pose_vector_error` counts ``expected_len``
+    components, and a ``(2, 8)`` array flattens to the sixteen a ``(4, 4)`` has,
+    so a length check accepts a matrix no homogeneous transform could be. The
+    shape is what the consumer needs - ``mink.SE3.from_matrix`` slices
+    ``matrix[:3, :3]`` and ``matrix[:3, 3]`` - so it is checked here and the
+    component domain still owns the values.
+
+    Args:
+        method: The public method being called, for the message.
+        param_name: The parameter name, so the caller is told which argument.
+        pose: The already-``asarray``-ed candidate pose.
+
+    Returns:
+        ``None`` when ``pose`` is ``(4, 4)``; otherwise a message naming the
+        method, the parameter, the required shape and the shape supplied.
+    """
+    if pose.shape != (4, 4):
+        return f"{method}: {param_name!r} must be a (4, 4) homogeneous pose matrix, got shape {pose.shape}"
+    return None
 
 
 def _damping_error(value: Any, context: str) -> str | None:
@@ -365,7 +391,14 @@ class MinkIKBridge:
             (``float64``).
 
         Raises:
-            ValueError: If ``qpos`` holds a non-finite value. The configuration
+            ValueError: If ``qpos`` is not ``model.nq`` finite numbers. The
+                length is the half this method documents and
+                ``mink.Configuration.update`` writes into: a wrong-width array
+                reached the numpy assignment and raised ``could not broadcast
+                input array from shape (6,) into shape (9,)``, naming neither
+                the parameter nor this class. It arrives from a caller through
+                :meth:`tracking_error`'s ``qpos_traj``, whose every row is read
+                back through here. The configuration
                 is applied rather than forwarded - it is the state forward
                 kinematics is evaluated at - so a single ``nan`` or ``inf``
                 reaches the returned pose, which comes back with a non-finite
@@ -385,7 +418,7 @@ class MinkIKBridge:
         # third public method reading a joint configuration and was the only one
         # that did not, which is why a bad value surfaced at the *next* solve
         # under another argument's name.
-        if text := finite_vector_error("ee_pose", "qpos", q):
+        if text := pose_vector_error("ee_pose", "qpos", q, self.model.nq):
             raise ValueError(text)
         self._configuration.update(q)
         transform = self._configuration.get_transform_frame_to_world(self.ee_frame_name, self.ee_frame_type)
@@ -405,6 +438,21 @@ class MinkIKBridge:
             ``q_init`` value exactly, so the caller can realize the answer.
 
         Raises:
+            ValueError: If ``target_pose`` is not a ``(4, 4)`` matrix, or
+                ``q_init`` is not ``model.nq`` long. Both shapes are documented
+                above and neither was checked: a wrong-shaped pose reached
+                ``mink.SE3.from_matrix``'s bare ``assert``, so the caller got an
+                ``AssertionError`` carrying *no message at all* - and under
+                ``python -O``, where that assertion is stripped, the same call
+                raised ``IndexError`` or ``TypeError`` instead, so the exception
+                type depended on an interpreter flag. A wrong-length seed
+                reached the numpy assignment and raised an anonymous broadcast
+                message. None of the three is the ``ValueError`` channel this
+                method documents. :meth:`solve_trajectory` already refused a
+                wrong-shaped ``poses`` batch by name and then delegated here per
+                waypoint, so one wrong pose was reported two different ways
+                depending on the entry point; checking here settles both,
+                because that method solves through this one.
             ValueError: If ``target_pose`` or ``q_init`` holds a non-finite
                 value. Both are read straight into the solver - the pose becomes
                 the frame task's target and the seed becomes the configuration
@@ -423,9 +471,11 @@ class MinkIKBridge:
         # is flattened for the check because ``finite_vector_error`` reads a
         # 2-D argument's *rows* as its elements and would refuse a clean
         # ``(4, 4)``; the seed is already the 1-D vector that domain expects.
+        if text := _homogeneous_pose_error("solve", "target_pose", pose):
+            raise ValueError(text)
         if text := finite_vector_error("solve", "target_pose", pose.ravel()):
             raise ValueError(text)
-        if text := finite_vector_error("solve", "q_init", q):
+        if text := pose_vector_error("solve", "q_init", q, self.model.nq):
             raise ValueError(text)
         self._configuration.update(q)
         self._posture_task.set_target(q)
@@ -483,6 +533,12 @@ class MinkIKBridge:
         Returns:
             ``{"mean_mm": float, "max_mm": float}`` - mean / max Euclidean
             position error in millimetres across the trajectory.
+
+        Raises:
+            ValueError: If ``poses`` and ``qpos_traj`` differ in length (the
+                ``strict=True`` zip), or a row of ``qpos_traj`` is not
+                ``model.nq`` finite numbers - :meth:`ee_pose` owns that refusal,
+                and every row is read back through it.
         """
         poses = np.asarray(poses, dtype=np.float32)
         errs = []

--- a/tests/simulation/test_ik_ee_pose_refuses_a_non_finite_configuration.py
+++ b/tests/simulation/test_ik_ee_pose_refuses_a_non_finite_configuration.py
@@ -81,6 +81,30 @@ from tests.policies.cosmos3.test_sim_ik_bridge_solve_loop import (
 #: cells are an independent oracle rather than a restatement of the module.
 DOMAIN = finite_vector_error
 
+#: The shared component domain, by every name it is applied under.
+#: :func:`~strands_robots.utils.pose_vector_error` is documented as the
+#: fixed-length wrapper *over* :func:`~strands_robots.utils.finite_vector_error`
+#: and defers to the same reader, so a call to either is the same per-component
+#: check - the second one also fixing the length a configuration reader
+#: documents. The structural cells below name the family rather than one member,
+#: so they stay about the property (every configuration reader reaches the shared
+#: domain) instead of about which spelling applies it.
+SHARED_VECTOR_DOMAINS = ("finite_vector_error", "pose_vector_error")
+
+
+def _first_shared_domain_call(source: str) -> int:
+    """Index of the earliest shared-domain call in ``source``.
+
+    Raises:
+        AssertionError: If ``source`` consults no member at all - the outcome
+            these cells exist to report, which ``str.index`` would otherwise
+            raise as a bare ``ValueError`` naming one spelling.
+    """
+    found = [source.index(f"{name}(") for name in SHARED_VECTOR_DOMAINS if f"{name}(" in source]
+    assert found, f"consults no shared vector domain at all: {SHARED_VECTOR_DOMAINS}"
+    return min(found)
+
+
 #: The method name the refusal must carry, stated locally for the same reason.
 METHOD = "ee_pose"
 
@@ -214,7 +238,7 @@ class TestANonFiniteConfigurationIsRefused:
 
     def test_the_guard_precedes_the_state_it_would_otherwise_poison(self) -> None:
         source = _source_of("ee_pose")
-        assert source.index("finite_vector_error(") < source.index("self._configuration.update(")
+        assert _first_shared_domain_call(source) < source.index("self._configuration.update(")
 
 
 class TestTheRefusalNamesTheMethodAndTheParameter:
@@ -383,12 +407,13 @@ class TestEveryConfigurationReaderSharesTheDomain:
 
     @pytest.mark.parametrize("method", sorted(_methods_that_apply_a_configuration()))
     def test_the_method_consults_the_shared_domain(self, method: str) -> None:
-        assert "finite_vector_error(" in _source_of(method)
+        source = _source_of(method)
+        assert any(f"{name}(" in source for name in SHARED_VECTOR_DOMAINS), SHARED_VECTOR_DOMAINS
 
     @pytest.mark.parametrize("method", sorted(_methods_that_apply_a_configuration()))
     def test_the_guard_precedes_the_update(self, method: str) -> None:
         source = _source_of(method)
-        assert source.index("finite_vector_error(") < source.index("self._configuration.update(")
+        assert _first_shared_domain_call(source) < source.index("self._configuration.update(")
 
     def test_the_derivation_is_not_vacuous(self) -> None:
         assert len(_methods_that_apply_a_configuration()) >= 2

--- a/tests/simulation/test_ik_refuses_a_wrong_shaped_pose_or_seed.py
+++ b/tests/simulation/test_ik_refuses_a_wrong_shaped_pose_or_seed.py
@@ -1,0 +1,304 @@
+"""``MinkIKBridge`` refuses a wrong-shaped pose or seed instead of letting the
+consumer break on it.
+
+Three methods document a shape and none checked it.
+:meth:`~strands_robots.simulation.ik.MinkIKBridge.solve` documents
+``target_pose`` as a ``(4, 4)`` homogeneous pose and ``q_init`` as "length
+``model.nq``"; :meth:`~strands_robots.simulation.ik.MinkIKBridge.ee_pose`
+documents ``qpos`` the same way. Measured against a Panda (``nq=9``) on a
+reachable 80 mm target, every wrong shape did raise - the defect is *what* it
+raised:
+
+* a pose that is not ``(4, 4)`` reached ``mink.SE3.from_matrix``, whose whole
+  shape check is a bare ``assert``, so the caller got an ``AssertionError``
+  carrying **no message at all** - for ``(3, 3)``, for a flat sixteen-vector and
+  for a ``(2, 4, 4)`` batch alike;
+* under ``python -O``, where that assertion is stripped, the same three calls
+  raised ``IndexError`` ("index 3 is out of bounds for axis 1 with size 3") or
+  ``TypeError`` from ``mju_mat2Quat`` instead - so the exception *type* depended
+  on an interpreter flag;
+* a wrong-length ``q_init`` raised ``ValueError: could not broadcast input array
+  from shape (6,) into shape (9,)`` out of the numpy assignment inside
+  ``mink.Configuration.update``, naming neither the parameter nor the class, and
+  a length-one seed raised ``mink.exceptions.InvalidTarget`` instead - a third
+  type for the same class of caller error;
+* ``ee_pose`` gave the same anonymous broadcast message, and it is reachable
+  with a caller's own array: ``tracking_error(poses, qpos_traj)`` reads every row
+  of ``qpos_traj`` back through it.
+
+None of those is the ``ValueError`` channel these methods document.
+:meth:`~strands_robots.simulation.ik.MinkIKBridge.solve_trajectory` meanwhile
+already refused a wrong-shaped ``poses`` batch **by name** and then delegated to
+``solve`` per waypoint, so one wrong pose was reported two different ways
+depending on which entry point a caller used.
+
+Two scope decisions are measured rather than assumed.
+
+The pose's shape cannot be delegated to the shared fixed-length domain:
+``pose_vector_error(..., 16)`` accepts a ``(2, 8)`` array, because sixteen
+components is what it checks and that is not what
+``mink.SE3.from_matrix``'s ``matrix[:3, :3]`` / ``matrix[:3, 3]`` slicing needs.
+So the shape is a local check and the component domain still owns the values.
+
+``ee_pose`` already consults the per-component domain for the *values* (#2879),
+so what it gains here is the **length**: ``finite_vector_error`` returns ``None``
+for a six-element seed on a nine-joint model, and the fixed-length domain that
+wraps it refuses the same array by name. Both methods therefore end up on one
+member, ``pose_vector_error``, for one contract - "``model.nq`` finite numbers" -
+rather than two spellings of half of it.
+
+The behavioural cells drive the real methods against the fake ``mink`` module the
+sibling suites already use, so nothing here needs ``mink``, ``mujoco`` or
+``qpsolvers`` installed.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import types
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.ik import MinkIKBridge
+from strands_robots.utils import finite_vector_error, pose_vector_error
+from tests.policies.cosmos3.test_sim_ik_bridge_solve_loop import (
+    _FakeConfiguration,
+    _FakeFrameTask,
+    _FakePostureTask,
+    _FakeSE3,
+    _model,
+    _solve_ik,
+    _target_pose,
+)
+
+#: The fake model's joint count, stated locally so these cells are an
+#: independent oracle rather than a restatement of the fixture.
+NQ = 7
+
+#: The shape every pose argument must have. Named locally for the same reason:
+#: a cell that read it off the module could not tell a changed contract from a
+#: changed expectation.
+POSE_SHAPE = (4, 4)
+
+
+@pytest.fixture
+def fake_mink(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Install the sibling suite's fake ``mink`` plus a stub ``qpsolvers``.
+
+    Declared here rather than imported: importing a fixture re-binds the name in
+    this module, which ``ruff`` reports as a redefinition for every cell that
+    then takes it as a parameter. Only the stand-in classes are shared.
+    """
+    mod = types.ModuleType("mink")
+    mod.Configuration = _FakeConfiguration  # type: ignore[attr-defined]
+    mod.FrameTask = _FakeFrameTask  # type: ignore[attr-defined]
+    mod.PostureTask = _FakePostureTask  # type: ignore[attr-defined]
+    mod.SE3 = _FakeSE3  # type: ignore[attr-defined]
+    mod.solve_ik = _solve_ik  # type: ignore[attr-defined]
+    monkeypatch.setitem(__import__("sys").modules, "mink", mod)
+
+    qp = types.ModuleType("qpsolvers")
+    qp.available_solvers = ["quadprog"]  # type: ignore[attr-defined]
+    monkeypatch.setitem(__import__("sys").modules, "qpsolvers", qp)
+    return mod
+
+
+def _bridge() -> MinkIKBridge:
+    return MinkIKBridge(model=_model(NQ), ee_frame_name="gripper", solver="quadprog")
+
+
+def _seed(nq: int = NQ) -> np.ndarray:
+    return np.zeros(nq, dtype=np.float64)
+
+
+#: Every wrong pose shape, and why each one is worth its own case. A flat
+#: sixteen-vector and a ``(2, 8)`` both carry the sixteen components the shared
+#: fixed-length domain would count, so they are what show the shape has to be
+#: checked as a shape.
+WRONG_POSE_SHAPES = (
+    pytest.param(np.eye(3), id="three-by-three"),
+    pytest.param(np.eye(4).ravel(), id="flat-sixteen-vector"),
+    pytest.param(np.zeros((2, 8)), id="two-by-eight-also-sixteen"),
+    pytest.param(np.stack([np.eye(4), np.eye(4)]), id="a-batch-not-a-pose"),
+    pytest.param(np.zeros((4, 5)), id="four-by-five"),
+)
+
+#: Wrong seed lengths on both sides of ``nq``, plus the length-one case that
+#: reached a third exception type in the real stack.
+WRONG_SEED_LENGTHS = (NQ - 3, NQ + 3, 1)
+
+
+class TestSolveRefusesAWrongShapedPose:
+    """``solve`` names the parameter and the shape instead of asserting."""
+
+    @pytest.mark.parametrize("pose", WRONG_POSE_SHAPES)
+    def test_a_pose_that_is_not_four_by_four_is_refused(self, fake_mink: types.ModuleType, pose: np.ndarray) -> None:
+        with pytest.raises(ValueError, match=r"solve: 'target_pose' must be a \(4, 4\) homogeneous pose matrix"):
+            _bridge().solve(pose, _seed())
+
+    @pytest.mark.parametrize("pose", WRONG_POSE_SHAPES)
+    def test_the_refusal_reports_the_shape_that_was_supplied(
+        self, fake_mink: types.ModuleType, pose: np.ndarray
+    ) -> None:
+        """A caller debugging this needs to know what it sent, not only what was wanted."""
+        with pytest.raises(ValueError, match=rf"got shape {np.shape(pose)}".replace("(", r"\(").replace(")", r"\)")):
+            _bridge().solve(pose, _seed())
+
+
+class TestSolveRefusesAWrongLengthSeed:
+    """``solve`` holds ``q_init`` to the length it documents."""
+
+    @pytest.mark.parametrize("nq", WRONG_SEED_LENGTHS)
+    def test_a_seed_that_is_not_nq_long_is_refused(self, fake_mink: types.ModuleType, nq: int) -> None:
+        with pytest.raises(ValueError, match=rf"solve: 'q_init' must be a {NQ}-element vector, got {nq}"):
+            _bridge().solve(_target_pose([0.1, 0.0, 0.0]), _seed(nq))
+
+    def test_the_trajectory_entry_point_inherits_the_refusal(self, fake_mink: types.ModuleType) -> None:
+        """``solve_trajectory`` solves through ``solve``, so one guard covers both."""
+        with pytest.raises(ValueError, match=r"solve: 'q_init' must be a 7-element vector"):
+            _bridge().solve_trajectory(np.stack([_target_pose([0.1, 0.0, 0.0])]), _seed(NQ - 3))
+
+    def test_a_wrong_shaped_waypoint_is_refused_by_name_through_either_entry_point(
+        self, fake_mink: types.ModuleType
+    ) -> None:
+        """The pair that used to disagree: the batch check, and the per-waypoint one."""
+        bridge = _bridge()
+        with pytest.raises(ValueError, match=r"poses must be \[N, 4, 4\]"):
+            bridge.solve_trajectory(np.stack([np.eye(3)]), _seed())
+        with pytest.raises(ValueError, match=r"'target_pose' must be a \(4, 4\) homogeneous pose matrix"):
+            bridge.solve(np.eye(3), _seed())
+
+
+class TestEePoseRefusesAWrongLengthConfiguration:
+    """``ee_pose`` holds ``qpos`` to the length it documents, and so does its reader."""
+
+    @pytest.mark.parametrize("nq", WRONG_SEED_LENGTHS)
+    def test_a_configuration_that_is_not_nq_long_is_refused(self, fake_mink: types.ModuleType, nq: int) -> None:
+        with pytest.raises(ValueError, match=rf"ee_pose: 'qpos' must be a {NQ}-element vector, got {nq}"):
+            _bridge().ee_pose(_seed(nq))
+
+    def test_tracking_error_inherits_the_refusal_for_a_wrong_width_row(self, fake_mink: types.ModuleType) -> None:
+        """``qpos_traj`` is a caller's array, and every row is read back through ``ee_pose``."""
+        with pytest.raises(ValueError, match=r"ee_pose: 'qpos' must be a 7-element vector"):
+            _bridge().tracking_error(np.stack([_target_pose([0.1, 0.0, 0.0])]), np.zeros((1, NQ - 3)))
+
+
+class TestTheShapeCheckCannotBeDelegatedToTheLengthDomain:
+    """Premise: the shared fixed-length domain accepts a matrix that is not a pose."""
+
+    def test_sixteen_components_do_not_establish_four_by_four(self) -> None:
+        """``pose_vector_error(..., 16)`` accepts a ``(2, 8)``, so it is not the check."""
+        assert pose_vector_error("solve", "target_pose", np.zeros((2, 8)).ravel(), 16) is None
+
+    def test_the_shared_domain_does_establish_the_seed_length(self) -> None:
+        """The seed is a flat vector, so the shared domain is exactly right for it."""
+        assert pose_vector_error("solve", "q_init", _seed(), NQ) is None
+        assert pose_vector_error("solve", "q_init", _seed(NQ - 3), NQ) is not None
+
+
+class TestTheAcceptedShapesStillSolve:
+    """Over-reach controls: nothing the contract allows became an error."""
+
+    def test_a_four_by_four_pose_and_an_nq_seed_still_solve(self, fake_mink: types.ModuleType) -> None:
+        out = _bridge().solve(_target_pose([0.1, 0.2, 0.3]), _seed())
+        assert out.shape == (NQ,)
+        assert np.allclose(out[:3], [0.1, 0.2, 0.3])
+
+    def test_an_nq_configuration_still_reads_forward(self, fake_mink: types.ModuleType) -> None:
+        pose = _bridge().ee_pose(np.array([0.4, 0.5, 0.6, 0.0, 0.0, 0.0, 0.0]))
+        assert pose.shape == POSE_SHAPE
+        assert np.allclose(pose[:3, 3], [0.4, 0.5, 0.6])
+
+    def test_a_trajectory_of_valid_poses_still_solves(self, fake_mink: types.ModuleType) -> None:
+        poses = np.stack([_target_pose([0.1, 0.0, 0.0]), _target_pose([0.2, 0.0, 0.0])])
+        out = _bridge().solve_trajectory(poses, _seed())
+        assert out.shape == (2, NQ)
+
+    def test_an_empty_batch_still_returns_the_documented_width(self, fake_mink: types.ModuleType) -> None:
+        assert _bridge().solve_trajectory(np.empty((0, 4, 4)), _seed()).shape == (0, NQ)
+
+    def test_tracking_error_still_reports_millimetres_for_matching_widths(self, fake_mink: types.ModuleType) -> None:
+        report = _bridge().tracking_error(np.stack([_target_pose([0.0, 0.0, 0.0])]), np.stack([_seed()]))
+        assert report == {"mean_mm": 0.0, "max_mm": 0.0}
+
+
+class TestBothMethodsEndOnOneMember:
+    """The two methods now apply one contract, not two spellings of half of it.
+
+    ``ee_pose`` already refused a non-finite configuration; what it lacked was the
+    length, which the per-component domain does not check. Both halves are pinned
+    here so a future edit cannot drop either one back to the narrower member.
+    """
+
+    def test_the_component_domain_alone_would_accept_a_wrong_length(self) -> None:
+        """Premise: this is exactly the half the narrower member does not cover."""
+        assert finite_vector_error("ee_pose", "qpos", _seed(NQ - 3)) is None
+        assert pose_vector_error("ee_pose", "qpos", _seed(NQ - 3), NQ) is not None
+
+    def test_a_two_dimensional_configuration_is_still_refused(self, fake_mink: types.ModuleType) -> None:
+        """Inherited: the component domain already refuses a column vector.
+
+        Recorded here rather than with the length cells because it holds either
+        way - a ``(nq, 1)`` has ``nq`` values and the wider member refuses it for
+        its elements, not its length - so it is the shape a reader would reach
+        for to argue the length check is redundant, and it is not.
+        """
+        with pytest.raises(ValueError, match=r"ee_pose: 'qpos' elements must be numbers"):
+            _bridge().ee_pose(_seed().reshape(NQ, 1))
+
+    def test_ee_pose_still_refuses_a_non_finite_configuration(self, fake_mink: types.ModuleType) -> None:
+        q = _seed()
+        q[0] = np.nan
+        with pytest.raises(ValueError, match=r"ee_pose: 'qpos' must contain finite numbers"):
+            _bridge().ee_pose(q)
+
+    def test_solve_still_refuses_a_non_finite_seed(self, fake_mink: types.ModuleType) -> None:
+        q = _seed()
+        q[0] = np.nan
+        with pytest.raises(ValueError, match=r"solve: 'q_init'"):
+            _bridge().solve(_target_pose([0.1, 0.0, 0.0]), q)
+
+    def test_solve_still_refuses_a_non_finite_pose(self, fake_mink: types.ModuleType) -> None:
+        pose = _target_pose([0.1, 0.0, 0.0])
+        pose[0, 3] = np.inf
+        with pytest.raises(ValueError, match=r"solve: 'target_pose'"):
+            _bridge().solve(pose, _seed())
+
+
+class TestTheChecksPrecedeTheStateTheyProtect:
+    """Structural: each guard runs before the call it exists to keep clean."""
+
+    def test_the_pose_shape_is_checked_before_its_components(self) -> None:
+        """The shape is the more specific diagnosis, so it is reported first."""
+        source = textwrap.dedent(inspect.getsource(MinkIKBridge.solve))
+        assert source.index("_homogeneous_pose_error(") < source.index('finite_vector_error("solve", "target_pose"')
+
+    def test_every_solve_guard_precedes_the_configuration_update(self) -> None:
+        source = textwrap.dedent(inspect.getsource(MinkIKBridge.solve))
+        last = max(source.rindex(f"{name}(") for name in ("_homogeneous_pose_error", "pose_vector_error"))
+        assert last < source.index("self._configuration.update(")
+        assert last < source.index("self._frame_task.set_target(")
+
+    def test_the_ee_pose_guard_precedes_the_configuration_update(self) -> None:
+        source = textwrap.dedent(inspect.getsource(MinkIKBridge.ee_pose))
+        assert source.index("pose_vector_error(") < source.index("self._configuration.update(")
+
+    def test_each_documented_shape_has_exactly_one_owner(self) -> None:
+        """One guard per contract, so the two entry points cannot drift apart."""
+        calls: dict[str, list[str]] = {}
+        for method in (MinkIKBridge.solve, MinkIKBridge.ee_pose, MinkIKBridge.solve_trajectory):
+            tree = ast.parse(textwrap.dedent(inspect.getsource(method)))
+            calls[method.__name__] = sorted(
+                node.func.id
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in {"_homogeneous_pose_error", "pose_vector_error"}
+            )
+        assert calls["solve"] == ["_homogeneous_pose_error", "pose_vector_error"]
+        assert calls["ee_pose"] == ["pose_vector_error"]
+        # solve_trajectory keeps only its own batch-shape check and inherits the rest.
+        assert calls["solve_trajectory"] == []

--- a/tests/simulation/test_ik_solve_refuses_a_non_finite_pose_or_seed.py
+++ b/tests/simulation/test_ik_solve_refuses_a_non_finite_pose_or_seed.py
@@ -74,6 +74,15 @@ from tests.policies.cosmos3.test_sim_ik_bridge_solve_loop import (
 #: independent oracle rather than a restatement of the module.
 ARRAY_PARAMETERS = ("target_pose", "q_init")
 
+#: The shared component domain, by every name it is applied under.
+#: :func:`~strands_robots.utils.pose_vector_error` is documented as the
+#: fixed-length wrapper *over* :func:`~strands_robots.utils.finite_vector_error`
+#: and defers to the same reader, so a call to either is the same per-component
+#: check - the second one also fixing the length. Naming the family rather than
+#: one member is what keeps these cells about the property (every array reaches
+#: the shared domain) instead of about which spelling applies it.
+SHARED_VECTOR_DOMAINS = ("finite_vector_error", "pose_vector_error")
+
 #: A joint the stand-in solver never drives - it moves only ``q[:3]`` onto the
 #: frame target - so a seed value here survives the solve and is what shows the
 #: seed became the warm-start configuration.
@@ -290,7 +299,12 @@ class TestTheRefusalCostsTheBridgeNothing:
 
 
 class TestBothArraysReachTheSharedDomain:
-    """Structural: the check is the shared domain, applied to each array, once."""
+    """Structural: the check is the shared domain, applied to each array, once.
+
+    "The shared domain" is :data:`SHARED_VECTOR_DOMAINS`, not one function: the
+    seed's check later became the fixed-length wrapper, which is the same
+    per-component domain plus the length ``solve`` documents and did not check.
+    """
 
     def test_solve_consults_the_shared_domain_for_every_array_it_reads(self) -> None:
         tree = ast.parse(textwrap.dedent(inspect.getsource(MinkIKBridge.solve)))
@@ -299,7 +313,7 @@ class TestBothArraysReachTheSharedDomain:
             for node in ast.walk(tree)
             if isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
-            and node.func.id == "finite_vector_error"
+            and node.func.id in SHARED_VECTOR_DOMAINS
             and len(node.args) >= 2
             and isinstance(node.args[1], ast.Constant)
             and isinstance(node.args[1].value, str)
@@ -308,9 +322,20 @@ class TestBothArraysReachTheSharedDomain:
 
     def test_the_checks_precede_the_state_the_solve_mutates(self) -> None:
         source = textwrap.dedent(inspect.getsource(MinkIKBridge.solve))
-        last_guard = source.rindex("finite_vector_error(")
+        # Only the members ``solve`` actually applies: a member that is absent must
+        # read as "consults no shared domain" rather than raising out of ``rindex``.
+        applied = [name for name in SHARED_VECTOR_DOMAINS if f"{name}(" in source]
+        assert applied, "solve consults no shared vector domain at all"
+        last_guard = max(source.rindex(f"{name}(") for name in applied)
         assert last_guard < source.index("self._configuration.update(")
         assert last_guard < source.index("self._frame_task.set_target(")
+
+    def test_the_named_family_is_the_shared_domain(self) -> None:
+        """Non-vacuity: every name in the family is a real shared member."""
+        import strands_robots.utils as shared
+
+        for name in SHARED_VECTOR_DOMAINS:
+            assert callable(getattr(shared, name, None)), name
 
     def test_the_pose_is_flattened_for_the_check(self) -> None:
         """A 2-D argument would be refused for the wrong reason; see the premise."""


### PR DESCRIPTION
## The defect

`MinkIKBridge` documents a shape on three methods. `solve` documents
`target_pose` as a `(4, 4)` homogeneous pose and `q_init` as "length `model.nq`";
`ee_pose` documents `qpos` the same way. #2879 landed the per-component half of
`ee_pose`'s contract; the **length** half was unchecked on both methods, and the
pose's **shape** on neither.

Every wrong shape did raise - the defect is *what* it raised. Measured against a
Franka Panda (`nq=9`) on a reachable 80 mm target:

| input | before | after |
|---|---|---|
| `solve` pose `(3, 3)` | `AssertionError` with an **empty message** | `ValueError: solve: 'target_pose' must be a (4, 4) homogeneous pose matrix, got shape (3, 3)` |
| `solve` pose flat 16-vector | `AssertionError` with an **empty message** | same, `got shape (16,)` |
| `solve` pose `(2, 4, 4)` | `AssertionError` with an **empty message** | same, `got shape (2, 4, 4)` |
| the same three under `python -O` | `IndexError` / `TypeError` from `mju_mat2Quat` | unchanged `ValueError` |
| `solve` seed `nq-3` | `ValueError: could not broadcast input array from shape (6,) into shape (9,)` | `ValueError: solve: 'q_init' must be a 9-element vector, got 6` |
| `solve` seed length 1 | `mink.exceptions.InvalidTarget` | same `ValueError` |
| `ee_pose` `qpos` `nq-3` | the same anonymous broadcast message | `ValueError: ee_pose: 'qpos' must be a 9-element vector, got 6` |
| `tracking_error` with a wrong-width `qpos_traj` row | the same anonymous broadcast message | the `ee_pose` refusal above |
| every accepted pose and seed | solves | **byte-identical** |

`mink.SE3.from_matrix`'s entire shape check is a bare `assert`, which is why the
message is empty and why stripping assertions changes the exception *type*. None
of the four types is the `ValueError` channel these methods document.

## Why it went unnoticed

`solve_trajectory` already refused a wrong-shaped batch **by name** -
`poses must be [N, 4, 4]; got (1, 3, 3)` - and then delegated to `solve` per
waypoint. So one wrong pose was reported two entirely different ways depending on
which entry point a caller used, and the named one was the entry point a reader
would test.

## The change

**Both methods end on one member for one contract.** `ee_pose` and `solve` now
apply `pose_vector_error` - the fixed-length wrapper *over* the
`finite_vector_error` they already used, deferring to the same reader - so
"`model.nq` finite numbers" is checked once rather than as two spellings of half
of it. The half that was missing is measurable in one line:
`finite_vector_error("ee_pose", "qpos", np.zeros(6))` returns `None` on a
nine-joint model, and the wrapper refuses the same array by name. A premise cell
pins exactly that.

**`solve` additionally refuses a pose that is not `(4, 4)`**, which cannot be
delegated to that domain: `pose_vector_error(..., 16)` accepts a `(2, 8)` array,
because sixteen components is what it counts and that is not what
`matrix[:3, :3]` / `matrix[:3, 3]` slicing needs. So the shape is a local check
and the component domain still owns the values. The mutation that delegates the
shape to a 16-length check fires the same fourteen cells as having no check at
all.

**One guard per contract**, so the entry points cannot drift: `solve_trajectory`
and `tracking_error` inherit both refusals because they solve and read forward
through those two methods. Guarding the callers instead would leave a direct
`solve` or `ee_pose` caller unguarded, and `tracking_error`'s `qpos_traj` is a
caller's own array read back row by row.

## Reachability

Latent through every shipped caller, and stated as such: `move_to` builds its
target as `np.eye(4)` and seeds from `data.qpos`, and the VERA action path builds
its seed from `model.qpos0`, so each already constructed a correct shape. The
cost is 8.44 us against `solve`'s 3.4 ms - 0.25% of a call, and 0.224% of a
closed-loop step by #2879's own measurement, since every `ee_pose` consumer pairs
it with a solve or a norm.

## Structural cells that named a spelling rather than a property

Four cells across #2875's and #2879's suites asserted `finite_vector_error` by
name, so widening the member to its own fixed-length wrapper failed them for the
wrong reason. They now name the family, with the reason recorded beside it, plus:

- a non-vacuity cell asserting each member of the family is a real
  `strands_robots.utils` export, so a local misspelling cannot read as a module
  that consults nothing;
- `_first_shared_domain_call`, so an ordering cell reports "consults no shared
  vector domain at all" instead of raising a bare `ValueError` out of `str.index`
  naming one spelling.

That is a widening, not a name bump: the property under test is that every array
reaches the shared domain before the state it would poison, and it is now stated
that way.

## Verification

Pre-fix split on the new file: **23 failed / 12 passed** - all 23 in the four
regression classes (10/10 pose shape, 5/5 seed length, 4/4 `ee_pose` length, 4/4
structural) and **0** in the over-reach controls (5), the "one member, both
halves" class (5) and the premise class (2).

Mutation table, each row measured against the new file and against the
`ik`-adjacent suites (`sib`):

| mutation | fires | sib |
|---|---|---|
| control | 0 | 0 |
| pose shape guard removed | 14 | 0 |
| pose shape delegated to a 16-length check | 14 (identical set) | 0 |
| seed guard reverted to the component domain (loses the length) | 6 | 0 |
| `ee_pose` guard reverted to the component domain | 7 | 0 |
| all three reverted | 25 | 7 |
| shape checked after its components | 1 | 0 |
| `ee_pose` guard after the configuration update | 1 | 0 |
| `solve` guards after the configuration update | 22 | 26 |

All detected, with distinct firing sets except the two 14s, which are the same set
for a structural reason: a 16-length check establishes the shape exactly as well
as no check does. `collected` is stable on every row and the source restores
byte-identically. The three single-guard reverts union to 24 of the full revert's
25; the one cell outside the union is `test_solve_still_refuses_a_non_finite_seed`,
which they keep passing because the component domain is still applied there. The
last row's `sib=26` is the pre-existing suite refusing to let the guards move
after the mutation they protect.

Gate: `ruff check` and `ruff format --check` clean over 1675 files. `mypy` **24 ==
24** against a base tree, normalized message sets byte-identical in both
directions, **0** attributable (the one `simulation/ik.py` message is present on
both). Paired pytest over an identical 368-path selection - all of
`tests/simulation/`, the `cosmos3` and `vera` policy suites, and every guard that
walks the tree, parses source or reads docstrings - with the new file withheld
from both sides: **19 on the branch, 18 on the base**, and the single difference
is `test_policy_runner_async_rtc.py::test_async_rtc_prefetch_blocks_when_inference_slow`,
a wall-clock budget (`assert 1.24 < 0.8`) on a file with **zero** references to
this module that passes **18/18 in isolation on three consecutive runs**. Of the
eighteen shared, seventeen need `awsiot`/`awscrt` (`find_spec` `None` locally,
declared in the `mesh-iot` extra that `all` pulls in, so CI installs them) and the
last is the lerobot-from-source `test_lerobot_e2e` `encode()` drift. The `+36
collected` is exactly the 35 new cells plus the one non-vacuity cell added to a
sibling file.

No visual artifact: this changes which exception a refused call raises and nothing
about the solve. Every accepted pose and seed returns byte-identically, pinned by
the five over-reach controls, so there is no rendered behaviour to show - the
measured refusal table above is the evidence.


## Round 2 changes

`67a5205` - **the changelog fragment's scope rationale still cited the premise this
fix refuted.** Review feedback named three artifacts carrying the pre-rebase
"`ee_pose` gets the length **only**" claim. Two were already reconciled at
`bd05fc6`: the invalidated premise cell and its class are gone, replaced by
`TestBothMethodsEndOnOneMember`, and `_configuration_length_error` was deleted
outright when both methods moved onto `pose_vector_error`. The third was not:

```
$ grep -n 'length \*\*only\*\*' changelog.d/2881-ik-pose-shape-and-seed-length-contracts.md
42:the length **only**, while `solve` keeps the full per-component domain: a
```

So the shipped rationale described a scope split the shipped module no longer
has, and quoted the isolated-call cost denominator (37% of a 22.9 us `ee_pose`)
that #2879's measurement replaced. The fragment was also internally
inconsistent: fifteen lines above, it already said `pose_vector_error` "subsumes
the per-component finiteness check it replaces".

The surviving scope decision is unchanged and still measured - a pose's shape
cannot be delegated to a flat sixteen-component count, because
`pose_vector_error(..., 16)` accepts a `(2, 8)` array no homogeneous transform
could be - and now stands alone, matching `_homogeneous_pose_error`'s docstring.
The replacement paragraph states what the code does: one member covering both
halves, with `finite_vector_error("ee_pose", "qpos", np.zeros(6))` returning
`None` on a nine-joint model as the measurable evidence of the half that was
missing, and the closed-loop denominator (0.25% of a solve, 0.224% of a step).

Changelog-only, `+14/-11` in one file, **no source change** - so every
measurement in the sections above stands as taken. `tests/test_changelog_fragment_gate.py`,
`test_changelog_fragments.py`, `test_duplicate_work_described_change_key.py` and
`test_markdown_links_resolve.py`: **163 passed**.
