### PR TITLE
fix(drivers/microduck): hold the transport knobs to the shared numeric domains

### DIFF
--- a/changelog.d/2884-microduck-transport-knob-domains.md
+++ b/changelog.d/2884-microduck-transport-knob-domains.md
@@ -1,0 +1,47 @@
+### Fixed: the Microduck transport knobs are refused rather than handed on unexamined
+
+`MicroduckDriver.__init__` takes three numeric knobs. Two of them reached a
+consumer that cannot report what it was given, and the driver's own actuation
+flags already follow the opposite convention: `active` and `enable_torque`'s `on`
+go through `boolean_flag_error` because reading them by truthiness would be
+silent wrong actuation. The transport knobs were the pair left outside it, and
+the sibling constructors both hold theirs to a shared domain - `G1Driver` checks
+`battery_floor_pct` with `finite_number_error`, and `ReachyDriver` refuses an
+unusable `api_port` before it has a daemon to address at all.
+
+`timeout` is handed to `socket.settimeout` and to the reply wait. Four of eight
+spellings raised out of `connect_eagerly` - a method declared `-> str | None`,
+whose whole contract is to name what went wrong - from inside the socket call,
+identifying neither the driver nor the parameter: `nan` and `-1.0` gave
+`ValueError`, `inf` an `OverflowError`, and `"5"` a `TypeError`. Reachable
+through the public route: `Robot("microduck", mode="real", timeout=float("nan"))`
+builds, then `connect_eagerly()` raises `ValueError: Invalid value NaN (not a
+number)`. The two that did *not* raise were worse. `True` set a silent one-second
+timeout, and `None` put the socket in blocking mode and made the reply wait
+unbounded - removing the only bound the parameter exists to impose. `0.0` did not
+time out either; it made the socket non-blocking, so an absent daemon was
+reported as "did not answer" for a reason that was not the one that happened.
+
+`subscribe_hz` is interpolated straight into the `robot.subscribe` params. Driven
+against the mock robotd over a real socket, `nan` and `inf` put
+`{"hz":NaN}` and `{"hz":Infinity}` on the wire while `connect_eagerly` returned
+success. Those are not JSON: RFC 8259 has no such literals, and a strict parser
+refuses the frame, so the driver reported an established connection having sent a
+subscribe robotd cannot read. `True` sent `{"hz":true}`, `2.5` sent `{"hz":2.5}`
+and `-5` sent `{"hz":-5}`, all where an integer decimation is expected, and a
+`numpy` integer is not JSON-serialisable at all - `json.dumps` raises on it.
+
+Both are now checked against the shared domains, `positive_finite_number_error`
+and `positive_count_error`, and refused at construction before any attribute is
+recorded, so a refused build leaves no half-made driver behind. The strict-int
+member is the right one for `subscribe_hz` precisely because robotd is sent an
+integer: it is what rejects the float and the `numpy` scalar that would otherwise
+reach the serialiser. `subscribe_hz=None` keeps its documented meaning of every
+control tick, and the usable spellings are unchanged - the default still sends no
+`hz` key and `subscribe_hz=30` still reaches the wire as `{"hz": 30}`.
+
+The third knob, `api_version`, is deliberately left without a domain, and the new
+suite records the measurement behind that rather than asserting it: a `nan`, a
+`True` or a `"1"` is compared against the Hello reply and already produces the
+named version-mismatch refusal, so a constructor check would only restate a
+refusal the handshake already gives.

--- a/strands_robots/drivers/microduck.py
+++ b/strands_robots/drivers/microduck.py
@@ -47,7 +47,12 @@ from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
 from strands_robots.policies.microduck import MICRODUCK_JOINT_NAMES
-from strands_robots.utils import boolean_flag_error, finite_number_error
+from strands_robots.utils import (
+    boolean_flag_error,
+    finite_number_error,
+    positive_count_error,
+    positive_finite_number_error,
+)
 
 if TYPE_CHECKING:
     from strands.types.tools import ToolSpec, ToolUse
