### PR TITLE
fix(doctor): the MUJOCO_GL remedy names a backend this host can load

### DIFF
--- a/changelog.d/2911-doctor-mujoco-gl-remedy-names-a-reachable-backend.md
+++ b/changelog.d/2911-doctor-mujoco-gl-remedy-names-a-reachable-backend.md
@@ -1,0 +1,28 @@
+### Fixed: the MUJOCO_GL remedy names a backend this host can load
+
+`check_mujoco_gl` already reasons about not recommending a value MuJoCo would refuse - its own comment
+says "what to recommend has to be valid here", and a sibling case pins that a Darwin remedy never
+offers a Linux backend. That validated the advice against the platform's vocabulary, and valid is not
+the same as reachable: each offscreen backend loads a system library, so a host can accept a value
+whose library is not installed.
+
+Measured on a headless Linux host with `libEGL.so.1` and no `libOSMesa.so`, the verdict was right and
+its remedy was not. `MUJOCO_GL=off` earned `FAIL  MUJOCO_GL=off disables MuJoCo's GL context` and then
+offered `export MUJOCO_GL=egl`, correct only because EGL sorts first; `MUJOCO_GL=glfw` earned a `WARN`
+and advised `Set MUJOCO_GL=egl or osmesa for headless`, naming a backend that cannot render there; and
+with neither library installed every one of those remedies offered an export where nothing exportable
+can render, because the real remedy is the library.
+
+`_configure_gl_backend` has always probed exactly this - it is how the package picks a backend at
+import - and the verdict did not read that probe. `_mujoco_gl_loadable_offscreen_values` is that probe
+as a helper, over one table of the `(backend, library)` pairs the configurator itself probes, so the
+two readers of that table cannot disagree about what a host can reach. The verdict now recommends from
+the reachable set and keeps the platform set only to tell "this platform has no offscreen backend"
+apart from "this host is missing their libraries", which earns the library name instead of a variable.
+The verdict a setting earns is unchanged; only the remedy moved.
+
+The sibling suite's `linux_headless` fixture staged the platform and not the libraries, so its remedy
+assertions read whichever libraries the machine running them happened to have - agreeing about the
+verdict while disagreeing about the advice. It now stages both axes, which is what its docstring
+already claimed, and a new case grades the probe against the loader directly rather than against the
+stand-in every host model installs.

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -250,7 +250,12 @@ def check_mujoco_gl() -> str:
             fix=f"export MUJOCO_GL=<one of: {offered}>  # or unset it for the platform default",
         )
 
