### PR TITLE
fix(tests/xref guard): classify an absent extra on the chained exception, not exc.name

### DIFF
--- a/changelog.d/2963-xref-guard-undecidable-import.md
+++ b/changelog.d/2963-xref-guard-undecidable-import.md
@@ -1,0 +1,39 @@
+### Fixed: one absent extra no longer ends the docstring cross-reference sweep
+
+`tests/test_docstring_xref_roles_resolve.py::test_qualified_strands_robots_xref_roles_resolve`
+separates the two causes of a failed import that need opposite verdicts -- a
+`strands_robots` path that names nothing (the rot it grades) versus a
+third-party module this environment does not have (a fact about the
+environment) -- and it did so by reading `exc.name`. That field is populated
+only on an exception the interpreter raises itself. It is `None` on one that
+code *constructs*, which is what 28 raise sites in the package do, including
+both raises in `strands_robots.utils.require_optional` -- the mechanism
+`AGENTS.md` convention 7 makes mandatory for every optional dependency. So a
+third-party absence took the branch reserved for package rot, and the member
+walk answers that branch with `raise`.
+
+Measured on a base install without `[all]`: the sweep aborted at target 676 of
+795 on `strands_robots.tools.lerobot_camera`, leaving **120 targets ungraded**
+and reporting one `ImportError` instead of a verdict. A contributor without the
+extras saw a red guard they did not break, could not distinguish it from a dead
+pointer they did introduce, and got no grading of the roles they had touched.
+The same install now grades all 795 (759 resolved, 0 dead, 36 undecidable).
+
+The classification is now made on the chained exception the raise site was
+handling rather than on the surface exception alone. `raise ... from None`
+clears `__cause__` and suppresses the *rendering* of `__context__`; it does not
+clear the attribute, so `require_optional` is reached by the same walk and no
+raise site needs to change. An `ImportError` carrying neither a name nor a
+chained one is reported as undecidable rather than as rot, because the
+interpreter never reports an absent module without naming it -- that backstop is
+what makes aborting the sweep unreachable whatever a future raise site does.
+
+The guard is unchanged where it matters: a `ModuleNotFoundError` naming a
+`strands_robots` path is still rot, and the existing control assertion that an
+absent extra and absent rot must not become the same verdict still holds. CI
+installs `[all,dev]`, so this was invisible there -- which is also why the
+guard's coverage in CI was order-dependent and unverified: any `[all,dev]`
+module failing to import for an unrelated reason stopped the sweep at that
+point instead of skipping that one target.
+
+Refs #2963, #2940 (whole-tree graders that stop covering the tree).

--- a/tests/test_docstring_xref_roles_resolve.py
+++ b/tests/test_docstring_xref_roles_resolve.py
@@ -84,6 +84,7 @@ import ast
 import importlib
 import inspect
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -91,6 +92,7 @@ from types import ModuleType
 import pytest
 
 import strands_robots
+from strands_robots.utils import require_optional
 
 _PKG_ROOT = Path(strands_robots.__file__).resolve().parent
 _REPO_ROOT = _PKG_ROOT.parent
@@ -103,20 +105,50 @@ _REPO_ROOT = _PKG_ROOT.parent
 _ROLE_RE = re.compile(r":(?:mod|class|func|meth|attr|data|obj|exc):`~?([A-Za-z_][^`]*)`")
 
 
-def _absent_dependency(exc: ImportError) -> str | None:
-    """The absent third-party module ``exc`` names, if that is what it reports.
+def _is_package_path(name: str) -> bool:
+    """True if ``name`` is ``strands_robots`` itself or a module inside it."""
+    return name == "strands_robots" or name.startswith("strands_robots.")
+
+
+def _undecidable_import(exc: ImportError) -> str | None:
+    """What this environment could not supply, or ``None`` if ``exc`` is the rot being graded.
 
     Both causes of a failed import here raise the same exception type and need
