### PR TITLE
fix(ros_telemetry): an inbound joint_command position must be finite

### DIFF
--- a/changelog.d/2923-inbound-joint-command-non-finite-position.md
+++ b/changelog.d/2923-inbound-joint-command-non-finite-position.md
@@ -1,0 +1,43 @@
+### Fixed: an inbound `joint_command` position must be finite, not merely readable
+
+`RosTelemetryBase._command_action` is the one inherited parser both hardware
+bridges and the simulation bridge deliver `/<robot>/joint_command` into.  It
+refused a position `float()` could not read and deliberately let a `nan`
+through, on this stated ground: "a nan position is a readable number that
+`send_action` refuses naming the joint".
+
+That is a claim about `send_action`, and the parser is shared by subclasses whose
+`send_action` is a different function.  It held for `SimRosBridge`, whose host
+does refuse a non-finite action value naming the key.  It did not hold for
+`HardwareRosBridge` or `HardwareRtpsBridge`: those reach `bus_access.write_action`,
+which takes the bus lock and delegates, and lerobot's follower writes
+`Goal_Position` with no finiteness check.  lerobot bounds a normalized position
+in `MotorsBus._unnormalize` with `min(100.0, max(-100.0, val))`, and `nan`
+compares false against both bounds, so `max` keeps its first argument and the
+clamp resolves the joint to an end stop instead of refusing it.
+
+Measured through the real `FeetechMotorsBus._unnormalize` on an SO-101's own
+default norm modes, with a shoulder calibrated `800..3200`: a position of `10.0`
+reached the wire as `2120`, a `nan` as `800` (the joint's `range_min`) and an
+`inf` as `3200` (its `range_max`) - each of them with zero warnings logged.  So
+a `joint_command` carrying a `nan` drove a real arm to an end stop under a
+`success` envelope: `_drive_from_command` warns only when `send_action` raises or
+answers `status="error"`, and it did neither.  The `joint_limits` branch below
+does catch it, because `not (low <= nan <= high)` is true, but `joint_limits` is
+optional and defaults to `None` on both bridges - so the default
+`ros2_bridge=True` configuration had nothing between the wire and the clamp.
+
+The parser now refuses a non-finite position WHOLE, which is the disposition its
+two siblings in the same method already have: a name/position length mismatch and
+an out-of-range value are both rejected entire rather than partially applied.  It
+asks `finite_number_error`, the same domain the `joint_limits` bounds a few lines
+above already use, so the accepted set cannot drift between the two.  The
+refusal names the bridge, the joint and the value.
+
+What is unchanged: every position that was accepted still is.  The domain is
+asked about the *coerced* value, so `True` is judged as `1.0` rather than as a
+`bool` the domain would reject; `0.0`, a negative position, an `int` and a
+numeric string all still resolve, and an empty keep-alive sample is still dropped
+silently.  The non-numeric branch keeps its own report, and a declared
+`joint_limits` still bounds an in-range position and still refuses an
+out-of-range one.

--- a/strands_robots/ros_telemetry.py
+++ b/strands_robots/ros_telemetry.py
@@ -340,8 +340,11 @@ class RosTelemetryBase:
         request) is dropped silently; an empty or length-mismatched message is
         otherwise rejected with a warning rather than partially applied, so a
         malformed command never drives the arm to a surprising pose. A position
-        that is not a readable number rejects the message the same way - it is
-        reported and returns ``None`` rather than raising, so the failure costs
+        that is not a readable number rejects the message the same way, and so
+        does one that is readable but not finite: ``nan``/``inf`` survive
+        ``float()`` and reach the actuator write, where lerobot's bounding
+        clamp resolves them to an end stop rather than refusing them. Both are
+        reported and return ``None`` rather than raising, so the failure costs
         exactly the one message on either transport.
 
         When ``joint_limits`` is supplied (``{"<motor>.pos": (min, max)}``), the
