### PR TITLE
fix(policies/microduck): raw_accel slot two is a gravity direction, not the reading

### DIFF
--- a/changelog.d/2913-microduck-raw-accel-gravity-direction.md
+++ b/changelog.d/2913-microduck-raw-accel-gravity-direction.md
@@ -1,0 +1,32 @@
+### Fixed: `raw_accel` slot two carries a gravity direction, not the accelerometer reading
+
+`build_observation(..., gravity_source="raw_accel")` wrote the `base_acc` reading
+into slot two of the observation vector unchanged.  Pollen's
+`get_raw_accelerometer` does not: it negates the reading, normalises it, and
+rotates `base_quat` instead when the magnitude is too small to carry a
+direction.  So both `gravity_source` branches produce a *unit* gravity direction
+in the base frame - they are two estimators of one quantity rather than two
+quantities in different units, which is what makes a `raw_accel` export
+interchangeable with an alpha export on the same robot.
+
+Measured on a settled duck (`scene.xml`, `|accel| = 9.8100`): the two reference
+branches agree to 1e-6, while the shipped write differed from the reference by
+`max|d| = 10.060244` with all three components sign-flipped - a vector 9.81x too
+long pointing the opposite way, in a slot the export was trained to receive a
+unit direction in.  In free fall (`|accel| = 0`, where the accelerometer carries
+no direction at all) the reference falls back to the rotation and the shipped
+write produced a zero block.  Both wrong values were finite and both were the
+documented width, so nothing downstream refused either.
+
+`raw_accel_gravity` now sits beside `projected_gravity` as the single owner of
+that estimator, and the raw-accel path requires `base_quat` as well as
+`base_acc`: the degenerate-reading fallback is the rotation, so requiring the
+orientation up front refuses a short observation dict on the first tick rather
+than at the moment the robot leaves the ground.  Both readings now match the
+reference at `max|d| = 0.000000`.
+
+The `projected_gravity` default - every currently shipped alpha policy - is
+unchanged and still reproduces its pre-change vector byte-for-byte.  This module
+still never rescales the assembled vector; the fused `EmpiricalNormalization`
+baked into the graph remains the only thing that does, and the one normalisation
+here is the estimator's own unit-vector step.

