### PR TITLE
test(mesh): a degraded probe's duration is graded against a measured interval

### DIFF
--- a/changelog.d/2915-degraded-duration-is-measured.md
+++ b/changelog.d/2915-degraded-duration-is-measured.md
@@ -1,0 +1,20 @@
+### Tests: a degraded probe's `for_seconds` is graded against a measured interval
+
+`Mesh._degraded_probes` publishes `for_seconds` so an observer on another
+machine can tell "this probe just failed" from "this probe has been failing
+since it was plugged in" -- two conditions the method's own docstring says want
+different operator responses. Every assertion the suite made about that field
+was satisfiable by a renderer returning the literal `0.0`: `>= 0.0` in the
+reason test, `< 60.0` in the wall-clock test, and the key-set check. So the
+field's presence and its clock *domain* were graded while nothing asserted the
+duration had been measured, and a renderer with the right clock vacuously -- one
+that subtracts a key no record carries -- is green under it.
+
+Measured with `record.get("since", now)` substituted for
+`record.get("since_mono", now)`, which is that shape and makes `for_seconds`
+always exactly `0.0`: this file and its sibling sweep report 32 passed before
+the new pin and `1 failed, 32 passed` after it, the failure naming the constant.
+
+`_degraded_probes` is unchanged -- it is correct, and what was missing was the
+assertion that keeps it correct. The clock is driven rather than slept on, so
+the interval is exact and the pin costs no runtime.

