### PR TITLE
fix(tools/serial_tool): the documented bound is the bound that is enforced

### DIFF
--- a/changelog.d/2812-serial-tool-documented-bounds.md
+++ b/changelog.d/2812-serial-tool-documented-bounds.md
@@ -1,0 +1,47 @@
+### Fixed: the serial_tool bound the model is told is the bound the tool enforces
+
+`serial_tool` is an agent tool, so each register field's `Args:` entry is lifted
+into the tool's input schema and that schema is the whole of what the model
+driving the bus knows about the field's domain. Two of the three bounds were
+restated in prose beside a bound decided in code, and nothing compared the copies.
+
+One had already drifted. `Goal_Velocity` is sign-magnitude, so a magnitude
+reaching bit 15 is read by the servo as full speed in the *opposite* direction --
+a different command rather than a faster one -- and the enforced ceiling was
+tightened to 32767 for exactly that reason. The docstring kept saying `[0, 65535]`:
+
+```
+field     documented   enforced
+velocity  [0, 65535]   [0, 32767]
+```
+
+So the tool advertised 32768 values it refuses, half the domain it offered, and a
+model that took the schema at its word got a well-worded refusal for a call the
+schema said was in range. The entry now states the ceiling that is applied and
+the reason it is not the two-byte maximum.
+
+The other copy is a drift that had not happened yet. The position full scale was
+spelled twice -- once as the `position` ceiling, once as the divisor the reported
+angle turns a count into degrees with -- while the ceiling's own reason string
+claimed the two are "the same full scale". That claim was asserted and never
+enforced, so a correction to either would have been invisible to the other. Both
+now read one name.
+
+`tests/tools/test_serial_tool_documented_bounds.py` grades both halves, deriving
+the fields it checks from the module so a field added without a documented bound
+is graded on arrival: the interval in the generated schema must equal the interval
+the validator applies, the documented ceiling must be accepted where one past it
+is refused, and the full scale must appear as a single integer literal in the
+module. On the previous arrangement those cells report `velocity: the tool schema
+tells the model (0, 65535) while the validator enforces (0, 32767)` and `the
+position full scale 4095 is spelled as 2 integer literals, on lines [85, 410]`.
+
+Still open, and deliberately untouched: which full scale is correct. Issue #2812
+reports that the family the registry declares spans two resolutions (`sts3215` at
+4096 counts, `scs0009` at 1024, the latter every motor of `hope_jr_hand`), so on an
+SCS-series bus the ceiling is four times the addressable maximum and the reported
+angle is four times low. Choosing between naming the model, reporting counts only,
+and narrowing the claim to the STS series changes the tool's public surface and
+wants hardware this suite does not have. Single-sourcing the number is the half
+that issue asks for regardless of which way it is settled, and it makes that
+correction one edit instead of two that can disagree.

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -68,6 +68,15 @@ _DIRECTION_BIT = 15
 # Largest magnitude either register carries with ``_DIRECTION_BIT`` still clear.
 _MAX_MAGNITUDE = (1 << _DIRECTION_BIT) - 1
 
+# Largest index ``Goal_Position`` addresses, and the divisor that turns a count
+# into the reported angle. One name carries both because the ceiling's own reason
+# below claims the two are "the same full scale": while they were separate
+# literals that claim was asserted rather than enforced, so a correction to
+# either was invisible to the other. See issue #2812, which reports that the
+# right full scale is model-dependent -- the registry declares SCS-series servos
+# at a quarter of this -- and that the choice is still open.
+_MAX_POSITION = 4095
+
 # Inclusive bounds and the reason for each ceiling, keyed by the parameter that
 # carries the field. The floor and the type are delegated to the shared count
 # domains so an off-type or negative value is reported in the words every other
