### PR TITLE
fix(policies/microduck): check the graph's action before it is used

### DIFF
--- a/changelog.d/2882-microduck-graph-action-width.md
+++ b/changelog.d/2882-microduck-graph-action-width.md
@@ -1,0 +1,47 @@
+### Fixed: the Microduck policy checks the graph's action before it uses it
+
+`MicroduckPolicy` holds three width contracts and checked two of them:
+`default_pose` against `len(joint_names)` in `_ensure_config`, and a `command`
+override against the width `command_names` declares in `_apply_command_kwargs`
+(whose own comment says the width check "lives in one place"). The third - the
+width of the action the ONNX graph itself returns - was not checked, and it is
+the one that differs from the other two by being fed *back*: `last_action` **is**
+that array, so it sets the width of the observation the graph is handed on the
+next tick.
+
+Measured with an injected stub session returning a width other than the joint
+count, recording the observation width the graph is actually fed:
+
+| graph action width | observation widths fed to the graph | outcome |
+|---|---|---|
+| 14 (the contract) | `[61, 61, 61]` | 3 x full 14-key action dict |
+| 1 | `[61, 48, 48]` | 3 x full 14-key action dict |
+| 15 / 13 / 7 | `[61]` | `ValueError` from inside numpy |
+
+A width of 1 broadcasts against `default_pose` inside `decode_action`, so it
+decoded silently, gave every joint the same target, and from tick 2 onward handed
+the graph a 48-wide vector where that graph's own `observation_names` metadata
+declares 61 - reporting a full action dict throughout. Any other width raised
+`operands could not be broadcast together with shapes (14,) (15,)` from inside
+numpy's decode, naming neither this policy nor the graph.
+
+A non-finite component had both consequences at once. A single `nan` in the raw
+action commanded **1 of 14** joints `nan` and fed that `nan` back into the next
+observation; an all-`inf` action commanded **14 of 14**. Both reported success.
+`EmpiricalNormalization` is fused into the exported graph, so nothing downstream
+sanitises the vector - which is the same reason the sibling scene-construction
+guards refuse a non-finite component, and `finite_vector_error`'s own docstring
+names both harms (a bare `ValueError` from a numpy assignment, and a `nan`
+propagated while reporting `success`).
+
+Both are now refused at the seam where the graph's output enters the policy,
+while the expected width and its source are still in hand, in the style of the
+two checks the class already performs. The finiteness half consults the shared
+`finite_vector_error` domain rather than a local `isfinite` loop.
+
+Nothing that worked changes: the contract width still reaches every joint over
+repeated ticks, a `(1, n)` row-shaped action is still squeezed and accepted, the
+legacy twist-only 51-D command width still works, a large but finite action is
+still accepted (the guard is not a magnitude bound), and a robot with a joint
+count other than 14 still works because the expected width is derived from
+`joint_names` rather than a literal.

--- a/strands_robots/policies/microduck/policy.py
+++ b/strands_robots/policies/microduck/policy.py
@@ -32,7 +32,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import name_list_error, require_optional
+from strands_robots.utils import finite_vector_error, name_list_error, require_optional
 
 from . import observation as obs_builder
 from ._session import MicroduckSession
@@ -228,6 +228,35 @@ class MicroduckPolicy(Policy):
         )
 
         raw_action = self.infer_raw(vector)
