### PR TITLE
feat(policies/microduck): episodic behaviors in MicroduckPolicyBundle auto-return on their own timer

### DIFF
--- a/changelog.d/389-microduck-episodic-auto-return.md
+++ b/changelog.d/389-microduck-episodic-auto-return.md
@@ -25,3 +25,11 @@ bundle asked to run an episodic behavior without being told its clock refuses
 loudly rather than assuming 50Hz. A running episode inhibits the velocity gate
 so a walk command mid-kick does not preempt the episodic skill, and `reset`
 clears the FSM before the next rollout.
+
+That `reset` normalisation is scoped to a bundle that declares episodic
+skills. A bundle that declares none is left exactly as it was: the active
+skill is the caller's to choose there, `switch` is the only thing that moves
+it, and the rollout calls `policy.reset(seed=...)` once per episode -- so
+normalising regardless of whether an episodic behavior was ever declared
+would have discarded an explicit `switch` at every episode boundary of a
+multi-episode run, with nothing reported.

--- a/changelog.d/389-microduck-episodic-auto-return.md
+++ b/changelog.d/389-microduck-episodic-auto-return.md
@@ -1,0 +1,27 @@
+### Added: episodic behaviors in `MicroduckPolicyBundle` auto-return on their own
+
+`MicroduckPolicyBundle` used to have one switching mode -- the velocity gate
+between a `move_key` and an `idle_key`. Pollen's reference `infer_policy.py`
+also carries a second, orthogonal mode: **timed episodic behaviors**
+(`kick_left` / `kick_right` / `roulade`) that run for a fixed duration and
+then auto-return to a default skill. Without this, a caller who did
+`bundle.switch("kick_left")` stayed on `kick_left` forever, feeding the
+walking/standing observation contract to an episodic policy that expects to
+end within ~1.2s.
+
+Two new constructor arguments cover the gap. `episodic_skills` maps a skill
+name to a duration in seconds; every entry must name a held policy and every
+duration goes through the shared `positive_finite_number_error` domain.
+`default_skill` is the revert target the bundle returns to when a timer
+expires -- refused if it names no held policy, and refused if it is itself an
+episodic skill, because an auto-return that re-arms its own timer never
+terminates.
+
+`bundle.trigger(name)` arms an episodic behavior; the tick loop then runs it
+until its timer reaches zero, at which point the bundle reverts to
+`default_skill`. The timer counts down at `1/control_frequency` per tick, read
+off the same `Policy.control_frequency` seam every other consumer uses; a
+bundle asked to run an episodic behavior without being told its clock refuses
+loudly rather than assuming 50Hz. A running episode inhibits the velocity gate
+so a walk command mid-kick does not preempt the episodic skill, and `reset`
+clears the FSM before the next rollout.

--- a/strands_robots/policies/microduck/composite.py
+++ b/strands_robots/policies/microduck/composite.py
@@ -13,6 +13,14 @@ the magnitude of the twist command - the same walking<->standing gate Pollen's
 ``infer_policy.py`` uses. Both gate keys must name held skills for that gate to
 fire, so they are checked when it is enabled. The previously active child's
 ``last_action`` history is left intact so returning to a skill resumes cleanly.
