### PR TITLE
fix(drivers/g1): a failed bring-up releases the subscribers it already built

### DIFF
--- a/changelog.d/2951-g1-connect-releases-a-partial-subscriber-set.md
+++ b/changelog.d/2951-g1-connect-releases-a-partial-subscriber-set.md
@@ -1,0 +1,30 @@
+### Fixed: a failed G1 bring-up releases the subscribers it already built
+
+`G1Driver.connect_eagerly` builds a `DDSSubscriberSet`, subscribes four topics in
+a loop, and then initialises the command publisher. Each `subscribe` call starts
+a `ch_reader` daemon thread and matches a CycloneDDS reader; the set is a local
+variable, and the driver only takes a handle on it (`self._subs`) once the whole
+bring-up has succeeded. Three of the four failure exits past the constructor
+returned their reason without closing it, so those readers stayed matched and
+those threads stayed looping for a driver that reports itself unconnected -- and
+with nothing left holding the set, nothing could close them afterwards.
+
+Measured on all four exits, with a recording endpoint standing in for the SDK's
+`ChannelSubscriber`: `start()` refusing had subscribed nothing, so it owed
+nothing; an unresolvable IDL class had subscribed one topic and closed none; a
+refused subscriber had subscribed two and closed none; and the publisher's own
+failure had subscribed four and closed four. That last branch already closed the
+set inline, which is what made the other three read as a deliberate choice
+rather than an omission.
+
+`cleanup()` cannot recover them either. It closes `self._subs`, which a failed
+bring-up never assigns, so it is a no-op for exactly the state this leaves
+behind -- and `connect_eagerly`'s own docstring invites the retry that makes it
+compound ("the driver stays usable, so a caller can fix the cause and call
+again"), which accumulates one more matched reader per attempt.
+
+Every failure exit past the constructor now routes through one `_abort_connect`
+helper that closes the set and records the reason, so the release cannot drift
+from the report the way an inline close on one branch already had. The reason a
+caller sees is unchanged on all four exits, and a successful bring-up still
+hands its live subscribers to the driver.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -519,6 +519,42 @@ class G1Driver:
     # Lifecycle and status.                                              #
     # ------------------------------------------------------------------ #
 
+    def _abort_connect(self, subs: DDSSubscriberSet, reason: str) -> str:
+        """Release a partially built subscriber set and record why. Returns ``reason``.
+
+        Every failure exit in :meth:`connect_eagerly` that happens after
+        ``subs`` exists routes through here, because a subscriber the driver
+        never records is one :meth:`cleanup` can never reach: it only closes
+        ``self._subs``, which is assigned once the whole bring-up has
+        succeeded. A ladder that gave up part way therefore used to leave the
+        topics it had already subscribed running - and
+        :meth:`DDSSubscriberSet.close` documents what that costs, since every
+        subscriber is built with a non-zero queue length and the ``ch_reader``
+        daemon thread that comes with it keeps the reader matched and keeps the
+        decoder callbacks writing caches for a driver that reports itself
+        disconnected. The retry this method's own docstring invites then
+        subscribes the same topics a second time.
+
+        Closing a set that never subscribed anything is a documented no-op, so
+        the exit where :meth:`DDSSubscriberSet.start` itself failed routes
+        through here too: the rule is that every exit past the constructor
+        releases the set, with no exception a later reader has to remember.
+        This is the driver-level counterpart of
+        :func:`~strands_robots.tools.g1._dds_engine._release_partial`, which
+        owns the same question one layer in for a single subscriber.
+
+        Args:
+            subs: The set built by this bring-up attempt, released here.
+            reason: The named failure, recorded on :attr:`_connect_error` so a
+                later retry can read why the previous attempt gave up.
+
+        Returns:
+            ``reason``, so each caller can ``return self._abort_connect(...)``.
+        """
+        subs.close()
+        self._connect_error = reason
+        return reason
+
     def connect_eagerly(self) -> str | None:
         """Attach to the DDS bus and subscribe every sensor topic. Idempotent.
 
@@ -546,17 +582,14 @@ class G1Driver:
         subs = DDSSubscriberSet(self._network_interface)
         err = subs.start()
         if err is not None:
-            self._connect_error = err
-            return err
+            return self._abort_connect(subs, err)
         for topic, cls_path, decoder in self._subscription_plan():
             message_class = _resolve_message_class(cls_path)
             if isinstance(message_class, str):
-                self._connect_error = message_class
-                return message_class
+                return self._abort_connect(subs, message_class)
             err = subs.subscribe(topic, message_class, decoder)
             if err is not None:
-                self._connect_error = err
-                return err
+                return self._abort_connect(subs, err)
         # Start the publisher on the same interface.  The subscriber set has
         # already run ``ensure_dds`` once, so :meth:`DDSPublisher.start`
         # returns ``None`` without a second SDK init - the shared lock keeps
@@ -566,11 +599,8 @@ class G1Driver:
         if err is not None:
             # The subscriber set is up; publisher failed.  Roll back so the
             # driver reports a single connect failure instead of a half-open
-            # state, and so :meth:`cleanup` on the caller's error path drops
-            # the subscribers cleanly.
-            subs.close()
-            self._connect_error = err
-            return err
+            # state rather than leaving the readers running.
+            return self._abort_connect(subs, err)
         self._pubs = pubs
         self._subs = subs
         self._connected = True

--- a/tests/drivers/test_g1_connect_releases_a_partial_subscriber_set.py
+++ b/tests/drivers/test_g1_connect_releases_a_partial_subscriber_set.py
@@ -1,0 +1,276 @@
+"""A connect that gives up part way releases the subscribers it already made.
+
+:meth:`~strands_robots.drivers.g1.G1Driver.connect_eagerly` builds a
+:class:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet`, subscribes four
+topics through it, then starts a publisher, and records the set on
+``self._subs`` only once all of that has succeeded. So a ladder that gave up
+part way left the topics it had already subscribed running with nothing holding
+a reference the driver could reach: :meth:`G1Driver.cleanup` closes
+``self._subs``, and on those exits ``self._subs`` is still ``None``.
+
+The publisher-failure exit already rolled back with ``subs.close()`` and said
+why in a comment. Its two siblings inside the subscribe loop - a topic whose IDL
+class will not resolve, and a subscriber the SDK refuses to construct - returned
+the reason without it. One function, three failure exits, one of them releasing
+what it built.
+
+What that costs is written down in :meth:`DDSSubscriberSet.close`: every
+subscriber is built with a non-zero queue length, and above zero
+``unitree_sdk2py`` starts a ``ch_reader`` daemon thread whose target is a bound
+method of the channel's reader. The thread keeps the channel reachable, so the
+CycloneDDS finaliser never runs - the reader stays matched and the decoder
+callbacks keep filling ``_lowstate`` and ``_battery`` for a driver whose
+``_connected`` is ``False``. And because :meth:`connect_eagerly` documents a
+retry as the supported response to a failure, the next attempt subscribes the
+same topics again: the duplicate subscription that the idempotence guard on a
+*connected* driver exists to prevent, reached instead through a failed one.
+
+The SDK is absent on a headless runner, so these cells drive the recording
+stand-in the sibling release suite already uses, and count ``Close()`` on the
+endpoints ``subscribe`` really built.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from collections import Counter
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers.g1 as g1_module
+import strands_robots.tools.g1._dds_engine as engine_module
+from strands_robots.drivers.g1 import G1Driver
+from strands_robots.tools.g1._dds_engine import DDSSubscriberSet
+from tests.drivers.test_g1_dds_engine_release import _install_channel, _RecordingEndpoint
+
+
+class _RefusingEndpoint(_RecordingEndpoint):
+    """An endpoint whose ``Init`` fails for one topic, the way the SDK's can."""
+
+    refuse_topic: str = ""
+
+    def Init(self, handler: Any = None, queue_len: int | None = None) -> None:  # noqa: N802 - SDK spelling
+        if self.topic == type(self).refuse_topic:
+            raise RuntimeError("dds reader could not be created")
+        super().Init(handler, queue_len)
+
+
+def _topics() -> tuple[str, ...]:
+    """The topics the driver's own subscription plan names, in order."""
+    return tuple(topic for topic, _cls, _decoder in G1Driver()._subscription_plan())
+
+
+def _bring_up(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    refuse_topic: str | None = None,
+    resolve_fails_on_call: int | None = None,
+    dds_error: str | None = None,
+    attempts: int = 1,
+) -> tuple[G1Driver, list[_RecordingEndpoint], str | None]:
+    """Run ``connect_eagerly`` against recording subscribers and report what it built.
+
+    Args:
+        monkeypatch: Pytest's patcher, used for every seam so a machine that
+            really has the SDK gets it back.
+        refuse_topic: A topic whose subscriber construction fails, driving the
+            ``subscribe`` exit.
+        resolve_fails_on_call: Make the Nth ``_resolve_message_class`` call
+            return a reason, driving the IDL-resolution exit.
+        dds_error: Make ``ensure_dds`` fail, driving the ``start`` exit before
+            anything is subscribed.
+        attempts: Call ``connect_eagerly`` this many times; two models the retry
+            the method's docstring invites.
+
+    Returns:
+        The driver, every endpoint ``subscribe`` built across all attempts, and
+        the last returned reason.
+    """
+    endpoint_class: type[_RecordingEndpoint] = _RecordingEndpoint
+    if refuse_topic is not None:
+        endpoint_class = type("_Refusing", (_RefusingEndpoint,), {"refuse_topic": refuse_topic})
+    built = _install_channel(monkeypatch, "ChannelSubscriber", endpoint_class)
+    monkeypatch.setattr(engine_module, "ensure_dds", lambda _interface: dds_error)
+
+    # Stand in for the IDL lookup unconditionally.  The real one imports the
+    # SDK's generated message modules, which a headless runner does not have,
+    # so resolving for real would fail the very first topic and every cell
+    # below would grade a ladder that never got started.
+    calls = {"n": 0}
+
+    def _resolve(class_path: tuple[str, str]) -> Any:
+        calls["n"] += 1
+        if resolve_fails_on_call is not None and calls["n"] == resolve_fails_on_call:
+            return "transient: IDL module not loaded yet"
+        return type(class_path[1], (), {})
+
+    monkeypatch.setattr(g1_module, "_resolve_message_class", _resolve)
+
+    driver = G1Driver()
+    reason: str | None = None
+    for _attempt in range(attempts):
+        reason = driver.connect_eagerly()
+    return driver, built, reason
+
+
+def _open(endpoints: list[_RecordingEndpoint]) -> list[_RecordingEndpoint]:
+    """The endpoints nothing has closed."""
+    return [endpoint for endpoint in endpoints if endpoint.closes == 0]
+
+
+def _connect_source() -> str:
+    """``connect_eagerly``'s source, dedented so :mod:`ast` will parse it."""
+    return textwrap.dedent(inspect.getsource(G1Driver.connect_eagerly))
+
+
+def _returns_after_the_set_exists() -> list[ast.Return]:
+    """Every ``return`` of a reason that happens once ``subs`` has been built.
+
+    Read from the source rather than listed, so an exit added later is held to
+    the same rule instead of inheriting an exemption by being absent from a
+    tuple here.
+    """
+    function = ast.parse(_connect_source()).body[0]
+    assert isinstance(function, ast.FunctionDef)
+    constructed = [
+        node.lineno
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "subs" for target in node.targets)
+    ]
+    assert constructed, "connect_eagerly no longer assigns a local named 'subs'"
+    first = min(constructed)
+    return [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Return)
+        and node.lineno > first
+        and not (isinstance(node.value, ast.Constant) and node.value.value is None)
+    ]
+
+
+class TestAFailedBringUpReleasesWhatItBuilt:
+    """The regression: every failure exit past the constructor closes the set."""
+
+    def test_a_refused_subscriber_does_not_leave_the_earlier_topics_running(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        topics = _topics()
+        driver, built, reason = _bring_up(monkeypatch, refuse_topic=topics[2])
+        assert reason is not None and topics[2] in reason
+        assert len(built) == 3, "the ladder should have reached the third topic"
+        assert _open(built) == [], "subscribers from the topics that did succeed were left open"
+
+    def test_an_unresolvable_idl_class_does_not_leave_the_earlier_topics_running(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        driver, built, reason = _bring_up(monkeypatch, resolve_fails_on_call=3)
+        assert reason == "transient: IDL module not loaded yet"
+        assert len(built) == 2, "the ladder should have subscribed the first two topics"
+        assert _open(built) == [], "subscribers from the topics that did succeed were left open"
+
+    def test_the_retry_the_docstring_invites_does_not_duplicate_a_subscription(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A transient failure then a second attempt: one reader per topic, not two."""
+        driver, built, reason = _bring_up(monkeypatch, resolve_fails_on_call=3, attempts=2)
+        assert reason is None, "the second attempt should have connected"
+        assert driver._connected is True
+        duplicated = {topic: count for topic, count in Counter(e.topic for e in _open(built)).items() if count > 1}
+        assert duplicated == {}, f"the retry left duplicate subscriptions: {duplicated}"
+
+    def test_cleanup_after_the_retry_leaves_no_orphan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Nothing survives teardown, because everything is on the recorded set."""
+        driver, built, _reason = _bring_up(monkeypatch, resolve_fails_on_call=3, attempts=2)
+        driver.cleanup()
+        assert _open(built) == [], "a subscriber outlived cleanup()"
+
+
+class TestTheFailureIsStillReportedTheSameWay:
+    """Releasing the set must not cost the caller the reason it gave up."""
+
+    def test_the_refusal_reason_is_returned_and_recorded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        topics = _topics()
+        driver, _built, reason = _bring_up(monkeypatch, refuse_topic=topics[2])
+        assert reason is not None
+        assert driver._connect_error == reason
+        assert driver._connected is False
+
+    def test_the_unresolvable_class_reason_is_returned_and_recorded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, _built, reason = _bring_up(monkeypatch, resolve_fails_on_call=3)
+        assert reason == "transient: IDL module not loaded yet"
+        assert driver._connect_error == reason
+        assert driver._connected is False
+
+
+class TestWhatIsUnchanged:
+    """A successful bring-up, and the exit that had nothing to release."""
+
+    def test_a_successful_connect_keeps_its_subscribers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The set is recorded and left running - closing it here would be the opposite bug."""
+        driver, built, reason = _bring_up(monkeypatch)
+        assert reason is None
+        assert len(built) == len(_topics())
+        assert _open(built) == built, "a successful connect closed its own subscribers"
+        assert driver._subs is not None
+
+    def test_a_successful_connect_is_still_torn_down_by_cleanup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, built, _reason = _bring_up(monkeypatch)
+        driver.cleanup()
+        assert _open(built) == []
+
+    def test_a_dds_init_failure_still_reports_without_subscribing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, built, reason = _bring_up(monkeypatch, dds_error="dds init failed: no such interface")
+        assert reason == "dds init failed: no such interface"
+        assert built == [], "nothing should be subscribed once start() has failed"
+        assert driver._connect_error == reason
+
+
+class TestPremises:
+    """Why an unrecorded set is unreachable, and why the first exit may share the path."""
+
+    def test_cleanup_can_only_close_the_recorded_set(self) -> None:
+        """``cleanup`` reads ``self._subs`` and nothing else, so a local is invisible to it."""
+        source = textwrap.dedent(inspect.getsource(G1Driver.cleanup))
+        closes = [
+            ast.unparse(node.func)
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "close"
+        ]
+        assert "self._subs.close" in closes
+        assert all(target.startswith("self._") for target in closes), closes
+
+    def test_closing_a_set_that_never_subscribed_is_a_no_op(self) -> None:
+        """Which is what lets the ``start``-failure exit share the release path."""
+        DDSSubscriberSet("eth0").close()
+
+    def test_the_set_is_recorded_only_after_the_publisher_is_up(self) -> None:
+        """The assignment ordering is the reason a partial ladder is unreachable."""
+        source = _connect_source()
+        assert source.index("self._pubs = pubs") < source.index("self._subs = subs")
+
+
+class TestOneOwnerReleasesThePartialSet:
+    """Structural: no exit past the constructor may forget the rollback."""
+
+    def test_every_failure_exit_routes_through_the_release_helper(self) -> None:
+        returns = _returns_after_the_set_exists()
+        assert len(returns) >= 4, f"expected the four failure exits, found {len(returns)}"
+        routed = [
+            isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "_abort_connect"
+            for node in returns
+        ]
+        assert all(routed), (
+            "a failure exit past the DDSSubscriberSet constructor returns without releasing it: "
+            f"{[ast.unparse(node) for node, ok in zip(returns, routed, strict=True) if not ok]}"
+        )
+
+    def test_the_connect_path_does_not_close_the_set_itself(self) -> None:
+        """One owner: ``subs.close()`` belongs to the helper, not to the ladder."""
+        assert "subs.close()" not in _connect_source()
+        assert "subs.close()" in textwrap.dedent(inspect.getsource(G1Driver._abort_connect))


### PR DESCRIPTION
## What is wrong

`G1Driver.connect_eagerly` builds a `DDSSubscriberSet`, subscribes four topics in
a loop, then initialises the command publisher. Each `subscribe` call starts a
`ch_reader` daemon thread and matches a CycloneDDS reader. The set is a **local
variable** and the driver only takes a handle on it (`self._subs`) once the whole
bring-up has succeeded, so three of the four failure exits past the constructor
returned their reason with those readers still matched, those threads still
looping, and nothing left holding the set that could close them.

Measured on all four exits, with a recording endpoint standing in for the SDK's
`ChannelSubscriber`:

| exit | subscribed | closed (before) | closed (after) |
| --- | --- | --- | --- |
| `start()` refuses | 0 | 0 | 0 |
| IDL class unresolvable | 1 | 0 | 1 |
| a subscriber is refused | 2 | 0 | 2 |
| publisher init refuses | 4 | 4 | 4 |

`cleanup()` cannot recover them. It closes `self._subs`, which a failed bring-up
never assigns, so it is a no-op for exactly the state this leaves behind. And the
method's own docstring invites the retry that compounds it - *"the driver stays
usable, so a caller can fix the cause and call again"* - which measured as three
endpoints built and **zero** closed across three attempts.

## Why nothing caught it

The publisher branch, the last of the four, already closed the set inline. That
made the other three read as a deliberate choice rather than an omission, and it
is also why a reader checking "does this path clean up?" on the branch nearest
the end of the function finds that it does.

## The fix

Every failure exit past the constructor now returns through one `_abort_connect`
helper that closes the set **and** records the reason, so the release cannot
drift from the report the way an inline close on a single branch already had.
The reason a caller sees is unchanged on all four exits, and a successful
bring-up still hands its live subscribers to the driver.

## Verification

Pre-fix split on `main`'s `connect_eagerly` with the new tests present: **6
failed / 8 passed**, and the failures are confined to the two regression classes
(4 + 2). Nothing fires in `TestPremises` (3), `TestWhatIsUnchanged` (3) or
`TestTheFailureIsStillReportedTheSameWay` (2) - the reason a caller reads and the
successful path are unaffected by the change.

Mutation table, 11 rows, control clean, `collected` stable at 14 and `sib` 0 on
every row but one:

| mutation | fires |
| --- | --- |
| control | 0 |
| all four exits un-routed (= `main`) | 6 |
| IDL-class exit un-routed | 4 |
| subscriber exit un-routed | 2 |
| publisher exit un-routed | 1 |
| `start()` exit un-routed | 1 |
| helper closes but forgets to record the reason | 3 (`sib` 1) |
| helper records the reason but does not close | 5 |
| OVER-REACH: a successful connect closes its set too | 2 |
| derived exit scan hardcoded to today's four | 0 |
| hardcoded scan **and** all four un-routed | 5 |

Three of those rows carry the design rather than a behaviour:

- The per-exit union is **5** against `main`'s 6, and the one cell only the full
  revert fires is `test_the_connect_path_does_not_close_the_set_itself` - with
  any single call site still routed, the helper remains the only closer, so only
  losing all four shows up as a single-ownership failure.
- The `start()` and publisher rows fire **only** the structural cell, for
  opposite reasons: `start()` refusing has subscribed nothing, and the publisher
  branch was already closing inline. Neither is observable behaviourally, which
  is what an AST cell over the exits is for.
- The derived-scan row firing **0** beside the hardcoded-plus-defect row firing
  **5** is the pair: hardcoding the exit list to today's four is invisible until
  a fifth exit is added, which is why the scan derives them.

Gate, all three lint commands run separately: `ruff check` clean, `ruff format
--check` 1744 files already formatted, `mypy` 24 errors in 9 files (the standing
baseline on this tree) with **0 attributable** to either changed file.

The new file is dependency-free and reads **14 passed in both dependency modes** -
with the vendor SDK importable, and with it hidden behind a `find_spec` plus
`meta_path` blocker. `tests/drivers/ tests/tools/g1/ tests/test_driver_seam.py`
reads `1133 passed, 3 skipped` and `1118 passed, 18 skipped` in those two modes,
so the same 1136 cells are collected either way with nothing failing. The 479
tree-walking graders read 21 failures, and the same 21 fail identically on
pristine `main` with the change stashed out (`comm` empty in both directions);
they are the standing environmental families on this box - `awsiotsdk`/`awscrt`
absent, which `[all]` installs in CI, plus the lerobot-from-source `encode()`
drift.

## Deliberately not done

`subscribe` appends to `self._subs` under the shared module init lock while
`close()` swaps the container under the instance lock. That asymmetry predates
this change and is untouched here; the fix is confined to which exits release
what the bring-up already built.

No visual artifact: this is a resource-lifecycle fix in a transport helper, not a
policy, simulation, rendering, recording or asset change. The measured
subscribed/closed table is the evidence.