@@ -473,13 +478,46 @@ class MicroduckDriver:
             api_version: API version to send in the Hello handshake, pinned to
                 :data:`MICRODUCK_API_VERSION`. A robotd answering a different
                 version is refused, not mis-parsed.
-            timeout: Socket and request timeout in seconds.
-            subscribe_hz: State-stream decimation. ``None`` = every control tick.
+            timeout: Socket and request timeout in seconds. A positive, finite
+                number: it is handed to ``socket.settimeout`` and to the reply
+                wait, neither of which can report what it was given.
+            subscribe_hz: State-stream decimation. ``None`` = every control tick;
+                otherwise a positive integer, because it is sent to robotd as one.
             **kwargs: Ignored; accepted so the factory can forward extras.
+
+        Raises:
+            ValueError: If ``timeout`` is not a positive finite number, or
+                ``subscribe_hz`` is neither ``None`` nor a positive integer.
+                Raised here rather than returned from
+                :meth:`connect_eagerly`, which is declared ``-> str | None``:
+                a value the transport cannot use is not a connection this
+                driver can degrade to reporting.
         """
         del cameras, data_config
         if kwargs:
             logger.debug("MicroduckDriver ignoring extra kwargs: %s", sorted(kwargs))
+
+        # The two transport knobs are held to the shared numeric domains for
+        # the same reason the actuation flags are held to ``boolean_flag_error``:
+        # each reaches a consumer that cannot report what it was handed.
+        # ``timeout`` goes to ``socket.settimeout`` and to the reply wait, so a
+        # ``nan``, an ``inf``, a negative or a numeric string raised out of
+        # :meth:`connect_eagerly` from inside the socket call - naming neither
+        # this driver nor the parameter, out of a method declared
+        # ``-> str | None`` - while ``True`` acted as a silent one second and
+        # ``None`` left both the socket and the reply wait unbounded.
+        # ``subscribe_hz`` is interpolated straight into the ``robot.subscribe``
+        # params: ``nan``/``inf`` serialise to the bare ``NaN``/``Infinity``
+        # tokens, which are not JSON (RFC 8259), so a strict daemon parser
+        # refuses the frame while ``connect_eagerly`` reports success; a
+        # ``numpy`` integer is not JSON-serialisable at all.  The strict-int
+        # domain is the right member because robotd is sent an integer.
+        if reason := positive_finite_number_error(timeout, "timeout", "MicroduckDriver"):
+            raise ValueError(reason)
+        if subscribe_hz is not None and (
+            reason := positive_count_error(subscribe_hz, "subscribe_hz", "MicroduckDriver")
+        ):
+            raise ValueError(reason)
 
         self._tool_name = tool_name
         self._socket_path = str(port) if port else DEFAULT_SOCKET

--- a/tests/drivers/microduck/test_microduck_transport_knob_domains.py
+++ b/tests/drivers/microduck/test_microduck_transport_knob_domains.py
@@ -1,0 +1,296 @@
+"""The Microduck transport knobs are checked, never handed on unexamined.
+
+``MicroduckDriver.__init__`` takes three numeric knobs. Two of them reach a
+consumer that cannot report what it was given:
+
+* ``timeout`` goes to ``socket.settimeout`` and to the reply wait. A ``nan``, an
+  ``inf``, a negative or a numeric string raised out of :meth:`connect_eagerly`
+  from inside the socket call - naming neither the driver nor the parameter, out
+  of a method declared ``-> str | None``. ``True`` acted as a silent one second
+  and ``None`` left both the socket and the reply wait unbounded.
+* ``subscribe_hz`` is interpolated straight into the ``robot.subscribe`` params,
+  so ``nan``/``inf`` put the bare ``NaN``/``Infinity`` tokens on the wire. Those
+  are not JSON (RFC 8259), so a strict daemon parser refuses the frame while
+  ``connect_eagerly`` reports the connection as established.
+
+The third, ``api_version``, needs no domain of its own and
+:class:`TestApiVersionIsCoveredByTheHandshake` records the measurement that says
+so: every unusable spelling already produces the named version-mismatch refusal.
+
+This is the same convention the driver's actuation flags already follow through
+``boolean_flag_error`` (``tests/drivers/microduck/test_microduck_flag_domain.py``
+holds that half), and the same one the sibling drivers' constructors follow -
+``G1Driver`` holds ``battery_floor_pct`` to ``finite_number_error`` and
+``ReachyDriver`` refuses an unusable ``api_port`` before it has a daemon to talk
+to. These knobs were the ones left outside it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import socket
+import threading
+
+import numpy as np
+import pytest
+
+from strands_robots.drivers import microduck as microduck_module
+from strands_robots.drivers.microduck import MICRODUCK_API_VERSION, MicroduckDriver
+from tests.mocks.microduck_robotd import MockRobotd
+
+#: A path no daemon answers: these cells grade the constructor, not the socket.
+ABSENT_SOCKET = "/tmp/microduck-transport-domain-no-such.sock"
+
+#: Spellings a caller reaches for that the transport cannot use as a timeout.
+#: ``0.0`` puts the socket in non-blocking mode rather than timing out, and
+#: ``None`` removes the bound the parameter exists to impose.
+UNUSABLE_TIMEOUTS: list[object] = [
+    float("nan"),
+    float("inf"),
+    -1.0,
+    0.0,
+    True,
+    False,
+    None,
+    "5",
+    [5],
+]
+
+#: Spellings robotd is not sent an integer decimation by. ``numpy`` integers are
+#: refused because ``json.dumps`` cannot serialise them at all.
+UNUSABLE_HZ: list[object] = [
+    float("nan"),
+    float("inf"),
+    True,
+    False,
+    0,
+    -5,
+    2.5,
+    "30",
+    np.int64(3),
+]
+
+#: The knobs that must reach a shared domain, and the one that must not need to.
+GUARDED_KNOBS = ("timeout", "subscribe_hz")
+EXEMPT_KNOBS = {
+    "api_version": (
+        "compared against the Hello reply, so every unusable spelling already "
+        "produces the named version-mismatch refusal"
+    )
+}
+
+#: The shared numeric domains in ``strands_robots.utils`` this driver may use.
+SHARED_NUMERIC_DOMAINS = (
+    "finite_number_error",
+    "positive_finite_number_error",
+    "positive_count_error",
+    "positive_whole_number_error",
+    "non_negative_whole_number_error",
+    "tcp_port_error",
+)
+
+
+def _numeric_init_params() -> list[str]:
+    """Every numeric-annotated constructor parameter, read off the signature.
+
+    Returns:
+        The parameter names annotated as an ``int``/``float`` (optionally
+        ``| None``), so a knob added later is graded rather than inheriting an
+        exemption by being absent from a literal list.
+    """
+    numeric = {"int", "float", "int | None", "float | None"}
+    found = []
+    for name, parameter in inspect.signature(MicroduckDriver.__init__).parameters.items():
+        annotation = parameter.annotation
+        text = annotation if isinstance(annotation, str) else getattr(annotation, "__name__", str(annotation))
+        if text in numeric:
+            found.append(name)
+    return found
+
+
+def _init_body_source() -> str:
+    """The constructor's own source, for reading which domains it consults."""
+    return inspect.getsource(MicroduckDriver.__init__)
+
+
+class TestTheConsumersCannotReportWhatTheyWereHanded:
+    """Premise: the harm is a property of the consumers, not of this driver."""
+
+    def test_a_non_finite_timeout_raises_inside_the_socket_call(self) -> None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(ValueError, match="NaN"):
+                sock.settimeout(float("nan"))
+        finally:
+            sock.close()
+
+    def test_a_true_timeout_is_a_silent_one_second_and_none_is_unbounded(self) -> None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.settimeout(True)
+            assert sock.gettimeout() == 1.0, "True must not be readable as a usable timeout"
+            sock.settimeout(None)
+            assert sock.gettimeout() is None, "None removes the bound rather than setting one"
+        finally:
+            sock.close()
+
+    def test_the_reply_wait_returns_at_once_for_a_non_finite_bound(self) -> None:
+        # A nan bound makes the wait fall straight through, so the request is
+        # reported as timed out having waited for nothing.
+        assert threading.Event().wait(float("nan")) is False
+
+    def test_a_non_finite_hz_is_not_json_and_a_numpy_int_is_not_serialisable(self) -> None:
+        def refuse_bare_constant(token: str) -> float:
+            raise ValueError(f"bare {token} is not JSON")
+
+        for value in (float("nan"), float("inf")):
+            frame = json.dumps({"hz": value})
+            with pytest.raises(ValueError, match="not JSON"):
+                json.loads(frame, parse_constant=refuse_bare_constant)
+        with pytest.raises(TypeError, match="not JSON serializable"):
+            json.dumps({"hz": np.int64(3)})
+
+
+class TestTimeoutIsAPositiveFiniteNumber:
+    """Every unusable timeout is refused at construction, naming itself."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_TIMEOUTS, ids=[repr(v)[:12] for v in UNUSABLE_TIMEOUTS])
+    def test_an_unusable_timeout_is_refused_naming_the_driver_and_the_knob(self, value: object) -> None:
+        with pytest.raises(ValueError) as caught:
+            MicroduckDriver(port=ABSENT_SOCKET, timeout=value)  # type: ignore[arg-type]
+        reason = str(caught.value)
+        assert "MicroduckDriver" in reason, f"the refusal must name the driver, got {reason!r}"
+        assert "timeout" in reason, f"the refusal must name the knob, got {reason!r}"
+
+    @pytest.mark.parametrize("value", UNUSABLE_TIMEOUTS, ids=[repr(v)[:12] for v in UNUSABLE_TIMEOUTS])
+    def test_connect_eagerly_is_never_reached_with_an_unusable_timeout(self, value: object) -> None:
+        # The whole point of refusing in the constructor: ``connect_eagerly`` is
+        # declared ``-> str | None`` and used to raise from inside the socket.
+        with pytest.raises(ValueError):
+            MicroduckDriver(port=ABSENT_SOCKET, timeout=value).connect_eagerly()  # type: ignore[arg-type]
+
+
+class TestSubscribeHzIsAPositiveIntegerWhenGiven:
+    """Every unusable decimation is refused before it can reach the wire."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_HZ, ids=[repr(v)[:12] for v in UNUSABLE_HZ])
+    def test_an_unusable_hz_is_refused_naming_the_driver_and_the_knob(self, value: object) -> None:
+        with pytest.raises(ValueError) as caught:
+            MicroduckDriver(port=ABSENT_SOCKET, subscribe_hz=value)  # type: ignore[arg-type]
+        reason = str(caught.value)
+        assert "MicroduckDriver" in reason, f"the refusal must name the driver, got {reason!r}"
+        assert "subscribe_hz" in reason, f"the refusal must name the knob, got {reason!r}"
+
+
+class TestTheUsableSpellingsAreUnchanged:
+    """Over-reach controls: nothing a caller legitimately passes is refused."""
+
+    @pytest.mark.parametrize("value", [5.0, 2, 0.25, 30.0], ids=["5.0", "2", "0.25", "30.0"])
+    def test_a_usable_timeout_still_builds_and_reports_rather_than_raising(self, value: float) -> None:
+        driver = MicroduckDriver(port=ABSENT_SOCKET, timeout=value)
+        reason = driver.connect_eagerly()
+        assert isinstance(reason, str) and "did not answer" in reason, (
+            f"an absent daemon must be reported, not raised; got {reason!r}"
+        )
+
+    def test_the_default_subscribe_sends_no_hz_key(self) -> None:
+        with MockRobotd(api_version=MICRODUCK_API_VERSION) as server:
+            driver = MicroduckDriver(port=server.path, timeout=2.0)
+            try:
+                assert driver.connect_eagerly() is None
+                frame = _subscribe_frame(server)
+                assert frame["params"] == {}, f"the default must send no decimation, got {frame['params']!r}"
+            finally:
+                driver.cleanup()
+
+    def test_a_positive_hz_reaches_the_wire_as_an_integer(self) -> None:
+        with MockRobotd(api_version=MICRODUCK_API_VERSION) as server:
+            driver = MicroduckDriver(port=server.path, timeout=2.0, subscribe_hz=30)
+            try:
+                assert driver.connect_eagerly() is None
+                frame = _subscribe_frame(server)
+                assert frame["params"] == {"hz": 30}, f"expected an integer decimation, got {frame['params']!r}"
+                assert isinstance(frame["params"]["hz"], int), "the wire value must stay an integer"
+            finally:
+                driver.cleanup()
+
+
+class TestApiVersionIsCoveredByTheHandshake:
+    """The measurement behind leaving the third numeric knob without a domain."""
+
+    @pytest.mark.parametrize("value", [float("nan"), True, "1"], ids=["nan", "True", "'1'"])
+    def test_an_unusable_api_version_already_yields_the_named_mismatch_refusal(self, value: object) -> None:
+        with MockRobotd(api_version=MICRODUCK_API_VERSION) as server:
+            driver = MicroduckDriver(port=server.path, timeout=2.0, api_version=value)  # type: ignore[arg-type]
+            try:
+                reason = driver.connect_eagerly()
+                assert isinstance(reason, str), "a mismatched version must be reported"
+                assert "api_version" in reason, f"the refusal must name the knob, got {reason!r}"
+                assert driver.is_connected is False
+            finally:
+                driver.cleanup()
+
+
+class TestEveryNumericKnobIsAccountedFor:
+    """Derived: a knob added later is graded, not exempted by absence."""
+
+    def test_the_numeric_knobs_are_the_ones_this_file_grades(self) -> None:
+        found = set(_numeric_init_params())
+        assert found, "the derivation must find the constructor's numeric knobs"
+        assert found == set(GUARDED_KNOBS) | set(EXEMPT_KNOBS), (
+            f"a numeric constructor knob is neither guarded nor exempted here: {found!r}"
+        )
+
+    def test_each_guarded_knob_reaches_a_shared_numeric_domain(self) -> None:
+        source = _init_body_source()
+        consulted = {name for name in SHARED_NUMERIC_DOMAINS if f"{name}(" in source}
+        assert consulted, f"the constructor consults no shared numeric domain: {sorted(SHARED_NUMERIC_DOMAINS)}"
+        for knob in GUARDED_KNOBS:
+            guarded = any(f"{name}({knob}," in source for name in SHARED_NUMERIC_DOMAINS)
+            assert guarded, f"{knob} is not handed to a shared numeric domain in __init__"
+
+    def test_every_exemption_states_a_reason(self) -> None:
+        for knob, reason in EXEMPT_KNOBS.items():
+            assert reason.strip(), f"{knob} is exempted without a reason"
+
+    def test_the_refusal_precedes_every_recorded_attribute(self) -> None:
+        # A refused construction must leave no half-built driver behind, so the
+        # guards sit above the first ``self._x = ...`` in the body.
+        tree = ast.parse(inspect.getsource(microduck_module))
+        init = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "__init__"
+            and any("subscribe_hz" == argument.arg for argument in node.args.kwonlyargs)
+        )
+        raises = [node.lineno for node in ast.walk(init) if isinstance(node, ast.Raise)]
+        stores = [
+            node.lineno
+            for node in ast.walk(init)
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Attribute)
+        ]
+        assert raises and stores, "expected both a refusal and recorded state in the constructor"
+        assert max(raises) < min(stores), (
+            f"the refusals must precede the first recorded attribute: raises={raises} stores={stores}"
+        )
+
+
+def _subscribe_frame(server: MockRobotd) -> dict[str, object]:
+    """The ``robot.subscribe`` request the driver put on the wire.
+
+    Args:
+        server: The mock daemon whose received lines are read.
+
+    Returns:
+        The decoded JSON-RPC request.
+    """
+    for raw in server.received:
+        frame = json.loads(raw)
+        if frame.get("method") == "robot.subscribe":
+            return dict(frame)
+    raise AssertionError(f"no robot.subscribe frame was sent; got {[bytes(r) for r in server.received]!r}")


