### PR TITLE
fix(policies/microduck): refuse a floating-base block the observation builder cannot read

### DIFF
--- a/changelog.d/2887-microduck-base-block-widths.md
+++ b/changelog.d/2887-microduck-base-block-widths.md
@@ -1,0 +1,30 @@
+### Fixed: `build_observation` refuses a floating-base block it cannot read
+
+`MicroduckPolicy`'s observation vector is assembled from four inputs. Three of them are the policy's own
+state and are held to a width at the policy seam: `default_pose` against `len(joint_names)` in
+`_ensure_config`, a `command` override against the width `command_names` declares in
+`_apply_command_kwargs`, and the graph's returned action - which becomes the next tick's `last_action` -
+in `get_actions`. The fourth arrives from the caller's observation dict: the two floating-base blocks
+`base_ang_vel` (3) and `base_quat` (4, wxyz). Those are read only inside the builder, so no seam ever
+sees them, and a truncating `[:3]` / `[:4]` slice took whatever width arrived.
+
+That is silent in both directions. One component short, `q[1:4]` is a 2-vector `np.cross` reads as
+planar, so the quaternion silently loses its `z`: the gravity block keeps the documented width and stays
+finite while the direction the robot is told is "down" moves 7.5 degrees for a small-yaw pose and 20.7
+for a roll-then-yaw one. Its norm drifts with it (0.991 and 0.935), but this module normalises nothing
+and reads no norm, so at a percent off unity that is not a signal anything acts on. Over-long, a
+7-element `[base_pos, base_quat]` slice - a caller handing over a floating-base `qpos` slice - is read as
+a quaternion made of positions, 70.9 degrees off. A short `base_ang_vel` instead falsified the builder's
+own documented `48 + len(command)` return width, handing the graph fewer values than its
+`observation_names` metadata declares.
+
+Both blocks now route through one reader that refuses any width other than the one the layout defines,
+naming the block, both widths and the contract it protects. The sibling locomotion observation builders
+in this package already hold every sub-vector this way via `wbc.observation._require_len`; this builder
+was the one that did not. NumPy 2.0 deprecated the 2-vector cross the short read relied on, so that path
+was already heading for a raise from inside numpy naming neither block.
+
+The shipped simulation backends slice these blocks at fixed widths, so the policy path is exactly right
+today and this is latent there. `build_observation` is a public export, and a caller assembling the dict
+from an IMU or teleop bridge has no seam at all. Finiteness of the base blocks is a separate axis and is
+pinned as deliberately unchanged.

--- a/strands_robots/policies/microduck/observation.py
+++ b/strands_robots/policies/microduck/observation.py
@@ -36,6 +36,12 @@ from numpy.typing import NDArray
 #: ``projected_gravity`` observation block.
 _WORLD_GRAVITY = np.array([0.0, 0.0, -1.0], dtype=np.float32)
 
