### PR TITLE
fix(policies/microduck): the command width follows the graph, not command_names

### DIFF
--- a/changelog.d/2903-microduck-command-width-follows-the-graph.md
+++ b/changelog.d/2903-microduck-command-width-follows-the-graph.md
@@ -1,0 +1,40 @@
+### Fixed: seven of the nine shipped Microduck policies could not be stepped at all
+
+`MicroduckPolicy` sized its command block by summing the `command_names` its
+ONNX metadata declares. Every one of the nine policies Pollen ships takes
+`obs [1, 61]`, but only `alpha_stand` and `alpha_walking` declare the full
+`twist,head_pose,body_pose` (13 components). `roulade`, `roller`,
+`roller_crouch`, `ball_kick_left`, `ball_kick_right` and `alpha_ground_pick`
+declare `twist` (3), and `alpha_sitstand` declares `twist,head_pose` (7).
+
+Summing those names built a 51- or 55-wide observation for a 61-wide graph, so
+onnxruntime refused the very first inference:
+
+```
+InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT :
+  Got invalid dimensions for input: obs for the following indices
+  index: 1 Got: 51 Expected: 61
+```
+
+The two policies that ran are the two the documentation demonstrates, so the
+gap was invisible: a bundle that advertised seven skills could step two.
+
+`command_names` names which command slots a skill *reads*; it is not a width.
+Pollen's reference runner emits one unified 13-component command for every skill
+in a bundle and leaves the slots a skill ignores present and zero - the
+dead-weight rule `microduck.observation.build_observation` already documents,
+"unused command slots stay PRESENT and zero ... so one obs layout serves every
+policy in a bundle" - and it reads the graph's own input shape to size that
+vector.
+
+The graph's declared input width is now the authority when it declares one, and
+the width is derived rather than hardcoded (`6 + 3 * len(joint_names)` fixed
+blocks, so another embodiment resolves its own command width). The
+`command_names` sum remains the fallback for a session that declares no usable
+shape, which is what keeps an injected stub - the seam tests use one, and it
+describes an input name and no shape - resolving exactly as it did before.
+
+Measured on all nine shipped exports driven through `run_policy` in MuJoCo at
+50 Hz: nine of nine now step, where two of nine did before. `roulade` travels
+0.51 m while dropping to a base height of 0.046 m, which is the roll that skill
+performs; `alpha_walking` covers 1.02 m in 8 s and stays upright.

--- a/strands_robots/policies/microduck/policy.py
+++ b/strands_robots/policies/microduck/policy.py
@@ -92,6 +92,12 @@ _DEFAULT_COMMAND_WIDTH = 13
 #: ONNX ``command_names`` metadata (dead-weight rule: slots stay present+zero).
 _COMMAND_COMPONENTS = {"twist": 3, "head_pose": 4, "body_pose": 6}
 
