### PR TITLE
fix(policies/lerobot_local): the RTC guidance ceiling reaches the config lerobot reads

### DIFF
--- a/changelog.d/2886-rtc-guidance-ceiling-reaches-the-config.md
+++ b/changelog.d/2886-rtc-guidance-ceiling-reaches-the-config.md
@@ -1,0 +1,50 @@
+### Fixed: the RTC guidance ceiling reaches the config lerobot reads
+
+`LerobotLocalPolicy` takes two Real-Time-Chunking overrides side by side, and
+only one of them could take effect. `rtc_execution_horizon` is a keyword argument
+of lerobot's `predict_action_chunk`, and `_predict_with_rtc` forwards it per call.
+`rtc_max_guidance_weight` is not: lerobot's denoiser reads that ceiling off
+`self.rtc_config.max_guidance_weight`, and the RTC keyword contract -
+`ActionSelectKwargs` - carries `inference_delay`, `prev_chunk_left_over` and
+`execution_horizon` and nothing else. So a ceiling kept on the policy object had
+nowhere to go.
+
+`_init_rtc` read the checkpoint's value as a *default* into
+`self._rtc_max_guidance_weight` and never wrote a caller's override back. The
+override's only remaining reader was one `logger.info("... max_guidance_weight=%.1f")`
+line. Measured against lerobot's genuine `RTCConfig(max_guidance_weight=10.0)`,
+asking for `2.0` left `rtc_config.max_guidance_weight` at `10.0` while the policy
+attribute read `2.0`: a checkpoint tuned for a tight ceiling ran the model's own,
+and the INFO line reported the number that was not in force. The override is now
+written onto the config, which is the field the clamp
+(`torch.minimum(guidance_weight, max_guidance_weight)`) and the
+`nan_to_num(..., posinf=max_guidance_weight)` fallback both read.
+
+Writing it there is what makes the second half necessary. The value had no domain
+while `actions_per_step`, `tokenizer_max_length` and `rtc_execution_horizon` in
+the same constructor all have one, so `0`, `0.0`, `-3.5`, `nan`, `inf`, `True`,
+`False`, `"2.0"`, a list and a dict were all accepted. Two of those - `0` and a
+negative - are values lerobot's own `RTCConfig.__post_init__` refuses outright
+with "max_guidance_weight must be positive". That constructor never sees this one,
+because the override lands on an already-built config, so the domain is asked
+where the caller names the value instead: `positive_finite_number_error` at the
+constructor, and at `preflight` beside the four sibling knobs it already checks,
+so a rollout gets a structured error before the weight download rather than a
+raise after it. An `inf` ceiling clamps nothing and a `nan` ceiling makes every
+clamped weight `nan`, which is why finiteness is part of the domain rather than
+just positivity.
+
+`None` keeps its documented meaning - adopt the checkpoint's own value - and that
+branch does not write to the config, so a policy that asked for nothing still
+leaves the config it read from untouched. Moving the write ahead of that default
+resolving trips four of the pre-existing RTC cells, which is the boundary this
+change is careful not to cross.
+
+Why the suite was green over it: `test_rtc_user_overrides_config_values` is named
+for both knobs overriding the config and asserts only that
+`policy._rtc_max_guidance_weight` keeps the value it was given - an attribute
+round-trip, which held either way - while `TestRTCConfigSchemaContract` pins that
+lerobot still *exposes* the field, grading the read and never the application. A
+new cell asserts the ceiling is absent from `ActionSelectKwargs`, so if lerobot
+ever accepts it as a keyword argument the author is told to forward it instead of
+writing the config.

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -20,7 +20,7 @@ from typing import Any
 import numpy as np
 import torch
 
-from ...utils import name_list_error, positive_count_error
+from ...utils import name_list_error, positive_count_error, positive_finite_number_error
 from .. import Policy, align_action_values, chunk_count_error
 from .._log_safety import sanitize_log_value
 from .._state_keys import drop_velocity_siblings
@@ -363,8 +363,10 @@ class LerobotLocalPolicy(Policy):
             :attr:`~strands_robots.policies.base.Policy.execution_horizon`
             resolves, so it must be a positive whole number. ``None`` (the
             default) adopts the model config value, else 10.
