### PR TITLE
fix(policies/protomotions): the anchor ladder reads its prefixed key spelling

### DIFF
--- a/changelog.d/2918-protomotions-anchor-key-prefix-convention.md
+++ b/changelog.d/2918-protomotions-anchor-key-prefix-convention.md
@@ -1,0 +1,35 @@
+### Fixed: the ProtoMotions anchor ladder reads its `observation.`-prefixed key spelling
+
+Every observation-key fallback ladder in `strands_robots` pairs a bare key with
+`observation.<that key>`.  `ProtoMotionsPolicy._extract_root_local_ang_vel`
+reads `("root_ang_vel_local", "observation.root_ang_vel_local")`, and both of
+`WBCPolicy`'s ladders read `("base_ang_vel", "observation.base_ang_vel")` and
+`("base_quat", "observation.base_quat")`.  The anchor-rotation ladder on that
+same tracker was the exception: it read `("anchor_rot_xyzw",
+"observation.anchor_rot")` - prefixed, but with the `_xyzw` suffix dropped - so
+the spelling the convention implies was absent.
+
+Measured on one observation dict whose two keys are both written to the
+convention, `observation.root_ang_vel_local` resolved and
+`observation.anchor_rot_xyzw` raised `KeyError`.  One dict, two ladders on one
+class, one convention, two answers, and the refusal that fired named the
+runtime's `body.<anchor>.quat` key, the `anchor_rot_xyzw=` kwarg and
+`body_rot_xyzw` - so a caller whose prefixed key had just been refused was not
+told that a prefixed spelling was read at all, nor which one.
+
+The ladder now reads `("anchor_rot_xyzw", "observation.anchor_rot_xyzw",
+"observation.anchor_rot")` and the refusal names the prefixed form.  The change
+is additive: the suffix-less `observation.anchor_rot` still resolves, because it
+is accepted today, and the runtime's declared-body rung is still checked ahead
+of the whole ladder, so a simulation rollout resolves exactly the rotation it
+always did.  All three anchor spellings now return the same `xyzw` quaternion -
+this rung does not reorder components, only the `body.<anchor>.quat` rung
+converts from MuJoCo's `wxyz`.
+
+The convention itself is now derived from the package rather than restated in a
+list, so a ladder added later is held to it the hour it lands.  The derivation
+reads a tuple or list of string literals that is *consumed as keys* - the
+iterable of a `for`, or a call argument - and that mixes a bare key with a
+prefixed one; the consumption site is what keeps a module-level list of default
+camera feature names and a membership test over dataset columns out of scope,
+neither of which is a fallback ladder.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -89,6 +89,20 @@ await policy.get_actions(
 )
 ```
 
+Either signal can instead sit on the observation dict itself, under its bare
+name or its `observation.`-prefixed spelling - the shape a runtime that
+namespaces its observation keys produces:
+
+| signal | accepted observation keys |
+| --- | --- |
+| anchor rotation, `xyzw` | `anchor_rot_xyzw`, `observation.anchor_rot_xyzw` |
+| root angular velocity, local frame | `root_ang_vel_local`, `observation.root_ang_vel_local` |
+
+The prefixed spelling is the bare name with `observation.` in front in both
+rows, so one dict can carry both signals written the same way. (`anchor_rot`
+without the `_xyzw` suffix is also still accepted for the anchor rotation, but
+it does not say which component order it carries, so prefer the suffixed name.)
+
 If neither the declared body pose nor an explicit override is present the policy
 raises, naming the key it wanted. It will not fall back to `base_quat` unless
 the config's anchor body *is* the floating base, in which case the two are the

--- a/strands_robots/policies/protomotions/policy.py
+++ b/strands_robots/policies/protomotions/policy.py
@@ -312,7 +312,13 @@ class ProtoMotionsPolicy(Policy):
                    ``anchor_rot_xyzw`` / ``root_ang_vel_local`` on ``kwargs``.
                 2. Per-joint entries under the GTP joint names (with ``.vel``
                    suffix for velocities), plus ``anchor_rot_xyzw`` /
-                   ``root_ang_vel_local`` on the obs dict itself.
+                   ``root_ang_vel_local`` on the obs dict itself. Each
+                   of those two is also read under its
+                   ``observation.``-prefixed spelling
+                   (``observation.anchor_rot_xyzw`` /
+                   ``observation.root_ang_vel_local``), which is the
+                   shape a runtime that namespaces its observation keys
+                   produces.
 
             instruction: Ignored - the tracker follows the loaded motion, not
                 a text prompt.
@@ -463,8 +469,18 @@ class ProtoMotionsPolicy(Policy):
         anchor_key = f"body.{self._config.anchor_body_name}.quat"
         if anchor_key in obs:
             return mujoco_wxyz_to_xyzw(np.asarray(obs[anchor_key], dtype=np.float32))
-        # Try well-known observation keys.
-        for key in ("anchor_rot_xyzw", "observation.anchor_rot"):
+        # Well-known observation keys. Every observation-key fallback ladder in
+        # this package pairs a bare key with ``observation.<that key>``: the
+        # sibling ladder in :meth:`_extract_root_local_ang_vel` below does, and
+        # so do both of ``WBCPolicy``'s. A caller who follows that convention
+        # therefore writes ``observation.anchor_rot_xyzw``, and that spelling
+        # was absent while the suffix-less ``observation.anchor_rot`` was
+        # accepted -- so one observation dict whose keys were both spelled to
+        # the convention had its angular velocity resolve and its anchor
+        # rotation raise. The suffix-less form is kept because it is accepted
+        # today; it is also the weaker name, since it does not say which
+        # component order it carries and this rung does not reorder.
+        for key in ("anchor_rot_xyzw", "observation.anchor_rot_xyzw", "observation.anchor_rot"):
             if key in obs:
                 return np.asarray(obs[key], dtype=np.float32)
         # Fallback: derive from a full body-rotation batch.
@@ -485,7 +501,9 @@ class ProtoMotionsPolicy(Policy):
             f"{anchor_key!r} in the observation. Through a simulation rollout "
             "the runtime supplies that key from this policy's "
             "`required_bodies`; a caller assembling observations by hand can "
-            "instead pass `anchor_rot_xyzw=[x,y,z,w]` via kwargs or supply "
+            "instead pass `anchor_rot_xyzw=[x,y,z,w]` via kwargs, or supply it "
+            "on the observation as `anchor_rot_xyzw` (or its prefixed spelling "
+            "`observation.anchor_rot_xyzw`), or supply "
             "`body_rot_xyzw`. Note that `base_quat` is the floating base "
             f"({self._config.root_body_name!r}), NOT the anchor."
         )

--- a/tests/policies/protomotions/test_prefixed_observation_keys_follow_the_convention.py
+++ b/tests/policies/protomotions/test_prefixed_observation_keys_follow_the_convention.py
@@ -1,0 +1,309 @@
+"""Both of the tracker's observation-key ladders read their prefixed spelling.
+
+:class:`~strands_robots.policies.protomotions.ProtoMotionsPolicy` resolves the
+two frame signals its ONNX graph needs -- the anchor-body rotation and the root
+angular velocity -- through a fallback ladder that tries several observation
+keys in turn. Every such ladder in ``strands_robots`` pairs a bare key with
+``observation.<that key>``: the root-angular-velocity ladder reads
+``("root_ang_vel_local", "observation.root_ang_vel_local")``, and both of
+``WBCPolicy``'s read ``("base_ang_vel", "observation.base_ang_vel")`` and
+``("base_quat", "observation.base_quat")``.
+
+The anchor ladder was the exception. It read ``("anchor_rot_xyzw",
+"observation.anchor_rot")`` -- prefixed, but with the ``_xyzw`` suffix dropped
+-- so the spelling the convention implies was absent. Measured on one
+observation dict whose two keys are both written to the convention:
+
+=================================  ============================  ===========
+observation key                    signal                        before
+=================================  ============================  ===========
+``observation.root_ang_vel_local`` root angular velocity         resolves
+``observation.anchor_rot_xyzw``    anchor rotation               ``KeyError``
+=================================  ============================  ===========
+
+One dict, two ladders on the same class, one convention, two answers. The
+refusal that fired named the runtime's ``body.<anchor>.quat`` key, the
+``anchor_rot_xyzw=`` kwarg and ``body_rot_xyzw`` -- not any prefixed spelling,
+so it did not tell the caller that a prefixed form was read at all, nor which
+one.
+
+Why nothing caught it
+---------------------
+The ladder rung is uncovered. ``_extract_anchor_rot``'s prefixed rung
+(``policy.py`` line 469 before this change) and the ``body_rot_xyzw`` rung below
+it were both absent from the coverage report, because every existing test
+supplies the anchor rotation either as a kwarg or as the runtime's
+``body.<anchor>.quat``. So neither the accepted spelling nor the refused one was
+graded, and no assertion anywhere compared the two ladders' key vocabularies.
+
+What this pins
+--------------
+* one observation dict carrying both signals under the convention spelling
+  resolves both, and to the same values the bare keys give;
+* the convention itself, derived from the package rather than listed here, so a
+  ladder added later is held to it the hour it lands;
+* the suffix-less ``observation.anchor_rot`` still resolves -- the fix is
+  additive and removes no spelling a caller may already write;
+* the runtime's ``body.<anchor>.quat`` still wins over the whole ladder, so a
+  simulation rollout resolves exactly the rotation it always did.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.policies.protomotions.policy as policy_mod
+from strands_robots.policies.protomotions import ProtoMotionsPolicy
+from strands_robots.policies.protomotions.state_utils import mujoco_wxyz_to_xyzw
+from tests.policies.protomotions.test_observation_state_reads_the_same_through_every_convention import (
+    _policy,
+)
+
+PACKAGE_ROOT = pathlib.Path(policy_mod.__file__).parent.parent.parent
+
+#: 45 degrees about +z in ``xyzw``. Every component differs from the identity
+#: quaternion, so a ladder that resolved nothing and fell through to a default
+#: could not coincide with the right answer.
+ANCHOR_XYZW: list[float] = [0.0, 0.0, 0.3826834, 0.9238795]
+
+#: Three distinct components, so a mis-ordered read is visible.
+ROOT_AVEL: list[float] = [0.1, -0.2, 0.3]
+
+#: A different rotation, used only where two candidate keys are present at once
+#: and the test is about which one wins.
+OTHER_WXYZ: list[float] = [0.7071068, 0.7071068, 0.0, 0.0]
+
+#: The observation-key ladders this package is known to carry, as
+#: ``module suffix -> how many``. A floor rather than an exact inventory: a
+#: ladder added later must raise the count, never lower it, and the derived scan
+#: below is what holds a new one to the convention.
+KNOWN_LADDER_FILES: dict[str, int] = {
+    "policies/protomotions/policy.py": 2,
+    "policies/wbc/policy.py": 2,
+}
+
+
+# ----------------------------------------------------------------------------
+# The convention, derived from source rather than restated
+# ----------------------------------------------------------------------------
+def _ladders_in_source(source: str) -> list[tuple[int, list[str], str]]:
+    """Every observation-key fallback ladder in ``source``.
+
+    A ladder is a tuple or list of string literals that is *consumed as keys* --
+    the iterable of a ``for`` statement, or an argument to a call -- and that
+    mixes at least one bare key with at least one ``observation.``-prefixed one.
+    Both halves of that test are load-bearing, and they earn their place on
+    different inputs. The consumption site is what excludes the two shapes this
+    package really has -- a module-level list of default camera feature keys
+    (``lerobot_local.molmoact2``) and a membership test over dataset columns
+    (``transforms.base``), neither of which is a fallback ladder, and the second
+    of which does carry a bare key. Requiring a bare key has no instance in the
+    package today, so it is graded on an exemplar below: an all-prefixed key
+    loop names nothing to derive the convention spelling from, and reading one
+    as a ladder would demand ``observation.observation.images.left``.
+
+    Args:
+        source: Python source. Taken as text rather than as a function object so
+            the same predicate can grade the shipped package and the constructed
+            exemplars below, which have no source file.
+
+    Returns:
+        One ``(line, keys, bare_key)`` per ladder, where ``bare_key`` is the
+        first key carrying no ``observation.`` prefix.
+    """
+    tree = ast.parse(source)
+    sites: list[ast.expr] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.For):
+            sites.append(node.iter)
+        elif isinstance(node, ast.Call):
+            sites.extend(node.args)
+            sites.extend(keyword.value for keyword in node.keywords)
+
+    found: list[tuple[int, list[str], str]] = []
+    for node in sites:
+        if not isinstance(node, ast.Tuple | ast.List):
+            continue
+        keys = [e.value for e in node.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+        if len(keys) != len(node.elts) or len(keys) < 2:
+            continue
+        bare = [k for k in keys if not k.startswith("observation.")]
+        if not bare or not any(k.startswith("observation.") for k in keys):
+            continue
+        found.append((node.lineno, keys, bare[0]))
+    return found
+
+
+def _ladders_in_package() -> list[tuple[str, int, list[str], str]]:
+    """Every observation-key ladder in ``strands_robots``, as ``(path, line, keys, bare)``."""
+    out: list[tuple[str, int, list[str], str]] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        for line, keys, bare in _ladders_in_source(path.read_text(encoding="utf-8")):
+            out.append((str(path.relative_to(PACKAGE_ROOT)), line, keys, bare))
+    return out
+
+
+def _violations(ladders: list[tuple[int, list[str], str]]) -> list[tuple[int, str]]:
+    """Ladders whose bare key has no ``observation.``-prefixed spelling beside it."""
+    return [(line, bare) for line, keys, bare in ladders if f"observation.{bare}" not in keys]
+
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+@pytest.fixture
+def tracker() -> ProtoMotionsPolicy:
+    """A tracker with a stub session and a flat reference motion."""
+    return _policy()
+
+
+def _anchor(pol: ProtoMotionsPolicy, obs: dict[str, Any], **kwargs: Any) -> np.ndarray:
+    return np.asarray(pol._extract_anchor_rot(obs, dict(kwargs))).ravel()
+
+
+def _avel(pol: ProtoMotionsPolicy, obs: dict[str, Any], **kwargs: Any) -> np.ndarray:
+    return np.asarray(pol._extract_root_local_ang_vel(obs, dict(kwargs))).ravel()
+
+
+# ----------------------------------------------------------------------------
+# The regression
+# ----------------------------------------------------------------------------
+class TestOneObservationDictResolvesBothSignals:
+    """The finding: two ladders, one convention, and they must agree."""
+
+    def test_both_signals_resolve_when_both_keys_carry_the_prefix(self, tracker: ProtoMotionsPolicy) -> None:
+        """The money case -- a caller who prefixes both keys the same way.
+
+        Before this change ``observation.root_ang_vel_local`` resolved and
+        ``observation.anchor_rot_xyzw`` raised ``KeyError``, out of one dict.
+        """
+        obs = {
+            "observation.anchor_rot_xyzw": ANCHOR_XYZW,
+            "observation.root_ang_vel_local": ROOT_AVEL,
+        }
+        assert _anchor(tracker, obs) == pytest.approx(ANCHOR_XYZW, abs=1e-6), (
+            "the prefixed anchor rotation must resolve, as its sibling ladder's prefixed key does"
+        )
+        assert _avel(tracker, obs) == pytest.approx(ROOT_AVEL, abs=1e-6), (
+            "premise: the sibling ladder already accepted its prefixed key"
+        )
+
+    @pytest.mark.parametrize(
+        "key",
+        ["anchor_rot_xyzw", "observation.anchor_rot_xyzw", "observation.anchor_rot"],
+        ids=["bare", "prefixed", "prefixed-suffixless"],
+    )
+    def test_every_anchor_ladder_key_resolves_the_same_rotation(self, tracker: ProtoMotionsPolicy, key: str) -> None:
+        """The ladder's rungs are spellings of one signal, so they must agree.
+
+        This rung does not reorder components -- only the runtime's
+        ``body.<anchor>.quat`` rung converts ``wxyz`` to ``xyzw`` -- so every key
+        here carries ``xyzw`` and must come back unchanged.
+        """
+        assert _anchor(tracker, {key: ANCHOR_XYZW}) == pytest.approx(ANCHOR_XYZW, abs=1e-6)
+
+    def test_the_refusal_names_the_prefixed_spelling(self, tracker: ProtoMotionsPolicy) -> None:
+        """A caller who reads the refusal must learn the prefixed form is read.
+
+        The old message named the runtime key, the kwarg and ``body_rot_xyzw``,
+        so a caller whose prefixed key had just been refused was not told that a
+        prefixed spelling existed at all.
+        """
+        with pytest.raises(KeyError) as excinfo:
+            _anchor(tracker, {})
+        assert "observation.anchor_rot_xyzw" in str(excinfo.value), (
+            "the remedy must name the prefixed spelling this ladder reads"
+        )
+
+
+class TestEveryLadderCarriesTheConventionSpelling:
+    """Derived from the package, so a ladder added later is graded on arrival."""
+
+    def test_every_observation_key_ladder_carries_the_convention_spelling(self) -> None:
+        offenders = [
+            f"{path}:{line} {keys} is missing 'observation.{bare}'"
+            for path, line, keys, bare in _ladders_in_package()
+            if f"observation.{bare}" not in keys
+        ]
+        assert not offenders, (
+            "every observation-key ladder pairs its bare key with "
+            "'observation.<that key>', so a caller can spell one dict's keys "
+            "one way: " + "; ".join(offenders)
+        )
+
+    def test_the_scan_finds_every_ladder_known_to_exist(self) -> None:
+        """Non-vacuity: a scan that reads nothing would pass the rule above."""
+        ladders = _ladders_in_package()
+        assert len(ladders) >= sum(KNOWN_LADDER_FILES.values()), (
+            f"the scan found {len(ladders)} ladders; it has gone blind"
+        )
+        by_file: dict[str, int] = {}
+        for path, _line, _keys, _bare in ladders:
+            by_file[path] = by_file.get(path, 0) + 1
+        for suffix, count in KNOWN_LADDER_FILES.items():
+            matched = sum(n for path, n in by_file.items() if path.replace("\\", "/").endswith(suffix))
+            assert matched >= count, f"expected at least {count} ladder(s) in {suffix}, found {matched}"
+
+    def test_the_rule_grades_a_constructed_ladder_and_reports_a_constructed_violation(self) -> None:
+        """The package is clean after the fix, so the rule is graded on exemplars."""
+        compliant = 'for key in ("gripper_width", "observation.gripper_width"):\n    read(obs, key)\n'
+        violating = 'for key in ("gripper_width", "observation.gripper"):\n    read(obs, key)\n'
+        not_a_ladder = 'DEFAULT_KEYS = ["observation.images.left", "observation.images.right"]\n'
+        prefixed_only = 'for key in ("observation.images.left", "observation.images.right"):\n    read(obs, key)\n'
+
+        assert _violations(_ladders_in_source(compliant)) == []
+        assert [bare for _line, bare in _violations(_ladders_in_source(violating))] == ["gripper_width"]
+        assert _ladders_in_source(not_a_ladder) == [], (
+            "a feature list that is never consumed as keys is not a fallback ladder"
+        )
+        assert _ladders_in_source(prefixed_only) == [], (
+            "an all-prefixed key loop names no bare key to derive the convention "
+            "spelling from, so it is not a ladder this rule can grade"
+        )
+        outcomes = {_violations(_ladders_in_source(src)) == [] for src in (compliant, violating)}
+        assert outcomes == {True, False}, "the rule must be able to answer both ways"
+
+
+class TestWhatIsUnchanged:
+    """Every cell here held before the change and must go on holding."""
+
+    def test_the_suffixless_prefixed_spelling_still_resolves(self, tracker: ProtoMotionsPolicy) -> None:
+        """The fix is additive: it removes no spelling a caller may already write."""
+        obs = {"observation.anchor_rot": ANCHOR_XYZW}
+        assert _anchor(tracker, obs) == pytest.approx(ANCHOR_XYZW, abs=1e-6)
+
+    def test_the_bare_keys_still_resolve(self, tracker: ProtoMotionsPolicy) -> None:
+        obs = {"anchor_rot_xyzw": ANCHOR_XYZW, "root_ang_vel_local": ROOT_AVEL}
+        assert _anchor(tracker, obs) == pytest.approx(ANCHOR_XYZW, abs=1e-6)
+        assert _avel(tracker, obs) == pytest.approx(ROOT_AVEL, abs=1e-6)
+
+    def test_an_explicit_kwarg_still_wins_over_the_ladder(self, tracker: ProtoMotionsPolicy) -> None:
+        obs = {"observation.anchor_rot_xyzw": [0.0, 0.0, 0.0, 1.0]}
+        got = _anchor(tracker, obs, anchor_rot_xyzw=ANCHOR_XYZW)
+        assert got == pytest.approx(ANCHOR_XYZW, abs=1e-6), "kwargs are checked before any observation key"
+
+    def test_the_runtime_supplied_body_quat_still_wins_over_the_ladder(self, tracker: ProtoMotionsPolicy) -> None:
+        """A simulation rollout resolves exactly the rotation it always did.
+
+        The runtime merges ``body.<anchor>.quat`` from this policy's
+        ``required_bodies``, and that rung is checked before the ladder. Adding a
+        key to the ladder therefore cannot move the rollout path, which is what
+        makes this change safe for every existing caller.
+        """
+        anchor_key = f"body.{tracker._config.anchor_body_name}.quat"
+        obs = {anchor_key: OTHER_WXYZ, "observation.anchor_rot_xyzw": ANCHOR_XYZW}
+        expected = np.asarray(mujoco_wxyz_to_xyzw(np.asarray(OTHER_WXYZ, dtype=np.float32))).ravel()
+        assert _anchor(tracker, obs) == pytest.approx(expected, abs=1e-6), (
+            "the runtime's declared-body rung must still win over the ladder below it"
+        )
+
+    def test_an_observation_that_resolves_nothing_still_raises(self, tracker: ProtoMotionsPolicy) -> None:
+        with pytest.raises(KeyError):
+            _anchor(tracker, {"some.unrelated.key": 1.0})
+        with pytest.raises(KeyError):
+            _avel(tracker, {"some.unrelated.key": 1.0})


### PR DESCRIPTION
## The finding

Every observation-key fallback ladder in `strands_robots` pairs a bare key with `observation.<that key>`:

| ladder | keys read |
| --- | --- |
| `ProtoMotionsPolicy._extract_root_local_ang_vel` | `root_ang_vel_local`, `observation.root_ang_vel_local` |
| `WBCPolicy._extract_base_ang_vel` | `base_ang_vel`, `observation.base_ang_vel` |
| `WBCPolicy._extract_base_quat` | `base_quat`, `observation.base_quat` |
| `ProtoMotionsPolicy._extract_anchor_rot` | `anchor_rot_xyzw`, `observation.anchor_rot` |

The last row is the exception. It is prefixed, but with the `_xyzw` suffix dropped, so the spelling the convention implies was absent. Measured on one observation dict whose two keys are both written to the convention:

| observation key | signal | before | after |
| --- | --- | --- | --- |
| `observation.root_ang_vel_local` | root angular velocity | resolves | resolves |
| `observation.anchor_rot_xyzw` | anchor rotation | **`KeyError`** | resolves |

One dict, two ladders on one class, one convention, two answers. `_extract_anchor_rot` is called on every `get_actions` tick, so a caller who names its keys that way gets a policy that cannot step at all.

The refusal that fired named the runtime's `body.<anchor>.quat` key, the `anchor_rot_xyzw=` kwarg and `body_rot_xyzw` -- not any prefixed spelling. So a caller whose prefixed key had just been refused was not told that a prefixed form was read at all, nor which one.

## Why nothing caught it

The rung is uncovered. `_extract_anchor_rot`'s prefixed rung (`policy.py:469` before this change) and the `body_rot_xyzw` rung below it were both absent from the coverage report, because every existing test supplies the anchor rotation either as a kwarg or as the runtime's `body.<anchor>.quat`. Neither the accepted spelling nor the refused one was graded, and no assertion anywhere compared the two ladders' key vocabularies.

## The change

* the ladder reads `("anchor_rot_xyzw", "observation.anchor_rot_xyzw", "observation.anchor_rot")`;
* the refusal names the prefixed spelling, so the message lists every form the method reads;
* `docs/policies/protomotions.md` gains the accepted keys for both signals as a table, beside the kwarg recipe it already documents.

The suffix-less `observation.anchor_rot` is **kept**, because it is accepted today. It is also the weaker name -- it does not say which component order it carries, and this rung does not reorder -- so the docs prefer the suffixed spelling and say why.

## What is unchanged, measured

* `anchor_rot_xyzw` (bare): `[0.0000, 0.0000, 0.3827, 0.9239]` before and after, byte-identical.
* the runtime's `body.<anchor>.quat` rung is still checked ahead of the whole ladder, so a simulation rollout resolves exactly the rotation it always did. Pinned by `test_the_runtime_supplied_body_quat_still_wins_over_the_ladder`, which supplies a *different* rotation under the runtime key and asserts it wins.
* an explicit `anchor_rot_xyzw=` kwarg still wins over every observation key.
* an observation that resolves nothing still raises.

## Visual

The quantity the ladder resolves is an orientation, so the artifact is that orientation, read out of the shipped code on both trees by one capture script. Panel 1 is the refusal with no frame resolved; panels 2 and 3 are the resolved frame. Their agreement is the finding: the prefixed spelling now resolves to exactly what the bare key gives, and the bare key did not move. Every number in the caption is asserted from the two captures before the figure is drawn.

![anchor rotation resolved by key spelling](https://github.com/cagataycali/robots/releases/download/artifacts/pr2918-anchor-key-prefix-convention.png)

## Tests

`tests/policies/protomotions/test_prefixed_observation_keys_follow_the_convention.py`, 13 cases in 4 classes. The structural half derives the convention from the package rather than restating it, so a ladder added later is held to it on arrival.

**Pre-fix split: 4 failed / 9 passed**, with `0 of 5` in the over-reach controls. The two parametrized anchor spellings that legitimately held before (`bare`, `prefixed-suffixless`) correctly pass, as do the non-vacuity floor and the constructed exemplars -- they grade constructed inputs and the scan, not the defect.

**Mutation table**, 11 mutations, 10 distinct firing sets, control clean, `collected` stable at 13 on every row, both files restored md5-identical:

| mutation | fires | which |
| --- | --- | --- |
| control | 0 | |
| ladder reverted (the defect) | 3 | derived rule, money case, `prefixed` param |
| refusal loses the prefixed spelling | 1 | the refusal cell |
| both reverted | 4 | the union, and the pre-fix split exactly |
| suffix-less spelling dropped | 2 | `prefixed-suffixless` param, additivity control |
| runtime `body.<anchor>.quat` rung dropped | 1 | the rollout-precedence control |
| scan accepts any tuple (no consumption site) | 1 | derived rule, on a real-tree false positive |
| scan drops the requires-a-bare-key half | 1 | the constructed exemplars |
| scan narrowed to one file | 1 | the non-vacuity floor |
| defect + scan narrowed to one file | 4 | floor plus the rule |
| defect + inventory hardcoded | 2 | the derived rule goes **silent** |
| inventory hardcoded, no defect | 0 | the control for the row above |

The last two rows are the vacuity pair: with the inventory derived the defect fires the rule; hardcoded to today's names, the rule cannot see it and only the behavioural cells fire. The two halves of the fix partition exactly -- the ladder row and the refusal row are disjoint and their union is the both-reverted row.

## Gate

* `ruff check` and `ruff format --check` clean over 1716 files.
* `mypy strands_robots tests tests_integ`: **24 == 24** against the base, normalized message sets identical in both directions, **0 attributable** (`checked 1713` vs `1712`, the one file being the new test).
* `mkdocs build --strict` clean.
* paired run over an identical 717-path selection (all of `tests/policies/` plus every guard that walks the tree, parses source, or reads docstrings and `docs/`), the new file withheld from both sides: identical **29478 collected** and `20 failed, 29350 passed, 108 skipped` on each tree, **20 == 20 failing ids, both `comm` directions empty**. All 20 are environmental and reproduce on the base alone: 17 in `tests/mesh/test_iot_*` need `awsiot`/`awscrt` (both `find_spec` absent locally, both declared in the `mesh-iot` extra, which `all` includes and the default hatch env installs), and 3 are the lerobot-from-source `encode()` drift.

## Deliberately not done

`observation.anchor_rot` is not removed. It is accepted on the current tree, so dropping it would be a breaking change for a caller who may already write it, and that is a separate decision from adding the spelling the convention implies. The docs say which form to prefer and why, and a control cell pins that the older one still resolves.