-    opposite verdicts, and the name it carries is what separates them. A
-    ``strands_robots`` path means no such module exists - the rot being graded. A
-    name outside the package means the cited module does exist and could not be
-    imported because an extra is not installed, which is a fact about this
-    environment and not about the docstring.
+    opposite verdicts. Only the import machinery reports "no such module", and
+    when it does it always populates ``name`` - so a ``strands_robots`` path in
+    ``exc.name`` is the sole signature of the rot this guard grades. Every other
+    ``ImportError`` reaching here was raised by a module body that *did* import,
+    which means the cited path exists and the failure is a fact about this
+    environment rather than about the docstring.
+
+    ``exc.name`` alone cannot make that split, because it is populated only on an
+    exception the interpreter raises itself and is ``None`` on one that code
+    constructs - which is what 28 raise sites in the package do, both of them in
+    :func:`strands_robots.utils.require_optional` included, the mechanism AGENTS.md
+    convention 7 makes mandatory for an absent extra. Reading the surface ``name``
+    and nothing else therefore classified every one of those as package rot, and
+    the member walk's ``raise`` ended the sweep at the first one it met (#2963).
+
+    So the absent module is recovered from the chained exception the raise site was
+    handling when it constructed its own. ``raise ... from None`` clears ``__cause__``
+    and suppresses the *rendering* of ``__context__``; it does not clear the
+    attribute, so ``require_optional`` is covered by the same walk.
+
+    A surface exception carrying neither a name nor a chained one is reported as
+    undecidable too, on what it said. The interpreter never reports an absent module
+    without naming it, so such an exception is not evidence that a ``strands_robots``
+    path is missing - and refusing to read it as rot is what makes aborting the sweep
+    unreachable, whatever a future raise site does.
     """
     name = getattr(exc, "name", None)
-    if not name or name == "strands_robots" or name.startswith("strands_robots."):
-        return None
-    return name
+    if name:
+        return None if _is_package_path(name) else name
+    for linked in (exc.__cause__, exc.__context__):
+        linked_name = getattr(linked, "name", None)
+        if linked_name and not _is_package_path(linked_name):
+            return linked_name
+    reported = str(exc).strip().splitlines()
+    return reported[0] if reported else repr(exc)
 
 
 def _resolves(target: str) -> bool | None:
@@ -131,9 +163,12 @@ def _resolves(target: str) -> bool | None:
 
     The member walk is guarded for the same reason the imports are: a package
     that imports its submodules from a module-level ``__getattr__`` raises
-    ``ModuleNotFoundError`` from inside ``hasattr``, which swallows only
-    ``AttributeError``. Left to propagate, one absent extra ends the sweep and
-    nothing is graded at all.
+    ``ImportError`` from inside ``hasattr``, which swallows only
+    ``AttributeError`` - and the submodule body typically constructs that
+    exception itself rather than letting the interpreter's
+    ``ModuleNotFoundError`` through, which is the distinction
+    :func:`_undecidable_import` has to make. Left to propagate, one absent extra
+    ends the sweep and nothing is graded at all.
 
     Returns:
         ``True`` when every component resolves, ``False`` when the path names
@@ -148,7 +183,7 @@ def _resolves(target: str) -> bool | None:
         try:
             module = importlib.import_module(".".join(parts[:i]))
         except ImportError as exc:
-            if _absent_dependency(exc):
+            if _undecidable_import(exc):
                 return None
             continue
         except Exception:
@@ -164,7 +199,7 @@ def _resolves(target: str) -> bool | None:
                 return False
             obj = getattr(obj, attr, obj)
         except ImportError as exc:
-            if _absent_dependency(exc):
+            if _undecidable_import(exc):
                 return None
             raise
     return True
@@ -369,9 +404,69 @@ def test_a_module_the_package_does_not_have_is_still_a_dead_pointer() -> None:
     assert _resolves("strands_robots.mesh_session.get_session") is False
     assert _resolves(_BOGUS) is False
 
-    assert _absent_dependency(ModuleNotFoundError("x", name="strands_robots.mesh_session")) is None
-    assert _absent_dependency(ModuleNotFoundError("x", name="strands_robots")) is None
-    assert _absent_dependency(ModuleNotFoundError("x", name="serial")) == "serial"
+    assert _undecidable_import(ModuleNotFoundError("x", name="strands_robots.mesh_session")) is None
+    assert _undecidable_import(ModuleNotFoundError("x", name="strands_robots")) is None
+    assert _undecidable_import(ModuleNotFoundError("x", name="serial")) == "serial"
+
+
+def test_an_absent_extra_reported_without_a_name_is_undecidable_not_rot() -> None:
+    """An ``ImportError`` the package constructs must not be read as package rot.
+
+    ``exc.name`` is populated only on an exception the interpreter raises itself,
+    so classifying on it alone put all 28 of the package's constructed raise sites
+    on the *rot* branch - the one the member walk answers with ``raise`` - and one
+    absent extra ended the whole sweep with nothing graded after it (#2963). Both
+    shapes the package actually uses are pinned here, because the surface exception
+    is identical in each and only the chain distinguishes them: the wrapping raise
+    at ``strands_robots/tools/lerobot_camera.py``, and
+    :func:`strands_robots.utils.require_optional`, which AGENTS.md convention 7
+    makes the mandatory mechanism - its ``raise ... from None`` suppresses only the
+    *rendering* of ``__context__``, which is why the same walk reaches both.
+    """
+    absent = "a_module_this_environment_does_not_have"
+
+    with pytest.raises(ImportError) as wrapped:
+        try:
+            importlib.import_module(absent)
+        except ImportError as inner:
+            raise ImportError(f"camera modules not available: {inner}")
+    assert getattr(wrapped.value, "name", None) is None
+    assert _undecidable_import(wrapped.value) == absent
+
+    with pytest.raises(ImportError) as required:
+        require_optional(absent, extra="probe")
+    assert getattr(required.value, "name", None) is None
+    assert required.value.__cause__ is None
+    assert _undecidable_import(required.value) == absent
+
+    # Neither a name nor a chain to read: still undecidable, because the interpreter
+    # never reports an absent module without naming it. Reported on what it said.
+    assert _undecidable_import(ImportError("camera modules not available")) == "camera modules not available"
+
+
+def test_a_member_walk_that_meets_an_absent_extra_is_skipped_not_propagated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sweep-level half: the member walk must return the tri-state, never raise.
+
+    ``strands_robots.tools.__getattr__`` imports the submodule a role names, so an
+    absent extra surfaces from inside the ``hasattr`` in :func:`_has_member`, which
+    swallows only ``AttributeError``. Left to propagate it ends the run at the first
+    such target rather than skipping it, which is the #2940 hazard: a whole-tree
+    grader that silently stops covering the tree. The probe stands in for any module
+    calling ``require_optional`` at import time - that is every optional-dependency
+    module AGENTS.md convention 7 sanctions, so a new one must not become a new
+    abort site.
+    """
+    probe = ModuleType("strands_robots.xref_probe")
+
+    def _report_absent_extra(attr: str) -> object:
+        return require_optional("a_module_this_environment_does_not_have", extra="probe")
+
+    probe.__getattr__ = _report_absent_extra  # type: ignore[method-assign]
+    monkeypatch.setitem(sys.modules, probe.__name__, probe)
+
+    assert _resolves(f"{probe.__name__}.CameraTool") is None
 
 
 def test_the_role_pattern_extracts_a_target_wrapped_over_a_line_break() -> None:


### PR DESCRIPTION
## Problem

`tests/test_docstring_xref_roles_resolve.py::test_qualified_strands_robots_xref_roles_resolve`
separates the two causes of a failed import that need opposite verdicts -- a
`strands_robots` path that names nothing (the rot it grades) versus a third-party
module this environment does not have (a fact about the environment) -- and it did
so by reading `exc.name`.

The interpreter populates that field only on an exception it raises itself. It is
`None` on one that code *constructs*, which is what 28 raise sites in the package
do:

```
grep -rn "raise ImportError(" strands_robots/ | grep -v "name=" | wc -l
-> 28
```

Both raises in `strands_robots.utils.require_optional` are among them -- the
mechanism `AGENTS.md` convention 7 makes **mandatory** for every optional
dependency. So `name is None` took the `not name` branch, the one reserved for a
`strands_robots` path, and a third-party absence was read as package rot. The
member walk answers that branch with `raise`.

Reproduced on a base install without `[all]`, on the pushed tree's parent:

```
pytest tests/test_docstring_xref_roles_resolve.py -q
-> 1 failed, 22 passed
   ImportError: LeRobot camera modules not available: No module named 'lerobot'
   strands_robots/tools/lerobot_camera.py:35
```

The cost is not the one red cell. Driving `_ROLE_RE` + `_resolves` directly over
the same tree shows where the sweep stopped:

```
PRE-FIX: aborted at target 676 of 795: strands_robots.tools.lerobot_camera._numeric_option_error
PRE-FIX: graded 675 of 795 (84%), ungraded 120
```

120 targets were not graded at all. A contributor without the extras saw a red
guard they did not break, could not distinguish it from a dead pointer they did
introduce, and got no grading of the roles they had actually touched -- the #2940
hazard, a whole-tree grader that silently stops covering the tree.

CI installs `[all,dev]`, so this was invisible there. It also means the guard's
coverage in CI was order-dependent and unverified: any `[all,dev]` module failing
to import for an unrelated reason stopped the sweep at that point rather than
skipping that one target.

## Change

The classifier (`_absent_dependency` -> `_undecidable_import`, because it no
longer only reports an absent dependency) makes the split on the chained
exception the raise site was handling, not on the surface exception alone.

**`raise ... from None` does not clear `__context__`.** It clears `__cause__` and
sets `__suppress_context__`, which suppresses the *rendering*; the attribute
survives. Measured directly:

```
require_optional('a_module_this_environment_does_not_have', extra='probe')
  .name       -> None
  __cause__   -> None
  __context__ -> ModuleNotFoundError("No module named 'a_module_this_environment_does_not_have'")
```

So one walk reaches both shapes the package uses -- the wrapping raise at
`lerobot_camera.py:35` and `require_optional` -- and **no raise site changes**.
The issue's option 2 (threading `name=` through 28 sites) is therefore not needed
to fix this, and is not done here.

An `ImportError` carrying neither a name nor a chained one is reported as
undecidable rather than as rot, on what it said. The interpreter never reports an
absent module without naming it, so such an exception is not evidence that a
`strands_robots` path is missing. That is the issue's option 3 as a two-line
backstop: it is what makes aborting the sweep unreachable whatever a future raise
site does, rather than fixing today's 28 and waiting for the 29th.

Also corrected, because the fix exposes it: `_resolves`'s docstring said the
member walk is guarded because `__getattr__` "raises `ModuleNotFoundError` from
inside `hasattr`". It raises a plain constructed `ImportError` in every case that
actually aborted -- the drift that let the defect read as intended behaviour.

## Measurements

Base install, no `[all]`, same tree:

| | targets | resolved | dead | undecidable | ungraded |
|---|---|---|---|---|---|
| before | 795 | 675 graded, then abort | -- | -- | **120** |
| after | 795 | 759 | 0 | 36 | **0** |

File-level suite in that environment: `1 failed, 22 passed` -> `25 passed`.

Detection table, all rows at `collected 25`:

| mutation | failed | cells |
|---|---|---|
| control | 0 | -- |
| the defect: classify on the surface `exc.name` alone | 3 | `test_a_member_walk_that_meets_an_absent_extra_is_skipped_not_propagated`, `test_an_absent_extra_reported_without_a_name_is_undecidable_not_rot`, `test_qualified_strands_robots_xref_roles_resolve` |
| chain walk dropped (backstop kept) | 1 | `test_an_absent_extra_reported_without_a_name_is_undecidable_not_rot` |
| backstop dropped (chain walk kept) | 1 | `test_an_absent_extra_reported_without_a_name_is_undecidable_not_rot` |
| `_is_package_path` verdict inverted | 10 | 9 cells incl. `test_a_module_the_package_does_not_have_is_still_a_dead_pointer` |

The two new cells are what matter, because the third cell in row 2 is the one CI
cannot see: `test_qualified_strands_robots_xref_roles_resolve` only fires where an
extra is absent. Both new tests name a module no environment has and drive
`require_optional` directly, so they fire under `[all,dev]` too. That is the
difference between pinning the fix and pinning the environment that happened to
expose it.

The last row is the control on the split itself: inverting the package-path
verdict turns real rot into a skip and fires the existing assertion that an absent
extra and absent rot must not become the same verdict. That verdict is unchanged
by this diff.

## Deliberately not done

- **No `name=` at the 28 raise sites** (issue option 2). The chain already carries
  the absent module at every one of them, so the guard needs nothing from the
  sources. Making these `ImportError`s introspectable is a real change with its own
  callers to find; it is not this fix's to smuggle in.
- **No `AGENTS.md` convention entry.** The learning (`exc.name` is populated only
  by the interpreter) lives in the classifier's docstring and the changelog
  fragment. #2940's own fragment records why coupling an `AGENTS.md` change to an
  independent fix creates a merge-order dependency between pull requests.
- **The rest of #2963's premise is corrected, not extended.** The issue states
  `from None` "clears both"; it does not, which is why the test-local fix covers
  `require_optional`. Left on the issue for whoever closes it.

## Gate

`ruff check` clean, `ruff format --check` clean (`1 file already formatted`),
`mypy tests/test_docstring_xref_roles_resolve.py` -> `Success: no issues found`,
`python scripts/check_changelog_fragment.py` OK, and
`pytest tests/test_docstring_xref_roles_resolve.py tests/test_whole_tree_graders_roster_is_complete.py tests/test_changelog_fragment_gate.py -q`
-> `88 passed`, all on a base install with no extras.

Refs #2963, #2940.
