### PR TITLE
fix(device_connect): the Reachy movement RPCs share the travel envelope with the native driver

### DIFF
--- a/changelog.d/2910-reachy-motion-envelope-is-shared.md
+++ b/changelog.d/2910-reachy-motion-envelope-is-shared.md
@@ -1,0 +1,38 @@
+### Fixed: both Reachy consumers hold the same axis to the same travel envelope
+
+`strands_robots.tools.reachy` exists for one reason, which its own package
+docstring states: it holds "what the *two* Reachy consumers must agree on and
+neither owns: the motion envelope". Only one of those two consumed it.
+`ReachyDriver.send_action` ran `envelope_error` over its action dict; the Device
+Connect driver's three movement RPCs ran `finite_number_error` and stopped
+there. So for the same physical robot `look(pitch=200)` reported `success` and
+sent a head pose built from 200 degrees of pitch on an axis whose travel is
++/-40, `body(yaw=400)` reported `success` and sent `{"body_yaw": 6.98}` — 400
+degrees in radians — on an axis whose travel is +/-160, and
+`send_action({"head_pitch": 200})` refused both while naming the limit.
+
+The exclusion was argued rather than overlooked. `_motion_domain_error` said the
+reachable workspace "is the daemon's to enforce -- it depends on hardware this
+library does not model", and that was true when it was written: the reason landed
+on 2026-08-07 and `MOTION_ENVELOPE_DEG` landed on 2026-08-26, nineteen days
+later, in a package that imports no transport and no driver and is importable
+with no Reachy attached. The reason is a claim about what the library can model,
+and a later change gave the library the model.
+
+Why nothing caught it: the two surfaces spell the same axis differently. `look`
+takes `pitch`/`roll`/`yaw` where the envelope keys
+`head_pitch`/`head_roll`/`head_yaw`, and `envelope_error` ignores a key it has no
+limit for — so handing it the RPC's own keyword dict bounds nothing and reports
+no error. `_ENVELOPE_AXIS_BY_PARAM` is that mapping, and a test grades it against
+the live limits so an axis added to the envelope cannot be silently left
+unmapped.
+
+Finiteness is still asked first, so an unusable value is named by the caller's
+own parameter spelling rather than by the axis it maps to, and a travel
+comparison against `nan` — which `abs(nan) <= 40` makes `False` — is never the
+message. Per-axis travel is the half that transfers: the envelope's head-body
+yaw coupling limit bounds `head_yaw - body_yaw` and needs both values in one
+call, which this RPC surface does not offer, and that stays with `send_action`.
+The millimetre offsets and the antenna angles carry no envelope entry and remain
+finiteness-only, held from both sides so this cannot grow into a bound the
+envelope never declared.

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -25,6 +25,7 @@ from strands_robots.device_connect.reachy_transport import (
     rpy_to_pose,
 )
 from strands_robots.mesh.security import ValidationError, validate_mesh_identifier
+from strands_robots.tools.reachy import envelope_error
 from strands_robots.utils import finite_number_error, tcp_port_error
 
 logger = logging.getLogger(__name__)
@@ -88,6 +89,20 @@ def _key_prefix_error(value: Any, param: str, cls_name: str) -> str | None:
     return None
 
 
