### PR TITLE
fix(scripts): the merge-blocker report separates a held fork run from a head with no run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1222,7 +1222,10 @@ hatch run format            # ruff check --fix, ruff format
    unresolved thread or a failing check (the author), a missing approval (any
    reviewer), an approval only its own pusher supplied (a different reviewer,
    per #1905), a required check absent because a fork run is held at
-   `action_required` (a maintainer), a check still running (nobody), a
+   `action_required` (a maintainer, by approving each run), a required check
+   absent because the head carries no check suite at all (also a maintainer,
+   but by closing and reopening: there is no held run to approve and no
+   suite to re-run), a check still running (nobody), a
    mergeability GitHub has not finished computing (nobody, until a re-read), or
    no unsatisfied rule at all, which is the #2574 case and the one worth saying
    out loud. A conflict, a draft, or an uncomputed mergeability is reported as

--- a/changelog.d/2914-merge-blockers-separate-a-held-run-from-no-run.md
+++ b/changelog.d/2914-merge-blockers-separate-a-held-run-from-no-run.md
@@ -1,0 +1,61 @@
+### Fixed: the merge-blocker report separates a held fork run from a head with no run
+
+`scripts/check_merge_blockers.py` reported one outcome, `required-check-absent`,
+for two situations that need opposite actions, and the remedy it printed was
+correct for only one of them. Both are identical in every field the check read:
+`mergeStateStatus` BLOCKED, a null-ish `statusCheckRollup`, `reviewDecision`
+REVIEW_REQUIRED, and the required context absent from `check_conclusions`. One
+field separates them and it was not read.
+
+A fork run held at `action_required` is cleared by approving each run. A head
+carrying no check suite at all is not: that is the shape a head commit written
+through the API under the Actions `GITHUB_TOKEN` produces, whose events are
+suppressed so a workflow cannot re-trigger itself, and it has no held run to
+approve and no suite to re-run. The outcome's own text named "authorising or
+re-running the workflow" for both, so on the second a reader following the
+printed advice had nothing to click - and the detail said so out loud, stating
+the ambiguity accurately and then leaving it unresolved at exactly the moment
+one field would settle it.
+
+The wrong guess is not symmetric, which is why these are now two outcomes rather
+than one with a longer sentence. The cheap reflex on a null-ish rollup is the
+close/reopen, and applied to a held fork run it is a no-op that looks like a
+completed remedy: the runs already exist and stay held, so the flip re-queues
+nothing while costing a closed/reopened pair on a contributor's pull request. The
+reverse error is harmless by comparison, because approving runs that do not exist
+is simply unavailable.
+
+`resolve_check_suites` reads the head's suite census and `evaluate` splits on it:
+suites present with at least one at `conclusion: action_required` keeps
+`required-check-absent` and prints the approval; zero suites is the new
+`check-suite-absent`, which says that neither authorising nor re-running is
+available rather than merely unhelpful; and suites present with none held keeps
+the older description, which is the one shape for which "never started" is
+honest. An unread census keeps the older ambiguous wording and says the
+observation was not made, so naming a remedy always follows from having looked -
+and every existing caller classifies exactly as before. The census is
+`tuple[str | None, ...] | None` rather than a count defaulting to zero for that
+reason: `()` is a positive observation and "not read" is a third answer, and a
+default would have silently picked one of the two remedies.
+
+The approval remedy also names which field to read, because the obvious
+confirmation is misleading. `action_required` is a *conclusion* on this surface,
+never a status: a held run reports `status: "completed"`, so a client-side scan
+comparing the `status` field matches none of them. Measured on a live pull
+request carrying two held suites, a scan of the field matched zero while the
+conclusion matched two. The query parameter is not the problem - `GET
+/actions/runs?status=action_required` does accept a conclusion there and returned
+every held run - so the remedy tells the reader to find the runs by `head_sha`
+and recognise them by conclusion, which is the part a status comparison gets
+wrong.
+
+Both branches are pinned in `tests/test_merge_blockers.py`, which drives the
+outcome table from fixtures, so the split needs no live pull request to grade.
+One of those pins asserts that neither remedy appears in the detail for the state
+it cannot clear, which is the property whose absence was the defect. Alongside
+them, a derived guard now requires every outcome the report can emit to have an
+owner in `_OWED_BY`, taken by dataflow from what `Blocker` is constructed with
+rather than by spelling: a spelling rule misses the single-word `draft` and,
+loosened to admit it, matches the single-word owner `nobody`.
+
+Closes #2912.

--- a/scripts/check_merge_blockers.py
+++ b/scripts/check_merge_blockers.py
@@ -89,9 +89,25 @@ is*, so the outcomes group that way rather than by severity:
     ``pusher-only-approval`` while it was ``DIRTY``. Re-read to resolve it.
 
 ``required-check-absent``
-    A **maintainer**, by authorising or re-running the workflow. A fork pull
-    request whose runs are held at ``action_required`` reports ``completed``
-    with a null-ish rollup, which reads identically to "never ran".
+    A **maintainer**. *Which* move is decided by the head's check-suite census,
+    which is why that is read rather than assumed. Suites present with at least
+    one at ``conclusion: action_required`` is a fork run awaiting
+    authorisation: approve per run, and find the runs by ``head_sha`` and
+    recognise them by their *conclusion* -- a held run reports ``status:
+    "completed"``, so a client-side scan of the ``status`` field matches none of
+    them. Suites present and none held is the one shape for which "never
+    started" is the honest description.
+
+``check-suite-absent``
+    A **maintainer**, and not by anything they can authorise. Zero check suites
+    on the head means no run was ever created -- the shape a head commit written
+    through the API under the Actions ``GITHUB_TOKEN`` produces, whose events
+    are suppressed so a workflow cannot re-trigger itself. Authorising names an
+    authorisation that does not exist and re-running names a suite that does
+    not exist; the branch is closed and reopened with a personal access token.
+    Separated from the entry above because the reflex on a null-ish rollup is
+    that flip, and spending it on a *held* run re-queues nothing while looking
+    like a completed remedy.
 
 ``no-unsatisfied-rule``
     Every rule the branch carries is satisfied and it still reads blocked. This
@@ -191,6 +207,7 @@ DRAFT = "draft"
 REQUIRED_CHECK_FAILING = "required-check-failing"
 REQUIRED_CHECK_PENDING = "required-check-pending"
 REQUIRED_CHECK_ABSENT = "required-check-absent"
+CHECK_SUITE_ABSENT = "check-suite-absent"
 UNRESOLVED_THREADS = "unresolved-threads"
 MISSING_APPROVAL = "missing-approval"
 PUSHER_ONLY_APPROVAL = "pusher-only-approval"
@@ -211,6 +228,7 @@ _OWED_BY: dict[str, str] = {
     REQUIRED_CHECK_FAILING: AUTHOR,
     REQUIRED_CHECK_PENDING: NOBODY,
     REQUIRED_CHECK_ABSENT: MAINTAINER,
+    CHECK_SUITE_ABSENT: MAINTAINER,
     UNRESOLVED_THREADS: AUTHOR,
     MISSING_APPROVAL: REVIEWER,
     PUSHER_ONLY_APPROVAL: OTHER_REVIEWER,
@@ -313,6 +331,12 @@ class PullRequestState:
     merge_state: str
     unresolved_threads: int
     check_conclusions: dict[str, str | None] = field(default_factory=dict)
+    # Each check suite's conclusion on the head, or ``None`` for a census that
+    # was not read. ``()`` is a positive observation -- zero suites exist -- and
+    # is not the same answer as "not read", which is why this is not an ``int``
+    # defaulting to zero: the two need opposite remedies and a default would
+    # silently pick one.
+    check_suite_conclusions: tuple[str | None, ...] | None = None
     approvers: tuple[str, ...] = ()
     pusher: str | None = None
 
@@ -325,6 +349,81 @@ class PullRequestState:
 
 def _plural(count: int, noun: str) -> str:
     return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+_HELD = "action_required"
+
+
+def _held_suites(census: tuple[str | None, ...]) -> int:
+    """Count the suites a maintainer can approve.
+
+    ``action_required`` is a *conclusion* on this surface, never a status, so it
+    is read from the conclusion field. That asymmetry is the whole reason this
+    counts rather than trusting a status filter.
+    """
+    return sum(1 for conclusion in census if (conclusion or "").lower() == _HELD)
+
+
+def _absent_check_blocker(context: str, state: PullRequestState) -> Blocker:
+    """Name the move for an absent required check; the suite census decides it.
+
+    A held fork run and a head that never had a run created are identical in
+    every other field: ``mergeStateStatus`` ``BLOCKED``, a null-ish rollup,
+    ``reviewDecision`` ``REVIEW_REQUIRED`` and the required context missing from
+    ``check_conclusions``. They need opposite actions, so reporting one outcome
+    for both prints a remedy that is wrong for one of them -- and the wrong
+    direction is not symmetric. The close/reopen reflex applied to a held run
+    re-queues nothing (the runs already exist and stay held) while looking like
+    a completed remedy, where offering to approve a run that does not exist is
+    simply unavailable.
+
+    An unread census keeps the older, deliberately ambiguous wording: naming a
+    remedy on an observation that was not made is the mistake this exists to
+    stop, so it says the census was not read instead.
+    """
+    head = state.head_sha[:8] or "(unknown head)"
+    census = state.check_suite_conclusions
+    if census is None:
+        return Blocker(
+            REQUIRED_CHECK_ABSENT,
+            "required_status_checks",
+            f"Required check {context!r} has not reported on {head}. A fork run "
+            f"held at action_required reads the same as one that never started, "
+            f"and the head's check-suite census was not read, so which of the "
+            f"two this is has not been established.",
+        )
+    if not census:
+        return Blocker(
+            CHECK_SUITE_ABSENT,
+            "required_status_checks",
+            f"Required check {context!r} has not reported on {head}, and the "
+            f"head carries no check suite at all -- no run was ever created for "
+            f"it. Neither authorising nor re-running is available: there is no "
+            f"held run to approve and no suite to re-run. Close and reopen the "
+            f"pull request with a personal access token, which is what creates "
+            f"the run.",
+        )
+    held = _held_suites(census)
+    if held:
+        return Blocker(
+            REQUIRED_CHECK_ABSENT,
+            "required_status_checks",
+            f"Required check {context!r} has not reported on {head}; "
+            f"{_plural(held, 'check suite')} on the head "
+            f"{'is' if held == 1 else 'are'} held at conclusion "
+            f"action_required, so this is a fork run awaiting authorisation. "
+            f"Approve per run: POST /repos/{{owner}}/{{repo}}/actions/runs/"
+            f"{{id}}/approve. Find the runs by head_sha and recognise them by "
+            f'their conclusion -- a held run reports status "completed", so a '
+            f"scan of the status field matches none of them.",
+        )
+    return Blocker(
+        REQUIRED_CHECK_ABSENT,
+        "required_status_checks",
+        f"Required check {context!r} has not reported on {head}. The head "
+        f"carries {_plural(len(census), 'check suite')} and none is held at "
+        f"action_required, so the check genuinely has not started.",
+    )
 
 
 def evaluate(state: PullRequestState, rules: Ruleset) -> tuple[Blocker, ...]:
@@ -385,15 +484,7 @@ def evaluate(state: PullRequestState, rules: Ruleset) -> tuple[Blocker, ...]:
 
     for context in rules.required_contexts:
         if context not in state.check_conclusions:
-            found.append(
-                Blocker(
-                    REQUIRED_CHECK_ABSENT,
-                    "required_status_checks",
-                    f"Required check {context!r} has not reported on "
-                    f"{state.head_sha[:8] or '(unknown head)'}. A fork run held at "
-                    f"action_required reads the same as one that never started.",
-                )
-            )
+            found.append(_absent_check_blocker(context, state))
             continue
         conclusion = state.check_conclusions[context]
         if conclusion is None:
@@ -610,6 +701,36 @@ def resolve_check_conclusions(repo: str, head_sha: str, token: str) -> dict[str,
     return conclusions
 
 
+def resolve_check_suites(repo: str, head_sha: str, token: str) -> tuple[str | None, ...]:
+    """Return each check suite's conclusion on the head, oldest surface first.
+
+    This is the one field that separates a fork run held at ``action_required``
+    from a head that never had a run created, which are otherwise identical in
+    every field the rules are evaluated against. An empty tuple is a positive
+    observation -- the head carries no suite -- and is reported as such rather
+    than folded into "the required check has not reported".
+
+    A conclusion is kept as ``None`` for a suite still running, matching the
+    sibling that reads check runs: "queued" and "concluded" ask for different
+    things. Read to a single page for the same reason as that sibling; a head
+    with more than a hundred suites is not a state this diagnosis has to
+    separate.
+    """
+    payload = _get(f"{API_ROOT}/repos/{repo}/commits/{head_sha}/check-suites?per_page=100", token)
+    if not isinstance(payload, dict):
+        return ()
+    suites = payload.get("check_suites")
+    if not isinstance(suites, list):
+        return ()
+    conclusions: list[str | None] = []
+    for suite in suites:
+        if not isinstance(suite, dict):
+            continue
+        conclusion = suite.get("conclusion")
+        conclusions.append(str(conclusion) if conclusion is not None else None)
+    return tuple(conclusions)
+
+
 def resolve_ruleset(repo: str, base_ref: str, token: str) -> Ruleset:
     quoted = urllib.parse.quote(base_ref, safe="")
     return parse_ruleset(_get(f"{API_ROOT}/repos/{repo}/rules/branches/{quoted}", token))
@@ -632,6 +753,7 @@ def resolve_state(repo: str, pr: int, token: str) -> PullRequestState:
         merge_state=str(payload.get("mergeable_state") or ""),
         unresolved_threads=resolve_unresolved_threads(repo, pr, token),
         check_conclusions=resolve_check_conclusions(repo, head_sha, token) if head_sha else {},
+        check_suite_conclusions=resolve_check_suites(repo, head_sha, token) if head_sha else None,
         approvers=current_approvers(reviews),
         pusher=resolve_pusher(repo, head_sha, token) if head_sha else None,
     )

--- a/tests/test_merge_blockers.py
+++ b/tests/test_merge_blockers.py
@@ -26,6 +26,7 @@ of AGENTS.md.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 from pathlib import Path
@@ -271,15 +272,135 @@ def test_a_check_that_did_not_fail_is_not_a_blocker(conclusion: str) -> None:
     assert outcomes(mod.evaluate(state(check_conclusions={REQUIRED: conclusion}), MAIN)) == [mod.NO_UNSATISFIED_RULE]
 
 
-def test_an_absent_required_check_names_the_held_fork_run() -> None:
-    """A fork run held at ``action_required`` reads the same as never having run.
+def test_an_unread_census_still_names_the_held_fork_run_it_cannot_rule_out() -> None:
+    """Without the census the two states are genuinely indistinguishable.
 
-    #1722 carried nine such runs, and three passes over #1905 described it as a
+    #1722 carried nine held runs, and three passes over #1905 described it as a
     missing run rather than a held one. The remedy differs: authorisation, not a
-    push, and it consumes no approval.
+    push, and it consumes no approval. That ambiguity is what the census below
+    resolves -- so with no census read this keeps naming the held run it cannot
+    rule out, and says the observation was not made rather than picking one.
     """
     blockers = mod.evaluate(state(check_conclusions={}), MAIN)
+    assert blockers[0].outcome == mod.REQUIRED_CHECK_ABSENT
     assert "action_required" in blockers[0].detail
+    assert "was not read" in blockers[0].detail
+
+
+# --------------------------------------------------------------------------
+# The head's check-suite census, which is what separates a held fork run from
+# a head that never had a run created. Measured shapes: #2907 carried two
+# suites at ``conclusion: action_required`` while eleven had concluded, every
+# commit on ``main`` carries suites with none held, and the #1987 shape (a head
+# written through the API under the Actions token) carries none at all.
+# --------------------------------------------------------------------------
+
+HELD_CENSUS = ("action_required", "success", "action_required", None)
+
+
+def test_a_held_fork_run_is_separated_from_a_head_with_no_run() -> None:
+    """One field decides it, so the two outcomes must not be the same name."""
+    held = mod.evaluate(state(check_conclusions={}, check_suite_conclusions=HELD_CENSUS), MAIN)[0]
+    none = mod.evaluate(state(check_conclusions={}, check_suite_conclusions=()), MAIN)[0]
+    assert held.outcome == mod.REQUIRED_CHECK_ABSENT
+    assert none.outcome == mod.CHECK_SUITE_ABSENT
+    assert held.outcome != none.outcome
+    # Both are still a maintainer's move; it is the printed action that differs.
+    assert held.owed_by == none.owed_by == mod.MAINTAINER
+
+
+def test_neither_remedy_is_printed_for_the_state_it_cannot_clear() -> None:
+    """The whole defect: one outcome printed a remedy wrong for half its cases.
+
+    Approving names an authorisation that does not exist on a head with no run,
+    and closing/reopening re-queues nothing on a run that is already held. Each
+    detail is asserted not to carry the other's move, because a reader following
+    the wrong one gets a no-op that reads like a completed remedy.
+    """
+    held = mod.evaluate(state(check_conclusions={}, check_suite_conclusions=HELD_CENSUS), MAIN)[0]
+    none = mod.evaluate(state(check_conclusions={}, check_suite_conclusions=()), MAIN)[0]
+
+    assert "approve" in held.detail.lower()
+    assert "reopen" not in held.detail.lower()
+
+    assert "reopen" in none.detail.lower()
+    assert "personal access token" in none.detail
+    assert "approve" not in none.detail.lower().replace("to approve", "")
+
+
+def test_the_held_remedy_names_the_conclusion_field_rather_than_the_status() -> None:
+    """``action_required`` is a conclusion here, and the status reads completed.
+
+    A held run reports ``status: "completed"``, so a client-side scan comparing
+    the status field matches none of them -- measured on #2907, where the field
+    matched zero and the conclusion matched two. The remedy has to say which
+    field to read or it sends the reader to the one that answers nothing.
+    """
+    detail = mod.evaluate(state(check_conclusions={}, check_suite_conclusions=HELD_CENSUS), MAIN)[0].detail
+    assert "head_sha" in detail
+    assert "conclusion" in detail
+    assert "status" in detail
+    assert "2 check suites" in detail
+
+
+def test_suites_present_and_none_held_is_where_never_started_is_honest() -> None:
+    """The residual case keeps the older description, which is true only here.
+
+    This is every commit on ``main``: suites exist, none is held, and the
+    required check has genuinely not reported yet. Naming a held run here would
+    be the same error in the opposite direction.
+    """
+    blocker = mod.evaluate(state(check_conclusions={}, check_suite_conclusions=("success", "success")), MAIN)[0]
+    assert blocker.outcome == mod.REQUIRED_CHECK_ABSENT
+    assert "has not started" in blocker.detail
+    assert "approve" not in blocker.detail.lower()
+    assert "reopen" not in blocker.detail.lower()
+
+
+def test_a_suite_still_running_is_not_counted_as_held() -> None:
+    """``None`` is "in progress", which nobody can approve."""
+    blocker = mod.evaluate(state(check_conclusions={}, check_suite_conclusions=(None, "success")), MAIN)[0]
+    assert blocker.outcome == mod.REQUIRED_CHECK_ABSENT
+    assert "has not started" in blocker.detail
+
+
+def test_a_reporting_required_check_is_unaffected_by_a_held_sibling_suite() -> None:
+    """#2907 today: two suites held, and the required context reports anyway.
+
+    The census only decides the wording of an *absent* required check, so a head
+    that carries held suites for other workflows is still read from the required
+    context itself.
+    """
+    running = state(check_conclusions={REQUIRED: None}, check_suite_conclusions=HELD_CENSUS)
+    assert outcomes(mod.evaluate(running, MAIN)) == [mod.REQUIRED_CHECK_PENDING]
+
+
+def test_every_outcome_the_report_can_emit_has_an_owner() -> None:
+    """A new outcome with no owner would print an empty next action.
+
+    Derived by dataflow rather than by spelling: the outcomes are whatever
+    constant is handed to ``Blocker`` as its name, so an outcome added later is
+    held to this the hour it lands. A spelling rule cannot do this job -- it
+    misses the single-word ``draft`` and, loosened to admit it, matches the
+    single-word owner ``nobody``, which is a table *value* and would report a
+    violation that is not one. ``_OWED_BY`` is the whole point of the report, so
+    a name missing from it is a blocker nobody is told to clear.
+    """
+    source = _SCRIPT.read_text(encoding="utf-8")
+    emitted = {
+        node.args[0].id
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Blocker"
+        and node.args
+        and isinstance(node.args[0], ast.Name)
+    }
+    assert len(emitted) > 5, f"the outcome scan found only {sorted(emitted)}; it has gone blind"
+    values = {getattr(mod, name) for name in emitted}
+    assert mod.CHECK_SUITE_ABSENT in values
+    unowned = values - set(mod._OWED_BY)
+    assert not unowned, f"outcomes the report can emit with no owner: {sorted(unowned)}"
 
 
 # --------------------------------------------------------------------------
@@ -522,6 +643,84 @@ def _fake_urlopen(payload: Any) -> Any:
         return _FakeResponse(payload)
 
     return opener
+
+
+# --------------------------------------------------------------------------
+# Check-suite parsing.
+# --------------------------------------------------------------------------
+
+
+def test_the_census_keeps_each_suite_conclusion_including_the_unfinished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shape measured on #2907: some held, some concluded, one running."""
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen(
+            {
+                "total_count": 3,
+                "check_suites": [
+                    {"conclusion": "action_required"},
+                    {"conclusion": "success"},
+                    {"conclusion": None},
+                ],
+            }
+        ),
+    )
+    assert mod.resolve_check_suites("o/r", "abc", "t") == ("action_required", "success", None)
+
+
+def test_the_resolved_state_carries_the_census_it_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The census has to reach ``evaluate``, not merely be resolvable.
+
+    Every other case here is graded on a fixture, and a fixture cannot see a
+    resolver that is never called. The split is decided by this one field, so
+    populating it is part of the fix rather than plumbing: without the wiring
+    the field keeps its ``None`` default and every held fork run reports the
+    older ambiguous wording again.
+    """
+    monkeypatch.setattr(
+        mod,
+        "_get",
+        lambda url, token: {
+            "head": {"sha": "abc12345"},
+            "base": {"ref": "main"},
+            "draft": False,
+            "mergeable": True,
+            "mergeable_state": "blocked",
+        },
+    )
+    monkeypatch.setattr(mod, "resolve_reviews", lambda *a: [])
+    monkeypatch.setattr(mod, "resolve_unresolved_threads", lambda *a: 0)
+    monkeypatch.setattr(mod, "resolve_check_conclusions", lambda *a: {})
+    monkeypatch.setattr(mod, "resolve_check_suites", lambda *a: ("action_required", "success"))
+    monkeypatch.setattr(mod, "resolve_pusher", lambda *a: "the-author")
+
+    resolved = mod.resolve_state("o/r", 1, "t")
+
+    assert resolved.check_suite_conclusions == ("action_required", "success")
+    # And it lands where the split reads it.
+    assert mod.evaluate(resolved, MAIN)[0].outcome == mod.REQUIRED_CHECK_ABSENT
+    assert "approve" in mod.evaluate(resolved, MAIN)[0].detail.lower()
+
+
+def test_a_head_with_no_suite_reads_as_an_empty_census_not_a_missing_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``()`` is the positive observation the second outcome is derived from.
+
+    Returning ``None`` here would collapse it back into "not read", which is the
+    ambiguity this census exists to remove.
+    """
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen({"total_count": 0, "check_suites": []}),
+    )
+    census = mod.resolve_check_suites("o/r", "abc", "t")
+    assert census == ()
+    assert census is not None
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

