### PR TITLE
feat(tools/g1): port g1_list_slam_map_name_rules and g1_slam_map_name_admits (refs #358)

### DIFF
--- a/changelog.d/3000-g1-slam-map-names-port.md
+++ b/changelog.d/3000-g1-slam-map-names-port.md
@@ -1,0 +1,32 @@
+### Added: a SLAM map name is decided before it is joined onto a path
+
+The neon bundle's SLAM save/load path (`cagataycali/neon-the-g1/tools/g1_slam.py`)
+routes an agent-authored map name through one containment check: it joins the
+name onto `~/maps`, resolves the result, and tests containment with
+`str(path).startswith(str(root))`. A string prefix is satisfied by a *sibling*
+directory whose name begins with the root's name, so `../maps-evil/pwn` is
+admitted and lands outside the root entirely, while `sub/dir` is admitted inside
+it but under a subdirectory the top-level `glob("*.npz")` listing cannot report --
+a map saved and then invisible to the caller who saved it.
+
+`g1_slam_map_name_admits` decides the same question before any join, on the name
+alone: admitted only when it is a single path component that is not a traversal
+token. Containment is then structural rather than tested -- `root / f"{name}.npz"`
+for an admitted name cannot be anywhere but directly inside `root`, whatever the
+root is and whatever the caller resolves afterwards. Six rules, each reporting
+its own id beside the bundle's own `invalid map name` verdict: a missing name, a
+bool (`str(True)` is an ordinary stem, so a flag would name a map after itself),
+a non-string, the empty string (it makes the file `.npz`, whose stem is `.npz`
+rather than the empty string, so the listing reports a name that cannot be loaded
+back), a name carrying a path separator or NUL, and `.` or `..`.
+
+Both separators are refused on every platform rather than only the deciding
+host's, because a map name travels -- authored by an agent, written on the robot,
+listed on an operator's laptop, asserted in CI -- and a rule keyed on `os.sep`
+would admit `a\b` on Linux as an ordinary filename and then have it name a
+directory the first time the same string reached a Windows path.
+
+`g1_list_slam_map_name_rules` names the whole rule set, the unexpanded map root,
+the suffix a writer appends, and the suffixes the listing enumerates in the
+bundle's own chaining order. Neither verb touches the filesystem, so the answer
+does not move with `$HOME` and is available before the map directory exists.

--- a/strands_robots/tools/g1/g1_slam_map_names.py
+++ b/strands_robots/tools/g1/g1_slam_map_names.py
@@ -25,19 +25,19 @@ The bundle joins first and tests the joined string afterwards::
 
 A resolved path is compared to the root by string prefix, and a *sibling
 directory whose name merely begins with the root's name* satisfies that
-prefix. Measured against ``MAPS_DIR = ~/maps`` on a host whose home is
-``/home/runner``:
+prefix. Measured against ``MAPS_DIR = ~/maps`` on a host whose home
+directory expands to ``$HOME``:
 
-===========================  =========================  =================
-``name``                     joined and resolved        bundle's verdict
-===========================  =========================  =================
-``ok``                       ``/home/runner/maps/ok.npz``    admitted
-``../maps-evil/pwn``         ``/home/runner/maps-evil/pwn.npz``  admitted
-``../maps.ssh/x``            ``/home/runner/maps.ssh/x.npz``     admitted
-``sub/dir``                  ``/home/runner/maps/sub/dir.npz``   admitted
-``../../etc/passwd``         (outside, no shared prefix)     refused
-``/etc/passwd``              (outside, no shared prefix)     refused
-===========================  =========================  =================
+===========================  =============================  =================
+``name``                     joined and resolved            bundle's verdict
+===========================  =============================  =================
+``ok``                       ``$HOME/maps/ok.npz``          admitted
+``../maps-evil/pwn``         ``$HOME/maps-evil/pwn.npz``    admitted
+``../maps.ssh/x``            ``$HOME/maps.ssh/x.npz``       admitted
+``sub/dir``                  ``$HOME/maps/sub/dir.npz``     admitted
+``../../etc/passwd``         (outside, no shared prefix)    refused
+``/etc/passwd``              (outside, no shared prefix)    refused
+===========================  =============================  =================
 
 So the rule refuses the traversal that leaves the *parent* and admits the
 one that lands beside the root: two of those admitted names write outside

--- a/strands_robots/tools/g1/g1_slam_map_names.py
+++ b/strands_robots/tools/g1/g1_slam_map_names.py
@@ -1,0 +1,375 @@
+"""Agent-facing lookup for the SLAM map names a save/load path can admit.
+
+The neon bundle's ``cagataycali/neon-the-g1/tools/g1_slam.py`` keeps its
+kiss-icp maps as one flat directory of ``.npz`` archives under
+``~/maps``, and every one of its four name-taking verbs (``g1_slam_save``,
+``g1_slam_load``, and the ``g1_slam_list_maps`` listing that reports the
+names those two exchange) routes the caller's string through one private
+containment check, ``_SlamRunner._safe_map_path``. That check is the whole
+of the decision: an admitted name becomes a filesystem path a moment
+later, and the name arrives from an agent (``g1_slam_save(name)`` is a
+``@tool`` whose ``name`` argument is model-authored text). This module
+ports that decision - and only the decision - as two agent-facing verbs:
+:func:`g1_list_slam_map_name_rules` (name the whole rule set) and
+:func:`g1_slam_map_name_admits` (decide one candidate). Refs
+strands-labs/robots#358.
+
+The port does not reproduce the bundle's rule
+=============================================
+
+The bundle joins first and tests the joined string afterwards::
+
+    path = (MAPS_DIR / f"{name}.npz").resolve()
+    if not str(path).startswith(str(MAPS_DIR.resolve())):
+        return None
+
+A resolved path is compared to the root by string prefix, and a *sibling
+directory whose name merely begins with the root's name* satisfies that
+prefix. Measured against ``MAPS_DIR = ~/maps`` on a host whose home is
+``/home/runner``:
+
+===========================  =========================  =================
+``name``                     joined and resolved        bundle's verdict
+===========================  =========================  =================
+``ok``                       ``/home/runner/maps/ok.npz``    admitted
+``../maps-evil/pwn``         ``/home/runner/maps-evil/pwn.npz``  admitted
+``../maps.ssh/x``            ``/home/runner/maps.ssh/x.npz``     admitted
+``sub/dir``                  ``/home/runner/maps/sub/dir.npz``   admitted
+``../../etc/passwd``         (outside, no shared prefix)     refused
+``/etc/passwd``              (outside, no shared prefix)     refused
+===========================  =========================  =================
+
+So the rule refuses the traversal that leaves the *parent* and admits the
+one that lands beside the root: two of those admitted names write outside
+``~/maps`` entirely, and the third writes into a subdirectory the
+top-level ``MAPS_DIR.glob("*.npz")`` listing cannot report, so the map is
+saved and then invisible to the caller who saved it.
+
+This module decides the name *before* any join, on the name alone: a
+candidate is admitted only when it is a single path component that is not
+a traversal token. Containment is then structural rather than tested -
+``root / f"{name}.npz"`` for an admitted ``name`` cannot be anywhere but
+directly inside ``root``, whatever the root is and whatever the caller
+resolves afterwards - which is why the port is not a transcription of the
+check it replaces. :data:`_REFUSED_CHARACTERS` and
+:data:`_REFUSED_COMPONENTS` are the two halves of that rule.
+
+What this module is deliberately *not*
+======================================
+
+* A filesystem read. Nothing here stats, globs, opens or resolves
+  anything: the verbs answer from module-level constants and the argument.
+  So the answer does not depend on ``$HOME``, on whether ``~/maps``
+  exists, on what it already holds, or on the platform - which is what
+  lets a headless CI runner and an operator laptop decide a name
+  identically, and what keeps the decision available before the directory
+  is created. Whether an admitted name is *free* (no map of that name yet)
+  is a directory read this module cannot make and does not claim.
+* A save or load path. There is no map I/O in this package yet; when a
+  driver-side SLAM verb lands it should reach this decision rather than
+  re-derive one, which is the reason to land the rule ahead of the writer
+  rather than inside it.
+* A byte-length or encoding bound. A name of 300 ASCII characters is
+  admitted here and refused by the kernel at ``open`` time with
+  ``ENAMETOOLONG``, because the limit is per-filesystem (255 bytes on
+  ext4, and it counts *encoded* bytes, so the admitted length in
+  characters varies with the name's own script). A bound stated here
+  would be a number this module cannot know, and stating it per-filesystem
+  needs the filesystem, which is the read above.
+* A case-collision answer. ``Map`` and ``map`` are two names here and one
+  file on a case-insensitive volume, so a name admitted on both hosts can
+  still collide on one of them. That is a property of the destination
+  volume, not of the name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+#: The map directory the neon bundle keeps its archives in, stated as the
+#: unexpanded spelling (``~/maps``) rather than as a resolved
+#: :class:`~pathlib.Path`. Two reasons, and both are about the answer being
+#: the same everywhere: expanding it would read ``$HOME`` at import, so the
+#: rule set a headless runner reported and the one an operator's shell
+#: reported would differ on a field that has nothing to do with the rules;
+#: and a resolved root invites the joined-then-tested shape this module
+#: exists to replace. The verbs never join it - it is surfaced so a caller
+#: knows *which* directory the admitted name is a name in.
+_MAP_ROOT_SPEC: str = "~/maps"
+
+#: The suffix the bundle's ``save_map`` appends to an admitted name. A
+#: caller passes the stem (``office``) and the file is ``office.npz``.
+_MAP_SUFFIX: str = ".npz"
+
+#: The suffixes the bundle's ``list_maps`` enumerates, in the order it
+#: chains them. ``.npy`` is a legacy single-array map that the listing
+#: still reports and ``save_map`` no longer writes; a stem carried by both
+#: suffixes is reported once, for the ``.npz``, because the listing dedupes
+#: on the stem and reaches ``.npz`` first. Surfaced so a caller reading a
+#: name back off the listing knows the two spellings collapse.
+_LISTED_SUFFIXES: tuple[str, ...] = (".npz", ".npy")
+
+#: The characters that make a candidate more than one path component. Both
+#: separators are refused on every platform, and stated as literals rather
+#: than read off ``os.sep`` / ``os.altsep``, because a map name travels:
+#: it is authored by an agent, written on the robot, listed on an
+#: operator's laptop and asserted in CI, and a rule keyed on the deciding
+#: host's own separator would admit ``a\b`` on Linux as an ordinary
+#: filename and then name a directory the moment the same string reached a
+#: Windows path. NUL is refused for the same reason it is not a filename
+#: character anywhere: it terminates the path the C library is handed, so
+#: the bytes after it are silently not part of the name.
+_REFUSED_CHARACTERS: tuple[str, ...] = ("/", "\\", "\x00")
+
+#: Printable labels for :data:`_REFUSED_CHARACTERS`, one per entry and in
+#: the same order. The refusal strings and the rule listing quote these
+#: rather than the characters themselves: a returned payload is text an
+#: agent reads back, and putting a raw NUL in it makes the rest of the
+#: string invisible to anything that treats the payload as a C string.
+_REFUSED_CHARACTER_LABELS: tuple[str, ...] = (
+    "'/' (forward slash)",
+    "'\\' (backslash)",
+    "NUL (0x00)",
+)
+
+#: The two strings that name a directory rather than a file in every path
+#: context. The bundle's join makes them inert by accident - ``.`` becomes
+#: the filename ``..npz`` - so refusing them changes no working call, and
+#: it is what makes the admitted answer independent of *where* a caller
+#: interpolates the name. A future writer that joins the name as its own
+#: component (``root / name / "map.npz"``, one directory per map) would
+#: otherwise escape on the same two strings the flat writer tolerated.
+_REFUSED_COMPONENTS: frozenset[str] = frozenset({".", ".."})
+
+#: The verdict string the bundle's ``save_map`` / ``load_map`` return to
+#: the caller when ``_safe_map_path`` refuses (``{"ok": False, "error":
+#: "invalid map name"}``). Quoted verbatim on every refusal here so a
+#: caller that plans a call with this lookup and then makes it reads one
+#: string for one verdict, rather than two wordings for the same refusal.
+_REFUSAL_TEXT: str = "invalid map name"
+
+#: The rule set, in the order :func:`g1_slam_map_name_admits` applies it.
+#: Each entry names the ``rule`` id the refusal reports, what the rule
+#: ``requires``, and ``why`` - the consequence of admitting what it
+#: refuses, stated as the outcome a caller would get rather than as the
+#: rule restated. The order is load-bearing and pinned: the type rules
+#: precede the content rules because a non-string has no characters to
+#: scan, and ``bool`` precedes the general type rule because
+#: ``isinstance(True, int)`` is not the confusion being reported - a
+#: caller who passed a flag wants to read that word in the refusal.
+_RULES: tuple[dict[str, str], ...] = (
+    {
+        "rule": "name_is_required",
+        "requires": "A name argument is passed.",
+        "why": (
+            "A missing name is refused decidably rather than defaulted. There is no map "
+            "this lookup could name on the caller's behalf, and a default would be a name "
+            "the caller did not choose that a later save would overwrite."
+        ),
+    },
+    {
+        "rule": "name_is_not_a_bool",
+        "requires": "The name is not a bool.",
+        "why": (
+            "str(True) is 'True', a perfectly ordinary stem, so a bool that reached a "
+            "save path would create a map named for a flag. The refusal names the type "
+            "so the caller sees the argument they passed, not the file it would make."
+        ),
+    },
+    {
+        "rule": "name_is_a_string",
+        "requires": "The name is a str.",
+        "why": (
+            "A non-string has no path-component answer. An int map index or a Path is a "
+            "caller mistake this lookup reports rather than coerces, because coercing "
+            "picks the spelling (str(Path('a/b')) is 'a/b') the next rule would refuse."
+        ),
+    },
+    {
+        "rule": "name_is_not_empty",
+        "requires": "The name is not the empty string.",
+        "why": (
+            "An empty name is the one candidate that breaks the listing round trip. It "
+            "makes the file '.npz', whose stem is '.npz' rather than '', so the listing "
+            "reports the name '.npz' and loading that name looks for '.npz.npz' - a map "
+            "saved, listed under a name, and not loadable by it."
+        ),
+    },
+    {
+        "rule": "name_is_one_path_component",
+        "requires": "The name carries no path separator and no NUL.",
+        "why": (
+            "This is the containment rule. A name with a separator is a path, and a path "
+            "decides for itself where it lands: '../maps-evil/pwn' escapes a '~/maps' "
+            "root that a string-prefix containment test still calls contained, and "
+            "'sub/dir' stays inside but under a subdirectory the flat top-level listing "
+            "cannot report. One component cannot do either."
+        ),
+    },
+    {
+        "rule": "name_is_not_a_dot_component",
+        "requires": "The name is not '.' or '..'.",
+        "why": (
+            "Both name a directory rather than a file. A writer that appends a suffix "
+            "makes them inert filenames ('..npz'), and one that joins the name as its "
+            "own component does not, so refusing them keeps an admitted name safe to "
+            "interpolate at either position."
+        ),
+    },
+)
+
+
+def _refuse(rule: str, reason: str) -> dict[str, Any]:
+    """Build the refusal envelope every rule returns.
+
+    One helper so the ``status`` / ``refusal_text`` / ``rule`` / ``reason``
+    shape is identical across the six rules, and so a caller can key on
+    ``rule`` without also parsing ``reason``: the id is the stable half and
+    the prose is the readable one.
+
+    Args:
+        rule: The id of the refusing rule, one of the ``rule`` values
+            :func:`g1_list_slam_map_name_rules` reports.
+        reason: Why this argument was refused, naming the argument.
+
+    Returns:
+        The refusal dict, carrying the bundle's own verdict string in
+        ``refusal_text``.
+    """
+    return {
+        "status": "error",
+        "refusal_text": _REFUSAL_TEXT,
+        "rule": rule,
+        "reason": reason,
+    }
+
+
+@tool
+def g1_list_slam_map_name_rules() -> dict[str, Any]:
+    """Return the rules a SLAM map name has to satisfy, and where such a name is a name.
+
+    Read-only. No driver instance, no DDS, no SDK, no filesystem: every
+    field is a module-level constant. Useful before ``g1_slam_save`` /
+    ``g1_slam_load`` on the neon side, or before a future driver-side map
+    verb here, so a caller can author a name that will be admitted instead
+    of discovering the refusal at save time - and so an agent that has to
+    *explain* a refusal reads the same ``why`` text this lookup refused on.
+
+    Returns:
+        A dict with ``status``; ``map_root`` naming the directory an
+        admitted name is a name in (``~/maps``, unexpanded - see
+        :data:`_MAP_ROOT_SPEC`); ``map_suffix`` naming the suffix a writer
+        appends (``.npz``); ``listed_suffixes`` naming every suffix the
+        bundle's listing enumerates, in its own chaining order;
+        ``refused_characters`` naming the characters that make a candidate
+        more than one component, as printable labels rather than as the
+        characters themselves; ``refused_components`` naming the two
+        traversal tokens, sorted; ``count`` naming the number of rules; a
+        ``rules`` list of descriptors in application order, each carrying
+        ``rule``, ``requires`` and ``why``; and ``refusal_text`` naming the
+        single verdict string a refusal reports.
+    """
+    return {
+        "status": "success",
+        "map_root": _MAP_ROOT_SPEC,
+        "map_suffix": _MAP_SUFFIX,
+        "listed_suffixes": list(_LISTED_SUFFIXES),
+        "refused_characters": list(_REFUSED_CHARACTER_LABELS),
+        "refused_components": sorted(_REFUSED_COMPONENTS),
+        "count": len(_RULES),
+        "rules": [dict(rule) for rule in _RULES],
+        "refusal_text": _REFUSAL_TEXT,
+    }
+
+
+@tool
+def g1_slam_map_name_admits(name: str | None = None) -> dict[str, Any]:
+    """Decide whether ``name`` is a SLAM map name a save or load path can take.
+
+    Read-only. Compares one argument against the rule set
+    :func:`g1_list_slam_map_name_rules` reports and returns the filename an
+    admitted name becomes, or the refusing rule and the bundle's own
+    ``invalid map name`` verdict on a miss. No driver instance, no DDS, no
+    SDK, and no filesystem access: the decision reads module-level
+    constants and the argument, which is what makes it answerable before
+    ``~/maps`` exists and identical on every host.
+
+    An admitted name is not the same as an admitted save. The name is
+    guaranteed to land directly inside the map root and nowhere else, and
+    to round-trip through the listing; it is *not* guaranteed to be unused
+    (a save overwrites a map of the same name), to be short enough for the
+    destination filesystem's per-name byte limit, or to be distinct from an
+    existing map under a case-insensitive volume. Those three are reads of
+    the destination, and this verb refuses to guess at them rather than
+    report an admission it cannot support.
+
+    Args:
+        name: The map name to check - the stem a writer appends
+            ``.npz`` to, not a path and not a filename. Must be a
+            non-empty ``str`` that is one path component (no ``/``, no
+            ``\\``, no NUL) and is not ``.`` or ``..``. ``bool`` is
+            refused ahead of the general type rule because ``str(True)``
+            is an ordinary stem and a flag that reached a save path would
+            create a map named for it. A missing argument (``None``) is
+            refused decidably rather than treated as a default.
+
+    Returns:
+        A dict with ``status``. On admit: ``name`` echoing the argument,
+        ``filename`` naming what a writer creates (``<name>.npz``),
+        ``map_root`` naming the directory it is created in, and
+        ``listed_suffixes`` naming the suffixes the listing reports it
+        under. On refuse: ``refusal_text`` carrying the bundle's verdict
+        string, ``rule`` naming the refusing rule id (one of the
+        ``rule`` values the listing verb reports), and ``reason``
+        naming the argument and why it was refused.
+    """
+    if name is None:
+        return _refuse(
+            "name_is_required",
+            "name is required; pass the stem of the map file (for example 'office') so "
+            "the lookup is decidable. Refs strands-labs/robots#358.",
+        )
+    if isinstance(name, bool):
+        return _refuse(
+            "name_is_not_a_bool",
+            f"name={name!r} is a bool; pass the map's stem as a str, because str({name!r}) "
+            f"is {str(name)!r} and would name a map after a flag. "
+            "Refs strands-labs/robots#358.",
+        )
+    if not isinstance(name, str):
+        return _refuse(
+            "name_is_a_string",
+            f"name={name!r} is not a str; pass the map's stem as a str rather than a path "
+            "object or an index. Refs strands-labs/robots#358.",
+        )
+    if not name:
+        return _refuse(
+            "name_is_not_empty",
+            f"name is the empty string; it would create the file {_MAP_SUFFIX!r}, which the "
+            f"listing reports under the name {_MAP_SUFFIX!r} and which loading that name "
+            "cannot find. Pass a non-empty stem. Refs strands-labs/robots#358.",
+        )
+    for character, label in zip(_REFUSED_CHARACTERS, _REFUSED_CHARACTER_LABELS, strict=True):
+        if character in name:
+            return _refuse(
+                "name_is_one_path_component",
+                f"name={name!r} contains {label}; a map name is one path component, so it "
+                f"names a file directly inside {_MAP_ROOT_SPEC} and cannot select another "
+                "directory. Refs strands-labs/robots#358.",
+            )
+    if name in _REFUSED_COMPONENTS:
+        return _refuse(
+            "name_is_not_a_dot_component",
+            f"name={name!r} names a directory rather than a file; pass the stem of a map "
+            f"file instead of one of {sorted(_REFUSED_COMPONENTS)}. "
+            "Refs strands-labs/robots#358.",
+        )
+    return {
+        "status": "success",
+        "name": name,
+        "filename": f"{name}{_MAP_SUFFIX}",
+        "map_root": _MAP_ROOT_SPEC,
+        "listed_suffixes": list(_LISTED_SUFFIXES),
+    }

--- a/tests/drivers/test_g1_slam_map_names_admits_one_path_component.py
+++ b/tests/drivers/test_g1_slam_map_names_admits_one_path_component.py
@@ -1,0 +1,530 @@
+"""The SLAM map-name lookup admits one path component and refuses the bundle's escape.
+
+:mod:`strands_robots.tools.g1.g1_slam_map_names` ports the containment
+decision behind the neon bundle's ``g1_slam_save`` / ``g1_slam_load``
+(``cagataycali/neon-the-g1/tools/g1_slam.py``, ``_SlamRunner._safe_map_path``)
+as two agent-facing verbs. The port deliberately does *not* reproduce the
+bundle's rule: the bundle joins the caller's name onto ``~/maps``, resolves
+the result and tests containment by string prefix, which admits a sibling
+directory whose name begins with the root's name. The module decides the
+name before any join instead, so containment is structural.
+
+The cells here grade three things:
+
+1. **The snapshot.** The root spelling, the suffixes and the refused sets
+   are read off the module's own constants rather than restated, so a widen
+   or narrow surfaces here as a shape change instead of as a table this
+   file would have to be remembered into.
+2. **The correction.** :func:`test_the_bundle_prefix_rule_admits_an_escape_this_lookup_refuses`
+   reimplements the bundle's check locally, against a temporary root, and
+   pins both halves: the prefix rule admits ``../<root>-evil/pwn`` and the
+   resulting path is outside the root, while the verb refuses that name.
+   That cell is the reason the port exists; without it the corrected rule
+   is indistinguishable from a transcription.
+3. **The structural guarantee.** Every admitted name joins to a file
+   directly inside an arbitrary root, checked by path algebra rather than
+   by writing anything.
+
+Two things these cells do not pin:
+
+* The filesystem's answer. Nothing here creates ``~/maps``, writes a map
+  or reads one: the verbs make no filesystem call, which is the property
+  under test in :func:`test_the_decision_reads_no_filesystem_state`, and a
+  test that touched the disk to check it would be asserting about the disk.
+* Whether an admitted name is free, short enough for the destination's
+  per-name byte limit, or distinct from an existing map on a
+  case-insensitive volume. The module's docstring names all three as reads
+  of the destination it does not make, and its returned payload claims none
+  of them.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.tools.g1.g1_slam_map_names import (
+    _LISTED_SUFFIXES,
+    _MAP_ROOT_SPEC,
+    _MAP_SUFFIX,
+    _REFUSAL_TEXT,
+    _REFUSED_CHARACTER_LABELS,
+    _REFUSED_CHARACTERS,
+    _REFUSED_COMPONENTS,
+    _RULES,
+    g1_list_slam_map_name_rules,
+    g1_slam_map_name_admits,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function when
+    called in-process, but a caller cannot rely on that: the wrapper's
+    contract is that it returns the wrapped function's return value
+    verbatim. This helper is where a shape drift would surface once,
+    rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def _bundle_admits(root: Path, name: str) -> Path | None:
+    """The neon bundle's ``_safe_map_path``, verbatim but parameterised on its root.
+
+    ``cagataycali/neon-the-g1/tools/g1_slam.py`` reads its root off a
+    module-level ``MAPS_DIR = Path.home() / "maps"``; the root is an
+    argument here so the cell that grades the rule can point it at a
+    ``tmp_path`` and assert about a real filesystem layout without
+    depending on the runner's home directory. The body is otherwise
+    unchanged - the join, the ``resolve``, and the ``str(...).startswith``
+    containment test - because a paraphrase would grade a rule the bundle
+    does not have.
+    """
+    try:
+        path = (root / f"{name}{_MAP_SUFFIX}").resolve()
+    except Exception:
+        return None
+    if not str(path).startswith(str(root.resolve())):
+        return None
+    return path
+
+
+def test_the_import_pulls_no_sdk_or_slam_stack() -> None:
+    """The tool module is loadable without the SDK and without the SLAM stack.
+
+    Every file under :mod:`strands_robots.tools.g1` must import with
+    ``unitree_sdk2py`` absent (refs strands-labs/robots#358). This module
+    carries a second half: the bundle's ``g1_slam`` module imports
+    ``numpy`` at module scope and ``open3d`` behind a ``try``, and drives
+    ``kiss_icp`` in its worker, none of which a name decision needs. A
+    lookup that pulled any of them would make the decision unavailable on
+    exactly the hosts that have to author a name before the SLAM extra is
+    installed.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_slam_map_names")
+    after = set(sys.modules)
+    leaked = {
+        name
+        for name in after - before
+        if any(probe in name.lower() for probe in ("unitree", "open3d", "kiss_icp", "numpy"))
+    }
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_slam_map_names imports pulled {leaked}. The rule for "
+        "this package is that the SDK loads only inside function bodies, and this module's "
+        "decision needs no array or registration library at all "
+        "(refs strands-labs/robots#358)."
+    )
+
+
+def test_the_map_root_is_named_unexpanded() -> None:
+    """The root is the ``~/maps`` spelling, not a resolved home directory.
+
+    The module states the root without expanding it so the reported rule
+    set does not vary with ``$HOME``: a headless CI runner and an
+    operator's shell have to report the same field, and an expansion here
+    would also reintroduce the resolved root the bundle's joined-then-
+    tested check needed.
+    """
+    assert _MAP_ROOT_SPEC == "~/maps"
+    assert _MAP_ROOT_SPEC.startswith("~"), "an expanded root would vary with the deciding host's home"
+    assert not Path(_MAP_ROOT_SPEC).is_absolute()
+
+
+def test_the_suffixes_match_the_bundle_writer_and_listing() -> None:
+    """One suffix is written; two are listed, in the bundle's chaining order.
+
+    ``save_map`` writes ``.npz`` only, while ``list_maps`` chains
+    ``glob("*.npz")`` ahead of ``glob("*.npy")`` and dedupes on the stem -
+    so the order is what decides which of two same-stem files the listing
+    reports, and it is pinned rather than sorted.
+    """
+    assert _MAP_SUFFIX == ".npz"
+    assert _LISTED_SUFFIXES == (".npz", ".npy")
+    assert _LISTED_SUFFIXES[0] == _MAP_SUFFIX
+    assert isinstance(_LISTED_SUFFIXES, tuple), "a mutable listing order could be reordered by a caller"
+
+
+def test_the_refused_characters_cover_both_separators_and_nul() -> None:
+    """Both path separators and NUL are refused on every platform.
+
+    Keyed on literals rather than on ``os.sep`` / ``os.altsep`` because a
+    map name is authored on one host and used on others: a rule that read
+    the deciding host's separator would admit ``a\\b`` on Linux and then
+    have it name a directory the first time the same string reached a
+    Windows path.
+    """
+    assert _REFUSED_CHARACTERS == ("/", "\\", "\x00")
+    assert len(_REFUSED_CHARACTER_LABELS) == len(_REFUSED_CHARACTERS)
+
+
+def test_the_refused_character_labels_are_printable_ascii() -> None:
+    """The labels a payload quotes carry no NUL and no non-ASCII.
+
+    A returned payload is text an agent reads back. Quoting the refused
+    characters themselves would put a NUL inside it, which truncates the
+    rest of the string for any consumer that treats the payload as a C
+    string - so the labels are what the verbs report, and they have to be
+    safe to report.
+    """
+    for label in _REFUSED_CHARACTER_LABELS:
+        assert label.isascii(), f"{label!r} is not ASCII"
+        assert "\x00" not in label
+        assert label.strip() == label
+
+
+def test_the_refused_components_are_the_two_traversal_tokens() -> None:
+    """Exactly ``.`` and ``..``, held immutably.
+
+    These are the only two strings that name a directory rather than a
+    file in every path context; the set is a ``frozenset`` so a caller
+    holding the module cannot widen the admitted set by mutating it.
+    """
+    assert _REFUSED_COMPONENTS == frozenset({".", ".."})
+    assert isinstance(_REFUSED_COMPONENTS, frozenset)
+
+
+def test_the_rule_ids_are_unique_and_ordered_as_applied() -> None:
+    """Each rule is named once, and the order is the application order.
+
+    The order is load-bearing: the type rules precede the content rules
+    because a non-string has no characters to scan, and ``name_is_not_a_bool``
+    precedes ``name_is_a_string`` so a caller who passed a flag reads that
+    word rather than a general type refusal.
+    """
+    ids = [rule["rule"] for rule in _RULES]
+    assert len(ids) == len(set(ids)), f"a rule id is reported twice: {ids}"
+    assert ids == [
+        "name_is_required",
+        "name_is_not_a_bool",
+        "name_is_a_string",
+        "name_is_not_empty",
+        "name_is_one_path_component",
+        "name_is_not_a_dot_component",
+    ]
+
+
+def test_every_rule_descriptor_carries_the_three_fields() -> None:
+    """A rule names its id, what it requires, and the consequence of admitting a miss.
+
+    ``why`` is the field an agent quotes when it has to explain a refusal
+    to an operator, so an empty one is a rule that cannot be explained.
+    """
+    for rule in _RULES:
+        assert set(rule) == {"rule", "requires", "why"}
+        for field, value in rule.items():
+            assert value.strip(), f"rule {rule['rule']!r} has an empty {field}"
+            assert value.isascii(), f"rule {rule['rule']!r} has a non-ASCII {field}"
+
+
+def test_the_listing_reports_the_snapshot() -> None:
+    """The listing verb reports every constant, and the rule count matches the list."""
+    payload = _call(g1_list_slam_map_name_rules)
+    assert payload["status"] == "success"
+    assert payload["map_root"] == _MAP_ROOT_SPEC
+    assert payload["map_suffix"] == _MAP_SUFFIX
+    assert payload["listed_suffixes"] == list(_LISTED_SUFFIXES)
+    assert payload["refused_characters"] == list(_REFUSED_CHARACTER_LABELS)
+    assert payload["refused_components"] == sorted(_REFUSED_COMPONENTS)
+    assert payload["count"] == len(_RULES)
+    assert [rule["rule"] for rule in payload["rules"]] == [rule["rule"] for rule in _RULES]
+    assert payload["refusal_text"] == _REFUSAL_TEXT
+
+
+def test_the_listing_reports_labels_rather_than_the_characters() -> None:
+    """No raw separator-or-NUL character reaches the returned payload.
+
+    The NUL half is the one that matters: a payload carrying it is
+    truncated for any consumer that reads it as a C string, and the
+    truncation is silent.
+    """
+    payload = _call(g1_list_slam_map_name_rules)
+    for reported in payload["refused_characters"]:
+        assert "\x00" not in reported
+    assert "\x00" not in repr(payload["rules"])
+
+
+def test_the_listing_hands_out_copies() -> None:
+    """A caller mutating the returned rules does not widen the module's own set."""
+    first = _call(g1_list_slam_map_name_rules)
+    first["rules"][0]["rule"] = "mutated"
+    first["listed_suffixes"].append(".bogus")
+    second = _call(g1_list_slam_map_name_rules)
+    assert second["rules"][0]["rule"] == "name_is_required"
+    assert second["listed_suffixes"] == list(_LISTED_SUFFIXES)
+    assert _RULES[0]["rule"] == "name_is_required"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "office",
+        "office-2",
+        "office_2",
+        "lab.floor2",
+        "Map",
+        "map",
+        "a",
+        "...",
+        ".hidden",
+        "office.npz",
+        "office.npy",
+        "  spaced  ",
+        "-leading-dash",
+    ],
+)
+def test_an_ordinary_stem_is_admitted(name: str) -> None:
+    """A single component is admitted, and the payload names the file it becomes.
+
+    ``.hidden`` is admitted deliberately: ``Path.glob`` matches a leading
+    dot, so the bundle's listing reports it and the name round-trips.
+    ``office.npz`` is admitted too - it becomes ``office.npz.npz``, whose
+    stem is ``office.npz``, so that name round-trips as well.
+    """
+    payload = _call(g1_slam_map_name_admits, name=name)
+    assert payload["status"] == "success", payload
+    assert payload["name"] == name
+    assert payload["filename"] == f"{name}{_MAP_SUFFIX}"
+    assert payload["map_root"] == _MAP_ROOT_SPEC
+    assert payload["listed_suffixes"] == list(_LISTED_SUFFIXES)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["office", "lab.floor2", ".hidden", "office.npz", "..."],
+)
+def test_an_admitted_name_round_trips_through_the_listing(name: str) -> None:
+    """The stem the listing would report for an admitted name is that name.
+
+    Path algebra only - nothing is written. The bundle's listing reports
+    ``p.stem`` for each globbed file and a caller loads what it read back,
+    so a name whose file has a different stem is a map that is listed
+    under a name it cannot be loaded by. That is exactly what the empty
+    name does, which is why it is refused rather than admitted.
+    """
+    assert _call(g1_slam_map_name_admits, name=name)["status"] == "success"
+    assert Path(f"{name}{_MAP_SUFFIX}").stem == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["office", "lab.floor2", ".hidden", "...", "office.npz"],
+)
+def test_an_admitted_name_joins_directly_inside_any_root(name: str, tmp_path: Path) -> None:
+    """Containment is structural: the joined path's parent is the root itself.
+
+    Checked against a ``tmp_path`` root rather than ``~/maps`` to make the
+    point that the guarantee is a property of the name and not of one
+    particular directory. ``is_relative_to`` alone would also accept a
+    subdirectory, so the parent is compared as well.
+    """
+    root = tmp_path / "maps"
+    payload = _call(g1_slam_map_name_admits, name=name)
+    joined = root / payload["filename"]
+    assert joined.parent == root
+    assert joined.is_relative_to(root)
+    assert len(joined.relative_to(root).parts) == 1
+
+
+def test_a_missing_name_is_refused_decidably() -> None:
+    """No default name; the refusal names the rule and the bundle's verdict."""
+    payload = _call(g1_slam_map_name_admits)
+    assert payload["status"] == "error"
+    assert payload["rule"] == "name_is_required"
+    assert payload["refusal_text"] == _REFUSAL_TEXT
+    assert "name is required" in payload["reason"]
+
+
+@pytest.mark.parametrize("name", [True, False])
+def test_a_bool_is_refused_ahead_of_the_general_type_rule(name: bool) -> None:
+    """A flag is reported as a flag, because ``str(True)`` is an ordinary stem.
+
+    A general type refusal would be true but unhelpful here: the caller's
+    mistake is that the argument is a flag, and the consequence is a map
+    file named ``True.npz``, so the refusal says so.
+    """
+    payload = _call(g1_slam_map_name_admits, name=name)
+    assert payload["status"] == "error"
+    assert payload["rule"] == "name_is_not_a_bool"
+    assert "bool" in payload["reason"]
+    assert str(name) in payload["reason"]
+
+
+@pytest.mark.parametrize("name", [0, 1, 2.5, ["office"], {"name": "office"}, Path("office")])
+def test_a_non_string_is_refused(name: Any) -> None:
+    """A path object or an index is reported rather than coerced.
+
+    Coercing would pick the spelling the containment rule then refuses -
+    ``str(Path("a/b"))`` is ``"a/b"`` - and report the wrong rule for the
+    caller's actual mistake.
+    """
+    payload = _call(g1_slam_map_name_admits, name=name)
+    assert payload["status"] == "error"
+    assert payload["rule"] == "name_is_a_string"
+
+
+def test_the_empty_name_is_refused_and_the_refusal_names_the_round_trip() -> None:
+    """The empty name is the one candidate the listing cannot round-trip.
+
+    It makes the file ``.npz``, and ``Path(".npz").stem`` is ``".npz"``
+    rather than ``""`` - so the listing reports the name ``.npz``, and
+    loading that name looks for ``.npz.npz``. Both halves are asserted
+    here: the path algebra that makes it a round-trip break, and the
+    refusal that reports it.
+    """
+    assert Path(_MAP_SUFFIX).stem == _MAP_SUFFIX
+    assert Path(f"{_MAP_SUFFIX}{_MAP_SUFFIX}").stem == _MAP_SUFFIX
+    payload = _call(g1_slam_map_name_admits, name="")
+    assert payload["status"] == "error"
+    assert payload["rule"] == "name_is_not_empty"
+    assert _MAP_SUFFIX in payload["reason"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "sub/dir",
+        "/absolute",
+        "../sibling",
+        "../../etc/passwd",
+        "windows\\path",
+        "trailing/",
+        "nul\x00byte",
+    ],
+)
+def test_a_name_that_is_more_than_one_component_is_refused(name: str) -> None:
+    """A separator or a NUL makes the string a path, and a path decides its own landing site."""
+    payload = _call(g1_slam_map_name_admits, name=name)
+    assert payload["status"] == "error"
+    assert payload["rule"] == "name_is_one_path_component"
+    assert payload["refusal_text"] == _REFUSAL_TEXT
+
+
+def test_a_refusal_reason_escapes_a_nul_rather_than_carrying_it() -> None:
+    """The reason quotes the offending name through ``repr``, so a NUL is escaped.
+
+    Interpolating the name raw would put the NUL in the payload the caller
+    reads back, truncating everything the refusal says after it.
+    """
+    payload = _call(g1_slam_map_name_admits, name="nul\x00byte")
+    assert "\x00" not in payload["reason"]
+    assert "\\x00" in payload["reason"]
+
+
+@pytest.mark.parametrize("name", [".", ".."])
+def test_a_dot_component_is_refused(name: str) -> None:
+    """Both traversal tokens are refused even though the flat writer makes them inert.
+
+    ``.`` becomes the filename ``..npz`` under a writer that appends a
+    suffix, so admitting it breaks nothing today. It is refused so that an
+    admitted name is safe to interpolate as a component too - a writer
+    that gave each map its own directory would escape on exactly these two
+    strings.
+    """
+    payload = _call(g1_slam_map_name_admits, name=name)
+    assert payload["status"] == "error"
+    assert payload["rule"] == "name_is_not_a_dot_component"
+
+
+def test_every_rule_in_the_listing_is_reachable() -> None:
+    """Each advertised rule is the one some candidate actually gets refused by.
+
+    Derived by driving the verb, not by restating the table: a rule that
+    no input can reach is documentation for a refusal that never happens,
+    and a rule reachable only by an input the listing does not describe is
+    the same drift in the other direction.
+    """
+    candidates: list[Any] = [None, True, 0, "", "sub/dir", "."]
+    reached = set()
+    for candidate in candidates:
+        payload = (
+            _call(g1_slam_map_name_admits) if candidate is None else _call(g1_slam_map_name_admits, name=candidate)
+        )
+        assert payload["status"] == "error", candidate
+        reached.add(payload["rule"])
+    assert reached == {rule["rule"] for rule in _RULES}
+
+
+def test_every_refusal_carries_the_bundle_verdict_and_the_issue_reference() -> None:
+    """One verdict string for one verdict, and every reason cites the porting issue."""
+    for candidate in (None, True, 0, "", "sub/dir", "."):
+        payload = (
+            _call(g1_slam_map_name_admits) if candidate is None else _call(g1_slam_map_name_admits, name=candidate)
+        )
+        assert payload["refusal_text"] == _REFUSAL_TEXT
+        assert "strands-labs/robots#358" in payload["reason"]
+        assert payload["reason"].isascii()
+
+
+def test_the_bundle_prefix_rule_admits_an_escape_this_lookup_refuses(tmp_path: Path) -> None:
+    """The corrected rule, pinned against the rule it replaces.
+
+    The bundle joins the name onto its root, resolves, and tests
+    containment with ``str(path).startswith(str(root))``. A sibling
+    directory whose name begins with the root's name satisfies that
+    prefix, so the escape is admitted and the write lands outside the
+    root. This lookup refuses the same name on the containment rule,
+    before any join.
+    """
+    root = tmp_path / "maps"
+    escape = f"../{root.name}-evil/pwn"
+
+    landed = _bundle_admits(root, escape)
+    assert landed is not None, "the bundle's prefix rule admits this name"
+    assert not landed.is_relative_to(root.resolve()), "and the admitted name lands outside the root"
+    assert landed == (tmp_path / f"{root.name}-evil" / f"pwn{_MAP_SUFFIX}")
+
+    payload = _call(g1_slam_map_name_admits, name=escape)
+    assert payload["status"] == "error"
+    assert payload["rule"] == "name_is_one_path_component"
+
+
+def test_the_bundle_prefix_rule_admits_a_subdirectory_the_listing_cannot_report(tmp_path: Path) -> None:
+    """The second half of the same defect: contained, but not listable.
+
+    ``sub/dir`` stays inside the root and is therefore admitted by the
+    prefix test, but the bundle's listing globs the top level only
+    (``MAPS_DIR.glob("*.npz")``), so the map is saved and then invisible
+    to the caller who saved it. Asserted as path algebra - the joined
+    path is two components deep - rather than by writing a file.
+    """
+    root = tmp_path / "maps"
+
+    landed = _bundle_admits(root, "sub/dir")
+    assert landed is not None
+    assert landed.is_relative_to(root.resolve())
+    assert len(landed.relative_to(root.resolve()).parts) == 2, "so a top-level glob does not report it"
+
+    payload = _call(g1_slam_map_name_admits, name="sub/dir")
+    assert payload["status"] == "error"
+    assert payload["rule"] == "name_is_one_path_component"
+
+
+def test_the_decision_reads_no_filesystem_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The verbs answer identically whatever ``$HOME`` is and whether ``~/maps`` exists.
+
+    The bundle's root is ``Path.home() / "maps"``, so a decision that
+    consulted it would move with the environment. Both verbs are driven
+    under two different homes - one with a populated ``maps`` directory,
+    one with no home directory at all - and required to return byte-equal
+    payloads.
+    """
+    populated = tmp_path / "home-with-maps"
+    (populated / "maps").mkdir(parents=True)
+    (populated / "maps" / f"office{_MAP_SUFFIX}").write_bytes(b"")
+
+    monkeypatch.setenv("HOME", str(populated))
+    monkeypatch.setenv("USERPROFILE", str(populated))
+    with_maps = (_call(g1_list_slam_map_name_rules), _call(g1_slam_map_name_admits, name="office"))
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home-that-is-absent"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home-that-is-absent"))
+    without_maps = (_call(g1_list_slam_map_name_rules), _call(g1_slam_map_name_admits, name="office"))
+
+    assert with_maps == without_maps
+    assert with_maps[1]["status"] == "success"


### PR DESCRIPTION
## Summary

Ports the containment decision behind the neon bundle's SLAM map save/load path (`cagataycali/neon-the-g1/tools/g1_slam.py`, `_SlamRunner._safe_map_path`) into two agent-facing lookups. The name that decision guards is model-authored text: `g1_slam_save(name)` is a `@tool`, and an admitted name becomes a filesystem path a moment later.

**This is not a transcription of that check.** The bundle's rule admits an escape, so the port decides the same question differently and pins both halves.

## The rule being replaced

The bundle joins first and tests the joined string afterwards:

```python
path = (MAPS_DIR / f"{name}.npz").resolve()
if not str(path).startswith(str(MAPS_DIR.resolve())):
    return None
```

A resolved path compared to the root by *string prefix* is satisfied by a sibling directory whose name merely begins with the root's name. Measured against `MAPS_DIR = ~/maps`, resolved against the deciding host's home, spelled `$HOME` below:

| `name` | joined and resolved | bundle's verdict |
|---|---|---|
| `ok` | `$HOME/maps/ok.npz` | admitted |
| `../maps-evil/pwn` | `$HOME/maps-evil/pwn.npz` | **admitted** |
| `../maps.ssh/x` | `$HOME/maps.ssh/x.npz` | **admitted** |
| `sub/dir` | `$HOME/maps/sub/dir.npz` | **admitted** |
| `../../etc/passwd` | (no shared prefix) | refused |
| `/etc/passwd` | (no shared prefix) | refused |
| `''` | `$HOME/maps/.npz` | **admitted** |

So it refuses the traversal that leaves the parent and admits the one that lands *beside* the root. Two of those admitted names write outside `~/maps` entirely; `sub/dir` stays inside but under a subdirectory the top-level `MAPS_DIR.glob("*.npz")` listing cannot report, so the map is saved and then invisible to the caller who saved it.

The empty name is a third, separate break: it makes the file `.npz`, and `Path(".npz").stem` is `".npz"` rather than `""`, so the listing reports the name `.npz` and loading *that* name looks for `.npz.npz`. A map listed under a name it cannot be loaded by.

## What lands

- **`g1_slam_map_name_admits`** decides one candidate *before* any join, on the name alone: admitted only when it is a single path component that is not a traversal token. Containment is then structural rather than tested -- `root / f"{name}.npz"` for an admitted name cannot be anywhere but directly inside `root`, whatever the root is and whatever the caller resolves afterwards. Six rules, applied in a pinned order, each reporting its own `rule` id beside the bundle's own `invalid map name` verdict string:
  - `name_is_required` -- refused decidably, not defaulted
  - `name_is_not_a_bool` -- ahead of the general type rule, because `str(True)` is an ordinary stem and the caller's mistake is that they passed a flag
  - `name_is_a_string` -- reported rather than coerced, because coercing picks the spelling (`str(Path("a/b"))`) the next rule would refuse and then reports the wrong rule
  - `name_is_not_empty` -- the refusal names the round-trip break above
  - `name_is_one_path_component` -- the containment rule: no `/`, no `\`, no NUL
  - `name_is_not_a_dot_component` -- `.` and `..`
- **`g1_list_slam_map_name_rules`** names the whole rule set, the map root, the suffix a writer appends, the suffixes the listing enumerates (in the bundle's own chaining order, which is what decides which of two same-stem files it reports), and a `why` per rule -- the field an agent quotes when it has to explain a refusal to an operator.

### Two design choices worth naming

**Both separators are refused on every platform**, stated as literals rather than read off `os.sep` / `os.altsep`. A map name travels: authored by an agent, written on the robot, listed on an operator's laptop, asserted in CI. A rule keyed on the deciding host's separator would admit `a\b` on Linux as an ordinary filename and then have it name a directory the first time the same string reached a Windows path.

**The root is stated unexpanded (`~/maps`) and never joined.** Expanding it would read `$HOME` at import, so the rule set a headless runner reports and the one an operator's shell reports would differ on a field that has nothing to do with the rules -- and a resolved root is what invites the joined-then-tested shape this module exists to replace. `test_the_decision_reads_no_filesystem_state` drives both verbs under two different homes (one with a populated `maps/`, one with no home at all) and requires byte-equal payloads.

`.` and `..` are refused even though the bundle's suffix-appending writer makes them inert (`.` becomes the filename `..npz`), so refusing them changes no working call. The reason is positional: an admitted name stays safe to interpolate as a *component* too, and a future writer that gave each map its own directory would escape on exactly those two strings.

## Refused characters are reported as labels, not as characters

A returned payload is text an agent reads back. Quoting the refused set verbatim would put a NUL inside it, which silently truncates everything after it for any consumer that treats the payload as a C string -- so the payload carries `"'/' (forward slash)"`, `"'\\' (backslash)"`, `"NUL (0x00)"`, and the refusal interpolates the offending name through `repr` so a NUL arrives escaped as `\x00`. Two cells pin that.

## Import hygiene

Read-only, no driver instance, no DDS, no SDK -- and no array or registration library either: `import strands_robots.tools.g1.g1_slam_map_names` pulls **no** `unitree_sdk2py` submodule, **no** `numpy`, **no** `open3d`, **no** `kiss_icp`. The bundle's `g1_slam` module imports `numpy` at module scope and `open3d` behind a `try`; a name decision needs none of it, and a lookup that pulled any would be unavailable on exactly the hosts that have to author a name before the SLAM extra is installed. One test fixes all four at CI.

## Tests

59 tests in `tests/drivers/test_g1_slam_map_names_admits_one_path_component.py`, all passing locally:

- 1 import-hygiene test (SDK + SLAM stack)
- 8 snapshot-fidelity tests (unexpanded root, suffixes and their order, both separators + NUL, labels are printable ASCII, the two traversal tokens, rule ids unique and ordered as applied, every descriptor carries `rule`/`requires`/`why`)
- 3 listing-shape tests (reports the snapshot, reports labels rather than characters, hands out copies)
- 13 admitted-name cells + 5 round-trip cells + 5 structural-containment cells (the joined path's parent *is* the root, checked against a `tmp_path` root so the guarantee is a property of the name and not of one directory)
- 15 refusal cells covering every rule, plus `name_is_one_path_component` over 7 shapes
- 1 reachability test deriving the reached rule set by *driving* the verb and requiring it to equal the advertised set -- a rule no input can reach is documentation for a refusal that never happens
- 1 test that every refusal carries the bundle's verdict string, cites `strands-labs/robots#358`, and is ASCII
- **2 correction cells**: `test_the_bundle_prefix_rule_admits_an_escape_this_lookup_refuses` reimplements the bundle's check verbatim against a `tmp_path` root and pins that it admits `../<root>-evil/pwn`, that the admitted path is outside the root, and that this verb refuses the same name. Its sibling pins the `sub/dir` half. Without these two the corrected rule is indistinguishable from a transcription.
- 1 filesystem-independence test (two homes, byte-equal payloads)

Nothing in the file writes a map or creates `~/maps`; every containment claim is path algebra.

## Gates

- `ruff check` clean; `ruff format --check` clean
- `mypy` clean on both files (zero errors; the pre-existing errors elsewhere in the tree are unrelated)
- Whole-tree graders run, not just the diff-scoped selector (refs #2940): `tests/test_no_host_paths.py` 26 passed, `tests/test_docstring_xref_roles_resolve.py` 25 passed, `tests/test_log_strings_are_ascii.py` 8 passed
- `tests/drivers -k "g1 or sdk_gated or native_driver"`: 1100 passed with this branch vs 1041 on the same tree with the two files removed, and the **same** 28 failures in both -- all `ModuleNotFoundError: No module named 'lerobot'` / `'mujoco'` on a base install, so none are attributable to this diff
- `scripts/check_duplicate_claim.py --repo strands-labs/robots --issue 358`: no competing claim

## What this is not

- **Not a save or load path.** There is no map I/O in this package yet. The rule lands ahead of the writer so a future driver-side SLAM verb reaches this decision instead of re-deriving one -- which is how the bundle got the prefix test.
- **Not a byte-length bound.** A 300-character name is admitted here and refused by the kernel at `open` with `ENAMETOOLONG`, because the limit is per-filesystem and counts *encoded* bytes. A number stated here would be one this module cannot know.
- **Not a freshness or collision answer.** Whether an admitted name is unused, or distinct from an existing map on a case-insensitive volume, are reads of the destination. The payload claims neither.

Refs #358.

---

## Round 1 changes

**Host-path grader, fixed in `35e9f3e`.** The module docstring measured the bundle's prefix escape against a concrete home directory. `tests/test_no_host_paths.py::test_no_host_specific_absolute_paths` applies `/home/[A-Za-z0-9._-]+` to every line of every committed `.py` file under the swept areas -- docstrings included -- and this module is not in the allowlist, which is reserved for files that are *about* the patterns. So the required `call-test-lint / Test and Lint` check could not go green on the previous head.

The measured table is now spelled `$HOME`, and the "on a host whose home is ..." clause names the deciding host's home instead of one runner's. The table loses nothing: the escape it documents is a property of the string-prefix test, not of one home directory, and the module's own unexpanded-root principle already argued for this spelling.

The same respelling is applied to the table in this description, so the description and the docstring do not drift.

Verified at `35e9f3e`:

| gate | result |
|---|---|
| `tests/test_no_host_paths.py` | 26 passed |
| `tests/drivers/test_g1_slam_map_names_admits_one_path_component.py` | 59 passed |
| `tests/test_docstring_xref_roles_resolve.py` | 25 passed |
| `tests/test_log_strings_are_ascii.py` | 8 passed |
| `ruff check` / `ruff format --check` | clean / 2 files already formatted |

The host-path sweep is now named in the Gates list above. Its absence there was the actual gap -- the list quoted the xref and ASCII graders and not this one, which is how a deterministic whole-tree failure reached review (refs #2940).