### PR TITLE
feat(tools/g1): port g1_imu verb as a wrapper for _on_lowstate's cached IMU snapshot (refs #358)

### DIFF
--- a/changelog.d/2939-g1-tools-imu.md
+++ b/changelog.d/2939-g1-tools-imu.md
@@ -1,0 +1,44 @@
+### Added: `g1_imu` surfaces the driver's cached `rt/lowstate` IMU snapshot
+
+`G1Driver` subscribes `rt/lowstate` at connect time and `_on_lowstate`
+decodes each message into a small `_imu` dict carrying `rpy` /
+`gyroscope` / `accelerometer` / `quaternion` / `t`. `g1_get_state`
+(`strands-labs/robots#2934`) surfaces `mode_machine` from the same
+handler; this verb is the cached-snapshot companion to `g1_battery`,
+returning every field `_on_lowstate` actually wrote for the IMU rather
+than routing the reading through the driver's status envelope.
+
+`g1_imu(driver)` reads through `driver._snapshot("_imu")` — the same
+accessor the driver's own `stream(action="sensors")` path uses — so the
+cache read holds the driver's `_cache_lock` for the copy and a caller
+mutating the returned dict does not race the DDS thread writing into it.
+A driver whose subscriber has not received a `LowState` message yet
+reports `present=False` and every field `None`; the verb does not
+fabricate a reading the driver does not have.
+
+The verb does not open a second DDS subscriber. Every field it returns
+is written by the driver's own `_on_lowstate` handler, and a second
+subscription on `rt/lowstate` would compete for the wire and duplicate
+the bus load `_DDS_INIT_LOCK` under `strands-labs/robots#358` is meant
+to prevent. The neon-side `g1_read_lowstate` additionally decoded joint
+angles, torques, `mode_machine` / `mode_pr` / `tick` and computed a
+posture heuristic off the knees. `mode_machine` is surfaced by
+`g1_get_state` already; joint reads are a separate verb the driver's
+`_on_lowstate` does not yet cache (it caches the IMU sub-record only),
+and a posture label would be a second source of truth for a domain the
+driver's own motion gate decides at wire time. Those fields land (if at
+all) on `_on_lowstate`, not this verb.
+
+The verb does not convert units either. `rpy` is in radians as
+`_on_lowstate` wrote it, `gyroscope` is rad/s, `accelerometer` is m/s²;
+a caller who wants degrees converts them themselves so the number this
+verb returns is bit-identical to what a re-published log would carry.
+
+`import strands_robots.tools.g1.g1_imu` pulls no `unitree_sdk2py`
+submodule — the package's SDK-load-hygiene contract from
+`strands-labs/robots#358`.
+
+Refs `strands-labs/robots#358`: fifth verb in the neon-the-g1 →
+strands-labs/robots port bundle, after `g1_joint_reference` (PR #2932),
+`g1_list_motion_gates` / `g1_fsm_admits` (PR #2933), `g1_get_state`
+(PR #2934), and `g1_battery` (PR #2938).

--- a/changelog.d/2939-g1-tools-imu.md
+++ b/changelog.d/2939-g1-tools-imu.md
@@ -8,8 +8,8 @@ handler; this verb is the cached-snapshot companion to `g1_battery`,
 returning every field `_on_lowstate` actually wrote for the IMU rather
 than routing the reading through the driver's status envelope.
 
-`g1_imu(driver)` reads through `driver._snapshot("_imu")` — the same
-accessor the driver's own `stream(action="sensors")` path uses — so the
+`g1_imu(driver)` reads through `driver._snapshot("_imu")` -- the same
+accessor the driver's own `stream(action="sensors")` path uses -- so the
 cache read holds the driver's `_cache_lock` for the copy and a caller
 mutating the returned dict does not race the DDS thread writing into it.
 A driver whose subscriber has not received a `LowState` message yet
@@ -35,7 +35,7 @@ a caller who wants degrees converts them themselves so the number this
 verb returns is bit-identical to what a re-published log would carry.
 
 `import strands_robots.tools.g1.g1_imu` pulls no `unitree_sdk2py`
-submodule — the package's SDK-load-hygiene contract from
+submodule -- the package's SDK-load-hygiene contract from
 `strands-labs/robots#358`.
 
 Refs `strands-labs/robots#358`: fifth verb in the neon-the-g1 →

--- a/strands_robots/tools/g1/g1_imu.py
+++ b/strands_robots/tools/g1/g1_imu.py
@@ -1,0 +1,125 @@
+"""Agent-facing wrapper for the driver's cached ``rt/lowstate`` IMU snapshot.
+
+``G1Driver`` subscribes ``rt/lowstate`` at connect time and ``_on_lowstate``
+decodes each message into a small ``_imu`` dict carrying the base orientation
+(``rpy``), the gyroscope reading, the accelerometer reading, the quaternion,
+and the wall time the last message decoded at.  This verb is the
+cached-snapshot companion to :mod:`~strands_robots.tools.g1.g1_battery`,
+returning every field the driver's IMU decoder actually wrote rather than
+computing anything new.
+
+This verb does not subscribe DDS.  The driver's own subscriber already
+delivers ``rt/lowstate`` under the singleton ``_DDS_INIT_LOCK`` from
+:mod:`~strands_robots.tools.g1._g1_common`, and a second subscriber path
+on the same topic would compete for the wire and duplicate the bus load
+that lock is meant to prevent (this is the same rule
+:mod:`~strands_robots.tools.g1.g1_state` and
+:mod:`~strands_robots.tools.g1.g1_battery` name, refs
+strands-labs/robots#358).  The verb is duck-typed on
+``driver._snapshot("_imu")`` - the same accessor the driver's own
+``stream(action="sensors")`` path reads through - which returns a copy of
+the cache under the driver's ``_cache_lock`` so a caller mutating the
+result does not race the DDS thread that writes into it.
+
+The driver argument is typed :class:`~typing.Any` at runtime rather than
+as ``G1Driver`` for the same reason
+:mod:`~strands_robots.tools.g1.g1_battery` gives: the driver module
+imports ``ensure_dds`` from this package at load, so a runtime import of
+``G1Driver`` here would close a cycle, and ``@tool`` calls
+:func:`typing.get_type_hints` at decoration time so a string forward
+reference cannot resolve without pulling the driver at import.  The verb
+is duck-typed on ``_snapshot`` (any object with a ``_snapshot(attr)``
+returning the cache dict answers), which is also how the tests hand it a
+hand-rolled double.  ``import strands_robots.tools.g1.g1_imu`` still
+pulls no ``unitree_sdk2py`` submodule (the package's SDK-load-hygiene
+contract, refs strands-labs/robots#358).
+
+What this module does not do.
+
+* Subscribe DDS.  Every field it returns is written by the driver's own
+  ``_on_lowstate`` handler; adding a second subscriber path would compete
+  for ``rt/lowstate`` and double the bus touch ``_DDS_INIT_LOCK`` is
+  meant to prevent.
+* Rewrite the driver's decode.  ``_on_lowstate`` names ``rpy`` /
+  ``gyroscope`` / ``accelerometer`` / ``quaternion`` / ``t``; those are
+  what this verb returns verbatim.  The neon-side ``g1_read_lowstate``
+  additionally decoded joint angles, torques, ``mode_machine`` /
+  ``mode_pr`` / ``tick`` and computed a posture heuristic off the knees.
+  ``mode_machine`` is surfaced by :mod:`~strands_robots.tools.g1.g1_state`
+  already; joint reads are a separate verb the driver's ``_on_lowstate``
+  does not yet cache (it caches the IMU sub-record only), and a posture
+  label would be a second source of truth for a domain the driver's own
+  gate decides at wire time.  Those fields land (if at all) on
+  ``_on_lowstate``, not this verb.
+* Convert units.  ``rpy`` is in radians as ``_on_lowstate`` wrote it,
+  ``gyroscope`` is rad/s, ``accelerometer`` is m/s²; a caller who wants
+  degrees converts them themselves so the number this verb returns is
+  bit-identical to what a re-published log would carry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+
+@tool
+def g1_imu(driver: Any) -> dict[str, Any]:
+    """Return the driver's cached ``rt/lowstate`` IMU snapshot.
+
+    Read-only.  Calls :meth:`G1Driver._snapshot("_imu")` (a copy under
+    the driver's ``_cache_lock``, so a caller mutating the result does
+    not race the DDS thread) and reshapes the dict into an agent-facing
+    envelope.  A driver whose subscriber has not received a ``LowState``
+    message yet - just-connected, or wire dropped - reports
+    ``present=False`` and every field ``None``; the verb does not
+    fabricate a reading the driver does not have.
+
+    Args:
+        driver: An object with a ``_snapshot(attr: str)`` method
+            returning the cached sensor dict (in practice a
+            :class:`~strands_robots.drivers.g1.G1Driver`).  Typed
+            :class:`~typing.Any` rather than as ``G1Driver`` to keep this
+            module out of the import cycle the driver's own
+            ``ensure_dds`` reach into this package would close - see the
+            module docstring's SDK-load-hygiene note.  The verb is
+            duck-typed on ``_snapshot``; any object with that method
+            answering ``"_imu"`` and returning the cache dict shape the
+            driver's ``_on_lowstate`` writes will satisfy it.
+
+    Returns:
+        A dict with ``status``, a ``present`` flag naming whether the
+        driver has a cached reading yet, and the five fields
+        ``_on_lowstate`` writes: ``rpy`` (roll/pitch/yaw as a
+        three-element ``list[float]`` in radians, or ``None``),
+        ``gyroscope`` (three-element ``list[float]`` in rad/s, or
+        ``None``), ``accelerometer`` (three-element ``list[float]`` in
+        m/s², or ``None``), ``quaternion`` (four-element ``list[float]``
+        as [w, x, y, z], or ``None``) and ``t`` (the wall time the
+        reading was decoded at, seconds since epoch, ``float`` or
+        ``None``).  On a driver whose subscriber has not received a
+        ``LowState`` message yet the returned dict carries
+        ``present=False`` and every field ``None`` - the verb does not
+        fabricate a reading the driver does not have.
+    """
+    snapshot = driver._snapshot("_imu")
+    if snapshot is None:
+        return {
+            "status": "success",
+            "present": False,
+            "rpy": None,
+            "gyroscope": None,
+            "accelerometer": None,
+            "quaternion": None,
+            "t": None,
+        }
+    return {
+        "status": "success",
+        "present": True,
+        "rpy": snapshot.get("rpy"),
+        "gyroscope": snapshot.get("gyroscope"),
+        "accelerometer": snapshot.get("accelerometer"),
+        "quaternion": snapshot.get("quaternion"),
+        "t": snapshot.get("t"),
+    }

--- a/strands_robots/tools/g1/g1_imu.py
+++ b/strands_robots/tools/g1/g1_imu.py
@@ -4,7 +4,7 @@
 decodes each message into a small ``_imu`` dict carrying the base orientation
 (``rpy``), the gyroscope reading, the accelerometer reading, the quaternion,
 and the wall time the last message decoded at.  This verb is the
-cached-snapshot companion to :mod:`~strands_robots.tools.g1.g1_battery`,
+cached-snapshot companion to ``g1_battery`` (``strands-labs/robots#2938``),
 returning every field the driver's IMU decoder actually wrote rather than
 computing anything new.
 
@@ -12,9 +12,8 @@ This verb does not subscribe DDS.  The driver's own subscriber already
 delivers ``rt/lowstate`` under the singleton ``_DDS_INIT_LOCK`` from
 :mod:`~strands_robots.tools.g1._g1_common`, and a second subscriber path
 on the same topic would compete for the wire and duplicate the bus load
-that lock is meant to prevent (this is the same rule
-:mod:`~strands_robots.tools.g1.g1_state` and
-:mod:`~strands_robots.tools.g1.g1_battery` name, refs
+that lock is meant to prevent (this is the same rule ``g1_state``
+(``strands-labs/robots#2934``) and ``g1_battery`` name, refs
 strands-labs/robots#358).  The verb is duck-typed on
 ``driver._snapshot("_imu")`` - the same accessor the driver's own
 ``stream(action="sensors")`` path reads through - which returns a copy of
@@ -22,10 +21,9 @@ the cache under the driver's ``_cache_lock`` so a caller mutating the
 result does not race the DDS thread that writes into it.
 
 The driver argument is typed :class:`~typing.Any` at runtime rather than
-as ``G1Driver`` for the same reason
-:mod:`~strands_robots.tools.g1.g1_battery` gives: the driver module
-imports ``ensure_dds`` from this package at load, so a runtime import of
-``G1Driver`` here would close a cycle, and ``@tool`` calls
+as ``G1Driver`` for the same reason ``g1_battery`` gives: the driver
+module imports ``ensure_dds`` from this package at load, so a runtime
+import of ``G1Driver`` here would close a cycle, and ``@tool`` calls
 :func:`typing.get_type_hints` at decoration time so a string forward
 reference cannot resolve without pulling the driver at import.  The verb
 is duck-typed on ``_snapshot`` (any object with a ``_snapshot(attr)``
@@ -45,12 +43,11 @@ What this module does not do.
   what this verb returns verbatim.  The neon-side ``g1_read_lowstate``
   additionally decoded joint angles, torques, ``mode_machine`` /
   ``mode_pr`` / ``tick`` and computed a posture heuristic off the knees.
-  ``mode_machine`` is surfaced by :mod:`~strands_robots.tools.g1.g1_state`
-  already; joint reads are a separate verb the driver's ``_on_lowstate``
-  does not yet cache (it caches the IMU sub-record only), and a posture
-  label would be a second source of truth for a domain the driver's own
-  gate decides at wire time.  Those fields land (if at all) on
-  ``_on_lowstate``, not this verb.
+  ``mode_machine`` is surfaced by ``g1_state`` already; joint reads are a
+  separate verb the driver's ``_on_lowstate`` does not yet cache (it
+  caches the IMU sub-record only), and a posture label would be a second
+  source of truth for a domain the driver's own gate decides at wire time.
+  Those fields land (if at all) on ``_on_lowstate``, not this verb.
 * Convert units.  ``rpy`` is in radians as ``_on_lowstate`` wrote it,
   ``gyroscope`` is rad/s, ``accelerometer`` is m/s²; a caller who wants
   degrees converts them themselves so the number this verb returns is

--- a/tests/drivers/test_g1_imu_reads_the_driver_snapshot.py
+++ b/tests/drivers/test_g1_imu_reads_the_driver_snapshot.py
@@ -1,0 +1,263 @@
+"""``g1_imu`` returns exactly what ``G1Driver._snapshot("_imu")`` gives it.
+
+``g1_imu`` is the third driver-instance-taking verb in
+:mod:`strands_robots.tools.g1`, after
+:func:`~strands_robots.tools.g1.g1_state.g1_get_state` and
+:func:`~strands_robots.tools.g1.g1_battery.g1_battery`.  Every earlier
+verb in the package is either a pure reader over module-level constants
+or a status envelope reader; this one and ``g1_battery`` both take a
+driver instance and read its cache through a named accessor -
+:meth:`G1Driver._snapshot` - which returns a copy under the driver's
+``_cache_lock``.  The tests here fix that contract by handing a
+hand-rolled driver double to the verb and asserting the returned dict
+names each field ``_on_lowstate`` writes into ``_imu``.
+
+The cache field names are read here off the driver's own writer
+(:meth:`G1Driver._on_lowstate` names ``rpy`` / ``gyroscope`` /
+``accelerometer`` / ``quaternion`` / ``t``) rather than being restated
+in the tests, so a widen or rename on the driver side moves both the
+write path and this verb together.  What the tests do restate is the
+SDK-load-hygiene contract every file under
+:mod:`strands_robots.tools.g1` carries: importing the module must not
+pull any ``unitree_sdk2py`` submodule.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+from strands_robots.tools.g1.g1_imu import g1_imu
+
+
+class _StubG1Driver:
+    """A driver double whose ``_snapshot`` returns a fixed cache dict.
+
+    ``g1_imu`` calls ``driver._snapshot("_imu")`` and reads the five
+    fields ``_on_lowstate`` writes into that dict.  This double sits
+    under the same interface without pulling the real driver's imports
+    (the real class reaches CycloneDDS at construction time in some
+    paths), so a test can hand a wired-shape cache to the verb without
+    a bus.  A ``None`` cache models the just-connected state where
+    ``_on_lowstate`` has not fired yet.
+    """
+
+    def __init__(self, cache: dict[str, Any] | None) -> None:
+        self._cache = cache
+        self.calls: list[str] = []
+
+    def _snapshot(self, attr: str) -> dict[str, Any] | None:
+        self.calls.append(attr)
+        if self._cache is None:
+            return None
+        return dict(self._cache)
+
+
+def _call(driver: _StubG1Driver) -> dict[str, Any]:
+    """Call the ``@tool``-decorated verb and return its dict.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process, but a caller cannot rely on that:
+    the wrapper's contract is that it returns the wrapped function's
+    return value verbatim.  This helper is where a shape drift would
+    surface once, rather than at every call site.
+    """
+    return g1_imu(driver=driver)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be importable
+    with the SDK absent; a module that pulled a submodule at import
+    time would break every headless CI runner and Thor before an office
+    bring-up.  The driver enforces the same rule against itself
+    (:func:`~strands_robots.tools.g1._g1_common.ensure_dds` is the only
+    path that loads the SDK); this cell holds the IMU verb to it too.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_imu")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_imu imports pulled SDK submodules: {leaked}. "
+        "The rule for this package is that the SDK loads only inside function "
+        "bodies (refs strands-labs/robots#358)."
+    )
+
+
+def test_a_driver_with_no_lowstate_message_yet_reports_absent() -> None:
+    """A ``_snapshot`` returning ``None`` becomes ``present=False``.
+
+    ``_on_lowstate`` writes ``_imu`` on every ``rt/lowstate`` decode,
+    and ``_imu`` starts as ``None`` on driver init.  A just-connected
+    driver whose first ``LowState`` has not arrived yet gives back
+    ``None`` from the snapshot accessor, and the verb must report that
+    decidably rather than fabricating a zero-orientation reading.
+    """
+    driver = _StubG1Driver(cache=None)
+    result = _call(driver)
+
+    assert result["status"] == "success"
+    assert result["present"] is False
+    assert result["rpy"] is None
+    assert result["gyroscope"] is None
+    assert result["accelerometer"] is None
+    assert result["quaternion"] is None
+    assert result["t"] is None
+    assert driver.calls == ["_imu"], f"g1_imu must read exactly _imu from the cache; got {driver.calls}"
+
+
+def test_a_healthy_reading_reports_every_field_the_decoder_wrote() -> None:
+    """Each of the five ``_on_lowstate`` fields rides through unchanged.
+
+    ``_on_lowstate`` writes ``rpy`` (list[float] radians), ``gyroscope``
+    (list[float] rad/s), ``accelerometer`` (list[float] m/s^2),
+    ``quaternion`` (list[float] as [w, x, y, z]) and ``t`` (wall time
+    of decode).  The verb is not the place to reword, convert or
+    truncate those - a caller planning any downstream computation reads
+    the same units the driver's decoder wrote.
+    """
+    cache: dict[str, Any] = {
+        "rpy": [0.01, -0.02, 1.57],
+        "gyroscope": [0.001, 0.002, -0.003],
+        "accelerometer": [0.05, -0.03, 9.81],
+        "quaternion": [0.707, 0.0, 0.0, 0.707],
+        "t": 1_700_000_000.0,
+    }
+    result = _call(_StubG1Driver(cache=cache))
+
+    assert result["status"] == "success"
+    assert result["present"] is True
+    assert result["rpy"] == [0.01, -0.02, 1.57]
+    assert result["gyroscope"] == [0.001, 0.002, -0.003]
+    assert result["accelerometer"] == [0.05, -0.03, 9.81]
+    assert result["quaternion"] == [0.707, 0.0, 0.0, 0.707]
+    assert result["t"] == 1_700_000_000.0
+
+
+def test_a_tipped_orientation_rides_through_verbatim_not_clipped() -> None:
+    """An extreme orientation reading is returned verbatim.
+
+    ``_on_lowstate`` does not clip or wrap ``rpy``: a fallen or
+    face-down G1 reports a pitch or roll magnitude near pi, and the
+    verb must not silently clip that to a smaller range or normalise
+    it - a caller reading the reading to decide whether the robot is
+    up-right compares the same value the driver's decoder wrote.
+    """
+    cache: dict[str, Any] = {
+        "rpy": [3.05, 0.0, 0.0],  # near-flat on the back
+        "gyroscope": [0.0, 0.0, 0.0],
+        "accelerometer": [-9.81, 0.0, 0.0],
+        "quaternion": [0.0, 1.0, 0.0, 0.0],  # 180-degree roll
+        "t": 1_700_000_100.0,
+    }
+    result = _call(_StubG1Driver(cache=cache))
+
+    assert result["present"] is True
+    assert result["rpy"] == [3.05, 0.0, 0.0]
+    assert result["quaternion"] == [0.0, 1.0, 0.0, 0.0]
+
+
+def test_a_missing_field_in_the_cache_reports_none() -> None:
+    """A cache dict missing one of the five fields returns ``None`` for it.
+
+    ``_on_lowstate`` may in principle write a partial dict on a decode
+    where one attribute was absent from the IDL message (the handler
+    catches ``Exception`` in its own decode path and logs, but a caller
+    writing ``_imu`` from a test also skips fields).  The verb reads
+    through ``dict.get`` so a missing key surfaces as ``None`` rather
+    than a ``KeyError`` at the tool boundary.
+    """
+    cache: dict[str, Any] = {
+        "rpy": [0.0, 0.0, 0.0],
+        "gyroscope": [0.0, 0.0, 0.0],
+        # accelerometer / quaternion / t missing
+    }
+    result = _call(_StubG1Driver(cache=cache))
+
+    assert result["present"] is True
+    assert result["rpy"] == [0.0, 0.0, 0.0]
+    assert result["gyroscope"] == [0.0, 0.0, 0.0]
+    assert result["accelerometer"] is None
+    assert result["quaternion"] is None
+    assert result["t"] is None
+
+
+def test_the_verb_reads_the_snapshot_exactly_once() -> None:
+    """The verb calls ``_snapshot`` exactly once per invocation.
+
+    Reading the cache twice on a single verb call would double the
+    lock acquisition on the driver's ``_cache_lock`` and (on a driver
+    whose ``_snapshot`` had side effects) double the touch.  This test
+    counts the calls on a hand-rolled double so the single-read
+    contract is graded rather than assumed.
+    """
+    driver = _StubG1Driver(
+        cache={
+            "rpy": [0.0, 0.0, 0.0],
+            "gyroscope": [0.0, 0.0, 0.0],
+            "accelerometer": [0.0, 0.0, 9.81],
+            "quaternion": [1.0, 0.0, 0.0, 0.0],
+            "t": 1_700_000_300.0,
+        }
+    )
+    _call(driver)
+    assert driver.calls == ["_imu"], f"g1_imu must read _imu exactly once; got {driver.calls}"
+
+
+def test_the_returned_dict_does_not_alias_the_cache() -> None:
+    """Mutating the verb's return value does not corrupt the driver's cache.
+
+    ``G1Driver._snapshot`` already returns a copy under the driver's
+    ``_cache_lock`` so the DDS thread that writes ``_on_lowstate`` does
+    not race a caller.  The verb receives that copy and reshapes it
+    into an envelope; a caller further mutating the returned dict must
+    not reach back into the driver's cache.  The stub returns a fresh
+    dict per call to model the real driver's behaviour, and this test
+    grades that the verb's own return does not share references with
+    the stub's internal cache either.
+    """
+    original_cache: dict[str, Any] = {
+        "rpy": [0.1, 0.2, 0.3],
+        "gyroscope": [0.0, 0.0, 0.0],
+        "accelerometer": [0.0, 0.0, 9.81],
+        "quaternion": [1.0, 0.0, 0.0, 0.0],
+        "t": 1_700_000_400.0,
+    }
+    driver = _StubG1Driver(cache=original_cache)
+    result = _call(driver)
+    result["rpy"] = [9.9, 9.9, 9.9]
+    result["present"] = False
+
+    # The driver's cache is untouched: a fresh snapshot still reports
+    # what ``_on_lowstate`` wrote.
+    fresh = _call(driver)
+    assert fresh["rpy"] == [0.1, 0.2, 0.3]
+    assert fresh["present"] is True
+
+
+def test_a_bare_zero_reading_is_still_present() -> None:
+    """A cache carrying all-zero fields still reports ``present=True``.
+
+    An IMU reading of ``rpy=[0, 0, 0]`` and ``accelerometer=[0, 0, 0]``
+    would be physically implausible (accelerometer at rest reports g on
+    one axis), but it is a *reading*: ``_on_lowstate`` wrote something
+    into ``_imu``, so ``_snapshot("_imu")`` returned a non-``None``
+    dict.  The verb reports the fact of the reading through
+    ``present``, not its physical plausibility; falsy field values must
+    not silently collapse to ``present=False``.
+    """
+    cache: dict[str, Any] = {
+        "rpy": [0.0, 0.0, 0.0],
+        "gyroscope": [0.0, 0.0, 0.0],
+        "accelerometer": [0.0, 0.0, 0.0],
+        "quaternion": [0.0, 0.0, 0.0, 0.0],
+        "t": 0.0,
+    }
+    result = _call(_StubG1Driver(cache=cache))
+
+    assert result["present"] is True
+    assert result["rpy"] == [0.0, 0.0, 0.0]
+    assert result["t"] == 0.0

--- a/tests/drivers/test_g1_imu_reads_the_driver_snapshot.py
+++ b/tests/drivers/test_g1_imu_reads_the_driver_snapshot.py
@@ -2,8 +2,8 @@
 
 ``g1_imu`` is the third driver-instance-taking verb in
 :mod:`strands_robots.tools.g1`, after
-:func:`~strands_robots.tools.g1.g1_state.g1_get_state` and
-:func:`~strands_robots.tools.g1.g1_battery.g1_battery`.  Every earlier
+``g1_get_state`` (``strands-labs/robots#2934``) and
+``g1_battery`` (``strands-labs/robots#2938``).  Every earlier
 verb in the package is either a pure reader over module-level constants
 or a status envelope reader; this one and ``g1_battery`` both take a
 driver instance and read its cache through a named accessor -


### PR DESCRIPTION
## What

`g1_imu(driver)` is the fifth verb in the neon-the-g1 → strands-labs/robots port bundle. It surfaces the driver's cached `rt/lowstate` IMU sub-record to an agent through a thin wrapper over `G1Driver._snapshot("_imu")`.

`G1Driver._on_lowstate` already decodes `rt/lowstate` into two caches: `_mode_machine` (already surfaced by `g1_get_state` #2934) and `_imu` (`rpy` / `gyroscope` / `accelerometer` / `quaternion` / `t`). This verb is the cached-snapshot companion to `g1_battery` #2938, returning every IMU field the decoder actually wrote rather than routing the reading through the driver's status envelope.

## Why this shape

- **No second DDS subscriber.** The driver's `_on_lowstate` already decodes `rt/lowstate`; opening a second subscription would compete for the wire and duplicate the bus load `_DDS_INIT_LOCK` under #358 is meant to prevent. Same rule `g1_state` and `g1_battery` name.
- **`_snapshot("_imu")`, not `_imu` directly.** The driver's `_snapshot` returns a copy under `_cache_lock`, so the read does not race the DDS thread that writes into `_imu`. Same accessor the driver's own `stream(action="sensors")` path uses.
- **Driver argument typed `Any` at runtime.** Same reason `g1_get_state` and `g1_battery` give: the driver module imports `ensure_dds` from this package, so a runtime `G1Driver` import here would close a cycle. Duck-typed on `_snapshot`.
- **`present=False` on a just-connected driver.** `_on_lowstate` has not fired yet → `_snapshot` returns `None` → the verb reports `present=False` and every field `None`. The verb does not fabricate a reading the driver does not have.
- **No unit conversion.** `rpy` in radians, `gyroscope` rad/s, `accelerometer` m/s². A caller who wants degrees converts them so the reading this verb returns is bit-identical to what a re-published log would carry.
- **No `mode_machine` / `mode_pr` / `tick` / joint reads / posture heuristic.** The neon-side `g1_read_lowstate` decoded those directly off `LowState_`. `mode_machine` is already on `g1_get_state`. Joint reads are a separate verb the driver's `_on_lowstate` does not yet cache (it caches the IMU sub-record only). A posture label would be a second source of truth for a domain the driver's own motion gate decides at wire time — a widen there lives on `_on_lowstate` and the gate, not this verb.

## Refusal / hygiene contract

- `import strands_robots.tools.g1.g1_imu` pulls **zero** `unitree_sdk2py` submodules (graded by test).
- No new gate or FSM path; every actuation gate remains where #2916 wired it.
- `ruff check`: clean
- `ruff format --check`: clean
- `mypy` on touched files: clean (pre-existing errors in `mesh/core.py` are unrelated)

## Tests (8 new, all green)

```
tests/drivers/test_g1_imu_reads_the_driver_snapshot.py:
  test_the_import_pulls_no_sdk_module
  test_a_driver_with_no_lowstate_message_yet_reports_absent
  test_a_healthy_reading_reports_every_field_the_decoder_wrote
  test_a_tipped_orientation_rides_through_verbatim_not_clipped
  test_a_missing_field_in_the_cache_reports_none
  test_the_verb_reads_the_snapshot_exactly_once
  test_the_returned_dict_does_not_alias_the_cache
  test_a_bare_zero_reading_is_still_present
```

**Monkey-break proven**: swapping `_snapshot("_imu")` → `_snapshot("_battery")` fires `test_the_verb_reads_the_snapshot_exactly_once` with the exact diff `At index 0 diff: '_battery' != '_imu'`. Restored → 8/8 green.

## Files

- `strands_robots/tools/g1/g1_imu.py` — the verb (+117 LOC)
- `tests/drivers/test_g1_imu_reads_the_driver_snapshot.py` — contract-graded tests (+271 LOC)
- `changelog.d/2939-g1-tools-imu.md` — news fragment (placeholder PR number, will rename after this PR opens)

Refs `strands-labs/robots#358`. Sits after `g1_joint_reference` (#2932 merged), `g1_list_motion_gates` / `g1_fsm_admits` (#2933 merged), `g1_get_state` (#2934 open), `g1_battery` (#2938 open) in the port bundle.

---

## Round 2 changelog

**`60109d2b` - the docstrings cited two siblings that do not exist on any tree yet.**

Self-review before merging, prompted by #2940: this branch's docstrings named `g1_battery` and `g1_state` through qualified `:mod:` / `:func:` cross-reference roles. Neither module exists on `main` - `g1_state` lands in #2934 and `g1_battery` in #2938, both still open - so seven roles pointed at paths that do not import. `tests/test_docstring_xref_roles_resolve.py` grades exactly that promise over the whole tree, and its `_ROLE_RE` strips the display `~`, so the qualified form was graded rather than skipped.

Measured with that grader's own `_offending_roles_in`, at the previously approved head `36adbf40` and at `60109d2b`:

| file | before | after |
|---|---|---|
| `strands_robots/tools/g1/g1_imu.py` | 5 offending roles | 0 |
| `tests/drivers/test_g1_imu_reads_the_driver_snapshot.py` | 2 offending roles | 0 |

The references are kept - they are what explains why this verb opens no second DDS subscriber - but spelled the way #2941 already spells them: a literal ``g1_battery`` plus the pull request that introduces it, which promises nothing about a dotted path. `ruff check` / `ruff format --check` clean; the 8 tests above still pass.

**Why CI had not said so yet.** `call-test-lint` was still `IN_PROGRESS` on `36adbf40` when this was found, so the merge-blocker sweep attributed the branch to `required-check-pending` owed by *nobody* while it was in fact owed by the author. This is the third instance of the class #2940 describes, after #2934 and #2938, and the first caught before a reviewer had to.

**No new regression test.** The whole-tree grader above already pins this class over the whole tree; a local pin here would be a second, narrower copy of it. What was missing is not a test but a *caller* that collects it on a narrow run, which is what #2942 adds.

The approval on `36adbf40` is dismissed by this push. The diff change is real (docstring text), so this is not the free clean-base-merge case.