### PR TITLE
fix(doctor): release the sim smoke test's renderer instead of leaving it to the finalizer

### DIFF
--- a/changelog.d/2896-doctor-sim-smoke-releases-the-renderer.md
+++ b/changelog.d/2896-doctor-sim-smoke-releases-the-renderer.md
@@ -1,0 +1,36 @@
+### Fixed: `strands-robots doctor` no longer prints EGL tracebacks beside "All checks passed"
+
+`strands_robots.doctor.check_sim_smoke` drove `Robot('so100')` through `step` and
+`get_observation` and never released it. That observation renders the robot's
+cameras, so it opens a MuJoCo GL context; left to the finalizer, the context was
+freed during interpreter teardown - after EGL had already been de-initialised -
+and MuJoCo's own `Renderer.__del__` wrote an `Exception ignored in` traceback to
+stderr.
+
+The command still exited 0 and still printed `All checks passed`, so a healthy
+install produced a verdict saying the setup was sound beside 1894 bytes of
+`EGLError(err = EGL_NOT_INITIALIZED)`. That is the first command a new reader
+runs to find out whether their machine is set up, and it is the one place the
+answer is supposed to be unambiguous. Measured 6 of 6 runs on mujoco 3.5.0 (the
+declared floor) and on 3.12.0, and 0 of 6 after the fix.
+
+Nothing about the verdict changes: the check still reports the observation key
+count, and the renderer was the only thing left behind. The scope was decided by
+where the context is opened rather than by who notices it last - `Robot()` as a
+module-level name happens not to reproduce it, because a function local becomes
+garbage when the function returns and a module global does not, so the shape of
+the caller was deciding whether a traceback appeared.
+
+The sim is released in a `finally`, so the paths that opened the context and then
+refused - an empty observation, an observation that raised - free it too. The
+release verb is `cleanup` rather than `with`: `Robot()` resolves to a simulation
+or to the hardware wrapper, and only the simulation implements the
+context-manager protocol, so `with` would release one of the two things the
+factory returns. A release that fails is reported rather than swallowed, because
+a sim that cannot be released is a real defect on that machine and the verdict
+this check reports covers the whole lifecycle it drives.
+
+The two `Robot` doubles in the doctor suite gain the release verb the real one
+always has. Without it the release would fail with `AttributeError`, and the
+cells asserting `FAIL` for an empty observation would still have been green while
+grading nothing.

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -342,18 +342,38 @@ def check_hf_auth() -> str:
 
 
 def check_sim_smoke() -> str:
-    """Run Robot('so100') -> step -> get_observation as a smoke test."""
+    """Run Robot('so100') -> step -> get_observation -> release as a smoke test.
+
+    The release is part of what this check verifies, not housekeeping after it.
+    ``get_observation`` opens a MuJoCo GL context to render the robot's cameras,
+    and a context left to the finalizer is freed during interpreter teardown -
+    after EGL has already been de-initialised - so MuJoCo's own
+    ``Renderer.__del__`` writes an ``Exception ignored in`` traceback to stderr.
+    That lands beside this command's "All checks passed" verdict, which is the
+    one place a new reader looks for a signal that their setup is sound.
+
+    ``cleanup`` is the release verb rather than ``with``: it is the one every
+    object :func:`strands_robots.Robot` can return carries, because the hardware
+    wrapper implements no context-manager protocol.
+    """
     try:
         # Suppress mesh warnings during doctor
         os.environ.setdefault("STRANDS_MESH", "false")
         from strands_robots import Robot
 
         sim = Robot("so100")
-        sim.step()
-        obs = sim.get_observation("so100")
-        if obs and len(obs) > 0:
-            return _pass(f"sim smoke test: Robot('so100') works ({len(obs)} obs keys)")
-        return _fail("sim smoke test: observation empty")
+        try:
+            sim.step()
+            obs = sim.get_observation("so100")
+            if obs and len(obs) > 0:
+                return _pass(f"sim smoke test: Robot('so100') works ({len(obs)} obs keys)")
+            return _fail("sim smoke test: observation empty")
+        finally:
+            # Released here rather than left to the finalizer, and deliberately
+            # not swallowed: a sim that cannot be released is a real defect on
+            # this machine, and the verdict this check reports covers the whole
+            # lifecycle it drives.
+            sim.cleanup()
     except Exception as e:
         return _fail(f"sim smoke test failed: {e}", fix="Check MUJOCO_GL and mujoco install")
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -313,6 +313,15 @@ class TestDoctorDegradedPaths:
             def get_observation(self, _name: str) -> dict:
                 return {}
 