+#: Observation components that are NOT the command block: ``base_ang_vel`` (3)
+#: and ``projected_gravity`` (3). The rest of the fixed part is three per-joint
+#: blocks (``joint_pos``, ``joint_vel``, ``last_action``), so the full non-command
+#: width is ``_BASE_OBS_WIDTH + 3 * len(joint_names)`` - 48 for the 14-DOF biped.
+_BASE_OBS_WIDTH = 6
+
 
 def _action_scale_error(value: Any, source: str) -> str | None:
     """Return why ``value`` cannot be an action scale, or ``None`` if it can.
@@ -414,10 +420,55 @@ class MicroduckPolicy(Policy):
         return cmd.copy()
 
     def _command_width(self) -> int:
-        """Command vector width - summed from ``command_names``, else the 13-D default."""
+        """Command vector width the graph will accept.
+
+        The graph's own declared input width is the authority when it declares
+        one: it is a hard constraint, and ``command_names`` is not a width. The
+        metadata names which command slots a skill READS, and Pollen's reference
+        runner emits ONE unified 13-component command for every skill in a
+        bundle, leaving the slots a skill ignores present and zero (the
+        dead-weight rule this module's observation builder documents). Seven of
+        the nine shipped Pollen exports declare a narrower ``command_names``
+        than their graph consumes - ``roulade`` declares ``twist`` (3) against
+        an ``obs`` input of 61 - so summing the names built a 51-wide vector for
+        a 61-wide graph and onnxruntime refused it with ``Got: 51 Expected:
+        61``, making those seven policies unrunnable.
+
+        Falls back to the ``command_names`` sum, then the 13-D default, when the
+        session declares no usable width (an injected stub, or a graph with a
+        dynamic first-axis symbol rather than an integer).
+        """
+        declared = self._declared_command_width()
+        if declared is not None:
+            return declared
         if not self._command_names:
             return _DEFAULT_COMMAND_WIDTH
         return sum(_COMMAND_COMPONENTS.get(name, 0) for name in self._command_names)
+
+    def _declared_command_width(self) -> int | None:
+        """Command width implied by the graph's declared ``obs`` input, else ``None``.
+
+        Returns ``None`` rather than raising whenever the width cannot be read as
+        a positive integer - no declared shape, a dynamic-axis symbol, a shape
+        that does not exceed the fixed blocks - so an injected stub keeps the
+        ``command_names`` behaviour instead of being held to a shape it never
+        declared.
+        """
+        if self._joint_names is None:
+            return None
+        get_inputs = getattr(self._session, "get_inputs", None)
+        if not callable(get_inputs):
+            return None
+        try:
+            shape = list(get_inputs()[0].shape)
+            total = shape[-1]
+        except Exception:  # noqa: BLE001 - a stub need not declare a shape
+            return None
+        if not isinstance(total, int) or isinstance(total, bool):
+            return None
+        fixed = _BASE_OBS_WIDTH + 3 * len(self._joint_names)
+        width = total - fixed
+        return width if width > 0 else None
 
     def _read_metadata(self) -> dict[str, str]:
         """Best-effort read of the ONNX ``custom_metadata_map`` (empty if absent)."""

--- a/tests/policies/microduck/test_microduck_command_width_follows_the_graph.py
+++ b/tests/policies/microduck/test_microduck_command_width_follows_the_graph.py
@@ -1,0 +1,224 @@
+"""The command width follows the graph's declared input, not ``command_names``.
+
+Seven of the nine ONNX policies Pollen ships declare a ``command_names``
+narrower than the ``obs`` input their graph consumes. Every shipped export takes
+``obs [1, 61]``; only ``alpha_stand`` and ``alpha_walking`` declare the full
+``twist,head_pose,body_pose`` (13). ``roulade``, ``roller``, ``roller_crouch``,
+``ball_kick_left``, ``ball_kick_right`` and ``alpha_ground_pick`` declare
+``twist`` (3), and ``alpha_sitstand`` declares ``twist,head_pose`` (7).
+
+Summing those names produced a 51- or 55-wide observation for a 61-wide graph,
+so onnxruntime refused the very first inference with
+``INVALID_ARGUMENT ... Got: 51 Expected: 61`` and those seven policies could not
+be run at all. ``command_names`` names which command slots a skill READS; it is
+not a width. Pollen's reference runner emits ONE unified 13-component command
+for every skill in a bundle (``infer_policy.py``: ``self.command =
+np.zeros(13 if self.new_cmd_obs else 3)``) and leaves the slots a skill ignores
+present and zero - the dead-weight rule ``observation.build_observation``
+already documents, and reads the graph's own input shape to size it.
+
+So the graph's declared input width is the authority when it declares one, and
+the ``command_names`` sum stays the fallback for a session that declares no
+usable shape. That fallback is what keeps an injected stub - which need not
+describe a shape at all - behaving exactly as before, and it is graded here
+alongside the fix so widening one cannot quietly narrow the other.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import MicroduckPolicy
+
+#: Fixed observation blocks that are not the command: ``base_ang_vel`` (3) plus
+#: ``projected_gravity`` (3), then three per-joint blocks. Stated locally so
+#: these cells are an independent oracle rather than a restatement of the module.
+BASE_OBS_WIDTH = 6
+PER_JOINT_BLOCKS = 3
+
+#: The 14-DOF biped every shipped export targets, and the ``obs`` width all nine
+#: of them declare. 6 + 3*14 = 48 fixed, so the command block is 61 - 48 = 13.
+JOINTS = 14
+SHIPPED_OBS_WIDTH = 61
+SHIPPED_COMMAND_WIDTH = 13
+
+#: What the seven under-declaring exports say, and what summing it would build.
+NARROW_COMMAND_NAMES = "twist"
+NARROW_SUM_WIDTH = 3
+
+
+def _fixed_width(n_joints: int) -> int:
+    """Non-command observation width for ``n_joints`` (independent of the module)."""
+    return BASE_OBS_WIDTH + PER_JOINT_BLOCKS * n_joints
+
+
+class _Meta:
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self.custom_metadata_map = mapping
+
+
+class _Session:
+    """A session that declares an ``obs`` shape, the way a real export does.
+
+    ``declared`` is the graph's input width. ``None`` models a stub that
+    describes no shape at all (the pre-existing stubs in the sibling suites),
+    and a ``str`` models a dynamic-axis symbol, which onnxruntime does emit.
+    """
+
+    def __init__(self, declared: int | str | None, command_names: str, n_joints: int = JOINTS) -> None:
+        self._declared = declared
+        self._n_joints = n_joints
+        self.obs_widths: list[int] = []
+        self.meta = {
+            "joint_names": ",".join(f"j{i}" for i in range(n_joints)),
+            "default_joint_pos": ",".join("0.0" for _ in range(n_joints)),
+            "action_scale": "1.0",
+        }
+        if command_names:
+            self.meta["command_names"] = command_names
+
+    def get_inputs(self) -> list[Any]:
+        declared = self._declared
+
+        class _Input:
+            name = "obs"
+
+            def __init__(self) -> None:
+                if declared is not None:
+                    self.shape = [1, declared]
+
+        return [_Input()]
+
+    def get_modelmeta(self) -> _Meta:
+        return _Meta(self.meta)
+
+    def run(self, _names: Any, feed: dict[str, Any]) -> list[np.ndarray]:
+        vector = np.asarray(next(iter(feed.values()))).reshape(-1)
+        self.obs_widths.append(int(vector.shape[0]))
+        # A real graph refuses a width it did not declare; model that so a cell
+        # cannot pass on a vector onnxruntime would have rejected. Only enforced
+        # for a width a real export could declare - one that leaves room for a
+        # command block. A degenerate declaration is the input under test in
+        # ``TestTheCommandNamesFallbackIsUnchanged``, where the policy is
+        # expected to ignore it, so enforcing it there would contradict the cell.
+        plausible = isinstance(self._declared, int) and not isinstance(self._declared, bool)
+        if plausible and self._declared > _fixed_width(self._n_joints):  # type: ignore[operator]
+            if vector.shape[0] != self._declared:
+                raise ValueError(
+                    f"Got invalid dimensions for input: obs. Got: {vector.shape[0]} Expected: {self._declared}"
+                )
+        return [np.zeros((1, self._n_joints), dtype=np.float32)]
+
+
+def _obs(n_joints: int = JOINTS) -> dict[str, Any]:
+    d: dict[str, Any] = {"base_ang_vel": [0.0, 0.0, 0.0], "base_quat": [1.0, 0.0, 0.0, 0.0]}
+    for i in range(n_joints):
+        d[f"j{i}"] = 0.1
+        d[f"j{i}.vel"] = 0.2
+    return d
+
+
+class TestThePremisesTheFixRestsOn:
+    """The arithmetic and the shipped shape, stated here rather than assumed."""
+
+    def test_the_fixed_blocks_leave_a_thirteen_wide_command(self) -> None:
+        assert _fixed_width(JOINTS) == 48
+        assert SHIPPED_OBS_WIDTH - _fixed_width(JOINTS) == SHIPPED_COMMAND_WIDTH
+
+    def test_summing_the_narrow_names_would_not_reach_the_graph(self) -> None:
+        """The whole defect in one line: the sum is not the declared width."""
+        assert NARROW_SUM_WIDTH != SHIPPED_COMMAND_WIDTH
+        assert _fixed_width(JOINTS) + NARROW_SUM_WIDTH != SHIPPED_OBS_WIDTH
+
+
+class TestAnUnderDeclaringExportStillRuns:
+    """The seven shipped policies whose ``command_names`` is narrower than the graph."""
+
+    def test_the_built_observation_matches_the_declared_input(self) -> None:
+        session = _Session(SHIPPED_OBS_WIDTH, NARROW_COMMAND_NAMES)
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(), "")
+        assert session.obs_widths == [SHIPPED_OBS_WIDTH]
+
+    def test_the_command_is_as_wide_as_the_graph_expects(self) -> None:
+        session = _Session(SHIPPED_OBS_WIDTH, NARROW_COMMAND_NAMES)
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(), "")
+        assert policy._command is not None
+        assert policy._command.shape[0] == SHIPPED_COMMAND_WIDTH
+
+    def test_a_target_velocity_still_writes_the_twist_slots(self) -> None:
+        """Widening must not move the twist block off the front of the vector."""
+        session = _Session(SHIPPED_OBS_WIDTH, NARROW_COMMAND_NAMES)
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(), "", target_velocity=[0.3, 0.0, 0.0])
+        assert policy._command is not None
+        assert list(policy._command[:3]) == [pytest.approx(0.3), 0.0, 0.0]
+        assert not np.any(policy._command[3:])
+
+    @pytest.mark.parametrize("names", ["twist", "twist,head_pose", "twist,head_pose,body_pose"])
+    def test_every_shipped_declaration_reaches_the_same_graph(self, names: str) -> None:
+        """All nine exports declare obs=61; three distinct ``command_names`` do not."""
+        session = _Session(SHIPPED_OBS_WIDTH, names)
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(), "")
+        assert session.obs_widths == [SHIPPED_OBS_WIDTH]
+
+    def test_an_initial_command_is_measured_against_the_declared_width(self) -> None:
+        """A caller supplying the graph's width is accepted, not refused as 13 != 3."""
+        session = _Session(SHIPPED_OBS_WIDTH, NARROW_COMMAND_NAMES)
+        policy = MicroduckPolicy(  # type: ignore[arg-type]
+            session=session, command=[0.0] * SHIPPED_COMMAND_WIDTH
+        )
+        policy.get_actions_sync(_obs(), "")
+        assert session.obs_widths == [SHIPPED_OBS_WIDTH]
+
+
+class TestTheJointCountIsNotHardcoded:
+    """The fixed part is ``6 + 3 * n_joints``, so another embodiment resolves too."""
+
+    def test_a_nine_joint_graph_resolves_its_own_command_width(self) -> None:
+        n, command = 9, 5
+        session = _Session(_fixed_width(n) + command, NARROW_COMMAND_NAMES, n_joints=n)
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(n), "")
+        assert session.obs_widths == [_fixed_width(n) + command]
+        assert policy._command is not None
+        assert policy._command.shape[0] == command
+
+
+class TestTheCommandNamesFallbackIsUnchanged:
+    """A session that declares no usable width keeps the pre-existing behaviour.
+
+    These hold on both trees. They are the boundary the fix must not cross: the
+    sibling suites' stubs describe an input NAME and no shape, so the
+    ``command_names`` sum has to stay authoritative for them.
+    """
+
+    def test_a_stub_without_a_declared_shape_sums_the_names(self) -> None:
+        session = _Session(None, NARROW_COMMAND_NAMES)
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(), "")
+        assert session.obs_widths == [_fixed_width(JOINTS) + NARROW_SUM_WIDTH]
+
+    def test_a_dynamic_axis_symbol_is_not_read_as_a_width(self) -> None:
+        session = _Session("batch_x_obs", NARROW_COMMAND_NAMES)
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(), "")
+        assert session.obs_widths == [_fixed_width(JOINTS) + NARROW_SUM_WIDTH]
+
+    def test_a_shapeless_stub_with_no_command_names_uses_the_thirteen_default(self) -> None:
+        session = _Session(None, "")
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(), "")
+        assert session.obs_widths == [_fixed_width(JOINTS) + SHIPPED_COMMAND_WIDTH]
+
+    def test_a_declared_width_at_or_below_the_fixed_blocks_is_ignored(self) -> None:
+        """A shape that leaves no room for a command is not a command width."""
+        session = _Session(_fixed_width(JOINTS), NARROW_COMMAND_NAMES)
+        policy = MicroduckPolicy(session=session)  # type: ignore[arg-type]
+        policy.get_actions_sync(_obs(), "")
+        assert session.obs_widths == [_fixed_width(JOINTS) + NARROW_SUM_WIDTH]


