### PR TITLE
fix(doctor): report a Warp build that cannot target this GPU's architecture

### DIFF
--- a/changelog.d/2893-doctor-warp-arch-agreement.md
+++ b/changelog.d/2893-doctor-warp-arch-agreement.md
@@ -1,0 +1,22 @@
+### Fixed: the doctor reports a Warp build that cannot target this GPU's architecture
+
+Warp chooses a device's architecture out of the table its binary was built with, so a build older than
+the GPU compiles for a different architecture rather than refusing. On an NVIDIA Thor, whose driver
+reports `sm_110`, Warp's CUDA-12 build offers a table with no `110` in it and settles on `sm_101` - and
+nothing says so. A simple kernel returns the right answer under that substitution, so the mismatch
+surfaces only once a kernel needs an instruction `sm_101` cannot express, by which point the symptom is
+a wrong result rather than a setup problem. `strands-robots doctor` reported `All checks passed` on such
+a node: `check_cuda` named the GPU and never asked whether the accelerator libraries agreed with the
+driver about its architecture.
+
+`check_warp_arch` asks. It names the architecture the driver reports, the one Warp settled on, the CUDA
+toolkit the build was made against, and the `+cuNN` wheel tag matching this driver. The verdict reads
+the arch table Warp reports rather than the wheel the environment was installed from, because a wheel
+tag cannot answer it: PyPI's `warp_lang` filenames carry no local version segment, so one release's
+CUDA-12 and CUDA-13 builds are indistinguishable by name, while the table is the value Warp itself
+reads. Warp ships in the `sim-newton` extra, and an install without it - or without a CUDA device - has
+no disagreement to report, so the check declines rather than failing.
+
+Only Warp is asked. torch reports an arch list too, but a torch build without the device's arch
+compiles from PTX instead, a documented fallback that still produces the right answer, and `check_cuda`
+already reports torch's posture.

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -280,6 +280,99 @@ def check_cuda() -> str:
         return _warn("torch not installed (needed for policy inference)", note="uv pip install torch")
 
 
