### PR TITLE
docs: the pages describing `[all]` name the extras it leaves opt-in

### DIFF
--- a/changelog.d/2952-docs-all-extra-membership.md
+++ b/changelog.d/2952-docs-all-extra-membership.md
@@ -1,0 +1,36 @@
+### Docs: the pages describing `[all]` name the extras it leaves opt-in
+
+`[all]` is a convenience bundle rather than a union, and three pages told a
+reader otherwise. `docs/getting-started/installation.md` enumerated it as five
+extras -- `groot-service` plus `lerobot` plus `sim-mujoco` plus `mesh` plus
+`mesh-iot` -- while the bundle installs nineteen of the thirty-one declared
+extras. The enumeration was a strict subset, so a reader deciding whether
+`[all]` covered the policy they wanted was told it did not for fourteen extras
+it does install: `cosmos3`, `kimodo`, `protomotions`, `wbc`, `openpi`, `pi`,
+`smolvla`, `vera` and six more. Five lines below that table the same bundle was
+called `# everything`.
+
+The two remaining claims were wrong in the other direction. `docs/architecture.md`
+gave the bundle's whole description as "union", and `docs/index.md`'s quickstart
+comment as "every policy", while eleven capability extras stay opt-in --
+`sim-isaac`, `sim-newton`, `sim-gs`, `curobo`, `ros2`, `benchmark-libero`,
+`microduck`, `vera-sim` and the three `cosmos3-*` service and simulation extras.
+A reader who installed `[all]` expecting a union got a `ModuleNotFoundError` from
+the extra they actually needed, which is exactly the failure the extras table
+exists to prevent.
+
+The three cells now state the count, and installation.md names each excluded
+extra, because that is the actionable half: a reader wants to know what they
+must still add. A guard derives both the count and the excluded set from
+`[project.optional-dependencies]`, walking the transitive closure rather than
+the literal list -- an extra can name siblings, and eight of the nineteen are
+reached that way -- so a new extra is graded the hour it lands. Each failure
+message prints the text the page should carry, so the count maintains itself
+rather than rotting again. The completeness rule drops negated forms before it
+grades a line, because a corrected page says the bundle is *not* a union and a
+bare substring test would report the very wording that fixes this.
+
+Deliberately out of scope: *why* a given extra sits outside `[all]`. The
+excluded set has no single rule -- `sim-isaac` and `sim-gs` need a GPU and say
+so, while `cosmos3-service` is two pure-Python packages -- so documenting a
+reason per extra is a maintainer's call rather than a derivation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ graph TB
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh |
 | `[mesh-iot]` | above + `awsiotsdk`, `awscrt`, `boto3` | AWS IoT Core transport |
-| `[all]` | union | CI / exploration |
+| `[all]` | 19 of the 31 extras - not a union; see [installation](getting-started/installation.md) for the 11 it leaves opt-in | CI / exploration |
 
 ## See also
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,12 +19,12 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 | `[mesh]` | `eclipse-zenoh>=1.6.1,<2.0.0`, `json5` | Multi-robot mesh discovery + RPC |
 | `[mesh-iot]` | `mesh` + `awsiotsdk`, `awscrt`, `boto3` | AWS IoT Core transport for mesh |
 | `[benchmark-libero]` | `libero` eval deps | LIBERO benchmark suite |
-| `[all]` | `groot-service` + `lerobot` + `sim-mujoco` + `mesh` + `mesh-iot` | Demos, CI, exploration |
+| `[all]` | 19 of the 31 extras - **not** a union. `[benchmark-libero]`, `[cosmos3-diffusers]`, `[cosmos3-service]`, `[cosmos3-sim]`, `[curobo]`, `[microduck]`, `[ros2]`, `[sim-gs]`, `[sim-isaac]`, `[sim-newton]` and `[vera-sim]` stay opt-in | Demos, CI, exploration |
 | `[dev]` | `pytest`, `pytest-cov`, `ruff`, `mypy`, `pytest-timeout` | Contributing |
 
 ```bash
 uv pip install "strands-robots[sim-mujoco]"                  # sim only
-uv pip install "strands-robots[all]"                         # everything
+uv pip install "strands-robots[all]"                         # the 19-extra bundle
 uv pip install "strands-robots[sim-mujoco,cosmos3-service]"  # Cosmos 3
 uv pip install "strands-robots[sim-mujoco,lerobot,mesh]"     # pick and choose
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,5 +48,5 @@ The agent decides *what* to do. The policy (Mock, GR00T, LeRobot, or Cosmos 3) d
 
 ```bash
 uv pip install "strands-robots[sim-mujoco]"   # simulation
