### PR TITLE
docs(robots): document the humanoid camera mount and grade it against the asset

### DIFF
--- a/changelog.d/2899-humanoid-camera-mount-recipe.md
+++ b/changelog.d/2899-humanoid-camera-mount-recipe.md
@@ -1,0 +1,31 @@
+### Docs: the humanoid camera mount is documented, and graded against the asset
+
+Every camera-mounting recipe in the tree is arm-shaped. `world-building.md` reads
+the mount from `list_bodies(...)["gripper_body"]`, and `camera-naming.md` and
+`annotation.md` both mount on `<arm>/gripper`. A humanoid reports
+`gripper_body: None`, because that hint set (`gripper`, `hand`, `jaw`, `ee`,
+`tool`) is arm-shaped, so the general recipe correctly declines and sends the
+reader to the full `bodies` list - without saying which body, or what offset.
+
+For a head camera there is nothing obvious to pick. No variant of the shipped
+Unitree G1 asset has a head, neck or eye body: `g1.xml`, `g1_mjx.xml`,
+`g1_with_hands.xml` and their three scene wrappers all report zero, and the only
+four sites are two IMUs and the two feet. The body tree ends at the wrists, so a
+reader hunting for a head mount finds none and has to derive the offset alone.
+
+`docs/robots/humanoids.md` now documents the mount that does work - the torso,
+with a local-frame offset - and `tests/simulation/test_humanoid_camera_mount_recipe.py`
+grades it, because the recipe is prose about a third-party asset this repository
+downloads rather than vendors. The guard parses the recipe's own fenced block
+instead of restating it, so the doc stays the single source of truth: editing the
+offset in the prose edits what the cells assert. It checks that the body the
+recipe names exists in the shipped asset, that the documented offset lands in
+that body's frame rather than the world's, that the mounted camera renders, and
+that the premise still holds - if a future asset revision adds a head link, the
+premise cell fails and the recipe should name that body instead of an offset.
+
+The same file pins why the arm-shaped guess declines here rather than naming a
+leg. A bare-substring match would answer `left_knee_link`, because `ee` occurs in
+`knee`; hints have matched name *components* since the word-boundary fix, and
+this holds that behaviour on a humanoid, where the knee is a body the robot
+actually has. Reverting the matcher to a bare substring fails this file.

--- a/docs/robots/humanoids.md
+++ b/docs/robots/humanoids.md
@@ -109,6 +109,32 @@ _Open Duck Mini V2 (16-DOF expressive biped, Feetech servos)_
 
 _Pollen Reachy Mini (6-DOF Stewart head + antennas, 9 actuators)_
 
+## Mounting a camera on a humanoid
+
+`add_camera(parent_body=...)` mounts a camera ON a body so it rides with the
+robot, and `position`/`target` are then in that body's LOCAL frame. The general
+recipe in [World building](../simulation/world-building.md) reads the mount from
+`list_bodies(robot_name=...)["gripper_body"]`, which is the right mount for an
+arm. A humanoid here reports `gripper_body: None`: that hint set (`gripper`,
+`hand`, `jaw`, `ee`, `tool`) is arm-shaped, and matching it on word boundaries is
+what keeps a leg out of the answer - a `knee` link is not an end-effector because
+`ee` occurs in its name. Pick the mount from the full `bodies` list instead.
+
+For a head camera there is no head link to pick. The Unitree G1 asset's body tree
+ends at the wrists - `pelvis` to hips/knees/ankles, and `waist_yaw_link` to
+`waist_roll_link` to `torso_link` to shoulders/elbows/wrists - with no
+`head_link`, `neck_link` or `eye_link`; its only sites are two IMUs and the two
+feet. Mount on the torso with a local offset instead:
+
+```python
+sim.add_camera(name="head", parent_body="g1/torso_link",
+               position=[0.08, 0.0, 0.35], target=[1.0, 0.0, 0.2])
+```
+
+That puts the camera 0.35 m above the torso frame, roughly head height, and it
+rides with the torso through waist yaw and roll. An arm camera mounts the same
+way on a wrist link (`g1/left_wrist_yaw_link`).
+
 ## See also
 
 - [Mobile](mobile.md) - quadrupeds and wheeled bases.