### PR DESCRIPTION
## What

`MicroduckDriver.__init__` takes three numeric knobs. Two of them reached a consumer that cannot report what it was handed, and both are now checked against the shared numeric domains the sibling constructors already use.

The driver's own actuation flags already follow this convention: `active` and `enable_torque`'s `on` go through `boolean_flag_error`, because reading a posture flag by truthiness is silent wrong actuation. `tests/drivers/microduck/test_microduck_flag_domain.py` holds that half, and its `UNUSABLE` set contains `math.nan` and `None` — the very spellings the transport knobs accepted. The sibling drivers do the same at construction: `G1Driver` holds `battery_floor_pct` to `finite_number_error`, and `ReachyDriver` refuses an unusable `api_port` before it has a daemon to address.

## `timeout` — handed to `socket.settimeout` and to the reply wait

Four of eight spellings raised out of `connect_eagerly`, a method declared `-> str | None` whose whole contract is to name what went wrong, from inside the socket call — naming neither the driver nor the parameter.

| `timeout=` | before | after |
|---|---|---|
| `5.0`, `2` | reports `did not answer` | unchanged |
| `nan` | **raises `ValueError: Invalid value NaN (not a number)`** | refused: `timeout must be > 0, got nan.` |
| `inf` | **raises `OverflowError: timestamp out of range`** | refused |
| `-1.0` | **raises `ValueError: Timeout value out of range`** | refused |
| `"5"` | **raises `TypeError: 'str' object cannot be interpreted as an integer`** | refused |
| `True` | silent 1.0 s timeout | refused |
| `0.0` | non-blocking socket, not a timeout | refused |
| `None` | blocking socket **and** an unbounded reply wait | refused |