+        # The graph's own output width is the third width contract in this class,
+        # and it was the one not checked: ``default_pose`` is held to
+        # ``len(joint_names)`` in ``_ensure_config`` and a ``command`` override to
+        # the width ``command_names`` declares in ``_apply_command_kwargs``. This
+        # one differs from both in being fed BACK - ``last_action`` is this array,
+        # so the observation the graph is handed on the NEXT tick is only
+        # ``48 + len(command)`` wide while this holds. A width that happens to
+        # broadcast against ``default_pose`` (1) therefore decoded silently and
+        # then changed the observation width from tick 2 onward, reporting a full
+        # action dict throughout; any other width raised
+        # ``operands could not be broadcast together`` from inside numpy's decode,
+        # naming neither this policy nor the graph. Refuse here, where both the
+        # expected width and its source are still in hand.
+        if raw_action.shape[0] != len(self._joint_names):
+            raise ValueError(
+                f"{type(self).__name__}: the ONNX graph returned {raw_action.shape[0]} action "
+                f"value(s) but there are {len(self._joint_names)} joints "
+                f"(from joint_names). The action feeds both the joint targets and "
+                f"the next tick's last_action observation block, so a width other "
+                f"than the joint count cannot be used."
+            )
+        # A non-finite component is refused for the same reason the sibling
+        # scene-construction guards refuse one: it is written straight out (here to
+        # every joint target) AND fed back into the next observation, so the
+        # rollout reports success while commanding nan and poisoning the vector the
+        # graph sees next. ``EmpiricalNormalization`` is baked into the graph, so
+        # nothing downstream sanitises it.
+        if error := finite_vector_error(f"{type(self).__name__}.get_actions", "the ONNX action", raw_action):
+            raise ValueError(error)
         self._last_action = raw_action.copy()
 
         motor_target = obs_builder.decode_action(

--- a/tests/policies/microduck/test_microduck_graph_action_is_checked_before_it_is_used.py
+++ b/tests/policies/microduck/test_microduck_graph_action_is_checked_before_it_is_used.py
@@ -1,0 +1,339 @@
+"""The raw action the ONNX graph returns is checked before the policy uses it.
+
+``MicroduckPolicy`` holds three width contracts. Two were checked: ``default_pose``
+against ``len(joint_names)`` in ``_ensure_config``, and a ``command`` override
+against the width ``command_names`` declares in ``_apply_command_kwargs``. The
+third - the width of the action the graph itself returns - was not, and it is the
+one that differs from the other two by being fed BACK: ``last_action`` *is* that
+array, so it sets the width of the observation the graph is handed on the next
+tick.
+
+Measured on the pre-fix tree, with a stub session returning a width other than the
+joint count:
+
+===================  ==============================  =========================
+graph action width   observation widths fed to graph  outcome
+===================  ==============================  =========================
+14 (the contract)    ``[61, 61, 61]``                 3 x full action dict
+1                    ``[61, 48, 48]``                 3 x full action dict
+15 / 13 / 7          ``[61]``                         ``ValueError`` from numpy
+===================  ==============================  =========================
+
+A width of 1 broadcasts against ``default_pose`` in ``decode_action``, so it
+decoded silently, gave every joint the same target, and from tick 2 onward handed
+the graph a 48-wide vector where that graph's own ``observation_names`` metadata
+declares 61 - reporting a full 14-key action dict throughout. Any other width
+raised ``operands could not be broadcast together with shapes (14,) (15,)`` from
+inside numpy, naming neither this policy nor the graph.
+
+A non-finite component had the same two consequences at once: it was written to a
+joint target *and* fed back into the next observation, with the rollout reporting
+success. ``EmpiricalNormalization`` is fused into the graph, so nothing downstream
+sanitises it - the same reason the sibling scene-construction guards refuse one.
+
+Why nothing caught it: ``_StubSession`` in the sibling suite already takes an
+``n_joints`` parameter, so the knob for this existed. Every one of its 14
+instantiations there leaves it at the default 14, which is measured below as a
+premise - a stub parametrised for a width it is never driven at cannot see a
+width defect.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import MICRODUCK_JOINT_NAMES, MicroduckPolicy
+from strands_robots.policies.microduck import policy as policy_mod
+from strands_robots.policies.microduck.observation import build_observation
+
+#: Widths the graph must not be allowed to return. ``1`` is the broadcastable one
+#: (silent pre-fix); the rest raised from inside numpy naming nothing.
+_WRONG_WIDTHS = (1, 7, 13, 15, 28)
+
+#: The command width the shipped alpha policies declare (twist 3 + head 4 + body 6).
+_ALPHA_COMMAND = ("twist", "head_pose", "body_pose")
+_ALPHA_COMMAND_WIDTH = 13
+
+#: Fixed part of the observation: ang_vel(3) + gravity(3) + pos(14) + vel(14) + last(14).
+_FIXED_OBS_WIDTH = 48
+
+
+class _WidthStub:
+    """Duck-typed session returning an action of a chosen width, recording obs widths.
+
+    The sibling suite's ``_StubSession`` self-describes through ONNX metadata; this
+    one takes its config explicitly so a cell can hand the policy a width the
+    metadata would never advertise - which is the whole point.
+    """
+
+    def __init__(self, action: np.ndarray) -> None:
+        self.action = action
+        self.obs_widths: list[int] = []
+
+    def get_inputs(self) -> list[Any]:
+        class _Input:
+            name = "obs"
+
+        return [_Input()]
+
+    def run(self, _output_names: Any, input_feed: dict[str, Any]) -> list[np.ndarray]:
+        vector = np.asarray(next(iter(input_feed.values()))).reshape(-1)
+        self.obs_widths.append(int(vector.shape[0]))
+        return [np.asarray(self.action, dtype=np.float32).reshape(1, -1)]
+
+
+def _joints(n: int = 14) -> list[str]:
+    return [f"j{i}" for i in range(n)]
+
+
+def _obs_dict(names: list[str]) -> dict[str, Any]:
+    d: dict[str, Any] = {"base_ang_vel": [0.0, 0.0, 0.0], "base_quat": [1.0, 0.0, 0.0, 0.0]}
+    for name in names:
+        d[name] = 0.1
+        d[f"{name}.vel"] = 0.2
+    return d
+
+
+def _policy(stub: _WidthStub, *, names: list[str] | None = None, command_names: tuple[str, ...] = _ALPHA_COMMAND):
+    names = names or _joints()
+    return MicroduckPolicy(
+        session=stub,  # type: ignore[arg-type]
+        joint_names=names,
+        default_pose=[0.0] * len(names),
+        action_scale=0.25,
+        command_names=list(command_names),
+    )
+
+
+def _tick(policy: MicroduckPolicy, names: list[str]) -> dict[str, float]:
+    return policy.get_actions_sync(_obs_dict(names), "")[0]
+
+
+class TestAWrongWidthActionIsRefused:
+    """The regression: the graph's action width is held to the joint count."""
+
+    @pytest.mark.parametrize("width", _WRONG_WIDTHS)
+    def test_a_width_other_than_the_joint_count_is_refused(self, width: int) -> None:
+        names = _joints()
+        stub = _WidthStub(np.zeros(width, dtype=np.float32))
+        with pytest.raises(ValueError, match="the ONNX graph returned"):
+            _tick(_policy(stub), names)
+
+    @pytest.mark.parametrize("width", _WRONG_WIDTHS)
+    def test_the_refusal_names_both_widths(self, width: int) -> None:
+        names = _joints()
+        stub = _WidthStub(np.zeros(width, dtype=np.float32))
+        with pytest.raises(ValueError) as excinfo:
+            _tick(_policy(stub), names)
+        text = str(excinfo.value)
+        assert f"returned {width} action" in text, text
+        assert f"{len(names)} joints" in text, text
+
+    def test_the_refusal_names_the_policy(self) -> None:
+        stub = _WidthStub(np.zeros(15, dtype=np.float32))
+        with pytest.raises(ValueError, match=r"^MicroduckPolicy:"):
+            _tick(_policy(stub), _joints())
+
+    def test_the_refusal_names_where_the_expected_width_comes_from(self) -> None:
+        stub = _WidthStub(np.zeros(15, dtype=np.float32))
+        with pytest.raises(ValueError, match="joint_names"):
+            _tick(_policy(stub), _joints())
+
+    def test_a_broadcastable_width_no_longer_narrows_the_next_observation(self) -> None:
+        """Width 1 was the silent one: it decoded, then changed the obs width."""
+        names = _joints()
+        stub = _WidthStub(np.zeros(1, dtype=np.float32))
+        with pytest.raises(ValueError, match="the ONNX graph returned 1 action"):
+            for _ in range(3):
+                _tick(_policy(stub), names)
+        # It is refused on the FIRST tick, so the graph is never handed a
+        # narrowed vector at all.
+        assert stub.obs_widths == [_FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH], stub.obs_widths
+
+    def test_the_refusal_arrives_before_any_joint_target_is_produced(self) -> None:
+        stub = _WidthStub(np.zeros(1, dtype=np.float32))
+        policy = _policy(stub)
+        with pytest.raises(ValueError):
+            _tick(policy, _joints())
+        # last_action is still the seeded zeros of the contract width, not the
+        # graph's 1-element output.
+        assert policy._last_action is not None
+        assert policy._last_action.shape[0] == len(_joints())
+
+
+class TestANonFiniteActionIsRefused:
+    """A nan/inf action is written to every joint AND fed back; refuse it."""
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            pytest.param(np.array([np.nan] + [0.0] * 13, dtype=np.float32), id="one-nan"),
+            pytest.param(np.full(14, np.inf, dtype=np.float32), id="all-inf"),
+            pytest.param(np.array([0.0] * 13 + [-np.inf], dtype=np.float32), id="trailing-neg-inf"),
+        ],
+    )
+    def test_a_non_finite_component_is_refused(self, action: np.ndarray) -> None:
+        stub = _WidthStub(action)
+        with pytest.raises(ValueError, match="must contain finite numbers"):
+            _tick(_policy(stub), _joints())
+
+    def test_the_non_finite_refusal_names_the_policy_and_the_action(self) -> None:
+        stub = _WidthStub(np.array([np.nan] + [0.0] * 13, dtype=np.float32))
+        with pytest.raises(ValueError) as excinfo:
+            _tick(_policy(stub), _joints())
+        text = str(excinfo.value)
+        assert "MicroduckPolicy.get_actions" in text, text
+        assert "the ONNX action" in text, text
+
+    def test_no_joint_receives_a_non_finite_target(self) -> None:
+        stub = _WidthStub(np.full(14, np.nan, dtype=np.float32))
+        with pytest.raises(ValueError):
+            _tick(_policy(stub), _joints())
+
+
+class TestTheGraphOutputIsCheckedAtTheRightPoint:
+    """Structural: the check precedes both consumers of the raw action."""
+
+    #: The width comparison, spelled so a literal joint count fails by name
+    #: rather than raising ``ValueError`` out of ``str.index``.
+    _WIDTH_GUARD = "raw_action.shape[0] != len(self._joint_names)"
+
+    def _get_actions_source(self) -> str:
+        return inspect.getsource(MicroduckPolicy.get_actions)
+
+    def _guard_offset(self, source: str) -> int:
+        assert self._WIDTH_GUARD in source, (
+            f"expected the width comparison {self._WIDTH_GUARD!r}, so the expected "
+            "width stays derived from joint_names rather than a literal"
+        )
+        return source.index(self._WIDTH_GUARD)
+
+    def test_the_width_check_precedes_the_last_action_record(self) -> None:
+        source = self._get_actions_source()
+        record = source.index("self._last_action = raw_action")
+        assert self._guard_offset(source) < record, "the width check must run before the action is fed back"
+
+    def test_the_width_check_precedes_the_decode(self) -> None:
+        source = self._get_actions_source()
+        decode = source.index("decode_action")
+        assert self._guard_offset(source) < decode, "the width check must run before the action becomes joint targets"
+
+    def test_the_finiteness_check_consults_the_shared_vector_domain(self) -> None:
+        """Not a local isfinite loop: the shared domain owns the component rule."""
+        calls = [
+            node
+            for node in ast.walk(ast.parse(textwrap.dedent(self._get_actions_source())))
+            if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "finite_vector_error"
+        ]
+        assert len(calls) == 1, f"expected exactly one shared-domain call, found {len(calls)}"
+
+    def test_the_shared_domain_is_a_real_export(self) -> None:
+        """Non-vacuity for the cell above: the name it looks for is importable."""
+        from strands_robots import utils
+
+        assert callable(utils.finite_vector_error)
+        assert policy_mod.finite_vector_error is utils.finite_vector_error
+
+
+class TestWhatTheContractWidthStillDoes:
+    """Over-reach controls: everything the pre-fix code accepted correctly still works."""
+
+    def test_the_contract_width_reaches_every_joint_for_many_ticks(self) -> None:
+        names = _joints()
+        stub = _WidthStub(np.arange(14, dtype=np.float32) * 0.01)
+        policy = _policy(stub)
+        for _ in range(3):
+            action = _tick(policy, names)
+            assert len(action) == len(names)
+            assert all(np.isfinite(v) for v in action.values())
+        assert stub.obs_widths == [_FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH] * 3, stub.obs_widths
+
+    def test_a_row_shaped_action_is_still_accepted(self) -> None:
+        """The graph returns ``(1, n)``; ``infer_raw`` squeezes it."""
+        stub = _WidthStub(np.zeros((1, 14), dtype=np.float32))
+        assert len(_tick(_policy(stub), _joints())) == 14
+
+    def test_the_legacy_twist_only_command_width_still_works(self) -> None:
+        stub = _WidthStub(np.zeros(14, dtype=np.float32))
+        policy = _policy(stub, command_names=("twist",))
+        _tick(policy, _joints())
+        assert stub.obs_widths == [_FIXED_OBS_WIDTH + 3], stub.obs_widths
+
+    def test_a_large_but_finite_action_is_accepted(self) -> None:
+        """Only non-finite is refused - the guard is not a magnitude bound."""
+        stub = _WidthStub(np.full(14, -1.0e6, dtype=np.float32))
+        action = _tick(_policy(stub), _joints())
+        assert all(np.isfinite(v) for v in action.values())
+
+    def test_a_robot_with_a_different_joint_count_still_works(self) -> None:
+        """The expected width is derived, not the literal 14."""
+        names = _joints(9)
+        stub = _WidthStub(np.zeros(9, dtype=np.float32))
+        assert len(_tick(_policy(stub, names=names), names)) == 9
+
+    def test_the_two_pre_existing_width_guards_are_untouched(self) -> None:
+        stub = _WidthStub(np.zeros(14, dtype=np.float32))
+        with pytest.raises(ValueError, match="command override has width"):
+            policy = _policy(stub)
+            policy.get_actions_sync(_obs_dict(_joints()), "", command=np.zeros(5, dtype=np.float32))
+
+
+class TestThePremisesTheDefectRestedOn:
+    """Facts that hold on both trees and make the measurement above legible."""
+
+    def test_numpy_broadcasts_a_one_element_action_against_the_pose(self) -> None:
+        """Why width 1 was silent rather than loud."""
+        assert (np.zeros(14, dtype=np.float32) + np.zeros(1, dtype=np.float32)).shape == (14,)
+        with pytest.raises(ValueError, match="could not be broadcast"):
+            _ = np.zeros(14, dtype=np.float32) + np.zeros(15, dtype=np.float32)
+
+    def test_the_observation_width_is_the_fixed_block_plus_the_command(self) -> None:
+        names = _joints()
+        vector = build_observation(
+            _obs_dict(names),
+            joint_names=names,
+            default_pose=np.zeros(14, dtype=np.float32),
+            last_action=np.zeros(14, dtype=np.float32),
+            command=np.zeros(_ALPHA_COMMAND_WIDTH, dtype=np.float32),
+        )
+        assert vector.shape[0] == _FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH == 61
+
+    def test_the_builder_takes_the_last_action_width_on_trust(self) -> None:
+        """The builder cannot keep its documented ``48 + len(command)`` promise alone.
+
+        This is why the guard belongs at the seam where the graph's output enters
+        the policy rather than inside the builder: a wrong-width ``last_action``
+        silently changes the width the builder returns.
+        """
+        names = _joints()
+        vector = build_observation(
+            _obs_dict(names),
+            joint_names=names,
+            default_pose=np.zeros(14, dtype=np.float32),
+            last_action=np.zeros(1, dtype=np.float32),
+            command=np.zeros(_ALPHA_COMMAND_WIDTH, dtype=np.float32),
+        )
+        assert vector.shape[0] == _FIXED_OBS_WIDTH - 14 + 1 + _ALPHA_COMMAND_WIDTH == 48
+
+    def test_the_sibling_stub_parametrises_a_width_it_is_never_driven_at(self) -> None:
+        """Why no existing cell could see this."""
+        from pathlib import Path
+
+        suite = Path(__file__).parent
+        sources = [p.read_text() for p in suite.glob("test_*.py") if p.name != Path(__file__).name]
+        joined = "\n".join(sources)
+        assert "n_joints" in joined, "the sibling stub is expected to carry a width knob"
+        assert not re.search(r"n_joints\s*=\s*(?!14\b)\d+", joined), (
+            "a sibling cell now drives the stub off the contract width - fold this "
+            "file's coverage into it rather than keeping two accounts"
+        )
+
+    def test_the_contract_joint_count_is_fourteen(self) -> None:
+        assert len(MICRODUCK_JOINT_NAMES) == 14