-    if value in offscreen_here:
+    # Classification is the platform's question, not this host's: an offscreen
+    # backend is one whether or not its library is installed here, so a value the
+    # reader set keeps the verdict it earns. Only what to *recommend* narrows to
+    # what can load, which is why this reads the accepted set and the remedies
+    # above and below read the reachable one.
+    if value in accepted_offscreen:
         return _pass(shown)
 
     # Every remaining accepted value routes MuJoCo to a backend that draws through

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -185,8 +185,10 @@ def check_mujoco_gl() -> str:
     rather than restated here.
     """
     from strands_robots.simulation.mujoco.backend import (
+        _MUJOCO_GL_OFFSCREEN_LIBRARIES,
         _is_headless,
         _mujoco_gl_disables_rendering,
+        _mujoco_gl_loadable_offscreen_values,
         _mujoco_gl_offscreen_values,
         _mujoco_gl_valid_values,
         _mujoco_gl_value,
@@ -201,13 +203,43 @@ def check_mujoco_gl() -> str:
     # What to recommend has to be valid here: on a platform whose only backend
     # draws through the window server there is no offscreen value to offer, and
     # naming one would send the reader after a value MuJoCo refuses.
-    offscreen_here = sorted(_mujoco_gl_offscreen_values())
+    #
+    # Valid is not the same as reachable. Each offscreen backend loads a system
+    # library, so on a host missing them every offscreen value MuJoCo accepts is
+    # one no export can render through, and the remedy is the library rather than
+    # a different variable. Both sets are kept, to tell "this platform has no
+    # offscreen backend" apart from "this host is missing their libraries".
+    accepted_offscreen = sorted(_mujoco_gl_offscreen_values())
+    offscreen_here = sorted(_mujoco_gl_loadable_offscreen_values())
+    absent_libraries = [
+        library
+        for value, library in _MUJOCO_GL_OFFSCREEN_LIBRARIES
+        if value in accepted_offscreen and value not in offscreen_here
+    ]
+
+    def _no_offscreen_remedy(platform_has_none: str) -> str:
+        """The remedy when no offscreen backend is reachable.
+
+        Args:
+            platform_has_none: What to say when the platform accepts none of them,
+                which is a property of the platform rather than of this host.
+
+        Returns:
+            The library advice when the platform accepts offscreen backends and
+            none of their libraries loads here, ``platform_has_none`` otherwise.
+        """
+        if accepted_offscreen:
+            return (
+                f"install an offscreen GL library ({', '.join(absent_libraries)}) - "
+                "no exported value can render without one"
+            )
+        return platform_has_none
 
     if _mujoco_gl_disables_rendering(value):
         fix = (
             f"export MUJOCO_GL={offscreen_here[0]}  # or unset it for the platform default"
             if offscreen_here
-            else "unset MUJOCO_GL  # the platform's own backend renders through its window server"
+            else _no_offscreen_remedy("unset MUJOCO_GL  # the platform's own backend renders through its window server")
         )
         return _fail(f"{shown} disables MuJoCo's GL context, so nothing can render", fix=fix)
 
@@ -227,7 +259,9 @@ def check_mujoco_gl() -> str:
         note = (
             f"Set MUJOCO_GL={' or '.join(offscreen_here)} for headless"
             if offscreen_here
-            else f"{platform.system()} has no offscreen MuJoCo backend, so a window server is required"
+            else _no_offscreen_remedy(
+                f"{platform.system()} has no offscreen MuJoCo backend, so a window server is required"
+            )
         )
         return _warn(f"{shown} (needs display)", note=note)
 
@@ -235,12 +269,21 @@ def check_mujoco_gl() -> str:
         if platform.system() == "Linux":
             return _pass("MUJOCO_GL unset (display detected, glfw will work)")
         return _pass(f"MUJOCO_GL unset ({platform.system()} renders through its native backend)")
-    # ``_is_headless`` is only ever true on Linux, so the remedy below is reached
-    # on the one platform where those two backends exist.
-    return _fail(
-        "MUJOCO_GL not set and no display detected",
-        fix="export MUJOCO_GL=egl  # or osmesa; add to ~/.bashrc",
-    )
+    # ``_is_headless`` is only ever true on Linux, the one platform where those two
+    # backends exist - so what remains to decide is which of them this host can
+    # actually load.
+    if not offscreen_here:
+        return _fail(
+            "MUJOCO_GL not set and no display detected",
+            fix=_no_offscreen_remedy(
+                f"{platform.system()} has no offscreen MuJoCo backend, so a window server is required"
+            ),
+        )
+    # The command has to stay runnable, so any second choice goes in the comment.
+    alternatives = " or ".join(offscreen_here[1:])
+    fix = f"export MUJOCO_GL={offscreen_here[0]}  # "
+    fix += f"or {alternatives}; add to ~/.bashrc" if alternatives else "add to ~/.bashrc"
+    return _fail("MUJOCO_GL not set and no display detected", fix=fix)
 
 
 def check_lerobot() -> str:

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -135,6 +135,57 @@ def _mujoco_gl_offscreen_values(system: str | None = None) -> frozenset[str]:
     return _MUJOCO_GL_OFFSCREEN & _mujoco_gl_valid_values(system)
 
 
+# The system library each offscreen backend loads, in the order
+# ``_configure_gl_backend`` probes them. A caller deciding what to *recommend*
+# reads this rather than the platform vocabulary above: the two answer different
+# questions, and only this one says whether a host can reach the backend.
+_MUJOCO_GL_OFFSCREEN_LIBRARIES: tuple[tuple[str, str], ...] = (
+    ("egl", "libEGL.so.1"),
+    ("osmesa", "libOSMesa.so"),
+)
+
+
+def _library_loads(name: str) -> bool:
+    """Whether a shared library can be loaded on this host.
+
+    Args:
+        name: Library soname, as :func:`ctypes.cdll.LoadLibrary` takes it.
+
+    Returns:
+        Whether the loader found it.
+    """
+    try:
+        ctypes.cdll.LoadLibrary(name)
+    except OSError:
+        return False
+    return True
+
+
+def _mujoco_gl_loadable_offscreen_values(system: str | None = None) -> frozenset[str]:
+    """Offscreen backends this host can reach, not merely the ones it accepts.
+
+    :func:`_mujoco_gl_offscreen_values` answers a platform question: which
+    offscreen values MuJoCo accepts on this operating system. Whether one of them
+    can *render* is a different question, because each loads a system library that
+    may not be installed. Recommending a value whose library is absent sends the
+    reader after an export that changes nothing - which is why a verdict offering
+    an offscreen backend reads this set and keeps the platform set only to tell
+    "this platform has no offscreen backend" apart from "its libraries are
+    missing".
+
+    Args:
+        system: Platform name as :func:`platform.system` reports it. Defaults to
+            the running platform.
+
+    Returns:
+        The platform's offscreen backends whose library loads here.
+    """
+    accepted = _mujoco_gl_offscreen_values(system)
+    return frozenset(
+        value for value, library in _MUJOCO_GL_OFFSCREEN_LIBRARIES if value in accepted and _library_loads(library)
+    )
+
+
 # glvnd EGL vendor ICD payload that points at the NVIDIA EGL library, plus the
 # standard directories glvnd scans for vendor ICD JSON files. When MUJOCO_GL is
 # "egl", libglvnd loads the first vendor whose ICD JSON is registered here; an

--- a/tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py
+++ b/tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py
@@ -77,11 +77,22 @@ def _recommended_values(verdict: str) -> set[str]:
 
 @pytest.fixture
 def linux_headless(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
-    """A headless Linux host: the platform where every backend name is available."""
+    """A headless Linux host: the platform where every backend name is available.
+
+    Availability has two axes and both are staged. The platform decides which
+    names MuJoCo *accepts*; the installed libraries decide which of them can
+    *render*, and a remedy is only worth offering when both hold. Staging only the
+    platform left every remedy assertion below reading the libraries of whichever
+    machine ran the suite, so a host without OSMesa disagreed about the advice
+    while agreeing about the verdict.
+    """
+    import strands_robots.simulation.mujoco.backend as backend
+
     monkeypatch.setattr(platform, "system", lambda: "Linux")
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.delenv("DISPLAY", raising=False)
     monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setattr(backend, "_library_loads", lambda _name: True)
     return monkeypatch
 
 

--- a/tests/test_doctor_mujoco_gl_remedy_names_a_reachable_backend.py
+++ b/tests/test_doctor_mujoco_gl_remedy_names_a_reachable_backend.py
@@ -146,6 +146,24 @@ class TestWhatIsUnchanged:
     command.
     """
 