Reachable through the public route — the registry declares `hardware: {"driver": "strands"}`, so no keyword is needed:

```python
r = Robot("microduck", mode="real", timeout=float("nan"))   # builds
r.connect_eagerly()   # ValueError: Invalid value NaN (not a number)
```

The two spellings that did *not* raise are the worse half. `None` removes the only bound the parameter exists to impose, on both the socket and the reply wait. `0.0` does not time out at all — it makes the socket non-blocking, so an absent daemon is reported as "did not answer" for a reason that is not the one that happened.

## `subscribe_hz` — interpolated into the `robot.subscribe` params

Driven against `MockRobotd` over a real `AF_UNIX` socket, reading the frame the driver actually sent:

| `subscribe_hz=` | frame on the wire | `connect_eagerly` | strict JSON |
|---|---|---|---|
| `None` (default) | `{}` | success | yes |
| `30` | `{"hz":30}` | success | yes |
| `nan` | `{"hz":NaN}` | **success** | **no** |
| `inf` | `{"hz":Infinity}` | **success** | **no** |
| `True` | `{"hz":true}` | success | yes, but not an integer |
| `2.5` | `{"hz":2.5}` | success | yes, but not an integer |
| `0` / `-5` | `{"hz":0}` / `{"hz":-5}` | success | yes, but not a rate |

