### PR TITLE
fix(drivers/feetech): stop advertising a robot the factory cannot build

### DIFF
--- a/changelog.d/2889-driver-advertised-robots-are-registered.md
+++ b/changelog.d/2889-driver-advertised-robots-are-registered.md
@@ -1,0 +1,39 @@
+### Fixed: a native driver no longer advertises a robot the factory cannot build
+
+`FeetechDriver.SUPPORTED_ROBOTS` named `moss`. That name appeared in exactly one place in
+the package -- the tuple itself. No entry in `registry/robots.json`, no lerobot robot type,
+no asset. Registration and resolution are two halves of one chain: the seam maps a canonical
+name to a driver class, and the factory maps that same name to a registry entry before it
+builds anything. A name in the first and absent from the second registered cleanly, reported
+itself through `list_native_drivers()`, and then raised
+`ValueError: Unknown robot 'moss'` from `Robot("moss", mode="real", driver="strands")` -- the
+exact refusal a native driver exists to remove, and the one
+`TestAskingForANativeDriverThatIsNotThere` grades from the other side. `Robot("so101", ...)`
+built a `FeetechDriver` on the same tree, so the failure was specific to the unregistered
+name rather than to the driver.
+
+The name is dropped rather than registered, because the comment directly above the tuple
+already states the invariant -- "Every entry corresponds to a canonical name in
+`strands_robots/registry/robots.json`" -- and its next sentence gives the disposition:
+"registering for a robot we cannot verify is a promise this driver does not yet keep." A
+robot with no registry entry, no lerobot type and no asset is exactly one we cannot verify.
+The changelog fragment that introduced the driver described the same set as "every
+Feetech-servo robot in the registry, and no other", which was true of the other five names;
+this corrects that record.
+
+Nothing in the tree related the two halves. `tests/test_driver_seam.py`, which grades every
+shipped driver against the seam, contained no registry lookup at all. The feetech cell named
+for the failure, `test_every_supported_robot_registers_the_driver_on_package_import`, asserts
+that each advertised name resolves to `FeetechDriver` -- the seam half -- while its own
+docstring names the consequence that lives in the other half ("a missing entry surfaces as
+`Robot(...)` raising `ValueError`"). `moss` satisfied that cell.
+
+So the relation is now graded twice. `tests/test_driver_seam.py` derives it over every entry
+in `_SHIPPED_DRIVERS`, through the same `shipped_robot_names` helper the registration itself
+uses, so a sixth driver is held to it the hour it lands instead of inheriting an exemption by
+being absent from a list; a non-vacuity cell pins that the derivation reaches all five
+shipped drivers, and a third cell registers a complete driver for an unregistered name and
+drives the factory refusal that makes the relation worth having. `tests/drivers/
+test_feetech_driver.py` keeps the local half beside the tuple, because that is where a name
+gets added. Reverting the source change fails both, one in each file; deleting either cell
+leaves the other catching it; deleting both is silent, which is the state that shipped.

--- a/strands_robots/drivers/feetech/driver.py
+++ b/strands_robots/drivers/feetech/driver.py
@@ -72,7 +72,6 @@ SUPPORTED_ROBOTS: tuple[str, ...] = (
     "so100",
     "so101",
     "lekiwi",
-    "moss",
     "hope_jr",
     "open_duck_mini",
 )

--- a/tests/drivers/test_feetech_driver.py
+++ b/tests/drivers/test_feetech_driver.py
@@ -30,6 +30,7 @@ from strands_robots.drivers import (
 )
 from strands_robots.drivers.feetech import FeetechDriver
 from strands_robots.drivers.feetech.driver import _NOT_WIRED, SUPPORTED_ROBOTS
+from strands_robots.registry import get_robot
 
 # ============================================================================
 # Surface.
@@ -75,6 +76,28 @@ class TestSurface:
                 f"the driver's not-wired refusal cannot reach a caller who cannot build it. "
                 f"Currently registered: {registered}"
             )
+
+    def test_every_supported_robot_is_one_the_registry_carries(self) -> None:
+        """The other half of the chain the cell above names.
+
+        Resolving to :class:`FeetechDriver` is registration; the factory reads
+        the *registry* before it builds anything, so a name this tuple declares
+        and ``robots.json`` omits resolves to the driver and then raises
+        ``ValueError: Unknown robot`` - the refusal the cell above says this
+        driver exists to remove. ``"moss"`` was such a name: it appeared in
+        exactly one place in the package, this tuple, with no registry entry
+        and no lerobot type.
+
+        Graded tree-wide over every shipped driver by
+        ``tests/test_driver_seam.py``; kept here too because this tuple is
+        where a name is added.
+        """
+        unregistered = [name for name in SUPPORTED_ROBOTS if get_robot(name) is None]
+        assert not unregistered, (
+            f"SUPPORTED_ROBOTS names robots the registry does not carry: {unregistered}. "
+            "Each resolves to FeetechDriver and then fails the factory's own lookup, so "
+            "the driver advertises a robot no caller can build."
+        )
 
 
 # ============================================================================

