### PR TITLE
fix(tests): the host-path gate refuses a terminal /Users/<name> literal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1719,7 +1719,7 @@ Corrections from code review that apply to all future contributions:
 - **Test import paths must match production** - If `src/` imports `from lerobot.datasets.X`, tests must use the same path. Mismatched paths cause silent skips via `except ImportError`.
 - **Round-trip tests for recording** - Any recording feature needs: start -> write -> stop -> reopen -> assert non-empty. Schema-only tests miss silent data loss.
 - **Pin regression tests for reviewed fixes** - Every review fix gets a test that fails on pre-fix code. Otherwise the next refactor silently reintroduces the bug.
-- **No host paths in test files** - Never commit `/Users/<name>/` or `/home/<name>/` paths. CI test `test_no_host_paths.py` enforces this.
+- **No host paths in test files** - Never commit `/Users/<name>` or `/home/<name>` paths, with or without a trailing segment. CI test `test_no_host_paths.py` enforces this.
 - **Name a test for its behaviour, not for its provenance** - a test class or function must not carry the release (`TestHardwareConfigV040Followups`) or review round (`...Followups`) that produced it. The name is the first thing a maintainer reads, so it has to say what is verified; and a name tied to a shipped release reads as historical, which invites skipping it. A bundle named for a review round is usually a bundle of unrelated checks - split it into one behaviour per class rather than inventing a name that covers all of them. Provenance belongs in the docstring, where the `#NNN` reference stays useful. A version token of one or two digits is fine: it names a *data format* under test (`test_load_v3_parses_every_field`), not a release. `Pinned by` `tests/test_test_case_names_describe_behaviour.py`.
 
 ### Performance

--- a/changelog.d/2929-host-path-sweep-terminal-literal.md
+++ b/changelog.d/2929-host-path-sweep-terminal-literal.md
@@ -1,0 +1,24 @@
+### Fixed: a host-specific path is refused whether or not a segment follows it
+
+`tests/test_no_host_paths.py` sweeps `strands_robots/`, `tests/` and
+`tests_integ/` for hardcoded home directories, and every one of its four
+patterns required a trailing separator (`/Users/[A-Za-z0-9._-]+/`). A literal
+that *ended* at the user segment therefore swept clean, which is the PR #85
+defect the file exists to catch, split across two statements:
+
+```python
+HOME = "/Users/cagatay"                        # not flagged
+model = Path(HOME) / "robots" / "policy.pt"
+```
+
+That fails on every machine that is not the author's exactly as the single-line
+form does. The separator is not what makes a path host-specific -- the user
+segment is -- so the patterns now end where that segment does, in both the
+backslash-escaped and raw spellings of the Windows form.
+
+The relaxation is a pure tightening: measured over the 1720 `.py` files in the
+scanned directories with the existing allowlist applied, it flags zero
+additional lines, so no allowlist entry was added. The boundary is pinned
+alongside the escape, because matching `/Users` or `/home` alone would flag
+portable paths such as `/homebrew/bin/mjpython`; `/Users/` with no user segment
+names no host and stays unflagged.

--- a/tests/test_no_host_paths.py
+++ b/tests/test_no_host_paths.py
@@ -6,8 +6,8 @@ author's laptop, got committed, and was only caught by CI because CI happens
 to not live at that path.
 
 This test is a cheap regex sweep over ``strands_robots/`` and ``tests/`` that
-fails fast if anyone re-introduces a ``/Users/<name>/``, ``/home/<name>/`` or
-``C:\\Users\\`` string. Prefer module-relative paths, ``pathlib.Path`` +
+fails fast if anyone re-introduces a ``/Users/<name>``, ``/home/<name>`` or
+``C:\\Users\\<name>`` string. Prefer module-relative paths, ``pathlib.Path`` +
 ``__file__``, ``importlib.resources``, or fixtures.
 
 Allowlist patterns live below - keep it narrow.
@@ -26,13 +26,20 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SCAN_DIRS = ("strands_robots", "tests", "tests_integ")
 
 # Patterns that indicate a hardcoded host-specific user path.