`NaN` and `Infinity` are not JSON literals (RFC 8259). A strict parser refuses the frame, so the driver reported an established connection having sent a subscribe robotd cannot read. And `json.dumps({"hz": numpy.int64(3)})` raises `TypeError: Object of type int64 is not JSON serializable`, so a numpy integer would fail at the serialiser rather than on the wire.

## Why nothing caught it

The driver has a domain suite, and it covers the flags. The numeric transport knobs were outside it, and no production caller passes either one — `subscribe_hz` has zero call sites outside the driver, and the only `timeout` callers are tests passing `2.0`. So the whole surface was reachable only from a caller's own keyword.

## The fix

Both knobs are checked at construction, before any attribute is recorded, so a refused build leaves no half-made driver:

```python
if reason := positive_finite_number_error(timeout, "timeout", "MicroduckDriver"):
    raise ValueError(reason)
if subscribe_hz is not None and (
    reason := positive_count_error(subscribe_hz, "subscribe_hz", "MicroduckDriver")
):
    raise ValueError(reason)
```

Raised rather than returned, following `ReachyDriver`'s stated reason: a value the transport cannot use is not a connection this driver can degrade to reporting.

The strict-int member is the right one for `subscribe_hz` *because* robotd is sent an integer — it is what rejects the float and the numpy scalar that would otherwise reach the serialiser. `positive_whole_number_error` would accept both. `subscribe_hz=None` keeps its documented meaning of every control tick, and the usable spellings are unchanged: the default still sends no `hz` key and `30` still reaches the wire as `{"hz": 30}`.

