### PR TITLE
fix(policies/protomotions): the missing-checkpoint remedy names a step, not the caller's argument

### DIFF
--- a/changelog.d/2897-protomotions-checkpoint-remedy.md
+++ b/changelog.d/2897-protomotions-checkpoint-remedy.md
@@ -1,0 +1,48 @@
+### Fixed: the ProtoMotions missing-checkpoint refusal names a step instead of the caller's argument
+
+`ProtoMotionsPolicy` takes `onnx_path` as a *local* file and resolves no
+HuggingFace model id. `WBCPolicy`, the sibling ONNX policy in the same package,
+does resolve one - `_maybe_download_checkpoint` fetches an `org/repo` checkpoint
+through `huggingface_hub` - and the `[protomotions]` extra declares that same hub
+client, which no module in `policies/protomotions/` imports. The install docs
+attributed the fetch to it ("`huggingface_hub` (fetches a checkpoint from a model
+id)"), so the documented next step for a reader with no weights on disk was to
+pass the model id the module docstring names.
+
+Doing that produced a refusal whose remedy was the argument itself:
+
+```
+ONNX artifact not found: cagataydev/protomotions-gtp-unitree-g1. Download from
+cagataydev/protomotions-gtp-unitree-g1 on HuggingFace.
+```
+
+The caller is told to download the string they just supplied. It is sound advice
+for a mistyped local path and a dead end for the value the docs pointed at, since
+no part of it turns a model id into the local file the parameter wants.
+
+The refusal now names that step - the canonical repo *and* file name, as a command
+whose output is the path to pass:
+
+```
+ONNX artifact not found: cagataydev/protomotions-gtp-unitree-g1. This parameter
+takes a local file, and this policy does not download one. Fetch the checkpoint
+first:
+  python -c "from huggingface_hub import hf_hub_download; print(hf_hub_download('cagataydev/protomotions-gtp-unitree-g1', 'unified_pipeline.onnx'))"
+then pass the path it prints as onnx_path.
+```
+
+That command was run against the live checkpoint: it exits 0 and prints a path to
+a 22,606,590-byte `unified_pipeline.onnx` in the local hub cache, which is the
+argument the constructor accepts. The install section now says the hub client is
+one the caller calls, rather than one the extra calls for them.
+
+The repo id and filename become module constants so the message cannot drift from
+the checkpoint the module docstring, `ProtoMotionsConfig` and this remedy all name;
+a test pins that the raised message interpolates them rather than spelling them a
+second time. Nothing else about the guard changes: a missing local path is still
+reported by that path, and an existing file still reaches the session build.
+
+Whether this policy *should* resolve a model id the way its sibling does is left
+alone - that would add a repo-id spelling to a `*_path` parameter and decide
+whether `yaml_path` follows, which is a public-surface choice rather than a
+wording one. This change makes the refusal actionable either way.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -19,8 +19,9 @@ pip install "strands-robots[protomotions]"
 ```
 
 That pulls `onnxruntime` (runs the graph), `pyyaml` (reads the
-`unified_pipeline.yaml` sidecar) and `huggingface_hub` (fetches a checkpoint from
-a model id). Weights are not bundled. Building a reference clip from `qpos` with
+`unified_pipeline.yaml` sidecar) and `huggingface_hub` — which you call yourself
+to fetch the checkpoint, because `onnx_path` and `yaml_path` take local files and
+this policy resolves no model id. Weights are not bundled. Building a reference clip from `qpos` with
 [`qpos_to_motion_data`](#bridging-a-qpos-clip) additionally needs MuJoCo, which
 ships in `strands-robots[sim-mujoco]`.
 

--- a/strands_robots/policies/protomotions/policy.py
+++ b/strands_robots/policies/protomotions/policy.py
@@ -59,6 +59,12 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["ProtoMotionsPolicy", "ProtoMotionsSession"]
 
+#: Canonical GTP checkpoint on HuggingFace. Nothing in this package downloads
+#: it - ``onnx_path``/``yaml_path`` take local files - so this is quoted in the
+#: not-found remedy rather than being resolved for the caller.
+_GTP_G1_HF_REPO = "cagataydev/protomotions-gtp-unitree-g1"
+_GTP_G1_ONNX_FILENAME = "unified_pipeline.onnx"
+
 
 @runtime_checkable
 class ProtoMotionsSession(Protocol):
@@ -422,9 +428,17 @@ class ProtoMotionsPolicy(Policy):
         )
 
         if not onnx_path.exists():
+            # ``onnx_path`` takes a local file, and nothing here resolves a
+            # model id (unlike WBCPolicy, which downloads its checkpoint). The
+            # old wording read "Download from <repo> on HuggingFace", which is
+            # circular for the caller who passed that repo id: it names the
+            # argument back instead of the step that produces a local path.
             raise FileNotFoundError(
-                f"ONNX artifact not found: {onnx_path}. Download from "
-                f"cagataydev/protomotions-gtp-unitree-g1 on HuggingFace."
+                f"ONNX artifact not found: {onnx_path}. This parameter takes a local file, "
+                f"and this policy does not download one. Fetch the checkpoint first:\n"
+                f'  python -c "from huggingface_hub import hf_hub_download; '
+                f"print(hf_hub_download('{_GTP_G1_HF_REPO}', '{_GTP_G1_ONNX_FILENAME}'))\"\n"
+                f"then pass the path it prints as onnx_path."
             )
 
         sess = ort.InferenceSession(  # type: ignore[attr-defined]

--- a/tests/policies/protomotions/test_missing_checkpoint_remedy_is_not_the_argument.py
+++ b/tests/policies/protomotions/test_missing_checkpoint_remedy_is_not_the_argument.py
@@ -1,0 +1,177 @@
+"""The missing-checkpoint refusal must name a step, not the caller's argument.
+
+``ProtoMotionsPolicy`` takes ``onnx_path`` as a *local* file and resolves no
+HuggingFace model id - unlike ``WBCPolicy``, whose ``checkpoint`` is downloaded
+through ``huggingface_hub``. The ``[protomotions]`` extra declares that hub
+client all the same, and the install docs used to attribute the fetch to it, so
+the documented next step for a reader was to pass the model id.
+
+Doing that produced::
+
+    ONNX artifact not found: cagataydev/protomotions-gtp-unitree-g1. Download
+    from cagataydev/protomotions-gtp-unitree-g1 on HuggingFace.
+
+- a remedy that names the argument back. The caller is told to download the
+string they just supplied, with no step that turns it into the local path the
+parameter wants. These cells pin the refusal on the step instead: the canonical
+repo *and* file name, as a command whose output is the path to pass.
+
+The value-domain cells for this constructor live in
+``test_history_length_sizes_the_window_it_names.py``; this file grades only the
+not-found remedy and the install sentence that sends a reader into it.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots import utils
+from strands_robots.policies.protomotions import policy as policy_mod
+from strands_robots.policies.protomotions.policy import ProtoMotionsPolicy
+
+_ROOT = Path(__file__).resolve().parents[3]
+_PACKAGE = _ROOT / "strands_robots" / "policies" / "protomotions"
+_DOC = _ROOT / "docs" / "policies" / "protomotions.md"
+
+#: Stated locally so these cells are an independent oracle rather than a
+#: restatement of the module constants they grade.
+REPO_ID = "cagataydev/protomotions-gtp-unitree-g1"
+ONNX_FILENAME = "unified_pipeline.onnx"
+
+_HUB = "huggingface_hub"
+
+
+class _Sentinel(Exception):
+    """Raised by the stub session to prove the not-found guard was passed."""
+
+
+class _StubSession:
+    def __init__(self, *_a: Any, **_k: Any) -> None:
+        raise _Sentinel("session build reached")
+
+
+@pytest.fixture
+def _ort(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Seed ``require_optional``'s cache so the guard under test is reachable.
+
+    ``_build_onnx_session`` resolves ``onnxruntime`` *before* it checks the
+    path, so the not-found branch is unreachable on a host without it. Seeding
+    the cache (rather than ``sys.modules``) is what ``require_optional`` reads
+    first, so this is deterministic whether or not the real package is present.
+    """
+    stub: Any = type("onnxruntime", (), {"InferenceSession": _StubSession})
+    monkeypatch.setitem(utils._lazy_modules, "onnxruntime", stub)
+
+
+def _refusal(value: str, _ort: None) -> str:
+    with pytest.raises(FileNotFoundError) as excinfo:
+        ProtoMotionsPolicy._build_onnx_session(Path(value), ["CPUExecutionProvider"])
+    return str(excinfo.value)
+
+
+def _module_scope_imports(path: Path) -> set[str]:
+    """Every module-scope import name in ``path`` (typing-only blocks skipped)."""
+    names: set[str] = set()
+    for node in ast.parse(path.read_text(encoding="utf-8")).body:
+        if isinstance(node, ast.Import):
+            names.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module.split(".")[0])
+    return names
+
+
+class TestWhyTheWordingMatters:
+    """Premises: the extra advertises a fetch this family never performs."""
+
+    def test_the_extra_declares_a_hub_client(self) -> None:
+        """``[protomotions]`` pins ``huggingface_hub`` - the docs' premise."""
+        declared = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        extra = declared["project"]["optional-dependencies"]["protomotions"]
+        assert any(_HUB in requirement for requirement in extra), extra
+
+    def test_the_family_resolves_no_model_id(self) -> None:
+        """No module in the family imports the hub client, unlike ``wbc``."""
+        importers = sorted(p.name for p in _PACKAGE.glob("*.py") if _HUB in _module_scope_imports(p))
+        assert importers == [], importers
+        wbc = _ROOT / "strands_robots" / "policies" / "wbc" / "policy.py"
+        assert _HUB in wbc.read_text(encoding="utf-8"), "sibling contrast is the point"
+
+
+class TestTheRemedyNamesAStep:
+    """Regression: the refusal must not hand the argument back."""
+
+    def test_a_model_id_is_not_told_to_download_itself(self, _ort: None) -> None:
+        """The remedy for a model id may not be that same model id."""
+        message = _refusal(REPO_ID, _ort)
+        assert f"Download from {REPO_ID}" not in message, message
+        remedy = message.split("Fetch the checkpoint first:", 1)[-1]
+        assert "hf_hub_download" in remedy, message
+
+    def test_the_remedy_names_the_repo_and_the_file(self, _ort: None) -> None:
+        """A reader needs both halves; the repo alone is not a fetchable step."""
+        message = _refusal(REPO_ID, _ort)
+        assert REPO_ID in message, message
+        assert ONNX_FILENAME in message, message
+
+    def test_the_remedy_is_a_runnable_one_liner(self, _ort: None) -> None:
+        """The quoted command must be valid Python, not prose about one."""
+        message = _refusal(REPO_ID, _ort)
+        match = re.search(r'python -c "(.+?)"\n', message, re.S)
+        assert match is not None, message
+        compile(match.group(1), "<remedy>", "exec")
+
+    def test_the_remedy_says_the_parameter_wants_a_local_file(self, _ort: None) -> None:
+        """Naming the contract is what makes the extra step make sense."""
+        assert "local file" in _refusal(REPO_ID, _ort)
+
+    def test_the_remedy_is_single_sourced_from_the_module_constants(self) -> None:
+        """The repo and file names are interpolated, not spelled twice.
+
+        A second literal would let the message drift from the checkpoint the
+        module docstring pins, which is how the circular wording survived.
+        """
+        assert policy_mod._GTP_G1_HF_REPO == REPO_ID
+        assert policy_mod._GTP_G1_ONNX_FILENAME == ONNX_FILENAME
+        source = ast.unparse(ast.parse(_PACKAGE.joinpath("policy.py").read_text(encoding="utf-8")))
+        raised = [line for line in source.splitlines() if "ONNX artifact not found" in line]
+        assert len(raised) == 1, raised
+        assert "_GTP_G1_HF_REPO" in raised[0], raised[0]
+        assert "_GTP_G1_ONNX_FILENAME" in raised[0], raised[0]
+
+
+class TestTheInstallSectionDoesNotPromiseAFetch:
+    """Regression: the docs sentence that sent readers down the dead end."""
+
+    def test_the_hub_client_is_not_described_as_fetching_for_you(self) -> None:
+        """The extra pulls the client; the caller calls it."""
+        text = " ".join(_DOC.read_text(encoding="utf-8").split())
+        assert "(fetches a checkpoint from a model id)" not in text
+        assert _HUB in text, "the dependency is still worth naming"
+
+    def test_the_install_section_says_the_paths_are_local(self) -> None:
+        """A reader must not be left to infer that a model id would work."""
+        text = " ".join(_DOC.read_text(encoding="utf-8").split())
+        install = text.split("## Install", 1)[-1].split("##", 1)[0]
+        assert "local file" in install, install
+
+
+class TestWhatStillHolds:
+    """Over-reach controls: nothing else about the guard may change."""
+
+    def test_a_missing_local_path_still_reports_that_path(self, _ort: None) -> None:
+        """The path a caller passed is still the first thing named."""
+        message = _refusal("/no/such/dir/unified_pipeline.onnx", _ort)
+        assert message.startswith("ONNX artifact not found: /no/such/dir/unified_pipeline.onnx")
+
+    def test_an_existing_file_reaches_the_session_build(self, tmp_path: Path, _ort: None) -> None:
+        """The guard refuses only a path that is absent."""
+        artifact = tmp_path / ONNX_FILENAME
+        artifact.write_bytes(b"not really onnx")
+        with pytest.raises(_Sentinel):
+            ProtoMotionsPolicy._build_onnx_session(artifact, ["CPUExecutionProvider"])


### PR DESCRIPTION
## The defect

`ProtoMotionsPolicy` takes `onnx_path` as a **local file** and resolves no
HuggingFace model id. `WBCPolicy` - the sibling ONNX policy in the same package -
does resolve one, and the `[protomotions]` extra declares the same hub client:

| | resolves an `org/repo` id | imports `huggingface_hub` | extra declares it |
|---|---|---|---|
| `WBCPolicy` | yes, `_maybe_download_checkpoint` | yes | `[wbc]` |
| `KimodoPolicy` | yes | yes | `[kimodo]` |
| `ProtoMotionsPolicy` | **no** | **0 modules** | `[protomotions]` |

The install docs attributed the fetch to that declared client - "`huggingface_hub`
(fetches a checkpoint from a model id)" - so the documented next step for a reader
with no weights on disk was to pass the model id the module docstring names.

Doing that produced a refusal whose remedy is the argument itself:

```
ONNX artifact not found: cagataydev/protomotions-gtp-unitree-g1. Download from
cagataydev/protomotions-gtp-unitree-g1 on HuggingFace.
```

The caller is told to download the string they just supplied. It is sound advice
for a mistyped local path and a dead end for the value the docs pointed at, because
nothing in it turns a model id into the local file the parameter wants.

## What changes

The refusal now names that step - the canonical repo **and** file name, as a
command whose output is the argument to pass:

```
ONNX artifact not found: cagataydev/protomotions-gtp-unitree-g1. This parameter
takes a local file, and this policy does not download one. Fetch the checkpoint
first:
  python -c "from huggingface_hub import hf_hub_download; print(hf_hub_download('cagataydev/protomotions-gtp-unitree-g1', 'unified_pipeline.onnx'))"