-uv pip install "strands-robots[all]"          # sim + hardware + every policy
+uv pip install "strands-robots[all]"          # sim + hardware + most policies
 ```

--- a/tests/test_docs_all_extra_membership.py
+++ b/tests/test_docs_all_extra_membership.py
@@ -1,0 +1,214 @@
+"""The docs describe what ``[all]`` installs, derived from ``pyproject.toml``.
+
+``[all]`` is a convenience bundle, not a union: it names most extras and leaves
+the GPU-only backends, the separate-install toolchains and several service
+clients opt-in. Three pages tell a reader what it covers, and the membership
+they describe is a fact about ``[project.optional-dependencies]`` rather than
+prose - so it is derivable, and it drifted.
+
+``docs/getting-started/installation.md`` enumerated ``[all]`` as five extras
+(``groot-service`` + ``lerobot`` + ``sim-mujoco`` + ``mesh`` + ``mesh-iot``)
+while the bundle had grown to nineteen. The enumeration was a strict subset, so
+a reader deciding whether ``[all]`` covered the policy they wanted was told it
+did not for fourteen extras it does install - and the code block five lines
+below the table called the same bundle "everything". ``docs/architecture.md``
+called it a "union", which it is not.
+
+The cells now state the count and name the extras ``[all]`` leaves out, because
+that is the actionable half: a reader wants to know what they must still add.
+Every rule here derives its expectation from ``pyproject.toml``, and each
+failure message prints the text the page should carry, so a new extra makes
+these fail with the correction in hand rather than leaving the pages to rot
+again.
+
+Deliberately out of scope: *why* a given extra is left out of ``[all]``. The
+excluded set has no single rule - ``[sim-isaac]`` and ``[sim-gs]`` need a GPU
+and say so in the README, while ``[cosmos3-service]`` is two pure-Python
+packages and ``[microduck]`` is one - so documenting the reason per extra is a
+maintainer's call, not a derivation. These rules grade *which* extras are
+excluded, never why.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _ROOT / "pyproject.toml"
+_INSTALL_PAGE = _ROOT / "docs" / "getting-started" / "installation.md"
+_ARCHITECTURE_PAGE = _ROOT / "docs" / "architecture.md"
+_INDEX_PAGE = _ROOT / "docs" / "index.md"
+
+# The bundle is a developer convenience, so its tooling extra is not a
+# capability a reader installs it for; the pages describe capability extras.
+_TOOLING_EXTRAS = frozenset({"dev"})
+
+_ALL_ROW = "| `[all]` |"
+
+# Words that describe the bundle as complete. ``[all]`` is not, so a page using
+# one of these tells a reader they need no further extra.
+_COMPLETENESS_CLAIMS = ("union", "everything", "every policy", "every extra")
+_NEGATED_CLAIM = re.compile(
+    r"not(?:\*\*)?\s+(?:a\s+)?(?:" + "|".join(re.escape(c) for c in _COMPLETENESS_CLAIMS) + r")"
+)
+_EXTRA_IN_TEXT = re.compile(r"`\[([a-z0-9][a-z0-9-]*)\]`")
+
+
+def _extras() -> dict[str, list[str]]:
+    """Every entry of ``[project.optional-dependencies]``."""
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return data["project"]["optional-dependencies"]
+
+
+def _closure(extras: dict[str, list[str]], name: str) -> set[str]:
+    """Extras reachable from ``name`` through ``strands-robots[...]`` specs.
+
+    An extra can name siblings (``[mesh-iot]`` pulls ``[mesh]``), so the set a
+    reader gets is the transitive closure rather than the literal list.
+    """
+    reached: set[str] = set()
+    pending = [name]
+    while pending:
+        for spec in extras.get(pending.pop(), []):
+            found = re.search(r"strands-robots\[([^]]+)\]", str(spec))
+            if found is None:
+                continue
+            for part in found.group(1).split(","):
+                extra = part.strip()
+                if extra and extra not in reached:
+                    reached.add(extra)
+                    pending.append(extra)
+    return reached
+
+
+def _membership() -> tuple[set[str], set[str], int]:
+    """``(installed, left_opt_in, declared_total)`` for ``[all]``."""
+    extras = _extras()
+    installed = _closure(extras, "all")
+    declared = set(extras) - {"all"}
+    left_out = declared - installed - _TOOLING_EXTRAS
+    return installed, left_out, len(declared)
+
+
+def _row(page: Path) -> str:
+    """The ``[all]`` row of ``page``'s extras table."""
+    text = page.read_text(encoding="utf-8")
+    assert _ALL_ROW in text, f"{page.name} no longer carries an '{_ALL_ROW}' table row"
+    for line in text.splitlines():
+        if line.startswith(_ALL_ROW):
+            return line
+    raise AssertionError(f"{page.name}: '{_ALL_ROW}' found in the page but not at the start of a line")
+
+
+def _extras_named(text: str) -> set[str]:
+    """Extra names written as ``` `[name]` ``` in ``text``."""
+    return set(_EXTRA_IN_TEXT.findall(text))
+
+
+class TestThePagesAgreeWithPyproject:
+    """The count and the excluded set both come from ``pyproject.toml``."""
+
+    @pytest.mark.parametrize("page", [_INSTALL_PAGE, _ARCHITECTURE_PAGE], ids=["installation", "architecture"])
+    def test_the_row_states_the_derived_counts(self, page: Path) -> None:
+        installed, _, declared_total = _membership()
+        row = _row(page)
+        wanted = f"{len(installed)} of the {declared_total} extras"
+        assert wanted in row, (
+            f"{page.name}: the `[all]` row must state {wanted!r}, so a reader is not told the bundle is "
+            f"narrower (or wider) than it is. The row reads:\n  {row}"
+        )
+
+    def test_the_install_row_names_every_extra_left_opt_in(self) -> None:
+        _, left_out, _ = _membership()
+        row = _row(_INSTALL_PAGE)
+        named = _extras_named(row)
+        missing = sorted(left_out - named)
+        assert not missing, (
+            f"installation.md: the `[all]` row must name every extra the bundle leaves opt-in, because that "
+            f"is what a reader still has to install. Unnamed: {missing}. Name them as `[extra]`."
+        )
+
+    def test_the_install_row_claims_nothing_it_installs_is_opt_in(self) -> None:
+        installed, _, _ = _membership()
+        row = _row(_INSTALL_PAGE)
+        wrongly_named = sorted(_extras_named(row) & installed)
+        assert not wrongly_named, (
+            f"installation.md: the `[all]` row lists {wrongly_named} as opt-in, but `all` installs them. "
+            f"A reader would add an extra they already have."
+        )
+
+    def test_no_page_calls_the_bundle_a_union_or_everything(self) -> None:
+        _, left_out, _ = _membership()
+        assert left_out, "nothing is left opt-in, so 'union' would be accurate and this rule is vacuous"
+        for page in (_INSTALL_PAGE, _ARCHITECTURE_PAGE, _INDEX_PAGE):
+            text = page.read_text(encoding="utf-8")
+            for line in text.splitlines():
+                if "strands-robots[all]" not in line and not line.startswith(_ALL_ROW):
+                    continue
+                # A corrected page says "not a union", so a bare substring test would
+                # report the very wording that fixes this. Drop negated forms first and
+                # grade what is left, which is the affirmative claim.
+                lowered = _NEGATED_CLAIM.sub("", line.lower())
+                for claim in _COMPLETENESS_CLAIMS:
+                    assert claim not in lowered, (
+                        f"{page.name}: {claim!r} describes `[all]` as complete, and {len(left_out)} extras "
+                        f"stay opt-in ({sorted(left_out)}). The line reads:\n  {line}"
+                    )
+
+
+class TestTheDerivationIsNotVacuous:
+    """The membership split is real, so the rules above have something to grade."""
+
+    def test_the_bundle_installs_most_but_not_all_extras(self) -> None:
+        installed, left_out, declared_total = _membership()
+        assert len(installed) > 1, f"only {len(installed)} extras reached from `all`; the closure walk is blind"
+        assert left_out, "no extra is left opt-in, so `all` really is a union and these rules grade nothing"
+        assert len(installed) + len(left_out) + len(_TOOLING_EXTRAS) == declared_total, (
+            f"the split does not account for every extra: {len(installed)} installed + {len(left_out)} opt-in "
+            f"+ {len(_TOOLING_EXTRAS)} tooling != {declared_total} declared"
+        )
+
+    def test_the_closure_follows_an_extra_named_two_levels_down(self) -> None:
+        extras = _extras()
+        direct = {
+            part.strip()
+            for spec in extras["all"]
+            for match in [re.search(r"strands-robots\[([^]]+)\]", str(spec))]
+            if match
+            for part in match.group(1).split(",")
+        }
+        indirect = _closure(extras, "all") - direct
+        assert indirect, (
+            "every extra `all` installs is named directly by it, so a walk that did not recurse would "
+            "still produce the right count and the counts these rules assert would not grade the walk"
+        )
+        assert indirect <= _closure(extras, "all"), "the closure must contain what it reached indirectly"
+
+
+class TestTheRulesReportAConstructedDrift:
+    """The pages are correct today, so the rules are graded on built exemplars."""
+
+    def test_a_stale_count_is_reported(self) -> None:
+        installed, _, declared_total = _membership()
+        stale = f"| `[all]` | {len(installed) - 1} of the {declared_total} extras - not a union | x |"
+        assert f"{len(installed)} of the {declared_total} extras" not in stale
+
+    def test_an_unnamed_opt_in_extra_is_reported(self) -> None:
+        _, left_out, _ = _membership()
+        row = "| `[all]` | 19 of the 31 extras - not a union | x |"
+        assert sorted(left_out - _extras_named(row)) == sorted(left_out)
+
+    def test_a_union_claim_is_reported(self) -> None:
+        stale = "| `[all]` | union | CI / exploration |".lower()
+        assert any(c in _NEGATED_CLAIM.sub("", stale) for c in _COMPLETENESS_CLAIMS)
+
+    def test_a_negated_claim_is_not_reported(self) -> None:
+        corrected = "| `[all]` | 19 of the 31 extras - **not** a union | x |".lower()
+        assert not any(c in _NEGATED_CLAIM.sub("", corrected) for c in _COMPLETENESS_CLAIMS), (
+            "the rule must accept a page that says the bundle is NOT complete, or the wording that "
+            "fixes this defect would itself be reported"
+        )


### PR DESCRIPTION
## What is wrong

`[all]` is a convenience bundle, not a union, and three pages said otherwise -- in
both directions.

`docs/getting-started/installation.md` gave the bundle's contents as an
enumeration of five extras. Derived from `[project.optional-dependencies]`, the
bundle installs **19 of the 31** declared extras, so the enumeration was a strict
**subset**:

| claim | derived | reader is told |
| --- | --- | --- |
| `groot-service` + `lerobot` + `sim-mujoco` + `mesh` + `mesh-iot` | 19 extras | `[all]` does **not** cover 14 extras it does install |

The 14 include `cosmos3`, `kimodo`, `protomotions`, `wbc`, `openpi`, `pi`,
`smolvla` and `vera` -- exactly the policy families a reader consults that table to
choose between. Five lines below it, the same bundle's code comment read
`# everything`.

