### PR TITLE
feat(tools/g1): port g1_list_damp_transitions and g1_damp_transition_admits (refs #358)

### DIFF
--- a/changelog.d/2975-g1-damp-transition-envelope-port.md
+++ b/changelog.d/2975-g1-damp-transition-envelope-port.md
@@ -16,9 +16,14 @@
   field naming the neon bundle's one-line semantic, so an agent-facing
   planner has the transition intent on hand without re-reading the
   neon docs. The verbs also surface `walk_ready_fsm_ids` (quoting
-  `WALK_FSMS`) and the `7404` gate-refusal code so a caller comparing
-  an intended write against the general locomotion gate has the FSM
-  set on hand too. No DDS is touched, no `unitree_sdk2py` submodule
+  `WALK_FSMS`) and a module-local gate-refusal text built from that
+  same set, so a caller comparing an intended write against the
+  general locomotion gate has the FSM set on hand too. No refusal
+  quotes an SDK return code: the driver's `_check_motion_gates`
+  returns free-text refusals and names none, and the two refusals this
+  module makes have different remedies (an FSM outside the locomotion
+  gate wants a transition; an unknown transition label wants a
+  different string), so each carries its own text. No DDS is touched, no `unitree_sdk2py` submodule
   loads at import (the same hygiene rule `g1_balance_modes`,
   `g1_arm_actions`, `g1_fsm_targets`, and `g1_motion_gates` carry).
   Refs #358.

--- a/changelog.d/2975-g1-damp-transition-envelope-port.md
+++ b/changelog.d/2975-g1-damp-transition-envelope-port.md
@@ -1,0 +1,24 @@
+### Feature
+
+- Added `strands_robots.tools.g1.g1_list_damp_transitions` and
+  `strands_robots.tools.g1.g1_damp_transition_admits`: pure-reference
+  agent-facing lookups over the safe damp-preamble transition
+  preconditions the neon bundle's `g1_safe_posture.py` verbs
+  (`cagataycali/neon-the-g1/tools/g1_safe_posture.py`) each front, so a
+  caller can decide the refusal decidably before a future driver-side
+  wrapper for the damp-preamble path is called. Snapshotted from the
+  neon bundle's `_assert_safe_for_damp` refusal boundary observed
+  against the real robot: three transitions (`squat_to_stand`,
+  `lie_to_stand`, `stand_to_squat`) each carrying the FSM set the
+  transition is safe from, a `pose_check` flag naming whether the
+  `avg_knee > 1.4 rad` refusal is enforced, and the `avg_knee_max_rad`
+  threshold when enabled. Each descriptor also carries a `description`
+  field naming the neon bundle's one-line semantic, so an agent-facing
+  planner has the transition intent on hand without re-reading the
+  neon docs. The verbs also surface `walk_ready_fsm_ids` (quoting
+  `WALK_FSMS`) and the `7404` gate-refusal code so a caller comparing
+  an intended write against the general locomotion gate has the FSM
+  set on hand too. No DDS is touched, no `unitree_sdk2py` submodule
+  loads at import (the same hygiene rule `g1_balance_modes`,
+  `g1_arm_actions`, `g1_fsm_targets`, and `g1_motion_gates` carry).
+  Refs #358.

--- a/strands_robots/tools/g1/g1_damp_transition_envelope.py
+++ b/strands_robots/tools/g1/g1_damp_transition_envelope.py
@@ -39,9 +39,9 @@ Two things this module is deliberately *not*:
   every other file in this package carries, refs
   strands-labs/robots#358. A revision of the neon bundle's observed
   preconditions is a driver-side update; when the driver's
-  damp-preamble method lands, its refusal will quote the same
-  ``7404`` gate-refusal code
-  :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries.
+  damp-preamble method lands, its refusal will name the same
+  locomotion gate this module's refusal text names. No SDK return
+  code is quoted on either side, because the driver quotes none.
 
 What this module does not decide.
 
@@ -67,7 +67,7 @@ from typing import Any
 
 from strands import tool
 
-from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
+from strands_robots.tools.g1._g1_common import WALK_FSMS
 
 #: The upper bound on the robot's average knee angle (radians) above
 #: which the neon bundle's ``_assert_safe_for_damp`` refuses the
@@ -81,26 +81,24 @@ from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
 #: not another SDK write.
 _AVG_KNEE_MAX_RAD: float = 1.4
 
-#: The pair of fields the SDK's own return-code table names when the
-#: driver's motion gate refuses a locomotion-shaped write on an FSM
-#: outside :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. Named
-#: here so the returned envelope carries the exact refusal string a
-#: future driver-side damp-preamble wrapper would surface, and so a
-#: re-wording of it lands in one place instead of drifting between
-#: the driver's log and this lookup.
-_GATE_REFUSAL_CODE: int = 7404
-
-#: The refusal code a future driver-side wrapper would quote on a
-#: transition name outside :data:`_DAMP_TRANSITIONS`. The SDK does not
-#: ship a distinct rc for "unknown damp-preamble transition" (the
-#: neon bundle owned the transition names, not the SDK); the neon
-#: bundle refused unknown names at the verb boundary, so this lookup
-#: uses the same ``7404`` gate-refusal shape a future driver-side
-#: wrapper would quote when refusing at the same boundary. Named
-#: separately from :data:`_GATE_REFUSAL_CODE` so a future SDK release
-#: that adds a dedicated "invalid transition" code lands here without
-#: also renaming the gate-refusal constant.
-_INVALID_TRANSITION_CODE: int = 7404
+# Refusals in this module carry module-local text and no ``code`` field,
+# because no SDK return code covers either refusal it makes.
+#
+# ``ERR_CODES[7404]`` ("Invalid FSM id - need FSM in {500, 501, 801}") is the
+# nearest-looking candidate and is wrong on both counts. This repository's
+# driver quotes it nowhere -- ``G1Driver._check_motion_gates`` returns
+# free-text refusals and never names a return code -- so it is not "the code
+# the driver quotes". And the set it names is not ``WALK_FSMS``
+# (``{501, 801}``), so a payload carrying that text beside its own
+# ``walk_ready_fsm_ids`` would contradict itself about which FSMs are
+# admitted.
+#
+# The two refusals also have different remedies, which is why they are
+# separate texts rather than one shared code: an FSM outside the locomotion
+# gate is a robot-state problem fixed by a transition, while an unknown
+# transition label is an argument problem fixed by passing a different
+# string. Quoting the FSM code for a mistyped label would hand an agent
+# planner a physical motion-state change as the remedy for a typo.
 
 
 #: Snapshot of the safe damp-preamble transitions the neon bundle's
@@ -170,6 +168,31 @@ _DAMP_TRANSITIONS: dict[str, dict[str, Any]] = {
 }
 
 
