### PR TITLE
docs(policies/microduck): name the scene each shipped skill needs

### DIFF
--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -32,7 +32,11 @@ python examples/microduck/render_video.py \
 `render_video.py` steps the sim manually at the control frequency and captures
 each frame with a tracking camera locked to the pelvis, so the duck stays
 centered as it walks. `--vx`/`--vy`/`--vyaw` set the twist command, and any
-shipped weight (`alpha_stand`, `roulade`, `ball_kick_*`, …) drops straight in.
+weight that runs on the default scene (`alpha_stand`, `roulade`,
+`alpha_sitstand`, `alpha_ground_pick`) drops straight in. The script builds
+`Robot("microduck")`, so the four skills that need a different scene -
+`roller`, `roller_crouch`, `ball_kick_left`, `ball_kick_right` - need the
+scene named for them in [Skill scenes](#skill-scenes) below.
 
 
 ## Install
@@ -65,6 +69,61 @@ sim.run_policy(
 
 See [`examples/microduck/microduck_walk_sim.py`](https://github.com/strands-labs/robots/blob/main/examples/microduck/microduck_walk_sim.py)
 for the runnable script.
+
+## Skill scenes
+
+A shipped weight and the scene it was trained in are one pair. `Robot("microduck")`
+resolves the entry's declared asset - flat ground, no props - which is what the
+walking, standing, sitstand, roulade and ground-pick skills need. Four skills
+need something the default scene does not contain, and Pollen ships the scene
+for each one in the same asset directory:
+
+| skill | scene | what the scene adds |
+| --- | --- | --- |
+| `alpha_walking`, `alpha_stand`, `alpha_sitstand`, `roulade`, `alpha_ground_pick` | `scene.xml` (the entry's declared asset) | nothing - flat ground |
+| `roller`, `roller_crouch` | `scene_rollers.xml` | four passive ankle wheels, so the feet can roll |
+| `ball_kick_left`, `ball_kick_right` | `scene_ball.xml` | a 70 mm, 15 g ball placed in front of the duck |
+
+Reach a non-default scene by path. The registry entry names the fourteen-hinge
+model deliberately - it is the layout the catalog documents - so the variants are
+loaded as an explicit asset rather than resolved by name:
+
+```python
+from pathlib import Path
+
+from strands_robots import Robot
+from strands_robots.policies.microduck import MicroduckPolicy
+from strands_robots.utils import get_search_paths
+
+scene = next(
+    candidate
+    for root in get_search_paths()
+    if (candidate := Path(root) / "microduck" / "scene_rollers.xml").exists()
+)
+sim = Robot("microduck", urdf_path=str(scene))
+sim.reset()
+sim.run_policy(policy_object=MicroduckPolicy(onnx_path="roller.onnx"), duration=8.0)
+```
+
+Running a skill on the default scene is not an error and reports success: a
+roller policy writes the same fourteen control targets, and with no wheels under
+the feet the duck simply stands; a ball-kick policy swings at a ball that is not
+there. Nothing refuses it, so the scene is the caller's to choose.
+
+### Reading joint positions on the rollers scene
+
+`scene_ball.xml` appends the ball's free joint after the robot's, so the robot's
+`qpos` layout is byte-for-byte the default one. `scene_rollers.xml` does not:
+it inserts two passive wheel joints after `left_ankle` and two more after
+`right_ankle`, which moves nine of the fourteen actuated joints to a different
+`qpos` index. A consumer that reads a flat `qpos[7:21]` slice therefore reads
+different joints there - the two left wheels arrive where `neck_pitch` and
+`head_pitch` sit on the default scene.
+
+The actuator order is identical across all three scenes, so a policy writing
+`ctrl` is unaffected, and `MicroduckPolicy` reads its observation by joint name
+rather than by slice, so the provider is immune either way. Only a raw position
+read has to care.
 
 ## The observation contract
 

--- a/tests/simulation/test_microduck_skill_scenes_are_documented.py
+++ b/tests/simulation/test_microduck_skill_scenes_are_documented.py
@@ -1,0 +1,272 @@
+"""Every Microduck skill the page advertises names the scene it needs.
+
+``docs/policies/microduck.md`` opens by listing the nine shipped Pollen weights
+:class:`~strands_robots.policies.microduck.MicroduckPolicy` wraps and says they
+drive the biped "through the standard ``Robot(...).run_policy`` seam - in MuJoCo
+or on hardware". Five of those nine run on the scene the registry entry declares.
+Four do not: ``roller`` and ``roller_crouch`` need the four passive ankle wheels
+that only ``scene_rollers.xml`` carries, and ``ball_kick_left`` /
+``ball_kick_right`` need the ball prop that only ``scene_ball.xml`` places.
+
+Running one of the four on the default scene is not an error. The policy writes
+the same fourteen control targets, the rollout reports success, and the physics
+simply has nothing to roll on or nothing to kick - so a reader who follows the
+page gets a duck standing still and no indication why. ``render_video.py`` builds
+a bare ``Robot("microduck")``, which is why the page used to say any shipped
+weight "drops straight in": true of the five, false of the four.
+
+The scenes are not missing. All three ship in the one asset directory the entry
+already downloads, and the entry keeps naming the fourteen-hinge model on purpose
+- ``tests/simulation/test_microduck_asset_matches_the_declared_shape.py`` pins
+that, and its ``TestTheEntryPointsAtTheDocumentedLayout`` records the reason ("a
+caller can load it by path"). So the gap was never reachability; it was that no
+page said which scene a skill needs, and nothing graded the claim.
+
+This file grades it in two layers. The first reads the page: every skill named in
+the opening paragraph must appear in the Skill scenes table, so a tenth weight
+cannot be advertised without naming its scene. The second reads the compiled
+models, so the table's claims are true rather than asserted - the scene a row
+names really does carry the wheels or the ball, and the default scene really does
+not. The second layer skips when the asset is absent, which is the case on a
+clean checkout; the first holds on any install, with no MuJoCo and no network.
+
+A registry ``variant=`` spelling would be a nicer front door and is deliberately
+not invented here: no entry among the seventy-three declares one, so the schema
+is a public-API decision rather than a docs fix.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PAGE = REPO_ROOT / "docs" / "policies" / "microduck.md"
+
+#: The directory the ``microduck`` entry downloads into, and the scene it names.
+ASSET_DIR = "microduck"
+DEFAULT_SCENE = "scene.xml"
+
+#: A skill list shorter than this means the opening paragraph stopped listing
+#: weights, so the cross-reference below would pass by having nothing to check.
+MINIMUM_SKILLS = 9
+
+#: Fewer rows than this means the table stopped covering the scenes, so the
+#: per-scene cells would pass by never reaching a non-default scene.
+MINIMUM_TABLE_ROWS = 3
+
+
+def _page() -> str:
+    return PAGE.read_text(encoding="utf-8")
+
+
+def _section(text: str, heading: str) -> str:
+    """Return one ``##`` section's body, so a rule reads only its own prose."""
+    start = text.index(heading)
+    rest = text[start + len(heading) :]
+    end = rest.find("\n## ")
+    return rest if end == -1 else rest[:end]
+
+
+def _advertised_skills(text: str) -> set[str]:
+    """The weights named in the opening sentence's parenthetical.
+
+    The list is read from the parenthetical that follows "policies", rather than
+    from the whole opening: the paragraph below it names metadata fields
+    (``joint_names``, ``action_scale``) in the same backticked style, and those
+    are not skills. Anchoring on the structure keeps the rule derived - a tenth
+    weight added to the list is graded - where a list of names to ignore would
+    have to be edited every time the prose grew.
+
+    A pair is spelled ``ball_kick_left``/``ball_kick_right`` inside one span
+    pair, so each backticked run is split on ``/`` rather than taken whole.
+    """
+    opening = text[: text.index("## Walking in MuJoCo")]
+    start = opening.index("policies (") + len("policies (")
+    listed = opening[start : opening.index(")", start)]
+    return {
+        token.strip()
+        for span in re.findall(r"`([^`]+)`", listed)
+        for token in span.split("/")
+        if re.fullmatch(r"[a-z][a-z0-9_]*", token.strip())
+    }
+
+
+def _scene_table(text: str) -> dict[str, str]:
+    """Map every skill named in the Skill scenes table to the scene it needs."""
+    rows: dict[str, str] = {}
+    for line in _section(text, "## Skill scenes").splitlines():
+        if not line.startswith("|") or "---" in line:
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) < 2 or cells[0] == "skill":
+            continue
+        scene = re.search(r"`([A-Za-z0-9_]+\.xml)`", cells[1])
+        if scene is None:
+            continue
+        for skill in re.findall(r"`([a-z][a-z0-9_]*)`", cells[0]):
+            rows[skill] = scene.group(1)
+    return rows
+
+
+def _scene_model(scene: str):
+    """Compile a scene the asset directory carries, or skip.
+
+    Reads the search paths rather than resolving through the asset manager,
+    which downloads a missing asset: a test that clones a third-party
+    repository fails on a host with no network instead of skipping.
+    """
+    mujoco = pytest.importorskip("mujoco")
+    from strands_robots.utils import get_search_paths
+
+    present = next(
+        (candidate for root in get_search_paths() if (candidate := Path(root) / ASSET_DIR / scene).exists()),
+        None,
+    )
+    if present is None:
+        pytest.skip(f"microduck {scene} is not downloaded, so its contents cannot be read")
+    return mujoco, mujoco.MjModel.from_xml_path(str(present))
+
+
+def _joint_names(mujoco, model) -> list[str]:
+    return [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i) for i in range(model.njnt)]
+
+
+def _wheel_joints(mujoco, model) -> list[str]:
+    return [name for name in _joint_names(mujoco, model) if name and "wheel" in name]
+
+
+def _ball_bodies(mujoco, model) -> list[str]:
+    names = [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, i) for i in range(model.nbody)]
+    return [name for name in names if name and "ball" in name]
+
+
+class TestThePageNamesASceneForEverySkill:
+    """Read from the page alone, so it holds with no asset and no MuJoCo."""
+
+    def test_the_opening_paragraph_still_lists_the_shipped_weights(self) -> None:
+        """Non-vacuity: the cross-reference needs a skill list to check."""
+        skills = _advertised_skills(_page())
+        assert len(skills) >= MINIMUM_SKILLS, f"expected at least {MINIMUM_SKILLS} skills, found {sorted(skills)}"
+
+    def test_the_table_still_covers_more_than_the_default_scene(self) -> None:
+        """Non-vacuity: a one-row table would name no variant to verify."""
+        scenes = set(_scene_table(_page()).values())
+        assert len(scenes) >= MINIMUM_TABLE_ROWS, f"expected at least {MINIMUM_TABLE_ROWS} scenes, found {scenes}"
+
+    def test_every_advertised_skill_appears_in_the_scene_table(self) -> None:
+        """A weight advertised without a scene is the gap this file closes."""
+        text = _page()
+        unnamed = sorted(_advertised_skills(text) - set(_scene_table(text)))
+        assert not unnamed, f"advertised with no scene named: {unnamed}"
+
+    def test_the_table_names_no_skill_the_page_does_not_advertise(self) -> None:
+        """Over-reach guard: the table describes the page, not a wider set."""
+        text = _page()
+        unadvertised = sorted(set(_scene_table(text)) - _advertised_skills(text))
+        assert not unadvertised, f"in the table but never advertised: {unadvertised}"
+
+
+class TestTheTablesClaimsAreTrueOfTheAssets:
+    """Re-derive each row from the model it names, so the table cannot drift."""
+
+    def test_every_scene_the_table_names_is_a_scene_that_compiles(self) -> None:
+        """A row pointing at a file that is not there is a dead instruction."""
+        for scene in sorted(set(_scene_table(_page()).values())):
+            mujoco, model = _scene_model(scene)
+            assert model.nu > 0, f"{scene} compiled with no actuators"
+
+    def test_the_default_scene_carries_neither_a_wheel_nor_a_ball(self) -> None:
+        """This is why four of the nine skills need a different scene."""
+        mujoco, model = _scene_model(DEFAULT_SCENE)
+        assert _wheel_joints(mujoco, model) == []
+        assert _ball_bodies(mujoco, model) == []
+
+    def test_a_roller_skill_is_pointed_at_a_scene_that_has_wheels(self) -> None:
+        """The rollers scene adds the four passive ankle wheels."""
+        scene = _scene_table(_page())["roller"]
+        assert scene != DEFAULT_SCENE, "roller must not be pointed at the wheel-less default"
+        mujoco, model = _scene_model(scene)
+        assert len(_wheel_joints(mujoco, model)) == 4
+
+    def test_a_ball_kick_skill_is_pointed_at_a_scene_that_has_a_ball(self) -> None:
+        """The ball scene places the prop the kick policies were trained on."""
+        scene = _scene_table(_page())["ball_kick_left"]
+        assert scene != DEFAULT_SCENE, "ball_kick must not be pointed at the ball-less default"
+        mujoco, model = _scene_model(scene)
+        assert _ball_bodies(mujoco, model) == ["ball"]
+
+    def test_the_two_roller_skills_share_one_scene(self) -> None:
+        """Both roller weights want the same wheels; one row covers them."""
+        table = _scene_table(_page())
+        assert table["roller"] == table["roller_crouch"]
+
+    def test_the_two_ball_kick_skills_share_one_scene(self) -> None:
+        """The ball sits in front of the duck; the side is the policy's."""
+        table = _scene_table(_page())
+        assert table["ball_kick_left"] == table["ball_kick_right"]
+
+
+class TestTheJointLayoutClaimsHold:
+    """The page tells a raw ``qpos`` reader which scene renumbers the slice."""
+
+    def test_the_actuator_order_is_the_same_on_every_documented_scene(self) -> None:
+        """Why a policy writing ``ctrl`` is unaffected by the scene choice."""
+        mujoco, default = _scene_model(DEFAULT_SCENE)
+
+        def actuators(model) -> list[str]:
+            return [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)]
+
+        expected = actuators(default)
+        assert len(expected) == 14
+        for scene in sorted(set(_scene_table(_page()).values())):
+            _, model = _scene_model(scene)
+            assert actuators(model) == expected, f"{scene} permutes the actuator order"
+
+    def test_the_ball_scene_leaves_the_robots_position_slice_alone(self) -> None:
+        """The ball's free joint is appended, so ``qpos[7:21]`` still holds."""
+        mujoco, default = _scene_model(DEFAULT_SCENE)
+        _, ball = _scene_model(_scene_table(_page())["ball_kick_left"])
+
+        def layout(model) -> dict[str, int]:
+            return {
+                name: int(model.jnt_qposadr[i])
+                for i, name in enumerate(_joint_names(mujoco, model))
+                if name is not None
+            }
+
+        base, with_ball = layout(default), layout(ball)
+        assert {name: adr for name, adr in with_ball.items() if name in base} == base
+
+    def test_the_rollers_scene_moves_nine_of_the_fourteen_joints(self) -> None:
+        """The count the page and the asset-shape guard both state."""
+        mujoco, default = _scene_model(DEFAULT_SCENE)
+        _, rollers = _scene_model(_scene_table(_page())["roller"])
+
+        def layout(model) -> dict[str, int]:
+            return {
+                name: int(model.jnt_qposadr[i])
+                for i, name in enumerate(_joint_names(mujoco, model))
+                if name is not None
+            }
+
+        base, moved_layout = layout(default), layout(rollers)
+        moved = [name for name, adr in base.items() if name in moved_layout and moved_layout[name] != adr]
+        assert len(moved) == 9, f"expected nine renumbered joints, got {sorted(moved)}"
+
+    def test_the_wheels_land_where_the_page_says_the_head_joints_sit(self) -> None:
+        """The concrete mis-read the page warns a slice reader about."""
+        mujoco, default = _scene_model(DEFAULT_SCENE)
+        _, rollers = _scene_model(_scene_table(_page())["roller"])
+
+        def at(model, addresses: set[int]) -> list[str]:
+            return [
+                name
+                for i, name in enumerate(_joint_names(mujoco, model))
+                if name is not None and int(model.jnt_qposadr[i]) in addresses
+            ]
+
+        assert at(default, {12, 13}) == ["neck_pitch", "head_pitch"]
+        assert at(rollers, {12, 13}) == ["passive_LF_wheel", "passive_LR_wheel"]