## Scope: `api_version` deliberately has no domain

The third numeric knob needs none, and the suite records the measurement rather than asserting it. A `nan`, a `True` or a `"1"` is compared against the Hello reply and already yields the named refusal — `robotd speaks api_version 16, this driver speaks nan; refusing rather than mis-parsing its frames` — and the driver stays disconnected. A constructor check would only restate a refusal the handshake already gives. `TestApiVersionIsCoveredByTheHandshake` pins that, so if the handshake ever stops covering it, that class fails rather than the gap reopening silently.

## Tests

`tests/drivers/microduck/test_microduck_transport_knob_domains.py`, 44 cells, reusing the existing faithful `MockRobotd` rather than mocking the socket away.

Pre-fix split: **27 failed / 17 passed**, and 0 of the 6 over-reach controls, 0 of the 4 premises and 0 of the 3 `api_version` boundary cells fire. Within `TestTimeoutIsAPositiveFiniteNumber`, 16 of 18 fire — the 2 that pass pre-fix are `nan` and `-1.0` through the `pytest.raises(ValueError)` cell, which already raised a `ValueError`, just from inside the socket and naming nothing; the message cell fails for all nine.

Mutation table, control clean, source restored md5-identical, `collected` stable at 44 on every row:

| mutation | new file | pre-existing suites |
|---|---|---|
| control | 0 | 0 |
| `timeout` guard removed | 17 | 0 |
| `subscribe_hz` guard removed | 10 | 0 |
| both removed (the shipped defect) | 27 | 0 |
| `timeout` -> `finite_number_error` (`0.0`/`-1.0` pass) | 3 | 0 |
| `subscribe_hz` -> `positive_whole_number_error` (`2.5`/numpy pass) | 10 | 0 |
| guards moved after the attribute stores | 1 | 0 |
| `subscribe_hz is not None` exemption dropped | 8 | **21** |