`scripts/check_merge_blockers.py` reported one outcome, `required-check-absent`, for two
situations that need opposite actions, and printed the remedy for only one of them.
`resolve_check_suites` now reads the head's check-suite census and `evaluate` splits on it.

Closes #2912.

## The two states

Identical in every field the check read - `mergeStateStatus` BLOCKED, a null-ish
`statusCheckRollup`, `reviewDecision` REVIEW_REQUIRED, and the required context absent from
`check_conclusions`:

| | held fork run | no run was ever created |
|---|---|---|
| cause | a fork run awaiting authorisation | head commit written through the API under the Actions `GITHUB_TOKEN`, whose events are suppressed so a workflow cannot re-trigger itself |
| suite census on the head | suites present, one or more at `conclusion: action_required` | zero suites |
| remedy | `POST /actions/runs/{id}/approve`, once per run | close and reopen with a personal access token |
| outcome before | `required-check-absent` | `required-check-absent` |
| outcome after | `required-check-absent` | `check-suite-absent` |

The outcome's own text named "authorising or re-running the workflow" for both, so on the
right-hand column a reader following it had nothing to click: there is no held run to approve
and no suite to re-run. Its detail stated the ambiguity accurately and then left it
unresolved, at exactly the moment one field would settle it.

Two outcomes rather than one longer sentence, because the wrong guess is not symmetric. The
cheap reflex on a null-ish rollup is the close/reopen, and applied to a **held** run it is a
no-op that looks like a completed remedy - the runs already exist and stay held, so the flip
re-queues nothing while costing a closed/reopened pair on a contributor's pull request. The
reverse error is harmless by comparison: approving runs that do not exist is unavailable.

