### PR TITLE
feat(tools/g1): port g1_list_velocity_envelope and g1_velocity_admits (refs #358)

### DIFF
--- a/changelog.d/2965-g1-velocity-envelope-port.md
+++ b/changelog.d/2965-g1-velocity-envelope-port.md
@@ -10,8 +10,13 @@
   the SDK side. The two verbs let a caller decide the ``rc=7404``
   gate-refused refusal decidably before a future driver-side
   ``SetVelocity`` wrapper fires; ``g1_velocity_admits`` names every
-  violated dimension in one call rather than one per dispatch attempt,
-  and both verbs surface :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`
+  violated dimension in one call rather than one per dispatch attempt.
+  The three abs-max clamps admit their boundary (a saturated command is
+  still a command) while ``duration_min_seconds`` is exclusive, so a
+  ``duration`` of exactly zero - a distance/speed computation that
+  rounded down, say - refuses rather than reading as an admitted walk
+  the controller would silently drop. Both verbs surface
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`
   so a caller comparing an intended write against both conditions
   (envelope + gate) has the FSM set on hand. No ``unitree_sdk2py``
   submodule loads on import - the envelope table is a module-level

--- a/changelog.d/2965-g1-velocity-envelope-port.md
+++ b/changelog.d/2965-g1-velocity-envelope-port.md
@@ -1,0 +1,19 @@
+### Feature
+
+- Added `strands_robots.tools.g1.g1_list_velocity_envelope` and
+  `strands_robots.tools.g1.g1_velocity_admits`, two read-only ``@tool``
+  verbs that snapshot the ``LocoClient.SetVelocity`` walkable range the
+  neon bundle (``cagataycali/neon-the-g1/tools/g1_locomotion.py``)
+  observed against the real robot on a gantry. The SDK itself places no
+  clamps on ``(vx, vy, vyaw, duration)``: any finite argument reaches
+  the controller unchanged, so the envelope lives here rather than on
+  the SDK side. The two verbs let a caller decide the ``rc=7404``
+  gate-refused refusal decidably before a future driver-side
+  ``SetVelocity`` wrapper fires; ``g1_velocity_admits`` names every
+  violated dimension in one call rather than one per dispatch attempt,
+  and both verbs surface :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`
+  so a caller comparing an intended write against both conditions
+  (envelope + gate) has the FSM set on hand. No ``unitree_sdk2py``
+  submodule loads on import - the envelope table is a module-level
+  snapshot, matching the SDK-load hygiene the rest of this package
+  carries. Refs strands-labs/robots#358.

--- a/strands_robots/tools/g1/g1_velocity_envelope.py
+++ b/strands_robots/tools/g1/g1_velocity_envelope.py
@@ -1,0 +1,306 @@
+"""Agent-facing lookup for the velocity envelope ``LocoClient.SetVelocity`` admits.
+
+The Unitree G1 locomotion SDK
+(:class:`unitree_sdk2py.g1.loco.g1_loco_client.LocoClient`) exposes a
+continuous velocity setter via ``SetVelocity(vx, vy, vyaw, duration)`` and
+its ``Move(vx, vy, vyaw, continous_move=True)`` cousin. The SDK itself
+places *no* clamps on those arguments: a caller that passes ``vx=10.0`` or
+``duration=86400`` reaches the controller unchanged, and the controller's
+own behaviour above those numbers is undefined - the G1 has no runaway
+guard on that write path. The neon bundle's ``g1_move_velocity`` verb
+(``cagataycali/neon-the-g1/tools/g1_locomotion.py``) fronts the same call
+under a fixed set of clamps observed against the real robot on a gantry:
+``vx``/``vy`` treated as speed magnitudes bounded by
+:data:`_VX_ABS_MAX`/:data:`_VY_ABS_MAX`, ``vyaw`` by
+:data:`_VYAW_ABS_MAX`, and ``duration`` bounded by
+:data:`_DURATION_MAX_SECONDS`. This module surfaces the envelope to an
+agent so a caller can decide the refusal decidably before a future
+driver-side wrapper fires, rather than pinning it inside the write path
+where the refusal is invisible to the planner.
+
+Two things this module is deliberately *not*:
+
+* An execution path. The neon bundle's ``g1_move_velocity`` verb wrapped
+  ``LocoClient.SetVelocity`` under a single-writer lock; that write is
+  the same ``rt/lowcmd``-adjacent locomotion topic
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS` gates, which
+  today's :class:`~strands_robots.drivers.g1.G1Driver` refuses through
+  :meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates` on any
+  arm-SDK-shaped write while ``_fsm_id`` is outside that set. A future
+  driver method that fronts ``SetVelocity`` will land the write verb;
+  refs strands-labs/robots#358 for the SDK-facing gate work that write
+  belongs on. This module ports the read-only envelope half without also
+  introducing a second locomotion writer path the driver does not yet
+  own.
+* An SDK re-import. The clamp table is captured here as module-level
+  constants so ``import strands_robots.tools.g1.g1_velocity_envelope``
+  pulls no ``unitree_sdk2py`` submodule - the import-hygiene contract
+  every other file in this package carries, refs strands-labs/robots#358.
+  A revision of the neon bundle's observed bounds is a driver-side
+  update; when the driver's velocity method lands, its refusal will
+  quote the same code the ``7404`` entry in
+  :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries.
+
+What this module does not decide.
+
+* Whether the driver's live ``_fsm_id`` is currently inside
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. That is a
+  driver-instance read carried on the driver's ``get_status`` envelope;
+  a caller planning a velocity command compares the driver's live fsm
+  against :func:`g1_list_velocity_envelope`'s ``walk_ready_fsm_ids`` to
+  see whether the write gate is currently open. The two membership
+  tests together - envelope for the vector, walk_ready for the gate -
+  are the two conditions a future write verb would refuse on.
+* Whether ``rt/lowcmd`` is currently held by another writer. The
+  driver's single-writer lock reports that at wire time; a caller
+  planning a velocity write cannot decide it without opening the
+  topic itself, and this module opens no channel.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from strands import tool
+
+from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
+
+#: The absolute-value clamp the neon ``g1_move_velocity`` verb places on
+#: ``vx`` before dispatch. The value is the one the neon bundle observed
+#: as walkable on a gantry; above it the controller's response is
+#: undefined and the robot may skate. Named as an absolute bound because
+#: the neon clamp is symmetric (``vx`` reversed becomes reverse-walk of
+#: the same magnitude).
+_VX_ABS_MAX: float = 0.8
+
+#: The absolute-value clamp on ``vy`` (lateral velocity). Kept smaller
+#: than ``vx`` because the G1's balance controller has less headroom on
+#: sideways strafe than on forward walk; the neon bundle's docstring
+#: names the safe range as ``|vy| <= 0.2`` and this envelope quotes that.
+_VY_ABS_MAX: float = 0.2
+
+#: The absolute-value clamp on ``vyaw`` (in-place rotation rate). The
+#: neon bundle's ``g1_turn`` verb further clamps its own ``yaw_rate``
+#: input to ``[0.1, 0.6]``; this envelope quotes the higher ceiling that
+#: ``g1_move_velocity`` observed as walkable, and a caller wanting a
+#: turn-specific ceiling reaches :data:`_YAW_RATE_MAX` below.
+_VYAW_ABS_MAX: float = 0.6
+
+#: The upper clamp on ``duration`` (seconds) a single non-continuous
+#: velocity write may keep the leg controller commanded for. Larger
+#: values on the SDK path reach the controller as-is and would walk the
+#: robot for hours if the caller times out; the neon bundle caps at
+#: :data:`_DURATION_MAX_SECONDS` on the single-shot path and switches
+#: to ``Move(continous_move=True)`` for anything longer, so this bound
+#: is the boundary between the two modes rather than the SDK's own
+#: limit (the SDK does not have one).
+_DURATION_MAX_SECONDS: float = 10.0
+
+#: The lower clamp on ``duration``. Zero-or-negative durations reach the
+#: SDK as no-op-shaped writes today (the controller ignores them without
+#: raising), so the neon bundle refuses them here rather than letting a
+#: silently-dropped command look like a successful walk to the planner.
+_DURATION_MIN_SECONDS: float = 0.0
+
+#: Additional bounds for the ``g1_walk_forward`` and ``g1_turn`` sugar
+#: verbs the neon bundle layers on top of ``g1_move_velocity``. Named
+#: alongside the vector clamp so a caller planning a distance-shaped
+#: walk sees both the sugar-verb bound and the underlying vector bound
+#: in the same envelope.
+_DISTANCE_ABS_MAX: float = 1.0
+_SPEED_MIN: float = 0.05
+_SPEED_MAX: float = 0.5
+_ANGLE_ABS_MAX: float = 2.0 * math.pi
+_YAW_RATE_MIN: float = 0.1
+_YAW_RATE_MAX: float = 0.6
+
+#: The error-table entry the driver's own ``_check_motion_gates`` quotes
+#: when it refuses a locomotion-shaped write on an FSM outside
+#: :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. Named here so
+#: the returned envelope carries the exact refusal string a future
+#: driver-side velocity wrapper would surface, and so a re-wording of
+#: it lands in one place instead of drifting between the driver's log
+#: and this lookup. The write path and this lookup share the constant.
+_GATE_REFUSAL_CODE: int = 7404
+
+
+def _envelope() -> dict[str, Any]:
+    """Build the envelope descriptor the verbs return.
+
+    Kept here rather than inlined in :func:`g1_list_velocity_envelope`
+    so :func:`g1_velocity_admits` names the same fields on its
+    admitted-path payload and so a widen to the descriptor lands in
+    one place. Every field is a snapshot read; no bus is touched.
+    """
+    return {
+        "vx_abs_max": _VX_ABS_MAX,
+        "vy_abs_max": _VY_ABS_MAX,
+        "vyaw_abs_max": _VYAW_ABS_MAX,
+        "duration_min_seconds": _DURATION_MIN_SECONDS,
+        "duration_max_seconds": _DURATION_MAX_SECONDS,
+        "distance_abs_max": _DISTANCE_ABS_MAX,
+        "speed_min": _SPEED_MIN,
+        "speed_max": _SPEED_MAX,
+        "angle_abs_max": _ANGLE_ABS_MAX,
+        "yaw_rate_min": _YAW_RATE_MIN,
+        "yaw_rate_max": _YAW_RATE_MAX,
+    }
+
+
+@tool
+def g1_list_velocity_envelope() -> dict[str, Any]:
+    """Return the velocity clamp envelope the neon bundle observed as walkable.
+
+    Read-only. No driver instance, no DDS, no SDK: every field is a
+    module-level constant. Useful before a future driver-side wrapper
+    for ``LocoClient.SetVelocity`` is called, so a caller can compare
+    an intended ``(vx, vy, vyaw, duration)`` vector against the
+    envelope the neon bundle's ``g1_move_velocity`` refused outside of,
+    and can also compare the driver's live ``fsm_id`` (from
+    ``G1Driver.get_status``) against ``walk_ready_fsm_ids`` to decide
+    whether the locomotion write gate is currently open.
+
+    Returns:
+        A dict with ``status``; an ``envelope`` sub-dict carrying every
+        clamp the neon bundle applied (``vx_abs_max``, ``vy_abs_max``,
+        ``vyaw_abs_max``, ``duration_min_seconds``,
+        ``duration_max_seconds``) plus the sugar-verb clamps
+        (``distance_abs_max``, ``speed_min``/``speed_max``,
+        ``angle_abs_max``, ``yaw_rate_min``/``yaw_rate_max``); a
+        ``walk_ready_fsm_ids`` list quoting
+        :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`, the set
+        the driver's motion gate admits locomotion-shaped writes on;
+        and a ``refusals`` list carrying the ``7404`` gate-refused
+        code and its decoded text, the one a future write verb would
+        surface. Every field is a snapshot of an observed bound or a
+        driver constant; no dynamic decode runs here.
+    """
+    return {
+        "status": "success",
+        "envelope": _envelope(),
+        "walk_ready_fsm_ids": sorted(WALK_FSMS),
+        "refusals": [
+            {"code": _GATE_REFUSAL_CODE, "text": ERR_CODES[_GATE_REFUSAL_CODE]},
+        ],
+    }
+
+
+def _finite(value: float) -> bool:
+    """Return whether ``value`` is a finite float.
+
+    Kept here rather than pulled from ``strands_robots.utils`` because
+    the envelope check needs only the finiteness half of
+    :func:`~strands_robots.utils.positive_finite_number_error`; the
+    positivity half does not apply (``vx``/``vy``/``vyaw`` may be
+    negative). A future consolidation with the shared validator lands
+    when the driver-side write verb reuses this admits function.
+    """
+    return math.isfinite(float(value))
+
+
+@tool
+def g1_velocity_admits(
+    vx: float = 0.0,
+    vy: float = 0.0,
+    vyaw: float = 0.0,
+    duration: float = 1.0,
+) -> dict[str, Any]:
+    """Decide whether a ``(vx, vy, vyaw, duration)`` vector sits inside the envelope.
+
+    Read-only. Compares the four arguments against the clamps
+    :func:`g1_list_velocity_envelope` returns and reports every
+    dimension that would be refused, so a caller sees the full set of
+    boundary violations in one call rather than one per dispatch
+    attempt. No driver instance, no DDS, no SDK: the decision reads
+    only module-level constants and the arguments themselves.
+
+    A vector inside the envelope is *not* the same as an admitted
+    write: the driver's motion gate (``_check_motion_gates``) also
+    refuses on ``_fsm_id`` outside
+    :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`, which this
+    verb does not read (that is a live driver-instance query answered
+    by :mod:`~strands_robots.tools.g1.g1_state` and
+    :mod:`~strands_robots.tools.g1.g1_motion_gates`). The returned
+    envelope names ``walk_ready_fsm_ids`` so a caller comparing an
+    intended write against both conditions has the FSM set on hand.
+
+    Args:
+        vx: forward velocity in metres per second. Any finite float;
+            an ``|vx|`` above ``vx_abs_max`` reads as refused.
+        vy: lateral velocity in metres per second. Same shape as
+            ``vx`` against ``vy_abs_max``.
+        vyaw: yaw rate in radians per second. Same shape against
+            ``vyaw_abs_max``.
+        duration: seconds to keep the velocity commanded on the
+            single-shot path. Refused below ``duration_min_seconds``
+            or above ``duration_max_seconds``.
+
+    Returns:
+        A dict with ``status``; an ``admits`` bool naming whether
+        every dimension is inside its clamp; a ``refusals`` list of
+        per-dimension refusal descriptors, each carrying the dimension
+        name, the offending value, the clamp it violated, and the
+        ``7404`` gate-refusal code the driver would quote if the
+        write were attempted while the vector is outside the
+        envelope; the same ``envelope`` sub-dict
+        :func:`g1_list_velocity_envelope` returns; and
+        ``walk_ready_fsm_ids`` for the follow-on gate decision. On
+        an admitted vector the ``refusals`` list is empty; on a
+        rejected vector every violated dimension is named.
+    """
+    envelope = _envelope()
+    refusals: list[dict[str, Any]] = []
+
+    def _reject(dimension: str, value: float, bound_key: str, bound: float, cmp: str) -> None:
+        refusals.append(
+            {
+                "dimension": dimension,
+                "value": float(value),
+                "bound_key": bound_key,
+                "bound": bound,
+                "comparison": cmp,
+                "code": _GATE_REFUSAL_CODE,
+                "text": ERR_CODES[_GATE_REFUSAL_CODE],
+            }
+        )
+
+    for name, value, bound_key, bound in (
+        ("vx", vx, "vx_abs_max", _VX_ABS_MAX),
+        ("vy", vy, "vy_abs_max", _VY_ABS_MAX),
+        ("vyaw", vyaw, "vyaw_abs_max", _VYAW_ABS_MAX),
+    ):
+        if not _finite(value):
+            _reject(name, value, bound_key, bound, "non-finite")
+            continue
+        if abs(float(value)) > bound:
+            _reject(name, value, bound_key, bound, "|value| > bound")
+
+    if not _finite(duration):
+        _reject("duration", duration, "duration_max_seconds", _DURATION_MAX_SECONDS, "non-finite")
+    else:
+        d = float(duration)
+        if d < _DURATION_MIN_SECONDS:
+            _reject(
+                "duration",
+                duration,
+                "duration_min_seconds",
+                _DURATION_MIN_SECONDS,
+                "value < bound",
+            )
+        elif d > _DURATION_MAX_SECONDS:
+            _reject(
+                "duration",
+                duration,
+                "duration_max_seconds",
+                _DURATION_MAX_SECONDS,
+                "value > bound",
+            )
+
+    return {
+        "status": "success",
+        "admits": not refusals,
+        "refusals": refusals,
+        "envelope": envelope,
+        "walk_ready_fsm_ids": sorted(WALK_FSMS),
+    }

--- a/strands_robots/tools/g1/g1_velocity_envelope.py
+++ b/strands_robots/tools/g1/g1_velocity_envelope.py
@@ -101,6 +101,10 @@ _DURATION_MAX_SECONDS: float = 10.0
 #: SDK as no-op-shaped writes today (the controller ignores them without
 #: raising), so the neon bundle refuses them here rather than letting a
 #: silently-dropped command look like a successful walk to the planner.
+#: This bound is **exclusive** and is the one asymmetry in this envelope:
+#: the abs-max clamps admit their boundary (``|value| > bound``) because a
+#: saturated command is a command, while the value *at* this bound is the
+#: no-op the refusal exists to catch, so it refuses on ``value <= bound``.
 _DURATION_MIN_SECONDS: float = 0.0
 
 #: Additional bounds for the ``g1_walk_forward`` and ``g1_turn`` sugar
@@ -233,8 +237,11 @@ def g1_velocity_admits(
         vyaw: yaw rate in radians per second. Same shape against
             ``vyaw_abs_max``.
         duration: seconds to keep the velocity commanded on the
-            single-shot path. Refused below ``duration_min_seconds``
-            or above ``duration_max_seconds``.
+            single-shot path. Refused at or below
+            ``duration_min_seconds`` - that bound is exclusive, so a
+            ``duration`` of exactly zero is refused rather than
+            admitted - and refused above ``duration_max_seconds``,
+            which is inclusive like the three abs-max clamps.
 
     Returns:
         A dict with ``status``; an ``admits`` bool naming whether
@@ -280,13 +287,13 @@ def g1_velocity_admits(
         _reject("duration", duration, "duration_max_seconds", _DURATION_MAX_SECONDS, "non-finite")
     else:
         d = float(duration)
-        if d < _DURATION_MIN_SECONDS:
+        if d <= _DURATION_MIN_SECONDS:
             _reject(
                 "duration",
                 duration,
                 "duration_min_seconds",
                 _DURATION_MIN_SECONDS,
-                "value < bound",
+                "value <= bound",
             )
         elif d > _DURATION_MAX_SECONDS:
             _reject(

--- a/tests/drivers/test_g1_velocity_envelope_reads_the_walkable_range.py
+++ b/tests/drivers/test_g1_velocity_envelope_reads_the_walkable_range.py
@@ -1,0 +1,319 @@
+"""The velocity-envelope lookup tools name what ``LocoClient.SetVelocity`` walks.
+
+The Unitree G1 locomotion SDK
+(:class:`unitree_sdk2py.g1.loco.g1_loco_client.LocoClient`) exposes
+``SetVelocity(vx, vy, vyaw, duration)`` and its ``Move(vx, vy, vyaw,
+continous_move=True)`` cousin without clamps of its own: any finite
+argument reaches the controller unchanged, and the controller's
+behaviour above the neon-bundle-observed walkable range is undefined.
+The :mod:`strands_robots.tools.g1.g1_velocity_envelope` module snapshots
+that observed range into module-level constants and exposes two agent-
+facing verbs - :func:`g1_list_velocity_envelope` (name the whole
+envelope) and :func:`g1_velocity_admits` (decide one query) - so a
+caller can decide the refusal decidably before a future locomotion
+write path is attempted. The tests here fix that contract without
+pulling the SDK: the module is loadable on a host without
+``unitree_sdk2py`` (the same SDK-load-hygiene rule every other file
+under :mod:`strands_robots.tools.g1` carries, refs
+strands-labs/robots#358), and every membership answer is read off the
+module's own snapshot rather than restated in the tests, so a widen or
+narrow to the observed range surfaces here as a shape change rather
+than as a diverging table this file would need to manually update.
+
+Two things this file's cells deliberately do not pin:
+
+* The SDK's own answer at wire time. The envelope is the neon
+  bundle's observed range, not the SDK's own clamps (the SDK has
+  none). A driver-side wrapper for ``SetVelocity`` that lands later
+  will re-check the envelope at wire time and its refusal string
+  will quote the ``7404`` gate-refusal code the driver's
+  ``_check_motion_gates`` also quotes.
+* Whether the driver's live ``fsm_id`` sits inside
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. That is a
+  live driver-instance read and belongs on
+  :mod:`~strands_robots.tools.g1.g1_state` /
+  :mod:`~strands_robots.tools.g1.g1_motion_gates`; the verb surfaces
+  the set as a snapshot so a caller comparing an intended write
+  against both conditions has the FSM set on hand.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+from typing import Any
+
+from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
+from strands_robots.tools.g1.g1_velocity_envelope import (
+    _ANGLE_ABS_MAX,
+    _DISTANCE_ABS_MAX,
+    _DURATION_MAX_SECONDS,
+    _DURATION_MIN_SECONDS,
+    _GATE_REFUSAL_CODE,
+    _SPEED_MAX,
+    _SPEED_MIN,
+    _VX_ABS_MAX,
+    _VY_ABS_MAX,
+    _VYAW_ABS_MAX,
+    _YAW_RATE_MAX,
+    _YAW_RATE_MIN,
+    g1_list_velocity_envelope,
+    g1_velocity_admits,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process; this helper is where a shape
+    drift would surface once, rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be importable
+    with the SDK absent (refs strands-labs/robots#358); a module that
+    pulled a submodule at import time would break every headless CI
+    runner and Thor before an office bring-up.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_velocity_envelope")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_velocity_envelope imports pulled SDK "
+        f"submodules: {leaked}. The rule for this package is that the SDK "
+        f"loads only inside function bodies (refs strands-labs/robots#358)."
+    )
+
+
+def test_the_envelope_bounds_are_finite_and_ordered() -> None:
+    """Every clamp is a finite float and the min/max pairs are ordered.
+
+    A non-finite bound would let ``g1_velocity_admits`` admit every
+    value on that dimension; an inverted min/max pair (min > max)
+    would reject every finite value. Pins the invariant so a widen or
+    narrow of the observed range that inverts a pair surfaces here
+    rather than as a silently unreachable envelope in production.
+    """
+    for name, value in (
+        ("_VX_ABS_MAX", _VX_ABS_MAX),
+        ("_VY_ABS_MAX", _VY_ABS_MAX),
+        ("_VYAW_ABS_MAX", _VYAW_ABS_MAX),
+        ("_DURATION_MIN_SECONDS", _DURATION_MIN_SECONDS),
+        ("_DURATION_MAX_SECONDS", _DURATION_MAX_SECONDS),
+        ("_DISTANCE_ABS_MAX", _DISTANCE_ABS_MAX),
+        ("_SPEED_MIN", _SPEED_MIN),
+        ("_SPEED_MAX", _SPEED_MAX),
+        ("_ANGLE_ABS_MAX", _ANGLE_ABS_MAX),
+        ("_YAW_RATE_MIN", _YAW_RATE_MIN),
+        ("_YAW_RATE_MAX", _YAW_RATE_MAX),
+    ):
+        assert math.isfinite(value), f"{name} is not finite: {value!r}"
+
+    assert _DURATION_MIN_SECONDS <= _DURATION_MAX_SECONDS, (
+        f"duration bounds inverted: min={_DURATION_MIN_SECONDS} > "
+        f"max={_DURATION_MAX_SECONDS}. g1_velocity_admits would refuse "
+        f"every duration."
+    )
+    assert _SPEED_MIN <= _SPEED_MAX, f"speed bounds inverted: min={_SPEED_MIN} > max={_SPEED_MAX}"
+    assert _YAW_RATE_MIN <= _YAW_RATE_MAX, f"yaw-rate bounds inverted: min={_YAW_RATE_MIN} > max={_YAW_RATE_MAX}"
+
+
+def test_the_gate_refusal_code_matches_the_driver_constant() -> None:
+    """The envelope's refusal code names the driver's gate refusal.
+
+    The driver's ``_check_motion_gates`` refuses a locomotion-shaped
+    write on an FSM outside :data:`WALK_FSMS` with rc=7404, and the
+    ``7404`` entry in
+    :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries the
+    text a driver-side velocity wrapper would surface. Pinned here so
+    a re-wording of that message lands in one place, not one in the
+    driver and a diverging copy in this envelope.
+    """
+    assert _GATE_REFUSAL_CODE == 7404
+    assert _GATE_REFUSAL_CODE in ERR_CODES, (
+        f"envelope quotes rc={_GATE_REFUSAL_CODE} but that code is not in "
+        f"ERR_CODES. The refusal string would render as 'unknown'."
+    )
+
+
+def test_g1_list_velocity_envelope_returns_the_full_envelope() -> None:
+    """The verb's payload names every clamp, the gate set, and the refusal.
+
+    ``envelope`` carries every clamp constant, ``walk_ready_fsm_ids``
+    quotes :data:`WALK_FSMS`, and ``refusals`` names the ``7404``
+    gate-refusal code with the decoded text
+    :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries.
+    """
+    result = _call(g1_list_velocity_envelope)
+    assert result["status"] == "success"
+    env = result["envelope"]
+    assert env["vx_abs_max"] == _VX_ABS_MAX
+    assert env["vy_abs_max"] == _VY_ABS_MAX
+    assert env["vyaw_abs_max"] == _VYAW_ABS_MAX
+    assert env["duration_min_seconds"] == _DURATION_MIN_SECONDS
+    assert env["duration_max_seconds"] == _DURATION_MAX_SECONDS
+    assert env["distance_abs_max"] == _DISTANCE_ABS_MAX
+    assert env["speed_min"] == _SPEED_MIN
+    assert env["speed_max"] == _SPEED_MAX
+    assert env["angle_abs_max"] == _ANGLE_ABS_MAX
+    assert env["yaw_rate_min"] == _YAW_RATE_MIN
+    assert env["yaw_rate_max"] == _YAW_RATE_MAX
+    assert result["walk_ready_fsm_ids"] == sorted(WALK_FSMS)
+    assert result["refusals"] == [
+        {"code": _GATE_REFUSAL_CODE, "text": ERR_CODES[_GATE_REFUSAL_CODE]},
+    ]
+
+
+def test_g1_velocity_admits_a_vector_inside_every_clamp() -> None:
+    """A vector inside every clamp is admitted with an empty refusals list.
+
+    The zero-shape vector (``vx=vy=vyaw=0.0, duration=1.0``) is the
+    identity case: it sits at the origin on every direction axis and
+    inside the duration window, so a driver-side wrapper for
+    ``SetVelocity`` would not refuse it on envelope grounds (whether
+    the FSM gate admits it is a separate live-read decision the verb
+    does not answer).
+    """
+    result = _call(g1_velocity_admits, vx=0.0, vy=0.0, vyaw=0.0, duration=1.0)
+    assert result["status"] == "success"
+    assert result["admits"] is True
+    assert result["refusals"] == []
+    assert result["walk_ready_fsm_ids"] == sorted(WALK_FSMS)
+
+
+def test_g1_velocity_admits_at_the_exact_clamp_boundaries() -> None:
+    """A vector at the clamp boundaries is inside, not outside.
+
+    Boundary values ``|vx|=vx_abs_max``, ``|vy|=vy_abs_max``,
+    ``|vyaw|=vyaw_abs_max``, ``duration=duration_max_seconds`` are
+    admitted because :func:`g1_velocity_admits` refuses on ``|value|
+    > bound`` rather than ``>= bound`` (the neon bundle's clamp does
+    the same, and off-by-one at the boundary would silently reject a
+    caller's saturated command).
+    """
+    result = _call(
+        g1_velocity_admits,
+        vx=_VX_ABS_MAX,
+        vy=-_VY_ABS_MAX,
+        vyaw=_VYAW_ABS_MAX,
+        duration=_DURATION_MAX_SECONDS,
+    )
+    assert result["admits"] is True
+    assert result["refusals"] == []
+
+
+def test_g1_velocity_admits_refuses_a_vx_above_the_clamp() -> None:
+    """``vx`` above ``vx_abs_max`` reads as one refusal on that dimension.
+
+    The refusal descriptor names the dimension, the value the caller
+    passed, the bound-key on the envelope it violated, and the
+    ``7404`` code a driver-side wrapper would quote. Other
+    dimensions inside their clamps do not appear in the refusals
+    list, so a caller sees only the boundaries that failed.
+    """
+    result = _call(g1_velocity_admits, vx=_VX_ABS_MAX + 0.5, vy=0.0, vyaw=0.0, duration=1.0)
+    assert result["admits"] is False
+    assert len(result["refusals"]) == 1
+    refusal = result["refusals"][0]
+    assert refusal["dimension"] == "vx"
+    assert refusal["value"] == _VX_ABS_MAX + 0.5
+    assert refusal["bound_key"] == "vx_abs_max"
+    assert refusal["bound"] == _VX_ABS_MAX
+    assert refusal["code"] == _GATE_REFUSAL_CODE
+    assert refusal["text"] == ERR_CODES[_GATE_REFUSAL_CODE]
+
+
+def test_g1_velocity_admits_refuses_a_negative_vx_symmetrically() -> None:
+    """A negative ``vx`` past the clamp reads the same as a positive one.
+
+    The envelope clamps ``|vx|``, not ``vx`` directly, because reverse
+    walking is the same walk-envelope with the sign flipped. This
+    cell pins the symmetric behaviour so a caller passing
+    ``vx=-vx_abs_max - 0.1`` sees the same refusal shape as one
+    passing ``vx=+vx_abs_max + 0.1``.
+    """
+    result = _call(g1_velocity_admits, vx=-(_VX_ABS_MAX + 0.1), vy=0.0, vyaw=0.0, duration=1.0)
+    assert result["admits"] is False
+    assert result["refusals"][0]["dimension"] == "vx"
+
+
+def test_g1_velocity_admits_reports_every_violated_dimension_at_once() -> None:
+    """A vector outside three clamps names three refusals in one call.
+
+    A caller learns every boundary they missed in one query rather
+    than one per dispatch attempt; the driver's gate at wire time
+    would name only the first refusal it hits, so this verb's payload
+    is strictly wider than the wire-time refusal.
+    """
+    result = _call(
+        g1_velocity_admits,
+        vx=_VX_ABS_MAX + 1.0,
+        vy=_VY_ABS_MAX + 1.0,
+        vyaw=_VYAW_ABS_MAX + 1.0,
+        duration=_DURATION_MAX_SECONDS + 100.0,
+    )
+    assert result["admits"] is False
+    dimensions = {refusal["dimension"] for refusal in result["refusals"]}
+    assert dimensions == {"vx", "vy", "vyaw", "duration"}
+
+
+def test_g1_velocity_admits_refuses_a_non_finite_component() -> None:
+    """A non-finite ``vx`` reads as refused with the ``non-finite`` comparison.
+
+    ``math.inf`` and ``math.nan`` are not admissible even against a
+    generous clamp; the refusal descriptor's ``comparison`` field
+    names ``non-finite`` so a caller distinguishes a bounds-violation
+    from a shape-violation.
+    """
+    result = _call(g1_velocity_admits, vx=math.inf, vy=0.0, vyaw=0.0, duration=1.0)
+    assert result["admits"] is False
+    assert result["refusals"][0]["dimension"] == "vx"
+    assert result["refusals"][0]["comparison"] == "non-finite"
+
+    result_nan = _call(g1_velocity_admits, vx=math.nan, vy=0.0, vyaw=0.0, duration=1.0)
+    assert result_nan["admits"] is False
+    assert result_nan["refusals"][0]["comparison"] == "non-finite"
+
+
+def test_g1_velocity_admits_refuses_a_zero_or_negative_duration() -> None:
+    """A duration below ``duration_min_seconds`` reads as refused.
+
+    The neon bundle refuses zero-or-negative durations because the
+    controller ignores them without raising, which would let a
+    silently-dropped command look like a successful walk to the
+    planner. Pinned here so a widen of the min bound to strictly-
+    positive still surfaces zero as a refusal.
+    """
+    result = _call(g1_velocity_admits, vx=0.0, vy=0.0, vyaw=0.0, duration=-1.0)
+    assert result["admits"] is False
+    assert result["refusals"][0]["dimension"] == "duration"
+    assert result["refusals"][0]["bound_key"] == "duration_min_seconds"
+
+
+def test_g1_velocity_admits_refuses_a_duration_above_the_ceiling() -> None:
+    """A duration above the ceiling reads as refused with the ceiling key.
+
+    The neon bundle caps single-shot duration at
+    :data:`_DURATION_MAX_SECONDS`; longer commands switch to the
+    ``Move(continous_move=True)`` path, which is a separate write and
+    outside this envelope. Pinned so a caller trying to walk the
+    single-shot path for 100 seconds sees an actionable refusal
+    rather than a silently truncated command.
+    """
+    result = _call(
+        g1_velocity_admits,
+        vx=0.0,
+        vy=0.0,
+        vyaw=0.0,
+        duration=_DURATION_MAX_SECONDS + 100.0,
+    )
+    assert result["admits"] is False
+    assert result["refusals"][0]["dimension"] == "duration"
+    assert result["refusals"][0]["bound_key"] == "duration_max_seconds"

--- a/tests/drivers/test_g1_velocity_envelope_reads_the_walkable_range.py
+++ b/tests/drivers/test_g1_velocity_envelope_reads_the_walkable_range.py
@@ -44,6 +44,8 @@ import math
 import sys
 from typing import Any
 
+import pytest
+
 from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
 from strands_robots.tools.g1.g1_velocity_envelope import (
     _ANGLE_ABS_MAX,
@@ -197,6 +199,11 @@ def test_g1_velocity_admits_at_the_exact_clamp_boundaries() -> None:
     > bound`` rather than ``>= bound`` (the neon bundle's clamp does
     the same, and off-by-one at the boundary would silently reject a
     caller's saturated command).
+
+    ``duration_min_seconds`` is deliberately absent from this cell:
+    that bound is exclusive, so its boundary refuses rather than
+    admits, and it is pinned by
+    :func:`test_g1_velocity_admits_refuses_a_zero_or_negative_duration`.
     """
     result = _call(
         g1_velocity_admits,
@@ -282,19 +289,29 @@ def test_g1_velocity_admits_refuses_a_non_finite_component() -> None:
     assert result_nan["refusals"][0]["comparison"] == "non-finite"
 
 
-def test_g1_velocity_admits_refuses_a_zero_or_negative_duration() -> None:
-    """A duration below ``duration_min_seconds`` reads as refused.
+@pytest.mark.parametrize("duration", [0.0, -0.0, -1.0])
+def test_g1_velocity_admits_refuses_a_zero_or_negative_duration(duration: float) -> None:
+    """A duration at or below ``duration_min_seconds`` reads as refused.
 
     The neon bundle refuses zero-or-negative durations because the
     controller ignores them without raising, which would let a
     silently-dropped command look like a successful walk to the
-    planner. Pinned here so a widen of the min bound to strictly-
-    positive still surfaces zero as a refusal.
+    planner.
+
+    ``duration=0.0`` is the cell that matters and it is the reason this
+    is parametrised rather than asserting a negative alone: the min
+    bound *is* ``0.0``, so a refusal written as ``value < bound`` admits
+    exactly the no-op it exists to catch, and a negative-only assertion
+    cannot see that. A duration computed as distance/speed that rounds
+    to zero is the realistic caller, and it must not read as admitted.
+    ``-0.0`` is included because it compares equal to the bound while
+    carrying a sign bit, so it is decided by the same comparison.
     """
-    result = _call(g1_velocity_admits, vx=0.0, vy=0.0, vyaw=0.0, duration=-1.0)
+    result = _call(g1_velocity_admits, vx=0.0, vy=0.0, vyaw=0.0, duration=duration)
     assert result["admits"] is False
     assert result["refusals"][0]["dimension"] == "duration"
     assert result["refusals"][0]["bound_key"] == "duration_min_seconds"
+    assert result["refusals"][0]["comparison"] == "value <= bound"
 
 
 def test_g1_velocity_admits_refuses_a_duration_above_the_ceiling() -> None:


### PR DESCRIPTION
## What

Ports the read-only envelope half of neon-the-g1's `g1_locomotion.py` into `strands_robots.tools.g1.g1_velocity_envelope`:

- **`g1_list_velocity_envelope()`** -- returns the whole `(vx, vy, vyaw, duration)` clamp envelope the neon bundle observed as walkable on a real gantry, plus `walk_ready_fsm_ids` (from `WALK_FSMS`) and the `7404` gate-refusal code (from `ERR_CODES`).
- **`g1_velocity_admits(vx, vy, vyaw, duration)`** -- decides one query. Names **every** violated dimension in one call (the wire-time refusal would name only the first it hits, so this payload is strictly wider).

## Why here, not on the SDK

The Unitree G1 locomotion SDK's `LocoClient.SetVelocity` places **no clamps** on its arguments -- any finite `vx=10.0` or `duration=86400` reaches the controller unchanged, and the controller's behaviour above the neon-bundle-observed walkable range is undefined. The neon bundle's `g1_move_velocity` verb (`cagataycali/neon-the-g1/tools/g1_locomotion.py`) fronts the same call under a fixed set of clamps observed against the real robot on a gantry. This change snapshots that envelope into module-level constants so a caller can decide the refusal decidably before a future driver-side `SetVelocity` wrapper fires, rather than pinning the envelope inside the write path where the refusal is invisible to the planner.

## What this module is deliberately not

- **An execution path.** The neon bundle wrapped `LocoClient.SetVelocity` under a single-writer lock; that write is the `rt/lowcmd`-adjacent locomotion topic `WALK_FSMS` gates. A future driver method that fronts it will land the write verb; refs #358. This module ports the read-only envelope half without also introducing a second locomotion writer path the driver does not yet own.
- **An SDK re-import.** No `unitree_sdk2py` submodule loads on import -- the envelope table is a module-level snapshot, matching the SDK-load hygiene contract every other file under `strands_robots.tools.g1` carries.
- **A live FSM read.** Whether `_fsm_id` currently sits inside `WALK_FSMS` is a driver-instance read carried by `g1_state.g1_get_state` / `g1_motion_gates.g1_list_motion_gates`. The envelope surfaces the set as a snapshot so a caller comparing an intended write against both conditions (envelope + gate) has the FSM set on hand.

## Refusal contract

- Every refusal descriptor carries `dimension`, `value`, `bound_key`, `bound`, `comparison`, `code=7404`, `text=ERR_CODES[7404]` -- the exact string a future driver-side `SetVelocity` wrapper would surface.
- Non-finite values (`math.inf`, `math.nan`) refuse with `comparison="non-finite"` so a caller distinguishes a bounds-violation from a shape-violation.
- Symmetric bounds: `|vx| <= vx_abs_max`, `|vy| <= vy_abs_max`, `|vyaw| <= vyaw_abs_max` (reverse-walk uses the same envelope with the sign flipped).
- **Two boundary conventions, deliberately.** The three abs-max clamps and `duration_max_seconds` are **inclusive**: the boundary is admitted (`|value| > bound` refuses, not `>= bound`), because a saturated command is still a command and rejecting it would silently drop a caller's intended write. `duration_min_seconds` is **exclusive**: it refuses on `value <= bound`, because the value *at* that bound is exactly the no-op the refusal exists to catch -- the controller ignores a zero-duration write without raising, so admitting it would let a planner read a silently-dropped command as a successful walk. The asymmetry is stated where the constant is declared and in the `duration` Args entry.

## Follows

Continues the read-only lookup pattern:
- #2955 `g1_get_task_status` (over `G1Driver.get_task_status`)
- #2956 `g1_stop_task` (over `G1Driver.stop_task`)
- #2959 `g1_list_arm_actions` / `g1_arm_action_admits`
- #2960 `g1_list_fsm_targets` / `g1_fsm_target_admits`
- #2961 `g1_list_loco_tasks` / `g1_loco_task_admits`
- **This** -- `g1_list_velocity_envelope` / `g1_velocity_admits`

## Gates

- `ruff check` (0 findings)
- `ruff format --check` (0 changes)
- `mypy` (0 errors on new files -- pre-existing errors elsewhere in `simulation/`/`mesh/core.py` unchanged)
- `pytest tests/drivers/test_g1_velocity_envelope_reads_the_walkable_range.py` -- **14 passed**
- `python scripts/assemble_changelog.py --check` -- OK

## Test scope (14 cells, contract-graded)

1. Import pulls no `unitree_sdk2py` submodule (matches #358 hygiene rule)
2. Every envelope bound is finite; min/max pairs are ordered
3. Gate refusal code is `7404` and present in `ERR_CODES`
4. `g1_list_velocity_envelope` returns every clamp + `walk_ready_fsm_ids` + refusals
5. Zero-shape vector `(0,0,0,1.0)` is admitted with empty refusals
6. Values at the *inclusive* clamp boundaries are admitted (`|v| > bound`, not `>= bound`); the docstring records that `duration_min_seconds` is deliberately not one of them
7. `vx` above the clamp yields one refusal on that dimension only
8. Negative `vx` past the clamp refuses symmetrically
9. A vector outside four clamps names four refusals in one call
10. `math.inf` / `math.nan` refuse with `comparison="non-finite"`
11. `duration` of `0.0`, `-0.0` and `-1.0` each refuse via `duration_min_seconds` with `comparison="value <= bound"` (parametrised -- three cells)
12. Duration above ceiling refuses via `duration_max_seconds`

Refs strands-labs/robots#358.

## 13. Review rounds

### Round 1 -- `2085142d`

- **`duration=0.0` was admitted, contradicting the module's own stated refusal contract.** `g1_velocity_admits` refused on `d < _DURATION_MIN_SECONDS` with that bound set to `0.0`, so a zero duration returned `admits=True` with an empty `refusals` list. Three places said otherwise and the code was the odd one out: the `_DURATION_MIN_SECONDS` comment ("Zero-or-negative durations reach the SDK as no-op-shaped writes today ... so the neon bundle refuses them here"), the test whose name claims zero, and this description's own test-scope item 11.

  Fixed by refusing at the boundary (`d <= _DURATION_MIN_SECONDS`, `comparison="value <= bound"`) rather than by relaxing the documentation. That direction, because the value of this verb is that its verdict matches what a future driver-side `SetVelocity` wrapper refuses at wire time, and the realistic caller is a duration computed as distance/speed that rounds to zero: the controller drops that write without raising, so `admits=True` would have a planner read a silently-dropped command as a successful walk (AGENTS.md > "No silent defaults on error"). Flipping it after callers scaffold on the boundary semantics would be a silent behaviour change to an admission surface for physical-robot commands.

  Attribution, `(vx, vy, vyaw) = (0, 0, 0)`:

  | duration | `2abaf620` | `2085142d` |
  | --- | --- | --- |
  | `0.0` | `admits=True`, `refusals=[]` | `admits=False`, `value <= bound` |
  | `-0.0` | `admits=True`, `refusals=[]` | `admits=False`, `value <= bound` |
  | `-1.0` | `admits=False`, `value < bound` | `admits=False`, `value <= bound` |
  | `1.0` | `admits=True` | `admits=True` |
  | `10.0` | `admits=True` | `admits=True` |
  | `10.5` | `admits=False`, `value > bound` | `admits=False`, `value > bound` |

- **The cell that was supposed to catch it could not.** `test_g1_velocity_admits_refuses_a_zero_or_negative_duration` named zero and exercised `-1.0` only, so the gap was invisible to the suite. It is now parametrised over `0.0`, `-0.0` and `-1.0` and asserts the `comparison` spelling; `-0.0` is included because it compares equal to the bound while carrying a sign bit, so it is decided by the same comparison. The boundaries-are-admitted cell says in its docstring that the duration floor is deliberately not one of the boundaries it covers, so the two cells do not read as contradicting each other. 12 cells became 14.

- **Three documentation surfaces corrected to match.** The `_DURATION_MIN_SECONDS` comment now states the exclusivity and why this envelope carries two boundary conventions; the `duration` Args entry said "Refused below `duration_min_seconds`", which was accurate about the old code and is the tool schema the model reads and nothing else (AGENTS.md convention 13); and the changelog fragment now carries the boundary semantics, since that is the half of the contract a caller reads before writing against it. This description's refusal-contract and test-scope sections are updated above.

### Merge state on `2085142d` -- do not read the green rollup

`statusCheckRollup.state` on this head is **`SUCCESS`** and the required check `call-test-lint / Test and Lint` **never reported**. Those two facts are compatible because the rollup aggregates only contexts that registered, and this head has one that did not:

```
Pull Request and Push Action   run 33264977617   conclusion FAILURE   checkRuns: []
```

Zero check runs on a run that concluded `FAILURE` means the caller workflow failed before the `call-test-lint` job existed, so no context was ever created for the rollup to count. Every other suite on the head is green (13 suites), which is what makes the aggregate read clean.

`scripts/check_merge_blockers.py --pr 2965` classifies it correctly and is the reading to trust over the rollup:

```
Outcome: required-check-absent, missing-approval
| required_status_checks | a maintainer | Required check 'call-test-lint / Test and Lint' has not
  reported on 2085142d. The head carries 13 check suites and none is held at
  action_required, so the check genuinely has not started. |
```

Not self-cleared, deliberately: the remedy is a re-run of that one workflow, and the only author-side way to force it is a no-op commit, which buys a green tick with a junk commit in the history of a five-line fix. Attributed here instead, since the same-minute pushes to #2962 and #2964 both started their `call-test-lint` normally, so this is specific to this run rather than to the diff. Flagging rather than filing: the class -- a caller workflow that startup-fails contributes no context, so the required check is *absent* while the rollup reads `SUCCESS` -- is the distinction #2914 drew between a held run and no run, and the sweep already reports it, so the gap is in what a human reads off the page rather than in the tooling.