+#: Component count of the ``base_ang_vel`` observation block (x, y, z).
+_BASE_ANG_VEL_LEN = 3
+
+#: Component count of the ``base_quat`` observation block (w, x, y, z).
+_BASE_QUAT_LEN = 4
+
 
 def quat_rotate_inverse(quat: NDArray[np.float32], vec: NDArray[np.float32]) -> NDArray[np.float32]:
     """Rotate ``vec`` by the inverse of quaternion ``quat`` (``[w, x, y, z]``).
@@ -55,6 +61,49 @@ def quat_rotate_inverse(quat: NDArray[np.float32], vec: NDArray[np.float32]) -> 
 def projected_gravity(base_quat: NDArray[np.float32]) -> NDArray[np.float32]:
     """World ``-Z`` expressed in the base frame, from the base quaternion (wxyz)."""
     return quat_rotate_inverse(base_quat, _WORLD_GRAVITY)
+
+
+def _require_base_block(observation_dict: dict[str, Any], key: str, expected_len: int) -> NDArray[np.float32]:
+    """Read a fixed-width floating-base block out of the observation dict.
+
+    The two base blocks are the only :func:`build_observation` inputs that arrive
+    from the caller's observation dict rather than from the policy's own state, so
+    this is the only place that holds them to a width. ``last_action`` and
+    ``command`` are checked at the policy seam instead - the graph's output width
+    in :meth:`MicroduckPolicy.get_actions` and a ``command`` override in
+    ``_apply_command_kwargs`` - and neither seam ever sees these two.
+
+    A wrong width used to be taken by a truncating slice, which is silent in both
+    directions. One component short, ``q[1:4]`` is a 2-vector that ``np.cross``
+    reads as planar, so ``base_quat`` silently loses its ``z``: the gravity block
+    is still three finite components at the documented width, 7.5 degrees from the
+    truth for a small-yaw pose at a norm of 0.991 - inside a percent of unity, and
+    this module normalises nothing - rising to 20.7 degrees at 0.935. Over-long, a
+    7-element ``[base_pos, base_quat]`` slice is read as a quaternion made of
+    positions, 70.9 degrees off. A short ``base_ang_vel`` instead narrowed the
+    returned vector below the documented ``48 + len(command)``, handing the graph
+    fewer values than its own ``observation_names`` metadata declares. NumPy 2.0
+    deprecated the 2-vector cross the short read relies on, so that path is on its
+    way to raising from inside numpy rather than answering.
+
+    The sibling locomotion observation builders hold their own sub-vectors the
+    same way (``strands_robots.policies.wbc.observation._require_len``).
+
+    Raises:
+        KeyError: If ``key`` is absent from the observation dict.
+        ValueError: If the block is not ``expected_len`` components wide.
+    """
+    block = np.asarray(observation_dict[key], dtype=np.float32).reshape(-1)
+    if block.shape[0] != expected_len:
+        raise ValueError(
+            f"build_observation: observation_dict[{key!r}] has {block.shape[0]} "
+            f"component(s) but the {key} observation block is {expected_len} wide. "
+            f"A different width cannot be used: the block is read into a fixed slot "
+            f"of the vector the ONNX graph consumes, so it either changes the "
+            f"returned width away from the documented 48 + len(command) or re-reads "
+            f"the block's own components from the wrong positions."
+        )
+    return block
 
 
 def build_observation(
@@ -83,9 +132,14 @@ def build_observation(
 
     Raises:
         KeyError: If a required joint / base key is absent from the obs dict.
+        ValueError: If ``base_ang_vel`` or ``base_quat`` is not the width its
+            observation block defines (3 and 4). Both are read into fixed slots
+            of the returned vector, so another width either changes the returned
+            width away from ``48 + len(command)`` or re-reads the block's own
+            components from the wrong positions.
     """
-    base_ang_vel = np.asarray(observation_dict["base_ang_vel"], dtype=np.float32).reshape(-1)[:3]
-    grav = projected_gravity(np.asarray(observation_dict["base_quat"], dtype=np.float32).reshape(-1)[:4])
+    base_ang_vel = _require_base_block(observation_dict, "base_ang_vel", _BASE_ANG_VEL_LEN)
+    grav = projected_gravity(_require_base_block(observation_dict, "base_quat", _BASE_QUAT_LEN))
 
     joint_pos = np.array([float(observation_dict[name]) for name in joint_names], dtype=np.float32)
     joint_pos_rel = joint_pos - np.asarray(default_pose, dtype=np.float32)

