### PR TITLE
docs(mesh): name the audit-log family's tamper-evidence and rotation knobs on the README matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,9 @@ touches ROS 2.
 | `ZENOH_LISTEN` | Comma-separated endpoints for the local Zenoh listener | unset |
 | `STRANDS_MESH_MULTICAST` | Opt in to multicast scouting for LAN discovery. Off by default: any device on the LAN can enumerate and attract the fleet, so enabling it logs a WARNING. Prefer explicit `ZENOH_CONNECT` endpoints | `false` |
 | `STRANDS_MESH_AUDIT_DIR` | Directory for the safety audit log (`mesh_audit.jsonl`) | `~/.strands_robots/` |
+| `STRANDS_MESH_AUDIT_PSK` | Pre-shared key that keys the per-record HMAC in the audit log. When set, `verify_audit_integrity` refuses a record whose HMAC does not match and refuses the whole log if the PSK changes mid-run; when unset, the `sig` field is absent and a writer with directory access can edit records without failing the check. Set on every peer that writes to the same directory | unset |
+| `STRANDS_MESH_AUDIT_MAX_BYTES` | Rotate the active audit file once it crosses this size (bytes). Values above the 10 GiB hard cap are clamped with a warning; non-integer, zero, or negative values fall back to the default with a warning, so a misconfiguration cannot silently disable rotation | `104857600` (100 MiB) |
+| `STRANDS_MESH_AUDIT_MAX_FILES` | Number of rotated `mesh_audit.jsonl.N` files kept alongside the active file. Older rotations are deleted as new ones arrive; total disk use is bounded by `_MAX_BYTES × _MAX_FILES`. Same clamping/warning behaviour as `_MAX_BYTES`; hard upper cap 100 | `5` |
 | `STRANDS_MESH_CA_PINS` | Additional SHA-256 CA pins (comma-separated 64-char hex) | unset |
 | `STRANDS_MESH_DISABLE_CA_PIN` | Skip CA pin check on download path (break-glass) | `false` |
 | `STRANDS_MESH_CAMERA_PRESIGN_TTL` | TTL (s) for S3 presigned camera URLs; capped at 3600 | `60` |

--- a/changelog.d/2979-mesh-audit-env-vars-matrix-rows.md
+++ b/changelog.d/2979-mesh-audit-env-vars-matrix-rows.md
@@ -1,0 +1,40 @@
+### Docs: the audit-log family's tamper-evidence and rotation knobs are named on the README matrix
+
+`STRANDS_MESH_AUDIT_DIR`, `STRANDS_MESH_AUDIT_PSK`, `STRANDS_MESH_AUDIT_MAX_BYTES`
+and `STRANDS_MESH_AUDIT_MAX_FILES` are the four sibling variables that configure
+one channel -- where the mesh writes its append-only JSONL audit log, whether
+each record carries a per-record HMAC that lets a downstream verifier reject a
+forged entry, and the per-file / rotation bounds that keep disk use finite. The
+security page documents them together under one heading. The README
+environment-variable matrix carried a row for `_DIR` alone and had no row for
+the other three, so a reader scanning the matrix for the audit family found
+one of four sibling variables and not the tamper-evidence gate the security
+page calls "the deliberate posture" or the rotation bounds the same page pairs
+it with.
+
+`_PSK` is the more consequential of the missing three. Without it, the `sig`
+field is absent from each record and `verify_audit_integrity` trusts the file;
+a writer with access to `STRANDS_MESH_AUDIT_DIR` can edit a record and leave
+no HMAC to fail against, and no downstream check will catch the edit. It is
+the pair a production posture must set beside `_DIR`, and the matrix that names
+one and not the other undersells it.
+
+`_MAX_BYTES` and `_MAX_FILES` are the disk-use bound. Both clamp to a hard
+upper cap with a warning, both fall back to the default on unparsable / zero /
+negative values with a warning (so a misconfiguration cannot silently disable
+rotation), and their product bounds total disk use for the log. An operator
+sizing storage for the audit trail needs their defaults and their caps, and
+the matrix is where the sizing question is asked.
+
+The three new rows sit beside the existing `_DIR` row, in matrix order, so the
+family is discovered together. `docs/security.md` already describes all four
+under `## Audit log` and needs no change; this closes the README half.
+
+A guard derives its graded population from `mesh/audit.py`'s own `os.getenv`
+literals, so a fifth `STRANDS_MESH_AUDIT_*` path added later is held to the
+same matrix rule the hour it lands. Four properties are graded: every audit
+variable the module reads has a matrix row (which is what makes the matrix a
+single index for the family), every one is named on the security page, the
+matrix rows sit contiguously (so a reader lands on all four without hunting),
+and the derivation is not empty (so the whole rule cannot pass vacuously if
+the scan ever goes blind).