+#: Per-RPC map from a movement RPC's own parameter name to the envelope axis it
+#: commands. This surface spells the head axes ``pitch`` / ``roll`` / ``yaw``
+#: where :data:`~strands_robots.tools.reachy.MOTION_ENVELOPE_DEG` keys them
+#: ``head_pitch`` / ``head_roll`` / ``head_yaw``, so the values have to be
+#: re-keyed before the envelope can bound them - handing it this RPC's own
+#: keyword dict would bound nothing, because it ignores a key it has no limit
+#: for. ``look``'s millimetre offsets and ``antennas``' angles carry no entry
+#: because the envelope declares no bound for them.
+_ENVELOPE_AXIS_BY_PARAM: dict[str, dict[str, str]] = {
+    "look": {"pitch": "head_pitch", "roll": "head_roll", "yaw": "head_yaw"},
+    "body": {"yaw": "body_yaw"},
+}
+
+
 def _motion_domain_error(rpc_name: str, values: dict[str, Any]) -> dict[str, str] | None:
     """Structured rejection when a motion argument cannot reach the robot.
 
@@ -108,11 +123,38 @@ def _motion_domain_error(rpc_name: str, values: dict[str, Any]) -> dict[str, str
     error`` out of the RPC from ``math.cos``, while an ``inf`` offset was
     divided by 1000 and reported as a successful move.
 
-    The bound is finiteness and numeric-ness only, via the shared
-    :func:`~strands_robots.utils.finite_number_error`. Both signs and zero are
-    legitimate (a negative pitch looks down, zero re-centres), and the robot's
-    reachable workspace is the daemon's to enforce -- it depends on hardware
-    this library does not model.
+    Two bounds, in this order. Finiteness and numeric-ness first, via the shared
+    :func:`~strands_robots.utils.finite_number_error`; both signs and zero are
+    legitimate there (a negative pitch looks down, zero re-centres). Then every
+    parameter that names a bounded joint is held to the shared travel envelope,
+    :func:`~strands_robots.tools.reachy.envelope_error`, through
+    :data:`_ENVELOPE_AXIS_BY_PARAM`.
+
+    That second bound used to be excused as the daemon's to enforce, on the
+    grounds that it depends on hardware this library does not model. That was
+    true when this helper was written and is no longer: the library models the
+    envelope. :data:`~strands_robots.tools.reachy.MOTION_ENVELOPE_DEG` gives
+    every bounded axis its travel in degrees, in a package whose own purpose
+    statement is "what the *two* Reachy consumers must agree on and neither
+    owns: the motion envelope", and which is importable with no Reachy and no
+    daemon attached. The other of those two consumers,
+    :meth:`~strands_robots.drivers.reachy.ReachyDriver.send_action`, already
+    consults it. So a head pitch of 200 degrees on a +/-40 degree axis was
+    refused by one driver and carried to the wire as 3.49 radians by the other,
+    for the same physical robot, and this RPC reported ``success``.
+
+    Finiteness is asked first for two reasons: an unusable value is then named
+    by the caller's own parameter spelling rather than by the axis it maps to,
+    and a travel comparison against ``nan`` is meaningless - ``abs(nan) <= 40``
+    is ``False``, so an unordered value would be refused with a message about
+    travel. That is the same ordering :func:`envelope_error` documents for its
+    own checks.
+
+    The head-body yaw coupling limit the envelope also carries is not reachable
+    from here: it bounds ``head_yaw - body_yaw`` and needs both values in one
+    call, where this surface splits them across :meth:`ReachyMiniDriver.look`
+    and :meth:`ReachyMiniDriver.body`. Per-axis travel is the half that
+    transfers; the pairwise limit stays with ``send_action``, which takes both.
 
     Args:
         rpc_name: The RPC that received the values, used as the message prefix.
@@ -126,6 +168,12 @@ def _motion_domain_error(rpc_name: str, values: dict[str, Any]) -> dict[str, str
         if (message := finite_number_error(value, param, rpc_name)) is not None:
             logger.warning("Rejected Reachy Mini %s: %s", rpc_name, message)
             return {"status": "error", "reason": message}
+
+    axis_by_param = _ENVELOPE_AXIS_BY_PARAM.get(rpc_name, {})
+    bounded = {axis: values[param] for param, axis in axis_by_param.items() if param in values}
+    if bounded and (message := envelope_error(bounded, rpc_name)) is not None:
+        logger.warning("Rejected Reachy Mini %s: %s", rpc_name, message)
+        return {"status": "error", "reason": message}
     return None
 
 
@@ -263,7 +311,9 @@ class ReachyMiniDriver(DeviceDriver):
             x: X offset in mm
             y: Y offset in mm
             z: Z offset in mm. Every value must be a finite number of
-                either sign; the workspace bound is the daemon's.
+                either sign, and ``pitch`` / ``roll`` / ``yaw`` must be inside
+                the shared travel envelope. The millimetre offsets carry no
+                envelope bound and are the daemon's to enforce.
 
         Returns:
             ``{"status": "success", ...}``, or a ``{"status": "error",
@@ -309,7 +359,7 @@ class ReachyMiniDriver(DeviceDriver):
 
         Args:
             yaw: Body yaw angle in degrees. Must be a finite number of
-                either sign.
+                either sign and inside the shared travel envelope.
 
         Returns:
             ``{"status": "success", ...}``, or a ``{"status": "error",

--- a/tests/test_reachy_motion_domain.py
+++ b/tests/test_reachy_motion_domain.py
@@ -29,8 +29,13 @@ all three mesh bridges; this package applied it nowhere. The constructor's own
 names the value, so it is the only point a caller can act on.
 
 ``TestWhyTheDriverOwnsTheDomain`` pins those premises rather than asserting
-them in prose. The reachable workspace is deliberately *not* bounded here: it
-depends on hardware this library does not model, and the daemon owns it.
+them in prose. Per-axis travel is bounded too, through the shared
+:func:`~strands_robots.tools.reachy.envelope_error`: this file's original
+scope note excused it as depending on hardware the library does not model,
+which stopped being true when that envelope landed. What is still the
+daemon's is whatever the envelope declares no limit for - ``look``'s
+millimetre offsets and the antenna angles - and the cells below hold that
+boundary from both sides.
 
 ``TestNoMotionRpcDrifts`` widens to every exported driver: an RPC carrying a
 number must either validate it or forward it to something that does. The two
@@ -72,7 +77,13 @@ UNUSABLE_MOTION_VALUES: list[Any] = [
     10**400,
 ]
 
-USABLE_MOTION_VALUES: list[Any] = [0, 0.0, -15.0, 15, 42.5, -0.5]
+# Values a motion RPC must still carry. Every one is inside the tightest axis
+# in ``MOTION_ENVELOPE_DEG`` (head pitch/roll, +/-40 deg), because these drive
+# every parameter of every RPC including the bounded ones - a value outside
+# that would be refused on travel and read as a finiteness regression. The
+# envelope's own suite grades the out-of-travel half; a cell there pins this
+# constant against the live limits so tightening an axis fails loudly here.
+USABLE_MOTION_VALUES: list[Any] = [0, 0.0, -15.0, 15, 32.5, -0.5]
 
 # Every motion RPC, and the parameters it carries, in signature order.
 MOTION_SURFACES: dict[str, list[str]] = {
@@ -156,7 +167,12 @@ class TestMotionArgumentDomain:
     @pytest.mark.parametrize("value", USABLE_MOTION_VALUES, ids=repr)
     @pytest.mark.parametrize("rpc_name", sorted(MOTION_SURFACES))
     def test_a_usable_argument_still_reaches_the_robot(self, rmd, rpc_name, value):
-        """The guard is additive: nothing that worked before is refused."""
+        """The finiteness guard is additive over values inside the envelope.
+
+        Scoped deliberately: a value outside an axis's travel is refused now,
+        which is the envelope's contract rather than a finiteness regression.
+        ``USABLE_MOTION_VALUES`` is bounded so the two cannot be confused.
+        """
         for param in MOTION_SURFACES[rpc_name]:
             driver, link = _driver(rmd)
             result = _call(driver, rpc_name, **{param: value})
@@ -165,7 +181,11 @@ class TestMotionArgumentDomain:
             assert json.dumps(link.commands[0], allow_nan=False)
 
     def test_the_accepted_domain_matches_the_shared_helper_exactly(self, rmd):
-        """Neither wider nor narrower than :func:`finite_number_error`."""
+        """Neither wider nor narrower than :func:`finite_number_error`.
+
+        Graded on ``body``, whose one parameter every value here is inside the
+        travel of, so the verdicts that differ can only differ on finiteness.
+        """
         for value in UNUSABLE_MOTION_VALUES + USABLE_MOTION_VALUES:
             shared_refuses = finite_number_error(value, "yaw", "body") is not None
             driver, _link = _driver(rmd)

--- a/tests/test_reachy_motion_envelope_is_shared_with_the_native_driver.py
+++ b/tests/test_reachy_motion_envelope_is_shared_with_the_native_driver.py
@@ -1,0 +1,347 @@
+"""Both Reachy consumers hold the same axis to the same travel envelope.
+
+:mod:`strands_robots.tools.reachy` exists for exactly one reason, which its own
+package docstring states: it "holds only what the *two* Reachy consumers must
+agree on and neither owns: the motion envelope". Only one of those two consumed
+it. :meth:`~strands_robots.drivers.reachy.ReachyDriver.send_action` ran
+:func:`~strands_robots.tools.reachy.envelope_error` over its action dict; the
+Device Connect driver's three movement RPCs ran
+:func:`~strands_robots.utils.finite_number_error` and stopped there, so a value
+one driver refused the other put on the wire, for the same physical robot:
+
+* ``look(pitch=200)`` reported ``success`` and sent ``head_pose`` built from 200
+  degrees of pitch on an axis whose travel is +/-40.
+* ``body(yaw=400)`` reported ``success`` and sent ``{"body_yaw": 6.98}`` - 400
+  degrees in radians - on an axis whose travel is +/-160.
+* ``send_action({"head_pitch": 200})`` refused both, naming the limit.
+
+The exclusion was argued rather than overlooked. ``_motion_domain_error`` said
+the reachable workspace "is the daemon's to enforce -- it depends on hardware
+this library does not model", and that was true when it was written: the reason
+landed on 2026-08-07 and ``MOTION_ENVELOPE_DEG`` landed on 2026-08-26, nineteen
+days later, in a package that imports no transport and no driver and is
+importable with no Reachy attached. The reason is a claim about what the library
+can model, and a later change gave the library the model.
+
+Why nothing caught it: the two surfaces spell the same axis differently.
+``look`` takes ``pitch``/``roll``/``yaw`` where the envelope keys
+``head_pitch``/``head_roll``/``head_yaw``, and ``envelope_error`` ignores a key
+it has no limit for - so handing it the RPC's own keyword dict bounds nothing
+and reports no error. :data:`_ENVELOPE_AXIS_BY_PARAM` is that mapping, and
+``TestTheEnvelopeIsNotReImplemented`` grades it against the live limits so an
+axis added to the envelope cannot be silently unmapped.
+
+Scope. Per-axis travel is the half that transfers. The envelope's head-body yaw
+coupling limit bounds ``head_yaw - body_yaw`` and needs both values in one call,
+which this RPC surface does not offer - ``look`` carries the head yaw and
+``body`` the body yaw. ``TestTheCouplingLimitIsNotReachableHere`` pins that as a
+property of the mapping rather than leaving it implied. The millimetre offsets
+and the antenna angles carry no envelope entry and stay finiteness-only, which
+``TestWhatTheEnvelopeDoesNotBound`` holds from both sides so this change cannot
+grow into a bound the envelope never declared.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import pathlib
+import textwrap
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.reachy import ReachyDriver
+from strands_robots.tools.reachy import (
+    HEAD_BODY_YAW_DELTA_LIMIT_DEG,
+    MOTION_ENVELOPE_DEG,
+    envelope_error,
+)
+from tests.test_reachy_mini_driver import _force_real_device_connect_edge
+from tests.test_reachy_motion_domain import USABLE_MOTION_VALUES
+
+
+def _outside(limit: float) -> float:
+    """A travel request comfortably outside ``limit``, in degrees."""
+    return limit * 5.0 + 10.0
+
+
+def _inside(limit: float) -> float:
+    """A travel request comfortably inside ``limit``, in degrees."""
+    return limit * 0.5
+
+
+@pytest.fixture
+def rmd() -> Any:
+    """The reachy_mini_driver module bound to the real device_connect_edge."""
+    _force_real_device_connect_edge()
+    import strands_robots.device_connect.reachy_mini_driver as module
+
+    return module
+
+
+class _RecordingLink:
+    """A hardware link that records what a driver hands it instead of dialing."""
+
+    def __init__(self) -> None:
+        self.commands: list[dict[str, Any]] = []
+
+    async def start(self, on_joints: Any, on_imu: Any) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def send_cmd(self, cmd: dict[str, Any]) -> None:
+        self.commands.append(cmd)
+
+
+def _device_connect(rmd: Any) -> tuple[Any, _RecordingLink]:
+    """A Device Connect driver with a recording link, built without dialing."""
+    driver = rmd.ReachyMiniDriver.__new__(rmd.ReachyMiniDriver)
+    driver._host = "bot.local"
+    driver._prefix = "reachy_mini"
+    driver._api_port = 8000
+    driver._latest_joints = None
+    driver._latest_imu = None
+    link = _RecordingLink()
+    driver._hw = link
+    return driver, link
+
+
+def _native() -> tuple[ReachyDriver, list[dict[str, Any]]]:
+    """A native driver reporting connected, recording what it would send."""
+    driver = ReachyDriver.__new__(ReachyDriver)
+    driver._tool_name = "reachy_mini"
+    driver._connected = True
+    sent: list[dict[str, Any]] = []
+
+    def _send(command: dict[str, Any]) -> str | None:
+        sent.append(command)
+        return None
+
+    driver._send_cmd = _send  # type: ignore[method-assign]
+    return driver, sent
+
+
+def _call(driver: Any, rpc_name: str, **kwargs: Any) -> Any:
+    """Invoke a movement RPC as an authorized caller would."""
+    return asyncio.run(getattr(driver, rpc_name)(**kwargs))
+
+
+def _text(envelope: dict[str, Any]) -> str:
+    """Every text block of a driver envelope, joined."""
+    return " ".join(block["text"] for block in envelope.get("content", []) if "text" in block)
+
+
+def _bounded_cases(rmd: Any) -> list[tuple[str, str, str, float]]:
+    """Every ``(rpc, param, axis, limit)`` the mapping bounds, from the tree.
+
+    Derived from the driver's own map and the envelope's own limits, so an axis
+    that gains a bound - or a parameter that gains a mapping - is graded here
+    without this file being edited.
+    """
+    return [
+        (rpc, param, axis, MOTION_ENVELOPE_DEG[axis])
+        for rpc, axes in sorted(rmd._ENVELOPE_AXIS_BY_PARAM.items())
+        for param, axis in sorted(axes.items())
+    ]
+
+
+def _case_ids(rmd: Any) -> list[str]:
+    return [f"{rpc}-{param}" for rpc, param, _axis, _limit in _bounded_cases(rmd)]
+
+
+class TestBothDriversRefuseTheSameTravel:
+    """The defect: one consumer refused a request the other carried to the wire."""
+
+    def test_the_device_connect_rpc_refuses_travel_outside_the_axis(self, rmd: Any) -> None:
+        for rpc, param, axis, limit in _bounded_cases(rmd):
+            driver, link = _device_connect(rmd)
+            result = _call(driver, rpc, **{param: _outside(limit)})
+            assert result["status"] == "error", f"{rpc}({param}={_outside(limit)}) -> {result}"
+            assert link.commands == [], f"{rpc}({param}) reached the wire: {link.commands}"
+            assert axis in result["reason"], result["reason"]
+
+    def test_the_native_driver_refuses_the_same_travel(self, rmd: Any) -> None:
+        """The consumer that already consulted the envelope, as the control."""
+        for _rpc, _param, axis, limit in _bounded_cases(rmd):
+            driver, sent = _native()
+            result = driver.send_action({axis: _outside(limit)})
+            assert result["status"] == "error", f"send_action({axis}) -> {result}"
+            assert sent == []
+            assert axis in _text(result)
+
+    def test_the_two_drivers_agree_on_every_bounded_axis(self, rmd: Any) -> None:
+        """The property the shared package exists for, over both verdicts."""
+        for rpc, param, axis, limit in _bounded_cases(rmd):
+            for value in (_inside(limit), _outside(limit)):
+                dc_driver, _link = _device_connect(rmd)
+                dc_status = _call(dc_driver, rpc, **{param: value})["status"]
+                native_driver, _sent = _native()
+                native_status = native_driver.send_action({axis: value})["status"]
+                assert dc_status == native_status, f"{axis}={value}: {dc_status} vs {native_status}"
+
+
+class TestTheRefusalNamesTheAxisAndTheLimit:
+    """A refusal a caller can act on: which axis, and what its travel is."""
+
+    def test_the_reason_names_the_rpc_the_axis_and_the_bound(self, rmd: Any) -> None:
+        driver, _link = _device_connect(rmd)
+        result = _call(driver, "body", yaw=400.0)
+        assert result["reason"] == "body: body_yaw 400 deg is outside the envelope +/-160 deg"
+
+    def test_an_unusable_value_is_still_named_by_the_callers_own_parameter(self, rmd: Any) -> None:
+        """Finiteness runs first, so ``nan`` is reported as ``pitch``, not ``head_pitch``.
+
+        The envelope keys the axis; the caller typed the parameter. Asking
+        finiteness first keeps the message in the caller's own vocabulary for the
+        one input class that cannot be compared against a travel bound at all.
+        """
+        driver, link = _device_connect(rmd)
+        result = _call(driver, "look", pitch=float("nan"))
+        assert result["reason"] == "look: pitch must be a finite number, got nan."
+        assert "head_pitch" not in result["reason"]
+        assert link.commands == []
+
+
+class TestTheEnvelopeIsNotReImplemented:
+    """One owner for the limits, and a mapping graded against it."""
+
+    def test_the_driver_consults_the_shared_envelope(self, rmd: Any) -> None:
+        """Graded on the CALL, not the source text.
+
+        This helper's docstring names ``envelope_error`` to explain the bound, so
+        a substring check would be satisfied by the prose alone - it passes on a
+        body that dropped the call.
+        """
+        tree = ast.parse(textwrap.dedent(inspect.getsource(rmd._motion_domain_error)))
+        called = {
+            node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "envelope_error" in called, f"the helper calls {sorted(called)}"
+        assert "finite_number_error" in called, f"the helper calls {sorted(called)}"
+
+    def test_every_mapped_axis_is_one_the_envelope_bounds(self, rmd: Any) -> None:
+        """A mapping entry naming an axis with no limit would bound nothing."""
+        for rpc, axes in rmd._ENVELOPE_AXIS_BY_PARAM.items():
+            for param, axis in axes.items():
+                assert axis in MOTION_ENVELOPE_DEG, f"{rpc}.{param} -> {axis} has no envelope limit"
+
+    def test_the_driver_declares_no_travel_limit_of_its_own(self, rmd: Any) -> None:
+        """The numbers live in the envelope, so this module restates none of them.
+
+        Read as numeric literals rather than as text, so a limit that appears in
+        a docstring explaining the bound is not mistaken for a second copy of it.
+        """
+        tree = ast.parse(pathlib.Path(str(rmd.__file__)).read_text(encoding="utf-8"))
+        literals = {
+            float(node.value)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, int | float)
+            and not isinstance(node.value, bool)
+        }
+        restated = sorted(literals & set(MOTION_ENVELOPE_DEG.values()))
+        assert not restated, f"travel limits restated as literals here: {restated}"
+
+    def test_the_mapping_is_not_empty(self, rmd: Any) -> None:
+        """Non-vacuity: an empty map would make every cell above pass trivially."""
+        cases = _bounded_cases(rmd)
+        assert len(cases) >= 4, f"expected the head axes and body yaw, mapped {cases}"
+
+
+class TestWhatTheEnvelopeDoesNotBound:
+    """The boundary held from both sides: no bound the envelope never declared."""
+
+    def test_a_usable_in_envelope_request_still_reaches_the_robot(self, rmd: Any) -> None:
+        for rpc, param, _axis, limit in _bounded_cases(rmd):
+            driver, link = _device_connect(rmd)
+            result = _call(driver, rpc, **{param: _inside(limit)})
+            assert result["status"] == "success", f"{rpc}({param}={_inside(limit)}) -> {result}"
+            assert len(link.commands) == 1
+
+    def test_a_millimetre_offset_is_not_bounded_by_the_envelope(self, rmd: Any) -> None:
+        """``look``'s offsets are millimetres; the envelope declares no limit."""
+        for param in ("x", "y", "z"):
+            assert param not in rmd._ENVELOPE_AXIS_BY_PARAM["look"]
+            driver, link = _device_connect(rmd)
+            result = _call(driver, "look", **{param: 9999.0})
+            assert result["status"] == "success", f"look({param}=9999) -> {result}"
+            assert len(link.commands) == 1
+
+    def test_an_antenna_angle_is_not_bounded_by_the_envelope(self, rmd: Any) -> None:
+        assert "antennas" not in rmd._ENVELOPE_AXIS_BY_PARAM
+        driver, link = _device_connect(rmd)
+        result = _call(driver, "antennas", left=500.0, right=-500.0)
+        assert result["status"] == "success", result
+        assert len(link.commands) == 1
+
+    def test_an_unmapped_rpc_keeps_the_finiteness_domain(self, rmd: Any) -> None:
+        """The change is additive for a surface the mapping does not name."""
+        driver, link = _device_connect(rmd)
+        assert _call(driver, "antennas", left=float("inf"))["status"] == "error"
+        assert link.commands == []
+
+
+class TestTheCouplingLimitIsNotReachableHere:
+    """Scope, pinned rather than implied: the pairwise limit needs both values.
+
+    Holds before and after the change. It records why the envelope's second
+    limit is not part of it, so a reader does not take the omission for an
+    oversight.
+    """
+
+    def test_no_single_rpc_carries_both_members_of_the_yaw_pair(self, rmd: Any) -> None:
+        for rpc, axes in rmd._ENVELOPE_AXIS_BY_PARAM.items():
+            mapped = set(axes.values())
+            assert not {"head_yaw", "body_yaw"} <= mapped, f"{rpc} maps both, so the coupling applies"
+
+    def test_the_coupling_limit_exists_and_the_native_driver_can_reach_it(self) -> None:
+        """The half that does have a surface taking both values at once."""
+        driver, sent = _native()
+        result = driver.send_action(
+            {"head_yaw": HEAD_BODY_YAW_DELTA_LIMIT_DEG + 20.0, "body_yaw": -HEAD_BODY_YAW_DELTA_LIMIT_DEG}
+        )
+        assert result["status"] == "error"
+        assert sent == []
+        assert "coupling" in _text(result)
+
+
+class TestThePremisesThisRestsOn:
+    """Measured rather than asserted in prose."""
+
+    def test_the_shared_package_names_both_consumers_as_its_purpose(self) -> None:
+        import strands_robots.tools.reachy as shared
+
+        doc = " ".join((shared.__doc__ or "").split())
+        assert "the *two* Reachy consumers must agree on and neither owns: the motion envelope" in doc
+
+    def test_the_envelope_ignores_a_key_it_has_no_limit_for(self) -> None:
+        """Why the mapping is needed: the RPC's own spelling bounds nothing."""
+        assert envelope_error({"pitch": 200.0}, "look") is None
+        assert envelope_error({"head_pitch": 200.0}, "look") is not None
+
+    def test_the_shared_module_needs_no_reachy_and_no_daemon(self) -> None:
+        """The reason the old exclusion gave is what this refutes."""
+        import strands_robots.tools.reachy._reachy_common as common
+
+        tree = ast.parse(pathlib.Path(str(common.__file__)).read_text(encoding="utf-8"))
+        imported = {node.module or "" for node in tree.body if isinstance(node, ast.ImportFrom)} | {
+            alias.name for node in tree.body if isinstance(node, ast.Import) for alias in node.names
+        }
+        assert imported == {"__future__", "typing", "strands_robots.utils"}, imported
+
+    def test_the_sibling_usable_values_stay_inside_every_bounded_axis(self) -> None:
+        """Drift guard: tightening an axis fails here, not in an unrelated sweep.
+
+        ``USABLE_MOTION_VALUES`` drives every parameter of every movement RPC,
+        including the bounded ones, so a value outside the tightest axis would be
+        refused on travel and read as a finiteness regression.
+        """
+        tightest = min(MOTION_ENVELOPE_DEG.values())
+        numeric = [value for value in USABLE_MOTION_VALUES if isinstance(value, int | float)]
+        assert numeric, "expected numeric values to grade"
+        for value in numeric:
+            assert abs(float(value)) <= tightest, f"{value!r} exceeds the tightest axis (+/-{tightest} deg)"