+def _driver_compute_arch() -> int | None:
+    """Architecture the CUDA driver reports for device 0, as an ``sm_NN`` integer.
+
+    Read through ``torch.cuda.get_device_capability``, which queries the driver
+    for the device's own properties rather than reporting anything about the
+    build torch was compiled for.
+
+    Returns:
+        The device architecture (``110`` for an ``sm_110`` GPU), or ``None`` when
+        there is no CUDA device to ask about - including when torch, the one
+        driver query this module has, is not installed.
+    """
+    try:
+        import torch
+    except ImportError:
+        return None
+    if not torch.cuda.is_available():
+        return None
+    major, minor = torch.cuda.get_device_capability(0)
+    return major * 10 + minor
+
+
+def _warp_cuda_report() -> tuple[tuple[int, ...], int, tuple[int, int], tuple[int, int]] | None:
+    """What the installed Warp build reports about CUDA device 0.
+
+    Returns:
+        A ``(supported_archs, chosen_arch, toolkit_version, driver_version)``
+        tuple, or ``None`` when Warp is not installed - it ships in the
+        ``sim-newton`` extra - or when it can see no CUDA device to report on.
+    """
+    try:
+        warp = importlib.import_module("warp")
+    except ImportError:
+        return None
+    if not warp.is_cuda_available() or warp.get_cuda_device_count() < 1:
+        return None
+    supported = tuple(int(arch) for arch in warp.get_cuda_supported_archs())
+    chosen = int(warp.get_device("cuda:0").arch)
+    toolkit = warp.get_cuda_toolkit_version()
+    driver = warp.get_cuda_driver_version()
+    return supported, chosen, (int(toolkit[0]), int(toolkit[1])), (int(driver[0]), int(driver[1]))
+
+
+def check_warp_arch() -> str:
+    """Warp's build can compile for the GPU architecture the driver reports.
+
+    Warp chooses a device's architecture out of the table its binary was built
+    with, so a build older than the GPU compiles for a different architecture
+    rather than refusing. On an NVIDIA Thor - the driver reports ``sm_110`` - the
+    CUDA-12 build offers a table with no ``110`` in it and settles on ``sm_101``,
+    and nothing says so: a simple kernel still returns the right answer, so the
+    substitution surfaces only once a kernel needs something ``sm_101`` cannot
+    express.
+
+    The verdict is about the arch table Warp reports rather than about the wheel
+    the environment was installed from. A wheel tag cannot answer it: PyPI's
+    filenames carry no local version segment, so one release's CUDA-12 and
+    CUDA-13 builds are indistinguishable by name, while the table is the value
+    Warp itself reads.
+
+    Only Warp is asked here. torch reports an arch list too, but a torch build
+    without the device's arch compiles from PTX instead - a documented fallback
+    that still produces the right answer - and ``check_cuda`` already reports
+    torch's posture.
+    """
+    device_arch = _driver_compute_arch()
+    if device_arch is None:
+        return _skip("Warp arch: no CUDA device to compare against")
+    report = _warp_cuda_report()
+    if report is None:
+        return _skip("Warp arch: warp not installed (sim-newton extra)")
+    supported, chosen, toolkit, driver = report
+    built_for = f"CUDA {toolkit[0]}.{toolkit[1]}"
+
+    if device_arch in supported:
+        return _pass(f"Warp targets sm_{device_arch} (built against {built_for})")
+
+    # Name the arch Warp settled on rather than deriving it. The substitution is
+    # not the nearest supported arch below the device's - a table offering both
+    # 101 and 103 settled on 101 for an sm_110 device - so a computed value here
+    # would describe a rule Warp does not follow.
+    return _fail(
+        f"Warp is built against {built_for}, whose arch table has no sm_{device_arch}, "
+        f"so it compiles for sm_{chosen} on this sm_{device_arch} device",
+        fix=(
+            f"Install the Warp build for CUDA {driver[0]}, the driver's own version: take the wheel "
+            f"whose version carries a '+cu{driver[0]}' tag from "
+            "https://github.com/NVIDIA/warp/releases (pip install --force-reinstall --no-deps <url>). "
+            "PyPI serves one build per release, so its wheel may not be the one this driver needs."
+        ),
+    )
+
+
 def check_serial_permissions() -> str:
     """Serial port permissions for real hardware."""
     if platform.system() != "Linux":
@@ -391,6 +484,7 @@ def run_doctor() -> int:
         ("MuJoCo GL", check_mujoco_gl),
         ("LeRobot", check_lerobot),
         ("CUDA/GPU", check_cuda),
+        ("Warp Arch", check_warp_arch),
         ("Serial", check_serial_permissions),
         ("HF Auth", check_hf_auth),
         ("Mesh", check_mesh),

