### PR TITLE
feat(tools/g1): port g1_slam_map_liveness_envelope lookup pair (refs #358)

### DIFF
--- a/changelog.d/3011-g1-tools-slam-map-liveness-envelope-port.md
+++ b/changelog.d/3011-g1-tools-slam-map-liveness-envelope-port.md
@@ -1,0 +1,25 @@
+### Added: g1_slam_map_liveness_envelope port names the neon SLAM relocalise precondition
+
+Ports the neon SLAM runner's ``_try_relocalize`` precondition
+(``cagataycali/neon-the-g1/tools/g1_slam.py`` reads
+``if _o3d is None or map_pts is None or len(map_pts) < 100: return None``)
+into a read-only agent-facing lookup pair in
+``strands_robots.tools.g1.g1_slam_map_liveness_envelope``. Twin of the
+merged ``g1_slam_relocalize_envelope`` (strands-labs/robots#3006), which
+names the match-quality dimensions on the same gate; this module names
+the point-count precondition the runner refuses before any ICP dispatch.
+
+- ``g1_list_slam_map_liveness_envelope()`` returns the envelope descriptor
+  (``point_count_min = 100``) plus the module-local refusal text a future
+  driver-side wrapper would surface on a below-floor map.
+- ``g1_slam_map_liveness_admits(point_count)`` reuses the shared
+  ``positive_count_error`` validator to refuse bool / non-int / value-below-one
+  shape mistakes decidably before the runner-observed floor is asked, then
+  grades the map-cardinality floor on top; refusals cite the module-local text
+  rather than borrowing the motion-FSM ``7404`` rc (which would name a
+  locomotion-FSM remedy for a map-cardinality argument).
+
+Import hygiene: the module pulls no ``unitree_sdk2py``, ``open3d`` or
+``kiss_icp`` submodule at load time -- a caller authoring a relocalise plan
+before any SLAM extra is installed still gets the floor back verbatim.
+Refs strands-labs/robots#358.

--- a/strands_robots/tools/g1/g1_slam_map_liveness_envelope.py
+++ b/strands_robots/tools/g1/g1_slam_map_liveness_envelope.py
@@ -1,0 +1,313 @@
+"""Agent-facing lookup for the map-liveness floor the neon SLAM runner admits a relocalise through.
+
+The neon bundle's SLAM runner
+(``cagataycali/neon-the-g1/tools/g1_slam.py::_SlamRunner._try_relocalize``)
+decides three things at once on a candidate ICP registration before
+it lets the fitted transform snap the runner's pose offset onto the
+map frame -- the ICP fitness must clear a floor, the fitted
+translation must not cross a ceiling, and the rotation trace must
+be non-negative (the three-dimension envelope
+:mod:`~strands_robots.tools.g1.g1_slam_relocalize_envelope` names).
+Before any of those three decisions runs, the runner first refuses
+on a *liveness* precondition:
+``if _o3d is None or map_pts is None or len(map_pts) < 100: return None``.
+The ``map_pts`` argument is the (N, K) LiDAR-return array the loaded
+map carries; a value of ``None`` names an unloaded / unsaved map,
+and a length below ``100`` names a map with too few point returns
+for an ICP registration to have a chance at correspondence.  The
+neon runner returns ``None`` on any of those three, which the
+caller reads as "no offset applied this frame".
+
+This module surfaces the point-count half of that liveness gate --
+the ``len(map_pts) >= 100`` floor -- as an agent-facing lookup pair
+so a caller planning a relocalise can decide the point-count
+precondition decidably before a future driver-side wrapper is
+called, rather than pinning the floor inside the write path where
+the refusal is invisible to the planner.  The ``_o3d is None`` and
+``map_pts is None`` halves belong on a future SLAM-liveness runner
+surface (whether the runner is up, whether a map is loaded) rather
+than this numeric envelope, because their refusals answer
+different remedies -- "install the SLAM extra" and "load a map"
+against "the loaded map is too sparse to fit against".
+
+Twin of :mod:`~strands_robots.tools.g1.g1_slam_relocalize_envelope`
+(the merged strands-labs/robots#3006), which names the
+match-quality dimensions on the same
+``_SlamRunner._try_relocalize`` gate.  The two modules stay
+separate because ``_try_relocalize`` reads them in order: this
+module's floor is a *precondition* on the caller's map argument
+(refused before any ICP dispatch, without needing a driver
+handle) and the twin's envelope is a *result*-side judgement on
+what the ICP produced (a live open3d registration result the
+runner reads under the SLAM extra).  Colocating them would hand
+an agent planner a single refusal payload that mixed a
+"build a bigger map before you try" remedy against a
+"the fit was aliased across the room" remedy.  Colocating them
+would also tie a future map-cardinality revision (a runner
+patch that lowered the ``100`` floor because ``o3d`` grew a
+sparser-cloud registration mode) to a match-quality revision the
+neon runner does not couple.
+
+Two things this module is deliberately *not*:
+
+* An execution path.  The neon runner's ``_try_relocalize`` runs
+  a full open3d ICP registration under
+  ``_SlamRunner._process_frame``'s thread; today's
+  :class:`~strands_robots.drivers.g1.G1Driver` does not front
+  that write, so no motion admission is at stake at this
+  precondition.  A future driver method that fronts SLAM
+  relocalise will surface the same module-local
+  :data:`_REFUSAL_TEXT` on a sparse-map refusal; this module
+  ports the read-only precondition half without also introducing
+  a second SLAM path the driver does not yet own, refs
+  strands-labs/robots#358.
+* An SDK re-import.  The floor is captured here as a module-level
+  constant so ``import strands_robots.tools.g1.g1_slam_map_liveness_envelope``
+  pulls no ``unitree_sdk2py`` submodule *and* pulls no ``numpy``,
+  ``open3d``, or ``kiss_icp`` submodule at import -- the
+  import-hygiene contract every other file in this package
+  carries, refs strands-labs/robots#358.  A caller authoring a
+  relocalise plan before any SLAM extra is installed on their
+  host still gets the floor back verbatim.
+
+Why this module does not quote a driver-side ``rc``.
+
+The G1 driver's :meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates`
+gates the *motion* surface (arm-SDK writes on ``rt/lowcmd``); its
+FSM rejections are the ``7404`` entry in
+:data:`~strands_robots.tools.g1._g1_common.ERR_CODES`
+(``"Invalid FSM id - need FSM in {500, 501, 801}"``).  The SLAM
+map-liveness decision runs on the neon runner's own thread
+against an in-memory map array -- it never touches ``rt/lowcmd``,
+never talks to the locomotion controller, and reaches no SDK RPC
+service that ships an rc table for a sparse-map refusal.
+Borrowing ``7404`` on a below-floor refusal would hand an agent
+planner a motion-FSM remedy for a map-cardinality argument.  The
+refusal shape this module returns names the numeric bound
+violation in module-local text so a planner reads a remedy that
+matches the surface, and a future driver-side SLAM relocalise
+wrapper will surface the same module-local text.  This mirrors
+the same-surface refusal rule
+:mod:`~strands_robots.tools.g1.g1_slam_relocalize_envelope` names
+for the ``_try_relocalize`` match-quality gate, refs
+strands-labs/robots#358.
+
+What this module does not decide.
+
+* Whether the map is loaded at all.  ``map_pts is None`` and
+  ``_o3d is None`` are the two other refusal shapes the neon
+  runner's precondition names, and each carries a different
+  remedy ("load a map" and "install the SLAM extra")
+  than the point-count floor's ("build a bigger map").  A future
+  SLAM-liveness verb that answers those two off a live driver
+  or runner handle will surface them; this envelope names only
+  the numeric precondition so a caller planning against an
+  intended map cardinality can decide the count half without a
+  driver handle or a SLAM extra installed.
+* Whether the loaded map's point count is a good match for the
+  runner's *live* frame density.  A map with exactly ``100``
+  points admits at this floor but would produce an ICP fit with
+  poor fitness against a ``50_000``-point live frame; the
+  match-quality dimension is exactly what the twin envelope
+  :mod:`~strands_robots.tools.g1.g1_slam_relocalize_envelope`
+  names (its ``fitness_min = 0.3`` floor).  The two envelopes
+  together answer the whole ``_try_relocalize`` decision -- this
+  one on the precondition, the twin on the result.
+* What the runner's *save* threshold is.  The neon runner's
+  save path (``_SlamRunner._save``) refuses on an empty
+  ``chunks`` list (``if not chunks: return {"ok": False, "error":
+  "no map data accumulated"}``); that is a distinct
+  refusal on a distinct surface (write-time save, not read-time
+  relocalise) and a future ``g1_slam_save_envelope`` lookup pair
+  will name that ``chunks`` floor.  A map that saves is not the
+  same as a map that relocalises against: the save path's floor
+  is on the accumulated chunk list, not on the point count that
+  a later load reproduces.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+from strands_robots.utils import positive_count_error
+
+#: The inclusive lower bound on the loaded map's point count that
+#: the neon SLAM runner's ``_try_relocalize`` admits an ICP
+#: registration through.  The neon bundle reads
+#: ``len(map_pts) < 100`` and returns ``None`` on strict-less, so a
+#: map of exactly ``100`` points is the boundary case the runner
+#: admits and this envelope quotes verbatim.  Named as an
+#: inclusive lower bound so :func:`g1_slam_map_liveness_admits`
+#: refuses a caller-supplied ``99`` and admits a caller-supplied
+#: ``100``, mirroring the runner's ``<`` refusal exactly.
+_MAP_LIVENESS_MIN: int = 100
+
+#: The module-local refusal text every ``g1_slam_map_liveness_admits``
+#: refusal quotes when the caller-supplied point count sits below
+#: the neon-runner-observed floor.  Named here rather than
+#: borrowed from
+#: :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` because
+#: the SLAM relocalise path ships no distinct rc -- the neon
+#: runner just returns ``None`` from ``_try_relocalize`` on a
+#: refused map, which the caller reads as "no offset applied this
+#: frame".  The motion-FSM ``7404`` entry (its nearest neighbour)
+#: reads ``"Invalid FSM id - need FSM in {500, 501, 801}"`` -- a
+#: remedy that points a planner at locomotion FSM transitions to
+#: fix a map-cardinality argument.  Surfacing the module-local
+#: text keeps the refusal payload's remedy on the same surface the
+#: write belongs on; a future driver-side SLAM relocalise wrapper
+#: will surface this same text rather than re-borrowing a motion
+#: code.
+_REFUSAL_TEXT: str = (
+    "map liveness gate refused - the loaded map's point count sits "
+    "below the neon-runner-observed floor for an ICP relocalise. "
+    "Refs strands-labs/robots#358."
+)
+
+
+def _envelope() -> dict[str, Any]:
+    """Build the envelope descriptor the verbs return.
+
+    Kept here rather than inlined in
+    :func:`g1_list_slam_map_liveness_envelope` so
+    :func:`g1_slam_map_liveness_admits` names the same field on
+    its admitted-path payload and so a widen to the descriptor
+    lands in one place.  Every field is a snapshot read; no bus
+    is touched.
+    """
+    return {
+        "point_count_min": _MAP_LIVENESS_MIN,
+    }
+
+
+@tool
+def g1_list_slam_map_liveness_envelope() -> dict[str, Any]:
+    """Return the point-count floor the neon SLAM runner admits a relocalise-map through.
+
+    Read-only.  No driver instance, no DDS, no SDK, no ``numpy`` /
+    ``open3d`` / ``kiss_icp`` submodule import at load time: the
+    field is a module-level constant.  Useful before a future
+    driver-side wrapper for SLAM relocalise is called, so a caller
+    can compare an intended map's point count against the floor
+    the neon runner's ``_try_relocalize`` refuses below and can
+    carry the module-local refusal text a driver-side wrapper
+    would surface on a bounds violation.
+
+    Returns:
+        A dict with ``status``; an ``envelope`` sub-dict carrying
+        the neon-runner-observed floor (``point_count_min``); and
+        a ``refusals`` list carrying a single descriptor with the
+        module-local :data:`_REFUSAL_TEXT` a future write verb
+        would surface on a below-floor map.  Every field is a
+        snapshot of an observed bound or a module-local text; no
+        dynamic decode runs here.
+    """
+    return {
+        "status": "success",
+        "envelope": _envelope(),
+        "refusals": [
+            {"text": _REFUSAL_TEXT},
+        ],
+    }
+
+
+@tool
+def g1_slam_map_liveness_admits(
+    point_count: int = _MAP_LIVENESS_MIN,
+) -> dict[str, Any]:
+    """Decide whether a candidate map's point count clears the relocalise floor.
+
+    Read-only.  Compares ``point_count`` against the floor
+    :func:`g1_list_slam_map_liveness_envelope` returns and reports
+    the bound the argument violates.  No driver instance, no DDS,
+    no SDK, no ``numpy`` / ``open3d`` / ``kiss_icp`` submodule
+    import: the decision reads only a module-level constant and
+    the argument itself.
+
+    A count above the floor is *not* the same as an admitted
+    snap: the neon runner also refuses on the match-quality
+    dimensions (fitness, translation, trace) which the twin
+    envelope :mod:`~strands_robots.tools.g1.g1_slam_relocalize_envelope`
+    names, and on the two other precondition halves
+    (``_o3d is None``, ``map_pts is None``) which are live-runner
+    reads this verb does not answer.  The returned payload names
+    only the numeric point-count decision.
+
+    Args:
+        point_count: The candidate map's point count, i.e.
+            ``len(map_pts)`` on the neon runner side.  The default
+            ``100`` (the observed floor) admits, so a caller who
+            does not pass an explicit argument lands on the
+            admitted boundary case the runner itself admits.  The
+            shared :func:`~strands_robots.utils.positive_count_error`
+            domain refuses non-``int`` inputs (including ``bool``,
+            which is an ``int`` subclass whose ``True`` would
+            otherwise be a silent ``1``), values below ``1``, and
+            any type coercion that could hide a floating-point
+            argument.  A count of ``0`` (an empty map) is refused
+            by the shared domain rather than by the map-liveness
+            floor because the runner's own precondition reads
+            ``map_pts is None or len(map_pts) < 100`` and treats
+            an empty array under the ``None`` half; this envelope
+            answers only the numeric decision, so a caller who
+            probed ``point_count=0`` receives the shared-domain
+            refusal that names the shape mistake decidably before
+            the ``100`` floor is asked.
+
+    Returns:
+        A dict with ``status``; an ``admits`` bool naming whether
+        the point count sits at or above the floor; a ``refusals``
+        list of refusal descriptors, each carrying the dimension
+        name, the offending value, the clamp it violated, the
+        comparison ("value < bound" or the shared-domain
+        "shared-domain" descriptor for a shape mistake), and the
+        module-local :data:`_REFUSAL_TEXT` a driver-side wrapper
+        would surface if the relocalise were attempted while the
+        map was below the floor; the same ``envelope`` sub-dict
+        :func:`g1_list_slam_map_liveness_envelope` returns.  On
+        an admitted count the ``refusals`` list is empty.
+    """
+    envelope = _envelope()
+    refusals: list[dict[str, Any]] = []
+
+    # Shared-domain shape check first: the shared
+    # positive_count_error refuses bool, non-int, and value < 1.
+    # This lands before the map-liveness floor check so a shape
+    # mistake reads decidably against the module-local floor.
+    domain_err = positive_count_error(point_count, "point_count", "g1_slam_map_liveness_admits")
+    if domain_err is not None:
+        refusals.append(
+            {
+                "dimension": "point_count",
+                "value": point_count,
+                "bound_key": "point_count_min",
+                "bound": _MAP_LIVENESS_MIN,
+                "comparison": "shared-domain",
+                "domain_error": domain_err,
+                "text": _REFUSAL_TEXT,
+            }
+        )
+    else:
+        # The shared domain has admitted the shape; now grade the
+        # map-liveness floor.  The runner reads len(map_pts) < 100
+        # and refuses on strict-less, so exactly 100 admits.
+        if point_count < _MAP_LIVENESS_MIN:
+            refusals.append(
+                {
+                    "dimension": "point_count",
+                    "value": point_count,
+                    "bound_key": "point_count_min",
+                    "bound": _MAP_LIVENESS_MIN,
+                    "comparison": "value < bound",
+                    "text": _REFUSAL_TEXT,
+                }
+            )
+
+    return {
+        "status": "success",
+        "admits": not refusals,
+        "refusals": refusals,
+        "envelope": envelope,
+    }

--- a/tests/drivers/test_g1_slam_map_liveness_gate_admits_the_envelope.py
+++ b/tests/drivers/test_g1_slam_map_liveness_gate_admits_the_envelope.py
@@ -1,0 +1,320 @@
+"""Tests for :mod:`strands_robots.tools.g1.g1_slam_map_liveness_envelope`.
+
+The module ports the neon SLAM runner's ``_try_relocalize``
+precondition (``cagataycali/neon-the-g1/tools/g1_slam.py``) into a
+read-only lookup pair.  The tests grade three things: import
+hygiene (no optional SLAM stack loads at import), snapshot
+fidelity (the envelope carries the neon-observed ``100``
+point-count floor on both verbs), and the admit/refuse decision
+matrix for the point-count dimension.
+
+The single refusal uses one module-local :data:`_REFUSAL_TEXT` on
+both a below-floor rejection and a shared-domain shape mistake, so
+a misread of either grade surfaces the same remedy string on the
+same surface -- consistent with the twin envelope
+:mod:`~strands_robots.tools.g1.g1_slam_relocalize_envelope` (the
+merged strands-labs/robots#3006).
+
+Refs strands-labs/robots#358.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+MODULE_PATH = "strands_robots.tools.g1.g1_slam_map_liveness_envelope"
+
+
+class TestTheImportPullsNoOptionalSlamModule:
+    """The module docstring's import-hygiene contract, refs strands-labs/robots#358.
+
+    A caller authoring a relocalise plan before any SLAM extra is
+    installed on their host still gets the floor back verbatim;
+    the module's advertised no-optional-import property is asserted
+    against the process's own :data:`sys.modules` after import.
+    """
+
+    def test_the_import_pulls_no_unitree_sdk2py_submodule(self) -> None:
+        # Snapshot before importing so a submodule loaded by an
+        # earlier test does not tar this one; only the delta this
+        # module's import introduces is graded.  Pop the target
+        # first so the delta is the module's own import cost even
+        # when a prior test has already loaded it.
+        sys.modules.pop(MODULE_PATH, None)
+        before = set(sys.modules)
+        importlib.import_module(MODULE_PATH)
+        added = set(sys.modules) - before
+        leaked = {name for name in added if "unitree" in name.lower()}
+        assert leaked == set(), (
+            f"the import of {MODULE_PATH} pulled unitree_sdk2py "
+            f"submodules {sorted(leaked)}; the neon bundle's SLAM "
+            "precondition ports as a lookup, not as an SDK call"
+        )
+
+    def test_the_import_pulls_no_new_optional_slam_submodule(self) -> None:
+        # numpy / open3d / kiss_icp are the SLAM extra the neon
+        # runner's own _try_relocalize reaches.  numpy (top-level)
+        # is often pre-loaded by the test session; the assertion
+        # here is that *this* import does not pull any of them, so
+        # a caller who imports the envelope on a host without the
+        # SLAM extra still lands on a working module.
+        sys.modules.pop(MODULE_PATH, None)
+        before = set(sys.modules)
+        importlib.import_module(MODULE_PATH)
+        added = set(sys.modules) - before
+        leaked = {
+            name
+            for name in added
+            if name == "open3d" or name.startswith("open3d.") or name == "kiss_icp" or name.startswith("kiss_icp.")
+        }
+        assert leaked == set(), (
+            f"the import of {MODULE_PATH} pulled SLAM-extra "
+            f"submodules {sorted(leaked)}; the module must load "
+            "verbatim on a host without the SLAM extra"
+        )
+
+
+class TestTheEnvelopeSnapshotFidelity:
+    """The floor matches the neon runner's observed constant, refs strands-labs/robots#358."""
+
+    def test_the_floor_is_a_positive_int(self) -> None:
+        from strands_robots.tools.g1 import g1_slam_map_liveness_envelope as m
+
+        # The floor is a discrete point count; it must be a strict
+        # int (not a numpy int64, not a bool) so the shared
+        # positive_count_error validator admits it on the default
+        # path.  The runner reads len(map_pts), which is Python's
+        # own int type, so this pins the type on both sides.
+        assert isinstance(m._MAP_LIVENESS_MIN, int)
+        assert not isinstance(m._MAP_LIVENESS_MIN, bool)
+        assert m._MAP_LIVENESS_MIN > 0
+
+    def test_the_neon_floor_matches_the_observed_snapshot(self) -> None:
+        from strands_robots.tools.g1 import g1_slam_map_liveness_envelope as m
+
+        # The neon runner reads `len(map_pts) < 100` and refuses on
+        # strict-less; the envelope names 100 as the inclusive
+        # lower bound.  A widen to this constant is a runner-side
+        # change that this test would catch as a diverged
+        # snapshot.
+        assert m._MAP_LIVENESS_MIN == 100
+
+    def test_g1_list_slam_map_liveness_envelope_returns_the_full_envelope(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_list_slam_map_liveness_envelope,
+        )
+
+        payload = g1_list_slam_map_liveness_envelope()
+        assert payload["status"] == "success"
+        assert payload["envelope"] == {"point_count_min": 100}
+        # Exactly one refusal descriptor -- the module-local text
+        # a future write verb would surface on a below-floor map.
+        assert len(payload["refusals"]) == 1
+        text = payload["refusals"][0]["text"]
+        assert "map liveness gate refused" in text
+        assert "strands-labs/robots#358" in text
+
+    def test_the_admits_envelope_matches_the_list_envelope(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_list_slam_map_liveness_envelope,
+            g1_slam_map_liveness_admits,
+        )
+
+        # The admits payload names the same envelope as the list
+        # payload, so a caller who read the envelope from admits
+        # (on a rejected count) reads the same fields as a caller
+        # who read it from the dedicated list verb.  Guards
+        # against a widen that landed in one verb only.
+        list_env = g1_list_slam_map_liveness_envelope()["envelope"]
+        admits_env = g1_slam_map_liveness_admits(point_count=100)["envelope"]
+        assert list_env == admits_env
+
+
+class TestG1SlamMapLivenessAdmitsAtTheFloor:
+    """Boundary case: exactly the floor admits, refs strands-labs/robots#358.
+
+    The neon runner's own check reads `len(map_pts) < 100` and
+    refuses on strict-less, so the boundary case at exactly 100 is
+    the case the runner admits.  This test pins that boundary in
+    the envelope's own admits verb.
+    """
+
+    def test_g1_slam_map_liveness_admits_at_the_min_boundary(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        payload = g1_slam_map_liveness_admits(point_count=100)
+        assert payload["status"] == "success"
+        assert payload["admits"] is True
+        assert payload["refusals"] == []
+
+    def test_g1_slam_map_liveness_admits_above_the_min_boundary(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        # A well-populated map admits without qualification; the
+        # runner would proceed to the match-quality dimensions the
+        # twin envelope names.
+        payload = g1_slam_map_liveness_admits(point_count=50_000)
+        assert payload["admits"] is True
+        assert payload["refusals"] == []
+
+    def test_g1_slam_map_liveness_admits_default_call_is_the_min_boundary(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        # The default argument is the observed floor; a zero-arg
+        # call must land on the admitted side so a caller probing
+        # the envelope shape reads a clean admits payload.
+        payload = g1_slam_map_liveness_admits()
+        assert payload["admits"] is True
+        assert payload["refusals"] == []
+
+
+class TestG1SlamMapLivenessRefusesBelowTheMin:
+    """A point count strictly below the floor refuses on the runner's own comparison."""
+
+    def test_g1_slam_map_liveness_admits_below_the_min(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            _REFUSAL_TEXT,
+            g1_slam_map_liveness_admits,
+        )
+
+        # 99 is the boundary-below case: the runner reads
+        # len(map_pts) < 100 and refuses on strict-less, so 99
+        # refuses.  The refusal names the dimension, the offending
+        # value, the clamp it violated, the "value < bound"
+        # comparison, and the module-local text.
+        payload = g1_slam_map_liveness_admits(point_count=99)
+        assert payload["admits"] is False
+        assert len(payload["refusals"]) == 1
+        r = payload["refusals"][0]
+        assert r["dimension"] == "point_count"
+        assert r["value"] == 99
+        assert r["bound_key"] == "point_count_min"
+        assert r["bound"] == 100
+        assert r["comparison"] == "value < bound"
+        assert r["text"] == _REFUSAL_TEXT
+
+    def test_g1_slam_map_liveness_admits_at_one_refuses_on_min(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        # A single point admits the shared positive_count_error
+        # domain (a positive int) but refuses on the map-liveness
+        # floor -- the shape is a valid count but the runner's
+        # ICP would still refuse for lack of correspondence.  The
+        # refusal names the "value < bound" comparison rather
+        # than the shared-domain shape refusal.
+        payload = g1_slam_map_liveness_admits(point_count=1)
+        assert payload["admits"] is False
+        r = payload["refusals"][0]
+        assert r["comparison"] == "value < bound"
+
+
+class TestG1SlamMapLivenessRefusesSharedDomainShapeMistakes:
+    """The shared positive_count_error refuses bool, non-int, and value < 1."""
+
+    def test_g1_slam_map_liveness_admits_refuses_zero_as_shape_mistake(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        # 0 is not a positive count; the shared domain refuses on
+        # the shape rather than the map-liveness floor.  This
+        # mirrors the runner's own precondition treating an empty
+        # array under the `map_pts is None` half (a distinct
+        # remedy from "build a bigger map").
+        payload = g1_slam_map_liveness_admits(point_count=0)
+        assert payload["admits"] is False
+        r = payload["refusals"][0]
+        assert r["comparison"] == "shared-domain"
+        assert "domain_error" in r
+        assert "positive integer" in r["domain_error"]
+
+    def test_g1_slam_map_liveness_admits_refuses_negative_as_shape_mistake(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        payload = g1_slam_map_liveness_admits(point_count=-1)
+        assert payload["admits"] is False
+        r = payload["refusals"][0]
+        assert r["comparison"] == "shared-domain"
+
+    def test_g1_slam_map_liveness_admits_refuses_bool_true_as_shape_mistake(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        # bool is an int subclass whose True would otherwise land
+        # as a silent count of 1; the shared domain refuses it
+        # explicitly so the shape mistake is decidable.
+        payload = g1_slam_map_liveness_admits(point_count=True)  # type: ignore[arg-type]
+        assert payload["admits"] is False
+        r = payload["refusals"][0]
+        assert r["comparison"] == "shared-domain"
+
+    def test_g1_slam_map_liveness_admits_refuses_bool_false_as_shape_mistake(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        payload = g1_slam_map_liveness_admits(point_count=False)  # type: ignore[arg-type]
+        assert payload["admits"] is False
+        r = payload["refusals"][0]
+        assert r["comparison"] == "shared-domain"
+
+    @pytest.mark.parametrize("bad", [1.0, 100.0, "100", None])
+    def test_g1_slam_map_liveness_admits_refuses_non_int_as_shape_mistake(self, bad: object) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            g1_slam_map_liveness_admits,
+        )
+
+        # A caller who computed a float count (a percentage, an
+        # np.float64 read from a stat) or handed a str/None must
+        # see the shape refusal, not the map-liveness floor
+        # refusal -- the shared domain names the type mistake
+        # decidably before the floor is asked.
+        payload = g1_slam_map_liveness_admits(point_count=bad)  # type: ignore[arg-type]
+        assert payload["admits"] is False
+        r = payload["refusals"][0]
+        assert r["comparison"] == "shared-domain"
+
+
+class TestTheRefusalTextIsShared:
+    """A misread of any grade surfaces the same remedy string, refs strands-labs/robots#358."""
+
+    def test_the_below_floor_refusal_uses_the_module_local_text(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            _REFUSAL_TEXT,
+            g1_slam_map_liveness_admits,
+        )
+
+        payload = g1_slam_map_liveness_admits(point_count=50)
+        assert payload["refusals"][0]["text"] == _REFUSAL_TEXT
+
+    def test_the_shared_domain_refusal_uses_the_module_local_text(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            _REFUSAL_TEXT,
+            g1_slam_map_liveness_admits,
+        )
+
+        payload = g1_slam_map_liveness_admits(point_count=0)
+        assert payload["refusals"][0]["text"] == _REFUSAL_TEXT
+
+    def test_the_list_verb_uses_the_module_local_text(self) -> None:
+        from strands_robots.tools.g1.g1_slam_map_liveness_envelope import (
+            _REFUSAL_TEXT,
+            g1_list_slam_map_liveness_envelope,
+        )
+
+        payload = g1_list_slam_map_liveness_envelope()
+        assert payload["refusals"][0]["text"] == _REFUSAL_TEXT


### PR DESCRIPTION
## What

Ports the neon SLAM runner's `_try_relocalize` precondition (`cagataycali/neon-the-g1/tools/g1_slam.py`, which reads `if _o3d is None or map_pts is None or len(map_pts) < 100: return None`) into a read-only agent-facing lookup pair: `g1_list_slam_map_liveness_envelope` returns the observed `point_count_min = 100` floor with the module-local refusal text; `g1_slam_map_liveness_admits(point_count)` grades a caller's candidate map's point count against the floor.

## Refusal strings

Single module-local text (`"map liveness gate refused - the loaded map's point count sits below the neon-runner-observed floor for an ICP relocalise. Refs strands-labs/robots#358."`) surfaces on two grades:

- `comparison = "value < bound"` — the runner-observed floor rejection (99 refuses, 100 admits, mirroring the runner's `<` strict-less comparison)
- `comparison = "shared-domain"` — the shared `positive_count_error` validator refuses `bool` (both `True` and `False`), non-`int` (float, str, None), and `value < 1` before the floor is asked

The refusal payload carries the shared `domain_error` message from `positive_count_error` so a caller reading a shape mistake sees the type-refusal reason plus the map-liveness text on the same surface.

## Why this shape

**Twin of `g1_slam_relocalize_envelope` (#3006)** — the match-quality dimensions on the same `_try_relocalize` gate. That envelope already forward-references "a future SLAM-liveness companion verb" for exactly this precondition; this PR lands it.

The two modules stay separate because `_try_relocalize` reads them in order:
- This module's floor is a **precondition** on the caller's map argument (refused before any ICP dispatch, without needing a driver handle or SLAM extra installed).
- The twin's envelope is a **result-side** judgement on what the ICP produced (a live `open3d` registration result the runner reads under the SLAM extra).

Colocating them would hand an agent planner a single refusal payload that mixed "build a bigger map before you try" against "the fit was aliased across the room".

## Constraints held

- **Module-load hygiene** — `import strands_robots.tools.g1.g1_slam_map_liveness_envelope` pulls zero `unitree_sdk2py` submodules, zero `open3d` submodules, zero `kiss_icp` submodules (2 tests assert this against `sys.modules` delta)
- **No writer path** — read-only lookup; no driver, no DDS, no SDK, no ICP dispatch
- **No new FSM gate** — this port introduces no motion admission; the driver's gate wired in #2916 stays the single truth
- **Refusal strings cite resolvable issues** — refs #358 (per #2872 rule)
- **Docstrings describe today, not aspiration** — per #2863
- **Shared value domain** — reuses `positive_count_error` (per #2765 / #2872 hard rule 6) rather than inventing a new count validator
- **Xfail markers** — none needed (the shared-domain refusal wraps the validator's own text verbatim in the returned `domain_error` field, and the test asserts on the substring `"positive integer"` which is the validator's own error phrase)

## Tests (22 all green, 0.40s)

Structured across five test classes:

1. **TestTheImportPullsNoOptionalSlamModule** — 2 tests
   - `test_the_import_pulls_no_unitree_sdk2py_submodule` — SDK load hygiene
   - `test_the_import_pulls_no_new_optional_slam_submodule` — `open3d` / `kiss_icp` load hygiene
2. **TestTheEnvelopeSnapshotFidelity** — 4 tests
   - `test_the_floor_is_a_positive_int` — type shape (int, not bool, not numpy int64)
   - `test_the_neon_floor_matches_the_observed_snapshot` — pins `100`
   - `test_g1_list_slam_map_liveness_envelope_returns_the_full_envelope` — verb payload shape
   - `test_the_admits_envelope_matches_the_list_envelope` — shared `_envelope()` builder
3. **TestG1SlamMapLivenessAdmitsAtTheFloor** — 3 tests (inclusive boundary at 100, well-above at 50k, default-arg boundary)
4. **TestG1SlamMapLivenessRefusesBelowTheMin** — 2 tests (99 boundary-below, 1 above-shape-below-floor)
5. **TestG1SlamMapLivenessRefusesSharedDomainShapeMistakes** — 8 tests (0, -1, True, False, and parametrized on `[1.0, 100.0, "100", None]`)
6. **TestTheRefusalTextIsShared** — 3 tests (below-floor / shared-domain / list verb all quote the same module-local text)

## Gates

- `ruff check` — ✅ all checks passed
- `ruff format --check` — ✅ 2 files formatted
- `mypy strands_robots/tools/g1/g1_slam_map_liveness_envelope.py` — ✅ file clean (unrelated pre-existing errors on `utils.py` / `ik.py` / `mesh/core.py` preserved on main)
- `pytest tests/drivers/test_g1_slam_map_liveness_gate_admits_the_envelope.py --no-cov` — ✅ **22 passed in 0.40s**

## Non-scope

- No live ICP dispatch — belongs on future driver-side ingest work when `G1Driver.run_policy` is extended with SLAM (refs #358)
- No `_o3d is None` / `map_pts is None` refusal shapes — those are live-runner state reads ("install the SLAM extra", "load a map") that need a driver or runner handle; a future `g1_slam_liveness` verb (built on a driver instance) will surface them alongside this envelope's numeric decision
- No decision on whether the loaded map's point count is a good *match* for the runner's live frame density — that dimension is exactly what #3006's envelope names (its `fitness_min = 0.3` floor)
- No save-side floor — the neon runner's `_save` refuses on an empty `chunks` list on a distinct surface; a future `g1_slam_save_envelope` will name that

Refs #358, #3006.