+#
+# None of these requires a trailing separator. A home directory is host-specific
+# whether or not a further segment follows it, and requiring the separator let a
+# *terminal* literal through untouched: ``HOME = "/Users/alice"`` on one line
+# with ``Path(HOME) / "robots"`` on the next is the PR #85 defect split across
+# two statements, and it swept clean. The user segment is what makes the path
+# host-specific, so the pattern ends where that segment does.
 HOST_PATH_PATTERNS = [
     # POSIX home directories with a specific user segment
-    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
-    re.compile(r"/home/[A-Za-z0-9._-]+/"),
-    # Windows user profile
-    re.compile(r"[A-Za-z]:\\\\Users\\\\[A-Za-z0-9._-]+\\\\"),
-    re.compile(r"[A-Za-z]:\\Users\\[A-Za-z0-9._-]+\\"),
+    re.compile(r"/Users/[A-Za-z0-9._-]+"),
+    re.compile(r"/home/[A-Za-z0-9._-]+"),
+    # Windows user profile, as it appears source-escaped and raw
+    re.compile(r"[A-Za-z]:\\\\Users\\\\[A-Za-z0-9._-]+"),
+    re.compile(r"[A-Za-z]:\\Users\\[A-Za-z0-9._-]+"),
 ]
 
 # Explicit allowlist - files or string occurrences that are ABOUT these patterns
@@ -78,7 +85,7 @@ def _iter_source_files() -> list[Path]:
 # protects every other test from genuine hangs.
 @pytest.mark.timeout(0)
 def test_no_host_specific_absolute_paths() -> None:
-    """Fail if any .py file contains ``/Users/<name>/`` or ``/home/<name>/``.
+    """Fail if any .py file contains ``/Users/<name>`` or ``/home/<name>``.
 
     If you need a path in a test, use module-relative resolution:
 
@@ -128,3 +135,63 @@ def test_host_path_sweep_disables_global_timeout() -> None:
     marks = [m for m in pytestmark if m.name == "timeout"]
     assert marks, "expected a @pytest.mark.timeout marker on the host-path sweep"
     assert marks[0].args == (0,), f"expected timeout(0) to disable the budget, got {marks[0].args!r}"
+
+
+# Source lines the sweep must flag. Each host path appears twice: once terminal
+# and once with a further segment. The terminal form is the escape this pins --
+# it carried no trailing separator, so the patterns did not match it -- and the
+# with-segment form is kept beside it so a future re-narrowing of the patterns
+# fails here instead of quietly restoring the gap. The Windows entries appear in
+# both the shapes real source takes: backslash-escaped, and raw.
+HOST_PATH_LINES = [
+    'HOME = "/Users/cagatay"',
+    'HOME = "/Users/cagatay/robots/policy.pt"',
+    "root = '/home/cagatay'",
+    "root = '/home/cagatay/datasets'",
+    r'win = "C:\\Users\\cagatay"',
+    r'win = "C:\\Users\\cagatay\\robots"',
+    r'win = r"C:\Users\cagatay"',
+    r'win = r"C:\Users\cagatay\robots"',
+]
+
+# Source lines the sweep must leave alone. These pin the boundary the patterns
+# must not cross now that a trailing separator is no longer required: the user
+# segment is mandatory, and ``/home`` is not a prefix match for ``/homebrew``.
+NON_HOST_PATH_LINES = [
+    'anchor = "/Users/"',
+    'anchor = "/home/"',
+    'brew = "/homebrew/bin/mjpython"',
+    'shared = "/usr/local/share/robots"',
+    'fixture = str(tmp_path / "calibration" / "so101.json")',
+]
+
+
+@pytest.mark.parametrize("line", HOST_PATH_LINES)
+def test_a_host_path_is_flagged_with_or_without_a_trailing_segment(line: str) -> None:
+    """A home directory is host-specific whether or not a segment follows it.
+
+    Every pattern required a trailing separator, so a literal that *ended* at
+    the user segment was not host-specific as far as the gate was concerned.
+    That splits the PR #85 defect across two statements and ships it:
+
+        HOME = "/Users/cagatay"        # swept clean
+        model = Path(HOME) / "robots" / "policy.pt"
+
+    which fails on every machine that is not the author's exactly as the
+    single-line form does.
+    """
+    assert any(pat.search(line) for pat in HOST_PATH_PATTERNS), f"host-specific path not detected: {line!r}"
+
+
+@pytest.mark.parametrize("line", NON_HOST_PATH_LINES)
+def test_a_path_without_a_user_segment_is_not_flagged(line: str) -> None:
+    """Dropping the trailing separator must not widen the gate past a user name.
+
+    ``/Users/`` with nothing after it names no host, and ``/homebrew`` is not a
+    home directory. Without these the patterns could be "fixed" into matching
+    the prefix alone, which flags portable paths and trains the next author to
+    reach for the allowlist.
+    """
+    assert not any(pat.search(line) for pat in HOST_PATH_PATTERNS), (
+        f"portable path wrongly flagged as host-specific: {line!r}"
+    )


