### PR TITLE
fix(mesh): refuse an RPC wait budget the mesh cannot honor

### DIFF
--- a/changelog.d/2885-mesh-rpc-timeout-domain.md
+++ b/changelog.d/2885-mesh-rpc-timeout-domain.md
@@ -1,0 +1,31 @@
+### Fixed: an unusable mesh RPC wait budget is refused instead of acted on
+
+`Mesh.send` and `Mesh.broadcast` handed their `timeout` straight to a
+`threading.Event` wait with no value domain. The `robot_mesh` tool already holds
+that same parameter to `positive_finite_number_error`, and the docstring of the
+tool's domain helper names these two methods as the consumer -- "every action
+that reads it hands it to a `threading.Event` wait (`Mesh.send`) ... Only a
+positive finite number can be honored". A caller reaching `Mesh` directly - a
+test, a third-party integration, anything that imports it - got no such check.
+That is the same tool-versus-library gap `send`'s own `validate_command` call
+closes for the command, left open for the budget.
+
+Every unusable spelling published the command first and only then failed. `nan`
+and a negative make `Event.wait` return immediately, so the caller was handed
+`{"status": "timeout"}` about 0.01ms after a command that did go out - the peer
+may be executing it. `inf` and a string raised `OverflowError` / `TypeError` out
+of methods contracted to return an envelope or a list of responses. `True` was
+silently a one-second budget, and `None` waited forever, so the call never
+returned.
+
+`broadcast` carried the sharper consequence: the comment on its wait explains
+that the window deliberately spans the full budget so an operator can tell "1 of
+12 stopped" from "all stopped". An unusable budget returned at once and reported
+an empty fleet for a broadcast that had been published.
+
+Both methods now consult the shared domain before the turn is registered and
+before `publish`, so nothing reaches the wire under a budget that cannot bound
+the wait. `send` answers with its structured error; `broadcast` logs the reason
+and returns no responses, which is how it already reports a client-side
+rejection. A usable budget - including the fractional values the mesh suites
+pass - is unchanged.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -44,7 +44,7 @@ from strands_robots.mesh.session import (
 from strands_robots.mesh.session import (
     get_peers as _session_get_peers,
 )
-from strands_robots.utils import partial_construction_repr
+from strands_robots.utils import partial_construction_repr, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -3358,6 +3358,26 @@ class Mesh(SensorLoopsMixin):
         # 128-bit turn id -- at 32 bits the birthday-collision window
         # under heavy concurrent RPC load was practical (~65k turns
         # before 50% collision); 128 bits removes that surface entirely.
+        # A wait budget only a positive finite number can honor. The
+        # ``robot_mesh`` tool already holds this same parameter to
+        # ``positive_finite_number_error`` and its domain docstring names *this*
+        # method as the consumer ("every action that reads it hands it to a
+        # threading.Event wait ... Only a positive finite number can be
+        # honored"), so a caller reaching Mesh directly - a test, a third-party
+        # integration, anything that imports Mesh - got no such check. That is
+        # the same tool-vs-library gap the ``validate_command`` call below closes
+        # for ``cmd``, left open for the budget.
+        #
+        # It is refused HERE, before the turn is registered and before
+        # ``publish``, because every unusable spelling still put the command on
+        # the wire and only then failed: ``nan`` and a negative make
+        # ``Event.wait`` return immediately, so the caller is handed
+        # ``{"status": "timeout"}`` after ~0.01ms while the peer is executing;
+        # ``inf`` and a string raise OverflowError / TypeError out of a method
+        # whose contract is to return this envelope; ``True`` is silently a
+        # one-second budget.
+        if text := positive_finite_number_error(timeout, "timeout", "Mesh.send"):
+            return {"status": "error", "error": text}
         turn = uuid.uuid4().hex
         event = threading.Event()
         with self._rpc_lock:
@@ -3413,6 +3433,19 @@ class Mesh(SensorLoopsMixin):
             cmd = _security.validate_command(cmd)
         except _security.ValidationError as exc:
             logger.warning("[mesh] %s: broadcast rejected client-side: %s", self.peer_id, exc)
+            return []
+        # Same wait-budget domain ``send`` applies, reported the way this method
+        # already reports a client-side rejection: its return type is
+        # ``list[dict]`` (responses), so there is no structured slot for an
+        # error - log the reason and return no responses.
+        #
+        # The window matters more here than for a single ``send``: the comment
+        # on the wait below explains that it deliberately spans the FULL budget
+        # so an operator can distinguish "1 of 12 stopped" from "all stopped".
+        # An unusable budget defeats exactly that - ``nan`` returns immediately
+        # and reports an empty fleet for a broadcast that did go out.
+        if text := positive_finite_number_error(timeout, "timeout", "Mesh.broadcast"):
+            logger.warning("[mesh] %s: broadcast rejected client-side: %s", self.peer_id, text)
             return []
         turn = uuid.uuid4().hex
         event = threading.Event()

--- a/tests/mesh/test_mesh_rpc_timeout_domain.py
+++ b/tests/mesh/test_mesh_rpc_timeout_domain.py
@@ -1,0 +1,216 @@
+"""Both mesh RPC publishers refuse a wait budget they cannot honor.
+
+:meth:`~strands_robots.mesh.core.Mesh.send` and
+:meth:`~strands_robots.mesh.core.Mesh.broadcast` hand ``timeout`` straight to a
+:class:`threading.Event` wait. The ``robot_mesh`` tool already holds that same
+parameter to :func:`~strands_robots.utils.positive_finite_number_error`, and the
+docstring of the tool's domain helper names *these* methods as the consumer --
+"every action that reads it hands it to a threading.Event wait
+(:meth:`strands_robots.mesh.core.Mesh.send`) ... Only a positive finite number
+can be honored". A caller reaching ``Mesh`` directly got no such check, which is
+the same tool-vs-library gap ``send``'s own ``validate_command`` call closes for
+``cmd`` -- left open for the budget.
+
+Every unusable spelling still published the command and only then failed:
+
+* ``nan`` and a negative make ``Event.wait`` return immediately, so the caller
+  is handed ``{"status": "timeout"}`` about 0.01ms after a command that did go
+  out -- the peer may be executing it.
+* ``inf`` and a string raise ``OverflowError`` / ``TypeError`` out of methods
+  whose contract is to return an envelope (``send``) or a list of responses
+  (``broadcast``).
+* ``True`` is silently a one-second budget.
+* ``None`` waits forever, so the call never returns.
+
+``broadcast`` carries the sharper consequence: the comment on its wait explains
+that it deliberately spans the FULL window so an operator can distinguish "1 of
+12 stopped" from "all stopped". An unusable budget returns immediately and
+reports an empty fleet for a broadcast that was published.
+"""
+
+import ast
+import inspect
+import logging
+import math
+import textwrap
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.robot_mesh as _tool
+from strands_robots.mesh import core
+from strands_robots.utils import positive_finite_number_error
+
+#: Budgets no ``Event.wait`` can honor as a wait of that length.
+_UNUSABLE: tuple[Any, ...] = (0, -1.0, math.nan, math.inf, -math.inf, True, False, "30", None, [0.5])
+
+#: Budgets a caller may legitimately ask for. ``0.05`` is the value the shipped
+#: mesh suites pass, so it is the over-reach control for this whole file.
+_USABLE: tuple[float, ...] = (0.05, 0.2, 1.0, 30.0)
+
+
+def _mesh() -> core.Mesh:
+    m = core.Mesh(robot=object(), peer_id="op")
+    m._running = True
+    return m
+
+
+def _drive(publisher: str, timeout: Any) -> tuple[Any, list[str]]:
+    """Run *publisher* with *timeout*, returning ``(result, keys that reached the wire)``."""
+    m = _mesh()
+    reached: list[str] = []
+    m.publish = lambda key, payload: reached.append(key)  # type: ignore[method-assign]
+    if publisher == "send":
+        return m.send("r1", {"action": "stop"}, timeout=timeout), reached
+    return m.broadcast({"action": "stop"}, timeout=timeout), reached
+
+
+class TestEventWaitCannotHonorTheseBudgets:
+    """Premise: the reason a domain is needed lives in the stdlib, not here."""
+
+    @pytest.mark.parametrize("budget", [0, -1.0, math.nan])
+    def test_a_non_positive_or_nan_budget_returns_at_once(self, budget: Any) -> None:
+        # These are the silent ones: the wait is a no-op, so the caller reads a
+        # timeout for a command that went out microseconds earlier.
+        started = time.monotonic()
+        assert threading.Event().wait(timeout=budget) is False
+        assert time.monotonic() - started < 0.01
+
+    def test_an_infinite_budget_raises_rather_than_waiting(self) -> None:
+        with pytest.raises(OverflowError):
+            threading.Event().wait(timeout=math.inf)
+
+    def test_a_string_budget_raises_rather_than_waiting(self) -> None:
+        with pytest.raises(TypeError):
+            threading.Event().wait(timeout="30")  # type: ignore[arg-type]
+
+    def test_a_true_budget_is_silently_one_second(self) -> None:
+        # ``bool`` is an ``int`` subclass, so this is accepted as a wait of 1.0s
+        # rather than reported as a flag handed to a budget.
+        started = time.monotonic()
+        assert threading.Event().wait(timeout=True) is False
+        assert 0.9 < time.monotonic() - started < 1.5
+
+
+class TestTheToolAlreadyHeldThisParameterToTheSameDomain:
+    """Premise: the domain is the tool's, adopted rather than invented here."""
+
+    def test_the_tool_consults_the_shared_positive_finite_domain(self) -> None:
+        source = textwrap.dedent(inspect.getsource(_tool._numeric_option_error))
+        assert "positive_finite_number_error(timeout" in source
+
+    def test_the_tools_domain_docstring_names_these_methods_as_the_consumer(self) -> None:
+        doc = " ".join((_tool._numeric_option_error.__doc__ or "").split())
+        assert "Mesh.send" in doc
+        assert "Only a positive finite number can be honored" in doc
+
+    def test_every_rpc_action_the_tool_exposes_reads_the_budget(self) -> None:
+        # Non-vacuity: the tool really does route these actions' timeout, so the
+        # library methods under them are the same quantity consumed the same way.
+        for action in ("send", "broadcast"):
+            assert "timeout" in _tool._ACTION_NUMERIC_OPTIONS[action]
+
+
+class TestSendRefusesTheBudgetBeforeTheCommandGoesOut:
+    """Regression: the refusal precedes ``publish``, not the wait."""
+
+    @pytest.mark.parametrize("budget", _UNUSABLE)
+    def test_an_unusable_budget_is_refused(self, budget: Any) -> None:
+        result, reached = _drive("send", budget)
+        assert result["status"] == "error"
+
+    @pytest.mark.parametrize("budget", _UNUSABLE)
+    def test_nothing_reaches_the_wire(self, budget: Any) -> None:
+        # The whole point of refusing here: previously every one of these
+        # published the command and only then failed.
+        _result, reached = _drive("send", budget)
+        assert reached == []
+
+    @pytest.mark.parametrize("budget", _UNUSABLE)
+    def test_the_refusal_names_the_method_and_the_parameter(self, budget: Any) -> None:
+        result, _reached = _drive("send", budget)
+        assert "Mesh.send" in result["error"]
+        assert "timeout" in result["error"]
+
+    def test_the_refusal_is_the_shared_domains_own_text(
+        self,
+    ) -> None:
+        result, _reached = _drive("send", math.nan)
+        expected = positive_finite_number_error(math.nan, "timeout", "Mesh.send")
+        assert result["error"] == expected
+
+
+class TestBroadcastRefusesTheSameBudget:
+    """Regression: reported the way this method reports a client-side rejection."""
+
+    @pytest.mark.parametrize("budget", _UNUSABLE)
+    def test_an_unusable_budget_yields_no_responses(self, budget: Any) -> None:
+        result, _reached = _drive("broadcast", budget)
+        assert result == []
+
+    @pytest.mark.parametrize("budget", _UNUSABLE)
+    def test_nothing_reaches_the_wire(self, budget: Any) -> None:
+        _result, reached = _drive("broadcast", budget)
+        assert reached == []
+
+    def test_the_reason_is_logged_since_the_return_type_has_no_error_slot(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # ``broadcast`` returns ``list[dict]``, so an empty list is also what a
+        # broadcast nobody answered returns. The log is the only place the
+        # difference can be recorded.
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+            _drive("broadcast", math.nan)
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("timeout" in m and "rejected client-side" in m for m in messages)
+
+
+class TestAUsableBudgetIsUnchanged:
+    """Over-reach control: every value a caller may legitimately ask for."""
+
+    @pytest.mark.parametrize("budget", _USABLE)
+    def test_the_domain_accepts_it(self, budget: float) -> None:
+        assert positive_finite_number_error(budget, "timeout", "Mesh.send") is None
+
+    def test_send_still_publishes_and_still_reports_a_timeout(self) -> None:
+        result, reached = _drive("send", 0.05)
+        assert reached == ["strands/r1/cmd"]
+        assert result == {"status": "timeout"}
+
+    def test_broadcast_still_publishes_and_still_returns_no_responses(self) -> None:
+        result, reached = _drive("broadcast", 0.05)
+        assert reached == ["strands/broadcast"]
+        assert result == []
+
+    def test_a_fractional_budget_is_honored_for_its_full_span(self) -> None:
+        # The continuous domain rather than a count: a sub-second budget is the
+        # value the shipped mesh suites pass.
+        started = time.monotonic()
+        _drive("send", 0.2)
+        assert 0.15 < time.monotonic() - started < 1.0
+
+
+class TestBothPublishersConsultTheSharedDomain:
+    """Structural: one domain, so the two methods cannot come to disagree."""
+
+    @pytest.mark.parametrize("method", ["send", "broadcast"])
+    def test_the_method_calls_the_shared_domain(self, method: str) -> None:
+        fn = getattr(core.Mesh, method)
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        called = {ast.unparse(node.func) for node in ast.walk(tree) if isinstance(node, ast.Call)}
+        assert "positive_finite_number_error" in called
+
+    @pytest.mark.parametrize("method", ["send", "broadcast"])
+    def test_the_guard_precedes_the_wait_it_bounds(self, method: str) -> None:
+        source = textwrap.dedent(inspect.getsource(getattr(core.Mesh, method)))
+        assert "positive_finite_number_error" in source, f"{method} consults no shared budget domain"
+        assert ".wait(timeout=timeout)" in source, f"{method} no longer waits on the budget"
+        assert source.index("positive_finite_number_error") < source.index(".wait(timeout=timeout)")
+
+    @pytest.mark.parametrize("method", ["send", "broadcast"])
+    def test_the_guard_precedes_the_publish_it_protects(self, method: str) -> None:
+        source = textwrap.dedent(inspect.getsource(getattr(core.Mesh, method)))
+        assert "self.publish(" in source, f"{method} no longer publishes"
+        assert source.index("positive_finite_number_error") < source.index("self.publish(")


### PR DESCRIPTION
## The defect

`Mesh.send` and `Mesh.broadcast` hand `timeout` straight to a `threading.Event`
wait with no value domain, while every other caller-supplied input on the same
methods is checked: `target` gets a type test, a non-empty test, a NUL test and
a reserved-sentinel test, and `cmd` goes through `validate_command` plus a
byte-cap pre-check.

The domain for this parameter already exists and already names these methods.
`robot_mesh`'s `_numeric_option_error` holds `timeout` to
`positive_finite_number_error`, and its docstring says:

> `timeout` is a wait budget: every action that reads it hands it to a
> `threading.Event` wait (`strands_robots.mesh.core.Mesh.send`) or to a Device
> Connect `invoke` [...] **Only a positive finite number can be honored**

So the tool path was checked and the library path was not. That is the same
tool-versus-library gap `send`'s own comment describes closing for the command --
"programmatic callers (tests, third-party integrations, anything that imports
Mesh directly) skipped `validate_command`" -- left open for the budget.

## Measured, before

Driven with `publish` recorded, so "wire?" is whether the command went out
before the budget was consumed:

| `timeout` | on the wire? | elapsed | outcome |
|---|---|---|---|
| `0.05` (control) | yes | 50.13 ms | `{'status': 'timeout'}` |
| `0` | yes | 0.07 ms | `{'status': 'timeout'}` |
| `-1.0` | yes | 0.01 ms | `{'status': 'timeout'}` |
| `nan` | yes | 0.01 ms | `{'status': 'timeout'}` |
| `True` | yes | 1000.28 ms | `{'status': 'timeout'}` |
| `inf` | yes | 0.08 ms | raised `OverflowError` |
| `"30"` | yes | 0.02 ms | raised `TypeError` |
| `None` | yes | never returns | blocks forever |

Every row published first. The consequences differ in kind:

- `nan`, `0` and a negative make `Event.wait` return at once, so the caller is
  handed `{"status": "timeout"}` about 0.01 ms after a command that did go out.
  The peer may be executing it. This is the silent row.
- `inf` and a string raise out of methods contracted to return an envelope
  (`send`) or a list of responses (`broadcast`), after the publish.
- `True` is silently a one-second budget, because `bool` is an `int` subclass.
- `None` waits forever, so the call never returns at all.

`broadcast` carries the sharper consequence. The comment on its wait explains
that the window deliberately spans the FULL budget rather than firing on the
first ack, so that an operator can distinguish "1 of 12 stopped" from "all
stopped". An unusable budget returns immediately and reports an empty fleet for
a broadcast that was published -- which is exactly the reading that comment
exists to prevent.

## Measured, after

| `timeout` | send: on the wire? | broadcast: on the wire? | send outcome |
|---|---|---|---|
| `0.05` (control) | yes | yes | `{'status': 'timeout'}` after 50 ms |
| `0` | no | no | `Mesh.send: timeout must be ...` |
| `-1.0` | no | no | `Mesh.send: timeout must be ...` |
| `nan` | no | no | `Mesh.send: timeout must be ...` |
| `True` | no | no | `Mesh.send: timeout must be ...` |
| `inf` | no | no | `Mesh.send: timeout must be ...` |
| `"30"` | no | no | `Mesh.send: timeout must be ...` |
| `None` | no | no | `Mesh.send: timeout must be ...` |

The guard is placed before the turn is registered and before `publish`, so an
unusable budget leaves no pending turn and puts nothing on the wire.

Dispositions follow each method's existing convention rather than a new one:
`send` returns its structured error; `broadcast` logs the reason and returns no
responses, which is how it already reports a client-side rejection ("its return
type is `list[dict]` (responses), so a validation failure has no structured
slot").

## Why nothing caught it

The tool suite covers this parameter -- `test_robot_mesh_numeric_option_domain.py`
drives `timeout=-1.0` and `timeout=0` through `robot_mesh`. Nothing drove the
library methods, so the checked path was tested and the unchecked path was the
one every programmatic caller uses.

## Break table

`tests/mesh/test_mesh_rpc_timeout_domain.py`, 74 cells.

| row | mutation | fires | note |
|---|---|---|---|
| b0 | control (as shipped) | 0 | |
| b1 | `send` guard removed | 32 | |
| b2 | `broadcast` guard removed | 18 | |
| b3 | both removed (pre-fix) | 50 | union of b1 and b2 equals b3, disjoint, 32 + 18 = 50 |
| b4 | signed domain instead | 13 | over-reach: admits `0` and negative |
| b5 | `send` guard moved after `publish` | 10 | the nothing-reaches-the-wire cells |
| b6 | `broadcast` refuses but logs nothing | 1 | the only record it can leave |
| b7 | `send` re-implements the domain inline | 18 | shared-domain and message cells |

`collected` was 74 on every row and the source was restored md5-identical after
each. The pre-fix split (50 of 74) fires only the two regression classes and the
structural class: **0 of the premise cells and 0 of the over-reach controls**.

b5 is the row that argues the placement, and b4 the row that argues the domain
member -- a signed domain would accept a zero or negative budget, which
`Event.wait` cannot honor as a wait.

## Gate

- `ruff check` clean over `strands_robots tests tests_integ`; `ruff format
  --check` 1688 files already formatted.
- `mypy` **5 == 5** against the same tree with the change reverted, normalized
  message sets byte-identical in both directions, **0 attributable**. The two
  `mesh/core.py` messages are the pre-existing `_dispatch_sim_policy`
  `[arg-type]` pair, present on both.
- Paired run over an identical 376-file selection (all of `tests/mesh/` plus
  every suite that walks the tree, parses source, or reads docstrings), with the
  new file withheld from both sides: identical **11271 collected** and
  `21 failed, 11159 passed, 67 skipped, 24 errors` on each, **45 == 45 failing
  ids, both `comm` directions empty**. All 45 need `awsiot`/`awscrt` (both
  absent locally, declared in the `mesh-iot` extra, which CI installs).
  `test_zenoh_transport_security.py` was excluded from the pair and verified
  alone: 9 passed, 2 skipped.

No visual artifact: this is a value domain on a transport helper, not a policy,
simulation, rendering, recording or asset change. The measured before/after
tables are the evidence.
