### PR TITLE
docs(policies/microduck): the ball scene carries the ball, not the kick geometry

### DIFF
--- a/changelog.d/2926-microduck-ball-scene-placement-invariant.md
+++ b/changelog.d/2926-microduck-ball-scene-placement-invariant.md
@@ -1,0 +1,22 @@
+### Docs: the Microduck ball scene carries the ball, not the kick geometry
+
+`docs/policies/microduck.md` points the two ball-kick weights at `scene_ball.xml`
+in its Skill scenes table, and the guard beside it grades the ball's presence: the
+row names a scene, and that scene carries a body named `ball`. Neither says where
+the ball sits, and the position is the half that decides whether a kick connects.
+
+The scene declares the ball 0.3 m straight ahead. Pollen's training reset placed it
+0.09 m ahead and 0.042 m to the side of the kicking foot, in the robot's yaw frame.
+Driven from the shipped position through `MicroduckPolicy`, `ball_kick_left`
+completes and reports success while no robot body ever touches the ball: across a
+four-second rollout at 50 Hz the closest any robot geom comes to the ball centre is
+0.109 m, against a 0.035 m radius. The ball still travels 0.474 m forward on its
+own - its geom sets a deliberately low rolling resistance - which is why the miss
+reads as a weak kick rather than as a miss.
+
+The page now says that naming the scene is necessary and not sufficient, and states
+both numbers so a reader can close the gap. It also records that the joint is
+`ball_free` in the file and that `add_robot(name=...)` prefixes every joint with the
+name the caller passed, so a caller resolves the name rather than assuming either
+spelling. Two guard docstrings that claimed the trained position while their cells
+graded only presence are corrected to say what they check.

--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -110,6 +110,28 @@ roller policy writes the same fourteen control targets, and with no wheels under
 the feet the duck simply stands; a ball-kick policy swings at a ball that is not
 there. Nothing refuses it, so the scene is the caller's to choose.
 
+### The ball scene carries the ball, not the kick geometry
+
+`scene_ball.xml` places the prop, and where it sits is not where the kick policies
+were trained to find it. The scene declares the ball 0.3 m straight ahead
+(`ball.xml`: `pos="0.3 0 0.035"`). Pollen's training reset placed it 0.09 m ahead and
+0.042 m to the side of the kicking foot, in the robot's yaw frame - 3.3x closer, and
+offset laterally to the foot that swings.
+
+Loading the scene is therefore necessary and not sufficient. Driven from the shipped
+position, `ball_kick_left` completes and reports success while no robot body ever
+touches the ball: across a four-second rollout the closest any robot geom comes to the
+ball centre is 0.109 m, against a 0.035 m radius. The ball still travels forward on its
+own - its geom sets a deliberately low rolling resistance - which is why the miss reads
+as a weak kick rather than as a miss.
+
+A caller who wants the trained geometry teleports the ball before the rollout, which is
+what Pollen's runtime does at the moment a kick is triggered: write the ball free
+joint's `qpos` to that offset rotated into the trunk's yaw frame, zero the joint's
+`qvel`, and step. The file names the joint `ball_free`; `add_robot(name=...)` prefixes
+every joint with the name the caller passed, so resolve the name rather than assuming
+either spelling.
+
 ### Reading joint positions on the rollers scene
 
 `scene_ball.xml` appends the ball's free joint after the robot's, so the robot's

--- a/tests/simulation/test_microduck_skill_scenes_are_documented.py
+++ b/tests/simulation/test_microduck_skill_scenes_are_documented.py
@@ -57,6 +57,13 @@ MINIMUM_SKILLS = 9
 #: per-scene cells would pass by never reaching a non-default scene.
 MINIMUM_TABLE_ROWS = 3
 