+    @pytest.mark.parametrize("value", ["egl", "osmesa"])
+    @pytest.mark.parametrize("loadable", [set(), {"egl"}, {"osmesa"}], ids=["neither", "only-egl", "only-osmesa"])
+    def test_an_offscreen_backend_passes_whether_or_not_its_library_is_here(
+        self, linux_host, value: str, loadable: set[str]
+    ) -> None:
+        """Classification is the platform's question, not this host's.
+
+        Whether ``egl`` *is* an offscreen backend is a property of MuJoCo, so a
+        reader who set one keeps the verdict it earns even where its library is
+        absent. Narrowing this to what can load reclassified such a value as a
+        display backend and warned that it needs a display - on a host that has
+        OSMesa and no EGL, ``MUJOCO_GL=egl`` read as ``WARN (needs display)``.
+        """
+        assert _marker(linux_host(loadable, value)) == "PASS", (
+            f"{value} is an offscreen backend on Linux however this host is provisioned: "
+            f"{_plain(linux_host(loadable, value))!r}"
+        )
+
     @pytest.mark.parametrize("value,expected", _REMEDY_SITES)
     def test_the_verdict_is_still_the_one_the_setting_earns(self, linux_host, value: str | None, expected: str) -> None:
         assert _marker(linux_host(set(), value)) == expected, "an absent library is not a different diagnosis"