+            def cleanup(self) -> None:
+                """Present because every object ``Robot()`` returns carries it.
+
+                A double without it would let ``check_sim_smoke``'s release fail
+                with ``AttributeError``, so this cell would still see a ``FAIL``
+                and pass for a reason that has nothing to do with an empty
+                observation.
+                """
+
         monkeypatch.setattr(strands_robots, "Robot", _EmptyObsRobot)
         result = check_sim_smoke()
         assert "  FAIL  " in result

--- a/tests/test_doctor_sim_smoke_releases_the_renderer.py
+++ b/tests/test_doctor_sim_smoke_releases_the_renderer.py
@@ -1,0 +1,231 @@
+"""``strands-robots doctor`` releases the sim its smoke test opened.
+
+``check_sim_smoke`` drives ``Robot('so100')`` through ``step`` and
+``get_observation``, and that observation renders the robot's cameras, so it
+opens a MuJoCo GL context. Left to the finalizer, that context is freed during
+interpreter teardown - after EGL has already been de-initialised - and MuJoCo's
+own ``Renderer.__del__`` writes an ``Exception ignored in`` traceback to stderr.
+
+The command that wrote it still exits 0 and still prints "All checks passed", so
+the reader of a first-run diagnostic is handed a wall of EGL tracebacks beside
+the verdict that says their setup is sound. The renderer is therefore released
+where the check opened it.
+
+The scope here is that release. Whether the surrounding command reports its
+findings well, and what a *failing* check should say, are the sibling suite's
+questions and are unchanged by these cells.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from strands_robots.doctor import check_sim_smoke
+
+# The marker MuJoCo writes when a GL context is freed after EGL is gone. Stated
+# here rather than imported so these cells grade the observable text a reader
+# meets rather than restating a constant the code under test could rename.
+_FINALIZER_MARKER = "Exception ignored in"
+
+_DOCTOR_SUITE = Path(__file__).with_name("test_doctor.py")
+
+
+class _Recorder:
+    """A ``Robot`` stand-in that records whether it was released.
+
+    Carries exactly the four members ``check_sim_smoke`` uses, so a cell that
+    passes here is not passing because the double happened to be permissive.
+    """
+
+    def __init__(self, obs_keys: int = 3, raise_on_observe: bool = False) -> None:
+        self.cleanup_calls = 0
+        self._obs_keys = obs_keys
+        self._raise_on_observe = raise_on_observe
+
+    def step(self) -> None:
+        return None
+
+    def get_observation(self, _name: str) -> dict[str, int]:
+        if self._raise_on_observe:
+            raise RuntimeError("observation exploded")
+        return {f"joint{i}": i for i in range(self._obs_keys)}
+
+    def cleanup(self) -> None:
+        self.cleanup_calls += 1
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, robot: object) -> None:
+    """Point the check's ``Robot`` lookup at ``robot``.
+
+    ``check_sim_smoke`` imports ``Robot`` from the package inside its own body,
+    so the attribute on the package is the seam every cell here drives.
+    """
+    import strands_robots
+
+    monkeypatch.setattr(strands_robots, "Robot", lambda *_a, **_k: robot)
+
+
+def _finalbody_release_calls() -> list[str]:
+    """Every release call the check makes from a ``finally`` block.
+
+    Read off the source rather than observed, because a release that happens on
+    the happy path only - or that a later edit moves out of the ``finally`` - is
+    invisible to a cell that drives the passing case.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(check_sim_smoke)))
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try) or not node.finalbody:
+            continue
+        for statement in node.finalbody:
+            for inner in ast.walk(statement):
+                if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute):
+                    found.append(inner.func.attr)
+    return found
+
+
+def _robot_doubles_in_the_doctor_suite() -> dict[str, set[str]]:
+    """Classes in the sibling suite that stand in for a ``Robot``.
+
+    Keyed by class name, valued by the members it defines. A class defining both
+    ``step`` and ``get_observation`` is standing in for what ``check_sim_smoke``
+    drives, whatever it is called.
+    """
+    tree = ast.parse(_DOCTOR_SUITE.read_text(encoding="utf-8"))
+    doubles: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        members = {m.name for m in node.body if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))}
+        if {"step", "get_observation"} <= members:
+            doubles[node.name] = members
+    return doubles
+
+
+class TestTheSimSmokeReleasesItsRenderer:
+    """The check releases the sim on every path out of it."""
+
+    def test_a_real_sim_smoke_writes_no_traceback_to_stderr(self) -> None:
+        """The observable defect: a passing check that still prints a traceback.
+
+        Driven in a subprocess because the finalizer that wrote it ran during
+        interpreter teardown, which an in-process cell cannot observe.
+        """
+        pytest.importorskip("mujoco")
+        script = "from strands_robots.doctor import check_sim_smoke\nprint('VERDICT', check_sim_smoke().strip())\n"
+        done = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env={**os.environ, "STRANDS_MESH": "false"},
+        )
+        if "PASS" not in done.stdout:
+            pytest.skip(f"sim smoke did not pass here, so no GL context was opened: {done.stdout.strip()}")
+        assert _FINALIZER_MARKER not in done.stderr, (
+            f"the check passed and still wrote {len(done.stderr)} bytes to stderr:\n{done.stderr}"
+        )
+
+    def test_the_sim_is_released_on_the_passing_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        robot = _Recorder(obs_keys=3)
+        _install(monkeypatch, robot)
+        result = check_sim_smoke()
+        assert "  PASS  " in result
+        assert robot.cleanup_calls == 1
+
+    def test_the_sim_is_released_when_the_observation_is_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A refused verdict still owes the release: the context was opened."""
+        robot = _Recorder(obs_keys=0)
+        _install(monkeypatch, robot)
+        result = check_sim_smoke()
+        assert "  FAIL  " in result
+        assert robot.cleanup_calls == 1
+
+    def test_the_sim_is_released_when_the_observation_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The path that opened the context and then failed still releases it."""
+        robot = _Recorder(raise_on_observe=True)
+        _install(monkeypatch, robot)
+        result = check_sim_smoke()
+        assert "  FAIL  " in result
+        assert "observation exploded" in result
+        assert robot.cleanup_calls == 1
+
+
+class TestTheReleaseIsStructurallyPinned:
+    """The release is reached from a ``finally``, not from the happy path."""
+
+    def test_the_check_releases_the_sim_in_a_finally(self) -> None:
+        assert "cleanup" in _finalbody_release_calls(), (
+            "check_sim_smoke must release the sim from a finally block, so a "
+            "refused or raising observation still frees the GL context it opened"
+        )
+
+
+class TestPremises:
+    """Facts these cells rest on, asserted rather than assumed."""
+
+    def test_cleanup_is_the_one_release_verb_every_robot_return_carries(self) -> None:
+        """Why ``cleanup`` and not ``with``.
+
+        ``Robot()`` resolves to a simulation or to the hardware wrapper. Only one
+        of those implements the context-manager protocol, so ``with`` would be a
+        release verb that works for one of the two things the factory returns.
+        """
+        from strands_robots.hardware_robot import Robot as HardwareRobot
+        from strands_robots.simulation.base import SimEngine
+
+        assert callable(getattr(HardwareRobot, "cleanup", None))
+        assert callable(getattr(SimEngine, "cleanup", None))
+        assert not hasattr(HardwareRobot, "__enter__")
+        assert hasattr(SimEngine, "__enter__")
+
+    def test_every_robot_double_in_the_doctor_suite_carries_the_release_verb(self) -> None:
+        """A permissive double would let these cells pass for the wrong reason.
+
+        ``check_sim_smoke`` now releases what it opened, so a stand-in without
+        ``cleanup`` turns that release into an ``AttributeError`` - and a cell
+        asserting ``FAIL`` would still be green while grading nothing.
+        """
+        doubles = _robot_doubles_in_the_doctor_suite()
+        assert doubles, f"found no Robot stand-in in {_DOCTOR_SUITE.name}; the scan has gone blind"
+        missing = sorted(name for name, members in doubles.items() if "cleanup" not in members)
+        assert not missing, f"Robot doubles without the release verb the real one always has: {missing}"
+
+
+class TestWhatIsUnchanged:
+    """The verdict this check reports is untouched by the release."""
+
+    def test_the_passing_verdict_still_names_the_observation_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        robot = _Recorder(obs_keys=13)
+        _install(monkeypatch, robot)
+        result = check_sim_smoke()
+        assert "  PASS  " in result
+        assert "13 obs keys" in result
+
+
+class TestTheReleaseFailureIsNotSwallowed:
+    """A release that fails is named, not hidden behind a passing observation."""
+
+    def test_a_release_failure_is_reported_rather_than_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A sim that cannot be released is a real defect on this machine.
+
+        The verdict covers the whole lifecycle the check drives, so the failure
+        is named rather than hidden behind a passing observation.
+        """
+
+        class _UnreleasableRobot(_Recorder):
+            def cleanup(self) -> None:
+                raise RuntimeError("gl context stuck")
+
+        _install(monkeypatch, _UnreleasableRobot(obs_keys=3))
+        result = check_sim_smoke()
+        assert "  FAIL  " in result
+        assert "gl context stuck" in result


### PR DESCRIPTION
## Problem

`strands_robots.doctor.check_sim_smoke` drove `Robot('so100')` through `step` and
`get_observation` and never released it. That observation renders the robot's cameras, so it
opens a MuJoCo GL context. Left to the finalizer, the context is freed during interpreter
teardown - after EGL has already been de-initialised - so MuJoCo's own `Renderer.__del__`
writes a traceback to stderr.

On a healthy install the command therefore exits 0 and prints `All checks passed` while
writing 1894 bytes of `EGLError(err = EGL_NOT_INITIALIZED)` to stderr. That is the first
command a new reader runs to find out whether their machine is set up.

Reproduced on `main` (`731e8235`), on both mujoco versions:

| mujoco | rc | stdout verdict | stderr | tracebacks |
|---|---|---|---|---|
| 3.5.0 (declared floor) | 0 | `All checks passed` | 1894 B | 6/6 runs |
| 3.12.0 (what PyPI resolves) | 0 | `All checks passed` | 1941 B | 6/6 runs |

Traced to one renderer, created by `check_sim_smoke` -> `get_observation` ->
`rendering._get_renderer`.

## Why the caller's shape was deciding it

The same code reproduces or not depending on where the sim is bound, which is why this is
easy to miss:

| binding | tracebacks |
|---|---|
| function local (what `check_sim_smoke` does) | 6/6 |
| module-level global | 0/6 |

A local becomes garbage when the function returns; a module global does not. So whether a
reader saw a traceback depended on the shape of the caller rather than on anything about
their machine.

## Fix

Release the sim in a `finally`, so the paths that opened the context and then refused - an
empty observation, an observation that raised - free it too.

| shape | tracebacks | stderr | obs keys |
|---|---|---|---|
| bare (before) | 6/6 | 1894 B | 13 |
| `cleanup()` in a `finally` (this PR) | 0/6 | 0 B | 13 |
| `with Robot(...)` | 0/6 | 0 B | 13 |

`cleanup` is the release verb rather than `with`, for a measured reason: `Robot()` resolves
to a simulation or to the hardware wrapper, and only one of those implements the
context-manager protocol.

| class | `cleanup` | `__enter__` |
|---|---|---|
| `simulation.base.SimEngine` | yes | yes |
| `hardware_robot.Robot` | yes | **no** |

So `with` would be a release verb that works for one of the two things the factory returns.
It also matches the convention in `examples/`, which call `robot.cleanup()`.

The release is not swallowed: a sim that cannot be released is a real defect on that
machine, and the verdict this check reports covers the whole lifecycle it drives.

## Why nothing caught it

The two `Robot` doubles in `tests/test_doctor.py` carry `step` and `get_observation` and no
release verb - more permissive than the real thing, which always has one. They gain
`cleanup` here; without it the release would fail with `AttributeError` and the cells
asserting `FAIL` for an empty observation would still be green while grading nothing. A new
premise cell derives every `Robot` stand-in in that suite and requires the release verb, so
a future double cannot reintroduce the hole.

## Tests

`tests/test_doctor_sim_smoke_releases_the_renderer.py`, 9 cells. Pre-fix split **6 failed /
9**, with **0 of 2 premise** and **0 of 1 control**:

| class | role | pre-fix |
|---|---|---|
| `TestTheSimSmokeReleasesItsRenderer` | regression | 4/4 |
| `TestTheReleaseIsStructurallyPinned` | regression (structural) | 1/1 |
| `TestTheReleaseFailureIsNotSwallowed` | regression | 1/1 |
| `TestPremises` | premise | 0/2 |
| `TestWhatIsUnchanged` | control | 0/1 |

The behavioural cell runs in a subprocess, because the finalizer that wrote the traceback
ran during interpreter teardown and an in-process cell cannot observe it. It skips when the
smoke test does not pass on the host, since no GL context was opened to leak.

## Mutations

`collected` stable at 9 on every row. `sib` is the three doctor suites; its baseline is 2,
measured on pristine `main` (a `PackageNotFoundError` pair from the editable install having
no distribution metadata in a bare worktree), so every row is +0.

| row | fires | sib | note |
|---|---|---|---|
| b0 control | 0 | +0 | clean |
| b1 release removed (= `main`) | 6 | +0 | the pre-fix state |
| b2 release on the happy path only | 3 | +0 | subset of b1; the refusing paths leak |
| b3 `with Robot(...)` instead of `cleanup` | 6 | +0 | not a subset of b1 - see below |
| b4 release swallowed | 1 | +0 | the no-swallow cell |
| b5 sibling double loses its release verb | 1 | +0 | the derived rule fires by name |
| b6 b5 + the double-scan hardcoded | 1 | +0 | the **non-vacuity floor** fires instead |

b5 and b6 fire the same cell on different assertions, which is the point of having both:
b5 reports `Robot doubles without the release verb the real one always has: ['_EmptyObsRobot']`,
and b6 reports `found no Robot stand-in in test_doctor.py; the scan has gone blind`. The
rule catches the missing verb; the floor catches a blinded scan.

b3 is not a subset of b1: the context-manager spelling fails against a stand-in that carries
`cleanup` and no `__enter__`, which is the same asymmetry the premise cell states.

## Gate

- `ruff check` and `ruff format --check` clean over 1700 files.
- `mypy strands_robots tests tests_integ`: **24 == 24** against the same tree with the change
  reverted, normalised message sets identical in both directions, **0 attributable**
  (`checked 1696` vs `1697`, the new test file).
- Paired run over a 472-file selection (every guard walking the tree, parsing source or
  reading docstrings, plus every doctor suite), the new file withheld from both sides:
  identical **22037 collected** and `24 failed, 21937 passed, 76 skipped` on each, **24 == 24
  identical failing ids, both `comm` directions empty**.
- All 24 shared failures classified by measurement: **17** need `awsiot`/`awscrt` (both
  `find_spec` `False`, both declared in `mesh-iot`, and `tool.hatch.envs.default.features` is
  `['all']`, so CI installs them), **3** the lerobot-from-source
  `TypeError: encode() takes 1 positional argument` drift, **2** the bare-worktree
  `PackageNotFoundError` pair, **2** need `device_connect_agent_tools`.
- Changed files pass on mujoco 3.5.0 and 3.12.0.

No visual artifact: nothing rendered changes. The subject is releasing the context rather
than what it draws, and the evidence is the measured stderr before and after.