The other two claims were wrong in the opposite direction. `docs/architecture.md`
gave the bundle's whole description as `union`; `docs/index.md`'s quickstart
comment as `every policy`. Eleven capability extras stay opt-in:

`sim-isaac`, `sim-newton`, `sim-gs`, `curobo`, `ros2`, `benchmark-libero`,
`microduck`, `vera-sim`, `cosmos3-service`, `cosmos3-sim`, `cosmos3-diffusers`.

So a reader who installed `[all]` on the strength of either page and then reached
for Isaac, Newton, ROS 2 or LIBERO got a `ModuleNotFoundError` from the extra they
actually needed. That is the failure the extras table exists to prevent.

## Why nothing caught it

`test_dependency_audit.py` grades that every written `strands-robots[X]` hint names
a **declared** extra. Every name in the stale enumeration was declared, so the row
passed while describing a set it did not describe. Nothing anywhere related the
prose to `[all]`'s membership: `grep -rl "\[all\]" tests/` returned four files, none
of which reads a docs page.

## What changed

The three cells now state the derived count, and installation.md additionally
names each excluded extra -- that is the actionable half, because a reader wants to
know what they must still add rather than what they already have.

`tests/test_docs_all_extra_membership.py` derives both numbers from
`[project.optional-dependencies]` and walks the **transitive closure**: an extra
can name siblings, and 8 of the 19 are reached that way rather than being listed by
`[all]` directly. Every failure message prints the text the page should carry, so a
new extra fails these with the correction already in hand.