--- a/tests/policies/microduck/test_microduck_observation_refuses_a_wrong_width_base_block.py
+++ b/tests/policies/microduck/test_microduck_observation_refuses_a_wrong_width_base_block.py
@@ -1,0 +1,386 @@
+"""``build_observation`` refuses a floating-base block it cannot read.
+
+``MicroduckPolicy``'s observation vector is assembled from four inputs. Three of
+them are the policy's own state and are held to a width at the policy seam:
+``default_pose`` against ``len(joint_names)`` in ``_ensure_config``, a ``command``
+override against the width ``command_names`` declares in ``_apply_command_kwargs``,
+and the graph's returned action - which becomes the next tick's ``last_action`` -
+in ``get_actions`` (#2882). The fourth arrives from the CALLER's observation dict:
+the two floating-base blocks ``base_ang_vel`` (3) and ``base_quat`` (4, wxyz).
+Those are read only inside the builder, so no seam ever sees them, and they were
+taken by a truncating ``[:3]`` / ``[:4]`` slice rather than checked.
+
+Measured on the pre-fix tree with the shipped alpha command width (C=13, so the
+documented return width is ``48 + 13 == 61``):
+
+=======================  ==========  =======  ==================================
+input                    outcome     width    what the vector then carried
+=======================  ==========  =======  ==================================
+ang=3 quat=4 (contract)  success     61       correct
+``base_ang_vel`` 2       success     60       one value short of the documented
+``base_ang_vel`` 1       success     59       two values short
+``base_quat`` 3          success     61       gravity 7.5-20.7 deg off
+``base_quat`` 7          success     61       gravity 70.9 deg off
+``base_quat`` 2          ValueError  -        raised from inside ``np.cross``
+=======================  ==========  =======  ==================================
+
+The ``base_quat`` rows are the ones nothing downstream can screen. One component
+short, ``np.cross`` reads the 2-element ``q[1:4]`` as a planar vector, which is
+exactly the quaternion with its ``z`` dropped: the gravity block keeps the
+documented width and stays finite while the direction the biped is told is "down"
+moves 7.5 degrees for a small-yaw pose and 20.7 for a roll-then-yaw one. Its norm
+drifts with it (0.991 and 0.935), but nothing here reads a norm - the module
+docstring says it normalises nothing - so at a percent off unity that is not a
+signal anything acts on either. Over-long, a
+7-element ``[base_pos, base_quat]`` slice - a caller handing over a floating-base
+``qpos`` slice - is read as a quaternion made of positions. A short
+``base_ang_vel`` instead falsifies the builder's own documented ``48 +
+len(command)`` return width, handing the graph fewer values than its
+``observation_names`` metadata declares - the same harm #2882 measured for the
+fed-back action, reached through the other input.
+
+Why nothing caught it: the shipped simulation backends produce these blocks from
+fixed-width slices (measured below), so the policy path is exactly right today and
+this is latent there. ``build_observation`` is a public export of
+``strands_robots.policies.microduck`` though, and a caller assembling the dict from
+a real IMU/teleop bridge - the consumer ``wbc.policy._extract_state`` documents -
+has no seam at all. The sibling locomotion observation builders in this same
+package already hold every sub-vector to a width via
+``wbc.observation._require_len``, including ``base_ang_vel``; this builder was the
+one that did not.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import build_observation, decode_action, projected_gravity
+from strands_robots.policies.microduck import observation as obs_mod
+
+#: The command width the shipped alpha policies declare (twist 3 + head 4 + body 6).
+_ALPHA_COMMAND_WIDTH = 13
+
+#: The fixed part of the layout: ang_vel 3 + gravity 3 + pos 14 + vel 14 + action 14.
+_FIXED_OBS_WIDTH = 48
+
+#: The contract joint count.
+_N_JOINTS = 14
+
+
+def _joints() -> list[str]:
+    return [f"j{i}" for i in range(_N_JOINTS)]
+
+
+def _obs_dict(
+    names: list[str],
+    *,
+    base_ang_vel: Any = (0.1, 0.2, 0.3),
+    base_quat: Any = (1.0, 0.0, 0.0, 0.0),
+) -> dict[str, Any]:
+    """A runtime observation dict with both base blocks at a chosen width."""
+    d: dict[str, Any] = {"base_ang_vel": base_ang_vel, "base_quat": base_quat}
+    for n in names:
+        d[n] = 0.0
+        d[f"{n}.vel"] = 0.0
+    return d
+
+
+def _build(**over: Any) -> np.ndarray:
+    names = _joints()
+    return build_observation(
+        _obs_dict(names, **over),
+        joint_names=names,
+        default_pose=np.zeros(_N_JOINTS, dtype=np.float32),
+        last_action=np.zeros(_N_JOINTS, dtype=np.float32),
+        command=np.zeros(_ALPHA_COMMAND_WIDTH, dtype=np.float32),
+    )
+
+
+#: Widths ``base_ang_vel`` must not be accepted at. 2 and 1 narrowed the returned
+#: vector; 5 was silently truncated.
+_WRONG_ANG_VEL_WIDTHS = (1, 2, 4, 5, 6)
+
+#: Widths ``base_quat`` must not be accepted at. 3 and 7 kept the documented width
+#: and changed the gravity block; 2 raised from inside numpy naming nothing.
+_WRONG_QUAT_WIDTHS = (1, 2, 3, 5, 6, 7)
+
+
+class TestAWrongWidthBaseBlockIsRefused:
+    """The regression: each block is held to the width its layout defines."""
+
+    @pytest.mark.parametrize("width", _WRONG_ANG_VEL_WIDTHS)
+    def test_a_wrong_width_angular_velocity_is_refused(self, width: int) -> None:
+        with pytest.raises(ValueError, match=re.escape("observation_dict['base_ang_vel']")):
+            _build(base_ang_vel=np.zeros(width, dtype=np.float32))
+
+    @pytest.mark.parametrize("width", _WRONG_QUAT_WIDTHS)
+    def test_a_wrong_width_quaternion_is_refused(self, width: int) -> None:
+        with pytest.raises(ValueError, match=re.escape("observation_dict['base_quat']")):
+            _build(base_quat=np.zeros(width, dtype=np.float32))
+
+    def test_a_scalar_block_is_refused(self) -> None:
+        """A bare float ravels to one component rather than to the block width."""
+        with pytest.raises(ValueError, match=re.escape("observation_dict['base_ang_vel']")):
+            _build(base_ang_vel=0.1)
+
+    def test_the_one_short_quaternion_that_kept_the_documented_width_is_refused(self) -> None:
+        """The unscreenable case: right width, unit norm, every component finite."""
+        with pytest.raises(ValueError, match="base_quat"):
+            _build(base_quat=(0.683, 0.183, 0.183))
+
+    def test_the_qpos_slice_a_caller_would_reach_for_is_refused(self) -> None:
+        """A 7-element ``[base_pos, base_quat]`` is not a quaternion."""
+        with pytest.raises(ValueError, match="base_quat"):
+            _build(base_quat=(1.5, -0.25, 0.31, 0.9659, 0.2588, 0.0, 0.0))
+
+    def test_the_first_wrong_block_is_the_one_named(self) -> None:
+        """Both wrong: the angular velocity is read first, so it is reported."""
+        with pytest.raises(ValueError, match="base_ang_vel"):
+            _build(base_ang_vel=(0.1, 0.2), base_quat=(1.0, 0.0, 0.0))
+
+
+class TestTheRefusalNamesWhatAReaderNeeds:
+    """A width refusal has to say which block, how wide, and why it matters."""
+
+    def test_the_refusal_names_the_builder(self) -> None:
+        with pytest.raises(ValueError, match="build_observation"):
+            _build(base_ang_vel=(0.1, 0.2))
+
+    def test_the_refusal_names_both_widths(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            _build(base_quat=(1.0, 0.0, 0.0))
+        text = str(exc.value)
+        assert "3 component(s)" in text, text
+        assert "4 wide" in text, text
+
+    def test_the_refusal_names_the_contract_it_protects(self) -> None:
+        """The documented return width is what a narrow block falsifies."""
+        with pytest.raises(ValueError, match=re.escape("48 + len(command)")):
+            _build(base_ang_vel=(0.1, 0.2))
+
+
+class TestTheAcceptedContractIsUnchanged:
+    """Cells that hold on both trees: nothing legitimate was refused."""
+
+    def test_the_exact_widths_still_build_the_documented_vector(self) -> None:
+        vector = _build()
+        assert vector.shape == (_FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH,)
+        assert vector.dtype == np.float32
+        assert bool(np.all(np.isfinite(vector)))
+
+    def test_the_legacy_twist_only_command_width_still_works(self) -> None:
+        names = _joints()
+        vector = build_observation(
+            _obs_dict(names),
+            joint_names=names,
+            default_pose=np.zeros(_N_JOINTS, dtype=np.float32),
+            last_action=np.zeros(_N_JOINTS, dtype=np.float32),
+            command=np.zeros(3, dtype=np.float32),
+        )
+        assert vector.shape[0] == _FIXED_OBS_WIDTH + 3 == 51
+
+    def test_a_row_shaped_block_is_still_accepted(self) -> None:
+        """``reshape(-1)`` is kept: a (1, 3) row is three components."""
+        vector = _build(base_ang_vel=np.zeros((1, 3), dtype=np.float32))
+        assert vector.shape[0] == _FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH
+
+    def test_a_python_list_block_is_still_accepted(self) -> None:
+        """The shipped backends hand over plain lists of floats."""
+        vector = _build(base_ang_vel=[0.1, 0.2, 0.3], base_quat=[1.0, 0.0, 0.0, 0.0])
+        assert vector.shape[0] == _FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH
+
+    def test_the_gravity_block_is_byte_identical_for_an_accepted_quaternion(self) -> None:
+        """The accepted path's arithmetic did not move."""
+        quat = np.array([0.683, 0.183, 0.183, 0.683], dtype=np.float32)
+        assert np.array_equal(_build(base_quat=quat)[3:6], projected_gravity(quat))
+
+    def test_a_missing_block_is_still_a_key_error(self) -> None:
+        """The documented ``KeyError`` contract is not replaced by the width one."""
+        names = _joints()
+        d = _obs_dict(names)
+        del d["base_quat"]
+        with pytest.raises(KeyError):
+            build_observation(
+                d,
+                joint_names=names,
+                default_pose=np.zeros(_N_JOINTS, dtype=np.float32),
+                last_action=np.zeros(_N_JOINTS, dtype=np.float32),
+                command=np.zeros(_ALPHA_COMMAND_WIDTH, dtype=np.float32),
+            )
+
+    def test_decode_action_is_untouched(self) -> None:
+        pose = np.array([0.1] * _N_JOINTS, dtype=np.float32)
+        raw = np.array([1.0] * _N_JOINTS, dtype=np.float32)
+        assert np.allclose(decode_action(raw, default_pose=pose, action_scale=0.25), 0.35)
+
+
+class TestWhatIsDeliberatelyLeftAlone:
+    """The boundary, pinned so a later widening is a deliberate edit."""
+
+    def test_the_last_action_width_is_still_taken_on_trust_here(self) -> None:
+        """It is checked at the policy seam instead - #2882's stated design.
+
+        The base blocks differ precisely in having no seam: they arrive from the
+        caller's dict and are read only here.
+        """
+        names = _joints()
+        vector = build_observation(
+            _obs_dict(names),
+            joint_names=names,
+            default_pose=np.zeros(_N_JOINTS, dtype=np.float32),
+            last_action=np.zeros(1, dtype=np.float32),
+            command=np.zeros(_ALPHA_COMMAND_WIDTH, dtype=np.float32),
+        )
+        assert vector.shape[0] == _FIXED_OBS_WIDTH - _N_JOINTS + 1 + _ALPHA_COMMAND_WIDTH
+
+    def test_a_non_finite_block_is_not_refused_here(self) -> None:
+        """Finiteness is a separate axis, refused at the action seam (#2882).
+
+        Recorded rather than fixed: this change is about the width contract the
+        builder's own docstring states.
+        """
+        vector = _build(base_quat=(float("nan"), 0.0, 0.0, 0.0))
+        assert vector.shape[0] == _FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH
+        assert not bool(np.all(np.isfinite(vector)))
+
+
+class TestBothBlocksRouteThroughTheOneReader:
+    """Derived: a base block added later cannot re-introduce a bare slice."""
+
+    @staticmethod
+    def _builder_tree() -> ast.FunctionDef:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(build_observation)))
+        fn = tree.body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        return fn
+
+    def test_no_base_key_is_read_by_a_bare_subscript(self) -> None:
+        fn = self._builder_tree()
+        literal_reads = [
+            node.slice.value
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "observation_dict"
+            and isinstance(node.slice, ast.Constant)
+            and isinstance(node.slice.value, str)
+        ]
+        assert [k for k in literal_reads if k.startswith("base_")] == [], (
+            "a floating-base block is read straight out of the dict again; route it "
+            "through _require_base_block so its width is held"
+        )
+
+    def test_every_base_block_is_read_through_the_reader(self) -> None:
+        fn = self._builder_tree()
+        keys: list[str] = []
+        for call in ast.walk(fn):
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "_require_base_block"
+                and len(call.args) >= 2
+                and isinstance(call.args[1], ast.Constant)
+                and isinstance(call.args[1].value, str)
+            ):
+                keys.append(call.args[1].value)
+        assert sorted(keys) == ["base_ang_vel", "base_quat"], keys
+
+    def test_the_widths_come_from_the_named_constants(self) -> None:
+        """Not restated at the call site, so the layout has one account."""
+        fn = self._builder_tree()
+        widths = [
+            ast.unparse(call.args[2])
+            for call in ast.walk(fn)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "_require_base_block"
+            and len(call.args) >= 3
+        ]
+        assert sorted(widths) == ["_BASE_ANG_VEL_LEN", "_BASE_QUAT_LEN"], widths
+        assert obs_mod._BASE_ANG_VEL_LEN == 3
+        assert obs_mod._BASE_QUAT_LEN == 4
+
+
+class TestThePremisesTheDefectRestedOn:
+    """Facts that hold on both trees and make the measurement above legible."""
+
+    def test_numpy_cross_accepts_a_two_element_vector_but_deprecates_it(self) -> None:
+        """Why a 3-element quaternion was silent - and why it will stop being.
+
+        NumPy 2.0 deprecated the planar form, so the truncating read was already
+        heading for a raise from inside numpy naming neither block.
+        """
+        with pytest.warns(DeprecationWarning, match="2-dimensional vectors are deprecated"):
+            planar = np.cross(np.array([0.2, 0.3]), np.array([0.0, 0.0, -1.0]))
+        assert planar.shape == (3,)
+        with pytest.raises(ValueError, match="dimension"):
+            _ = np.cross(np.array([0.2, 0.3, 0.4, 0.5]), np.array([0.0, 0.0, -1.0]))
+
+    @pytest.mark.filterwarnings("ignore:Arrays of 2-dimensional vectors:DeprecationWarning")
+    def test_a_three_element_quaternion_reads_as_the_quaternion_with_z_dropped(self) -> None:
+        short = np.array([0.683, 0.183, 0.183], dtype=np.float32)
+        with_zero_z = np.array([0.683, 0.183, 0.183, 0.0], dtype=np.float32)
+        assert np.array_equal(projected_gravity(short), projected_gravity(with_zero_z))
+
+    @pytest.mark.filterwarnings("ignore:Arrays of 2-dimensional vectors:DeprecationWarning")
+    @pytest.mark.parametrize(
+        ("quat", "min_tilt_deg", "norm_tolerance"),
+        [
+            # A small-yaw pose: the norm stays inside a percent of unity, so even a
+            # norm check with a sane tolerance would pass it.
+            ((0.9098, -0.0665, 0.1604, 0.3769), 5.0, 0.01),
+            # A roll-then-yaw pose: the worst tilt measured, still finite.
+            ((0.683, 0.183, 0.183, 0.683), 15.0, 0.07),
+        ],
+    )
+    def test_the_wrong_reading_stays_finite_and_near_unit_norm(
+        self, quat: tuple[float, ...], min_tilt_deg: float, norm_tolerance: float
+    ) -> None:
+        """Width and finiteness are intact and the norm barely moves."""
+        full = np.asarray(quat, dtype=np.float32)
+        full = full / np.linalg.norm(full)
+        wrong = projected_gravity(full[:3])
+        right = projected_gravity(full)
+        assert bool(np.all(np.isfinite(wrong)))
+        assert float(np.linalg.norm(right)) == pytest.approx(1.0, abs=1e-3)
+        assert float(np.linalg.norm(wrong)) == pytest.approx(1.0, abs=norm_tolerance)
+        cos = float(np.clip(np.dot(right, wrong) / (np.linalg.norm(right) * np.linalg.norm(wrong)), -1.0, 1.0))
+        assert np.degrees(np.arccos(cos)) > min_tilt_deg
+
+    def test_nothing_in_this_module_reads_a_norm(self) -> None:
+        """So the norm drift is not a signal anything acts on."""
+        source = inspect.getsource(obs_mod)
+        assert "linalg.norm" not in source
+        assert "This module never normalises." in source
+
+    def test_the_sibling_locomotion_builder_holds_the_same_block_to_a_width(self) -> None:
+        """The in-package convention this builder was the exception to."""
+        from strands_robots.policies.wbc import observation as wbc_obs
+
+        with pytest.raises(ValueError, match="base_ang_vel must have length 3"):
+            wbc_obs._require_len(np.zeros(2), 3, "base_ang_vel")
+
+    def test_the_mujoco_backend_produces_fixed_width_base_blocks(self) -> None:
+        """Why the policy path is right today, i.e. why this is latent there."""
+        from strands_robots.simulation.mujoco import rendering
+
+        source = inspect.getsource(rendering)
+        assert re.search(r'obs\["base_quat"\]\s*=\s*\[[^\]]*qpos\[qadr \+ 3 : qadr \+ 7\]', source), (
+            "the backend no longer slices a fixed 4 for base_quat"
+        )
+        assert re.search(r'obs\["base_ang_vel"\]\s*=\s*\[[^\]]*qvel\[vadr \+ 3 : vadr \+ 6\]', source), (
+            "the backend no longer slices a fixed 3 for base_ang_vel"
+        )
+
+    def test_the_builder_is_a_public_export(self) -> None:
+        """Why a caller with no policy seam is a first-class consumer."""
+        import strands_robots.policies.microduck as pkg
+
+        assert "build_observation" in pkg.__all__


