### PR TITLE
fix(policies/microduck): the velocity gate refuses a goal it cannot read

### DIFF
--- a/changelog.d/2919-microduck-gate-refuses-a-velocity-it-cannot-read.md
+++ b/changelog.d/2919-microduck-gate-refuses-a-velocity-it-cannot-read.md
@@ -1,0 +1,37 @@
+### Fixed: the Microduck velocity gate refuses a goal it cannot read, before the selection moves
+
+`MicroduckPolicyBundle`'s `switch_on_velocity` gate reads the per-call
+`target_velocity` and picks `move_key` or `idle_key` from its magnitude. It was
+the third reader of that well-known goal key in this family and the only one not
+held to a domain - the other operand of its own comparison, `switch_on_velocity`,
+goes through `positive_finite_number_error` at construction, and the child's
+`MicroduckPolicy._apply_command_kwargs` consults `finite_vector_error` for the
+same key one layer down.
+
+The child's guard states two reasons for its own existence, and both applied to
+the gate. A non-numeric value surfaced as a bare "could not convert string to
+float" out of the gate's own `np.asarray` - a `TypeError` for a mapping, where
+every documented refusal in this family is a `ValueError` - naming neither the
+bundle the caller called nor the parameter it passed. And a non-finite component
+made the magnitude `nan`, which is `>=` nothing, so the gate silently selected
+`idle_key`: a caller asking the robot to move at a `nan` velocity got the
+standing skill.
+
+The selection moving is what made that a defect rather than a lost tick. The
+child refused the tick a line later, against a name the caller never used, but
+the gate had already written `self._active` - and the gate is skipped on any tick
+that carries no velocity, so the flip outlived the failed call and was still
+choosing the skill on every tick after it. A component count outside the two the
+child documents behaved the same way: the gate read a magnitude out of `[0.5]`,
+or out of the first three of `[0.5, 0.0, 0.0, 99.0]`, moved the selection, and
+only then did the tick refuse the width.
+
+The gate now asks the two questions the tick itself will ask - the shared
+per-component vector domain, then `TARGET_VELOCITY_WIDTHS` - before it reads a
+magnitude and before it moves anything, so a refused tick leaves the active skill
+exactly as it was and the refusal names the bundle the caller called. Both
+questions are the child's own helper and the child's own constant, so the two
+readers cannot drift apart on what a velocity is; the regression asserts that
+equality over the whole grid rather than as two lists. An absent velocity is
+still simply "no goal this tick" and leaves the selection alone, which is why the
+early return for it stays above the guard.

--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -214,6 +214,16 @@ magnitude, so a threshold of `0` or below could never select the idle skill and
 a non-finite one could never select the move skill. Omit it (the default) to
 leave the gate off and switch only explicitly.
 
+The velocity it is compared against is held to the same standard as the threshold
+it is compared with. With the gate on, a `target_velocity` this tick cannot honor
+is refused before the gate arbitrates, naming the bundle and the parameter — so a
+refused tick leaves the active skill exactly as it was, rather than selecting the
+idle skill from a `nan` magnitude and keeping that selection on every tick after.
+The accepted values are the ones the active skill accepts: finite numeric
+components, and the same two component counts documented above. An absent
+`target_velocity` is still simply "no goal this tick" and leaves the selection
+alone.
+
 `move_key` and `idle_key` name the two skills that gate selects between, and each
 must be one of the bundle's own keys whenever the gate is enabled. The gate reads
 both every tick, so a key naming no held skill leaves it inert rather than

--- a/strands_robots/policies/microduck/composite.py
+++ b/strands_robots/policies/microduck/composite.py
@@ -30,9 +30,40 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import positive_finite_number_error
+from strands_robots.utils import finite_vector_error, positive_finite_number_error
 
