### PR TITLE
feat(tools/g1): port g1_list_turn_envelope and g1_turn_admits (refs #358)

### DIFF
--- a/changelog.d/2974-g1-turn-envelope-port.md
+++ b/changelog.d/2974-g1-turn-envelope-port.md
@@ -1,0 +1,33 @@
+### Feature
+
+- Added `strands_robots.tools.g1.g1_list_turn_envelope` and
+  `strands_robots.tools.g1.g1_turn_admits`, two read-only ``@tool``
+  verbs that snapshot the ``(angle_rad, yaw_rate)`` clamp pair the
+  neon bundle (``cagataycali/neon-the-g1/tools/g1_locomotion.py::g1_turn``)
+  narrows to before it dispatches ``LocoClient.SetVelocity`` for a
+  yaw-only turn-in-place. The SDK itself places *no* clamps on
+  either argument, so the envelope lives in the tool layer. The
+  neon wrapper narrows ``angle_rad`` to
+  ``max(-2*pi, min(2*pi, float(angle_rad)))`` and ``yaw_rate`` to
+  ``max(0.1, min(0.6, abs(float(yaw_rate))))`` before composing
+  ``duration = abs(angle_rad) / yaw_rate`` and picking the sign of
+  ``vyaw`` from the sign of ``angle_rad`` (``+yaw_rate`` on
+  non-negative angle, ``-yaw_rate`` on strictly-negative). Both
+  verbs surface the composed ``duration`` at the arguments
+  as-passed so a caller can chain the admission against
+  ``g1_locomotion_duration_admits`` (port #2972) without composing
+  the arithmetic itself; the returned envelope names the composed-
+  duration overhang (``~62.83`` s at ``angle_rad=2*pi, yaw_rate=0.1``,
+  above the duration envelope's ``10.0`` s upper clamp) so a caller
+  comparing the two admission layers sees where they disagree.
+  ``g1_turn_admits`` refuses on ``rc=7404`` with a per-axis
+  ``dimension in {"angle_rad", "yaw_rate"}`` refusal descriptor;
+  non-finite input (``math.inf``, ``math.nan``) refuses with
+  ``comparison="non-finite"`` so a caller distinguishes a bounds
+  violation from a shape one. Both verbs surface
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS` so a caller
+  comparing an intended write against both conditions (envelope +
+  gate) has the FSM set on hand. No ``unitree_sdk2py`` submodule
+  loads on import - the envelope table is a module-level snapshot,
+  matching the SDK-load hygiene the rest of this package carries.
+  Refs strands-labs/robots#358.

--- a/strands_robots/tools/g1/g1_turn_envelope.py
+++ b/strands_robots/tools/g1/g1_turn_envelope.py
@@ -70,8 +70,8 @@ What this module does not decide.
   rather than the turn surface.
 * Whether the composed ``duration = abs(angle_rad) / yaw_rate`` sits
   inside the duration envelope. That is a separate lookup
-  (:mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`,
-  port #2972, refs strands-labs/robots#358). At the turn clamps the
+  (``g1_locomotion_duration_envelope``, port #2972, refs
+  strands-labs/robots#358). At the turn clamps the
   composed duration is bounded to ``[0.0 / 0.6, 2*pi / 0.1]``
   = ``[0.0, ~62.83]`` seconds, which overhangs the duration
   envelope's ``[0.0, 10.0]`` upper clamp: a turn call at
@@ -158,8 +158,7 @@ _ANGLE_SIGN_THRESHOLD: float = 0.0
 #: at the turn clamps: ``_ANGLE_RAD_MAX / _YAW_RATE_MIN``
 #: = ``2*pi / 0.1`` ≈ ``62.832`` seconds. Above the neon bundle's
 #: locomotion-duration envelope's own ``10.0`` s upper clamp
-#: (:mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`,
-#: port #2972), so a turn call at ``angle_rad=2*pi, yaw_rate=0.1``
+#: (``g1_locomotion_duration_envelope``, port #2972), so a turn call at ``angle_rad=2*pi, yaw_rate=0.1``
 #: composes to a duration the duration envelope would clamp down to
 #: ``10.0`` s at the ``g1_move_velocity`` layer. Named on the
 #: returned envelope so a caller comparing the two admission layers

--- a/strands_robots/tools/g1/g1_turn_envelope.py
+++ b/strands_robots/tools/g1/g1_turn_envelope.py
@@ -1,0 +1,418 @@
+"""Agent-facing lookup for the turn envelope ``LocoClient.SetVelocity`` admits.
+
+The Unitree G1 locomotion SDK
+(:class:`unitree_sdk2py.g1.loco.g1_loco_client.LocoClient`) exposes
+``SetVelocity(vx, vy, vyaw, duration_s)`` as the bounded write for a
+yaw-only turn-in-place, and the neon bundle
+(``cagataycali/neon-the-g1/tools/g1_locomotion.py::g1_turn``) fronts
+it with a two-argument surface -- ``angle_rad`` in radians and
+``yaw_rate`` in rad/s -- that composes to a ``(0.0, 0.0, vyaw)``
+velocity command with a computed ``duration = abs(angle_rad) / yaw_rate``
+and the sign of ``vyaw`` picked from the sign of ``angle_rad``. The
+SDK itself places *no* clamps on either input: a caller that passes
+``angle_rad=100.0`` or ``yaw_rate=5.0`` reaches the controller
+unchanged, and the controller's behaviour above the neon-bundle-
+observed range is undefined -- the G1 has no runaway guard on that
+write path. The neon bundle's own wrapper narrows the two arguments
+to ``angle_rad = max(-2*pi, min(2*pi, float(angle_rad)))`` and
+``yaw_rate = max(0.1, min(0.6, abs(float(yaw_rate))))`` before
+dispatch, so this module snapshots that clamp pair into module-level
+constants and exposes two agent-facing verbs --
+:func:`g1_list_turn_envelope` (name the whole envelope) and
+:func:`g1_turn_admits` (decide one query) -- so a caller can decide
+the refusal decidably before a future driver-side wrapper fires.
+Refs strands-labs/robots#358.
+
+Two things this module is deliberately *not*:
+
+* An execution path. The neon bundle's ``g1_turn`` verb composes
+  ``(angle_rad, yaw_rate)`` into a ``SetVelocity`` call under the
+  same DDS singleton :func:`~strands_robots.tools.g1._g1_common.ensure_dds`
+  the driver holds; that write is the same locomotion topic
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS` gates, which
+  today's :class:`~strands_robots.drivers.g1.G1Driver` refuses through
+  :meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates` on
+  any locomotion-shaped write while ``_fsm_id`` is outside that set.
+  A future driver method that fronts the ``angle_rad/yaw_rate``
+  surface will land the write verb; refs strands-labs/robots#358 for
+  the SDK-facing gate work that write belongs on. This module ports
+  the read-only envelope half without also introducing a second
+  locomotion writer path the driver does not yet own.
+* An SDK re-import. The clamp table is captured here as module-level
+  constants so ``import strands_robots.tools.g1.g1_turn_envelope``
+  pulls no ``unitree_sdk2py`` submodule -- the import-hygiene
+  contract every other file in this package carries, refs
+  strands-labs/robots#358. A revision of the neon bundle's observed
+  bounds is a driver-side update; when the driver's turn method
+  lands, its refusal will quote the same ``7404`` code the entry in
+  :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries.
+
+What this module does not decide.
+
+* Whether the driver's live ``_fsm_id`` is currently inside
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. That is a
+  driver-instance read carried on the driver's ``get_status``
+  envelope; a caller planning a turn command compares the driver's
+  live fsm against :func:`g1_list_turn_envelope`'s
+  ``walk_ready_fsm_ids`` to see whether the write gate is currently
+  open. The three membership tests together -- envelope for angle,
+  envelope for yaw_rate, walk_ready for the gate -- are the
+  conditions a future write verb would refuse on.
+* Whether the composed ``(0.0, 0.0, vyaw)`` yaw magnitude sits inside
+  the velocity envelope. That is a separate lookup
+  (:mod:`~strands_robots.tools.g1.g1_velocity_envelope`, port #2965,
+  refs strands-labs/robots#358). The neon wrapper's ``yaw_rate``
+  clamp (``[0.1, 0.6]``) already sits strictly inside the velocity
+  envelope's ``vyaw`` clamp, so a value admitted here is also
+  admitted there; a caller that wants to reach the velocity
+  envelope's wider ``vyaw`` range must call
+  :mod:`~strands_robots.tools.g1.g1_velocity_envelope` directly
+  rather than the turn surface.
+* Whether the composed ``duration = abs(angle_rad) / yaw_rate`` sits
+  inside the duration envelope. That is a separate lookup
+  (:mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`,
+  port #2972, refs strands-labs/robots#358). At the turn clamps the
+  composed duration is bounded to ``[0.0 / 0.6, 2*pi / 0.1]``
+  = ``[0.0, ~62.83]`` seconds, which overhangs the duration
+  envelope's ``[0.0, 10.0]`` upper clamp: a turn call at
+  ``angle_rad=2*pi, yaw_rate=0.1`` composes to a ~63-second turn
+  the duration envelope would clamp down to 10.0 s at the
+  ``g1_move_velocity`` layer. The overhang is named on the returned
+  envelope so a caller comparing the two admission layers sees it
+  without composing the arithmetic itself.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from strands import tool
+
+from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
+
+#: The lower clamp the neon ``g1_turn`` verb places on the
+#: ``angle_rad`` argument before dispatch. The value is the one the
+#: neon bundle's own wrapper
+#: (``max(-2*pi, min(2*pi, float(angle_rad)))``) rounds up to for
+#: any value below ``-2*pi``. Named as an inclusive lower bound
+#: because a saturated clockwise-turn command is still a command;
+#: refusing it would drop the neon bundle's own admitted range. A
+#: negative ``angle_rad`` is admitted because the neon wrapper picks
+#: the sign of ``vyaw`` from the sign of ``angle_rad``
+#: (``vyaw = yaw_rate if angle_rad >= 0 else -yaw_rate``), so a
+#: strictly-negative ``angle_rad`` reaches the controller as a
+#: clockwise (CW) turn rather than as a shape violation.
+_ANGLE_RAD_MIN: float = -2.0 * math.pi
+
+#: The upper clamp the neon ``g1_turn`` verb places on the
+#: ``angle_rad`` argument before dispatch. The value is the one the
+#: neon bundle's own wrapper rounds down to for any value above
+#: ``2*pi``. Above this the controller's response is undefined (the
+#: SDK does not clamp), and the composed duration
+#: (``abs(angle_rad) / yaw_rate``) grows without bound -- a caller
+#: passing ``angle_rad=100.0`` would turn the robot for many minutes
+#: at the neon bundle's minimum yaw rate. Named as an inclusive
+#: upper bound because a saturated counter-clockwise-turn command is
+#: a command; the neon bundle picks positive-angle as CCW per the
+#: G1's right-handed body frame.
+_ANGLE_RAD_MAX: float = 2.0 * math.pi
+
+#: The lower clamp the neon ``g1_turn`` verb places on the
+#: ``yaw_rate`` argument before dispatch. The value is the one the
+#: neon bundle's own wrapper
+#: (``max(0.1, min(0.6, abs(float(yaw_rate))))``) rounds up to for
+#: any strictly-positive value below ``0.1``. The neon wrapper takes
+#: the absolute value first, so a negative ``yaw_rate`` is folded to
+#: positive before the clamp; the sign of the composed ``vyaw``
+#: comes from the sign of ``angle_rad``, not from the sign of
+#: ``yaw_rate``. Named as an inclusive lower bound because ``0.1``
+#: rad/s is the minimum turnable yaw rate the neon bundle observed
+#: on the G1; below this the controller stalls rather than turns.
+_YAW_RATE_MIN: float = 0.1
+
+#: The upper clamp the neon ``g1_turn`` verb places on the
+#: ``yaw_rate`` argument before dispatch. The value is the one the
+#: neon bundle's own wrapper rounds down to for any value above
+#: ``0.6``. Above this the controller's response is undefined (the
+#: SDK does not clamp), and the neon bundle never observed a stable
+#: turn-in-place above this rate on a walkable surface. Named as an
+#: inclusive upper bound because a saturated yaw-rate command is a
+#: command.
+_YAW_RATE_MAX: float = 0.6
+
+#: The zero of the sign axis the neon wrapper reads to pick the
+#: direction of ``vyaw``. The neon bundle's conditional is
+#: ``vyaw = yaw_rate if angle_rad >= 0 else -yaw_rate``, so
+#: ``angle_rad == 0.0`` (and ``angle_rad == -0.0``, which Python's
+#: ``>=`` comparison reads as non-negative) routes to CCW-turn at
+#: ``vyaw = +yaw_rate`` and composes to a zero-duration no-op the
+#: SDK does not refuse. Named here so a future revision of the neon
+#: wrapper that changed the sign convention (for example to
+#: ``angle_rad > 0`` strict, which would route ``0.0`` to CW-turn)
+#: lands as a shape change on this constant rather than as a silent
+#: divergence in the tests.
+_ANGLE_SIGN_THRESHOLD: float = 0.0
+
+#: The upper bound of the composed ``duration = abs(angle_rad) / yaw_rate``
+#: at the turn clamps: ``_ANGLE_RAD_MAX / _YAW_RATE_MIN``
+#: = ``2*pi / 0.1`` ≈ ``62.832`` seconds. Above the neon bundle's
+#: locomotion-duration envelope's own ``10.0`` s upper clamp
+#: (:mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`,
+#: port #2972), so a turn call at ``angle_rad=2*pi, yaw_rate=0.1``
+#: composes to a duration the duration envelope would clamp down to
+#: ``10.0`` s at the ``g1_move_velocity`` layer. Named on the
+#: returned envelope so a caller comparing the two admission layers
+#: sees the overhang without composing the arithmetic itself.
+_MAX_COMPOSED_DURATION: float = (2.0 * math.pi) / 0.1
+
+#: The lower bound of the composed ``duration = abs(angle_rad) / yaw_rate``
+#: at the turn clamps: ``0.0 / _YAW_RATE_MAX`` = ``0.0`` seconds.
+#: The neon bundle's ``g1_move_velocity`` verb refuses on
+#: ``duration <= 0`` before the SDK is touched, but the turn surface
+#: passes the composed value through untransformed, so a caller at
+#: ``angle_rad=0.0`` reaches that refusal at the underlying layer
+#: rather than at the turn surface. Named so a caller comparing the
+#: two admission layers sees the shape of the composed duration
+#: without composing it itself.
+_MIN_COMPOSED_DURATION: float = 0.0
+
+#: The SDK method the neon bundle's ``g1_turn`` dispatches through.
+#: The neon wrapper calls ``g1_move_velocity`` internally, which
+#: fronts ``LocoClient.SetVelocity`` under the same single-writer
+#: DDS singleton the driver holds. Named here so the returned
+#: envelope carries the exact SDK entry a driver-side wrapper would
+#: target, and so a firmware release that renamed the SDK method
+#: lands in one place instead of drifting between the neon bundle
+#: and this lookup.
+_SDK_METHOD: str = "SetVelocity"
+
+#: The error-table entry the driver's own ``_check_motion_gates``
+#: quotes when it refuses a locomotion-shaped write on an FSM outside
+#: :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. Named here
+#: so the returned envelope carries the exact refusal string a future
+#: driver-side turn wrapper would surface, and so a re-wording of it
+#: lands in one place instead of drifting between the driver's log
+#: and this lookup. The write path and this lookup share the constant.
+_GATE_REFUSAL_CODE: int = 7404
+
+
+def _envelope() -> dict[str, Any]:
+    """Build the envelope descriptor the verbs return.
+
+    Kept here rather than inlined in :func:`g1_list_turn_envelope`
+    so :func:`g1_turn_admits` names the same fields on its
+    admitted-path payload and so a widen to the descriptor lands in
+    one place. Every field is a snapshot read; no bus is touched.
+    """
+    return {
+        "angle_rad_min": _ANGLE_RAD_MIN,
+        "angle_rad_max": _ANGLE_RAD_MAX,
+        "yaw_rate_min": _YAW_RATE_MIN,
+        "yaw_rate_max": _YAW_RATE_MAX,
+        "angle_sign_threshold": _ANGLE_SIGN_THRESHOLD,
+        "composed_duration_min": _MIN_COMPOSED_DURATION,
+        "composed_duration_max": _MAX_COMPOSED_DURATION,
+        "sdk_method": _SDK_METHOD,
+    }
+
+
+@tool
+def g1_list_turn_envelope() -> dict[str, Any]:
+    """Return the turn envelope the neon bundle clamps to.
+
+    Read-only. No driver instance, no DDS, no SDK: every field is a
+    module-level constant. Useful before a future driver-side wrapper
+    for the turn surface is called, so a caller can compare an
+    intended ``(angle_rad, yaw_rate)`` pair against the clamps the
+    neon bundle's ``g1_turn`` narrows to, and can also compare the
+    driver's live ``fsm_id`` (from ``G1Driver.get_status``) against
+    ``walk_ready_fsm_ids`` to decide whether the locomotion write
+    gate is currently open.
+
+    The envelope names two argument clamps the neon bundle stacks
+    on top of the SDK: ``[angle_rad_min, angle_rad_max]`` =
+    ``[-2*pi, 2*pi]`` rad (a negative ``angle_rad`` routes to CW
+    turn; the sign of the composed ``vyaw`` is picked from the sign
+    of ``angle_rad`` against ``angle_sign_threshold``), and
+    ``[yaw_rate_min, yaw_rate_max]`` = ``[0.1, 0.6]`` rad/s (the neon
+    wrapper takes ``abs(yaw_rate)`` before clamping, so a negative
+    ``yaw_rate`` is folded to positive; the direction comes from
+    ``angle_rad``, not from ``yaw_rate``). The composed
+    ``duration = abs(angle_rad) / yaw_rate`` sits in
+    ``[composed_duration_min, composed_duration_max]`` =
+    ``[0.0, 2*pi/0.1]`` seconds at the turn clamps, which overhangs
+    the locomotion-duration envelope's own ``10.0`` s upper clamp --
+    a turn call at ``angle_rad=2*pi, yaw_rate=0.1`` composes to a
+    ~62.83 s duration the duration envelope would clamp down to
+    ``10.0`` s at the ``g1_move_velocity`` layer.
+
+    Returns:
+        A dict with ``status``; an ``envelope`` sub-dict carrying
+        both argument clamps, the sign threshold, the composed-
+        duration range, and the SDK method name
+        (``angle_rad_min``, ``angle_rad_max``, ``yaw_rate_min``,
+        ``yaw_rate_max``, ``angle_sign_threshold``,
+        ``composed_duration_min``, ``composed_duration_max``,
+        ``sdk_method``); a ``walk_ready_fsm_ids`` list quoting
+        :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`, the
+        set the driver's motion gate admits locomotion-shaped writes
+        on; and a ``refusals`` list carrying the ``7404`` gate-
+        refused code and its decoded text, the one a future write
+        verb would surface. Every field is a snapshot of an observed
+        bound or a driver constant; no dynamic decode runs here.
+    """
+    return {
+        "status": "success",
+        "envelope": _envelope(),
+        "walk_ready_fsm_ids": sorted(WALK_FSMS),
+        "refusals": [
+            {"code": _GATE_REFUSAL_CODE, "text": ERR_CODES[_GATE_REFUSAL_CODE]},
+        ],
+    }
+
+
+def _finite(value: float) -> bool:
+    """Return whether ``value`` is a finite float.
+
+    Kept here rather than pulled from ``strands_robots.utils`` because
+    the envelope check needs only the finiteness half of the shared
+    validator; the positivity half does not apply on the
+    ``angle_rad`` axis (a strictly-negative ``angle_rad`` is a
+    legitimate CW-turn command the neon wrapper admits), and on the
+    ``yaw_rate`` axis the neon wrapper takes ``abs(yaw_rate)`` before
+    clamping so a shared positive-finite validator would refuse a
+    negative ``yaw_rate`` the neon wrapper would silently fold to
+    positive. A future consolidation with the shared validator lands
+    when the driver-side write verb reuses this admits function and
+    the sign-handling contract is settled with #358.
+    """
+    return math.isfinite(float(value))
+
+
+@tool
+def g1_turn_admits(angle_rad: float = 0.5, yaw_rate: float = 0.3) -> dict[str, Any]:
+    """Decide whether an ``(angle_rad, yaw_rate)`` pair sits inside the turn envelope.
+
+    Read-only. Compares each argument against the clamps
+    :func:`g1_list_turn_envelope` returns and reports whether the
+    neon bundle's wrapper would dispatch the pair unchanged (it
+    clamps silently for out-of-range values, but this verb surfaces
+    the refusal so the caller sees which bound would be hit). No
+    driver instance, no DDS, no SDK: the decision reads only module-
+    level constants and the two arguments themselves.
+
+    A pair inside both clamps is *not* the same as an admitted write:
+    the driver's motion gate (``_check_motion_gates``) also refuses
+    on ``_fsm_id`` outside
+    :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`, which this
+    verb does not read (that is a live driver-instance query answered
+    by :mod:`~strands_robots.tools.g1.g1_state` and
+    :mod:`~strands_robots.tools.g1.g1_motion_gates`). The returned
+    envelope names ``walk_ready_fsm_ids`` so a caller comparing an
+    intended write against both conditions has the FSM set on hand.
+
+    The routing conventions:
+
+    * ``angle_rad`` inside ``[angle_rad_min, angle_rad_max]`` and
+      ``yaw_rate`` inside ``[yaw_rate_min, yaw_rate_max]`` ->
+      admitted. Both bounds are inclusive on both axes (a saturated
+      command is a command); the composed ``vyaw`` sign is picked
+      from ``angle_rad >= angle_sign_threshold`` (``+yaw_rate`` on
+      non-negative angle, ``-yaw_rate`` on strictly-negative).
+    * ``angle_rad`` outside the angle clamp OR ``yaw_rate`` outside
+      the yaw-rate clamp -> refused. Every violated bound is named
+      on its own refusal descriptor so a caller sees which axis
+      (and which bound on that axis) blocked the pair.
+    * Either argument non-finite (``math.inf``, ``math.nan``) ->
+      refused with ``comparison="non-finite"`` on that axis's
+      refusal. A NaN cannot be compared decidably against the
+      clamps (``nan < min`` is ``False`` but so is ``nan >= min``),
+      and an infinity would overrun the outer bound on either axis;
+      both are shape violations rather than value ones.
+
+    Args:
+        angle_rad: The radians-to-turn argument the neon ``g1_turn``
+            verb clamps to ``[angle_rad_min, angle_rad_max]`` before
+            dispatch. A strictly-negative ``angle_rad`` routes to
+            CW-turn (``vyaw = -yaw_rate``) rather than to a shape
+            violation.
+        yaw_rate: The yaw-rate argument the neon ``g1_turn`` verb
+            clamps to ``[yaw_rate_min, yaw_rate_max]`` after taking
+            ``abs(yaw_rate)``. This admits helper reads ``yaw_rate``
+            directly rather than through ``abs()``, so a negative
+            ``yaw_rate`` refuses on the ``yaw_rate_min`` bound; a
+            caller who means to fold the sign should pass
+            ``abs(yaw_rate)`` at the call site to match the neon
+            wrapper's behaviour.
+
+    Returns:
+        A dict with ``status``; an ``admits`` bool naming whether
+        both arguments sit inside their clamps; a ``refusals`` list
+        carrying one refusal descriptor per violated bound (each
+        with the offending dimension ``"angle_rad"`` or
+        ``"yaw_rate"``, the offending value, the bound it violated,
+        the comparison, and the ``7404`` gate-refusal code the
+        driver would quote); a ``composed_duration`` float naming
+        what ``abs(angle_rad) / yaw_rate`` would evaluate to at the
+        arguments as-passed (``None`` on a rejected pair, and
+        ``None`` on ``yaw_rate == 0.0`` to avoid a divide-by-zero --
+        a caller can distinguish the two by inspecting
+        ``refusals``); the same ``envelope`` sub-dict
+        :func:`g1_list_turn_envelope` returns; and
+        ``walk_ready_fsm_ids`` for the follow-on gate decision. On
+        an admitted pair the ``refusals`` list is empty and
+        ``composed_duration`` is a finite float; on a rejected pair
+        every violated bound is named.
+    """
+    envelope = _envelope()
+    refusals: list[dict[str, Any]] = []
+
+    def _reject(dimension: str, value: float, bound_key: str, bound: float, cmp: str) -> None:
+        refusals.append(
+            {
+                "dimension": dimension,
+                "value": float(value),
+                "bound_key": bound_key,
+                "bound": bound,
+                "comparison": cmp,
+                "code": _GATE_REFUSAL_CODE,
+                "text": ERR_CODES[_GATE_REFUSAL_CODE],
+            }
+        )
+
+    if not _finite(angle_rad):
+        _reject("angle_rad", angle_rad, "angle_rad_max", _ANGLE_RAD_MAX, "non-finite")
+    else:
+        a = float(angle_rad)
+        if a < _ANGLE_RAD_MIN:
+            _reject("angle_rad", a, "angle_rad_min", _ANGLE_RAD_MIN, "value < bound")
+        elif a > _ANGLE_RAD_MAX:
+            _reject("angle_rad", a, "angle_rad_max", _ANGLE_RAD_MAX, "value > bound")
+
+    if not _finite(yaw_rate):
+        _reject("yaw_rate", yaw_rate, "yaw_rate_max", _YAW_RATE_MAX, "non-finite")
+    else:
+        y = float(yaw_rate)
+        if y < _YAW_RATE_MIN:
+            _reject("yaw_rate", y, "yaw_rate_min", _YAW_RATE_MIN, "value < bound")
+        elif y > _YAW_RATE_MAX:
+            _reject("yaw_rate", y, "yaw_rate_max", _YAW_RATE_MAX, "value > bound")
+
+    # Composed duration reported only on an admitted pair with a
+    # non-zero yaw_rate; a caller who wants to reach the duration
+    # envelope with a rejected pair reads the refusals list first.
+    composed_duration: float | None = None
+    if not refusals:
+        y = float(yaw_rate)
+        if y != 0.0:
+            composed_duration = abs(float(angle_rad)) / y
+
+    return {
+        "status": "success",
+        "admits": not refusals,
+        "refusals": refusals,
+        "composed_duration": composed_duration,
+        "envelope": envelope,
+        "walk_ready_fsm_ids": sorted(WALK_FSMS),
+    }

--- a/tests/drivers/test_g1_turn_envelope_reads_the_angle_and_yaw_rate_clamps.py
+++ b/tests/drivers/test_g1_turn_envelope_reads_the_angle_and_yaw_rate_clamps.py
@@ -165,7 +165,7 @@ def test_the_composed_duration_bounds_match_the_clamp_pair() -> None:
     """The advertised composed-duration range matches ``[0 / yaw_max, angle_max / yaw_min]``.
 
     A caller comparing this envelope against
-    :mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`
+    ``g1_locomotion_duration_envelope`` (port #2972)
     reads ``composed_duration_max`` to see whether the turn surface
     can compose a duration the duration envelope would clamp. Pinned
     so a widen of either the angle or yaw-rate clamp that shifted

--- a/tests/drivers/test_g1_turn_envelope_reads_the_angle_and_yaw_rate_clamps.py
+++ b/tests/drivers/test_g1_turn_envelope_reads_the_angle_and_yaw_rate_clamps.py
@@ -1,0 +1,428 @@
+"""The turn envelope lookup tools name what ``LocoClient.SetVelocity`` admits.
+
+The Unitree G1 locomotion SDK
+(:class:`unitree_sdk2py.g1.loco.g1_loco_client.LocoClient`) exposes
+``SetVelocity(vx, vy, vyaw, duration_s)`` without clamps of its own;
+the neon bundle
+(``cagataycali/neon-the-g1/tools/g1_locomotion.py::g1_turn``) narrows
+a two-argument ``(angle_rad, yaw_rate)`` surface to
+``angle_rad = max(-2*pi, min(2*pi, float(angle_rad)))`` and
+``yaw_rate = max(0.1, min(0.6, abs(float(yaw_rate))))`` before
+dispatch. The :mod:`strands_robots.tools.g1.g1_turn_envelope` module
+snapshots that clamp pair into module-level constants and exposes
+two agent-facing verbs -- :func:`g1_list_turn_envelope` (name the
+whole envelope) and :func:`g1_turn_admits` (decide one query) -- so
+a caller can decide the refusal decidably before a future locomotion
+write path is attempted. The tests here fix that contract without
+pulling the SDK: the module is loadable on a host without
+``unitree_sdk2py`` (the same SDK-load-hygiene rule every other file
+under :mod:`strands_robots.tools.g1` carries, refs
+strands-labs/robots#358), and every membership answer is read off
+the module's own snapshot rather than restated in the tests, so a
+widen or narrow to the observed range surfaces here as a shape
+change rather than as a diverging table this file would need to
+manually update.
+
+Two things this file's cells deliberately do not pin:
+
+* The SDK's own answer at wire time. The envelope is the neon
+  bundle's observed range, not the SDK's own clamps (the SDK has
+  none). A driver-side wrapper for the turn surface that lands later
+  will re-check the envelope at wire time and its refusal string
+  will quote the ``7404`` gate-refusal code the driver's
+  ``_check_motion_gates`` also quotes.
+* Whether the driver's live ``fsm_id`` sits inside
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. That is a
+  live driver-instance read and belongs on
+  :mod:`~strands_robots.tools.g1.g1_state` /
+  :mod:`~strands_robots.tools.g1.g1_motion_gates`; the verb surfaces
+  the set as a snapshot so a caller comparing an intended write
+  against both conditions has the FSM set on hand.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+from typing import Any
+
+import pytest
+
+from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
+from strands_robots.tools.g1.g1_turn_envelope import (
+    _ANGLE_RAD_MAX,
+    _ANGLE_RAD_MIN,
+    _ANGLE_SIGN_THRESHOLD,
+    _GATE_REFUSAL_CODE,
+    _MAX_COMPOSED_DURATION,
+    _MIN_COMPOSED_DURATION,
+    _SDK_METHOD,
+    _YAW_RATE_MAX,
+    _YAW_RATE_MIN,
+    g1_list_turn_envelope,
+    g1_turn_admits,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process; this helper is where a shape
+    drift would surface once, rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be importable
+    with the SDK absent (refs strands-labs/robots#358); a module that
+    pulled a submodule at import time would break every headless CI
+    runner and Thor before an office bring-up.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_turn_envelope")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_turn_envelope imports pulled SDK "
+        f"submodules: {leaked}. The rule for this package is that the SDK "
+        f"loads only inside function bodies (refs strands-labs/robots#358)."
+    )
+
+
+def test_the_envelope_bounds_are_finite_and_ordered() -> None:
+    """Every clamp is a finite float and each min/max pair is ordered.
+
+    A non-finite bound would let :func:`g1_turn_admits` admit every
+    value on that dimension; an inverted min/max pair (min > max)
+    would reject every finite value. Pins the invariant on both the
+    angle and yaw-rate axes so a widen or narrow that inverts either
+    pair surfaces here rather than as a silently unreachable envelope
+    in production.
+    """
+    for name, value in (
+        ("_ANGLE_RAD_MIN", _ANGLE_RAD_MIN),
+        ("_ANGLE_RAD_MAX", _ANGLE_RAD_MAX),
+        ("_YAW_RATE_MIN", _YAW_RATE_MIN),
+        ("_YAW_RATE_MAX", _YAW_RATE_MAX),
+        ("_ANGLE_SIGN_THRESHOLD", _ANGLE_SIGN_THRESHOLD),
+        ("_MIN_COMPOSED_DURATION", _MIN_COMPOSED_DURATION),
+        ("_MAX_COMPOSED_DURATION", _MAX_COMPOSED_DURATION),
+    ):
+        assert math.isfinite(value), f"{name} is not finite: {value!r}"
+
+    assert _ANGLE_RAD_MIN <= _ANGLE_RAD_MAX, (
+        f"angle bounds inverted: min={_ANGLE_RAD_MIN} > max={_ANGLE_RAD_MAX}. "
+        f"g1_turn_admits would refuse every finite angle."
+    )
+    assert _YAW_RATE_MIN <= _YAW_RATE_MAX, (
+        f"yaw-rate bounds inverted: min={_YAW_RATE_MIN} > max={_YAW_RATE_MAX}. "
+        f"g1_turn_admits would refuse every finite yaw rate."
+    )
+    assert _MIN_COMPOSED_DURATION <= _MAX_COMPOSED_DURATION, (
+        f"composed-duration bounds inverted: "
+        f"min={_MIN_COMPOSED_DURATION} > max={_MAX_COMPOSED_DURATION}. "
+        f"The advertised composed range would be empty."
+    )
+
+
+def test_the_yaw_rate_clamp_stays_strictly_positive() -> None:
+    """The yaw-rate lower clamp is strictly positive.
+
+    The neon wrapper takes ``abs(yaw_rate)`` before clamping, and its
+    minimum ``0.1`` rad/s is the neon-bundle-observed minimum
+    turnable rate. A future revision that dropped the floor to zero
+    (or below) would either divide-by-zero in the composed-duration
+    computation or route a stall-rate argument through to the
+    controller. Pinned so that shift lands here rather than in
+    production.
+    """
+    assert _YAW_RATE_MIN > 0.0, (
+        f"_YAW_RATE_MIN must be strictly positive to avoid a divide-by-zero in composed-duration; got {_YAW_RATE_MIN!r}"
+    )
+
+
+def test_the_angle_clamp_is_symmetric_two_pi() -> None:
+    """The angle clamp is exactly ``[-2*pi, 2*pi]``.
+
+    The neon wrapper's ``max(-2*pi, min(2*pi, float(angle_rad)))``
+    admits one full revolution in either direction; a caller passing
+    ``4*pi`` (two full revolutions) reaches the outer clamp and the
+    composed duration doubles. Pinned so a future revision that
+    widened the clamp to ``4*pi`` (multiple turns) or narrowed it to
+    ``pi`` (half turn) lands here rather than in production.
+    """
+    assert _ANGLE_RAD_MIN == pytest.approx(-2.0 * math.pi)
+    assert _ANGLE_RAD_MAX == pytest.approx(2.0 * math.pi)
+    assert _ANGLE_RAD_MIN == pytest.approx(-_ANGLE_RAD_MAX)
+
+
+def test_the_composed_duration_bounds_match_the_clamp_pair() -> None:
+    """The advertised composed-duration range matches ``[0 / yaw_max, angle_max / yaw_min]``.
+
+    A caller comparing this envelope against
+    :mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`
+    reads ``composed_duration_max`` to see whether the turn surface
+    can compose a duration the duration envelope would clamp. Pinned
+    so a widen of either the angle or yaw-rate clamp that shifted
+    the composed range surfaces here rather than as a silent
+    divergence.
+    """
+    assert _MIN_COMPOSED_DURATION == 0.0
+    assert _MAX_COMPOSED_DURATION == pytest.approx(_ANGLE_RAD_MAX / _YAW_RATE_MIN)
+
+
+def test_the_gate_refusal_code_matches_the_driver_constant() -> None:
+    """The envelope's refusal code names the driver's gate refusal.
+
+    The driver's ``_check_motion_gates`` refuses a locomotion-shaped
+    write on an FSM outside :data:`WALK_FSMS` with rc=7404, and the
+    ``7404`` entry in
+    :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries the
+    text a driver-side turn wrapper would surface. Pinned here so a
+    re-wording of that message lands in one place, not one in the
+    driver and a diverging copy in this envelope.
+    """
+    assert _GATE_REFUSAL_CODE == 7404
+    assert _GATE_REFUSAL_CODE in ERR_CODES, (
+        f"envelope quotes rc={_GATE_REFUSAL_CODE} but that code is not in "
+        f"ERR_CODES. The refusal string would render as 'unknown'."
+    )
+
+
+def test_the_sdk_method_name_is_set_velocity() -> None:
+    """The SDK method the envelope names is ``SetVelocity``.
+
+    The neon bundle's ``g1_turn`` verb composes into a
+    ``g1_move_velocity`` call which fronts ``LocoClient.SetVelocity``;
+    a driver-side turn wrapper would target the same SDK method.
+    Pinned here so a firmware release that renamed the SDK entry
+    surfaces on this constant rather than as a diverging copy in
+    production.
+    """
+    assert _SDK_METHOD == "SetVelocity"
+
+
+def test_g1_list_turn_envelope_returns_the_full_envelope() -> None:
+    """The verb's payload names every clamp, the gate set, and the refusal.
+
+    ``envelope`` carries every clamp constant plus the sign threshold,
+    the composed-duration range, and the SDK method name;
+    ``walk_ready_fsm_ids`` quotes :data:`WALK_FSMS`; and ``refusals``
+    names the ``7404`` gate-refusal code with the decoded text
+    :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries.
+    """
+    result = _call(g1_list_turn_envelope)
+    assert result["status"] == "success"
+    env = result["envelope"]
+    assert env["angle_rad_min"] == _ANGLE_RAD_MIN
+    assert env["angle_rad_max"] == _ANGLE_RAD_MAX
+    assert env["yaw_rate_min"] == _YAW_RATE_MIN
+    assert env["yaw_rate_max"] == _YAW_RATE_MAX
+    assert env["angle_sign_threshold"] == _ANGLE_SIGN_THRESHOLD
+    assert env["composed_duration_min"] == _MIN_COMPOSED_DURATION
+    assert env["composed_duration_max"] == _MAX_COMPOSED_DURATION
+    assert env["sdk_method"] == _SDK_METHOD
+    assert result["walk_ready_fsm_ids"] == sorted(WALK_FSMS)
+    assert result["refusals"] == [
+        {"code": _GATE_REFUSAL_CODE, "text": ERR_CODES[_GATE_REFUSAL_CODE]},
+    ]
+
+
+def test_g1_turn_admits_a_pair_inside_both_envelopes() -> None:
+    """An ``(angle_rad, yaw_rate)`` pair strictly inside both clamps is admitted.
+
+    The identity case (``angle_rad=0.5``, ``yaw_rate=0.3``) is the
+    neon bundle's own default and sits strictly inside both clamps,
+    so a driver-side turn wrapper would not refuse it on envelope
+    grounds (whether the FSM gate admits it is a separate live-read
+    decision the verb does not answer). ``composed_duration`` names
+    what ``abs(angle_rad) / yaw_rate`` would evaluate to at those
+    arguments.
+    """
+    result = _call(g1_turn_admits, angle_rad=0.5, yaw_rate=0.3)
+    assert result["status"] == "success"
+    assert result["admits"] is True
+    assert result["refusals"] == []
+    assert result["composed_duration"] == pytest.approx(0.5 / 0.3)
+    assert result["walk_ready_fsm_ids"] == sorted(WALK_FSMS)
+
+
+def test_g1_turn_admits_at_the_exact_clamp_boundaries() -> None:
+    """Both clamps are inclusive on both axes.
+
+    The neon wrapper's ``max(-2*pi, min(2*pi, ...))`` and
+    ``max(0.1, min(0.6, ...))`` are both inclusive at the boundary
+    (a saturated command is a command); a strict-inequality refusal
+    would silently drop the neon-bundle-admitted saturated case.
+    """
+    for a, y in (
+        (_ANGLE_RAD_MIN, _YAW_RATE_MIN),
+        (_ANGLE_RAD_MIN, _YAW_RATE_MAX),
+        (_ANGLE_RAD_MAX, _YAW_RATE_MIN),
+        (_ANGLE_RAD_MAX, _YAW_RATE_MAX),
+        (_ANGLE_SIGN_THRESHOLD, _YAW_RATE_MIN),
+    ):
+        result = _call(g1_turn_admits, angle_rad=a, yaw_rate=y)
+        assert result["admits"] is True, f"boundary ({a}, {y}) refused: {result['refusals']!r}"
+        assert result["refusals"] == []
+
+
+def test_g1_turn_admits_a_strictly_negative_angle_as_cw_turn() -> None:
+    """A strictly-negative angle is admitted; the composed duration is on ``abs(angle_rad)``.
+
+    The neon wrapper picks the sign of ``vyaw`` from the sign of
+    ``angle_rad`` (``vyaw = yaw_rate if angle_rad >= 0 else -yaw_rate``);
+    the magnitude the composed duration reads is ``abs(angle_rad)``.
+    So an ``angle_rad=-math.pi, yaw_rate=0.3`` call is admitted and
+    composes the same duration a ``angle_rad=math.pi`` call would;
+    the caller who wants to distinguish CW-turn from CCW-turn reads
+    the sign of the argument directly.
+    """
+    result = _call(g1_turn_admits, angle_rad=-math.pi, yaw_rate=0.3)
+    assert result["status"] == "success"
+    assert result["admits"] is True
+    assert result["refusals"] == []
+    assert result["composed_duration"] == pytest.approx(math.pi / 0.3)
+
+
+def test_g1_turn_admits_an_angle_beyond_the_ceiling() -> None:
+    """An angle above ``angle_rad_max`` refuses on that bound.
+
+    The refusal descriptor names ``dimension="angle_rad"``, the
+    offending value, the bound it violated, and the ``7404``
+    gate-refusal code. ``composed_duration`` is ``None`` because a
+    rejected pair does not yield a duration a caller could pass to
+    the duration envelope.
+    """
+    over = _ANGLE_RAD_MAX + 0.1
+    result = _call(g1_turn_admits, angle_rad=over, yaw_rate=0.3)
+    assert result["status"] == "success"
+    assert result["admits"] is False
+    assert result["composed_duration"] is None
+    assert len(result["refusals"]) == 1
+    r = result["refusals"][0]
+    assert r["dimension"] == "angle_rad"
+    assert r["value"] == over
+    assert r["bound_key"] == "angle_rad_max"
+    assert r["bound"] == _ANGLE_RAD_MAX
+    assert r["comparison"] == "value > bound"
+    assert r["code"] == _GATE_REFUSAL_CODE
+    assert r["text"] == ERR_CODES[_GATE_REFUSAL_CODE]
+
+
+def test_g1_turn_admits_a_yaw_rate_below_the_floor() -> None:
+    """A yaw rate below ``yaw_rate_min`` refuses on that bound.
+
+    The neon wrapper's ``max(0.1, ...)`` clamps a stall-rate input
+    up to the turnable minimum; this verb refuses instead so the
+    caller sees the bound rather than the silent clamp. A negative
+    ``yaw_rate`` also lands here (the admits helper reads
+    ``yaw_rate`` directly, not through ``abs()`` -- the neon-
+    wrapper's sign fold is documented on the module-level constant).
+    """
+    result = _call(g1_turn_admits, angle_rad=0.5, yaw_rate=0.05)
+    assert result["status"] == "success"
+    assert result["admits"] is False
+    assert result["composed_duration"] is None
+    assert len(result["refusals"]) == 1
+    r = result["refusals"][0]
+    assert r["dimension"] == "yaw_rate"
+    assert r["bound_key"] == "yaw_rate_min"
+    assert r["bound"] == _YAW_RATE_MIN
+    assert r["comparison"] == "value < bound"
+
+
+def test_g1_turn_admits_names_both_violated_bounds() -> None:
+    """A pair violating both axes surfaces both refusals.
+
+    A caller passing an out-of-range angle and an out-of-range
+    yaw-rate sees two refusal descriptors, one per axis; the shape
+    lets a caller decide the refusal message without composing
+    which axis's bound was hit first.
+    """
+    result = _call(g1_turn_admits, angle_rad=_ANGLE_RAD_MAX + 0.1, yaw_rate=_YAW_RATE_MAX + 0.1)
+    assert result["admits"] is False
+    assert result["composed_duration"] is None
+    dims = {r["dimension"] for r in result["refusals"]}
+    assert dims == {"angle_rad", "yaw_rate"}
+
+
+@pytest.mark.parametrize("bad_angle", [math.inf, -math.inf, math.nan])
+def test_g1_turn_admits_refuses_non_finite_angle(bad_angle: float) -> None:
+    """``math.inf`` / ``-math.inf`` / ``math.nan`` on the angle axis refuse.
+
+    A NaN cannot be compared decidably against the clamps
+    (``nan < min`` is ``False`` but ``nan >= min`` is also ``False``,
+    so neither branch admits it), and an infinity would overrun the
+    outer angle bound and compose an unbounded duration; both are
+    shape violations rather than value ones. Named on the refusal
+    descriptor with ``comparison="non-finite"``.
+    """
+    result = _call(g1_turn_admits, angle_rad=bad_angle, yaw_rate=0.3)
+    assert result["status"] == "success"
+    assert result["admits"] is False
+    assert result["composed_duration"] is None
+    dims = {r["dimension"]: r for r in result["refusals"]}
+    assert "angle_rad" in dims
+    assert dims["angle_rad"]["comparison"] == "non-finite"
+    assert dims["angle_rad"]["code"] == _GATE_REFUSAL_CODE
+
+
+@pytest.mark.parametrize("bad_yaw", [math.inf, -math.inf, math.nan])
+def test_g1_turn_admits_refuses_non_finite_yaw_rate(bad_yaw: float) -> None:
+    """``math.inf`` / ``-math.inf`` / ``math.nan`` on the yaw-rate axis refuse.
+
+    Symmetric partner to the angle-side non-finite check. A non-
+    finite yaw rate would either divide-by-zero (``nan`` and ``inf``
+    both propagate through the composed-duration division in shape-
+    violating ways) or route the controller a bogus yaw command;
+    both are shape violations rather than value ones.
+    """
+    result = _call(g1_turn_admits, angle_rad=0.5, yaw_rate=bad_yaw)
+    assert result["status"] == "success"
+    assert result["admits"] is False
+    assert result["composed_duration"] is None
+    dims = {r["dimension"]: r for r in result["refusals"]}
+    assert "yaw_rate" in dims
+    assert dims["yaw_rate"]["comparison"] == "non-finite"
+
+
+def test_g1_turn_admits_default_call_is_neon_shape() -> None:
+    """Calling with no arguments admits a conservative default pair.
+
+    The verb's defaults ``angle_rad=0.5, yaw_rate=0.3`` sit strictly
+    inside both clamps, so a zero-arg invocation ("what would a
+    conservative turn do?") returns ``admits=True`` with a finite
+    ``composed_duration``. Pinned so a change to the defaults that
+    silently shifted the conservative-query answer surfaces here.
+    """
+    result = _call(g1_turn_admits)
+    assert result["status"] == "success"
+    assert result["admits"] is True
+    assert result["refusals"] == []
+    assert result["composed_duration"] == pytest.approx(0.5 / 0.3)
+
+
+def test_g1_turn_admits_composed_duration_overhangs_the_duration_envelope() -> None:
+    """The maximum-composed-duration case overhangs the duration envelope's clamp.
+
+    A turn call at ``angle_rad=2*pi, yaw_rate=0.1`` composes to a
+    ``~62.83`` s duration, which is above the locomotion-duration
+    envelope's ``10.0`` s upper clamp (port #2972). The pair is
+    admitted at the turn envelope layer (both arguments sit at their
+    own clamps' inner boundaries), and the ``composed_duration`` the
+    verb returns names the overhang so a caller comparing this
+    envelope's admission against the duration envelope's admission
+    sees where the two disagree. Pinned so a widen of either the
+    turn or the duration clamps that closed the overhang surfaces
+    here.
+    """
+    result = _call(g1_turn_admits, angle_rad=_ANGLE_RAD_MAX, yaw_rate=_YAW_RATE_MIN)
+    assert result["admits"] is True
+    assert result["composed_duration"] == pytest.approx(_MAX_COMPOSED_DURATION)
+    assert result["composed_duration"] == pytest.approx((2.0 * math.pi) / 0.1)


### PR DESCRIPTION
Ports the turn envelope from
`cagataycali/neon-the-g1/tools/g1_locomotion.py::g1_turn` into
`strands_robots.tools.g1.g1_turn_envelope` as a pair of read-only
`@tool` verbs. Refs strands-labs/robots#358, follows #2973.

## What it does today

Snapshots the `(angle_rad, yaw_rate)` clamp pair the neon wrapper
narrows to before it dispatches `LocoClient.SetVelocity` for a
yaw-only turn-in-place -- the SDK itself places no clamps on
either argument, so the envelope lives in the tool layer. Two
verbs:

- **`g1_list_turn_envelope`** -- name the whole envelope
  (`angle_rad_min=-2*pi`, `angle_rad_max=2*pi`, `yaw_rate_min=0.1`,
  `yaw_rate_max=0.6`, plus the composed-duration range and SDK
  method name) alongside `WALK_FSMS` and the `rc=7404` refusal
  string.
- **`g1_turn_admits(angle_rad, yaw_rate)`** -- decide one query,
  report every violated bound on its own refusal descriptor
  (`dimension` in `{"angle_rad", "yaw_rate"}`), and expose the
  composed `duration = abs(angle_rad) / yaw_rate` so a caller can
  pass it to `g1_locomotion_duration_admits` (port #2972) without
  composing the arithmetic itself.

Neither verb touches the bus, opens the SDK, or reads a driver
instance -- every field is a module-level snapshot of a constant
the neon wrapper carries. Non-finite input (`math.inf`, `math.nan`)
refuses with `comparison="non-finite"` so a caller distinguishes a
bounds violation from a shape one.

The composed duration envelope `[0.0, 2*pi/0.1]` ~= `[0.0, 62.83]`
seconds overhangs the locomotion-duration envelope's
`[0.0, 10.0]` s upper clamp (port #2972); the overhang is named on
the returned envelope so a caller comparing the two admission
layers sees it without composing the arithmetic itself.

## Refusal strings (rule 3, #2872)

- `rc=7404` -- the driver's `_check_motion_gates` refusal on a
  locomotion-shaped write outside
  `strands_robots.tools.g1._g1_common.WALK_FSMS`. Named on both
  verbs; the write path and this lookup share the constant.

## Gates

- `ruff check` clean on both files
- `ruff format --check` clean on both files
- `mypy` clean on the new module
- `pytest tests/drivers/test_g1_turn_envelope_reads_the_angle_and_yaw_rate_clamps.py` -- **22/22 passing**

## Import-hygiene contract (rule 1)

`import strands_robots.tools.g1.g1_turn_envelope` pulls zero
`unitree_sdk2py` submodules -- the envelope table is a module-level
snapshot. Pinned by `test_the_import_pulls_no_sdk_module`.

## Series

Same shape as #2965 (velocity), #2966 (stand_height), #2970
(swing_height), #2967 (balance_modes), #2968 (audio_volume), #2971
(mode_machines), #2972 (locomotion_duration), #2973 (walk_forward);
follows the extract-and-port cadence for #358.

---

## 13. Round-1 changelog

**`ac9a034a` - cite the unlanded duration envelope as a literal, not a role** (addresses the review finding on the dead `:mod:` targets)

The review split one report into two targets needing different remedies, and that split is what the fix follows.

`g1_velocity_envelope` needed no edit at the current head: #2965 landed on `main` as `00b71e76`, and this branch's merge base is now that same commit, so the module is present in the branch tree and both roles (lines 63 and 69) resolve. They stay as `:mod:` roles deliberately.

`g1_locomotion_duration_envelope` took the literal-downgrade option, since #2972 is still open and no commit on this branch can make that path importable. All three sites are now plain ``` ``g1_locomotion_duration_envelope`` ``` with the existing `port #2972` annotation retained so the pointer still reaches a reader: the module docstring (line 73), the `_MAX_COMPOSED_DURATION` `#:` block (line 161), and the test docstring on `test_the_composed_duration_bounds_match_the_clamp_pair`. The `#:` block is not graded by the sweep, since comments are not docstrings, but it is the same dead pointer for a reader, so it is fixed alongside the two that were.

That leaves the asymmetry the guard wants - a `:mod:` role for the sibling that has landed, a literal for the one that has not - and removes the merge-order coupling in both directions rather than sequencing this PR behind an unmerged sibling. The role for the duration envelope is restored in a follow-up once #2972 merges.

**Verification.** The whole-tree sweep cannot run in a sandbox without every optional extra: `strands_robots/tools/lerobot_camera.py` re-raises a bare `ImportError` with no `name` attribute, so the guard's `_absent_dependency` cannot classify it as an absent extra and the run dies there. Graded this PR's two files instead with the guard's own `_ROLE_RE` and `_resolves` helpers imported directly from the test module: **20 qualified `strands_robots.*` targets, 0 offenders.** `pytest` over the module suite plus `no_unicode_dashes` and `no_emoji` is 28 passed. `ruff check` / `ruff format --check` clean; longest touched line is 104 against the 120 limit.