### PR DESCRIPTION
## Problem

`MicroduckPolicy` sized its command block by summing the `command_names` its ONNX
metadata declares. Every one of the nine policies Pollen ships takes `obs [1, 61]`,
but only two of them declare a `command_names` that adds up to the 13 the graph
leaves room for:

| policy | declares `command_names` | sum | obs it built | graph declares |
|---|---|---|---|---|
| `alpha_stand` | `twist,head_pose,body_pose` | 13 | 61 | 61 |
| `alpha_walking` | `twist,head_pose,body_pose` | 13 | 61 | 61 |
| `alpha_sitstand` | `twist,head_pose` | 7 | **55** | 61 |
| `alpha_ground_pick` | `twist` | 3 | **51** | 61 |
| `ball_kick_left` | `twist` | 3 | **51** | 61 |
| `ball_kick_right` | `twist` | 3 | **51** | 61 |
| `roller` | `twist` | 3 | **51** | 61 |
| `roller_crouch` | `twist` | 3 | **51** | 61 |
| `roulade` | `twist` | 3 | **51** | 61 |

So seven of the nine could not be stepped at all. onnxruntime refused the very
first inference:

```
InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT :
  Got invalid dimensions for input: obs for the following indices
  index: 1 Got: 51 Expected: 61
```