--- a/tests/simulation/test_humanoid_camera_mount_recipe.py
+++ b/tests/simulation/test_humanoid_camera_mount_recipe.py
@@ -89,11 +89,21 @@ def _asset_path() -> Path:
     assert info is not None, f"recipe names robot {alias!r}, which the registry does not know"
     asset = info.get("asset") or {}
     assert asset.get("dir") and asset.get("model_xml"), f"{canonical} declares no MuJoCo asset to mount on"
-    for root in get_search_paths():
-        candidate = Path(root) / asset["dir"] / asset["model_xml"]
-        if candidate.is_file():
-            return candidate
-    pytest.skip(f"{canonical} asset is not present in any search path")
+    # One explicit return: a loop that returns and then falls through to
+    # ``pytest.skip`` reads as an implicit ``return None`` to a static
+    # analyser, even though ``skip`` is annotated ``NoReturn``.  Resolving
+    # the candidate first keeps the single exit this function documents.
+    present = next(
+        (
+            candidate
+            for root in get_search_paths()
+            if (candidate := Path(root) / asset["dir"] / asset["model_xml"]).is_file()
+        ),
+        None,
+    )
+    if present is None:
+        pytest.skip(f"{canonical} asset is not present in any search path")
+    return present
 
 
 def _robot_alias() -> str:

--- a/tests/simulation/test_humanoid_camera_mount_recipe.py
+++ b/tests/simulation/test_humanoid_camera_mount_recipe.py
@@ -1,0 +1,257 @@
+"""The humanoid camera-mount recipe must describe the asset it names.
+
+``docs/robots/humanoids.md`` carries the only mounting recipe written for a
+humanoid. Every other one in the tree is arm-shaped - ``world-building.md``
+reads the mount from ``list_bodies(...)["gripper_body"]``, ``camera-naming.md``
+and ``annotation.md`` both mount on ``<arm>/gripper`` - and a humanoid in this
+catalog reports ``gripper_body: None``, because that hint set (``gripper``,
+``hand``, ``jaw``, ``ee``, ``tool``) is arm-shaped. So the humanoid recipe names
+a body directly, and naming a body directly is what makes it rot: the recipe is
+prose about a third-party asset this repository downloads rather than vendors.
+
+Two things could rot independently, so both are graded here:
+
+* The recipe's *premise* - that the asset has no head link, which is the whole
+  reason it mounts on the torso. If a future asset revision adds one, the
+  premise cell fails and the recipe should name the head link instead of an
+  offset.
+* The recipe's *mechanics* - that the body it names exists, that the offset it
+  documents is applied in that body's local frame rather than the world frame,
+  and that a camera mounted there renders.
+
+The expectations are parsed out of the recipe rather than restated, so the doc
+is the single source of truth: editing the offset in the prose edits what these
+cells assert. ``tests/test_docs_python_examples_are_callable.py`` already grades
+the block's *keywords* against ``add_camera``'s signature; it does not resolve
+the body name, the frame or the render, which is the gap this file closes.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.registry import get_robot, resolve_name
+from strands_robots.simulation.ik import GRIPPER_BODY_HINTS, hint_matches_name
+from strands_robots.simulation.model_registry import get_search_paths
+
+_DOC = Path(__file__).resolve().parents[2] / "docs" / "robots" / "humanoids.md"
+_HEADING = "## Mounting a camera on a humanoid"
+
+# Body-name components that would mean the asset had grown a head mount, making
+# the torso offset the recipe documents the wrong advice.
+_HEAD_WORDS = ("head", "neck", "eye")
+
+
+def _recipe_call() -> dict[str, Any]:
+    """Parse the recipe's ``add_camera`` keywords out of the humanoid page.
+
+    Returns:
+        The call's keyword arguments, with literal values evaluated - e.g.
+        ``{"name": "head", "parent_body": "g1/torso_link", "position": [...],
+        "target": [...]}``.
+    """
+    text = _DOC.read_text(encoding="utf-8")
+    assert _HEADING in text, f"{_DOC.name} no longer has a {_HEADING!r} section"
+    section = text.split(_HEADING, 1)[1].split("\n## ", 1)[0]
+    blocks = re.findall(r"```python\n(.*?)```", section, re.S)
+    assert len(blocks) == 1, f"expected exactly one python fence in the recipe, found {len(blocks)}"
+    calls = [
+        node
+        for node in ast.walk(ast.parse(blocks[0]))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "add_camera"
+    ]
+    assert len(calls) == 1, f"expected one add_camera call in the recipe, found {len(calls)}"
+    return {kw.arg: ast.literal_eval(kw.value) for kw in calls[0].keywords if kw.arg}
+
+
+def _asset_path() -> Path:
+    """Locate the recipe's robot asset without reaching the network.
+
+    ``resolve_model_path`` would download a missing asset; this walks the
+    configured search paths instead so a host with no asset cache skips rather
+    than fetching one.
+
+    Returns:
+        The model XML path.
+    """
+    alias = _robot_alias()
+    canonical = resolve_name(alias) or alias
+    info = get_robot(canonical)
+    # An unregistered name is a defect in the recipe, not a reason to skip: a
+    # skip here would let a typo in the documented body name quietly stop every
+    # cell below from grading anything. Only a genuinely absent asset file - a
+    # host with no download cache - is a skip.
+    assert info is not None, f"recipe names robot {alias!r}, which the registry does not know"
+    asset = info.get("asset") or {}
+    assert asset.get("dir") and asset.get("model_xml"), f"{canonical} declares no MuJoCo asset to mount on"
+    for root in get_search_paths():
+        candidate = Path(root) / asset["dir"] / asset["model_xml"]
+        if candidate.is_file():
+            return candidate
+    pytest.skip(f"{canonical} asset is not present in any search path")
+
+
+def _robot_alias() -> str:
+    """Return the robot alias the recipe's ``parent_body`` is namespaced with."""
+    parent = _recipe_call()["parent_body"]
+    alias, _, _body = str(parent).partition("/")
+    return alias
+
+
+def _mount_suffix() -> str:
+    """Return the recipe's mount body with its robot namespace stripped."""
+    parent = _recipe_call()["parent_body"]
+    _alias, _, body = str(parent).partition("/")
+    return body
+
+
+def _body_names(model: Any) -> list[str]:
+    """Return every named body in a compiled model."""
+    import mujoco
+
+    names = [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, i) for i in range(model.nbody)]
+    return [name for name in names if name]
+
+
+class TestTheRecipeIsReadable:
+    """Non-vacuity: the cells below grade a recipe that is actually there."""
+
+    def test_the_recipe_names_a_namespaced_body_and_a_three_vector(self) -> None:
+        call = _recipe_call()
+        parent = str(call["parent_body"])
+        assert "/" in parent, f"recipe mount {parent!r} is not namespaced <robot>/<body>"
+        assert _robot_alias(), "recipe mount carries no robot namespace"
+        assert _mount_suffix(), "recipe mount carries no body name"
+        assert len(call["position"]) == 3, f"recipe position is not a 3-vector: {call['position']!r}"
+
+    def test_the_recipe_mounts_above_its_parent(self) -> None:
+        """The documented offset must be the head-height lift the prose claims."""
+        vertical = float(_recipe_call()["position"][2])
+        floor = 0.0
+        assert vertical > floor, f"recipe offset does not lift the camera: {vertical}"
+
+    def test_the_recipe_robot_alias_names_a_registered_robot(self) -> None:
+        """``resolve_name`` normalises rather than validates, so read the entry.
+
+        For an unknown name ``resolve_name`` returns that name lowercased rather
+        than ``None``, so ``resolve_name(x) is not None`` accepts anything. The
+        registry entry is the existence oracle.
+        """
+        alias = _robot_alias()
+        assert get_robot(resolve_name(alias) or alias) is not None, (
+            f"recipe names robot {alias!r}, which the registry does not know"
+        )
+
+
+class TestTheRecipePremiseHolds:
+    """Why the recipe mounts on the torso rather than on a head link."""
+
+    def test_the_asset_has_no_head_link_to_mount_on(self) -> None:
+        """A head body would make the documented torso offset the wrong advice.
+
+        This is the recipe's premise, not an aspiration: if a future revision of
+        the third-party asset adds a head, neck or eye body, this cell fails and
+        the recipe should name that body instead of an offset from the torso.
+        """
+        mujoco = pytest.importorskip("mujoco")
+        model = mujoco.MjModel.from_xml_path(str(_asset_path()))
+        heads = [name for name in _body_names(model) if any(word in name.lower() for word in _HEAD_WORDS)]
+        assert heads == [], (
+            f"{_robot_alias()} now has head-like bodies {heads}; the recipe in "
+            f"{_DOC.name} mounts on a torso offset because it had none"
+        )
+
+    def test_the_arm_shaped_mount_guess_declines_for_this_humanoid(self) -> None:
+        """``gripper_body`` must stay ``None`` here - and not name a leg.
+
+        The recipe exists because the arm-shaped guess has no answer for this
+        robot. A bare-substring match would have answered ``left_knee_link``,
+        because ``ee`` occurs in ``knee``; hints match name components instead,
+        so the guess declines rather than naming a leg.
+        """
+        mujoco = pytest.importorskip("mujoco")
+        model = mujoco.MjModel.from_xml_path(str(_asset_path()))
+        matched = [
+            name
+            for name in _body_names(model)
+            if any(hint_matches_name(hint, name.rsplit("/", 1)[-1]) for hint in GRIPPER_BODY_HINTS)
+        ]
+        assert matched == [], f"{_robot_alias()} now has a gripper-like body {matched}; the recipe can name it"
+        knee = [name for name in _body_names(model) if "knee" in name.lower()]
+        assert knee, "expected this humanoid to have a knee link for the word-boundary check to be meaningful"
+        for name in knee:
+            hits = [hint for hint in GRIPPER_BODY_HINTS if hint_matches_name(hint, name)]
+            assert hits == [], f"a leg link {name!r} matched end-effector hints {hits}"
+
+
+class TestTheRecipeMechanicsHold:
+    """The recipe's body name, frame and render, driven as written."""
+
+    @pytest.fixture
+    def mounted(self) -> Any:
+        """Add the recipe's robot and camera to a world, exactly as documented."""
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation import create_simulation
+
+        call = _recipe_call()
+        sim: Any = create_simulation("mujoco")
+        sim.create_world()
+        added = sim.add_robot(name=_robot_alias(), urdf_path=str(_asset_path()))
+        assert added["status"] == "success", added
+        result = sim.add_camera(
+            name=call["name"],
+            parent_body=call["parent_body"],
+            position=call["position"],
+            target=call["target"],
+        )
+        yield sim, call, result
+        sim.cleanup()
+
+    def test_the_documented_mount_is_accepted(self, mounted: Any) -> None:
+        _sim, call, result = mounted
+        assert result["status"] == "success", (
+            f"{_DOC.name} documents parent_body={call['parent_body']!r}, which add_camera refused: {result}"
+        )
+
+    def test_the_offset_is_applied_in_the_body_local_frame(self, mounted: Any) -> None:
+        """The prose says LOCAL frame; a world-frame read would not ride along."""
+        import mujoco
+
+        sim, call, _result = mounted
+        model = sim._world._model
+        camera_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, call["name"])
+        assert camera_id >= 0, f"camera {call['name']!r} is not in the compiled model"
+        documented = [float(value) for value in call["position"]]
+        stored = [float(value) for value in model.cam_pos[camera_id]]
+        assert stored == pytest.approx(documented), (
+            f"documented offset {documented} did not land in the body frame (cam_pos={stored})"
+        )
+        parent = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, int(model.cam_bodyid[camera_id]))
+        assert parent == call["parent_body"], f"camera is parented to {parent!r}, not {call['parent_body']!r}"
+
+    def test_the_camera_rides_above_its_parent_by_the_documented_lift(self, mounted: Any) -> None:
+        """The world pose must show the documented vertical lift once posed."""
+        import mujoco
+
+        sim, call, _result = mounted
+        model, data = sim._world._model, sim._world._data
+        mujoco.mj_forward(model, data)
+        camera_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, call["name"])
+        body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, call["parent_body"])
+        lift = float(data.cam_xpos[camera_id][2] - data.xpos[body_id][2])
+        documented_lift = float(call["position"][2])
+        assert lift == pytest.approx(documented_lift, abs=1e-6), (
+            f"camera sits {lift} m above the torso, the recipe documents {documented_lift} m"
+        )
+
+    def test_the_mounted_camera_renders(self, mounted: Any) -> None:
+        sim, call, _result = mounted
+        frame = sim.render(camera_name=call["name"], width=320, height=240)
+        assert frame["status"] == "success", frame
+        blocks = [key for block in frame["content"] for key in block]
+        assert "image" in blocks, f"render returned no image block: {blocks}"