### PR DESCRIPTION
## The defect

`strands_robots.tools.reachy` exists for one reason, which its own package docstring states: it holds "what the *two* Reachy consumers must agree on and neither owns: the motion envelope".

Only one of those two consumed it. `ReachyDriver.send_action` ran `envelope_error` over its action dict. The Device Connect driver's three movement RPCs ran `finite_number_error` and stopped there, so the same physical quantity was refused by one driver and carried to the wire by the other.

Both drivers driven with the same quantity, recording link, no daemon:

| quantity | `ReachyMiniDriver` RPC | `ReachyDriver.send_action` | reached the wire? |
|---|---|---|---|
| head pitch 200 deg (travel +/-40) | `success` | `error` | YES |
| head roll 200 deg (travel +/-40) | `success` | `error` | YES |
| head yaw 400 deg (travel +/-180) | `success` | `error` | YES |
| body yaw 400 deg (travel +/-160) | `success` | `error` | YES |
| head pitch 20 deg (control, in range) | `success` | `success` | YES |

`body(yaw=400)` put `{"body_yaw": 6.981317007977318}` on the wire — 400 degrees in radians — and answered `success`. The native driver answered `send_action: body_yaw 400 deg is outside the envelope +/-160 deg`.

## Why the exclusion was there, and why it stopped holding

