### PR TITLE
docs(policies/microduck): the stance every weight was trained in

### DIFF
--- a/changelog.d/2927-microduck-trained-stance.md
+++ b/changelog.d/2927-microduck-trained-stance.md
@@ -1,0 +1,41 @@
+### Added: the Microduck page names the stance every weight was trained in
+
+`docs/policies/microduck.md` carries the skill-to-scene table, and a weight and
+its stance are a pair in the same way a weight and its scene are.
+`changelog.d/2900-microduck-skill-scenes.md` closed the scene half; the stance
+half was still undocumented, and the page's own example spawns without it.
+
+Every shipped Pollen weight bakes the stance it was trained in into its ONNX
+metadata as `default_joint_pos`, and all nine declare the pairwise-identical
+fourteen values. `MicroduckPolicy` reads them into `default_pose` and decodes
+every action relative to that origin - the module's own docstring states it as
+`motor_target = default_pose + raw_action * action_scale` - so the stance is not
+advice, it is what the network's output is measured from. The same values ship as
+`strands_robots.policies.microduck.MICRODUCK_DEFAULT_POSE`.
+
+The asset ships the stance too, and `add_robot(keyframe=...)` seats a robot
+there:
+
+    scene.xml          keyframes=['STAND']  spawn at STAND -> 4e-05 rad from MICRODUCK_DEFAULT_POSE
+    scene_rollers.xml  keyframes=['STAND']  spawn without   -> 0.458 rad away, reported success
+    scene_ball.xml     keyframes=[]         keyframe="STAND" refused, naming the keyframes declared
+
+A keyframe spawn is sticky: `reset()` restores the pose and the actuator command
+that holds it, so every episode of a `run_policy` plus `reset` loop begins from
+the same stance. Spawning without `keyframe` is not an error - the robot starts
+at the zero configuration, 0.458 rad from the trained stance at the widest joint,
+while the policy still decodes relative to the stance it expects, so the first
+inference reads a pose no shipped weight was trained on.
+
+Two details the section records because a caller meets both. The live keyframe is
+named `STAND`: the asset's own comment calls the current values "STAND2" because
+they supersede an earlier `STAND` commented out beside them, so `"STAND2"` is
+refused. And `scene_ball.xml` declares no keyframe at all, so the route is
+unavailable on the one scene a ball kick needs.
+
+The page names the constant rather than repeating the numbers, because the asset
+has revised this pose once already: the superseded `STAND` sits 0.066 rad from
+the current one at the hip and flips the sign of `head_pitch`. A cell now asserts
+that the shipped keyframe and the exported constant still agree to within 1e-3,
+so revising either fails that cell rather than leaving the page describing a pose
+the asset no longer declares. No library code changes.

--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -110,6 +110,45 @@ roller policy writes the same fourteen control targets, and with no wheels under
 the feet the duck simply stands; a ball-kick policy swings at a ball that is not
 there. Nothing refuses it, so the scene is the caller's to choose.
 
+### The stance every weight was trained in
+
+A weight and its scene are one pair; so are a weight and the stance it starts
+from. Every shipped Pollen weight bakes that stance into its ONNX metadata as
+`default_joint_pos`, and all nine declare the same fourteen values.
+`MicroduckPolicy` reads it into `default_pose` and decodes every action relative
+to it - `motor_target = default_pose + raw_action * action_scale` - so the stance
+is not advice, it is the origin the network's output is measured from. The same
+values ship as `strands_robots.policies.microduck.MICRODUCK_DEFAULT_POSE`, the
+fallback the provider uses when a session carrying no metadata is injected.
+
+The asset ships that stance too, as the `STAND` keyframe in `scene.xml` and
+`scene_rollers.xml`. Name it at spawn and the robot starts there:
+
+```python
+sim = Robot("microduck", urdf_path=str(scene), keyframe="STAND")
+```
+
+A keyframe spawn is sticky across resets: `sim.reset()` restores the pose and the
+actuator command that holds it, so every episode of a `run_policy` + `reset` loop
+begins from the same stance.
+
+Spawning without `keyframe` is not an error and reports success. The robot starts
+at the zero configuration, 0.458 rad from the trained stance at the widest joint
+- legs straight rather than crouched - while the policy still decodes relative to
+the stance it expects. Nothing refuses it, so the first inference of the rollout
+reads a pose no shipped weight was trained on.
+
+Two details a caller meets:
+
+- The keyframe is named `STAND`. The asset's own comment calls the current values
+  "STAND2", because they supersede an earlier `STAND` that is commented out
+  beside them; the live keyframe kept the name. `keyframe="STAND2"` is refused,
+  and the refusal names the keyframes the model does declare.
+- `scene_ball.xml` declares no keyframe at all, so the route above is unavailable
+  on the one scene a ball kick needs. Seat the stance yourself there, reading it
+  from `MICRODUCK_DEFAULT_POSE` rather than copying the numbers - the asset has
+  already revised this pose once.
+
 ### Reading joint positions on the rollers scene
 
 `scene_ball.xml` appends the ball's free joint after the robot's, so the robot's