@@ -377,7 +380,7 @@ class RosTelemetryBase:
         action: dict[str, float] = {}
         for name, pos in zip(names, positions):
             try:
-                action[name] = float(pos)
+                value = float(pos)
             except (TypeError, ValueError):
                 # A position this cannot read is a malformed command, not a
                 # reason to raise: this method's contract is an action dict or
@@ -387,9 +390,7 @@ class RosTelemetryBase:
                 # the one message. Escaping instead reached each transport's
                 # loop tolerance, and the cyclonedds loop has already taken a
                 # batch by then, so the samples behind this one were dropped
-                # with it. Finiteness is deliberately not checked here: a nan
-                # position is a readable number that ``send_action`` refuses
-                # naming the joint.
+                # with it.
                 logger.warning(
                     "%s: ignoring joint_command with a non-numeric position for %r: %r",
                     type(self).__name__,
@@ -397,6 +398,23 @@ class RosTelemetryBase:
                     pos,
                 )
                 return None
+            # A readable number is not yet a usable position, and the refusal
+            # ``nan``/``inf`` were left to is not one both bridges have. The
+            # simulation host's ``send_action`` does refuse a non-finite action
+            # value naming the joint; the hardware path does not. lerobot bounds
+            # a normalized position with ``min(hi, max(lo, val))``, which
+            # ``nan`` defeats in both directions - measured through
+            # ``FeetechMotorsBus._unnormalize`` on an SO-101's own calibration,
+            # a ``nan`` shoulder position resolved to the joint's ``range_min``
+            # and an ``inf`` to its ``range_max``, so the arm drove to an end
+            # stop under a ``success`` envelope with nothing logged. The
+            # ``joint_limits`` branch below does catch it (``not (lo <= nan <=
+            # hi)`` is true), but it is optional and defaults to ``None``.
+            # Refused here, whole, on the domain those bounds already use.
+            if error := finite_number_error(value, f"position for {name!r}", type(self).__name__):
+                logger.warning("%s Whole command dropped, no partial application.", error)
+                return None
+            action[name] = value
         if joint_limits:
             for name, pos in action.items():
                 bounds = joint_limits.get(name)

--- a/tests/test_inbound_command_costs_one_message.py
+++ b/tests/test_inbound_command_costs_one_message.py
@@ -15,8 +15,7 @@ depended on the transport:
 
 The parser now reports the position and returns ``None``, so a malformed command
 costs itself on either transport. The classes below pin that, the values that