### PR DESCRIPTION
## The defect

`MicroduckPolicy` holds three width contracts and checked two of them:

| contract | checked where |
|---|---|
| `default_pose` vs `len(joint_names)` | `_ensure_config` |
| a `command` override vs the width `command_names` declares | `_apply_command_kwargs` |
| **the width of the action the ONNX graph returns** | **nowhere** |

The third differs from the other two by being fed *back*: `last_action` **is** that
array, so it sets the width of the observation the graph is handed on the next tick.

Measured with an injected stub session (`session=` is an explicit constructor
parameter, so no `onnxruntime` is needed), recording the observation width the graph
is actually fed:

| graph action width | observation widths fed to the graph | outcome |
|---|---|---|
| 14 (the contract) | `[61, 61, 61]` | 3 x full 14-key action dict |
| **1** | `[61, **48**, **48**]` | 3 x full 14-key action dict |
| 15 / 13 / 7 | `[61]` | `ValueError` from inside numpy |

A width of 1 broadcasts against `default_pose` inside `decode_action`, so it decoded
silently, gave every joint the same target, and from tick 2 onward handed the graph a
48-wide vector where that graph's own `observation_names` metadata declares 61 -
reporting a full action dict throughout. Any other width raised `operands could not be
broadcast together with shapes (14,) (15,)` from inside numpy, naming neither this
policy nor the graph.

