### PR TITLE
test(tools/g1): fail the live-handle sweep when its own discovery narrows

### DIFF
--- a/changelog.d/2958-live-handle-discovery-cross-check.md
+++ b/changelog.d/2958-live-handle-discovery-cross-check.md
@@ -1,0 +1,26 @@
+### Tests: the g1 live-handle sweep now fails when its own discovery narrows
+
+`tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py` derives the
+population it grades from the package, and every rule in the file iterates that
+one scan. A scan that narrows therefore does not fail - it grades fewer verbs
+and still reports green. The only self-check was `test_the_population_is_not_empty`,
+which fires on an *empty* population; the narrowing that actually shipped left
+seven of nine verbs in place, so it passed, and `g1_get_task_status` reached main
+raising `AttributeError` past the structured response on all six wrong handles
+while the file read green.
+
+The population is now derived a second time from the package *source* by AST and
+the two routes are compared. The routes share no mechanism - the source scan
+never imports, so it cannot inherit a narrowing from the `pkgutil` enumeration,
+from `__wrapped__` being absent on a verb, or from `__wrapped__.__module__`
+disagreeing with the module a verb is defined in. It is deliberately wider than
+the runtime scan in two ways, so that either kind of narrowing is loud: it reads
+private modules too, and it accepts every spelling of `Any` rather than only the
+bare one.
+
+The disagreement is reported by naming the verbs rather than by a count, and no
+verb is named in the assertion, so a verb the package gains is covered without
+this file being edited. Measured against the narrowing this replaces, the check
+fails naming exactly `g1_get_state` and `g1_get_task_status`; measured against a
+new verb annotated `typing.Any`, the four existing population rules all pass and
+this one fails naming it.

--- a/tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py
+++ b/tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py
@@ -30,6 +30,13 @@ grades neither while appearing to grade the package.  Both are async-or-not and
 both are called through ``_call``, because a coroutine returned unawaited is a
 verb inside the population that is still ungraded.
 
+``TestTheDiscoveryIsCrossChecked`` grades the discovery itself, by deriving the
+population a second time from the package *source* and comparing.  Every rule
+here iterates one scan, so a scan that narrows does not fail - it grades less
+and still reports green.  The non-vacuity check below cannot catch that, because
+it fires only on an *empty* population, and a partial narrowing is both likelier
+and quieter than a total one.
+
 ``TestTheRefusalNamesWhatACallerNeeds`` grades the message, because a refusal
 that does not name the parameter leaves a caller no better off than the
 traceback did.
@@ -155,6 +162,67 @@ def _live_handle_verbs() -> dict[str, Any]:
     return found
 
 
