### PR TITLE
fix(policies/microduck): refuse a command override the method cannot honor

### DIFF
--- a/changelog.d/2905-microduck-command-override-domain.md
+++ b/changelog.d/2905-microduck-command-override-domain.md
@@ -1,0 +1,37 @@
+### Fixed: a Microduck command override the method cannot honor is refused rather than absorbed
+
+`MicroduckPolicy.get_actions` recognises two per-call overrides that write the
+command vector - `command` (wholesale) and `target_velocity` (the twist slots) -
+and neither was held to a value domain, while two sibling providers reading the
+same well-known goal key already are (`WBCPolicy._validate_velocity`, and the
+`param_name="target_velocity"` guard MotionBricks applies on both its constructor
+and its per-call path).
+
+`target_velocity` was written as `self._command[:n] = tv[:n]` with
+`n = min(3, len(tv), len(command))`, so a component count the method does not
+document was silently absorbed. A longer vector lost its tail. A shorter one
+wrote only the slots it covered, and this policy's command vector persists across
+ticks, so `target_velocity=[0.3]` left the previous tick's lateral and yaw
+components commanding the robot under a reported success; a bare scalar was read
+as one component the same way.
+
+A non-finite component in either override was assigned first and refused
+afterwards by `build_observation`, which names `command` and the assembled
+observation rather than the parameter the caller passed - and by then the
+poisoned vector was already in `self._command`, so a caller that handled that
+error and kept ticking carried it into every later tick and every later episode.
+A non-numeric `command` reached `np.asarray(..., dtype=np.float32)` and surfaced
+as a bare "could not convert string to float", naming neither the policy nor the
+parameter.
+
+Both overrides now consult the shared `finite_vector_error` under the caller's
+own parameter name, before the write, and `target_velocity` is held to the two
+component counts the method documents (`TARGET_VELOCITY_WIDTHS`). The documented
+two-component spelling is kept: because the command persists, "set vx and vy,
+leave omega" is a coherent request - which is why the family's other readers,
+whose command is rebuilt per call, require three. The provider documentation now
+also states that what the twist slots MEAN is a property of the loaded weights
+rather than of this provider: Pollen's locomotion exports read them as a
+velocity, which is what `target_velocity` writes, while other exports in the
+family read the same three slots under a different convention that the ONNX
+metadata does not distinguish.