### PR DESCRIPTION
## What is wrong

`MicroduckPolicy`'s observation vector is assembled from four inputs. Three of them are the policy's own
state, and each is held to a width **at the policy seam**:

| input | width contract | where it is checked |
| --- | --- | --- |
| `default_pose` | `len(joint_names)` | `_ensure_config` |
| `command` override | the width `command_names` declares | `_apply_command_kwargs` |
| the graph's action (becomes `last_action`) | `len(joint_names)` | `get_actions` |
| **`base_ang_vel` (3), `base_quat` (4, wxyz)** | **the layout** | **nowhere** |

The fourth arrives from the **caller's observation dict**. Those two blocks are read only inside
`build_observation`, so no seam ever sees them, and a truncating `[:3]` / `[:4]` slice took whatever
width arrived.

## Measured, pre-fix

With the shipped alpha command width (C=13, so the builder's own documented return width is
`48 + 13 == 61`):

| input | outcome | returned width | what the vector then carried |
| --- | --- | --- | --- |
| `ang=3 quat=4` (contract) | success | 61 | correct |
| `base_ang_vel` 2 | success | **60** | one value short of the documented width |
| `base_ang_vel` 1 | success | **59** | two values short |
| `base_quat` 3 | success | 61 | gravity **7.5 - 20.7 deg** off |
| `base_quat` 7 | success | 61 | gravity **70.9 deg** off |
| `base_quat` 2 | `ValueError` | - | raised from inside `np.cross`, naming nothing |