The two that ran are the two the documentation demonstrates, which is why the gap
was invisible: a bundle advertising seven skills could step two.

## Why `command_names` is not a width

It names which command slots a skill *reads*. Pollen's reference runner emits one
unified 13-component command for **every** skill in a bundle and leaves the slots
a skill ignores present and zero, sizing that vector from the graph's own input
shape rather than from the names.

This module already documents the same rule. `microduck.observation.build_observation`:

> unused command slots stay PRESENT and zero (the dead-weight rule) so one obs
> layout serves every policy in a bundle

The implementation did not honour it for the seven exports that under-declare.

## Change

The graph's declared input width is the authority when it declares one; the
`command_names` sum stays the fallback. The fixed part is derived rather than
hardcoded (`6 + 3 * len(joint_names)`), so another embodiment resolves its own
command width instead of inheriting the 14-DOF biped's 48.

The fallback is what keeps an injected session behaving exactly as before: the
seam tests' stubs describe an input name and no shape, so they resolve through
`command_names` as they always did, and both shipped `legacy twist-only` cells
pass untouched.

## Measured

Nine shipped exports driven through `run_policy` in MuJoCo at 50 Hz
(`control_frequency=50.0`, which resolves to 10 substeps at the model's 0.002 s
timestep):

| policy | before | after | travel | min base z |
|---|---|---|---|---|
| `alpha_stand` | ran | ran | +0.003 m | 0.115 |
| `alpha_walking` | ran | ran | +0.492 m | 0.113 |
| `alpha_sitstand` | **refused** | ran | +0.005 m | 0.115 |
| `alpha_ground_pick` | **refused** | ran | -0.027 m | 0.094 |
| `ball_kick_left` | **refused** | ran | +0.018 m | 0.110 |
| `ball_kick_right` | **refused** | ran | -0.014 m | 0.109 |
| `roller` | **refused** | ran | -0.027 m | 0.058 |
| `roller_crouch` | **refused** | ran | +0.015 m | 0.079 |
| `roulade` | **refused** | ran | +0.510 m | 0.046 |