--- a/tests/mesh/test_docs_mesh_audit_env_vars_reference.py
+++ b/tests/mesh/test_docs_mesh_audit_env_vars_reference.py
@@ -1,0 +1,221 @@
+"""Grade the mesh audit-log environment reference against the module's env surface.
+
+The mesh audit log is one channel with four sibling environment knobs. Each
+one configures the same file: where it is written (``STRANDS_MESH_AUDIT_DIR``),
+whether records carry a per-record HMAC that lets a verifier reject a forged
+entry (``STRANDS_MESH_AUDIT_PSK``), and the per-file / rotation bounds that
+keep disk use finite (``STRANDS_MESH_AUDIT_MAX_BYTES`` and
+``STRANDS_MESH_AUDIT_MAX_FILES``). ``docs/security.md`` documents them together
+under ``## Audit log``. Until this file's companion change, the README
+environment-variable matrix carried a row for ``_DIR`` alone -- so a reader
+scanning the matrix for the audit family found one variable of four and not
+the tamper-evidence gate the security page calls "a deliberate posture" or
+the rotation bounds that same page pairs it with.
+
+The rules below read the module's own ``os.getenv`` literals so the graded
+population tracks the code rather than a list maintained beside it. A fifth
+``STRANDS_MESH_AUDIT_*`` path added later is held to the same rule the hour it
+lands. Four properties, plus one keep-the-derivation-honest premise:
+
+- **Every audit variable the module reads has a README matrix row.** This is
+  what makes the matrix a single index for the family; a reader scanning the
+  matrix section for the audit family should find every knob that configures
+  the same file.
+- **Every one of them is named on the security page.** The prose surface that
+  describes the posture must name the variables that shape it, or the posture
+  is unconfigurable.
+- **The matrix rows sit contiguously.** One channel, one place to look: an
+  operator sizing storage or hardening tamper-evidence should not have to
+  hunt for siblings scattered through 32 unrelated rows.
+- **The derivation is not empty.** If the scan ever goes blind (module moved,
+  literals inlined, a refactor breaks the AST walk) every rule above would
+  pass vacuously; a positive premise refuses that state.
+"""
+
+import ast
+import pathlib
+import re
+
+from strands_robots.mesh import audit as _audit_module
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_MODULE = _ROOT / "strands_robots" / "mesh" / "audit.py"
+_PAGE = _ROOT / "docs" / "security.md"
+_README = _ROOT / "README.md"
+
+_PREFIX = "STRANDS_MESH_AUDIT_"
+_KNOWN = frozenset(
+    {
+        "STRANDS_MESH_AUDIT_DIR",
+        "STRANDS_MESH_AUDIT_PSK",
+        "STRANDS_MESH_AUDIT_MAX_BYTES",
+        "STRANDS_MESH_AUDIT_MAX_FILES",
+    }
+)
+
+
+def _audit_env_reads() -> frozenset[str]:
+    """Return every ``STRANDS_MESH_AUDIT_*`` name the audit module reads.
+
+    Derived from the module's own source so a variable added later is held to
+    the same documentation rule without editing a list here.
+    """
+    tree = ast.parse(_MODULE.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        literal = None
+        if isinstance(node, ast.Call) and ast.unparse(node.func) in (
+            "os.getenv",
+            "os.environ.get",
+        ):
+            if node.args and isinstance(node.args[0], ast.Constant):
+                literal = node.args[0].value
+        elif isinstance(node, ast.Subscript) and ast.unparse(node.value) == "os.environ":
+            if isinstance(node.slice, ast.Constant):
+                literal = node.slice.value
+        if isinstance(literal, str) and literal.startswith(_PREFIX):
+            names.add(literal)
+    return frozenset(names)
+
+
+def _documented(text: str) -> frozenset[str]:
+    """Return the ``STRANDS_MESH_AUDIT_*`` names a document names."""
+    return frozenset(re.findall(rf"{_PREFIX}[A-Z_]+", text))
+
+
+def _readme_matrix_rows() -> frozenset[str]:
+    """Return the ``STRANDS_MESH_AUDIT_*`` names carrying a README matrix row.
+
+    A mention in prose is not a matrix row: the matrix is a scan index for
+    the family, so the rule reads the table.
+    """
+    rows = re.findall(
+        rf"^\|\s*`({_PREFIX}[A-Z_]+)`\s*\|",
+        _README.read_text(encoding="utf-8"),
+        re.M,
+    )
+    return frozenset(rows)
+
+
+def _readme_matrix_row_order() -> list[str]:
+    """Return the ``STRANDS_MESH_AUDIT_*`` names in the matrix, in order of appearance."""
+    return re.findall(
+        rf"^\|\s*`({_PREFIX}[A-Z_]+)`\s*\|",
+        _README.read_text(encoding="utf-8"),
+        re.M,
+    )
+
+
+def _audit_headings_naming(name: str) -> list[str]:
+    """Return every ``##``/``###`` heading whose section names ``name``."""
+    text = _PAGE.read_text(encoding="utf-8")
+    parts = re.split(r"^(#{2,3} .+)$", text, flags=re.M)
+    out = []
+    for index in range(1, len(parts), 2):
+        if name in parts[index + 1]:
+            out.append(parts[index].lstrip("# ").strip())
+    return out
+
+
+class TestThePopulationIsDerived:
+    """The rules read the module, not a list maintained beside them."""
+
+    def test_the_module_reads_the_four_known_audit_variables(self) -> None:
+        reads = _audit_env_reads()
+        assert _KNOWN <= reads, (
+            f"expected the four documented audit knobs among the module's reads, got {sorted(reads)}"
+        )
+
+    def test_the_derivation_is_not_empty(self) -> None:
+        assert _audit_env_reads(), (
+            "the audit env scan found nothing; the derivation has gone blind and every rule below would pass vacuously"
+        )
+
+    def test_the_audit_module_still_lives_where_the_scan_expects(self) -> None:
+        # If audit.py moves, this rule points the failing test at the reason.
+        assert _MODULE.exists(), (
+            "strands_robots/mesh/audit.py is gone; move the scan target to wherever the audit env-reads live now"
+        )
+        # Behavioural premise: the constant table also names its knobs.  Keeps
+        # the AST literal walk honest against a rewrite that pulls names from
+        # a dict, since :func:`_read_env_max_bytes` and friends would still
+        # call ``os.getenv``.
+        _module_source = _MODULE.read_text(encoding="utf-8")
+        assert 'os.getenv("STRANDS_MESH_AUDIT_PSK")' in _module_source, (
+            "the AST walk finds only literal os.getenv calls; a refactor to a "
+            "dict-driven read must update this test's scan to match"
+        )
+
+
+class TestEveryAuditVariableIsDocumented:
+    """A knob the audit log honours and no page names cannot be configured."""
+
+    def test_the_readme_matrix_names_every_audit_variable(self) -> None:
+        missing = sorted(_audit_env_reads() - _readme_matrix_rows())
+        assert not missing, (
+            f"the README env-var matrix has no row for {missing}; the audit "
+            "family is documented as one channel and the matrix is the scan "
+            "index a reader uses to discover the family's knobs"
+        )
+
+    def test_the_security_page_names_every_audit_variable(self) -> None:
+        missing = sorted(_audit_env_reads() - _documented(_PAGE.read_text(encoding="utf-8")))
+        assert not missing, (
+            f"docs/security.md names none of {missing}; the audit posture is "
+            "described there and a variable that shapes it must be nameable"
+        )
+
+
+class TestTheyAreDocumentedTogether:
+    """One channel, one place to look."""
+
+    def test_the_matrix_rows_are_contiguous(self) -> None:
+        rows = _readme_matrix_row_order()
+        reads = _audit_env_reads()
+        indices = [i for i, name in enumerate(rows) if name in reads]
+        if not indices:
+            return
+        span = indices[-1] - indices[0] + 1
+        assert span == len(indices), (
+            f"the audit matrix rows are not contiguous: {rows[indices[0] : indices[-1] + 1]}; "
+            "an operator sizing storage or hardening tamper-evidence should "
+            "find every knob together, not scattered through unrelated rows"
+        )
+
+    def test_every_audit_variable_is_named_under_one_security_heading(self) -> None:
+        headings = {name: _audit_headings_naming(name) for name in sorted(_audit_env_reads())}
+        assert all(headings.values()), f"an audit variable is named under no security-page heading: {headings}"
+        shared = set.intersection(*(set(v) for v in headings.values()))
+        assert shared, f"the audit variables are split across headings with none in common: {headings}"
+
+
+class TestTheBehaviourThePagesExistToMakeDiscoverable:
+    """The prose cannot drift away from what the audit module honours."""
+
+    def test_the_psk_read_lives_where_the_page_says_it_does(self) -> None:
+        # docs/security.md says: "when set, per-record HMAC is on".
+        # The module read is the wire between them.  If the read moves or its
+        # env name changes, the page's promise no longer resolves.
+        assert 'os.getenv("STRANDS_MESH_AUDIT_PSK")' in _MODULE.read_text(encoding="utf-8"), (
+            "the audit module no longer reads STRANDS_MESH_AUDIT_PSK by that "
+            "name; docs/security.md promises HMAC when the variable is set, "
+            "and the promise must reach the loader"
+        )
+
+    def test_the_size_and_file_caps_are_read_by_the_declared_names(self) -> None:
+        source = _MODULE.read_text(encoding="utf-8")
+        for name in ("STRANDS_MESH_AUDIT_MAX_BYTES", "STRANDS_MESH_AUDIT_MAX_FILES"):
+            assert f'os.getenv("{name}")' in source, (
+                f"{name} is no longer read at that name; the README matrix "
+                "and the security page both promise it, and the promise must "
+                "reach the rotator"
+            )
+
+    def test_the_module_is_reachable_via_its_public_import_path(self) -> None:
+        # Grounds the behavioural cells above in the same import surface docs
+        # readers use.  If the module is renamed, the scan needs to move with
+        # it, and this cell names the reason at the failure line.
+        assert getattr(_audit_module, "__file__", None), (
+            "strands_robots.mesh.audit could not resolve to a file; the "
+            "scan target and the documented posture are diverging"
+        )


### PR DESCRIPTION
## The gap

The mesh audit log is one channel with four sibling environment knobs. Each configures the same file: where it is written (`STRANDS_MESH_AUDIT_DIR`), whether records carry a per-record HMAC that lets a verifier reject a forged entry (`STRANDS_MESH_AUDIT_PSK`), and the per-file / rotation bounds that keep disk use finite (`STRANDS_MESH_AUDIT_MAX_BYTES` and `STRANDS_MESH_AUDIT_MAX_FILES`). `docs/security.md` already documents all four together under `## Audit log`.

The README env-var matrix, which lists 32 other `STRANDS_MESH_*` variables as a single scan index, carried a row for `_DIR` alone:

| variable | README matrix row | security page |
|---|---|---|
| `STRANDS_MESH_AUDIT_DIR` | ✅ present | ✅ documented |
| `STRANDS_MESH_AUDIT_PSK` | ❌ missing | ✅ documented |
| `STRANDS_MESH_AUDIT_MAX_BYTES` | ❌ missing | ✅ documented |
| `STRANDS_MESH_AUDIT_MAX_FILES` | ❌ missing | ✅ documented |

So a reader scanning the matrix for the audit family found one of four sibling knobs and not the tamper-evidence gate the security page calls a deliberate posture (`## Audit log`, paragraph 1: *"a tamper-evidence step is off: the mode is a deliberate posture, not a default that hides"*), or the rotation bounds that same page pairs it with.

## Why the three missing ones matter

**`_PSK` is the pair a production posture must set beside `_DIR`.** Measured in `strands_robots/mesh/audit.py`:

```
audit.py:250:    psk = os.getenv("STRANDS_MESH_AUDIT_PSK")
audit.py:905:                "STRANDS_MESH_AUDIT_PSK was set when the audit log first "
audit.py:913:                "STRANDS_MESH_AUDIT_PSK was unset when the audit log first "
```

Without it, the `sig` field is absent from each record and `verify_audit_integrity` trusts the file; a writer with `STRANDS_MESH_AUDIT_DIR` access can edit records with no HMAC to fail against. `docs/security.md:216-222` calls this out. The README matrix naming `_DIR` and not `_PSK` undersells the pair.

**`_MAX_BYTES` and `_MAX_FILES` bound disk use.** Both clamp to a hard cap with a warning, both fall back to the default on unparsable / zero / negative values so a misconfiguration cannot silently disable rotation, and their product bounds total disk use (default `500 MiB`). Sizing storage for the audit trail is what the matrix scan exists to answer.

## The change

Three README matrix rows sit beside the existing `_DIR` row, in matrix order (line 1184-1187). No `docs/security.md` change: the security page already names all four exhaustively (`## Audit log`, lines 199-230).

`tests/mesh/test_docs_mesh_audit_env_vars_reference.py` derives its graded population from `mesh/audit.py`'s own `os.getenv` literals via AST walk, so a fifth `STRANDS_MESH_AUDIT_*` path added later is held to the same rule the hour it lands.

Four properties are graded:

- **Every audit variable the module reads has a README matrix row.** The matrix is the scan index for the family; a reader looking up "audit" should find every knob that configures the same file.
- **Every one of them is named on the security page.** Posture is unconfigurable if the prose that describes it does not name its variables.
- **The matrix rows sit contiguously.** One channel, one place to look — an operator sizing storage or hardening tamper-evidence should not have to hunt for siblings scattered through 32 unrelated rows.
- **The derivation is not empty.** If the AST walk ever goes blind (module moved, literals inlined) every rule above would pass vacuously; a positive premise refuses that state.

Plus three behavioural premise cells that pin the specific literal reads (`_PSK`, `_MAX_BYTES`, `_MAX_FILES`), so a rename in `audit.py` fails a named test instead of quietly passing under the AST walk.

## Verification

**Mutation table:**

| mutation | fires | rule |
|---|---|---|
| control (this PR at HEAD) | 0 / 10 | |
| revert README to `upstream/main` (drop 3 rows) | **1 / 10** | `test_the_readme_matrix_names_every_audit_variable` names exactly `['STRANDS_MESH_AUDIT_MAX_BYTES', 'STRANDS_MESH_AUDIT_MAX_FILES', 'STRANDS_MESH_AUDIT_PSK']` |

**Scoped surface (audit guard + TLS sibling + changelog gates + changelog format):** `56 passed in 0.72s`.

**Gate:**
- `ruff check` clean; `ruff format --check` clean
- `mkdocs build --strict` clean in 1.65s
- `tests/test_doctor.py`: **2 failures reproduce byte-identical on stock `upstream/main`** and read none of the changed surfaces (`torch.cuda.get_device_name` absent under the env's numpy torch mock). Same baseline fire 138's report called out.

## Scope, deliberately

`STRANDS_MESH_NAMESPACE` and `STRANDS_MESH_POLICY_TYPE_ALLOW` are the next two families with 0 documentation footprint on either surface. They are a separate scoped shipment — the audit family is one channel and a single guard reads it end-to-end; conflating it with two other channels would weaken the derivation. Refs #376.

## Files

- `README.md` (+3, -0): 3 matrix rows
- `changelog.d/2979-mesh-audit-env-vars-matrix-rows.md` (+40, -0): docs/quality entry
- `tests/mesh/test_docs_mesh_audit_env_vars_reference.py` (+221, -0): derived-population guard

Total: 3 files, 264 additions, 0 deletions.