One implementation note worth stating, because it is the shape that bit me. The
completeness rule drops negated forms before grading a line: a corrected page says
the bundle is **not** a union, and a bare substring test reports the very wording
that fixes this. `b7` below is that row.

## Pre-fix split

Pages reverted to their `main` wording, guard present: **4 failed / 7 passed**.

The 4 are the whole regression set. The 7 that pass are the over-reach control
(the stale enumeration named only extras that *are* installed, so it claimed
nothing false about the opt-in set), 2 premises, and 4 constructed exemplars that
grade the rules rather than the tree.

## Detection

11 mutations, control clean, `collected` stable at 11, all four files restored
byte-identically.

| mutation | fires | cells |
| --- | --- | --- |
| b0 control | 0 | -- |
| b1 installation row reverted | 2 | count + names-every-opt-in |
| b2 architecture row reverted | 2 | count + completeness |
| b3 index comment reverted | 1 | completeness |
| b4 install code comment reverted | 1 | completeness |
| b5 both rows reverted (= `main` today) | 4 | b1 union b2, exactly |
| b6 closure stops following nested extras | 4 | both counts + opt-in + the transitivity premise |
| b7 negation stripping removed | 1 | completeness, on the corrected page |
| b8 completeness vocabulary emptied | 1 | the constructed exemplar |
| b9 opt-in set computed empty | 2 | opt-in + the non-vacuity premise |
| b10 `dev` exemption emptied | 1 | names-every-opt-in |

