### PR TITLE
fix(docs): a cross-reference role naming a file is reported, not exempted

### DIFF
--- a/changelog.d/2944-xref-role-target-is-what-sits-between-the-backticks.md
+++ b/changelog.d/2944-xref-role-target-is-what-sits-between-the-backticks.md
@@ -1,0 +1,21 @@
+### Fixed: a cross-reference role naming a file is reported rather than exempted
+
+`strands_robots.policies.moveit2.policy`'s module docstring pointed a reader at
+the sidecar deployment with a `:mod:` role whose target was
+`strands_robots.policies.moveit2.server.docker-compose.yml` - a fully-qualified
+target naming a YAML file. No module answers to that dotted path, so Sphinx
+rendered a plain-text token and an IDE could not follow it: the dead pointer
+`tests/test_docstring_xref_roles_resolve.py` exists to catch. The compose file
+is real, so the citation's intent was sound; it is now named the way the sibling
+`server` package's own docstring names it, as a plain code span.
+
+That guard graded the role one line above it and never saw this one. Its target
+pattern admits whitespace so a role wrapped over a line break is reported rather
+than failing to match and exempting itself - the module docstring states that
+reasoning - and the same pattern excluded every other character a wrong target
+carries, so a hyphen stopped the match before the closing backtick. The pattern
+now admits any non-backtick character after the leading identifier: the
+backticks delimit the target, so whatever sits between them is the target as
+written. The leading identifier is still required, which keeps a relative role
+(`:mod:`.protocol``) out of scope, since that resolves against Sphinx's
+current-module context rather than here.

--- a/strands_robots/policies/moveit2/policy.py
+++ b/strands_robots/policies/moveit2/policy.py
@@ -29,8 +29,9 @@ service mode:
 The ROS 2 / ``moveit_py`` deps stay out of ``pyproject.toml`` - only the
 client side (``pyzmq``, ``msgpack``) is installed via the ``[moveit2]`` extra.
 See :mod:`strands_robots.policies.moveit2.server` for the sidecar reference
