### PR TITLE
fix(tools/g1): g1_battery and g1_mainboard refuse a wrong driver handle

### DIFF
--- a/changelog.d/9997-g1-battery-and-mainboard-refuse-a-wrong-handle.md
+++ b/changelog.d/9997-g1-battery-and-mainboard-refuse-a-wrong-handle.md
@@ -1,0 +1,40 @@
+### Fixed: `g1_battery` and `g1_mainboard` refuse a wrong driver handle instead of raising
+
+`snapshot_handle_refusal` is the shared guard every G1 sensor verb owes its
+caller: the driver handle is a live Python object typed `Any`, so the annotation
+carries no type into the generated tool schema and a caller reaches these verbs
+with whatever it has. Its own docstring says it is "shared because five verbs
+need it rather than restated in each" -- and three had it. `g1_battery` and
+`g1_mainboard` called `driver._snapshot(...)` as their first statement, so an
+unusable handle surfaced as an `AttributeError` naming a private attribute
+rather than as a refusal naming the parameter.
+
+Measured across the five live-handle verbs the package exposes, before this
+change:
+
+| verb | `None` | a robot name | `{}` | `7` | `[]` |
+| --- | --- | --- | --- | --- | --- |
+| `g1_battery` | raises | raises | raises | raises | raises |
+| `g1_mainboard` | raises | raises | raises | raises | raises |
+| `g1_imu` | refused | refused | refused | refused | refused |
+| `g1_lidar_state` | refused | refused | refused | refused | refused |
+| `g1_lidar_summary` | refused | refused | refused | refused | refused |
+
+All five refuse after it. `tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py`
+goes from 8 failed / 10 passed to 18 passed.
+
+The two verbs now route through the same helper the other three do, so the
+refusal for a wrong handle is identical everywhere rather than merely equivalent
+in verdict, and a caller told `'NoneType' object has no attribute '_snapshot'`
+is instead told which verb refused, which parameter it refused, and what to pass.
+
+Why the graders were green on each half. The sweep derives its population from
+the tree -- any `@tool` in the package whose first parameter is annotated `Any`
+-- so it grades a verb added later without being edited, which is the right
+shape. It went green on the branch that introduced it because neither
+`g1_battery` nor `g1_mainboard` was on that branch's base, and green on each
+verb's own branch because the sweep was not there yet. The merge-base overlap
+check did not bridge them either: it intersects *changed file paths*, and a
+tree-derived sweep reads files it never touches, so the pair showed no overlap
+(`strands-labs/robots#2791`). A whole-tree grader is the one a diff-scoped
+selector cannot see (`strands-labs/robots#2940`).

--- a/strands_robots/tools/g1/g1_battery.py
+++ b/strands_robots/tools/g1/g1_battery.py
@@ -60,6 +60,8 @@ from typing import Any
 
 from strands import tool
 
+from strands_robots.tools.g1._g1_common import snapshot_handle_refusal
+
 
 @tool
 def g1_battery(driver: Any) -> dict[str, Any]:
@@ -97,6 +99,10 @@ def g1_battery(driver: Any) -> dict[str, Any]:
         carries ``present=False`` and every field ``None`` - the verb
         does not fabricate a reading the driver does not have.
     """
+    refusal = snapshot_handle_refusal("g1_battery", driver)
+    if refusal is not None:
+        return refusal
+
     snapshot = driver._snapshot("_battery")
     if snapshot is None:
         return {

--- a/strands_robots/tools/g1/g1_mainboard.py
+++ b/strands_robots/tools/g1/g1_mainboard.py
@@ -67,6 +67,8 @@ from typing import Any
 
 from strands import tool
 
+from strands_robots.tools.g1._g1_common import snapshot_handle_refusal
+
 
 @tool
 def g1_mainboard(driver: Any) -> dict[str, Any]:
@@ -112,6 +114,10 @@ def g1_mainboard(driver: Any) -> dict[str, Any]:
         default), so a partial reading is decidable rather than
         surfaced as an empty dict.
     """
