### PR TITLE
fix(doctor): report a torch build that carries no code for this GPU

### DIFF
--- a/changelog.d/2893-doctor-warp-arch-agreement.md
+++ b/changelog.d/2893-doctor-warp-arch-agreement.md
@@ -17,6 +17,6 @@ CUDA-12 and CUDA-13 builds are indistinguishable by name, while the table is the
 reads. Warp ships in the `sim-newton` extra, and an install without it - or without a CUDA device - has
 no disagreement to report, so the check declines rather than failing.
 
-Only Warp is asked. torch reports an arch list too, but a torch build without the device's arch
-compiles from PTX instead, a documented fallback that still produces the right answer, and `check_cuda`
-already reports torch's posture.
+Only Warp is asked here. torch's arch table is asked by `check_torch_arch`, because the two builds
+fail differently: Warp substitutes a nearby architecture and keeps computing, while torch's own
+compatibility check reports the device as not compatible with the build.

--- a/changelog.d/2908-doctor-torch-arch-agreement.md
+++ b/changelog.d/2908-doctor-torch-arch-agreement.md
@@ -1,0 +1,32 @@
+### Fixed: the doctor reports a torch build that carries no code for this GPU
+
+`torch.cuda.is_available()` answers about the driver, not about the build, so it is `True` on a host
+whose torch build carries no CUDA code for the GPU that driver reports. torch's own compatibility check
+calls such a build "not compatible with the current PyTorch installation" and refuses every kernel on
+it - but it says so through a `warnings.warn` on the first CUDA call, which goes to stderr, is shown
+once per process, and is consumed by anything that touched CUDA earlier in the same process.
+
+`check_cuda` therefore passed on such an install, naming the device and the version, and
+`strands-robots doctor` printed `All checks passed` and exited 0. Measured with an arch list of
+`sm_80 sm_90` against an `sm_110` device: the table read `PASS  CUDA available: NVIDIA Thor (torch
+2.11.0+cu130)`, the run exited 0, and 964 bytes of torch's own "not compatible" went to stderr - the
+same shape as the EGL tracebacks, in the same command a new reader runs to find out whether their
+machine is set up.
+
+`check_torch_arch` asks. It names the architectures the build carries, the one the driver reports, and
+the CUDA releases whose torch build covers this device, taken from the table torch ships for its own
+remedy. The comparison is torch's own predicate rather than a rule derived here, so the doctor and
+torch cannot reach opposite verdicts about one install. That predicate reads a table of intervals: code
+carrying `sm_80` supports `>=8.0,<9.0 except {8.7}`, so it does not cover a Jetson Orin, while the
+coarser backward-compatible-within-a-major-version rule that torch's cubin check documents admits that
+pair. The interval table is preferred for that reason and the coarse rule is only the fallback for an
+install too old to expose it, since the supported floor is `torch>=2.0.0`. torch ships in the extras
+that run a policy, and an install without it - or without a CUDA device, or with a CPU-only build that
+reports no architectures at all - has no disagreement to report, so the check declines rather than
+failing.
+
+The Warp check's scope paragraph excluded torch on the grounds that a build without the device's arch
+compiles from PTX instead. That is refuted three ways: the torch build shipped for an `sm_110` device
+carries no `compute_*` PTX entry at all, torch's own words for the case are "not compatible", and its
+rule is the interval table rather than a PTX fallback. `check_cuda` is unchanged - it answers about the
+driver, which is the half it was always reporting.

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -17,6 +17,7 @@ import logging
 import os
 import platform
 import sys