then pass the path it prints as onnx_path.
```

That command was extracted from the raised message and run against the live
checkpoint: `rc=0`, printing a path to a **22,606,590-byte** `unified_pipeline.onnx`
in the local hub cache - which is the argument the constructor accepts. The
install section now says the hub client is one the caller calls, rather than one
the extra calls for them, and the repo id and filename become module constants so
the message cannot drift from the checkpoint the module docstring pins.

## Deliberately not done

Whether this policy *should* resolve a model id the way its sibling does is left
alone: that adds a repo-id spelling to a `*_path` parameter and has to decide
whether `yaml_path` follows and which filename a bare repo id means. That is a
public-surface choice rather than a wording one, and this change makes the refusal
actionable either way.

## Why nothing caught it

The install sentence attributes a purpose per dependency, and two of its three
attributions are true (`onnxruntime` runs the graph, `pyyaml` reads the sidecar);
only the third describes work the family never performs. Nothing grades a declared
dependency against its readers, and no cell drove the not-found branch with a
repo-id-shaped value - the shipped suite reaches `_build_onnx_session` nowhere.

## Pre-fix split

`7 failed / 4 passed`, with both non-regression classes clean:

| class | role | pre-fix |
|---|---|---|
| `TestTheRemedyNamesAStep` | regression | **5 / 5 fail** |
| `TestTheInstallSectionDoesNotPromiseAFetch` | regression | **2 / 2 fail** |
| `TestWhyTheWordingMatters` | premise | 0 / 2 |
| `TestWhatStillHolds` | over-reach control | 0 / 2 |

## Mutation table

7 mutations, 7 distinct firing sets, control clean, `collected` stable at 11,
`sib` = 0 on every row (265 pre-existing cells in `tests/policies/protomotions/`
and `tests/policies/wbc/`), source restored md5-identical.

| # | mutation | fires | cells |
|---|---|---|---|
| b0 | control | 0 | - |
| b1 | refusal reverted to the circular wording | 5 | the whole remedy class |
| b2 | docs install sentence reverted | 2 | both docs cells |
| b3 | both reverted | 7 | b1 and b2, disjoint |
| b4 | remedy hardcodes the literals | 1 | single-sourcing only |
| b5 | remedy names the repo but not the file | 2 | names-repo-and-file |
| b6 | remedy is prose, not a runnable command | 4 | runnable-one-liner |
| b7 | docs stops naming the hub client at all | 1 | the dependency is still worth naming |

`b1` and `b2` are **disjoint** and their union is exactly `b3`, so each half is
independently pinned. `b4` fires only the drift guard, which is what makes the
module constants load-bearing rather than tidy.

## Gate

- `ruff check` and `ruff format --check` clean over 1700 files (no reformat).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a base tree, both
  normalized `comm` directions empty, **0 attributable** (`checked 1697` vs `1696`).
- `mkdocs build --strict`: clean in 1.67 s.
- Paired 493-path selection (all of `tests/policies/protomotions/` and
  `tests/policies/wbc/`, plus every guard walking the tree, parsing source, or
  reading docstrings, `docs/`, `pyproject.toml`, `Args:`, `Raises:` or `__all__`),
  new file withheld from **both** sides: identical **22738 collected** and
  `20 failed, 22642 passed, 76 skipped` on each, **20 == 20 failing ids with both
  `comm` directions empty**. All 20 environmental and reproduced on the base
  alone: 17 need `awsiot` (`find_spec` false, declared in `[mesh-iot]`, which the
  default env installs via `all`), 3 are the lerobot-from-source `encode()` drift.
- `tests/policies/protomotions/` whole: **276 passed**.

No visual artifact: this changes a refusal message and an install sentence, not a
policy, simulation, rendering, recording or asset.
