### PR TITLE
fix(mesh/security): a wire count is refused when fractional, not truncated

### DIFF
--- a/changelog.d/2925-wire-counts-are-whole-numbers.md
+++ b/changelog.d/2925-wire-counts-are-whole-numbers.md
@@ -1,0 +1,45 @@
+### Fixed: a wire-side count is refused when fractional, never truncated
+
+`validate_command` coerces four caller-supplied integers through one helper,
+`_coerce_int`: `step.steps`, and `policy_port` / `action_horizon` / `n_steps` on
+`start` / `execute`. That helper's docstring says it "mirrors the defences in
+`_coerce_float`", and it mirrored two of them -- the `math.isfinite` check and
+the coercion-error wrap -- while missing the property that makes `_coerce_float`
+safe at all: it returns the caller's value or refuses it, and never a third
+number. `int(...)` rounds toward zero, so the helper answered with a value
+nobody sent.
+
+Three consequences on the wire, every one silent, all reachable from an ordinary
+payload -- `json.dumps` renders an integer held in a Python float as `2.0`, so a
+float here is a normal shape rather than a contrived one. A count nobody asked
+for was honoured: `{"steps": 2.5}` validated as `2`, and `{"policy_port":
+5556.7}` as `5556`, which names a different endpoint rather than rounding a
+magnitude. A below-floor refusal quoted a number the caller never wrote:
+`{"steps": 0.9}` reported `steps=0 out of bounds [1, 10000]` -- the verdict was
+right and the value in it was invented by the coercion.
+
+The third is the one that mattered most: **the ceiling stopped refusing.** The
+coercion runs before the bounds compare, so every one of the four fields carried
+a value from above `hi` down to exactly `hi` and accepted it, while the integer
+one step further was refused by name. `{"n_steps": 10000000.5}` was accepted as
+`10000000` and `{"n_steps": 10000001}` was refused -- the same intent, two
+answers, decided by how the JSON number was spelled. The comment above those
+bounds says they "match the `SimEngine.run_policy` surface so a wire-side
+`tell()` cannot drive the runner to absurd frequencies / step counts", so a
+value over the cap is exactly what they exist to refuse.
+
+A float with a fractional part is now refused under its own name, before the
+coercion and after the finiteness check -- `float("nan").is_integer()` is False,
+so a whole-number check placed first would answer a non-finite value with the
+wrong reason. An integral float is still accepted: nothing is lost in coercing
+`3.0`, and refusing it would refuse ordinary wire payloads for no gain. That is
+exactly the split `positive_whole_number_error` applies to the same quantity on
+the simulation side, which is the surface these bounds are declared to match --
+`SimEngine.step` and `run_policy` already refuse a fractional horizon by name,
+and `_coerce_float` is untouched because a fractional rate or duration is
+perfectly usable.
+
+The `step.steps` type case in the sibling suite had recorded the old behaviour
+as an aside -- "a float is accepted and truncated, matching `int(...)`
+semantics" -- in a file that refuses `bool` precisely because it "must not be
+accepted as a count". That sentence has been corrected.

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -844,6 +844,30 @@ def _coerce_int(name: str, value: Any, *, lo: int, hi: int, default: int | None)
     audit shape. Without these, ``{"action": "step", "steps": NaN}``
     would log as a generic "dispatch error" and be invisible to the
     validation-rejection forensics path.