-implementation and :mod:`strands_robots.policies.moveit2.server.docker-compose.yml`
-for the recommended deployment.
+implementation, and the ``docker-compose.yml`` beside it for the recommended
+deployment - a compose file is not an importable module, so it is named the way
+that package's own docstring names it rather than dressed as a :mod: target.
 """
 
 from __future__ import annotations

--- a/tests/test_docstring_xref_roles_resolve.py
+++ b/tests/test_docstring_xref_roles_resolve.py
@@ -29,6 +29,17 @@ import - and neither does the whitespace-collapsed form a renderer would see.
 The pattern here therefore admits whitespace inside the target and reports such
 a role, rather than failing to match it and exempting it from the guard.
 
+The same reasoning covers every other character a wrong target carries. A role
+whose target is a FILENAME (``server.docker-compose.yml``) or a call expression
+(``Cls.method("arg")``) is a dead pointer for the same reason a wrapped one is,
+and a target pattern restricted to word characters and dots does not match it -
+so such a role was exempted rather than reported, which is the outcome admitting
+whitespace exists to prevent. The pattern therefore admits any non-backtick
+character after the leading identifier: the backticks delimit the target, so
+whatever sits between them is the target as written. The leading identifier is
+still required, which keeps a relative role (``:mod:`.protocol```) out of scope,
+since that resolves against Sphinx's current-module context rather than here.
+
 Two spellings of the same promise are graded, because a target only has to
 resolve - it does not have to be fully qualified to be checkable:
 
@@ -89,7 +100,7 @@ _REPO_ROOT = _PKG_ROOT.parent
 # target so a role whose long dotted path was wrapped over a line break is
 # still extracted and checked: a pattern that stopped at the newline skipped
 # such a role outright, which exempted it from this guard entirely.
-_ROLE_RE = re.compile(r":(?:mod|class|func|meth|attr|data|obj|exc):`~?([A-Za-z_][\w.\s]*)`")
+_ROLE_RE = re.compile(r":(?:mod|class|func|meth|attr|data|obj|exc):`~?([A-Za-z_][^`]*)`")
 
 
 def _absent_dependency(exc: ImportError) -> str | None:
@@ -680,3 +691,50 @@ def test_a_qualified_target_that_names_nothing_is_still_reported() -> None:
     assert not _resolves(_BOGUS)
     assert _offending_roles_in(f"See :func:`~{_BOGUS}`.") == [_BOGUS]
     assert not _resolves("strands_robots.simulation.base.SimEngine.no_such_method")
+
+
+# The compose file the moveit2 client docstring pointed a reader at with a
+# ``:mod:`` role. The file is real; a module at that dotted path is not, and the
+# sibling ``server`` package's own docstring names it as a plain code span.
+_FILENAME_TARGET = "strands_robots.policies.moveit2.server.docker-compose.yml"
+
+
+def test_the_role_pattern_extracts_a_target_that_is_not_a_dotted_name() -> None:
+    """A filename dressed as a role is still a role target, so the pattern must match it.
+
+    A pattern restricted to word characters and dots stops at the hyphen and
+    never reaches the closing backtick, so it finds nothing here - which is how
+    this role escaped every check below it while its neighbour was graded.
+    """
+    doc = f"See :mod:`{_FILENAME_TARGET}` for the recommended deployment."
+
+    assert _ROLE_RE.findall(doc) == [_FILENAME_TARGET]
+
+
+def test_a_qualified_target_naming_a_file_is_reported() -> None:
+    """The pointer is dead for the same reason a wrapped one is, so it is reported.
+
+    The compose file exists, so the citation's intent was sound; what does not
+    exist is a module at that dotted path, which is what the role promises.
+    """
+    assert (_REPO_ROOT / "strands_robots/policies/moveit2/server/docker-compose.yml").is_file(), (
+        "premise: the cited file is real, so only the spelling was wrong"
+    )
+    assert _resolves(_FILENAME_TARGET) is False, "premise: no module answers to that dotted path"
+
+    assert _offending_roles_in(f"See :mod:`{_FILENAME_TARGET}` for deployment.") == [_FILENAME_TARGET]
+
+
+def test_the_widened_pattern_leaves_the_documented_exclusions_out_of_scope() -> None:
+    """Over-reach control: admitting the character must not grade what has no target here.
+
+    A relative role resolves against Sphinx's current-module context and a bare
+    unqualified one against its current class, neither of which is available -
+    so both stay unreported, exactly as before the pattern was widened.
+    """
+    assert _ROLE_RE.findall("See :mod:`.protocol` for the codec.") == [], (
+        "a relative role has no leading identifier, so it is still not a target here"
+    )
+    assert _offending_roles_in("Call :meth:`build(world)` once per scene.") == [], (
+        "an unqualified target names nothing this guard can resolve"
+    )


### PR DESCRIPTION
## What is wrong

`strands_robots/policies/moveit2/policy.py`'s module docstring pointed a reader
at the sidecar deployment like this:

```
See :mod:`strands_robots.policies.moveit2.server` for the sidecar reference
implementation and :mod:`strands_robots.policies.moveit2.server.docker-compose.yml`
for the recommended deployment.
```

The second target names a **YAML file**. Measured:

| target | resolves? |
| --- | --- |
| `strands_robots.policies.moveit2.server` | yes, a real module |
| `strands_robots.policies.moveit2.server.docker-compose.yml` | **no module answers to that path** |

The file itself is real (`strands_robots/policies/moveit2/server/docker-compose.yml`,
2433 bytes), so the citation's *intent* was sound. What does not exist is a
module at that dotted path, which is what a `:mod:` role promises - so Sphinx
renders a plain-text token and an IDE cannot follow it. That is exactly the dead
pointer `tests/test_docstring_xref_roles_resolve.py` was written to catch.

## Why the guard could not see it

The guard graded the role **one line above** this one and never saw this one.

Its target pattern, `_ROLE_RE`, was `:(?:mod|class|...):`~?([A-Za-z_][\w.\s]*)``.
The body
class admits word characters, dots and whitespace. It admits whitespace
deliberately, and the module docstring states why:

> A target only counts as named if it is a CONTIGUOUS dotted path. [...] The
> pattern here therefore admits whitespace inside the target and reports such a
> role, rather than failing to match it and exempting it from the guard.

A hyphen is not in that class, so the match stops at `...server.docker` and never
reaches the closing backtick. No match, no target, no check - the role was
**exempted by the same mechanism the whitespace admission exists to prevent**.

Measured on `main` today, with a deliberately permissive probe pattern
(`[^\`]+`) against the shipped one, over `strands_robots/`, `tests/` and
`tests_integ/`:

| target shape | count | in scope by the guard's stated rules? |
| --- | --- | --- |
| relative (`:mod:`.protocol``) | 14 | no - resolves against Sphinx's current-module context |
| call expression (`:meth:`build(world)``) | 1 | no - unqualified, names nothing resolvable here |
| path with a slash | 1 | no - unqualified |
| **fully-qualified, naming a file** | **1** | **yes, and it was invisible** |

## The change

The pattern now admits any non-backtick character after the leading identifier:

```
-([A-Za-z_][\w.\s]*)
+([A-Za-z_][^`]*)
```

The backticks are what delimit a role's target, so whatever sits between them is
the target as written. The leading identifier is still required, which keeps the
relative form out of scope - unchanged, and pinned by a control.

Widening the pattern reports **exactly one** new offender on `main`: the role
above. No floodgate.

## Verification

Break table, running the whole guard file (`restore()` first and in a `finally`,
`ast.parse` before every write, both files restored byte-identically):

| variant | fires | collected | ids |
| --- | --- | --- | --- |
| b0 control (as shipped) | 0 | 23 | |
| b1 docstring reverted, pattern widened | 1 | 23 | `test_qualified_strands_robots_xref_roles_resolve` |
| b2 pattern narrowed back, docstring fixed | 2 | 23 | the pattern self-test + the behavioural cell |
| **b3 both reverted (= `main` today)** | **0** | **20** | **- silent** |
| b4 leading identifier dropped (over-wide) | 1 | 23 | `test_the_widened_pattern_leaves_the_documented_exclusions_out_of_scope` |
| b5 docstring paragraph reverted | 0 | 23 | |
| b6 pattern admits only the hyphen | 0 | 23 | |

**b3 is the finding**: on `main`, with the dead role present and the narrow
pattern, the guard reports nothing - and `collected` drops 23 to 20, which is the
three cells this PR adds. b1 and b2 are disjoint, so each half is independently
pinned. b4 shows the leading-identifier anchor is load-bearing.

Two rows deserve their reasons rather than a count:

- **b5 fires 0.** The docstring paragraph is prose and nothing grades it. Stated
  rather than implied.
- **b6 fires 0.** A narrower widening - admitting only the hyphen - also fixes
  today's instance, so `[^\`]*` is not the minimum that makes this one role
  visible. It is the form the stated principle implies, and the difference is
  measurable rather than aesthetic: a target carrying a call expression and
  quotes is matched by `[^\`]*` and missed by `[\w.\s-]*`. The wide form is what
  makes the guard's own sentence true for every non-name target, not just this
  one's punctuation.

Three cells added, mirroring the shapes the file already uses for the wrapped
case:

- `test_the_role_pattern_extracts_a_target_that_is_not_a_dotted_name` - the
  pattern self-test (fires under b2).
- `test_a_qualified_target_naming_a_file_is_reported` - behavioural, with two
  premises: the compose file exists, and no module answers to that path.
- `test_the_widened_pattern_leaves_the_documented_exclusions_out_of_scope` - the
  over-reach control (fires under b4).

Gate:

- `ruff check strands_robots tests tests_integ` - clean.
- `ruff format --check strands_robots tests tests_integ` - 1730 files already
  formatted, none reformatted.
- `mypy strands_robots tests tests_integ` - 24 errors in 9 files, the standing
  baseline, **0 attributable** to either changed file.
- The changed guard: 20 passed before the new cells, **23 passed** after.
- Paired guard-class run, 472 paths (every suite that walks the tree, parses
  source, or reads docstrings / `Args:` / `Raises:` / `__all__` / `changelog.d`,
  plus everything naming `moveit2`), the changed guard withheld from **both**
  sides: identical **21989 collected** and `20 failed, 21893 passed, 76 skipped`
  on each, **both `comm` directions empty**. The 20 are environmental and were
  classified rather than assumed: 17 need `awsiot`/`awscrt` (`find_spec` `None`
  for both, both declared in the `mesh-iot` extra, which `[all]` includes, and
  hatch's default features are `['all']` - so CI installs them), and 3 are the
  lerobot-from-source `encode()` drift.
- Rebased onto `545429f1`; zero overlap on either changed file, and the two guard
  files `main` added since my base pass against this head (69 passed together
  with the changed guard).

No docs page change is owed: `docstring cross-reference` prose lives in the
guard's own module docstring, which this PR extends, and `grep -rn moveit2 docs/`
returns nothing for the compose file.

## Deliberately not done

The 14 relative roles (`:mod:`.protocol``) stay out of scope. Resolving one needs
the current-module context Sphinx supplies and this guard does not have, so
grading them is a contract decision rather than a pattern fix. They are pinned as
out of scope by the over-reach control, so a later decision to grade them is a
deliberate edit rather than a silent side effect of this one.