It was argued rather than overlooked. `_motion_domain_error` said the reachable workspace "is the daemon's to enforce -- it depends on hardware this library does not model", and `tests/test_reachy_motion_domain.py` recorded the same scope note.

That was true when it was written. The dates are the whole finding:

| artifact | landed |
|---|---|
| the "library does not model it" reason | `c8ec272d`, 2026-08-07 |
| `MOTION_ENVELOPE_DEG` + `envelope_error` | `97ab1b02`, 2026-08-26 |

Nineteen days apart. The reason is a claim about what the library can model, and a later change gave the library the model — in a package whose module-scope imports measure exactly `{__future__, typing, strands_robots.utils}`, so it needs no Reachy and no daemon.

## Why nothing caught it

The two surfaces spell the same axis differently. `look` takes `pitch`/`roll`/`yaw` where the envelope keys `head_pitch`/`head_roll`/`head_yaw`, and `envelope_error` ignores a key it has no limit for:

```
envelope_error({"pitch": 200.0},      "look")  ->  None
envelope_error({"head_pitch": 200.0}, "look")  ->  "look: head_pitch 200 deg is outside the envelope +/-40 deg"
```

So handing the envelope this RPC's own keyword dict bounds nothing and reports no error. `_ENVELOPE_AXIS_BY_PARAM` is that mapping, and a test grades every entry against the live `MOTION_ENVELOPE_DEG` so an axis that gains a bound cannot be silently left unmapped.

