### PR TITLE
fix(tools/g1): the live-handle refusal reaches every sensor verb

### DIFF
--- a/changelog.d/2954-live-handle-refusal-reaches-every-g1-sensor-verb.md
+++ b/changelog.d/2954-live-handle-refusal-reaches-every-g1-sensor-verb.md
@@ -1,0 +1,21 @@
+### Fixed: the live-handle refusal reaches every G1 sensor verb
+
+`g1_battery` and `g1_mainboard` dereferenced `driver._snapshot(...)` on trust, so a
+handle that is not a G1 driver raised past the `@tool` boundary that
+`strands_robots.tools.g1`'s module docstring says never raises: a robot name in place
+of the handle, an omitted handle, or an object carrying the accessor as data rather
+than as a method each surfaced as an `AttributeError` or a `TypeError` instead of the
+structured error envelope. Both verbs now consult
+`strands_robots.tools.g1._g1_common.snapshot_handle_refusal` before touching the
+driver, which is what their three sibling sensor verbs already did.
+
+The two verbs and the guard that grades them crossed on `main`, which is why neither
+pull request could see it. `g1_battery` merged forty minutes before the derived
+guard; `g1_mainboard` landed eighty seconds after it. The required status check reads
+a pull request's head alone, so a branch that forked before the guard never runs it,
+and a branch that forked before a verb never sees that verb - both merged green and
+the two together left `main` red. On `main` today
+`tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py` reports 8 failed
+and 10 passed; with this change it reports 18 passed. That guard discovers every
+live-handle verb from the package rather than naming them, so it covers these two
+without a new cell and covers the next one on arrival.

--- a/strands_robots/tools/g1/g1_battery.py
+++ b/strands_robots/tools/g1/g1_battery.py
@@ -60,6 +60,8 @@ from typing import Any
 
 from strands import tool
 
+from strands_robots.tools.g1._g1_common import snapshot_handle_refusal
+
 
 @tool
 def g1_battery(driver: Any) -> dict[str, Any]:
@@ -97,6 +99,10 @@ def g1_battery(driver: Any) -> dict[str, Any]:
         carries ``present=False`` and every field ``None`` - the verb
         does not fabricate a reading the driver does not have.
     """
+    refusal = snapshot_handle_refusal("g1_battery", driver)
+    if refusal is not None:
+        return refusal
+
     snapshot = driver._snapshot("_battery")
     if snapshot is None:
         return {

--- a/strands_robots/tools/g1/g1_mainboard.py
+++ b/strands_robots/tools/g1/g1_mainboard.py
@@ -67,6 +67,8 @@ from typing import Any
 
 from strands import tool
 
+from strands_robots.tools.g1._g1_common import snapshot_handle_refusal
+
 
 @tool
 def g1_mainboard(driver: Any) -> dict[str, Any]:
@@ -112,6 +114,10 @@ def g1_mainboard(driver: Any) -> dict[str, Any]:
         default), so a partial reading is decidable rather than
         surfaced as an empty dict.
     """
+    refusal = snapshot_handle_refusal("g1_mainboard", driver)
+    if refusal is not None:
+        return refusal
+
     snapshot = driver._snapshot("_mainboard")
     if snapshot is None:
         return {


### PR DESCRIPTION
## What this fixes

`main` is red right now. `tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py`
reports **8 failed, 10 passed** on `upstream/main` at `a2fd1c95`, and both offenders are
sensor verbs that dereference `driver._snapshot(...)` without checking the handle first.

Five verbs in `strands_robots.tools.g1` take a live `driver` handle. Three consult
`_g1_common.snapshot_handle_refusal` before touching it; `g1_battery` and `g1_mainboard` did not,
so an unusable handle raised past the `@tool` boundary that the package's own module
docstring promises never raises:

| handle | `g1_battery` on main | `g1_battery` here |
|---|---|---|
| `"g1"` (a robot name) | `AttributeError: 'str' object has no attribute '_snapshot'` | `error` naming the verb and the parameter |
| omitted (`None`) | `AttributeError: 'NoneType' object has no attribute '_snapshot'` | `error` |
| an object carrying `_snapshot` as data | `TypeError: 'NoneType' object is not callable` | `error` |
| an integer, a list, an empty mapping | `AttributeError` | `error` |

`g1_mainboard` behaves identically. The last row is the one a presence test would
miss: the attribute exists and is not callable, which is reachable from any object
built out of a cached dump.

## Why neither pull request could catch it

The two verbs and the guard that grades them crossed on `main`:

| landed | change |
|---|---|
| 12:15:07Z | `g1_battery` (#2938) |
| 12:55:58Z | the derived guard (#2948) |
| 12:57:18Z | `g1_mainboard` (#2947) |

The required status check reads a pull request's head alone, so `g1_battery`'s branch
forked before the guard existed and never ran it, and the guard's branch forked before
`g1_mainboard` existed and never saw it. Both merged green, and the two together left
`main` red. Nothing here is a defect in either review.

## Regression evidence

The guard added by #2948 **is** the regression test: it discovers every live-handle verb
from the package rather than naming them, so it already covers these two and will cover
the next one on arrival. No new cell is added.

| tree | that guard |
|---|---|
| `upstream/main` | 8 failed, 10 passed |
| this branch | **18 passed** |

Attributed against a pristine `main` with the change stashed out, `tests/tools/g1/` plus
`tests/drivers/` goes from **9 failures to 1**: 8 fixed, 0 introduced.

## Gate

`ruff check` clean; `ruff format --check` 1750 files already formatted; `mypy` 24 errors
in 9 files, which is this tree's standing baseline, with **0 attributable** to either
changed file. `tests/tools/g1/` plus `tests/drivers/`: 1152 passed, 3 skipped.

## Deliberately not done

The one remaining failure in that area is unrelated and is **not** visible to CI.
`tests/drivers/test_g1_mainboard_reads_the_declared_fields.py::TestTheFrozenDeclarationIsTrue`
reports that the frozen declaration has dropped `sys_state` and `tick` relative to the
SDK's real `MainBoardState_`. That cell is gated on the vendor SDK, which is installed
from a git clone rather than from an index, so it **skips** where the SDK is absent
(`17 passed, 1 skipped`) and fails only where it is present (`1 failed, 17 passed`) - on
any machine attached to a robot. It is a different defect in a different file with its
own contract question about which declaration is authoritative, so it belongs in its own
change rather than being folded into a red-main fix.