### PR DESCRIPTION
## The gap

`docs/policies/microduck.md` opens by listing the nine shipped Pollen weights
`MicroduckPolicy` wraps and says they drive the biped "through the standard
`Robot(...).run_policy` seam - in MuJoCo or on hardware". Five of the nine run on
the scene the registry entry declares. Four do not, and nothing on the page said so.

Measured through the public seam, compiling what each route resolves:

| route | wheel joints | ball bodies |
| --- | --- | --- |
| `Robot("microduck")` - what the page's examples build | 0 | 0 |
| `Robot("microduck", urdf_path=".../scene_rollers.xml")` | 4 | 0 |
| `Robot("microduck", urdf_path=".../scene_ball.xml")` | 0 | 1 |

`roller` and `roller_crouch` need the four passive ankle wheels; `ball_kick_left`
and `ball_kick_right` need the ball prop. Running one of the four on the default
scene is not an error and reports success - the policy writes the same fourteen
control targets, and the physics simply has nothing to roll on or nothing to
kick. `examples/microduck/render_video.py` builds a bare `Robot("microduck")`,
which is why the page said any shipped weight "drops straight in": true of the
five, false of the four.

## The scenes were never missing

All three ship in the one asset directory the entry already downloads
(16 XML files, including `scene_rollers.xml`, `scene_ball.xml` and `ball.xml`).
The entry names the fourteen-hinge model on purpose, and
`tests/simulation/test_microduck_asset_matches_the_declared_shape.py` pins that -
`TestTheEntryPointsAtTheDocumentedLayout` records the reason in its own words:
"Nothing here objects to that variant - a caller can load it by path."