-        rtc_max_guidance_weight: Maximum guidance weight for RTC correction.
-            Defaults to model config value or 10.0.
+        rtc_max_guidance_weight: Ceiling on the RTC guidance weight, written
+            onto the checkpoint's own ``rtc_config`` because that is where
+            lerobot reads it. Must be a positive finite number. ``None`` (the
+            default) adopts the model config value, else 10.0.
         camera_key_map: Optional explicit mapping of robot/sim camera name
             (e.g. "top") to the policy's declared image feature key
             (e.g. "observation.images.top"). When omitted, cameras are
@@ -563,6 +565,22 @@ class LerobotLocalPolicy(Policy):
             if error:
                 raise ValueError(error)
         self._rtc_execution_horizon = rtc_execution_horizon
+        # lerobot clamps the RTC guidance weight with
+        # ``torch.minimum(guidance_weight, max_guidance_weight)`` and also feeds
+        # it to ``nan_to_num(..., posinf=max_guidance_weight)``, so the ceiling
+        # has to be a positive finite number: an ``inf`` clamps nothing, a
+        # ``nan`` makes every clamped weight ``nan``, and a ``0`` or a negative
+        # value pins the correction to a ceiling lerobot's own
+        # ``RTCConfig.__post_init__`` refuses outright ("max_guidance_weight
+        # must be positive"). That constructor cannot see this value - the
+        # override is written onto an already-built config in ``_init_rtc`` -
+        # so the domain is asked here instead. ``None`` is the documented
+        # "adopt the model's value" request rather than a weight, so only a
+        # supplied one is checked, exactly as for the horizon above.
+        if rtc_max_guidance_weight is not None:
+            error = positive_finite_number_error(rtc_max_guidance_weight, "rtc_max_guidance_weight", "lerobot_local")
+            if error:
+                raise ValueError(error)
         self._rtc_max_guidance_weight = rtc_max_guidance_weight
         self._rtc_prev_chunk: torch.Tensor | None = None
         # Absolute-coordinate copy of the leftover tail, populated ONLY for
@@ -1508,6 +1526,17 @@ class LerobotLocalPolicy(Policy):
             if error:
                 raise ValueError(error)
 
+        # The RTC guidance ceiling, on the same reasoning as the horizon above:
+        # it is honored whenever RTC is active, which the model config decides,
+        # so it cannot be scoped to an embodiment either. Checked for a supplied
+        # value only - ``None`` asks for the checkpoint's own ceiling.
+        if policy_config.get("rtc_max_guidance_weight") is not None:
+            error = positive_finite_number_error(
+                policy_config["rtc_max_guidance_weight"], "rtc_max_guidance_weight", "lerobot_local"
+            )
+            if error:
+                raise ValueError(error)
+
         # The instruction's token budget, on the same reasoning: it is honored
         # for every configuration that tokenizes at all, so it cannot be scoped
         # to an embodiment either, and checking it here refuses it before the
@@ -1739,6 +1768,21 @@ class LerobotLocalPolicy(Policy):
             self._rtc_execution_horizon = getattr(rtc_config, "execution_horizon", 10)
         if self._rtc_max_guidance_weight is None:
             self._rtc_max_guidance_weight = getattr(rtc_config, "max_guidance_weight", 10.0)