The `base_quat` rows are the ones nothing downstream can screen. One component short, `q[1:4]` is a
2-vector that `np.cross` reads as planar, which is exactly the quaternion with its `z` dropped: the
gravity block keeps the documented width and stays finite while the direction the robot is told is
"down" moves 7.5 degrees for a small-yaw pose and 20.7 for a roll-then-yaw one. Its norm drifts with it
(0.991 and 0.935) - but this module reads no norm and its own docstring says it "never normalises", so at
a percent off unity that is not a signal anything acts on either. Over-long, a 7-element
`[base_pos, base_quat]` slice - a caller handing over a floating-base `qpos` slice - is read as a
quaternion made of positions.

A short `base_ang_vel` is the other face: it falsifies the builder's own documented `48 + len(command)`
return width, handing the graph fewer values than its `observation_names` metadata declares.

NumPy 2.0 deprecated the 2-vector cross the short read relies on, so that path was already heading for a
raise from inside numpy naming neither block.

## Why nothing caught it

The shipped simulation backends produce these blocks from fixed-width slices
(`qpos[qadr + 3 : qadr + 7]`, `qvel[vadr + 3 : vadr + 6]`), so the policy path is exactly right today and
this is latent there. `build_observation` is a public export of `strands_robots.policies.microduck`
though, and a caller assembling the dict from an IMU or teleop bridge has no seam at all. The sibling
locomotion observation builders in this same package already hold every sub-vector to a width via
`wbc.observation._require_len`, including `base_ang_vel`; this builder was the one that did not.