So the gap was never reachability. It was that no page said which scene a skill
needs, and nothing graded the claim: no test in the tree reads this page.

## The change

`docs/policies/microduck.md` gains a skill-to-scene table, the by-path route, and
the layout invariant a raw position read has to care about. The "drops straight
in" sentence is scoped to the five weights it is true of.

Every claim in the new section is re-derived from the compiled models:

| claim | measured |
| --- | --- |
| actuator order identical on all three scenes | 14 names, identical order on `scene.xml`, `scene_rollers.xml`, `scene_ball.xml` |
| `scene_ball.xml` leaves the robot's `qpos` layout alone | every robot joint at its default address; `ball_free` appended at 21 |
| `scene_rollers.xml` moves nine of the fourteen | exactly 9 actuated joints at a different address |
| the two left wheels land on the head-joint addresses | default `qpos` 12,13 = `neck_pitch`, `head_pitch`; rollers 12,13 = `passive_LF_wheel`, `passive_LR_wheel` |

## The guard

`tests/simulation/test_microduck_skill_scenes_are_documented.py`, 14 cells in two
layers. The first reads the page alone, so it holds with no MuJoCo, no downloaded
asset and no network: every skill named in the opening parenthetical must appear
in the table, and the table may name no skill the page does not advertise. The
second re-derives each row from the model it names, so the table's claims are
measured rather than asserted; it skips when the asset is absent, which is the
case on a clean checkout.