--- a/tests/mesh/test_state_degraded_probes_are_published.py
+++ b/tests/mesh/test_state_degraded_probes_are_published.py
@@ -15,6 +15,9 @@ API. These tests pin the contract that removes the need:
   ``reason`` (the exception's type name -- the discriminator
   ``_warn_read_state_once`` documents as selecting the operator's next move),
   ``detail`` (its message, bounded), ``failures`` and ``for_seconds``;
+* ``for_seconds`` is the interval that has elapsed since the fault began,
+  measured on the monotonic clock -- a duration a renderer could report as a
+  constant and satisfy every other assertion here;
 * the entry disappears on the tick the probe answers again;
 * a healthy peer's snapshot is unchanged -- no key is added when nothing failed;
 * the block makes the snapshot non-empty, so a hardware-only peer whose one
@@ -285,7 +288,57 @@ class TestTheSilencedPeerKeepsPublishing:
 
 
 class TestTheDurationIsMeasuredNotStamped:
-    """``for_seconds`` is a duration, so it belongs on the monotonic clock."""
+    """``for_seconds`` is a duration, so it is measured on the monotonic clock.
+
+    Two independent properties, and the second one is what stops the first from
+    being satisfiable by a literal: the duration must not track the wall clock,
+    AND it must actually be derived from a clock rather than reported as a
+    constant. A renderer that returns ``0.0`` unconditionally has the right
+    clock domain vacuously.
+    """
+
+    def test_the_duration_is_the_interval_the_probe_has_been_failing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constant satisfies every other assertion this file makes about it.
+
+        ``for_seconds >= 0.0`` in
+        :meth:`TestAFailingProbeNamesItselfOnTheWire.test_the_reason_is_the_exception_type`,
+        ``for_seconds < 60.0`` in the wall-clock test beside this one, and the
+        key-set check below are all true of a hardcoded ``0.0``, so the suite
+        graded the field's presence and its clock DOMAIN while asserting nothing
+        about whether it had been measured. Under that grading a renderer whose
+        duration is always zero -- because it subtracts a key no record carries,
+        which is the shape a second renderer of this block took in review -- is
+        green, and the operator-visible consequence is the one
+        :meth:`strands_robots.mesh.core.Mesh._degraded_probes` exists to
+        prevent: "this probe failed" and "this probe has been failing since it
+        was plugged in" want different responses, and a duration pinned at zero
+        reports the second as the first.
+
+        The clock is driven rather than slept on, so the interval is exact and
+        the test does not trade runtime for the assertion's strength.
+        """
+        from strands_robots.mesh import core
+
+        elapsed = [1000.0]
+        monkeypatch.setattr(core.time, "monotonic", lambda: elapsed[0])
+
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        first = m._read_state()
+        elapsed[0] += 3.5
+        second = m._read_state()
+
+        assert first is not None and second is not None
+        assert first["degraded"]["hw_joints"]["for_seconds"] == pytest.approx(0.0), (
+            "premise: the tick that records the fault has measured no interval yet"
+        )
+        assert second["degraded"]["hw_joints"]["for_seconds"] == pytest.approx(3.5), (
+            "for_seconds must be the measured interval since the fault began, "
+            "not a constant that happens to be non-negative"
+        )
+        assert second["degraded"]["hw_joints"]["failures"] == 2, (
+            "premise: the second tick is the same standing fault, not a new one"
+        )
 
     def test_a_wall_clock_step_does_not_move_the_duration(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """An NTP correction mid-fault must not invent hours of downtime.


### PR DESCRIPTION
A degraded state probe publishes `degraded[<category>]["for_seconds"]` so an observer on another machine can tell "this probe just failed" from "this probe has been failing since it was plugged in" -- two conditions `_degraded_probes`' own docstring says want different operator responses.

Every assertion this repository made about that field was satisfiable by a renderer that returns the literal `0.0`.

| assertion | where | true of a constant `0.0`? |
|---|---|---|
| `for_seconds >= 0.0` | `TestAFailingProbeNamesItselfOnTheWire.test_the_reason_is_the_exception_type` | yes |
| `for_seconds < 60.0` after a wall-clock step | `TestTheDurationIsMeasuredNotStamped.test_a_wall_clock_step_does_not_move_the_duration` | yes |
| the key set is `{reason, detail, failures, for_seconds}` | `test_the_monotonic_stamp_stays_off_the_wire` | yes |

So the suite graded the field's **presence** and its clock **domain**, and said nothing about whether the duration had been measured at all. A renderer with the right clock vacuously -- because it subtracts a key no record carries -- is green under it, and the failure is silent in the reassuring direction: a mesh that has been degraded for hours reports `for_seconds: 0.0`, which reads as a fault that just started.

## What this changes

One test method, `TestTheDurationIsMeasuredNotStamped::test_the_duration_is_the_interval_the_probe_has_been_failing`, plus the class and module docstrings that describe what the class grades. No production code: `_degraded_probes` is correct on `main` and stays byte-identical.

The clock is driven (`monkeypatch.setattr(core.time, "monotonic", ...)`) rather than slept on, in the same style as the wall-clock test beside it, so the interval is exact and the pin costs no runtime.

## Measurement

The defect shape is `record.get("since", now)` in place of `record.get("since_mono", now)`: no record anywhere in the tree carries a `since` key, so the `now` default always wins and `for_seconds` is always exactly `0.0`. Applied to `_degraded_probes` on this tree:

| suite | with the defect | with the defect + this pin |
|---|---|---|
| `tests/mesh/test_state_degraded_probes_are_published.py` + `tests/mesh/test_read_state_probe_failures_are_reported.py` | 32 passed | 1 failed, 32 passed |

The failure names the constant: `for_seconds must be the measured interval since the fault began, not a constant that happens to be non-negative -- assert 0.0 == 3.5 +/- 3.5e-06`.

Unmutated, on `main` + this commit:

```
tests/mesh/test_state_degraded_probes_are_published.py    21 passed
tests/test_test_case_names_describe_behaviour.py          15 passed
tests/test_no_host_paths.py                               2 passed
ruff check / ruff format --check                          clean
```

## Provenance, and what this is not

This is the reviewable half of the third row of #2878. That issue proposed extracting three safety-reporting defects out of #2848 into a small `mesh/`-only PR, on the stated grounds that they are "in code that the e-stop and degraded-state paths run today". Measured against `main` at `0c85ac0`, that premise does not hold for any of the four items:

```
grep -rn "degraded_report\|NORM_MODE_UNITS\|input_envelope_for_units" strands_robots/   ->  no match
```

`degraded_report`, `summarise_probe_error`, the unit-envelope table and both `mesh_bridge.py` sites are **added** by that branch, not pre-existing. So there is nothing to extract: those four fixes can only be a deletion or a correction inside #2848, and a `mesh/`-only PR against `main` fixing them cannot be written. I will record that on #2878 rather than leave the slice reading as ready to pick up.

What *is* on `main` is the reason the always-zero renderer reached a third review round without a red test: the grading above. That is what this PR closes, and it is worth closing on its own -- the next renderer of this block, in that branch or another, is now graded on arrival.

This PR claims no issue: it does not fix #2878's four defects, so a closing keyword here would drop them.

## S13 Review Rounds

| Round | Concern | Fix commit | Pin test path |
|---|---|---|---|
| R0 | initial | `3f1cf47` | `tests/mesh/test_state_degraded_probes_are_published.py::TestTheDurationIsMeasuredNotStamped::test_the_duration_is_the_interval_the_probe_has_been_failing` |
