### PR TITLE
fix(mesh/iot): read a keyword presign TTL before clamping it

### DIFF
--- a/changelog.d/2931-camera-presign-ttl-readability.md
+++ b/changelog.d/2931-camera-presign-ttl-readability.md
@@ -10,15 +10,21 @@ anything that compares false against both bounds.
 
 `nan` is the value that matters, because the bound it walked through is a
 security bound -- the module's own comment says the ceiling exists "to prevent
-accidental day- or week-long URLs". `botocore` interpolates `ExpiresIn` into the
-signature without reading it, so the presigned URL carried `X-Amz-Expires=nan`
-and the `/ref` message published beside it carried `expires_at: nan`. A signed
-URL whose expiry field is not a number is one AWS refuses at request time, so
-the frame is unreadable *and* the window was never bounded. Three more spellings
-resolved to something the caller never named: a fractional TTL signed
-`X-Amz-Expires=2.5`, `True` stored a silent one-second TTL, and `inf` tripped
-the ceiling but its notice renders the value with `%d`, so `logging` raised and
-the operator saw an error where the clamp notice belonged.
+accidental day- or week-long URLs". `botocore` does not read `ExpiresIn`
+either, and what it does instead depends on the signer. Its pure-python signer
+interpolates the value verbatim, so the presigned URL carried
+`X-Amz-Expires=nan` -- a URL AWS refuses at request time, so the frame is
+unreadable *and* the window was never bounded. The `awscrt` signer that the
+`mesh-iot` extra installs, which is therefore the shipped configuration, instead
+fails inside the signer with a bare `AssertionError` naming no TTL, losing the
+frame outright. The `/ref` message published beside the URL carried
+`expires_at: nan` either way.
+
+Three more spellings resolved to something the caller never named: a fractional
+TTL signed `X-Amz-Expires=2.5` on the pure-python signer and raises `TypeError`
+from inside the CRT one, `True` stored a silent one-second TTL, and `inf`
+tripped the ceiling but its notice renders the value with `%d`, so `logging`
+raised and the operator saw an error where the clamp notice belonged.
 
 The keyword now goes through a readability check first. Only readability is
 decided there -- the range is still the clamps' to decide -- so `0` remains the

--- a/changelog.d/2931-camera-presign-ttl-readability.md
+++ b/changelog.d/2931-camera-presign-ttl-readability.md
@@ -1,0 +1,28 @@
+### Fixed: a keyword presign TTL is read before it is clamped
+
+`CameraOffloader` resolves the lifetime of the presigned GET URL it hands out
+per camera frame from two places, and they disagreed. The environment path runs
+`int(raw)` on a string and falls back to the default when that raises, so
+`STRANDS_MESH_CAMERA_PRESIGN_TTL` of `2.5`, `nan` or `inf` each resolve to the
+default. The `presign_ttl=` keyword had no such step: it went straight to two
+comparisons against the floor and the ceiling, and a comparison is permeable to
+anything that compares false against both bounds.
+
+`nan` is the value that matters, because the bound it walked through is a
+security bound -- the module's own comment says the ceiling exists "to prevent
+accidental day- or week-long URLs". `botocore` interpolates `ExpiresIn` into the
+signature without reading it, so the presigned URL carried `X-Amz-Expires=nan`
+and the `/ref` message published beside it carried `expires_at: nan`. A signed
+URL whose expiry field is not a number is one AWS refuses at request time, so
+the frame is unreadable *and* the window was never bounded. Three more spellings
+resolved to something the caller never named: a fractional TTL signed
+`X-Amz-Expires=2.5`, `True` stored a silent one-second TTL, and `inf` tripped
+the ceiling but its notice renders the value with `%d`, so `logging` raised and
+the operator saw an error where the clamp notice belonged.
+
+The keyword now goes through a readability check first. Only readability is
+decided there -- the range is still the clamps' to decide -- so `0` remains the
+documented keyword-versus-environment precedence sentinel, `-99` remains a
+call-site bug that clamps to `1` with a warning, and a value above the ceiling
+still clamps to it. An integral float is accepted rather than refused, because
+that is how `json.dumps` renders an integer held in a float.

--- a/strands_robots/mesh/iot/camera_offload.py
+++ b/strands_robots/mesh/iot/camera_offload.py
@@ -94,12 +94,15 @@ def _whole_seconds_or_none(value: Any) -> int | None:
     ``nan`` is the value that matters. ``nan > MAX_PRESIGN_TTL_SECONDS`` is
     ``False`` and ``nan < 1`` is ``False``, so it passed the ceiling whose
     documented purpose is to stop "accidental day- or week-long URLs" and
