### PR TITLE
feat(examples/microduck): --scene reaches the scene a skill was trained in

### DIFF
--- a/changelog.d/2922-microduck-render-video-scene.md
+++ b/changelog.d/2922-microduck-render-video-scene.md
@@ -1,0 +1,36 @@
+### Added: the Microduck render example can reach a variant scene
+
+`docs/policies/microduck.md` carries the skill-to-scene table, and four of the
+nine shipped Pollen weights need a scene the registry entry does not declare.
+`changelog.d/2900-microduck-skill-scenes.md` said so when it corrected the page:
+"`examples/microduck/render_video.py` builds exactly that, which is why the page
+said any shipped weight 'drops straight in'". The page was corrected; the example
+it names was not. It built `Robot("microduck", mesh=False)` and had no flag for
+anything else, so the by-path route the page documents in prose was reachable
+from no shipped example.
+
+`--scene` names a scene file under the Microduck asset directory. The three
+scenes that ship in the one asset directory the entry already downloads:
+
+    scene.xml          njnt=15  nu=14  nq=21  wheel joints=0  ball bodies=0
+    scene_rollers.xml  njnt=19  nu=14  nq=25  wheel joints=4  ball bodies=0
+    scene_ball.xml     njnt=16  nu=14  nq=28  wheel joints=0  ball bodies=1
+
+`roller` and `roller_crouch` need the four wheels only `scene_rollers.xml`
+carries, and the `ball_kick` pair needs the prop only `scene_ball.xml` places.
+`nu` is 14 in all three, which is why nothing refuses the mismatch: the policy
+writes exactly the same fourteen control targets whichever scene is loaded, and
+the physics has nothing to roll on or nothing to kick. The run reports success
+and the rendered video shows a duck going nowhere with no indication why.
+
+The scene is resolved by name through `strands_robots.utils.get_search_paths` -
+the same route the page documents - rather than as a path the caller spells out,
+so all three are reachable by the names the table uses. A name no asset root
+carries is refused, naming the directories that were searched: a misspelled
+`--scene` that quietly resolved the entry's declared scene would render that same
+duck-going-nowhere and report success, which is the failure the flag exists to
+remove.
+
+Omitting `--scene` forwards no asset at all, so the five weights that run on the
+declared scene resolve the registry entry by name exactly as before. No library
+code changes.

--- a/examples/microduck/render_video.py
+++ b/examples/microduck/render_video.py
@@ -37,6 +37,17 @@ Examples::
         --onnx ../microduck/policies/alpha_stand.onnx \
         --duration 5 --out /tmp/microduck_viz/stand.mp4
 
+    # A skill trained in a variant scene names it with --scene. Without one the
+    # duck rolls on a floor with no wheels under its feet, or swings at a ball
+    # that is not there.
+    python examples/microduck/render_video.py \
+        --onnx ../microduck/policies/roller.onnx --scene scene_rollers.xml \
+        --vx 0.3 --duration 8 --out /tmp/microduck_viz/roller.mp4
+
+    python examples/microduck/render_video.py \
+        --onnx ../microduck/policies/ball_kick_left.onnx --scene scene_ball.xml \
+        --vx 0 --duration 4 --out /tmp/microduck_viz/kick.mp4
+
 Dependencies::
 
     pip install "strands-robots[sim-mujoco,microduck]"   # rollout + video
@@ -47,6 +58,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -117,13 +129,61 @@ def _encode_gif(frames, gif_path, gif_fps, gif_width):
     print(f"  wrote gif {gif_path} ({new_w}x{new_h}, {size_mb:.2f} MB)")
 
 