+#: The offset ``reset_ball_in_front_of_foot`` trained the two kick weights on, read
+#: off Pollen's reference runtime (``scripts/infer_policy.py``, ``BALL_OFFSET_X`` and
+#: ``BALL_OFFSET_ABS_Y``). The scene's own declared position is not this, which is
+#: what the page's placement paragraph exists to say.
+TRAINED_BALL_OFFSET_X = 0.09
+TRAINED_BALL_ABS_Y = 0.042
+
 
 def _page() -> str:
     return PAGE.read_text(encoding="utf-8")
@@ -143,6 +150,33 @@ def _ball_bodies(mujoco, model) -> list[str]:
     return [name for name in names if name and "ball" in name]
 
 
+#: The subsection the placement invariant lives in.
+PLACEMENT_HEADING = "### The ball scene carries the ball, not the kick geometry"
+
+
+def _placement_section(text: str) -> str:
+    """The placement paragraph, refusing by name when the heading is gone.
+
+    ``_section`` resolves with ``str.index``, so a renamed heading would surface
+    as ``ValueError: substring not found`` and name nothing. Asserting presence
+    first means a rename fails saying which heading it could not find.
+    """
+    assert PLACEMENT_HEADING in text, f"the page no longer carries {PLACEMENT_HEADING!r}"
+    return _section(text, PLACEMENT_HEADING)
+
+
+def _declared_ball_position(mujoco, model) -> list[float]:
+    """Where the scene puts the ball, read off the compiled model.
+
+    ``body_pos`` is the declared placement, so this needs no ``MjData`` and no
+    stepping: the question is where the file puts the prop, not where physics
+    carries it.
+    """
+    body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "ball")
+    assert body >= 0, "the ball scene must carry a body named 'ball'"
+    return [float(value) for value in model.body_pos[body]]
+
+
 class TestThePageNamesASceneForEverySkill:
     """Read from the page alone, so it holds with no asset and no MuJoCo."""
 
@@ -192,7 +226,7 @@ class TestTheTablesClaimsAreTrueOfTheAssets:
         assert len(_wheel_joints(mujoco, model)) == 4
 
     def test_a_ball_kick_skill_is_pointed_at_a_scene_that_has_a_ball(self) -> None:
-        """The ball scene places the prop the kick policies were trained on."""
+        """The ball scene carries the prop. Where it sits is graded separately."""
         scene = _scene_table(_page())["ball_kick_left"]
         assert scene != DEFAULT_SCENE, "ball_kick must not be pointed at the ball-less default"
         mujoco, model = _scene_model(scene)
@@ -204,7 +238,7 @@ class TestTheTablesClaimsAreTrueOfTheAssets:
         assert table["roller"] == table["roller_crouch"]
 
     def test_the_two_ball_kick_skills_share_one_scene(self) -> None:
-        """The ball sits in front of the duck; the side is the policy's."""
+        """One scene carries the prop for both; the side is the policy's."""
         table = _scene_table(_page())
         assert table["ball_kick_left"] == table["ball_kick_right"]
 
@@ -270,3 +304,48 @@ class TestTheJointLayoutClaimsHold:
 
         assert at(default, {12, 13}) == ["neck_pitch", "head_pitch"]
         assert at(rollers, {12, 13}) == ["passive_LF_wheel", "passive_LR_wheel"]
