### PR TITLE
fix(policies/microduck): refuse a non-finite observation component instead of feeding it to the graph

### DIFF
--- a/changelog.d/2890-microduck-observation-finiteness.md
+++ b/changelog.d/2890-microduck-observation-finiteness.md
@@ -1,0 +1,31 @@
+### Fixed: a non-finite observation component is refused instead of reaching the ONNX graph
+
+`strands_robots.policies.microduck.build_observation` held its two floating-base
+blocks to a width, and a width was the only thing it held anything to. Every
+value it reads passed into the vector the ONNX graph consumes without anyone
+asking whether it was a number: `base_ang_vel` and `base_quat` from the caller's
+observation dict, the per-joint `<joint>` and `<joint>.vel` scalars from the same
+dict, the previous action, and the command.
+
+All six paths reported success at the documented `48 + len(command)` width, so a
+poisoned observation is shaped exactly like a healthy one and nothing downstream
+can screen it by shape. What happened next depended on the checkpoint. A graph
+that tolerates the value answered with a number nobody could trace. A graph that
+propagates it - which is what any real one does - returned a `nan` action that
+`get_actions`' own finiteness guard then refused **as** `'the ONNX action'`,
+reporting the checkpoint's graph for a `nan` the caller's observation supplied.
+
+The builder now refuses it first, and the message names the offending block; a
+joint block names the joint. The check runs once, on the assembled vector, which
+is the single place all six input paths meet - guarding each input separately
+would be six checks that drift apart and would still miss whatever a later block
+adds. It is a plain `numpy.isfinite` rather than the shared vector domain for a
+measured reason: at that point the value is a `float32` 1-D array the builder
+itself made, so none of the spellings that domain exists to judge can reach it,
+the two agree on everything that can, and the shared domain costs more than the
+whole build (40.68 us against a 37.63 us build) where the `isfinite` pass costs
+2.00 us end to end (+5.31%).
+
+The width axis is unchanged: a block that is both wrong-width and non-finite is
+still reported by width, which is the more basic mistake. A large finite reading
+is still a reading - the guard refuses `nan`/`inf`, not magnitude.

--- a/strands_robots/policies/microduck/observation.py
+++ b/strands_robots/policies/microduck/observation.py
@@ -42,6 +42,9 @@ _BASE_ANG_VEL_LEN = 3
 #: Component count of the ``base_quat`` observation block (w, x, y, z).
 _BASE_QUAT_LEN = 4
 