+def _resolve_scene(name: str) -> str:
+    """Resolve a Microduck scene file by name through the asset search paths.
+
+    A shipped weight and the scene it was trained in are one pair: ``roller`` and
+    ``roller_crouch`` need the four passive ankle wheels only ``scene_rollers.xml``
+    carries, and the ``ball_kick_*`` pair needs the prop only ``scene_ball.xml``
+    places. All three scenes ship in the one asset directory the registry entry
+    already downloads, so this resolves by name through
+    :func:`~strands_robots.utils.get_search_paths` - the same route
+    ``docs/policies/microduck.md`` documents - rather than taking a path the
+    caller has to spell out.
+
+    Args:
+        name: A scene file name under the ``microduck`` asset directory, such as
+            ``scene_rollers.xml``.
+
+    Returns:
+        The absolute path of the first match, searching the asset roots in the
+        order :func:`get_search_paths` returns them.
+
+    Raises:
+        SystemExit: If no asset root carries ``microduck/<name>``, naming the
+            roots that were searched. A misspelled scene is refused rather than
+            silently rendering the entry's declared scene, which reports success
+            and shows a duck standing still with no indication why.
+    """
+    from strands_robots.utils import get_search_paths  # noqa: PLC0415
+
+    roots = get_search_paths()
+    for root in roots:
+        candidate = Path(root) / "microduck" / name
+        if candidate.is_file():
+            return str(candidate)
+    searched = ", ".join(str(Path(root) / "microduck") for root in roots)
+    raise SystemExit(f"scene {name!r} not found; searched {searched}")
+
+
+def _sim_kwargs(args) -> dict[str, str]:
+    """The ``Robot(...)`` keyword arguments the requested scene needs.
+
+    Empty when no ``--scene`` was given, so the registry entry resolves its own
+    declared scene exactly as before.
+    """
+    if not getattr(args, "scene", None):
+        return {}
+    return {"urdf_path": _resolve_scene(args.scene)}
+
+
 async def _rollout(args):
     from strands_robots import Robot  # noqa: PLC0415
     from strands_robots.policies.microduck import MicroduckPolicy  # noqa: PLC0415
 
     mujoco = _load_mujoco()
 
-    sim = Robot("microduck", mesh=False)
+    sim = Robot("microduck", mesh=False, **_sim_kwargs(args))
     sim.reset()
     model, data = sim.mj_model, sim.mj_data
 
@@ -188,6 +248,13 @@ async def _rollout(args):
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--onnx", default="../microduck/policies/alpha_walking.onnx")
+    ap.add_argument(
+        "--scene",
+        default=None,
+        help="scene file under the microduck asset dir, for a skill trained in a "
+        "variant scene (scene_rollers.xml for the roller pair, scene_ball.xml for "
+        "the ball-kick pair); omit to use the scene the registry entry declares",
+    )
     ap.add_argument("--duration", type=float, default=8.0, help="seconds of rollout")
     ap.add_argument("--vx", type=float, default=0.3, help="forward velocity command (m/s)")
     ap.add_argument("--vy", type=float, default=0.0, help="lateral velocity command (m/s)")

