### PR TITLE
docs(changelog): fragment for the Microduck skill-scene documentation

### DIFF
--- a/changelog.d/2900-microduck-skill-scenes.md
+++ b/changelog.d/2900-microduck-skill-scenes.md
@@ -1,0 +1,39 @@
+### Docs: every Microduck skill names the scene it needs
+
+`docs/policies/microduck.md` opens by listing the nine shipped Pollen weights
+`MicroduckPolicy` wraps and says they drive the biped "through the standard
+`Robot(...).run_policy` seam - in MuJoCo or on hardware". Five of the nine run on
+the scene the registry entry declares. Four do not: `roller` and `roller_crouch`
+need the four passive ankle wheels that only `scene_rollers.xml` carries, and
+`ball_kick_left` / `ball_kick_right` need the ball prop that only
+`scene_ball.xml` places. `Robot("microduck")` resolves a scene with zero wheel
+joints and zero ball bodies, and `examples/microduck/render_video.py` builds
+exactly that, which is why the page said any shipped weight "drops straight in".
+
+Running one of the four there is not an error and reports success: the policy
+writes the same fourteen control targets, and the physics has nothing to roll on
+or nothing to kick. A reader following the page got a duck standing still with no
+indication why.
+
+The scenes were never missing. All three ship in the one asset directory the
+entry already downloads, and the entry names the fourteen-hinge model on purpose
+- `tests/simulation/test_microduck_asset_matches_the_declared_shape.py` pins
+that, and records the reason ("a caller can load it by path"). The gap was that
+no page said which scene a skill needs.
+
+The page now carries a skill-to-scene table, the by-path route for the two
+variants, and the layout invariant a raw position read has to care about:
+`scene_ball.xml` appends the ball's free joint, so the robot's `qpos` layout is
+byte-for-byte the default one, while `scene_rollers.xml` inserts two passive
+wheel joints after `left_ankle` and two after `right_ankle`, moving nine of the
+fourteen actuated joints - the two left wheels land where `neck_pitch` and
+`head_pitch` sit on the default scene. The actuator order is identical on all
+three, so a policy writing `ctrl` is unaffected, and `MicroduckPolicy` reads its
+observation by joint name rather than by slice.
+
+No behaviour changes. A new guard cross-references the advertised list against
+the table, so a tenth weight cannot be advertised without naming its scene, and
+re-derives every row from the compiled model, so the table's claims are measured
+rather than asserted. A registry `variant=` spelling would be a nicer front door
+and is deliberately not invented here: none of the seventy-three entries declares
+one, so that schema is a public-API decision rather than a docs fix.


### PR DESCRIPTION
## Why

strands-labs/robots#2900 merged with two files - `docs/policies/microduck.md` and
its guard - and no changelog fragment, so the release notes carry no record of
the change. This adds it.

The fragment is named `2900-microduck-skill-scenes.md`, for the change it
describes rather than for this pull request, so the assembled entry sits with the
work it documents.

## What it records

Four of the nine weights `docs/policies/microduck.md` advertises need a scene the
registry entry does not declare. Measured through the public seam:

| route | wheel joints | ball bodies |
| --- | --- | --- |
| `Robot("microduck")` | 0 | 0 |
| `urdf_path=".../scene_rollers.xml"` | 4 | 0 |
| `urdf_path=".../scene_ball.xml"` | 0 | 1 |

`roller` / `roller_crouch` need the wheels and `ball_kick_left` /
`ball_kick_right` need the ball, so running one on the default scene reports
success with nothing to roll on or nothing to kick. The page now names the scene
each skill needs, gives the by-path route, and states which variant renumbers a
raw `qpos` slice.

## Gate

- `tests/test_changelog_fragments.py` and `tests/test_changelog_format.py`:
  30 passed
- `scripts/assemble_changelog.py --print` includes the entry (verified by
  grepping the assembled output, not the pending count)
- No source or test change, so nothing else can move