+#: Component count of the projected-gravity block ``base_quat`` is reduced to.
+_GRAVITY_LEN = 3
+
 
 def quat_rotate_inverse(quat: NDArray[np.float32], vec: NDArray[np.float32]) -> NDArray[np.float32]:
     """Rotate ``vec`` by the inverse of quaternion ``quat`` (``[w, x, y, z]``).
@@ -106,6 +109,77 @@ def _require_base_block(observation_dict: dict[str, Any], key: str, expected_len
     return block
 
 
+def _non_finite_observation_error(
+    observation: NDArray[np.float32], joint_names: list[str], command_len: int
+) -> str | None:
+    """Name the blocks of an assembled observation that carry a non-finite value.
+
+    ``build_observation`` holds its two floating-base blocks to a width, and a
+    width is the only thing it held them to: a ``nan`` or ``inf`` component
+    passed straight into the vector the ONNX graph reads. That is silent when
+    the graph tolerates it, and misattributed when it does not - the value
+    propagates and
+    :meth:`~strands_robots.policies.microduck.MicroduckPolicy.get_actions`
+    refuses it as ``'the ONNX action'``, blaming the checkpoint's graph for a
+    number the caller supplied.
+
+    The check runs on the ASSEMBLED vector rather than on each input, because
+    the assembled vector is the one place every input path meets: the two base
+    blocks, the ``len(joint_names)`` position and velocity scalars, the previous
+    action and the command. One pass covers all of them.
+
+    It is a plain :func:`numpy.isfinite` rather than
+    :func:`~strands_robots.utils.finite_vector_error` because at this point the
+    value is a ``float32`` 1-D array this function built, so none of the
+    spellings that shared domain exists to judge - a nested sequence, a
+    ``bool``, a 0-d scalar, a non-numeric - can reach it, and the two agree on
+    everything that can. On the shipped 51-wide observation the shared domain
+    costs 40.68 us against a 37.92 us build, where this costs 1.27 us.
+
+    Args:
+        observation: The assembled 1-D ``float32`` observation vector.
+        joint_names: The joints the position / velocity blocks were read for, in
+            the order they were read; used to name the offending joint.
+        command_len: Width of the trailing command block.
+
+    Returns:
+        A message naming each offending block, or ``None`` when every component
+        is finite. Built only on the refusal path, so the happy path pays for
+        the :func:`numpy.isfinite` pass alone.
+    """
+    if bool(np.isfinite(observation).all()):
+        return None
+    bad = np.flatnonzero(~np.isfinite(observation))
+
+    nj = len(joint_names)
+    layout: list[tuple[str, int]] = [
+        ("base_ang_vel", _BASE_ANG_VEL_LEN),
+        ("projected_gravity (from base_quat)", _GRAVITY_LEN),
+        ("joint_pos", nj),
+        ("joint_vel", nj),
+        ("last_action", nj),
+        ("command", command_len),
+    ]
+    offenders: list[str] = []
+    start = 0
+    for name, width in layout:
+        hits = [int(i) - start for i in bad if start <= int(i) < start + width]
+        if hits:
+            if name in ("joint_pos", "joint_vel"):
+                joints = ", ".join(joint_names[h] for h in hits)
+                offenders.append(f"{name} ({joints})")
+            else:
+                offenders.append(f"{name} at {hits}")
+        start += width
+    return (
+        f"build_observation: the assembled observation carries {bad.size} non-finite "
+        f"component(s) in {', '.join(offenders)}. A nan/inf here is read into the "
+        f"vector the ONNX graph consumes: the graph propagates it and get_actions "
+        f"then refuses 'the ONNX action', reporting the checkpoint's graph for a "
+        f"number this observation supplied."
+    )
+
+
 def build_observation(
     observation_dict: dict[str, Any],
     *,
@@ -136,7 +210,11 @@ def build_observation(
             observation block defines (3 and 4). Both are read into fixed slots
             of the returned vector, so another width either changes the returned
             width away from ``48 + len(command)`` or re-reads the block's own
-            components from the wrong positions.
+            components from the wrong positions. Or if any component of the
+            assembled vector is not finite - the offending blocks are named, and
+            a joint block names the joint. A ``nan``/``inf`` reaches the graph
+            otherwise, which propagates it and makes ``get_actions`` refuse it
+            as ``'the ONNX action'``.
     """
     base_ang_vel = _require_base_block(observation_dict, "base_ang_vel", _BASE_ANG_VEL_LEN)
     grav = projected_gravity(_require_base_block(observation_dict, "base_quat", _BASE_QUAT_LEN))
