### PR TITLE
fix(ci): a cancelled required check is not a failing one owed by the author

### DIFF
--- a/changelog.d/3017-cancelled-required-check-is-not-a-failing-one.md
+++ b/changelog.d/3017-cancelled-required-check-is-not-a-failing-one.md
@@ -1,0 +1,48 @@
+### Fixed: a cancelled required check is not reported as a failing one owed by the author
+
+`scripts/check_merge_blockers.py` read a `cancelled` conclusion on the required
+context as `required-check-failing`, whose documented owner is *the author*, and
+the `--all-open` sweep then printed `::warning title=Blocked on something no
+reviewer can clear` and exited `1`. A cancellation is a statement about the
+scheduler, not about the diff, so there was nothing for the author to fix and the
+one signal a scheduled pass acts on pointed at work nobody owed.
+
+Two defects composed, both in the direction that reads as diligence rather than
+as a mistake. The classification fell through to the generic "not success,
+neutral or skipped" branch. And in `resolve_check_conclusions` a context
+appearing twice kept its worst answer with `(None, "success")` exempted -- where
+`None` means *still running*, so a **superseded** run's terminal `cancelled`
+overwrote the live run that had replaced it, turning `pending` into a terminal
+verdict. That half also ran the other way: read as `[cancelled, failure]` the
+resolved answer was `cancelled`, so a genuinely failing required check was
+recorded as a cancellation, and only the shared outcome name hid it.
+
+Measured on #3014, head `ecb07a41`, which carried the required context twice --
+`cancelled` at 13:15:35Z and a run still in progress at 13:45:32Z, with all ten
+sibling checks `success`. It read `required-check-failing, missing-approval` owed
+by *the author*; its sibling #3015, the same change shape with no cancelled
+predecessor, correctly read `required-check-pending`. Both now read alike.
+
+A cancellation is now ranked below every verdict rather than above them: it
+neither displaces a recorded answer nor survives one, so the pair resolves to the
+live run in either page order -- which matters because #1914 measured two reads
+of one unchanged sha disagreeing ten minutes apart, and the order this page
+arrives in is the API's business. It gets its own `required-check-cancelled`
+outcome owed by **a maintainer**, by re-running the run. It stays a blocker,
+because the head genuinely carries no verdict for a required context, but it is
+not a *finding*: a finding is defined here as what an author-side pass can clear
+alone. Its detail warns off the push, which re-triggers the check but costs the
+approval twice under `dismiss_stale_reviews_on_push` plus
+`require_last_push_approval`.
+
+`timed_out` deliberately stays with the author. That job ran and failed to finish
+inside its own deadline, which *is* a statement about the tree, and folding it in
+would send a real failure to a maintainer as a re-run.
+
+#1800 established the roll-up reading and #1914 measured this pair on a pull
+request head, but #1914 closed explicitly not claiming how such a pair is read,
+and this check was written afterwards. #1915 removed the producer that was
+avoidable; the one that remains is deliberate, because reopening a pull request
+is the documented remedy both for a head carrying no check suite (#1987) and for
+a stale `headRefOid` (#2508), and a reopen necessarily cancels the run in flight.
+So the state is reachable by following AGENTS.md and can only be read correctly.

--- a/scripts/check_merge_blockers.py
+++ b/scripts/check_merge_blockers.py
@@ -88,6 +88,27 @@ is*, so the outcomes group that way rather than by severity:
     owed by a reviewer -- measured on #1035, which read
     ``pusher-only-approval`` while it was ``DIRTY``. Re-read to resolve it.
 
+``required-check-cancelled``
+    A **maintainer**, by re-running the run. A cancelled run is not a verdict
+    about the tree; it is what the concurrency group leaves behind when a
+    second ``pull_request`` event arrives for one head, so the branch is
+    unjudged rather than judged badly. #1800 established that reading for the
+    roll-up and #1914 for a pull request head, and #1915 removed the producer
+    that was avoidable -- the sha-invariant ``types`` override. The producer
+    that remains is deliberate: reopening a pull request is this repository's
+    documented remedy both for a head carrying no check suite (#1987) and for a
+    stale ``headRefOid`` (#2508), and it necessarily cancels the run in flight.
+    So the state is reachable by following AGENTS.md, and cannot be removed --
+    only read correctly.
+
+    Kept apart from ``required-check-failing`` because the two name opposite
+    parties, and this one was misfiled as that one. Measured on #3014, whose
+    head ``ecb07a41`` carried the required context twice: ``cancelled`` at
+    13:15:35Z, superseded by the run still in progress at 13:45:32Z. This check
+    reported ``required-check-failing`` owed by *the author*, beside a
+    ``::warning`` asserting no reviewer could clear it. Nothing had failed and
+    the author owed nothing -- the answer was not in yet.
+
 ``required-check-absent``
     A **maintainer**. *Which* move is decided by the head's check-suite census,
     which is why that is read rather than assumed. Suites present with at least
@@ -206,6 +227,7 @@ MERGE_STATE_UNKNOWN = "merge-state-unknown"
 DRAFT = "draft"
 REQUIRED_CHECK_FAILING = "required-check-failing"
 REQUIRED_CHECK_PENDING = "required-check-pending"
+REQUIRED_CHECK_CANCELLED = "required-check-cancelled"
 REQUIRED_CHECK_ABSENT = "required-check-absent"
 CHECK_SUITE_ABSENT = "check-suite-absent"
 UNRESOLVED_THREADS = "unresolved-threads"
@@ -227,6 +249,7 @@ _OWED_BY: dict[str, str] = {
     DRAFT: AUTHOR,
     REQUIRED_CHECK_FAILING: AUTHOR,
     REQUIRED_CHECK_PENDING: NOBODY,
+    REQUIRED_CHECK_CANCELLED: MAINTAINER,
     REQUIRED_CHECK_ABSENT: MAINTAINER,
     CHECK_SUITE_ABSENT: MAINTAINER,
     UNRESOLVED_THREADS: AUTHOR,
@@ -352,6 +375,18 @@ def _plural(count: int, noun: str) -> str:
 
 
 _HELD = "action_required"
+_CANCELLED = "cancelled"
+
+
+def _is_cancelled(conclusion: str | None) -> bool:
+    """Whether a conclusion is a cancellation, i.e. the absence of a verdict.
+
+    ``timed_out`` is deliberately not folded in here. A job killed by its own
+    deadline did run and did fail to finish, which is a statement about the
+    tree the author owes; a cancellation is a statement about the *scheduler*
+    and says nothing about the diff.
+    """
+    return (conclusion or "").lower() == _CANCELLED
 
 
 def _held_suites(census: tuple[str | None, ...]) -> int:
@@ -493,6 +528,18 @@ def evaluate(state: PullRequestState, rules: Ruleset) -> tuple[Blocker, ...]:
                     REQUIRED_CHECK_PENDING,
                     "required_status_checks",
                     f"Required check {context!r} is still running.",
+                )
+            )
+        elif _is_cancelled(conclusion):
+            found.append(
+                Blocker(
+                    REQUIRED_CHECK_CANCELLED,
+                    "required_status_checks",
+                    f"Required check {context!r} was cancelled, so the head "
+                    f"carries no verdict for it and none is alleged. Re-run "
+                    f"the run rather than pushing: a push re-triggers the "
+                    f"check but dismisses every approval and makes the pushing "
+                    f"account ineligible to re-supply one.",
                 )
             )
         elif conclusion.lower() not in ("success", "neutral", "skipped"):
@@ -674,6 +721,10 @@ def resolve_check_conclusions(repo: str, head_sha: str, token: str) -> dict[str,
     kept as ``None`` rather than coerced: "still running" and "failed" ask for
     different things. Both surfaces are read because a required context can be
     supplied by either, and the ruleset names a context without saying which.
+
+    One context can appear more than once on a head, and then the answer kept is
+    the worst *verdict* -- with a cancellation ranked below all of them, because
+    it is not a verdict. See ``_is_cancelled``.
     """
     conclusions: dict[str, str | None] = {}
 
@@ -684,11 +735,21 @@ def resolve_check_conclusions(repo: str, head_sha: str, token: str) -> dict[str,
         if not name:
             continue
         conclusion = run.get("conclusion")
-        # A context appearing twice keeps its worst answer: a re-run that
-        # succeeded does not retire a sibling that did not.
-        if name in conclusions and conclusions[name] not in (None, "success"):
-            continue
-        conclusions[str(name)] = conclusion
+        key = str(name)
+        if key in conclusions:
+            recorded = conclusions[key]
+            # A cancelled run carries no verdict, so it neither displaces one
+            # nor survives one. Both directions are needed because the ordering
+            # of this page is the API's business: the superseded half of a
+            # restarted required check must not answer for the run that
+            # superseded it, whichever of the two is read first.
+            if _is_cancelled(conclusion):
+                continue
+            # Otherwise a context appearing twice keeps its worst answer: a
+            # re-run that succeeded does not retire a sibling that did not.
+            if not _is_cancelled(recorded) and recorded not in (None, "success"):
+                continue
+        conclusions[key] = conclusion
 
     status = _get(f"{API_ROOT}/repos/{repo}/commits/{head_sha}/status", token)
     if isinstance(status, dict):

--- a/tests/test_merge_blockers.py
+++ b/tests/test_merge_blockers.py
@@ -252,7 +252,7 @@ def test_2480_a_pending_check_does_not_mask_a_reviewer_who_can_act_now() -> None
     [
         ({REQUIRED: "failure"}, "required-check-failing", mod.AUTHOR),
         ({REQUIRED: "timed_out"}, "required-check-failing", mod.AUTHOR),
-        ({REQUIRED: "cancelled"}, "required-check-failing", mod.AUTHOR),
+        ({REQUIRED: "cancelled"}, "required-check-cancelled", mod.MAINTAINER),
         ({REQUIRED: None}, "required-check-pending", mod.NOBODY),
         ({}, "required-check-absent", mod.MAINTAINER),
         ({"some other check": "failure"}, "required-check-absent", mod.MAINTAINER),
@@ -747,6 +747,121 @@ def test_a_rerun_that_succeeded_does_not_retire_a_failing_sibling(
 
     monkeypatch.setattr(mod, "_get", fake_get)
     assert mod.resolve_check_conclusions("o/r", "abc", "t") == {REQUIRED: "failure"}
+
+
+@pytest.mark.parametrize(
+    "order",
+    [
+        ("live-first", (None, "cancelled")),
+        ("cancelled-first", ("cancelled", None)),
+    ],
+    ids=lambda case: case[0],
+)
+def test_3014_a_cancelled_run_does_not_answer_for_the_run_that_superseded_it(
+    monkeypatch: pytest.MonkeyPatch, order: tuple[str, tuple[str | None, ...]]
+) -> None:
+    """#3014's head carried the required context cancelled *and* still running.
+
+    Head ``ecb07a41`` at 2026-08-30: the run started 13:15:35Z was cancelled by
+    the concurrency group when a second ``pull_request`` event arrived for the
+    same sha, and the run that replaced it was still in progress at 13:45:32Z.
+    The sweep reported ``required-check-failing`` owed by *the author* and warned
+    that no reviewer could clear it. Nothing had failed.
+
+    Parametrized over both page orders because which run the API lists first is
+    its business, not this check's -- and #1914 measured exactly that
+    instability: two reads of one unchanged sha ten minutes apart disagreed.
+    """
+    _, conclusions = order
+
+    def fake_get(url: str, token: str) -> Any:
+        if "check-runs" in url:
+            return {"check_runs": [{"name": REQUIRED, "conclusion": c} for c in conclusions]}
+        return {"statuses": []}
+
+    monkeypatch.setattr(mod, "_get", fake_get)
+    assert mod.resolve_check_conclusions("o/r", "abc", "t") == {REQUIRED: None}
+
+
+@pytest.mark.parametrize("order", [("cancelled", "failure"), ("failure", "cancelled")])
+def test_a_cancellation_does_not_retire_a_real_failure_either(
+    monkeypatch: pytest.MonkeyPatch, order: tuple[str, str]
+) -> None:
+    """Ranking a cancellation below every verdict must not hide one.
+
+    The fix above makes a cancellation lose to a live sibling; this is the other
+    direction, and it is the one that would be expensive to get wrong -- a
+    genuinely failing required check reported as cancelled sends the author away
+    from work they do owe.
+    """
+
+    def fake_get(url: str, token: str) -> Any:
+        if "check-runs" in url:
+            return {"check_runs": [{"name": REQUIRED, "conclusion": c} for c in order]}
+        return {"statuses": []}
+
+    monkeypatch.setattr(mod, "_get", fake_get)
+    assert mod.resolve_check_conclusions("o/r", "abc", "t") == {REQUIRED: "failure"}
+
+
+def test_a_cancelled_required_check_is_not_owed_by_the_author() -> None:
+    """The two outcomes name opposite parties, so they cannot share a name.
+
+    A cancellation is a statement about the scheduler, not about the diff, so
+    there is nothing for the author to fix and the remedy is a re-run. It stays
+    a blocker -- the head carries no verdict for a required context -- but not a
+    *finding*, because a finding is defined as what an author-side pass can
+    clear alone, and this is not that.
+    """
+    blockers = mod.evaluate(state(check_conclusions={REQUIRED: "cancelled"}), MAIN)
+
+    assert outcomes(blockers) == [mod.REQUIRED_CHECK_CANCELLED]
+    assert blockers[0].owed_by == mod.MAINTAINER
+    assert not blockers[0].is_finding
+    # The remedy names the re-run, and warns off the push that would cost the
+    # approval twice under dismiss_stale_reviews_on_push plus
+    # require_last_push_approval.
+    assert "re-run" in blockers[0].detail.lower()
+    assert "dismiss" in blockers[0].detail.lower()
+
+
+def test_a_timed_out_required_check_is_still_the_authors() -> None:
+    """The boundary of the rule above, in the direction that costs more.
+
+    ``timed_out`` reads like a scheduler verdict and is not one: the job ran and
+    failed to finish inside its own deadline, which is a statement about the
+    tree. Folding it in with the cancellations would send a real failure to a
+    maintainer as a re-run.
+    """
+    blockers = mod.evaluate(state(check_conclusions={REQUIRED: "timed_out"}), MAIN)
+
+    assert outcomes(blockers) == [mod.REQUIRED_CHECK_FAILING]
+    assert blockers[0].owed_by == mod.AUTHOR
+
+
+def test_a_cancelled_required_check_does_not_warn_that_the_author_owes_it(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end: the ``::warning`` and the exit status both stop firing.
+
+    This is the whole cost of the defect. The sweep printed "Blocked on
+    something no reviewer can clear" over #3014 and exited 1, which is the
+    signal a scheduled pass acts on -- so it spent a cycle looking for a failure
+    that did not exist, on the one pull request where the honest answer was that
+    the answer was not in yet.
+    """
+    monkeypatch.setattr(mod, "resolve_open_pull_requests", lambda repo, token: [3014])
+    monkeypatch.setattr(
+        mod, "resolve_state", lambda repo, pr, token: state(number=pr, check_conclusions={REQUIRED: "cancelled"})
+    )
+    monkeypatch.setattr(mod, "resolve_ruleset", lambda repo, base, token: MAIN)
+
+    exit_code = mod.main(["--repo", "o/r", "--token", "t", "--all-open"])
+    captured = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "::warning" not in captured
+    assert "required-check-cancelled | a maintainer" in captured
 
 
 def test_a_legacy_commit_status_can_supply_a_required_context(


### PR DESCRIPTION
Closes #3017

## The concern

`scripts/check_merge_blockers.py` read a `cancelled` conclusion on the required context as `required-check-failing`, whose documented owner is **the author**, so the `--all-open` sweep printed `::warning title=Blocked on something no reviewer can clear` and exited `1` over a branch on which nothing had failed. A cancellation is a statement about the scheduler, not about the diff.

That matters because the sweep's exit status is the signal a scheduled pass acts on, and this check exists specifically to stop a mechanical blocker being misfiled (#1905). Here it misfiled in the opposite direction: it named the one party who owed nothing.

## Measured

PR #3014, head `ecb07a41`, carried the required context twice:

| check run | started | status | conclusion |
| --- | --- | --- | --- |
| `99263123873` | 2026-08-30T13:15:35Z | completed | **cancelled** |
| `99266754258` | 2026-08-30T13:45:32Z | in_progress | `null` |

All ten sibling checks on that head were `success`. Before and after, same repository, same instant:

| | #3014 | exit |
| --- | --- | --- |
| before | `required-check-failing, missing-approval` -- owed by **the author**, plus a `::warning` | `1` |
| after | `required-check-pending, missing-approval` -- owed by **any reviewer** | `0` |

#3015 is the control: the same change shape with no cancelled predecessor, which already read `required-check-pending`. The two now read alike.

## Two defects, one concern

Both are in the direction that reads as diligence rather than as a mistake.

1. **Classification.** `cancelled` fell through to the generic `not in ("success", "neutral", "skipped")` branch.
2. **Resolution precedence.** `resolve_check_conclusions` kept a context's worst answer while exempting only `(None, "success")` -- and `None` means *still running*, so the **superseded** run's terminal `cancelled` overwrote the live run that had replaced it, turning `pending` into a terminal verdict.

The second half also ran the other way, which is the more dangerous direction: read as `[cancelled, failure]` the resolved answer was `cancelled`, so a **genuinely failing** required check was recorded as a cancellation. Only the shared outcome name hid it, and separating the outcomes is exactly what would have exposed it -- so the two halves ship together.

## What changed

- A cancellation is ranked **below** every verdict rather than above them: it neither displaces a recorded answer nor survives one, so the pair resolves to the live run **in either page order**. #1914 measured two reads of one unchanged sha disagreeing ten minutes apart, and which run this page lists first is the API's business, so the order-independence is pinned in both directions.
- A new `required-check-cancelled` outcome owed by **a maintainer**, by re-running the run. It stays a blocker -- the head genuinely carries no verdict for a required context -- but is not a *finding*, since a finding is defined in this module as what an author-side pass can clear alone. This matches the existing treatment of `required-check-absent` and `check-suite-absent`.
- Its detail warns off the push, which re-triggers the check but costs the approval twice under `dismiss_stale_reviews_on_push` plus `require_last_push_approval`.
- `timed_out` deliberately stays with the author: that job ran and failed to finish inside its own deadline, which *is* a statement about the tree. Pinned as a boundary control.

## Why the producer cannot just be removed

#1800 established the roll-up reading, and AGENTS.md already tells a reader to consult each context's own `conclusion` -- this check *does* read the individual conclusion and then still classified it as failing, so the documented discipline did not reach it.

#1914 measured this exact pair on a pull request head and #1915 removed the producer that was avoidable (the sha-invariant `types` override). #1914 closes with:

> **Explicitly not claimed:** I have not verified whether a same-name CANCELLED entry also gates the merge under the branch ruleset.

That is the question left open, and this check was written afterwards and answered it wrongly. The producer that remains is **deliberate**: reopening a pull request is this repository's documented remedy both for a head carrying no check suite (#1987) and for a stale `headRefOid` (#2508), and a reopen necessarily cancels the run in flight. So an agent following AGENTS.md manufactures this state -- and was then told the author had broken something.

## Verification

- `tests/test_merge_blockers.py`: **80 passed**. Against pre-fix `scripts/`, **6 of the new cases fail** -- the pins are real rather than tautological.
- The pin that recorded the wrong answer as intended (`{REQUIRED: "cancelled"} -> required-check-failing, AUTHOR`) is repointed rather than deleted, so the change of verdict is visible in the diff.
- `ruff format`, `ruff check`, `mypy scripts/check_merge_blockers.py`: clean.
- Whole-tree graders (#2940): `test_no_host_paths`, `test_parameter_deletes_precede_the_body_they_narrow`, `test_whole_tree_graders_roster_is_complete`, `test_test_case_names_describe_behaviour`, `test_except_tuples_state_their_real_scope`, `test_timeline_filter_count_is_unfiltered`, `test_merge_mutation_error_is_not_a_verdict` -- **205 passed** together. `tests/tools/test_agent_tool_parameter_descriptions.py` needs the full `strands` runtime and inventories `@tool` verbs; this diff adds no `@tool` and touches no `strands_robots/` source.
- Ran live against `strands-labs/robots --all-open`: 8 pull requests, no false finding, exit `0`.

No behaviour outside the required-check classification is touched: no `strands_robots/` source, no workflow, one script and its test.

## §13 Round changelog

- **Round 1** (initial): as described above.