### PR DESCRIPTION
Closes #2929.

## The escape

`tests/test_no_host_paths.py` is the gate that keeps hardcoded home directories out of `strands_robots/`, `tests/` and `tests_integ/`. All four of its patterns required a **trailing separator**, so a literal that *ended* at the user segment was not host-specific as far as the gate was concerned. Measured on the merge base `00b09a1`:

```
'HOME = "/Users/cagatay"'          -> caught: False
'root = "/home/cagatay"'           -> caught: False
'p = "/Users/cagatay/robots/x"'    -> caught: True
```

The first line is the PR #85 defect this file's own docstring cites as its reason for existing, split across two statements:

```python
HOME = "/Users/cagatay"                        # swept clean
model = Path(HOME) / "robots" / "policy.pt"
```

That fails on every machine that is not the author's exactly as the single-line form does, and the gate written to catch it did not. The separator is not what makes a path host-specific; the user segment is. Each pattern now ends where that segment does, in both the backslash-escaped and raw spellings of the Windows form.

## Why this is a tightening, not a migration

Measured over the **1720** `.py` files in the three scanned directories, with the existing allowlist applied, the relaxed patterns flag **zero** additional lines. No allowlist entry was added and no existing file needed changing, so the whole diff is the four patterns plus the pins and the prose that described them.

## The pins

| test | grades |
|---|---|
| `test_a_host_path_is_flagged_with_or_without_a_trailing_segment` | 8 literals: each of `/Users/<name>`, `/home/<name>` and the two Windows spellings, once terminal and once with a further segment |
| `test_a_path_without_a_user_segment_is_not_flagged` | 5 literals pinning the boundary: `/Users/`, `/home/`, `/homebrew/bin/mjpython`, `/usr/local/share/robots`, a `tmp_path` fixture |

The with-segment half is kept beside the terminal half deliberately, so a future re-narrowing of the patterns fails here rather than quietly restoring the gap.

The negative set is load-bearing rather than decorative. The obvious over-correction is to match `/Users` or `/home` alone, which flags portable paths such as `/homebrew/bin/mjpython` and trains the next author to reach for the allowlist instead of fixing the path -- that is the failure mode that turns a hygiene gate into noise. `/Users/` with no user segment names no host and must stay unflagged.

## Verification

The new pins fail on pre-fix patterns and pass after. Measured by restoring only the four pattern literals and keeping the tests:

| check | before | after |
|---|---|---|
| `tests/test_no_host_paths.py` | **4 failed** / 11 passed | **15 passed** |

The four failures are exactly the four terminal literals, each naming itself:

```
FAILED test_a_host_path_is_flagged_with_or_without_a_trailing_segment[HOME = "/Users/cagatay"]
FAILED test_a_host_path_is_flagged_with_or_without_a_trailing_segment[root = '/home/cagatay']
FAILED test_a_host_path_is_flagged_with_or_without_a_trailing_segment[win = "C:\\Users\\cagatay"]
FAILED test_a_host_path_is_flagged_with_or_without_a_trailing_segment[win = r"C:\Users\cagatay"]
```

All five boundary negatives pass both before and after, which is what shows the change is a tightening rather than a widening.

Also run:

| check | result |
|---|---|
| `tests/test_no_host_paths.py` (incl. the repo-wide sweep) | 15 passed |
| `tests/test_test_case_names_describe_behaviour.py` | 30 passed with the above |
| `tests/test_changelog_fragments.py` | 41 passed with the above |
| `scripts/assemble_changelog.py --check` | `changelog fragments OK (928 pending)` |
| `ruff check`, `ruff format --check` | clean |

## Doc drift closed in the same change

The trailing-separator shape was stated in three places besides the patterns, and all three now state what the gate enforces:

- `AGENTS.md:1722` -- the rule as written for contributors
- the module docstring
- the sweep's own docstring

Leaving those behind would mean the documented rule and the enforced rule disagree in the direction that reads as permission.