+
+    The third defence is what makes that parity real rather than
+    partial: **a fractional float is refused, not truncated.**
+    :func:`_coerce_float` either returns the caller's value or refuses
+    it, and ``int(...)`` does neither -- it rounds toward zero. That had
+    three consequences on the wire, all of them silent:
+
+    * a value the caller never sent was honoured -- ``{"steps": 2.5}``
+      ran two steps, and ``{"policy_port": 5556.7}`` dialled 5556;
+    * **the ceiling stopped refusing.** ``int(...)`` runs before the
+      bounds compare, so ``{"n_steps": 10000000.5}`` was carried from
+      above ``hi`` to exactly ``hi`` and accepted, while the integer one
+      step further was refused by name. Same intent, two answers,
+      decided by how the JSON number was spelled;
+    * a below-floor refusal named a number the caller never wrote --
+      ``{"steps": 0.9}`` reported ``steps=0 out of bounds``.
+
+    An integral float (``3.0``, which is how ``json.dumps`` renders an
+    integer held in a float) is still accepted: nothing is lost in
+    coercing it, so refusing it would break wire payloads for no gain.
+    That is exactly the split
+    :func:`~strands_robots.utils.positive_whole_number_error` applies to
+    the same quantity on the simulation side, which is the surface the
+    ``action_horizon`` / ``n_steps`` bounds below are declared to match.
     """
     if value is None:
         if default is None:
@@ -853,6 +877,8 @@ def _coerce_int(name: str, value: Any, *, lo: int, hi: int, default: int | None)
         raise ValidationError(f"{name} must be an integer, got {type(value).__name__}")
     if isinstance(value, float) and not math.isfinite(value):
         raise ValidationError(f"{name} must be finite, got {value}")
+    if isinstance(value, float) and not value.is_integer():
+        raise ValidationError(f"{name} must be a whole number, got {value}")
     try:
         coerced = int(value)
     except (ValueError, OverflowError) as exc:

--- a/tests/mesh/test_validate_command_counts_are_whole_numbers.py
+++ b/tests/mesh/test_validate_command_counts_are_whole_numbers.py
@@ -1,0 +1,333 @@
+"""A wire-side count is refused when it is fractional, never truncated.
+
+``validate_command`` in ``strands_robots/mesh/security.py`` coerces four
+caller-supplied integers through one helper, ``_coerce_int``: ``step.steps``,
+and ``policy_port`` / ``action_horizon`` / ``n_steps`` on ``start`` /
+``execute``. That helper's docstring says it "mirrors the defences in
+``_coerce_float``", and it did mirror two of them -- the ``math.isfinite`` check
+and the coercion-error wrap -- while missing the property that makes
+``_coerce_float`` safe at all: it returns the caller's value or refuses it, and
+never a third number.
+
+``int(...)`` rounds toward zero, so the helper answered with a value nobody
+sent. Three consequences, every one of them silent, all measured through the
+public validator on a payload that has been through ``json.dumps`` /
+``json.loads`` (Python renders an integer held in a float as ``2.0``, so a float
+here is an ordinary wire shape rather than a contrived one):
+
+* **A count the caller never asked for was honoured.** ``{"steps": 2.5}``
+  validated as ``2``, and ``{"policy_port": 5556.7}`` as ``5556`` -- a port is an
+  exact address, so that is a different endpoint, not a rounded magnitude.
+* **The ceiling stopped refusing.** ``int(...)`` runs *before* the bounds
+  compare, so every one of the four fields carried a value from above ``hi`` to
+  exactly ``hi`` and accepted it, while the integer one step further was refused
+  by name. ``{"n_steps": 10000000.5}`` was accepted as ``10000000`` and
+  ``{"n_steps": 10000001}`` was refused. Same intent, two answers, decided by
+  how the JSON number was spelled. The comment above those bounds says they
+  "match the ``SimEngine.run_policy`` surface so a wire-side ``tell()`` cannot
+  drive the runner to absurd frequencies / step counts", so a value over the cap
+  is exactly what they exist to refuse.
+* **A refusal named a number the caller never wrote.** ``{"steps": 0.9}``
+  reported ``steps=0 out of bounds [1, 10000]`` -- the verdict was right and the
+  quoted value was invented by the coercion.
+
+The split this pins is the one the simulation side already applies to the same
+quantity. ``SimEngine.step`` / ``run_policy`` resolve their step horizon through
+``strands_robots.utils.positive_whole_number_error``, which accepts an integral
+real and refuses a fractional one; ``tests/simulation/test_rollout_step_horizon_domain.py``
+and ``tests/simulation/mujoco/test_control_substeps_validation.py`` are that
+contract, and the second is titled for it -- a count must be "honored or
+rejected, never silently clamped". So ``3.0`` stays accepted here (nothing is
+lost in coercing it, and refusing it would break wire payloads for no gain) and
+``2.5`` is refused under its own name.
+
+Why the existing wire-side suites did not see it: the two that grade these
+helpers cover the other edges. ``test_validate_command_finite_numerics`` pins
+NaN / inf, and ``test_validate_command_numeric_coercion_none_handling`` pins
+``None`` and type rejection -- including ``bool``, refused precisely because it
+"must not be accepted as a count". Its ``step.steps`` type case parametrised
+over ``str`` / ``list`` / ``dict`` and recorded the float behaviour as an aside:
+"a float is accepted and truncated, matching ``int(...)`` semantics". That
+sentence was the contract nobody had questioned; it has been corrected with this
+change.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import math
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh import security
+from strands_robots.mesh.security import ValidationError, validate_command
+from strands_robots.utils import positive_whole_number_error
+
+# Every field ``validate_command`` routes through ``_coerce_int``, with the
+# minimal payload that reaches it and the ``hi`` bound declared at its call
+# site. ``TestEveryWireCountIsHeldToTheDomain`` derives the same set from the
+# source, so a fifth call site added later fails this file rather than
+# inheriting an exemption by being absent from a hand-written list.
+_INT_FIELDS: dict[str, int] = {
+    "steps": 10_000,
+    "policy_port": 65_535,
+    "action_horizon": 10_000,
+    "n_steps": 10_000_000,
+}
+
+# A ``_coerce_float`` field, as the over-reach control: a fractional wait budget
+# or rate is perfectly usable and must stay accepted.
+_FLOAT_FIELD_HI: dict[str, float] = {"control_frequency": 2000.0, "duration": 3600.0}
+
+
+def _payload(field: str, value: Any) -> dict[str, Any]:
+    """Return the smallest command that carries *field* to its coercion.
+
+    Routed through ``json.dumps`` / ``json.loads`` so the value under test is
+    the shape a peer's payload really arrives as rather than a Python literal.
+    """
+    if field == "steps":
+        cmd: dict[str, Any] = {"action": "step", "steps": value}
+    else:
+        cmd = {
+            "action": "start",
+            "instruction": "go",
+            "policy_provider": "mock",
+            field: value,
+        }
+    return json.loads(json.dumps(cmd))
+
+
+def _validated(field: str, value: Any) -> Any:
+    """Return what the validator made of *value*, or raise ``ValidationError``."""
+    return validate_command(_payload(field, value))[field]
+
+
+class TestAFractionalCountIsRefusedNotTruncated:
+    """The regression: a value with a fractional part is not answered with another."""
+
+    @pytest.mark.parametrize("field", sorted(_INT_FIELDS))
+    def test_a_fractional_count_is_refused(self, field: str) -> None:
+        with pytest.raises(ValidationError, match=f"{field} must be a whole number"):
+            _validated(field, 2.5)
+
+    @pytest.mark.parametrize("field", sorted(_INT_FIELDS))
+    def test_the_refusal_quotes_the_value_the_caller_sent(self, field: str) -> None:
+        with pytest.raises(ValidationError) as caught:
+            _validated(field, 2.5)
+        assert "2.5" in str(caught.value)
+
+    def test_a_port_is_never_answered_with_a_different_port(self) -> None:
+        """A port is an exact address; truncating it names another endpoint."""
+        with pytest.raises(ValidationError, match="policy_port must be a whole number"):
+            _validated("policy_port", 5556.7)
+
+
+class TestTheCeilingRefusesWhicheverWayTheNumberIsSpelled:
+    """A value over ``hi`` is refused whether it is spelled as a float or an int.
+
+    This is the half that made the bound stop working: the coercion ran first,
+    so a fractional value above the cap was carried down to the cap and
+    accepted.
+    """
+
+    @pytest.mark.parametrize("field", sorted(_INT_FIELDS))
+    def test_a_fractional_value_over_the_ceiling_is_refused(self, field: str) -> None:
+        over = _INT_FIELDS[field] + 0.5
+        with pytest.raises(ValidationError):
+            _validated(field, over)
+
+    @pytest.mark.parametrize("field", sorted(_INT_FIELDS))
+    def test_it_is_not_accepted_as_the_ceiling(self, field: str) -> None:
+        """The specific failure: the answer used to be ``hi`` itself."""
+        hi = _INT_FIELDS[field]
+        try:
+            answered = _validated(field, hi + 0.5)
+        except ValidationError:
+            return
+        pytest.fail(f"{field}={hi + 0.5} was accepted as {answered!r}, carried into range by the coercion")
+
+    @pytest.mark.parametrize("field", sorted(_INT_FIELDS))
+    def test_the_integer_one_step_further_is_still_refused_by_the_bound(self, field: str) -> None:
+        """Unchanged: the bounds compare still owns the integer case, by name."""
+        hi = _INT_FIELDS[field]
+        with pytest.raises(ValidationError, match="out of bounds"):
+            _validated(field, hi + 1)
+
+    @pytest.mark.parametrize("field", sorted(_INT_FIELDS))
+    def test_the_ceiling_itself_is_still_accepted(self, field: str) -> None:
+        assert _validated(field, _INT_FIELDS[field]) == _INT_FIELDS[field]
+
+
+class TestABelowFloorRefusalNamesTheCallersOwnValue:
+    """``{"steps": 0.9}`` used to report ``steps=0``, a number nobody sent."""
+
+    def test_the_message_carries_the_supplied_value(self) -> None:
+        with pytest.raises(ValidationError) as caught:
+            _validated("steps", 0.9)
+        assert "0.9" in str(caught.value)
+
+    def test_the_message_does_not_invent_the_truncated_one(self) -> None:
+        with pytest.raises(ValidationError) as caught:
+            _validated("steps", 0.9)
+        assert "steps=0 " not in str(caught.value)
+
+
+class TestAnIntegralFloatIsStillAccepted:
+    """Over-reach control: ``3.0`` loses nothing in coercion, so it is honoured.
+
+    ``json.dumps`` renders an integer held in a Python float as ``3.0``, so
+    refusing this would refuse ordinary wire payloads for no gain. It is also
+    the accepted side of the same split the simulation surface applies.
+    """
+
+    @pytest.mark.parametrize("field", sorted(_INT_FIELDS))
+    def test_an_integral_float_coerces_to_its_integer(self, field: str) -> None:
+        assert _validated(field, 4.0) == 4
+
+    @pytest.mark.parametrize("field", sorted(_INT_FIELDS))
+    def test_a_plain_int_is_unchanged(self, field: str) -> None:
+        assert _validated(field, 4) == 4
+
+    def test_a_negative_zero_float_is_still_refused_by_the_floor(self) -> None:
+        """``-0.0`` is integral, so it reaches the bound and the floor refuses it."""
+        with pytest.raises(ValidationError, match="out of bounds"):
+            _validated("steps", -0.0)
+
+
+class TestTheFloatSiblingIsUnchanged:
+    """Over-reach control: a fractional *continuous* value is still usable."""
+
+    @pytest.mark.parametrize("field", sorted(_FLOAT_FIELD_HI))
+    def test_a_fractional_value_is_accepted(self, field: str) -> None:
+        assert _validated(field, 12.5) == 12.5
+
+    @pytest.mark.parametrize("field", sorted(_FLOAT_FIELD_HI))
+    def test_a_fractional_value_over_the_ceiling_was_already_refused(self, field: str) -> None:
+        """``float(...)`` never truncated, which is why this half always worked."""
+        with pytest.raises(ValidationError, match="out of bounds"):
+            _validated(field, _FLOAT_FIELD_HI[field] + 0.5)
+
+
+class TestTheEarlierGuardsStillOwnTheirCases:
+    """The new check sits after the type and finiteness guards, not in front."""
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_a_non_finite_count_is_still_refused_as_non_finite(self, bad: float) -> None:
+        """``nan.is_integer()`` is False, so an earlier guard must answer first."""
+        with pytest.raises(ValidationError, match="steps must be finite"):
+            _validated("steps", bad)
+
+    def test_a_bool_is_still_refused_by_type(self) -> None:
+        with pytest.raises(ValidationError, match="steps must be an integer, got bool"):
+            _validated("steps", True)
+
+    def test_a_string_is_still_refused_by_type(self) -> None:
+        with pytest.raises(ValidationError, match="steps must be an integer, got str"):
+            _validated("steps", "3")
+
+
+class TestTheGuardSitsAfterTheFinitenessCheck:
+    """Structural: the ordering the ``nan`` case above depends on, read off source.
+
+    ``float("nan").is_integer()`` is False, so a whole-number check placed first
+    would answer a non-finite value with the wrong reason. The behavioural cell
+    covers that for ``steps``; this states the ordering itself so a reordering
+    fails by name rather than only where a payload happens to reach it.
+    """
+
+    def test_both_checks_are_present(self) -> None:
+        """Fails by name pre-fix, rather than as a ``ValueError`` from ``index``."""
+        source = inspect.getsource(security._coerce_int)
+        assert "must be finite" in source
+        assert "must be a whole number" in source, "the whole-number guard is absent"
+
+    def test_the_finiteness_check_precedes_the_whole_number_check(self) -> None:
+        source = inspect.getsource(security._coerce_int)
+        assert "must be a whole number" in source, "the whole-number guard is absent"
+        assert source.index("must be finite") < source.index("must be a whole number")
+
+
+class TestTheSplitIsTheOneTheSimulationSurfaceApplies:
+    """Premise: the shared domain the sim uses makes exactly this cut.
+
+    ``SimEngine.step`` / ``run_policy`` resolve a step horizon through
+    ``positive_whole_number_error``. Grading the validator's verdicts against
+    that domain's is what makes "the same quantity now answers the same way on
+    both surfaces" a measurement rather than a claim, and it needs no simulator.
+    """
+
+    @pytest.mark.parametrize("value", [2.5, 0.9, 10_000.5])
+    def test_the_shared_domain_refuses_what_the_validator_now_refuses(self, value: float) -> None:
+        assert positive_whole_number_error(value, "steps", "step") is not None
+        with pytest.raises(ValidationError):
+            _validated("steps", value)
+
+    @pytest.mark.parametrize("value", [3, 4.0, 10_000])
+    def test_the_shared_domain_accepts_what_the_validator_accepts(self, value: float) -> None:
+        assert positive_whole_number_error(value, "steps", "step") is None
+        assert _validated("steps", value) == int(value)
+
+    def test_the_domain_is_the_whole_number_one_and_not_the_strict_int_one(self) -> None:
+        """Non-vacuity: the two candidate shared domains disagree on ``4.0``.
+
+        ``positive_count_error`` refuses an integral float. Naming which domain
+        the verdicts match is what makes the comparison above load-bearing.
+        """
+        from strands_robots.utils import positive_count_error
+
+        assert positive_whole_number_error(4.0, "steps", "step") is None
+        assert positive_count_error(4.0, "steps", "step") is not None
+
+
+class TestEveryWireCountIsHeldToTheDomain:
+    """Derived: the graded set is read off ``validate_command``'s own source.
+
+    A fifth ``_coerce_int`` call site added later is refused here by name rather
+    than inheriting an exemption by being absent from ``_INT_FIELDS``.
+    """
+
+    @staticmethod
+    def _coerced_int_fields() -> set[str]:
+        source = pathlib.Path(security.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        found: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name != "validate_command":
+                continue
+            for call in ast.walk(node):
+                if not isinstance(call, ast.Call):
+                    continue
+                target = call.func
+                if not isinstance(target, ast.Name) or target.id != "_coerce_int":
+                    continue
+                if call.args and isinstance(call.args[0], ast.Constant):
+                    field = call.args[0].value
+                    if isinstance(field, str):
+                        found.add(field)
+        return found
+
+    def test_the_scan_finds_the_fields_this_file_grades(self) -> None:
+        assert self._coerced_int_fields() == set(_INT_FIELDS)
+
+    def test_the_scan_is_not_empty(self) -> None:
+        """Non-vacuity: a scan that matched nothing would report clean."""
+        assert len(self._coerced_int_fields()) >= 4
+
+    def test_the_helper_refuses_a_fractional_value_directly(self) -> None:
+        """Unit-level, so the guard is graded even for a field with no payload."""
+        with pytest.raises(ValidationError, match="probe must be a whole number"):
+            security._coerce_int("probe", 2.5, lo=1, hi=10, default=None)
+
+    def test_the_helper_accepts_an_integral_float_directly(self) -> None:
+        assert security._coerce_int("probe", 4.0, lo=1, hi=10, default=None) == 4
+
+    def test_an_integral_float_is_exactly_what_is_integer_reports(self) -> None:
+        """The predicate, stated locally so the guard is not its own oracle."""
+        assert (4.0).is_integer() is True
+        assert (2.5).is_integer() is False
+        assert math.isnan(float("nan")) is True

--- a/tests/mesh/test_validate_command_numeric_coercion_none_handling.py
+++ b/tests/mesh/test_validate_command_numeric_coercion_none_handling.py
@@ -82,8 +82,12 @@ def test_start_control_frequency_rejects_bool():
 
 @pytest.mark.parametrize("bad", ["3", [3], {"n": 3}])
 def test_step_steps_rejects_non_integer(bad):
-    """``step.steps`` (an int field) rejects str / list / dict (a float is
-    accepted and truncated, matching ``int(...)`` semantics)."""
+    """``step.steps`` (an int field) rejects str / list / dict.
+
+    A float is accepted only when it is integral (``3.0``); a fractional one is
+    refused under its own name rather than truncated, which
+    ``test_validate_command_counts_are_whole_numbers`` pins.
+    """
     with pytest.raises(ValidationError, match="steps must be an integer"):
         validate_command({"action": "step", "steps": bad})
 


### PR DESCRIPTION
## The defect

`validate_command` coerces four caller-supplied integers through one helper,
`_coerce_int`: `step.steps`, and `policy_port` / `action_horizon` / `n_steps` on
`start` / `execute`. That helper's docstring says it "mirrors the defences in
`_coerce_float`", and it mirrored two of them -- the `math.isfinite` check and the
coercion-error wrap -- while missing the property that makes `_coerce_float` safe at
all: it returns the caller's value or refuses it, and never a third number.
`int(...)` rounds toward zero.

Measured through the public validator on a `json.loads(json.dumps(...))` payload,
because `json.dumps` renders an integer held in a Python float as `2.0` -- a float
here is an ordinary wire shape rather than a contrived one:

| payload | before | after |
| --- | --- | --- |
| `{"steps": 2.5}` | accepted as `2` | `steps must be a whole number, got 2.5` |
| `{"policy_port": 5556.7}` | accepted as `5556` | `policy_port must be a whole number, got 5556.7` |
| `{"action_horizon": 8.5}` | accepted as `8` | `action_horizon must be a whole number, got 8.5` |
| `{"n_steps": 2.5}` | accepted as `2` | `n_steps must be a whole number, got 2.5` |
| `{"steps": 3}` | accepted as `3` | accepted as `3` |
| `{"steps": 3.0}` | accepted as `3` | accepted as `3` |

A port is an exact address, so `5556.7` naming `5556` is a different endpoint
rather than a rounded magnitude.

### The ceiling stopped refusing

The coercion runs *before* the bounds compare, so every one of the four fields
carried a value from above `hi` down to exactly `hi` and accepted it, while the
integer one step further was refused by name:

| payload | before | after |
| --- | --- | --- |
| `{"n_steps": 10000000.5}` | accepted as `10000000` | refused, names `10000000.5` |
| `{"n_steps": 10000001}` | `n_steps=10000001 out of bounds [1, 10000000]` | unchanged |
| `{"policy_port": 65535.9}` | accepted as `65535` | refused, names `65535.9` |
| `{"action_horizon": 10000.5}` | accepted as `10000` | refused, names `10000.5` |

Same intent, two answers, decided by how the JSON number was spelled. The comment
above those bounds says they "match the `SimEngine.run_policy` surface so a
wire-side `tell()` cannot drive the runner to absurd frequencies / step counts",
so a value over the cap is exactly what they exist to refuse.

### A refusal quoted a number the caller never wrote

`{"steps": 0.9}` reported `steps=0 out of bounds [1, 10000]`. The verdict was
right and the value in it was invented by the coercion; it now reports
`steps must be a whole number, got 0.9`.

## The split this restores is the sibling surface's

`SimEngine.step` / `run_policy` resolve a step horizon through
`positive_whole_number_error`, which accepts an integral real and refuses a
fractional one. On the same tree, for the same quantity:

| value | `sim.step(n_steps=)` | wire `validate_command` (before) |
| --- | --- | --- |
| `3.0` | accepted | accepted as `3` |
| `2.7` | `n_steps must be a non-negative whole number` | accepted as `2` |
| `10000.5` | `n_steps must be a non-negative whole number` | accepted as `10000` |

So `3.0` stays accepted here (nothing is lost in coercing it, and refusing it
would refuse ordinary wire payloads for no gain) and a fractional value is
refused under its own name. `_coerce_float` is untouched: a fractional rate or
duration is perfectly usable, and `float(...)` never truncated, which is why that
half always worked -- `{"control_frequency": 2000.5}` was already refused by the
bound.

## The change

Two lines in `_coerce_int`, placed after the finiteness check and before the
coercion. `float("nan").is_integer()` is False, so a whole-number check placed
first would answer a non-finite value with the wrong reason -- the ordering is
asserted both behaviourally and off the source.

## Why nothing caught it

The two suites that grade these helpers cover the other edges.
`test_validate_command_finite_numerics` pins NaN / inf, and
`test_validate_command_numeric_coercion_none_handling` pins `None` and type
rejection -- including `bool`, refused precisely because it "must not be accepted
as a count". Its `step.steps` type case parametrised over `str` / `list` / `dict`
and recorded the float behaviour as an aside: *"a float is accepted and
truncated, matching `int(...)` semantics"*. That sentence was the contract nobody
had questioned; it is corrected here, and the cell now points at the new file.

## Verification

New file `tests/mesh/test_validate_command_counts_are_whole_numbers.py`, 59
cases. Pre-fix split with the source reverted: **24 failed / 35 passed**.

| class | pre-fix | role |
| --- | --- | --- |
| `TestAFractionalCountIsRefusedNotTruncated` | 9/9 | regression |
| `TestTheCeilingRefusesWhicheverWayTheNumberIsSpelled` | 8/16 | regression; the 8 passing are the "ceiling still accepted" and "integer still refused" halves |
| `TestABelowFloorRefusalNamesTheCallersOwnValue` | 2/2 | regression |
| `TestTheGuardSitsAfterTheFinitenessCheck` | 2/2 | structural |
| `TestEveryWireCountIsHeldToTheDomain` | 1/5 | derived |
| `TestTheSplitIsTheOneTheSimulationSurfaceApplies` | 2/7 | premise |
| `TestAnIntegralFloatIsStillAccepted` | **0/9** | over-reach control |
| `TestTheFloatSiblingIsUnchanged` | **0/4** | over-reach control |
| `TestTheEarlierGuardsStillOwnTheirCases` | **0/5** | control |

Mutation table. `sib` is failures in the three pre-existing wire-side suites;
`collected` was 59 on every row and both files were restored byte-identically.

| # | mutation | fires | sib |
| --- | --- | --- | --- |
| b0 | control | 0 | 0 |
| b1 | guard removed (= the shipped state) | 24 | 0 |
| b2 | guard placed *before* the finiteness check | 4 | **1** |
| b3 | the tempting alternative: `round()` instead of refusing | 23 | 0 |
| b4 | over-reach: refuses any float, integral or not | 7 | 0 |
| b5 | fixed only `steps` | 14 | 0 |
| b6 | message drops the caller's value | 11 | 0 |
| b7 | over-reach: the same guard added to `_coerce_float` | 4 | **4** |
| b10 | a fifth `_coerce_int` call site planted, scan derived | 1 | 0 |
| b11 | the same plant, scan hardcoded to today's four names | **0** | 0 |

Three rows carry the design. **b2** trips
`test_the_int_finite_guard_is_what_refuses_a_non_finite_step_count`, which exists
to pin which guard answers a non-finite count -- so the ordering is held by a
pre-existing suite as well as by this one. **b7** trips
`test_execute_duration_rejects_non_finite` (all three parameters) and
`test_isnan_check_independent_from_bounds`, because `nan.is_integer()` is False,
which is what pins the guard to the integer helper. **b3** shows the obvious
alternative is measurably worse: rounding accepts `{"steps": 0.9}` as one step,
where truncating at least refused it.

**b10 / b11** are the derived-inventory pair: a fifth `_coerce_int` call site is
named by the scan when it is derived from `validate_command`'s own source, and is
completely silent when the same set is hardcoded.

Gate, all three lint commands run separately: `ruff check` clean,
`ruff format --check` 1718 files already formatted, `mypy` 24 errors (the
standing baseline) with **0 attributable**. Paired run over an identical 617-path
selection -- every `tests/mesh/` file plus every guard that walks the tree,
parses source, or reads docstrings, with the new file withheld from both sides:
identical `25552` collected and `24 failed, 25425 passed, 79 skipped, 24 errors`
on each, **48 == 48 failing ids, both `comm` directions empty**. All 48 reproduce
on the base: 45 need `awsiot` / `awscrt` (both absent here, both declared in
`[mesh-iot]`, which `[all]` includes, so CI installs them) and 3 are lerobot
from-source drift in `tests/training/test_lerobot*`.

No docs change: `docs/` does not document these wire bounds, so `_coerce_int`'s
docstring is the surface, and it now records the third defence and why an
integral float stays accepted.