--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -110,6 +110,21 @@ roller policy writes the same fourteen control targets, and with no wheels under
 the feet the duck simply stands; a ball-kick policy swings at a ball that is not
 there. Nothing refuses it, so the scene is the caller's to choose.
 
+### Reading joint positions on the rollers scene
+
+`scene_ball.xml` appends the ball's free joint after the robot's, so the robot's
+`qpos` layout is byte-for-byte the default one. `scene_rollers.xml` does not:
+it inserts two passive wheel joints after `left_ankle` and two more after
+`right_ankle`, which moves nine of the fourteen actuated joints to a different
+`qpos` index. A consumer that reads a flat `qpos[7:21]` slice therefore reads
+different joints there - the two left wheels arrive where `neck_pitch` and
+`head_pitch` sit on the default scene.
+
+The actuator order is identical across all three scenes, so a policy writing
+`ctrl` is unaffected, and `MicroduckPolicy` reads its observation by joint name
+rather than by slice, so the provider is immune either way. Only a raw position
+read has to care.
+
 ### The stance every weight was trained in
 
 A weight and its scene are one pair; so are a weight and the stance it starts
@@ -148,21 +163,6 @@ Two details a caller meets:
   on the one scene a ball kick needs. Seat the stance yourself there, reading it
   from `MICRODUCK_DEFAULT_POSE` rather than copying the numbers - the asset has
   already revised this pose once.
-
-### Reading joint positions on the rollers scene
-
-`scene_ball.xml` appends the ball's free joint after the robot's, so the robot's
-`qpos` layout is byte-for-byte the default one. `scene_rollers.xml` does not:
-it inserts two passive wheel joints after `left_ankle` and two more after
-`right_ankle`, which moves nine of the fourteen actuated joints to a different
-`qpos` index. A consumer that reads a flat `qpos[7:21]` slice therefore reads
-different joints there - the two left wheels arrive where `neck_pitch` and
-`head_pitch` sit on the default scene.
-
-The actuator order is identical across all three scenes, so a policy writing
-`ctrl` is unaffected, and `MicroduckPolicy` reads its observation by joint name
-rather than by slice, so the provider is immune either way. Only a raw position
-read has to care.
 
 ## The observation contract
 

--- a/tests/simulation/test_microduck_skill_scenes_are_documented.py
+++ b/tests/simulation/test_microduck_skill_scenes_are_documented.py
@@ -30,6 +30,14 @@ names really does carry the wheels or the ball, and the default scene really doe
 not. The second layer skips when the asset is absent, which is the case on a
 clean checkout; the first holds on any install, with no MuJoCo and no network.
 
+A weight and its stance are a pair in the same way, so the stance section below
+is graded here too. Every shipped weight bakes the stance it was trained in into
+its ONNX metadata, the asset ships the same stance as its ``STAND`` keyframe, and
+``add_robot(keyframe=...)`` seats a robot there and keeps it across resets. What
+was missing was any page saying so, and any check that the exported values and
+the shipped keyframe still agree - the asset has revised this pose once already,
+which is why the page names the constant instead of repeating the numbers.
+
 A registry ``variant=`` spelling would be a nicer front door and is deliberately
 not invented here: no entry among the seventy-three declares one, so the schema
 is a public-API decision rather than a docs fix.
@@ -37,10 +45,15 @@ is a public-API decision rather than a docs fix.
 
 from __future__ import annotations
 
+import contextlib
 import re
 from pathlib import Path
+from typing import Any
 
+import numpy as np
 import pytest
+
+from strands_robots.policies.microduck import MICRODUCK_DEFAULT_POSE, MICRODUCK_JOINT_NAMES
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 PAGE = REPO_ROOT / "docs" / "policies" / "microduck.md"
@@ -56,6 +69,23 @@ MINIMUM_SKILLS = 9
 #: Fewer rows than this means the table stopped covering the scenes, so the
 #: per-scene cells would pass by never reaching a non-default scene.
 MINIMUM_TABLE_ROWS = 3
