### PR TITLE
fix(examples/kimodo): verify the recorded dataset through the canonical checker

### DIFF
--- a/changelog.d/2894-example-dataset-verified-through-canonical-checker.md
+++ b/changelog.d/2894-example-dataset-verified-through-canonical-checker.md
@@ -1,0 +1,31 @@
+### Fixed: a recording example verifies its dataset through the canonical checker
+
+`examples/kimodo/kimodo_g1_dataset_headcam.py` records N episodes and then confirmed the
+count by re-reading the parquet itself, opening `data/chunk-000/file-000.parquet` by name.
+LeRobot v3 does not guarantee that name. `data/` is written in files capped at
+`DEFAULT_DATA_FILE_SIZE_IN_MB` (100 MB), so a recording that outgrows the cap spills into
+`file-001.parquet` while the far smaller `meta/episodes` parquet still holds every row.
+Reading only the leading file then sees only the leading episodes.
+
+Measured on a healthy twenty-episode dataset whose `data/` spilled at episode twelve:
+`verify_dataset` reported `status='success'` with `total_episodes=20`, and the example's own
+check raised `parquet truth FAIL: unique episode_index=[0, ... 11], expected [0, ... 19]`.
+A head-cam dataset -- two camera streams, twenty episodes -- passes 100 MB well before it
+finishes, so the check written to catch the mega-episode corruption (every frame buffered
+into `episode_index=0`) was refusing the successful runs instead. Its own docstring calls
+that check "the same contract the autonomous harness uses", which is what makes the false
+refusal expensive: it trains a reader to disbelieve the one signal that would catch a real
+fabrication.
+
+The example now calls `strands_robots.verify_dataset.verify_dataset(root, expected=N)`,
+which globs `meta/episodes/**/*.parquet` and takes that as the ground truth, so it is
+size-independent by construction. It also checks two corruptions a count-only read cannot
+see: a per-episode MP4 that is absent, empty or truncated, and an `action` /
+`observation.state` column written identically zero across an episode. The head-cam feature
+assertion stays in the example, because that both cameras are declared is this script's own
+contract rather than a property every LeRobot dataset has to satisfy.
+
+This does not widen what is refused. `meta/episodes` is the declared ground truth, and
+`verify_dataset` already reported success for a dataset whose `data/` tail is unreadable --
+it did so before this pairing too. The change removes a false refusal; it does not add
+detection of a corrupt `data/` file.

--- a/examples/kimodo/kimodo_g1_dataset_headcam.py
+++ b/examples/kimodo/kimodo_g1_dataset_headcam.py
@@ -59,7 +59,7 @@ def _make_stub_motion_agent():
         def sample(self, prompt, num_frames, diffusion_steps, guidance_scale, seed):
             qpos = np.zeros((num_frames, 7 + 29), dtype=np.float32)
             qpos[:, 2] = 0.75  # standing z
-            qpos[:, 6] = 1.0   # quat w
+            qpos[:, 6] = 1.0  # quat w
             t = np.linspace(0.0, 4.0 * np.pi, num_frames, dtype=np.float32)
             # left/right shoulder pitch — indices matched to KIMODO_G1_JOINTS
             qpos[:, 7 + 15] = 0.5 * np.sin(t)
@@ -70,42 +70,38 @@ def _make_stub_motion_agent():
 
 
 def _verify_parquet_truth(dataset_root: Path, n_episodes: int) -> None:
-    """Parquet-truth verification — matches the autonomous harness contract."""
-    import pyarrow.parquet as pq
+    """Parquet-truth verification, via the library's canonical checker.
+
+    Delegates the dataset integrity check to
+    :func:`strands_robots.verify_dataset.verify_dataset` instead of re-reading
+    the parquet here. Opening a single ``chunk-000/file-000.parquet`` by name
+    reports a false failure as soon as a recording outgrows LeRobot's
+    ``DEFAULT_DATA_FILE_SIZE_IN_MB`` (100 MB) and spills into
+    ``file-001.parquet``: the first file then holds only the leading episodes,
+    so a healthy twenty-episode run reads back as a truncated one. The
+    canonical checker globs every chunk and file, and additionally verifies the
+    per-episode MP4 tracks and flags an all-zero control column - two
+    corruptions a count-only check cannot see.
+
+    The head-cam feature assertion stays here. That both cameras are declared
+    is this script's own contract rather than a property every LeRobot dataset
+    has to satisfy.
+    """
+    from strands_robots.verify_dataset import verify_dataset
+
+    report = verify_dataset(dataset_root, expected=n_episodes)
+    if report["status"] != "success":
+        raise SystemExit("parquet truth FAIL: " + "; ".join(report["problems"]))
 
     info = json.loads((dataset_root / "meta" / "info.json").read_text())
-    total_episodes = info.get("total_episodes")
-    if total_episodes != n_episodes:
-        raise SystemExit(
-            f"parquet truth FAIL: info.total_episodes={total_episodes}, expected {n_episodes}"
-        )
-
-    ep_tab = pq.read_table(
-        dataset_root / "meta" / "episodes" / "chunk-000" / "file-000.parquet"
-    )
-    if ep_tab.num_rows != n_episodes:
-        raise SystemExit(
-            f"parquet truth FAIL: meta/episodes rows={ep_tab.num_rows}, expected {n_episodes}"
-        )
-
-    data_tab = pq.read_table(
-        dataset_root / "data" / "chunk-000" / "file-000.parquet"
-    )
-    ep_col = data_tab.column("episode_index").to_pylist()
-    unique = sorted(set(ep_col))
-    if unique != list(range(n_episodes)):
-        raise SystemExit(
-            f"parquet truth FAIL: unique episode_index={unique}, expected {list(range(n_episodes))}"
-        )
-
     features = list(info.get("features", {}).keys())
     for expected in ("observation.images.head", "observation.images.front"):
         if expected not in features:
             raise SystemExit(f"parquet truth FAIL: missing feature {expected}")
 
     print(
-        f"✓ parquet truth PASS: {total_episodes} eps, "
-        f"{info.get('total_frames')} frames, features={features}"
+        f"\u2713 parquet truth PASS: {report['total_episodes']} eps, "
+        f"{report['total_frames']} frames, features={features}"
     )
 
 
@@ -115,8 +111,9 @@ def main() -> int:
     parser.add_argument("--n-episodes", type=_positive_int, default=3)
     parser.add_argument("--n-steps", type=_positive_int, default=100)
     parser.add_argument("--control-hz", type=_positive_int, default=25)
-    parser.add_argument("--num-frames", type=_positive_int, default=180,
-                        help="Kimodo motion length in native frames (<=196)")
+    parser.add_argument(
+        "--num-frames", type=_positive_int, default=180, help="Kimodo motion length in native frames (<=196)"
+    )
     parser.add_argument(
         "--stub",
         action="store_true",
@@ -193,8 +190,7 @@ def main() -> int:
         control_frequency=args.control_hz,
         n_episodes=args.n_episodes,
         reset_between=True,
-        video={"path": str(args.out.parent / "kimodo_headcam.mp4"),
-               "fps": args.control_hz, "camera": "head"},
+        video={"path": str(args.out.parent / "kimodo_headcam.mp4"), "fps": args.control_hz, "camera": "head"},
     )
     status = result.get("status") if isinstance(result, dict) else str(result)
     print(f"run_policy status: {status}")