-    reached both consumers intact: ``botocore`` interpolates ``ExpiresIn``
-    into the signature without reading it, so the presigned URL carried
-    ``X-Amz-Expires=nan``, and the ``/ref`` message published alongside it
-    carried ``expires_at: nan``. A signed URL whose expiry field is not a
-    number is one AWS refuses at request time, so the frame is unreadable
-    *and* the window was never bounded.
+    reached both consumers intact. ``botocore`` does not read ``ExpiresIn``
+    either, and what it does instead depends on the signer: the pure-python
+    one interpolates the value verbatim, so the presigned URL carried
+    ``X-Amz-Expires=nan`` -- a URL AWS refuses at request time, so the frame
+    is unreadable *and* the window was never bounded -- while the ``awscrt``
+    signer the ``[mesh-iot]`` extra installs fails inside the signer with a
+    bare ``AssertionError`` naming no TTL, losing the frame outright. The
+    ``/ref`` message published alongside carried ``expires_at: nan`` either
+    way.
 
     Three more spellings resolved to something the caller did not name. A
     fractional TTL survived both clamps and signed ``X-Amz-Expires=2.5``.
@@ -108,6 +111,11 @@ def _whole_seconds_or_none(value: Any) -> int | None:
     clamp's own notice renders the value with ``%d``, and ``"%d" % inf``
     raises inside ``logging`` -- so the operator saw
     ``--- Logging error ---`` where the clamp notice belonged.
+
+    The signed values quoted above are the pure-python signer's. Under
+    ``awscrt`` every fractional TTL raises ``TypeError`` from inside the
+    signer instead, which is the same finding with a louder symptom: no
+    signer turns an unreadable TTL into the lifetime the caller named.
 
     Only readability is decided here; the range is still the clamps' to
     decide, which is why this is deliberately sign-agnostic. ``0`` remains

--- a/strands_robots/mesh/iot/camera_offload.py
+++ b/strands_robots/mesh/iot/camera_offload.py
@@ -60,6 +60,7 @@ hardening is tracked in #249.
 from __future__ import annotations
 
 import logging
+import numbers
 import os
 import time
 from typing import Any
@@ -76,6 +77,75 @@ logger = logging.getLogger(__name__)
 # (1 hour) to prevent accidental day- or week-long URLs.
 DEFAULT_PRESIGN_TTL_SECONDS = 60
 MAX_PRESIGN_TTL_SECONDS = 3600
+
+
+def _whole_seconds_or_none(value: Any) -> int | None:
+    """Read *value* as a whole number of seconds, or ``None`` when it is not one.
+
+    The two ways a caller names this TTL resolved it differently. The
+    environment path runs ``int(raw)`` on a string and falls back to the
+    default when that raises, so ``STRANDS_MESH_CAMERA_PRESIGN_TTL`` of
+    ``2.5``, ``nan`` or ``inf`` each resolve to
+    :data:`DEFAULT_PRESIGN_TTL_SECONDS`. The ``presign_ttl=`` keyword had no
+    such step: whatever was passed went straight to the two clamps below,
+    which compare it and are therefore permeable to anything that compares
+    false against both bounds.
+
+    ``nan`` is the value that matters. ``nan > MAX_PRESIGN_TTL_SECONDS`` is
+    ``False`` and ``nan < 1`` is ``False``, so it passed the ceiling whose
+    documented purpose is to stop "accidental day- or week-long URLs" and
+    reached both consumers intact: ``botocore`` interpolates ``ExpiresIn``
+    into the signature without reading it, so the presigned URL carried
+    ``X-Amz-Expires=nan``, and the ``/ref`` message published alongside it
+    carried ``expires_at: nan``. A signed URL whose expiry field is not a
+    number is one AWS refuses at request time, so the frame is unreadable
+    *and* the window was never bounded.
+
+    Three more spellings resolved to something the caller did not name. A
+    fractional TTL survived both clamps and signed ``X-Amz-Expires=2.5``.
+    ``True`` is a ``numbers.Real``, so it stored a silent one-second TTL and
+    signed ``X-Amz-Expires=True``. ``inf`` did trip the ceiling, but the
+    clamp's own notice renders the value with ``%d``, and ``"%d" % inf``
+    raises inside ``logging`` -- so the operator saw
+    ``--- Logging error ---`` where the clamp notice belonged.
+
+    Only readability is decided here; the range is still the clamps' to
+    decide, which is why this is deliberately sign-agnostic. ``0`` remains
+    the documented keyword-versus-environment precedence sentinel and
+    ``-99`` remains a call-site bug that clamps to ``1`` with a warning
+    (#262). An integral float is accepted rather than refused: ``3600.0`` is
+    how ``json.dumps`` renders an integer held in a float, and nothing is
+    lost in reading it as ``3600`` -- the same split
+    :func:`~strands_robots.mesh.security._coerce_int` applies to the wire
+    counts it guards.
+
+    Args:
+        value: The keyword a caller passed, of any type.
+
+    Returns:
+        The value as an ``int`` when it names a whole number of seconds,
+        otherwise ``None``.
+    """
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return None
+    try:
+        # ``numbers.Real`` carries no ``__int__`` in mypy's view, so the
+        # conversion needs the same waiver the shared whole-number domain in
+        # ``strands_robots.utils`` takes for the identical narrowing.
+        integral = int(value)  # type: ignore[call-overload]
+    except (OverflowError, TypeError, ValueError):
+        # One conversion answers every value no count of seconds can be read
+        # from: ``int(nan)`` raises ``ValueError`` and ``int(+-inf)``
+        # ``OverflowError``, so no separate ``isfinite`` is needed -- and none
+        # is possible, because ``isfinite`` needs a ``float()`` whose own
+        # ``OverflowError`` on an int wider than a float is the escape this
+        # form removes.
+        return None
+    if integral != value:
+        # Fractional: refused rather than truncated, so a TTL the caller never
+        # named is never honoured.
+        return None
+    return integral
 
 
 class CameraOffloader:
@@ -96,7 +166,15 @@ class CameraOffloader:
         self.bucket = bucket or os.getenv("STRANDS_MESH_CAMERA_S3_BUCKET", "")
         self.prefix = (prefix or os.getenv("STRANDS_MESH_CAMERA_S3_PREFIX") or "").strip("/")
         if presign_ttl is not None:
-            ttl_raw = presign_ttl
+            readable = _whole_seconds_or_none(presign_ttl)
+            if readable is None:
+                logger.warning(
+                    "[camera_offload] presign_ttl=%r is not a whole number of seconds; using default %ds",
+                    presign_ttl,
+                    DEFAULT_PRESIGN_TTL_SECONDS,
+                )
+                readable = DEFAULT_PRESIGN_TTL_SECONDS
+            ttl_raw = readable
         else:
             raw_env = os.getenv("STRANDS_MESH_CAMERA_PRESIGN_TTL")
             if raw_env is None or raw_env == "":

--- a/tests/mesh/test_camera_presign_ttl_is_a_whole_number_of_seconds.py
+++ b/tests/mesh/test_camera_presign_ttl_is_a_whole_number_of_seconds.py
@@ -1,0 +1,242 @@
+"""The presign TTL a caller names by keyword is read like the one it names by env.
+
+``CameraOffloader`` resolves one quantity -- the lifetime of the presigned GET
+URL it hands out per camera frame -- from two places, and they disagreed. The
+environment path runs ``int(raw)`` on a string and falls back to the default
+when that raises, so ``STRANDS_MESH_CAMERA_PRESIGN_TTL`` of ``2.5``, ``nan`` or
+``inf`` each resolve to ``DEFAULT_PRESIGN_TTL_SECONDS``. The ``presign_ttl=``
+keyword had no such step: it went straight to two *comparisons* against the
+floor and the ceiling, and a comparison is permeable to anything that compares
+false against both bounds.
+
+``nan`` is the value that matters, because the ceiling it walks through is a
+security bound: the module's own comment says it exists "to prevent accidental
+day- or week-long URLs". ``botocore`` interpolates ``ExpiresIn`` into the
+signature without reading it, so the URL carried ``X-Amz-Expires=nan`` and the
+``/ref`` message published beside it carried ``expires_at: nan``. AWS refuses a
+signed URL whose expiry field is not a number, so the frame is unreadable *and*
+the window was never bounded.
+
+What is deliberately unchanged is the *range*: ``0`` is still the documented
+keyword-versus-environment precedence sentinel, ``-99`` is still a call-site bug
+that clamps to ``1`` with a warning, and ``7200`` still clamps to the ceiling
+(#262). Only readability moved, which is why
+``_whole_seconds_or_none`` is sign-agnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import pytest
+
+from strands_robots.mesh.iot.camera_offload import (
+    DEFAULT_PRESIGN_TTL_SECONDS,
+    MAX_PRESIGN_TTL_SECONDS,
+    CameraOffloader,
+    _whole_seconds_or_none,
+)
+
+#: Spellings no count of seconds can be read from. Each one survived both
+#: clamps (or, for ``inf``, tripped the ceiling with a notice that raised
+#: inside ``logging``) and reached the signed URL.
+UNREADABLE = [
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(float("-inf"), id="negative-inf"),
+    pytest.param(2.5, id="fractional"),
+    pytest.param(1800.5, id="fractional-mid-range"),
+    pytest.param(3600.5, id="fractional-just-over-the-ceiling"),
+    pytest.param(True, id="true"),
+    pytest.param(False, id="false"),
+]
+
+#: Values the module already resolved correctly, and must keep resolving the
+#: same way. The last three are the #262 clamp contract.
+UNCHANGED = [
+    pytest.param(60, 60, id="the-default-named-explicitly"),
+    pytest.param(3600, MAX_PRESIGN_TTL_SECONDS, id="exactly-the-ceiling"),
+    pytest.param(1, 1, id="exactly-the-floor"),
+    pytest.param(7200, MAX_PRESIGN_TTL_SECONDS, id="above-the-ceiling-clamps"),
+    pytest.param(0, 1, id="the-precedence-sentinel-clamps-to-the-floor"),
+    pytest.param(-99, 1, id="a-negative-call-site-bug-clamps-to-the-floor"),
+]
+
+
+def _offloader(monkeypatch, **kwargs):
+    """Build an offloader with no environment override in play."""
+    monkeypatch.delenv("STRANDS_MESH_CAMERA_PRESIGN_TTL", raising=False)
+    monkeypatch.delenv("STRANDS_MESH_CAMERA_S3_BUCKET", raising=False)
+    return CameraOffloader(bucket="frames", **kwargs)
+
+
+class TestPremises:
+    """Facts that hold before and after, and are why the keyword needed reading."""
+
+    def test_a_comparison_against_both_bounds_cannot_refuse_nan(self):
+        """``nan`` passes the floor and the ceiling, so no clamp can catch it.
+
+        This is the whole mechanism. The two guards are ``<`` and ``>`` tests,
+        and every comparison against ``nan`` is false, so a guard built only
+        from comparisons has nothing to say about it. The other unreadable
+        spellings *are* caught by one bound or the other -- which is why they
+        were resolved to a value the caller never named rather than passed
+        straight through, a quieter failure but a failure of the same guard.
+        """
+        nan = float("nan")
+        assert not (nan > MAX_PRESIGN_TTL_SECONDS)
+        assert not (nan < 1)
+
+    def test_the_other_unreadable_spellings_are_caught_by_exactly_one_bound(self):
+        """Recorded so the two halves of the defect stay distinguishable.
+
+        ``nan`` walked through the security ceiling untouched; the rest were
+        resolved to some other number. Both are the comparison-only guard
+        failing, and only the first is a URL with no bounded lifetime.
+        """
+        caught_by_a_bound = {
+            value
+            for value in (float("inf"), float("-inf"), 2.5, 1800.5, 3600.5, True, False)
+            if value > MAX_PRESIGN_TTL_SECONDS or value < 1
+        }
+        assert caught_by_a_bound == {float("inf"), float("-inf"), 3600.5, False}
+
+    def test_botocore_interpolates_the_expiry_without_reading_it(self):
+        """A non-numeric ``ExpiresIn`` reaches the signed URL verbatim.
+
+        Grounds the severity against the real consumer rather than against a
+        stand-in: ``boto3`` ships in the ``mesh-iot`` extra this module needs,
+        so this runs wherever the module is usable.
+        """
+        boto3 = pytest.importorskip("boto3")
+        from botocore.config import Config
+
+        client = boto3.client(
+            "s3",
+            region_name="us-east-1",
+            aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+            aws_secret_access_key="x" * 40,
+            config=Config(signature_version="s3v4"),
+        )
+        url = client.generate_presigned_url("get_object", Params={"Bucket": "b", "Key": "k"}, ExpiresIn=float("nan"))
+        assert "X-Amz-Expires=nan" in url, (
+            "botocore is expected to sign whatever it is handed, which is why the "
+            "TTL has to be readable before it gets there"
+        )
+
+    @pytest.mark.parametrize("value", UNREADABLE)
+    def test_the_environment_path_already_refused_these(self, monkeypatch, value):
+        """The same spellings, named by env, already resolved to the default.
+
+        This is the asymmetry the keyword now matches: one quantity, two ways
+        to name it, and only one of them was read.
+        """
+        monkeypatch.delenv("STRANDS_MESH_CAMERA_S3_BUCKET", raising=False)
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_PRESIGN_TTL", str(value))
+        assert CameraOffloader(bucket="frames").presign_ttl == DEFAULT_PRESIGN_TTL_SECONDS
+
+
+class TestAKeywordTtlIsReadBeforeItIsClamped:
+    """The regression: an unreadable keyword no longer reaches the consumers."""
+
+    @pytest.mark.parametrize("value", UNREADABLE)
+    def test_an_unreadable_keyword_resolves_to_the_default(self, monkeypatch, value):
+        assert _offloader(monkeypatch, presign_ttl=value).presign_ttl == DEFAULT_PRESIGN_TTL_SECONDS
+
+    @pytest.mark.parametrize("value", UNREADABLE)
+    def test_the_stored_ttl_is_always_a_finite_whole_number(self, monkeypatch, value):
+        """What both consumers require, asserted on the stored value.
+
+        ``ExpiresIn`` is signed verbatim and ``expires_at`` is published as
+        ``ts + presign_ttl``, so a stored value that is not a finite integer is
+        a non-number in a signed URL and on the wire.
+        """
+        ttl = _offloader(monkeypatch, presign_ttl=value).presign_ttl
+        assert isinstance(ttl, int) and not isinstance(ttl, bool)
+        assert math.isfinite(ttl)
+
+    @pytest.mark.parametrize("value", UNREADABLE)
+    def test_both_ways_of_naming_the_ttl_now_agree(self, monkeypatch, value):
+        """One quantity, two spellings, one answer."""
+        by_keyword = _offloader(monkeypatch, presign_ttl=value).presign_ttl
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_PRESIGN_TTL", str(value))
+        by_environment = CameraOffloader(bucket="frames").presign_ttl
+        assert by_keyword == by_environment
+
+    def test_a_fractional_ttl_is_refused_rather_than_truncated(self, monkeypatch):
+        """2.5 seconds must not become 2 seconds.
+
+        Truncating would honour a TTL the caller never named, which is the
+        defect ``mesh.security._coerce_int`` was given the same split to avoid.
+        """
+        ttl = _offloader(monkeypatch, presign_ttl=2.5).presign_ttl
+        assert ttl != 2
+        assert ttl == DEFAULT_PRESIGN_TTL_SECONDS
+
+    def test_the_ceiling_clamp_notice_no_longer_raises_inside_logging(self, monkeypatch, caplog):
+        """``inf`` used to reach a notice rendered with ``%d``.
+
+        ``"%d" % inf`` raises, so ``logging`` emitted ``--- Logging error ---``
+        where the clamp notice belonged and the operator learnt nothing.
+        """
+        with caplog.at_level(logging.WARNING):
+            _offloader(monkeypatch, presign_ttl=float("inf"))
+        assert any("not a whole number of seconds" in record.getMessage() for record in caplog.records)
+
+    def test_the_refusal_names_the_value_and_the_default(self, monkeypatch, caplog):
+        with caplog.at_level(logging.WARNING):
+            _offloader(monkeypatch, presign_ttl=2.5)
+        text = " ".join(record.getMessage() for record in caplog.records)
+        assert "2.5" in text
+        assert str(DEFAULT_PRESIGN_TTL_SECONDS) in text
+
+
+class TestWhatIsUnchanged:
+    """Every readable spelling, including the whole #262 clamp contract."""
+
+    @pytest.mark.parametrize(("value", "expected"), UNCHANGED)
+    def test_a_readable_keyword_resolves_exactly_as_before(self, monkeypatch, value, expected):
+        assert _offloader(monkeypatch, presign_ttl=value).presign_ttl == expected
+
+    def test_an_integral_float_is_accepted_not_refused(self, monkeypatch):
+        """``3600.0`` is how ``json.dumps`` renders an integer held in a float.
+
+        Nothing is lost in reading it, so refusing it would break a config
+        round-trip for no gain -- the split the wire-count guard applies too.
+        """
+        assert _offloader(monkeypatch, presign_ttl=3600.0).presign_ttl == MAX_PRESIGN_TTL_SECONDS
+
+    def test_no_keyword_still_reads_the_environment(self, monkeypatch):
+        monkeypatch.delenv("STRANDS_MESH_CAMERA_S3_BUCKET", raising=False)
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_PRESIGN_TTL", "120")
+        assert CameraOffloader(bucket="frames").presign_ttl == 120
+
+    def test_neither_source_leaves_the_default_unreachable(self, monkeypatch):
+        assert _offloader(monkeypatch).presign_ttl == DEFAULT_PRESIGN_TTL_SECONDS
+
+
+class TestTheReadabilityHelper:
+    """``_whole_seconds_or_none`` decides readability, never range."""
+
+    @pytest.mark.parametrize("value", UNREADABLE)
+    def test_an_unreadable_value_answers_none(self, value):
+        assert _whole_seconds_or_none(value) is None
+
+    @pytest.mark.parametrize("value", [0, 1, -99, 60, 3600, 7200, 3600.0, -1.0])
+    def test_a_whole_number_is_returned_as_an_int_whatever_its_sign(self, value):
+        """Sign-agnostic on purpose: the clamps below own the range."""
+        result = _whole_seconds_or_none(value)
+        assert result == int(value)
+        assert isinstance(result, int) and not isinstance(result, bool)
+
+    @pytest.mark.parametrize("value", ["60", None, [60], {"ttl": 60}, object()])
+    def test_a_non_number_answers_none(self, value):
+        assert _whole_seconds_or_none(value) is None
+
+    def test_a_count_wider_than_a_float_is_still_read(self):
+        """``int``-only, so no float round-trip can refuse a large whole number.
+
+        The clamp then bounds it; readability and range stay separate.
+        """
+        assert _whole_seconds_or_none(10**400) == 10**400

