### PR TITLE
feat(tools/g1): port g1_list_safe_posture_fsm_gates and g1_safe_posture_fsm_admits (refs #358)

### DIFF
--- a/changelog.d/2987-g1-safe-posture-fsm-gates-port.md
+++ b/changelog.d/2987-g1-safe-posture-fsm-gates-port.md
@@ -1,0 +1,34 @@
+### Added: agent-facing lookup for the neon safe-posture FSM whitelists
+
+The neon bundle's ``g1_safe_posture.py``
+(``cagataycali/neon-the-g1/tools/g1_safe_posture.py``) refuses the
+``LocoClient.Damp()`` preamble every one of its three compound-posture
+verbs issues (``g1_safe_squat_to_stand`` / ``g1_safe_lie_to_stand`` /
+``g1_safe_stand_to_squat``) unless the driver's live FSM sits inside a
+verb-specific whitelist -- ``{3, 4, 706}``, ``{1, 702}``, and
+``{500, 501, 801}`` respectively. Damping a robot outside those sets
+leaves the joints without an active controller and collapses the pose,
+so the gate is a hard safety precondition rather than a stylistic
+check.
+
+``strands_robots.tools.g1.g1_safe_posture_fsm_gates`` snapshots the
+three whitelists as a module-level ``dict[str, frozenset[int]]`` and
+surfaces them as two agent-facing verbs -- ``g1_list_safe_posture_fsm_gates``
+returns the whole envelope, ``g1_safe_posture_fsm_admits`` decides one
+membership query -- so a caller planning a compound-posture rollout can
+name the precondition decidably before any Damp-preamble verb lands on
+the driver side. The verb pair pulls no ``unitree_sdk2py`` submodule at
+import time (the SDK-load-hygiene contract every other file in the
+package carries, refs strands-labs/robots#358), and every FSM id in
+every whitelist is cross-checked against
+``strands_robots.tools.g1.g1_fsm_targets._FSM_NAME_MAP`` -- the
+SDK-admitted transition-target set -- so a neon-side widen that named
+an FSM id the SDK does not admit would surface at CI rather than at
+wire time.
+
+Mirrors the pattern already merged for ``g1_motion_gates``,
+``g1_fsm_targets``, and ``g1_dds_topics``: one snapshot per
+neon/SDK-facing table, one verb pair per snapshot. Refs
+strands-labs/robots#358, follows the merged strands-labs/robots#2916
+which wired the driver-side FSM gate every safe-posture actuation
+path must eventually route through.

--- a/strands_robots/tools/g1/g1_safe_posture_fsm_gates.py
+++ b/strands_robots/tools/g1/g1_safe_posture_fsm_gates.py
@@ -1,0 +1,250 @@
+"""Agent-facing lookup for the FSM-set preconditions the neon safe-posture verbs gate on.
+
+The neon bundle's ``g1_safe_posture.py``
+(``cagataycali/neon-the-g1/tools/g1_safe_posture.py``) carries three
+compound-posture verbs (``g1_safe_squat_to_stand``,
+``g1_safe_lie_to_stand``, ``g1_safe_stand_to_squat``) that each issue a
+``LocoClient.Damp()`` preamble before their target transition. Every one
+of them guards the Damp preamble behind an ``_assert_safe_for_damp``
+call that refuses unless the driver's live FSM sits inside a
+verb-specific whitelist:
+
+* ``g1_safe_squat_to_stand`` requires the FSM in ``{3, 4, 706}`` -
+  ``3`` Sit, ``4`` StandUp, ``706`` Squat2StandUp - so the controller
+  is one that already carries the robot's weight before the Damp fires.
+* ``g1_safe_lie_to_stand`` requires the FSM in ``{1, 702}`` -
+  ``1`` Damp, ``702`` Lie2StandUp - so the robot is already flat on the
+  floor with a controller aware of the pose.
+* ``g1_safe_stand_to_squat`` requires the FSM in ``{500, 501, 801}`` -
+  ``500`` Start, ``501`` Walk, ``801`` BalanceExpert - so the robot is
+  actively balancing before the transition to Squat is issued.
+
+The neon comment on those sets is that Damp is a
+controller-to-controller handoff smoother, not a wake-from-limp helper:
+firing Damp against an unheld robot leaves it slumping toward the
+floor. This module surfaces the three whitelist sets as a module-level
+constant snapshot and two agent-facing verbs
+(:func:`g1_list_safe_posture_fsm_gates` returns the whole envelope;
+:func:`g1_safe_posture_fsm_admits` decides one membership query) so a
+caller planning a compound-posture rollout can name the precondition
+decidably before any Damp-preamble verb lands on the driver side.
+Refs strands-labs/robots#358.
+
+Two things this module is deliberately *not*:
+
+* An execution path. The neon verbs actually call
+  ``LocoClient.Damp()`` then ``Squat2StandUp`` / ``Lie2StandUp`` /
+  ``SetFsmId(2)``; those writes are the ``rt/lowcmd``-adjacent
+  locomotion path :class:`~strands_robots.drivers.g1.G1Driver` gates
+  through :meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates`
+  (refs the merged strands-labs/robots#2916). A future driver method
+  that fronts a compound-posture transition will land the actuation
+  half; this module ports the read-only precondition table without
+  also introducing a second locomotion writer path.
+* An SDK re-import. The FSM ids are captured here as
+  module-level ``frozenset`` constants snapshotted from the neon
+  ``_assert_safe_for_damp`` whitelists; the sets live here rather than
+  being re-imported from the SDK so ``import
+  strands_robots.tools.g1.g1_safe_posture_fsm_gates`` pulls no
+  ``unitree_sdk2py`` submodule (the import-hygiene contract every
+  other file in this package carries, refs strands-labs/robots#358).
+  An SDK release that widens or narrows the FSM name table
+  (:mod:`~strands_robots.tools.g1.g1_fsm_targets` names the full set)
+  is a driver-side update; the whitelist rows this module carries are
+  bounded by that name table and the sibling test asserts every id
+  in every whitelist is also in the SDK-admitted name map, so a
+  neon-side widen that named an id the SDK does not admit would
+  surface at CI.
+
+What this module does not decide.
+
+* Whether the robot is *actually* held by a controller at the moment
+  of the query. The FSM-set precondition is a necessary but not
+  sufficient check: the neon verbs also read
+  ``avg_knee`` off the LowState cache to refuse a deep-squat pose that
+  the controller has already lost, and pass ``force=True`` to bypass
+  both. That live-pose check is a driver-instance read
+  (:mod:`~strands_robots.tools.g1.g1_state`); this lookup answers the
+  FSM-set half without also taking a driver handle.
+* Whether the Damp preamble is sound on the target FSM. The three
+  whitelists are the neon bundle's chosen preconditions today; a
+  future safe-posture verb (e.g. ``g1_safe_kneel_to_stand``) would
+  ship its own whitelist row, and this table would grow by one entry.
+  The verb-to-set mapping here is the one contract callers can rely
+  on before a driver-side wrapper exists; the actuation contract
+  belongs on the driver's ``_check_motion_gates`` (refs the merged
+  strands-labs/robots#2916).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+#: Snapshot of the FSM-id whitelists the neon ``_assert_safe_for_damp``
+#: gate refuses Damp preambles outside of. Each key names the neon
+#: verb the row gates, each value is a ``frozenset`` of admitted FSM
+#: ids (matching the neon ``expected_fsms`` argument byte-for-byte).
+#:
+#: The verb names carry the ``g1_safe_`` prefix the neon module ships
+#: with, so a caller reading a refusal that names the verb can find
+#: this row by string match. The FSM ids are integers, matching the
+#: SDK's own ``SetFsmId(int)`` API and the name map surfaced by
+#: :mod:`~strands_robots.tools.g1.g1_fsm_targets` (an SDK-side widen
+#: of that name map would leave the whitelist rows here unchanged
+#: unless the neon bundle also widened; a sibling test asserts every
+#: id here is admitted by the SDK).
+_SAFE_POSTURE_FSM_GATES: dict[str, frozenset[int]] = {
+    "g1_safe_squat_to_stand": frozenset({3, 4, 706}),
+    "g1_safe_lie_to_stand": frozenset({1, 702}),
+    "g1_safe_stand_to_squat": frozenset({500, 501, 801}),
+}
+
+#: Human-readable description of what each safe-posture verb transitions
+#: from-to, mirrored from the neon docstrings so a returned envelope
+#: names the verb's intent alongside the FSM set. Kept here rather than
+#: in the neon docstrings because the neon file is not importable from
+#: this package (import-hygiene contract, refs strands-labs/robots#358)
+#: and a caller reading the envelope wants both the FSM set and the
+#: transition it gates in one place.
+_SAFE_POSTURE_DESCRIPTIONS: dict[str, str] = {
+    "g1_safe_squat_to_stand": (
+        "Damp preamble then Squat2StandUp; safe only when a controller "
+        "already carries the robot (Sit, StandUp, or in-progress "
+        "Squat2StandUp)."
+    ),
+    "g1_safe_lie_to_stand": (
+        "Damp preamble then Lie2StandUp; safe only when the robot is flat "
+        "on the floor with a controller aware of the pose (Damp or "
+        "in-progress Lie2StandUp)."
+    ),
+    "g1_safe_stand_to_squat": (
+        "Damp preamble then SetFsmId(2) into Squat; safe only when the "
+        "robot is actively balancing (Start, Walk, or BalanceExpert)."
+    ),
+}
+
+
+@tool
+def g1_list_safe_posture_fsm_gates(verb: str = "") -> dict[str, Any]:
+    """Return the FSM-id whitelists the neon safe-posture verbs gate Damp on.
+
+    Read-only. Every field is a module-level constant snapshotted from
+    the neon ``_assert_safe_for_damp`` gate; no bus is touched, no
+    driver instance is required. Useful before a compound-posture
+    rollout is planned, so a caller can compare the driver's live
+    ``fsm_id`` (from a status read) against the whitelist a future
+    driver-side safe-posture verb would refuse outside of.
+
+    Args:
+        verb: Optional verb-name filter. One of the three neon safe
+            posture verb names (``"g1_safe_squat_to_stand"``,
+            ``"g1_safe_lie_to_stand"``, ``"g1_safe_stand_to_squat"``);
+            empty returns all three rows so a caller can see the whole
+            gate at once.
+
+    Returns:
+        A dict with ``status`` and a ``gates`` list of records, one per
+        returned verb (sorted lexicographically by verb name). Each
+        record carries ``verb``, an ``fsm_ids`` list (sorted ascending,
+        integers only), a ``description`` naming the transition the row
+        gates, and the ``fsm_count`` so a caller can see the whitelist
+        cardinality without walking the ids. On an unknown verb name
+        the returned dict carries ``status="error"`` and a ``message``
+        naming the valid verbs as a resolvable domain.
+    """
+    if verb and verb not in _SAFE_POSTURE_FSM_GATES:
+        valid = sorted(_SAFE_POSTURE_FSM_GATES)
+        return {
+            "status": "error",
+            "message": (f"unknown verb {verb!r}. Valid verbs are {valid}. Refs strands-labs/robots#358."),
+        }
+    verbs = (verb,) if verb else tuple(sorted(_SAFE_POSTURE_FSM_GATES))
+    gates = [
+        {
+            "verb": name,
+            "fsm_ids": sorted(_SAFE_POSTURE_FSM_GATES[name]),
+            "fsm_count": len(_SAFE_POSTURE_FSM_GATES[name]),
+            "description": _SAFE_POSTURE_DESCRIPTIONS[name],
+        }
+        for name in verbs
+    ]
+    return {
+        "status": "success",
+        "count": len(gates),
+        "verb": verb or None,
+        "verbs": sorted(_SAFE_POSTURE_FSM_GATES),
+        "gates": gates,
+    }
+
+
+@tool
+def g1_safe_posture_fsm_admits(fsm_id: int, verb: str = "") -> dict[str, Any]:
+    """Decide whether a given FSM id is inside a safe-posture verb's whitelist.
+
+    Read-only. Reads the module-level whitelist for the named verb and
+    returns the same membership answer the neon
+    ``_assert_safe_for_damp`` gate would compute. A caller with a live
+    ``fsm_id`` from a G1 status read uses this to phrase a refusal in
+    its own voice, rather than triggering the neon gate's refusal at
+    wire time. When ``verb`` is empty the query is refused as a shape
+    error because the whitelist is verb-specific (the three neon verbs
+    have different admitted FSM sets); a caller that wants to see all
+    three rows uses :func:`g1_list_safe_posture_fsm_gates` instead.
+
+    Args:
+        fsm_id: The FSM id to test. Must be an int; ``bool`` is refused
+            (``True`` is ``int(1)`` but a dict-key typo of ``True`` for
+            an FSM id is a caller mistake, not a valid gate query).
+        verb: Which safe-posture verb's whitelist to test. One of
+            ``"g1_safe_squat_to_stand"`` / ``"g1_safe_lie_to_stand"`` /
+            ``"g1_safe_stand_to_squat"``; empty is refused with the
+            valid verb list because the whitelist is verb-specific.
+
+    Returns:
+        A dict with ``status``, the requested ``verb``, the tested
+        ``fsm_id``, an ``admitted`` boolean naming whether the neon
+        gate would open, the ``fsm_ids`` list the answer was computed
+        against, and the verb's ``description``. On an unknown verb
+        or a non-int ``fsm_id``, ``status="error"`` and a ``message``
+        names the resolution.
+    """
+    if not isinstance(verb, str):
+        return {
+            "status": "error",
+            "message": (f"verb must be a str; got {type(verb).__name__} {verb!r}. Refs strands-labs/robots#358."),
+        }
+    if not verb:
+        valid = sorted(_SAFE_POSTURE_FSM_GATES)
+        return {
+            "status": "error",
+            "message": (
+                f"verb is required; the safe-posture whitelist is verb-specific. "
+                f"Valid verbs are {valid}. "
+                "Use g1_list_safe_posture_fsm_gates() to see all rows at once. "
+                "Refs strands-labs/robots#358."
+            ),
+        }
+    if verb not in _SAFE_POSTURE_FSM_GATES:
+        valid = sorted(_SAFE_POSTURE_FSM_GATES)
+        return {
+            "status": "error",
+            "message": (f"unknown verb {verb!r}. Valid verbs are {valid}. Refs strands-labs/robots#358."),
+        }
+    if isinstance(fsm_id, bool) or not isinstance(fsm_id, int):
+        return {
+            "status": "error",
+            "message": (
+                f"fsm_id must be an int; got {type(fsm_id).__name__} {fsm_id!r}. Refs strands-labs/robots#358."
+            ),
+        }
+    admitted = fsm_id in _SAFE_POSTURE_FSM_GATES[verb]
+    return {
+        "status": "success",
+        "verb": verb,
+        "fsm_id": fsm_id,
+        "admitted": admitted,
+        "fsm_ids": sorted(_SAFE_POSTURE_FSM_GATES[verb]),
+        "description": _SAFE_POSTURE_DESCRIPTIONS[verb],
+    }

--- a/tests/drivers/test_g1_safe_posture_fsm_gates_reads_the_neon_precondition.py
+++ b/tests/drivers/test_g1_safe_posture_fsm_gates_reads_the_neon_precondition.py
@@ -1,0 +1,334 @@
+"""The safe-posture-fsm-gate tools name exactly what the neon _assert_safe_for_damp whitelists gate on.
+
+``cagataycali/neon-the-g1/tools/g1_safe_posture.py::_assert_safe_for_damp``
+refuses a ``LocoClient.Damp()`` preamble whenever the driver's live
+``_fsm_id`` sits outside a verb-specific whitelist: ``{3, 4, 706}`` for
+``g1_safe_squat_to_stand``, ``{1, 702}`` for ``g1_safe_lie_to_stand``,
+``{500, 501, 801}`` for ``g1_safe_stand_to_squat``. Two agent-facing
+tools - :func:`g1_list_safe_posture_fsm_gates` and
+:func:`g1_safe_posture_fsm_admits` - exist to surface those three
+whitelists before the neon verb (or a future driver-side wrapper for it)
+is called, so a caller can decide the refusal decidably rather than
+firing the Damp preamble against an out-of-set FSM.
+
+The membership rules the tools carry are cross-checked here against
+:data:`~strands_robots.tools.g1.g1_fsm_targets._FSM_NAME_MAP` (the
+SDK-admitted transition-target set), so a neon-side widen that named
+an FSM id the SDK does not admit as a transition target would surface
+here at CI rather than at wire time. What the tests do restate is the
+shape of each returned record and the SDK-load-hygiene contract every
+file under :mod:`strands_robots.tools.g1` carries: importing the
+module must not pull any ``unitree_sdk2py`` submodule.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+from strands_robots.tools.g1.g1_fsm_targets import _FSM_NAME_MAP
+from strands_robots.tools.g1.g1_safe_posture_fsm_gates import (
+    _SAFE_POSTURE_DESCRIPTIONS,
+    _SAFE_POSTURE_FSM_GATES,
+    g1_list_safe_posture_fsm_gates,
+    g1_safe_posture_fsm_admits,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process, but a caller cannot rely on that:
+    the wrapper's contract is that it returns the wrapped function's
+    return value verbatim. This helper is where a shape drift would
+    surface once, rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be importable
+    with the SDK absent; a module that pulled a submodule at import
+    time would break every headless CI runner and Thor before an
+    office bring-up. This test holds the safe-posture-fsm-gate module
+    to that rule.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_safe_posture_fsm_gates")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        "strands_robots.tools.g1.g1_safe_posture_fsm_gates imports pulled "
+        f"SDK submodules: {leaked}. The rule for this package is that the "
+        "SDK loads only inside function bodies (refs "
+        "strands-labs/robots#358)."
+    )
+
+
+def test_whitelist_verbs_are_the_three_neon_safe_posture_verb_names() -> None:
+    """The whitelist covers exactly the three neon safe-posture verbs today.
+
+    A neon-side widen that added a fourth safe-posture verb would ship
+    a new whitelist row here (the port grows by one). A caller reading
+    the envelope wants the row count to match the neon module's verb
+    count, so this test pins the whole set rather than any single row.
+    """
+    expected = {
+        "g1_safe_squat_to_stand",
+        "g1_safe_lie_to_stand",
+        "g1_safe_stand_to_squat",
+    }
+    assert set(_SAFE_POSTURE_FSM_GATES) == expected, (
+        f"whitelist verbs {sorted(_SAFE_POSTURE_FSM_GATES)} diverged from "
+        f"the neon safe-posture verb set {sorted(expected)}. Update the "
+        "port or the expectation."
+    )
+
+
+def test_every_whitelist_id_is_admitted_by_the_sdk_transition_set() -> None:
+    """Every FSM id on every whitelist is one the SDK admits as a target.
+
+    A neon-side whitelist that named an FSM id the SDK's own
+    ``SetFsmId`` handler refuses would leave a caller unable to enter
+    the FSM the safe-posture verb requires. The cross-check here is
+    against :data:`~strands_robots.tools.g1.g1_fsm_targets._FSM_NAME_MAP`
+    (the SDK-admitted transition-target set); an id in a whitelist
+    that is not in the name map is either a neon-side typo or an SDK
+    contraction the port has to follow.
+    """
+    admitted = set(_FSM_NAME_MAP)
+    for verb, fsm_ids in _SAFE_POSTURE_FSM_GATES.items():
+        strays = set(fsm_ids) - admitted
+        assert strays == set(), (
+            f"safe-posture whitelist {verb!r} named FSM ids {sorted(strays)} "
+            f"not in the SDK-admitted set {sorted(admitted)}. Refs "
+            "strands-labs/robots#358."
+        )
+
+
+def test_squat_to_stand_whitelist_matches_the_neon_expected_fsms_verbatim() -> None:
+    """The squat-to-stand row is the exact neon ``{3, 4, 706}`` set.
+
+    The neon file cites ``expected_fsms={3, 4, 706}`` for the verb;
+    the port has to reproduce that byte-for-byte or a caller reading
+    a refusal would see a different admitted set than the neon gate
+    would compute.
+    """
+    assert _SAFE_POSTURE_FSM_GATES["g1_safe_squat_to_stand"] == frozenset({3, 4, 706})
+
+
+def test_lie_to_stand_whitelist_matches_the_neon_expected_fsms_verbatim() -> None:
+    """The lie-to-stand row is the exact neon ``{1, 702}`` set."""
+    assert _SAFE_POSTURE_FSM_GATES["g1_safe_lie_to_stand"] == frozenset({1, 702})
+
+
+def test_stand_to_squat_whitelist_matches_the_neon_expected_fsms_verbatim() -> None:
+    """The stand-to-squat row is the exact neon ``{500, 501, 801}`` set."""
+    assert _SAFE_POSTURE_FSM_GATES["g1_safe_stand_to_squat"] == frozenset({500, 501, 801})
+
+
+def test_description_table_keys_match_whitelist_keys() -> None:
+    """Every whitelist row carries a description; no orphan rows either way.
+
+    The description table is the human-readable half of the envelope
+    the list verb returns; a row on one side without a row on the
+    other would surface either as a ``KeyError`` at call time or as a
+    silently-dropped description in the returned record.
+    """
+    assert set(_SAFE_POSTURE_DESCRIPTIONS) == set(_SAFE_POSTURE_FSM_GATES), (
+        f"description keys {sorted(_SAFE_POSTURE_DESCRIPTIONS)} diverged "
+        f"from whitelist keys {sorted(_SAFE_POSTURE_FSM_GATES)}."
+    )
+
+
+def test_list_returns_every_whitelist_the_module_names() -> None:
+    """The list verb with no argument returns all three whitelist rows.
+
+    The neon file has three safe-posture verbs today; the envelope
+    reports three ``gates`` entries and a matching ``count``. A row
+    count drift would surface here.
+    """
+    result = _call(g1_list_safe_posture_fsm_gates)
+    assert result["status"] == "success"
+    assert result["count"] == len(_SAFE_POSTURE_FSM_GATES)
+    assert len(result["gates"]) == len(_SAFE_POSTURE_FSM_GATES)
+    returned_verbs = {row["verb"] for row in result["gates"]}
+    assert returned_verbs == set(_SAFE_POSTURE_FSM_GATES)
+
+
+def test_list_returns_gates_sorted_lexicographically_by_verb() -> None:
+    """The ``gates`` list is stable across calls and sorted by verb name.
+
+    The list verb has no ordering argument, so callers rely on a
+    stable order for diff-shaped comparisons. Sort by verb name
+    ascending matches the sibling ``g1_list_motion_gates`` /
+    ``g1_list_dds_topics`` verbs.
+    """
+    result = _call(g1_list_safe_posture_fsm_gates)
+    verbs_in_order = [row["verb"] for row in result["gates"]]
+    assert verbs_in_order == sorted(verbs_in_order)
+    assert result["verbs"] == sorted(_SAFE_POSTURE_FSM_GATES)
+
+
+def test_every_gate_row_carries_the_whitelist_and_description() -> None:
+    """Every returned row carries ``fsm_ids``, ``fsm_count``, and ``description``.
+
+    The row shape has to be uniform across all three verbs so a
+    caller can walk the list without special-casing any single row.
+    """
+    result = _call(g1_list_safe_posture_fsm_gates)
+    for row in result["gates"]:
+        verb = row["verb"]
+        assert row["fsm_ids"] == sorted(_SAFE_POSTURE_FSM_GATES[verb])
+        assert row["fsm_count"] == len(_SAFE_POSTURE_FSM_GATES[verb])
+        assert row["description"] == _SAFE_POSTURE_DESCRIPTIONS[verb]
+
+
+def test_verb_filter_returns_that_verb_verbatim() -> None:
+    """Passing a valid verb name returns exactly that one row.
+
+    The verb-filter argument is the way a caller reads a single
+    row without walking the whole list; passing a known verb narrows
+    the envelope to that row and reports the same verb on the top-level
+    ``verb`` field.
+    """
+    result = _call(g1_list_safe_posture_fsm_gates, verb="g1_safe_squat_to_stand")
+    assert result["status"] == "success"
+    assert result["count"] == 1
+    assert result["verb"] == "g1_safe_squat_to_stand"
+    assert len(result["gates"]) == 1
+    row = result["gates"][0]
+    assert row["verb"] == "g1_safe_squat_to_stand"
+    assert row["fsm_ids"] == [3, 4, 706]
+
+
+def test_verb_filter_refuses_an_unknown_verb_by_name() -> None:
+    """An off-partition verb name is refused with the valid set listed.
+
+    A caller that typos a verb name gets both the refused input and
+    the resolution path (the three valid verb names) in one refusal,
+    so no follow-up call is needed to recover.
+    """
+    result = _call(g1_list_safe_posture_fsm_gates, verb="g1_safe_headstand")
+    assert result["status"] == "error"
+    assert "g1_safe_headstand" in result["message"]
+    for valid_verb in _SAFE_POSTURE_FSM_GATES:
+        assert valid_verb in result["message"]
+
+
+def test_admits_reports_membership_the_neon_gate_would_compute() -> None:
+    """The admits verb returns ``True`` for every id in the named whitelist.
+
+    The neon ``_assert_safe_for_damp`` gate refuses the Damp preamble
+    when the FSM sits outside the whitelist; the admits verb reports
+    the same membership answer without firing the gate.
+    """
+    for verb, fsm_ids in _SAFE_POSTURE_FSM_GATES.items():
+        for fsm_id in fsm_ids:
+            result = _call(g1_safe_posture_fsm_admits, fsm_id=fsm_id, verb=verb)
+            assert result["status"] == "success"
+            assert result["admitted"] is True, (
+                f"verb {verb!r} whitelist id {fsm_id} was reported as refused; expected admitted."
+            )
+            assert result["fsm_ids"] == sorted(fsm_ids)
+
+
+def test_admits_reports_a_non_member_as_refused() -> None:
+    """An FSM outside the whitelist is refused with the same set the gate would test.
+
+    A caller with a live FSM outside the whitelist gets the ``admitted``
+    boolean plus the verb's whitelist, so it can phrase its own refusal
+    without a follow-up call. The FSM used here (``2`` Squat) is on
+    the SDK-admitted set but not on any of the three safe-posture
+    whitelists, so this is a real off-partition query rather than a
+    shape typo.
+    """
+    result = _call(g1_safe_posture_fsm_admits, fsm_id=2, verb="g1_safe_squat_to_stand")
+    assert result["status"] == "success"
+    assert result["admitted"] is False
+    assert result["fsm_ids"] == [3, 4, 706]
+    assert result["verb"] == "g1_safe_squat_to_stand"
+
+
+def test_admits_refuses_an_empty_verb_with_the_valid_set_listed() -> None:
+    """Empty verb is refused because the whitelist is verb-specific.
+
+    The three safe-posture verbs have three different admitted FSM
+    sets; asking ``does FSM=500 admit?`` without naming the verb is a
+    shape error - the answer depends on which verb the caller has in
+    mind. The refusal names all three valid verb names and points at
+    :func:`g1_list_safe_posture_fsm_gates` for the whole-envelope
+    read.
+    """
+    result = _call(g1_safe_posture_fsm_admits, fsm_id=500, verb="")
+    assert result["status"] == "error"
+    assert "verb is required" in result["message"]
+    for valid_verb in _SAFE_POSTURE_FSM_GATES:
+        assert valid_verb in result["message"]
+    assert "g1_list_safe_posture_fsm_gates" in result["message"]
+
+
+def test_admits_refuses_an_unknown_verb_by_name() -> None:
+    """An off-partition verb name is refused with the three valid names listed."""
+    result = _call(g1_safe_posture_fsm_admits, fsm_id=500, verb="g1_safe_backflip")
+    assert result["status"] == "error"
+    assert "g1_safe_backflip" in result["message"]
+    for valid_verb in _SAFE_POSTURE_FSM_GATES:
+        assert valid_verb in result["message"]
+
+
+def test_admits_refuses_bool_as_fsm_id_despite_being_int_subclass() -> None:
+    """``bool`` is refused even though ``True`` is ``int(1)``.
+
+    ``True`` is a Python-side coincidence with FSM id ``1`` (Damp);
+    a caller passing a boolean where an FSM id is expected has made
+    a typing mistake and should get a decidable refusal rather than
+    a coincidentally-correct admits answer.
+    """
+    result = _call(g1_safe_posture_fsm_admits, fsm_id=True, verb="g1_safe_lie_to_stand")
+    assert result["status"] == "error"
+    assert "bool" in result["message"]
+
+
+def test_admits_refuses_non_int_fsm_id_and_names_the_type() -> None:
+    """A non-int FSM id is refused and the returned message names the offending type."""
+    for bad_input in ("500", 500.0, None, [500], (500,)):
+        result = _call(
+            g1_safe_posture_fsm_admits,
+            fsm_id=bad_input,
+            verb="g1_safe_stand_to_squat",
+        )
+        assert result["status"] == "error", f"non-int fsm_id {bad_input!r} was not refused"
+        assert type(bad_input).__name__ in result["message"]
+
+
+def test_admits_refuses_non_str_verb() -> None:
+    """A non-str verb is refused decidably rather than through key-lookup coercions."""
+    for bad_verb in (None, 42, 3.14, ["g1_safe_squat_to_stand"]):
+        result = _call(g1_safe_posture_fsm_admits, fsm_id=3, verb=bad_verb)
+        assert result["status"] == "error", f"non-str verb {bad_verb!r} was not refused"
+        assert type(bad_verb).__name__ in result["message"]
+
+
+def test_whitelists_are_disjoint_or_overlap_deliberately() -> None:
+    """The three whitelists partition the SDK-admitted set into three roles.
+
+    ``{3, 4, 706}`` (squat-to-stand) and ``{1, 702}`` (lie-to-stand)
+    are disjoint - a robot is either sitting or lying, not both. The
+    ``{500, 501, 801}`` (stand-to-squat) set is also disjoint from
+    the other two; this is the neon bundle's chosen invariant today.
+    A future safe-posture verb that overlapped an existing whitelist
+    would be a caller-visible ambiguity (``fsm_id=500`` would admit
+    two verbs at once); the invariant is captured here so a neon-side
+    widen that broke it would surface at CI.
+    """
+    squat = _SAFE_POSTURE_FSM_GATES["g1_safe_squat_to_stand"]
+    lie = _SAFE_POSTURE_FSM_GATES["g1_safe_lie_to_stand"]
+    stand = _SAFE_POSTURE_FSM_GATES["g1_safe_stand_to_squat"]
+    assert squat & lie == frozenset()
+    assert squat & stand == frozenset()
+    assert lie & stand == frozenset()


### PR DESCRIPTION
## What this does

Ports the read-only FSM-precondition half of the neon bundle's `g1_safe_posture.py` (`cagataycali/neon-the-g1/tools/g1_safe_posture.py`) into `strands_robots.tools.g1.g1_safe_posture_fsm_gates` as a pair of agent-facing verbs. Refs strands-labs/robots#358, follows the merged #2916 which wired the driver-side FSM gate every safe-posture actuation path must eventually route through.

## The envelope

The neon `_assert_safe_for_damp` gate refuses the `LocoClient.Damp()` preamble every one of its three compound-posture verbs issues unless the driver's live FSM sits inside a verb-specific whitelist:

| Verb | Admitted FSM ids | Transition |
|---|---|---|
| `g1_safe_squat_to_stand` | `{3, 4, 706}` (Sit, StandUp, Squat2StandUp) | controller-managed squat → stand |
| `g1_safe_lie_to_stand` | `{1, 702}` (Damp, Lie2StandUp) | face-up flat → stand |
| `g1_safe_stand_to_squat` | `{500, 501, 801}` (Start, Walk, BalanceExpert) | active balance → squat |

Damping a robot outside those sets leaves the joints without an active controller and collapses the pose. This is a hard safety precondition, not a stylistic check.

Two agent-facing verbs:

- **`g1_list_safe_posture_fsm_gates(verb: str = "")`** — names the whole envelope: `gates` list of per-verb descriptors sorted by `verb` ascending, each carrying `verb` / `fsm_ids` / `fsm_count` / `description`, and a sorted `verbs` list. Optional `verb` filter narrows to one row.
- **`g1_safe_posture_fsm_admits(fsm_id: int, verb: str)`** — decides one membership query. Returns `admitted` boolean, the tested `fsm_id`, the `fsm_ids` set the answer was computed against, and the verb's `description`. Empty verb is refused decidably (the whitelist is verb-specific) with the three valid verb names + a pointer to `g1_list_safe_posture_fsm_gates` for the whole-envelope read.

Mirrors the pattern already merged for `g1_motion_gates`, `g1_fsm_targets`, `g1_dds_topics`, `g1_balance_modes`: one snapshot per neon/SDK-facing table, one verb pair per snapshot.

## Cross-lookup invariant

Every FSM id in every whitelist is cross-checked at CI against `strands_robots.tools.g1.g1_fsm_targets._FSM_NAME_MAP` — the SDK-admitted transition-target set. A neon-side widen that named an FSM id the SDK does not admit as a transition target would surface here at CI rather than at wire time (`test_every_whitelist_id_is_admitted_by_the_sdk_transition_set`).

The three whitelists are also asserted to be pairwise disjoint (`test_whitelists_are_disjoint_or_overlap_deliberately`), which is the neon bundle's chosen invariant today — a robot is either sitting or lying or balancing, not two at once. A future safe-posture verb that overlapped an existing whitelist would be a caller-visible ambiguity (`fsm_id=500` would admit two verbs at once); the invariant guards against that drift.

## Refusal strings (rule 3, #2872)

- Unknown verb: names the refused input + lists all three valid verb names + cites `strands-labs/robots#358`.
- Empty verb: explicitly names why (whitelist is verb-specific) + valid verb names + pointer to `g1_list_safe_posture_fsm_gates` + issue ref.
- Non-int `fsm_id`: names the offending type + issue ref.
- Non-str verb: names the offending type + issue ref.
- `bool` `fsm_id`: refused despite being `int` subclass (dict-key-typo `True` is not a valid FSM id).

## Import hygiene

No `unitree_sdk2py` submodules pull at import time. `test_the_import_pulls_no_sdk_module` walks `sys.modules` before and after the import and asserts no `unitree`-flavored module leaked.

## Test count

**20 tests** in `tests/drivers/test_g1_safe_posture_fsm_gates_reads_the_neon_precondition.py`, all green locally (1.75s wall):

- import hygiene (no SDK submodule leak)
- whitelist verbs = the three neon safe-posture verb names
- every whitelist id is admitted by the SDK transition set
- each whitelist matches the neon `expected_fsms` verbatim (3 pinned tests: squat/lie/stand)
- description table keys match whitelist keys
- list verb returns every row
- list verb sorted lexicographically by verb
- every gate row carries whitelist + count + description
- verb filter returns row verbatim
- verb filter refuses unknown verb with valid set listed
- admits reports membership neon gate would compute (walks every id in every whitelist)
- admits reports a non-member as refused (uses SDK-admitted-but-off-whitelist id `2` Squat)
- admits refuses empty verb with the valid set + pointer to list verb
- admits refuses an unknown verb by name
- admits refuses bool as fsm_id despite being int subclass
- admits refuses non-int fsm_id and names the type (str, float, None, list, tuple)
- admits refuses non-str verb (None, int, float, list)
- whitelists are pairwise disjoint (invariant capture)

## Gates

- `ruff check strands_robots/tools/g1/g1_safe_posture_fsm_gates.py tests/drivers/test_g1_safe_posture_fsm_gates_reads_the_neon_precondition.py`: pass
- `ruff format --check` on both files: pass
- `mypy strands_robots/tools/g1/g1_safe_posture_fsm_gates.py`: zero errors on this file (4 pre-existing errors in unrelated `strands_robots/utils.py`, `strands_robots/simulation/ik.py`, `strands_robots/mesh/core.py` are not touched by this PR)
- `pytest tests/drivers/test_g1_safe_posture_fsm_gates_reads_the_neon_precondition.py --no-cov`: 20 passed
- `pytest tests/test_docstring_xref_roles_resolve.py tests/test_source_strings_no_emoji.py tests/test_changelog_fragments.py tests/test_docstrings_no_dangling_doc_refs.py tests/test_args_docstring_completeness.py tests/test_raises_docstring_completeness.py tests/test_attributes_docstring_completeness.py tests/test_asset_docstring_module_xrefs.py`: 540 passed

## Naming decision

Chose `g1_list_safe_posture_fsm_gates` / `g1_safe_posture_fsm_admits` (rather than `g1_list_safe_postures` / `g1_safe_posture_admits`) to keep the `fsm_gates` domain explicit in every verb name and match the sibling `g1_list_motion_gates` naming shape. The port is specifically the FSM-precondition table — not the safe-posture verbs themselves (those are actuation and belong on a future driver-side wrapper) — so the `fsm_gates` qualifier is load-bearing.

Chose to refuse empty `verb` on `g1_safe_posture_fsm_admits` (rather than default to any single verb) because the three whitelists are meaningfully different: `fsm_id=500` admits `g1_safe_stand_to_squat` but is refused by the other two. Defaulting to any single verb would silently pick a partition; refusing decidably with the three valid names + a pointer to the list verb keeps the caller's intent explicit.

## Changelog fragment

`changelog.d/2987-g1-safe-posture-fsm-gates-port.md` — placeholder number 2987 (next likely PR number), will be renamed to the actual PR number after this opens.

## Autonomy

Named the verbs by the most defensible convention (`safe_posture_fsm_gates` matches sibling `motion_gates` shape), refused empty `verb` decidably rather than defaulting silently, and shipped. No blockers surface to the operator — the port is a straight enumeration of a small stable neon constant with three cross-check invariants (whitelist ids ⊂ SDK admitted set; whitelist verbs = neon safe-posture verbs; whitelists pairwise disjoint) all captured as tests.