--- a/tests/test_driver_seam.py
+++ b/tests/test_driver_seam.py
@@ -26,6 +26,7 @@ and no arm moves.
 from __future__ import annotations
 
 import ast
+import importlib
 import inspect
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import strands_robots.drivers as drivers_mod
 import strands_robots.drivers.registry as drivers_registry_mod
 import strands_robots.registry.robots as registry_robots_mod
 from strands_robots import Robot
@@ -46,13 +48,19 @@ from strands_robots.drivers import (
     missing_driver_members,
     register_native_driver,
     resolve_driver,
+    shipped_robot_names,
 )
-from strands_robots.registry import get_driver
+from strands_robots.registry import get_driver, get_robot
 from strands_robots.registry.loader import _validate
 
 # A robot every real-mode test builds. Registered, has a lerobot type, and its
 # driver comes from the default rather than a declaration.
 _ROBOT = "so101"
+
+# A name no registry entry carries, used to drive the two halves of the seam
+# apart on purpose. Must stay absent from robots.json for that cell to mean
+# anything, which the cell asserts before it relies on it.
+_UNREGISTERED_ROBOT = "not_a_registered_robot"
 
 
 @pytest.fixture(autouse=True)
@@ -282,6 +290,75 @@ class TestAskingForANativeDriverThatIsNotThere:
         register_native_driver("unitree_g1", _CompleteDriver)
         with pytest.raises(ValueError, match="unitree_g1"):
             Robot(_ROBOT, mode="real", driver="strands", port="/dev/null")
+
+
+class TestEveryAdvertisedRobotIsOneTheFactoryCanBuild:
+    """A driver may only advertise a robot the registry carries.
+
+    Registration and resolution are two halves of one chain. The seam maps a
+    canonical name to a driver class; the factory maps that same name to a
+    registry entry before it builds anything. A name present in the first and
+    absent from the second registers cleanly, reports itself through
+    ``list_native_drivers()``, and then raises ``ValueError: Unknown robot`` at
+    the call the driver exists to serve -- the exact refusal
+    :class:`TestAskingForANativeDriverThatIsNotThere` grades from the other
+    side.
+
+    ``FeetechDriver`` shipped naming ``"moss"``, which appeared in exactly one
+    place in the package: its own ``SUPPORTED_ROBOTS``. No registry entry, no
+    lerobot type, no asset. The driver's own comment above that tuple states
+    the invariant this class now measures -- "Every entry corresponds to a
+    canonical name in ``strands_robots/registry/robots.json``" -- and its next
+    sentence gives the disposition: "registering for a robot we cannot verify
+    is a promise this driver does not yet keep."
+
+    Derived from :data:`~strands_robots.drivers._SHIPPED_DRIVERS` through the
+    same :func:`~strands_robots.drivers.shipped_robot_names` helper the
+    registration itself uses, so the sixth driver is held to this the hour it
+    lands rather than inheriting an exemption by being absent from a list.
+    """
+
+    @staticmethod
+    def _advertised() -> list[tuple[str, str]]:
+        """Every ``(driver class, canonical name)`` the shipped table declares."""
+        pairs: list[tuple[str, str]] = []
+        for module_path, class_name, names in drivers_mod._SHIPPED_DRIVERS:
+            module = importlib.import_module(module_path)
+            for canonical in shipped_robot_names(module, names):
+                pairs.append((class_name, canonical))
+        return pairs
+
+    def test_the_derivation_reaches_every_shipped_driver(self) -> None:
+        """Non-vacuity: an empty or truncated table would pass silently."""
+        pairs = self._advertised()
+        classes = {cls for cls, _ in pairs}
+        assert len(drivers_mod._SHIPPED_DRIVERS) >= 5, drivers_mod._SHIPPED_DRIVERS
+        assert len(classes) == len(drivers_mod._SHIPPED_DRIVERS), classes
+        assert len(pairs) >= 10, pairs
+
+    def test_every_advertised_name_resolves_in_the_registry(self) -> None:
+        """The relation itself: advertised implies registered."""
+        unregistered = [(cls, name) for cls, name in self._advertised() if get_robot(name) is None]
+        assert not unregistered, (
+            f"these drivers advertise robots the registry does not carry: {unregistered}. "
+            "Each one registers cleanly and then raises ValueError('Unknown robot') from "
+            "Robot(name, mode='real', driver='strands'). Either register the robot or stop "
+            "advertising it."
+        )
+
+    def test_an_advertised_name_that_is_not_registered_is_refused_by_the_factory(self) -> None:
+        """Why the relation matters: the two halves disagreeing is a hard refusal.
+
+        Registers a complete driver for a name no registry entry carries and
+        drives the call the seam exists to serve. The driver resolves; the
+        factory refuses. That pair is the failure the relation above prevents.
+        """
+        register_native_driver(_UNREGISTERED_ROBOT, _CompleteDriver)
+        assert get_native_driver_class(_UNREGISTERED_ROBOT) is _CompleteDriver
+        assert get_robot(_UNREGISTERED_ROBOT) is None
+
+        with pytest.raises(ValueError, match="Unknown robot"):
+            Robot(_UNREGISTERED_ROBOT, mode="real", driver="strands", port="/dev/null")
 
 
 class TestBuildingARegisteredNativeDriver:


### PR DESCRIPTION
## The defect

`FeetechDriver.SUPPORTED_ROBOTS` named `moss`. That name appears in **exactly one place in the package** -- the tuple itself. No entry in `registry/robots.json` (73 robots), no lerobot robot type (16 registered), no asset.

Registration and resolution are two halves of one chain. The seam maps a canonical name to a driver class; the factory maps that same name to a **registry** entry before it builds anything. A name in the first and absent from the second registers cleanly and then fails at the call the driver exists to serve:

```
list_native_drivers()["moss"]                       -> 'FeetechDriver'
get_robot("moss")                                   -> None
Robot("moss",  mode="real", driver="strands")       -> ValueError: Unknown robot 'moss'
Robot("so101", mode="real", driver="strands")       -> FeetechDriver          # control
```

The control matters: the driver is fine, and the failure is specific to the unregistered name. Over all five shipped drivers the relation has exactly one violation:

| driver | advertised | unregistered |
|---|---|---|
| `DynamixelDriver` | 6 | - |
| `FeetechDriver` | 6 | `moss` |
| `G1Driver` | 2 | - |
| `ReachyDriver` | 1 | - |
| `MicroduckDriver` | 1 | - |

## Why the name is dropped rather than registered

The comment directly above the tuple already states the invariant this violates:

> Every entry corresponds to a canonical name in `strands_robots/registry/robots.json`.

and its next sentence gives the disposition:

> registering for a robot we cannot verify is a promise this driver does not yet keep.

A robot with no registry entry, no lerobot type and no asset is exactly one we cannot verify, so this drops the name. The other five are registered and unaffected.

## Why nothing caught it

`tests/test_driver_seam.py` grades every shipped driver against the seam and contained **no registry lookup at all** (`get_robot`, `list_robots`, `resolve_name`: zero references).

The feetech cell named for this failure grades the other half of the chain. `test_every_supported_robot_registers_the_driver_on_package_import` asserts each advertised name resolves to `FeetechDriver` -- name to driver class -- while its own docstring names the consequence that lives in the *registry* half:

> A missing entry surfaces as `Robot("so101", mode="real", driver="strands")` raising `ValueError` - the exact failure this driver is here to remove.

`moss` satisfied that cell, because it really was registered in the seam. The `ValueError` comes from the lookup the cell does not perform.

## The fix

- `SUPPORTED_ROBOTS` drops `moss`.
- `tests/test_driver_seam.py` gains `TestEveryAdvertisedRobotIsOneTheFactoryCanBuild`: the relation **derived over every entry in `_SHIPPED_DRIVERS`**, through the same `shipped_robot_names` helper the registration itself uses, so a sixth driver is held to it the hour it lands rather than inheriting an exemption by being absent from a list. Plus a non-vacuity cell, and a cell that registers a complete driver for an unregistered name and drives the factory refusal, so the reason the relation is worth having is measured rather than asserted.
- `tests/drivers/test_feetech_driver.py` closes the chain its neighbouring cell names, beside the tuple where a name gets added.

## Verification

Break table over `tests/test_driver_seam.py` + `tests/drivers/test_feetech_driver.py` + `tests/drivers/test_dynamixel_driver.py`, source restored byte-identically (md5) after every row:

| row | collected | fires | which |
|---|---|---|---|
| control | 138 | 0 | - |
| unregistered name restored | 138 | **2** | both new cells |
| ... and the seam relation cell deleted | 137 | 1 | the feetech cell alone |
| ... and the feetech cell deleted | 137 | 1 | the seam cell alone |
| ... and **both** deleted (the shipped state) | 136 | **0** | silent |
| defect + derived scan hardcoded | 138 | 2 | feetech cell + the non-vacuity cell |
| scan hardcoded, no defect | 138 | 1 | non-vacuity cell |
| table truncated + floor dropped | 138 | 1 | still caught, by the class-count half |
| factory-refusal cell deleted | 137 | 0 | passes either way, by design |

`b1` partitions **exactly** into the two single-cell rows (union equal, intersection empty), so each half is independently pinned; the both-deleted row reproducing the shipped state is the "nothing caught it" measurement. The last row is honest: that cell demonstrates the mechanism rather than detecting the defect, and never fires.

Gate, with the three changed files swapped to their `main` versions for the base side (identical 494-path selection):

- `20 == 20` failing ids, **both `comm` directions empty**; `collected` 22648 vs 22644, the `+4` being exactly the four new cells. All 20 shared: 17 need `awsiot`/`awscrt` (`find_spec` `None`, declared in the `mesh-iot` extra, which `hatch`'s `features = ['all']` installs in CI), 3 are lerobot-from-source drift.
- `ruff check` clean, `ruff format --check` 1693 files already formatted.
- `mypy` **24 == 24**, normalized message sets byte-identical both directions, **0 attributable**.
- The three affected files: **138 passed**.

No visual artifact: this is a registration relation and a refusal, not policy, simulation, rendering, recording or an asset.