## Ordering

Finiteness stays first, for two reasons. An unusable value is then named by the caller's own parameter spelling rather than by the axis it maps to — `look: pitch must be a finite number, got nan.` and not `head_pitch` — and a travel comparison against `nan` is meaningless, since `abs(nan) <= 40` is `False` and would refuse an unordered value with a message about travel. That is the order `envelope_error` documents for its own checks.

## Scope, pinned rather than implied

Per-axis travel is the half that transfers. Held unchanged, from both sides:

- **The millimetre offsets.** `look(x=9999)` still succeeds; the envelope declares no bound for them.
- **The antenna angles.** `antennas(left=500)` still succeeds, and `antennas(left=inf)` is still refused, so the change is additive for a surface the mapping does not name.
- **The head-body yaw coupling limit.** It bounds `head_yaw - body_yaw` and needs both values in one call, which this RPC surface does not offer — `look` carries the head yaw and `body` the body yaw. A test pins that as a property of the mapping, and pins that `send_action`, which does take both, still reaches it.

## Tests

Pre-fix split, behavioural revert (the map kept defined, only the envelope call undone): **3 failed / 16 passed**, with **0 of 4** premise cells, **0 of 4** boundary cells and **0 of 2** coupling-scope cells firing. The native-driver control passes pre-fix, correctly — it already consulted the envelope.