--- a/tests/mesh/test_camera_presign_ttl_is_a_whole_number_of_seconds.py
+++ b/tests/mesh/test_camera_presign_ttl_is_a_whole_number_of_seconds.py
@@ -11,11 +11,15 @@ false against both bounds.
 
 ``nan`` is the value that matters, because the ceiling it walks through is a
 security bound: the module's own comment says it exists "to prevent accidental
-day- or week-long URLs". ``botocore`` interpolates ``ExpiresIn`` into the
-signature without reading it, so the URL carried ``X-Amz-Expires=nan`` and the
-``/ref`` message published beside it carried ``expires_at: nan``. AWS refuses a
-signed URL whose expiry field is not a number, so the frame is unreadable *and*
-the window was never bounded.
+day- or week-long URLs". ``botocore`` does not read ``ExpiresIn`` either, and
+what it does instead depends on the signer: its pure-python one interpolates the
+value into the signature verbatim, so the URL carried ``X-Amz-Expires=nan``,
+while the ``awscrt`` signer the ``[mesh-iot]`` extra installs fails inside the
+signer with a bare ``AssertionError``. Both leave the caller worse off than a
+refusal here -- AWS rejects a signed URL whose expiry is not a number, so the
+frame is unreadable *and* the window was never bounded, and the CRT path loses
+the frame to an error naming no TTL. The ``/ref`` message published beside the
+URL carried ``expires_at: nan`` either way.
 
 What is deliberately unchanged is the *range*: ``0`` is still the documented
 keyword-versus-environment precedence sentinel, ``-99`` is still a call-site bug