## Before and after

Same fixture, same required context, three censuses. The "before" column is byte-identical in
all three, which is the defect.

| census | before | after |
|---|---|---|
| 2 of 4 suites at `action_required` | `required-check-absent`, "A fork run held at action_required reads the same as one that never started." | `required-check-absent`, names the count, `POST .../approve`, and which field identifies the runs |
| zero suites | *identical text* | `check-suite-absent`, "Neither authorising nor re-running is available ... Close and reopen the pull request with a personal access token" |
| 2 suites, none held | *identical text* | `required-check-absent`, "The head carries 2 check suites and none is held at action_required, so the check genuinely has not started" |

All three censuses are measured shapes: a live pull request carried two suites at
`conclusion: action_required` while eleven had concluded; every commit on `main` carries
suites with none held; the zero-suite shape is the one AGENTS.md already records.

## A correction to the issue's second finding

#2912 claimed `GET /actions/runs?status=action_required` "returns no matching runs" and
concluded that a sweep filtering on status reports a clean queue over a held one. Measured, the
**query parameter is fine** - it accepts a conclusion there and returned every held run
(23 of them, all `completed`/`action_required`). What does not work is a **client-side scan of
the `status` field**, because a held run reports `status: "completed"`: on a page where the
field matched zero, the conclusion matched two.