@@ -145,16 +223,20 @@ def build_observation(
     joint_pos_rel = joint_pos - np.asarray(default_pose, dtype=np.float32)
     joint_vel = np.array([float(observation_dict[f"{name}.vel"]) for name in joint_names], dtype=np.float32)
 
-    return np.concatenate(
+    command_block = np.asarray(command, dtype=np.float32).reshape(-1)
+    observation = np.concatenate(
         [
             base_ang_vel,
             grav,
             joint_pos_rel,
             joint_vel,
             np.asarray(last_action, dtype=np.float32).reshape(-1),
-            np.asarray(command, dtype=np.float32).reshape(-1),
+            command_block,
         ]
     ).astype(np.float32)
+    if reason := _non_finite_observation_error(observation, joint_names, command_block.shape[0]):
+        raise ValueError(reason)
+    return observation
 
 
 def decode_action(

--- a/tests/policies/microduck/test_microduck_observation_refuses_a_non_finite_component.py
+++ b/tests/policies/microduck/test_microduck_observation_refuses_a_non_finite_component.py
@@ -1,0 +1,377 @@
+"""``build_observation`` refuses a non-finite component instead of feeding it to the graph.
+
+#2887 held the two floating-base blocks to a width, and a width was the only
+thing the builder held anything to. Every value it reads - the two base blocks,
+the ``len(joint_names)`` position and velocity scalars, the previous action and
+the command - reached the vector the ONNX graph consumes without anyone asking
+whether it was a number.
+
+Measured on the pre-fix tree with the shipped alpha command width (C=13, so the
+documented return width is ``48 + 13 == 61``):
+
+============================  =========  ==========================================
+caller input                  outcome    what reached the graph
+============================  =========  ==========================================
+contract (control)            success    61 finite components
+``base_quat`` has a ``nan``   success    3 non-finite (the whole gravity block)
+``base_ang_vel`` has a ``nan``  success  1 non-finite
+a joint position is ``nan``   success    1 non-finite
+a joint velocity is ``nan``   success    1 non-finite
+``last_action`` has a ``nan``   success  1 non-finite
+``command`` has a ``nan``     success    1 non-finite
+============================  =========  ==========================================
+
+Every row reported success at the documented width, which is what makes the
+failure hard to attribute: a ``nan`` observation is shaped exactly like a healthy
+one. What happens next depends on the checkpoint. A graph that tolerates the
+value answers with a number nobody can trace, and a graph that propagates it -
+which is what any real one does - hands back a ``nan`` action that
+``get_actions``' own finiteness guard (#2882) then refuses **as** ``'the ONNX
+action'``:
+
+    MicroduckPolicy.get_actions: 'the ONNX action' must contain finite numbers
+    (no nan/inf), got array([nan, ...], dtype=float32)
+
+So the caller was told the checkpoint's graph produced a bad action, for a
+``nan`` the caller's own observation dict supplied. That is the same
+misattribution shape as an IK solve refusing ``target_pose`` for a seed the
+caller never named (#2879).
+
+The guard runs on the ASSEMBLED vector, once, because that is the single place
+every input path meets. It is a plain :func:`numpy.isfinite` rather than
+:func:`~strands_robots.utils.finite_vector_error` for a measured reason: at that
+point the value is a ``float32`` 1-D array the builder itself made, so none of
+the spellings the shared domain exists to judge can reach it, the two agree on
+everything that can, and the shared domain costs more than the whole build
+(40.68 us against a 37.92 us build, where the ``isfinite`` pass costs 1.27 us).
+``TestTheSharedDomainWouldAgreeHere`` pins the agreement so the equivalence is
+measured rather than assumed.
+
+The sibling locomotion policy holds its caller-supplied vectors to both width and
+finiteness and says so in its own module docstring
+(``strands_robots.policies.motionbricks.observation``: "Every component must be a
+finite number; a count outside two or three, a ``nan``/``inf`` component or a
+``bool`` is refused by name"). This package refused a non-finite vector on the
+graph's OUTPUT and not on the caller's INPUT.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import build_observation
+from strands_robots.policies.microduck import observation as obs_mod
+from strands_robots.utils import finite_vector_error
+
+#: The shipped alpha command width, matching the width-refusal sibling.
+_ALPHA_COMMAND_WIDTH = 13
+
+#: Fixed part of the observation: 3 + 3 + 14 + 14 + 14.
+_FIXED_OBS_WIDTH = 48
+
+_N_JOINTS = 14
+
+#: The two non-finite spellings. Both are float32-representable, so both survive
+#: the builder's own ``astype`` and reach the graph.
+_NON_FINITE = (float("nan"), float("inf"))
+
+
+def _joints() -> list[str]:
+    return [f"j{i}" for i in range(_N_JOINTS)]
+
+
+def _obs_dict(**over: Any) -> dict[str, Any]:
+    """A contract-shaped observation dict, with named keys overridden."""
+    d: dict[str, Any] = {}
+    for name in _joints():
+        d[name] = 0.1
+        d[f"{name}.vel"] = 0.0
+    d["base_ang_vel"] = [0.0, 0.0, 0.0]
+    d["base_quat"] = [1.0, 0.0, 0.0, 0.0]
+    d.update(over)
+    return d
+
+
+def _build(obs_over: dict[str, Any] | None = None, **kw: Any) -> np.ndarray:
+    joints = _joints()
+    args: dict[str, Any] = {
+        "joint_names": joints,
+        "default_pose": np.zeros(_N_JOINTS, np.float32),
+        "last_action": np.zeros(_N_JOINTS, np.float32),
+        "command": np.zeros(_ALPHA_COMMAND_WIDTH, np.float32),
+    }
+    args.update(kw)
+    return build_observation(_obs_dict(**(obs_over or {})), **args)
+
+
+def _poisoned_vector(index: int, value: float) -> np.ndarray:
+    v = np.zeros(_N_JOINTS, np.float32)
+    v[index] = np.float32(value)
+    return v
+
+
+class TestEveryInputPathIsRefused:
+    """A non-finite component is refused wherever the builder reads it from.
+
+    Six paths reach the assembled vector. The two base blocks and the per-joint
+    scalars come from the caller's observation dict; ``last_action`` and
+    ``command`` are passed in. All six were unchecked.
+    """
+
+    @pytest.mark.parametrize("bad", _NON_FINITE, ids=["nan", "inf"])
+    def test_a_base_quat_component_is_refused(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            _build({"base_quat": [1.0, bad, 0.0, 0.0]})
+
+    @pytest.mark.parametrize("bad", _NON_FINITE, ids=["nan", "inf"])
+    def test_a_base_ang_vel_component_is_refused(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            _build({"base_ang_vel": [bad, 0.0, 0.0]})
+
+    @pytest.mark.parametrize("bad", _NON_FINITE, ids=["nan", "inf"])
+    def test_a_joint_position_is_refused(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            _build({_joints()[0]: bad})
+
+    @pytest.mark.parametrize("bad", _NON_FINITE, ids=["nan", "inf"])
+    def test_a_joint_velocity_is_refused(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            _build({f"{_joints()[3]}.vel": bad})
+
+    @pytest.mark.parametrize("bad", _NON_FINITE, ids=["nan", "inf"])
+    def test_a_last_action_component_is_refused(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            _build(last_action=_poisoned_vector(2, bad))
+
+    @pytest.mark.parametrize("bad", _NON_FINITE, ids=["nan", "inf"])
+    def test_a_command_component_is_refused(self, bad: float) -> None:
+        cmd = np.zeros(_ALPHA_COMMAND_WIDTH, np.float32)
+        cmd[1] = np.float32(bad)
+        with pytest.raises(ValueError, match="non-finite"):
+            _build(command=cmd)
+
+
+class TestTheRefusalNamesTheBlockAReaderMustFix:
+    """The message names the offending block, and a joint block names the joint.
+
+    An observation is assembled from six blocks and the caller controls each one
+    separately, so "the observation has a nan" leaves them to bisect it. The
+    layout is known here, so the block can be named for free on the refusal path.
+    """
+
+    def test_a_base_ang_vel_offender_is_named(self) -> None:
+        with pytest.raises(ValueError, match=r"base_ang_vel at \[0\]"):
+            _build({"base_ang_vel": [float("nan"), 0.0, 0.0]})
+
+    def test_a_base_quat_offender_is_named_through_the_block_it_becomes(self) -> None:
+        # base_quat is reduced to projected_gravity before it reaches the vector,
+        # so the assembled block carries the fault and the message says which
+        # input it came from.
+        with pytest.raises(ValueError, match=r"projected_gravity \(from base_quat\)"):
+            _build({"base_quat": [1.0, float("nan"), 0.0, 0.0]})
+
+    def test_a_joint_position_offender_names_the_joint(self) -> None:
+        joint = _joints()[5]
+        with pytest.raises(ValueError, match=rf"joint_pos \({joint}\)"):
+            _build({joint: float("nan")})
+
+    def test_a_joint_velocity_offender_names_the_joint(self) -> None:
+        joint = _joints()[9]
+        with pytest.raises(ValueError, match=rf"joint_vel \({joint}\)"):
+            _build({f"{joint}.vel": float("nan")})
+
+    def test_a_last_action_offender_is_named(self) -> None:
+        with pytest.raises(ValueError, match=r"last_action at \[2\]"):
+            _build(last_action=_poisoned_vector(2, float("nan")))
+
+    def test_the_block_names_are_derived_from_the_joints_they_were_read_for(self) -> None:
+        # The layout the message walks is built from len(joint_names), not from
+        # the 14 the shipped checkpoint happens to use. A robot with a different
+        # joint count would otherwise have its offender attributed to the wrong
+        # block, which is worse than not naming one at all. The offender is a
+        # VELOCITY: a joint_pos one sits at 6 + i whatever the count is, so only
+        # a block after the first discriminates a wrong count from the right one.
+        joints = [f"k{i}" for i in range(9)]
+        obs: dict[str, Any] = {f"{n}{suf}": v for n in joints for suf, v in (("", 0.1), (".vel", 0.0))}
+        obs["base_ang_vel"] = [0.0, 0.0, 0.0]
+        obs["base_quat"] = [1.0, 0.0, 0.0, 0.0]
+        obs[f"{joints[7]}.vel"] = float("nan")
+        with pytest.raises(ValueError, match=rf"joint_vel \({joints[7]}\)"):
+            build_observation(
+                obs,
+                joint_names=joints,
+                default_pose=np.zeros(len(joints), np.float32),
+                last_action=np.zeros(len(joints), np.float32),
+                command=np.zeros(_ALPHA_COMMAND_WIDTH, np.float32),
+            )
+
+    def test_a_command_offender_is_named(self) -> None:
+        cmd = np.zeros(_ALPHA_COMMAND_WIDTH, np.float32)
+        cmd[7] = np.float32("nan")
+        with pytest.raises(ValueError, match=r"command at \[7\]"):
+            _build(command=cmd)
+
+    def test_two_offenders_in_different_blocks_are_both_named(self) -> None:
+        joint = _joints()[1]
+        with pytest.raises(ValueError) as excinfo:
+            _build({"base_ang_vel": [float("nan"), 0.0, 0.0], joint: float("inf")})
+        text = str(excinfo.value)
+        assert "base_ang_vel" in text
+        assert f"joint_pos ({joint})" in text
+        assert "2 non-finite" in text
+
+    def test_the_message_says_what_the_value_would_have_done(self) -> None:
+        # The reason a nan matters here is that get_actions refuses it as the
+        # graph's output, so the message names that consequence.
+        with pytest.raises(ValueError, match="the ONNX graph consumes"):
+            _build({"base_ang_vel": [float("nan"), 0.0, 0.0]})
+
+
+class TestTheGuardSitsOnTheAssembledVector:
+    """One check, after the concatenate, reading the vector every path feeds.
+
+    Guarding each input separately would be six checks that drift apart, and it
+    would still miss whatever a later block adds. The structural cells hold the
+    placement so a future edit cannot move the check ahead of a block.
+    """
+
+    def test_the_builder_has_exactly_one_finiteness_owner(self) -> None:
+        src = textwrap.dedent(inspect.getsource(obs_mod))
+        calls = [
+            node
+            for node in ast.walk(ast.parse(src))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_non_finite_observation_error"
+        ]
+        assert len(calls) == 1, "the finiteness check has one owner and one call site"
+
+    def test_the_check_follows_the_concatenate_it_reads(self) -> None:
+        src = textwrap.dedent(inspect.getsource(obs_mod.build_observation))
+        assert "np.concatenate" in src, "the builder still assembles by concatenate"
+        assert "_non_finite_observation_error(" in src, "the builder consults the check"
+        assert src.index("np.concatenate") < src.index("_non_finite_observation_error("), (
+            "the check must read the assembled vector, so it follows the concatenate"
+        )
+
+    def test_the_refusal_precedes_the_return(self) -> None:
+        src = textwrap.dedent(inspect.getsource(obs_mod.build_observation))
+        assert src.index("raise ValueError(reason)") < src.rindex("return observation"), (
+            "a refused observation must not be returned"
+        )
+
+
+class TestTheSharedDomainWouldAgreeHere:
+    """The fast path is equivalent to the shared vector domain at this point.
+
+    A hand-rolled finiteness test is only safe when it cannot silently accept
+    something the shared domain rejects. Here the value is a ``float32`` 1-D
+    array the builder produced, so the nested sequences, ``bool``s, 0-d scalars
+    and non-numerics that domain exists to judge are unreachable - and these
+    cells measure the agreement rather than asserting it.
+    """
+
+    def test_the_assembled_value_is_already_normalised(self) -> None:
+        vec = _build()
+        assert vec.dtype == np.float32
+        assert vec.ndim == 1
+
+    @pytest.mark.parametrize("bad", [None, *_NON_FINITE], ids=["clean", "nan", "inf"])
+    def test_both_readers_reach_the_same_verdict(self, bad: float | None) -> None:
+        vec = _build()
+        if bad is not None:
+            vec = vec.copy()
+            vec[7] = np.float32(bad)
+        shared_ok = finite_vector_error("build_observation", "the observation", vec) is None
+        fast_ok = bool(np.isfinite(vec).all())
+        assert shared_ok == fast_ok
+
+
+class TestThePremisesTheDefectRestedOn:
+    """What made the non-finite value reachable and invisible."""
+
+    def test_the_layout_the_message_reads_covers_the_whole_vector(self) -> None:
+        # The block names are only useful if their widths sum to the vector, or a
+        # trailing offender would be attributed to the wrong block (or to none).
+        # Holds on both trees: it is a statement about the layout, not the guard.
+        joints = _joints()
+        vec = _build()
+        widths = (3, 3, len(joints), len(joints), len(joints), _ALPHA_COMMAND_WIDTH)
+        assert sum(widths) == vec.shape[0] == _FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH
+
+    def test_a_non_finite_float_survives_the_float32_cast(self) -> None:
+        # Both spellings are representable in float32, so neither is lost by the
+        # builder's own astype - which is why they reached the graph.
+        for bad in _NON_FINITE:
+            assert not np.isfinite(np.float32(bad))
+
+    def test_the_returned_width_does_not_depend_on_the_values(self) -> None:
+        # This is why a non-finite component was invisible: the width is a
+        # function of the block widths alone, so a poisoned observation is shaped
+        # exactly like a healthy one and nothing downstream can screen it by
+        # shape. Stated with finite values so it holds on both trees.
+        joints = _joints()
+        assert _build().shape == _build({joints[0]: 1e30, joints[1]: -1e30}).shape
+
+    def test_the_graph_output_guard_is_the_one_that_used_to_fire(self) -> None:
+        # get_actions holds the graph's returned action to the shared finiteness
+        # domain (#2882). That guard is what produced the misattributed refusal:
+        # with the builder silent, a caller's nan came back named as the graph's.
+        from strands_robots.policies.microduck import policy as policy_mod
+
+        src = textwrap.dedent(inspect.getsource(policy_mod.MicroduckPolicy.get_actions))
+        assert "finite_vector_error(" in src, "the graph's action is held to the domain"
+        assert "the ONNX action" in src, "and it is named as the graph's action"
+
+    def test_the_sibling_policy_holds_its_caller_vectors_to_finiteness(self) -> None:
+        from strands_robots.policies.motionbricks import observation as mb_obs
+
+        doc = " ".join((mb_obs.__doc__ or "").split())
+        assert "finite" in doc, "the sibling observation builder states this rule"
+
+
+class TestWhatIsUnchanged:
+    """The accepted contract, and the refusals that were already there."""
+
+    def test_a_contract_observation_still_builds(self) -> None:
+        vec = _build()
+        assert vec.shape == (_FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH,)
+        assert bool(np.isfinite(vec).all())
+
+    def test_a_large_but_finite_value_is_accepted(self) -> None:
+        # The guard refuses nan/inf, not magnitude: a big reading is a reading.
+        vec = _build({_joints()[0]: 1e30})
+        assert bool(np.isfinite(vec).all())
+
+    def test_the_most_negative_float32_is_accepted(self) -> None:
+        vec = _build({_joints()[2]: float(np.finfo(np.float32).min)})
+        assert bool(np.isfinite(vec).all())
+
+    def test_a_wrong_width_base_block_is_still_refused_by_width(self) -> None:
+        with pytest.raises(ValueError, match="component"):
+            _build({"base_quat": [1.0, 0.0, 0.0]})
+
+    def test_the_width_refusal_still_precedes_the_finiteness_one(self) -> None:
+        # A block that is both wrong-width and non-finite is reported by width:
+        # the width is read first, and it is the more basic mistake.
+        with pytest.raises(ValueError, match="wide"):
+            _build({"base_quat": [1.0, float("nan"), 0.0]})
+
+    def test_an_absent_key_is_still_a_key_error(self) -> None:
+        joints = _joints()
+        d = _obs_dict()
+        del d[joints[0]]
+        with pytest.raises(KeyError):
+            build_observation(
+                d,
+                joint_names=joints,
+                default_pose=np.zeros(_N_JOINTS, np.float32),
+                last_action=np.zeros(_N_JOINTS, np.float32),
+                command=np.zeros(_ALPHA_COMMAND_WIDTH, np.float32),
+            )

--- a/tests/policies/microduck/test_microduck_observation_refuses_a_wrong_width_base_block.py
+++ b/tests/policies/microduck/test_microduck_observation_refuses_a_wrong_width_base_block.py
@@ -240,15 +240,22 @@ class TestWhatIsDeliberatelyLeftAlone:
         )
         assert vector.shape[0] == _FIXED_OBS_WIDTH - _N_JOINTS + 1 + _ALPHA_COMMAND_WIDTH
 
-    def test_a_non_finite_block_is_not_refused_here(self) -> None:
-        """Finiteness is a separate axis, refused at the action seam (#2882).
+    def test_the_finiteness_axis_is_no_longer_left_alone(self) -> None:
+        """The boundary this class pinned has moved, deliberately.
 
-        Recorded rather than fixed: this change is about the width contract the
-        builder's own docstring states.
+        This cell recorded finiteness as "a separate axis, refused at the action
+        seam (#2882)". The first half was right and is why it is a separate
+        change. The second half named a refusal that does exist and blames the
+        wrong party: #2882 holds the graph's RETURNED action to the domain, so a
+        caller's ``nan`` propagated through the graph and came back as
+        ``'the ONNX action'`` - the checkpoint reported for a number the caller
+        supplied. The builder now refuses it first, naming the block.
+
+        The two axes stay independent: a wrong width is still reported by width,
+        which the rest of this file holds.
         """
-        vector = _build(base_quat=(float("nan"), 0.0, 0.0, 0.0))
-        assert vector.shape[0] == _FIXED_OBS_WIDTH + _ALPHA_COMMAND_WIDTH
-        assert not bool(np.all(np.isfinite(vector)))
+        with pytest.raises(ValueError, match=r"projected_gravity \(from base_quat\)"):
+            _build(base_quat=(float("nan"), 0.0, 0.0, 0.0))
 
 
 class TestBothBlocksRouteThroughTheOneReader:


### PR DESCRIPTION
## What was wrong

`build_observation` held its two floating-base blocks to a width (#2887). A width
was the only thing it held anything to. Every value it reads reached the vector
the ONNX graph consumes without anyone asking whether it was a number.

Measured on `main` with the shipped alpha command width (C=13, so the documented
return width is `48 + 13 == 61`):

| caller input | outcome | non-finite reaching the graph |
|---|---|---|
| contract (control) | success | 0 / 61 |
| `base_quat` has a `nan` | success | 3 / 61 (the whole gravity block) |
| `base_ang_vel` has a `nan` | success | 1 / 61 |
| a joint position is `nan` | success | 1 / 61 |
| a joint velocity is `nan` | success | 1 / 61 |
| `last_action` has a `nan` | success | 1 / 61 |
| `command` has a `nan` | success | 1 / 61 |

Every row is the documented width, so a poisoned observation is shaped exactly
like a healthy one and nothing downstream can screen it by shape.

## Why it matters: the refusal named the wrong party

What happens next depends on the checkpoint. A graph that tolerates the value
answers with a number nobody can trace. A graph that **propagates** it - which is
what any real one does - returns a `nan` action, and `get_actions`' own finiteness
guard (#2882) then refuses it **as** `'the ONNX action'`:

```
MicroduckPolicy.get_actions: 'the ONNX action' must contain finite numbers
(no nan/inf), got array([nan, nan, ...], dtype=float32)
```

That was measured end to end through the policy with a graph that propagates, for
a `base_quat` `nan` and for a joint-position `nan`. The caller is told the
checkpoint's graph produced a bad action, for a number the caller's own
observation dict supplied - the same misattribution shape as an IK solve refusing
`target_pose` for a seed the caller never named (#2879).

## Why nothing caught it

#2887 shipped a cell that pins it: `TestWhatIsDeliberatelyLeftAlone::
test_a_non_finite_block_is_not_refused_here`, whose docstring reads

> Finiteness is a separate axis, refused at the action seam (#2882). Recorded
> rather than fixed: this change is about the width contract the builder's own
> docstring states.

The first clause is right, and it is why this is a separate change. The second
clause names a refusal that does exist and blames the wrong party - #2882 holds
the graph's **returned** action to the domain, not the caller's input. So the
exclusion was licensed by a coverage claim that is misleading rather than false.
That cell is **repaired, not deleted**: it now records that the boundary moved,
and states the correction.

The sibling locomotion policy already holds its caller-supplied vectors to both
axes and says so in its own module docstring
(`strands_robots.policies.motionbricks.observation`: "Every component must be a
finite number; a count outside two or three, a `nan`/`inf` component or a `bool`
is refused by name"). This package refused a non-finite vector on the graph's
**output** and not on the caller's **input**.

## The change

One `isfinite` pass on the **assembled** vector - the single place all six input
paths meet. Guarding each input separately would be six checks that drift apart,
and it would still miss whatever a later block adds. The refusal names the
offending block, and a joint block names the joint:

```
build_observation: the assembled observation carries 1 non-finite component(s)
in joint_pos (left_hip_yaw). A nan/inf here is read into the vector the ONNX
graph consumes: the graph propagates it and get_actions then refuses
'the ONNX action', reporting the checkpoint's graph for a number this
observation supplied.
```

It is a plain `numpy.isfinite` rather than `finite_vector_error` for a measured
reason: at that point the value is a `float32` 1-D array the builder itself made,
so none of the spellings that shared domain exists to judge - a nested sequence,
a `bool`, a 0-d scalar, a non-numeric - can reach it, and the two agree on
everything that can. `TestTheSharedDomainWouldAgreeHere` pins the agreement so
the equivalence is measured rather than assumed.

Cost, same methodology both sides (best of 3 x 4000 ticks, C=13):

| | per tick |
|---|---|
| unguarded (`main`) | 37.63 us |
| guarded (this branch) | 39.63 us |
| delta | +2.00 us = **+5.31%** |
| `finite_vector_error` on the same vector, for contrast | 40.68 us (**+108%**) |

## Scope

The width axis is unchanged: a block that is both wrong-width and non-finite is
still reported by width, the more basic mistake. A large finite reading is still
a reading - the guard refuses `nan`/`inf`, not magnitude, pinned at
`float32`'s most negative value.

## Mutation table

Run against the new file; `sib` is failures in `tests/policies/microduck/` and
`tests/policies/motionbricks/` outside it. `coll` is stable at 39 on every row,
so no row hides a deselection.

| mutation | fires | sib |
|---|---|---|
| b0 control (no mutation) | 0 | 0 |
| b1 the guard call removed (= the defect) | 24 | 1 |
| b2 helper always answers `None` | 21 | 1 |
| b3 `isfinite` replaced by a magnitude test | 1 | 0 |
| b4 guard reads only `nan`, not `inf` | 5 | 0 |
| b5 `all()` weakened to `any()` | 21 | 1 |
| b6 gravity dropped from the layout | 7 | 1 |
| b7 joint blocks report an index, not the joint | 4 | 0 |
| b8 command width hardcoded in the layout | 1 | 0 |
| b9 message drops the consequence it names | 1 | 0 |
| b10 joint widths hardcoded to 14, not derived | 1 | 0 |

All 10 mutations detected, control clean, source restored md5-identical.

The `sib=1` rows are #2887's repaired boundary cell, which now depends on this
guard - that is the point of repairing it rather than deleting it. b3 fires the
`float32`-minimum control, which is what makes a magnitude-based mis-spelling
detectable. b10 needed care: a `joint_pos` offender sits at `6 + i` whatever the
joint count is, so only a block **after** the first discriminates a derived count
from a hardcoded one; the cell uses a joint velocity on a 9-joint robot.

## Pre-fix split

23 failed / 15 passed, with **0 in every premise and control class**:

| class | failed / total | role |
|---|---|---|
| `TestEveryInputPathIsRefused` | 12 / 12 | regression |
| `TestTheRefusalNamesTheBlockAReaderMustFix` | 8 / 8 | regression |
| `TestTheGuardSitsOnTheAssembledVector` | 3 / 3 | structural |
| `TestTheSharedDomainWouldAgreeHere` | 0 / 4 | premise |
| `TestThePremisesTheDefectRestedOn` | 0 / 5 | premise |
| `TestWhatIsUnchanged` | 0 / 6 | control |

## Gate

- `ruff check` and `ruff format --check` clean over 1697 files.
- `mypy strands_robots tests tests_integ`: **0 errors attributable** to the
  changed files. The 5 reported are pre-existing (`mesh/core.py` x2,
  `moveit2/server/zmq_node.py`, `simulation/ik.py`, `utils.py`).
- Paired run over an identical 648-path selection (all of `tests/policies/` plus
  every suite that walks the tree, parses source, or reads docstrings / `Args:` /
  `Raises:` / `__all__` / `changelog.d`), with the new file withheld from **both**
  sides: identical **26466 collected** and `20 failed, 26366 passed, 80 skipped`
  on each, **both `comm` directions empty**.
- Those 20 are environmental and classified by measurement: 17 in
  `tests/mesh/test_iot_*` need `awsiot`/`awscrt` (both `find_spec` `None` here,
  declared in the `mesh-iot` extra, which CI installs - `hatch` default features
  are `['all']`); 3 in `tests/training/test_lerobot*` are the
  lerobot-0.6.2-from-source `encode()` drift.
- New file alone: 39 cells. `tests/policies/microduck/` +
  `tests/policies/motionbricks/`: 480 passed, 2 skipped.

## No visual artifact

The change is a value-domain refusal in an observation builder - not policy
behaviour, simulation, rendering, recording or an asset. Nothing a valid
observation produces moves; the guard refuses inputs that previously reached the
graph. The measured tables above are the evidence, and the direct sibling in the
same function (#2887) shipped the same way.