--- a/tests/test_doctor_mujoco_gl_remedy_names_a_reachable_backend.py
+++ b/tests/test_doctor_mujoco_gl_remedy_names_a_reachable_backend.py
@@ -1,0 +1,248 @@
+"""A MUJOCO_GL remedy names a backend this host can reach, not merely accept.
+
+``check_mujoco_gl`` already reasons about not recommending a value MuJoCo would
+refuse: its own docstring says "what to recommend has to be valid here", and a
+sibling case pins that a Darwin remedy never offers a Linux backend. That
+validates the advice against the *platform's vocabulary*.
+
+Reachability is a second axis. Each offscreen backend loads a system library -
+``egl`` needs ``libEGL.so.1``, ``osmesa`` needs ``libOSMesa.so`` - and a host can
+accept a value whose library is not installed. Recommending it then sends the
+reader after an export that changes nothing, and on a host with neither library
+the real remedy is the library rather than a different variable. The backend
+module already probes exactly this, in ``_configure_gl_backend``, and its own
+warning names the packages; the verdict did not read that probe, so on a host
+missing OSMesa it still offered ``osmesa``, and on a host missing both it offered
+an export where nothing exportable can render.
+
+The library table below is transcribed rather than imported, so these cases grade
+the shipped behaviour against a second opinion; one drift case pins the two
+against each other, and another pins the configurator's own probe against it so
+the two readers of that table cannot disagree about what a host can reach.
+"""
+
+from __future__ import annotations
+
+import inspect
+import platform
+import re
+import sys
+
+import pytest
+
+# The offscreen backends and the library each one loads, transcribed independently.
+_OFFSCREEN_LIBRARIES = (("egl", "libEGL.so.1"), ("osmesa", "libOSMesa.so"))
+
+
+def _plain(verdict: str) -> str:
+    """The verdict with ANSI colour removed."""
+    return re.sub(r"\033\[[0-9;]*m", "", verdict)
+
+
+def _marker(verdict: str) -> str:
+    """The status a caller can recover from a verdict line."""
+    for name in ("FAIL", "WARN", "PASS", "SKIP"):
+        if f"  {name}  " in verdict:
+            return name
+    raise AssertionError(f"verdict carries no status marker: {verdict!r}")
+
+
+def _remedy(verdict: str) -> str:
+    """The remedy lines, without the headline that names the value under complaint."""
+    return "\n".join(_plain(verdict).split("\n")[1:])
+
+
+def _offscreen_values_recommended(verdict: str) -> set[str]:
+    """Offscreen backends the remedy tells the reader to set.
+
+    Matched case-sensitively and on a word boundary, so the library sonames a
+    remedy may name - ``libEGL.so.1``, ``libOSMesa.so`` - do not read as advice to
+    export a value. :meth:`TestTheProbeSetsAnswerDifferentQuestions.
+    test_a_library_soname_does_not_read_as_a_recommended_value` grades that.
+    """
+    remedy = _remedy(verdict)
+    return {value for value, _library in _OFFSCREEN_LIBRARIES if re.search(rf"\b{value}\b", remedy)}
+
+
+# Every setting that reaches a remedy naming an offscreen backend, with the
+# verdict it carries. ``None`` means the variable is unset.
+_REMEDY_SITES = [
+    pytest.param("off", "FAIL", id="a-disabled-gl-context"),
+    pytest.param("glfw", "WARN", id="a-display-backend-while-headless"),
+    pytest.param(None, "FAIL", id="unset-while-headless"),
+]
+
+
+@pytest.fixture
+def linux_host(monkeypatch: pytest.MonkeyPatch):
+    """A headless Linux host whose installed GL libraries the caller chooses.
+
+    Returns a callable taking the set of loadable backend names, so a case can
+    model a host with both libraries, one, or neither without touching the
+    machine running the suite.
+    """
+    import strands_robots.simulation.mujoco.backend as backend
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    def stage(loadable: set[str], mujoco_gl: str | None = None):
+        present = {library for value, library in _OFFSCREEN_LIBRARIES if value in loadable}
+        monkeypatch.setattr(backend, "_library_loads", lambda name: name in present)
+        if mujoco_gl is None:
+            monkeypatch.delenv("MUJOCO_GL", raising=False)
+        else:
+            monkeypatch.setenv("MUJOCO_GL", mujoco_gl)
+        from strands_robots.doctor import check_mujoco_gl
+
+        return check_mujoco_gl()
+
+    return stage
+
+
+class TestARemedyNamesOnlyAReachableBackend:
+    """A backend whose library is absent is advice the reader cannot follow."""
+
+    @pytest.mark.parametrize("value,expected", _REMEDY_SITES)
+    @pytest.mark.parametrize("loadable", [{"egl"}, {"osmesa"}], ids=["only-egl", "only-osmesa"])
+    def test_only_the_loadable_backend_is_recommended(
+        self, linux_host, value: str | None, expected: str, loadable: set[str]
+    ) -> None:
+        verdict = linux_host(loadable, value)
+        assert _marker(verdict) == expected, f"the verdict itself is unchanged: {_plain(verdict)!r}"
+        assert _offscreen_values_recommended(verdict) == loadable, (
+            f"a host that can load only {sorted(loadable)} must be offered only that; remedy was {_remedy(verdict)!r}"
+        )
+
+
+class TestNoOffscreenBackendIsReachable:
+    """With neither library installed, the remedy is the library, not a variable."""
+
+    @pytest.mark.parametrize("value,expected", _REMEDY_SITES)
+    def test_the_remedy_names_the_absent_libraries(self, linux_host, value: str | None, expected: str) -> None:
+        verdict = linux_host(set(), value)
+        remedy = _remedy(verdict)
+        for _value, library in _OFFSCREEN_LIBRARIES:
+            assert library in remedy, f"the reader needs the name of what is missing; remedy was {remedy!r}"
+
+    @pytest.mark.parametrize("value,expected", _REMEDY_SITES)
+    def test_the_remedy_recommends_no_export(self, linux_host, value: str | None, expected: str) -> None:
+        verdict = linux_host(set(), value)
+        assert _offscreen_values_recommended(verdict) == set(), (
+            "no exported value can render when neither library loads, so naming one is advice "
+            f"that cannot be followed: {_remedy(verdict)!r}"
+        )
+
+
+class TestWhatIsUnchanged:
+    """Over-reach controls: these hold before and after, and must keep holding.
+
+    The remedy is the only thing that moved. A host missing a library still earns
+    the verdict its setting earns, and the recommended command was already
+    runnable - a second choice has always belonged in the comment rather than in
+    the exported value, because ``export MUJOCO_GL=egl or osmesa`` is not a
+    command.
+    """
+
+    @pytest.mark.parametrize("value,expected", _REMEDY_SITES)
+    def test_the_verdict_is_still_the_one_the_setting_earns(self, linux_host, value: str | None, expected: str) -> None:
+        assert _marker(linux_host(set(), value)) == expected, "an absent library is not a different diagnosis"
+
+    @pytest.mark.parametrize("value,expected", _REMEDY_SITES)
+    @pytest.mark.parametrize("loadable", [{"egl"}, {"osmesa"}, {"egl", "osmesa"}], ids=["egl", "osmesa", "both"])
+    def test_the_recommended_command_stays_runnable(
+        self, linux_host, value: str | None, expected: str, loadable: set[str]
+    ) -> None:
+        verdict = linux_host(loadable, value)
+        for match in re.finditer(r"export MUJOCO_GL=(\S+)", _remedy(verdict)):
+            assert match.group(1) in {v for v, _ in _OFFSCREEN_LIBRARIES}, (
+                f"an exported value has to be one backend name, not a list: {_remedy(verdict)!r}"
+            )
+
+
+class TestTheProbeSetsAnswerDifferentQuestions:
+    """Premises: what each set is for, and that the extractor above is sound."""
+
+    def test_the_platform_set_ignores_the_libraries(self, linux_host) -> None:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        linux_host(set())
+        assert sorted(backend._mujoco_gl_offscreen_values()) == ["egl", "osmesa"], (
+            "the platform set answers what MuJoCo accepts on Linux, whatever is installed"
+        )
+
+    @pytest.mark.parametrize("loadable", [set(), {"egl"}, {"osmesa"}, {"egl", "osmesa"}])
+    def test_the_reachable_set_is_the_installed_subset(self, linux_host, loadable: set[str]) -> None:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        linux_host(loadable)
+        reachable = backend._mujoco_gl_loadable_offscreen_values()
+        assert reachable == loadable
+        assert reachable <= backend._mujoco_gl_offscreen_values(), "reachable is a subset of accepted"
+
+    def test_a_library_soname_does_not_read_as_a_recommended_value(self) -> None:
+        """Non-vacuity for :func:`_offscreen_values_recommended`."""
+        named = "  FAIL  x\n        install an offscreen GL library (libEGL.so.1, libOSMesa.so)"
+        assert _offscreen_values_recommended(named) == set(), "a soname is not an export instruction"
+        exported = "  FAIL  x\n        export MUJOCO_GL=egl  # or osmesa"
+        assert _offscreen_values_recommended(exported) == {"egl", "osmesa"}, "an export instruction is one"
+
+
+class TestTheProbeItselfAnswersAboutTheLoader:
+    """The probe, not the stub the cases above install.
+
+    Every case that models a host installs a stand-in for :func:`_library_loads`,
+    so nothing there grades the probe. These do, against the loader directly.
+    """
+
+    def test_a_soname_no_distribution_supplies_is_absent(self) -> None:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        assert not backend._library_loads("libstrands_robots_no_such_library.so.99"), (
+            "a probe that reports every soname present would recommend a backend on any host"
+        )
+
+    @pytest.mark.parametrize("library", [library for _value, library in _OFFSCREEN_LIBRARIES])
+    def test_the_probe_agrees_with_the_loader(self, library: str) -> None:
+        import ctypes
+
+        import strands_robots.simulation.mujoco.backend as backend
+
+        try:
+            ctypes.cdll.LoadLibrary(library)
+            present = True
+        except OSError:
+            present = False
+        assert backend._library_loads(library) is present, (
+            f"the probe and the loader disagree about {library} on this host"
+        )
+
+
+class TestTheProbeHasOneOwner:
+    """The configurator and the verdict must agree about what a host can reach."""
+
+    def test_the_table_matches_the_module(self) -> None:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        assert backend._MUJOCO_GL_OFFSCREEN_LIBRARIES == _OFFSCREEN_LIBRARIES, (
+            "the transcribed second opinion above has drifted from the module"
+        )
+
+    def test_the_configurator_probes_the_libraries_the_table_names(self) -> None:
+        """``_configure_gl_backend`` picks a backend from the same libraries.
+
+        It keeps its own ordered first-match probe, because it also stages the
+        NVIDIA vendor ICD when it selects EGL. What must not drift is *which*
+        libraries decide: a configurator probing one soname while the verdict
+        recommends from another would disagree about the same host.
+        """
+        import strands_robots.simulation.mujoco.backend as backend
+
+        source = inspect.getsource(backend._configure_gl_backend)
+        probed = set(re.findall(r"LoadLibrary\(\"([^\"]+)\"\)", source))
+        assert probed == {library for _value, library in _OFFSCREEN_LIBRARIES}, (
+            f"the configurator probes {sorted(probed)}, the recommendation table names "
+            f"{sorted(library for _v, library in _OFFSCREEN_LIBRARIES)}"
+        )