### PR DESCRIPTION
## Problem

Every camera-mounting recipe in the tree is arm-shaped. `docs/simulation/world-building.md` reads the mount from `list_bodies(robot_name=...)["gripper_body"]`, and `docs/policies/camera-naming.md` and `docs/data/annotation.md` both mount on `<arm>/gripper`. A humanoid reports `gripper_body: None`, because that hint set (`gripper`, `hand`, `jaw`, `ee`, `tool`) is arm-shaped. The general recipe handles that correctly - it says to pick the mount from the full `bodies` list instead - but it does not say which body, or what offset.

For a head camera there is nothing obvious to pick. No variant of the shipped Unitree G1 asset has a head, neck or eye body:

| asset | njnt | nu | nbody | hand bodies | head/neck/eye bodies |
| --- | --- | --- | --- | --- | --- |
| `g1.xml` (the registered `model_xml`) | 30 | 29 | 31 | 0 | **0** |
| `g1_mjx.xml` | 30 | 29 | 31 | 0 | **0** |
| `g1_with_hands.xml` | 44 | 43 | 45 | 14 | **0** |
| `scene.xml` | 30 | 29 | 31 | 0 | **0** |
| `scene_mjx.xml` | 30 | 29 | 31 | 0 | **0** |
| `scene_with_hands.xml` | 44 | 43 | 45 | 14 | **0** |

