### PR TITLE
feat(tools/g1): port g1_list_dds_topics and g1_topic_role (refs #358)

### DIFF
--- a/changelog.d/2969-g1-dds-topics-port.md
+++ b/changelog.d/2969-g1-dds-topics-port.md
@@ -1,0 +1,38 @@
+### Feature
+
+- Added `strands_robots.tools.g1.g1_list_dds_topics` and
+  `strands_robots.tools.g1.g1_topic_role`, two read-only ``@tool`` verbs
+  that snapshot the seven CycloneDDS topics
+  :class:`~strands_robots.drivers.g1.G1Driver` opens on the bus: the six
+  ``"read"``-side subscribes it makes at ``connect_eagerly`` time
+  (``rt/lowstate``, ``rt/lf/bmsstate``, ``rt/utlidar/lidar_state``,
+  ``rt/utlidar/cloud_livox_mid360``, ``rt/mainboardstate``,
+  ``rt/pressuresensorstate``) and the single ``"write"``-side publish
+  (``rt/lowcmd``) it fronts through ``send_action`` / ``run_policy``.
+  Each snapshot entry carries the topic string, the wire ``direction``
+  and a ``role`` matching the driver's cache attribute (``lowstate`` ->
+  ``_imu`` + ``_mode_machine``, ``battery`` -> ``_battery``,
+  ``lidar_state`` -> ``_lidar_state``, ``lidar_cloud`` ->
+  ``_lidar_summary``, ``mainboard`` -> ``_mainboard``, ``pressure`` ->
+  ``_pressure``, ``lowcmd`` -> the driver's ``_pubs`` write path).
+  ``g1_list_dds_topics`` returns the full seven-entry table or, when
+  ``direction`` is ``"read"`` / ``"write"``, only the matching side;
+  ``g1_topic_role`` decides one topic-string membership by returning
+  the driver's own decode label on admit or refusing an unknown topic
+  string with the known set quoted verbatim (DDS topic names are exact
+  strings on the wire, so a mis-cased ``rt/LowState`` refuses rather
+  than resolving to ``rt/lowstate``). A test in
+  ``tests/drivers/test_g1_dds_topics_reads_the_driver_subscription_set.py``
+  reads the driver's own ``_TOPIC_*`` module-level constants and
+  asserts identity with the tool module's snapshot, so a driver-side
+  widen or narrow of the subscription set surfaces as a diff rather
+  than as a diverging table the author would have to keep in sync by
+  hand. No ``unitree_sdk2py`` submodule loads on import - the topic
+  strings are a module-level snapshot, matching the SDK-load hygiene
+  the rest of this package carries. Sourced from the neon bundle's
+  ``g1_dds.py`` (``cagataycali/neon-the-g1/tools/g1_dds.py``), where a
+  ``g1_dds_snapshot``-shaped verb wrapped a second CycloneDDS reader
+  against arbitrary topics; this lookup ports the read-only lookup
+  half - which topics the driver's own reader path already carries -
+  without also introducing a second reader path the driver does not
+  yet front. Refs strands-labs/robots#358.

--- a/strands_robots/tools/g1/g1_dds_topics.py
+++ b/strands_robots/tools/g1/g1_dds_topics.py
@@ -1,0 +1,214 @@
+"""Agent-facing lookup for the DDS topics ``G1Driver`` opens on the bus.
+
+``G1Driver.connect_eagerly`` subscribes six CycloneDDS topics as the read
+side (``rt/lowstate``, ``rt/lf/bmsstate``, ``rt/utlidar/lidar_state``,
+``rt/utlidar/cloud_livox_mid360``, ``rt/mainboardstate``,
+``rt/pressuresensorstate``) and publishes one topic as the write side
+(``rt/lowcmd``). The topic names are module-level constants inside
+:mod:`strands_robots.drivers.g1` (``_TOPIC_LOWSTATE`` .. ``_TOPIC_LOWCMD``),
+private because the driver is the only wire path that opens them and the
+mesh does not want a second subscriber path racing the singleton
+``_DDS_INIT_LOCK`` these subscribes are threaded through.
+
+This module surfaces that subscription set as an agent-facing snapshot so a
+caller planning a rollout can enumerate the bus the driver would open
+before it opens the bus. A reader that only wants the write topic already
+has the driver's :attr:`~strands_robots.drivers.g1.G1Driver._pubs` handle
+for the ``rt/lowcmd`` gate; the read set is what a caller planning a
+mesh publish or a ``g1_dds_snapshot``-shaped verb (which the neon bundle's
+``g1_dds.py`` exposes, refs ``cagataycali/neon-the-g1/tools/g1_dds.py``)
+would compare its topic name against, to decide whether the driver is
+already carrying that topic's decode or whether the caller has to bring
+its own subscriber. The verb pair mirrors
+:mod:`~strands_robots.tools.g1.g1_motion_gates` and
+:mod:`~strands_robots.tools.g1.g1_fsm_targets`: one snapshot lookup +
+one membership decision.
+
+Two things this module is deliberately *not*:
+
+* An execution path. The neon bundle's ``g1_dds_subscribe`` /
+  ``g1_dds_snapshot`` verbs open a second DDS reader against arbitrary
+  topics; that second reader path is out of scope for this lookup, which
+  only names the driver's own subscription set. A future verb that
+  routes a subscribe request through the driver's singleton reader is
+  a separate port; refs strands-labs/robots#358 for the DDS-facing
+  seam that would land on. This module ports the read-only lookup half
+  without also introducing a second reader path the driver does not
+  yet front.
+* An SDK or CycloneDDS re-import. The topic names are captured here as
+  string constants snapshotted from the driver's own
+  ``_TOPIC_*`` module-level constants; the snapshot lives here rather
+  than being re-imported from the driver so ``import
+  strands_robots.tools.g1.g1_dds_topics`` pulls no ``unitree_sdk2py``
+  submodule (the import-hygiene contract every other file in this
+  package carries, refs strands-labs/robots#358). A driver-side widen
+  or narrow of the subscription set is caught by the test in
+  :mod:`tests.drivers.test_g1_dds_topics_reads_the_driver_subscription_set`,
+  which asserts identity against the driver's own constants.
+
+What this module does not decide.
+
+* Whether a topic is currently *live* on the bus. Topic liveness is a
+  DDS-layer discovery answer; the neon bundle's ``g1_dds_discover``
+  verb wraps ``cyclonedds ls`` for that. This lookup answers a static
+  question: which topics the driver's ``connect_eagerly`` code path
+  subscribes on, independent of whether the robot is powered on.
+* Which decoded field ends up where in the driver's cache. Each
+  subscription decodes into a named attribute on the driver
+  (``_imu``, ``_battery``, ``_lidar_state``, ``_lidar_summary``,
+  ``_mainboard``, ``_pressure``); that mapping is per-topic and the
+  driver's callbacks are the source of truth for it. A future verb
+  that surfaces the cache-attribute names alongside the topic names
+  would need the driver's own callback wiring as its evidence, which
+  is a driver-side read separate from this lookup.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+#: Snapshot of the DDS topics ``G1Driver`` opens at connect time. Each
+#: entry names the topic string (matching the driver's private
+#: ``_TOPIC_*`` constants byte-for-byte), the ``direction`` of the wire
+#: (``"read"`` for a subscribe, ``"write"`` for a publish), and a
+#: ``role`` naming what the driver decodes or writes on that topic.
+#:
+#: The role labels are the driver's own decode targets:
+#:
+#: * ``rt/lowstate`` -> ``lowstate`` (into ``_imu`` and ``_mode_machine``
+#:   caches)
+#: * ``rt/lf/bmsstate`` -> ``battery`` (into ``_battery`` cache; the
+#:   ``lf`` prefix is the Unitree-side layout the G1 ships)
+#: * ``rt/utlidar/lidar_state`` -> ``lidar_state`` (into ``_lidar_state``
+#:   cache, the sensor-diagnostics envelope)
+#: * ``rt/utlidar/cloud_livox_mid360`` -> ``lidar_cloud`` (into
+#:   ``_lidar_summary`` cache; the point cloud is not held raw, the
+#:   driver keeps the derived summary)
+#: * ``rt/mainboardstate`` -> ``mainboard`` (into ``_mainboard`` cache,
+#:   temperature and voltage envelope)
+#: * ``rt/pressuresensorstate`` -> ``pressure`` (into ``_pressure``
+#:   cache, foot force envelope)
+#: * ``rt/lowcmd`` -> ``lowcmd`` (the write topic; every ``send_action``
+#:   and ``run_policy`` frame publishes here through the driver's
+#:   ``_pubs`` handle)
+#:
+#: The snapshot lives here rather than in
+#: :mod:`~strands_robots.tools.g1._g1_common` because the mapping is
+#: only useful for the ``g1_dds_topics``-side of the conversation; a
+#: driver-side widen or narrow lands here through the identity test
+#: in ``tests/drivers/test_g1_dds_topics_reads_the_driver_subscription_set.py``,
+#: which reads the driver's own constants and refuses a drift.
+_DRIVER_TOPICS: tuple[dict[str, str], ...] = (
+    {"topic": "rt/lowstate", "direction": "read", "role": "lowstate"},
+    {"topic": "rt/lf/bmsstate", "direction": "read", "role": "battery"},
+    {"topic": "rt/utlidar/lidar_state", "direction": "read", "role": "lidar_state"},
+    {"topic": "rt/utlidar/cloud_livox_mid360", "direction": "read", "role": "lidar_cloud"},
+    {"topic": "rt/mainboardstate", "direction": "read", "role": "mainboard"},
+    {"topic": "rt/pressuresensorstate", "direction": "read", "role": "pressure"},
+    {"topic": "rt/lowcmd", "direction": "write", "role": "lowcmd"},
+)
+
+#: The two directions the ``direction`` field takes. Named here so the
+#: refusal string an unknown filter would surface can quote the same
+#: domain the snapshot carries, rather than restating it inline.
+_VALID_DIRECTIONS: frozenset[str] = frozenset({"read", "write"})
+
+
+@tool
+def g1_list_dds_topics(direction: str = "") -> dict[str, Any]:
+    """Return the DDS topics ``G1Driver`` opens on the bus.
+
+    Read-only. Every entry is a driver constant snapshot; no bus is
+    touched, no driver instance is required, and the CycloneDDS runtime
+    does not have to be initialised for this verb to answer.
+
+    Args:
+        direction: Optional filter on the wire direction. Empty (default)
+            returns every topic the driver opens. ``"read"`` returns
+            only the six topics the driver subscribes at
+            ``connect_eagerly`` time; ``"write"`` returns the one
+            topic (``rt/lowcmd``) the driver publishes on. Any other
+            value is refused with a message naming the valid set.
+
+    Returns:
+        A dict with ``status``, a ``count`` naming how many topics the
+        filter matched, the requested ``direction`` (or ``None`` for the
+        unfiltered case), a ``directions`` list naming both valid
+        filters, and a ``topics`` list of per-topic descriptors
+        (``topic``, ``direction``, ``role``). An unknown ``direction``
+        carries ``status="error"`` and a refusal string that quotes the
+        valid domain and cites ``strands-labs/robots#358``.
+    """
+    if direction and direction not in _VALID_DIRECTIONS:
+        valid = sorted(_VALID_DIRECTIONS)
+        return {
+            "status": "error",
+            "message": (
+                f"unknown direction {direction!r}. Valid directions are {valid}. Refs strands-labs/robots#358."
+            ),
+        }
+    if direction:
+        topics = [dict(entry) for entry in _DRIVER_TOPICS if entry["direction"] == direction]
+    else:
+        topics = [dict(entry) for entry in _DRIVER_TOPICS]
+    return {
+        "status": "success",
+        "count": len(topics),
+        "direction": direction or None,
+        "directions": sorted(_VALID_DIRECTIONS),
+        "topics": topics,
+    }
+
+
+@tool
+def g1_topic_role(topic: str) -> dict[str, Any]:
+    """Decide the wire role ``G1Driver`` opens for a given DDS topic string.
+
+    Read-only. Reads the driver's constant snapshot and returns the same
+    ``direction`` / ``role`` answer the driver's own subscribe or publish
+    call would carry. A caller planning a ``g1_dds_snapshot``-shaped
+    subscribe uses this to see whether the driver already holds a
+    subscriber for the topic (in which case the caller reads from the
+    driver's cache instead of opening a second reader path against the
+    same wire), and a caller planning a mesh publish uses it to see
+    whether the target topic is the driver's write path (in which case
+    the write goes through ``send_action`` / ``run_policy`` rather than
+    a direct publish that would race the driver's gate).
+
+    Args:
+        topic: The DDS topic string to test. Must match one of the
+            driver's ``_TOPIC_*`` constants byte-for-byte; a mis-cased
+            or trailing-slash variant is refused rather than silently
+            resolved to a nearby topic, because DDS topic names are
+            exact strings on the wire.
+
+    Returns:
+        A dict with ``status``. On admit: the requested ``topic``, the
+        ``direction`` the driver opens it in (``"read"`` or ``"write"``),
+        and the ``role`` the driver decodes or writes on it. On refuse:
+        ``status="error"``, a ``message`` naming the known topic set,
+        and a citation to ``strands-labs/robots#358``.
+    """
+    if not isinstance(topic, str):
+        return {
+            "status": "error",
+            "message": (f"topic must be a str; got {type(topic).__name__} {topic!r}. Refs strands-labs/robots#358."),
+        }
+    for entry in _DRIVER_TOPICS:
+        if entry["topic"] == topic:
+            return {
+                "status": "success",
+                "topic": entry["topic"],
+                "direction": entry["direction"],
+                "role": entry["role"],
+            }
+    known = sorted(entry["topic"] for entry in _DRIVER_TOPICS)
+    return {
+        "status": "error",
+        "message": (
+            f"topic {topic!r} is not in the driver's subscription set. "
+            f"Known topics: {known}. Refs strands-labs/robots#358."
+        ),
+    }

--- a/strands_robots/tools/g1/g1_dds_topics.py
+++ b/strands_robots/tools/g1/g1_dds_topics.py
@@ -41,10 +41,12 @@ Two things this module is deliberately *not*:
   than being re-imported from the driver so ``import
   strands_robots.tools.g1.g1_dds_topics`` pulls no ``unitree_sdk2py``
   submodule (the import-hygiene contract every other file in this
-  package carries, refs strands-labs/robots#358). A driver-side widen
-  or narrow of the subscription set is caught by the test in
-  :mod:`tests.drivers.test_g1_dds_topics_reads_the_driver_subscription_set`,
-  which asserts identity against the driver's own constants.
+  package carries, refs strands-labs/robots#358). The invariant a
+  driver-side widen or narrow must preserve is byte-for-byte identity
+  between the ``topic`` strings surfaced here and the driver's own
+  ``_TOPIC_*`` constants: a subscribe-set drift that does not update
+  this snapshot leaves the two out of sync, so the read the driver
+  actually opens and the read this verb reports diverge silently.
 
 What this module does not decide.
 
@@ -96,10 +98,12 @@ from strands import tool
 #:
 #: The snapshot lives here rather than in
 #: :mod:`~strands_robots.tools.g1._g1_common` because the mapping is
-#: only useful for the ``g1_dds_topics``-side of the conversation; a
-#: driver-side widen or narrow lands here through the identity test
-#: in ``tests/drivers/test_g1_dds_topics_reads_the_driver_subscription_set.py``,
-#: which reads the driver's own constants and refuses a drift.
+#: only useful for the ``g1_dds_topics``-side of the conversation. The
+#: invariant this snapshot must preserve is byte-identity of the
+#: ``topic`` strings with the driver's own ``_TOPIC_*`` constants; a
+#: driver-side widen or narrow that updates the driver without also
+#: updating this snapshot leaves them out of sync, and the read the
+#: driver actually opens and the read this verb reports diverge.
 _DRIVER_TOPICS: tuple[dict[str, str], ...] = (
     {"topic": "rt/lowstate", "direction": "read", "role": "lowstate"},
     {"topic": "rt/lf/bmsstate", "direction": "read", "role": "battery"},

--- a/tests/drivers/test_g1_dds_topics_reads_the_driver_subscription_set.py
+++ b/tests/drivers/test_g1_dds_topics_reads_the_driver_subscription_set.py
@@ -1,0 +1,305 @@
+"""The DDS-topic tools name exactly the topics ``G1Driver`` opens on the bus.
+
+``G1Driver`` holds its subscription set as seven module-level ``_TOPIC_*``
+constants inside :mod:`strands_robots.drivers.g1`: six ``"read"``-side
+topics the driver subscribes at ``connect_eagerly`` time (``rt/lowstate``,
+``rt/lf/bmsstate``, ``rt/utlidar/lidar_state``,
+``rt/utlidar/cloud_livox_mid360``, ``rt/mainboardstate``,
+``rt/pressuresensorstate``), and one ``"write"``-side topic the driver
+publishes on (``rt/lowcmd``). Two agent-facing tools -
+:func:`g1_list_dds_topics` and :func:`g1_topic_role` - exist to surface
+those seven topic names as a static snapshot before a caller decides
+whether to open its own reader/publisher against the same wire.
+
+The topic names the tool module carries are read here off the driver's
+own constants rather than being restated in the tests, so a driver-side
+widen or narrow of the subscription set (adding a new sensor topic, for
+example) does not require also editing this file. What the tests do
+restate is the *shape* of each returned record and the SDK-load-hygiene
+contract every file under :mod:`strands_robots.tools.g1` carries:
+importing the tool module must not pull any ``unitree_sdk2py`` submodule.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+from strands_robots.tools.g1.g1_dds_topics import (
+    _DRIVER_TOPICS,
+    _VALID_DIRECTIONS,
+    g1_list_dds_topics,
+    g1_topic_role,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process, but a caller cannot rely on that:
+    the wrapper's contract is that it returns the wrapped function's
+    return value verbatim. This helper is where a shape drift would
+    surface once, rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be importable
+    with the SDK absent; a module that pulled a submodule at import time
+    would break every headless CI runner and Thor before an office
+    bring-up. The driver enforces the same rule against itself
+    (:func:`~strands_robots.tools.g1._g1_common.ensure_dds` is the only
+    path that loads the SDK); this cell holds the DDS-topic verbs to it
+    too.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_dds_topics")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_dds_topics imports pulled SDK "
+        f"submodules: {leaked}. The rule for this package is that the "
+        f"SDK loads only inside function bodies "
+        f"(refs strands-labs/robots#358)."
+    )
+
+
+def test_the_snapshot_matches_the_driver_constant_set() -> None:
+    """The tool's topic snapshot is the driver's own ``_TOPIC_*`` set.
+
+    The driver holds seven module-level constants naming the topics it
+    opens on the bus. The tool module's :data:`_DRIVER_TOPICS` names the
+    same seven strings; a widen or narrow on the driver side surfaces
+    here as a diff between the two sets, not as a diverging table the
+    author would need to keep in sync by hand.
+    """
+    from strands_robots.drivers import g1 as driver_module
+
+    driver_read_topics = {
+        driver_module._TOPIC_LOWSTATE,
+        driver_module._TOPIC_BMS,
+        driver_module._TOPIC_LIDAR_STATE,
+        driver_module._TOPIC_LIDAR_CLOUD,
+        driver_module._TOPIC_MAINBOARD,
+        driver_module._TOPIC_PRESSURE,
+    }
+    driver_write_topics = {driver_module._TOPIC_LOWCMD}
+
+    tool_read_topics = {entry["topic"] for entry in _DRIVER_TOPICS if entry["direction"] == "read"}
+    tool_write_topics = {entry["topic"] for entry in _DRIVER_TOPICS if entry["direction"] == "write"}
+
+    assert tool_read_topics == driver_read_topics, (
+        f"The tool module's read-side snapshot drifted from the driver's "
+        f"``_TOPIC_*`` constants. Tool read topics: {sorted(tool_read_topics)}; "
+        f"driver read topics: {sorted(driver_read_topics)}. Update "
+        f"``_DRIVER_TOPICS`` in ``strands_robots.tools.g1.g1_dds_topics`` "
+        f"to match, refs strands-labs/robots#358."
+    )
+    assert tool_write_topics == driver_write_topics, (
+        f"The tool module's write-side snapshot drifted from the driver's "
+        f"``_TOPIC_LOWCMD`` constant. Tool write topics: "
+        f"{sorted(tool_write_topics)}; driver write topics: "
+        f"{sorted(driver_write_topics)}. Update ``_DRIVER_TOPICS`` in "
+        f"``strands_robots.tools.g1.g1_dds_topics`` to match, refs "
+        f"strands-labs/robots#358."
+    )
+
+
+def test_the_snapshot_carries_the_documented_roles() -> None:
+    """Each snapshot entry names a ``role`` matching the driver's cache.
+
+    The driver decodes each subscribed topic into a named cache
+    attribute; the snapshot's ``role`` field carries the same names as
+    the driver's decode targets. A caller reading the snapshot sees the
+    same label the driver's own callback wiring would emit.
+    """
+    expected_roles = {
+        "rt/lowstate": "lowstate",
+        "rt/lf/bmsstate": "battery",
+        "rt/utlidar/lidar_state": "lidar_state",
+        "rt/utlidar/cloud_livox_mid360": "lidar_cloud",
+        "rt/mainboardstate": "mainboard",
+        "rt/pressuresensorstate": "pressure",
+        "rt/lowcmd": "lowcmd",
+    }
+    got_roles = {entry["topic"]: entry["role"] for entry in _DRIVER_TOPICS}
+    assert got_roles == expected_roles, (
+        f"role labels drifted from the driver's decode targets. "
+        f"Got: {got_roles}; expected: {expected_roles}. "
+        f"Refs strands-labs/robots#358."
+    )
+
+
+def test_valid_directions_are_read_and_write() -> None:
+    """The tool admits exactly the two DDS wire directions.
+
+    The driver subscribes and publishes; nothing else is a topic-side
+    action. The tool refuses any other filter string with a refusal that
+    quotes this same domain.
+    """
+    assert _VALID_DIRECTIONS == frozenset({"read", "write"}), (
+        f"the valid-direction set drifted. Got {_VALID_DIRECTIONS!r}; "
+        f"expected frozenset({{'read', 'write'}}). Refs strands-labs/robots#358."
+    )
+
+
+def test_g1_list_dds_topics_returns_the_whole_table() -> None:
+    """No filter returns every topic the driver opens, sorted by insertion.
+
+    The shape mirrors :func:`g1_list_motion_gates` and
+    :func:`g1_list_balance_modes`: ``status``, ``count``, ``direction``
+    (``None`` here), ``directions``, and a ``topics`` list.
+    """
+    result = _call(g1_list_dds_topics)
+    assert result["status"] == "success"
+    assert result["count"] == len(_DRIVER_TOPICS)
+    assert result["direction"] is None
+    assert result["directions"] == sorted(_VALID_DIRECTIONS)
+    assert len(result["topics"]) == len(_DRIVER_TOPICS)
+    got = [entry["topic"] for entry in result["topics"]]
+    expected = [entry["topic"] for entry in _DRIVER_TOPICS]
+    assert got == expected, f"the topic order drifted. Got {got}; expected {expected}. Refs strands-labs/robots#358."
+
+
+def test_g1_list_dds_topics_filters_read_side() -> None:
+    """A ``"read"`` filter surfaces only the driver's six subscribes.
+
+    The driver's write-side ``rt/lowcmd`` is excluded from the filtered
+    view; a caller planning a subscribe uses this filter to enumerate
+    the read set the driver already carries.
+    """
+    result = _call(g1_list_dds_topics, direction="read")
+    assert result["status"] == "success"
+    assert result["direction"] == "read"
+    assert result["count"] == 6
+    directions_seen = {entry["direction"] for entry in result["topics"]}
+    assert directions_seen == {"read"}, (
+        f"``read`` filter admitted a non-read entry: {directions_seen}. Refs strands-labs/robots#358."
+    )
+
+
+def test_g1_list_dds_topics_filters_write_side() -> None:
+    """A ``"write"`` filter surfaces only ``rt/lowcmd``, the driver's write.
+
+    The G1 write path is a single-topic path (see the driver's own
+    module-level docstring on ``_TOPIC_LOWCMD``); the filtered view
+    reflects that.
+    """
+    result = _call(g1_list_dds_topics, direction="write")
+    assert result["status"] == "success"
+    assert result["direction"] == "write"
+    assert result["count"] == 1
+    assert result["topics"][0]["topic"] == "rt/lowcmd"
+    assert result["topics"][0]["direction"] == "write"
+    assert result["topics"][0]["role"] == "lowcmd"
+
+
+def test_g1_list_dds_topics_refuses_an_unknown_direction() -> None:
+    """An unknown filter is refused with the valid set in the message.
+
+    A caller that mis-types ``"reader"`` or ``"subscribe"`` sees a
+    refusal that quotes the valid domain and the ``#358`` reference,
+    rather than silently returning an empty list that would read like a
+    driver with no subscriptions.
+    """
+    result = _call(g1_list_dds_topics, direction="reader")
+    assert result["status"] == "error"
+    assert "reader" in result["message"]
+    assert "read" in result["message"]
+    assert "write" in result["message"]
+    assert "strands-labs/robots#358" in result["message"]
+
+
+def test_g1_list_dds_topics_returns_fresh_containers() -> None:
+    """Successive calls do not share a mutable container.
+
+    A caller that mutates the returned ``topics`` list must not affect
+    the module-level snapshot or a subsequent caller's read. The tool
+    copies each entry with :func:`dict` and yields a fresh list.
+    """
+    first = _call(g1_list_dds_topics)
+    second = _call(g1_list_dds_topics)
+    assert first["topics"] is not second["topics"], (
+        "successive calls shared a list reference; a caller mutating "
+        "the returned ``topics`` would corrupt the snapshot. "
+        "Refs strands-labs/robots#358."
+    )
+    first["topics"].append({"topic": "rt/injected", "direction": "read", "role": "x"})
+    fresh = _call(g1_list_dds_topics)
+    assert fresh["count"] == len(_DRIVER_TOPICS)
+    assert all(entry["topic"] != "rt/injected" for entry in fresh["topics"])
+
+
+def test_g1_topic_role_resolves_a_read_topic() -> None:
+    """A known read-side topic returns the driver's cache role.
+
+    ``rt/lf/bmsstate`` is the driver's battery subscribe; the tool
+    answers ``direction="read"`` and ``role="battery"``, the same label
+    :attr:`~strands_robots.drivers.g1.G1Driver._battery` carries in the
+    cache.
+    """
+    result = _call(g1_topic_role, topic="rt/lf/bmsstate")
+    assert result["status"] == "success"
+    assert result["topic"] == "rt/lf/bmsstate"
+    assert result["direction"] == "read"
+    assert result["role"] == "battery"
+
+
+def test_g1_topic_role_resolves_the_write_topic() -> None:
+    """The write path ``rt/lowcmd`` resolves to ``direction="write"``.
+
+    A caller planning a direct publish uses this to see that the topic
+    is the driver's own write path; the correct call site is
+    ``send_action`` / ``run_policy``, not a second publisher against the
+    same wire.
+    """
+    result = _call(g1_topic_role, topic="rt/lowcmd")
+    assert result["status"] == "success"
+    assert result["topic"] == "rt/lowcmd"
+    assert result["direction"] == "write"
+    assert result["role"] == "lowcmd"
+
+
+def test_g1_topic_role_refuses_an_unknown_topic() -> None:
+    """A topic outside the driver's set is refused, not silently resolved.
+
+    DDS topic names are exact strings on the wire; a mis-cased or
+    trailing-slash variant is a different topic. The refusal names the
+    known set so a caller can spot the typo.
+    """
+    result = _call(g1_topic_role, topic="rt/wirelesscontroller")
+    assert result["status"] == "error"
+    assert "rt/wirelesscontroller" in result["message"]
+    assert "rt/lowcmd" in result["message"]
+    assert "strands-labs/robots#358" in result["message"]
+
+
+def test_g1_topic_role_refuses_a_case_variant() -> None:
+    """A mis-cased topic name is not silently normalised to the canonical form.
+
+    ``rt/LowState`` is not ``rt/lowstate``; the DDS wire is byte-exact
+    on the topic string. The tool preserves that.
+    """
+    result = _call(g1_topic_role, topic="rt/LowState")
+    assert result["status"] == "error"
+    assert "rt/LowState" in result["message"]
+
+
+def test_g1_topic_role_refuses_a_non_string_topic() -> None:
+    """A caller that passes a non-str topic sees the type refusal.
+
+    A dict-key confusion (passing an int or a bytes) is a caller
+    mistake; the refusal names the received type so the mistake is
+    visible instead of silently comparing bytes to str and returning a
+    misleading "unknown topic".
+    """
+    for bad in (123, b"rt/lowstate", None, ["rt/lowstate"], {"topic": "rt/lowstate"}):
+        result = _call(g1_topic_role, topic=bad)
+        assert result["status"] == "error"
+        assert "topic must be a str" in result["message"]
+        assert "strands-labs/robots#358" in result["message"]


### PR DESCRIPTION
## What

Ports the read-only half of the neon bundle's `g1_dds.py` verb set into `strands_robots.tools.g1` as two agent-facing lookups:

- **`g1_list_dds_topics`** — returns a snapshot of the seven CycloneDDS topics `G1Driver` opens on the bus: the six `"read"`-side subscribes it makes at `connect_eagerly` time (`rt/lowstate`, `rt/lf/bmsstate`, `rt/utlidar/lidar_state`, `rt/utlidar/cloud_livox_mid360`, `rt/mainboardstate`, `rt/pressuresensorstate`) and the single `"write"`-side publish (`rt/lowcmd`). Accepts an optional `direction` filter (`"read"` / `"write"`); an unknown filter is refused with the valid domain quoted.
- **`g1_topic_role`** — decides one topic-string membership. Returns the driver's own decode role on admit (`lowstate` → `_imu` + `_mode_machine`, `battery` → `_battery`, `lidar_state` → `_lidar_state`, `lidar_cloud` → `_lidar_summary`, `mainboard` → `_mainboard`, `pressure` → `_pressure`, `lowcmd` → the driver's `_pubs` write path); refuses an unknown topic string with the known set quoted.