+
+#: The subsection that documents the stance, and the keyframe name it teaches.
+#: The asset's own comment calls the current values "STAND2" because they
+#: supersede an earlier ``STAND`` commented out beside them; the live keyframe
+#: kept the name, so ``keyframe="STAND2"`` is refused.
+STANCE_HEADING = "### The stance every weight was trained in"
+STANCE_KEYFRAME = "STAND"
+
+#: The one scene a ball kick needs, and the one that declares no keyframe.
+BALL_SCENE = "scene_ball.xml"
+
+#: The shipped keyframe rounds the exported stance to four decimals, so the two
+#: agree to about 4e-05. This sits far under the smallest revision the asset has
+#: already shipped - the superseded ``STAND`` is 0.066 rad away at the hip and
+#: flips the sign of ``head_pitch`` - so a retune fails a cell here rather than
+#: leaving the page quietly describing a pose the asset no longer declares.
+STANCE_TOLERANCE = 1e-3
 
 
 def _page() -> str:
@@ -111,14 +141,13 @@ def _scene_table(text: str) -> dict[str, str]:
     return rows
 
 
-def _scene_model(scene: str):
-    """Compile a scene the asset directory carries, or skip.
+def _scene_path(scene: str) -> Path:
+    """Locate a scene the asset directory carries, or skip.
 
     Reads the search paths rather than resolving through the asset manager,
     which downloads a missing asset: a test that clones a third-party
     repository fails on a host with no network instead of skipping.
     """
-    mujoco = pytest.importorskip("mujoco")
     from strands_robots.utils import get_search_paths
 
     present = next(
@@ -127,7 +156,60 @@ def _scene_model(scene: str):
     )
     if present is None:
         pytest.skip(f"microduck {scene} is not downloaded, so its contents cannot be read")
-    return mujoco, mujoco.MjModel.from_xml_path(str(present))
+    return present
+
+
+def _scene_model(scene: str):
+    """Compile a scene the asset directory carries, or skip."""
+    mujoco = pytest.importorskip("mujoco")
+    return mujoco, mujoco.MjModel.from_xml_path(str(_scene_path(scene)))
+
+
+def _subsection(text: str, heading: str) -> str:
+    """Return one ``###`` subsection's body, so a rule reads only its own prose."""
+    start = text.index(heading)
+    rest = text[start + len(heading) :]
+    ends = [offset for offset in (rest.find("\n### "), rest.find("\n## ")) if offset != -1]
+    return rest if not ends else rest[: min(ends)]
+
+
+@contextlib.contextmanager
+def _spawned(scene: str, keyframe: str | None = None):
+    """Spawn the duck on ``scene``, optionally at a named keyframe."""
+    mujoco = pytest.importorskip("mujoco")
+    path = _scene_path(scene)
+    from strands_robots.simulation import create_simulation
+
+    sim = create_simulation("mujoco")
+    assert sim.create_world().get("status") == "success"
+    # Annotated ``Any`` because ``add_robot`` takes mixed types: a homogeneous
+    # ``dict[str, str]`` splat reads as the ``position`` list to a type checker.
+    extra: dict[str, Any] = {"keyframe": keyframe} if keyframe is not None else {}
+    try:
+        yield mujoco, sim, sim.add_robot(name="duck", urdf_path=str(path), **extra)
+    finally:
+        sim.destroy()
+
+
+def _stance_in_sim(mujoco, model, data) -> np.ndarray:
+    """Read the fourteen actuated joints by NAME, not by a flat qpos slice.
+
+    The rollers scene renumbers that slice, so a name-indexed read is the only
+    one that means the same thing on every scene the page names.
+    """
+    out = []
+    for short in MICRODUCK_JOINT_NAMES:
+        joint = next(
+            (
+                i
+                for i in range(model.njnt)
+                if (name := mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i)) and name.split("/")[-1] == short
+            ),
+            None,
+        )
+        assert joint is not None, f"{short} is not a joint of the compiled model"
+        out.append(float(data.qpos[model.jnt_qposadr[joint]]))
+    return np.asarray(out)
 
 
 def _joint_names(mujoco, model) -> list[str]:
@@ -270,3 +352,70 @@ class TestTheJointLayoutClaimsHold:
 
         assert at(default, {12, 13}) == ["neck_pitch", "head_pitch"]
         assert at(rollers, {12, 13}) == ["passive_LF_wheel", "passive_LR_wheel"]