+
+Pollen's reference ``infer_policy.py`` also supports **episodic behaviors** -
+short skills like ``kick_left`` / ``kick_right`` / ``roulade`` that run for a
+fixed wall-clock duration and then auto-return to the default skill. Callers
+declare these via ``episodic_skills={"kick_left": 1.2, "roulade": 2.0}`` and
+activate them with :meth:`trigger`. Each tick decrements a timer by
+``1/control_frequency``; when it reaches zero, the bundle reverts to
+``default_skill``. This matches ``_end_behavior`` in the upstream FSM.
 """
 
 from __future__ import annotations
@@ -58,6 +66,8 @@ class MicroduckPolicyBundle(Policy):
         switch_on_velocity: float | None = None,
         move_key: str = "walk",
         idle_key: str = "stand",
+        episodic_skills: dict[str, float] | None = None,
+        default_skill: str | None = None,
     ) -> None:
         if not policies:
             raise ValueError("MicroduckPolicyBundle requires at least one policy.")
@@ -99,6 +109,43 @@ class MicroduckPolicyBundle(Policy):
                 )
         self._move_key = move_key
         self._idle_key = idle_key
+        # Episodic-behavior FSM state (mirrors Pollen `infer_policy.py`).
+        # A caller who omits ``episodic_skills`` gets exactly the previous
+        # velocity-gated bundle: :meth:`trigger` refuses, no timer runs, and
+        # ``get_actions`` never decrements anything. So an ONNX bundle that
+        # never means to kick pays no cost per tick and cannot revert unexpectedly.
+        self._episodic_durations: dict[str, float] = {}
+        if episodic_skills is not None:
+            unknown = [name for name in episodic_skills if name not in self._policies]
+            if unknown:
+                raise ValueError(
+                    f"MicroduckPolicyBundle: episodic_skills names no held skill(s) {unknown!r}; "
+                    f"have {list(self._policies)}. Every episodic skill must be one of policies."
+                )
+            for name, duration in episodic_skills.items():
+                if error := positive_finite_number_error(
+                    duration, f"episodic_skills[{name!r}]", "MicroduckPolicyBundle"
+                ):
+                    raise ValueError(error)
+                self._episodic_durations[name] = float(duration)
+        if default_skill is not None and default_skill not in self._policies:
+            raise ValueError(
+                f"MicroduckPolicyBundle: default_skill={default_skill!r} names no held skill; "
+                f"have {list(self._policies)}."
+            )
+        # Fallback for :meth:`_end_episode`: the caller's declared default,
+        # else the initially-active skill (the same identity the bundle started
+        # in). Never an episodic skill itself, because auto-returning INTO an
+        # episodic skill would immediately arm its timer and never terminate.
+        resolved_default = default_skill if default_skill is not None else self._active
+        if resolved_default in self._episodic_durations:
+            raise ValueError(
+                f"MicroduckPolicyBundle: default_skill={resolved_default!r} is itself an episodic skill; "
+                "auto-return would re-arm the timer immediately."
+            )
+        self._default_skill = resolved_default
+        self._episodic_active: str | None = None
+        self._episodic_time_left: float = 0.0
 
     @property
     def provider_name(self) -> str:
@@ -116,9 +163,49 @@ class MicroduckPolicyBundle(Policy):
         return tuple(self._policies.values())
 
     def switch(self, name: str) -> None:
-        """Select ``name`` as the active skill."""
+        """Select ``name`` as the active skill.
+
+        Cancels any running episodic behavior: :meth:`switch` is the explicit
+        override path, so a caller who names a skill wins over the FSM timer.
+        """
         if name not in self._policies:
             raise ValueError(f"MicroduckPolicyBundle: unknown skill {name!r}; have {list(self._policies)}.")
+        self._active = name
+        self._episodic_active = None
+        self._episodic_time_left = 0.0
+
+    @property
+    def episodic_active(self) -> str | None:
+        """The currently running episodic skill, or ``None`` if none is armed."""
+        return self._episodic_active
+
+    def trigger(self, name: str) -> None:
+        """Arm an episodic behavior; the bundle will run it until its timer ends.
+
+        Args:
+            name: The episodic skill to activate. Must be a key of
+                ``episodic_skills`` passed at construction time.
+
+        Raises:
+            ValueError: If ``name`` is not a declared episodic skill, or if
+                another episodic behavior is already running (matches
+                ``_end_behavior`` gating in Pollen ``infer_policy.py`` - only
+                one behavior at a time; the caller must let it finish or use
+                :meth:`switch` to cancel).
+        """
+        if name not in self._episodic_durations:
+            declared = list(self._episodic_durations)
+            raise ValueError(
+                f"MicroduckPolicyBundle: {name!r} is not a declared episodic skill; "
+                f"have {declared!r}. Pass episodic_skills={{{name!r}: <duration>}} at construction time."
+            )
+        if self._episodic_active is not None:
+            raise ValueError(
+                f"MicroduckPolicyBundle: episodic skill {self._episodic_active!r} is already running "
+                f"({self._episodic_time_left:.3f}s left); let it finish or call switch() to override."
+            )
+        self._episodic_active = name
+        self._episodic_time_left = self._episodic_durations[name]
         self._active = name
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
@@ -133,20 +220,62 @@ class MicroduckPolicyBundle(Policy):
             pol.set_control_frequency(hz)
 
     def reset(self, seed: int | None = None) -> None:
-        """Reset every held skill's per-episode state."""
+        """Reset every held skill's per-episode state and clear the episodic timer."""
         for pol in self._policies.values():
             pol.reset(seed)
