### PR TITLE
feat(tools/g1): port g1_list_bidi_audio_dependencies and g1_bidi_audio_dependency_admits (refs #358)

### DIFF
--- a/changelog.d/2988-g1-bidi-audio-dependencies-port.md
+++ b/changelog.d/2988-g1-bidi-audio-dependencies-port.md
@@ -1,0 +1,30 @@
+### Feature
+
+- Added `strands_robots.tools.g1.g1_list_bidi_audio_dependencies` and
+  `strands_robots.tools.g1.g1_bidi_audio_dependency_admits`, two read-only
+  ``@tool`` verbs that snapshot the three module-import names the neon
+  bundle's ``g1_speak`` verb
+  (``cagataycali/neon-the-g1/tools/g1_speak.py``) reads inside its
+  ``_probe_bidi`` guard: ``pywebrtc_audio`` (the WebRTC-lineage
+  acoustic-echo-cancellation front-end), ``pyaudio`` (the PortAudio mic
+  capture the ``autopick_mic`` helper selects a device on), and
+  ``strands.experimental.bidi`` (the strands experimental bidi agent
+  factory ``BidiAgent`` is imported from). Each admitted dependency
+  carries a ``role`` label classifying its contribution to the bidi audio
+  path (``aec_frontend``, ``mic_capture``, ``bidi_agent``) and a
+  ``pip_hint`` naming a suggested distribution name a caller would
+  ``pip install`` to satisfy the probe on a host missing the module.
+  The two verbs let a caller decide the ``rc=7404`` gate-refused refusal
+  decidably before a future driver-side ``g1_speak`` wrapper fires
+  ``_probe_bidi`` against the host, so a headless CI runner reading the
+  dependency set can enumerate the three module names without pulling
+  the audio stack itself. No ``unitree_sdk2py`` submodule and no bidi
+  audio-stack submodule (``pywebrtc_audio``, ``pyaudio``,
+  ``strands.experimental.bidi``) load on import - the dependency table
+  is a module-level string snapshot, matching the SDK-load hygiene the
+  rest of this package carries and letting a machine without the optional
+  audio deps read the admitted set. Non-string, bool, empty-string, and
+  missing arguments to ``g1_bidi_audio_dependency_admits`` refuse
+  decidably with reason strings that name the shape error rather than
+  falling through to a confusing "unknown dependency" refusal. Refs
+  strands-labs/robots#358.

--- a/strands_robots/tools/g1/g1_bidi_audio_dependencies.py
+++ b/strands_robots/tools/g1/g1_bidi_audio_dependencies.py
@@ -1,0 +1,303 @@
+"""Agent-facing lookup for the imports the neon bidi audio path probes.
+
+The neon bundle's ``g1_speak`` verb
+(``cagataycali/neon-the-g1/tools/g1_speak.py``) runs a ``_probe_bidi``
+guard before spawning its bidi-audio background thread: it ``import``s
+three optional modules - ``pywebrtc_audio`` (the AEC front-end),
+``pyaudio`` (the PortAudio input capture), and
+``strands.experimental.bidi.BidiAgent`` (the bidi agent factory) - and
+returns ``False`` if any raises ``ImportError``. That probe is *not* a
+snapshot answer; it is a live host read, and a headless CI runner or
+Thor before an office bring-up has none of those three modules
+installed. The refusal the ``g1_speak`` verb quotes on a failed probe
+is a shape-level refusal ("bidi audio deps missing") without naming
+which of the three the caller has to install, so a planner asked to
+diagnose the refusal has to read the neon source itself to enumerate
+the dependency set.
+
+This module snapshots that dependency set as an agent-facing lookup
+so a caller planning a ``g1_speak`` rollout can name the three
+modules the future driver-side wrapper's audio probe would reach
+for, without also running the probe. The verb pair mirrors
+:mod:`~strands_robots.tools.g1.g1_voice_providers` and
+:mod:`~strands_robots.tools.g1.g1_arm_actions`: one snapshot lookup
+naming the whole set, one membership decision on one query.
+
+Two things this module is deliberately *not*:
+
+* An execution path. The neon bundle's ``_probe_bidi`` runs the
+  actual ``import`` statements against the host; that probe is out
+  of scope for this lookup, which only names the three module names
+  the probe reads. A future verb that fronts the probe through the
+  driver's own audio-writer path is a separate port; refs
+  strands-labs/robots#358 for the SDK-facing seam that audio path
+  belongs on. This module ports the read-only lookup half without
+  also introducing a second audio-probe path the driver does not
+  yet own.
+* An SDK or audio-stack re-import. The dependency names are
+  captured here as string constants; a snapshot lookup reading this
+  module does not pull ``pywebrtc_audio`` or ``pyaudio`` or
+  ``strands.experimental.bidi`` (the module-load hygiene contract
+  every other file in this package carries, refs
+  strands-labs/robots#358). The invariant a neon-side probe change
+  must preserve is byte-for-byte identity between the module names
+  quoted here and the module names the ``_probe_bidi`` guard
+  imports: a widen or narrow of the probe that does not update this
+  snapshot leaves the two out of sync, so the probe the neon
+  verb actually runs and the probe this lookup reports diverge
+  silently.
+
+What this module does not decide.
+
+* Whether a dependency is currently *installed* on the host.
+  Import availability is a host-layer answer; the neon bundle's
+  ``_probe_bidi`` reaches for it. This lookup answers a static
+  question: which three modules the probe would ``import``,
+  independent of whether they resolve.
+* Which pip package a dependency ships with. The three names are
+  module-import names (``import pywebrgc_audio``), not
+  distribution names; the distribution a caller installs to obtain
+  the module is out of scope for this snapshot. The ``pip_hint``
+  field surfaces a suggested distribution name where the module's
+  name and the pip package's name are unambiguously the same, so a
+  caller reading the payload has a starting install command; the
+  hint is *not* a canonical resolver answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+from strands_robots.tools.g1._g1_common import ERR_CODES
+
+#: Snapshot of the module-import names the neon bundle's
+#: ``_probe_bidi`` guard reads. Each entry names the module
+#: (matching the neon source's ``import`` statement byte-for-byte),
+#: a ``role`` describing what the module contributes to the bidi
+#: audio path, and a ``pip_hint`` surfacing a suggested distribution
+#: name where the module name and the distribution name coincide.
+#:
+#: The role labels are the neon-observed contributions:
+#:
+#: * ``aec_frontend`` for ``pywebrtc_audio``, the WebRTC-lineage
+#:   acoustic-echo-cancellation front-end the neon path runs mic
+#:   input through before handing frames to the bidi agent.
+#: * ``mic_capture`` for ``pyaudio``, the PortAudio binding the
+#:   neon path uses to read the USB mic device the ``autopick_mic``
+#:   helper selects.
+#: * ``bidi_agent`` for ``strands.experimental.bidi.BidiAgent``, the
+#:   agent factory the neon runtime instantiates the ``g1_speak``
+#:   bidi loop against; the module is inside ``strands`` and its
+#:   ``experimental`` submodule may be gated behind an
+#:   ``experimental`` install extra.
+_BIDI_AUDIO_DEPENDENCIES: dict[str, dict[str, str]] = {
+    "pywebrtc_audio": {
+        "role": "aec_frontend",
+        "description": (
+            "WebRTC-lineage acoustic-echo-cancellation front-end. "
+            "The neon bundle's ``_probe_bidi`` guard imports this "
+            "module before instantiating the bidi agent; a caller "
+            "planning a ``g1_speak`` write on a host without this "
+            "module is refused by the probe with a shape-level "
+            "``bidi audio deps missing`` refusal."
+        ),
+        "pip_hint": "pywebrtc-audio",
+    },
+    "pyaudio": {
+        "role": "mic_capture",
+        "description": (
+            "PortAudio Python binding. The neon bundle reads mic "
+            "frames through this module and hands them to the "
+            "``autopick_mic`` helper's device-index result; the "
+            "``_probe_bidi`` guard imports it before the bidi loop "
+            "starts. On Jetson this ships as a system package a "
+            "caller installs through ``apt`` rather than ``pip``, "
+            "so the ``pip_hint`` is the PyPI distribution name a "
+            "non-Jetson host would use."
+        ),
+        "pip_hint": "pyaudio",
+    },
+    "strands.experimental.bidi": {
+        "role": "bidi_agent",
+        "description": (
+            "The strands experimental bidi agent factory. The "
+            "neon bundle imports ``BidiAgent`` from this submodule "
+            "and instantiates the bidi loop against it; the "
+            "``experimental`` submodule may be gated behind an "
+            "install extra on the ``strands`` distribution. A "
+            "future driver-side ``g1_speak`` wrapper would front "
+            "the same import; refs strands-labs/robots#358 for "
+            "the SDK-facing seam that write path belongs on."
+        ),
+        "pip_hint": "strands-agents",
+    },
+}
+
+#: The error-table entry a future driver-side wrapper would quote on
+#: a dependency name outside :data:`_BIDI_AUDIO_DEPENDENCIES`. The
+#: neon bundle's ``_probe_bidi`` guard raises ``ImportError`` on the
+#: import statements themselves; a caller-side membership refusal
+#: uses the ``7404`` gate-refusal shape a future driver-side wrapper
+#: would quote when refusing at the same boundary. The write path
+#: and this lookup share the constant. Named separately from the
+#: voice-provider constant so a future SDK release that ships a
+#: dedicated "invalid audio dependency" code lands here without
+#: also renaming the shared gate-refusal constant.
+_INVALID_DEPENDENCY_CODE: int = 7404
+
+
+def _describe(name: str) -> dict[str, Any]:
+    """Build the per-dependency descriptor the verbs return.
+
+    Kept here rather than inlined in
+    :func:`g1_list_bidi_audio_dependencies` so
+    :func:`g1_bidi_audio_dependency_admits`'s admitted-path payload
+    names the same fields, and so a widen to the descriptor lands in
+    one place. Every field is a snapshot read; no bus is touched
+    and no dependency is imported.
+    """
+    entry = _BIDI_AUDIO_DEPENDENCIES[name]
+    return {
+        "name": name,
+        "role": entry["role"],
+        "description": entry["description"],
+        "pip_hint": entry["pip_hint"],
+        "admits_bidi_writes": True,
+    }
+
+
+@tool
+def g1_list_bidi_audio_dependencies() -> dict[str, Any]:
+    """Return the module names the neon bidi audio probe reads.
+
+    Read-only. No driver instance, no DDS, no SDK, no audio stack:
+    every field is a module-level constant. Useful before a future
+    driver-side wrapper for ``g1_speak`` is called, so a caller can
+    compare an intended dependency name against the set the neon
+    bundle's ``_probe_bidi`` guard imports, and can also read the
+    ``pip_hint`` on each descriptor to name the distribution a host
+    would install to satisfy the probe.
+
+    Returns:
+        A dict with ``status``; a ``dependencies`` list of
+        per-dependency descriptors sorted by ``name`` ascending,
+        each carrying ``name`` (the module-import name the neon
+        ``_probe_bidi`` guard reads), ``role`` (a short label
+        describing what the module contributes to the bidi audio
+        path: ``aec_frontend``, ``mic_capture``, or
+        ``bidi_agent``), ``description`` (the neon-observed
+        contribution the module makes), ``pip_hint`` (a suggested
+        distribution name a caller would ``pip install`` to obtain
+        the module), and ``admits_bidi_writes`` (always ``True``,
+        because every admitted dependency is inside the neon
+        bundle's probe set by definition; the flag is surfaced so
+        the descriptor shape matches
+        :mod:`~strands_robots.tools.g1.g1_voice_providers` and
+        :mod:`~strands_robots.tools.g1.g1_arm_actions` verbatim);
+        a ``names`` list quoting the admitted module names in
+        sorted order; and a ``refusals`` list naming the ``7404``
+        refusal code a future driver-side wrapper would quote on
+        a dependency name outside the admitted set. Every field is
+        a snapshot of a neon-observed module name; no dynamic
+        decode runs here.
+    """
+    return {
+        "status": "success",
+        "dependencies": [_describe(name) for name in sorted(_BIDI_AUDIO_DEPENDENCIES)],
+        "names": sorted(_BIDI_AUDIO_DEPENDENCIES),
+        "refusals": [
+            {"code": _INVALID_DEPENDENCY_CODE, "text": ERR_CODES[_INVALID_DEPENDENCY_CODE]},
+        ],
+    }
+
+
+@tool
+def g1_bidi_audio_dependency_admits(name: str | None = None) -> dict[str, Any]:
+    """Decide whether a module ``name`` sits inside the probe set.
+
+    Read-only. Compares one argument against the neon-observed
+    :data:`_BIDI_AUDIO_DEPENDENCIES` and reports the admitted
+    descriptor on match, or the ``7404`` refusal code a future
+    driver-side wrapper would quote on miss. No driver instance,
+    no DDS, no SDK, no audio stack: the decision reads only
+    module-level constants and the argument itself.
+
+    A dependency inside the admitted set is *not* the same as an
+    admitted write: the neon bundle's ``_probe_bidi`` also refuses
+    when the module fails to ``import`` at runtime, and the
+    ``g1_speak`` verb refuses independently on missing
+    ``credential_env`` for the chosen provider (see
+    :mod:`~strands_robots.tools.g1.g1_voice_providers`). Neither of
+    those is a snapshot answer; both are live-host reads a caller
+    reaches after this verb admits the dependency name. The
+    returned payload names ``pip_hint`` so a caller comparing an
+    intended write against both conditions (membership + host
+    install) has the distribution name on hand.
+
+    Args:
+        name: The module-import name to check (``"pywebrtc_audio"``,
+            ``"pyaudio"``, or ``"strands.experimental.bidi"``
+            today). The comparison is case-sensitive against the
+            snapshot in :data:`_BIDI_AUDIO_DEPENDENCIES`; a
+            mis-cased or unknown name is refused with the ``7404``
+            code. Bool values (``True``/``False``) are refused with
+            the same code because ``str(True) == "True"`` would
+            otherwise silently mis-match; a non-string non-bool
+            argument is refused with the same code for the same
+            reason. An empty string is refused decidably rather
+            than treated as a default.
+
+    Returns:
+        A dict with ``status``; on admit, a ``dependency``
+        descriptor with ``name``, ``role``, ``description``,
+        ``pip_hint``, and ``admits_bidi_writes`` (the same shape
+        :func:`g1_list_bidi_audio_dependencies` returns). On
+        refuse, ``refusal_code`` and ``refusal_text`` name the
+        ``7404`` code and its decoded text, plus a ``reason``
+        string that names why the argument was refused (missing
+        argument, bool argument, non-string argument, empty-string
+        argument, or unknown module name).
+    """
+    if name is None:
+        return {
+            "status": "error",
+            "refusal_code": _INVALID_DEPENDENCY_CODE,
+            "refusal_text": ERR_CODES[_INVALID_DEPENDENCY_CODE],
+            "reason": (f"name is required; pass one of {sorted(_BIDI_AUDIO_DEPENDENCIES)} so the lookup is decidable"),
+        }
+    if isinstance(name, bool):
+        return {
+            "status": "error",
+            "refusal_code": _INVALID_DEPENDENCY_CODE,
+            "refusal_text": ERR_CODES[_INVALID_DEPENDENCY_CODE],
+            "reason": (f"name={name!r} is a bool; pass one of {sorted(_BIDI_AUDIO_DEPENDENCIES)} as a string"),
+        }
+    if not isinstance(name, str):
+        return {
+            "status": "error",
+            "refusal_code": _INVALID_DEPENDENCY_CODE,
+            "refusal_text": ERR_CODES[_INVALID_DEPENDENCY_CODE],
+            "reason": (f"name={name!r} is not a string; pass one of {sorted(_BIDI_AUDIO_DEPENDENCIES)} as a string"),
+        }
+    if name == "":
+        return {
+            "status": "error",
+            "refusal_code": _INVALID_DEPENDENCY_CODE,
+            "refusal_text": ERR_CODES[_INVALID_DEPENDENCY_CODE],
+            "reason": (
+                f"name is the empty string; pass one of {sorted(_BIDI_AUDIO_DEPENDENCIES)} so the lookup is decidable"
+            ),
+        }
+    if name not in _BIDI_AUDIO_DEPENDENCIES:
+        return {
+            "status": "error",
+            "refusal_code": _INVALID_DEPENDENCY_CODE,
+            "refusal_text": ERR_CODES[_INVALID_DEPENDENCY_CODE],
+            "reason": (f"name={name!r} is not in the admitted set {sorted(_BIDI_AUDIO_DEPENDENCIES)}"),
+        }
+    return {
+        "status": "success",
+        "dependency": _describe(name),
+    }

--- a/tests/drivers/test_g1_bidi_audio_dependencies_reads_the_neon_probe_import_set.py
+++ b/tests/drivers/test_g1_bidi_audio_dependencies_reads_the_neon_probe_import_set.py
@@ -1,0 +1,406 @@
+"""The bidi-audio dependency lookup tools name what ``_probe_bidi`` reads.
+
+The neon bundle's ``g1_speak`` verb
+(``cagataycali/neon-the-g1/tools/g1_speak.py``) runs a ``_probe_bidi``
+guard before spawning its bidi-audio thread: it ``import``s three
+optional modules - ``pywebrtc_audio`` (AEC front-end), ``pyaudio``
+(PortAudio mic capture), and ``strands.experimental.bidi.BidiAgent``
+(the bidi agent factory) - and refuses on ``ImportError``. The
+:mod:`strands_robots.tools.g1.g1_bidi_audio_dependencies` module
+snapshots that dependency set into a module-level dict and exposes
+two agent-facing verbs -
+:func:`g1_list_bidi_audio_dependencies` (name the whole set) and
+:func:`g1_bidi_audio_dependency_admits` (decide one query) - so a
+caller can name the module set decidably before a future driver-side
+wrapper for ``g1_speak`` is attempted. The tests here fix that
+contract without pulling the SDK or the audio stack: the module is
+loadable on a host without ``unitree_sdk2py`` *and* without the
+optional bidi audio deps, so a headless CI runner and Thor before an
+office bring-up can read the dependency set without triggering an
+import-time refusal.
+
+Two things this file's cells deliberately do not pin:
+
+* The runtime probe. The neon bundle's ``_probe_bidi`` is a live
+  ``ImportError``-shaped check for ``pywebrtc_audio`` + ``pyaudio``
+  + ``strands.experimental.bidi.BidiAgent``; a caller comparing an
+  intended write against both conditions (membership + audio
+  stack present) reaches the probe after this verb admits the
+  dependency name. This file does not exercise the probe.
+* The pip package a module ships with. The ``pip_hint`` field
+  surfaces a suggested distribution name where the module name and
+  the distribution name coincide, but this file does not read PyPI
+  or the local ``pip`` index; the hint is a starting-point label,
+  not a canonical resolver answer.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+from strands_robots.tools.g1._g1_common import ERR_CODES
+from strands_robots.tools.g1.g1_bidi_audio_dependencies import (
+    _BIDI_AUDIO_DEPENDENCIES,
+    _INVALID_DEPENDENCY_CODE,
+    g1_bidi_audio_dependency_admits,
+    g1_list_bidi_audio_dependencies,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process; this helper is where a shape
+    drift would surface once, rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be importable
+    with the SDK absent (refs strands-labs/robots#358); a module that
+    pulled a submodule at import time would break every headless CI
+    runner and Thor before an office bring-up. The dependency snapshot
+    is a string table; no SDK submodule should load on the import path.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_bidi_audio_dependencies")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_bidi_audio_dependencies imports pulled "
+        f"SDK submodules: {leaked}. The rule for this package is that the "
+        "SDK loads on driver ``connect_eagerly``, not on tool import."
+    )
+
+
+def test_the_import_pulls_no_audio_stack_module() -> None:
+    """The tool module is loadable without the optional bidi audio deps.
+
+    The neon bundle's ``_probe_bidi`` check reaches for
+    ``pywebrtc_audio`` + ``pyaudio`` +
+    ``strands.experimental.bidi.BidiAgent`` at runtime; those are
+    optional dependencies the ``strands-robots`` package does not
+    require. A caller who only wants to read the dependency set must
+    not be forced to install the audio stack; a module that pulled
+    any of those on import would refuse on a headless host the
+    ``strands-robots`` package must run on.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_bidi_audio_dependencies")
+    after = set(sys.modules)
+    audio_dep_prefixes = ("pywebrtc_audio", "pyaudio", "strands.experimental.bidi")
+    leaked = {
+        name
+        for name in after - before
+        if any(name == prefix or name.startswith(prefix + ".") for prefix in audio_dep_prefixes)
+    }
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_bidi_audio_dependencies imports pulled "
+        f"audio-stack submodules: {leaked}. The dependency snapshot is a "
+        "string table; the audio stack loads on the write path, not on "
+        "tool import."
+    )
+
+
+def test_the_snapshot_covers_the_neon_observed_set() -> None:
+    """The snapshot names the three modules the neon probe imports.
+
+    The neon bundle's ``_probe_bidi`` guard imports ``pywebrtc_audio``,
+    ``pyaudio``, and ``strands.experimental.bidi.BidiAgent``; a widen
+    or narrow to the observed set is a driver-side decision. Pinning
+    the count here surfaces a silent drift as a shape change rather
+    than as a quiet re-labeling of an existing dependency.
+    """
+    assert len(_BIDI_AUDIO_DEPENDENCIES) == 3, (
+        f"expected 3 admitted dependencies, got {len(_BIDI_AUDIO_DEPENDENCIES)}: {sorted(_BIDI_AUDIO_DEPENDENCIES)}"
+    )
+    assert set(_BIDI_AUDIO_DEPENDENCIES) == {
+        "pywebrtc_audio",
+        "pyaudio",
+        "strands.experimental.bidi",
+    }, f"dependency snapshot drifted from the neon-observed set: {sorted(_BIDI_AUDIO_DEPENDENCIES)}"
+
+
+def test_every_snapshot_entry_carries_a_role() -> None:
+    """Every admitted dependency names a non-empty role label.
+
+    The role is what the caller reads to classify the dependency
+    (``aec_frontend`` vs ``mic_capture`` vs ``bidi_agent``); an
+    empty role would leave the caller reading a bare module name
+    without context.
+    """
+    for name, entry in _BIDI_AUDIO_DEPENDENCIES.items():
+        assert "role" in entry, (
+            f"dependency {name!r} has no role; every admitted dependency "
+            "must name what it contributes to the bidi audio path"
+        )
+        assert isinstance(entry["role"], str) and entry["role"], (
+            f"dependency {name!r} has an empty role: {entry['role']!r}"
+        )
+
+
+def test_the_three_roles_are_distinct() -> None:
+    """Each admitted dependency plays a distinct role in the path.
+
+    The neon bundle reaches for the three modules for three
+    different reasons (AEC front-end, mic capture, bidi factory); a
+    silent collapse of two roles onto one label would let a widen
+    to a fourth dependency land without the caller reading a
+    distinct role classification. The three roles must be pairwise
+    distinct.
+    """
+    roles = [entry["role"] for entry in _BIDI_AUDIO_DEPENDENCIES.values()]
+    assert len(set(roles)) == len(roles), (
+        f"dependency roles are not pairwise distinct: {roles}. Every "
+        "admitted dependency must name a distinct contribution to the "
+        "bidi audio path."
+    )
+
+
+def test_every_snapshot_entry_carries_a_description() -> None:
+    """Every admitted dependency carries a non-empty description.
+
+    The description is what the caller reads to understand why the
+    neon path reaches for the module; an empty description would
+    leave the caller reading a bare enum without context.
+    """
+    for name, entry in _BIDI_AUDIO_DEPENDENCIES.items():
+        assert "description" in entry, (
+            f"dependency {name!r} has no description; every admitted dependency must carry a caller-facing label"
+        )
+        assert isinstance(entry["description"], str) and entry["description"], (
+            f"dependency {name!r} has an empty description"
+        )
+
+
+def test_every_snapshot_entry_carries_a_pip_hint() -> None:
+    """Every admitted dependency names a non-empty pip hint.
+
+    The ``pip_hint`` is a suggested distribution name the caller
+    would ``pip install`` to satisfy the probe; an empty hint would
+    force the caller to know the distribution name out of band.
+    """
+    for name, entry in _BIDI_AUDIO_DEPENDENCIES.items():
+        assert "pip_hint" in entry, (
+            f"dependency {name!r} has no pip_hint; every admitted "
+            "dependency must name a distribution a caller would install"
+        )
+        assert isinstance(entry["pip_hint"], str) and entry["pip_hint"], (
+            f"dependency {name!r} has an empty pip_hint: {entry['pip_hint']!r}"
+        )
+
+
+def test_the_refusal_code_matches_the_shared_gate_refusal() -> None:
+    """The refusal code sits inside the shared error table.
+
+    The neon bundle refused unknown dependencies at the probe
+    boundary with an ``ImportError``; this lookup uses the ``7404``
+    gate-refusal shape a future driver-side wrapper would quote when
+    refusing at the same boundary. The code must decode against
+    :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` so a caller
+    reading ``refusal_text`` sees the same string the driver's own
+    ``_check_motion_gates`` would quote.
+    """
+    assert _INVALID_DEPENDENCY_CODE in ERR_CODES, (
+        f"_INVALID_DEPENDENCY_CODE={_INVALID_DEPENDENCY_CODE} is not in "
+        f"ERR_CODES; the refusal string would not decode. Update "
+        "``_g1_common.ERR_CODES`` or point the constant at a "
+        "registered code."
+    )
+
+
+def test_list_returns_every_dependency_in_sorted_order() -> None:
+    """The list verb surfaces the admitted names in stable order.
+
+    A caller iterating the ``dependencies`` list must see the same
+    order across calls so a diff against the returned payload does
+    not fluctuate with dict-iteration order under a hostile Python
+    build; the verb sorts by name ascending.
+    """
+    payload = _call(g1_list_bidi_audio_dependencies)
+    names = [descriptor["name"] for descriptor in payload["dependencies"]]
+    assert names == sorted(_BIDI_AUDIO_DEPENDENCIES), (
+        f"list verb returned dependencies in unsorted order: {names}. "
+        f"Expected sorted: {sorted(_BIDI_AUDIO_DEPENDENCIES)}"
+    )
+
+
+def test_list_names_every_snapshot_dependency_and_no_others() -> None:
+    """The list verb round-trips the snapshot with no drift.
+
+    A silent divergence between the snapshot and the list verb's
+    surface would let a widen on one side land without the other;
+    the test round-trips the two sets to fix that contract.
+    """
+    payload = _call(g1_list_bidi_audio_dependencies)
+    listed = {descriptor["name"] for descriptor in payload["dependencies"]}
+    assert listed == set(_BIDI_AUDIO_DEPENDENCIES), (
+        f"list verb surface {listed} drifted from snapshot {set(_BIDI_AUDIO_DEPENDENCIES)}"
+    )
+    assert set(payload["names"]) == set(_BIDI_AUDIO_DEPENDENCIES), (
+        f"list verb names field {set(payload['names'])} drifted from snapshot {set(_BIDI_AUDIO_DEPENDENCIES)}"
+    )
+
+
+def test_list_surfaces_every_descriptor_with_admits_flag_true() -> None:
+    """Every listed descriptor names ``admits_bidi_writes=True``.
+
+    The flag is surfaced so the descriptor shape matches
+    :mod:`~strands_robots.tools.g1.g1_voice_providers` and
+    :mod:`~strands_robots.tools.g1.g1_arm_actions` verbatim; every
+    admitted dependency is inside the neon probe set by definition,
+    so the flag is always ``True`` on the list side. A caller
+    reading the payload for shape parity across verbs must see the
+    same flag on every row.
+    """
+    payload = _call(g1_list_bidi_audio_dependencies)
+    for descriptor in payload["dependencies"]:
+        assert descriptor.get("admits_bidi_writes") is True, (
+            f"listed descriptor for {descriptor.get('name')!r} does not carry admits_bidi_writes=True: {descriptor}"
+        )
+
+
+def test_list_surfaces_the_refusal_code_and_text() -> None:
+    """The envelope carries the ``7404`` refusal code and decoded text.
+
+    A caller planning a ``g1_speak`` call reads the ``refusals``
+    list to see the string a future driver-side wrapper would surface
+    on an unknown dependency; the string must decode against the
+    shared error table.
+    """
+    payload = _call(g1_list_bidi_audio_dependencies)
+    codes = {refusal["code"]: refusal["text"] for refusal in payload["refusals"]}
+    assert _INVALID_DEPENDENCY_CODE in codes, (
+        f"envelope refusals list does not carry the {_INVALID_DEPENDENCY_CODE} code: {payload['refusals']}"
+    )
+    assert codes[_INVALID_DEPENDENCY_CODE] == ERR_CODES[_INVALID_DEPENDENCY_CODE], (
+        f"envelope refusal text drifted from ERR_CODES: "
+        f"{codes[_INVALID_DEPENDENCY_CODE]!r} vs "
+        f"{ERR_CODES[_INVALID_DEPENDENCY_CODE]!r}"
+    )
+
+
+def test_admits_returns_true_on_every_snapshot_dependency() -> None:
+    """The admits verb round-trips every admitted name.
+
+    Every entry in the snapshot must be admitted by the verb; a
+    divergence would let a widen on the snapshot side land without
+    the verb agreeing.
+    """
+    for name in _BIDI_AUDIO_DEPENDENCIES:
+        payload = _call(g1_bidi_audio_dependency_admits, name=name)
+        assert payload["status"] == "success", f"admits verb refused a snapshot dependency {name!r}: {payload}"
+        assert payload["dependency"]["name"] == name, (
+            f"admits verb returned a different dependency than requested: "
+            f"asked {name!r}, got {payload['dependency']['name']!r}"
+        )
+        assert payload["dependency"]["role"] == _BIDI_AUDIO_DEPENDENCIES[name]["role"], (
+            f"admits verb role drifted from snapshot for {name!r}: "
+            f"verb={payload['dependency']['role']!r} vs "
+            f"snapshot={_BIDI_AUDIO_DEPENDENCIES[name]['role']!r}"
+        )
+        assert payload["dependency"]["pip_hint"] == _BIDI_AUDIO_DEPENDENCIES[name]["pip_hint"], (
+            f"admits verb pip_hint drifted from snapshot for {name!r}: "
+            f"verb={payload['dependency']['pip_hint']!r} vs "
+            f"snapshot={_BIDI_AUDIO_DEPENDENCIES[name]['pip_hint']!r}"
+        )
+
+
+def test_admits_refuses_an_off_set_dependency_with_the_shared_code() -> None:
+    """An off-set name refuses with the ``7404`` code and decoded text.
+
+    A caller passing a dependency name outside the snapshot must see
+    the same refusal shape a future driver-side wrapper would
+    surface; the reason string names the admitted set so the caller
+    can correct the argument.
+    """
+    payload = _call(g1_bidi_audio_dependency_admits, name="alsa_audio")
+    assert payload["status"] == "error", f"admits verb admitted an off-set dependency: {payload}"
+    assert payload["refusal_code"] == _INVALID_DEPENDENCY_CODE, (
+        f"admits verb refusal_code drifted: {payload['refusal_code']} vs {_INVALID_DEPENDENCY_CODE}"
+    )
+    assert payload["refusal_text"] == ERR_CODES[_INVALID_DEPENDENCY_CODE], (
+        f"admits verb refusal_text drifted: {payload['refusal_text']!r} vs {ERR_CODES[_INVALID_DEPENDENCY_CODE]!r}"
+    )
+    assert "alsa_audio" in payload["reason"], (
+        f"admits verb reason string does not quote the argument: {payload['reason']!r}"
+    )
+
+
+def test_admits_refuses_a_bool_argument_as_a_shape_error() -> None:
+    """A ``True`` / ``False`` argument refuses decidably.
+
+    Python's ``bool`` would silently mis-match against the string
+    snapshot; the verb rejects it up front so the caller sees a
+    shape error rather than a confusing "unknown dependency" refusal.
+    """
+    for value in (True, False):
+        payload = _call(g1_bidi_audio_dependency_admits, name=value)
+        assert payload["status"] == "error", f"admits verb admitted bool argument {value!r}: {payload}"
+        assert payload["refusal_code"] == _INVALID_DEPENDENCY_CODE, (
+            f"admits verb refusal_code for bool {value!r} drifted: {payload['refusal_code']}"
+        )
+        assert "bool" in payload["reason"], (
+            f"admits verb reason for bool {value!r} does not name the shape error: {payload['reason']!r}"
+        )
+
+
+def test_admits_refuses_a_non_str_argument_as_a_shape_error() -> None:
+    """A non-string non-bool argument refuses decidably.
+
+    Ints, floats, lists, dicts, tuples: none of them are module
+    names; the verb rejects them up front rather than reaching the
+    membership branch where ``in`` would refuse for the wrong reason
+    (or worse, silently match on a coincidental repr).
+    """
+    for value in (0, 1, 1.5, [], {}, (), object()):
+        payload = _call(g1_bidi_audio_dependency_admits, name=value)
+        assert payload["status"] == "error", f"admits verb admitted non-str argument {value!r}: {payload}"
+        assert payload["refusal_code"] == _INVALID_DEPENDENCY_CODE, (
+            f"admits verb refusal_code for {value!r} drifted: {payload['refusal_code']}"
+        )
+        assert "not a string" in payload["reason"], (
+            f"admits verb reason for {value!r} does not name the shape error: {payload['reason']!r}"
+        )
+
+
+def test_admits_refuses_the_empty_string_as_a_shape_error() -> None:
+    """An empty ``name`` refuses decidably, not as an off-set query.
+
+    A caller who passes ``name=""`` almost certainly forgot to fill
+    the argument; the verb rejects it with a shape reason so the
+    error names the missing input rather than falsely claiming the
+    empty string is an unknown module.
+    """
+    payload = _call(g1_bidi_audio_dependency_admits, name="")
+    assert payload["status"] == "error", f"admits verb admitted empty string: {payload}"
+    assert payload["refusal_code"] == _INVALID_DEPENDENCY_CODE, (
+        f"admits verb refusal_code for '' drifted: {payload['refusal_code']}"
+    )
+    assert "empty" in payload["reason"], (
+        f"admits verb reason for '' does not name the empty-string shape error: {payload['reason']!r}"
+    )
+
+
+def test_admits_refuses_the_missing_argument_as_a_shape_error() -> None:
+    """A ``None`` (default) ``name`` refuses with a missing-argument reason.
+
+    A caller who invokes the verb without passing ``name`` sees the
+    Python default of ``None``; the verb rejects that up front with a
+    "name is required" reason so the caller sees the missing argument
+    named, not a downstream membership refusal.
+    """
+    payload = _call(g1_bidi_audio_dependency_admits)
+    assert payload["status"] == "error", f"admits verb admitted a missing name argument: {payload}"
+    assert payload["refusal_code"] == _INVALID_DEPENDENCY_CODE, (
+        f"admits verb refusal_code for missing name drifted: {payload['refusal_code']}"
+    )
+    assert "required" in payload["reason"], (
+        f"admits verb reason for missing name does not name the required argument: {payload['reason']!r}"
+    )


### PR DESCRIPTION
## What

Ports two read-only `@tool` verbs from `cagataycali/neon-the-g1/tools/g1_speak.py` into `strands_robots.tools.g1.g1_bidi_audio_dependencies`:

- `g1_list_bidi_audio_dependencies` — names the three modules the neon bundle's `_probe_bidi` guard reads
- `g1_bidi_audio_dependency_admits(name)` — decides whether a module name sits inside the probe set

The probe imports:

| Module | Role | pip_hint |
|---|---|---|
| `pywebrtc_audio` | `aec_frontend` | `pywebrtc-audio` |
| `pyaudio` | `mic_capture` | `pyaudio` |
| `strands.experimental.bidi` | `bidi_agent` | `strands-agents` |

Every descriptor carries `name`, `role`, `description`, `pip_hint`, and `admits_bidi_writes` (always `True` — shape parity with `g1_voice_providers` and `g1_arm_actions`).

## Why

The neon bundle's `g1_speak` refuses on failed `_probe_bidi` with a shape-level `"bidi audio deps missing"` message that does not name *which* of the three the caller has to install. A planner asked to diagnose the refusal has to read the neon source itself to enumerate the dependency set. This lookup lets a caller name the three modules decidably before any driver-side `g1_speak` wrapper is attempted — so a headless CI runner and Thor before an office bring-up can read the probe set without triggering an import-time refusal.

Refusal shape mirrors the merged `g1_voice_providers` / `g1_arm_actions` / `g1_dds_topic_idl_types` PRs: `rc=7404` gate-refused, decoded via `ERR_CODES` from `_g1_common`.

## Hard rules (per the port shepherd contract)

- ✅ **Module-load hygiene**: `import strands_robots.tools.g1.g1_bidi_audio_dependencies` pulls zero `unitree_sdk2py` submodules and zero audio-stack submodules (`pywebrtc_audio`, `pyaudio`, `strands.experimental.bidi`). Verified by two dedicated tests that snapshot `sys.modules` before/after import.
- ✅ **One gate**: no actuation path — pure read-only lookup.
- ✅ **Refusal string**: `7404` sits in the shared `_g1_common.ERR_CODES` table.
- ✅ **Docstrings**: describe what the code does today (snapshot the neon `_probe_bidi` set) — the "future driver-side wrapper" is named explicitly as future work per #358.
- ✅ **Ruff check**: clean.
- ✅ **Ruff format --check**: clean.
- ✅ **Mypy**: zero errors on the touched file (4 pre-existing errors in unrelated files: `simulation/ik.py`, `mesh/core.py:2254,2268`, `utils.py:975` — not this port's lane).
- ✅ **Pytest**: 18/18 green in `tests/drivers/test_g1_bidi_audio_dependencies_reads_the_neon_probe_import_set.py`.
- ✅ **Changelog fragment**: `changelog.d/2988-g1-bidi-audio-dependencies-port.md` (will rename if PR number differs).

## Test count

18 tests, all green. Coverage:
- 2 import-hygiene (no SDK, no audio stack leaked)
- 6 snapshot shape (3 entries, distinct roles, non-empty description + pip_hint, refusal code in ERR_CODES)
- 4 list verb (sorted order, round-trip, admits_flag=True on every row, envelope refusal)
- 6 admits verb (accepts every snapshot member; refuses off-set, bool, non-str, empty, and None decidably)

## Refs

- Issue: strands-labs/robots#358 (the SDK-facing seam this port series lands on)
- Neon source: `cagataycali/neon-the-g1/tools/g1_speak.py` — `_probe_bidi` function
- Pattern precedents (merged): #2983 (voice_providers), #2986 (dds_topic_idl_types), #2974 (turn_envelope), #2969 (dds_topics)
