### PR TITLE
fix(tools/g1): a short-form role names a member, not a call expression

### DIFF
--- a/changelog.d/2946-short-form-role-names-a-member.md
+++ b/changelog.d/2946-short-form-role-names-a-member.md
@@ -1,0 +1,10 @@
+### Fixed: a short-form docstring cross-reference names a member, not a call
+
+The `g1_imu` and `g1_lidar_summary` verbs cited the driver's cache accessor as
+`:meth:`G1Driver._snapshot("_imu")`` -- a role whose target is the literal
+`_snapshot("_imu")`, which no class defines, so
+`tests/test_docstring_xref_roles_resolve.py::test_short_form_xref_roles_resolve`
+refused both. `G1Driver._snapshot` is the driver's only cache accessor and is
+deliberately internal, so there is no public member to cite instead; both are
+now spelled as the literal ``driver._snapshot("_imu")`` their own module
+docstrings and the `g1_lidar_state` sibling already use.

--- a/strands_robots/tools/g1/g1_imu.py
+++ b/strands_robots/tools/g1/g1_imu.py
@@ -65,7 +65,7 @@ from strands import tool
 def g1_imu(driver: Any) -> dict[str, Any]:
     """Return the driver's cached ``rt/lowstate`` IMU snapshot.
 
-    Read-only.  Calls :meth:`G1Driver._snapshot("_imu")` (a copy under
+    Read-only.  Calls ``driver._snapshot("_imu")`` (a copy under
     the driver's ``_cache_lock``, so a caller mutating the result does
     not race the DDS thread) and reshapes the dict into an agent-facing
     envelope.  A driver whose subscriber has not received a ``LowState``

--- a/strands_robots/tools/g1/g1_lidar_summary.py
+++ b/strands_robots/tools/g1/g1_lidar_summary.py
@@ -66,7 +66,7 @@ from strands import tool
 def g1_lidar_summary(driver: Any) -> dict[str, Any]:
     """Return the driver's cached lidar-cloud header summary.
 
-    Read-only. Calls :meth:`G1Driver._snapshot("_lidar_summary")` (a
+    Read-only. Calls ``driver._snapshot("_lidar_summary")`` (a
     copy under the driver's ``_cache_lock``, so a caller mutating the
     result does not race the DDS thread) and reshapes the dict into an
     agent-facing envelope. A driver whose subscriber has not received a


### PR DESCRIPTION
## What

`main` is red. `tests/test_docstring_xref_roles_resolve.py::test_short_form_xref_roles_resolve` fails on the tip, and it fails on two docstrings rather than one:

```
Offending docstrings: {
  'strands_robots.tools.g1.g1_imu::g1_imu': ['G1Driver._snapshot("_imu")'],
  'strands_robots.tools.g1.g1_lidar_summary::g1_lidar_summary': ['G1Driver._snapshot("_lidar_summary")'],
}
```

Both verbs spell the driver's cache accessor as a `:meth:` role that carries the argument, so the member the grader resolves is the literal `_snapshot("_imu")` -- a name no class defines. This drops the two roles to the literal spelling the rest of the tree already uses.

## Why drop the role rather than fix its target

The grader's message offers both: "Cite the member that exists ... or drop the role." Here there is nothing to cite. `G1Driver._snapshot` is the driver's *only* cache accessor and is deliberately internal -- it sits under the `Internal helpers` banner in `strands_robots/drivers/g1.py`, and the class exposes no public equivalent (`snapshot` at line 1704 belongs to a different class). A role pointing at a private helper is the "private spelling" the grader's own message calls a dead pointer twice over.

The literal is also what the neighbours already say. Both files use it in their **module** docstrings (`driver._snapshot("_imu")`, `driver._snapshot("_lidar_summary")`), and `g1_lidar_state` -- the sibling that landed clean -- uses it in the verb docstring too. So this is three files agreeing rather than a new convention, and it keeps the duck-typed contract honest: the verb takes any object with `_snapshot(attr)`, not a `G1Driver`.

## Why no branch could have caught this

This is a merge-base interaction, and both halves were green alone:

| | tree it was graded on | verdict |
|---|---|---|
| the grader tightening | did not yet contain either docstring | green |
| each verb port | was graded before the short form was graded at all | green |
| `main` | contains both | **red** |

`Detect an untested overlap with the base branch` keys on the **intersection of changed paths**. A whole-tree grader's input is the rest of the repository rather than any path in the diff, so an empty path intersection is exactly what it reports -- correctly, by its own key, and uselessly here. That is the blindness tracked in #2791, and this is a second worked instance of it to cite there.

It is also the #2940 class seen from the other side: #2942's preflight runs the graders a narrow selector cannot see, which catches a branch that is *already* wrong. It cannot catch a branch that is right until something else lands, because the grader's input changes without the branch changing.

## Verification

Ran the grader that is red on `main`, against this tree:

```
tests/test_docstring_xref_roles_resolve.py .......................
22 passed
```

(`test_qualified_strands_robots_xref_roles_resolve` needs the `lerobot` extra, absent in the ad-hoc env used here; CI installs `features=["all"]`.)

- `pytest tests/drivers/ -k "g1_imu or g1_lidar_summary"` -- **34 passed**
- `ruff format --check` on both touched files -- clean
- `ruff check` on both touched files -- clean

No regression test is added: `test_short_form_xref_roles_resolve` *is* the pin, it fails deterministically on the defect, and it grades the whole tree, so a second assertion would restate it on a narrower input.

## Files

- `strands_robots/tools/g1/g1_imu.py` -- one docstring line
- `strands_robots/tools/g1/g1_lidar_summary.py` -- one docstring line

Refs #2791, #2940.
