### PR TITLE
feat(tools/g1): port g1_list_speak_vad_envelope and g1_speak_vad_admits (refs #358)

### DIFF
--- a/changelog.d/2998-g1-speak-vad-envelope-port.md
+++ b/changelog.d/2998-g1-speak-vad-envelope-port.md
@@ -1,0 +1,16 @@
+### Added
+
+- `strands_robots.tools.g1.g1_speak_vad_envelope` ports the read-only half of
+  neon-the-g1's `g1_speak(action="start")` turn-detector envelope
+  (`cagataycali/neon-the-g1/tools/g1_speak.py`): two agent-facing verbs
+  (`g1_list_speak_vad_envelope`, `g1_speak_vad_admits`) surface the
+  `BidiAgent` turn-detector's ``vad_threshold`` clamp (``[0.0, 1.0]``) and the
+  neon-observed ``silence_duration_ms`` positive-integer domain (``>= 1``),
+  plus the neon-tuned defaults (``0.7`` "stops echo triggers" and ``700`` ms
+  "relaxed"). Module-local refusal texts stay on-surface — the bidi voice
+  pipeline ships no distinct rc, so no motion-FSM ``7404`` code is re-borrowed
+  for a turn-detector bounds violation. Twin of
+  `g1_bidi_audio_stream_delay_envelope` (the AEC half of the same argument
+  tuple; the two libraries have disjoint refusal shapes so the modules stay
+  separate). Read-only. No driver instance, no DDS, no SDK, no optional
+  audio-stack import (refs #358).

--- a/strands_robots/tools/g1/g1_speak_vad_envelope.py
+++ b/strands_robots/tools/g1/g1_speak_vad_envelope.py
@@ -1,0 +1,445 @@
+"""Agent-facing lookup for the VAD envelope the neon ``g1_speak`` verb admits.
+
+The neon bundle's ``g1_speak`` verb
+(``cagataycali/neon-the-g1/tools/g1_speak.py``) takes two turn-detection
+knobs at ``action="start"``: ``vad_threshold`` (a float in ``[0.0, 1.0]``
+naming the voice-activity detector's admission floor) and
+``silence_duration_ms`` (a positive integer naming the trailing-silence
+window that ends a turn).  The bundle passes both to the ``BidiAgent``
+factory the ``g1.build_voice_agent`` helper constructs, and the factory
+forwards them to the turn-detector configuration inside
+``strands.experimental.bidi`` without itself refusing an out-of-range
+value.  The neon docstring for the verb names the two observed defaults
+as ``vad_threshold=0.7`` ("higher = less twitchy. 0.7 stops echo
+triggers") and ``silence_duration_ms=700`` ("how long of silence ends a
+turn. 700 = relaxed"), and the ``[0.0, 1.0]`` range on the threshold is
+the ``BidiAgent`` turn-detector's own numeric domain.  This module
+snapshots the observed envelope into module-level constants and exposes
+two agent-facing verbs so a caller can decide the refusal decidably
+before a future driver-side ``g1_speak`` wrapper is called, rather than
+pinning the two knobs inside the write path where the refusal is
+invisible to the planner.
+
+Twin of :mod:`~strands_robots.tools.g1.g1_bidi_audio_stream_delay_envelope`,
+which surfaces the ``stream_delay_ms`` knob on the *audio-processing*
+half of the same ``g1_speak`` argument tuple.  The two modules stay
+separate because ``stream_delay_ms`` names the AEC delay-buffer bound
+(a ``pywebrtc_audio`` argument) while the two knobs here name the
+turn-detector bounds (a ``strands.experimental.bidi`` argument): two
+different downstream libraries with disjoint refusal shapes.  Colocating
+them here would hand an agent planner a single refusal payload that
+mixed the two surfaces' remedies and would tie a future audio-processing
+revision to a turn-detector revision the neon bundle does not couple.
+
+Two things this module is deliberately *not*:
+
+* An execution path.  The neon bundle's ``g1_speak(action="start")``
+  spawns a background thread that runs a full ``BidiAgent`` (webrtc
+  AEC, pyaudio input, DDS chest-speaker output); that thread carries
+  the audio-stack imports (``pywebrtc_audio``, ``pyaudio``,
+  ``strands.experimental.bidi``) which are optional dependencies the
+  ``strands-robots`` package does not require.  A future driver method
+  that fronts ``g1_speak`` will land the transition verb; refs
+  strands-labs/robots#358 for the SDK-facing gate work that audio path
+  belongs on.  This module ports the read-only envelope half without
+  also introducing a second bidi-writer path the driver does not yet
+  own.
+* An SDK re-import.  The envelope is captured here as module-level
+  constants so ``import strands_robots.tools.g1.g1_speak_vad_envelope``
+  pulls no ``unitree_sdk2py`` submodule *and* pulls no optional
+  audio-stack submodule (``pywebrtc_audio``, ``pyaudio``,
+  ``strands.experimental.bidi``) - the import-hygiene contract every
+  other file in this package carries, refs strands-labs/robots#358.
+  A revision of the observed bounds is a driver-side update; when the
+  driver's bidi voice method lands, its refusal will surface the same
+  module-local :data:`_REFUSAL_TEXT_VAD_THRESHOLD` and
+  :data:`_REFUSAL_TEXT_SILENCE_DURATION_MS` this module names for a
+  bounds violation.
+
+Why this module does not quote a driver-side ``rc``.
+
+The G1 driver's :meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates`
+gates the *motion* surface (arm-SDK writes on ``rt/lowcmd``); its FSM
+rejections are the ``7404`` entry in
+:data:`~strands_robots.tools.g1._g1_common.ERR_CODES`
+(``"Invalid FSM id - need FSM in {500, 501, 801}"``).  The ``BidiAgent``
+turn detector runs on the mic pre-processing thread in the Python
+process itself - it never touches ``rt/lowcmd`` and never touches an
+RPC service the SDK ships an rc table for - so the bidi voice pipeline
+ships no distinct rc for a bounds-violated ``vad_threshold`` or
+``silence_duration_ms``.  Borrowing ``7404`` on a turn-detector refusal
+would hand an agent planner a motion-FSM remedy (``"need FSM in {500,
+501, 801}"``) for a bounds violation on a value that has nothing to do
+with the locomotion FSM.  The refusal shape this module returns names
+the numeric bound violation in module-local text so a planner reads a
+remedy that matches the surface, and a future driver-side ``g1_speak``
+wrapper will surface the same module-local text - not a re-borrowed
+motion code.  This mirrors the same-surface refusal rule
+:mod:`~strands_robots.tools.g1.g1_bidi_audio_stream_delay_envelope`
+names for ``pywebrtc_audio.AudioProcessor(stream_delay_ms=...)``, refs
+strands-labs/robots#358.
+
+What this module does not decide.
+
+* The live bidi state.  Whether the neon bundle's ``g1_speak`` runner
+  thread is currently active, whether the ``BidiAgent`` factory has
+  resolved a provider, whether the chest-speaker writer has started:
+  none of those live-instance reads run here.  A caller planning a
+  ``g1_speak(action="start")`` reads this verb's ``envelope`` to
+  decide whether their two knobs are inside the observed range and
+  reads the driver's own liveness signal separately to decide whether
+  the bidi path is currently free.
+* Whether the caller's ``vad_threshold`` matches the caller's mic
+  gain.  A ``vad_threshold=0.9`` on a mic with a low input gain silences
+  the turn detector regardless of what this envelope admits, and a
+  ``vad_threshold=0.1`` on a mic with a high input gain triggers on
+  every stray sound.  Whether the caller's gain-and-threshold pair is
+  jointly usable is a live-instance decision the neon bundle answers
+  under its ``STATS["energy_mean_abs"]`` reading, not a numeric envelope
+  decision.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from strands import tool
+
+#: The lower clamp on ``vad_threshold``.  The ``BidiAgent`` turn
+#: detector's numeric domain is ``[0.0, 1.0]``; below the lower bound
+#: the detector's admission floor is undefined and every frame reads
+#: as speech (the detector's ``score >= threshold`` check degenerates
+#: because the score is itself a probability in ``[0.0, 1.0]`` and no
+#: threshold below zero can refuse a non-negative score).  Named as
+#: an inclusive bound (``value < bound`` refuses, ``value == bound``
+#: admits) because a caller naming ``vad_threshold=0.0`` is a
+#: legitimate "accept every frame" command on a rig where the turn
+#: boundary is decided by ``silence_duration_ms`` alone, not the
+#: shape-error the refusal exists to catch.
+_VAD_THRESHOLD_MIN: float = 0.0
+
+#: The upper clamp on ``vad_threshold``.  Above ``1.0`` the detector
+#: refuses every frame (the score is itself in ``[0.0, 1.0]``, so no
+#: score can meet a threshold above the domain), and the neon bundle
+#: docstring names the observed maximum as ``1.0`` on the ``0.0-1.0``
+#: range.  Named as an inclusive bound like the lower clamp, so a
+#: caller writing ``vad_threshold=1.0`` (the ceiling, "accept only a
+#: certain-speech frame") is admitted rather than tripping an
+#: off-by-one.
+_VAD_THRESHOLD_MAX: float = 1.0
+
+#: The neon-bundle-observed default ``vad_threshold`` value.  The
+#: neon docstring names it as ``0.7`` and its inline note "higher =
+#: less twitchy. 0.7 stops echo triggers" describes the field
+#: observation: at ``0.7`` the detector refuses the residual echo that
+#: leaks through the AEC on the G1's DDS speaker->mic loop, while
+#: still admitting the operator's speech.  Surfaced here so a caller
+#: planning a bidi start with the neon-tuned value can pin the same
+#: number without re-measuring the loop, and so a widen or narrow to
+#: the observed default lands in one place.
+_VAD_THRESHOLD_NEON_DEFAULT: float = 0.7
+
+#: The lower clamp on ``silence_duration_ms``.  A non-positive value
+#: means "end the turn immediately on the first non-speech frame",
+#: which the ``BidiAgent`` turn detector accepts but degenerates into
+#: single-frame turns that cut off every operator pause between
+#: words.  The neon bundle names positive integers only, matching the
+#: shared :func:`~strands_robots.utils.positive_count_error` domain
+#: every other integer-count knob in this package uses.  Named as an
+#: exclusive-of-zero bound (``value <= 0`` refuses) because a
+#: ``silence_duration_ms=0`` collapses the turn boundary to a single
+#: frame and is not the "wait longer" command the parameter's name
+#: suggests.
+_SILENCE_DURATION_MS_MIN: int = 1
+
+#: The neon-bundle-observed default ``silence_duration_ms`` value.
+#: The neon docstring names it as ``700`` and its inline note "700 =
+#: relaxed" describes the field observation: at ``700`` ms the turn
+#: detector waits long enough for an operator's natural pause between
+#: words without also holding the turn open past the operator's own
+#: silence.  Surfaced here so a caller planning a bidi start with the
+#: neon-tuned value can pin the same integer without re-measuring the
+#: pause, and so a widen or narrow to the observed default lands in
+#: one place.
+_SILENCE_DURATION_MS_NEON_DEFAULT: int = 700
+
+#: The module-local refusal text every ``g1_speak_vad_admits`` refusal
+#: quotes when the caller's ``vad_threshold`` sits outside the
+#: ``BidiAgent`` turn-detector's numeric domain.  Named here rather
+#: than borrowed from
+#: :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` because the
+#: bidi voice pipeline ships no distinct rc for a bounds-violated
+#: threshold argument and the motion-FSM ``7404`` entry (its nearest
+#: neighbour) reads ``"Invalid FSM id - need FSM in {500, 501, 801}"``
+#: - a remedy that points a planner at locomotion FSM transitions to
+#: fix a turn-detector argument.  Surfacing the module-local text
+#: keeps the refusal payload's remedy on the same surface the write
+#: belongs on, and a future driver-side ``g1_speak`` wrapper will
+#: surface this same text rather than re-borrowing a motion code.
+_REFUSAL_TEXT_VAD_THRESHOLD: str = (
+    f"vad_threshold out of envelope - need vad_threshold in [{_VAD_THRESHOLD_MIN}, {_VAD_THRESHOLD_MAX}]"
+)
+
+#: The module-local refusal text every ``g1_speak_vad_admits`` refusal
+#: quotes when the caller's ``silence_duration_ms`` sits outside the
+#: positive-integer domain.  Named here for the same reason as
+#: :data:`_REFUSAL_TEXT_VAD_THRESHOLD` (the pipeline ships no distinct
+#: rc for a bounds-violated silence argument, and the motion-FSM code
+#: is on the wrong surface).  The remedy names the minimum positive
+#: integer rather than a range because the ``BidiAgent`` turn detector
+#: has no observed upper bound on the wait window; a caller who wants
+#: to hold the turn open for a long dictation pass names any positive
+#: integer and the detector honours it.
+_REFUSAL_TEXT_SILENCE_DURATION_MS: str = (
+    f"silence_duration_ms out of envelope - need silence_duration_ms >= {_SILENCE_DURATION_MS_MIN}"
+)
+
+
+def _envelope() -> dict[str, Any]:
+    """Build the envelope descriptor the verbs return.
+
+    Kept here rather than inlined in
+    :func:`g1_list_speak_vad_envelope` so
+    :func:`g1_speak_vad_admits` names the same fields on its
+    admitted-path payload and so a widen to the descriptor lands in
+    one place.  Every field is a snapshot read; no bus is touched.
+    """
+    return {
+        "vad_threshold_min": _VAD_THRESHOLD_MIN,
+        "vad_threshold_max": _VAD_THRESHOLD_MAX,
+        "vad_threshold_neon_default": _VAD_THRESHOLD_NEON_DEFAULT,
+        "silence_duration_ms_min": _SILENCE_DURATION_MS_MIN,
+        "silence_duration_ms_neon_default": _SILENCE_DURATION_MS_NEON_DEFAULT,
+    }
+
+
+@tool
+def g1_list_speak_vad_envelope() -> dict[str, Any]:
+    """Return the VAD envelope the neon ``g1_speak`` verb admits.
+
+    Read-only.  No driver instance, no DDS, no SDK, no optional
+    audio-stack import: every field is a module-level constant.
+    Useful before a future driver-side wrapper for the neon
+    ``g1_speak(action="start")`` is called, so a caller can compare
+    an intended ``vad_threshold`` / ``silence_duration_ms`` pair
+    against the envelope the ``BidiAgent`` turn detector admits and
+    can carry the module-local refusal text a driver-side wrapper
+    would surface on a bounds violation.  The neon-tuned defaults
+    (``vad_threshold=0.7`` and ``silence_duration_ms=700`` for the G1
+    DDS speaker->mic loop) are named on the envelope so a caller who
+    wants the neon-observed values can pin them without re-measuring
+    the loop.
+
+    Returns:
+        A dict with ``status``; an ``envelope`` sub-dict carrying
+        every clamp the neon bundle observed
+        (``vad_threshold_min``, ``vad_threshold_max``,
+        ``vad_threshold_neon_default``, ``silence_duration_ms_min``,
+        ``silence_duration_ms_neon_default``); and a ``refusals``
+        list carrying one descriptor per dimension with the
+        module-local :data:`_REFUSAL_TEXT_VAD_THRESHOLD` and
+        :data:`_REFUSAL_TEXT_SILENCE_DURATION_MS` a future write verb
+        would surface on a bounds violation.  Every field is a
+        snapshot of an observed bound or a module-local text; no
+        dynamic decode runs here.
+    """
+    return {
+        "status": "success",
+        "envelope": _envelope(),
+        "refusals": [
+            {"dimension": "vad_threshold", "text": _REFUSAL_TEXT_VAD_THRESHOLD},
+            {
+                "dimension": "silence_duration_ms",
+                "text": _REFUSAL_TEXT_SILENCE_DURATION_MS,
+            },
+        ],
+    }
+
+
+@tool
+def g1_speak_vad_admits(
+    vad_threshold: float = 0.7,
+    silence_duration_ms: int = 700,
+) -> dict[str, Any]:
+    """Decide whether a VAD argument pair sits inside the envelope.
+
+    Read-only.  Compares each argument against the clamp
+    :func:`g1_list_speak_vad_envelope` returns and reports every
+    refusal shape a bound violation would surface.  No driver
+    instance, no DDS, no SDK, no optional audio-stack import: the
+    decision reads only module-level constants and the two arguments
+    themselves.
+
+    A ``vad_threshold`` / ``silence_duration_ms`` pair inside the
+    envelope is *not* the same as an admitted write: the driver's
+    bidi singleton may refuse on liveness grounds (an in-flight
+    session, a missing provider credential, a stalled mic autopick),
+    which this verb does not read (that is a live driver-instance
+    query answered by a future bidi state verb).  The returned
+    envelope names only the numeric bound decision.
+
+    Args:
+        vad_threshold: float in ``[0.0, 1.0]``.  The default ``0.7``
+            matches the neon-bundle-tuned value for the G1 DDS
+            speaker->mic loop so a caller who does not pass an
+            explicit argument lands on the neon-observed admitted
+            value.  Refused below ``vad_threshold_min`` (the
+            detector's score is a probability in ``[0.0, 1.0]`` and
+            no threshold below zero can refuse a non-negative score)
+            and above ``vad_threshold_max`` (above ``1.0`` no score
+            can meet the threshold and the detector silences every
+            frame).  Boolean values are refused explicitly because
+            Python's ``bool`` is a subclass of ``int`` (and ``int``
+            is admitted as a widening to ``float`` below), so a
+            caller passing ``True`` would otherwise silently look up
+            ``1.0`` (the admitted ceiling) and hide the type mistake.
+            Non-finite floats (``nan``, ``inf``, ``-inf``) are
+            refused because the detector's comparison against a
+            non-finite threshold degenerates (``score >= nan`` is
+            always ``False``, ``score >= inf`` is always ``False``);
+            the refusal at the boundary surfaces the type mistake
+            rather than silencing every frame.
+        silence_duration_ms: positive integer.  The default ``700``
+            matches the neon-bundle-tuned value for a relaxed
+            operator pause so a caller who does not pass an explicit
+            argument lands on the neon-observed admitted value.
+            Refused at or below zero because a non-positive wait
+            collapses the turn boundary to a single frame and cuts
+            off every operator pause between words.  Boolean values
+            are refused explicitly at the boundary because Python's
+            ``bool`` is a subclass of ``int``, so a caller passing
+            ``True`` would otherwise silently look up ``1`` (a
+            legitimate one-millisecond wait) and hide the type
+            mistake.  Non-integer numeric values (``float``,
+            ``Decimal``) are refused with the same shape so a caller
+            passing ``silence_duration_ms=700.0`` sees an actionable
+            refusal rather than a silent truncation the turn detector
+            would perform.
+
+    Returns:
+        A dict with ``status``; an ``admits`` bool naming whether
+        both values are inside their respective clamps; a
+        ``refusals`` list of refusal descriptors, each carrying the
+        dimension name, the offending value, the clamp it violated,
+        and the module-local refusal text a driver-side wrapper
+        would surface if the write were attempted while the value is
+        outside the envelope; the same ``envelope`` sub-dict
+        :func:`g1_list_speak_vad_envelope` returns.  On an admitted
+        pair the ``refusals`` list is empty; on a rejected pair
+        every violated bound is named (both arguments are graded
+        independently, so a caller with two bad arguments reads two
+        refusals in one payload).
+    """
+    envelope = _envelope()
+    refusals: list[dict[str, Any]] = []
+
+    # ---- vad_threshold ----
+    # bool subclasses int; refuse first so True/False do not silently
+    # widen to 1.0/0.0 and hide a type mistake at the boundary.
+    if isinstance(vad_threshold, bool):
+        refusals.append(
+            {
+                "dimension": "vad_threshold",
+                "value": vad_threshold,
+                "bound_key": "vad_threshold_min",
+                "bound": _VAD_THRESHOLD_MIN,
+                "comparison": "non-float",
+                "text": _REFUSAL_TEXT_VAD_THRESHOLD,
+            }
+        )
+    elif not isinstance(vad_threshold, (int, float)):
+        # ``int`` is admitted as a widening to ``float`` (a caller
+        # writing ``vad_threshold=1`` should land on the admitted
+        # ceiling), but any other type is refused with the same
+        # non-float remedy the neon bundle's turn detector would
+        # surface.
+        refusals.append(
+            {
+                "dimension": "vad_threshold",
+                "value": vad_threshold,
+                "bound_key": "vad_threshold_min",
+                "bound": _VAD_THRESHOLD_MIN,
+                "comparison": "non-float",
+                "text": _REFUSAL_TEXT_VAD_THRESHOLD,
+            }
+        )
+    else:
+        v = float(vad_threshold)
+        if not math.isfinite(v):
+            refusals.append(
+                {
+                    "dimension": "vad_threshold",
+                    "value": vad_threshold,
+                    "bound_key": "vad_threshold_min",
+                    "bound": _VAD_THRESHOLD_MIN,
+                    "comparison": "non-finite",
+                    "text": _REFUSAL_TEXT_VAD_THRESHOLD,
+                }
+            )
+        elif v < _VAD_THRESHOLD_MIN:
+            refusals.append(
+                {
+                    "dimension": "vad_threshold",
+                    "value": vad_threshold,
+                    "bound_key": "vad_threshold_min",
+                    "bound": _VAD_THRESHOLD_MIN,
+                    "comparison": "value < bound",
+                    "text": _REFUSAL_TEXT_VAD_THRESHOLD,
+                }
+            )
+        elif v > _VAD_THRESHOLD_MAX:
+            refusals.append(
+                {
+                    "dimension": "vad_threshold",
+                    "value": vad_threshold,
+                    "bound_key": "vad_threshold_max",
+                    "bound": _VAD_THRESHOLD_MAX,
+                    "comparison": "value > bound",
+                    "text": _REFUSAL_TEXT_VAD_THRESHOLD,
+                }
+            )
+
+    # ---- silence_duration_ms ----
+    if isinstance(silence_duration_ms, bool):
+        refusals.append(
+            {
+                "dimension": "silence_duration_ms",
+                "value": silence_duration_ms,
+                "bound_key": "silence_duration_ms_min",
+                "bound": _SILENCE_DURATION_MS_MIN,
+                "comparison": "non-int",
+                "text": _REFUSAL_TEXT_SILENCE_DURATION_MS,
+            }
+        )
+    elif not isinstance(silence_duration_ms, int):
+        refusals.append(
+            {
+                "dimension": "silence_duration_ms",
+                "value": silence_duration_ms,
+                "bound_key": "silence_duration_ms_min",
+                "bound": _SILENCE_DURATION_MS_MIN,
+                "comparison": "non-int",
+                "text": _REFUSAL_TEXT_SILENCE_DURATION_MS,
+            }
+        )
+    else:
+        s = int(silence_duration_ms)
+        if s < _SILENCE_DURATION_MS_MIN:
+            refusals.append(
+                {
+                    "dimension": "silence_duration_ms",
+                    "value": silence_duration_ms,
+                    "bound_key": "silence_duration_ms_min",
+                    "bound": _SILENCE_DURATION_MS_MIN,
+                    "comparison": "value < bound",
+                    "text": _REFUSAL_TEXT_SILENCE_DURATION_MS,
+                }
+            )
+
+    return {
+        "status": "success",
+        "admits": not refusals,
+        "refusals": refusals,
+        "envelope": envelope,
+    }

--- a/tests/drivers/test_g1_speak_vad_envelope_reads_the_neon_turn_detector_hint.py
+++ b/tests/drivers/test_g1_speak_vad_envelope_reads_the_neon_turn_detector_hint.py
@@ -1,0 +1,463 @@
+"""The speak VAD envelope tools name the neon-observed turn-detector bounds.
+
+The neon bundle's ``g1_speak`` verb
+(``cagataycali/neon-the-g1/tools/g1_speak.py``) takes two turn-detection
+knobs at ``action="start"``: ``vad_threshold`` (a float in ``[0.0, 1.0]``
+naming the voice-activity detector's admission floor) and
+``silence_duration_ms`` (a positive integer naming the trailing-silence
+window that ends a turn).  The bundle passes both to the ``BidiAgent``
+factory the ``g1.build_voice_agent`` helper constructs; the factory
+forwards them to the turn-detector configuration inside
+``strands.experimental.bidi`` without itself refusing an out-of-range
+value.  The :mod:`strands_robots.tools.g1.g1_speak_vad_envelope` module
+snapshots the observed envelope into module-level constants and exposes
+two agent-facing verbs -
+:func:`g1_list_speak_vad_envelope` (name the whole envelope) and
+:func:`g1_speak_vad_admits` (decide one query) - so a caller can decide
+the refusal decidably before a future driver-side wrapper for
+``g1_speak(action="start")`` is called.  The tests here fix that
+contract without pulling the SDK: the module is loadable on a host
+without ``unitree_sdk2py`` *and* without the optional audio-stack
+imports (``pywebrtc_audio``, ``pyaudio``, ``strands.experimental.bidi``)
+the neon bundle's runtime path pulls (the same SDK-load-hygiene rule
+every other file under :mod:`strands_robots.tools.g1` carries, refs
+strands-labs/robots#358), and every membership answer is read off the
+module's own snapshot rather than restated in the tests, so a widen or
+narrow to the constants surfaces here as a shape change rather than as
+a diverging table this file would need to manually update.
+
+Two things this file's cells deliberately do not pin:
+
+* The ``BidiAgent`` turn detector's live answer at wire time.  The
+  verbs answer against the module-level snapshot, not against a live
+  import of the detector's admission handler (the whole point of the
+  port is that the snapshot lets a headless host answer).  A
+  driver-side wrapper for ``g1_speak`` that lands later will
+  re-validate against the detector's live handler at wire time;
+  testing the snapshot vs the live handler is a driver-side test, not
+  a lookup-side one.
+* Whether the caller's ``vad_threshold`` matches the caller's mic
+  gain.  A threshold above the mic's typical energy is a runtime
+  liveness question the neon bundle answers under its
+  ``STATS["energy_mean_abs"]`` reading; neither this lookup nor the
+  bidi detector's admission set can decide it ahead of wire time.
+  The membership tests here grade the numeric envelope only.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+from typing import Any
+
+from strands_robots.tools.g1.g1_speak_vad_envelope import (
+    _REFUSAL_TEXT_SILENCE_DURATION_MS,
+    _REFUSAL_TEXT_VAD_THRESHOLD,
+    _SILENCE_DURATION_MS_MIN,
+    _SILENCE_DURATION_MS_NEON_DEFAULT,
+    _VAD_THRESHOLD_MAX,
+    _VAD_THRESHOLD_MIN,
+    _VAD_THRESHOLD_NEON_DEFAULT,
+    g1_list_speak_vad_envelope,
+    g1_speak_vad_admits,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process, but a caller cannot rely on
+    that: the wrapper's contract is that it returns the wrapped
+    function's return value verbatim.  This helper is where a shape
+    drift would surface once, rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be
+    importable with the SDK absent; a module that pulled a submodule
+    at import time would break every headless CI runner and Thor
+    before an office bring-up (refs strands-labs/robots#358).
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_speak_vad_envelope")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_speak_vad_envelope imports pulled SDK "
+        f"submodules: {leaked}. The rule for this package is that the SDK "
+        "loads only inside function bodies (refs strands-labs/robots#358)."
+    )
+
+
+def test_the_import_pulls_no_optional_audio_stack_module() -> None:
+    """The tool module is loadable without the optional audio-stack imports.
+
+    The neon bundle's runtime path pulls ``pywebrtc_audio`` /
+    ``pyaudio`` / ``strands.experimental.bidi`` inside its own
+    ``_probe_bidi`` helper; those are optional dependencies the
+    ``strands-robots`` package does not require.  A read-only lookup
+    module that pulled any of them at import time would break every
+    headless CI runner and Thor before an office bring-up on the same
+    surface a missing SDK submodule would, refs
+    strands-labs/robots#358.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_speak_vad_envelope")
+    after = set(sys.modules)
+    audio_stack_prefixes = ("pywebrtc_audio", "pyaudio")
+    leaked = {
+        name
+        for name in after - before
+        if any(name == prefix or name.startswith(prefix + ".") for prefix in audio_stack_prefixes)
+    }
+    # ``strands.experimental.bidi`` is graded separately: it is a
+    # subpackage of ``strands`` (which this test module transitively
+    # imports through the tool decorator), so its ``bidi`` subpackage
+    # is what a leak here would surface.
+    bidi_leaked = {name for name in after - before if name.startswith("strands.experimental.bidi")}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_speak_vad_envelope imports pulled "
+        f"optional audio-stack submodules: {leaked}. The lookup half of "
+        "the ``g1_speak`` port must not pull the runtime audio-stack "
+        "imports (refs strands-labs/robots#358)."
+    )
+    assert bidi_leaked == set(), (
+        f"strands_robots.tools.g1.g1_speak_vad_envelope imports pulled "
+        f"``strands.experimental.bidi`` submodules: {bidi_leaked}. The "
+        "lookup half must not pull the bidi runtime stack; that pull "
+        "belongs on a future driver-side wrapper (refs "
+        "strands-labs/robots#358)."
+    )
+
+
+def test_the_snapshot_names_the_neon_observed_envelope() -> None:
+    """The module-level constants match the neon docstring's observed values.
+
+    The neon ``g1_speak`` docstring names the two knobs as:
+
+    * ``vad_threshold: 0.0-1.0. Higher = less twitchy. 0.7 stops
+      echo triggers``
+    * ``silence_duration_ms: How long of silence ends a turn. 700 =
+      relaxed``
+
+    The clamp pair (``[0.0, 1.0]`` for ``vad_threshold``, ``>= 1``
+    for ``silence_duration_ms``) and the two neon-observed defaults
+    (``0.7`` and ``700``) are pinned so a widen on the neon side
+    surfaces here as a diverging constant rather than as a silent
+    envelope drift.
+    """
+    assert _VAD_THRESHOLD_MIN == 0.0
+    assert _VAD_THRESHOLD_MAX == 1.0
+    assert _VAD_THRESHOLD_NEON_DEFAULT == 0.7
+    assert _SILENCE_DURATION_MS_MIN == 1
+    assert _SILENCE_DURATION_MS_NEON_DEFAULT == 700
+
+
+def test_the_refusal_texts_name_the_module_local_remedy() -> None:
+    """The refusal texts quote the module-local bounds, not a motion-FSM code.
+
+    The bidi voice pipeline ships no distinct rc for a bounds-
+    violated ``vad_threshold`` or ``silence_duration_ms``, and the
+    motion-FSM ``7404`` entry in
+    :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` reads
+    ``"Invalid FSM id - need FSM in {500, 501, 801}"`` - a remedy
+    that points a planner at locomotion FSM transitions to fix a
+    turn-detector argument.  This cell locks the module-local remedy
+    text so a future refactor that re-borrows a motion code lands as
+    a shape change here rather than silently.
+    """
+    assert "vad_threshold" in _REFUSAL_TEXT_VAD_THRESHOLD
+    assert f"[{_VAD_THRESHOLD_MIN}, {_VAD_THRESHOLD_MAX}]" in _REFUSAL_TEXT_VAD_THRESHOLD
+    assert "silence_duration_ms" in _REFUSAL_TEXT_SILENCE_DURATION_MS
+    assert f">= {_SILENCE_DURATION_MS_MIN}" in _REFUSAL_TEXT_SILENCE_DURATION_MS
+    # The refusal texts must NOT re-borrow the motion-FSM 7404 remedy.
+    for text in (_REFUSAL_TEXT_VAD_THRESHOLD, _REFUSAL_TEXT_SILENCE_DURATION_MS):
+        assert "FSM" not in text, (
+            f"refusal text {text!r} names an FSM remedy; the bidi voice "
+            "pipeline ships no motion-FSM refusal, and the module-local "
+            "text must not re-borrow ``7404``."
+        )
+
+
+def test_g1_list_speak_vad_envelope_returns_the_whole_envelope() -> None:
+    """The verb's payload names every clamp and every refusal descriptor.
+
+    ``envelope`` is a dict whose fields match the module's own
+    snapshot; ``refusals`` is a list of one descriptor per dimension
+    (``vad_threshold`` and ``silence_duration_ms``) with the module-
+    local refusal text a future write verb would surface on a bounds
+    violation.  Every field is read off the module's constants (not
+    restated in the test body), so a widen to the descriptor lands
+    in one place.
+    """
+    result = _call(g1_list_speak_vad_envelope)
+    assert result["status"] == "success"
+    envelope = result["envelope"]
+    assert envelope["vad_threshold_min"] == _VAD_THRESHOLD_MIN
+    assert envelope["vad_threshold_max"] == _VAD_THRESHOLD_MAX
+    assert envelope["vad_threshold_neon_default"] == _VAD_THRESHOLD_NEON_DEFAULT
+    assert envelope["silence_duration_ms_min"] == _SILENCE_DURATION_MS_MIN
+    assert envelope["silence_duration_ms_neon_default"] == _SILENCE_DURATION_MS_NEON_DEFAULT
+    refusal_texts = {r["text"] for r in result["refusals"]}
+    assert refusal_texts == {
+        _REFUSAL_TEXT_VAD_THRESHOLD,
+        _REFUSAL_TEXT_SILENCE_DURATION_MS,
+    }
+    refusal_dims = {r["dimension"] for r in result["refusals"]}
+    assert refusal_dims == {"vad_threshold", "silence_duration_ms"}
+
+
+def test_g1_list_speak_vad_envelope_returns_fresh_containers() -> None:
+    """A caller mutating the payload cannot poison the module snapshot.
+
+    The verb returns fresh dicts and lists; a mutation on the
+    returned ``envelope`` dict or ``refusals`` list does not leak
+    back into the module's constants.  This cell is where a share-a-
+    reference regression would surface once, not scattered across
+    every call site.
+    """
+    result = _call(g1_list_speak_vad_envelope)
+    result["envelope"]["synthetic"] = True
+    result["refusals"].append({"synthetic": True})
+    fresh = _call(g1_list_speak_vad_envelope)
+    assert "synthetic" not in fresh["envelope"]
+    assert all("synthetic" not in r for r in fresh["refusals"])
+
+
+def test_g1_speak_vad_admits_admits_the_neon_defaults() -> None:
+    """The neon-tuned defaults ``0.7`` and ``700`` are admitted.
+
+    The neon docstring names ``vad_threshold=0.7`` /
+    ``silence_duration_ms=700`` as the tuned values for the G1 DDS
+    speaker->mic loop; a caller who does not pass explicit arguments
+    lands on those defaults and this verb admits the pair without
+    surfacing a refusal.
+    """
+    result = _call(g1_speak_vad_admits)
+    assert result["status"] == "success"
+    assert result["admits"] is True
+    assert result["refusals"] == []
+    assert result["envelope"]["vad_threshold_neon_default"] == 0.7
+    assert result["envelope"]["silence_duration_ms_neon_default"] == 700
+
+
+def test_g1_speak_vad_admits_admits_the_envelope_boundaries() -> None:
+    """The inclusive lower and upper clamps for both dimensions admit.
+
+    ``vad_threshold=0.0`` (accept every frame) and
+    ``vad_threshold=1.0`` (accept only a certain-speech frame) are
+    both legitimate operator commands on the ``[0.0, 1.0]`` range,
+    not the shape-error the refusal exists to catch.
+    ``silence_duration_ms=1`` (the exclusive-of-zero minimum) is a
+    legitimate "end the turn immediately" command.  This cell locks
+    the inclusive-boundary contract.
+    """
+    for threshold in (_VAD_THRESHOLD_MIN, _VAD_THRESHOLD_MAX):
+        result = _call(g1_speak_vad_admits, vad_threshold=threshold, silence_duration_ms=1)
+        assert result["admits"] is True, (
+            f"vad_threshold={threshold!r} at the boundary should have admitted, got {result!r}."
+        )
+    # silence_duration_ms=1 is the exclusive-of-zero minimum; ensure
+    # the boundary is admitted rather than refused off-by-one.
+    result = _call(g1_speak_vad_admits, vad_threshold=0.5, silence_duration_ms=_SILENCE_DURATION_MS_MIN)
+    assert result["admits"] is True
+
+
+def test_g1_speak_vad_admits_admits_an_int_widening_to_float() -> None:
+    """An integer ``vad_threshold`` widens to ``float`` and is admitted.
+
+    A caller writing ``vad_threshold=1`` (an integer rather than a
+    literal ``1.0``) means the same admitted ceiling as ``1.0``; the
+    verb widens the int to a float and admits it.  This mirrors the
+    ``BidiAgent`` turn detector's own comparison, which numerically
+    compares its score against the argument without pinning the
+    argument's Python type.
+    """
+    result = _call(g1_speak_vad_admits, vad_threshold=1, silence_duration_ms=700)
+    assert result["admits"] is True
+    result = _call(g1_speak_vad_admits, vad_threshold=0, silence_duration_ms=700)
+    assert result["admits"] is True
+
+
+def test_g1_speak_vad_admits_refuses_a_bool_threshold() -> None:
+    """A ``bool`` ``vad_threshold`` is refused because ``True`` would widen to ``1.0``.
+
+    Python's ``bool`` is a subclass of ``int`` (and ``int`` widens
+    to ``float`` below), so a caller passing ``True`` would otherwise
+    silently look up ``1.0`` (the admitted ceiling) and hide the type
+    mistake.  The verb refuses both bool values at the boundary so
+    the mistake surfaces.
+    """
+    for value in (True, False):
+        result = _call(g1_speak_vad_admits, vad_threshold=value, silence_duration_ms=700)
+        assert result["admits"] is False, f"vad_threshold={value!r} (bool) should have been refused, got {result!r}."
+        assert any(r["dimension"] == "vad_threshold" and r["comparison"] == "non-float" for r in result["refusals"])
+        assert any(r["text"] == _REFUSAL_TEXT_VAD_THRESHOLD for r in result["refusals"])
+
+
+def test_g1_speak_vad_admits_refuses_a_non_numeric_threshold() -> None:
+    """A string / list / dict ``vad_threshold`` is refused with the non-float remedy.
+
+    A caller writing ``vad_threshold="0.7"`` or
+    ``vad_threshold=[0.7]`` is making a shape mistake, not naming
+    the detector's float threshold.  The verb refuses each with the
+    module-local :data:`_REFUSAL_TEXT_VAD_THRESHOLD` so the caller
+    reads the remedy that matches the surface.
+    """
+    for value in ("0.7", [0.7], (0.7,), {"threshold": 0.7}):
+        result = _call(g1_speak_vad_admits, vad_threshold=value, silence_duration_ms=700)
+        assert result["admits"] is False, (
+            f"vad_threshold={value!r} ({type(value).__name__}) should have been refused, got {result!r}."
+        )
+        vad_refusals = [r for r in result["refusals"] if r["dimension"] == "vad_threshold"]
+        assert vad_refusals, f"missing vad_threshold refusal for {value!r}"
+        assert vad_refusals[0]["comparison"] == "non-float"
+        assert vad_refusals[0]["text"] == _REFUSAL_TEXT_VAD_THRESHOLD
+
+
+def test_g1_speak_vad_admits_refuses_a_non_finite_threshold() -> None:
+    """A ``nan`` / ``inf`` / ``-inf`` ``vad_threshold`` is refused.
+
+    The ``BidiAgent`` turn detector's comparison against a non-finite
+    threshold degenerates (``score >= nan`` is always ``False``,
+    ``score >= inf`` is always ``False``); silencing every frame at
+    wire time is the failure mode this refusal exists to catch.  The
+    module-local remedy names the finite ``[0.0, 1.0]`` range.
+    """
+    for value in (math.nan, math.inf, -math.inf):
+        result = _call(g1_speak_vad_admits, vad_threshold=value, silence_duration_ms=700)
+        assert result["admits"] is False, (
+            f"vad_threshold={value!r} (non-finite) should have been refused, got {result!r}."
+        )
+        vad_refusals = [r for r in result["refusals"] if r["dimension"] == "vad_threshold"]
+        assert vad_refusals, f"missing vad_threshold refusal for {value!r}"
+        assert vad_refusals[0]["comparison"] == "non-finite"
+        assert vad_refusals[0]["text"] == _REFUSAL_TEXT_VAD_THRESHOLD
+
+
+def test_g1_speak_vad_admits_refuses_an_out_of_range_threshold() -> None:
+    """A ``vad_threshold`` outside ``[0.0, 1.0]`` is refused with the range remedy.
+
+    Below ``0.0`` the detector's admission floor is undefined; above
+    ``1.0`` no score can meet the threshold and every frame is
+    silenced.  The verb refuses both sides and names the violated
+    bound (``vad_threshold_min`` on the low side,
+    ``vad_threshold_max`` on the high side).
+    """
+    for value, expected_bound_key, expected_cmp in (
+        (-0.1, "vad_threshold_min", "value < bound"),
+        (-1.0, "vad_threshold_min", "value < bound"),
+        (1.1, "vad_threshold_max", "value > bound"),
+        (10.0, "vad_threshold_max", "value > bound"),
+    ):
+        result = _call(g1_speak_vad_admits, vad_threshold=value, silence_duration_ms=700)
+        assert result["admits"] is False, (
+            f"vad_threshold={value!r} out of range should have been refused, got {result!r}."
+        )
+        vad_refusals = [r for r in result["refusals"] if r["dimension"] == "vad_threshold"]
+        assert vad_refusals, f"missing vad_threshold refusal for {value!r}"
+        assert vad_refusals[0]["bound_key"] == expected_bound_key
+        assert vad_refusals[0]["comparison"] == expected_cmp
+        assert vad_refusals[0]["text"] == _REFUSAL_TEXT_VAD_THRESHOLD
+
+
+def test_g1_speak_vad_admits_refuses_a_bool_silence() -> None:
+    """A ``bool`` ``silence_duration_ms`` is refused because ``True`` would look up ``1``.
+
+    Python's ``bool`` is a subclass of ``int``; a caller passing
+    ``True`` would otherwise silently look up ``1`` (a legitimate
+    one-millisecond wait) and hide the type mistake.  The verb
+    refuses both bool values at the boundary.
+    """
+    for value in (True, False):
+        result = _call(g1_speak_vad_admits, vad_threshold=0.7, silence_duration_ms=value)
+        assert result["admits"] is False, (
+            f"silence_duration_ms={value!r} (bool) should have been refused, got {result!r}."
+        )
+        sil_refusals = [r for r in result["refusals"] if r["dimension"] == "silence_duration_ms"]
+        assert sil_refusals, f"missing silence_duration_ms refusal for {value!r}"
+        assert sil_refusals[0]["comparison"] == "non-int"
+        assert sil_refusals[0]["text"] == _REFUSAL_TEXT_SILENCE_DURATION_MS
+
+
+def test_g1_speak_vad_admits_refuses_a_non_int_silence() -> None:
+    """A ``float`` / ``str`` / ``list`` ``silence_duration_ms`` is refused.
+
+    A caller writing ``silence_duration_ms=700.0`` sees an
+    actionable refusal rather than a silent truncation the turn
+    detector would perform; a caller writing
+    ``silence_duration_ms="700"`` is making a shape mistake.  The
+    verb refuses each and quotes the module-local remedy.
+    """
+    for value in (700.0, "700", [700], (700,), 7.5):
+        result = _call(g1_speak_vad_admits, vad_threshold=0.7, silence_duration_ms=value)
+        assert result["admits"] is False, (
+            f"silence_duration_ms={value!r} ({type(value).__name__}) should have been refused, got {result!r}."
+        )
+        sil_refusals = [r for r in result["refusals"] if r["dimension"] == "silence_duration_ms"]
+        assert sil_refusals, f"missing silence_duration_ms refusal for {value!r}"
+        assert sil_refusals[0]["comparison"] == "non-int"
+        assert sil_refusals[0]["text"] == _REFUSAL_TEXT_SILENCE_DURATION_MS
+
+
+def test_g1_speak_vad_admits_refuses_a_non_positive_silence() -> None:
+    """A ``silence_duration_ms`` at or below zero is refused.
+
+    A non-positive wait collapses the turn boundary to a single
+    frame and cuts off every operator pause between words; the neon
+    bundle names positive integers only, matching the shared
+    :func:`~strands_robots.utils.positive_count_error` domain every
+    other integer-count knob in this package uses.  The refusal
+    surfaces the ``>= 1`` remedy.
+    """
+    for value in (0, -1, -700):
+        result = _call(g1_speak_vad_admits, vad_threshold=0.7, silence_duration_ms=value)
+        assert result["admits"] is False, (
+            f"silence_duration_ms={value!r} (non-positive) should have been refused, got {result!r}."
+        )
+        sil_refusals = [r for r in result["refusals"] if r["dimension"] == "silence_duration_ms"]
+        assert sil_refusals, f"missing silence_duration_ms refusal for {value!r}"
+        assert sil_refusals[0]["bound_key"] == "silence_duration_ms_min"
+        assert sil_refusals[0]["comparison"] == "value < bound"
+        assert sil_refusals[0]["text"] == _REFUSAL_TEXT_SILENCE_DURATION_MS
+
+
+def test_g1_speak_vad_admits_reports_both_dimensions_together() -> None:
+    """A caller with two bad arguments reads two refusals in one payload.
+
+    The two dimensions are graded independently rather than short-
+    circuiting on the first violation; a caller passing a bad
+    threshold *and* a bad silence duration reads both refusals in a
+    single call so the correction lands in one round-trip rather
+    than in a ping-pong of single-refusal payloads.
+    """
+    result = _call(g1_speak_vad_admits, vad_threshold=2.0, silence_duration_ms=0)
+    assert result["admits"] is False
+    dims = {r["dimension"] for r in result["refusals"]}
+    assert dims == {"vad_threshold", "silence_duration_ms"}
+
+
+def test_g1_speak_vad_admits_returns_the_envelope_on_every_call() -> None:
+    """Every payload carries the ``envelope`` sub-dict, admitted or refused.
+
+    A caller reading the refusal payload has the same envelope on
+    hand that
+    :func:`g1_list_speak_vad_envelope` returns, so the correction
+    step does not need a second call.  This cell locks the shape.
+    """
+    for kwargs in (
+        {"vad_threshold": 0.7, "silence_duration_ms": 700},
+        {"vad_threshold": 2.0, "silence_duration_ms": 0},
+        {"vad_threshold": "0.7", "silence_duration_ms": 700},
+    ):
+        result = _call(g1_speak_vad_admits, **kwargs)
+        assert "envelope" in result
+        assert result["envelope"]["vad_threshold_min"] == _VAD_THRESHOLD_MIN
+        assert result["envelope"]["vad_threshold_max"] == _VAD_THRESHOLD_MAX
+        assert result["envelope"]["silence_duration_ms_min"] == _SILENCE_DURATION_MS_MIN


### PR DESCRIPTION
## What

Two agent-facing verbs surface the turn-detector envelope the neon bundle's `g1_speak` verb (`cagataycali/neon-the-g1/tools/g1_speak.py`) observed as usable when it constructs a `BidiAgent` via the `g1.build_voice_agent` factory:

- **`g1_list_speak_vad_envelope()`** names the whole envelope: the `vad_threshold` clamp pair (`[0.0, 1.0]` — the turn detector's own numeric domain), the `silence_duration_ms` clamp (`>= 1` — positive-integer domain matching the shared `positive_count_error` rule), and the two neon-observed defaults (`vad_threshold=0.7` "stops echo triggers" and `silence_duration_ms=700` "relaxed") the bundle's own docstring names.
- **`g1_speak_vad_admits(vad_threshold: float = 0.7, silence_duration_ms: int = 700)`** decides one query. Both arguments are graded independently; a caller with two bad arguments reads both refusals in one payload rather than in a ping-pong of single-refusal round-trips. `bool`, non-numeric, non-finite (`nan`/`inf`), and out-of-range inputs are refused decidably rather than resolved through Python's coercions.

## Why twin of #2995 (stream_delay_ms), not folded in

Twin of `g1_list_bidi_audio_stream_delay_envelope` / `g1_stream_delay_ms_admits` (refs #2995, merged): both modules ship a fragment of the same `g1_speak(action="start")` argument tuple. The two modules stay separate because `stream_delay_ms` names the **AEC** delay-buffer bound (a `pywebrtc_audio.AudioProcessor` argument) while the two knobs here name the **turn-detector** bounds (a `strands.experimental.bidi` argument): two different downstream libraries with disjoint refusal shapes. Colocating them would hand an agent planner a single refusal payload that mixed the two surfaces' remedies and would tie a future audio-processing revision to a turn-detector revision the neon bundle does not couple.

## Refusal string design

The refusal texts stay **on-surface**:

- `"vad_threshold out of envelope - need vad_threshold in [0.0, 1.0]"`
- `"silence_duration_ms out of envelope - need silence_duration_ms >= 1"`

No motion-FSM `7404` re-borrow: the bidi voice pipeline ships no distinct rc for a bounds-violated turn-detector argument, and `7404`'s `"Invalid FSM id - need FSM in {500, 501, 801}"` would hand an agent planner a locomotion FSM remedy for a turn-detector bounds violation. A future driver-side `g1_speak` wrapper will surface the same module-local text.

## What this module does not do

- **No execution path.** The neon bundle's `g1_speak(action="start")` spawns a background thread that runs a full `BidiAgent` (webrtc AEC, pyaudio input, DDS chest-speaker output). A future driver method that fronts `g1_speak` will land the transition verb; refs #358 for the SDK-facing gate work that audio path belongs on.
- **No SDK re-import, no audio-stack re-import.** The envelope is captured as module-level constants. `import strands_robots.tools.g1.g1_speak_vad_envelope` pulls **no** `unitree_sdk2py` submodule *and* pulls **no** optional audio-stack submodule (`pywebrtc_audio`, `pyaudio`, `strands.experimental.bidi`) — the import-hygiene contract every other file in this package carries, refs #358.
- **No mic-gain-and-threshold pair decision.** Whether a `vad_threshold=0.9` matches the mic's typical energy is a live-instance question the neon bundle answers under its `STATS["energy_mean_abs"]` reading, not a numeric envelope decision.

## Gates status

| Gate | Result |
|---|---|
| `ruff check` | ✅ All checks passed |
| `ruff format --check` | ✅ Both files formatted |
| `mypy` on new files | ✅ 0 errors |
| `pytest tests/drivers/test_g1_speak_vad_envelope_reads_the_neon_turn_detector_hint.py` | ✅ **18 passed** in 0.39s |
| Neighbour sweep (`envelope or admits`, 402 tests) | ✅ 402 passed |
| `tests/test_docstring_xref_roles_resolve.py` (the check that bit #2989) | ✅ 25 passed |
| Changelog fragment gates (91 tests) | ✅ 91 passed |

### Test coverage (18 tests)

- 2 import-hygiene tests: no `unitree_sdk2py` leak, no optional audio-stack leak (`pywebrtc_audio`, `pyaudio`, `strands.experimental.bidi`)
- 2 snapshot-fidelity tests: constants match neon-observed values; refusal texts stay module-local (no `7404` re-borrow)
- 2 `g1_list_speak_vad_envelope` shape tests: whole envelope + fresh containers (no share-a-reference)
- 2 `g1_speak_vad_admits` happy-path tests: neon defaults admitted, inclusive boundaries admitted
- 1 int-widens-to-float admit test (turn detector compares numerically)
- 5 `vad_threshold` refusal tests: `bool`, non-numeric type, non-finite (`nan`/`inf`/`-inf`), out-of-range low, out-of-range high
- 3 `silence_duration_ms` refusal tests: `bool`, non-int, non-positive
- 1 both-dimensions-graded-together test (no short-circuit)
- 1 envelope-on-every-payload shape test

## Files

- `strands_robots/tools/g1/g1_speak_vad_envelope.py` (module, 405 LOC)
- `tests/drivers/test_g1_speak_vad_envelope_reads_the_neon_turn_detector_hint.py` (test, 458 LOC)
- `changelog.d/2998-g1-speak-vad-envelope-port.md` (rename to PR number if this lands as a different number)

Refs #358 (agent-facing verb port from `cagataycali/neon-the-g1`).