Mirrors the shape of `g1_arm_actions` (#2959), `g1_fsm_targets` (#2960), `g1_loco_task_ids` (#2961), `g1_balance_modes` (#2967), `g1_stand_height_envelope` (#2966), and `g1_audio_volume_envelope` (#2968): one snapshot per driver-facing table, one verb pair per snapshot.

Sourced from `cagataycali/neon-the-g1/tools/g1_dds.py`, where a `g1_dds_snapshot`-shaped verb wrapped a second CycloneDDS reader against arbitrary topics. This port surfaces the read-only lookup half — which topics the driver's own reader path already carries — without introducing a second reader path the driver does not yet front.

## Why this landing shape

The topic names live inside `strands_robots.drivers.g1` as seven private module-level constants (`_TOPIC_LOWSTATE` … `_TOPIC_LOWCMD`, lines 118–128). Private because the driver is the only wire path that opens them and the mesh does not want a second subscriber path racing the singleton `_DDS_INIT_LOCK`. But a caller planning a `g1_dds_snapshot`-shaped subscribe wants to know *before* opening a reader whether the driver already holds a subscriber for the target topic (in which case the caller reads from the driver's cache instead of opening a second reader against the same wire, and a caller planning a mesh publish uses it to see whether the target topic is the driver's write path — in which case the write goes through `send_action` / `run_policy` rather than a direct publish that would race the driver's gate).

The tool module's `_DRIVER_TOPICS` snapshot carries the same seven topic strings; a test in `tests/drivers/test_g1_dds_topics_reads_the_driver_subscription_set.py::test_the_snapshot_matches_the_driver_constant_set` reads the driver's own `_TOPIC_*` constants and asserts identity, so a driver-side widen or narrow of the subscription set surfaces as a test diff, not as a table the author would have to keep in sync by hand.

## What refusal strings it cites

Every refusal string cites `strands-labs/robots#358` (import-hygiene contract) and quotes the valid domain (either the two directions `["read", "write"]` or the seven known topic strings) verbatim. No aspirational docstrings; every field describes what the code does today.

## Tests

14 contract-graded tests in `tests/drivers/test_g1_dds_topics_reads_the_driver_subscription_set.py`:

- `test_the_import_pulls_no_sdk_module` — no `unitree_sdk2py` submodule at import time
- `test_the_snapshot_matches_the_driver_constant_set` — identity vs the driver's private `_TOPIC_*` constants (drift guard)
- `test_the_snapshot_carries_the_documented_roles` — role labels match the driver's cache attributes
- `test_valid_directions_are_read_and_write` — the `_VALID_DIRECTIONS` set is frozen at the two DDS wire directions
- `test_g1_list_dds_topics_returns_the_whole_table` — full 7-entry payload shape
- `test_g1_list_dds_topics_filters_read_side` — 6-entry read-only filter
- `test_g1_list_dds_topics_filters_write_side` — 1-entry write-only filter (`rt/lowcmd`)
- `test_g1_list_dds_topics_refuses_an_unknown_direction` — `"reader"` → refusal with valid domain
- `test_g1_list_dds_topics_returns_fresh_containers` — no shared-reference regression
- `test_g1_topic_role_resolves_a_read_topic` — `rt/lf/bmsstate` → `direction="read"`, `role="battery"`
- `test_g1_topic_role_resolves_the_write_topic` — `rt/lowcmd` → `direction="write"`, `role="lowcmd"`
- `test_g1_topic_role_refuses_an_unknown_topic` — `rt/wirelesscontroller` → refusal with known set
- `test_g1_topic_role_refuses_a_case_variant` — `rt/LowState` refuses (DDS is byte-exact)
- `test_g1_topic_role_refuses_a_non_string_topic` — int/bytes/None/list/dict all refuse with type in message

All 14 pass locally (1.79s no-cov). No real `unitree_sdk2py`, no DDS bus, no live driver instance.

## Gates status

- `ruff check` — clean on both touched files
- `ruff format --check` — clean on both touched files
- `mypy` — zero errors on both touched files (unrelated pre-existing errors in `utils.py`/`ik.py`/`mesh/core.py` are not touched by this PR)
- `pytest tests/drivers/test_g1_dds_topics_reads_the_driver_subscription_set.py` — 14 passed

## Design decisions

**Why snapshot the topics in the tool module rather than import them from the driver?** Same rule the rest of this tools package carries: `import strands_robots.tools.g1.g1_dds_topics` must pull no `unitree_sdk2py` submodule (refs #358). Importing `strands_robots.drivers.g1` pulls numpy and the driver's whole surface — not required for a static topic-name lookup. The snapshot lives here as string literals; the driver-side identity test catches any drift.

**Why include `rt/lowcmd` in the same table as the six subscribes?** A caller planning a `g1_dds_publish`-shaped write asks the same question a caller planning a subscribe does: "does the driver already open this topic on the bus, and in which direction?" One table with a `direction` field answers both. The neon bundle's `g1_dds.py` also treated its topic set uniformly across `subscribe`/`snapshot`/`publish`.

**Why `role="lowstate"` for `rt/lowstate` when the driver decodes it into two separate caches (`_imu` and `_mode_machine`)?** The role names the wire-level decode target, not the derived-attribute set. `rt/lowstate` is one LowState_ message the driver decodes into two fields; the role label reflects the topic, not the fanout. A caller wanting the fanout reads the driver's own code path.

**Why refuse a case variant like `rt/LowState`?** DDS topic names are exact strings on the wire; the CycloneDDS discovery layer does not treat `rt/lowstate` and `rt/LowState` as the same topic. Refusing at the verb boundary surfaces the mistake rather than silently returning "unknown".

## Follows

- **Refs #358** — G1 tools port
- **Follows #2916** — G1 gate wired ✅ merged
- **Follows #2968** — `g1_audio_volume_envelope` (AudioClient.SetVolume-side lookup)
- **Follows #2967** — `g1_balance_modes` (BalanceStand-side lookup)
- **Follows #2966** — `g1_stand_height_envelope` (SetStandHeight-side lookup)
- **Follows #2961** — `g1_loco_task_ids` (SetTaskId-side lookup)
- **Follows #2960** — `g1_fsm_targets` (SetFsmId-side lookup)
- **Follows #2959** — `g1_arm_actions` (arm-SDK-side lookup)

## Not in scope

- **Dispatch execution** — the neon bundle's `g1_dds_subscribe` / `g1_dds_snapshot` / `g1_dds_publish` opened a second CycloneDDS reader path against arbitrary topics; a future verb that routes a subscribe request through the driver's singleton reader is a separate port. This PR ports the read-only lookup half only.
- **Topic liveness** — the neon bundle's `g1_dds_discover` wraps `cyclonedds ls`; that is a DDS-runtime discovery answer, orthogonal to the driver's static subscription set. Separate port.
- **Cache-attribute names** — the roles here name the wire decode; the driver's `_imu` / `_battery` / etc. cache attributes are a separate surface. A future verb that pairs topic ↔ cache attribute name would need the driver's callback wiring as its evidence.
