### PR TITLE
fix(policies/microduck): the velocity gate arbitrates between its pair instead of selecting into it

### DIFF
--- a/changelog.d/2902-microduck-gate-arbitrates-between-the-pair.md
+++ b/changelog.d/2902-microduck-gate-arbitrates-between-the-pair.md
@@ -1,0 +1,41 @@
+### Fixed: the `MicroduckPolicyBundle` velocity gate arbitrates between its pair instead of selecting into it
+
+`switch_on_velocity` exists to choose between a `move_key` and an `idle_key` by
+`|twist|` each tick, and both the module docstring and the parameter's own
+documentation say it selects *between* them. It read the magnitude whatever skill
+was active, so an explicit `switch(...)` — or `select=` on a previous tick — to
+any third skill was undone by the very next tick that carried a
+`target_velocity`, before the skill that was asked for had been ticked once.
+
+There was no value a caller could have passed to stay, because every skill the
+provider ships beyond the pair reads the same twist slots for something that is
+not a velocity. `alpha_sitstand` is the case that makes it a motion fault rather
+than a lost tick: for that policy `twist[0]` is a posture flag, `1` sit and `0`
+stand, with the same policy sitting, holding and standing back up. So its
+documented sit command has magnitude 1.0 and routed to `move_key`, handing the
+walking policy the flag as a 1.0 forward velocity, and its stand command has
+magnitude 0.0 and routed to `idle_key`. Both directions of the only control that
+policy has left it unreachable, and neither reached it even to be refused. The
+same applies to `roulade`, the `ball_kick_*` family and `alpha_ground_pick`,
+which read phase and behaviour encodings there.
+
+Pollen's `infer_policy.py` draws the boundary in the same place. Its
+`_update_policy_session` is documented "Switch between walking and standing
+sessions based on vel_cmd magnitude" and returns early for each of its non-pair
+modes — `ground_pick_mode`, `sit_mode` ("Don't switch while sitting"),
+`slope_mode` and an active `behavior_mode` — before it computes the magnitude.
+Our gate carried only the first of those five guards, the one checking that both
+sessions are loaded.
+
+The gate now returns early when the active skill is neither of its two keys, one
+statement after that existing check and before the magnitude is read. Nothing
+about the pair changes: a bundle holding only `move_key` and `idle_key` — the
+two-skill shape the documentation's own example builds — behaves exactly as
+before in both directions and at the threshold itself, an absent key still
+leaves the gate inert, `select=` still wins per tick, and selecting a gate key
+again hands arbitration straight back.
+
+Nothing graded it because the only cell exercising the gate builds a bundle
+holding exactly the pair, where the missing guard cannot change an outcome: with
+no third skill available to be active, "arbitrates between the pair" and "selects
+into the pair from anywhere" agree on every input.