Mutation table, 9 mutations, control clean, `collected` stable at 19, both files restored md5-identical:

| mutation | new file | sibling suites |
|---|---|---|
| control | 0 | 0 |
| envelope check dropped | 4 | 0 |
| map emptied | 3 | 0 |
| body axis unmapped only | 2 | 0 |
| head axes unmapped only | 2 | 0 |
| RPC keywords passed unmapped | 3 | 0 |
| envelope asked BEFORE finiteness | 1 | **21** |
| mm offsets given a bound too | 3 | 0 |
| limits restated locally, not shared | 4 | 0 |
| sibling value set back outside the envelope | 1 | 1 |

Nine distinct firing sets. The per-axis reverts partition exactly: `b3 | b4 == b2`, sharing only the non-vacuity cell, which fires if either half goes. Asking the envelope before finiteness trips **21 pre-existing cells**, so the ordering is load-bearing at runtime and not only in an assertion.

## One sibling value had to move

`USABLE_MOTION_VALUES` in `tests/test_reachy_motion_domain.py` contained `42.5`, which exceeds the tightest axis (head pitch/roll, +/-40). It drives every parameter of every RPC including the bounded ones, so it is now `32.5`, and a new cell pins the whole set against `min(MOTION_ENVELOPE_DEG.values())` — tightening an axis fails there by name instead of surfacing as a finiteness regression in an unrelated sweep. That cell is the one the last mutation row fires. Two claims in that file were also narrower than they read and now say so.

## Gate

- Paired selection of **472 files** (every guard walking the tree, parsing source or reading docstrings, plus the whole reachy and device-connect area), the new file withheld from both sides: identical **21974 collected** and `22 failed, 21869 passed, 83 skipped` on each tree, **both `comm` directions empty**.
- The 22 are environmental and identical on both trees: 17 need `awsiot`/`awscrt` (`find_spec` False, declared in `[mesh-iot]`), 2 need `device_connect_agent_tools` (`[device-connect]`), 3 are lerobot-from-source drift. Hatch's default env features are `['all']`, so CI installs all three.
- `mypy` **24 == 24** against the base, normalized message sets byte-identical in both directions, **0 attributable**.
- `ruff check` and `ruff format --check` clean over 1711 files.
- The whole reachy area on the rebased tree: **458 passed**.
- Import cost of the shared envelope from the device-connect side: **0.262 ms, 2 new modules**, and no cycle — `_reachy_common` imports only `__future__`, `typing` and `strands_robots.utils`.

No visual artifact: this is a refusal on an RPC surface, not a policy, simulation, rendering, recording or asset change. The measured before/after tables are the evidence.