+
+
+class TestThePageDocumentsTheTrainedStance:
+    """Read the page and the package, so these hold with no asset and no MuJoCo."""
+
+    def test_the_exported_stance_is_public_and_covers_every_joint(self) -> None:
+        """Non-vacuity: every rule below compares against this constant."""
+        from strands_robots.policies import microduck
+
+        assert "MICRODUCK_DEFAULT_POSE" in microduck.__all__
+        assert len(MICRODUCK_DEFAULT_POSE) == len(MICRODUCK_JOINT_NAMES)
+
+    def test_the_section_names_the_keyframe_that_reaches_the_stance(self) -> None:
+        """A reader who cannot name the keyframe cannot reach the stance."""
+        body = _subsection(_page(), STANCE_HEADING)
+        assert f'keyframe="{STANCE_KEYFRAME}"' in body
+
+    def test_the_section_names_the_constant_rather_than_repeating_the_pose(self) -> None:
+        """A copied pose drifts: the asset has already revised this one."""
+        body = _subsection(_page(), STANCE_HEADING)
+        assert "MICRODUCK_DEFAULT_POSE" in body
+
+    def test_the_section_names_the_scene_where_the_route_is_unavailable(self) -> None:
+        """The one scene a ball kick needs declares no keyframe at all."""
+        assert BALL_SCENE in _subsection(_page(), STANCE_HEADING)
+
+
+class TestTheStanceClaimsAreTrueOfTheAssets:
+    """Re-derive the stance from the shipped models, so the page cannot drift."""
+
+    def test_the_shipped_keyframe_is_the_stance_the_package_exports(self) -> None:
+        """The drift guard: a revised keyframe fails here instead of diverging."""
+        mujoco, model = _scene_model(DEFAULT_SCENE)
+        names = [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_KEY, i) for i in range(model.nkey)]
+        assert STANCE_KEYFRAME in names, f"{DEFAULT_SCENE} declares {names}"
+        keyed = model.key_qpos[names.index(STANCE_KEYFRAME)][7 : 7 + len(MICRODUCK_DEFAULT_POSE)]
+        gap = float(np.max(np.abs(np.asarray(keyed) - np.asarray(MICRODUCK_DEFAULT_POSE))))
+        assert gap <= STANCE_TOLERANCE, f"{STANCE_KEYFRAME} is {gap:.6g} rad from MICRODUCK_DEFAULT_POSE"
+
+    def test_the_keyframe_route_reaches_the_stance_and_survives_a_reset(self) -> None:
+        """The route the section documents, and the stickiness it promises."""
+        with _spawned(DEFAULT_SCENE, STANCE_KEYFRAME) as (mujoco, sim, result):
+            assert result.get("status") == "success", result
+            spawned = _stance_in_sim(mujoco, sim._world._model, sim._world._data)
+            assert np.allclose(spawned, MICRODUCK_DEFAULT_POSE, atol=STANCE_TOLERANCE)
+            assert sim.reset().get("status") == "success"
+            after = _stance_in_sim(mujoco, sim._world._model, sim._world._data)
+            assert np.allclose(after, MICRODUCK_DEFAULT_POSE, atol=STANCE_TOLERANCE), (
+                "a keyframe spawn must survive reset, or every episode after the first starts elsewhere"
+            )
+
+    def test_a_spawn_without_a_keyframe_starts_at_the_zero_configuration(self) -> None:
+        """The counterfactual: no refusal, and the wrong origin for the decode."""
+        with _spawned(DEFAULT_SCENE, None) as (mujoco, sim, result):
+            assert result.get("status") == "success", result
+            spawned = _stance_in_sim(mujoco, sim._world._model, sim._world._data)
+            assert np.allclose(spawned, 0.0)
+            gap = float(np.max(np.abs(spawned - np.asarray(MICRODUCK_DEFAULT_POSE))))
+            assert gap > STANCE_TOLERANCE, "the zero configuration must not already be the trained stance"
+
+    def test_the_ball_scene_declares_no_keyframe_so_the_route_refuses_there(self) -> None:
+        """Why the section names the ball scene as the exception."""
+        _mujoco, model = _scene_model(BALL_SCENE)
+        assert model.nkey == 0, f"{BALL_SCENE} now declares {model.nkey} keyframe(s)"
+        with _spawned(BALL_SCENE, STANCE_KEYFRAME) as (_mj, _sim, result):
+            assert result.get("status") == "error"
+            assert "no <keyframe>" in result["content"][0]["text"]