### PR DESCRIPTION
## The defect

`check_mujoco_gl` already reasons about not recommending a value MuJoCo would refuse. Its own comment
says so, and a sibling case pins that a Darwin remedy never offers a Linux backend:

```python
# What to recommend has to be valid here: on a platform whose only backend
# draws through the window server there is no offscreen value to offer, and
# naming one would send the reader after a value MuJoCo refuses.
offscreen_here = sorted(_mujoco_gl_offscreen_values())
```

That validates the advice against the **platform's vocabulary**. Valid is not the same as reachable:
each offscreen backend loads a system library, so a host can accept a value whose library is not
installed. `_configure_gl_backend` has always probed exactly this - it is how the package picks a
backend at import - and the verdict did not read that probe.

Measured on a headless Linux host with `libEGL.so.1` and no `libOSMesa.so`. Every verdict is correct;
every remedy naming an offscreen backend is not:

| `MUJOCO_GL` | verdict | remedy before | remedy after |
|---|---|---|---|
| `off` | `FAIL` disables MuJoCo's GL context | `export MUJOCO_GL=egl  # or unset it...` | unchanged |
| `glfw` | `WARN` (needs display) | `Set MUJOCO_GL=egl or osmesa for headless` | `Set MUJOCO_GL=egl for headless` |
| unset | `FAIL` not set and no display | `export MUJOCO_GL=egl  # or osmesa; add to ~/.bashrc` | `export MUJOCO_GL=egl  # add to ~/.bashrc` |