So the approval remedy tells the reader to find the runs by `head_sha` and recognise them by
their **conclusion**, and says the status field matches none of them. That is the part a status
comparison gets wrong, and the filter is not blamed for something it does correctly.

## Why the census is `tuple[str | None, ...] | None`

`()` is a positive observation - the head carries no suite - and "not read" is a third answer.
An `int` defaulting to zero would have silently picked one of the two remedies. An unread
census keeps the older ambiguous wording and says the observation was not made, so naming a
remedy always follows from having looked, and every existing caller classifies exactly as
before. Two pre-existing parametrized cases pin that default, and both fire if it changes.

## Tests

`tests/test_merge_blockers.py` drives the outcome table from fixtures, so the split needs no
live pull request to grade. Pre-fix split with the source at `main`: **11 failed, 62 passed**,
all 11 the new or re-aimed cells, 0 pre-existing.

| # | mutation | fires | firing set |
|---|---|---|---|
| b0 | control | 0 | - |
| b1 | whole fix reverted | 10 | every new cell |
| b2 | zero-suite branch removed | 2 | the split, the no-collapse pin |
| b3 | held branch removed | 2 | the no-collapse pin, the conclusion-field pin |
| b4 | unread census treated as zero suites | 3 | the unread pin **plus 2 pre-existing cases** |
| b5 | held count always zero | 2 | the no-collapse pin, the conclusion-field pin |
| b6 | held detection reads the status field instead | 2 | the no-collapse pin, the conclusion-field pin |
| b7 | held remedy also prescribes the reopen | 1 | the no-collapse pin |
| b8 | zero remedy also prescribes approving | 1 | the no-collapse pin |
| b9 | census field defaults to `()` not `None` | 3 | the unread pin **plus 2 pre-existing cases** |
| b10 | resolver returns `None` for zero suites | 1 | the empty-census pin |
| b11 | new outcome dropped from `_OWED_BY` | 2 | the split, the derived owner guard |
| b12 | resolver not wired into `resolve_state` | 1 | the wiring pin |
| b13 | suite count dropped from the held detail | 1 | the conclusion-field pin |

