### PR TITLE
docs(registry): name the traversal guard by the spelling it is defined with

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1674,7 +1674,7 @@ hatch run format            # ruff check --fix, ruff format
 - **Nested asset paths** (e.g. `"model_xml": "xmls/asimov.xml"`) are allowed when
   the upstream source repo uses a subdir layout. Example: `asimov_v0` maps to
   `asimovinc/asimov-v0` which has `sim-model/xmls/asimov.xml` +
-  `sim-model/assets/`. The `_safe_join` helper in `strands_robots/utils.py`
+  `sim-model/assets/`. The `safe_join` helper in `strands_robots/utils.py`
   guards against traversal (`..`).
 - **Auto-download strategy** - every robot with an `asset` block must declare
   exactly one of:

--- a/changelog.d/2892-safe-join-guard-name.md
+++ b/changelog.d/2892-safe-join-guard-name.md
@@ -1,0 +1,23 @@
+### Docs: the traversal guard is named by the spelling it is defined with
+
+`strands_robots/utils.py` defines the traversal guard as `safe_join`, and its 13
+call sites across `assets/manager.py`, `assets/download.py`,
+`simulation/task_objects/catalog.py` and `tools/harness_memory.py` spell it that
+way. Two pieces of prose spelled it `_safe_join`: the `.. warning:: Security`
+block on `register_robot`, which tells a future implementer to "validate all
+paths with" it, and the registry-conventions section of `AGENTS.md`, which
+attributed it to the right file under the wrong name.
+
+A reader who grepped the documented spelling therefore found no implementation,
+because the only `_safe_join` in the tree was a synthetic stub inside a test
+fixture string. That conclusion was reached and written into a repository audit,
+which reported the guard as a phantom with no implementation anywhere in
+`strands_robots/`, while it was present and tested the whole time. A security
+warning naming a symbol nobody can find reads as though the remediation were
+still unwritten.
+
+The six references now name `safe_join`, and the security warning points at it
+through a resolvable cross-reference. No behaviour changes. A new sweep grades
+every public callable `utils.py` defines and derives its exemptions from the
+tree, so an underscored spelling that resolves to nothing is refused while a real
+private wrapper such as `_coerce_rgba` is not.

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -134,7 +134,7 @@ def register_robot(
         agent could register a robot pointing to attacker-controlled MJCF
         that executes code via MuJoCo plugins.  If tool exposure is needed
         in the future, gate it behind STRANDS_TRUST_REMOTE_CODE and
-        validate all paths with _safe_join.
+        validate all paths with :func:`strands_robots.utils.safe_join`.
 
     The robot becomes immediately available in ``get_robot()``,
     ``list_robots()``, ``resolve_model_path()``, ``sim.add_robot()``, etc.

--- a/tests/test_documented_guard_names_resolve.py
+++ b/tests/test_documented_guard_names_resolve.py
@@ -1,0 +1,199 @@
+"""Repo hygiene: a guard named in prose is named by the spelling it was defined with.
+
+History: ``strands_robots/utils.py`` defines the traversal guard as ``safe_join``
+and 13 call sites across ``assets/manager.py``, ``assets/download.py``,
+``simulation/task_objects/catalog.py`` and ``tools/harness_memory.py`` spell it
+that way. Two pieces of prose spelled it ``_safe_join`` instead - the
+``.. warning:: Security`` block on :func:`strands_robots.registry.register_robot`,
+which tells a future implementer to "validate all paths with" it, and the
+registry-conventions section of ``AGENTS.md``, which attributed it to the right
+file under the wrong name.
+
+The cost is measurable rather than theoretical. A reader who greps the documented
+spelling finds no implementation - the only ``_safe_join`` in the tree was a
+synthetic stub inside a test fixture string - and concludes the remediation does
+not exist. That conclusion was written down: a repository audit reported
+``_safe_join`` as "a phantom helper" and "no ``_safe_join`` implementation
+anywhere in ``strands_robots/``", on the strength of a grep for the documented
+name, while the guard was present and tested the whole time. A security warning
+that names a symbol nobody can find reads as though the remediation were still
+unwritten, which is the same failure shape as a caller-less table: prose that
+looks like it is enforcing something.
+
+The rule below is derived from the tree on both sides, so it needs no allowlist:
+
+* The graded set is every **public** callable ``utils.py`` defines - 39 of them -
+  rather than a list of names someone has to remember to extend.
+* The exemption is also derived. ``_coerce_rgba`` is a real, distinct private
+  function in ``simulation/mujoco/physics.py`` that wraps the public
+  ``coerce_rgba``, so the underscored spelling is correct there. Any
+  underscore-prefixed name that is genuinely defined somewhere in the tree is
+  therefore allowed; only a spelling that resolves to nothing is drift.
+
+That second point is what keeps this from being a blacklist: the sweep asks
+whether the name a reader would grep for exists, not whether a particular string
+appears.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: Where a reader looks for a guard's name: source, tests, docs, and the two
+#: root markdown files that carry project rules.
+SCAN_DIRS = ("strands_robots", "tests", "tests_integ", "docs", "scripts")
+SCAN_ROOT_FILES = ("AGENTS.md", "README.md")
+
+#: Symbol-defining directories. The exemption set is derived from these, so a
+#: private helper only excuses an underscored spelling if it is really there.
+DEFINITION_DIRS = ("strands_robots", "tests", "tests_integ", "scripts")
+
+SKIP_PARTS = {"__pycache__", ".venv", "node_modules", "build", "dist"}
+
+
+def _iter_files(suffixes: frozenset[str]) -> list[Path]:
+    files: list[Path] = []
+    for name in SCAN_ROOT_FILES:
+        candidate = REPO_ROOT / name
+        if candidate.is_file() and candidate.suffix in suffixes:
+            files.append(candidate)
+    for directory in SCAN_DIRS:
+        root = REPO_ROOT / directory
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.suffix not in suffixes or not path.is_file():
+                continue
+            if SKIP_PARTS & set(path.parts):
+                continue
+            files.append(path)
+    return files
+
+
+def _public_utils_guards() -> list[str]:
+    """Every public callable ``utils.py`` defines, derived from its AST."""
+    tree = ast.parse((REPO_ROOT / "strands_robots" / "utils.py").read_text(encoding="utf-8"))
+    return sorted(
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) and not node.name.startswith("_")
+    )
+
+
+def _defined_names() -> set[str]:
+    """Every name bound at any scope across the tree's Python sources.
+
+    Deliberately generous: an import alias, a class attribute and a nested
+    function all count. A name that is bound *anywhere* is a name a reader can
+    find, which is the property this sweep is about.
+    """
+    names: set[str] = set()
+    for path in _iter_files(frozenset({".py"})):
+        if REPO_ROOT / "strands_robots" not in path.parents and not any(
+            (REPO_ROOT / d) in path.parents or (REPO_ROOT / d) == path.parent for d in DEFINITION_DIRS
+        ):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                names.add(node.name)
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                names.add(node.target.id)
+            elif isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    names.add(alias.asname or alias.name)
+    return names
+
+
+def _unresolvable_private_spellings(guards: list[str], defined: set[str]) -> list[str]:
+    """Underscored spellings of public guards that resolve to nothing."""
+    return [f"_{guard}" for guard in guards if f"_{guard}" not in defined]
+
+
+def _find(spelling: str, text: str) -> list[int]:
+    pattern = re.compile(r"(?<![A-Za-z0-9_])" + re.escape(spelling) + r"(?![A-Za-z0-9_])")
+    return [text[: match.start()].count("\n") + 1 for match in pattern.finditer(text)]
+
+
+class TestAGuardIsNamedBySpellingThatResolves:
+    """A public ``utils.py`` guard is never referred to by an underscored name.
+
+    The graded set is the module's own public surface, so a guard added later is
+    held to the rule without anyone editing this file.
+    """
+
+    def test_the_graded_set_is_the_public_utils_surface(self) -> None:
+        """Guard the sweep's own reach: an empty graded set would pass vacuously."""
+        guards = _public_utils_guards()
+        assert "safe_join" in guards, "the traversal guard must be in the graded set"
+        assert len(guards) > 20, f"expected the full public surface, graded {len(guards)}"
+        assert all(not g.startswith("_") for g in guards)
+
+    def test_the_exemption_is_derived_and_not_a_list(self) -> None:
+        """``_coerce_rgba`` is a real private wrapper, so it must not be flagged.
+
+        This is the assertion that keeps the rule from being a blacklist. If the
+        exemption stopped being derived from the tree, this case is the one that
+        would start failing.
+        """
+        defined = _defined_names()
+        assert "_coerce_rgba" in defined, "the private rgba wrapper is a real symbol"
+        assert "coerce_rgba" in _public_utils_guards()
+        assert "_coerce_rgba" not in _unresolvable_private_spellings(_public_utils_guards(), defined)
+
+    def test_no_prose_names_a_guard_by_an_unresolvable_private_spelling(self) -> None:
+        guards = _public_utils_guards()
+        unresolvable = _unresolvable_private_spellings(guards, _defined_names())
+        assert unresolvable, "expected at least one guard with no private twin to grade"
+
+        offences: list[str] = []
+        for path in _iter_files(frozenset({".py", ".md"})):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            if path.resolve() == Path(__file__).resolve():
+                continue
+            for spelling in unresolvable:
+                if spelling not in text:
+                    continue
+                for line in _find(spelling, text):
+                    offences.append(
+                        f"{path.relative_to(REPO_ROOT)}:{line} names {spelling}, defined nowhere; use {spelling[1:]}"
+                    )
+
+        assert not offences, "a guard is referred to by a name that resolves to nothing:\n" + "\n".join(
+            sorted(offences)
+        )
+
+
+class TestTheSweepDetectsTheDriftItWasWrittenFor:
+    """Shown to reach: the rule fires on the pre-fix spelling and not on a real one."""
+
+    @pytest.mark.parametrize(
+        ("prose", "should_flag"),
+        [
+            ("validate all paths with _safe_join.", True),
+            ("validate all paths with safe_join.", False),
+            ("The `_safe_join` helper in `strands_robots/utils.py` guards traversal.", True),
+            ("The `safe_join` helper in `strands_robots/utils.py` guards traversal.", False),
+            ("colour goes through _coerce_rgba first.", False),
+        ],
+    )
+    def test_the_rule_grades_prose_as_expected(self, prose: str, should_flag: bool) -> None:
+        unresolvable = _unresolvable_private_spellings(_public_utils_guards(), _defined_names())
+        flagged = any(_find(spelling, prose) for spelling in unresolvable)
+        assert flagged is should_flag

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -689,7 +689,7 @@ def _scan_direct_renders(source: str) -> dict[str, tuple[tuple[str, str], ...]]:
     ``camera_fov_error``'s interval branch and ``validation_split_error``, which
     render plainly and reach the same escape.
 
-    Text a function *raises* is excluded: ``_safe_join`` renders an untrusted path
+    Text a function *raises* is excluded: ``safe_join`` renders an untrusted path
     into a deliberate ``ValueError`` rather than answering a caller through a
     return value, so it is not in this contract.
 
@@ -1022,15 +1022,15 @@ class TestNoGuardRendersACallerValueDirectly:
         assert _scan_direct_renders(labels_only) == {}
 
     def test_the_scanner_ignores_a_value_rendered_into_a_raise(self) -> None:
-        """``_safe_join`` raises by design; this contract is about returned text."""
+        """``safe_join`` raises by design; this contract is about returned text."""
         raising = textwrap.dedent(
             """
-            def _safe_join(base: Path, untrusted: Any) -> Path:
+            def safe_join(base: Path, untrusted: Any) -> Path:
                 raise ValueError(f"Path traversal blocked: {untrusted!r} escapes {base}")
             """
         )
         assert _scan_direct_renders(raising) == {}
-        assert "_safe_join" not in KNOWN_DIRECT_RENDERS
+        assert "safe_join" not in KNOWN_DIRECT_RENDERS
 
 
 class TestNoGuardReadsACallerValueOutsideATry:


### PR DESCRIPTION
## The concern

`strands_robots/utils.py:233` defines the traversal guard as **`safe_join`**, and all 13 of its call sites spell it that way:

```
strands_robots/assets/manager.py         5 calls
strands_robots/assets/download.py        5 calls
strands_robots/simulation/task_objects/catalog.py   1 call
strands_robots/tools/harness_memory.py   2 calls
```

Two pieces of prose spelled it `_safe_join` instead:

| site | what it says |
|---|---|
| `strands_robots/registry/user_registry.py:137` | the `.. warning:: Security` block on `register_robot` tells a future implementer to "gate it behind `STRANDS_TRUST_REMOTE_CODE` and validate all paths with `_safe_join`" |
| `AGENTS.md:1677` | "The `_safe_join` helper in `strands_robots/utils.py` guards against traversal" - right file, wrong name |

A test fixture that models the guard carried the same misspelling in its stub and two docstrings.

## Why this is worth a PR rather than a passing edit

The cost is measured, not theoretical. A reader who greps the documented spelling finds no implementation, because the only `_safe_join` in the tree was a synthetic stub inside a test fixture *string*:

```
$ grep -rn 'def _safe_join' --include='*.py' strands_robots/
(no output)
```

That conclusion was actually reached and written down. A repository audit on #2878 reported `_safe_join` as **"a phantom helper"** with **"no `_safe_join` implementation anywhere in `strands_robots/`"**, and recommended either implementing it or rewording the warning - while the guard was present, documented and tested the whole time. The grep was for the documented name, so it could only miss.

A security warning that names a symbol nobody can find reads as though the remediation were still unwritten. That is the same failure shape as a caller-less table: prose that looks like it is enforcing something.

## The diff

Six references, three files, no behaviour change:

- `user_registry.py:137` now names ``:func:`strands_robots.utils.safe_join` ``, matching the cross-reference style already used in `catalog.py:58` and `harness_memory.py:294`.
- `AGENTS.md:1677` names `safe_join`.
- `tests/test_refusal_messages_never_raise.py` - stub + 2 docstrings.

Renaming the fixture stub is **behaviour-neutral**: `_scan_direct_renders` keys on the `Any` annotation rather than on the function name, so the render-into-a-raise case still scans empty. It is also a small improvement - `assert "safe_join" not in KNOWN_DIRECT_RENDERS` now asserts something about a guard that really exists and really raises, instead of about a fictional name.

## The pin

`tests/test_documented_guard_names_resolve.py` derives **both** sides from the tree, so it carries no allowlist:

- **Graded set:** every public callable `utils.py` defines - 39 today - so a guard added later is held to the rule without editing the test.
- **Exemption:** any underscored spelling that is genuinely bound somewhere in the tree. This is what keeps `_coerce_rgba` from being flagged: it is a real, distinct private wrapper in `simulation/mujoco/physics.py:171` around the public `coerce_rgba`, so the underscore is correct there. Only a spelling that resolves to **nothing** is reported.

That second point is what keeps this from being a blacklist - the sweep asks whether the name a reader would grep for exists, not whether a particular string appears. `TestTheSweepDetectsTheDriftItWasWrittenFor` pins that distinction directly, including the `_coerce_rgba` negative case.

Rejected two broader rules first, on measurement:

| candidate rule | population | result |
|---|---|---|
| every fully-qualified `:func:`/`:meth:` cross-ref in package docstrings resolves | 1062 refs | already 100% green - pins nothing here, and its one apparent hit (`MuJoCoSimEngine.set_body_properties`) was a false negative of the probe, since the method is inherited from `physics.py` |
| any docstring token that is a near-miss of a real symbol modulo underscores | 18005 tokens | **287 hits, nearly all legitimate** - `base_height`, `json`, `grasped` etc. are DSL predicate keys and parameters that correctly pair with private implementations. Too noisy to be a gate |

The shipped rule is the one that fires on exactly the drift and nothing else.

## Verification

| check | before | after |
|---|---|---|
| `tests/test_documented_guard_names_resolve.py` | **1 failed / 7 passed** | **8 passed** |
| `tests/test_refusal_messages_never_raise.py` (file I edited) | 102 passed | **102 passed** |
| `tests/test_no_host_paths.py`, `test_user_registry.py`, `test_registry_integrity.py` | - | passed |
| `ruff check`, `ruff format --check` | - | clean on all three files |
| `mypy` | - | `Success: no issues found in 2 source files` |
| remaining `_safe_join` in tree | 6 | **0** |

The pre-fix failure names all six sites with `file:line` and the spelling to use:

```
AGENTS.md:1677 names _safe_join, defined nowhere; use safe_join
strands_robots/registry/user_registry.py:137 names _safe_join, defined nowhere; use safe_join
tests/test_refusal_messages_never_raise.py:692 names _safe_join, defined nowhere; use safe_join
tests/test_refusal_messages_never_raise.py:1025 names _safe_join, defined nowhere; use safe_join
tests/test_refusal_messages_never_raise.py:1028 names _safe_join, defined nowhere; use safe_join
tests/test_refusal_messages_never_raise.py:1033 names _safe_join, defined nowhere; use safe_join
```

One unrelated pre-existing failure in this verification env, identical on clean `main` at `731e823` (measured by stashing the diff): `tests/test_dependency_audit.py::test_declared_qp_backends_are_real_qpsolvers_extras` raises `PackageNotFoundError: qpsolvers`, because the optional extra is not installed here. Not touched by this diff.

## Scope

Does **not** touch `safe_join` itself, its call sites, or `register_robot`'s behaviour - the warning's own precondition (library-only, not agent-exposed) is unchanged and still holds. This is the naming half only.

Towards #2878, which recorded the finding; does not close it.

---

## S13 Review Rounds

| Round | Concern | Fix commit | Pin test path |
|---|---|---|---|
| R0 | Initial submission. | `79f26cd` | `tests/test_documented_guard_names_resolve.py::TestAGuardIsNamedBySpellingThatResolves::test_no_prose_names_a_guard_by_an_unresolvable_private_spelling` |