The `off` row is right by luck: `egl` sorts first, so the platform-derived list happened to lead with
the one backend that works. The other two name a backend that cannot render there.

With **neither** library installed, all three offered an export where nothing exportable can render:

| | before | after |
|---|---|---|
| `off` | `export MUJOCO_GL=egl  # or unset it...` | `install an offscreen GL library (libEGL.so.1, libOSMesa.so) - no exported value can render without one` |
| `glfw` | `Set MUJOCO_GL=egl or osmesa for headless` | same library advice |
| unset | `export MUJOCO_GL=egl  # or osmesa; add to ~/.bashrc` | same library advice |

That is the reachable state a new reader hits: the module's own warning already tells them at import
that neither library loaded, and the command they run to find out whether their machine is set up
answered with a variable.

## The change

`_mujoco_gl_loadable_offscreen_values` is `_configure_gl_backend`'s probe as a helper, over one table
of the `(backend, library)` pairs the configurator itself probes, so the two readers of that table
cannot disagree about what a host can reach. The configurator keeps its own ordered first-match probe
because it also stages the NVIDIA vendor ICD when it selects EGL; what must not drift is *which*
libraries decide, and a case pins that.

The verdict recommends from the reachable set and keeps the platform set only to tell "this platform
has no offscreen backend" apart from "this host is missing their libraries" - the first earns the
existing window-server wording, the second earns the library name. **The verdict a setting earns is
unchanged; only the remedy moved.** No new install-advice string: `rendering.py` owns the
`apt-get install libosmesa6-dev` sentence and a guard pins it to one occurrence, so this names the
sonames from the new table instead.

