### PR TITLE
fix(policies/microduck): refuse a scale or threshold that silently changes what the policy commands

### DIFF
--- a/changelog.d/2883-microduck-scalar-value-domains.md
+++ b/changelog.d/2883-microduck-scalar-value-domains.md
@@ -1,0 +1,64 @@
+### Fixed: a Microduck scale or threshold that silently changes what the policy commands is refused
+
+The Microduck provider validates its *structural* arguments carefully.
+`MicroduckPolicyBundle` refuses an empty mapping, refuses a value that is not a
+`MicroduckPolicy` (by name and by type), and refuses an `active` skill that is
+not one of its keys; `MicroduckPolicy.set_robot_state_keys` routes its list
+through the shared `name_list_error` domain. The two caller-supplied *numbers* in
+that surface reached their consumer through a bare `float()`.
+
+Neither number fails when it is unusable - each one silently changes what the
+policy commands. Measured through the public surfaces on a 14-DOF stub-backed
+policy, with the decode `motor_target = default_pose + raw_action * action_scale`:
+
+| `action_scale` | accepted | non-finite targets | targets == `default_pose` |
+| --- | --- | --- | --- |
+| `0.25` (control) | yes | 0/14 | no |
+| `0` | yes | 0/14 | **yes** |
+| `False` | yes | 0/14 | **yes** |
+| `nan` | yes | **14/14** | no |
+| `inf` | yes | **14/14** | no |
+
+A scale of `0` (or `False`, an `int` subclass) makes every target exactly
+`default_pose`: the network's decision is discarded and the biped holds its
+nominal stance while the rollout reports success. A non-finite scale makes all
+fourteen targets `nan`. Nothing downstream checked it - `decode_action` runs per
+tick inside `get_actions`, so a non-real value surfaced as a bare `TypeError`
+from its own `float()` only after the session had loaded and the rollout had
+started. The scale reaches the decode two ways, the constructor kwarg and the
+ONNX `action_scale` metadata, and both were bare, so guarding one route only
+would have let the same value in through the other. A declared value that is not
+a number now names the policy and the field instead of raising a bare
+`could not convert string to float: 'fast'`.
+
+The bundle's velocity gate is `|twist| >= switch_on_velocity`, and a magnitude is
+never negative, so the threshold has the same shape of failure in both
+directions:
+
+| `switch_on_velocity` | accepted | `|twist|=0.5` selects | `|twist|=0.0` selects |
+| --- | --- | --- | --- |
+| `0.1` (control) | yes | `walk` | `stand` |
+| `nan` | yes | **`stand`** | `stand` |
+| `inf` | yes | **`stand`** | `stand` |
+| `-1.0` | yes | `walk` | **`walk`** |
+| `-inf` | yes | `walk` | **`walk`** |
+| `True` | yes (as `1.0`) | `stand` | `stand` |
+
+A non-finite threshold can never select the move skill, because no magnitude
+compares `>=` to it - a biped told to walk stands still. A threshold of `0` or
+below can never select the idle skill - a biped told to stop keeps walking. Both
+are reported as a successful tick.
+
+All three routes now consult `positive_finite_number_error`, which is not a new
+judgement: `WBCConfig` - the other ONNX locomotion provider, decoding with the
+same `default_angles + action_scale * raw_action` formula - already holds its
+identically-named `action_scale` to that domain, and `Policy.set_control_frequency`
+in the base class states the same reason for its own rate ("`nan` and `inf` both
+survive a bare `hz <= 0` test"). Usable values are unchanged: a float, an `int`,
+a numpy float and a threshold as small as `1e-9` all still build and still gate
+both ways, and omitting `switch_on_velocity` still leaves the gate off.
+
+The two `action_scale` routes share one domain owner rather than two copies, and
+the accompanying test derives the inventory of caller-supplied scalars from the
+package's own annotations, so a third number arriving in this surface is graded
+when it lands instead of inheriting an exemption by being absent from a list.

--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -86,6 +86,14 @@ never hardcoded, and unused command slots stay present and zero (the
 dead-weight rule) so one observation layout serves every skill. Actions decode
 as `motor_target = DEFAULT_POSE + action * action_scale`.
 
+`action_scale` is the only path from the network's output to the joint targets,
+so it must be a positive finite number. A scale of `0` would make every target
+exactly `DEFAULT_POSE` — the network's decision discarded and the biped holding
+its nominal stance while the rollout reports success — and a non-finite one
+would make all fourteen targets `nan`. Both routes to the decode are held to
+that domain: an explicit `action_scale=` and the value read from the ONNX
+`action_scale` metadata.
+
 ## Commanding motion
 
 The command vector defaults to all-zero (stand in place). Steer with the
@@ -116,6 +124,11 @@ bundle = MicroduckPolicyBundle(
 ```
 
 Select explicitly with `get_actions(..., select="walk")` or `bundle.switch(...)`.
+
+`switch_on_velocity` must be a positive finite number. The gate compares a
+magnitude, so a threshold of `0` or below could never select the idle skill and
+a non-finite one could never select the move skill. Omit it (the default) to
+leave the gate off and switch only explicitly.
 
 ## Byte-compatibility
 

--- a/strands_robots/policies/microduck/composite.py
+++ b/strands_robots/policies/microduck/composite.py
@@ -21,6 +21,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
+from strands_robots.utils import positive_finite_number_error
 
 from .policy import MicroduckPolicy
 
@@ -32,7 +33,11 @@ class MicroduckPolicyBundle(Policy):
         policies: Mapping of skill name -> :class:`MicroduckPolicy`.
         active: The initially selected skill name. Defaults to the first key.
         switch_on_velocity: If set, auto-switch between ``move_key`` and
-            ``idle_key`` by ``|twist|`` against this threshold each tick.
+            ``idle_key`` by ``|twist|`` against this threshold each tick. Must
+            be a positive finite number - the gate compares a magnitude, so a
+            threshold of ``0`` or below can never select ``idle_key`` and a
+            non-finite one can never select ``move_key``. Pass ``None`` (the
+            default) to leave the gate off.
         move_key / idle_key: Skill names for the velocity gate (default
             ``"walk"`` / ``"stand"`` when those keys exist).
     """
@@ -62,6 +67,10 @@ class MicroduckPolicyBundle(Policy):
             raise ValueError(
                 f"MicroduckPolicyBundle: active skill {self._active!r} is not one of {list(self._policies)}."
             )
+        if switch_on_velocity is not None and (
+            error := positive_finite_number_error(switch_on_velocity, "switch_on_velocity", "MicroduckPolicyBundle")
+        ):
+            raise ValueError(error)
         self._switch_on_velocity = float(switch_on_velocity) if switch_on_velocity is not None else None
         self._move_key = move_key
         self._idle_key = idle_key

--- a/strands_robots/policies/microduck/policy.py
+++ b/strands_robots/policies/microduck/policy.py
@@ -32,7 +32,12 @@ import numpy as np
 from numpy.typing import NDArray
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import finite_vector_error, name_list_error, require_optional
+from strands_robots.utils import (
+    finite_vector_error,
+    name_list_error,
+    positive_finite_number_error,
+    require_optional,
+)
 
 from . import observation as obs_builder
 from ._session import MicroduckSession
@@ -88,6 +93,36 @@ _DEFAULT_COMMAND_WIDTH = 13
 _COMMAND_COMPONENTS = {"twist": 3, "head_pose": 4, "body_pose": 6}
 
 
+def _action_scale_error(value: Any, source: str) -> str | None:
+    """Return why ``value`` cannot be an action scale, or ``None`` if it can.
+
+    ``action_scale`` is the only path from the network's raw output to the joint
+    targets - ``motor_target = default_pose + raw_action * action_scale`` - so a
+    value that is not a positive finite number does not fail, it silently
+    changes what the policy commands. A scale of ``0`` (or ``False``, an ``int``
+    subclass) makes every target exactly ``default_pose``: the network's
+    decision is discarded and the biped holds its nominal stance while the
+    rollout reports success. A non-finite scale makes all fourteen targets
+    ``nan``. Neither is checked downstream - :func:`observation.decode_action`
+    runs per tick inside :meth:`MicroduckPolicy.get_actions`, so a non-real
+    value surfaced as a bare ``TypeError`` from its own ``float()`` only after
+    the session had loaded and the rollout had started.
+
+    The scale reaches the decode two ways - the constructor kwarg and the ONNX
+    ``action_scale`` metadata - and both consult this one domain, so a scale a
+    caller is refused cannot arrive through the file instead. ``source`` names
+    which route the value came from so the refusal points at the thing to fix.
+
+    Args:
+        value: The candidate scale, from a caller or from ONNX metadata.
+        source: Human-readable route, e.g. ``"constructor"``.
+
+    Returns:
+        The refusal text, or ``None`` when ``value`` is usable.
+    """
+    return positive_finite_number_error(value, "action_scale", f"MicroduckPolicy ({source})")
+
+
 class MicroduckPolicy(Policy):
     """ONNX locomotion policy for the Pollen Microduck 14-DOF biped.
 
@@ -103,9 +138,14 @@ class MicroduckPolicy(Policy):
             ``command_names`` metadata; defaults to all-zero (stand in place).
             Per-tick overrides arrive via ``get_actions(command=...)`` or the
             well-known ``target_velocity`` kwarg (writes the twist block).
-        joint_names / default_pose / action_scale / command_names: Explicit
-            config overrides. When omitted, read from the ONNX metadata on first
-            inference. Explicit values always win.
+        joint_names / default_pose / command_names: Explicit config overrides.
+            When omitted, read from the ONNX metadata on first inference.
+            Explicit values always win.
+        action_scale: Scale applied to the raw ONNX output before it becomes a
+            joint-position offset. Must be a positive finite number: a scale of
+            ``0`` discards the network's decision and holds ``default_pose``,
+            and a non-finite one makes every target ``nan``. When omitted, read
+            from the ONNX ``action_scale`` metadata and held to the same domain.
     """
 
     #: Proprioceptive locomotion - no cameras.
@@ -139,6 +179,8 @@ class MicroduckPolicy(Policy):
         self._default_pose: NDArray[np.float32] | None = (
             np.asarray(default_pose, dtype=np.float32) if default_pose is not None else None
         )
+        if action_scale is not None and (error := _action_scale_error(action_scale, "constructor")):
+            raise ValueError(error)
         self._action_scale: float | None = float(action_scale) if action_scale is not None else None
         self._command_names: list[str] | None = list(command_names) if command_names else None
         self._configured = False
@@ -321,7 +363,14 @@ class MicroduckPolicy(Policy):
                 else np.array(MICRODUCK_DEFAULT_POSE, dtype=np.float32)
             )
         if self._action_scale is None:
-            self._action_scale = float(meta.get("action_scale", 1.0))
+            declared = meta.get("action_scale", 1.0)
+            try:
+                parsed = float(declared)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"MicroduckPolicy: ONNX metadata action_scale={declared!r} is not a number.") from exc
+            if error := _action_scale_error(parsed, "ONNX metadata"):
+                raise ValueError(error)
+            self._action_scale = parsed
         if self._command_names is None:
             cn = meta.get("command_names")
             self._command_names = [s.strip() for s in cn.split(",")] if cn else None

--- a/tests/policies/microduck/test_microduck_scalar_value_domain.py
+++ b/tests/policies/microduck/test_microduck_scalar_value_domain.py
@@ -1,0 +1,359 @@
+"""Value-domain contracts for the Microduck policy surface's two scalars.
+
+Both classes in this package validate their *structural* arguments carefully.
+:class:`MicroduckPolicyBundle` refuses an empty mapping, refuses a value that is
+not a :class:`MicroduckPolicy` (by name and by type), and refuses an ``active``
+skill that is not one of its keys; :meth:`MicroduckPolicy.set_robot_state_keys`
+routes its list through the shared ``name_list_error`` domain. The two
+caller-supplied *numbers* reached their consumer through a bare ``float()``.
+
+Neither number fails when it is unusable - each one silently changes what the
+policy commands, which is why the guard belongs where the value arrives:
+
+* ``motor_target = default_pose + raw_action * action_scale``, so a scale of
+  ``0`` (or ``False``, an ``int`` subclass) makes every target exactly
+  ``default_pose``: the network's decision is discarded and the biped holds its
+  nominal stance while the rollout reports success. A non-finite scale makes all
+  fourteen targets ``nan``. It reaches the decode two ways - the constructor
+  kwarg and the ONNX ``action_scale`` metadata - and a guard on one route only
+  would let the same value in through the other.
+* the bundle's velocity gate is ``|twist| >= switch_on_velocity``, and a
+  magnitude is never negative, so a threshold of ``0`` or below can never select
+  the idle skill (a biped told to stop keeps walking) and a non-finite one can
+  never select the move skill (a biped told to walk stands still). Both are
+  reported as a successful tick.
+
+The domain member is not a new judgement. ``WBCConfig`` - the other ONNX
+locomotion provider, decoding with the same
+``default_angles + action_scale * raw_action`` formula - already holds its
+identically-named ``action_scale`` to ``positive_finite_number_error``, and
+:meth:`Policy.set_control_frequency` in the base class states the same reason
+for its own rate ("``nan`` and ``inf`` both survive a bare ``hz <= 0`` test").
+These tests pin that domain through the public surfaces a caller reaches, and
+pin the values that stay first-class so the guard cannot creep into refusing a
+controller a caller may legitimately ask for.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import math
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import MicroduckPolicy, MicroduckPolicyBundle
+from strands_robots.policies.microduck.policy import MICRODUCK_DEFAULT_POSE, MICRODUCK_JOINT_NAMES
+from tests.policies.microduck.test_microduck_policy import _obs_dict, _StubSession
+
+#: The values neither knob can use. Every one of them was accepted before, and
+#: every one of them changes what the policy commands rather than raising.
+_UNUSABLE = [
+    pytest.param(0.0, id="zero"),
+    pytest.param(-0.25, id="negative"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(float("-inf"), id="neg-inf"),
+    pytest.param(True, id="true"),
+    pytest.param(False, id="false"),
+    pytest.param("0.25", id="numeric-string"),
+    pytest.param([0.25], id="one-element-list"),
+]
+
+#: Values that must keep working, so the guard is a domain and not a narrowing.
+_USABLE = [
+    pytest.param(0.25, id="float"),
+    pytest.param(1, id="int"),
+    pytest.param(np.float64(0.25), id="numpy-float"),
+    pytest.param(1e-9, id="tiny-but-positive"),
+]
+
+_PACKAGE = pathlib.Path(MicroduckPolicy.__module__.replace(".", "/")).parent
+
+
+def _scaled_session(scale: str) -> _StubSession:
+    """A stub session whose ONNX metadata declares ``action_scale=scale``."""
+    return _StubSession(
+        meta={
+            "joint_names": ",".join(MICRODUCK_JOINT_NAMES),
+            "default_joint_pos": ",".join(f"{v}" for v in MICRODUCK_DEFAULT_POSE),
+            "action_scale": scale,
+            "command_names": "twist,head_pose,body_pose",
+        }
+    )
+
+
+def _targets(policy: MicroduckPolicy) -> np.ndarray:
+    """One tick's motor targets, in joint order."""
+    out = asyncio.run(policy.get_actions(_obs_dict(), ""))[0]
+    return np.array([out[name] for name in MICRODUCK_JOINT_NAMES], dtype=float)
+
+
+def _bundle(**kwargs: Any) -> MicroduckPolicyBundle:
+    """A two-skill bundle whose children are stub-backed."""
+    return MicroduckPolicyBundle(
+        {"walk": MicroduckPolicy(session=_StubSession()), "stand": MicroduckPolicy(session=_StubSession())},
+        active="stand",
+        **kwargs,
+    )
+
+
+class TestTheArithmeticThatMakesItSilent:
+    """Why a bare comparison cannot stand in for the domain.
+
+    Premises: they hold on either version of the code, and they are the reason
+    the guard has to be at the constructor rather than at the comparison.
+    """
+
+    @pytest.mark.parametrize("magnitude", [0.0, 0.5, 1e9])
+    def test_a_non_finite_threshold_loses_every_comparison(self, magnitude: float) -> None:
+        # The gate can never select the move skill: no magnitude clears it.
+        for threshold in (math.nan, math.inf):
+            assert not (magnitude >= threshold)
+
+    @pytest.mark.parametrize("threshold", [0.0, -1.0, -math.inf])
+    def test_a_non_positive_threshold_wins_every_comparison(self, threshold: float) -> None:
+        # A magnitude is never negative, so the gate can never select idle:
+        # these are constants, not thresholds.
+        for magnitude in (0.0, 0.5, 1e9):
+            assert magnitude >= threshold
+
+    def test_a_bool_is_an_int_subclass_so_a_flag_reads_as_a_number(self) -> None:
+        assert isinstance(True, int) and float(True) == 1.0
+        assert float(False) == 0.0
+
+    def test_the_sibling_provider_already_holds_this_knob_to_this_domain(self) -> None:
+        from strands_robots.policies.wbc import config as wbc_config
+
+        source = inspect.getsource(wbc_config)
+        assert 'positive_finite_number_error(self.action_scale, "action_scale"' in source
+
+
+class TestTheActionScaleConstructorRoute:
+    """The scale a caller hands the constructor is checked where it arrives."""
+
+    @pytest.mark.parametrize("value", _UNUSABLE)
+    def test_an_unusable_scale_is_refused_at_construction(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"action_scale"):
+            MicroduckPolicy(session=_StubSession(), action_scale=value)
+
+    def test_the_refusal_names_the_class_the_field_and_the_route(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            MicroduckPolicy(session=_StubSession(), action_scale=0.0)
+        text = str(excinfo.value)
+        assert text.startswith("MicroduckPolicy (constructor): action_scale")
+        assert "must be > 0" in text
+
+    def test_the_scale_is_refused_before_it_is_stored(self) -> None:
+        # A guard after the coercion would leave a nan on the instance.
+        with pytest.raises(ValueError):
+            MicroduckPolicy(session=_StubSession(), action_scale=float("nan"))
+
+
+class TestTheActionScaleMetadataRoute:
+    """The same scale arriving from the ONNX file meets the same domain.
+
+    The metadata route is resolved lazily on the first inference, so the refusal
+    surfaces from ``get_actions`` rather than from the constructor - but it is
+    the same domain, and a caller cannot route around the constructor's check by
+    exporting the value into the file instead.
+    """
+
+    @pytest.mark.parametrize("declared", ["0", "0.0", "-0.25", "nan", "inf", "-inf"])
+    def test_an_unusable_declared_scale_is_refused(self, declared: str) -> None:
+        policy = MicroduckPolicy(session=_scaled_session(declared))
+        with pytest.raises(ValueError, match=r"action_scale"):
+            asyncio.run(policy.get_actions(_obs_dict(), ""))
+
+    def test_the_refusal_names_the_route_it_came_from(self) -> None:
+        policy = MicroduckPolicy(session=_scaled_session("nan"))
+        with pytest.raises(ValueError) as excinfo:
+            asyncio.run(policy.get_actions(_obs_dict(), ""))
+        assert str(excinfo.value).startswith("MicroduckPolicy (ONNX metadata): action_scale")
+
+    def test_a_declared_scale_that_is_not_a_number_names_the_field(self) -> None:
+        policy = MicroduckPolicy(session=_scaled_session("fast"))
+        with pytest.raises(ValueError) as excinfo:
+            asyncio.run(policy.get_actions(_obs_dict(), ""))
+        text = str(excinfo.value)
+        assert "MicroduckPolicy" in text and "action_scale" in text and "'fast'" in text
+
+    def test_an_explicit_scale_still_wins_over_the_file(self) -> None:
+        policy = MicroduckPolicy(session=_scaled_session("0.5"), action_scale=0.25)
+        assert policy._action_scale == 0.25
+        assert np.all(np.isfinite(_targets(policy)))
+
+
+class TestTheVelocityGateThreshold:
+    """The gate's threshold is a magnitude bound, so it must be positive."""
+
+    @pytest.mark.parametrize("value", _UNUSABLE)
+    def test_an_unusable_threshold_is_refused_at_construction(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"switch_on_velocity"):
+            _bundle(switch_on_velocity=value)
+
+    def test_the_refusal_names_the_class_and_the_field(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _bundle(switch_on_velocity=float("nan"))
+        text = str(excinfo.value)
+        assert text.startswith("MicroduckPolicyBundle: switch_on_velocity")
+        assert "must be > 0" in text
+
+    def test_the_structural_checks_still_run_first(self) -> None:
+        # An unusable threshold must not mask the identity error a caller would
+        # rather hear about: the active-skill check precedes it.
+        with pytest.raises(ValueError, match=r"active skill"):
+            MicroduckPolicyBundle(
+                {"walk": MicroduckPolicy(session=_StubSession())},
+                active="nope",
+                switch_on_velocity=float("nan"),
+            )
+
+
+class TestOneOwnerForBothActionScaleRoutes:
+    """Both routes to the decode consult one domain helper, not two copies."""
+
+    def test_both_routes_call_the_shared_helper(self) -> None:
+        from strands_robots.policies.microduck import policy as policy_module
+
+        tree = ast.parse(inspect.getsource(policy_module))
+        callers = {
+            fn.name
+            for fn in ast.walk(tree)
+            if isinstance(fn, ast.FunctionDef)
+            for call in ast.walk(fn)
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id == "_action_scale_error"
+        }
+        assert callers == {"__init__", "_ensure_config"}, callers
+
+    def test_the_module_states_the_domain_in_exactly_one_place(self) -> None:
+        from strands_robots.policies.microduck import policy as policy_module
+
+        source = inspect.getsource(policy_module)
+        assert source.count('positive_finite_number_error(value, "action_scale"') == 1
+
+
+class TestEveryCallerSuppliedScalarConsultsADomain:
+    """Derived: a scalar knob added later is held to the same rule.
+
+    The inventory is read off the annotations rather than listed, so a third
+    number arriving in this package is graded the hour it lands instead of
+    inheriting an exemption by being absent from a tuple. A parameter is a
+    *scalar* here when its annotation mentions ``float`` and does not also name
+    an array or sequence type - the vector parameters (``command``,
+    ``default_pose``) are a different domain member and are out of scope.
+
+    The rule is scoped to the two public CLASSES, which is where a caller of the
+    provider hands values in. The module-level primitives in
+    :mod:`~strands_robots.policies.microduck.observation` are called per tick by
+    the policy with values it has already checked, so a second check there would
+    be a per-tick cost with no producer - the same split the WBC provider makes
+    between ``WBCConfig`` (guarded) and ``compute_targets`` (not).
+    """
+
+    @staticmethod
+    def _scalar_knobs() -> dict[str, list[str]]:
+        found: dict[str, list[str]] = {}
+        for path in sorted(_PACKAGE.glob("*.py")):
+            tree = ast.parse(path.read_text())
+            for klass in ast.walk(tree):
+                if not isinstance(klass, ast.ClassDef) or klass.name.startswith("_"):
+                    continue
+                for fn in klass.body:
+                    if not isinstance(fn, ast.FunctionDef):
+                        continue
+                    if fn.name.startswith("_") and fn.name != "__init__":
+                        continue
+                    for arg in fn.args.args + fn.args.kwonlyargs:
+                        if arg.arg in ("self", "cls") or arg.annotation is None:
+                            continue
+                        annotation = ast.unparse(arg.annotation)
+                        if "float" not in annotation:
+                            continue
+                        if any(t in annotation for t in ("NDArray", "list", "Sequence", "tuple", "dict")):
+                            continue
+                        found.setdefault(f"{path.name}::{fn.name}", []).append(arg.arg)
+        return found
+
+    @staticmethod
+    def _consults_a_domain(path: pathlib.Path, fn_name: str, param: str) -> bool:
+        tree = ast.parse(path.read_text())
+        for fn in ast.walk(tree):
+            if not isinstance(fn, ast.FunctionDef) or fn.name != fn_name:
+                continue
+            for call in ast.walk(fn):
+                if not isinstance(call, ast.Call):
+                    continue
+                rendered = ast.unparse(call)
+                if param not in rendered:
+                    continue
+                target = call.func
+                name = target.id if isinstance(target, ast.Name) else getattr(target, "attr", "")
+                # Either a domain call here, or delegation to the base class
+                # that owns the check (``super().set_control_frequency(hz)``).
+                if name.endswith(("_error", "_problems")) or name == fn_name:
+                    return True
+        return False
+
+    def test_the_inventory_is_not_empty(self) -> None:
+        knobs = self._scalar_knobs()
+        flat = {param for params in knobs.values() for param in params}
+        assert {"action_scale", "switch_on_velocity"} <= flat, knobs
+
+    def test_every_scalar_knob_consults_a_domain(self) -> None:
+        unguarded = [
+            f"{where}:{param}"
+            for where, params in self._scalar_knobs().items()
+            for param in params
+            if not self._consults_a_domain(_PACKAGE / where.split("::")[0], where.split("::")[1], param)
+        ]
+        assert unguarded == [], (
+            f"caller-supplied scalar(s) reaching a consumer with no value domain: {unguarded}. "
+            "Route the value through a shared domain in strands_robots.utils where it arrives."
+        )
+
+
+class TestWhatStaysFirstClass:
+    """The guard is a domain, not a narrowing: these must keep working."""
+
+    @pytest.mark.parametrize("value", _USABLE)
+    def test_a_usable_scale_still_builds_and_offsets_from_the_default_pose(self, value: Any) -> None:
+        policy = MicroduckPolicy(session=_StubSession(), action_scale=value)
+        targets = _targets(policy)
+        assert np.all(np.isfinite(targets))
+        # A discarded decision is EXACT equality with the default pose; any
+        # positive scale moves at least one joint off it, however slightly.
+        assert not np.array_equal(targets, np.array(MICRODUCK_DEFAULT_POSE, dtype=float))
+
+    @pytest.mark.parametrize("value", _USABLE)
+    def test_a_usable_threshold_still_gates_both_ways(self, value: Any) -> None:
+        bundle = _bundle(switch_on_velocity=value)
+        asyncio.run(bundle.get_actions(_obs_dict(), "", target_velocity=[float(value) * 10.0, 0.0, 0.0]))
+        assert bundle.active == "walk"
+        asyncio.run(bundle.get_actions(_obs_dict(), "", target_velocity=[0.0, 0.0, 0.0]))
+        assert bundle.active == "stand"
+
+    def test_omitting_the_threshold_leaves_the_gate_off(self) -> None:
+        bundle = _bundle()
+        assert bundle._switch_on_velocity is None
+        asyncio.run(bundle.get_actions(_obs_dict(), "", target_velocity=[9.0, 0.0, 0.0]))
+        assert bundle.active == "stand"
+
+    def test_omitting_the_scale_still_reads_it_from_the_file(self) -> None:
+        policy = MicroduckPolicy(session=_scaled_session("0.5"))
+        assert np.all(np.isfinite(_targets(policy)))
+        assert policy._action_scale == 0.5
+
+    def test_the_free_decode_helper_is_unchanged(self) -> None:
+        # ``decode_action`` is reached from the policy, which has already
+        # checked the scale; it keeps taking whatever it is handed.
+        from strands_robots.policies.microduck.observation import decode_action
+
+        raw = np.arange(14, dtype=np.float32) * 0.01
+        default = np.array(MICRODUCK_DEFAULT_POSE, dtype=np.float32)
+        out = decode_action(raw, default_pose=default, action_scale=2.0)
+        assert np.allclose(out, default + raw * 2.0)


### PR DESCRIPTION
## The defect

The Microduck provider validates its *structural* arguments carefully.
`MicroduckPolicyBundle` refuses an empty mapping, refuses a value that is not a
`MicroduckPolicy` (by name and by type), and refuses an `active` skill that is not
one of its keys; `MicroduckPolicy.set_robot_state_keys` routes its list through the
shared `name_list_error` domain. The two caller-supplied **numbers** in that surface
reached their consumer through a bare `float()`.

Neither number fails when it is unusable. Each one silently changes what the policy
commands.

### `action_scale`

The decode is `motor_target = default_pose + raw_action * action_scale`, so the scale
is the only path from the network's output to the joints. Measured through
`get_actions` on a 14-DOF stub-backed policy:

| `action_scale` | accepted | non-finite targets | targets == `default_pose` |
| --- | --- | --- | --- |
| `0.25` (control) | yes | 0/14 | no |
| `0` | yes | 0/14 | **yes** |
| `False` | yes | 0/14 | **yes** |
| `nan` | yes | **14/14** | no |
| `inf` | yes | **14/14** | no |

A scale of `0` (or `False`, an `int` subclass) makes every target exactly
`default_pose`: the network's decision is discarded and the biped holds its nominal
stance while the rollout reports success. A non-finite scale makes all fourteen
targets `nan`. Nothing downstream checked it — `decode_action` runs per tick inside
`get_actions`, so a non-real value surfaced as a bare `TypeError` from its own
`float()` only after the session had loaded and the rollout had started.

The scale reaches the decode **two ways**, and both were bare, so a guard on one
route would have let the same value in through the other:

| ONNX metadata `action_scale` | before | after |
| --- | --- | --- |
| `"0.25"` (control) | accepted, 0/14 non-finite | unchanged |
| `"0"` | accepted, targets == `default_pose` | refused |
| `"nan"` / `"inf"` | accepted, **14/14** non-finite | refused |
| `"fast"` | `ValueError: could not convert string to float: 'fast'` | names the policy and the field |

### `switch_on_velocity`

The bundle's gate is `|twist| >= switch_on_velocity`, and a magnitude is never
negative, so the threshold degenerates in both directions:

| `switch_on_velocity` | accepted | `\|twist\|=0.5` selects | `\|twist\|=0.0` selects |
| --- | --- | --- | --- |
| `0.1` (control) | yes | `walk` | `stand` |
| `nan` | yes | **`stand`** | `stand` |
| `inf` | yes | **`stand`** | `stand` |
| `-1.0` | yes | `walk` | **`walk`** |
| `-inf` | yes | `walk` | **`walk`** |
| `True` | yes (as `1.0`) | `stand` | `stand` |

A non-finite threshold can never select the move skill, because no magnitude compares
`>=` to it — a biped told to walk stands still. A threshold of `0` or below can never
select the idle skill — a biped told to stop keeps walking. Both are reported as a
successful tick.

## The change

All three routes now consult `positive_finite_number_error` where the value arrives.
The domain member is not a new judgement: `WBCConfig` — the other ONNX locomotion
provider, decoding with the same `default_angles + action_scale * raw_action` formula
— already holds its identically-named `action_scale` to that domain, and
`Policy.set_control_frequency` in the base class states the same reason for its own
rate ("`nan` and `inf` both survive a bare `hz <= 0` test"). The two `action_scale`
routes share one domain owner rather than two copies.

Usable values are unchanged: a float, an `int`, a numpy float and a threshold as
small as `1e-9` all still build and still gate both ways, and omitting
`switch_on_velocity` still leaves the gate off.

## Visual

The `action_scale=0` case is directly renderable, because "the decision is discarded"
is a pose. All three panels are the same shipped Microduck asset under one
deterministic stub session, rendered headless in MuJoCo:

![action_scale is the only path from the network to the joints](https://github.com/cagataycali/robots/releases/download/artifacts/microduck_action_scale.png)

Panels A and B are the same policy under two different commands — the pose follows
the decision, 20019 pixels apart. Panel C is what `action_scale=0` commands:
byte-identical to the float32 `default_pose` for **every one of the three
observations** (`max|d| = 0.0`; the `1.23e-08` rad float64 gap is the constant's own
float32 rounding), so the policy is a constant. A usable scale is byte-identical
across the two trees; the camera and headlight are asserted equal in all three panels
from the two captures' own JSON.

## Tests

`tests/policies/microduck/test_microduck_scalar_value_domain.py`, 54 cases, named for
the sibling provider's own `test_wbc_config_value_domain.py`.

Pre-fix split, **32 failed / 22 passed**:

| class | pre-fix | role |
| --- | --- | --- |
| `TestTheActionScaleConstructorRoute` | 11/11 | regression |
| `TestTheVelocityGateThreshold` | 10/11 | regression |
| `TestTheActionScaleMetadataRoute` | 8/9 | regression |
| `TestOneOwnerForBothActionScaleRoutes` | 2/2 | structural |
| `TestEveryCallerSuppliedScalarConsultsADomain` | 1/2 | derived drift guard |
| `TestTheArithmeticThatMakesItSilent` | **0/8** | premise |
| `TestWhatStaysFirstClass` | **0/11** | over-reach control |

Mutation table — 12 rows, control clean, `collected` stable at 54, no row disturbs the
two pre-existing Microduck suites, source restored md5-identical:

| mutation | fires | notes |
| --- | --- | --- |
| control | 0 | |
| constructor guard removed | 13 | |
| metadata guard removed (the tempting half fix) | 8 | |
| bundle threshold guard removed | 11 | |
| all three removed | 30 | exactly the union of the three route reverts |
| domain loosened to `finite_number_error` | 7 | exactly the zero and negative cells — this is the row that chooses the domain member |
| threshold checked before the identity check | 1 | an unusable number must not mask the error a caller would rather hear |
| metadata parse failure left unnamed | 1 | |
| route label dropped from the refusal | 2 | |
| the one owner inlined into two copies | 1 | structural only, behaviourally a no-op today — which is what the drift looks like before it drifts |
| bundle reverted + the scan's inventory hardcoded | 11 | the derived rule goes silent; the non-vacuity floor catches it instead |
| the scan's inventory hardcoded alone | 1 | the floor, by itself |

The three per-route reverts partition the full revert exactly, and the two shared
cells are shared by construction: the single-owner cell fires if *either* scale route
stops consulting the helper, and the derived-inventory cell fires if *any* knob loses
its guard.

The derived guard reads the inventory of caller-supplied scalars off the package's own
annotations, so a third number arriving in this surface is graded when it lands rather
than inheriting an exemption by being absent from a list. It is scoped to the two
public classes — the per-tick primitives in `observation.py` are called with values the
policy has already checked, the same split WBC makes between `WBCConfig` (guarded) and
`compute_targets` (not).

## Gate

- `ruff check` and `ruff format --check` clean over 1688 files.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine base, normalized
  message sets byte-identical in both directions, **0 attributable**.
- Paired run over a 719-file selection (all of `tests/policies/` plus every suite that
  walks the tree, parses source, or reads docstrings / `Args:` / `Raises:` / `__all__` /
  `changelog.d`), with the new file withheld from both sides: identical **29368 collected**,
  and after the one guard fix below the failing-id sets are identical with both `comm`
  directions empty. The 20 shared failures are 17 needing `awsiot`/`awscrt` (absent
  locally, declared in the `mesh-iot` extra) and 3 the lerobot-from-source `encode()` drift.
- `mkdocs build --strict` clean.

The broad run caught one thing a scoped run would not: my premise class first stated the
arithmetic as `assert 0.0 >= 0.0`, which `tests/test_no_vacuous_comparisons.py` correctly
refuses as a comparison whose result is fixed when it is typed. The premise now binds the
magnitudes and thresholds and sweeps them, which is a better statement of the property
anyway.

## Docs

`docs/policies/microduck.md` states the domain beside the decode formula and beside the
bundle example — the two places a reader copies these values from.