+        self._episodic_active = None
+        self._episodic_time_left = 0.0
+        self._active = self._default_skill
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, Any]]:
-        """Delegate this tick to the active skill, after any requested switch."""
+        """Delegate this tick to the active skill, after any requested switch.
+
+        Ordering per tick (mirrors Pollen ``infer_policy.py``): an explicit
+        ``select=`` cancels any running episodic behavior (like :meth:`switch`);
+        otherwise if an episodic behavior is running it stays active and the
+        velocity gate is skipped (so the FSM cannot yank a kick mid-episode);
+        otherwise the velocity gate fires. After the active child runs, the
+        episodic timer decrements by ``1/control_frequency`` and, if it hits
+        zero, the bundle reverts to ``default_skill`` for the NEXT tick. The
+        last tick of the episode still executes the episodic skill, so a
+        1.2s / 60-step kick at 50Hz produces 60 kick actions and the 61st
+        tick runs default_skill.
+        """
         select = kwargs.get("select")
         if select is not None:
             self.switch(str(select))
-        elif self._switch_on_velocity is not None:
+        elif self._episodic_active is None and self._switch_on_velocity is not None:
             self._auto_switch(kwargs.get("target_velocity"))
-        return await self._policies[self._active].get_actions(observation_dict, instruction, **kwargs)
+        result = await self._policies[self._active].get_actions(observation_dict, instruction, **kwargs)
+        if self._episodic_active is not None:
+            self._tick_episodic()
+        return result
+
+    def _tick_episodic(self) -> None:
+        """Decrement the episodic timer by one control step; revert on expiry.
+
+        A missing ``control_frequency`` refuses (loudly) rather than silently
+        assuming 50Hz - an assumed rate would mis-time every kick at any other
+        loop rate. The runtime is expected to call :meth:`set_control_frequency`
+        before the rollout, same contract as every other Policy consumer.
+        """
+        if self.control_frequency is None:
+            raise RuntimeError(
+                "MicroduckPolicyBundle: episodic timer requires control_frequency; "
+                "call set_control_frequency(hz) before running an episodic behavior."
+            )
+        dt = 1.0 / self.control_frequency
+        self._episodic_time_left -= dt
+        if self._episodic_time_left <= 0.0:
+            self._end_episode()
+
+    def _end_episode(self) -> None:
+        """Complete the running episodic behavior and revert to ``default_skill``."""
+        self._episodic_active = None
+        self._episodic_time_left = 0.0
+        self._active = self._default_skill
 
     def _auto_switch(self, target_velocity: Any) -> None:
         """Gate move<->idle by twist magnitude, when both keys exist."""

--- a/strands_robots/policies/microduck/composite.py
+++ b/strands_robots/policies/microduck/composite.py
@@ -111,9 +111,10 @@ class MicroduckPolicyBundle(Policy):
         self._idle_key = idle_key
         # Episodic-behavior FSM state (mirrors Pollen `infer_policy.py`).
         # A caller who omits ``episodic_skills`` gets exactly the previous
-        # velocity-gated bundle: :meth:`trigger` refuses, no timer runs, and
-        # ``get_actions`` never decrements anything. So an ONNX bundle that
-        # never means to kick pays no cost per tick and cannot revert unexpectedly.
+        # velocity-gated bundle: :meth:`trigger` refuses, no timer runs,
+        # ``get_actions`` never decrements anything, and :meth:`reset` leaves
+        # the active skill alone. So an ONNX bundle that never means to kick
+        # pays no cost per tick and cannot revert unexpectedly.
         self._episodic_durations: dict[str, float] = {}
         if episodic_skills is not None:
             unknown = [name for name in episodic_skills if name not in self._policies]
@@ -220,12 +221,25 @@ class MicroduckPolicyBundle(Policy):
             pol.set_control_frequency(hz)
 
     def reset(self, seed: int | None = None) -> None:
-        """Reset every held skill's per-episode state and clear the episodic timer."""
+        """Reset every held skill's per-episode state and clear the episodic timer.
+
+        A bundle that declares episodic skills also normalises the active
+        skill here: an episode may be mid-flight, and the runtime calls this
+        between episodes, so leaving a half-run kick selected would start the
+        next episode inside a behaviour whose timer has been cleared.
+
+        A bundle that declares none is left exactly as it was. The active
+        skill is the caller's to choose there - ``switch`` is the only way it
+        moves - and this seam is called once per episode by the rollout, so
+        normalising unconditionally would silently discard that choice at
+        every episode boundary of a multi-episode run.
+        """
         for pol in self._policies.values():
             pol.reset(seed)