@@ -82,7 +91,7 @@ _REGISTER_FIELDS: dict[str, tuple[int, int, str]] = {
     ),
     "position": (
         0,
-        4095,
+        _MAX_POSITION,
         "Goal_Position is a 12-bit register, the same full scale the reported angle divides by",
     ),
     "velocity": (
@@ -266,7 +275,9 @@ def serial_tool(
             which 254 (0xfe) is the broadcast every servo receives. An action
             that reads a reply back accepts only a single servo, [1, 253]
         position: Target position for Feetech motors; an integer in [0, 4095]
-        velocity: Target velocity for Feetech motors; an integer in [0, 65535]
+        velocity: Target velocity for Feetech motors; an integer in [0, 32767].
+            Goal_Velocity is sign-magnitude, so a magnitude reaching bit 15
+            commands the opposite direction instead of a faster move
         read_bytes: Number of bytes to read; a positive integer
 
     Validation:
@@ -407,7 +418,9 @@ def serial_tool(
             return {
                 "status": "success",
                 "content": [
-                    {"text": f"Feetech Motor {motor_id} -> Position {position} ({position / 4095 * 360:.1f} deg)"}
+                    {
+                        "text": f"Feetech Motor {motor_id} -> Position {position} ({position / _MAX_POSITION * 360:.1f} deg)"
+                    }
                 ],
             }
 

--- a/tests/tools/test_serial_tool_documented_bounds.py
+++ b/tests/tools/test_serial_tool_documented_bounds.py
@@ -1,0 +1,181 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The bound ``serial_tool`` documents must be the bound ``serial_tool`` enforces.
+
+``serial_tool`` is an agent tool, so the ``Args:`` entry for each register field
+is not commentary: ``docstring_parser`` lifts it into the tool's input schema and
+that schema is the whole of what the model driving the tool knows about the
+field's domain. A bound restated in prose beside a bound decided in code is two
+copies of one fact, and nothing compared them.
+
+Measured on ``de9762a``, one of the three had already drifted::
+
+    field     documented        enforced
+    motor_id  [1, 254]          [1, 254]
+    position  [0, 4095]         [0, 4095]
+    velocity  [0, 65535]        [0, 32767]     <-- 50% of the advertised domain
+
+The enforced ceiling is the correct one and was tightened deliberately:
+``Goal_Velocity`` is sign-magnitude, so 65535 sets bit 15 and the servo reads it
+as full speed in the *opposite* direction -- a different command, not a faster
+one. ``tests/tools/test_serial_tool_numeric_domain.py`` records that change and
+asserts 32767. What went unchanged was the docstring, so the tool went on
+offering the model 32768 values it refuses, each with a well-worded refusal for a
+call the schema said was in range.
+
+The second half is the drift that had not happened yet. The full scale was
+spelled twice -- once as the ``position`` ceiling and once as the divisor the
+reported angle turns a count into degrees with -- while the ceiling's own reason
+string claimed they are "the same full scale". That claim was asserted and never
+enforced, so a correction to one would have been invisible to the other. Issue
+#2812 reports that the family the registry declares spans two resolutions
+(``sts3215`` at 4096 counts, ``scs0009`` at 1024) and asks for the ceiling and
+the divisor to be single-sourced whichever way the model question is settled.
+This module pins that, so the correction is one edit rather than two that can
+disagree.
+
+Deliberately out of scope: which full scale is right. Choosing between naming the
+model, reporting counts only, and narrowing the claim to the STS series is the
+open decision in #2812 and needs hardware this suite does not have. These cells
+grade only that the number is stated once and reported honestly.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+from typing import Any
+
+import pytest
+import serial
+
+import strands_robots.tools.serial_tool as serial_mod
+
+#: The bound a field's schema entry declares, as the model reads it. ``motor_id``
+#: carries a second interval for the reply-expecting actions, so the *first*
+#: interval is the domain of the parameter itself.
+_INTERVAL = re.compile(r"\[\s*(-?\d+)\s*,\s*(-?\d+)\s*\]")
+
+#: Every register field the tool bounds, derived from the module rather than
+#: listed here, so a field added without a documented bound is graded on arrival.
+_REGISTER_FIELDS = tuple(serial_mod._REGISTER_FIELDS)
+
+
+class _FakeSerial:
+    """Stand-in for ``serial.Serial`` recording the bytes that reach the wire."""
+
+    def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+        self.writes: list[bytes] = []
+        self.in_waiting = 0
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    def read(self, n: int = 1) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.fixture
+def opened(monkeypatch: pytest.MonkeyPatch) -> list[_FakeSerial]:
+    created: list[_FakeSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _FakeSerial:
+        instance = _FakeSerial(port, baudrate, timeout)
+        created.append(instance)
+        return instance
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return created
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    return serial_mod.serial_tool(port="/dev/fake0", **kwargs)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+def _documented_bound(field: str) -> tuple[int, int]:
+    """The interval this field's entry declares in the generated tool schema."""
+    properties = serial_mod.serial_tool.tool_spec["inputSchema"]["json"]["properties"]
+    description = " ".join(properties[field]["description"].split())
+    match = _INTERVAL.search(description)
+    assert match is not None, f"{field}: schema entry declares no [lo, hi] interval: {description!r}"
+    return int(match.group(1)), int(match.group(2))
+
+
+class TestTheDocumentedBoundIsTheEnforcedBound:
+    """A domain the schema advertises and the validator refuses is not a domain."""
+
+    @pytest.mark.parametrize("field", _REGISTER_FIELDS)
+    def test_the_schema_declares_the_bound_the_validator_applies(self, field: str) -> None:
+        floor, ceiling, _reason = serial_mod._REGISTER_FIELDS[field]
+
+        assert _documented_bound(field) == (floor, ceiling), (
+            f"{field}: the tool schema tells the model {_documented_bound(field)} "
+            f"while the validator enforces {(floor, ceiling)}"
+        )
+
+    @pytest.mark.parametrize(
+        "action,field",
+        [("feetech_position", "position"), ("feetech_velocity", "velocity")],
+    )
+    def test_the_documented_ceiling_is_accepted_and_one_past_it_is_refused(
+        self, action: str, field: str, opened: list[_FakeSerial]
+    ) -> None:
+        ceiling = _documented_bound(field)[1]
+
+        accepted = _call(action=action, motor_id=1, **{field: ceiling})
+        assert accepted["status"] == "success", f"{field}={ceiling} is documented as in range: {_text(accepted)}"
+
+        refused = _call(action=action, motor_id=1, **{field: ceiling + 1})
+        assert refused["status"] == "error"
+        assert str(ceiling) in _text(refused)
+
+
+class TestTheFullScaleIsSingleSourced:
+    """The ceiling and the report divisor are one number, not two that agree."""
+
+    def test_the_full_scale_appears_as_one_literal_in_the_module(self) -> None:
+        # Taken from the enforced ceiling rather than from the constant that now
+        # holds it, so this cell states the property and not the fix's spelling.
+        full_scale = serial_mod._REGISTER_FIELDS["position"][1]
+        tree = ast.parse(inspect.getsource(serial_mod))
+        literals = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and node.value.__class__ is int and node.value == full_scale
+        ]
+
+        assert len(literals) == 1, (
+            f"the position full scale {full_scale} is spelled as {len(literals)} "
+            f"integer literals, on lines {[node.lineno for node in literals]}; the "
+            "ceiling and the reported angle's divisor must read one name so a "
+            "correction to either cannot leave the other behind"
+        )
+
+    def test_the_reported_angle_divides_by_the_enforced_ceiling(self, opened: list[_FakeSerial]) -> None:
+        _floor, ceiling, _reason = serial_mod._REGISTER_FIELDS["position"]
+
+        result = _call(action="feetech_position", motor_id=1, position=ceiling)
+
+        assert result["status"] == "success"
+        # Full scale is a full turn. Were the divisor to keep a scale the ceiling
+        # no longer uses, the count the servo treats as its limit would report as
+        # a fraction of one -- #2812 measures that as 89.9 deg on an scs0009.
+        assert "360.0 deg" in _text(result), (
+            f"position={ceiling} is the enforced ceiling, so it is full scale, but the tool reported: {_text(result)}"
+        )
+
+    def test_half_the_enforced_ceiling_reports_half_a_turn(self, opened: list[_FakeSerial]) -> None:
+        _floor, ceiling, _reason = serial_mod._REGISTER_FIELDS["position"]
+
+        result = _call(action="feetech_position", motor_id=1, position=ceiling // 2)
+
+        assert result["status"] == "success"
+        assert f"{ceiling // 2 / ceiling * 360:.1f} deg" in _text(result)


### PR DESCRIPTION
## What this fixes

`serial_tool` is an agent tool, so each register field's `Args:` entry is lifted into the tool's input schema by `docstring_parser`, and that schema is the whole of what the model driving the servo bus knows about the field's domain. Two of the three register bounds were **restated in prose beside a bound decided in code**, and nothing compared the copies.

One had already drifted. Measured on `de9762a` through the generated schema:

| field | documented (schema) | enforced (validator) | |
|---|---|---|---|
| `motor_id` | `[1, 254]` | `[1, 254]` | match |
| `position` | `[0, 4095]` | `[0, 4095]` | match |
| `velocity` | `[0, 65535]` | `[0, 32767]` | **drift** |

The **enforced** ceiling is the correct one, and it was tightened deliberately: `Goal_Velocity` is sign-magnitude, so a magnitude reaching bit 15 is read by the servo as full speed in the *opposite* direction, which is a different command rather than a faster one. `tests/tools/test_serial_tool_numeric_domain.py:162` records exactly that change ("32767 replaces the 65535 this case used to assert"). What went unchanged was the docstring.

So the tool advertised 32768 values it refuses - **half the domain it offered the model**:

```
velocity=    0 -> accepted        (validation cleared, reached the port)
velocity=32767 -> accepted        (validation cleared, reached the port)
velocity=32768 -> REFUSED         advertised as in range
velocity=40000 -> REFUSED         advertised as in range
velocity=65535 -> REFUSED         advertised as in range

refused span = 32768 of the 65536 advertised = 50.0% of the domain
```

The refusal itself is well worded and names its reason. The schema was the part that was wrong, and a model that took it at its word got a refusal for a call the schema said was in range.

## The second copy: a drift that had not happened yet

The position full scale was spelled **twice** - once as the `position` ceiling, once as the divisor the reported angle turns a count into degrees with - while the ceiling's own reason string claims the two are *"the same full scale the reported angle divides by"*. That claim was asserted and never enforced, so a correction to either would have been invisible to the other. Both now read one name, `_MAX_POSITION`.

## The pin

`tests/tools/test_serial_tool_documented_bounds.py` (8 cells) derives the fields it grades from `_REGISTER_FIELDS` rather than listing them, so a field added without a documented bound is graded on arrival:

- `test_the_schema_declares_the_bound_the_validator_applies` - the first interval in the generated schema entry must equal the interval the validator enforces.
- `test_the_documented_ceiling_is_accepted_and_one_past_it_is_refused` - end to end, through the tool, on a recording fake port.
- `test_the_full_scale_appears_as_one_literal_in_the_module` - AST walk; the full scale must be a single integer literal. Takes the value from the enforced ceiling rather than from the new constant, so the cell states the property and not this fix's spelling.
- `test_the_reported_angle_divides_by_the_enforced_ceiling` / `test_half_the_enforced_ceiling_reports_half_a_turn` - the behavioural half, so a ceiling changed without the divisor fails even if the literal count stays at one.

Verified by reverting only the source fix and keeping the pin - **3 failed / 5 passed** on the previous arrangement, 8 passed on this one:

```
FAILED ...::test_the_schema_declares_the_bound_the_validator_applies[velocity]
  velocity: the tool schema tells the model (0, 65535) while the validator enforces (0, 32767)

FAILED ...::test_the_documented_ceiling_is_accepted_and_one_past_it_is_refused[feetech_velocity-velocity]
  velocity=65535 is documented as in range: feetech_velocity: velocity must be at most 32767 (...)

FAILED ...::test_the_full_scale_appears_as_one_literal_in_the_module
  the position full scale 4095 is spelled as 2 integer literals, on lines [85, 410]
```

## Gate

- `tests/tools/test_serial_tool.py` + `test_serial_tool_numeric_domain.py` + this file: **104 passed**.
- With the Feetech wire-format suites (`test_feetech_velocity_direction_bit.py`, `test_feetech_status_packet_framing.py`): **172 passed, 17 skipped**.
- `tests/test_changelog_fragments.py` + `test_changelog_format.py`: 30 passed; `scripts/assemble_changelog.py --check` OK.
- `tests/test_no_host_paths.py`: 2 passed. `ruff check` + `ruff format --check` clean. 0 non-ASCII characters in all three changed files.
- Schema re-verified after the reword: no parameter fell back to a `"Parameter <name>"` placeholder (AGENTS.md convention 13).

## What this PR does NOT do

**It does not decide which full scale is right.** #2812 measures the registry as spanning two resolutions - `sts3215`/`sts3250`/`sm8512bl` at 4096 counts, and `scs0009` at **1024**, which is every one of `hope_jr_hand`'s 16 motors. On an SCS-series bus today's ceiling is 4x the addressable maximum and the reported angle is 4x low. Choosing between (1) naming the model, (2) reporting counts only, and (3) narrowing the claim to the STS series changes the tool's public surface, and #2812 deliberately leaves it to a maintainer because it turns on what an `scs0009` does with a position of 4095 - hardware neither that issue nor this suite has.

This PR takes only the half that issue asks for **regardless of which way that is settled**: *"single-sourcing the ceiling and the report divisor so the reason string's 'the same full scale' is enforced rather than asserted belongs in the same change."* It makes that correction one edit instead of two that can disagree. No public behaviour changes for any value in the enforced domain.

Refs #2812

---

### 13. Changelog

Round 1 - initial submission. `changelog.d/2812-serial-tool-documented-bounds.md`.