+
+
+class TestThePageSaysTheSceneDoesNotPlaceTheBallWhereTrainingDid:
+    """Naming the scene is necessary and not sufficient, and the page says so.
+
+    ``TestTheTablesClaimsAreTrueOfTheAssets`` grades the ball's **presence**: the row
+    points at a scene, and that scene carries a body named ``ball``. It says nothing
+    about **where**, and the position is the half that decides whether a kick connects.
+    The scene declares the ball far enough ahead that no robot body reaches it, so a
+    reader who follows the table alone still gets an air-swing - the outcome the table
+    was added to remove for the roller skills.
+
+    The first cell is a premise about the asset and holds either way - it is what
+    makes the paragraph worth writing. The other two read the page and fail without
+    it.
+    """
+
+    def test_the_scene_does_not_declare_the_ball_at_the_trained_offset(self) -> None:
+        """The premise: naming the scene leaves the geometry wrong.
+
+        Both axes differ. Forward, the scene is more than twice the trained offset;
+        laterally it is centred where training offset the ball to the kicking foot.
+        """
+        mujoco, model = _scene_model(_scene_table(_page())["ball_kick_left"])
+        forward, lateral, _height = _declared_ball_position(mujoco, model)
+        assert forward > 2 * TRAINED_BALL_OFFSET_X, (
+            f"the scene declares the ball {forward} m ahead, which is no longer far "
+            f"enough past the trained {TRAINED_BALL_OFFSET_X} m for this page's "
+            "placement paragraph to be the reason a kick misses"
+        )
+        assert lateral == 0.0, f"the scene now offsets the ball laterally to {lateral} m"
+
+    def test_the_page_records_the_trained_offset_and_the_scenes_own_position(self) -> None:
+        """Both numbers, so a reader can see the gap rather than take it on trust."""
+        section = _placement_section(_page())
+        mujoco, model = _scene_model(_scene_table(_page())["ball_kick_left"])
+        forward = _declared_ball_position(mujoco, model)[0]
+        for number in (f"{forward} m", f"{TRAINED_BALL_OFFSET_X} m", f"{TRAINED_BALL_ABS_Y} m"):
+            assert number in section, f"the placement paragraph does not state {number}"
+
+    def test_the_page_tells_the_reader_the_joint_name_is_not_fixed(self) -> None:
+        """``add_robot`` prefixes every joint, so a fixed default resolves for one caller."""
+        section = _placement_section(_page())
+        assert "ball_free" in section, "the paragraph does not name the joint to write"
+        assert "add_robot" in section, "the paragraph does not say the name is prefixed"


### PR DESCRIPTION
## The table grades the ball's presence; the position is what decides whether a kick connects

`docs/policies/microduck.md` carries a Skill scenes table that points the two ball-kick
weights at `scene_ball.xml`, and `tests/simulation/test_microduck_skill_scenes_are_documented.py`
grades that row: the scene compiles, and it carries a body named `ball`. Neither the row
nor the guard says **where** the ball sits, and two of the guard's own docstrings claimed
the position anyway - "The ball scene places the prop the kick policies were trained on"
and "The ball sits in front of the duck".

Both are false, and the gap is the difference between a kick that connects and one that
does not.

### Measured

`ball.xml` declares the ball at `pos="0.3 0 0.035"`. Pollen's reference runtime places it
at `BALL_OFFSET_X = 0.09` ahead and `BALL_OFFSET_ABS_Y = 0.042` to the side of the kicking
foot, in the robot's yaw frame, citing `reset_ball_in_front_of_foot` as the source - 3.3x
closer, and offset laterally to the foot that swings.

I drove `ball_kick_left.onnx` through `MicroduckPolicy` on `scene_ball.xml` twice, 4.0 s at
50 Hz, sampling `d.contact` on every physics step:

| ball start, relative to the trunk | robot bodies touching the ball | closest robot geom to the ball centre | ball displacement |
| --- | --- | --- | --- |
| `(0.2566, 0.0)` - as the scene ships | **none** - `world` only | **0.1088 m** | `(+0.474, -0.000)` |
| `(0.0900, 0.0419)` - the trained offset | `jaw_soft` | **0.0366 m** | `(-0.259, +0.692)` |

The ball's radius is `0.035`, so `0.0366` is surface contact and `0.1088` is a miss by
about 7.4 cm. Across 200 control steps on the shipped scene **no robot body ever touches
the ball**. It still travels `0.474 m` forward, because its geom sets
`friction="0.5 0.005 0.0001"` - a deliberately low rolling resistance - which is why the
miss reads as a weak kick rather than as a miss. Placed at the trained offset a robot body
contacts it and it leaves to the left, which is the left-foot kick direction.