### PR DESCRIPTION
## The gap

`docs/policies/microduck.md` documents which **scene** each of the nine shipped
Pollen weights needs (#2900) and says nothing about the **stance** they start
from. Those are the same kind of pair.

Every shipped weight bakes the stance it was trained in into its ONNX metadata as
`default_joint_pos`, and all nine declare the pairwise-identical fourteen values.
`MicroduckPolicy` reads them into `default_pose` and decodes every action
relative to that origin - the module's own docstring states it as
`motor_target = default_pose + raw_action * action_scale`. So the stance is not
advice; it is what the network's output is measured from.

The asset ships the stance as its `STAND` keyframe, and `add_robot(keyframe=...)`
seats a robot there. Nothing said so, and the page's own example spawns without
it:

| spawn | stance reached | distance from `MICRODUCK_DEFAULT_POSE` | status |
| --- | --- | --- | --- |
| `keyframe="STAND"` | the trained stance | `4e-05 rad` (the keyframe's 4-decimal rounding) | `success` |
| no `keyframe` | the zero configuration | `0.458 rad` at the widest joint | `success` |

Both report success. The second decodes every action relative to a stance the
robot is not in, and the first inference of the rollout reads a pose no shipped
weight was trained on.

## What the section adds

A `### The stance every weight was trained in` subsection under `## Skill
scenes`, recording the route, its stickiness, and the two details a caller meets:

| scene | keyframes declared | `keyframe="STAND"` |
| --- | --- | --- |
| `scene.xml` | `['STAND']` | seats the stance |
| `scene_rollers.xml` | `['STAND']` | seats the stance |
| `scene_ball.xml` | `[]` | refused, naming the keyframes the model declares |

- The live keyframe is named `STAND`. The asset's own comment calls the current
  values "STAND2" because they supersede an earlier `STAND` commented out beside
  them; the live keyframe kept the name, so `keyframe="STAND2"` is refused.
- `scene_ball.xml` declares no keyframe at all, so the route is unavailable on
  the one scene a ball kick needs. The section says to seat the stance from
  `MICRODUCK_DEFAULT_POSE` there rather than from a copy of the numbers.

A keyframe spawn is sticky: `reset()` restores the pose and the actuator command
that holds it, so every episode of a `run_policy` plus `reset` loop begins from
the same stance.

## Why the page names the constant instead of the numbers

The asset has revised this pose once already. The superseded `STAND` sits
`0.066 rad` from the current one at the hip and flips the sign of `head_pitch`. A
copied pose would drift silently, so the page names
`strands_robots.policies.microduck.MICRODUCK_DEFAULT_POSE` and a cell asserts
that the shipped keyframe and the exported constant still agree to within `1e-3`
- comfortably tighter than that revision, so a retune fails a test instead of
leaving the page describing a pose the asset no longer declares.

## Where the cells went

Into `tests/simulation/test_microduck_skill_scenes_are_documented.py`, which
already owns this page section, rather than a new file. It keeps its two-layer
shape: the page rules hold with no asset and no MuJoCo; the asset rules skip when
the asset is not downloaded. `_scene_path` is extracted so the single
network-free skip helper serves both layers.

## Detection

Every claim mutated, on the formatted tree. Control clean, `collected` stable at
22, all files restored byte-identically.

| mutation | fires | cells |
| --- | --- | --- |
| b0 control | 0 | - |
| b1 the whole section reverted | 3 | the three page cells |
| b2 section drops `keyframe="STAND"` | 1 | names-the-keyframe |
| b3 section repeats the numbers (both mentions) | 1 | names-the-constant |
| b4 section drops the ball-scene exception | 1 | names-the-scene |
| b5 constant revised to the superseded `STAND` | 2 | the drift guard, and the route cell |
| b6 `reset` stops restoring the keyframe | 1 | survives-a-reset |
| b7 keyframe ignored at spawn | 1 | reaches-the-stance |
| b8 subsection scoping removed | 0 | measured no-op, see below |

**b5** is the row worth reading: the mutation is not invented, it is the asset's
own previous values, and the drift guard fires on it. It fires the route cell too,
because both measure against the same constant - a wrong constant is caught twice.

**b8** is an honest zero. Every token the page rules match is unique to this
subsection today, so scoping the reader to the subsection is precision rather
than detection. It becomes load-bearing the first time another section mentions a
keyframe.

**b3** fired 0 on my first attempt: the section names the constant twice and I
had replaced one mention. Re-aimed at both, it fires 1.

## Verification

- `ruff check` clean; `ruff format --check` `1719 files already formatted`
- `mypy strands_robots tests tests_integ`: 24 errors, the standing baseline, **0
  attributable** (`checked 1716`)
- `mkdocs build --strict`: clean
- The changed file: **22 passed**. With the sibling asset, docs-example,
  markdown-link and render-example guards on this base: **72 passed**
- Guard class (454 files that walk the tree, parse source or read `docs/`):
  `19 failed, 21147 passed, 73 skipped`. All 19 are the two standing
  environmental families, measured rather than assumed - `awsiot`/`awscrt` both
  `find_spec` False and both declared in `[mesh-iot]`, which `all` includes, so
  CI installs them; plus the lerobot-from-source `encode()` drift. None is in a
  file this branch touches.

## Deliberately not done

No library change. `add_robot(keyframe=...)` already reaches the stance and
already survives `reset`; what was missing was the page and the drift guard.

A `Policy.requires_init_pose` attribute that `run_policy` would apply
automatically is a larger and better-informed change than this one: it is a new
public attribute on the `Policy` base, it has to decide what happens when a
policy declares a pose the loaded scene cannot seat (`scene_ball.xml` is exactly
that case), and it would want a warm-up contract beside it. That is a public-API
decision rather than a docs fix, so this change documents the route that ships
and leaves the schema to whoever takes it.

The stance is also not made a refusal. A caller may legitimately want a policy
driven from somewhere else, and a spawn that is merely out of distribution is not
one the library can distinguish from a deliberate one.

## Composition with #2926

#2926 documents the other half of the same symptom - the ball scene places the
prop 3.3x further out than the two kick weights were trained to find it - and it
extends the same page section and the same test file. Both PRs were open at the
same time, so I measured the composition rather than assuming it.

The two subsections were initially inserted at the same anchor. This branch's
section now sits at the end of `## Skill scenes`, after
`### Reading joint positions on the rollers scene`, which puts about fifty lines
between the two hunks: **the page now merges cleanly, 0 conflict markers.**

The shared test file still conflicts, in **2** places, and both are purely
additive - a module constant block and an appended class. The resolution is the
union with the markers dropped; no name is defined twice on either side. Composed
that way:

| tree | failures | cells |
| --- | --- | --- |
| both applied | 0 | 25 collected (22 here, 3 there) |
| this section reverted | 3 | the three page cells here |
| their section reverted | 2 | the two page cells there |

The two break sets are disjoint, so neither side's cells are riding on the
other's. `ruff check` and `mkdocs build --strict` are clean on the composed tree.
Either merge order works; whichever lands second takes that two-marker union.


## Round 2 — the composition landed

The ball-scene placement section merged to main at 04:45:43Z, so this branch
went `CONFLICTING`. Resolved by merging main in, exactly as the section above
predicted, with no force-push.

| prediction | outcome |
| --- | --- |
| `docs/policies/microduck.md` merges cleanly | auto-merged, 0 conflict markers |
| the shared test file conflicts in 2 places | conflicted in 2 places |
| both purely additive, resolution is the union | a module constant block and an appended class; union taken, markers dropped |
| no name defined twice on either side | 0 duplicate top-level names, 6 test classes |
| composed tree collects 25 | **25 collected**, 11 passed, 14 skipped |

The union puts the already-landed constants and class first and appends this
branch's, so the diff against main is the addition it was before.

**The break sets are still disjoint**, measured on the composed tree rather
than carried over from the earlier measurement:

| mutation | fires | cells |
| --- | --- | --- |
| control | 0 | - |
| this branch's page subsection reverted | 3 | the three page cells here |
| the ball-placement subsection reverted | 2 | the two page cells there |

Neither side's cells ride on the other's. The page restored byte-identically
after each mutation.

The 14 skips are the asset layer, which skips without the downloaded asset by
design - the two-layer shape described under *Where the cells went*. The 11
that run are the page rules plus the non-vacuity premise.

Re-verified on the merged tree: `ruff check` clean, `ruff format --check`
`1 file already formatted`, `mkdocs build --strict` clean. The diff against
main is the same three files, now `+154/-4` on the test file - one line of
blank-line spacing between the two constant blocks.

Approval was dismissed by the push, which is this repository's stale-review
behaviour and not a new finding; `mergeable` is back to `MERGEABLE`.