## The change

Both blocks route through one reader that refuses any width other than the one the layout defines. The
refusal names the block, both widths, and the contract it protects:

```
build_observation: observation_dict['base_quat'] has 3 component(s) but the base_quat observation
block is 4 wide. A different width cannot be used: the block is read into a fixed slot of the vector
the ONNX graph consumes, so it either changes the returned width away from the documented
48 + len(command) or re-reads the block's own components from the wrong positions.
```

**Placement.** It is in the builder rather than at a seam because these two inputs have no seam - that
asymmetry is already written down: `last_action`'s width is deliberately checked in `get_actions` and
deliberately taken on trust here, and that boundary is pinned unchanged by a cell in this PR.

## Verification

**Pre-fix split** (behavioural revert: the reader kept, both call sites reverted to the bare slice) -
`21 failed, 17 passed`:

| class | failed/total |
| --- | --- |
| `TestAWrongWidthBaseBlockIsRefused` | 15/15 |
| `TestTheRefusalNamesWhatAReaderNeeds` | 3/3 |
| `TestBothBlocksRouteThroughTheOneReader` | 3/3 |
| `TestTheAcceptedContractIsUnchanged` | 0/7 |
| `TestThePremisesTheDefectRestedOn` | 0/8 |
| `TestWhatIsDeliberatelyLeftAlone` | 0/2 |