+def _walk_gate_refusal() -> str:
+    """The refusal text a future driver-side damp-preamble wrapper would surface.
+
+    Built from :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`
+    rather than spelled as a literal, so a widen of the locomotion
+    gate carries into this message instead of leaving a stale set
+    behind. This is the refusal a caller gets for a *robot-state*
+    problem, and its remedy is an FSM transition.
+    """
+    return f"fsm_id outside the locomotion gate - need FSM in {sorted(WALK_FSMS)}"
+
+
+def _unknown_transition_refusal() -> str:
+    """The refusal text for a transition label this module does not carry.
+
+    Built from :data:`_DAMP_TRANSITIONS` so an added transition widens
+    the message too. Kept strictly distinct from
+    :func:`_walk_gate_refusal`: a mistyped or unknown label is an
+    *argument* problem whose remedy is to pass a different string, and
+    handing such a caller the FSM-gate remedy would point it at a
+    physical motion-state change it never asked for.
+    """
+    return f"unknown damp-preamble transition - need one of {sorted(_DAMP_TRANSITIONS)}"
+
+
 def _describe(name: str) -> dict[str, Any]:
     """Build the per-transition descriptor the verbs return.
 
@@ -214,17 +237,20 @@ def g1_list_damp_transitions() -> dict[str, Any]:
         semantic); a ``walk_ready_fsm_ids`` list quoting
         :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`, the set
         the driver's motion gate admits locomotion-shaped writes on;
-        and a ``refusals`` list carrying the ``7404`` gate-refusal
-        code and its decoded text, the one a future write verb would
-        surface. Every field is a snapshot of an observed neon
-        precondition or a driver constant; no dynamic decode runs here.
+        and a ``refusals`` list carrying the module-local gate-refusal
+        ``text`` a future write verb would surface, built from
+        ``WALK_FSMS`` so it cannot drift from ``walk_ready_fsm_ids`` in
+        the same payload. No ``code`` field: the driver quotes no SDK
+        return code on this gate. Every field is a snapshot of an
+        observed neon precondition or a driver constant; no dynamic
+        decode runs here.
     """
     return {
         "status": "success",
         "transitions": [_describe(name) for name in sorted(_DAMP_TRANSITIONS)],
         "walk_ready_fsm_ids": sorted(WALK_FSMS),
         "refusals": [
-            {"code": _GATE_REFUSAL_CODE, "text": ERR_CODES[_GATE_REFUSAL_CODE]},
+            {"text": _walk_gate_refusal()},
         ],
     }
 
@@ -235,7 +261,7 @@ def g1_damp_transition_admits(name: str) -> dict[str, Any]:
 
     Read-only. Compares ``name`` against the neon-observed
     :data:`_DAMP_TRANSITIONS` and reports the admitted descriptor on
-    match, or the ``7404`` gate-refusal code the driver would quote
+    match, or a refusal naming the unknown label and the admitted set
     on miss. No driver instance, no DDS, no SDK: the decision reads
     only module-level constants and the argument itself.
 
@@ -256,9 +282,10 @@ def g1_damp_transition_admits(name: str) -> dict[str, Any]:
         name: The transition label to check. Case-sensitive against
             the snapshot in :data:`_DAMP_TRANSITIONS` (``squat_to_stand``,
             ``lie_to_stand``, or ``stand_to_squat`` today). A
-            mis-cased or unknown label is refused with the ``7404``
-            code. A non-string argument is refused with the same
-            code because the lookup is by string key.
+            mis-cased or unknown label is refused with the
+            unknown-transition text. A non-string argument is refused
+            with the same text, because the lookup is by string key and
+            both are the same argument mistake.
 
     Returns:
         A dict with ``status``; on admit, a ``transition`` descriptor
@@ -266,23 +293,23 @@ def g1_damp_transition_admits(name: str) -> dict[str, Any]:
         ``avg_knee_max_rad``, and ``description`` (the same shape
         :func:`g1_list_damp_transitions` returns), plus
         ``walk_ready_fsm_ids`` for the follow-on gate decision. On