-from .policy import MicroduckPolicy
+from .policy import TARGET_VELOCITY_WIDTHS, MicroduckPolicy
+
+
+def _target_velocity_error(source: str, value: object) -> str | None:
+    """Return why ``value`` cannot be a ``target_velocity``, or ``None`` if it can.
+
+    The two questions the tick itself will ask, asked before the velocity gate
+    reads a magnitude out of the value: the shared per-component vector domain,
+    and the component counts :class:`~strands_robots.policies.microduck.MicroduckPolicy`
+    documents for the same key. Both come from the child's own module, so the
+    gate and the tick cannot drift apart on what a velocity is.
+
+    Args:
+        source: The surface to name in the message - the bundle's own
+            ``get_actions``, since that is the method the caller called.
+        value: The candidate ``target_velocity``.
+
+    Returns:
+        A message naming the parameter and the reason, or ``None`` if the value
+        is a velocity both readers accept.
+    """
+    if error := finite_vector_error(source, "target_velocity", value):
+        return error
+    width = int(np.asarray(value, dtype=np.float32).reshape(-1).shape[0])
+    if width not in TARGET_VELOCITY_WIDTHS:
+        widths = " or ".join(str(w) for w in sorted(TARGET_VELOCITY_WIDTHS, reverse=True))
+        return (
+            f"{source}: target_velocity has {width} component(s), expected {widths} "
+            f"([vx, vy, omega] or [vx, vy]). The gate reads a magnitude from these "
+            f"components, so a width the tick refuses must not move the selection."
+        )
+    return None
 
 
 class MicroduckPolicyBundle(Policy):
@@ -256,6 +287,10 @@ class MicroduckPolicyBundle(Policy):
         last tick of the episode still executes the episodic skill, so a
         1.2s / 60-step kick at 50Hz produces 60 kick actions and the 61st
         tick runs default_skill.
+
+        When the velocity gate is on, a ``target_velocity`` this tick cannot
+        honor is refused before the gate arbitrates, naming this bundle and the
+        parameter - so a refused tick leaves the active skill exactly as it was.
         """
         select = kwargs.get("select")
         if select is not None:
@@ -310,6 +345,17 @@ class MicroduckPolicyBundle(Policy):
         the same boundary in ``_update_policy_session``, which returns early for
         each of its non-pair modes ("Don't switch while sitting") before it looks
         at the magnitude.
+
+        A ``target_velocity`` the tick will refuse is refused here first, before
+        the selection moves, so no failed tick leaves the bundle running a skill
+        the caller did not ask for. An absent one (``None``) is still simply "no
+        goal this tick" and leaves the selection alone.
+
+        Raises:
+            ValueError: If ``target_velocity`` is present but is not a velocity
+                both this gate and the active child can read - a non-numeric or
+                non-finite component, or a component count outside
+                :data:`~strands_robots.policies.microduck.policy.TARGET_VELOCITY_WIDTHS`.
         """
         if self._move_key not in self._policies or self._idle_key not in self._policies:
             return
@@ -317,5 +363,22 @@ class MicroduckPolicyBundle(Policy):
             return
         if target_velocity is None or self._switch_on_velocity is None:
             return
+        # Asked before the coercion below, and before the selection moves. This
+        # is the third reader of the well-known ``target_velocity`` key in the
+        # family and was the only one not held to a domain - the other operand of
+        # the very comparison two lines down, ``switch_on_velocity``, is held to
+        # ``positive_finite_number_error`` at construction. The child's
+        # ``_apply_command_kwargs`` states both reasons for its own guard, and
+        # both of them apply here one layer up. A non-numeric value otherwise
+        # surfaced as a bare ``could not convert string to float`` out of the
+        # ``np.asarray`` below (a ``TypeError`` for a mapping, where this family
+        # documents ``ValueError``), naming neither the bundle the caller called
+        # nor the parameter it passed. And a non-finite one made ``mag`` ``nan``,
+        # which is ``>=`` nothing, so the gate silently selected ``idle_key``: a
+        # caller asking the robot to move at a ``nan`` velocity got the standing
+        # skill, the tick was then refused by the child against a name the caller
+        # never used, and the moved selection outlived that failed call.
+        if error := _target_velocity_error(f"{type(self).__name__}.get_actions", target_velocity):
+            raise ValueError(error)
         mag = float(np.linalg.norm(np.asarray(target_velocity, dtype=np.float32).reshape(-1)[:3]))
         self._active = self._move_key if mag >= self._switch_on_velocity else self._idle_key