+        else:
+            # Written onto the config, because that is the only place lerobot
+            # reads it: ``RTCInferenceMixin`` takes the ceiling from
+            # ``self.rtc_config.max_guidance_weight``, and the RTC kwarg
+            # contract (``ActionSelectKwargs``) carries only ``inference_delay``,
+            # ``prev_chunk_left_over`` and ``execution_horizon``. Kept only on
+            # this policy - as it was - the caller's ceiling reached the INFO
+            # line below and nothing else, so a checkpoint tuned with a ``2.0``
+            # ceiling ran the model's own ``10.0``. The horizon needs no
+            # equivalent write: it IS a kwarg, and ``_predict_with_rtc``
+            # forwards it per call.
+            # narrow for mypy: the enable branches above only reach here with a
+            # non-None rtc_config, as the comment on the default block states.
+            assert rtc_config is not None
+            rtc_config.max_guidance_weight = self._rtc_max_guidance_weight
 
         logger.info(
             "RTC enabled for '%s': execution_horizon=%d, max_guidance_weight=%.1f",

--- a/tests/policies/lerobot_local/test_rtc_guidance_ceiling_reaches_the_config.py
+++ b/tests/policies/lerobot_local/test_rtc_guidance_ceiling_reaches_the_config.py
@@ -1,0 +1,309 @@
+"""``rtc_max_guidance_weight`` reaches the field lerobot reads, or is refused.
+
+lerobot's RTC denoiser takes the guidance ceiling from
+``self.rtc_config.max_guidance_weight`` - it clamps with
+``torch.minimum(guidance_weight, max_guidance_weight)`` and feeds the same value
+to ``nan_to_num(..., posinf=max_guidance_weight)``. It is *not* part of the RTC
+kwarg contract: ``ActionSelectKwargs`` carries ``inference_delay``,
+``prev_chunk_left_over`` and ``execution_horizon`` and nothing else.
+
+So a ceiling kept only on the policy object cannot take effect. Pre-fix
+``_init_rtc`` read the checkpoint's value as a *default* into
+``self._rtc_max_guidance_weight`` and never wrote a caller's override back, so
+the override reached one ``logger.info`` line and nothing else: a caller asking
+for ``2.0`` ran the model's own ``10.0``. Its adjacent twin
+``rtc_execution_horizon`` did take effect, because that one IS a kwarg and
+``_predict_with_rtc`` forwards it per call.
+
+The value also had no domain, while every numeric sibling in the same
+constructor has one - so ``0``, ``-5.0``, ``nan``, ``inf``, ``True`` and
+``"abc"`` were all accepted. ``0`` and a negative are values lerobot's own
+``RTCConfig.__post_init__`` refuses outright ("max_guidance_weight must be
+positive"); that constructor never sees this one, because the override is
+written onto an already-built config, so the domain is asked at the seam the
+caller names instead.
+
+Why the suite was green over it: ``test_rtc_user_overrides_config_values`` is
+named for both knobs overriding the config and asserts only that
+``policy._rtc_max_guidance_weight`` keeps the value it was given - an attribute
+round-trip, which held either way. ``TestRTCConfigSchemaContract`` pins that
+lerobot still *exposes* the field, i.e. it grades the read and never the
+application.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import textwrap
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.policies.lerobot_local import policy as policy_module
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+# The ceiling the stand-in checkpoint declares. Distinct from every value a cell
+# asks for, so "the override landed" and "the model's own value survived" can
+# never be the same reading.
+MODEL_CEILING = 10.0
+
+# Values that cannot serve as a clamp. ``0`` and ``-3.5`` are the two lerobot's
+# own config constructor refuses; the rest are the spellings a bare comparison
+# would let through (``nan`` compares False against everything, ``inf`` clamps
+# nothing, ``bool`` is an ``int`` subclass, and the last three are not numbers).
+UNUSABLE: tuple[Any, ...] = (0, 0.0, -3.5, math.nan, math.inf, True, False, "2.0", [2.0], {"w": 2.0})
+
+# Accepted spellings: a float, an int, and a value below the model's own.
+USABLE: tuple[Any, ...] = (2.0, 0.5, 1, 25.0)
+
+
+class _StubRtcConfig:
+    """The RTC block a flow-matching checkpoint (Pi0, SmolVLA) carries.
+
+    A plain class rather than a ``MagicMock``: a mock auto-provides every
+    attribute and accepts every assignment, so it cannot distinguish "the
+    override was written onto the config" from "nothing happened". Field names
+    are pinned against lerobot's real dataclass in
+    :class:`TestThePremisesThisRestsOn`.
+    """
+
+    def __init__(self, *, enabled: bool = True, horizon: int = 15, ceiling: float = MODEL_CEILING) -> None:
+        self.enabled = enabled
+        self.execution_horizon = horizon
+        self.max_guidance_weight = ceiling
+
+
+def _policy(**kwargs: Any) -> LerobotLocalPolicy:
+    """Build the policy with model loading disabled, as the sibling suite does."""
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(LerobotLocalPolicy, "_load_model", lambda self: None)
+        return LerobotLocalPolicy(model_path="stub", **kwargs)
+
+
+def _enable_rtc(pol: LerobotLocalPolicy, cfg: _StubRtcConfig) -> _StubRtcConfig:
+    """Drive ``_init_rtc`` against ``cfg`` and hand the same object back.
+
+    Returns the config so a cell reads the ceiling off the object lerobot would
+    read it from, rather than off the policy's own copy.
+    """
+    loaded = MagicMock()
+    loaded.predict_action_chunk = MagicMock()
+    loaded.config.rtc_config = cfg
+    pol._policy = loaded
+    pol._loaded = True
+    pol._init_rtc()
+    return cfg
+
+
+class TestTheOverrideReachesTheFieldLerobotReads:
+    """A supplied ceiling lands on ``rtc_config``, not only on the policy."""
+
+    @pytest.mark.parametrize("weight", USABLE)
+    def test_a_supplied_ceiling_is_written_onto_the_checkpoint_config(self, weight: Any) -> None:
+        pol = _policy(rtc_enabled=True, rtc_max_guidance_weight=weight)
+        cfg = _enable_rtc(pol, _StubRtcConfig())
+
+        assert cfg.max_guidance_weight == weight, (
+            f"asked for a {weight} ceiling and rtc_config still carries "
+            f"{cfg.max_guidance_weight}; lerobot reads the clamp from this field, "
+            "so a ceiling kept only on the policy never reaches the denoiser"
+        )
+
+    def test_the_policy_and_the_config_agree_after_init(self) -> None:
+        """The two copies cannot disagree: one is written from the other."""
+        pol = _policy(rtc_enabled=True, rtc_max_guidance_weight=2.0)
+        cfg = _enable_rtc(pol, _StubRtcConfig())
+
+        assert pol._rtc_max_guidance_weight == cfg.max_guidance_weight == 2.0
+
+    def test_a_real_config_takes_the_override(self) -> None:
+        """The whole path, against lerobot's genuine dataclass.
+
+        The stand-in config is a plain class; this is the same assertion against
+        the real ``RTCConfig``, so a rename of the field would fail here too.
+        """
+        config = pytest.importorskip("lerobot.policies.rtc.configuration_rtc")
+        cfg = config.RTCConfig(enabled=True, execution_horizon=15, max_guidance_weight=MODEL_CEILING)
+
+        pol = _policy(rtc_enabled=True, rtc_max_guidance_weight=2.0)
+        loaded = MagicMock()
+        loaded.predict_action_chunk = MagicMock()
+        loaded.config.rtc_config = cfg
+        pol._policy = loaded
+        pol._loaded = True
+        pol._init_rtc()
+
+        assert cfg.max_guidance_weight == 2.0
+
+    def test_the_model_ceiling_is_replaced_not_merely_shadowed(self) -> None:
+        """The pre-fix reading is gone: the model's own value must not survive."""
+        pol = _policy(rtc_enabled=True, rtc_max_guidance_weight=2.0)
+        cfg = _enable_rtc(pol, _StubRtcConfig(ceiling=MODEL_CEILING))
+
+        assert cfg.max_guidance_weight != MODEL_CEILING
+
+
+class TestADomainThatMatchesTheClamp:
+    """A ceiling that cannot clamp is refused where the caller names it."""
+
+    @pytest.mark.parametrize("weight", UNUSABLE)
+    def test_the_constructor_refuses_an_unusable_ceiling(self, weight: Any) -> None:
+        with pytest.raises(ValueError, match=r"rtc_max_guidance_weight must be > 0"):
+            _policy(rtc_enabled=True, rtc_max_guidance_weight=weight)
+
+    @pytest.mark.parametrize("weight", UNUSABLE)
+    def test_the_preflight_refuses_an_unusable_ceiling(self, weight: Any) -> None:
+        """The dict entry point refuses it too, beside its four siblings.
+
+        :meth:`LerobotLocalPolicy.preflight` already refuses ``actions_per_step``,
+        ``image_keys``, ``rtc_execution_horizon`` and ``tokenizer_max_length``
+        there, so that a rollout gets a structured error before the weight
+        download rather than a raise from ``__init__`` after it.
+        """
+        with pytest.raises(ValueError, match=r"rtc_max_guidance_weight must be > 0"):
+            LerobotLocalPolicy.preflight(set(), rtc_max_guidance_weight=weight)
+
+    def test_the_refusal_names_the_parameter_and_the_provider(self) -> None:
+        with pytest.raises(ValueError) as caught:
+            _policy(rtc_enabled=True, rtc_max_guidance_weight=-1.0)
+
+        text = str(caught.value)
+        assert "rtc_max_guidance_weight" in text
+        assert "lerobot_local" in text
+
+    def test_the_module_consults_the_shared_domain(self) -> None:
+        """A local re-implementation would drift from the sibling knobs."""
+        calls = [
+            node
+            for node in ast.walk(ast.parse(inspect.getsource(policy_module)))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "positive_finite_number_error"
+        ]
+        assert len(calls) == 2, f"expected the constructor and the pre-flight to share the domain, found {len(calls)}"
+
+    def test_the_guard_precedes_the_write_onto_the_config(self) -> None:
+        """A refused value must never be assigned onto the checkpoint's config.
+
+        Structural, because the behavioural cells cannot see it: the constructor
+        refuses first, so ``_init_rtc`` is unreachable with a bad value. If the
+        order were reversed a direct ``_init_rtc`` caller would install a ceiling
+        that clamps nothing.
+        """
+        source = textwrap.dedent(inspect.getsource(LerobotLocalPolicy.__init__))
+        guard = source.index("positive_finite_number_error(")
+        store = source.index("self._rtc_max_guidance_weight = rtc_max_guidance_weight")
+        assert guard < store, "the domain must be consulted before the value is stored"
+
+
+class TestWhatIsUnchanged:
+    """The over-reach controls: what the fix must not disturb."""
+
+    def test_none_still_adopts_the_checkpoint_ceiling(self) -> None:
+        """``None`` is the documented "use the model's value" request."""
+        pol = _policy(rtc_enabled=True, rtc_max_guidance_weight=None)
+        cfg = _enable_rtc(pol, _StubRtcConfig(ceiling=8.0))
+
+        assert pol._rtc_max_guidance_weight == 8.0
+        assert cfg.max_guidance_weight == 8.0, "defaulting must not rewrite the config it read from"
+
+    def test_the_default_construction_supplies_no_ceiling(self) -> None:
+        """Omitting the parameter is the same request as passing ``None``."""
+        assert _policy(rtc_enabled=True)._rtc_max_guidance_weight is None
+
+    def test_a_config_without_the_field_still_falls_back_to_ten(self) -> None:
+        pol = _policy(rtc_enabled=True)
+        loaded = MagicMock()
+        loaded.predict_action_chunk = MagicMock()
+        loaded.config.rtc_config = MagicMock(spec=["enabled"])
+        loaded.config.rtc_config.enabled = True
+        pol._policy = loaded
+        pol._loaded = True
+        pol._init_rtc()
+
+        assert pol._rtc_max_guidance_weight == 10.0
+
+    def test_the_horizon_twin_is_untouched(self) -> None:
+        """``execution_horizon`` is a kwarg, so it needs no write onto the config.
+
+        Recorded as a control because it is the shape a reader would reach for to
+        argue the ceiling needed forwarding rather than assigning, and it is not:
+        the horizon reaches the model through ``rtc_kwargs``, the ceiling cannot.
+        """
+        pol = _policy(rtc_enabled=True, rtc_execution_horizon=20)
+        cfg = _enable_rtc(pol, _StubRtcConfig(horizon=15))
+
+        assert pol._rtc_execution_horizon == 20
+        assert pol.execution_horizon == 20
+        assert cfg.execution_horizon == 15, "the horizon is forwarded per call, not written onto the config"
+
+    def test_a_usable_ceiling_leaves_the_rest_of_the_config_alone(self) -> None:
+        pol = _policy(rtc_enabled=True, rtc_max_guidance_weight=2.0)
+        cfg = _enable_rtc(pol, _StubRtcConfig(enabled=True, horizon=15))
+
+        assert cfg.enabled is True
+        assert cfg.execution_horizon == 15
+
+    def test_rtc_stays_off_when_the_checkpoint_carries_no_rtc_config(self) -> None:
+        """A supplied ceiling must not enable RTC on a policy that cannot run it."""
+        pol = _policy(rtc_enabled=True, rtc_max_guidance_weight=2.0)
+        loaded = MagicMock()
+        loaded.predict_action_chunk = MagicMock()
+        loaded.config = MagicMock(spec=[])
+        pol._policy = loaded
+        pol._loaded = True
+        pol._init_rtc()
+
+        assert pol._rtc_enabled is False
+
+
+class TestThePremisesThisRestsOn:
+    """The lerobot-side facts the fix is built on, asserted against lerobot."""
+
+    def test_the_rtc_kwarg_contract_does_not_carry_the_ceiling(self) -> None:
+        """If it ever becomes a kwarg, forwarding beats assigning - fail here.
+
+        The ceiling is written onto the config precisely *because* it is absent
+        from this contract. Were it added upstream, this cell fires and the
+        author reconsiders the write.
+        """
+        smolvla = pytest.importorskip("lerobot.policies.smolvla.modeling_smolvla")
+        keys = set(smolvla.ActionSelectKwargs.__annotations__)
+
+        assert "execution_horizon" in keys, "premise: the horizon IS a kwarg"
+        assert "max_guidance_weight" not in keys, (
+            "lerobot now accepts the ceiling as an RTC kwarg; forward it in "
+            "_predict_with_rtc instead of writing it onto rtc_config"
+        )
+
+    def test_lerobot_reads_the_ceiling_off_its_config(self) -> None:
+        """The field written to is the field the denoiser reads."""
+        rtc = pytest.importorskip("lerobot.policies.rtc.modeling_rtc")
+        source = inspect.getsource(rtc)
+
+        assert "self.rtc_config.max_guidance_weight" in source
+
+    def test_lerobot_refuses_the_ceilings_this_domain_refuses(self) -> None:
+        """The two agree on ``<= 0``, which is why the domain is not stricter."""
+        config = pytest.importorskip("lerobot.policies.rtc.configuration_rtc")
+
+        for weight in (0, -3.5):
+            with pytest.raises(ValueError, match="max_guidance_weight must be positive"):
+                config.RTCConfig(enabled=True, max_guidance_weight=weight)
+
+
+class TestTheProbeSetIsHonest:
+    """Non-vacuity: the swept values are what the cells claim they are."""
+
+    def test_no_probe_value_collides_with_the_model_ceiling(self) -> None:
+        """Otherwise "the override landed" and "the default survived" coincide."""
+        assert MODEL_CEILING not in USABLE
+
+    def test_the_unusable_set_covers_both_failure_kinds(self) -> None:
+        """A domain that only refused non-numbers would miss the ``0`` case."""
+        numeric = [v for v in UNUSABLE if isinstance(v, (int, float)) and not isinstance(v, bool)]
+        assert numeric, "premise: some refused values are numbers"
+        assert [v for v in UNUSABLE if not isinstance(v, (int, float))], "and some are not"


### PR DESCRIPTION
## The defect

`LerobotLocalPolicy` takes two RTC overrides side by side. One of them could not work.

`rtc_execution_horizon` is a keyword argument of lerobot's `predict_action_chunk`, and `_predict_with_rtc` forwards it per call. `rtc_max_guidance_weight` is not a keyword argument at all: lerobot's denoiser reads that ceiling off `self.rtc_config.max_guidance_weight`, and the RTC keyword contract carries three keys and not this one.

```python
# lerobot/policies/smolvla/modeling_smolvla.py
class ActionSelectKwargs(TypedDict, total=False):
    inference_delay: int | None
    prev_chunk_left_over: Tensor | None
    execution_horizon: int | None      # <- forwarded; the ceiling is absent

# lerobot/policies/rtc/modeling_rtc.py
max_guidance_weight = torch.as_tensor(self.rtc_config.max_guidance_weight)
guidance_weight = torch.minimum(guidance_weight, max_guidance_weight)
```

`_init_rtc` read the checkpoint's value as a *default* into `self._rtc_max_guidance_weight` and never wrote a caller's override back, so the override's only remaining reader was one `logger.info(... max_guidance_weight=%.1f)` line.

Measured against lerobot's genuine `RTCConfig`:

| asked for | policy attribute | `rtc_config.max_guidance_weight` | in force |
|---|---|---|---|
| `2.0` | `2.0` | **`10.0`** | the model's own |
| `0.5` | `0.5` | **`10.0`** | the model's own |
| `rtc_execution_horizon=20` (control) | `20` | n/a - a kwarg | `20` |

A checkpoint tuned for a tight ceiling ran the model's own, and the INFO line reported the number that was not in force.

## The domain half

The value had no domain, while `actions_per_step`, `tokenizer_max_length` and `rtc_execution_horizon` in the same constructor all have one. Every spelling was accepted:

| value | before | after | note |
|---|---|---|---|
| `0`, `0.0`, `-3.5` | accepted | refused | lerobot's own `RTCConfig.__post_init__` refuses these outright |
| `nan` | accepted | refused | every clamped weight becomes `nan` |
| `inf` | accepted | refused | `torch.minimum(x, inf)` clamps nothing |
| `True`, `False` | accepted | refused | a flag is not a ceiling |
| `"2.0"`, `[2.0]`, `{...}` | accepted | refused | not a number |
| `2.0`, `0.5`, `1`, `25.0` | accepted | accepted | unchanged |
| `None` | accepted | accepted | the documented "adopt the model's value" request |

Writing the override onto an already-built config is exactly why the domain is needed here: `RTCConfig.__post_init__` runs at construction and cannot see a later assignment, so `positive_finite_number_error` is asked at the two seams a caller names - the constructor, and `preflight` beside the four sibling knobs it already checks, so a rollout gets a structured error *before* the weight download rather than a raise after it.

## Why nothing caught it

`test_rtc_user_overrides_config_values` is named for both knobs overriding the config and asserts only that `policy._rtc_max_guidance_weight` keeps the value it was given - an attribute round-trip, which held either way. `TestRTCConfigSchemaContract` pins that lerobot still *exposes* the field, i.e. it grades the read and never the application. One test name covering two knobs, true for only one of them.

## Verification

Pre-fix split, all three halves reverted: **30 failed / 11 passed**, with `TestWhatIsUnchanged` **6/6 passing** (controls clean) and the two premise cells that grade lerobot's own contract also passing.

Mutation table - `collected` stable at 41 on every row, source restored md5-identical:

| # | mutation | mine | sib |
|---|---|---|---|
| b0 | control | 0 | 0 |
| b1 | write-onto-config removed | 7 | 0 |
| b2 | constructor guard removed | 13 | 0 |
| b3 | preflight guard removed | 11 | 0 |
| b4 | both guards removed | 23 | 0 |
| b5 | write + both guards removed (= pre-fix) | 30 | 0 |
| b6 | kept on the policy, not written | 7 | 0 |
| b7 | written *before* the `None` default resolves | 2 | **4** |
| b8 | domain weakened to a bare `> 0` | 7 | 0 |
| b9 | constructor guard moved after the store | 1 | 0 |

Set arithmetic: `b2 | b3 == b4` exactly, sharing one cell (the structural "both seams consult the shared domain" assertion, which fires when either guard is missing). `b1 | b4 == b5` exactly with **`b1 & b4` empty** - the write half and the domain half are independently pinned. b6 is the same defect spelled differently and fires the identical set as b1, which is the honest reading rather than an extra row. b8 fires exactly the spellings a bare comparison cannot refuse (`inf`, `True`, the string, the list, the dict) and *not* `nan`, because `not nan > 0` is already `True`.

b7 is the over-reach boundary: writing the override before the `None` default resolves trips **four pre-existing** RTC cells, because a policy that asked for the model's value would then clobber it.

Gate, byte-identical: an identical 641-path selection (all of `tests/policies/` plus every suite walking the tree, parsing source, or reading docstrings / `Args:` / `Raises:` / `__all__` / `changelog.d`), with the new file withheld from **both** sides, gives `20 failed, 26043 passed, 80 skipped` on each, 20 == 20 failing ids and **both `comm` directions empty**. All 20 are environmental and reproduce on the base alone: 17 need `awsiot`/`awscrt` (both `find_spec` absent locally, declared in the `mesh-iot` extra, and `hatch`'s default features is `['all']` so CI installs them), 3 are the lerobot-from-source `encode() takes 1 positional argument` drift.

`ruff check` and `ruff format --check` clean over 1690 files. `mypy strands_robots tests tests_integ` = 24 errors in 9 files, the standing baseline, with **0 attributable** to either changed file. `tests/policies/lerobot_local/ tests/policies/test_chunk_count_domain.py` = 1130 passed, and with the two microduck suites `main` added during this work, 1282 passed.

## Scope

Three sites for one knob and one contract: the domain at the two entry points a caller names, and the application at the one place lerobot reads it. A new cell asserts the ceiling is **absent** from `ActionSelectKwargs`, so if lerobot ever accepts it as a keyword argument that cell fires and the author forwards it in `_predict_with_rtc` instead of writing the config.

No visual artifact: this is a value-domain and parameter-plumbing change, not policy, simulation, rendering, recording or asset behaviour.