A non-finite component had both consequences at once:

| raw action | joints commanded non-finite | fed back into the next observation | reported |
|---|---|---|---|
| one `nan` | 1 of 14 | yes | success |
| all `inf` | 14 of 14 | yes | success |

`EmpiricalNormalization` is fused into the exported graph, so nothing downstream
sanitises the vector. That is the same reason the sibling scene-construction guards
refuse a non-finite component, and `finite_vector_error`'s own docstring names both
harms: a bare `ValueError` from a numpy assignment, and a `nan` propagated "while
silently poisoning" under a reported success.

## The change

One guard pair at the seam where the graph's output enters the policy - before it is
recorded as `last_action` and before it becomes joint targets - in the style of the two
checks the class already performs. The finiteness half consults the shared
`finite_vector_error` domain rather than a local `isfinite` loop. `+34/-1` in the
policy; the expected width is derived from `joint_names`, not a literal.

## Why nothing caught it

`_StubSession` in the sibling suite already takes an `n_joints` parameter, so the knob
for this existed. `n_joints=` appears **0** times across that suite's 14
instantiations - all of them leave it at the default 14. A stub parametrised for a
width it is never driven at cannot see a width defect. That is pinned as a premise
here, and it fails if a sibling cell ever starts driving it, so the two accounts cannot
silently diverge.