Probe cost is `34.27 us` for both libraries, on a path `_configure_gl_backend` already walks at every
package import.

## Why nothing caught it

The sibling suite's fixture stages one of the two axes, and its docstring already claimed both:

```python
def linux_headless(monkeypatch):
    """A headless Linux host: the platform where every backend name is available."""
    monkeypatch.setattr(platform, "system", lambda: "Linux")
    ...
```

So every remedy assertion in it read whichever libraries the machine running the suite happened to
have - agreeing about the verdict while disagreeing about the advice. On this host, four of its cases
disagreed. The fixture now stages both axes, and the four are byte-identical to before on a host with
both libraries, which is what CI installs.

## Verification

**Pre-fix split** (behavioural: the backend helper kept, the verdict's use of it reverted) -
`11 failed / 104 passed`:

| class | failed/total | role |
|---|---|---|
| `TestNoOffscreenBackendIsReachable` | 6/6 | regression |
| `TestARemedyNamesOnlyAReachableBackend` | 5/6 | regression |
| `TestWhatIsUnchanged` | 0/12 | over-reach control |
| `TestTheProbeSetsAnswerDifferentQuestions` | 0/6 | premise |
| `TestTheProbeItselfAnswersAboutTheLoader` | 0/3 | premise |
| `TestTheProbeHasOneOwner` | 0/2 | drift pin |
| 9 sibling classes | 0/83 | unchanged |

The one passing regression case is the `only-egl` + `MUJOCO_GL=off` cell: the pre-fix code offered
`egl` there because it sorts first. A raw revert of both files is a setup error instead, since the
repaired fixture references a symbol main lacks.

**Mutation table** (`mine` = failures in the new file beyond the control; `sib` = in the four
neighbouring suites):

| mutation | mine | sib |
|---|---|---|
| control | 0 | 0 |
| the verdict reads the accepted set, not the reachable one | 11 | 0 |
| unset+headless reverts to the hardcoded pair | 2 | 0 |
| the no-offscreen remedy never names the libraries | 3 | 0 |
| the reachable helper ignores the probe | 14 | 0 |
| the table names a soname the configurator does not probe | 6 | 0 |
| the probe always reports the library present | 2 | 0 |
| the probe reports present on a load error | 2 | 0 |
| absent libraries listed whatever the platform accepts | 0 | 0 |

The last row is a measured no-op with a structural reason: no platform accepts exactly one of
`egl`/`osmesa`, so on Linux that filter is always true and on Darwin the branch is not reached. It is
kept because it is the correct expression of "libraries for backends this platform accepts".

The probe rows were `0` until a case graded the probe against the loader directly - every host model
installs a stand-in for it, so nothing reached the real `ctypes` call.

**Gate.** Identical 670-path selection (every suite walking the tree, parsing source, or reading
docstrings, `Args:`, `Raises:`, `__all__` or `changelog.d`, plus every `tests/test_doctor*` and
`tests/simulation/mujoco/`), new file withheld from both sides: `26022` collected each,
**branch-only failures EMPTY**, 22 shared. All 22 measured environmental: 17 need `awsiot`/`awscrt`
(`find_spec` False, declared in `[mesh-iot]`, which `all` includes and hatch installs), 3 the
lerobot-from-source `encode()` drift, 2 `PackageNotFoundError` for the editable install's metadata in
a bare worktree. mypy `5 == 5` with both normalized diffs empty and 0 attributable. `ruff check` and
`ruff format --check` clean. `35 passed` in the new file; `250 passed` across it, the sibling suite and
the neighbouring doctor/backend suites.

No visual artifact: this is a diagnostic verdict's remedy text, not a policy, simulation, rendering,
recording or asset change. The measured before/after tables are the evidence.

## Deliberately not done

`_configure_gl_backend` keeps its own probe rather than delegating: it needs ordered first-match plus a
conditional side effect (the vendor ICD), and a case pins the libraries instead. The refusal for a
value MuJoCo rejects still offers the platform's whole accepted set, including `glfw` - it answers
"what does MuJoCo accept", which is the right question for a value MuJoCo refuses.

## Correction, second commit

The first commit narrowed the offscreen set used for **classification** as well as for the
recommendation. `check_mujoco_gl` decides whether a value the reader set is an offscreen backend with
the same set it recommends from, so on a host with OSMesa and no EGL - which is how CI is provisioned -
`MUJOCO_GL=egl` stopped reading as an offscreen backend and earned `WARN  MUJOCO_GL=egl (needs
display)` with `Set MUJOCO_GL=osmesa for headless`. The "the verdict a setting earns is unchanged"
claim above was false of that commit; it is true of this one.

Whether `egl` *is* an offscreen backend is a property of MuJoCo, not of this host's libraries, so
classification reads the platform vocabulary and only the recommendation narrows to what can load. On
an OSMesa-only host `MUJOCO_GL=egl` now reads `PASS  MUJOCO_GL=egl`.

| mutation | mine | sib |
|---|---|---|
| classification narrowed to the loadable set (what the first commit shipped) | 4 | 0 |

That `sib` of `0` is the point: `tests/test_doctor.py::TestDockerChecksPlaceholder` aside, the sibling
case that caught this can only fail where EGL is absent, so a run on a host with EGL and no OSMesa
cannot see it. The case added here stages loadability, so it holds on either host - and the two are
exact complements, which is why the gate above was clean and CI was not.