### The change

A new subsection on the page states that naming the scene is necessary and not sufficient,
gives both numbers so a reader can see the gap rather than take it on trust, and records
that the joint is `ball_free` in the file while `add_robot(name=...)` prefixes every joint
with the name the caller passed - so a caller resolves the name rather than assuming either
spelling. That last part matters: the plain `mj_name2id(model, mjOBJ_JOINT, "ball_free")`
that works for a direct `MjModel.from_xml_path` returns `-1` under `add_robot`, and a
`microduck/`-prefixed spelling returns `-1` for a caller who passed any other name.

Three cells grade it, in a class of their own so the presence claim and the position claim
stay separate:

- `test_the_scene_does_not_declare_the_ball_at_the_trained_offset` reads `body_pos` off the
  compiled model - no `MjData`, no stepping - and holds either way. It is the premise that
  makes the paragraph worth writing, and it fires the day the asset moves the ball toward
  the trained offset, at which point the paragraph should go.
- `test_the_page_records_the_trained_offset_and_the_scenes_own_position` derives the
  scene's own number from the model and requires the page to state it beside the two
  trained ones, so the prose cannot drift from the asset.
- `test_the_page_tells_the_reader_the_joint_name_is_not_fixed` requires the paragraph to
  name `ball_free` and `add_robot`.

Both page-reading cells resolve the section through one `_placement_section` accessor that
asserts the heading is present first. `_section` resolves with `str.index`, so without that
a renamed heading surfaces as `ValueError: substring not found` and names nothing.

### Pre-fix split

With the page reverted to `main` and the new cells kept: **2 failed, 15 passed**. Both
failures name the missing heading. The premise cell passes, correctly - it is about the
asset, not the page.

### Detection

| mutation | fires | cells |
| --- | --- | --- |
| control, as shipped | 0 | |
| the whole paragraph reverted to `main` | 2 | both page-reading cells |
| the heading kept, the three numbers dropped | 1 | `..._records_the_trained_offset_...` |
| the joint-name guidance dropped | 1 | `..._the_joint_name_is_not_fixed` |
| the subsection heading renamed | 2 | both, by name via the presence assert |
| the premise threshold weakened to `> 0.0` | 0 | measured no-op, see below |

The two per-claim rows partition the full revert exactly and their firing sets are
disjoint, so each half of the paragraph is independently pinned. The premise row fires
nothing because the premise is a drift guard rather than behaviour today: `0.3 > 2 * 0.09`
holds by a wide margin, and the assertion exists so that a future asset change moving the
ball toward the trained offset fails the file with a message saying the paragraph's reason
has gone. Dropping the presence assert fires the same two cells as the plain revert, but
with `ValueError` instead of a named refusal, which is what that accessor is for.

### Gate

`ruff check` and `ruff format --check` clean over 1719 files. `mypy strands_robots tests
tests_integ` reports the same 24 errors in 9 files as `main`, none of them in the changed
file. `mkdocs build --strict` builds in 1.75 s. The changed guard is 17 passed, up from 14.
The 135 test files that read `docs/`, `.md` or `mkdocs` are **3609 passed, 9 skipped, 0
failed**. No production module changes, so the selection is scoped to the guards that read
the page plus the changed file's own suite.

`onnxruntime` is not a hard dependency, so the rollout that produced the contact table is
not shipped as a test - it needs the weights, which the asset does not carry. The cells
here read the compiled model and the page, which is why they run anywhere `mujoco` does.

### Deliberately not done

A shared helper that teleports the ball to the trained offset. That is the fix a caller
wants, and it needs two decisions this PR should not make: whether it lives in
`simulation/mujoco/` (which already owns mujoco and every other `jnt_qposadr` writer) or in
`policies/microduck/` (which imports no mujoco at all today), and whether its joint-name
defaults are the bare spellings the file declares or resolved against both. Documenting the
invariant is useful either way, and it is the half that needs no public-surface call.