+# The spellings of ``Any`` a first parameter can carry.  :func:`_live_handle_verbs`
+# compares against the bare string or the object, so a verb annotated
+# ``typing.Any`` sits outside its population; the source scan accepts every
+# spelling on purpose, so that gap is a failure here rather than an exemption
+# there.
+_ANY_SPELLINGS = frozenset({"Any", "typing.Any", "t.Any"})
+
+
+def _is_tool_decorated(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Whether a definition carries the ``@tool`` decorator, bare or called."""
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if getattr(target, "id", None) == "tool" or getattr(target, "attr", None) == "tool":
+            return True
+    return False
+
+
+def _live_handle_verbs_from_source() -> set[str]:
+    """The live-handle population read from the package *source*, not from imports.
+
+    This shares no mechanism with :func:`_live_handle_verbs`: it reads text and
+    never imports, so it cannot inherit a narrowing from the ``pkgutil``
+    enumeration, from ``__wrapped__`` being absent on a verb, or from
+    ``__wrapped__.__module__`` disagreeing with the module a verb is defined in.
+    That independence is the point.  #2958 measured what a narrowing costs:
+    keyed on the module name, the discovery found 7 of 9 verbs, and the two it
+    dropped were ``g1_get_state`` and ``g1_get_task_status`` - the second of
+    which had no handle guard at all and raised past the structured response on
+    all six wrong handles, while every rule in this file read green.
+
+    It is deliberately *wider* than the runtime scan in two ways, so that either
+    kind of narrowing fails rather than passing quietly:
+
+    * Private modules are read too.  A ``@tool`` in ``_g1_common.py`` is
+      invisible to the runtime scan, which skips a leading underscore.  A verb
+      belongs in a public module and a shared helper is not a verb, so the two
+      routes disagreeing here is the right outcome and it names the file.
+    * Every spelling of ``Any`` is accepted, not only the bare one.  A verb
+      annotated ``typing.Any`` would sit outside the runtime population; here it
+      is inside it, so the disagreement is loud instead of silent.
+
+    Positional-only parameters are included because ``inspect.signature`` counts
+    them, so both routes read the same first parameter.
+    """
+    found: set[str] = set()
+    package_dir = Path(g1_package.__file__).parent
+    for path in sorted(package_dir.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not _is_tool_decorated(node):
+                continue
+            positional = node.args.posonlyargs + node.args.args
+            if not positional or positional[0].annotation is None:
+                continue
+            if ast.unparse(positional[0].annotation).strip("\"'") in _ANY_SPELLINGS:
+                found.add(node.name)
+    return found
+
+
 def _snapshot_family_verbs() -> dict[str, Any]:
     """The live-handle verbs reading their handle through the shared snapshot guard.
 
@@ -270,6 +338,36 @@ class TestEveryLiveHandleVerbRefusesAWrongHandle:
             result = _call(tool, handle)
             assert isinstance(result, dict), f"{name} returned {type(result).__name__} for {label}"
             assert result.get("status") == "error", f"{name} did not refuse {label}: {result!r}"
+
+
+class TestTheDiscoveryIsCrossChecked:
+    """The population every rule above grades is derived twice and compared.
+
+    ``test_the_population_is_not_empty`` fires only when the scan finds
+    *nothing*.  #2958's narrowing left five verbs in the population, so it
+    passed, and so did every rule that iterates it.  Comparing against a second
+    route derived by a different mechanism is what turns "the discovery
+    narrowed" into a failure, and a count derived that way is preferred to a
+    literal, which would be churn on every verb the package gains.
+    """
+
+    def test_the_source_scan_is_not_empty(self) -> None:
+        """Non-vacuity: an empty second route agrees with any runtime population."""
+        assert _live_handle_verbs_from_source(), (
+            "the source scan found no live-handle verb, so it agrees with any "
+            "runtime population and the cross-check below is vacuous"
+        )
+
+    def test_the_runtime_scan_and_the_source_scan_find_the_same_verbs(self) -> None:
+        """A verb in the source and outside the population is one nothing grades."""
+        runtime = set(_live_handle_verbs())
+        source = _live_handle_verbs_from_source()
+        assert source == runtime, (
+            "the two discovery routes disagree, so the rules in this file do not "
+            "grade the package they claim to. Defined in the source and ungraded: "
+            f"{sorted(source - runtime)}. Graded but absent from the source scan: "
+            f"{sorted(runtime - source)}"
+        )
 
 
 class TestTheRefusalNamesWhatACallerNeeds:


### PR DESCRIPTION
Fixes #2958

## The gap

`tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py` derives the population it grades from the package rather than from a list, and **every rule in the file iterates that one scan**. So a discovery that narrows is not a failure - it grades fewer verbs and still reports green.

The file's only self-check is:

```python
assert verbs, "found no g1 verb whose first parameter is a live handle typed Any; ..."
```

which fires only when the population is **empty**. The narrowing that actually shipped left seven of nine verbs in place, so it passed - and so did every rule that iterates it. `g1_get_task_status` reached `main` raising `AttributeError` past the structured response on all six wrong handles while this file read green. #2958 put it exactly: the author of that assertion guarded the total-blindness case, *"and partial blindness is both likelier and quieter"*.

Items 1, 3 and 4 of #2958 have landed (`_tools_defined_in` scans module attributes, `_call` awaits the async verb, `g1_task_status` carries `live_handle_refusal`). This is item 2, the last one: **assert the population against a second, independent route rather than merely against non-emptiness.**

## The change

`_live_handle_verbs_from_source()` derives the population a second time from the package **source**, by AST, and `TestTheDiscoveryIsCrossChecked` compares the two.

The routes share no mechanism. The source scan never imports, so it cannot inherit a narrowing from the `pkgutil` enumeration, from `__wrapped__` being absent on a verb, or from `__wrapped__.__module__` disagreeing with the module a verb is defined in - the three mechanisms the runtime scan is built out of.

It is deliberately **wider** than the runtime scan in two ways, so either kind of narrowing is loud rather than quiet:

- **Private modules are read too.** A `@tool` in `_g1_common.py` is invisible to the runtime scan, which skips a leading underscore. A verb belongs in a public module and a shared helper is not a verb, so the routes disagreeing here is the right outcome and it names the file. Currently vacuous - measured, no private g1 module defines a `@tool`.
- **Every spelling of `Any` is accepted**, not only the bare one. `_live_handle_verbs` compares against `("Any", Any)`, so a verb annotated `typing.Any` sits outside its population. Here it is inside it. Also currently vacuous - all nine verbs annotate bare `Any`.

Positional-only parameters are included, because `inspect.signature` counts them, so both routes read the same first parameter.

## Why a second route and not a count

#2958 asked for the population's *size* and then immediately scoped it: *"A bare literal would be churn on every verb added, so the second route matters more than the number."* So the assertion carries **no number and no verb name** - it reports the set difference. A verb the package gains is covered without this file being edited, which is the property the file's own docstring already claims for the signature filter.

This is also why the two existing name-listing rules are kept rather than replaced: `test_the_scan_reaches_the_three_sensor_verbs_on_main` and `test_a_verb_named_unlike_its_module_is_still_graded` are historical pins on the specific verbs the rule was written for, and they are cheap.

## Measured

Both routes agree on `main` at `3f459be`, so the guard is preventive and adds no red cell:

```
route A (runtime scan): 9
route C (AST scan)    : 9
C - A (in source, ungraded): []
A - C (graded, absent from source): []
```

**Mutation 1 - restore the pre-#2958 module-name-keyed discovery.** The cross-check fails, naming the two verbs #2958 documented, *without either name appearing in the assertion*:

```
AssertionError: the two discovery routes disagree, so the rules in this file do not
grade the package they claim to. Defined in the source and ungraded:
['g1_get_state', 'g1_get_task_status']. Graded but absent from the source scan: []
```

**Mutation 2 - a future verb annotated `typing.Any`.** This is the case the existing rules cannot see, and it is the reason the source scan is wider rather than merely different:

```
-k "sensor_verbs_on_main or named_unlike or not_keyed_on or population_is_not_empty"
  -> 4 passed        # all four existing population rules pass on a tree with an ungraded verb
-k "same_verbs"
  -> 1 failed        # Defined in the source and ungraded: ['g1_scratch_probe']
```

**Suite.** Tests only, no runtime file touched, `+124 / -0` across two files:

```
tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py   24 passed
tests/tools/g1/ (whole directory) + 5 whole-tree graders          220 passed, 11 skipped
tests/test_changelog_fragments.py + test_changelog_fragment_gate.py 87 passed
ruff check / ruff format --check                                   clean
non-ASCII sweep on both added files                                none
```

The whole-tree graders were run explicitly rather than by a diff-scoped selector, per #2940.

## Scope

Tests only. No verb, no guard and no runtime module is touched, so no behaviour changes - what changes is whether a future narrowing of this sweep is silent. Direction 2 of #2963 (making constructed `ImportError`s machine-readable) is unrelated and stays open there.