--- a/tests/policies/microduck/test_microduck_gate_refuses_a_velocity_it_cannot_read.py
+++ b/tests/policies/microduck/test_microduck_gate_refuses_a_velocity_it_cannot_read.py
@@ -1,0 +1,329 @@
+"""The velocity gate refuses a goal it cannot read, before the selection moves.
+
+``MicroduckPolicyBundle``'s ``switch_on_velocity`` gate reads the per-tick
+``target_velocity`` and picks ``move_key`` or ``idle_key`` from its magnitude.
+It was the third reader of that well-known key in this family and the only one
+not held to a domain. The other operand of its own comparison is: the threshold
+``switch_on_velocity`` goes through ``positive_finite_number_error`` at
+construction. One comparison, two operands, one guarded.
+
+The child's ``MicroduckPolicy._apply_command_kwargs`` states the two reasons for
+its own guard, and both of them applied here one layer up:
+
+* A non-numeric value surfaced as a bare ``could not convert string to float``
+  out of the gate's own ``np.asarray`` - and a ``TypeError`` for a mapping, where
+  this family documents ``ValueError`` - naming neither the bundle the caller
+  called nor the parameter it passed.
+* A non-finite value made the magnitude ``nan``, and ``nan`` is ``>=`` nothing,
+  so the gate silently selected ``idle_key``. A caller asking the robot to move
+  at a ``nan`` velocity got the standing skill. The child then refused the tick
+  against a name the caller never used - and the moved selection outlived that
+  failed call, so a caller that handled the error and kept ticking was running a
+  skill it never asked for.
+
+A width outside the two the child documents behaved the same way: the gate read
+a magnitude out of ``[0.5]`` or the first three of ``[0.5, 0, 0, 99]``, moved the
+selection, and only then did the tick refuse the width.
+
+Nothing graded it because every cell that exercises the gate passes a velocity
+both readers accept, and every cell that exercises a bad velocity drives the
+child directly - so no cell held a bundle and a value the tick would refuse. The
+invariant below is the one that was missing: a refused tick leaves the active
+skill exactly as it was.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import math
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import MicroduckPolicy, MicroduckPolicyBundle
+from strands_robots.policies.microduck import composite as composite_mod
+from strands_robots.policies.microduck import policy as policy_mod
+from strands_robots.policies.microduck.policy import TARGET_VELOCITY_WIDTHS
+
+from .test_microduck_gate_arbitrates_between_the_pair import (
+    _GATE_THRESHOLD,
+    _IDLE_KEY,
+    _MOVE_KEY,
+    _bundle,
+)
+from .test_microduck_policy import _obs_dict, _StubSession
+
+#: Velocities neither the gate nor the tick can honor, one per failure kind the
+#: two guards cover: a non-finite component, a non-numeric one, and a component
+#: count outside the pair the child documents.
+_REFUSED: tuple[Any, ...] = (
+    pytest.param([float("nan"), 0.0, 0.0], id="nan-in-vx"),
+    pytest.param([0.0, 0.0, float("nan")], id="nan-in-omega"),
+    pytest.param([float("inf"), 0.0, 0.0], id="positive-inf"),
+    pytest.param([float("-inf"), 0.0, 0.0], id="negative-inf"),
+    pytest.param([0.5, None, 0.0], id="none-component"),
+    pytest.param("fast", id="string"),
+    pytest.param({"vx": 1.0}, id="mapping"),
+    pytest.param(["a", "b", "c"], id="string-components"),
+    pytest.param(0.5, id="bare-scalar"),
+    pytest.param([0.5], id="one-component"),
+    pytest.param([0.5, 0.0, 0.0, 99.0], id="four-components"),
+)
+
+#: Velocities both readers accept, with the skill the magnitude selects. The
+#: two-component spelling is documented and deliberately kept.
+_ACCEPTED: tuple[Any, ...] = (
+    pytest.param([0.5, 0.0, 0.0], _MOVE_KEY, id="three-components-moving"),
+    pytest.param([0.0, 0.0, 0.0], _IDLE_KEY, id="three-components-still"),
+    pytest.param([0.5, 0.0], _MOVE_KEY, id="two-components-moving"),
+    pytest.param([0.0, 0.0], _IDLE_KEY, id="two-components-still"),
+    pytest.param([1, 0, 0], _MOVE_KEY, id="integer-components"),
+    pytest.param(np.array([0.4, 0.0, 0.0], dtype=np.float32), _MOVE_KEY, id="numpy-vector"),
+)
+
+#: The prefix the bundle's own refusals carry. Matched as a prefix rather than a
+#: containment: ``MicroduckPolicy`` is a substring of ``MicroduckPolicyBundle``,
+#: so "the child is not named" cannot be spelled with ``not in``.
+_BUNDLE_PREFIX = f"{MicroduckPolicyBundle.__name__}.get_actions:"
+
+
+def _tick(bundle: MicroduckPolicyBundle, **kwargs: Any) -> None:
+    asyncio.run(bundle.get_actions(_obs_dict(), "", **kwargs))
+
+
+def _tick_error(bundle: MicroduckPolicyBundle, **kwargs: Any) -> Exception | None:
+    """Run one tick; return the exception it raised, or ``None`` on success.
+
+    Deliberately not ``BaseException``: every refusal on this path is a
+    ``ValueError`` and the pre-fix ones a ``ValueError`` or ``TypeError``, so the
+    narrowest superset that can hold the measurement is ``Exception``.
+    """
+    try:
+        _tick(bundle, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - the exception type is the measurement
+        return exc
+    return None
+
+
+def _child_refuses(value: Any) -> bool:
+    """Whether the active child refuses ``value`` on its own, through its own path.
+
+    Measured by driving a bare :class:`MicroduckPolicy`, not by reading the
+    child's source, so the parity cell below grades behaviour rather than
+    spelling.
+    """
+    policy = MicroduckPolicy(session=_StubSession())  # type: ignore[arg-type]
+    asyncio.run(policy.get_actions(_obs_dict(), ""))  # configure from metadata
+    try:
+        asyncio.run(policy.get_actions(_obs_dict(), "", target_velocity=value))
+    except Exception:
+        return True
+    return False
+
+
+def _auto_switch_body() -> list[ast.stmt]:
+    source = textwrap.dedent(inspect.getsource(MicroduckPolicyBundle._auto_switch))
+    function = ast.parse(source).body[0]
+    assert isinstance(function, ast.FunctionDef)
+    return function.body
+
+
+def _statement_index(predicate) -> int:
+    """The index of the first top-level statement in ``_auto_switch`` matching."""
+    for index, statement in enumerate(_auto_switch_body()):
+        if predicate(ast.unparse(statement)):
+            return index
+    raise AssertionError("no statement in _auto_switch matched the predicate")
+
+
+class TestARefusedTickDoesNotMoveTheSelection:
+    """The invariant: a velocity the tick cannot honor leaves the skill alone."""
+
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_the_tick_is_refused(self, value):
+        assert isinstance(_tick_error(_bundle(active=_MOVE_KEY), target_velocity=value), ValueError)
+
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_the_active_skill_is_unchanged_from_move(self, value):
+        bundle = _bundle(active=_MOVE_KEY)
+        _tick_error(bundle, target_velocity=value)
+        assert bundle.active == _MOVE_KEY
+
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_the_active_skill_is_unchanged_from_idle(self, value):
+        # The other direction: a magnitude the gate would have read as moving
+        # must not pull the bundle out of idle on a tick that fails.
+        bundle = _bundle(active=_IDLE_KEY)
+        _tick_error(bundle, target_velocity=value)
+        assert bundle.active == _IDLE_KEY
+
+    def test_the_selection_does_not_move_across_a_later_tick_either(self):
+        # The failure mode that made this a defect rather than a lost tick: the
+        # gate is skipped when no velocity is carried, so a flip it made on a
+        # refused tick was still commanding the robot on every tick after.
+        bundle = _bundle(active=_MOVE_KEY)
+        assert isinstance(_tick_error(bundle, target_velocity=[float("nan"), 0.0, 0.0]), ValueError)
+        _tick(bundle)
+        assert bundle.active == _MOVE_KEY
+
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_no_held_skill_ran(self, value):
+        # A refused tick must not have handed the value to a policy either.
+        bundle = _bundle(active=_MOVE_KEY)
+        _tick_error(bundle, target_velocity=value)
+        assert all(pol._session.last_input is None for pol in bundle._policies.values())  # type: ignore[union-attr]
+
+
+class TestTheRefusalNamesTheBundleAndTheParameter:
+    """The diagnosis half: a bare numpy message named neither."""
+
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_the_message_names_the_surface_the_caller_called(self, value):
+        error = _tick_error(_bundle(active=_MOVE_KEY), target_velocity=value)
+        assert str(error).startswith(_BUNDLE_PREFIX), str(error)
+
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_the_message_names_the_parameter(self, value):
+        error = _tick_error(_bundle(active=_MOVE_KEY), target_velocity=value)
+        assert "target_velocity" in str(error), str(error)
+
+    @pytest.mark.parametrize("value", [pytest.param({"vx": 1.0}, id="mapping")])
+    def test_a_mapping_is_the_documented_error_type(self, value):
+        # This one used to be a ``TypeError`` out of ``float()`` inside numpy,
+        # where every documented refusal in this family is a ``ValueError``.
+        assert type(_tick_error(_bundle(active=_MOVE_KEY), target_velocity=value)) is ValueError
+
+    def test_a_wrong_width_says_which_widths_it_expects(self):
+        error = _tick_error(_bundle(active=_MOVE_KEY), target_velocity=[0.5])
+        text = " ".join(str(error).split())
+        assert "target_velocity has 1 component(s)" in text, text
+        for width in TARGET_VELOCITY_WIDTHS:
+            assert str(width) in text, text
+
+
+class TestTheGateRefusesExactlyWhatTheTickRefuses:
+    """Parity, derived: the gate's verdict equals the child's on every value.
+
+    This is what makes the width question the gate's business as well as the
+    child's. Refusing less leaves a refused tick moving the selection; refusing
+    more would reject a goal a caller may legitimately ask for. Asserted as an
+    equality over both grids rather than as two lists, so a future widening on
+    either side has to move both.
+    """
+
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_the_gate_refuses_a_value_the_tick_refuses(self, value):
+        gate_refuses = composite_mod._target_velocity_error(_BUNDLE_PREFIX, value) is not None
+        assert gate_refuses is _child_refuses(value) is True
+
+    @pytest.mark.parametrize("value,expected", _ACCEPTED)
+    def test_the_gate_accepts_a_value_the_tick_accepts(self, value, expected):
+        gate_refuses = composite_mod._target_velocity_error(_BUNDLE_PREFIX, value) is not None
+        assert gate_refuses is _child_refuses(value) is False
+
+
+class TestTheChildsRefusalSetIsThePremise:
+    """What the child does on its own. Holds on the pre-fix code too.
+
+    The gate is being held to this set, so the set itself is worth stating: it
+    is measured by driving a bare :class:`MicroduckPolicy`, not by reading the
+    child's source, so the parity above grades behaviour rather than spelling.
+    """
+
+    @pytest.mark.parametrize("value", _REFUSED)
+    def test_the_tick_alone_refuses_it(self, value):
+        assert _child_refuses(value)
+
+    @pytest.mark.parametrize("value,expected", _ACCEPTED)
+    def test_the_tick_alone_accepts_it(self, value, expected):
+        assert not _child_refuses(value)
+
+    def test_the_refused_set_covers_every_kind_the_two_guards_answer(self):
+        # Non-vacuity: the grid above must keep reaching all three failure kinds,
+        # so it cannot shrink to one and still look exhaustive.
+        values = [param.values[0] for param in _REFUSED]
+        non_finite = [
+            v for v in values if isinstance(v, list) and any(isinstance(c, float) and not math.isfinite(c) for c in v)
+        ]
+        non_numeric = [v for v in values if isinstance(v, str | dict)]
+        wrong_width = [v for v in values if isinstance(v, list) and len(v) not in TARGET_VELOCITY_WIDTHS]
+        assert non_finite and non_numeric and wrong_width
+
+
+class TestWhatIsUnchangedEitherWay:
+    """The boundary. Every cell here holds on the pre-fix code too."""
+
+    @pytest.mark.parametrize("value,expected", _ACCEPTED)
+    def test_a_readable_velocity_still_arbitrates(self, value, expected):
+        bundle = _bundle(active=_MOVE_KEY if expected == _IDLE_KEY else _IDLE_KEY)
+        _tick(bundle, target_velocity=value)
+        assert bundle.active == expected
+
+    def test_the_threshold_is_still_inclusive_at_its_own_value(self):
+        bundle = _bundle(active=_IDLE_KEY)
+        _tick(bundle, target_velocity=[_GATE_THRESHOLD, 0.0, 0.0])
+        assert bundle.active == _MOVE_KEY
+
+    def test_an_absent_velocity_is_still_no_goal_rather_than_a_refusal(self):
+        # ``None`` reaches the shared domain as a refusal, so the early return
+        # for it has to stay above the guard: a tick that carries no goal is the
+        # ordinary case, not a bad velocity.
+        bundle = _bundle(active=_MOVE_KEY)
+        assert _tick_error(bundle, target_velocity=None) is None
+        assert bundle.active == _MOVE_KEY
+
+    def test_a_tick_with_no_velocity_kwarg_at_all_is_still_accepted(self):
+        bundle = _bundle(active=_MOVE_KEY)
+        assert _tick_error(bundle) is None
+        assert bundle.active == _MOVE_KEY
+
+    def test_the_gate_being_off_leaves_the_refusal_to_the_child(self):
+        # With no threshold ``_auto_switch`` is never called, so the value is
+        # forwarded untouched and the child is the one that refuses it - the
+        # selection was never at risk on that path, and still is not.
+        bundle = _bundle(active=_MOVE_KEY, gate=None)
+        assert isinstance(_tick_error(bundle, target_velocity=[float("nan"), 0.0, 0.0]), ValueError)
+        assert bundle.active == _MOVE_KEY
+
+    def test_a_third_skill_active_is_still_left_alone(self):
+        bundle = _bundle(active="sitstand")
+        _tick_error(bundle, target_velocity=[float("nan"), 0.0, 0.0])
+        assert bundle.active == "sitstand"
+
+
+class TestTheGuardIsAskedBeforeTheSelectionMoves:
+    """Structural: ordering is the whole point, so it is asserted directly."""
+
+    def test_the_guard_precedes_the_magnitude(self):
+        guard = _statement_index(lambda text: "_target_velocity_error" in text)
+        magnitude = _statement_index(lambda text: "linalg.norm" in text)
+        assert guard < magnitude
+
+    def test_the_guard_precedes_the_assignment_that_moves_the_selection(self):
+        guard = _statement_index(lambda text: "_target_velocity_error" in text)
+        assignment = _statement_index(lambda text: "self._active =" in text)
+        assert guard < assignment
+
+    def test_the_absent_velocity_return_precedes_the_guard(self):
+        early = _statement_index(lambda text: "target_velocity is None" in text)
+        guard = _statement_index(lambda text: "_target_velocity_error" in text)
+        assert early < guard
+
+
+class TestTheDomainIsTheChildsOwn:
+    """Single-sourced: the gate and the tick read one helper and one constant."""
+
+    def test_the_helper_consults_the_shared_vector_domain(self):
+        assert "finite_vector_error" in inspect.getsource(composite_mod._target_velocity_error)
+
+    def test_the_width_refusal_reads_the_shared_constant(self):
+        # Not a restated literal: widening the child's accepted spellings widens
+        # the gate's, so the two cannot drift apart on what a velocity is.
+        assert "TARGET_VELOCITY_WIDTHS" in inspect.getsource(composite_mod._target_velocity_error)
+
+    def test_the_constant_is_the_childs_own_object(self):
+        assert composite_mod.TARGET_VELOCITY_WIDTHS is policy_mod.TARGET_VELOCITY_WIDTHS


### PR DESCRIPTION
## The finding

`MicroduckPolicyBundle`'s `switch_on_velocity` gate reads the per-call
`target_velocity` and picks `move_key` or `idle_key` from its magnitude
(`composite.py`, `_auto_switch`). It was the only reader of that well-known goal
key in this family not held to a value domain, and the asymmetry is inside its
own comparison:

| operand of `mag >= self._switch_on_velocity` | domain | where |
| --- | --- | --- |
| `switch_on_velocity` (the threshold) | `positive_finite_number_error` | bundle constructor |
| the magnitude, from `target_velocity` | none | read straight into `np.asarray` |

One comparison, two operands, one guarded. The child's
`MicroduckPolicy._apply_command_kwargs` states two reasons for its own guard on
the same key, and both of them applied here one layer up.

## Measured, on a bundle holding `walk` + `stand` with the gate at 0.1

**A non-finite component silently selected the idle skill.** `nan` is `>=`
nothing, so a caller asking the robot to move at a `nan` velocity got the
standing skill:

| `target_velocity` | magnitude | gate selected | the call then |
| --- | --- | --- | --- |
| `[0.5, 0.0, 0.0]` | 0.5000 | `walk` | success |
| `[0.0, 0.0, 0.0]` | 0.0000 | `stand` | success |
| `[nan, 0.0, 0.0]` | nan | `stand` | refused by the child |
| `[0.0, 0.0, nan]` | nan | `stand` | refused by the child |
| `[inf, 0.0, 0.0]` | inf | `walk` | refused by the child |

**The selection moving is what made that a defect rather than a lost tick.**
The child refuses the tick a line later, so the caller sees an error - but the
gate has already written `self._active`, and the gate is skipped on any tick that
carries no velocity. So the flip outlived the failed call:

| step | active |
| --- | --- |
| start | `walk` |
| tick `[nan, 0, 0]` (raises) | `stand` |
| tick with no velocity (succeeds) | `stand` |
| tick `[0.5, 0, 0]` (succeeds) | `walk` |

Row 3 is the damage: a caller that handled the error and kept ticking was
running the standing skill, and nothing in the successful tick said so.

**A non-numeric value produced a bare third-party message, and for a mapping the
wrong exception type.** Every documented refusal in this family is a
`ValueError`:

| `target_velocity` | before | after |
| --- | --- | --- |
| `"fast"` | `ValueError: could not convert string to float: 'fast'` | `ValueError: MicroduckPolicyBundle.get_actions: 'target_velocity' elements must be numbers, got 'fast'` |
| `{"vx": 1.0}` | `TypeError: float() argument must be a string or a real number, not 'dict'` | `ValueError: MicroduckPolicyBundle.get_actions: ...` |
| `["a", "b", "c"]` | `ValueError: could not convert string to float: 'a'` | `ValueError: MicroduckPolicyBundle.get_actions: ...` |

**A component count outside the two the child documents behaved the same way**
as the non-finite case: the gate read a magnitude out of `[0.5]`, or out of the
first three of `[0.5, 0.0, 0.0, 99.0]`, moved the selection, and only then did
the tick refuse the width. A bare scalar was read as one component.

## Why nothing caught it

Every cell that exercises the gate passes a velocity both readers accept, and
every cell that exercises a bad velocity drives the child directly - so no cell
held a bundle and a value the tick would refuse. Measured: reverting this change
fires **0** of the pre-existing cells in `tests/policies/microduck/`, on every one
of the nine mutations in the table below.

## The change

`_auto_switch` now asks the two questions the tick itself will ask, before it
reads a magnitude and before it moves anything:

1. the shared per-component vector domain, `finite_vector_error`, under the
   caller's own parameter name;
2. the component counts the child documents, `TARGET_VELOCITY_WIDTHS`.

Both are the child's own helper and the child's own constant, so the gate and the
tick cannot drift apart on what a velocity is. The refusal names
`MicroduckPolicyBundle.get_actions`, which is the surface the caller called. An
absent `target_velocity` is still simply "no goal this tick", which is why the
early return for it stays above the guard.

## Verification

Pre-fix split with the new suite kept and the source reverted: **48 failed / 73
passed**, per class:

| class | fires | role |
| --- | --- | --- |
| `TestARefusedTickDoesNotMoveTheSelection` | 10 / 45 | the invariant |
| `TestTheRefusalNamesTheBundleAndTheParameter` | 15 / 24 | the diagnosis |
| `TestTheGateRefusesExactlyWhatTheTickRefuses` | 17 / 17 | derived parity |
| `TestTheGuardIsAskedBeforeTheSelectionMoves` | 3 / 3 | structural |
| `TestTheDomainIsTheChildsOwn` | 3 / 3 | single-sourcing |
| `TestTheChildsRefusalSetIsThePremise` | **0 / 18** | premise, holds either way |
| `TestWhatIsUnchangedEitherWay` | **0 / 11** | controls |

The mixed parametrized classes are honest: some spellings the pre-fix code did
refuse (the child refused the tick, so `test_the_tick_is_refused` passed) and
some it did name (`target_velocity` appears in the child's own message). The
cells that fire are the ones about the selection and about which surface is
named.

Mutation table, run against my file and against the rest of
`tests/policies/microduck/` separately (`collected` stable at 121 on every row):

| row | mutation | mine | siblings |
| --- | --- | --- | --- |
| b0 | control | 0 | 0 |
| b1 | guard removed entirely (the pre-fix state) | 48 | 0 |
| b2 | guard asked after the magnitude and the assignment | 19 | 0 |
| b3 | shared domain only, no width question | 6 | 0 |
| b4 | width question only, no shared domain | 28 | 0 |
| b5 | absent-velocity return moved below the guard | 4 | 0 |
| b6 | width refusal restates the literal pair | 1 | 0 |
| b7 | domain told a name the caller never used | 9 | 0 |
| b8 | message names the child, not the bundle | 11 | 0 |
| b9 | refusal raised as `TypeError` | 13 | 0 |

Ten mutations, ten distinct firing sets, control clean, source restored
md5-identical. `b3` and `b4` are **disjoint** (overlap 0) and their union is a
strict subset of `b1` (34 of 48): the 14 residual cells name
`_target_velocity_error` directly, so they need the helper to exist rather than
merely to be correct, and in `b3`/`b4` it still does.

Green gate: `ruff check` clean, `ruff format --check` 1718 files already
formatted, `mypy` **24 == 24** against the base with both normalised message-set
diffs empty and 0 attributable, `mkdocs build --strict` clean.

Paired suite over an identical 652-path selection (every `tests/policies/` file,
every guard that walks the tree or reads docstrings, and everything naming
`finite_vector_error` / `TARGET_VELOCITY_WIDTHS` / `MicroduckPolicyBundle`), with
the new test file withheld from both sides: identical **26908 collected** and
`20 failed, 26808 passed, 80 skipped` on each, **both failing-id diffs empty**.
All 20 are on the base too: 17 need `awsiot` / `awscrt` (both `find_spec` False
here, both declared in the `mesh-iot` extra that `all` pulls in, so CI has them)
and 3 are the lerobot-from-source `encode()` drift.

## No visual artifact, and why

The accepted path is byte-identical: every value in the accepted grid selects the
same skill as before, and the 356 pre-existing cells in
`tests/policies/microduck/` pass unchanged. The changed path is a refusal, so it
produces no rollout to render. The before/after selection and refusal tables above
are the evidence. This matches the sibling change that gave the same parameter its
domain one layer down (#2905: changelog, docs, source, test).

## Deliberately not done

The two-component spelling stays accepted, because this policy's command vector
persists across ticks and "set vx and vy, leave omega" is therefore a coherent
request - the same reason the child keeps it. What the twist slots *mean* is still
a property of the loaded weights rather than of the gate, so a bundle whose
`move_key` reads slot 0 as a posture flag is out of the gate's pair by design and
is left alone; that boundary is unchanged and pinned.