The body tree ends at the wrists (`pelvis` to hips/knees/ankles, and `waist_yaw_link` to `waist_roll_link` to `torso_link` to shoulders/elbows/wrists), and the only four sites are `imu_in_pelvis`, `imu_in_torso`, `left_foot` and `right_foot`. So a reader hunting for a head mount finds none and has to derive the offset alone.

## What changed

`docs/robots/humanoids.md` gains a `Mounting a camera on a humanoid` section documenting the mount that does work - the torso, with a local-frame offset - and states plainly that there is no head link and why `gripper_body` declines here.

`tests/simulation/test_humanoid_camera_mount_recipe.py` grades it. The recipe is prose about a third-party asset this repository downloads rather than vendors, so it can rot in two independent ways, and both are graded: its **premise** (the asset has no head link, which is the whole reason it mounts on the torso) and its **mechanics** (the body it names exists, the offset lands in that body's frame rather than the world's, and the camera renders).

The expectations are parsed out of the recipe's own fenced block rather than restated, so the doc stays the single source of truth - editing the offset in the prose edits what the cells assert. `tests/test_docs_python_examples_are_callable.py` already grades that block's *keywords* against `add_camera`'s signature; it does not resolve the body name, the frame or the render, which is the gap this closes.

## Measured

Driven on the shipped asset through the public surface:

| measurement | value |
| --- | --- |
| `list_bodies(robot_name="g1")["gripper_body"]` | `None` |
| G1 bodies matching any of the 5 gripper hints | 0 of 30 |
| hints matching `left_knee_link` | `[]` |
| hints a **bare substring** match would have found in `left_knee_link` | `['ee']` |
| requested `position` | `[0.08, 0.0, 0.35]` |
| `model.cam_pos` (body frame) | `[0.08, 0.0, 0.35]` |
| camera world pose | `[0.076, 0.0, 1.187]` |
| `torso_link` world pose | `[-0.004, 0.0, 0.837]` |
| lift above the torso frame | `0.3500 m` |
| `render(camera_name="head")` | `success`, with an image block |