b12 fired **0** on the first pass - nothing graded that the resolver was reached, because every
other case is a fixture and a fixture cannot see a resolver that is never called. That gap is
closed by `test_the_resolved_state_carries_the_census_it_read`, and the row now fires 1.

b4 and b9 each trip two **pre-existing** parametrized cases, which is what pins the `None`
default as load-bearing rather than incidental.

The load-bearing pin is `test_neither_remedy_is_printed_for_the_state_it_cannot_clear`: each
detail is asserted not to carry the other's move. That property's absence was the defect, and
b7 and b8 are the mutations that reintroduce it.

Also added: a derived guard requiring every outcome the report can emit to have an owner in
`_OWED_BY`, taken **by dataflow** from what `Blocker` is constructed with rather than by
spelling. A spelling rule cannot do this job - it misses the single-word `draft`, and loosened
to admit it, matches the single-word owner `nobody`, which is a table value. The dataflow
derivation finds all 11 outcomes exactly.

## Gate

| run | result |
|---|---|
| `tests/test_merge_blockers.py` | 73 passed |
| `ruff check` / `ruff format --check` | clean |
| `mypy scripts/check_merge_blockers.py` | Success: no issues found |
| changelog + format guards | 103 passed |
| paired 572-file guard class (base vs branch, identical selection) | `19 failed, 25553 passed, 103 skipped` on **both**, 19 == 19 identical ids, both `comm` directions empty |

The 19 are classified by measurement, not by name: 17 need `awsiot`, whose `find_spec` is
`False` here and which is declared as `awsiotsdk`/`awscrt` in the `[mesh-iot]` extra that CI
installs via `features = ['all']`; 2 are the lerobot-from-source `encode()` drift. 0
attributable.

Dogfooded on the live board afterwards: the report renders on both an open pull request whose
required check has concluded and on this one.

## Scope

Behaviour change is to the printed diagnosis only. The script reports and does not gate, so no
branch turns a different colour, and the `--all-open` sweep gains the split for free since it
shares the per-pull-request path. `_OWED_BY` still names a maintainer for both, because the
close/reopen needs a personal access token - it is the printed **action** that moves, not the
owed party.

AGENTS.md enumerates this check's outcomes in prose, so that clause is split in the same change;
the diff there is one line out and four in, with no pre-existing line touched.

No visual artifact: this is a diagnostic script, its tests and its prose, none of which is a
policy, simulation, rendering, recording or asset surface. The before/after detail table above
is the evidence.

`scripts/check_pr_head_is_current.py` is a neighbour and is unaffected - it compares the
recorded head against the branch tip, which is a different question answered separately.