-        refuse, ``refusal_code`` and ``refusal_text`` name the ``7404``
-        code and its decoded text, plus a ``reason`` string that names
-        why the argument was refused (unknown name or non-string
-        argument).
+        refuse, ``refusal_text`` names the unknown-transition refusal
+        (the admitted labels, never the FSM gate -- the remedy for a bad
+        label is a different string, not a motion-state change), plus a
+        ``reason`` string that names why the argument was refused
+        (unknown name or non-string argument). There is no
+        ``refusal_code``: no SDK return code covers this refusal.
     """
     if not isinstance(name, str):
         return {
             "status": "error",
-            "refusal_code": _INVALID_TRANSITION_CODE,
-            "refusal_text": ERR_CODES[_INVALID_TRANSITION_CODE],
+            "refusal_text": _unknown_transition_refusal(),
             "reason": (f"name={name!r} is not a str; pass one of {sorted(_DAMP_TRANSITIONS)}"),
         }
     if name not in _DAMP_TRANSITIONS:
         return {
             "status": "error",
-            "refusal_code": _INVALID_TRANSITION_CODE,
-            "refusal_text": ERR_CODES[_INVALID_TRANSITION_CODE],
+            "refusal_text": _unknown_transition_refusal(),
             "reason": (f"name={name!r} is not in the admitted set {sorted(_DAMP_TRANSITIONS)}"),
         }
     return {

--- a/strands_robots/tools/g1/g1_damp_transition_envelope.py
+++ b/strands_robots/tools/g1/g1_damp_transition_envelope.py
@@ -1,0 +1,292 @@
+"""Agent-facing lookup for the safe-damp transition envelope.
+
+The neon bundle's ``g1_safe_posture.py`` verbs
+(``cagataycali/neon-the-g1/tools/g1_safe_posture.py``) each front a
+``LocoClient.Damp()`` preamble followed by an FSM transition. The
+preamble is only *safe* when the loco controller is actively holding
+the robot: ``Damp()`` on an uncontrolled robot removes what little
+holding torque the joint drives had and the robot collapses further.
+The neon bundle observed against the real robot that each transition
+is safe from a small set of controller-managed FSMs, and that a
+deep-squat pose (``avg_knee > 1.4 rad``) means the controller has
+already let go and no damp-preamble path will recover it. Those two
+membership tests — expected FSM set and knee-angle threshold — are
+the transition envelope; this module surfaces them so a caller can
+decide the refusal decidably before a future driver-side wrapper for
+the damp-preamble path is attempted, rather than pinning it inside
+the write path where the refusal is invisible to the planner.
+
+Two things this module is deliberately *not*:
+
+* An execution path. The neon bundle's ``g1_safe_squat_to_stand``,
+  ``g1_safe_lie_to_stand``, and ``g1_safe_stand_to_squat`` verbs each
+  wrap ``LocoClient.Damp()`` followed by a locomotion-shaped write
+  (``Squat2StandUp``, ``Lie2StandUp``, or ``SetFsmId(2)``); that pair
+  of writes is the ``rt/lowcmd``-adjacent locomotion topic today's
+  :class:`~strands_robots.drivers.g1.G1Driver` refuses through
+  :meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates` on
+  any locomotion-shaped write while ``_fsm_id`` is outside
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. A future
+  driver method that fronts the damp-preamble path will land the
+  write verb; refs strands-labs/robots#358 for the SDK-facing gate
+  work that write belongs on. This module ports the read-only
+  envelope half without also introducing a second locomotion writer
+  path the driver does not yet own.
+* An SDK re-import. The transition table is captured here as
+  module-level constants so
+  ``import strands_robots.tools.g1.g1_damp_transition_envelope``
+  pulls no ``unitree_sdk2py`` submodule - the import-hygiene contract
+  every other file in this package carries, refs
+  strands-labs/robots#358. A revision of the neon bundle's observed
+  preconditions is a driver-side update; when the driver's
+  damp-preamble method lands, its refusal will quote the same
+  ``7404`` gate-refusal code
+  :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries.
+
+What this module does not decide.
+
+* Whether the driver's live ``_fsm_id`` currently sits inside a
+  transition's ``expected_fsm_ids``. That is a live driver-instance
+  read carried on the driver's ``get_status`` envelope; a caller
+  planning a damp-preamble compares the driver's live fsm against
+  the transition's ``expected_fsm_ids`` this verb surfaces to decide
+  whether the damp gate is currently open.
+* Whether the driver's live average knee angle is below the knee
+  threshold. That is a live LowState read carried on the driver's
+  ``get_status`` envelope; the threshold this verb surfaces is the
+  refusal boundary, not a live sample.
+* Whether ``rt/lowcmd`` is currently held by another writer. The
+  driver's single-writer lock reports that at wire time; a caller
+  planning a damp-preamble write cannot decide it without opening
+  the topic itself, and this module opens no channel.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
+
+#: The upper bound on the robot's average knee angle (radians) above
+#: which the neon bundle's ``_assert_safe_for_damp`` refuses the
+#: damp-preamble. The neon bundle observed that at ``avg_knee > 1.4``
+#: the robot is in a deep squat or is sagging: the loco controller
+#: has already released holding torque, so ``Damp()`` will remove the
+#: last resistance and the robot will collapse further. Named as an
+#: absolute upper bound because a knee angle below this value is
+#: within the controller-holdable range, and a value above means the
+#: physical intervention path (gantry, remote) is the safe answer,
+#: not another SDK write.
+_AVG_KNEE_MAX_RAD: float = 1.4
+
+#: The pair of fields the SDK's own return-code table names when the
+#: driver's motion gate refuses a locomotion-shaped write on an FSM
+#: outside :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. Named
+#: here so the returned envelope carries the exact refusal string a
+#: future driver-side damp-preamble wrapper would surface, and so a
+#: re-wording of it lands in one place instead of drifting between
+#: the driver's log and this lookup.
+_GATE_REFUSAL_CODE: int = 7404
+
+#: The refusal code a future driver-side wrapper would quote on a
+#: transition name outside :data:`_DAMP_TRANSITIONS`. The SDK does not
+#: ship a distinct rc for "unknown damp-preamble transition" (the
+#: neon bundle owned the transition names, not the SDK); the neon
+#: bundle refused unknown names at the verb boundary, so this lookup
+#: uses the same ``7404`` gate-refusal shape a future driver-side
+#: wrapper would quote when refusing at the same boundary. Named
+#: separately from :data:`_GATE_REFUSAL_CODE` so a future SDK release
+#: that adds a dedicated "invalid transition" code lands here without
+#: also renaming the gate-refusal constant.
+_INVALID_TRANSITION_CODE: int = 7404
+
+
+#: Snapshot of the safe damp-preamble transitions the neon bundle's
+#: ``g1_safe_posture.py`` verbs each front. Each entry captures the
+#: three fields the neon bundle's ``_assert_safe_for_damp`` observes
+#: at refusal time:
+#:
+#: * ``expected_fsm_ids`` — the FSM ids the controller must be in for
+#:   the damp-preamble to be safe. Sourced from the neon bundle's own
+#:   ``expected_fsms`` argument on each verb's call to
+#:   ``_assert_safe_for_damp``.
+#: * ``pose_check`` — whether the neon bundle's ``avg_knee`` refusal
+#:   is enforced for this transition. Sourced from the same verb's
+#:   ``pose_check`` argument. Only ``squat_to_stand`` uses the pose
+#:   check today; ``lie_to_stand`` and ``stand_to_squat`` skip it (a
+#:   lying robot can be at any knee angle; a stand-to-squat caller
+#:   asks for a lower knee angle by definition).
+#: * ``description`` — the neon bundle's own docstring summary of
+#:   what the transition does, so an agent-facing planner has the
+#:   one-line semantic on hand without re-reading the neon docs.
+#:
+#: The snapshot lives here rather than in
+#: :mod:`~strands_robots.tools.g1._g1_common` because the mapping is
+#: only useful for the damp-preamble-side of the conversation; a
+#: caller that only needs the FSM set reaches
+#: :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS` or the
+#: transition-specific ``expected_fsm_ids`` directly. Colocating the
+#: map with the verb mirrors ``_BALANCE_MODE_MAP`` in
+#: :mod:`~strands_robots.tools.g1.g1_balance_modes` and
+#: ``_ARM_ACTION_MAP`` in
+#: :mod:`~strands_robots.tools.g1.g1_arm_actions`: one snapshot per
+#: SDK-facing transition table, one verb pair per snapshot.
+_DAMP_TRANSITIONS: dict[str, dict[str, Any]] = {
+    "squat_to_stand": {
+        "expected_fsm_ids": frozenset({3, 4, 706}),
+        "pose_check": True,
+        "description": (
+            "Damp preamble then Squat2StandUp. Safe from Sit (3), "
+            "StandUp (4), or Squat2StandUp (706). Refuses when the "
+            "average knee angle exceeds the threshold, because that "
+            "means the controller has already let go."
+        ),
+    },
+    "lie_to_stand": {
+        "expected_fsm_ids": frozenset({1, 702}),
+        "pose_check": False,
+        "description": (
+            "Damp preamble then Lie2StandUp. Safe from Damp (1) or "
+            "Lie2StandUp (702) — the face-up lying poses the "
+            "controller can lift from. Pose check skipped because a "
+            "lying robot's knee angle is not the deciding factor."
+        ),
+    },
+    "stand_to_squat": {
+        "expected_fsm_ids": frozenset({500, 501, 801}),
+        "pose_check": False,
+        "description": (
+            "Damp preamble then SetFsmId(2=Squat) — works around the "
+            "SDK bug where LocoClient.StandUp2Squat() dispatches to "
+            "FSM 706 (stand-up) instead of FSM 2 (squat). Safe from "
+            "Start (500), Walk (501), or BalanceExpert (801) — the "
+            "upright, actively-balancing FSMs. Pose check skipped "
+            "because a caller asking for a stand-to-squat expects a "
+            "lower knee angle by definition."
+        ),
+    },
+}
+
+
+def _describe(name: str) -> dict[str, Any]:
+    """Build the per-transition descriptor the verbs return.
+
+    Kept here rather than inlined in
+    :func:`g1_list_damp_transitions` so
+    :func:`g1_damp_transition_admits`'s admitted-path payload names the
+    same fields, and so a widen to the descriptor lands in one place.
+    Every field is a snapshot read; no bus is touched.
+    """
+    entry = _DAMP_TRANSITIONS[name]
+    return {
+        "name": name,
+        "expected_fsm_ids": sorted(entry["expected_fsm_ids"]),
+        "pose_check": entry["pose_check"],
+        "avg_knee_max_rad": _AVG_KNEE_MAX_RAD if entry["pose_check"] else None,
+        "description": entry["description"],
+    }
+
+
+@tool
+def g1_list_damp_transitions() -> dict[str, Any]:
+    """Return the safe damp-preamble transitions the neon bundle documented.
+
+    Read-only. No driver instance, no DDS, no SDK: every field is a
+    module-level constant. Useful before a future driver-side wrapper
+    for the damp-preamble path is called, so a caller can name the
+    transitions the neon bundle observed as safe against the real
+    robot, and can also compare the driver's live ``fsm_id`` (from
+    ``G1Driver.get_status``) and ``avg_knee`` (also from
+    ``get_status``) against the per-transition ``expected_fsm_ids``
+    and ``avg_knee_max_rad`` to decide whether the damp gate is
+    currently open.
+
+    Returns:
+        A dict with ``status``; a ``transitions`` list of per-transition
+        descriptors sorted by ``name`` ascending, each carrying
+        ``name`` (the neon-observed transition label), ``expected_fsm_ids``
+        (the FSM set the transition is safe from), ``pose_check``
+        (whether the knee-angle refusal is enforced), ``avg_knee_max_rad``
+        (the knee threshold in radians when ``pose_check`` is enabled,
+        else ``None``), and ``description`` (the neon bundle's one-line
+        semantic); a ``walk_ready_fsm_ids`` list quoting
+        :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`, the set
+        the driver's motion gate admits locomotion-shaped writes on;
+        and a ``refusals`` list carrying the ``7404`` gate-refusal
+        code and its decoded text, the one a future write verb would
+        surface. Every field is a snapshot of an observed neon
+        precondition or a driver constant; no dynamic decode runs here.
+    """
+    return {
+        "status": "success",
+        "transitions": [_describe(name) for name in sorted(_DAMP_TRANSITIONS)],
+        "walk_ready_fsm_ids": sorted(WALK_FSMS),
+        "refusals": [
+            {"code": _GATE_REFUSAL_CODE, "text": ERR_CODES[_GATE_REFUSAL_CODE]},
+        ],
+    }
+
+
+@tool
+def g1_damp_transition_admits(name: str) -> dict[str, Any]:
+    """Decide whether a transition ``name`` sits inside the admitted set.
+
+    Read-only. Compares ``name`` against the neon-observed
+    :data:`_DAMP_TRANSITIONS` and reports the admitted descriptor on
+    match, or the ``7404`` gate-refusal code the driver would quote
+    on miss. No driver instance, no DDS, no SDK: the decision reads
+    only module-level constants and the argument itself.
+
+    A transition inside the admitted set is *not* the same as an
+    admitted write: the driver's motion gate
+    (``_check_motion_gates``) also refuses on ``_fsm_id`` outside the
+    transition's ``expected_fsm_ids`` and (when ``pose_check`` is
+    enabled) on ``avg_knee`` above :data:`_AVG_KNEE_MAX_RAD`, both of
+    which this verb does not read (they are live driver-instance
+    queries answered by
+    :mod:`~strands_robots.tools.g1.g1_state` and
+    :mod:`~strands_robots.tools.g1.g1_motion_gates`). The returned
+    payload names ``walk_ready_fsm_ids`` so a caller comparing an
+    intended write against the general locomotion gate has the FSM
+    set on hand too.
+
+    Args:
+        name: The transition label to check. Case-sensitive against
+            the snapshot in :data:`_DAMP_TRANSITIONS` (``squat_to_stand``,
+            ``lie_to_stand``, or ``stand_to_squat`` today). A
+            mis-cased or unknown label is refused with the ``7404``
+            code. A non-string argument is refused with the same
+            code because the lookup is by string key.
+
+    Returns:
+        A dict with ``status``; on admit, a ``transition`` descriptor
+        with ``name``, ``expected_fsm_ids``, ``pose_check``,
+        ``avg_knee_max_rad``, and ``description`` (the same shape
+        :func:`g1_list_damp_transitions` returns), plus
+        ``walk_ready_fsm_ids`` for the follow-on gate decision. On
+        refuse, ``refusal_code`` and ``refusal_text`` name the ``7404``
+        code and its decoded text, plus a ``reason`` string that names
+        why the argument was refused (unknown name or non-string
+        argument).
+    """
+    if not isinstance(name, str):
+        return {
+            "status": "error",
+            "refusal_code": _INVALID_TRANSITION_CODE,
+            "refusal_text": ERR_CODES[_INVALID_TRANSITION_CODE],
+            "reason": (f"name={name!r} is not a str; pass one of {sorted(_DAMP_TRANSITIONS)}"),
+        }
+    if name not in _DAMP_TRANSITIONS:
+        return {
+            "status": "error",
+            "refusal_code": _INVALID_TRANSITION_CODE,
+            "refusal_text": ERR_CODES[_INVALID_TRANSITION_CODE],
+            "reason": (f"name={name!r} is not in the admitted set {sorted(_DAMP_TRANSITIONS)}"),
+        }
+    return {
+        "status": "success",
+        "transition": _describe(name),
+        "walk_ready_fsm_ids": sorted(WALK_FSMS),
+    }