@@ -28,6 +32,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 
 import pytest
 
@@ -40,7 +45,7 @@ from strands_robots.mesh.iot.camera_offload import (
 
 #: Spellings no count of seconds can be read from. Each one survived both
 #: clamps (or, for ``inf``, tripped the ceiling with a notice that raised
-#: inside ``logging``) and reached the signed URL.
+#: inside ``logging``) and reached ``botocore``.
 UNREADABLE = [
     pytest.param(float("nan"), id="nan"),
     pytest.param(float("inf"), id="inf"),
@@ -62,6 +67,50 @@ UNCHANGED = [
     pytest.param(0, 1, id="the-precedence-sentinel-clamps-to-the-floor"),
     pytest.param(-99, 1, id="a-negative-call-site-bug-clamps-to-the-floor"),
 ]
+
+
+#: ``UNREADABLE`` carries ``pytest.param`` wrappers for the ids; the premise
+#: below loops in one cell instead, so it needs the bare values.
+UNREADABLE_VALUES = [param.values[0] for param in UNREADABLE]
+
+#: The one outcome that would retire this module's readability step: botocore
+#: signing exactly the whole number of seconds the caller named.
+_AS_NAMED = "signed as named"
+
+
+def _s3_sigv4_client():
+    """An offline sigv4 S3 client, or a skip where ``boto3`` is absent."""
+    boto3 = pytest.importorskip("boto3")
+    from botocore.config import Config
+
+    return boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key="x" * 40,
+        config=Config(signature_version="s3v4"),
+    )
+
+
+def _presign_outcome(client, expires_in) -> str:
+    """Classify what botocore does with *expires_in*, without signing anything real.
+
+    Returns :data:`_AS_NAMED` only when the signed URL carries exactly the
+    digits the caller passed. Every other outcome is named so a change in
+    botocore's behaviour reads as a different string rather than a bare False.
+    """
+    try:
+        url = client.generate_presigned_url("get_object", Params={"Bucket": "b", "Key": "k"}, ExpiresIn=expires_in)
+    except Exception as exc:  # noqa: BLE001 - the class is the finding, not a failure to handle
+        return f"refused inside the signer: {type(exc).__name__}"
+    signed = re.search(r"[?&]X-Amz-Expires=([^&]*)", url)
+    if signed is None:
+        return "signed with no expiry at all"
+    if not re.fullmatch(r"[0-9]+", signed.group(1)):
+        return f"signed a non-numeric expiry: {signed.group(1)}"
+    if signed.group(1) != f"{expires_in}":
+        return f"signed a number the caller never named: {signed.group(1)}"
+    return _AS_NAMED
 
 
 def _offloader(monkeypatch, **kwargs):
@@ -102,28 +151,46 @@ class TestPremises:
         }
         assert caught_by_a_bound == {float("inf"), float("-inf"), 3600.5, False}
 