+    refusal = snapshot_handle_refusal("g1_mainboard", driver)
+    if refusal is not None:
+        return refusal
+
     snapshot = driver._snapshot("_mainboard")
     if snapshot is None:
         return {


### PR DESCRIPTION
## What is wrong

**`main` is red at `3004559e`.** `tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py` is **8 failed, 10 passed** on the current default branch, so the required `call-test-lint / Test and Lint` check cannot go green for anyone until this lands.

`snapshot_handle_refusal` is the shared guard a G1 sensor verb owes its caller. The `driver` parameter is a live Python object typed `Any` -- that annotation is deliberate (it keeps this package out of the import cycle the driver's reach into `ensure_dds` would close) but it carries no type into the generated tool schema, so a caller reaches these verbs with whatever handle it has. The helper's own docstring states the intended population:

> This is that guard, shared because **five** verbs need it rather than restated in each.

Three called it. `g1_battery` and `g1_mainboard` opened with `driver._snapshot(...)` as their first statement, so an unusable handle surfaced as `AttributeError: 'NoneType' object has no attribute '_snapshot'` -- a message that names a private attribute and tells the caller nothing about which verb refused or what to pass.

Measured across all five live-handle verbs the package exposes, on the five wrong-handle shapes the sweep grades:

| verb | `None` | a robot name | `{}` | `7` | `[]` |
| --- | --- | --- | --- | --- | --- |
| `g1_battery` | raises | raises | raises | raises | raises |
| `g1_mainboard` | raises | raises | raises | raises | raises |
| `g1_imu` | refused | refused | refused | refused | refused |
| `g1_lidar_state` | refused | refused | refused | refused | refused |
| `g1_lidar_summary` | refused | refused | refused | refused | refused |

## Why every check was green on each half

This is the part worth reading, because no single PR was wrong.

The sweep derives its population **from the tree** -- every `@tool` in the g1 package whose first parameter is annotated `Any` -- rather than from a list of names, so a verb added later is graded without the file being edited. That is the right shape, and it is exactly why it grades these two now.

It went green on both sides of the merge anyway:

- green on the branch that introduced the sweep, because neither `g1_battery` (#2938) nor `g1_mainboard` (#2947) was on that branch's merge base;
- green on each verb's own branch, because the sweep was not there yet.

And `Detect an untested overlap with the base branch` did not bridge them, because it intersects **changed file paths**: the sweep touches `tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py` and the verbs touch `strands_robots/tools/g1/g1_*.py`, so the intersection is empty while the semantic dependency is total. That is #2791 ("the file-path intersection is blind to a test that reads a file the base changed") landing for real rather than hypothetically, and the same class as #2940: **a whole-tree grader is the one a diff-scoped selector cannot see.** I am adding this measurement to both issues rather than widening the check here.

## The change

Two verbs now route through the same helper the other three do -- one import and a three-line guard each, ahead of the accessor call:

```python
refusal = snapshot_handle_refusal("g1_mainboard", driver)
if refusal is not None:
    return refusal
```

So the refusal for a wrong handle is *identical* everywhere rather than merely equivalent in verdict, which is the property the shared helper exists to buy (AGENTS.md convention 11). 12 lines of code across two files; no behaviour on the accepted path is touched.

## Verification

| | before | after |
| --- | --- | --- |
| `test_a_live_handle_verb_refuses_a_wrong_handle.py` | 8 failed, 10 passed | **18 passed** |
| all five verbs x five wrong shapes | 10 raise, 15 refuse | **25 refuse** |

`tests/tools/g1` + `tests/drivers`: no id changes beyond the eight fixed above (29 remaining failures are `lerobot` / `awsiotsdk` absent in this sandbox, all present on the base and installed in CI). Changelog gates `tests/test_changelog_fragment_gate.py`, `test_changelog_fragments.py`, `test_changelog_format.py`: 89 passed. `ruff check` and `ruff format --check` clean on both touched files.

No visual artifact: this is a refusal path in two agent-facing reader verbs -- no policy, simulation, rendering, recording or asset change. The tables above are the evidence.

## Deliberately not done

- **Not widening the overlap check.** The path-intersection gap is real and is #2791's subject; fixing it inside a hotfix for red `main` would couple an urgent one-line-per-verb fix to a CI redesign. Measurement posted to #2791.
- **Not renaming the sweep's three-verb anchor cell.** `test_the_scan_reaches_the_three_sensor_verbs_on_main` asserts `expected <= verbs`, a subset, so it stays correct with five verbs in the population. Renaming it is churn in a file this PR does not otherwise touch.
- **Not guarding `g1_state`.** It reads `get_status`, not `_snapshot`, so it is outside this helper's contract; #2950 is the PR for that verb.