The skill list is read from the parenthetical that follows "policies" rather than
from the whole opening, because the paragraph below names metadata fields
(`joint_names`, `action_scale`) in the same backticked style. Anchoring on the
structure keeps the rule derived - a tenth weight is graded - where a list of
names to ignore would need editing every time the prose grew. My first version
did use such a list and this cell caught it.

## Break table

Pre-fix split: with the page at its current `main` state, **12 of the 14 fire**.
The two that pass are the ones that do not depend on the new section - the
non-vacuity floor on the skill list, and the pure asset fact that the default
scene carries neither a wheel nor a ball.

| mutation | fires | notes |
| --- | --- | --- |
| b0 control, as shipped | 0 | |
| b1 page reverted to `main` | 12 | the pre-fix split |
| b2 table points `roller` at `scene.xml` | 4 | incl. the roller-has-wheels cell |
| b3 table points `ball_kick` at `scene.xml` | 2 | incl. the ball cell |
| b4 a tenth weight advertised, no table row | 1 | the drift this exists for |
| b5 a table row for an unadvertised skill | 1 | the over-reach cell |
| b6 b4 with the skill scan DERIVED | 1 | names the unlisted weight |
| b7 b4 with the skill scan HARDCODED | **0** | silent |
| b8 scan hardcoded, page intact | 0 | b7's control |
| b9 table gutted to the default row | 9 | |
| b10 b9 with the non-vacuity floors removed | 8 | the floor is the cell that catches a gutted table |
| b11 row points at a wheel-less scene, roller cell weakened to a shape check | 2 | |
| b12 same defect, roller cell intact | 3 | the wheel count is load-bearing over `nu == 14` |