--- a/strands_robots/tools/g1/g1_damp_transition_envelope.py
+++ b/strands_robots/tools/g1/g1_damp_transition_envelope.py
@@ -10,7 +10,7 @@ The neon bundle observed against the real robot that each transition
 is safe from a small set of controller-managed FSMs, and that a
 deep-squat pose (``avg_knee > 1.4 rad``) means the controller has
 already let go and no damp-preamble path will recover it. Those two
-membership tests — expected FSM set and knee-angle threshold — are
+membership tests - expected FSM set and knee-angle threshold - are
 the transition envelope; this module surfaces them so a caller can
 decide the refusal decidably before a future driver-side wrapper for
 the damp-preamble path is attempted, rather than pinning it inside
@@ -108,17 +108,17 @@ _INVALID_TRANSITION_CODE: int = 7404
 #: three fields the neon bundle's ``_assert_safe_for_damp`` observes
 #: at refusal time:
 #:
-#: * ``expected_fsm_ids`` — the FSM ids the controller must be in for
+#: * ``expected_fsm_ids`` - the FSM ids the controller must be in for
 #:   the damp-preamble to be safe. Sourced from the neon bundle's own
 #:   ``expected_fsms`` argument on each verb's call to
 #:   ``_assert_safe_for_damp``.
-#: * ``pose_check`` — whether the neon bundle's ``avg_knee`` refusal
+#: * ``pose_check`` - whether the neon bundle's ``avg_knee`` refusal
 #:   is enforced for this transition. Sourced from the same verb's
 #:   ``pose_check`` argument. Only ``squat_to_stand`` uses the pose
 #:   check today; ``lie_to_stand`` and ``stand_to_squat`` skip it (a
 #:   lying robot can be at any knee angle; a stand-to-squat caller
 #:   asks for a lower knee angle by definition).
-#: * ``description`` — the neon bundle's own docstring summary of
+#: * ``description`` - the neon bundle's own docstring summary of
 #:   what the transition does, so an agent-facing planner has the
 #:   one-line semantic on hand without re-reading the neon docs.
 #:
@@ -149,7 +149,7 @@ _DAMP_TRANSITIONS: dict[str, dict[str, Any]] = {
         "pose_check": False,
         "description": (
             "Damp preamble then Lie2StandUp. Safe from Damp (1) or "
-            "Lie2StandUp (702) — the face-up lying poses the "
+            "Lie2StandUp (702) - the face-up lying poses the "
             "controller can lift from. Pose check skipped because a "
             "lying robot's knee angle is not the deciding factor."
         ),
@@ -158,10 +158,10 @@ _DAMP_TRANSITIONS: dict[str, dict[str, Any]] = {
         "expected_fsm_ids": frozenset({500, 501, 801}),
         "pose_check": False,
         "description": (
-            "Damp preamble then SetFsmId(2=Squat) — works around the "
+            "Damp preamble then SetFsmId(2=Squat) - works around the "
             "SDK bug where LocoClient.StandUp2Squat() dispatches to "
             "FSM 706 (stand-up) instead of FSM 2 (squat). Safe from "
-            "Start (500), Walk (501), or BalanceExpert (801) — the "
+            "Start (500), Walk (501), or BalanceExpert (801) - the "
             "upright, actively-balancing FSMs. Pose check skipped "
             "because a caller asking for a stand-to-squat expects a "
             "lower knee angle by definition."

--- a/tests/drivers/test_g1_damp_transition_envelope_reads_the_neon_precondition_set.py
+++ b/tests/drivers/test_g1_damp_transition_envelope_reads_the_neon_precondition_set.py
@@ -1,0 +1,336 @@
+"""The damp-transition envelope names what the neon damp-preamble verbs admit.
+
+The neon bundle's ``g1_safe_posture.py`` verbs
+(``cagataycali/neon-the-g1/tools/g1_safe_posture.py``) each front a
+``LocoClient.Damp()`` preamble followed by an FSM transition. The
+neon bundle observed against the real robot that each transition is
+safe from a small set of controller-managed FSMs, and that a
+deep-squat pose (``avg_knee > 1.4 rad``) means the controller has
+already released holding torque and no damp-preamble path will
+recover it. The :mod:`strands_robots.tools.g1.g1_damp_transition_envelope`
+module snapshots those preconditions into a module-level dict and
+exposes two agent-facing verbs -
+:func:`g1_list_damp_transitions` (name the whole set) and
+:func:`g1_damp_transition_admits` (decide one query) - so a caller
+can decide the refusal decidably before a future damp-preamble write
+path is attempted. The tests here fix that contract without pulling
+the SDK: the module is loadable on a host without ``unitree_sdk2py``
+(the same SDK-load-hygiene rule every other file under
+:mod:`strands_robots.tools.g1` carries, refs strands-labs/robots#358),
+and every membership answer is read off the module's own snapshot
+rather than restated in the tests, so a widen or narrow to the
+observed set surfaces here as a shape change rather than as a
+diverging table this file would need to manually update.
+
+Two things this file's cells deliberately do not pin:
+
+* The SDK's own answer at wire time. The snapshot is the neon
+  bundle's observed precondition set, not the SDK's own admissions
+  (the SDK admits any FSM id silently; the neon bundle drew the
+  refusal boundary from field observation). A driver-side wrapper
+  for the damp-preamble path that lands later will re-check the
+  preconditions at wire time and its refusal string will quote the
+  ``7404`` gate-refusal code the driver's ``_check_motion_gates``
+  also quotes.
+* Whether the driver's live ``fsm_id`` sits inside a transition's
+  ``expected_fsm_ids``. That is a live driver-instance read and
+  belongs on :mod:`~strands_robots.tools.g1.g1_state` /
+  :mod:`~strands_robots.tools.g1.g1_motion_gates`; the verb surfaces
+  the set as a snapshot so a caller comparing an intended write
+  against the transition preconditions has the FSM set on hand.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
+from strands_robots.tools.g1.g1_damp_transition_envelope import (
+    _AVG_KNEE_MAX_RAD,
+    _DAMP_TRANSITIONS,
+    _GATE_REFUSAL_CODE,
+    _INVALID_TRANSITION_CODE,
+    g1_damp_transition_admits,
+    g1_list_damp_transitions,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process; this helper is where a shape
+    drift would surface once, rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be importable
+    with the SDK absent (refs strands-labs/robots#358); a module that
+    pulled a submodule at import time would break every headless CI
+    runner and Thor before an office bring-up.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_damp_transition_envelope")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_damp_transition_envelope imports "
+        f"pulled SDK submodules: {leaked}. The rule for this package is "
+        f"that the SDK loads only inside function bodies (refs "
+        f"strands-labs/robots#358)."
+    )
+
+
+def test_the_snapshot_covers_the_neon_observed_transitions() -> None:
+    """The transition map pins the three transitions the neon bundle documented.
+
+    ``squat_to_stand``, ``lie_to_stand``, and ``stand_to_squat`` are
+    the three verbs ``cagataycali/neon-the-g1/tools/g1_safe_posture.py``
+    exposed against the real robot. A widen or narrow of that set
+    surfaces here as a shape change the tests read off the module's
+    own snapshot, not as a diverging copy this file would need to
+    update.
+    """
+    assert set(_DAMP_TRANSITIONS) == {
+        "squat_to_stand",
+        "lie_to_stand",
+        "stand_to_squat",
+    }, (
+        f"Damp-transition snapshot drifted from the neon-observed set. "
+        f"Got {sorted(_DAMP_TRANSITIONS)}, expected "
+        f"['lie_to_stand', 'squat_to_stand', 'stand_to_squat']. Update "
+        f"the snapshot and this test together."
+    )
+
+
+def test_the_squat_to_stand_precondition_matches_the_neon_argument() -> None:
+    """The ``squat_to_stand`` entry names the FSMs neon's verb refuses outside.
+
+    The neon bundle's ``g1_safe_squat_to_stand`` verb calls
+    ``_assert_safe_for_damp(expected_fsms={3, 4, 706}, pose_check=True)``.
+    The snapshot pins that exact set and the pose-check flag so a
+    driver-side wrapper's refusal string quotes the same boundary
+    the neon bundle observed.
+    """
+    entry = _DAMP_TRANSITIONS["squat_to_stand"]
+    assert entry["expected_fsm_ids"] == frozenset({3, 4, 706}), (
+        f"squat_to_stand expected_fsm_ids drifted; got {sorted(entry['expected_fsm_ids'])}, expected [3, 4, 706]"
+    )
+    assert entry["pose_check"] is True, (
+        f"squat_to_stand pose_check drifted; got {entry['pose_check']!r}, "
+        f"expected True (the neon bundle's own argument)"
+    )
+
+
+def test_the_lie_to_stand_precondition_matches_the_neon_argument() -> None:
+    """The ``lie_to_stand`` entry names the FSMs neon's verb refuses outside.
+
+    The neon bundle's ``g1_safe_lie_to_stand`` verb calls
+    ``_assert_safe_for_damp(expected_fsms={1, 702}, pose_check=False)``.
+    The snapshot pins that exact set and the pose-check flag: a
+    lying robot's knee angle is not the deciding factor, so neon
+    skipped the pose check.
+    """
+    entry = _DAMP_TRANSITIONS["lie_to_stand"]
+    assert entry["expected_fsm_ids"] == frozenset({1, 702}), (
+        f"lie_to_stand expected_fsm_ids drifted; got {sorted(entry['expected_fsm_ids'])}, expected [1, 702]"
+    )
+    assert entry["pose_check"] is False
+
+
+def test_the_stand_to_squat_precondition_matches_the_neon_argument() -> None:
+    """The ``stand_to_squat`` entry names the FSMs neon's verb refuses outside.
+
+    The neon bundle's ``g1_safe_stand_to_squat`` verb calls
+    ``_assert_safe_for_damp(expected_fsms={500, 501, 801}, pose_check=False)``
+    — the upright, actively-balancing FSMs. The snapshot pins that
+    exact set and the pose-check flag: a caller asking for a
+    stand-to-squat expects a lower knee angle by definition, so neon
+    skipped the pose check.
+    """
+    entry = _DAMP_TRANSITIONS["stand_to_squat"]
+    assert entry["expected_fsm_ids"] == frozenset({500, 501, 801}), (
+        f"stand_to_squat expected_fsm_ids drifted; got {sorted(entry['expected_fsm_ids'])}, expected [500, 501, 801]"
+    )
+    assert entry["pose_check"] is False
+
+
+def test_the_knee_threshold_matches_the_neon_observation() -> None:
+    """The knee threshold pins the ``avg_knee > 1.4 rad`` refusal.
+
+    The neon bundle's ``_assert_safe_for_damp`` compared ``avg_knee``
+    against the literal ``1.4`` before refusing. Named here so a
+    re-observation against the real robot lands as a single constant
+    change rather than three verb-side edits.
+    """
+    assert _AVG_KNEE_MAX_RAD == 1.4
+
+
+def test_the_gate_refusal_code_matches_the_driver_constant() -> None:
+    """The verb's refusal code names the driver's gate refusal.
+
+    The driver's ``_check_motion_gates`` refuses a locomotion-shaped
+    write on an FSM outside :data:`WALK_FSMS` with rc=7404, and the
+    ``7404`` entry in
+    :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries the
+    text a driver-side damp-preamble wrapper would surface. Pinned
+    here so a re-wording of that message lands in one place, not one
+    in the driver and a diverging copy in this verb.
+    """
+    assert _GATE_REFUSAL_CODE == 7404
+    assert _INVALID_TRANSITION_CODE == 7404
+    assert _GATE_REFUSAL_CODE in ERR_CODES, (
+        f"verb quotes rc={_GATE_REFUSAL_CODE} but that code is not in "
+        f"ERR_CODES. The refusal string would render as 'unknown'."
+    )
+
+
+def test_g1_list_damp_transitions_returns_the_whole_table() -> None:
+    """The verb's payload names every transition, the gate set, and the refusal.
+
+    ``transitions`` carries every entry in :data:`_DAMP_TRANSITIONS`
+    sorted by ``name``, ``walk_ready_fsm_ids`` quotes
+    :data:`WALK_FSMS`, and ``refusals`` names the ``7404``
+    gate-refusal code with the decoded text :data:`ERR_CODES` carries.
+    """
+    result = _call(g1_list_damp_transitions)
+    assert result["status"] == "success"
+    names = [t["name"] for t in result["transitions"]]
+    assert names == sorted(_DAMP_TRANSITIONS), (
+        f"g1_list_damp_transitions returned {names}, expected {sorted(_DAMP_TRANSITIONS)} (sorted-ascending)"
+    )
+    assert result["walk_ready_fsm_ids"] == sorted(WALK_FSMS)
+    assert result["refusals"] == [
+        {"code": _GATE_REFUSAL_CODE, "text": ERR_CODES[_GATE_REFUSAL_CODE]},
+    ]
+
+
+def test_g1_list_damp_transitions_descriptor_names_every_field() -> None:
+    """Every transition descriptor names every field the module documents.
+
+    The descriptor shape is the contract
+    :func:`g1_damp_transition_admits` mirrors on admit; a field added
+    in one code path but not the other would drift the payload
+    silently. This test reads the field set off the first descriptor
+    and pins the full membership.
+    """
+    result = _call(g1_list_damp_transitions)
+    first = result["transitions"][0]
+    assert set(first) == {
+        "name",
+        "expected_fsm_ids",
+        "pose_check",
+        "avg_knee_max_rad",
+        "description",
+    }, (
+        f"transition descriptor drifted; got fields {sorted(first)}, "
+        f"expected ['avg_knee_max_rad', 'description', "
+        f"'expected_fsm_ids', 'name', 'pose_check']"
+    )
+
+
+def test_g1_list_damp_transitions_pose_check_field_matches_snapshot() -> None:
+    """The ``avg_knee_max_rad`` field is populated exactly when ``pose_check`` is on.
+
+    When ``pose_check`` is ``True`` the threshold is
+    :data:`_AVG_KNEE_MAX_RAD`; when ``False`` the field is ``None``
+    because there is no refusal boundary to surface. The two fields
+    move together; this test pins that pair contract so a future
+    widen (e.g. per-transition thresholds) surfaces here.
+    """
+    result = _call(g1_list_damp_transitions)
+    for transition in result["transitions"]:
+        if transition["pose_check"]:
+            assert transition["avg_knee_max_rad"] == _AVG_KNEE_MAX_RAD, (
+                f"{transition['name']}: pose_check True but "
+                f"avg_knee_max_rad={transition['avg_knee_max_rad']!r}, "
+                f"expected {_AVG_KNEE_MAX_RAD}"
+            )
+        else:
+            assert transition["avg_knee_max_rad"] is None, (
+                f"{transition['name']}: pose_check False but "
+                f"avg_knee_max_rad={transition['avg_knee_max_rad']!r}, "
+                f"expected None"
+            )
+
+
+def test_g1_damp_transition_admits_returns_the_descriptor_on_a_known_name() -> None:
+    """The admit-path returns the same descriptor shape ``g1_list_*`` returns.
+
+    Reads the expected descriptor off :data:`_DAMP_TRANSITIONS` rather
+    than restating it, so a widen to the descriptor surfaces here
+    once. The ``walk_ready_fsm_ids`` field is named too so a caller
+    comparing an intended write against the general locomotion gate
+    has the FSM set on hand.
+    """
+    result = _call(g1_damp_transition_admits, name="squat_to_stand")
+    assert result["status"] == "success"
+    assert result["transition"]["name"] == "squat_to_stand"
+    assert result["transition"]["expected_fsm_ids"] == sorted(_DAMP_TRANSITIONS["squat_to_stand"]["expected_fsm_ids"])
+    assert result["transition"]["pose_check"] is True
+    assert result["transition"]["avg_knee_max_rad"] == _AVG_KNEE_MAX_RAD
+    assert result["walk_ready_fsm_ids"] == sorted(WALK_FSMS)
+
+
+def test_g1_damp_transition_admits_refuses_a_bogus_name() -> None:
+    """A name outside the snapshot is refused with the ``7404`` code.
+
+    The refusal string quotes the sorted set of admitted names so
+    the caller can decide the next intent without a second query.
+    """
+    result = _call(g1_damp_transition_admits, name="pirouette")
+    assert result["status"] == "error"
+    assert result["refusal_code"] == _INVALID_TRANSITION_CODE
+    assert result["refusal_text"] == ERR_CODES[_INVALID_TRANSITION_CODE]
+    assert "pirouette" in result["reason"]
+    for admitted in _DAMP_TRANSITIONS:
+        assert admitted in result["reason"], (
+            f"refusal reason should list the admitted set so the "
+            f"caller can decide next; got {result['reason']!r} which "
+            f"omits {admitted!r}"
+        )
+
+
+def test_g1_damp_transition_admits_refuses_a_miscased_name() -> None:
+    """The name match is case-sensitive against the snapshot.
+
+    The snapshot keys are lowercase-underscore; a caller passing
+    ``"Squat_To_Stand"`` is refused so the returned envelope names
+    the exact string a driver-side wrapper would refuse on.
+    """
+    result = _call(g1_damp_transition_admits, name="Squat_To_Stand")
+    assert result["status"] == "error"
+    assert result["refusal_code"] == _INVALID_TRANSITION_CODE
+
+
+def test_g1_damp_transition_admits_refuses_a_non_string_argument() -> None:
+    """A non-string argument is refused with the ``7404`` code.
+
+    The lookup is by string key; a caller passing an int would
+    otherwise raise on the ``in`` check, and this envelope's
+    contract is to refuse with a decidable code, not raise.
+    """
+    result = _call(g1_damp_transition_admits, name=706)  # type: ignore[arg-type]
+    assert result["status"] == "error"
+    assert result["refusal_code"] == _INVALID_TRANSITION_CODE
+    assert "not a str" in result["reason"]
+
+
+def test_every_transition_carries_a_non_empty_description() -> None:
+    """Each transition names the semantic the neon bundle documented.
+
+    The description is what an agent-facing planner reads to decide
+    which transition to select; an empty description would leave
+    the caller with only the FSM set. Pinned here so a snapshot
+    edit that drops the description surfaces immediately.
+    """
+    for name, entry in _DAMP_TRANSITIONS.items():
+        assert entry["description"], (
+            f"{name}: description is empty; the neon bundle carried a one-line semantic per verb, port that in too"
+        )

--- a/tests/drivers/test_g1_damp_transition_envelope_reads_the_neon_precondition_set.py
+++ b/tests/drivers/test_g1_damp_transition_envelope_reads_the_neon_precondition_set.py
@@ -29,9 +29,10 @@ Two things this file's cells deliberately do not pin:
   (the SDK admits any FSM id silently; the neon bundle drew the
   refusal boundary from field observation). A driver-side wrapper
   for the damp-preamble path that lands later will re-check the
-  preconditions at wire time and its refusal string will quote the
-  ``7404`` gate-refusal code the driver's ``_check_motion_gates``
-  also quotes.
+  preconditions at wire time and its refusal string will name the
+  same locomotion gate this module's refusal text names. Neither side
+  quotes an SDK return code: the driver's ``_check_motion_gates``
+  returns free-text refusals and names no code at all.
 * Whether the driver's live ``fsm_id`` sits inside a transition's
   ``expected_fsm_ids``. That is a live driver-instance read and
   belongs on :mod:`~strands_robots.tools.g1.g1_state` /
@@ -46,12 +47,12 @@ import importlib
 import sys
 from typing import Any
 
-from strands_robots.tools.g1._g1_common import ERR_CODES, WALK_FSMS
+from strands_robots.tools.g1._g1_common import WALK_FSMS
 from strands_robots.tools.g1.g1_damp_transition_envelope import (
     _AVG_KNEE_MAX_RAD,
     _DAMP_TRANSITIONS,
-    _GATE_REFUSAL_CODE,
-    _INVALID_TRANSITION_CODE,
+    _unknown_transition_refusal,
+    _walk_gate_refusal,
     g1_damp_transition_admits,
     g1_list_damp_transitions,
 )
@@ -172,23 +173,60 @@ def test_the_knee_threshold_matches_the_neon_observation() -> None:
     assert _AVG_KNEE_MAX_RAD == 1.4
 
 
-def test_the_gate_refusal_code_matches_the_driver_constant() -> None:
-    """The verb's refusal code names the driver's gate refusal.
+def test_no_refusal_borrows_an_sdk_return_code() -> None:
+    """No refusal this module emits carries a ``code`` field.
 
-    The driver's ``_check_motion_gates`` refuses a locomotion-shaped
-    write on an FSM outside :data:`WALK_FSMS` with rc=7404, and the
-    ``7404`` entry in
-    :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` carries the
-    text a driver-side damp-preamble wrapper would surface. Pinned
-    here so a re-wording of that message lands in one place, not one
-    in the driver and a diverging copy in this verb.
+    The driver quotes no SDK return code on this gate:
+    ``G1Driver._check_motion_gates`` returns free-text refusals only.
+    Pinned so a future edit cannot reintroduce a borrowed rc -- which
+    would put a wrong remedy on an agent-facing refusal, and would let
+    the refusal text and ``walk_ready_fsm_ids`` in the same payload
+    disagree about which FSMs are admitted.
     """
-    assert _GATE_REFUSAL_CODE == 7404
-    assert _INVALID_TRANSITION_CODE == 7404
-    assert _GATE_REFUSAL_CODE in ERR_CODES, (
-        f"verb quotes rc={_GATE_REFUSAL_CODE} but that code is not in "
-        f"ERR_CODES. The refusal string would render as 'unknown'."
-    )
+    listed = _call(g1_list_damp_transitions)
+    for refusal in listed["refusals"]:
+        assert "code" not in refusal, f"refusal descriptor borrowed an SDK code: {refusal!r}"
+        assert refusal["text"]
+    for bad in ("pirouette", "Squat_To_Stand"):
+        refused = _call(g1_damp_transition_admits, name=bad)
+        assert refused["status"] == "error"
+        assert "refusal_code" not in refused, f"refusal for {bad!r} borrowed an SDK code: {refused!r}"
+
+
+def test_the_gate_and_label_refusals_are_distinct_channels() -> None:
+    """The two refusals never collapse, because their remedies differ.
+
+    An FSM outside the locomotion gate is a robot-state problem whose
+    remedy is a transition; an unknown transition label is an argument
+    problem whose remedy is a different string. Handing the FSM-gate
+    remedy to a caller who mistyped a label would point an agent
+    planner at a physical motion-state change it never asked for, so
+    the two texts are pinned distinct and each is pinned to name its
+    own domain.
+    """
+    gate, label = _walk_gate_refusal(), _unknown_transition_refusal()
+    assert gate != label
+    # The gate text names the locomotion FSM set and no transition label.
+    assert str(sorted(WALK_FSMS)) in gate
+    assert not any(name in gate for name in _DAMP_TRANSITIONS)
+    # The label text names every admitted label and no FSM id.
+    for name in _DAMP_TRANSITIONS:
+        assert name in label
+    assert not any(str(fsm) in label for fsm in WALK_FSMS)
+
+
+def test_the_gate_refusal_is_built_from_the_walk_fsm_set() -> None:
+    """A widen of ``WALK_FSMS`` carries into the gate refusal text.
+
+    The text is composed from
+    :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS` rather than
+    spelled as a literal, so the payload's ``refusals`` entry cannot
+    drift from the ``walk_ready_fsm_ids`` shipped beside it. Pinned
+    because that drift is exactly what a hardcoded set produces.
+    """
+    listed = _call(g1_list_damp_transitions)
+    assert listed["refusals"] == [{"text": _walk_gate_refusal()}]
+    assert str(listed["walk_ready_fsm_ids"]) in listed["refusals"][0]["text"]
 
 
 def test_g1_list_damp_transitions_returns_the_whole_table() -> None:
@@ -196,8 +234,8 @@ def test_g1_list_damp_transitions_returns_the_whole_table() -> None:
 
     ``transitions`` carries every entry in :data:`_DAMP_TRANSITIONS`
     sorted by ``name``, ``walk_ready_fsm_ids`` quotes
-    :data:`WALK_FSMS`, and ``refusals`` names the ``7404``
-    gate-refusal code with the decoded text :data:`ERR_CODES` carries.
+    :data:`WALK_FSMS`, and ``refusals`` names the module-local
+    gate-refusal text.
     """
     result = _call(g1_list_damp_transitions)
     assert result["status"] == "success"
@@ -206,9 +244,7 @@ def test_g1_list_damp_transitions_returns_the_whole_table() -> None:
         f"g1_list_damp_transitions returned {names}, expected {sorted(_DAMP_TRANSITIONS)} (sorted-ascending)"
     )
     assert result["walk_ready_fsm_ids"] == sorted(WALK_FSMS)
-    assert result["refusals"] == [
-        {"code": _GATE_REFUSAL_CODE, "text": ERR_CODES[_GATE_REFUSAL_CODE]},
-    ]
+    assert result["refusals"] == [{"text": _walk_gate_refusal()}]
 
 
 def test_g1_list_damp_transitions_descriptor_names_every_field() -> None:
@@ -279,15 +315,14 @@ def test_g1_damp_transition_admits_returns_the_descriptor_on_a_known_name() -> N
 
 
 def test_g1_damp_transition_admits_refuses_a_bogus_name() -> None:
-    """A name outside the snapshot is refused with the ``7404`` code.
+    """A name outside the snapshot is refused by naming the admitted labels.
 
     The refusal string quotes the sorted set of admitted names so
     the caller can decide the next intent without a second query.
     """
     result = _call(g1_damp_transition_admits, name="pirouette")
     assert result["status"] == "error"
-    assert result["refusal_code"] == _INVALID_TRANSITION_CODE
-    assert result["refusal_text"] == ERR_CODES[_INVALID_TRANSITION_CODE]
+    assert result["refusal_text"] == _unknown_transition_refusal()
     assert "pirouette" in result["reason"]
     for admitted in _DAMP_TRANSITIONS:
         assert admitted in result["reason"], (
@@ -306,19 +341,19 @@ def test_g1_damp_transition_admits_refuses_a_miscased_name() -> None:
     """
     result = _call(g1_damp_transition_admits, name="Squat_To_Stand")
     assert result["status"] == "error"
-    assert result["refusal_code"] == _INVALID_TRANSITION_CODE
+    assert result["refusal_text"] == _unknown_transition_refusal()
 
 
 def test_g1_damp_transition_admits_refuses_a_non_string_argument() -> None:
-    """A non-string argument is refused with the ``7404`` code.
+    """A non-string argument is refused with the unknown-transition text.
 
     The lookup is by string key; a caller passing an int would
     otherwise raise on the ``in`` check, and this envelope's
-    contract is to refuse with a decidable code, not raise.
+    contract is to refuse decidably, not raise.
     """
     result = _call(g1_damp_transition_admits, name=706)  # type: ignore[arg-type]
     assert result["status"] == "error"
-    assert result["refusal_code"] == _INVALID_TRANSITION_CODE
+    assert result["refusal_text"] == _unknown_transition_refusal()
     assert "not a str" in result["reason"]
 
 

--- a/tests/drivers/test_g1_damp_transition_envelope_reads_the_neon_precondition_set.py
+++ b/tests/drivers/test_g1_damp_transition_envelope_reads_the_neon_precondition_set.py
@@ -149,7 +149,7 @@ def test_the_stand_to_squat_precondition_matches_the_neon_argument() -> None:
 
     The neon bundle's ``g1_safe_stand_to_squat`` verb calls
     ``_assert_safe_for_damp(expected_fsms={500, 501, 801}, pose_check=False)``
-    — the upright, actively-balancing FSMs. The snapshot pins that
+    - the upright, actively-balancing FSMs. The snapshot pins that
     exact set and the pose-check flag: a caller asking for a
     stand-to-squat expects a lower knee angle by definition, so neon
     skipped the pose check.


### PR DESCRIPTION
## What

Adds `g1_list_damp_transitions` and `g1_damp_transition_admits` - pure-reference agent-facing lookups over the safe damp-preamble transition preconditions the neon bundle's `g1_safe_posture.py` verbs each front. Continues the neon -> strands-labs port line (refs #2967, #2965, #2966, #2970, follows the balance_modes/envelope pattern).

## Where the snapshot comes from

Sourced verbatim from the neon bundle's `_assert_safe_for_damp` refusal boundary in `cagataycali/neon-the-g1/tools/g1_safe_posture.py`. Three transitions, one entry per neon `@tool`:

| transition | `expected_fsm_ids` | `pose_check` | source verb |
|---|---|---|---|
| `squat_to_stand` | `{3, 4, 706}` | `True` | `g1_safe_squat_to_stand` |
| `lie_to_stand` | `{1, 702}` | `False` | `g1_safe_lie_to_stand` |
| `stand_to_squat` | `{500, 501, 801}` | `False` | `g1_safe_stand_to_squat` |

Knee-angle refusal threshold `_AVG_KNEE_MAX_RAD = 1.4` matches the literal in the neon bundle's `_assert_safe_for_damp`.

## Contract

- **Read-only.** No DDS, no driver instance, no SDK import at module-load - same hygiene rule `g1_balance_modes`/`g1_arm_actions`/`g1_fsm_targets` carry.
- **Refusal strings**: two of them, module-local, and no SDK return code on either. The gate refusal is built from `WALK_FSMS` so it cannot drift from the `walk_ready_fsm_ids` shipped beside it; the label refusal is built from `_DAMP_TRANSITIONS`. They are kept distinct because their remedies differ: an FSM outside the locomotion gate wants a transition, while an unknown transition label wants a different string. See §13 for why no `code` field is carried.
- **Descriptor shape**: mirrors `g1_balance_mode_admits` / `g1_arm_action_admits` - every field on `g1_list_damp_transitions` is named identically on the `g1_damp_transition_admits` admit-path.
- **Refuses**: non-string arg, miscased key, unknown key. The refusal reason quotes the sorted admitted set so a caller can decide next without a second query.

## Tests

`tests/drivers/test_g1_damp_transition_envelope_reads_the_neon_precondition_set.py` - **17 tests, all green**. Contract-graded off the module's own snapshot (a widen of `_DAMP_TRANSITIONS` surfaces here as a shape change, not a diverging table). Coverage:

- SDK-load hygiene (import pulls no `unitree_sdk2py`)
- Snapshot covers the three neon-observed transitions
- Each transition's `expected_fsm_ids` and `pose_check` match the neon call site
- `_AVG_KNEE_MAX_RAD == 1.4` (the neon literal)
- No refusal borrows an SDK return code (no `code` / `refusal_code` field on any path)
- The gate and label refusals are distinct channels, each naming its own domain and never the other's
- The gate refusal is composed from `WALK_FSMS`, so it cannot drift from `walk_ready_fsm_ids`
- `g1_list_damp_transitions` returns whole table, sorted, with `walk_ready_fsm_ids` + `refusals`
- Descriptor names all 5 fields (`name`, `expected_fsm_ids`, `pose_check`, `avg_knee_max_rad`, `description`)
- `avg_knee_max_rad` populated iff `pose_check` is on
- `g1_damp_transition_admits` returns descriptor on admit, refuses miscased / unknown / non-string
- Every entry carries a non-empty description

## Gates (local)

- `ruff check` / `ruff format --check` clean on both files
- `mypy strands_robots/tools/g1/g1_damp_transition_envelope.py` clean
- `pytest` on the module suite plus the source-string gate family (`no_unicode_dashes`, `no_emoji`, `no_review_archaeology`, `log_strings_are_ascii`, `resolve_their_issue_references`, `no_internal_file_paths`, `no_host_paths`): **72 passed**

## Not this PR

- No write path. A future driver-side wrapper for `Damp() -> Squat2StandUp`/`Lie2StandUp`/`SetFsmId(2)` will land the transition verb; refs #358 for the SDK-facing gate work.
- No live pose read. `avg_knee` sampling is a live driver-instance query already covered by `g1_state` / `g1_motion_gates`; this envelope surfaces the refusal boundary constant, not a live sample.

Refs #358.

---

## 13. Round-1 changelog

**`199fde8a` - ASCII hyphens in the envelope strings** (addresses the review finding)

The module embedded `U+2014` on seven lines (13, 111, 115, 121, 152, 161, 164 - line 152 carried two, so 8 codepoints), three of them inside the `description` strings the tool result returns to the caller. `tests/test_source_strings_no_unicode_dashes.py` scans every line of every `*.py` under `strands_robots/`, so this file was the sole offender and the required check failed deterministically. Each is now the sanctioned ASCII `-`; the substitution is one character for one, so no line length changed and no reflow was needed. The one em dash in the new test module's docstring went with it, since it quotes the `stand_to_squat` description verbatim and would otherwise misquote the string it pins.

**`55cc970b` - stop borrowing rc 7404 for the refusals** (found by self-review while in the file; not raised in review)

`_GATE_REFUSAL_CODE` and `_INVALID_TRANSITION_CODE` were both `7404` borrowed from `ERR_CODES`, and the claim that the driver quotes it does not hold in this tree: `grep 7404 strands_robots/drivers/g1.py` returns nothing, and `_check_motion_gates` returns free-text refusals naming no return code at all. Two concrete defects followed.

1. `ERR_CODES[7404]` decodes to `"Invalid FSM id - need FSM in {500, 501, 801}"`, but `WALK_FSMS` is `{501, 801}`. So `g1_list_damp_transitions` shipped a `refusals` entry naming one set directly beside its own `walk_ready_fsm_ids: [501, 801]` naming another - a payload contradicting itself about which FSMs are admitted.
2. `g1_damp_transition_admits` returned that same FSM text as `refusal_text` for a mistyped or non-string transition *label*. `g1_damp_transition_admits(name="Squat_To_Stand")` answered `"Invalid FSM id - need FSM in {500, 501, 801}"`, pointing an agent planner at a physical motion-state change as the remedy for an argument typo.

Since `refusal_text` is the field a planner matches on to pick a recovery action, re-scoping it after release would be a behaviour change under consumers, so it is settled pre-merge. Both constants and the `ERR_CODES` import are dropped. The gate refusal is now `_walk_gate_refusal()`, composed from `WALK_FSMS`; the label refusal is `_unknown_transition_refusal()`, composed from `_DAMP_TRANSITIONS`. Neither carries a `code` field - the SDK ships no rc for either boundary, and omitting one is better than inventing it by borrowing an unrelated code. Same remedy shape accepted on #2968.

Now: `refusals: [{'text': 'fsm_id outside the locomotion gate - need FSM in [501, 801]'}]` beside `walk_ready_fsm_ids: [501, 801]`, and a bad label answers `"unknown damp-preamble transition - need one of ['lie_to_stand', 'squat_to_stand', 'stand_to_squat']"`.

Three new pins: `test_no_refusal_borrows_an_sdk_return_code`, `test_the_gate_and_label_refusals_are_distinct_channels`, `test_the_gate_refusal_is_built_from_the_walk_fsm_set`. The docstrings, the changelog fragment and the Contract section above all drop the driver claim.