Nine of nine step, where two of nine did. The low base heights on `roller`,
`roller_crouch`, `alpha_ground_pick` and `roulade` are the crouch and the roll
those skills perform, not falls - `roulade` recovers to 0.115 m by the end of the
rollout.

### Rollouts

`roulade`, which could not be stepped before this change - rolls forward 0.50 m
and recovers upright:

https://github.com/cagataycali/robots/releases/download/artifacts/microduck_2903_roulade.mp4

`alpha_walking` for reference - 1.02 m in 8 s, upright throughout:

https://github.com/cagataycali/robots/releases/download/artifacts/microduck_2903_walk.mp4

Both recorded through the shipped `run_policy(video=...)` path with a chase camera
mounted on `duck/trunk_base`, headless EGL, 640x480 at 30 fps.

## Tests

`tests/policies/microduck/test_microduck_command_width_follows_the_graph.py`, 14
cells. Pre-fix split: **7 failed / 7 passed**, the failures carrying the real
error (`Got: 51 Expected: 61` and `Got: 55 Expected: 61`).

The stub declares an `obs` shape the way a real export does and refuses a width it
did not declare, so a cell cannot pass on a vector onnxruntime would have
rejected. The four cells in `TestTheCommandNamesFallbackIsUnchanged` hold on both
trees: they are the boundary this change must not cross.