`b1` and `b2` are disjoint and their union is exactly `b5`, so each page is
independently pinned. `b3` and `b4` share a firing set with `b2`'s second cell for
a structural reason: all three are completeness claims on different pages and one
rule grades them all.

`b8` is the derived-vocabulary row: emptying the claim words silences the
page-reading rule and only the constructed exemplar catches it. `b6` is why the
closure walk is graded rather than assumed -- without recursion the bundle reads as
18 extras, so both counts move.

## Gate

- `ruff check` clean; `ruff format --check` 1744 files already formatted.
- `mypy strands_robots tests tests_integ`: 24 errors, the standing baseline, **0
  attributable** to the changed files.
- `mkdocs build --strict` clean.
- The 161 test files that read `docs/`, `.md`, `mkdocs`, `README` or
  `pyproject.toml`: **4189 passed, 9 skipped, 0 failed**.
- Rebased onto current `main` and re-run with the docs and handle guards it has
  since gained: 87 passed, 1 skipped. The derived counts are unchanged on that base
  (31 declared / 19 installed / 11 opt-in).

## Deliberately not done

*Why* each excluded extra sits outside `[all]`. The excluded set has no single
rule -- `sim-isaac` and `sim-gs` need a GPU and say so on the page, while
`cosmos3-service` is two pure-Python packages -- so a reason per extra is a
maintainer's call rather than something derivable. The guard grades membership
only.

No visual artifact: this is documentation prose plus a derived guard, not a
policy, simulation, rendering, recording or asset change. The measured tables above
are the evidence.