The `['ee']` row is why the same file also pins that the arm-shaped guess declines here rather than naming a leg: hints have matched name *components* since #2288, and this holds that behaviour on a humanoid, where the knee is a body the robot actually has.

## Break table

Seven mutations plus a control, run against the new file. `collected` was stable at 9 on every row, and the tree was restored between rows.

| row | fires | cells |
| --- | --- | --- |
| b0 control, no mutation | 0 | 9 passed |
| b1 recipe names a body the asset lacks | 4 | all four mechanics cells |
| b2 recipe robot alias is not registered | 7 | the alias cell plus the mechanics half |
| b3 documented offset does not lift the camera | 1 | `test_the_recipe_mounts_above_its_parent` |
| b4 recipe section heading renamed | 9 | every cell - the recipe becomes unfindable |
| b5 hint matcher reverted to a bare substring | 1 | `test_the_arm_shaped_mount_guess_declines_for_this_humanoid` |
| b6 vacuity probe: premise word list widened to a body the asset has | 1 | `test_the_asset_has_no_head_link_to_mount_on` |
| b7 whole recipe section removed (the state before this change) | 9 | every cell, i.e. nothing graded this before |

Seven distinct firing sets. b5 is the row that matters most: it shows this file detects the defect the word-boundary fix removed, on a robot where a leg link is present to be mis-matched. b6 is a vacuity probe rather than a defect - it shows the premise cell really reads the asset's bodies instead of asserting an empty list against nothing.

b2 caught a defect in the test itself during development. As first written, an unregistered robot name made six cells silently **skip** rather than fail, and the alias cell passed - because `resolve_name` normalises rather than validates (for an unknown name it returns that name lowercased, not `None`). Both are fixed: the registry entry is now the existence oracle, and only a genuinely absent asset file is a skip.

## Gate

Identical 820-path selection on both trees - all of `tests/simulation/` plus every guard that walks the tree, parses source, or reads docstrings, `docs/` or `__all__` - with the new file withheld from both sides:

```
branch: 24 failed, 29468 passed, 264 skipped in 1357.44s
base:   24 failed, 29468 passed, 264 skipped in 1266.48s
24 == 24 failing ids, comm EMPTY in both directions
```

All 24 are pre-existing and environmental, classified by measurement rather than by name: 17 in `tests/mesh/test_iot_*` need `awsiot`/`awscrt` (both `find_spec` -> `None`, both declared in the `mesh-iot` extra, and the hatch default env's `features` is `['all']`, so CI installs them); 5 in `test_recording_frame_loss_is_not_tolerated.py` and `test_rendering_pacers_survive_a_clock_step.py` pass **29/29 in isolation**; 2 in `tests/training/test_lerobot.py` are the lerobot-from-source `encode()` drift.

`ruff check` clean; `ruff format --check` clean over 1700 files; `mypy strands_robots tests tests_integ` 5 errors in 4 other files, **0 attributable**; `mkdocs build --strict` clean in 1.73s. The new file is 9 passed, and it plus the docs guards and the guard `main` added in #2892 are 57 passed on the rebased tree.

## Artifact

![humanoid head camera mount](https://github.com/cagataycali/robots/releases/download/artifacts/g1_head_cam_mount.png)

Both panels are rendered from the one camera definition parsed out of the recipe, headless under `MUJOCO_GL=egl`. Every number in the caption is asserted from the capture before the figure is drawn, and each panel is verified to be embedded verbatim in the composed PNG. The dark upper region of the right panel is the empty world above the horizon, which is what a head camera at this height sees.

## Deliberately not changed

The registry's `joints: 46` for this robot is left alone. It is neither variant's joint count (the shipped model is 30, the hands variant 44), and its provenance is a raw `<joint>` text count of `g1_mjx.xml` - 30 real joints plus 16 templates inside `<default>` class blocks. But `tests/registry/test_asset_family_joint_counts.py` argues at length that `joints` follows no settled convention, and 12 further entries declare a figure above the maximum in their own asset directory because they describe hardware DOF rather than the sim asset. Picking a convention here would rewrite those numbers on a guess, so it stays a separate question.