--- a/tests/test_examples_microduck_render_video_reaches_a_variant_scene.py
+++ b/tests/test_examples_microduck_render_video_reaches_a_variant_scene.py
@@ -1,0 +1,268 @@
+"""The Microduck render example can reach the scene a skill was trained in.
+
+A shipped Pollen weight and the scene it was trained in are one pair.
+``docs/policies/microduck.md`` carries the skill-to-scene table: five of the nine
+weights run on the scene the registry entry declares, and four do not - ``roller``
+and ``roller_crouch`` need the four passive ankle wheels only ``scene_rollers.xml``
+carries, and ``ball_kick_left`` / ``ball_kick_right`` need the prop only
+``scene_ball.xml`` places.
+
+The page documents the by-path route in prose, and until this guard landed no
+shipped example could take it. ``examples/microduck/render_video.py`` built
+``Robot("microduck", mesh=False)`` and had no flag for anything else, which is
+what ``changelog.d/2900-microduck-skill-scenes.md`` recorded when it fixed the
+page: "``examples/microduck/render_video.py`` builds exactly that, which is why
+the page said any shipped weight 'drops straight in'". The page was corrected;
+the example it names was not.
+
+Measured on ``de9762a9``, comparing the scene the example could build against the
+ones those four skills need::
+
+    scene.xml          njnt=15  nu=14  nq=21  wheel joints=0  ball bodies=0
+    scene_rollers.xml  njnt=19  nu=14  nq=25  wheel joints=4  ball bodies=0
+    scene_ball.xml     njnt=16  nu=14  nq=28  wheel joints=0  ball bodies=1
+
+The four wheels ``scene_rollers.xml`` adds are ``passive_LF_wheel``,
+``passive_LR_wheel``, ``passive_RF_wheel`` and ``passive_RR_wheel``. ``nu`` is 14
+in all three, which is why nothing refuses the mismatch: a roller policy writes
+exactly the same fourteen control targets whichever scene is loaded, and the
+physics simply has nothing to roll on. The rollout reports success and the
+rendered video shows a duck going nowhere with no indication why.
+
+No rollout is measured here or in this guard - ``onnxruntime`` is absent on the
+machine this was written on, so the shipped weights could not be stepped. The
+claim above is about scene composition, which is what the flag addresses.
+
+Why a refusal rather than a fallback: a misspelled ``--scene`` that quietly
+resolved the entry's declared scene would render exactly that same
+duck-going-nowhere and report success, which is the failure this flag exists to
+remove. :func:`_resolve_scene` raises instead, naming the roots it searched.
+
+Every cell here is hermetic - it points the asset root at a temporary directory
+and writes the scene files it needs - so the guard runs on an install that has
+downloaded no Microduck asset, has no ``mujoco`` and has no ``onnxruntime``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLE = _REPO_ROOT / "examples" / "microduck" / "render_video.py"
+_DOCS_PAGE = _REPO_ROOT / "docs" / "policies" / "microduck.md"
+
+# The scene the registry entry declares. Every other scene the page names is a
+# variant a weight needs, and is what --scene exists to reach.
+_DECLARED_SCENE = "scene.xml"
+
+
+def _load_example() -> ModuleType:
+    """Import the example by path - it is a script, not a package module."""
+    spec = importlib.util.spec_from_file_location("microduck_render_video", _EXAMPLE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _documented_variant_scenes() -> set[str]:
+    """The variant scenes ``docs/policies/microduck.md`` names, derived from the page.
+
+    Read from the page rather than restated here, so a tenth weight that needs a
+    new scene fails this guard until the flag's help names it too.
+    """
+    named = set(re.findall(r"`(scene[A-Za-z0-9_]*\.xml)`", _DOCS_PAGE.read_text(encoding="utf-8")))
+    return named - {_DECLARED_SCENE}
+
+
+def _asset_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *scenes: str) -> Path:
+    """Point the asset search at ``tmp_path`` and write the named scene files."""
+    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(tmp_path))
+    microduck = tmp_path / "microduck"
+    microduck.mkdir(parents=True, exist_ok=True)
+    for scene in scenes:
+        (microduck / scene).write_text("<mujoco/>", encoding="utf-8")
+    return microduck
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+class TestAVariantSceneIsReachable:
+    """The flag resolves a scene by name and hands it to ``Robot`` as the asset."""
+
+    def test_the_flag_resolves_a_scene_under_the_asset_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        microduck = _asset_root(monkeypatch, tmp_path, "scene_rollers.xml")
+        module = _load_example()
+
+        resolved = module._resolve_scene("scene_rollers.xml")
+
+        assert Path(resolved) == microduck / "scene_rollers.xml"
+
+    def test_the_resolved_scene_is_forwarded_as_the_robot_asset(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        microduck = _asset_root(monkeypatch, tmp_path, "scene_ball.xml")
+        module = _load_example()
+
+        kwargs = module._sim_kwargs(_args(scene="scene_ball.xml"))
+
+        assert kwargs == {"urdf_path": str(microduck / "scene_ball.xml")}
+
+    def test_the_first_matching_asset_root_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Precedence is the shared search order, not whichever root is checked last.
+
+        Both asset roots carry the scene, so only the order decides which one the
+        example loads - and the answer has to be the one ``get_search_paths``
+        returns first.
+        """
+        first = _asset_root(monkeypatch, tmp_path / "user", "scene_rollers.xml")
+        project = tmp_path / "project"
+        second = project / "assets" / "microduck"
+        second.mkdir(parents=True)
+        (second / "scene_rollers.xml").write_text("<mujoco/>", encoding="utf-8")
+        monkeypatch.chdir(project)
+        module = _load_example()
+        from strands_robots.utils import get_search_paths
+
+        roots = get_search_paths()
+        assert [first.parent, second.parent] == roots, roots
+
+        assert Path(module._resolve_scene("scene_rollers.xml")) == first / "scene_rollers.xml"
+
+    @pytest.mark.parametrize("scene", sorted(_documented_variant_scenes()))
+    def test_every_documented_variant_scene_is_reachable_by_name(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, scene: str
+    ) -> None:
+        microduck = _asset_root(monkeypatch, tmp_path, scene)
+        module = _load_example()
+
+        assert Path(module._resolve_scene(scene)) == microduck / scene
+
+
+class TestAMisspelledSceneIsRefused:
+    """A scene no asset root carries is refused, not quietly swapped for the default."""
+
+    def test_a_scene_no_root_carries_is_refused(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        _asset_root(monkeypatch, tmp_path, "scene_rollers.xml")
+        module = _load_example()
+
+        with pytest.raises(SystemExit):
+            module._resolve_scene("scene_rollrs.xml")
+
+    def test_the_refusal_names_the_scene_that_was_asked_for(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _asset_root(monkeypatch, tmp_path)
+        module = _load_example()
+
+        with pytest.raises(SystemExit) as excinfo:
+            module._resolve_scene("scene_rollrs.xml")
+
+        assert "scene_rollrs.xml" in str(excinfo.value), str(excinfo.value)
+
+    def test_the_refusal_names_the_directories_it_searched(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A caller who has not downloaded the asset needs to see where to look."""
+        microduck = _asset_root(monkeypatch, tmp_path)
+        module = _load_example()
+
+        with pytest.raises(SystemExit) as excinfo:
+            module._resolve_scene("scene_rollrs.xml")
+
+        assert str(microduck) in str(excinfo.value), str(excinfo.value)
+
+    def test_the_refusal_reaches_the_caller_through_the_robot_kwargs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The rollout asks for the kwargs before it builds anything, so it refuses first."""
+        _asset_root(monkeypatch, tmp_path)
+        module = _load_example()
+
+        with pytest.raises(SystemExit):
+            module._sim_kwargs(_args(scene="scene_rollrs.xml"))
+
+
+class TestTheDeclaredSceneRouteIsUnchanged:
+    """The flag does not disturb the route the five default-scene weights take.
+
+    A caller who names no scene has to keep getting the registry entry resolved by
+    name. The second cell holds before and after - the example still names the
+    entry. The first cannot run before the fix, because it reads the helper the fix
+    introduces; it is the over-reach guard that a no-scene run forwards no asset at
+    all rather than a resolved path.
+    """
+
+    def test_omitting_the_flag_forwards_no_asset(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        _asset_root(monkeypatch, tmp_path, "scene_rollers.xml")
+        module = _load_example()
+
+        assert module._sim_kwargs(_args(scene=None)) == {}
+
+    def test_the_example_still_resolves_the_registry_entry_by_name(self) -> None:
+        source = _EXAMPLE.read_text(encoding="utf-8")
+
+        assert 'Robot("microduck"' in source, "the example no longer names the registry entry"
+
+
+class TestTheResolutionIsSingleSourced:
+    """The scene is found through the shared search paths, and the flag is declared."""
+
+    def test_the_resolver_consults_the_shared_search_paths(self) -> None:
+        """Not a hardcoded ``~/.strands_robots`` path, so ``STRANDS_ASSETS_DIR`` is honored."""
+        tree = ast.parse(_EXAMPLE.read_text(encoding="utf-8"))
+        resolver = next(
+            node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_resolve_scene"
+        )
+        names = {node.id for node in ast.walk(resolver) if isinstance(node, ast.Name)}
+        names |= {node.attr for node in ast.walk(resolver) if isinstance(node, ast.Attribute)}
+
+        assert "get_search_paths" in names, sorted(names)
+
+    def test_the_command_line_declares_the_scene_flag(self) -> None:
+        tree = ast.parse(_EXAMPLE.read_text(encoding="utf-8"))
+        flags = {
+            argument.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "add_argument"
+            for argument in node.args
+            if isinstance(argument, ast.Constant) and isinstance(argument.value, str)
+        }
+
+        assert "--scene" in flags, sorted(flags)
+
+    def test_the_example_names_every_documented_variant_scene(self) -> None:
+        """A reader has to be able to discover which scene a weight needs from here.
+
+        Graded over the whole file rather than the ``--scene`` help alone, because
+        either surface answers the question - the docstring carries a runnable
+        invocation per variant scene and the help lists them. A tenth weight that
+        needs a new scene fails this cell until one of the two names it.
+        """
+        documented = _documented_variant_scenes()
+        source = _EXAMPLE.read_text(encoding="utf-8")
+
+        missing = sorted(scene for scene in documented if scene not in source)
+
+        assert not missing, f"the example never names {missing}, which the page says a weight needs"
+
+
+class TestTheRuleIsNotVacuous:
+    """The derived scene set is read from the page and is not empty."""
+
+    def test_the_page_names_at_least_two_variant_scenes(self) -> None:
+        documented = _documented_variant_scenes()
+
+        assert len(documented) >= 2, documented
+        assert _DECLARED_SCENE not in documented, documented


### PR DESCRIPTION
## The problem

`docs/policies/microduck.md` carries the skill-to-scene table: four of the nine
shipped Pollen weights need a scene the registry entry does not declare. `roller`
and `roller_crouch` need the four passive ankle wheels only `scene_rollers.xml`
carries, and `ball_kick_left` / `ball_kick_right` need the prop only
`scene_ball.xml` places.

The page documents the by-path route in prose, and no shipped example could take
it. `examples/microduck/render_video.py` built `Robot("microduck", mesh=False)`
and had no flag for anything else. `changelog.d/2900-microduck-skill-scenes.md`
recorded exactly that when it corrected the page:

> `examples/microduck/render_video.py` builds exactly that, which is why the page
> said any shipped weight "drops straight in".

The page was corrected; the example it names was not.

## What was measured

All three scenes ship in the one asset directory the registry entry already
downloads:

| scene | njnt | nu | nq | wheel joints | ball bodies |
|---|---|---|---|---|---|
| `scene.xml` (declared) | 15 | 14 | 21 | 0 | 0 |
| `scene_rollers.xml` | 19 | 14 | 25 | **4** | 0 |
| `scene_ball.xml` | 16 | 14 | 28 | 0 | **1** |

The four wheels are `passive_LF_wheel`, `passive_LR_wheel`, `passive_RF_wheel`
and `passive_RR_wheel`.

`nu` is 14 in all three, which is why nothing refuses the mismatch: a roller
policy writes exactly the same fourteen control targets whichever scene is
loaded, and the physics simply has nothing to roll on. The run reports success,
so the rendered video is a duck going nowhere with no indication why.

**No rollout is measured in this PR.** `onnxruntime` is absent on the machine
this was written on, so the shipped weights could not be stepped. The claim above
is about scene composition, which is what the flag addresses.

## The change

`--scene` names a scene file under the Microduck asset directory.
`_resolve_scene` resolves it through `strands_robots.utils.get_search_paths` -
the same route the page documents - rather than taking a path the caller has to
spell out, so all three scenes are reachable by the names the table uses.
`_sim_kwargs` returns `{"urdf_path": ...}` when a scene was named and `{}` when
one was not, so a caller who names no scene resolves the registry entry by name
exactly as before.

A name no asset root carries is refused, naming the directories that were
searched. A misspelled `--scene` that quietly resolved the entry's declared scene
would render that same duck-going-nowhere and report success, which is the
failure the flag exists to remove.

No library code changes. `examples/` is outside the lint scope, so the two
pre-existing `ruff format` candidates in that file are left alone rather than
swept into this diff.

## Tests

`tests/test_examples_microduck_render_video_reaches_a_variant_scene.py`, 15
cells, fully hermetic: each points the asset root at a temporary directory and
writes the scene files it needs, so the guard runs on an install that has
downloaded no Microduck asset and has neither `mujoco` nor `onnxruntime`. 0.09 s.

Pre-fix split with the source at `de9762a9`: **12 failed / 2 passed** before the
cell split, now 13 of 15. The 2 that pass either way are the vacuity cell and
`test_the_example_still_resolves_the_registry_entry_by_name`. One cell in
`TestTheDeclaredSceneRouteIsUnchanged` cannot run pre-fix because it reads the
helper this PR introduces; its class docstring says so.

The variant-scene set is derived from the docs page rather than restated, so a
tenth weight needing a new scene fails the guard until the example names it.

| mutation | fires | which |
|---|---|---|
| control | 0 | - |
| `--scene` not declared | 1 | the CLI cell |
| a missing scene silently falls back to the declared one | 3 | all three refusal cells |
| kwargs forwarded even with no `--scene` | 1 | the over-reach cell |
| resolver hardcodes the default asset dir | 7 | resolution + refusal + structural |
| the LAST matching root wins | 1 | the precedence cell |
| resolver drops the `microduck` subdir | 5 | the resolution cells |
| refusal drops the scene name | 1 | names-the-scene |
| refusal drops the searched roots | 1 | names-the-roots |
| a tenth weight needs a scene the example does not name | 1 | the page-derived cell |
| derived scene set forced empty | 1 | the vacuity cell |

`collected` is stable at 15 on every row except the last two, which move it to 16
and 13 - the derived set really is read from the page. The two refusal-message
rows fire disjoint single cells after that assertion was split in two.

## Gates

- `ruff check strands_robots tests tests_integ` clean; `ruff format --check` 1718 files already formatted; `mypy` 24 errors, the standing baseline, **0 attributable**.
- Paired run over an identical 173-path selection (every guard walking the tree, parsing source, reading docstrings or `docs/`, plus all `tests/test_examples_*` and the Microduck suites), with the new file withheld from both sides: **`5889 passed, 58 skipped, 0 failed` on each**. Tree restored md5-identical.
- Changelog fragment gates 30 passed; fragment inclusion verified through `assemble_changelog.py --print`.

## Deliberately not done

- **A registry `variant=` spelling.** No entry among the seventy-three declares one, so the schema is a public-API decision rather than an example fix. The by-path route this flag takes is the one the page documents today.
- **Refusing an unknown sim kwarg.** `Robot("microduck", variant="rollers")` is silently accepted and returns the declared scene, but `tests/simulation/test_constructor_rejects_setup_kwargs.py` pins tolerate-and-drop as a deliberate cross-backend forward-compatibility sink, so tightening it is a separate contract question.
- **A rollout artifact.** Rendering one needs `onnxruntime` and the weights; see above.