`collected` was 14 on every row and the tree restored byte-identically. b6/b7/b8
is the derived-vs-hardcoded proof: the same drift is named when the list is read
off the page and completely silent when it is hardcoded to today's nine.

## Gate

- `ruff check` clean; `ruff format --check` 1702 files already formatted
- `mypy` **24 == 24** against the base with the new file parked (`checked 1699` vs `1698`), 0 attributable
- `mkdocs build --strict` clean in 1.65 s - the check that grades a docs edit
- Paired guard-class run, 468 paths (every suite walking the tree, parsing source
  or reading docstrings / `Args:` / `Raises:` / `__all__` / `changelog.d`, plus all
  four microduck suites), new file withheld from both sides:
  **`20 failed, 21814 passed, 78 skipped` on each**, 20 == 20 ids, both `comm`
  directions EMPTY. Classified by measurement: 17 need `awsiot`/`awscrt`
  (`find_spec` False, declared in `[mesh-iot]`, which `features = ["all"]`
  installs in CI); 3 are the lerobot-from-source
  `TypeError: encode() takes 1 positional argument` drift.
- The four microduck suites plus the new file: 231 passed, 2 skipped

## Deliberately not done

A registry `variant=` spelling would be a nicer front door than a path. It is not
invented here: **none of the seventy-three entries declares a `variants` key**, so
the schema is a public-API decision rather than a docs fix, and the pinned default
("the model whose `qpos` layout the catalog documents") is part of that decision.
Worth noting for whoever takes it: `Robot("microduck", variant="rollers")` is
accepted today and silently returns the wheel-less model, because the factory ends
in `**kwargs` - as does `variant="nonsense"`, and any unknown sim kwarg. That is a
property of the kwarg surface rather than of this entry, so refusing one name here
would be arbitrary.

No visual artifact: this changes prose and adds a test. The measured scene-
composition tables above are the evidence.