**Mutation table** - 11 mutations, control 0, `collected` stable at 38 on every row, and 0 failures in
the pre-existing `tests/policies/microduck/` + `tests/policies/wbc/` suites on every row:

| mutation | cells fired |
| --- | --- |
| both call sites -> bare truncating slice | 21 |
| `base_ang_vel` call site only | 12 |
| `base_quat` call site only | 12 |
| check weakened to `<` (accept over-long) | 7 |
| check weakened to `>` (accept short) | 11 |
| reader truncates instead of raising | 18 |
| message drops the block key | 12 |
| message drops the `48 + len(command)` contract | 1 |
| widths hardcoded at the call sites | 1 |
| `reshape(-1)` dropped from the reader | 2 |

`b2 | b3 == b1` exactly, with an empty residual; the three cells they share are the structural ones,
which fire if **either** block skips the reader. So each block is independently pinned.

**Gate.** `ruff check` and `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports
`Success: no issues found in 1689 source files`, so branch-only is 0 by construction. A 629-path paired
selection (all of `tests/policies/` plus every suite that walks the tree, parses source, or reads
docstrings / `Args:` / `Raises:` / `__all__` / `changelog.d`), with the new file withheld from both
sides, gives an identical 26177 collected and `7 failed, 26094 passed, 76 skipped` on **both** trees -
7 == 7 identical ids, both `comm` directions empty. Those 7 are environmental to the box that ran them
(5 assert `rclpy` is absent where it resolves, 2 need a `docker` binary) and are unrelated to this
change. `tests/policies/microduck/` + `tests/policies/wbc/`: 804 passed.

## Scope

Finiteness of the base blocks is a separate axis - it is refused at the action seam - and is pinned here
as deliberately unchanged, as is `last_action` staying on trust inside the builder. No visual artifact:
this changes a refusal, not a policy, simulation, render, recording or asset.

## Composition with #2883

That PR also touches this package and shared **zero** changed paths with this one, which is the topology
a path-keyed overlap check cannot see. It merged at 11:11:38Z while this branch was being gated, so the
composition below is now the shipped state rather than a prediction, and this branch is rebased onto it.

Measured before it landed: trial merge conflict-free, the composition ran `793 passed, 2 skipped`.
Measured again after rebasing onto real `main`: `793 passed, 2 skipped`, and reverting each side on that
tree fires 21 cells (this PR) and 32 (that one) - both halves stay live, neither goes vacuous. `mypy`
reports `Success: no issues found in 1690 source files` on the composed tree.