- 2 premise cells: the fixed blocks leave 13, and the narrow sum does not reach the graph.
- 7 regression cells: an under-declaring export runs, the command is the graph's width, `target_velocity` still writes the twist slots at the front, and a caller-supplied 13-wide initial command is accepted rather than refused as `13 != 3`.
- 1 cell for a 9-joint graph, so the fixed part is not hardcoded to 48.
- 4 boundary cells: no declared shape, a dynamic-axis symbol, no `command_names`, and a declared width that leaves no room for a command all resolve through the fallback.

## Gate

- `ruff check` and `ruff format --check` clean over 1702 files.
- `mypy strands_robots tests tests_integ`: 24 == 24 against the base, normalized message sets byte-identical in both directions, 0 attributable.
- Paired run over an identical 475-file selection (all of `tests/policies/` plus every guard that walks the tree, parses source, or reads docstrings), with the new file withheld from both sides: `20 failed, 22223 passed, 78 skipped` on **both**, 20 == 20 failing ids, both `comm` directions empty. All 20 are environmental and reproduce on the base alone - 17 need `awsiot`/`awscrt` (absent here, declared in `mesh-iot`, which `all` pulls in so CI installs them) and 3 are the lerobot-from-source `encode() takes 1 positional argument` drift.
- `tests/policies/microduck/` 240 passed on the rebased base before this change, 254 after.

## Composition with the other open microduck PR

strands-labs/robots#2902 also touches this package (`composite.py`); the two share
no changed path, so the path-keyed overlap check is silent on the pair by
construction. Composed locally onto this branch: 0 conflicts, `tests/policies/microduck/`
293 passed. Verified by breaking each side on the composed tree rather than by the
pass count - reverting this PR's change fires 7 cells, all in this PR's file;
reverting strands-labs/robots#2902's fires 26, all in that PR's file. Disjoint, so
neither side goes vacuous in the other's presence and the merge order is free.