--- a/tests/test_examples_verify_a_dataset_through_the_canonical_checker.py
+++ b/tests/test_examples_verify_a_dataset_through_the_canonical_checker.py
@@ -1,0 +1,280 @@
+"""A recording example verifies its dataset with the library's own checker.
+
+An example that records N episodes and then re-reads the parquet itself to
+confirm the count is printing a verdict about a document it opened by name.
+LeRobot v3 does not guarantee that name. ``data/`` is written in files capped at
+``lerobot.datasets.utils.DEFAULT_DATA_FILE_SIZE_IN_MB`` (100 MB), so a recording
+that outgrows the cap spills into ``file-001.parquet`` while
+``meta/episodes/chunk-000/file-000.parquet`` - two orders of magnitude smaller -
+still holds every row. Opening only ``data/chunk-000/file-000.parquet`` then
+reads the leading episodes and nothing else.
+
+Measured on ``731e8235``, before the call site this module guards was paired. A
+healthy twenty-episode dataset whose ``data/`` had spilled at episode twelve::
+
+    strands_robots.verify_dataset.verify_dataset(root, expected=20)
+        -> status='success'  total_episodes=20
+
+    examples/kimodo/kimodo_g1_dataset_headcam.py::_verify_parquet_truth(root, 20)
+        -> SystemExit: parquet truth FAIL: unique episode_index=[0, ... 11],
+                       expected [0, ... 19]
+
+The example's own docstring calls that check "the same contract the autonomous
+harness uses", and a head-cam dataset - two camera streams, twenty episodes -
+passes 100 MB well before it finishes. So the failure direction is the damaging
+one: the check exists to catch the mega-episode corruption (N episodes buffered
+into ``episode_index=0``) and instead refuses the successful runs, which trains
+a reader to disbelieve it.
+
+``verify_dataset`` globs ``meta/episodes/**/*.parquet`` and takes that as the
+ground truth, so it is size-independent by construction. It also checks two
+corruptions a count-only read cannot see: a per-episode MP4 that is absent,
+empty or truncated, and an ``action`` / ``observation.state`` column written
+identically zero across an episode.
+
+What this module does NOT claim: delegating does not add detection of a corrupt
+file under ``data/``. ``meta/episodes`` is the declared ground truth and
+``verify_dataset`` reports success for a dataset whose ``data/`` tail is
+unreadable - it did so before this pairing too. The change here removes a false
+refusal; it does not widen what is refused.
+
+The structural half is scoped to this one call site rather than swept over
+``examples/``: exactly one example reads a dataset root today, and ``tests/``
+legitimately names ``chunk-000`` because a fixture *writes* those files at a
+path it chooses. Naming a path you are creating is not the same act as trusting
+a path you are reading, so the rule is graded against constructed exemplars.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import io
+import json
+import re
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+import pyarrow as pa  # noqa: E402
+import pyarrow.parquet as pq  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_EXAMPLE = _REPO_ROOT / "examples" / "kimodo" / "kimodo_g1_dataset_headcam.py"
+
+_EPISODES = 20
+_SPILL_AT = 12
+_FRAMES_PER_EPISODE = 10
+_CAMERA_FEATURES = ("observation.images.head", "observation.images.front")
+
+# A dataset path written with the chunk/file index spelled as a literal. Reading
+# one is what this module refuses; a fixture *writing* one is not the same act.
+_CHUNK_BY_NAME = re.compile(r"""["']chunk-\d+["']""")
+
+
+def _verifier_ast() -> ast.FunctionDef:
+    """The example's verifier, parsed."""
+    source = _EXAMPLE.read_text(encoding="utf-8")
+    return next(
+        node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.FunctionDef) and node.name == "_verify_parquet_truth"
+    )
+
+
+def _load_example() -> Any:
+    """Import the example module without running its ``main``."""
+    spec = importlib.util.spec_from_file_location("_headcam_example", _EXAMPLE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_headcam_example"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_dataset(
+    root: Path,
+    *,
+    episodes: int = _EPISODES,
+    spill_at: int | None = _SPILL_AT,
+    features: tuple[str, ...] = _CAMERA_FEATURES,
+) -> None:
+    """Write a healthy LeRobot v3 dataset, optionally spilling ``data/``.
+
+    ``spill_at`` splits ``data/`` across ``file-000`` and ``file-001`` the way
+    the 100 MB cap does on a real recording, leaving the small
+    ``meta/episodes`` parquet in a single file - the on-disk shape a head-cam
+    run produces.
+    """
+    (root / "meta" / "episodes" / "chunk-000").mkdir(parents=True, exist_ok=True)
+    (root / "data" / "chunk-000").mkdir(parents=True, exist_ok=True)
+    indices = list(range(episodes))
+    lengths = [_FRAMES_PER_EPISODE] * episodes
+
+    pq.write_table(
+        pa.table({"episode_index": indices, "length": lengths}),
+        root / "meta" / "episodes" / "chunk-000" / "file-000.parquet",
+    )
+
+    def _frames(start: int, stop: int) -> pa.Table:
+        rows: list[int] = []
+        for episode in indices[start:stop]:
+            rows += [episode] * _FRAMES_PER_EPISODE
+        return pa.table({"episode_index": rows, "frame_index": list(range(len(rows)))})
+
+    spans = [(0, episodes)] if spill_at is None else [(0, spill_at), (spill_at, episodes)]
+    for file_index, (start, stop) in enumerate(spans):
+        pq.write_table(_frames(start, stop), root / "data" / "chunk-000" / f"file-{file_index:03d}.parquet")
+
+    (root / "meta" / "info.json").write_text(
+        json.dumps(
+            {
+                "total_episodes": episodes,
+                "total_frames": sum(lengths),
+                "features": {name: {"dtype": "image"} for name in features} | {"action": {"dtype": "float32"}},
+            }
+        )
+    )
+
+
+def _verify(root: Path, episodes: int = _EPISODES) -> str:
+    """Run the example's verifier, returning what it printed."""
+    captured = io.StringIO()
+    with redirect_stdout(captured):
+        _load_example()._verify_parquet_truth(root, episodes)
+    return captured.getvalue()
+
+
+class TestASpilledDatasetIsNotReadAsTruncated:
+    """The regression: the cap is reached, every episode is present."""
+
+    def test_a_dataset_whose_data_spilled_is_accepted(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path)
+        spilled = sorted(p.name for p in (tmp_path / "data" / "chunk-000").glob("*.parquet"))
+        assert spilled == ["file-000.parquet", "file-001.parquet"], spilled
+
+        printed = _verify(tmp_path)
+
+        assert "parquet truth PASS" in printed
+        assert f"{_EPISODES} eps" in printed
+
+    def test_the_leading_file_alone_does_not_hold_every_episode(self, tmp_path: Path) -> None:
+        """Premise: the spill is what a by-name read would have missed."""
+        _write_dataset(tmp_path)
+        leading = pq.read_table(tmp_path / "data" / "chunk-000" / "file-000.parquet")
+        present = sorted(set(leading.column("episode_index").to_pylist()))
+
+        assert present == list(range(_SPILL_AT))
+        assert len(present) < _EPISODES
+
+
+class TestTheCheckStillRefusesWhatItIsFor:
+    """Over-reach controls: delegating must not accept a broken dataset."""
+
+    def test_a_short_recording_is_still_refused(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, episodes=13, spill_at=None)
+        with pytest.raises(SystemExit) as excinfo:
+            _verify(tmp_path)
+        assert "parquet truth FAIL" in str(excinfo.value)
+
+    def test_a_mega_episode_recording_is_still_refused(self, tmp_path: Path) -> None:
+        """Every frame buffered into one episode - the corruption class."""
+        _write_dataset(tmp_path, episodes=1, spill_at=None)
+        with pytest.raises(SystemExit) as excinfo:
+            _verify(tmp_path)
+        assert "parquet truth FAIL" in str(excinfo.value)
+
+    def test_a_missing_head_camera_is_still_refused(self, tmp_path: Path) -> None:
+        """The script's own contract, which the shared checker does not own.
+
+        Unspilled deliberately: the point of this control is the feature check,
+        and a spilled fixture would make the pre-pairing code refuse on the
+        count before it ever read ``features``.
+        """
+        _write_dataset(tmp_path, spill_at=None, features=("observation.images.front",))
+        with pytest.raises(SystemExit) as excinfo:
+            _verify(tmp_path)
+        assert "observation.images.head" in str(excinfo.value)
+
+    def test_a_healthy_unspilled_dataset_is_accepted(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, spill_at=None)
+        assert "parquet truth PASS" in _verify(tmp_path)
+
+
+class TestTheExampleReadsTheDatasetThroughTheSharedChecker:
+    """Structural: the verdict is the library's, not a local re-read."""
+
+    def test_the_verifier_calls_verify_dataset(self) -> None:
+        source = _EXAMPLE.read_text(encoding="utf-8")
+        function = next(
+            node
+            for node in ast.parse(source).body
+            if isinstance(node, ast.FunctionDef) and node.name == "_verify_parquet_truth"
+        )
+        called = {
+            node.func.id
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "verify_dataset" in called, sorted(called)
+
+    def test_the_verifier_names_no_chunk_file(self) -> None:
+        """The shape rule of :class:`TestTheRuleIsNotVacuous`, applied here."""
+        assert _CHUNK_BY_NAME.search(ast.unparse(_verifier_ast())) is None
+
+    def test_the_verifier_opens_no_parquet_of_its_own(self) -> None:
+        source = _EXAMPLE.read_text(encoding="utf-8")
+        function = next(
+            node
+            for node in ast.parse(source).body
+            if isinstance(node, ast.FunctionDef) and node.name == "_verify_parquet_truth"
+        )
+        body = ast.unparse(function)
+        assert "read_table" not in body
+        assert "pyarrow" not in body
+
+
+class TestTheRuleIsNotVacuous:
+    """The by-name read is what is refused, and it is refused by shape."""
+
+    @pytest.mark.parametrize(
+        ("label", "snippet", "flagged"),
+        [
+            pytest.param(
+                "reads-a-named-chunk",
+                'pq.read_table(root / "data" / "chunk-000" / "file-000.parquet")',
+                True,
+                id="reads-a-named-chunk",
+            ),
+            pytest.param(
+                "globs-every-chunk",
+                'sorted((root / "data").glob("**/*.parquet"))',
+                False,
+                id="globs-every-chunk",
+            ),
+            pytest.param(
+                "delegates",
+                "verify_dataset(root, expected=n_episodes)",
+                False,
+                id="delegates",
+            ),
+        ],
+    )
+    def test_the_shape_rule_grades_constructed_exemplars(self, label: str, snippet: str, flagged: bool) -> None:
+        assert bool(_CHUNK_BY_NAME.search(snippet)) is flagged, label
+
+    def test_both_outcomes_are_reachable(self) -> None:
+        """Non-vacuity: the rule accepts and refuses something."""
+        outcomes = {
+            bool(_CHUNK_BY_NAME.search(snippet))
+            for snippet in (
+                'pq.read_table(root / "chunk-000" / "file-000.parquet")',
+                "verify_dataset(root)",
+            )
+        }
+        assert outcomes == {True, False}


### PR DESCRIPTION
## Problem

`examples/kimodo/kimodo_g1_dataset_headcam.py` records N episodes and then confirmed the count by re-reading the parquet itself, opening `data/chunk-000/file-000.parquet` **by name**.

LeRobot v3 does not guarantee that name. `data/` is written in files capped at `lerobot.datasets.utils.DEFAULT_DATA_FILE_SIZE_IN_MB` (100 MB), so a recording that outgrows the cap spills into `file-001.parquet` while the far smaller `meta/episodes` parquet still holds every row. Reading only the leading file then sees only the leading episodes.

## Measured

A **healthy** twenty-episode dataset whose `data/` spilled at episode twelve, `meta/episodes` in a single file (the shape a real head-cam run produces, since `meta/` is orders of magnitude smaller than `data/`):

| on-disk layout | `verify_dataset(root, expected=20)` | the example's own check |
|---|---|---|
| `data/` single file (small dataset) | `success` (eps=20) | PASS |
| **`data/` spilled to `file-001` (>100 MB)** | **`success` (eps=20)** | **`SystemExit: parquet truth FAIL: unique episode_index=[0, ... 11], expected [0, ... 19]`** |

The failure direction is the damaging one. The check exists to catch the mega-episode corruption (every frame buffered into `episode_index=0`) and instead refuses the successful runs. A head-cam dataset -- two camera streams, twenty episodes -- passes 100 MB well before it finishes, and the example's own docstring presents that check as the project's dataset-integrity contract, which is what makes the false refusal expensive: it trains a reader to disbelieve the one signal that would catch a real fabrication.

## Change

The example now delegates to `strands_robots.verify_dataset.verify_dataset(root, expected=N)`, which already ships and is the CLI behind `strands-robots verify-dataset`. It globs `meta/episodes/**/*.parquet` and takes that as the ground truth, so it is size-independent by construction, and it additionally checks two corruptions a count-only read cannot see: a per-episode MP4 that is absent, empty or truncated, and an `action` / `observation.state` column written identically zero across an episode.

The head-cam feature assertion stays in the example. That both cameras are declared is this script's own contract rather than a property every LeRobot dataset has to satisfy.

Net `-28 / +24` in the example: a weaker local re-read replaced by a call, per the shared-owner convention.

## What this does not claim

Delegating does **not** widen what is refused. `meta/episodes` is the declared ground truth and `verify_dataset` reports success for a dataset whose `data/` tail is unreadable -- it did so before this pairing too. This removes a false refusal; it does not add detection of a corrupt `data/` file.

## Tests

`tests/test_examples_verify_a_dataset_through_the_canonical_checker.py`, 13 cases.

Pre-fix split (example reverted, tests kept): **4 failed / 9 passed**, and the roles are clean:

| class | role | pre-fix |
|---|---|---|
| `TestASpilledDatasetIsNotReadAsTruncated` | regression + premise | 1 of 2 fail |
| `TestTheExampleReadsTheDatasetThroughTheSharedChecker` | structural regression | 3 of 3 fail |
| `TestTheCheckStillRefusesWhatItIsFor` | over-reach controls | **0 of 4** |
| `TestTheRuleIsNotVacuous` | constructed exemplars | **0 of 4** |

The controls hold that delegating did not soften anything: a short recording, a mega-episode recording and a missing head camera are each still refused, and a healthy unspilled dataset is still accepted. The premise cell pins that the leading file really does hold only episodes 0..11, so the regression is measuring the spill rather than a fixture accident.

`TestTheRuleIsNotVacuous` grades the shape rule against constructed exemplars (a named-chunk read is flagged; a glob and a delegation are not) plus a `{True, False}` reachability check, because after this change `examples/` contains no by-name chunk read for the rule to exercise.

### Scope of the structural half

Scoped to this one call site rather than swept over `examples/`: exactly one example reads a dataset root today, and `tests/` legitimately names `chunk-000` because a fixture **writes** those files at a path it chooses. Naming a path you are creating is not the same act as trusting a path you are reading.

## Gate

- `ruff check` + `ruff format --check`: clean on both changed files
- `mypy strands_robots tests tests_integ`: 24 errors in 9 files (the standing baseline), **0 attributable** to either changed file
- 20 guard files covering examples, `verify_dataset` and the episode judge: **562 passed, 54 skipped, 0 failed**
- New file: 13 passed; changelog gates: 30 passed

The full 464-file tree-walking guard class exceeded this run's wall budget, so it is not claimed here; the 20 files above are the subset that reads `examples/` or the dataset checker.