-        self._episodic_active = None
-        self._episodic_time_left = 0.0
-        self._active = self._default_skill
+        if self._episodic_durations:
+            self._episodic_active = None
+            self._episodic_time_left = 0.0
+            self._active = self._default_skill
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/tests/policies/microduck/test_microduck_episodic_timer.py
+++ b/tests/policies/microduck/test_microduck_episodic_timer.py
@@ -1,0 +1,303 @@
+"""Episodic behaviors in :class:`MicroduckPolicyBundle` auto-return on their own.
+
+Pollen's reference ``scripts/infer_policy.py`` has a second, orthogonal
+switching mode alongside the walking/standing velocity gate: **timed episodic
+behaviors**. ``trigger_behavior("kick_left")`` arms a short skill with a fixed
+duration; ``update_behavior(dt)`` decrements ``behavior_time_left`` each tick
+and ``_end_behavior`` reverts to the default when it reaches zero.
+
+Without this the bundle exposes a switching FSM that only ever enters a state.
+A caller who wanted a walk -> kick -> walk sequence had ``switch("kick_left")``,
+which stayed on ``kick_left`` forever, feeding the walking/standing observation
+contract to an episodic policy that expects to end within ~1.2s. This test
+holds the new API to the reference FSM's contract: only declared skills can be
+triggered; a running episodic behavior blocks another (matches
+``_end_behavior`` gating); the timer counts down at exactly the control rate
+the runtime told the bundle; the last tick of the episode still executes the
+episodic skill; and the auto-return goes to ``default_skill``, which is
+refused if it names an episodic skill (an auto-return that re-arms its own
+timer never terminates).
+
+The control rate is read off :attr:`Policy.control_frequency`, the same seam
+every other consumer uses; a bundle asked to run an episodic behavior without
+being told its clock refuses loudly rather than assuming 50Hz, because an
+assumed rate mis-times every kick at any other loop rate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.microduck import MicroduckPolicy, MicroduckPolicyBundle
+from tests.policies.microduck.test_microduck_policy import _obs_dict, _StubSession
+
+#: Skills the bundle holds. ``walk`` and ``stand`` are the non-episodic
+#: defaults; the three ``kick_*`` / ``roulade`` names match the upstream
+#: reference and each pair with a duration in seconds.
+DEFAULT_MOVE = "walk"
+DEFAULT_IDLE = "stand"
+KICK_LEFT = "kick_left"
+KICK_RIGHT = "kick_right"
+ROULADE = "roulade"
+
+#: The rate every runtime tick advances at. 50Hz is the shipped default and
+#: makes a 1.2s kick land on 60 ticks exactly - a whole-integer count the
+#: revert-tick assertion can name without epsilon slop.
+CONTROL_HZ = 50.0
+KICK_DURATION_S = 1.2
+KICK_STEPS = 60  # 1.2 s @ 50 Hz
+
+
+def _policy() -> MicroduckPolicy:
+    """A real policy over an injected stub session - no onnxruntime needed."""
+    return MicroduckPolicy(session=_StubSession())
+
+
+def _bundle(
+    *,
+    episodic_skills: dict[str, float] | None = None,
+    default_skill: str | None = None,
+    active: str | None = None,
+    set_hz: bool = True,
+) -> MicroduckPolicyBundle:
+    """A four-skill bundle over stubs, matching the upstream skill set.
+
+    Args:
+        episodic_skills: Passed through to the constructor. When ``None``, the
+            episodic path is entirely off - :meth:`trigger` refuses, the timer
+            never runs, and the shape of the previous velocity-gated bundle is
+            unchanged.
+        default_skill: The skill the bundle reverts to when an episode ends.
+            ``None`` uses the initially active skill.
+        active: Initial active skill. Defaults to ``walk`` so the auto-return
+            fallback is a stable non-episodic anchor.
+        set_hz: Whether to call :meth:`set_control_frequency`. Off only for the
+            one test that holds the bundle to a refusal when the clock is
+            missing.
+    """
+    bundle = MicroduckPolicyBundle(
+        {
+            DEFAULT_MOVE: _policy(),
+            DEFAULT_IDLE: _policy(),
+            KICK_LEFT: _policy(),
+            KICK_RIGHT: _policy(),
+            ROULADE: _policy(),
+        },
+        active=active or DEFAULT_MOVE,
+        episodic_skills=episodic_skills,
+        default_skill=default_skill,
+    )
+    if set_hz:
+        bundle.set_control_frequency(CONTROL_HZ)
+    return bundle
+
+
+def _tick(bundle: MicroduckPolicyBundle, **kwargs: Any) -> None:
+    """One tick, without asserting shape - the test cares about ``active``."""
+    asyncio.run(bundle.get_actions(_obs_dict(), "", **kwargs))
+
+
+class TestTriggerIsGatedByTheDeclaredEpisodicSkillSet:
+    """A caller who never declared an episodic skill cannot trigger one.
+
+    ``trigger`` is the ``trigger_behavior`` seam from ``infer_policy.py``. The
+    upstream FSM refuses a name it never registered; the bundle inherits the
+    same rule off the ``episodic_skills`` mapping, which also holds the
+    per-skill duration the timer counts down.
+    """
+
+    def test_a_bundle_with_no_episodic_skills_refuses_every_trigger(self) -> None:
+        bundle = _bundle()
+        with pytest.raises(ValueError, match="is not a declared episodic skill"):
+            bundle.trigger(KICK_LEFT)
+
+    def test_a_bundle_names_the_declared_set_when_it_refuses_an_unknown(self) -> None:
+        bundle = _bundle(episodic_skills={KICK_LEFT: KICK_DURATION_S})
+        with pytest.raises(ValueError, match=r"have \['kick_left'\]"):
+            bundle.trigger(KICK_RIGHT)
+
+    def test_an_episodic_skill_that_names_no_held_policy_is_refused_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="names no held skill"):
+            MicroduckPolicyBundle(
+                {DEFAULT_MOVE: _policy(), DEFAULT_IDLE: _policy()},
+                episodic_skills={"phantom_skill": KICK_DURATION_S},
+            )
+
+    @pytest.mark.parametrize("bad_duration", [0.0, -0.5, float("nan"), float("inf")])
+    def test_a_duration_that_is_not_a_positive_finite_number_is_refused(self, bad_duration: float) -> None:
+        with pytest.raises(ValueError):
+            MicroduckPolicyBundle(
+                {DEFAULT_MOVE: _policy(), KICK_LEFT: _policy()},
+                episodic_skills={KICK_LEFT: bad_duration},
+            )
+
+
+class TestDefaultSkillIsHeldAndCannotBeEpisodic:
+    """The revert target is validated at construction, same seam every other key is.
+
+    ``default_skill`` is where the bundle lands when a timer expires. Two rules
+    hold: it must name a held policy (like ``active`` and the two gate keys),
+    and it cannot itself be an episodic skill - an auto-return into an episodic
+    skill would re-arm the timer the tick it fires and never terminate.
+    """
+
+    def test_a_default_skill_that_names_no_held_policy_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="default_skill='ghost'"):
+            MicroduckPolicyBundle(
+                {DEFAULT_MOVE: _policy(), DEFAULT_IDLE: _policy()},
+                default_skill="ghost",
+            )
+
+    def test_a_default_skill_that_is_itself_episodic_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="is itself an episodic skill"):
+            MicroduckPolicyBundle(
+                {DEFAULT_MOVE: _policy(), KICK_LEFT: _policy()},
+                episodic_skills={KICK_LEFT: KICK_DURATION_S},
+                default_skill=KICK_LEFT,
+            )
+
+
+class TestTheTimerCountsDownAtTheControlRate:
+    """The bundle uses :attr:`control_frequency` as the tick rate, no assumption.
+
+    At 50 Hz a 1.2 s kick is 60 ticks. The 60th tick still executes the
+    episodic skill; the 61st runs ``default_skill``. That off-by-one holds
+    because :meth:`get_actions` decrements the timer AFTER delegating to the
+    active child - a caller reading the last frame of the episode sees the
+    episodic policy's output, not the next skill's.
+    """
+
+    def test_a_bundle_with_no_clock_refuses_when_the_first_tick_would_decrement(self) -> None:
+        bundle = _bundle(
+            episodic_skills={KICK_LEFT: KICK_DURATION_S},
+            default_skill=DEFAULT_MOVE,
+            set_hz=False,
+        )
+        bundle.trigger(KICK_LEFT)
+        with pytest.raises(RuntimeError, match="requires control_frequency"):
+            _tick(bundle)
+
+    def test_the_last_tick_of_the_episode_runs_the_episodic_skill(self) -> None:
+        bundle = _bundle(
+            episodic_skills={KICK_LEFT: KICK_DURATION_S},
+            default_skill=DEFAULT_MOVE,
+        )
+        bundle.trigger(KICK_LEFT)
+        for _ in range(KICK_STEPS - 1):
+            _tick(bundle)
+            assert bundle.active == KICK_LEFT
+            assert bundle.episodic_active == KICK_LEFT
+        # The 60th tick still runs the kick policy; the timer expires AFTER.
+        _tick(bundle)
+        assert bundle.episodic_active is None
+        assert bundle.active == DEFAULT_MOVE
+
+    def test_the_first_tick_after_expiry_runs_the_default_skill(self) -> None:
+        bundle = _bundle(
+            episodic_skills={KICK_LEFT: KICK_DURATION_S},
+            default_skill=DEFAULT_MOVE,
+        )
+        bundle.trigger(KICK_LEFT)
+        for _ in range(KICK_STEPS):
+            _tick(bundle)
+        _tick(bundle)
+        assert bundle.active == DEFAULT_MOVE
+        assert bundle.episodic_active is None
+
+
+class TestOnlyOneEpisodicBehaviorAtATime:
+    """Trigger during an active episode refuses, mirroring ``_end_behavior``.
+
+    The upstream FSM does not queue behaviors - a running one wins. A second
+    ``trigger`` must be refused explicitly (naming the running one and its
+    remaining time) so the caller either waits or overrides via
+    :meth:`switch`, which cancels.
+    """
+
+    def test_triggering_a_second_episodic_skill_mid_episode_is_refused(self) -> None:
+        bundle = _bundle(
+            episodic_skills={KICK_LEFT: KICK_DURATION_S, KICK_RIGHT: KICK_DURATION_S},
+            default_skill=DEFAULT_MOVE,
+        )
+        bundle.trigger(KICK_LEFT)
+        _tick(bundle)  # one tick in, ~1.18s left
+        with pytest.raises(ValueError, match="'kick_left' is already running"):
+            bundle.trigger(KICK_RIGHT)
+
+    def test_switch_cancels_a_running_episode_and_frees_the_next_trigger(self) -> None:
+        bundle = _bundle(
+            episodic_skills={KICK_LEFT: KICK_DURATION_S, KICK_RIGHT: KICK_DURATION_S},
+            default_skill=DEFAULT_MOVE,
+        )
+        bundle.trigger(KICK_LEFT)
+        _tick(bundle)
+        bundle.switch(DEFAULT_MOVE)
+        assert bundle.episodic_active is None
+        assert bundle.active == DEFAULT_MOVE
+        # A trigger now succeeds without complaint about kick_left running.
+        bundle.trigger(KICK_RIGHT)
+        assert bundle.episodic_active == KICK_RIGHT
+        assert bundle.active == KICK_RIGHT
+
+
+class TestTheVelocityGateAndEpisodicBehaviorDoNotFightEachOther:
+    """During an episode the velocity gate is inhibited.
+
+    Otherwise a caller who commanded twist=[0.3, 0, 0] during a kick would see
+    the bundle yank ``walk`` back mid-kick every tick - the walking/standing
+    gate would override the episodic FSM. The reference ``infer_policy.py``
+    resolves this by treating a running behavior as top-priority; the bundle
+    does the same by skipping ``_auto_switch`` while ``episodic_active`` is
+    non-``None``.
+    """
+
+    def test_a_running_kick_is_not_preempted_by_a_move_command(self) -> None:
+        bundle = MicroduckPolicyBundle(
+            {DEFAULT_MOVE: _policy(), DEFAULT_IDLE: _policy(), KICK_LEFT: _policy()},
+            active=DEFAULT_IDLE,
+            switch_on_velocity=0.05,
+            move_key=DEFAULT_MOVE,
+            idle_key=DEFAULT_IDLE,
+            episodic_skills={KICK_LEFT: KICK_DURATION_S},
+            default_skill=DEFAULT_IDLE,
+        )
+        bundle.set_control_frequency(CONTROL_HZ)
+        bundle.trigger(KICK_LEFT)
+        _tick(bundle, target_velocity=[0.3, 0.0, 0.0])
+        assert bundle.active == KICK_LEFT
+
+    def test_the_velocity_gate_resumes_after_the_episode_ends(self) -> None:
+        bundle = MicroduckPolicyBundle(
+            {DEFAULT_MOVE: _policy(), DEFAULT_IDLE: _policy(), KICK_LEFT: _policy()},
+            active=DEFAULT_IDLE,
+            switch_on_velocity=0.05,
+            move_key=DEFAULT_MOVE,
+            idle_key=DEFAULT_IDLE,
+            episodic_skills={KICK_LEFT: KICK_DURATION_S},
+            default_skill=DEFAULT_IDLE,
+        )
+        bundle.set_control_frequency(CONTROL_HZ)
+        bundle.trigger(KICK_LEFT)
+        for _ in range(KICK_STEPS):
+            _tick(bundle, target_velocity=[0.3, 0.0, 0.0])
+        _tick(bundle, target_velocity=[0.3, 0.0, 0.0])
+        assert bundle.active == DEFAULT_MOVE
+        assert bundle.episodic_active is None
+
+
+class TestResetClearsTheEpisodicFSM:
+    """``reset`` is the per-rollout seam; it must not leave the timer armed."""
+
+    def test_reset_mid_episode_clears_the_episode_and_returns_to_default(self) -> None:
+        bundle = _bundle(
+            episodic_skills={KICK_LEFT: KICK_DURATION_S},
+            default_skill=DEFAULT_MOVE,
+        )
+        bundle.trigger(KICK_LEFT)
+        _tick(bundle)
+        bundle.reset()
+        assert bundle.episodic_active is None
+        assert bundle.active == DEFAULT_MOVE

--- a/tests/policies/microduck/test_microduck_episodic_timer.py
+++ b/tests/policies/microduck/test_microduck_episodic_timer.py
@@ -68,8 +68,8 @@ def _bundle(
     Args:
         episodic_skills: Passed through to the constructor. When ``None``, the
             episodic path is entirely off - :meth:`trigger` refuses, the timer
-            never runs, and the shape of the previous velocity-gated bundle is
-            unchanged.
+            never runs, :meth:`reset` leaves the active skill alone, and the
+            shape of the previous velocity-gated bundle is unchanged.
         default_skill: The skill the bundle reverts to when an episode ends.
             ``None`` uses the initially active skill.
         active: Initial active skill. Defaults to ``walk`` so the auto-return
@@ -291,6 +291,24 @@ class TestTheVelocityGateAndEpisodicBehaviorDoNotFightEachOther:
 class TestResetClearsTheEpisodicFSM:
     """``reset`` is the per-rollout seam; it must not leave the timer armed."""
 
+    def test_an_episodic_bundle_normalises_the_active_skill_with_no_episode_running(self) -> None:
+        """Declaring an episodic skill is what makes ``reset`` normalise ``active``.
+
+        The runtime calls this between episodes, so a bundle that can kick starts
+        every episode from ``default_skill`` whether or not the previous episode
+        ended mid-behaviour. Gating the normalisation on a *running* episode
+        instead would leave the two cases disagreeing for no reason a caller can
+        see.
+        """
+        bundle = _bundle(
+            episodic_skills={KICK_LEFT: KICK_DURATION_S},
+            default_skill=DEFAULT_IDLE,
+        )
+        bundle.switch(DEFAULT_MOVE)
+        assert bundle.episodic_active is None
+        bundle.reset()
+        assert bundle.active == DEFAULT_IDLE
+
     def test_reset_mid_episode_clears_the_episode_and_returns_to_default(self) -> None:
         bundle = _bundle(
             episodic_skills={KICK_LEFT: KICK_DURATION_S},
@@ -301,3 +319,51 @@ class TestResetClearsTheEpisodicFSM:
         bundle.reset()
         assert bundle.episodic_active is None
         assert bundle.active == DEFAULT_MOVE
+
+
+class TestABundleWithNoEpisodicSkillsIsUntouched:
+    """The compatibility claim: declaring no episodic skill changes nothing.
+
+    ``reset`` is the seam where that claim is easiest to break, because the
+    episodic FSM and the active skill are cleared together and only one of them
+    belongs to the new feature. The rollout calls ``policy.reset(seed=...)``
+    once per episode, so a bundle that normalised the active skill regardless of
+    whether it declared an episodic behaviour would discard an explicit
+    :meth:`switch` at every episode boundary of a multi-episode run - a caller
+    who never asked for a timer would find episode two running a skill they had
+    switched away from, with nothing reported.
+    """
+
+    def test_a_switched_skill_survives_a_reset_when_no_episodic_skill_is_declared(self) -> None:
+        bundle = _bundle(active=DEFAULT_MOVE)
+        bundle.switch(DEFAULT_IDLE)
+        bundle.reset()
+        assert bundle.active == DEFAULT_IDLE
+
+    def test_the_velocity_gate_does_not_change_that(self) -> None:
+        """The gate reads ``active``; it must not be handed a reverted one."""
+        bundle = MicroduckPolicyBundle(
+            {DEFAULT_MOVE: _policy(), DEFAULT_IDLE: _policy()},
+            active=DEFAULT_MOVE,
+            switch_on_velocity=0.1,
+        )
+        bundle.set_control_frequency(CONTROL_HZ)
+        bundle.switch(DEFAULT_IDLE)
+        bundle.reset(seed=7)
+        assert bundle.active == DEFAULT_IDLE
+
+    def test_reset_still_reaches_every_child(self) -> None:
+        """The gate must scope the episodic block, not the child reset.
+
+        ``MicroduckPolicy.reset`` clears ``_last_action``, so a child that has
+        run carries one until the bundle forwards the reset. Asserting only that
+        the next tick returns actions is too weak - it does that either way,
+        because ``_ensure_config`` rebuilds lazily.
+        """
+        walk = _policy()
+        bundle = MicroduckPolicyBundle({DEFAULT_MOVE: walk, DEFAULT_IDLE: _policy()}, active=DEFAULT_MOVE)
+        bundle.set_control_frequency(CONTROL_HZ)
+        _tick(bundle)
+        assert walk._last_action is not None
+        bundle.reset(seed=7)
+        assert walk._last_action is None


### PR DESCRIPTION
## What

Adds `trigger()` and `episodic_skills` constructor argument to `MicroduckPolicyBundle` so a caller can arm a short skill (`kick_left` / `kick_right` / `roulade`) that runs for a fixed duration and then reverts to `default_skill` on its own. Mirrors Pollen's `infer_policy.py` `_end_behavior` contract.

## Why

The bundle used to have one switching mode: the velocity gate between a `move_key` and an `idle_key`. Pollen's reference `infer_policy.py` carries a second, orthogonal mode: **timed episodic behaviors**. Without this, a caller who did `bundle.switch('kick_left')` stayed on `kick_left` forever, feeding the walking/standing observation contract to an episodic policy that expects to end within ~1.2s. Any walk-kick-walk demo needed either a manual timer in the caller (which every caller would reinvent) or this seam inside the bundle.

## Contract

- Only skills declared in `episodic_skills` are triggerable; unknown names refuse and name the declared set.
- Duration goes through `positive_finite_number_error`, the shared numeric domain.
- `default_skill` must be a held policy AND cannot itself be an episodic skill (an auto-return into an episodic skill would re-arm the timer the tick it fires and never terminate).
- The timer counts down at `1/control_frequency` per tick, read off `Policy.control_frequency` -- same seam every other consumer uses. A bundle asked to run an episodic behavior without being told its clock refuses **loudly** rather than assuming 50Hz.
- A running episode inhibits the velocity gate (a walk command mid-kick does not preempt).
- `switch()` cancels a running episode; `reset()` clears the FSM.
- The last tick of the episode still executes the episodic skill (timer decrements AFTER the active child runs), so a 1.2s / 60-step kick at 50Hz produces 60 kick actions and the 61st tick runs `default_skill`.

## Tests

`tests/policies/microduck/test_microduck_episodic_timer.py` (17 cases across 6 classes) holds:

- Trigger is gated by the declared episodic skill set (unknown name; empty set; unheld policy; non-positive-finite duration).
- Default skill is held and cannot be episodic.
- Timer counts down at the control rate (no clock -> refuse; last tick runs the episodic skill; first tick after expiry runs default).
- Only one episodic behavior at a time (`_end_behavior` gating; `switch` cancels).
- The velocity gate and episodic FSM don't fight (a walk command during a kick is inhibited; the gate resumes after the episode ends).
- `reset` clears the FSM mid-episode.

Local: 17/17 pass on the new file, 243/243 pass across the full `tests/policies/microduck/`, zero regressions.

## LOC

+469 lines (139 impl in `composite.py` bringing it to 287 LOC / 158 -> 287; 303 test; 27 changelog).

## Not in scope

- `unitree_sdk2py` import guard: unchanged (no new imports at module load).
- Phase-encoding command path (harness#390): separate change; the episodic timer works with either the current twist domain or the phase-encoding one because the observation contract is the child policy's problem, not the bundle's.
- E2E MP4 regression (harness#392): this is the seam that unblocks a walk -> kick -> walk demo; the actual video will land under #392.

Closes cagataycali/robots-harness#389