--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -163,6 +163,24 @@ wholesale with `command=`:
 await policy.get_actions(obs, "", target_velocity=[0.3, 0.0, 0.2])  # vx, vy, ω
 ```
 
+`target_velocity` takes three components (`[vx, vy, omega]`) or two
+(`[vx, vy]`, which leaves `omega` at its current value - the command vector
+persists across ticks). Any other component count is refused rather than
+truncated or partially written, and a `nan`/`inf` component is refused before it
+reaches the command; `command=` must be `command_names`-wide and finite for the
+same reasons.
+
+What the twist slots MEAN, however, is a property of the loaded weights rather
+than of this provider. Pollen's locomotion exports (`alpha_walking`,
+`alpha_stand`, the `roller*` pair) read them as a velocity, which is exactly what
+`target_velocity` writes. Other exports in the family read the same three slots
+differently - `alpha_ground_pick`, for instance, reads them as a progress
+encoding through a one-shot motion rather than as a velocity - and for those a
+caller supplies the slots wholesale through `command=` and advances them itself.
+`target_velocity` is a locomotion kwarg, not a universal one, and the ONNX
+metadata does not distinguish the two: several exports declare the same
+`command_names` (`twist`) while reading it under different conventions.
+
 ## Hot-swapping skills
 
 `MicroduckPolicyBundle` holds several `MicroduckPolicy` instances warm and

--- a/strands_robots/policies/microduck/policy.py
+++ b/strands_robots/policies/microduck/policy.py
@@ -93,6 +93,16 @@ _DEFAULT_COMMAND_WIDTH = 13
 _COMMAND_COMPONENTS = {"twist": 3, "head_pose": 4, "body_pose": 6}
 
 
+#: The component counts :meth:`MicroduckPolicy.get_actions` documents for the
+#: well-known ``target_velocity`` kwarg: ``[vx, vy, omega]`` and ``[vx, vy]``.
+#: Single-sourced so the refusal and the docstring cannot drift apart. The
+#: two-component form is deliberately kept: this policy's command vector
+#: persists across ticks, so "set vx and vy, leave omega" is a coherent request
+#: - which is why the family's other readers, whose command is rebuilt per call,
+#: require three.
+TARGET_VELOCITY_WIDTHS: frozenset[int] = frozenset({2, 3})
+
+
 def _action_scale_error(value: Any, source: str) -> str | None:
     """Return why ``value`` cannot be an action scale, or ``None`` if it can.
 
@@ -247,10 +257,25 @@ class MicroduckPolicy(Policy):
 
         Recognised ``**kwargs``:
 
-        * ``command``: full command vector override for this tick.
-        * ``target_velocity``: ``[vx, vy, omega]`` (or ``[vx, vy]``) written
-          into the twist slots of the command vector - the well-known
-          locomotion goal kwarg.
+        * ``command``: full command vector override for this tick. Must be
+          ``command_names``-wide and finite.
+        * ``target_velocity``: ``[vx, vy, omega]`` (or ``[vx, vy]``, which leaves
+          ``omega`` at its current value) written into the twist slots of the
+          command vector - the well-known locomotion goal kwarg. Must carry
+          finite numbers and one of the two component counts above; any other
+          width is refused rather than truncated or partially written.
+
+        Note that what the twist slots MEAN is a property of the loaded weights,
+        not of this method. Pollen's locomotion exports read them as a velocity,
+        which is what ``target_velocity`` writes; other exports in the family read
+        the same three slots differently, and for those a caller supplies the
+        slots wholesale through ``command``.
+
+        Raises:
+            ValueError: If ``command`` or ``target_velocity`` carries a
+                non-numeric or non-finite component, if ``command`` is not
+                ``command_names``-wide, or if ``target_velocity``'s component
+                count is not in :data:`TARGET_VELOCITY_WIDTHS`.
         """
         self._ensure_config()
         assert self._joint_names is not None and self._default_pose is not None
@@ -333,6 +358,16 @@ class MicroduckPolicy(Policy):
         """Fold per-call command overrides into the running command vector."""
         assert self._command is not None
         if kwargs.get("command") is not None:
+            # Asked before the coercion, for the same two reasons as the sibling
+            # ``target_velocity`` below: a non-numeric element otherwise surfaced
+            # as a bare ``could not convert string to float`` from numpy, naming
+            # neither this policy nor the parameter; and a nan/inf one was
+            # assigned to ``self._command`` and only refused afterwards by
+            # ``build_observation``, so a caller that handled that error and kept
+            # ticking carried the poisoned command into every later tick and every
+            # later episode.
+            if error := finite_vector_error(f"{type(self).__name__}.get_actions", "command", kwargs["command"]):
+                raise ValueError(error)
             new = np.asarray(kwargs["command"], dtype=np.float32).reshape(-1)
             if new.shape[0] != self._command.shape[0]:
                 raise ValueError(
@@ -342,8 +377,33 @@ class MicroduckPolicy(Policy):
             self._command = new
         tv = kwargs.get("target_velocity")
         if tv is not None:
+            # Two sibling providers reading this same well-known goal key hold it
+            # to a domain that names it - ``WBCPolicy._validate_velocity`` and the
+            # ``param_name="target_velocity"`` guard MotionBricks applies on both
+            # its constructor and per-call paths - and this one did not. A
+            # non-finite component WAS still refused, but downstream by
+            # ``build_observation``, which names ``command`` and the assembled
+            # observation rather than the parameter the caller passed. Ask here,
+            # where the caller's own parameter name is still in hand.
+            if error := finite_vector_error(f"{type(self).__name__}.get_actions", "target_velocity", tv):
+                raise ValueError(error)
             tv = np.asarray(tv, dtype=np.float32).reshape(-1)
-            n = min(3, tv.shape[0], self._command.shape[0])
+            # This method documents exactly two spellings for the kwarg,
+            # ``[vx, vy, omega]`` and ``[vx, vy]``, and the write accepted any
+            # width. A longer one was silently truncated to its first three
+            # components; a shorter one wrote only the slots it covered, and the
+            # command vector persists across ticks, so ``target_velocity=[0.3]``
+            # left the PREVIOUS tick's lateral and yaw components commanding the
+            # robot under a reported success. The sibling ``command`` override in
+            # this same method already refuses a width it cannot honor, naming the
+            # expected width and its source; this one now does too.
+            if tv.shape[0] not in TARGET_VELOCITY_WIDTHS:
+                raise ValueError(
+                    f"MicroduckPolicy: target_velocity has {tv.shape[0]} component(s), "
+                    f"expected {' or '.join(f'{w}' for w in sorted(TARGET_VELOCITY_WIDTHS, reverse=True))} "
+                    f"([vx, vy, omega] or [vx, vy])."
+                )
+            n = min(tv.shape[0], self._command.shape[0])
             self._command[:n] = tv[:n]
 
     def _ensure_config(self) -> None:

--- a/tests/policies/microduck/test_microduck_command_override_domain.py
+++ b/tests/policies/microduck/test_microduck_command_override_domain.py
@@ -1,0 +1,305 @@
+"""The two command overrides refuse a vector they cannot honor, before it lands.
+
+:meth:`MicroduckPolicy.get_actions` recognises two per-call overrides that write
+the command vector - ``command`` (wholesale) and ``target_velocity`` (the twist
+slots). Both are caller-supplied numeric vectors, and neither was held to a
+domain:
+
+* ``target_velocity`` was written as ``self._command[:n] = tv[:n]`` with
+  ``n = min(3, len(tv), len(command))``, so a width the method does not document
+  was silently absorbed. A LONGER vector lost its tail; a SHORTER one wrote only
+  the slots it covered, and this policy's command vector persists across ticks -
+  so ``target_velocity=[0.3]`` left the previous tick's lateral and yaw
+  components commanding the robot, under a reported success.
+* A non-finite component in either override was assigned first and refused
+  afterwards by :func:`~strands_robots.policies.microduck.observation.build_observation`,
+  which names ``command`` and the assembled observation rather than the parameter
+  the caller passed. The refusal also arrived too late to protect the state: the
+  poisoned vector stayed in ``self._command`` for every later tick.
+* A non-numeric ``command`` reached ``np.asarray(..., dtype=np.float32)`` and
+  surfaced as a bare ``could not convert string to float``, naming neither this
+  policy nor the parameter.
+
+Two sibling providers reading this same well-known goal key already hold it to a
+domain that names it - ``WBCPolicy._validate_velocity`` and the
+``param_name="target_velocity"`` guard MotionBricks applies on both its
+constructor and its per-call path - which is the convention these cells hold this
+one to. The two-component ``target_velocity`` spelling is deliberately KEPT
+(see :data:`TARGET_VELOCITY_WIDTHS`); the family's other readers require three
+because their command is rebuilt per call rather than carried across ticks.
+
+Everything here runs through an injected stub session, so no ``onnxruntime`` and
+no weights are needed.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import math
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import MicroduckPolicy
+from strands_robots.policies.microduck import policy as policy_mod
+from strands_robots.policies.microduck.policy import TARGET_VELOCITY_WIDTHS
+from tests.policies.microduck.test_microduck_policy import _obs_dict, _StubSession
+
+#: The shared vector domain both overrides must consult. Named locally so these
+#: cells state the rule rather than reading it back out of the code they grade.
+_SHARED_VECTOR_DOMAIN = "finite_vector_error"
+
+#: A twist the first tick establishes, so a partial write is observable as the
+#: PREVIOUS tick's components surviving rather than as a zero.
+_STALE_TWIST = (7.0, 8.0, 9.0)
+
+
+def _policy() -> MicroduckPolicy:
+    return MicroduckPolicy(session=_StubSession())
+
+
+def _ticked() -> MicroduckPolicy:
+    """A policy whose twist slots already hold :data:`_STALE_TWIST`."""
+    p = _policy()
+    asyncio.run(p.get_actions(_obs_dict(), "", target_velocity=list(_STALE_TWIST)))
+    assert np.allclose(_cmd(p)[:3], _STALE_TWIST), "fixture did not establish the stale twist"
+    return p
+
+
+def _tick(p: MicroduckPolicy, **kwargs: Any) -> None:
+    asyncio.run(p.get_actions(_obs_dict(), "", **kwargs))
+
+
+def _cmd(p: MicroduckPolicy) -> np.ndarray:
+    """The running command vector, narrowed once.
+
+    ``_command`` is ``NDArray | None`` until ``_ensure_config`` has run; every
+    cell here has ticked the policy at least once, so the narrowing is asserted
+    here rather than at each read.
+    """
+    assert p._command is not None, "the policy has not been configured by a tick"
+    return p._command
+
+
+def _method_source() -> str:
+    return textwrap.dedent(inspect.getsource(MicroduckPolicy._apply_command_kwargs))
+
+
+def _recognised_overrides() -> set[str]:
+    """Every kwarg name ``_apply_command_kwargs`` reads, derived from its source.
+
+    Keyed on the read rather than on a list, so an override added later - the
+    third command semantics the family's non-locomotion exports want, say -
+    is held to the same rule the hour it lands instead of inheriting an
+    exemption by being absent from a tuple here.
+    """
+    names: set[str] = set()
+    for node in ast.walk(ast.parse(_method_source())):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "get":
+            if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+                names.add(node.args[0].value)
+        if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant):
+            if isinstance(node.slice.value, str):
+                names.add(node.slice.value)
+    return names
+
+
+def _domain_guarded_params() -> set[str]:
+    """The ``param_name`` each shared-domain call in the method reports under."""
+    guarded: set[str] = set()
+    for node in ast.walk(ast.parse(_method_source())):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if node.func.id != _SHARED_VECTOR_DOMAIN:
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                guarded.add(arg.value)
+    return guarded
+
+
+class TestPremises:
+    """Facts these cells rest on. They hold before and after the fix."""
+
+    def test_the_command_vector_persists_across_ticks(self):
+        # This is why a PARTIAL write is a live command rather than a zero: the
+        # slots the caller did not cover still carry the previous tick's request.
+        p = _ticked()
+        _tick(p)  # no override at all
+        assert np.allclose(_cmd(p)[:3], _STALE_TWIST)
+
+    def test_the_shared_domain_is_a_real_export(self):
+        from strands_robots import utils
+
+        assert callable(getattr(utils, _SHARED_VECTOR_DOMAIN, None))
+
+    def test_the_documented_widths_are_exactly_two_and_three(self):
+        assert TARGET_VELOCITY_WIDTHS == frozenset({2, 3})
+
+    def test_the_method_recognises_both_overrides(self):
+        # Non-vacuity for the derived cell below: it grades a set, and an empty
+        # set would satisfy any subset rule.
+        assert {"command", "target_velocity"} <= _recognised_overrides()
+
+    def test_a_sibling_provider_holds_the_same_key_to_a_named_domain(self):
+        # The convention these cells hold this provider to. If the family stops
+        # validating the shared key, this premise fails and the reader learns the
+        # convention moved rather than reading a rule with no basis.
+        from strands_robots.policies.wbc.policy import WBCPolicy
+
+        with pytest.raises(ValueError, match="target_velocity"):
+            WBCPolicy._validate_velocity([float("nan"), 0.0, 0.0])
+
+
+class TestAWidthTheMethodDoesNotDocumentIsRefused:
+    @pytest.mark.parametrize("width", [0, 1, 4, 7])
+    def test_an_undocumented_width_is_refused(self, width):
+        p = _ticked()
+        with pytest.raises(ValueError, match="target_velocity has"):
+            _tick(p, target_velocity=[0.3] * width)
+
+    @pytest.mark.parametrize("width", [1, 4])
+    def test_the_refusal_names_the_count_and_both_accepted_spellings(self, width):
+        p = _ticked()
+        with pytest.raises(ValueError) as exc:
+            _tick(p, target_velocity=[0.3] * width)
+        text = str(exc.value)
+        assert f"{width} component(s)" in text
+        assert "[vx, vy, omega]" in text and "[vx, vy]" in text
+
+    def test_a_scalar_is_refused_rather_than_read_as_one_component(self):
+        p = _ticked()
+        with pytest.raises(ValueError, match="target_velocity"):
+            _tick(p, target_velocity=0.3)
+
+    @pytest.mark.parametrize("width", [1, 4])
+    def test_a_refused_width_leaves_the_running_command_untouched(self, width):
+        p = _ticked()
+        with pytest.raises(ValueError):
+            _tick(p, target_velocity=[0.3] * width)
+        assert np.allclose(_cmd(p)[:3], _STALE_TWIST)
+
+
+class TestANonFiniteOverrideIsRefusedAtTheSeamThatNamesIt:
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    @pytest.mark.parametrize("param", ["command", "target_velocity"])
+    def test_the_refusal_names_the_parameter_the_caller_passed(self, param, bad):
+        p = _ticked()
+        width = 13 if param == "command" else 3
+        vec = [bad] + [0.0] * (width - 1)
+        with pytest.raises(ValueError) as exc:
+            _tick(p, **{param: vec})
+        text = str(exc.value)
+        assert f"'{param}'" in text, text
+        assert "MicroduckPolicy" in text, text
+
+    @pytest.mark.parametrize("param", ["command", "target_velocity"])
+    def test_a_non_finite_override_does_not_reach_the_running_command(self, param):
+        # The refusal used to arrive after the assignment, so a caller that
+        # handled it and kept ticking carried nan in its command for the rest of
+        # the rollout AND into every later episode.
+        p = _ticked()
+        width = 13 if param == "command" else 3
+        with pytest.raises(ValueError):
+            _tick(p, **{param: [float("nan")] + [0.0] * (width - 1)})
+        assert np.allclose(_cmd(p)[:3], _STALE_TWIST)
+        assert not np.isnan(_cmd(p)).any()
+
+    @pytest.mark.parametrize("param", ["command", "target_velocity"])
+    def test_a_non_numeric_override_is_named_rather_than_coerced(self, param):
+        p = _ticked()
+        width = 13 if param == "command" else 3
+        with pytest.raises(ValueError) as exc:
+            _tick(p, **{param: ["a"] * width})
+        text = str(exc.value)
+        assert f"'{param}'" in text, text
+        assert "convert string to float" not in text, text
+
+    def test_a_later_tick_still_works_after_a_refusal(self):
+        p = _ticked()
+        with pytest.raises(ValueError):
+            _tick(p, target_velocity=[float("nan"), 0.0, 0.0])
+        _tick(p, target_velocity=[0.1, 0.2, 0.3])
+        assert np.allclose(_cmd(p)[:3], [0.1, 0.2, 0.3])
+
+
+class TestTheDomainIsAskedOfEveryOverrideTheMethodReads:
+    def test_every_recognised_override_reports_under_the_shared_domain(self):
+        missing = sorted(_recognised_overrides() - _domain_guarded_params())
+        assert not missing, (
+            f"{sorted(_recognised_overrides())} are read from kwargs by "
+            f"_apply_command_kwargs, but {missing} never reach "
+            f"{_SHARED_VECTOR_DOMAIN}, so a non-numeric or non-finite component "
+            f"there is either coerced by numpy or written into the command and "
+            f"reported later against a name the caller never used."
+        )
+
+    def test_the_width_refusal_reads_the_shared_constant(self):
+        # Not a restated literal: the docstring and the refusal both derive from
+        # TARGET_VELOCITY_WIDTHS, so they cannot drift apart.
+        source = _method_source()
+        assert "TARGET_VELOCITY_WIDTHS" in source, source
+
+    def test_the_docstring_documents_the_widths_it_enforces(self):
+        doc = " ".join((MicroduckPolicy.get_actions.__doc__ or "").split())
+        assert "[vx, vy, omega]" in doc and "[vx, vy]" in doc
+        assert "TARGET_VELOCITY_WIDTHS" in doc
+
+
+class TestWhatIsDeliberatelyUnchanged:
+    """The documented spellings, and the meaning of the slots.
+
+    Every cell here holds on the pre-fix code too. They are the boundary: the
+    change refuses widths the method never documented and values it cannot
+    honor, and it must not narrow what a locomotion caller may ask for.
+    """
+
+    def test_the_three_component_spelling_writes_all_three_slots(self):
+        p = _ticked()
+        _tick(p, target_velocity=[0.3, -0.2, 0.1])
+        assert np.allclose(_cmd(p)[:3], [0.3, -0.2, 0.1])
+
+    def test_the_two_component_spelling_leaves_omega_at_its_current_value(self):
+        # Documented, and coherent because the command persists: "set vx and vy,
+        # leave omega". Refusing it would narrow the documented surface.
+        p = _ticked()
+        _tick(p, target_velocity=[0.3, -0.2])
+        assert np.allclose(_cmd(p)[:3], [0.3, -0.2, _STALE_TWIST[2]])
+
+    def test_a_full_width_finite_command_override_still_replaces_the_vector(self):
+        p = _ticked()
+        _tick(p, command=[0.5] * 13)
+        assert np.allclose(_cmd(p), [0.5] * 13)
+
+    def test_the_command_width_refusal_still_names_its_source(self):
+        p = _ticked()
+        with pytest.raises(ValueError, match="from command_names"):
+            _tick(p, command=[0.1] * 5)
+
+    def test_a_zero_twist_is_a_legal_request(self):
+        # The stand-in-place command for the locomotion exports; it must not be
+        # mistaken for an absent override.
+        p = _ticked()
+        _tick(p, target_velocity=[0.0, 0.0, 0.0])
+        assert np.allclose(_cmd(p)[:3], [0.0, 0.0, 0.0])
+
+    def test_integer_components_are_accepted(self):
+        p = _ticked()
+        _tick(p, target_velocity=[1, 0, 0])
+        assert np.allclose(_cmd(p)[:3], [1.0, 0.0, 0.0])
+
+    def test_a_numpy_vector_is_accepted(self):
+        p = _ticked()
+        _tick(p, target_velocity=np.array([0.4, 0.0, 0.0], dtype=np.float32))
+        assert np.allclose(_cmd(p)[:3], [0.4, 0.0, 0.0])
+
+    def test_the_widths_the_method_documents_are_not_a_hardcoded_pair_here(self):
+        # Non-vacuity for the boundary above: the accepted spellings are read
+        # from the module, so widening TARGET_VELOCITY_WIDTHS widens these cells
+        # rather than leaving them contradicting the code.
+        assert all(math.isfinite(w) and w > 0 for w in TARGET_VELOCITY_WIDTHS)
+        assert getattr(policy_mod, "TARGET_VELOCITY_WIDTHS") is TARGET_VELOCITY_WIDTHS


### PR DESCRIPTION
## The defect

`MicroduckPolicy.get_actions` recognises two per-call overrides that write the command vector - `command` (wholesale) and `target_velocity` (the twist slots). Both are caller-supplied numeric vectors, and neither was held to a value domain.

Two sibling providers reading this same well-known goal key already are:

| Provider | Holds `target_velocity` to a domain? | How |
| --- | --- | --- |
| `WBCPolicy` (and its gait path) | yes | `_validate_velocity`: numeric sequence, `len >= 3`, per-component finite, each refusal naming `target_velocity` and the index |
| `MotionBricksPolicy` | yes | `_unit_direction(..., param_name="target_velocity")`, on **both** the constructor and the per-call path |
| `MicroduckPolicy` | **no** | `n = min(3, len(tv), len(command))`; `self._command[:n] = tv[:n]` |

MotionBricks' constructor even says why it validates there: *"Through the same door a per-call `target_velocity` goes through ... This mirrors the sibling locomotion family, whose constructor validates its own `target_velocity` default with the guard its per-call path uses."*

## Measured, through an injected stub session

The first tick establishes `[7, 8, 9]` so a partial write is observable as the previous tick's components surviving rather than as a zero.

| spelling | before | twist after | outcome |
| --- | --- | --- | --- |
| `target_velocity=[0.3, 0.0, 0.2]` (control) | `[7 8 9]` | `[0.3 0.0 0.2]` | success |
| `target_velocity=[0.3]` | `[7 8 9]` | **`[0.3 8.0 9.0]`** | **success** |
| `target_velocity=0.3` (scalar) | `[7 8 9]` | **`[0.3 8.0 9.0]`** | **success** |
| `target_velocity=[0.3, 0.0, 0.2, 99.0]` | `[7 8 9]` | `[0.3 0.0 0.2]` (tail dropped) | **success** |
| `target_velocity=[nan, 0, 0]` | `[7 8 9]` | **`[nan 0.0 0.0]`** | ValueError from `build_observation`, naming `command` |
| `command=['a']*13` | `[7 8 9]` | `[7 8 9]` | `could not convert string to float: 'a'` |
| `command=[nan]*13` | `[7 8 9]` | **`[nan nan nan]`** | ValueError from `build_observation` |
| `command=[0.1]*5` (control) | `[7 8 9]` | `[7 8 9]` | `command override has width 5, expected 13 (from command_names)` |

Three distinct consequences:

1. **A width the method does not document was silently absorbed.** The method's own docstring documents exactly two spellings, `[vx, vy, omega]` and `[vx, vy]`. A longer vector lost its tail; a shorter one wrote only the slots it covered. This policy's command vector **persists across ticks**, so `target_velocity=[0.3]` left the previous tick's lateral and yaw components commanding the robot - a caller who changed forward speed kept commanding 8 m/s sideways and 9 rad/s of yaw, under a reported success.
2. **A non-finite component was assigned before it was refused.** The refusal came from `build_observation`, which names `command` and the assembled observation rather than the parameter the caller passed - and it arrived too late to protect the state: the poisoned vector stayed in `self._command`, so a caller that handled the error and kept ticking carried `nan` into every later tick and, through `_episode_start_command`, was one `reset` away from carrying it into later episodes.
3. **A non-numeric `command` was coerced rather than refused**, surfacing as a bare numpy message naming neither the policy nor the parameter.

The sibling `command` override in the *same method* already refuses a width it cannot honor, naming the expected width and its source. That is the convention this change extends.

## The change

Both overrides consult the shared `finite_vector_error` under the caller's own parameter name, **before** the write, and `target_velocity` is held to the two component counts the method documents (`TARGET_VELOCITY_WIDTHS`, single-sourced so the refusal and the docstring cannot drift).

After: every row above is refused by name, and every refused row leaves the running command untouched (`[7 8 9]`).

The documented **two**-component spelling is deliberately kept. Because the command persists, "set `vx` and `vy`, leave `omega`" is a coherent request - which is why the family's other readers, whose command is rebuilt per call, require three. That asymmetry is now written down rather than implicit.

## Why nothing caught it

`tests/policies/microduck/test_microduck_policy.py::test_target_velocity_writes_twist_slots` drives width 3 only, and every other `target_velocity` call site in the tree (tests, docs, the driver) is width 3. No spelling outside the happy path was exercised, so both the truncation and the misattributed refusal were invisible.

## Verification

- **Pre-fix split** (behavioural revert - the constant kept, the three guards undone; a raw revert is a collection error because the tests import the constant): **21 failed / 15 passed**, `0/5` premise cells and `0/8` over-reach controls.

  | class | failed/total | role |
  | --- | --- | --- |
  | `TestAWidthTheMethodDoesNotDocumentIsRefused` | 9/9 | regression |
  | `TestANonFiniteOverrideIsRefusedAtTheSeamThatNamesIt` | 10/11 | regression |
  | `TestTheDomainIsAskedOfEveryOverrideTheMethodReads` | 2/3 | structural |
  | `TestPremises` | **0/5** | premise |
  | `TestWhatIsDeliberatelyUnchanged` | **0/8** | over-reach control |

- **Mutation table** (11 rows; `coll` stable at 36 on every row, `sib` 0 across all of `tests/policies/microduck/`, source restored md5-identical):

  | row | fires | note |
  | --- | --- | --- |
  | b0 control | 0 | |
  | b1 `command` finiteness guard removed | 6 | |
  | b2 `target_velocity` finiteness guard removed | 6 | |
  | b3 width refusal removed (silent `min`) | 9 | |
  | b4 all three removed | 21 | equals the pre-fix split |
  | b5 finiteness asked AFTER the write | 2 | exactly the two "does not reach the running command" cells |
  | b6 widths restated as literals in both places | 1 | the single-sourcing cell |
  | b7 widths widened to admit 1 | 4 | over-reach the other way |
  | b8 refusal drops the accepted spellings | 2 | |
  | b9 a third override added, scan **derived** | 1 | names the unguarded override |
  | b10 the same third override, scan **hardcoded** | **0** | silent |

  b1, b2 and b3 are near-disjoint (`b1 & b3` and `b2 & b3` empty; `b1 & b2` is the one cell that fires when either finiteness guard goes). Their union is 20 of b4's 21; the residual is `test_a_scalar_is_refused_rather_than_read_as_one_component`, because *either* guard alone catches a scalar - finiteness refuses it as "not a list/tuple of numbers", and the width check refuses it as one component - so it slips only when both are gone.

  b9/b10 is the pair that matters for the next reader: the derived cell reads the overrides `_apply_command_kwargs` actually consults, so a **third** override added later is held to the same rule the hour it lands. With that scan hardcoded to today's two names the same unguarded override is completely silent.

- **Paired gate**, identical 489-path selection (every suite walking the tree, parsing source, or reading docstrings / `Args:` / `Raises:` / `__all__` / `changelog.d`, plus all of `tests/policies/{microduck,wbc,motionbricks}`), the new file withheld from both sides, base = pristine `main`: identical **22822 collected** and `20 failed, 22724 passed, 78 skipped` on each, **20 == 20 failing ids with both `comm` directions empty**. All 20 classified by measurement: 17 need `awsiot`/`awscrt` (both `find_spec` absent, both declared in the `mesh-iot` extra, and the hatch default env's `features` is `["all"]`, so CI installs them); 3 are the `lerobot`-from-source `encode()` drift.
- **mypy** `24 == 24` against pristine `main`, normalized message sets byte-identical in both directions, **0 attributable**.
- `ruff check` and `ruff format --check` clean over 1707 files; `mkdocs build --strict` clean.
- On the rebased tree, with the five guard files `main` added in the meantime: **1701 passed, 2 skipped**.

No visual artifact: this is a refusal at a policy's kwarg seam, not a policy, simulation, rendering, recording or asset change. The measured before/after table is the evidence.

## Scope

The provider documentation now also states that what the twist slots MEAN is a property of the loaded weights rather than of this provider. Pollen's locomotion exports read them as a velocity, which is what `target_velocity` writes; other exports in the family read the same three slots under a different convention, and the ONNX metadata does not distinguish the two - several exports declare the same `command_names` (`twist`) while reading it differently. Adding a *new* command semantics for those exports is a separate public-surface change and is not attempted here; this change makes the one semantics the method already documents actually enforced, which is the seam such an addition would extend.