--- a/strands_robots/policies/microduck/__init__.py
+++ b/strands_robots/policies/microduck/__init__.py
@@ -24,6 +24,7 @@ from .observation import (
     decode_action,
     projected_gravity,
     quat_rotate_inverse,
+    raw_accel_gravity,
 )
 from .policy import (
     MICRODUCK_DEFAULT_POSE,
@@ -41,5 +42,6 @@ __all__ = [
     "build_observation",
     "decode_action",
     "projected_gravity",
+    "raw_accel_gravity",
     "quat_rotate_inverse",
 ]

--- a/strands_robots/policies/microduck/observation.py
+++ b/strands_robots/policies/microduck/observation.py
@@ -9,10 +9,11 @@ The layout is a fixed concatenation (measured off Pollen's reference
 ``observation_names`` metadata)::
 
     base_ang_vel        (3)
-    projected_gravity   (3)   world -Z rotated into the base frame from
-                              ``base_quat``.  A ``gravity_source="raw_accel"``
-                              export reads ``base_acc`` (3, m/s^2) verbatim
-                              into this slot instead - the choice is
+    projected_gravity   (3)   a UNIT gravity direction in the base frame. A
+                              ``projected_gravity`` export rotates world -Z
+                              from ``base_quat``; a ``gravity_source="raw_accel"``
+                              export estimates the same direction from
+                              ``base_acc`` (3, m/s^2). The choice is
                               training-time and baked into the ONNX metadata.
     joint_pos_relative  (14)  current joint pos - DEFAULT_POSE, contract order
     joint_vel           (14)  contract order
@@ -26,7 +27,10 @@ command slots stay PRESENT and zero (the dead-weight rule) so one obs layout
 serves every policy in a bundle.
 
 CRITICAL: ``EmpiricalNormalization`` is baked INTO the exported ONNX graph, so
-the vector built here is fed RAW to the session. This module never normalises.
+the vector built here is fed RAW to the session. This module never rescales the
+assembled vector. The one normalisation it performs is inside
+:func:`raw_accel_gravity`, and that is the ``raw_accel`` export's own estimator -
+Pollen returns a unit gravity direction there - rather than a scaling choice.
 """
 
 from __future__ import annotations
@@ -52,14 +56,22 @@ _BASE_ACC_LEN = 3
 #: Component count of the projected-gravity block ``base_quat`` is reduced to.
 _GRAVITY_LEN = 3
 
-#: The two ONNX ``gravity_source`` values ``build_observation`` accepts.  Slot
-#: two of the vector is either the projected-gravity block (world ``-Z`` rotated
-#: into the base frame from ``base_quat``) or the raw accelerometer reading
-#: (``base_acc``, m/s^2) verbatim.  Older Pollen exports and some backlash
-#: variants ship with ``raw_accel``; every currently-shipped alpha policy is
-#: ``projected_gravity``, which is why that stays the default when the metadata
-#: is silent.  Both spellings are exactly the two ``self.use_projected_gravity``
-#: branches Pollen's own ``get_observations`` selects between.
+#: Magnitude below which the negated accelerometer carries no usable direction
+#: and :func:`raw_accel_gravity` rotates ``base_quat`` instead. Pollen's own
+#: threshold; free fall reads ``|accel| = 0`` and lands here.
+_RAW_ACCEL_MIN_MAGNITUDE = 0.1
+
+#: The two ONNX ``gravity_source`` values ``build_observation`` accepts. Slot two
+#: of the vector is a UNIT gravity direction in the base frame either way: the
+#: ``projected_gravity`` branch rotates world ``-Z`` from ``base_quat``, and the
+#: ``raw_accel`` branch estimates the same direction from the accelerometer (see
+#: :func:`raw_accel_gravity`). They are two estimators of ONE quantity, not two
+#: quantities - on a settled duck they agree to 1e-6. Older Pollen exports and
+#: some backlash variants ship with ``raw_accel``; every currently-shipped alpha
+#: policy is ``projected_gravity``, which is why that stays the default when the
+#: metadata is silent. Both spellings are exactly the two
+#: ``self.use_projected_gravity`` branches Pollen's own ``get_observations``
+#: selects between.
 GRAVITY_SOURCE_PROJECTED = "projected_gravity"
 GRAVITY_SOURCE_RAW_ACCEL = "raw_accel"
 _GRAVITY_SOURCES: tuple[str, ...] = (GRAVITY_SOURCE_PROJECTED, GRAVITY_SOURCE_RAW_ACCEL)
@@ -83,6 +95,44 @@ def quat_rotate_inverse(quat: NDArray[np.float32], vec: NDArray[np.float32]) -> 
 def projected_gravity(base_quat: NDArray[np.float32]) -> NDArray[np.float32]:
     """World ``-Z`` expressed in the base frame, from the base quaternion (wxyz)."""
     return quat_rotate_inverse(base_quat, _WORLD_GRAVITY)
+
+
+def raw_accel_gravity(base_acc: NDArray[np.float32], base_quat: NDArray[np.float32]) -> NDArray[np.float32]:
+    """Gravity direction estimated from the accelerometer, as Pollen derives it.
+
+    A resting IMU measures the reaction to gravity, so the NEGATED reading points
+    along gravity, and normalising it gives the same UNIT direction
+    :func:`projected_gravity` derives from the orientation. Pollen's
+    ``get_raw_accelerometer`` is exactly that - negate, normalise, and, when the
+    magnitude is too small to carry a direction, rotate world ``-Z`` instead:
+
+        accel_negated = -accel_raw
+        mag = np.linalg.norm(accel_negated)
+        if mag > 0.1:
+            return accel_negated / mag
+        else:
+            return self.quat_rotate_inverse(quat, world_gravity)
+
+    So the two ``gravity_source`` branches are two estimators of ONE quantity. On
+    a settled duck (``|accel| = 9.81``) they agree to 1e-6. Writing ``base_acc``
+    into slot two unchanged instead hands the network a vector 9.81x too long
+    with every component sign-flipped, and a robot in free fall
+    (``|accel| = 0``) a zero vector carrying no direction at all - both finite,
+    both the documented width, and neither what the export was trained on.
+
+    Args:
+        base_acc: Accelerometer reading (3, m/s^2) in the base frame.
+        base_quat: Base orientation (4, wxyz). Read only for the degenerate
+            fallback, which is why this path requires it.
+
+    Returns:
+        A unit ``float32`` gravity direction in the base frame.
+    """
+    negated = -np.asarray(base_acc, dtype=np.float32)
+    magnitude = float(np.linalg.norm(negated))
+    if magnitude > _RAW_ACCEL_MIN_MAGNITUDE:
+        return (negated / magnitude).astype(np.float32)
+    return projected_gravity(base_quat)
 
 
 def _require_base_block(observation_dict: dict[str, Any], key: str, expected_len: int) -> NDArray[np.float32]:
@@ -228,8 +278,9 @@ def build_observation(
         gravity_source: Which reading fills slot two of the vector.
             ``"projected_gravity"`` (default) rotates world ``-Z`` into the
             base frame from ``base_quat`` (the shipped alpha convention);
-            ``"raw_accel"`` reads ``base_acc`` verbatim (older exports, some
-            backlash variants).  Both are the two branches Pollen's own
+            ``"raw_accel"`` estimates the same unit direction from ``base_acc``
+            (older exports, some backlash variants) - see
+            :func:`raw_accel_gravity`.  Both are the two branches Pollen's own
             ``get_observations`` selects between under
             ``self.use_projected_gravity``; the choice is a training-time flag
             baked into the export, so ``MicroduckPolicy`` reads it out of the
@@ -246,6 +297,10 @@ def build_observation(
 
     Raises:
         KeyError: If a required joint / base key is absent from the obs dict.
+            ``raw_accel`` needs BOTH ``base_acc`` and ``base_quat``, because the
+            degenerate-reading fallback is the rotation; requiring it up front
+            refuses at the first tick rather than at the moment the robot leaves
+            the ground.
         ValueError: If ``base_ang_vel`` or the ``gravity_source`` block is not
             the width its observation block defines (3 and 4 for ``base_quat``,
             3 for ``base_acc``). Both are read into fixed slots of the returned
@@ -271,12 +326,18 @@ def build_observation(
     if gravity_source == GRAVITY_SOURCE_PROJECTED:
         grav = projected_gravity(_require_base_block(observation_dict, "base_quat", _BASE_QUAT_LEN))
     else:
-        # ``raw_accel``: slot two is the accelerometer reading verbatim, no
-        # rotation and no normalisation - Pollen's ``get_raw_accelerometer``
-        # returns ``sensordata`` for the IMU as-is, and any scaling the export
-        # expects lives inside the fused normaliser baked into the ONNX graph
-        # (the same reason ``projected_gravity`` is not normalised here).
-        grav = _require_base_block(observation_dict, "base_acc", _BASE_ACC_LEN)
+        # ``raw_accel``: the accelerometer is a second ESTIMATOR of the same unit
+        # gravity direction, not a second quantity - Pollen's
+        # ``get_raw_accelerometer`` negates, normalises, and falls back to the
+        # rotation for a degenerate reading. See :func:`raw_accel_gravity`. This
+        # is the one normalisation this module performs, and it is the export's
+        # own contract rather than a scaling choice: the fused
+        # ``EmpiricalNormalization`` inside the graph is still the only thing
+        # that rescales the assembled vector.
+        grav = raw_accel_gravity(
+            _require_base_block(observation_dict, "base_acc", _BASE_ACC_LEN),
+            _require_base_block(observation_dict, "base_quat", _BASE_QUAT_LEN),
+        )
 
     joint_pos = np.array([float(observation_dict[name]) for name in joint_names], dtype=np.float32)
     joint_pos_rel = joint_pos - np.asarray(default_pose, dtype=np.float32)

--- a/tests/policies/microduck/test_microduck_gravity_source.py
+++ b/tests/policies/microduck/test_microduck_gravity_source.py
@@ -2,8 +2,10 @@
 
 Pollen's reference ``scripts/infer_policy.py`` supports two ``get_observations``
 branches at slot two of the 61-D vector: ``projected_gravity`` (world ``-Z``
-rotated into the base frame from ``base_quat``) and ``raw_accel`` (the
-accelerometer's ``sensordata`` verbatim).  The choice is a training-time flag
+rotated into the base frame from ``base_quat``) and ``raw_accel`` (the same unit
+direction estimated from the accelerometer - ``get_raw_accelerometer`` negates
+the reading, normalises it, and rotates ``base_quat`` when the magnitude is too
+small to carry a direction).  The choice is a training-time flag
 (``self.use_projected_gravity``) baked into the export, and every currently
 shipped alpha policy is ``projected_gravity``.  ``build_observation``, before
 this change, unconditionally rotated ``base_quat``; a ``raw_accel`` export fed
@@ -13,7 +15,9 @@ resulting drift was silent - the network kept producing plausible actions.
 This file grades the four contracts the switch has to satisfy:
 
 1. ``build_observation(..., gravity_source="raw_accel")`` reads ``base_acc`` (3)
-   and writes it VERBATIM into slot two.  No rotation, no scaling, no sign flip.
+   and ``base_quat`` (4) and writes the UNIT gravity direction Pollen's
+   ``get_raw_accelerometer`` derives from them into slot two.  Both branches
+   estimate ONE quantity: for a resting reading they agree to 1e-6.
 2. The same call refuses a missing ``base_acc`` key with the shared
    :func:`~strands_robots.utils.finite_vector_error`-style contract that
    ``_require_base_block`` already applies to ``base_quat``.
@@ -44,6 +48,7 @@ from strands_robots.policies.microduck import (
     MICRODUCK_JOINT_NAMES,
     MicroduckPolicy,
     build_observation,
+    projected_gravity,
 )
 
 
@@ -77,36 +82,160 @@ def _command_zeros(width: int = 13) -> np.ndarray:
 # ---------------------------------------------------------------------------
 
 
-def test_raw_accel_writes_base_acc_verbatim_into_slot_two() -> None:
-    """``gravity_source="raw_accel"`` reads ``base_acc`` and places it in slot two unchanged.
+def _pollen_raw_accelerometer(accel: Any, quat: Any) -> np.ndarray:
+    """Pollen's ``get_raw_accelerometer``, transcribed from ``infer_policy.py``.
 
-    Slot two spans indices 3..5 (base_ang_vel is 0..2).  A ``base_acc`` of
-    ``[0.5, -1.25, 9.81]`` (a lightly-non-canonical acceleration a hardware
-    IMU might report) has to appear at exactly those indices.  The floating
-    point comparison is byte-identical (``==``) rather than
-    :func:`numpy.testing.assert_allclose` because the pre-change ``base_quat``
-    path went through ``quat_rotate_inverse`` and produced a slot two that
-    was 0.999...-something; a ``raw_accel`` implementation that quietly
-    normalises or rotates the vector would still be ``allclose`` but would
-    fail this cell.
+    Stated locally rather than imported so the cells below grade the shipped
+    estimator against a second, independent statement of the reference instead
+    of against itself.
     """
-    accel = np.array([0.5, -1.25, 9.81], dtype=np.float32)
-    obs = _base_dict(extra={"base_acc": accel.tolist()})
+    negated = -np.asarray(accel, dtype=np.float32)
+    magnitude = float(np.linalg.norm(negated))
+    if magnitude > 0.1:
+        return np.asarray(negated / magnitude, dtype=np.float32)
+    q = np.asarray(quat, dtype=np.float32)
+    world_gravity = np.array([0.0, 0.0, -1.0], dtype=np.float32)
+    t = np.cross(q[1:4], world_gravity) * 2.0
+    return np.asarray(world_gravity - q[0] * t + np.cross(q[1:4], t), dtype=np.float32)
 
+
+def _slot_two(obs: dict[str, Any], source: str) -> np.ndarray:
+    """Build the vector and return slot two (indices 3..5)."""
     vector = build_observation(
         obs,
         joint_names=list(MICRODUCK_JOINT_NAMES),
         default_pose=np.array(MICRODUCK_DEFAULT_POSE, dtype=np.float32),
         last_action=_last_action_zeros(),
         command=_command_zeros(),
-        gravity_source=GRAVITY_SOURCE_RAW_ACCEL,
+        gravity_source=source,
     )
-
     assert vector.dtype == np.float32
     # 48 layout components + 13 command = 61-D alpha vector, unchanged.
     assert vector.shape == (61,)
-    # Slot two: indices 3..5 = base_acc verbatim.
-    np.testing.assert_array_equal(vector[3:6], accel)
+    return np.asarray(vector[3:6], dtype=np.float32)
+
+
+def test_raw_accel_writes_the_unit_gravity_direction_not_the_reading() -> None:
+    """``gravity_source="raw_accel"`` negates and normalises ``base_acc`` into slot two.
+
+    Slot two spans indices 3..5 (base_ang_vel is 0..2).  Pollen's
+    ``get_raw_accelerometer`` returns ``-accel / |accel|`` for a usable reading,
+    so the block is a UNIT gravity direction - the same quantity the
+    ``projected_gravity`` branch derives from the orientation, in the same units.
+
+    Writing the reading unchanged instead puts a vector ``|accel|``-times too
+    long, with every component sign-flipped, into a slot the export was trained
+    to receive a unit direction in.  Both are finite and both are the documented
+    width, so nothing downstream refuses either; this cell is what makes the
+    difference observable at all.
+    """
+    accel = np.array([0.5, -1.25, 9.81], dtype=np.float32)
+    obs = _base_dict(extra={"base_acc": accel.tolist()})
+
+    slot_two = _slot_two(obs, GRAVITY_SOURCE_RAW_ACCEL)
+
+    np.testing.assert_allclose(slot_two, _pollen_raw_accelerometer(accel, (1.0, 0.0, 0.0, 0.0)), rtol=0, atol=1e-6)
+    assert np.isclose(float(np.linalg.norm(slot_two)), 1.0, atol=1e-6)
+    # Not the reading: the scale and every sign differ.
+    assert not np.allclose(slot_two, accel)
+    assert float(np.linalg.norm(accel)) > 9.0
+
+
+@pytest.mark.parametrize(
+    "accel",
+    [
+        (0.5, -1.25, 9.81),
+        (-9.1296, 0.0001, 3.5898),  # the settled duck's own reading, measured in sim
+        (0.0, 0.0, 9.81),
+        (1e-3, -2e-3, 4e-3),  # |accel| = 4.6e-3, below the 0.1 threshold: the fallback
+        (3.0, 4.0, 0.0),
+    ],
+    ids=["non-canonical", "settled-duck", "canonical-up", "degenerate", "planar"],
+)
+def test_the_shipped_estimator_matches_pollens_for_every_reading(accel: tuple[float, ...]) -> None:
+    """Slot two equals the reference estimator for usable AND degenerate readings.
+
+    The reference is stated locally in :func:`_pollen_raw_accelerometer`, so this
+    is a parity check against a second statement of Pollen's algorithm rather
+    than a restatement of the implementation.  The ``degenerate`` row is below
+    the ``0.1`` magnitude threshold and therefore exercises the rotation
+    fallback through the same seam.
+    """
+    # Exactly unit in float32 (0.6^2 + 0.8^2 == 1.0), so the rotation preserves
+    # the norm and a 1e-6 unit-length assertion is a real check rather than a
+    # tolerance for the fixture's own rounding.
+    quat = (0.6, 0.0, 0.8, 0.0)
+    obs = _base_dict(base_quat=quat, extra={"base_acc": list(accel)})
+
+    slot_two = _slot_two(obs, GRAVITY_SOURCE_RAW_ACCEL)
+
+    np.testing.assert_allclose(slot_two, _pollen_raw_accelerometer(accel, quat), rtol=0, atol=1e-6)
+    assert np.isclose(float(np.linalg.norm(slot_two)), 1.0, atol=1e-6)
+
+
+def test_the_two_branches_agree_for_a_resting_reading() -> None:
+    """A resting IMU makes the two ``gravity_source`` branches one quantity.
+
+    At rest the accelerometer measures the reaction to gravity, so its reading is
+    ``-g`` times the projected-gravity direction.  Feeding that reading to the
+    ``raw_accel`` branch has to reproduce the ``projected_gravity`` branch's slot
+    two - which is what "two estimators of one quantity" means, and what makes a
+    ``raw_accel`` export interchangeable with an alpha export on the same robot.
+
+    Measured in sim on a settled duck the two agree to 1e-6; this cell states the
+    same property without needing MuJoCo.
+    """
+    quat = (0.6, 0.0, 0.8, 0.0)  # exactly unit in float32
+    projected = projected_gravity(np.array(quat, dtype=np.float32))
+    resting_reading = (-9.81 * projected).astype(np.float32)
+
+    from_quaternion = _slot_two(_base_dict(base_quat=quat), GRAVITY_SOURCE_PROJECTED)
+    from_accelerometer = _slot_two(
+        _base_dict(base_quat=quat, extra={"base_acc": resting_reading.tolist()}),
+        GRAVITY_SOURCE_RAW_ACCEL,
+    )
+
+    np.testing.assert_allclose(from_accelerometer, from_quaternion, rtol=0, atol=1e-6)
+
+
+def test_a_degenerate_reading_falls_back_to_the_rotation_rather_than_a_zero_block() -> None:
+    """An all-zero ``base_acc`` yields the rotated direction, not a zero vector.
+
+    Free fall reads ``|accel| == 0``: the accelerometer carries no direction at
+    all.  Pollen rotates ``base_quat`` in that case, so slot two stays a unit
+    vector.  Passing the reading through unchanged would hand the network a zero
+    block - finite, the documented width, and pointing nowhere.
+    """
+    quat = (0.6, 0.0, 0.8, 0.0)  # exactly unit in float32
+    obs = _base_dict(base_quat=quat, extra={"base_acc": [0.0, 0.0, 0.0]})
+
+    slot_two = _slot_two(obs, GRAVITY_SOURCE_RAW_ACCEL)
+
+    np.testing.assert_allclose(slot_two, projected_gravity(np.array(quat, dtype=np.float32)), rtol=0, atol=1e-6)
+    assert np.isclose(float(np.linalg.norm(slot_two)), 1.0, atol=1e-6)
+    assert not np.allclose(slot_two, np.zeros(3, dtype=np.float32))
+
+
+def test_raw_accel_requires_base_quat_for_the_fallback() -> None:
+    """The ``raw_accel`` path refuses a dict with no ``base_quat``, at the first tick.
+
+    The degenerate-reading fallback is the rotation, so this branch needs the
+    orientation as well as the accelerometer.  Requiring it up front means a
+    caller is refused on tick one rather than at the moment the robot leaves the
+    ground, which is the worst time to discover a missing key.
+    """
+    obs = _base_dict(extra={"base_acc": [0.5, -1.25, 9.81]})
+    del obs["base_quat"]
+
+    with pytest.raises(KeyError):
+        build_observation(
+            obs,
+            joint_names=list(MICRODUCK_JOINT_NAMES),
+            default_pose=np.array(MICRODUCK_DEFAULT_POSE, dtype=np.float32),
+            last_action=_last_action_zeros(),
+            command=_command_zeros(),
+            gravity_source=GRAVITY_SOURCE_RAW_ACCEL,
+        )
 
 
 def test_raw_accel_refuses_a_missing_base_acc_key() -> None:

--- a/tests/policies/microduck/test_microduck_observation_refuses_a_wrong_width_base_block.py
+++ b/tests/policies/microduck/test_microduck_observation_refuses_a_wrong_width_base_block.py
@@ -301,7 +301,10 @@ class TestBothBlocksRouteThroughTheOneReader:
         # is the projected-gravity block (from ``base_quat``) or the raw
         # accelerometer verbatim, chosen by ``gravity_source``.  All three
         # floating-base reads route through the width-holding reader.
-        assert sorted(keys) == ["base_acc", "base_ang_vel", "base_quat"], keys
+        # Deduplicated: ``base_quat`` is read on BOTH branches now (the raw-accel
+        # estimator falls back to the rotation), and the property here is that
+        # every base key goes through the reader, not that each is read once.
+        assert sorted(set(keys)) == ["base_acc", "base_ang_vel", "base_quat"], keys
 
     def test_the_widths_come_from_the_named_constants(self) -> None:
         """Not restated at the call site, so the layout has one account."""
@@ -318,7 +321,7 @@ class TestBothBlocksRouteThroughTheOneReader:
         # accelerometer contract.  Each of the three keys is held to the
         # width its observation block defines through a named constant, so
         # a layout change has one place to touch.
-        assert sorted(widths) == ["_BASE_ACC_LEN", "_BASE_ANG_VEL_LEN", "_BASE_QUAT_LEN"], widths
+        assert sorted(set(widths)) == ["_BASE_ACC_LEN", "_BASE_ANG_VEL_LEN", "_BASE_QUAT_LEN"], widths
         assert obs_mod._BASE_ANG_VEL_LEN == 3
         assert obs_mod._BASE_QUAT_LEN == 4
         assert obs_mod._BASE_ACC_LEN == 3
@@ -370,11 +373,26 @@ class TestThePremisesTheDefectRestedOn:
         cos = float(np.clip(np.dot(right, wrong) / (np.linalg.norm(right) * np.linalg.norm(wrong)), -1.0, 1.0))
         assert np.degrees(np.arccos(cos)) > min_tilt_deg
 
-    def test_nothing_in_this_module_reads_a_norm(self) -> None:
-        """So the norm drift is not a signal anything acts on."""
+    def test_the_only_norm_this_module_reads_is_the_accelerometer_estimator(self) -> None:
+        """So the norm drift is still not a signal anything acts on.
+
+        :func:`raw_accel_gravity` reads a norm to turn the accelerometer into the
+        unit gravity direction Pollen's ``get_raw_accelerometer`` returns - the
+        estimator's own arithmetic, on a block whose width the reader already
+        held. Nothing reads a norm to JUDGE a block, so a wrong-width
+        ``base_quat`` still produces no signal any code acts on, which is the
+        premise the measurement above rests on.
+        """
         source = inspect.getsource(obs_mod)
-        assert "linalg.norm" not in source
-        assert "This module never normalises." in source
+        norm_readers = sorted(
+            node.name
+            for node in ast.parse(source).body
+            if isinstance(node, ast.FunctionDef) and "linalg.norm" in ast.unparse(node)
+        )
+        assert norm_readers == ["raw_accel_gravity"], norm_readers
+        # Whitespace-normalised: the claim spans a line wrap in the docstring, so a
+        # raw substring match would grade the wrapping rather than the sentence.
+        assert "This module never rescales the assembled vector." in " ".join(source.split())
 
     def test_the_sibling_locomotion_builder_holds_the_same_block_to_a_width(self) -> None:
         """The in-package convention this builder was the exception to."""


### PR DESCRIPTION
## What is wrong

`build_observation(..., gravity_source="raw_accel")` wrote the `base_acc` reading into slot two of the observation vector unchanged. Pollen's `get_raw_accelerometer` does not (`microduck_rl/scripts/infer_policy.py:538-553`):

```python
accel_negated = -accel_raw
mag = np.linalg.norm(accel_negated)
if mag > 0.1:
    return accel_negated / mag
else:
    quat = self.data.xquat[self.trunk_base_id]...
    return self.quat_rotate_inverse(quat, world_gravity)
```

It negates the reading, normalises it, and rotates `base_quat` when the magnitude is too small to carry a direction. So **both `gravity_source` branches produce a unit gravity direction in the base frame** - they are two estimators of one quantity rather than two quantities in different units, which is exactly what makes a `raw_accel` export interchangeable with an alpha export on the same robot. `get_projected_gravity` is the same three lines the fallback runs.

## Measured

Driving the shipped `build_observation` on the registry asset in MuJoCo (headless), same reading into both trees:

| case | `\|accel\|` | reference | shipped slot two | `max\|d\|` | norm |
|---|---|---|---|---|---|
| settled on the floor | 9.8100 | `[0.930642, -9e-06, -0.365930]` | `[-9.129601, 9.3e-05, 3.589772]` | **10.060244** | 9.8100 |
| free fall | 1.8e-15 | `[0, -0, -1]` | `[1.3e-17, 1.1e-17, -1.8e-15]` | **1.000000** | 1.8e-15 |

All three components are sign-flipped in the settled case and the block is 9.81x too long; in free fall the reading carries no direction at all. Both wrong values are finite and both are the documented width, so nothing downstream refuses either - the graph consumes them and keeps producing plausible actions.

On the same readings the two reference branches agree to **1e-6**, which is the "one quantity" property. After this change both cases match the reference at **`max|d| = 0.000000`**.

![slot two before and after](https://github.com/cagataycali/robots/releases/download/artifacts/microduck_raw_accel_gravity.png)

## The change

`raw_accel_gravity` sits beside `projected_gravity` as the single owner of that estimator, and the raw-accel path requires `base_quat` as well as `base_acc`: the degenerate-reading fallback *is* the rotation, so requiring the orientation up front refuses a short observation dict on the first tick rather than at the moment the robot leaves the ground.

`projected_gravity` - the default, and every currently shipped alpha policy - is untouched and still reproduces its pre-change vector byte-for-byte.

The module's `CRITICAL` note now says it never rescales the *assembled vector* rather than that it never normalises: the fused `EmpiricalNormalization` inside the graph remains the only thing that rescales the vector, and the one normalisation here is the estimator's own unit-vector step. The sibling width suite's `nothing_in_this_module_reads_a_norm` premise is re-aimed at "the only norm read is the estimator's own", which is what keeps its argument standing - nothing reads a norm to *judge* a block, so a wrong-width `base_quat` still produces no signal any code acts on.

The contract cell that asserted the verbatim write is re-aimed at parity with the reference. Its own docstring had said an implementation "that quietly normalises or rotates the vector would ... fail this cell", so it was pinning the defect; leaving it would have told the next reader the wrong value was the contract.

## Verification

Pre-fix split (the branch reverted to the verbatim write, everything else kept): **9 failed / 45 passed**, 0 in the four premise and control classes.

| mutation | fires | note |
|---|---|---|
| b1 branch writes the reading verbatim (pre-fix) | 9 | the split above |
| b2 estimator drops the negation | 6 | identical set to b3 |
| b3 estimator drops the normalisation | 6 | both make slot two not a unit direction |
| b4 estimator drops the degenerate fallback | 2 | identical set to b5 |
| b5 fallback returns a zero block | 2 | both make the degenerate case not the rotation |
| b6 threshold widened so a usable reading falls back | 5 | |
| b7 threshold restated as the literal `0.1` | 0 | measured no-op: same value, so the named constant is a drift guard rather than behaviour |
| b8 raw-accel no longer requires `base_quat` | 2 | not a subset of b1: also adds a second norm reader |
| b9 estimator inlined at the call site | 1 | identical set to b10 |
| b10 the `CRITICAL` prose reverted | 1 | both caught by the single-owner cell |

Every row `sib=0` across the three sibling microduck suites, `collected` stable at 54, control clean, all three collisions confirmed as set identities, source restored byte-identically.

Gate: `ruff check` + `ruff format --check` clean over 1713 files; `mypy strands_robots tests tests_integ` **24 == 24** against the merge base with **0 attributable**; paired 557-path selection (every guard that walks the tree, parses source or reads docstrings, plus all of `tests/policies/`, with the two changed test files withheld from both sides) - identical **23344 collected** and `20 failed, 23254 passed, 70 skipped` on each side, 20 == 20 failing ids, **both `comm` directions empty**. Of the 20, 17 need `awsiot`/`awscrt` (`find_spec` false for both, both declared in the `mesh-iot` extra, which `all` pulls in, so CI installs them) and 3 are the lerobot-from-source `encode() takes 1 positional argument` drift.

## Deliberately not done

`base_acc` has no producer in the package - the MuJoCo backend emits `base_quat`, so the raw-accel branch is reached by a caller that supplies the reading itself for a `raw_accel` export. The fix is therefore latent on the shipped alpha path and correct for the branch the metadata flag selects; adding a `base_acc` producer is a backend question, not this one.