--- a/tests/test_doctor_warp_arch_agrees_with_the_driver.py
+++ b/tests/test_doctor_warp_arch_agrees_with_the_driver.py
@@ -1,0 +1,210 @@
+"""The Warp verdict is about the arch table Warp reports, not the wheel installed.
+
+Warp chooses a device's architecture out of the table its binary was built with.
+A build older than the GPU therefore compiles for a *different* architecture
+instead of refusing: on an NVIDIA Thor, whose driver reports ``sm_110``, the
+CUDA-12 build offers a table with no ``110`` in it and settles on ``sm_101``. A
+simple kernel still returns the right answer under that substitution, so nothing
+surfaces until a kernel needs an instruction ``sm_101`` cannot express - which is
+why the doctor has to ask rather than waiting for a runtime error.
+
+A wheel tag cannot answer the question. PyPI's ``warp_lang`` filenames carry no
+local version segment, so one release's CUDA-12 and CUDA-13 builds are
+indistinguishable by name, while the arch table is the value Warp itself reads.
+
+The archs below are written out here rather than imported, so these cases grade
+the shipped behaviour against a second opinion. The pair (a table missing the
+device's arch, and one containing it) is taken from the two builds of Warp
+1.16.0: the CUDA-12.9 build reports ``101`` and ``103`` but not ``110``, and the
+CUDA-13.0 build reports ``110``.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+# The device architecture an NVIDIA Thor's driver reports, and the arch Warp's
+# CUDA-12 build settles on there. 103 is in that build's table too and sits
+# below 110, so it is what a "nearest supported arch below the device's" rule
+# would name - and Warp does not follow that rule.
+THOR_ARCH = 110
+CUDA12_CHOSEN_ARCH = 101
+CUDA12_NEAREST_BELOW = 103
+CUDA12_TABLE = (50, 52, 70, 80, 89, 90, 100, CUDA12_CHOSEN_ARCH, CUDA12_NEAREST_BELOW, 120, 121)
+CUDA13_TABLE = (75, 80, 89, 90, 100, 103, THOR_ARCH, 120, 121)
+
+
+def _install_torch(monkeypatch: pytest.MonkeyPatch, capability: tuple[int, int] | None) -> None:
+    """Make the driver report ``capability`` for device 0, or no CUDA device at all."""
+    cuda = SimpleNamespace(
+        is_available=lambda: capability is not None,
+        get_device_capability=lambda _index: capability,
+    )
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(cuda=cuda))
+
+
+def _install_warp(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    table: tuple[int, ...],
+    chosen: int,
+    toolkit: tuple[int, int],
+    driver: tuple[int, int] = (13, 0),
+) -> None:
+    """Make Warp report ``table`` as its build's archs and ``chosen`` for device 0."""
+    warp: Any = SimpleNamespace(
+        is_cuda_available=lambda: True,
+        get_cuda_device_count=lambda: 1,
+        get_cuda_supported_archs=lambda: list(table),
+        get_device=lambda _alias: SimpleNamespace(arch=chosen),
+        get_cuda_toolkit_version=lambda: toolkit,
+        get_cuda_driver_version=lambda: driver,
+    )
+    monkeypatch.setitem(sys.modules, "warp", warp)
+
+
+def _thor_on_cuda12(monkeypatch: pytest.MonkeyPatch) -> str:
+    """The verdict for a Thor running Warp's CUDA-12 build."""
+    from strands_robots.doctor import check_warp_arch
+
+    _install_torch(monkeypatch, (11, 0))
+    _install_warp(monkeypatch, table=CUDA12_TABLE, chosen=CUDA12_CHOSEN_ARCH, toolkit=(12, 9))
+    return check_warp_arch()
+
+
+class TestABuildOlderThanTheGpuIsRefused:
+    """A build whose arch table cannot name the device is reported, not tolerated."""
+
+    def test_a_table_without_the_device_arch_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        result = _thor_on_cuda12(monkeypatch)
+        assert "FAIL" in result
+        assert f"sm_{THOR_ARCH}" in result
+
+    def test_the_refusal_names_the_arch_warp_settled_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The substitution is the number a user saw in Warp's own banner."""
+        assert f"sm_{CUDA12_CHOSEN_ARCH}" in _thor_on_cuda12(monkeypatch)
+
+    def test_the_refusal_does_not_name_the_nearest_supported_arch_below(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Warp's choice is read from Warp, not derived from its table.
+
+        Deriving it would name ``103`` here - the highest entry below ``110`` -
+        and describe a rule Warp does not follow.
+        """
+        assert str(CUDA12_NEAREST_BELOW) not in _thor_on_cuda12(monkeypatch)
+
+    def test_the_refusal_names_the_toolkit_the_build_was_made_against(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The toolkit version is what distinguishes two builds of one release."""
+        assert "CUDA 12.9" in _thor_on_cuda12(monkeypatch)
+
+    def test_the_remedy_names_the_cuda_major_the_driver_reports(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The wheel to fetch is the one matching the driver, not the one PyPI serves."""
+        result = _thor_on_cuda12(monkeypatch)
+        assert "+cu13" in result
+        assert "github.com/NVIDIA/warp/releases" in result
+
+
+class TestABuildThatCoversTheDeviceIsAccepted:
+    """The verdict turns on the table alone, so a matching build passes."""
+
+    def test_a_table_containing_the_device_arch_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_warp_arch
+
+        _install_torch(monkeypatch, (11, 0))
+        _install_warp(monkeypatch, table=CUDA13_TABLE, chosen=THOR_ARCH, toolkit=(13, 0))
+        result = check_warp_arch()
+        assert "PASS" in result
+        assert f"sm_{THOR_ARCH}" in result
+
+    def test_an_older_gpu_on_the_cuda12_build_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The refusal is about this device, not about the build's age."""
+        from strands_robots.doctor import check_warp_arch
+
+        _install_torch(monkeypatch, (8, 9))
+        _install_warp(monkeypatch, table=CUDA12_TABLE, chosen=89, toolkit=(12, 9))
+        assert "PASS" in check_warp_arch()
+
+
+class TestTheCheckDeclinesWhenThereIsNothingToCompare:
+    """No device, or no Warp, is not a failure - there is no disagreement to report."""
+
+    def test_no_cuda_device_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_warp_arch
+
+        _install_torch(monkeypatch, None)
+        _install_warp(monkeypatch, table=CUDA12_TABLE, chosen=CUDA12_CHOSEN_ARCH, toolkit=(12, 9))
+        assert "SKIP" in check_warp_arch()
+
+    def test_torch_absent_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """torch is this module's only driver query, so without it there is no truth to compare to."""
+        from strands_robots.doctor import check_warp_arch
+
+        monkeypatch.setitem(sys.modules, "torch", None)
+        _install_warp(monkeypatch, table=CUDA12_TABLE, chosen=CUDA12_CHOSEN_ARCH, toolkit=(12, 9))
+        assert "SKIP" in check_warp_arch()
+
+    def test_warp_absent_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Warp ships in the ``sim-newton`` extra, so most installs have nothing to check."""
+        from strands_robots.doctor import check_warp_arch
+
+        _install_torch(monkeypatch, (11, 0))
+        monkeypatch.setitem(sys.modules, "warp", None)
+        assert "SKIP" in check_warp_arch()
+
+    def test_warp_seeing_no_cuda_device_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_warp_arch
+
+        _install_torch(monkeypatch, (11, 0))
+        warp: Any = SimpleNamespace(is_cuda_available=lambda: False, get_cuda_device_count=lambda: 0)
+        monkeypatch.setitem(sys.modules, "warp", warp)
+        assert "SKIP" in check_warp_arch()
+
+
+class TestTheDoctorRunsTheCheckAndFailsOnIt:
+    """A verdict nothing runs is decoration, so the wiring is graded too."""
+
+    def test_a_refusal_from_the_check_fails_the_doctor(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from strands_robots import doctor
+
+        sentinel = "  FAIL  warp-arch-sentinel"
+        monkeypatch.setattr(doctor, "check_warp_arch", lambda: sentinel)
+        exit_code = doctor.run_doctor()
+        assert sentinel in capsys.readouterr().out
+        assert exit_code == 1
+
+
+class TestAgainstTheInstalledWarp:
+    """The stand-ins above agree with a real Warp about what it reports."""
+
+    def test_the_installed_build_can_target_this_devices_arch(self) -> None:
+        pytest.importorskip("warp", reason="warp ships in the sim-newton extra")
+        from strands_robots.doctor import _driver_compute_arch, _warp_cuda_report
+
+        device_arch = _driver_compute_arch()
+        report = _warp_cuda_report()
+        if device_arch is None or report is None:
+            pytest.skip("no CUDA device for Warp to report on")
+        supported, chosen, _toolkit, _driver = report
+        assert device_arch in supported, (
+            f"the installed Warp build targets {sorted(supported)} and settled on sm_{chosen} "
+            f"for this sm_{device_arch} device"
+        )
+        assert chosen == device_arch
+
+    def test_a_real_warp_answers_every_call_the_stand_ins_make(self) -> None:
+        """The stand-ins are only faithful while these remain Warp's public surface."""
+        warp = pytest.importorskip("warp", reason="warp ships in the sim-newton extra")
+        for name in (
+            "is_cuda_available",
+            "get_cuda_device_count",
+            "get_cuda_supported_archs",
+            "get_device",
+            "get_cuda_toolkit_version",
+            "get_cuda_driver_version",
+        ):
+            assert callable(getattr(warp, name)), name


### PR DESCRIPTION
## The defect

Warp chooses a device's architecture out of the arch table its binary was built with. A build older than
the GPU therefore compiles for a *different* architecture rather than refusing, and says nothing about
it. `strands-robots doctor` reported `All checks passed` on a machine where every Warp kernel was being
compiled for the wrong architecture: `check_cuda` named the GPU and never asked whether the accelerator
libraries agreed with the driver about its architecture.

Warp ships in the `sim-newton` extra (`warp-lang>=1.14.0,<2.0.0`), so this is a supported install.

## Measured

One machine, one driver, **one Warp version (1.16.0)** - only the build differs. The second row is the
wheel a plain `pip install warp-lang` resolves to:

| build | dist version | CUDA toolkit | arch table | driver's `110` present | arch Warp chose |
| --- | --- | --- | --- | --- | --- |
| NVIDIA release, `+cu13` | `1.16.0+cu13` | 13.0 | `75,80,86,87,88,89,90,100,103,110,120,121` | yes | `110` |
| PyPI | `1.16.0` | 12.9 | `50..100,101,103,120,121` | **no** | **101** |

The driver reports `sm_110` (`torch.cuda.get_device_capability(0) == (11, 0)`) on both.

It is a **build** problem rather than a version problem, so no version constraint expresses it: the
`>=1.14.0` this repo already declares resolves to exactly the misdetecting wheel.

### Why nothing surfaces

The same kernel under both builds, identical input:

| build | arch Warp chose | kernel output | correct |
| --- | --- | --- | --- |
| `+cu13` | `110` | `[1, 3, 5, 7, 9, 11, 13, 15]` | yes |
| PyPI | `101` | `[1, 3, 5, 7, 9, 11, 13, 15]` | yes |

No error, the right answer, the wrong architecture. The substitution surfaces only once a kernel needs
an instruction `sm_101` cannot express, by which point the symptom is a wrong result rather than a setup
problem - which is why the doctor has to ask rather than wait for a runtime error.

## Before and after

Before, on the misdetecting build, all eleven checks passed and the command exited 0:

```
  PASS  CUDA available: NVIDIA Thor (torch 2.11.0+cu130)
  ...
All checks passed. Ready to use strands-robots.
```

After, with `check_warp_arch` registered beside `check_cuda`, the same two builds:

```
  PASS  Warp targets sm_110 (built against CUDA 13.0)

  FAIL  Warp is built against CUDA 12.9, whose arch table has no sm_110, so it
        compiles for sm_101 on this sm_110 device
        Fix: Install the Warp build for CUDA 13, the driver's own version: take
        the wheel whose version carries a '+cu13' tag from
        https://github.com/NVIDIA/warp/releases (pip install --force-reinstall
        --no-deps <url>). PyPI serves one build per release, so its wheel may not
        be the one this driver needs.
```

Every number in that message is read rather than derived: the driver's arch, the arch Warp settled on,
the toolkit the build was made against, and the `+cuNN` tag from the driver's own CUDA version.

## Why the arch table rather than the wheel

A wheel tag cannot answer the question. PyPI's filenames carry **no local version segment**
(`warp_lang-1.16.0-py3-none-manylinux_2_34_aarch64.whl`), so one release's CUDA-12 and CUDA-13 builds
are indistinguishable by name, while the arch table is the value Warp itself reads.

This is the discipline `check_mujoco_gl` already states for its own verdict - "answers about the value
MuJoCo will read rather than about the string that was typed", because "re-deriving that vocabulary
loosely answered about a spelling". Reading the table means the check also holds for a future
architecture with no table here to maintain.

`warp.get_cuda_supported_archs`, `get_cuda_toolkit_version`, `get_cuda_driver_version`,
`is_cuda_available` and `get_cuda_device_count` are all public.

## What the refusal deliberately does not derive

Warp's substitution is **not** the nearest supported arch below the device's. Its CUDA-12 table offers
both `101` and `103`, and it settled on `101` for an `sm_110` device. The message therefore reports the
arch Warp itself chose; computing one here would describe a rule Warp does not follow. A cell pins that
(a derived value would name `103`).

## Scope

`check_warp_arch` extends `strands_robots/doctor.py` rather than adding a `tools/gpu_preflight.py`: `tools/` is the
agent-facing `@tool` package, while the doctor is the setup diagnostic, has three dedicated test files,
and already carries the sibling `check_cuda` and `check_mujoco_gl` checks. A second diagnostic surface
would be two names for one thing.

**Only Warp is asked.** torch reports an arch list too, but a torch build without the device's arch
compiles from PTX instead - a documented fallback that still produces the right answer - and
`check_cuda` already reports torch's posture. Whether that deserves a verdict is a separate question,
left alone here.

An install with no Warp, or no CUDA device, has no disagreement to report, so the check declines rather
than failing. torch is this module's only driver query, so without torch the check also declines.

## Tests

`tests/test_doctor_warp_arch_agrees_with_the_driver.py`, 14 cells. The arch tables are written out in
the test rather than imported, so the cases grade the shipped behaviour against a second opinion; the
pair is taken from the two real builds above.

Both layers, measured:

| run | result |
| --- | --- |
| Warp installed | `14 passed` |
| Warp hidden, as CI sees it | `12 passed, 2 skipped` |

`12 + 2 == 14 + 0 == 14 collected` - the same cells are collected either way and only their disposition
moves, so every regression cell runs in CI, where Warp is absent (`sim-newton` is not in `all`). The two
that skip are the ones asking a real Warp: that its build can target the device it is running on, and
that it still answers every call the stand-ins make.

The wiring is graded too - a verdict nothing runs is decoration - by monkeypatching the check to a
sentinel refusal and asserting `run_doctor` both prints it and exits 1.

### Mutation table

Ten mutations of the shipped fix, `collected` stable at 14 on every row, source restored byte-identical:

| mutation | cells firing |
| --- | --- |
| control | 0 |
| check not registered in `run_doctor` | 1 |
| never refuses (table check always true) | 3 |
| `chosen` derived as nearest supported below | 2 |
| toolkit dropped from the refusal | 1 |
| remedy tag from the toolkit, not the driver | 1 |
| Warp-absent reported as `PASS` not `SKIP` | 2 |
| refusal downgraded to a warning | 5 |
| Warp CUDA-availability guard dropped | 1 |
| device arch as `major` only, not `major*10+minor` | 4 |

## Gate

`ruff check` and `ruff format --check` clean over 1700 files. mypy **24 == 24** against the base with
both normalized `comm` directions empty and 0 errors attributable to the changed files (`checked 1696`
vs `1697`, the new test file).

Paired 463-file selection - every test walking the tree, parsing source, or reading docstrings, `Args:`,
`Raises:`, `__all__` or `changelog.d`, plus every `tests/test_doctor*.py` - with the new test file
withheld from both sides: identical **21849 collected** and `22 failed, 21751 passed, 76 skipped` on
each, 22 identical ids, **both `comm` directions empty**. Classified by measurement: 17 need
`awsiot`/`awscrt` (both absent here, declared in `mesh-iot`, which `all` pulls in, so CI installs them),
3 are a lerobot-from-source `TypeError: encode() takes 1 positional argument` drift, and 2 are
`PackageNotFoundError` for the editable install's absent distribution metadata - all 22 reproduced on a
pristine base tree.

No visual artifact: the change is a setup diagnostic, not policy, simulation, rendering, recording or an
asset. The before-and-after console output above is the evidence.
