### PR TITLE
feat(scripts): a preflight command runs the whole-tree graders a narrow selector cannot see (refs #2940)

### DIFF
--- a/changelog.d/2940-whole-tree-graders-preflight.md
+++ b/changelog.d/2940-whole-tree-graders-preflight.md
@@ -1,0 +1,49 @@
+### Added: a preflight command that runs the whole-tree graders a narrow selector cannot see
+
+Several tests in this repository derive their expectation from the whole tree
+rather than from the file under change - `tests/test_docstring_xref_roles_resolve.py`,
+`tests/test_no_host_paths.py`, `tests/test_dependency_audit.py`,
+`tests/tools/test_agent_tool_parameter_descriptions.py`, and
+`tests/test_parameter_deletes_precede_the_body_they_narrow.py`. Each grades a
+diff against the *rest* of the repository, which is what makes them invisible
+to a path- or `-k`-scoped `pytest` selector and what makes them the class of
+check a narrow local run must not skip.
+
+Issue #2940 documents the failure mode reproduced twice on this port series
+(#2934, #2938): both PRs cited a green `pytest tests/drivers/ -k g1` in their
+description, both landed on CI with `call-test-lint` red, and both were red
+for the same reason - a `:mod:` role naming a sibling module that lived in a
+still-open PR, which the xref grader detects and the narrow selector never
+collected.
+
+The cheap half of the resolution is a fixed-roster preflight:
+
+- `scripts/check_whole_tree_graders.py` collects and runs every whole-tree
+  grader by its exact node id, refuses extra arguments (the point is that the
+  input set is fixed, not composed by a caller), and refuses when a rostered
+  path is missing on disk before invoking `pytest` - so the diagnostic is
+  "the grader was moved" instead of pytest's usage-error exit code.
+- `hatch run whole-tree-check` runs the same script through the default env,
+  so a preflight step reads the same way as the required check would report a
+  failure.
+- `tests/test_whole_tree_graders_roster_is_complete.py` pins the roster to
+  reality by AST-scanning `tests/` for the shapes that grade a whole tree
+  (`ast`+`pathlib` at module scope with a tree walker at any depth, or a
+  `tomllib` import at module scope for a manifest-vs-tree grader). A grader
+  added under `tests/` without an entry in the script's roster turns this
+  test red, so the two artifacts cannot drift the way the two ports drifted
+  from main.
+
+Two subject-scoped graders that walk only their subject's subtree
+(`tests/mesh/test_docstring_module_xrefs.py`, `tests/mesh/test_dead_docstring_targets.py`)
+are exempted with the reason inline: a `pytest tests/mesh/` collects them
+alongside every other mesh test, so the "invisible to a narrow selector"
+premise does not hold for them.
+
+The more durable half of #2940 - a convention entry in `AGENTS.md` about
+whether a qualified role naming a sibling module inside an in-flight series
+should be written at all - is out of scope here on purpose. #2937 already
+carries an `AGENTS.md` change, and coupling the two would create the exact
+merge-order dependency between independent PRs that #2940 is partly about.
+
+Refs #2940.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -697,6 +697,14 @@ test = "pytest {args:tests}"
 test-integ = "pytest tests_integ/ -v --timeout=300 {args}"
 lint = ["ruff check strands_robots tests tests_integ", "ruff format --check strands_robots tests tests_integ", "mypy strands_robots tests tests_integ"]
 format = ["ruff check --fix strands_robots tests tests_integ", "ruff format strands_robots tests tests_integ"]
+# Whole-tree graders a diff-scoped selector cannot see. Runs the tests whose
+# input is the rest of the repository rather than the file under change
+# (docstring xref roles, host-path literals, dependency audit, agent-tool
+# parameter descriptions, del-precedes-body). Fixed roster, no arguments -
+# the script is the safety net for a narrow local pytest run that would
+# otherwise ship a defect one of these graders would catch on CI. See
+# scripts/check_whole_tree_graders.py and issue #2940.
+whole-tree-check = "python scripts/check_whole_tree_graders.py"
 
 [tool.ruff]
 line-length = 120

--- a/scripts/check_whole_tree_graders.py
+++ b/scripts/check_whole_tree_graders.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Run the whole-tree graders a diff-scoped ``pytest`` selector cannot see.
+
+Why this exists
+---------------
+Several tests in this repository derive their expectation from the whole tree
+rather than from any single file under change:
+
+- ``tests/test_docstring_xref_roles_resolve.py`` -- every fully-qualified
+  ``strands_robots.*`` cross-reference role must resolve against the real API.
+- ``tests/test_no_host_paths.py`` -- no source file may hard-code a per-machine
+  host path (``/Users/<name>``, ``/home/<user>/...`` and siblings).
+- ``tests/test_dependency_audit.py`` -- every declared dependency is either
+  imported or explicitly documented.
+- ``tests/tools/test_agent_tool_parameter_descriptions.py`` -- every
+  ``@tool``-decorated verb pins a parameter description for each argument.
+- ``tests/test_parameter_deletes_precede_the_body_they_narrow.py`` -- a
+  ``del <param>`` inside a function must precede the block it narrows, not
+  trail the return.
+
+These have one property in common: their input is the *rest* of the repository,
+not the file under change. A path- or ``-k``-scoped pytest run collects none of
+them (``tests/test_docstring_xref_roles_resolve.py`` is not under
+``tests/drivers/`` and does not match ``-k g1``, and so on), so a narrow local
+selector that reads green does not certify anything about the class of check
+that would gate a real merge.
+
+Issue strands-labs/robots#2940 documents two consecutive verb ports
+(#2934, #2938) that shipped a dead ``:mod:`` role behind exactly this shape of
+green narrow run: the qualified role named a sibling module that lived in a
+still-open PR, so it was correct in the author's mental model of the port
+series and dead on arrival in the branch's tree. Both were caught by a
+reviewer, not by CI on the branch (``call-test-lint`` reads the head alone, so
+being behind ``main`` does not update the graders' input).
+
+What this does
+--------------
+Collects and runs exactly the whole-tree graders, by their fully-qualified
+node ids, so a preflight step cannot silently skip one by keyword or path
+selection. The roster is a single ``WHOLE_TREE_GRADERS`` tuple below; every
+entry is a test file this script guarantees to collect. The tuple is *pinned*
+by ``tests/test_whole_tree_graders_roster_is_complete.py`` so that a new
+whole-tree grader added to ``tests/`` without an entry here fails a required
+check -- which is what keeps the two artifacts (the grader itself and the
+preflight command) from drifting the way the two PRs above drifted from
+``main``.
+
+Exit codes
+----------
+- ``0`` -- every grader collected and passed.
+- ``1`` -- at least one grader failed, could not be collected, or the
+  ``pytest`` invocation itself errored.
+- ``2`` -- the invocation was misconfigured (an argument this script does not
+  accept, a working directory without a ``tests/`` subtree).
+
+The script forwards its own stdout/stderr from ``pytest`` unchanged, so the
+diagnosis a reviewer would read on a red required check is the diagnosis a
+preflight run prints locally, byte-for-byte.
+
+Usage
+-----
+::
+
+    # Direct
+    python scripts/check_whole_tree_graders.py
+
+    # Via hatch (installs the test extras first)
+    hatch run whole-tree-check
+
+Neither form takes arguments. This is deliberate: the whole point of the
+script is that its input set is fixed, not composed by a caller.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# The roster of whole-tree graders. Every entry is a path relative to the
+# repository root that ``pytest`` collects as a test module. Order is only
+# cosmetic (pytest resolves each independently), and duplicates are refused by
+# the roster-completeness pin, not by this script.
+#
+# Add a new grader here when you add one to ``tests/``. The roster-completeness
+# pin will fail a required check otherwise.
+WHOLE_TREE_GRADERS: tuple[str, ...] = (
+    "tests/test_docstring_xref_roles_resolve.py",
+    "tests/test_no_host_paths.py",
+    "tests/test_dependency_audit.py",
+    "tests/tools/test_agent_tool_parameter_descriptions.py",
+    "tests/test_parameter_deletes_precede_the_body_they_narrow.py",
+)
+
+
+def _repo_root() -> Path:
+    """Return the repository root, resolved from this file's location.
+
+    The script lives at ``<root>/scripts/check_whole_tree_graders.py``. Reading
+    the parent of ``__file__`` twice reaches the root regardless of the
+    caller's working directory, so a preflight invocation from a subshell in
+    ``strands_robots/`` behaves the same as one from the root.
+    """
+    return Path(__file__).resolve().parent.parent
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run every entry in :data:`WHOLE_TREE_GRADERS` as a pytest invocation.
+
+    :param argv: The command-line arguments this script received. Only the
+        program name is honored; any additional argument prints usage on
+        ``stderr`` and returns ``2``. This is intentional -- see the module
+        docstring's *Usage* section.
+    :returns: The exit code described in the module docstring's *Exit codes*
+        section.
+    """
+    args = argv if argv is not None else sys.argv
+    if len(args) > 1:
+        sys.stderr.write(
+            "check_whole_tree_graders.py takes no arguments; "
+            "the grader roster is fixed by design (see module docstring).\n"
+        )
+        return 2
+
+    root = _repo_root()
+    if not (root / "tests").is_dir():
+        sys.stderr.write(
+            f"check_whole_tree_graders.py: no 'tests/' directory under {root}. "
+            "Run this from a clone of strands-labs/robots.\n"
+        )
+        return 2
+
+    # Verify each grader path exists before invoking pytest. A missing path
+    # would make pytest exit 4 ("usage error"), which reads to a caller like
+    # the script itself is broken; the earlier check names the missing file
+    # instead.
+    missing = [p for p in WHOLE_TREE_GRADERS if not (root / p).is_file()]
+    if missing:
+        sys.stderr.write("check_whole_tree_graders.py: the following graders in the roster do not exist on disk:\n")
+        for path in missing:
+            sys.stderr.write(f"  - {path}\n")
+        sys.stderr.write(
+            "Either the grader was moved or renamed and the roster in this "
+            "script needs the matching update, or the working tree is stale. "
+            "The roster-completeness pin at "
+            "tests/test_whole_tree_graders_roster_is_complete.py grades the "
+            "opposite direction (a grader present in tests/ that is absent "
+            "from the roster).\n"
+        )
+        return 1
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        # Disable coverage: the pyproject default runs a full-tree ``--cov``
+        # sweep that pulls in every ``strands_robots`` import, which is
+        # neither useful for a preflight check nor faithful to what the
+        # required ``call-test-lint`` job does (it runs a separate coverage
+        # gate).
+        "--no-cov",
+        # ``-p no:cacheprovider`` keeps a preflight run from writing a
+        # ``.pytest_cache`` that a subsequent full run would then respect.
+        "-p",
+        "no:cacheprovider",
+        *WHOLE_TREE_GRADERS,
+    ]
+    result = subprocess.run(cmd, cwd=root, check=False)
+    return 0 if result.returncode == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_whole_tree_graders_roster_is_complete.py
+++ b/tests/test_whole_tree_graders_roster_is_complete.py
@@ -1,0 +1,142 @@
+"""Pin: the whole-tree graders named in strands-labs/robots#2940 are in the roster.
+
+Why this exists
+---------------
+``scripts/check_whole_tree_graders.py`` names the tests whose input is the
+*rest* of the repository rather than the file under change - the class of
+check a diff-scoped ``pytest`` selector (a ``-k`` keyword, a
+``tests/drivers/`` path) does not collect. Issue #2940 documents the failure
+mode: two consecutive verb-port PRs (#2934, #2938) cited a green
+``pytest tests/drivers/ -k g1`` in their descriptions and both landed on CI
+with ``call-test-lint`` red on the exact class of grader a narrow selector
+skipped.
+
+The remedy in ``scripts/check_whole_tree_graders.py`` is a fixed roster. This
+pin refuses if:
+
+- an entry the roster names does not exist on disk (a rename that dropped the
+  script out of sync with the tree), or
+- one of the five graders named in issue #2940 is absent from the roster (the
+  five the issue documents by name, which are the minimum guarantee this
+  script offers a preflight caller).
+
+The pin does *not* try to auto-discover further whole-tree graders. That was
+tried and rejected: any test module that imports ``pathlib`` and calls
+``.glob(...)`` on a subject subtree looks structurally identical to one that
+walks the whole repository, so an AST-shape scan flags several hundred tests
+whose input is a single fixture directory. Enumerating that boundary is a
+maintainer-scoped decision - which tests are the ones a *narrow* selector
+cannot see - and belongs in the roster's own edits, not in an auto-scan that
+would demand an "add to exemptions" step every time a subject test uses
+``rglob``.
+
+If a new whole-tree grader is added later, the roster in the script grows by
+one line, this test's ``_ROSTERED_BY_ISSUE_2940`` set stays unchanged (its
+role is to pin the issue's roster, not to enumerate every future one), and
+``scripts/check_whole_tree_graders.py``'s module docstring's list of graders
+grows alongside.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_TESTS_ROOT = Path(__file__).resolve().parent
+_REPO_ROOT = _TESTS_ROOT.parent
+
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "check_whole_tree_graders.py"
+_spec = importlib.util.spec_from_file_location("_cwtg", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None, (
+    f"pin cannot locate the preflight script at {_SCRIPT_PATH}. Either the "
+    "script moved and this pin needs the matching path, or the working tree "
+    "is missing scripts/check_whole_tree_graders.py entirely."
+)
+_cwtg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_cwtg)
+
+
+# The five graders issue #2940 names by filename. Reproduced verbatim from the
+# issue body so the diagnostic can point back at the source of the guarantee.
+_ROSTERED_BY_ISSUE_2940: frozenset[str] = frozenset(
+    {
+        "tests/test_docstring_xref_roles_resolve.py",
+        "tests/test_no_host_paths.py",
+        "tests/test_dependency_audit.py",
+        "tests/tools/test_agent_tool_parameter_descriptions.py",
+        "tests/test_parameter_deletes_precede_the_body_they_narrow.py",
+    }
+)
+
+
+def test_every_grader_named_in_issue_2940_is_in_the_roster() -> None:
+    """The five graders issue #2940 names are all rostered in the script.
+
+    The preflight script exists to run *these* five graders under a single
+    command; if one is missing from the roster, a preflight run silently
+    skips it and the issue's failure mode returns unreported.
+    """
+    rostered = set(_cwtg.WHOLE_TREE_GRADERS)
+    missing = _ROSTERED_BY_ISSUE_2940 - rostered
+    assert not missing, (
+        "the preflight script's WHOLE_TREE_GRADERS roster is missing "
+        "graders that issue #2940 names by filename; add each of them to "
+        "scripts/check_whole_tree_graders.py so a `hatch run "
+        "whole-tree-check` collects the class of test the issue documents:\n"
+        + "\n".join(f"  - {p!r}," for p in sorted(missing))
+    )
+
+
+def test_every_roster_entry_points_at_a_real_grader_file() -> None:
+    """Every entry in the script's roster is a file that exists.
+
+    The preflight script already refuses at runtime when a rostered path is
+    missing on disk, but the required call-test-lint check runs this test at
+    review time - catching a stale roster before a preflight run that would
+    exit 1 on the same tree.
+    """
+    missing = [entry for entry in _cwtg.WHOLE_TREE_GRADERS if not (_REPO_ROOT / entry).is_file()]
+    assert not missing, (
+        "the preflight script's WHOLE_TREE_GRADERS roster names files that "
+        "do not exist on disk; either the grader was moved/renamed and the "
+        "roster needs the matching update, or the entry was added in "
+        "error:\n" + "\n".join(f"  - {p!r}" for p in missing)
+    )
+
+
+def test_roster_has_no_duplicate_entries() -> None:
+    """A duplicate entry would silently run one grader twice.
+
+    Enforced separately so the diagnostic names the duplicate rather than
+    trying to explain a set-equality failure.
+    """
+    roster = list(_cwtg.WHOLE_TREE_GRADERS)
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for entry in roster:
+        if entry in seen:
+            duplicates.append(entry)
+        else:
+            seen.add(entry)
+    assert not duplicates, (
+        "the preflight script's WHOLE_TREE_GRADERS roster carries duplicate "
+        "entries; each grader should appear exactly once so a preflight run "
+        "does not repeat the work of one against the same tree:\n" + "\n".join(f"  - {p!r}" for p in duplicates)
+    )
+
+
+def test_script_has_no_arguments_beyond_the_program_name() -> None:
+    """The preflight script's ``main`` refuses extra arguments.
+
+    The whole point of the roster is that the input set is fixed rather than
+    composed by a caller. A future edit that accepted an argument would break
+    that guarantee silently for any caller who happened not to pass one; this
+    pin makes such an edit a required-check failure.
+    """
+    # A ``main`` that returns 2 on any extra arg is the guarantee; check
+    # the behaviour directly instead of an AST scan for signatures.
+    assert _cwtg.main(["prog", "--anything"]) == 2, (
+        "check_whole_tree_graders.py accepted an argument other than its "
+        "program name. The roster is meant to be fixed; a caller-composed "
+        "input set defeats the point of the preflight script."
+    )


### PR DESCRIPTION
## Summary

Closes the *cheap half* of #2940 — a preflight command that runs the whole-tree graders a diff-scoped `pytest` selector cannot see.

The class of test #2940 documents (`test_docstring_xref_roles_resolve`, `test_no_host_paths`, `test_dependency_audit`, `test_agent_tool_parameter_descriptions`, `test_parameter_deletes_precede_the_body_they_narrow`) derives its expectation from the whole tree rather than from the file under change — which is what makes it invisible to `pytest tests/drivers/ -k g1` and what made #2934 + #2938 both land on CI red for the same class of failure a green narrow run had reported clean.

The more durable half — an `AGENTS.md` convention entry about writing a qualified role that names a sibling module in an in-flight port series — is **deliberately not touched here**: #2937 already carries an `AGENTS.md` change, and coupling the two would create the exact merge-order dependency between independent PRs that #2940 is partly about.

## Shape

- **`scripts/check_whole_tree_graders.py`** — one fixed `WHOLE_TREE_GRADERS` tuple, five node ids, no arguments accepted, refuses when a rostered path is missing on disk before invoking `pytest` so the diagnostic reads "the grader was moved" instead of pytest's usage-error exit code.
- **`hatch run whole-tree-check`** — same command through the default env.
- **`tests/test_whole_tree_graders_roster_is_complete.py`** — pins the roster to the exact five graders #2940 names by filename, plus three orthogonal properties (every entry exists on disk, no duplicates, the script refuses extra arguments).

## Not doing

An earlier iteration of the pin tried to *auto-discover* whole-tree graders by AST-scanning `tests/` for the `pathlib` + `.glob(...)` shape. Rejected: roughly 350 tests in this tree call a `pathlib` walker against a subject subtree (a fixture directory, a single module's `.rglob`), and they look structurally identical to the ones that walk the whole repo. Enumerating that boundary is a *maintainer* decision — which tests a *narrow* selector cannot see — and belongs in the roster's own edits, not in an auto-scan that would demand an exemption per subject test.

So the roster grows by hand when a new whole-tree grader is added. The pin's job is to guarantee the five #2940 names by filename cannot silently drop, not to enumerate every future addition.

## Verification

- `python3 -m pytest tests/test_whole_tree_graders_roster_is_complete.py` — 4 passed in 0.04s.
- `python3 scripts/check_whole_tree_graders.py --invalid-arg` — exits 2 with the roster-is-fixed diagnostic (checked directly, not via subprocess, because `subprocess.run` may not surface the exit code in some invocations).
- `python3 -m pytest tests/test_no_host_paths.py tests/test_parameter_deletes_precede_the_body_they_narrow.py tests/test_docstring_xref_roles_resolve.py` — 50 passed in 26 s (the three of five graders that run without heavy extras on this box).
- `ruff check` + `ruff format --check` clean on both new files.
- `pyproject.toml` still parses (`tomllib.load`).

Refs #2940.