## Tests

34 cells, no optional dependency (`onnxruntime`/`mujoco` not required).

Pre-fix split, per class:

| class | failed/total |
|---|---|
| `TestAWrongWidthActionIsRefused` | 14/14 |
| `TestANonFiniteActionIsRefused` | 5/5 |
| `TestTheGraphOutputIsCheckedAtTheRightPoint` | 4/4 |
| `TestWhatTheContractWidthStillDoes` (over-reach controls) | **0/6** |
| `TestThePremisesTheDefectRestedOn` | **0/5** |

`23 failed, 11 passed`, and the row extraction was asserted against pytest's own
summary. The behavioural revert (both guards removed, the import kept) is 22; the extra
cell in the raw revert is the one asserting the shared domain is importable at all.

## Mutation table

Each row mutates the source and runs this file, plus the rest of `tests/policies/microduck/`
with this file deselected (`sib`). `collected` stayed 34 on every row, and the source was
restored byte-identically.

| # | mutation | fires | sib | note |
|---|---|---|---|---|
| b0 | control (as shipped) | 0 | 0 | |
| b1 | width guard removed | 16 | 0 | |
| b2 | finiteness guard removed | 6 | 0 | |
| b3 | both removed | 22 | 0 | the union of b1 and b2 exactly, and disjoint |
| b4 | width guard moved *after* the `last_action` record | 2 | 0 | the ordering cells |
| b5 | width compared to the literal `14` | 3 | 0 | fires the different-joint-count control |
| b6 | comparison weakened to `<` | 8 | 0 | only the wide widths survive |
| b7 | finiteness re-implemented as a local `np.isfinite` | 1 | 0 | the shared-domain cell |
| b8 | message drops the expected width | 5 | 0 | |
| b9 | message drops where the width comes from | 1 | 0 | |