-    def test_botocore_interpolates_the_expiry_without_reading_it(self):
-        """A non-numeric ``ExpiresIn`` reaches the signed URL verbatim.
+    def test_botocore_does_not_read_the_ttl_for_us(self):
+        """Grounds the severity against the real consumer, on either signer.
 
-        Grounds the severity against the real consumer rather than against a
-        stand-in: ``boto3`` ships in the ``mesh-iot`` extra this module needs,
-        so this runs wherever the module is usable.
+        ``boto3`` ships in the ``mesh-iot`` extra this module needs, so this
+        runs wherever the module is usable. Which *signer* it runs through is
+        not fixed: ``botocore`` signs S3 sigv4 through ``awscrt`` when that is
+        importable and through its own pure-python signer otherwise, and the
+        two disagree about an unreadable ``ExpiresIn``. The extra declares
+        ``awscrt``, so the shipped configuration is the CRT one -- but the
+        module is importable without it, so the premise is asserted as the
+        disjunction rather than pinned to whichever signer CI happens to have.
+
+        Neither signer produces the lifetime the caller named:
+
+        | ``ExpiresIn`` | pure-python signer | CRT signer |
+        | --- | --- | --- |
+        | ``nan``, ``-inf``, ``False`` | signed verbatim | bare ``AssertionError`` |
+        | ``inf``, ``2.5``, ``1800.5``, ``3600.5`` | signed verbatim | ``TypeError: argument 13 must be int, not float`` |
+        | ``True`` | signed ``X-Amz-Expires=True`` | signed ``X-Amz-Expires=1`` |
+
+        So the failure is one of three, and all three are wrong: a signed URL
+        whose expiry is not a number (AWS refuses it at request time, so the
+        window was never bounded), an opaque refusal from inside the signer
+        with no message naming the TTL, or a silent one-second URL. That is
+        why the TTL has to be readable *before* it gets here.
         """
-        boto3 = pytest.importorskip("boto3")
-        from botocore.config import Config
+        client = _s3_sigv4_client()
+        for value in UNREADABLE_VALUES:
+            assert _presign_outcome(client, value) != _AS_NAMED, (
+                f"botocore resolved ExpiresIn={value!r} to the lifetime named, so this "
+                "module would no longer need to read it first"
+            )
 
-        client = boto3.client(
-            "s3",
-            region_name="us-east-1",
-            aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
-            aws_secret_access_key="x" * 40,
-            config=Config(signature_version="s3v4"),
-        )
-        url = client.generate_presigned_url("get_object", Params={"Bucket": "b", "Key": "k"}, ExpiresIn=float("nan"))
-        assert "X-Amz-Expires=nan" in url, (
-            "botocore is expected to sign whatever it is handed, which is why the "
-            "TTL has to be readable before it gets there"
-        )
+    def test_the_same_client_does_sign_a_readable_ttl_as_named(self):
+        """Non-vacuity: the cell above fails for a reason, not for every input.
+
+        Without this, a client that refused everything -- bad credentials, a
+        signer that never returns -- would satisfy the premise trivially.
+        """
+        assert _presign_outcome(_s3_sigv4_client(), 60) == _AS_NAMED
 
     @pytest.mark.parametrize("value", UNREADABLE)
     def test_the_environment_path_already_refused_these(self, monkeypatch, value):


### PR DESCRIPTION
## The defect

`CameraOffloader` resolves one quantity -- the lifetime of the presigned GET URL it hands out per camera frame -- from two places, and they disagreed.

The environment path runs `int(raw)` on a string and falls back to `DEFAULT_PRESIGN_TTL_SECONDS` when that raises. The `presign_ttl=` keyword had no such step: it went straight to two *comparisons*, against the floor and against `MAX_PRESIGN_TTL_SECONDS`. A comparison is permeable to anything that compares false against both bounds.

`nan` is the value that matters, because the bound it walks through is a security bound. The ceiling's own comment says it exists "to prevent accidental day- or week-long URLs", and `nan > 3600` is `False` while `nan < 1` is also `False`, so it reached both consumers untouched.

Measured, one value per row, all through the shipped code:

| `presign_ttl=` | stored, before | stored, after | `X-Amz-Expires=` on the signed URL, before |
|---|---|---|---|
| `nan` | `nan` | `60` | `nan` |
| `2.5` | `2.5` | `60` | `2.5` |
| `1800.5` | `1800.5` | `60` | `1800.5` |
| `True` | `1` | `60` | `True` |
| `inf` | `3600` | `60` | `3600` |

`botocore` interpolates `ExpiresIn` into the signature without reading it -- a premise cell asserts that directly against `boto3`, which ships in the `mesh-iot` extra this module needs. So the URL carried `X-Amz-Expires=nan`, and the `/ref` message published beside it carried `expires_at: nan` (`ts + presign_ttl`). A signed URL whose expiry field is not a number is one AWS refuses at request time, so the frame is unreadable **and** the window was never bounded.

`inf` did trip the ceiling, but that notice renders the value with `%d`, and `"%d" % inf` raises inside `logging`:

```
--- Logging error ---
TypeError: %d format: a real number is required, not float
Message: '[camera_offload] STRANDS_MESH_CAMERA_PRESIGN_TTL=%d > %d cap; clamping'
```

So the operator saw an error where the clamp notice belonged.

## Why nothing caught it

`test_camera_acl.py` pins the clamp contract at four points -- above the cap, `0`, `-5`, `999999` -- and every one of them is an `int`. The suite graded the *range* thoroughly and never asked whether the value was a count of seconds. The same file's docstring calls `presign_ttl` "the presigned URL TTL in seconds", which is the contract the comparisons could not enforce.

## The fix

`_whole_seconds_or_none` decides **readability only**, and the keyword consults it before either clamp. The range stays the clamps' to decide, which is why the helper is deliberately sign-agnostic:

- `0` remains the documented keyword-versus-environment precedence sentinel (clamps to `1`, no warning)
- `-99` remains a call-site bug (clamps to `1`, with the warning)
- `7200` still clamps to the ceiling
- `3600.0` is **accepted**, because that is how `json.dumps` renders an integer held in a float -- the same accept/refuse split `mesh.security._coerce_int` applies to the wire counts it guards

`inf` is now refused before it reaches the `%d` notice, so that render can no longer raise.

## Verification

Pre-fix split, with the guard reverted and the helper left importable so the run is readable rather than a collection error: **24 failed / 45 passed**, `0` of 11 premise cells and `0` of 9 `TestWhatIsUnchanged` cells firing. Three regression cells legitimately pass pre-fix and are named in the table below.

Mutation table. `mine` is the new file, `sib` is the two pre-existing camera suites (55 cells), `coll` is stable at 69 on every row.

| row | mutation | mine | sib |
|---|---|---|---|
| b0 | control, no mutation | 0 | 0 |
| b1 | the guard is dropped: the keyword goes straight to the two clamps | 25 | 0 |
| b2 | the `bool` refusal is dropped: `True` becomes a silent one-second TTL again | 6 | 0 |
| b3 | an unreadable keyword resolves to the **floor** instead of the default | 17 | 0 |
| b4 | the fractional refusal is dropped: `2.5` truncates to `2` rather than being refused | 11 | 0 |
| b5 | the refusal notice stops naming the value and the default | 27 | 0 |
| b6 | **over-reach:** the helper is made positive-only, so it decides range as well as readability | 5 | **5** |

Seven rows, seven distinct firing sets, control clean, both files restored md5-identical afterwards.

b6 is the row that pins the scope: making the helper refuse a non-positive value trips **5 pre-existing cells** in `test_camera_acl.py`, which is the `#262` clamp contract objecting. Every other row leaves the siblings untouched. b2 and b4 are disjoint, so the `bool` half and the fractional half are independently pinned.

Three regression cells pass pre-fix, and they are honest about why: `test_the_stored_ttl_is_always_a_finite_whole_number[fractional-just-over-the-ceiling]` and `[false]` both describe values the old code *clamped* to a finite `int` (`3600` and `1`) rather than passing through, so the stored value satisfied that assertion for the wrong reason.

Gate: `ruff check` clean, `ruff format --check` **1724 files already formatted**, `mypy strands_robots tests tests_integ` **5 errors, 0 attributable** to either changed file. The `numbers.Real` narrowing carries the same waiver the shared whole-number domain in `strands_robots.utils` needs for the identical conversion. The new file plus `test_iot_camera_offload.py` plus `test_camera_acl.py`: **124 passed**.

## Deliberately not done

The environment path's own `int(raw)` accepts `"3600"` and refuses `"2.5"` by raising `ValueError` -- that is where the two paths already agreed, and it is untouched. No bound was added to `expires_at` on the wire: the TTL that produces it is now a finite whole number, so the published field is arithmetic on two integers.

## Round 1 — the premise was asserting the wrong signer

CI failed one cell, `TestPremises::test_botocore_interpolates_the_expiry_without_reading_it`,
and the failure was worth having.

`botocore` signs S3 sigv4 through `awscrt` when that is importable and through
its own pure-python signer otherwise. The two disagree about an unreadable
`ExpiresIn`, and the cell asserted only the pure-python outcome, so it failed
under the CRT signer with a bare `AssertionError` out of `AwsSigningConfig`.

The `mesh-iot` extra this module needs **declares `awscrt`**, so the CRT signer
is the shipped configuration - the cell was pinned to the half that does not
ship. Measured both, offline, on botocore 1.43.83:

| `ExpiresIn` | pure-python signer | CRT signer |
| --- | --- | --- |
| `nan`, `-inf`, `False` | signed verbatim | bare `AssertionError` |
| `inf`, `2.5`, `1800.5`, `3600.5` | signed verbatim | `TypeError: argument 13 must be int, not float` |
| `True` | `X-Amz-Expires=True` | `X-Amz-Expires=1` |
| `60` | `X-Amz-Expires=60` | `X-Amz-Expires=60` |

The premise holds on both, by different mechanisms. What is durable is the
disjunction - **no signer turns an unreadable TTL into the lifetime the caller
named** - so that is what the cell now asserts, through a `_presign_outcome`
classifier that names each wrong outcome (`refused inside the signer: TypeError`,
`signed a non-numeric expiry: nan`, `signed a number the caller never named: 1`)
rather than returning a bare False. A change in botocore reads as a different
string instead of an opaque failure. A second cell pins the non-vacuity the old
single-value cell could not state: the same client does sign a readable `60` as
named.

### This raises the severity, so three docs were corrected

The bottom row of that table is the one that matters beyond this cell: under the
shipped CRT signer a merely **fractional, in-range** TTL - `1800.5`, well inside
the ceiling - also fails. So reading the TTL to a whole number is not only a
`nan` guard; it is what lets the shipped configuration accept a fractional TTL
at all. The module docstring, the test module docstring and the changelog
fragment each claimed the pure-python outcome as if it were the only one, and
now name both.

The module edit is **docstring-only**: verified by parsing both revisions,
stripping every docstring and comparing the ASTs - `executable AST identical:
True`. No logic moved in this round.

### Verification

- the changed file: **70 passed** with `awscrt` installed, and **70 passed**
  with it absent. Both paths, since that is the point of the change.
- `tests/mesh/`: **0 failures** with the `mesh-iot` extras present (`awscrt`,
  `awsiot`, `json5`). Without them, 90 fail - the standing environmental
  families, measured rather than assumed by installing them and watching the
  count go to zero.
- detection, on the formatted tree: adding a readable `60` to the premise's
  inputs fires the premise cell (1); reverting the readability step at the call
  site fires **25** cells. Control clean at 70; both files restored
  byte-identically.
- `ruff check` clean, `ruff format --check` clean, `mypy` clean on both changed
  source files.