The last row is the scope evidence: refusing `None` breaks 21 pre-existing cells, because `None` is the default every existing microduck test constructs with.

Per-half arithmetic is exact: `17 + 10 - 1 shared + 1 residual = 27`. The shared cell is `test_each_guarded_knob_reaches_a_shared_numeric_domain`, which fires if either knob loses its guard. The residual is `test_the_refusal_precedes_every_recorded_attribute`, whose `assert raises and stores` still holds while one guard remains — only with both gone does the constructor carry no refusal at all.

`TestEveryNumericKnobIsAccountedFor` derives the numeric knobs off the constructor signature and requires each to be either guarded or exempted with a reason, so a knob added later is graded rather than inheriting an exemption by being absent from a literal list.

## Gate

- `ruff check` clean; `ruff format --check` 1688 files already formatted
- `mypy strands_robots tests tests_integ`: **24 == 24** against the pre-fix tree, normalized message sets byte-identical in both directions, **0 attributable** (`checked 1685` vs `1684`, the new test file)
- Paired pytest over an identical 490-file selection (all of `tests/drivers/`, plus every suite walking the tree, parsing source, reading docstrings or `changelog.d`, plus everything naming `list_native_drivers` / `DRIVER_SURFACE` / the registry / `docs/robots`), the new file withheld from both sides: identical **22541 collected** and `20 failed, 22442 passed, 78 skipped, 1 xfailed` on each, **both `comm` directions empty**. The 20 are pre-existing and environmental: 17 in `tests/mesh/test_iot_*` need `awsiot`/`awscrt` (`find_spec` `None` locally, declared in the `mesh-iot` extra, which the hatch default env installs via `all`), and 3 are the lerobot-from-source `encode()` drift.
- New file: 44 passed. `tests/drivers/microduck/` plus `tests/policies/microduck/`: 261 passed.

No visual artifact: this is a constructor refusal on a transport knob, none of the policy, simulation, rendering, recording or asset surfaces. The measured before/after tables and the captured wire frames are the evidence.