-were always readable (including ``nan``, whose finiteness ``send_action`` owns),
-and the three contracts of the cyclonedds poll loop that its rclpy sibling has
+were always readable, and the three contracts of the cyclonedds poll loop that its rclpy sibling has
 pinned all along in ``test_hardware_ros_bridge.py``: a sample taken by the loop
 is dispatched, a reader failure costs only that tick, and a second start spawns
 no second thread (that last one lives beside its siblings in
@@ -148,17 +147,19 @@ class TestEveryReadablePositionStaysReadable:
         base = RosTelemetryBase()
         assert base._command_action(_JointState(name=["j0"], position=[position])) == {"j0": expected}
 
-    def test_a_nan_position_is_still_read(self) -> None:
-        """Finiteness is not this parser's job.
+    def test_a_non_finite_position_is_refused_not_read(self) -> None:
+        """A readable number is not yet a usable position.
 
-        ``nan`` is a readable number, and ``send_action`` already refuses a
-        non-finite action value naming the joint - so checking it here would
-        move that report away from the surface that owns it.
+        This cell used to assert the opposite, on the stated grounds that
+        ``send_action`` owns finiteness. Only the simulation host's does; the
+        hardware bridge's reaches lerobot, whose bounding clamp resolves a
+        ``nan`` to a joint's ``range_min``. The refusal now happens here, where
+        the whole-message contract already lives -
+        ``test_inbound_command_refuses_a_non_finite_position.py`` measures both
+        halves.
         """
         base = RosTelemetryBase()
-        action = base._command_action(_JointState(name=["j0"], position=[float("nan")]))
-        assert action is not None
-        assert action["j0"] != action["j0"]  # nan
+        assert base._command_action(_JointState(name=["j0"], position=[float("nan")])) is None
 
 
 class TestBothTransportsGetTheSameRefusal:

--- a/tests/test_inbound_command_refuses_a_non_finite_position.py
+++ b/tests/test_inbound_command_refuses_a_non_finite_position.py
@@ -1,0 +1,284 @@
+"""An inbound ``joint_command`` position must be finite, not merely readable.
+
+:meth:`~strands_robots.ros_telemetry.RosTelemetryBase._command_action` is the one
+inherited parser both hardware bridges and the simulation bridge deliver
+``/<robot>/joint_command`` into. It refused a position ``float()`` could not read
+and deliberately let a ``nan`` through, on this stated ground:
+
+    Finiteness is deliberately not checked here: a nan position is a readable
+    number that ``send_action`` refuses naming the joint.
+
+That is a claim about ``send_action``, and the parser is shared by subclasses
+whose ``send_action`` is a different function. It held for one of them:
+
+* :class:`~strands_robots.simulation.ros_bridge.SimRosBridge` drives a
+  simulation host, and ``MuJoCoSimEngine.send_action`` does refuse a non-finite
+  action value, naming the key: ``send_action: action value for key '1' must be
+  finite (no nan/inf), got nan``.
+* :class:`~strands_robots.hardware_ros_bridge.HardwareRosBridge` drives a real
+  arm through ``bus_access.write_action``, which takes the bus lock and
+  delegates, and lerobot's ``SOFollower.send_action`` checks nothing before
+  ``bus.sync_write("Goal_Position", ...)``.
+
+lerobot bounds a normalized position in ``MotorsBus._unnormalize`` with
+``min(100.0, max(-100.0, val))`` (and ``min(100.0, max(0.0, val))`` for the
+gripper's ``RANGE_0_100``). ``nan`` compares false against both bounds, so
+``max`` keeps its first argument and the clamp resolves the joint to an end
+stop instead of refusing it. Measured through the real
+``FeetechMotorsBus._unnormalize`` on an SO-101's own default norm modes, with a
+shoulder calibrated ``800..3200``:
+
+===============  =========================  =========
+position          wire value                 warnings
+===============  =========================  =========
+``10.0``          ``2120``                   0
+``nan``           ``800``  (``range_min``)   0
+``inf``           ``3200`` (``range_max``)   0
+===============  =========================  =========
+
+So a ``joint_command`` carrying a ``nan`` drove a real arm to an end stop under
+a ``success`` envelope with nothing logged: ``_drive_from_command`` warns only
+when ``send_action`` raises or answers ``status="error"``, and it did neither.
+``joint_limits`` catches it when supplied - ``not (low <= nan <= high)`` is true -
+but it is optional and defaults to ``None`` on both bridges, so the default
+``ros2_bridge=True`` configuration had nothing between the wire and the clamp.
+
+The parser now refuses a non-finite position WHOLE, which is the disposition its
+two siblings already have (a length mismatch and an out-of-range value are both
+rejected entire, never partially applied), on the same
+:func:`~strands_robots.utils.finite_number_error` domain the ``joint_limits``
+bounds above it already use.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import math
+import textwrap
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_ros_bridge import HardwareRosBridge
+from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
+from strands_robots.ros_telemetry import RosTelemetryBase
+from tests.test_hardware_rtps_bridge import _FakeRobot, _JointState
+
+_LOGGER = "strands_robots.ros_telemetry"
+
+#: Readable numbers that are not usable positions.
+_NON_FINITE = [
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(float("-inf"), id="negative-inf"),
+]
+
+#: Positions that were accepted before this change and must stay accepted.
+#: ``True`` is here because the domain rejects ``bool`` and the parser asks it
+#: about the *coerced* value, so ``float(True)`` is judged as ``1.0``.
+_STILL_ACCEPTED = [
+    pytest.param(0.5, 0.5, id="float"),
+    pytest.param(1, 1.0, id="int"),
+    pytest.param("0.5", 0.5, id="numeric-string"),
+    pytest.param(True, 1.0, id="bool"),
+    pytest.param(0.0, 0.0, id="zero"),
+    pytest.param(-99.5, -99.5, id="negative"),
+]
+
+
+def _base() -> RosTelemetryBase:
+    return RosTelemetryBase()
+
+
+class TestANonFinitePositionRefusesTheMessage:
+    """The regression: a readable-but-non-finite position drops the command."""
+
+    @pytest.mark.parametrize("position", _NON_FINITE)
+    def test_a_non_finite_position_returns_none(self, position: float) -> None:
+        assert _base()._command_action(_JointState(name=["j0"], position=[position])) is None
+
+    @pytest.mark.parametrize("position", _NON_FINITE)
+    def test_a_non_finite_position_is_reported(self, position: float, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            _base()._command_action(_JointState(name=["j0"], position=[position]))
+        assert len(caplog.records) == 1
+        assert "j0" in caplog.text
+        assert "finite" in caplog.text
+
+    @pytest.mark.parametrize("position", _NON_FINITE)
+    def test_no_part_of_the_message_is_applied(self, position: float) -> None:
+        """Whole-message rejection, matching the length-mismatch sibling."""
+        action = _base()._command_action(
+            _JointState(name=["j0", "j1"], position=[0.25, position]),
+        )
+        assert action is None
+
+    @pytest.mark.parametrize("position", _NON_FINITE)
+    def test_a_bad_first_joint_does_not_let_the_rest_through(self, position: float) -> None:
+        """The check is per-position, not a single look at the last one.
+
+        Ordering is the whole difference between a per-position refusal and one
+        asked once after the loop: with the bad value last, an after-the-loop
+        check still catches it, so only this case distinguishes them.
+        """
+        action = _base()._command_action(
+            _JointState(name=["j0", "j1"], position=[position, 0.25]),
+        )
+        assert action is None
+
+    def test_nothing_reaches_send_action(self) -> None:
+        """The refusal is upstream of the actuator write, so the arm never moves."""
+        bridge: Any = HardwareRosBridge.__new__(HardwareRosBridge)
+        bridge._joint_limits = None
+        robot = _FakeRobot()
+        bridge._drive_from_command(robot, _JointState(name=["j0"], position=[float("nan")]))
+        assert robot.sent_actions == []
+
+
+class TestBothBridgesShareTheRefusal:
+    """One inherited parser, so no transport can drift from another."""
+
+    def test_the_parser_is_shared(self) -> None:
+        assert HardwareRosBridge._command_action is RosTelemetryBase._command_action
+        assert HardwareRtpsBridge._command_action is RosTelemetryBase._command_action
+
+    @pytest.mark.parametrize("bridge_cls", [HardwareRosBridge, HardwareRtpsBridge])
+    def test_each_bridge_refuses_a_non_finite_position(self, bridge_cls: Any) -> None:
+        # ``__new__`` on purpose: the parser reads only ``type(self).__name__``.
+        bridge: Any = bridge_cls.__new__(bridge_cls)
+        assert bridge._command_action(_JointState(name=["j0"], position=[float("nan")])) is None
+
+    def test_the_refusal_names_the_bridge(self, caplog: pytest.LogCaptureFixture) -> None:
+        bridge: Any = HardwareRosBridge.__new__(HardwareRosBridge)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            bridge._command_action(_JointState(name=["j0"], position=[float("nan")]))
+        assert "HardwareRosBridge" in caplog.text
+
+
+class TestTheRefusalConsultsTheSharedDomain:
+    """Single-sourced with the ``joint_limits`` bounds in the same module."""
+
+    def test_the_parser_calls_the_shared_domain(self) -> None:
+        source = textwrap.dedent(inspect.getsource(RosTelemetryBase._command_action))
+        called = {
+            node.func.id
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "finite_number_error" in called
+
+    def test_the_domain_is_the_one_the_bounds_use(self) -> None:
+        """``_validate_joint_limits`` has always used it; the position now does."""
+        bounds_source = inspect.getsource(RosTelemetryBase._validate_joint_limits)
+        assert "finite_number_error" in bounds_source
+
+
+class TestWhatIsUnchanged:
+    """The refused set is exactly the non-finite one - nothing wider."""
+
+    @pytest.mark.parametrize(("position", "expected"), _STILL_ACCEPTED)
+    def test_an_accepted_position_is_still_accepted(self, position: Any, expected: float) -> None:
+        assert _base()._command_action(_JointState(name=["j0"], position=[position])) == {"j0": expected}
+
+    @pytest.mark.parametrize(("position", "expected"), _STILL_ACCEPTED)
+    def test_an_accepted_position_is_reported_silently(
+        self, position: Any, expected: float, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            _base()._command_action(_JointState(name=["j0"], position=[position]))
+        assert caplog.records == []
+
+    def test_a_healthy_command_still_reaches_send_action(self) -> None:
+        bridge: Any = HardwareRosBridge.__new__(HardwareRosBridge)
+        bridge._joint_limits = None
+        robot = _FakeRobot()
+        bridge._drive_from_command(robot, _JointState(name=["j0"], position=[0.25]))
+        assert robot.sent_actions == [{"j0": 0.25}]
+
+    def test_an_unreadable_position_keeps_its_own_refusal(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The non-numeric branch still reports non-numeric, not non-finite."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            assert _base()._command_action(_JointState(name=["j0"], position=["nope"])) is None
+        assert "non-numeric" in caplog.text
+
+    def test_an_empty_keepalive_is_still_dropped_silently(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            assert _base()._command_action(_JointState(name=[], position=[]), skip_empty=True) is None
+        assert caplog.records == []
+
+
+class TestTheOptInJointLimitsPathIsUnchanged:
+    """``joint_limits`` caught a ``nan`` already; it still does, and still bounds."""
+
+    def test_a_non_finite_position_is_still_refused_with_limits_declared(self) -> None:
+        assert (
+            _base()._command_action(
+                _JointState(name=["j0"], position=[float("nan")]),
+                joint_limits={"j0": (-100.0, 100.0)},
+            )
+            is None
+        )
+
+    def test_an_out_of_range_position_keeps_its_own_refusal(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            assert (
+                _base()._command_action(
+                    _JointState(name=["j0"], position=[150.0]),
+                    joint_limits={"j0": (-100.0, 100.0)},
+                )
+                is None
+            )
+        assert "outside declared range" in caplog.text
+
+    def test_an_in_range_position_is_still_accepted(self) -> None:
+        assert _base()._command_action(
+            _JointState(name=["j0"], position=[50.0]),
+            joint_limits={"j0": (-100.0, 100.0)},
+        ) == {"j0": 50.0}
+
+    def test_joint_limits_defaults_to_none_on_both_bridges(self) -> None:
+        """Why the clamp was reachable: the mitigation is opt-in."""
+        for cls in (HardwareRosBridge, HardwareRtpsBridge):
+            assert inspect.signature(cls.__init__).parameters["joint_limits"].default is None
+
+
+class TestPremises:
+    """Why the old reason was unsafe, measured rather than asserted."""
+
+    def test_python_min_max_do_not_bound_a_nan(self) -> None:
+        """The arithmetic lerobot's clamp is built from."""
+        assert min(100.0, max(-100.0, float("nan"))) == -100.0
+        assert min(100.0, max(0.0, float("nan"))) == 0.0
+        assert min(100.0, max(-100.0, float("inf"))) == 100.0
+
+    def test_a_non_finite_position_survives_float(self) -> None:
+        """Which is why the non-numeric branch could never have caught it."""
+        assert math.isnan(float(float("nan")))
+        assert math.isinf(float(float("inf")))
+
+    def test_lerobot_resolves_a_non_finite_position_to_an_end_stop(self) -> None:
+        """The refusal the old reason relied on does not exist on this path."""
+        feetech = pytest.importorskip("lerobot.motors.feetech")
+        motors_mod = pytest.importorskip("lerobot.motors")
+        motors = {
+            "shoulder_pan": motors_mod.Motor(1, "sts3215", motors_mod.MotorNormMode.RANGE_M100_100),
+        }
+        calibration = {
+            "shoulder_pan": motors_mod.MotorCalibration(
+                id=1, drive_mode=0, homing_offset=0, range_min=800, range_max=3200
+            ),
+        }
+        bus = feetech.FeetechMotorsBus(port="/dev/null", motors=motors, calibration=calibration)
+        assert bus._unnormalize({1: 10.0})[1] == 2120
+        assert bus._unnormalize({1: float("nan")})[1] == 800
+        assert bus._unnormalize({1: float("inf")})[1] == 3200
+
+    def test_the_hardware_write_path_adds_no_finiteness_check(self) -> None:
+        """``write_action`` takes the bus lock and delegates - nothing else."""
+        from strands_robots.bus_access import write_action
+
+        source = inspect.getsource(write_action)
+        assert "isfinite" not in source
+        assert "finite_number_error" not in source


### PR DESCRIPTION
## The defect

`RosTelemetryBase._command_action` is the one inherited parser that both hardware
bridges and the simulation bridge deliver `/<robot>/joint_command` into. It
refused a position `float()` could not read and deliberately let a `nan` through,
on this stated ground:

> Finiteness is deliberately not checked here: a nan position is a readable
> number that `send_action` refuses naming the joint.

That is a claim about `send_action`, and the parser is inherited by subclasses
whose `send_action` is a different function. It held for one of them.

| bridge | what its `send_action` reaches | non-finite position |
|---|---|---|
| `SimRosBridge` | `MuJoCoSimEngine.send_action` | refused: `action value for key '1' must be finite (no nan/inf), got nan` |
| `HardwareRosBridge` | `bus_access.write_action` then lerobot | accepted |
| `HardwareRtpsBridge` | same | accepted |

`bus_access.write_action` takes the bus lock and delegates; lerobot's follower
writes `Goal_Position` with no finiteness check. lerobot bounds a normalized
position in `MotorsBus._unnormalize` with `min(100.0, max(-100.0, val))`, and
`nan` compares false against both bounds, so `max` keeps its first argument and
the clamp resolves the joint to an end stop rather than refusing it.

## What reached the wire

Measured end to end through the real `FeetechMotorsBus._unnormalize`, on an
SO-101's own default norm modes, with a shoulder calibrated `800..3200` and the
default `joint_limits=None`:

| position | wire value | warnings logged |
|---|---|---|
| `10.0` | `2120` | 0 |
| `nan` | `800`, the joint's `range_min` | 0 |
| `inf` | `3200`, its `range_max` | 0 |
| `-inf` | `3200` | 0 |

So a `joint_command` carrying a `nan` drove a real arm to an end stop under a
`success` envelope with nothing logged: `_drive_from_command` warns only when
`send_action` raises or answers `status="error"`, and it did neither.

The `joint_limits` branch a few lines below does catch it, because
`not (low <= nan <= high)` is true. But `joint_limits` is optional and defaults
to `None` on both bridges, so the default `ros2_bridge=True` configuration had
nothing between the wire and the clamp. With limits declared the same message is
refused, both before and after this change.

## Why nothing caught it

`tests/test_inbound_command_costs_one_message.py` had a cell asserting the old
behaviour, on the old reason:

> `nan` is a readable number, and `send_action` already refuses a non-finite
> action value naming the joint - so checking it here would move that report away
> from the surface that owns it.

It is repaired in place, and its module docstring's matching clause with it.

## The change

The parser now refuses a non-finite position WHOLE, which is the disposition its
two siblings in the same method already have: a name/position length mismatch and
an out-of-range value are both rejected entire rather than partially applied. It
asks `finite_number_error`, the same domain the `joint_limits` bounds above it
already use, so the accepted set cannot drift between the two. The refusal names
the bridge, the joint and the value.

The readable set is otherwise unchanged. The domain is asked about the *coerced*
value, so `True` is judged as `1.0` rather than as a `bool` the domain rejects;
`0.0`, a negative position, an `int` and a numeric string all still resolve, and
an empty keep-alive sample is still dropped silently.

## Pre-fix split

Source reverted, both test files kept: **18 failed / 47 passed**.

| class | role | failed / total |
|---|---|---|
| `TestANonFinitePositionRefusesTheMessage` | regression | 13 / 13 |
| `TestBothBridgesShareTheRefusal` | regression | 3 / 4 |
| `TestTheRefusalConsultsTheSharedDomain` | structural | 1 / 2 |
| `TestEveryReadablePositionStaysReadable` (repaired sibling) | regression | 1 / 5 |
| `TestWhatIsUnchanged` | control | 0 / 15 |
| `TestTheOptInJointLimitsPathIsUnchanged` | control | 0 / 4 |
| `TestPremises` | premise | 0 / 4 |

The two cells that pass either way are the structural facts that do not depend on
this change: the parser is one inherited function, and `_validate_joint_limits`
has always consulted the shared domain.

## Mutation table

`collected` was stable at 42 on every row and the source restored
byte-identically after each. `sib` is the six pre-existing bridge and telemetry
suites, with the new file excluded.

| row | mutation | fires | sib |
|---|---|---|---|
| b0 | control, no mutation | 0 | 0 |
| b1 | finiteness guard removed entirely | 17 | 1 |
| b2 | shared domain replaced by a local finiteness test | 4 | 0 |
| b3 | guard asked once after the loop, not per position | 3 | 0 |
| b4 | warns but does not return `None` | 12 | 1 |
| b5 | refusal no longer names the joint | 3 | 0 |
| b6 | narrowed to `nan` only, `inf` accepted | 8 | 0 |
| b7 | over-reach: judges the raw value, not the coerced one | 4 | 2 |

b7 is the boundary: judging `pos` rather than the coerced `value` makes the
domain reject `True` as a `bool`, which trips two pre-existing cells as well as
two of mine. b3 initially fired 0, because the multi-joint case put the bad
position last, where a check asked once after the loop still catches it; a cell
with the bad position first closed that, and it is the only case that
distinguishes a per-position refusal from an after-the-loop one.

## Gate

Byte-identical paired run over an identical 508-path selection, every path
verified present on both trees, the branch-only test file withheld from both:
**24385 collected** and `20 failed, 24289 passed, 76 skipped` on each side, with
both `comm` directions empty.

All 20 are shared and environmental, classified by measurement: 17 in
`tests/mesh/test_iot_*` need `awsiot`/`awscrt`, both `find_spec` absent here and
both declared in the `mesh-iot` extra, which `all` includes and the default hatch
features install; 3 are the known lerobot-from-source drift in
`tests/training/test_lerobot*`.

`ruff check` and `ruff format --check` clean over 1718 files. mypy 24 errors, the
standing baseline on this tree, with **0** attributable to the three changed
files.

## Deliberately not done

The simulation bridge's own refusal is unchanged and still fires where it always
did; this parser now declines the same message one layer earlier, so no motion
path gains or loses a check. `joint_limits` keeps both of its own refusals. A
bound on the *magnitude* of an accepted position stays where it is: that is what
`joint_limits` is for, and it is a caller's declaration rather than a property of
the number.