--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -125,6 +125,13 @@ bundle = MicroduckPolicyBundle(
 
 Select explicitly with `get_actions(..., select="walk")` or `bundle.switch(...)`.
 
+An explicit selection is not undone by the gate: it arbitrates *between*
+`move_key` and `idle_key`, and leaves any other skill alone until a gate key is
+selected again. That matters most for `alpha_sitstand`, whose `twist[0]` is a
+posture flag (`1` sit, `0` stand) rather than a velocity — both of its commands
+have a magnitude the gate would otherwise read as a walk or an idle request, so
+neither would have reached the skill that was asked for.
+
 `switch_on_velocity` must be a positive finite number. The gate compares a
 magnitude, so a threshold of `0` or below could never select the idle skill and
 a non-finite one could never select the move skill. Omit it (the default) to

--- a/strands_robots/policies/microduck/composite.py
+++ b/strands_robots/policies/microduck/composite.py
@@ -149,8 +149,28 @@ class MicroduckPolicyBundle(Policy):
         return await self._policies[self._active].get_actions(observation_dict, instruction, **kwargs)
 
     def _auto_switch(self, target_velocity: Any) -> None:
-        """Gate move<->idle by twist magnitude, when both keys exist."""
+        """Arbitrate between ``move_key`` and ``idle_key`` by twist magnitude.
+
+        The gate selects BETWEEN those two skills. It does not select INTO them
+        from a third one, so an explicit :meth:`switch` (or ``select=``) to a
+        skill outside the pair is not undone by the next tick that carries a
+        ``target_velocity``.
+
+        Every other skill the provider ships reads the same twist slots for
+        something that is not a velocity, which is why the pair is the gate's
+        whole domain. ``alpha_sitstand`` is the sharpest case: ``twist[0]`` is a
+        posture flag there (``1`` sit, ``0`` stand, the same policy sitting,
+        holding and standing back up), so both of its commands have a magnitude
+        the gate would read as a walk request or an idle one - the sit routing to
+        ``move_key`` at 1.0 and the stand to ``idle_key`` at 0.0. Neither ever
+        reached the skill that was asked for. Pollen's ``infer_policy.py`` draws
+        the same boundary in ``_update_policy_session``, which returns early for
+        each of its non-pair modes ("Don't switch while sitting") before it looks
+        at the magnitude.
+        """
         if self._move_key not in self._policies or self._idle_key not in self._policies:
+            return
+        if self._active not in (self._move_key, self._idle_key):
             return
         if target_velocity is None or self._switch_on_velocity is None:
             return

--- a/tests/policies/microduck/test_microduck_gate_arbitrates_between_the_pair.py
+++ b/tests/policies/microduck/test_microduck_gate_arbitrates_between_the_pair.py
@@ -1,0 +1,283 @@
+"""The velocity gate arbitrates between its two keys instead of selecting into them.
+
+``MicroduckPolicyBundle``'s ``switch_on_velocity`` gate exists to choose between
+a ``move_key`` and an ``idle_key`` by ``|twist|`` each tick. Its own docstring
+said "between", and it read the magnitude whatever skill was active - so an
+explicit :meth:`~MicroduckPolicyBundle.switch` to any third skill was undone by
+the very next tick that carried a ``target_velocity``, before that skill was
+ticked even once.
+
+Every skill the provider ships beyond the pair reads the same twist slots for
+something that is not a velocity, so there is no value of ``target_velocity`` a
+caller could have passed to stay. ``alpha_sitstand`` is the sharpest case, and
+the one that makes the failure a motion fault rather than a lost tick: for that
+policy ``twist[0]`` is a posture flag, ``1`` sit and ``0`` stand, with the same
+policy sitting, holding and standing back up. So the documented sit command has
+magnitude 1.0 and routed to ``move_key`` - a sit executed as a forward walk at
+the flag's own value - and the stand command has magnitude 0.0 and routed to
+``idle_key``. Both directions of the only control that policy has left it
+unreachable, and the walking policy received the flag as a velocity.
+
+Pollen's ``infer_policy.py`` draws the boundary in the same place. Its
+``_update_policy_session`` is documented "Switch between walking and standing
+sessions based on vel_cmd magnitude" and returns early for each of its non-pair
+modes - ``ground_pick_mode``, ``sit_mode`` ("Don't switch while sitting"),
+``slope_mode`` and an active ``behavior_mode`` - before it computes the
+magnitude. Our gate carried only the first of those guards, the one that checks
+both sessions are loaded.
+
+Nothing graded it because the only cell exercising the gate builds a bundle
+holding exactly the pair, where the missing guard cannot change an outcome: with
+no third skill to be active, "arbitrates between the pair" and "selects into the
+pair from anywhere" agree on every input. The cells below hold a bundle that
+also carries third skills, which is the population the guard is about.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import textwrap
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import (
+    MICRODUCK_JOINT_NAMES,
+    MicroduckPolicy,
+    MicroduckPolicyBundle,
+)
+from strands_robots.policies.microduck import composite as composite_mod
+
+from .test_microduck_policy import _obs_dict, _StubSession
+
+#: The command block's offset in the observation vector, derived from the layout
+#: rather than restated: base_ang_vel(3) + projected_gravity(3) + three
+#: per-joint blocks (joint_pos, joint_vel, last_action).
+_COMMAND_OFFSET = 3 + 3 + 3 * len(MICRODUCK_JOINT_NAMES)
+
+#: The gate's own two keys, and the skills that are not either of them. Kept as
+#: names the provider actually ships so the population is the real one.
+_MOVE_KEY = "walk"
+_IDLE_KEY = "stand"
+_THIRD_SKILLS = ("sitstand", "kick", "roulade", "ground_pick")
+
+#: The two commands ``alpha_sitstand`` accepts, by Pollen's convention: the flag
+#: rides ``twist[0]`` and the rest of the twist stays zero. Their magnitudes are
+#: what the gate reads, which is why both of them routed away.
+_SIT = [1.0, 0.0, 0.0]
+_STAND = [0.0, 0.0, 0.0]
+
+_GATE_THRESHOLD = 0.1
+
+
+def _bundle(*, active: str, gate: float | None = _GATE_THRESHOLD, skills=None) -> MicroduckPolicyBundle:
+    """A bundle holding the gate's pair plus third skills, each with its own stub."""
+    names = skills if skills is not None else (_MOVE_KEY, _IDLE_KEY, *_THIRD_SKILLS)
+    return MicroduckPolicyBundle(
+        {name: MicroduckPolicy(session=_StubSession()) for name in names},  # type: ignore[arg-type]
+        active=active,
+        switch_on_velocity=gate,
+        move_key=_MOVE_KEY,
+        idle_key=_IDLE_KEY,
+    )
+
+
+def _recorded_input(policy: MicroduckPolicy) -> np.ndarray | None:
+    """The observation a held skill's stub last received, or ``None`` if unticked.
+
+    ``MicroduckPolicy._session`` is typed ``MicroduckSession | None`` and the
+    stub's recording attribute is not on that protocol, so the narrowing lives
+    here once instead of at every read - the same ``union-attr`` ignore the
+    sibling suites carry, in one place.
+    """
+    return policy._session.last_input  # type: ignore[union-attr]
+
+
+def _tick(bundle: MicroduckPolicyBundle, **kwargs: object) -> list[str]:
+    """Run one tick and report which held skills the graph was actually run for."""
+    asyncio.run(bundle.get_actions(_obs_dict(), "", **kwargs))
+    return [name for name, pol in bundle._policies.items() if _recorded_input(pol) is not None]
+
+
+def _command_block(bundle: MicroduckPolicyBundle, name: str) -> np.ndarray:
+    """The command a held skill was handed, read off its own stub."""
+    recorded = _recorded_input(bundle._policies[name])
+    assert recorded is not None, f"{name} was never ticked"
+    return recorded.reshape(-1)[_COMMAND_OFFSET:]
+
+
+class TestAnExplicitSelectionSurvivesTheGate:
+    """The regression: a third skill stays selected and is the one that runs."""
+
+    @pytest.mark.parametrize("skill", _THIRD_SKILLS)
+    @pytest.mark.parametrize("velocity,label", [(_SIT, "sit-flag"), (_STAND, "stand-flag")])
+    def test_the_selected_skill_is_still_active_after_the_tick(self, skill, velocity, label):
+        bundle = _bundle(active=_IDLE_KEY)
+        bundle.switch(skill)
+        _tick(bundle, target_velocity=velocity)
+        assert bundle.active == skill
+
+    @pytest.mark.parametrize("skill", _THIRD_SKILLS)
+    @pytest.mark.parametrize("velocity,label", [(_SIT, "sit-flag"), (_STAND, "stand-flag")])
+    def test_the_selected_skill_is_the_one_that_runs(self, skill, velocity, label):
+        bundle = _bundle(active=_IDLE_KEY)
+        bundle.switch(skill)
+        assert _tick(bundle, target_velocity=velocity) == [skill]
+
+    @pytest.mark.parametrize("skill", _THIRD_SKILLS)
+    def test_the_pair_is_not_run_instead(self, skill):
+        """The gate's own keys must not receive a tick meant for a third skill."""
+        bundle = _bundle(active=_IDLE_KEY)
+        bundle.switch(skill)
+        ticked = _tick(bundle, target_velocity=_SIT)
+        assert _MOVE_KEY not in ticked
+        assert _IDLE_KEY not in ticked
+
+
+class TestThePostureFlagReachesTheSitstandPolicy:
+    """The sharpest case: both values of the flag reach the skill that reads it."""
+
+    @pytest.mark.parametrize("velocity,expected", [(_SIT, 1.0), (_STAND, 0.0)])
+    def test_the_flag_lands_in_the_first_twist_slot_of_that_policy(self, velocity, expected):
+        bundle = _bundle(active=_IDLE_KEY)
+        bundle.switch("sitstand")
+        _tick(bundle, target_velocity=velocity)
+        assert _command_block(bundle, "sitstand")[0] == pytest.approx(expected)
+
+    def test_the_rest_of_the_twist_stays_zero(self):
+        """Pollen writes the flag alone: ``cmd[0] = 1.0 if sit else 0.0``."""
+        bundle = _bundle(active=_IDLE_KEY)
+        bundle.switch("sitstand")
+        _tick(bundle, target_velocity=_SIT)
+        assert list(_command_block(bundle, "sitstand")[1:3]) == [0.0, 0.0]
+
+    def test_the_walking_policy_never_receives_the_flag(self):
+        """A sit command reaching ``move_key`` is the motion fault, not a lost tick."""
+        bundle = _bundle(active=_IDLE_KEY)
+        bundle.switch("sitstand")
+        _tick(bundle, target_velocity=_SIT)
+        assert _recorded_input(bundle._policies[_MOVE_KEY]) is None
+
+
+class TestTheGateStillArbitratesBetweenItsPair:
+    """Over-reach controls: the documented walk<->stand behaviour is unchanged."""
+
+    def test_a_moving_command_selects_the_move_key_from_idle(self):
+        bundle = _bundle(active=_IDLE_KEY)
+        _tick(bundle, target_velocity=[0.5, 0.0, 0.0])
+        assert bundle.active == _MOVE_KEY
+
+    def test_a_zero_command_selects_the_idle_key_from_move(self):
+        bundle = _bundle(active=_MOVE_KEY)
+        _tick(bundle, target_velocity=_STAND)
+        assert bundle.active == _IDLE_KEY
+
+    def test_the_threshold_is_still_inclusive_at_its_own_value(self):
+        bundle = _bundle(active=_IDLE_KEY)
+        _tick(bundle, target_velocity=[_GATE_THRESHOLD, 0.0, 0.0])
+        assert bundle.active == _MOVE_KEY
+
+    def test_a_bundle_holding_only_the_pair_is_unaffected(self):
+        """The guard is a no-op for the two-skill bundle the docs example builds."""
+        bundle = _bundle(active=_IDLE_KEY, skills=(_MOVE_KEY, _IDLE_KEY))
+        _tick(bundle, target_velocity=[0.5, 0.0, 0.0])
+        assert bundle.active == _MOVE_KEY
+        _tick(bundle, target_velocity=_STAND)
+        assert bundle.active == _IDLE_KEY
+
+    def test_returning_to_the_pair_re_enables_the_gate(self):
+        """Selecting a gate key again is how a caller hands arbitration back.
+
+        Whether the third skill survived the intervening tick is the regression
+        above; this holds either way, and pins that the guard does not latch.
+        """
+        bundle = _bundle(active=_IDLE_KEY)
+        bundle.switch("sitstand")
+        _tick(bundle, target_velocity=_SIT)
+        bundle.switch(_IDLE_KEY)
+        _tick(bundle, target_velocity=[0.5, 0.0, 0.0])
+        assert bundle.active == _MOVE_KEY
+
+
+class TestWhatIsUnchangedEitherWay:
+    """Premises and neighbours: true before and after, recorded so they stay so."""
+
+    @pytest.mark.parametrize("skill", _THIRD_SKILLS)
+    def test_an_explicit_per_tick_selection_still_wins(self, skill):
+        """``select=`` is checked before the gate and is not affected by it."""
+        bundle = _bundle(active=_IDLE_KEY)
+        assert _tick(bundle, select=skill, target_velocity=_SIT) == [skill]
+        assert bundle.active == skill
+
+    @pytest.mark.parametrize("skill", _THIRD_SKILLS)
+    def test_the_gate_being_off_already_left_a_third_skill_alone(self, skill):
+        """With no threshold there is no gate to guard against."""
+        bundle = _bundle(active=_IDLE_KEY, gate=None)
+        bundle.switch(skill)
+        assert _tick(bundle, target_velocity=_SIT) == [skill]
+
+    def test_a_tick_with_no_velocity_leaves_the_active_skill_alone(self):
+        bundle = _bundle(active=_IDLE_KEY)
+        bundle.switch("sitstand")
+        assert _tick(bundle) == ["sitstand"]
+
+    def test_a_bundle_missing_a_gate_key_is_refused_before_it_can_tick(self):
+        """Why the pair-held check the gate already carried is not the one at issue.
+
+        A key naming no held skill is refused at construction, so that guard can
+        no longer be reached through the constructor and the gate always has both
+        of its skills by the time it runs. The membership this cell's siblings are
+        about is the ACTIVE skill's, which construction says nothing about.
+        """
+        with pytest.raises(ValueError, match=r"names no held skill"):
+            _bundle(active="sitstand", skills=("sitstand", _IDLE_KEY))
+
+    def test_the_flag_magnitudes_are_what_the_gate_would_have_read(self):
+        """Why both posture commands routed away, as arithmetic rather than prose."""
+        assert float(np.linalg.norm(_SIT)) >= _GATE_THRESHOLD
+        assert float(np.linalg.norm(_STAND)) < _GATE_THRESHOLD
+
+
+class TestTheGuardIsAskedBeforeTheMagnitude:
+    """Structural: the pair check precedes the arithmetic it exists to skip."""
+
+    @staticmethod
+    def _auto_switch_body() -> ast.FunctionDef:
+        source = textwrap.dedent(inspect.getsource(MicroduckPolicyBundle._auto_switch))
+        node = ast.parse(source).body[0]
+        assert isinstance(node, ast.FunctionDef)
+        return node
+
+    def test_the_active_skill_is_checked_against_both_gate_keys(self):
+        """A guard reading only one key would leave the other direction open."""
+        node = self._auto_switch_body()
+        reads = {
+            ast.unparse(sub) for statement in node.body for sub in ast.walk(statement) if isinstance(sub, ast.Attribute)
+        }
+        assert "self._move_key" in reads
+        assert "self._idle_key" in reads
+
+    def test_the_pair_membership_check_precedes_the_magnitude(self):
+        node = self._auto_switch_body()
+        guard_line = next(
+            (
+                statement.lineno
+                for statement in node.body
+                if isinstance(statement, ast.If) and "self._active" in ast.unparse(statement.test)
+            ),
+            None,
+        )
+        assert guard_line is not None, "no statement guards on the active skill"
+        magnitude_line = next(
+            (statement.lineno for statement in node.body if "linalg.norm" in ast.unparse(statement)),
+            None,
+        )
+        assert magnitude_line is not None, "the gate no longer computes a magnitude"
+        assert guard_line < magnitude_line
+
+    def test_the_module_records_why_the_pair_is_the_whole_domain(self):
+        doc = " ".join((composite_mod.MicroduckPolicyBundle._auto_switch.__doc__ or "").split())
+        assert "sitstand" in doc
+        assert "posture flag" in doc


### PR DESCRIPTION
## The defect

`MicroduckPolicyBundle`'s `switch_on_velocity` gate exists to choose between a
`move_key` and an `idle_key` by `|twist|` each tick. It read the magnitude
whatever skill was active, so an explicit `switch(...)` to any third skill was
undone by the very next tick that carried a `target_velocity`, before the skill
that was asked for had been ticked once.

Both docstrings already said "between". The module docstring: "the bundle also
auto-selects **between** a `move_key` and an `idle_key`". The parameter's own
documentation, as of #2898: "`move_key` / `idle_key`: Skill names the velocity
gate **selects between**." The implementation selected *into* the pair from
anywhere.

## Why it is a motion fault rather than a lost tick

Every skill the provider ships beyond the pair reads the same twist slots for
something that is not a velocity, so there was no value a caller could have
passed to stay. `alpha_sitstand` is the sharpest case: for that policy
`twist[0]` is a posture flag, `1` sit and `0` stand, with the same policy
sitting, holding and standing back up.

Driven on a bundle holding the pair plus four third skills, gate at `0.1`,
`move_key="walk"` / `idle_key="stand"`, one `switch(...)` then one tick:

| switched to | `target_velocity` | before: ended on | before: ticked | after |
| --- | --- | --- | --- | --- |
| `sitstand` | `[1.0, 0, 0]` (sit) | `walk` | `walk` | `sitstand` |
| `sitstand` | `[0.0, 0, 0]` (stand) | `stand` | `stand` | `sitstand` |
| `kick` | `[1.0, 0, 0]` | `walk` | `walk` | `kick` |
| `kick` | `[0.0, 0, 0]` | `stand` | `stand` | `kick` |
| `roulade` | `[1.0, 0, 0]` | `walk` | `walk` | `roulade` |
| `roulade` | `[0.0, 0, 0]` | `stand` | `stand` | `roulade` |
| `ground_pick` | `[1.0, 0, 0]` | `walk` | `walk` | `ground_pick` |
| `ground_pick` | `[0.0, 0, 0]` | `stand` | `stand` | `ground_pick` |

All 8 routed away, and the skill that was asked for was never run: its session
recorded no input at all. For `sitstand` the walking policy received
`twist=[1.0, 0, 0]` as a 1.0 forward velocity, which is the flag's own value read
as a speed. Both directions of the only control that policy has left it
unreachable.

## The reference draws the same boundary

Pollen's `infer_policy.py` documents `_update_policy_session` as "Switch between
walking and standing sessions based on vel_cmd magnitude" and returns early for
each of its non-pair modes before it computes the magnitude:

```python
if not (self.walking_session and self.standing_session):
    return  # Only one policy loaded, no switching
if self.ground_pick_mode:
    return  # Don't switch during ground pick
if self.sit_mode:
    return  # Don't switch while sitting
if self.slope_mode:
    return  # Don't switch during slope mode
if self.behavior_mode is not None:
    return  # Don't switch during a kick/roulade
```

Our gate carried only the first of those five. Its own comment for the flag says
the same thing from the other side: "Sitstand posture flag: 1 = sit, 0 = stand.
NOT zeros - the all-zero twist is the STAND command for this policy."

## The change

One statement, placed after the existing pair-held check and before the magnitude
is read, so the gate skips the arithmetic it has no business doing:

```python
if self._active not in (self._move_key, self._idle_key):
    return
```

Nothing about the pair changes. A bundle holding only `move_key` and `idle_key` -
the two-skill shape the documentation's own example builds - behaves exactly as
before in both directions and at the threshold itself; an absent key still leaves
the gate inert; `select=` still wins per tick; and selecting a gate key again
hands arbitration straight back.

## Why nothing caught it

The only cell exercising the gate, `test_velocity_gate_auto_switches`, builds a
bundle holding exactly the pair. With no third skill available to be active,
"arbitrates between the pair" and "selects into the pair from anywhere" agree on
every input, so the missing guard could not change an outcome there.

## Tests

43 new cells. Pre-fix split, source reverted and the suite kept:

| class | role | failed / total |
| --- | --- | --- |
| `TestAnExplicitSelectionSurvivesTheGate` | regression | 20 / 20 |
| `TestThePostureFlagReachesTheSitstandPolicy` | regression | 4 / 4 |
| `TestTheGuardIsAskedBeforeTheMagnitude` | structural | 2 / 3 |
| `TestTheGateStillArbitratesBetweenItsPair` | over-reach control | 0 / 5 |
| `TestWhatIsUnchangedEitherWay` | premise / unchanged | 0 / 11 |

26 failed / 17 passed, with nothing failing in the control or premise classes.
The per-class counts were extracted from the run and asserted to sum to pytest's
own summary.

## Mutations

Each row mutates the shipped source and reports cells fired in the new file, and
in the four sibling microduck suites. `collected` was 43 on every row and the
tree was restored md5-identical.

| mutation | new file | siblings |
| --- | --- | --- |
| control, no mutation | 0 | 0 |
| pair guard removed (the defect) | 25 | 0 |
| guard reads `move_key` only | 4 | 5 |
| guard reads `idle_key` only | 2 | 5 |
| guard weakened to held-skill membership | 24 | 0 |
| guard moved after the selection | 25 | 0 |
| guard moved after the magnitude | 1 | 0 |
| gate ignores the magnitude (always move) | 2 | 5 |
| docstring reverted to the old one-liner | 1 | 0 |

The defect row fires 25 against a pre-fix split of 26: the difference is the
docstring cell, which that row leaves satisfied because it removes only the
guard. 25 + 1 = 26.

Two rows are worth reading together. Reading one key only is an over-reach in
each direction and trips five pre-existing sibling cells, which is what pins the
guard to the pair rather than to one of its members. Weakening it to held-skill
membership - a condition always true - fires 24 rather than 25, because the
structural cell looks for a guard on the active skill and that mutation still has
one; it is the behavioural cells that catch it.

Moving the guard below the magnitude fires exactly one cell, the ordering one.
That mutation is behaviourally harmless today, which is what makes the structural
cell load-bearing rather than decoration.

## Gate

- `ruff check` and `ruff format --check` clean over 1706 files.
- `mypy strands_robots tests tests_integ`: normalised message sets paired against
  the base with the source reverted and the new file withheld. Branch-only diff
  empty, 0 attributable to either changed file.
- Paired pytest over an identical 654-path selection (all of `tests/policies/`
  plus every suite walking the tree, parsing source, or reading docstrings and
  `docs/`), the new file withheld from both sides: `20 failed, 26462 passed, 80
  skipped` on each, 20 identical failing ids, both `comm` directions empty. 17 of
  the 20 need `awsiot` / `awscrt`, absent here and declared in the `mesh-iot`
  extra that the default hatch features install; 3 are the lerobot-from-source
  `encode()` drift. Both reproduce on the base alone.
- The 465-file guard class re-run on the final tree including the changelog
  fragment: the same 20, none attributable.
- `mkdocs build --strict` clean.
- Rebased onto `main` after #2894, #2896, #2897 and #2898 landed. #2898 touches
  both changed files; its construction-time gate-key check and this runtime pair
  check coexist, and one premise cell was re-aimed at that new refusal rather
  than duplicating its suite. The break table and the pre-fix split were
  re-measured on the rebased tree and are unchanged.

## Scope

No new API and no new keyword. The two remaining parts of a posture-control
surface are deliberately left out: a name for the flag, and a way to tell a
sitstand export from a walking one. There is no metadata discriminator available
for the second - `twist` occupies slots `[0:3]` of every command vector the
provider builds, including the one carrying the flag, so a rule keyed on
`command_names` containing `twist` would refuse the very policy it is meant to
serve. Pollen distinguishes them by which file the operator loaded
(`is_sitstand`), not by anything in the graph. Naming the flag is a separate
public-surface decision; today it is reachable through `command=` and, now,
through `target_velocity` on a skill that stays selected.