+import warnings
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -323,6 +324,166 @@ def _warp_cuda_report() -> tuple[tuple[int, ...], int, tuple[int, int], tuple[in
     return supported, chosen, (int(toolkit[0]), int(toolkit[1])), (int(driver[0]), int(driver[1]))
 
 
+def _arch_entry_version(entry: str) -> int | None:
+    """The architecture an entry of torch's arch list names, as an ``sm_NN`` integer.
+
+    torch spells its entries ``sm_90`` and ``compute_80``, and appends a family
+    suffix for architecture-specific code (``sm_90a``, ``sm_120f``). That spelling
+    is torch's, so prefer torch's own parser and fall back to reading the
+    documented shape only on an install too old to expose it.
+
+    Args:
+        entry: One element of :func:`torch.cuda.get_arch_list`.
+
+    Returns:
+        The architecture as an integer (``90`` for ``sm_90a``), or ``None`` when
+        the entry does not carry one.
+    """
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - the caller resolved a report first
+        parse = None
+    else:
+        parse = getattr(torch.cuda, "_extract_arch_version", None)
+    if parse is not None:
+        try:
+            return int(parse(entry))
+        except (IndexError, ValueError):
+            return None
+    parts = entry.split("_", maxsplit=2)
+    if len(parts) < 2:
+        return None
+    digits = parts[1].removesuffix("a").removesuffix("f")
+    return int(digits) if digits.isdigit() else None
+
+
+def _torch_cuda_report() -> tuple[tuple[int, ...], str] | None:
+    """The architectures the installed torch build carries, and its version.
+
+    Returns:
+        A ``(build_archs, version)`` tuple, or ``None`` when torch is not
+        installed - it ships in the extras that run a policy - or when it cannot
+        report an arch list at all.
+    """
+    try:
+        import torch
+    except ImportError:
+        return None
+    try:
+        entries = torch.cuda.get_arch_list()
+    except Exception:
+        return None
+    archs = tuple(arch for arch in (_arch_entry_version(entry) for entry in entries) if arch is not None)
+    return archs, str(torch.__version__)
+
+
+def _torch_build_supports(device_arch: int, build_archs: tuple[int, ...]) -> bool:
+    """Whether torch's own compatibility rule admits this device for this build.
+
+    The rule is torch's rather than one derived here, so this check and torch
+    cannot reach opposite verdicts about one install. ``_code_compatible_with_device``
+    is the predicate torch's own capability check consults, and it reads a table
+    of intervals: a build carrying ``sm_80`` code supports ``>=8.0,<9.0 except
+    {8.7}``, so it does *not* cover a Jetson Orin. The coarser
+    backward-compatible-within-a-major-version rule that torch's cubin check
+    documents admits that pair, which is why the interval table is preferred and
+    the coarse rule is only the fallback for an install too old to expose it.
+
+    Args:
+        device_arch: Architecture the driver reports, as an ``sm_NN`` integer.
+        build_archs: Architectures the installed build carries code for.
+
+    Returns:
+        ``True`` when some entry of the build covers the device.
+    """
+    compatible = None
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - the caller resolved a report first
+        pass
+    else:
+        compatible = getattr(torch.cuda, "_code_compatible_with_device", None)
+
+    if compatible is None:
+        return any(arch // 10 == device_arch // 10 for arch in build_archs)
+
+    # The predicate warns when a build names an architecture its own table does
+    # not know - a note about the table's age rather than about this device. The
+    # verdict below carries that answer, so the note is suppressed rather than
+    # printed beside it.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return any(bool(compatible(device_arch, arch)) for arch in build_archs)
+
+
+def _torch_compatible_releases(device_arch: int) -> tuple[str, ...]:
+    """CUDA versions whose torch release carries code this device can run.
+
+    Read from the table torch ships for its own remedy, so the versions offered
+    are the ones torch would name rather than a guess about what PyPI serves.
+
+    Args:
+        device_arch: Architecture the driver reports, as an ``sm_NN`` integer.
+
+    Returns:
+        The CUDA versions, or an empty tuple when torch ships no such table.
+    """
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - the caller resolved a report first
+        return ()
+    table = getattr(torch.cuda, "PYTORCH_RELEASES_CODE_CC", None)
+    if not isinstance(table, dict):
+        return ()
+    return tuple(str(cuda) for cuda, build_ccs in table.items() if _torch_build_supports(device_arch, tuple(build_ccs)))
+
+
+def check_torch_arch() -> str:
+    """torch's build carries CUDA code for the GPU architecture the driver reports.
+
+    A torch build that carries no code for the device runs no CUDA kernel at all,
+    and ``torch.cuda.is_available()`` is ``True`` regardless - it answers about the
+    driver, not about the build. So :func:`check_cuda` passes on such an install,
+    naming the device and the version, and the only signal is a ``warnings.warn``
+    torch emits on its first CUDA call: it goes to stderr while this table goes to
+    stdout, it is shown once per process, and it lands beside this command's "All
+    checks passed" verdict - the one place a new reader looks to find out whether
+    their setup is sound.
+
+    The verdict is torch's own (see :func:`_torch_build_supports`), so this check
+    reports what torch already decided rather than deciding it again. It is
+    reported as a failure rather than a warning because the consequence is total:
+    where Warp substitutes a nearby architecture and keeps returning right answers
+    for simple kernels, torch's own words for this build are "not compatible".
+    """
+    device_arch = _driver_compute_arch()
+    if device_arch is None:
+        return _skip("torch arch: no CUDA device to compare against")
+    report = _torch_cuda_report()
+    if report is None:
+        return _skip("torch arch: torch not installed (needed for policy inference)")
+    build_archs, version = report
+    if not build_archs:
+        return _skip(f"torch arch: torch {version} reports no CUDA architectures")
+
+    offered = " ".join(f"sm_{arch}" for arch in sorted(set(build_archs)))
+    if _torch_build_supports(device_arch, build_archs):
+        return _pass(f"torch {version} carries code for sm_{device_arch} (build: {offered})")
+
+    releases = _torch_compatible_releases(device_arch)
+    fix = "Install a torch build for this GPU: https://pytorch.org/get-started/locally/"
+    if releases:
+        fix = (
+            f"Install a torch release built against CUDA {', '.join(releases)} - torch's own table names "
+            f"those as carrying code for sm_{device_arch}: https://pytorch.org/get-started/locally/"
+        )
+    return _fail(
+        f"torch {version} carries code for {offered}, and torch's own compatibility check reports "
+        f"this sm_{device_arch} device as not compatible with that build",
+        fix=fix,
+    )
+
+
 def check_warp_arch() -> str:
     """Warp's build can compile for the GPU architecture the driver reports.
 
@@ -340,10 +501,10 @@ def check_warp_arch() -> str:
     CUDA-13 builds are indistinguishable by name, while the table is the value
     Warp itself reads.
 
-    Only Warp is asked here. torch reports an arch list too, but a torch build
-    without the device's arch compiles from PTX instead - a documented fallback
-    that still produces the right answer - and ``check_cuda`` already reports
-    torch's posture.
+    torch's arch table is asked by :func:`check_torch_arch` rather than here,
+    because the two builds fail differently: Warp substitutes a nearby
+    architecture and keeps computing, while torch's own compatibility check
+    reports the device as not compatible with the build.
     """
     device_arch = _driver_compute_arch()
     if device_arch is None:
@@ -504,6 +665,7 @@ def run_doctor() -> int:
         ("MuJoCo GL", check_mujoco_gl),
         ("LeRobot", check_lerobot),
         ("CUDA/GPU", check_cuda),
+        ("Torch Arch", check_torch_arch),
         ("Warp Arch", check_warp_arch),
         ("Serial", check_serial_permissions),
         ("HF Auth", check_hf_auth),

--- a/tests/test_doctor_torch_arch_agrees_with_the_driver.py
+++ b/tests/test_doctor_torch_arch_agrees_with_the_driver.py
@@ -1,0 +1,375 @@
+"""The torch verdict is about the code the build carries, not about the driver.
+
+``torch.cuda.is_available()`` answers about the driver, so it is ``True`` on a
+host whose torch build carries no code for the GPU that driver reports. Every
+CUDA kernel on such an install is refused by torch itself - its own words are
+"not compatible with the current PyTorch installation" - and the only signal is a
+``warnings.warn`` on the first CUDA call: it goes to stderr while the doctor's
+table goes to stdout, and it is shown once per process, so anything that touched
+CUDA earlier consumes it. ``check_cuda`` therefore passed, naming the device and
+the version, beside a final "All checks passed".
+
+The architectures below are written out rather than imported, so these cases
+grade the shipped behaviour against a second opinion. ``BUILD_WITHOUT_THOR`` is
+the pair an Ampere/Hopper wheel carries; ``ORIN_ARCH`` on ``AMPERE_ONLY`` is the
+pair the coarse rule and the interval table disagree about, which is what makes
+reading torch's table rather than re-deriving a rule load-bearing.
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+# The architecture an NVIDIA Thor's driver reports, and a build that predates it.
+THOR_ARCH = 110
+BUILD_WITHOUT_THOR = (80, 90)
+BUILD_WITH_THOR = (80, 90, 100, THOR_ARCH, 120)
+
+# A Jetson Orin, and a build carrying Ampere code. torch's interval table excludes
+# 8.7 from what ``sm_80`` code supports; the coarse major-version rule admits it.
+ORIN_ARCH = 87
+AMPERE_ONLY = (80,)
+
+# CUDA versions and the architectures their torch release carries, in the shape
+# torch ships for its own remedy.
+RELEASES = {"12.8": {80, 90, 100, 120}, "13.0": {80, 90, 100, THOR_ARCH, 120}}
+THOR_RELEASE = "13.0"
+
+TORCH_VERSION = "2.11.0+cu130"
+DEVICE_NAME = "NVIDIA Thor"
+
+
+def _interval_rule(device_cc: int, code_cc: int) -> bool:
+    """torch's interval rule for the architectures these cases use.
+
+    Read off torch's own ``DEVICE_REQUIREMENT``: code carrying ``sm_80`` supports
+    ``>=8.0,<9.0 except {8.7}``, and every other entry used here supports its own
+    major version. ``TestAgainstTheInstalledTorch`` grades this against the real
+    predicate, so the two cannot drift.
+    """
+    if code_cc == 80:
+        return 80 <= device_cc < 90 and device_cc != ORIN_ARCH
+    return code_cc // 10 == device_cc // 10
+
+
+def _extract(arch_string: str) -> int:
+    """torch's own spelling of an arch-list entry, as its parser reads it."""
+    base = arch_string.split("_", maxsplit=2)[1]
+    return int(base.removesuffix("a").removesuffix("f"))
+
+
+def _install_torch(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    capability: tuple[int, int] | None,
+    arch_list: list[str] | None = None,
+    interval_table: bool = True,
+    releases: dict[str, set[int]] | None = RELEASES,
+    raising_arch_list: bool = False,
+) -> None:
+    """Make torch report ``capability`` for device 0 and ``arch_list`` for its build.
+
+    ``interval_table=False`` stands in for an install too old to expose the
+    predicate torch's capability check consults, which is the one degradation the
+    supported floor (``torch>=2.0.0``) still admits.
+    """
+
+    def _arch_list() -> list[str]:
+        if raising_arch_list:
+            raise RuntimeError("this build reports no arch list")
+        return list(arch_list or [])
+
+    cuda: Any = SimpleNamespace(
+        is_available=lambda: capability is not None,
+        get_device_capability=lambda _index: capability,
+        get_device_name=lambda _index: DEVICE_NAME,
+        get_arch_list=_arch_list,
+        _extract_arch_version=_extract,
+    )
+    if interval_table:
+        cuda._code_compatible_with_device = _interval_rule
+    if releases is not None:
+        cuda.PYTORCH_RELEASES_CODE_CC = releases
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(cuda=cuda, __version__=TORCH_VERSION))
+
+
+def _thor_on_an_older_build(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> str:
+    """The verdict for a Thor whose torch build predates it."""
+    from strands_robots.doctor import check_torch_arch
+
+    _install_torch(
+        monkeypatch,
+        capability=(11, 0),
+        arch_list=[f"sm_{arch}" for arch in BUILD_WITHOUT_THOR],
+        **kwargs,
+    )
+    return check_torch_arch()
+
+
+class TestABuildWithoutTheDevicesCodeIsRefused:
+    """A build that carries no code the device can run is reported, not tolerated."""
+
+    def test_a_build_that_carries_no_code_for_the_device_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        result = _thor_on_an_older_build(monkeypatch)
+        assert "FAIL" in result
+        assert f"sm_{THOR_ARCH}" in result
+
+    def test_the_refusal_names_the_architectures_the_build_carries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The reader has to see which build they have, not only which device."""
+        result = _thor_on_an_older_build(monkeypatch)
+        for arch in BUILD_WITHOUT_THOR:
+            assert f"sm_{arch}" in result
+
+    def test_the_refusal_attributes_the_verdict_to_torchs_own_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The verdict is torch's, so the wording says so rather than claiming a symptom."""
+        assert "not compatible" in _thor_on_an_older_build(monkeypatch)
+
+    def test_the_remedy_names_a_release_from_torchs_own_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Which CUDA release covers this device is torch's answer, not a guess."""
+        result = _thor_on_an_older_build(monkeypatch)
+        assert THOR_RELEASE in result
+        assert "pytorch.org/get-started/locally" in result
+
+    def test_the_remedy_omits_a_release_that_does_not_cover_the_device(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Naming every release would send the reader after one that changes nothing."""
+        assert "12.8" not in _thor_on_an_older_build(monkeypatch)
+
+    def test_a_build_with_no_covering_release_still_offers_the_install_page(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Jetson wheels are not on PyPI, so torch's table names no release for an Orin."""
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=(8, 7), arch_list=[f"sm_{a}" for a in AMPERE_ONLY])
+        result = check_torch_arch()
+        assert "FAIL" in result
+        assert "pytorch.org/get-started/locally" in result
+
+
+class TestThePairTheCoarseRuleWouldAdmit:
+    """The interval table is preferred because a coarser rule disagrees with it."""
+
+    def test_an_orin_on_an_ampere_only_build_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=(8, 7), arch_list=[f"sm_{a}" for a in AMPERE_ONLY])
+        result = check_torch_arch()
+        assert "FAIL" in result
+        assert f"sm_{ORIN_ARCH}" in result
+
+    def test_the_coarse_major_version_rule_would_admit_that_pair(self) -> None:
+        """Premise: the two rules really do disagree, so reading torch's is load-bearing."""
+        coarse = any(arch // 10 == ORIN_ARCH // 10 for arch in AMPERE_ONLY)
+        assert coarse is True
+        assert _interval_rule(ORIN_ARCH, AMPERE_ONLY[0]) is False
+
+    def test_the_fallback_rule_is_the_coarse_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An install without the table gets the rule torch's cubin check documents.
+
+        That rule admits the Orin pair, so this passes where the case above fails -
+        the difference between the two verdicts is exactly what the table buys.
+        """
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(
+            monkeypatch,
+            capability=(8, 7),
+            arch_list=[f"sm_{a}" for a in AMPERE_ONLY],
+            interval_table=False,
+        )
+        assert "PASS" in check_torch_arch()
+
+    def test_the_fallback_still_refuses_a_different_major_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The fallback is coarser, not absent."""
+        assert "FAIL" in _thor_on_an_older_build(monkeypatch, interval_table=False)
+
+
+class TestABuildThatCoversTheDeviceIsAccepted:
+    """The verdict turns on the build's own architectures, so a matching build passes."""
+
+    def test_a_build_carrying_the_devices_arch_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=(11, 0), arch_list=[f"sm_{a}" for a in BUILD_WITH_THOR])
+        result = check_torch_arch()
+        assert "PASS" in result
+        assert f"sm_{THOR_ARCH}" in result
+
+    def test_an_older_gpu_on_that_build_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The refusal is about this device, not about the build's age."""
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=(9, 0), arch_list=[f"sm_{a}" for a in BUILD_WITHOUT_THOR])
+        assert "PASS" in check_torch_arch()
+
+    def test_a_ptx_entry_counts_as_an_architecture(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A build can ship ``compute_NN`` instead of ``sm_NN``, and torch reads both."""
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=(11, 0), arch_list=[f"compute_{THOR_ARCH}"])
+        assert "PASS" in check_torch_arch()
+
+    def test_an_architecture_specific_suffix_is_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """torch appends ``a``/``f`` for architecture-specific code."""
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=(9, 0), arch_list=["sm_90a"])
+        assert "PASS" in check_torch_arch()
+
+
+class TestTheCheckDeclinesWhenThereIsNothingToCompare:
+    """No device, or no torch, is not a failure - there is no disagreement to report."""
+
+    def test_no_cuda_device_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=None, arch_list=[f"sm_{a}" for a in BUILD_WITHOUT_THOR])
+        assert "SKIP" in check_torch_arch()
+
+    def test_torch_absent_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """torch ships in the extras that run a policy, so a base install has nothing to ask."""
+        from strands_robots.doctor import check_torch_arch
+
+        monkeypatch.setitem(sys.modules, "torch", None)
+        assert "SKIP" in check_torch_arch()
+
+    def test_a_build_reporting_no_architectures_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A CPU-only build carries no CUDA code, which ``check_cuda`` already reports."""
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=(11, 0), arch_list=[])
+        assert "SKIP" in check_torch_arch()
+
+    def test_an_arch_list_that_raises_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_torch_arch
+
+        _install_torch(monkeypatch, capability=(11, 0), raising_arch_list=True)
+        assert "SKIP" in check_torch_arch()
+
+    def test_a_build_without_torchs_remedy_table_still_refuses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The table is the remedy's source, not the verdict's."""
+        assert "FAIL" in _thor_on_an_older_build(monkeypatch, releases=None)
+
+
+class TestTheDoctorRunsTheCheckAndFailsOnIt:
+    """A verdict nothing runs is decoration, so the wiring is graded too."""
+
+    def test_a_refusal_from_the_check_fails_the_doctor(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from strands_robots import doctor
+
+        sentinel = "  FAIL  torch-arch-sentinel"
+        monkeypatch.setattr(doctor, "check_torch_arch", lambda: sentinel)
+        exit_code = doctor.run_doctor()
+        out = capsys.readouterr().out
+        assert sentinel in out
+        assert "All checks passed" not in out
+        assert exit_code == 1
+
+
+class TestWhatIsDeliberatelyLeftAlone:
+    """The division of labour between the two CUDA checks, recorded either way."""
+
+    def test_check_cuda_still_answers_about_the_driver(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """It reports availability and the device name, which the driver decides.
+
+        Its verdict is unchanged for the build the new check refuses: that is the
+        division of labour rather than an oversight, and moving it would drop the
+        one line that names the device on a healthy host.
+        """
+        from strands_robots.doctor import check_cuda
+
+        _install_torch(monkeypatch, capability=(11, 0), arch_list=[f"sm_{a}" for a in BUILD_WITHOUT_THOR])
+        result = check_cuda()
+        assert "PASS" in result
+        assert DEVICE_NAME in result
+
+    def test_the_warp_verdict_reads_only_warps_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Warp's arch check is unaffected by what torch's build carries."""
+        from strands_robots.doctor import check_warp_arch
+
+        _install_torch(monkeypatch, capability=(11, 0), arch_list=[f"sm_{a}" for a in BUILD_WITHOUT_THOR])
+        warp: Any = SimpleNamespace(
+            is_cuda_available=lambda: True,
+            get_cuda_device_count=lambda: 1,
+            get_cuda_supported_archs=lambda: [80, 90, 100, THOR_ARCH],
+            get_device=lambda _alias: SimpleNamespace(arch=THOR_ARCH),
+            get_cuda_toolkit_version=lambda: (13, 0),
+            get_cuda_driver_version=lambda: (13, 0),
+        )
+        monkeypatch.setitem(sys.modules, "warp", warp)
+        assert "PASS" in check_warp_arch()
+
+
+class TestAgainstTheInstalledTorch:
+    """The stand-ins above agree with a real torch about what it reports."""
+
+    def test_the_installed_build_carries_code_for_this_devices_arch(self) -> None:
+        pytest.importorskip("torch", reason="torch ships in the extras that run a policy")
+        from strands_robots.doctor import _driver_compute_arch, _torch_build_supports, _torch_cuda_report
+
+        device_arch = _driver_compute_arch()
+        report = _torch_cuda_report()
+        if device_arch is None or report is None:
+            pytest.skip("no CUDA device for torch to report on")
+        build_archs, version = report
+        assert _torch_build_supports(device_arch, build_archs), (
+            f"the installed torch {version} carries code for {sorted(set(build_archs))} "
+            f"and this device reports sm_{device_arch}"
+        )
+
+    def test_a_real_torch_answers_every_call_the_stand_ins_make(self) -> None:
+        """The stand-ins are only faithful while these remain torch's surface."""
+        torch = pytest.importorskip("torch", reason="torch ships in the extras that run a policy")
+        for name in ("is_available", "get_device_capability", "get_device_name", "get_arch_list"):
+            assert callable(getattr(torch.cuda, name)), name
+        assert isinstance(torch.__version__, str)
+
+    def test_the_interval_rule_agrees_with_torchs_own_predicate(self) -> None:
+        """The written-out rule is graded against the predicate it stands in for."""
+        torch = pytest.importorskip("torch", reason="torch ships in the extras that run a policy")
+        predicate = getattr(torch.cuda, "_code_compatible_with_device", None)
+        if predicate is None:
+            pytest.skip("this torch predates the interval table")
+        pairs = ((ORIN_ARCH, 80), (THOR_ARCH, 80), (THOR_ARCH, 90), (THOR_ARCH, THOR_ARCH), (90, 90))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            for device_cc, code_cc in pairs:
+                assert bool(predicate(device_cc, code_cc)) is _interval_rule(device_cc, code_cc), (
+                    device_cc,
+                    code_cc,
+                )
+
+    def test_the_arch_parser_agrees_with_torchs_own(self) -> None:
+        torch = pytest.importorskip("torch", reason="torch ships in the extras that run a policy")
+        parse = getattr(torch.cuda, "_extract_arch_version", None)
+        if parse is None:
+            pytest.skip("this torch does not expose its arch parser")
+        for entry in ("sm_80", "sm_90a", "sm_120f", "compute_80"):
+            assert int(parse(entry)) == _extract(entry) == _extract_via_doctor(entry), entry
+
+    def test_torch_calls_such_a_build_not_compatible_in_its_own_words(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The refusal's wording is quoted from torch, so torch is asked to say it."""
+        torch = pytest.importorskip("torch", reason="torch ships in the extras that run a policy")
+        if not torch.cuda.is_available():
+            pytest.skip("no CUDA device for torch to report on")
+        major, _minor = torch.cuda.get_device_capability(0)
+        other_major = 8 if major != 8 else 9
+        monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: [f"sm_{other_major}0"])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            torch.cuda._check_cubins()
+        assert any("not compatible" in str(entry.message) for entry in caught), [str(entry.message) for entry in caught]
+
+
+def _extract_via_doctor(entry: str) -> int | None:
+    """The shipped parser, read through the module under test."""
+    from strands_robots.doctor import _arch_entry_version
+
+    return _arch_entry_version(entry)


### PR DESCRIPTION
## What happens

`torch.cuda.is_available()` answers about the **driver**, not about the build, so it is `True` on a host whose torch build carries no CUDA code for the GPU that driver reports. torch's own compatibility check calls such a build *"not compatible with the current PyTorch installation"* and refuses every kernel on it — but it says so through a `warnings.warn` on the first CUDA call, which goes to stderr, is shown once per process, and is consumed by anything that touched CUDA earlier in the same process.

`check_cuda` therefore passed on such an install and `run_doctor` reported success. Measured on an `sm_110` device with the build's arch list reporting `sm_80 sm_90`:

```
BEFORE (main)                                    exit code: 0
  PASS  CUDA available: NVIDIA Thor (torch 2.11.0+cu130)
  PASS  Warp targets sm_110 (built against CUDA 13.0)
All checks passed. Ready to use strands-robots.
  ... and 964 bytes on stderr, containing torch's own "not compatible"

AFTER (this branch)                              exit code: 1
  PASS  CUDA available: NVIDIA Thor (torch 2.11.0+cu130)
  FAIL  torch 2.11.0+cu130 carries code for sm_80 sm_90, and torch's own
        compatibility check reports this sm_110 device as not compatible with that build
        Fix: Install a torch release built against CUDA 13.0 - torch's own table names
        those as carrying code for sm_110: https://pytorch.org/get-started/locally/
  PASS  Warp targets sm_110 (built against CUDA 13.0)
Some checks failed. Fix the issues above and re-run: python -m strands_robots doctor
```

That is the same shape as the EGL tracebacks fixed in strands-labs/robots#2896 — a real problem reaching only stderr, beside a verdict saying the setup is sound, in the one command a new reader runs to find out whether it is.

## Why nothing caught it

The accelerator side already asks this question of Warp (`check_warp_arch`, strands-labs/robots#2893) and its scope paragraph excluded torch:

> Only Warp is asked here. torch reports an arch list too, but a torch build without the device's arch compiles from PTX instead - a documented fallback that still produces the right answer - and `check_cuda` already reports torch's posture.

Measured, that reason is refuted three ways:

| Claim | Measurement |
|---|---|
| "compiles from PTX instead" | the torch build shipped for this `sm_110` device reports `['sm_80','sm_90','sm_100','sm_110','sm_120']` — **no `compute_*` entry at all**, so there is no PTX to compile from |
| "still produces the right answer" | torch's own words for the case are `not compatible with the current PyTorch installation` |
| "`check_cuda` already reports torch's posture" | `check_cuda` reads availability, the device name and the version; `get_arch_list` is read **nowhere** in the tree (0 occurrences before this change) |

The reason covers the case where a build *does* ship PTX and is silent on the case where it does not — which is the case the platform ships.

## The fix

`check_torch_arch` compares the architectures the build carries against the one the driver reports. The comparison is **torch's own predicate** rather than a rule derived here, so the doctor and torch cannot reach opposite verdicts about one install.

That predicate reads a table of intervals, and the interval table is preferred over the coarser rule for a measured reason:

| device | build carries | coarse major-version rule | torch's interval table |
|---|---|---|---|
| `sm_87` (Jetson Orin) | `sm_80` | compatible | **not compatible** (`>=8.0,<9.0 except {8.7}`) |
| `sm_110` | `sm_80 sm_90` | not compatible | not compatible |
| `sm_86` | `sm_80` | compatible | compatible |

The coarse backward-compatible-within-a-major-version rule that torch's cubin check documents admits the Orin pair; the interval table does not. So the table is consulted when present and the coarse rule is only the fallback for an install too old to expose it — the supported floor is `torch>=2.0.0`, so that degradation is reachable and it is graded. The remedy's CUDA versions come from the table torch ships for its own remedy, so the releases offered are the ones torch would name.

Reported as a failure rather than a warning because the consequence is total: where Warp substitutes a nearby architecture and keeps returning right answers for simple kernels, torch's own verdict for this build is that it is not compatible.

## Scope

* `check_cuda` is **unchanged**. It answers about the driver, which is the half it was always reporting, and it still names the device on a healthy host. Both halves are pinned either way in `TestWhatIsDeliberatelyLeftAlone`.
* `check_warp_arch` is unchanged apart from its scope paragraph, which now says which check asks about torch and why the two builds fail differently.
* No CUDA device, no torch, a CPU-only build reporting no architectures, and an arch list that raises all `SKIP` — there is no disagreement to report.
* The still-pending strands-labs/robots#2893 changelog fragment ends with the same refuted paragraph. It is unreleased, so it would be published verbatim; its final paragraph is corrected in the same commit as this fragment rather than left to contradict the entry beside it.

## Verification

**Pre-fix split** (source reverted, new suite kept): **21 failed / 6 passed**. The 6 passing are the 2 over-reach controls (`check_cuda` and `check_warp_arch` unchanged), the arithmetic premise that the two rules disagree, and the 3 cells that ask the installed torch directly — including the one that makes torch say *"not compatible"* in its own words, which is where the refusal's wording is quoted from.

**Break table** — 11 mutations, all 11 detected, 11 distinct firing sets, `collected` stable at 27 on every row, source restored byte-identically:

| mutation | fires | naming |
|---|---|---|
| control | 0 | — |
| check not wired into `run_doctor` | 1 | `test_a_refusal_from_the_check_fails_the_doctor` |
| verdict uses the coarse rule, not torch's table | 2 | `test_an_orin_on_an_ampere_only_build_is_refused` |
| refusal drops the device arch | 1 | the Orin refusal |
| refusal drops the build's architectures | 1 | `test_the_refusal_names_the_architectures_the_build_carries` |
| refusal drops the "not compatible" attribution | 1 | `test_the_refusal_attributes_the_verdict_to_torchs_own_check` |
| remedy names every release, unfiltered | 1 | `test_the_remedy_omits_a_release_that_does_not_cover_the_device` |
| remedy table never consulted | 1 | `test_the_remedy_names_a_release_from_torchs_own_table` |
| PTX entries filtered out (the cubin-check rule) | 1 | `test_a_ptx_entry_counts_as_an_architecture` |
| arch parser drops the family suffix | 2 | `test_an_architecture_specific_suffix_is_read` |
| empty arch list no longer skipped | 1 | `test_a_build_reporting_no_architectures_is_skipped` |
| verdict always admits the build | 7 | every refusal cell |

`sib` is 0 attributable on all 11 rows across the five sibling doctor suites: those runs show 2 pre-existing failures (`PackageNotFoundError: No package metadata was found for strands-robots`), reproduced identically on a pristine tree with this change stashed out — `2 failed, 169 passed` both ways.

**Paired gate** — identical 133-file selection (all five doctor suites plus every guard walking the tree, parsing source, or reading docstrings, `Args:`, `Raises:`, `__all__` or `changelog.d`), new file withheld from both sides:

| | collected | result |
|---|---|---|
| base | 5208 | `2 failed, 5150 passed, 56 skipped` |
| branch | 5208 | `2 failed, 5150 passed, 56 skipped` |

2 == 2 identical failing ids, both `comm` directions empty; both are the metadata pair above.

**Lint** — `ruff check` and `ruff format --check` clean over 1707 files. **mypy** — 24 == 24 against a tree with this change reverted, normalized message sets byte-identical in both directions, 0 attributable.

New suite: **27 passed, 0 skipped**, and it needs neither a CUDA device nor a real torch — the stand-in supplies torch's surface, and a separate class grades that stand-in against the installed torch so the two cannot drift.

No visual artifact: this changes a diagnostic CLI verdict, not a policy, simulation, rendering, recording or asset. The measured console output above is the artifact, and the two sibling checks landed the same way.