b1 and b2 are disjoint and their union is exactly b3, so each half is
independently pinned. `sib` is 0 on every row: no mutation here disturbs any
pre-existing cell.

## Gate

Paired against the same tree with the source reverted and the new file parked, over an
identical 641-path selection (all of `tests/policies/` plus every suite that walks the
tree, parses source, or reads docstrings):

| | collected | result |
|---|---|---|
| branch | 26143 | `20 failed, 26043 passed, 80 skipped` |
| base | 26143 | `20 failed, 26043 passed, 80 skipped` |

**20 == 20 failing ids, both `comm` directions empty.** All 20 reproduce on the base
alone: 17 in `tests/mesh/test_iot_*` need `awsiot`/`awscrt` (both `find_spec` `False`
here, both declared in the `mesh-iot` extra, which CI installs via `features = ["all"]`),
and 3 are the known lerobot-from-source `encode() takes 1 positional argument` drift.

`ruff check` and `ruff format --check` clean over 1688 files. mypy **24 == 24** with the
normalized message sets byte-identical in both directions and **0** attributable
(`checked 1685` vs `1684`, the difference being the new test file).

## Scope

No visual artifact: this is a refusal in a policy's inference seam, not a policy
rollout, simulation, rendering, recording or asset change - the same file shape as the
two sibling IK refusal changes.

`build_observation` is a public export and still takes `last_action`'s width on trust,
so a *direct* caller can hand it a wrong-width array and get a vector narrower than its
documented `48 + len(command)`. That is recorded here as a premise cell rather than
fixed: the guard belongs at the seam where the graph's output enters the policy, because
that is the only place both consequences (the decode and the feed-back) are caught at
their source on the first tick. Widening the public builder's contract is a separate
question about a separate caller.
