### PR TITLE
feat(tools/g1): port g1_list_dds_topic_descriptions and g1_dds_topic_description_admits (refs #358)

### DIFF
--- a/changelog.d/3020-g1-tools-dds-topic-descriptions-port.md
+++ b/changelog.d/3020-g1-tools-dds-topic-descriptions-port.md
@@ -4,7 +4,8 @@ Ports the third position of the neon bundle's ``TOPIC_CATALOG`` value tuple
 (``cagataycali/neon-the-g1/tools/_dds_engine.py``) - the plain-text description
 column naming what each of the twenty-two G1 DDS topics decodes at the wire
 (e.g. ``"IMU, joints, motors (~1kHz)"`` for ``rt/lowstate`` or
-``"Low-level motor cmd (🚨)"`` for ``rt/lowcmd``) - into
+``"Low-level motor cmd (drives every joint on the low-level control loop)"``
+for ``rt/lowcmd``) - into
 ``strands_robots.tools.g1``. Twin of the already-shipped
 :mod:`~strands_robots.tools.g1.g1_dds_topic_idl_types` (positions one and two
 of the same tuple) and :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`
@@ -12,5 +13,9 @@ of the same tuple) and :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`
 catalog decidably, so a caller planning a bus-side read or write can resolve
 the intent of a topic before a future driver-side wrapper for the neon
 ``g1_dds_snapshot`` verb dispatches. The import pulls no ``unitree_sdk2py``
-submodule (SDK-load-hygiene rule, refs strands-labs/robots#358). Refs
-strands-labs/robots#358.
+submodule (SDK-load-hygiene rule, refs strands-labs/robots#358). The five
+write-side topics the neon table marks with an emoji glyph reuse the plain-text
+descriptions :mod:`~strands_robots.tools.g1.g1_dangerous_publish_topics`
+already ships for the same column, so one neon description has one spelling on
+the tool surface and no caller has to substring-scan prose to decide a publish
+refusal. Refs strands-labs/robots#358.

--- a/changelog.d/3020-g1-tools-dds-topic-descriptions-port.md
+++ b/changelog.d/3020-g1-tools-dds-topic-descriptions-port.md
@@ -1,0 +1,16 @@
+### Added: `g1_list_dds_topic_descriptions` and `g1_dds_topic_description_admits` verb pair
+
+Ports the third position of the neon bundle's ``TOPIC_CATALOG`` value tuple
+(``cagataycali/neon-the-g1/tools/_dds_engine.py``) - the plain-text description
+column naming what each of the twenty-two G1 DDS topics decodes at the wire
+(e.g. ``"IMU, joints, motors (~1kHz)"`` for ``rt/lowstate`` or
+``"Low-level motor cmd (🚨)"`` for ``rt/lowcmd``) - into
+``strands_robots.tools.g1``. Twin of the already-shipped
+:mod:`~strands_robots.tools.g1.g1_dds_topic_idl_types` (positions one and two
+of the same tuple) and :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`
+(position four); together the three lookups now name every column of the neon
+catalog decidably, so a caller planning a bus-side read or write can resolve
+the intent of a topic before a future driver-side wrapper for the neon
+``g1_dds_snapshot`` verb dispatches. The import pulls no ``unitree_sdk2py``
+submodule (SDK-load-hygiene rule, refs strands-labs/robots#358). Refs
+strands-labs/robots#358.

--- a/strands_robots/tools/g1/g1_dds_topic_descriptions.py
+++ b/strands_robots/tools/g1/g1_dds_topic_descriptions.py
@@ -9,8 +9,8 @@ first two positions; :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`
 names the fourth. The remaining third position - the plain-text
 description a caller reads to name what the topic decodes at the
 wire (e.g. ``"IMU, joints, motors (~1kHz)"`` for ``rt/lowstate`` or
-``"Low-level motor cmd (\\U0001f6a8)"`` for ``rt/lowcmd``) - is what this
-module surfaces.
+``"Low-level motor cmd (drives every joint on the low-level control
+loop)"`` for ``rt/lowcmd``) - is what this module surfaces.
 
 This module snapshots the twenty-two topic descriptions as a
 module-level constant and surfaces them as two agent-facing verbs
@@ -54,6 +54,14 @@ What this module does not decide.
   :mod:`~strands_robots.tools.g1.g1_dds_topic_idl_types`, which
   already answers it. This module carries only the plain-text
   description column.
+* Whether the topic is dangerous to publish. The five write-side
+  topics the neon catalog marks with an emoji glyph are named as a
+  bare set by
+  :mod:`~strands_robots.tools.g1.g1_dangerous_publish_topics`, which
+  answers the membership question decidably. This module does not
+  re-encode that partition as a marker inside the description
+  string, so a caller never has to substring-scan prose to decide a
+  refusal.
 * Which category label partitions the topic. That belongs on
   :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`, which
   already answers it. A caller who wants both fields dispatches to
@@ -68,13 +76,25 @@ from strands import tool
 
 #: Snapshot of the neon-catalog topic-description column, keyed by
 #: DDS topic name. Twenty-two entries: nine ``state``, two ``lidar``,
-#: one ``joystick``, four ``control`` (each entry carries the
-#: dangerous-publish marker naming the refusal list), two ``hand``
-#: (the command topic also carries the dangerous-publish marker), three ``slam``, and one
-#: ``config``. The strings are captured byte-for-byte from the neon
-#: catalog; a neon-side widen or narrow of a description lands in
-#: the same PR as the neon table (the parity test surfaces the
-#: drift if the strings diverge).
+#: one ``joystick``, four ``control``, two ``hand``, three ``slam``,
+#: and one ``config``.
+#:
+#: The strings are captured from the neon catalog verbatim except for
+#: the five write-side topics the neon table marks with an emoji
+#: glyph. Those five carry the plain-text expansions
+#: :data:`~strands_robots.tools.g1.g1_dangerous_publish_topics._TOPIC_DESCRIPTIONS`
+#: already shipped for the same neon column, so one neon description
+#: has exactly one spelling on the tool surface rather than two. The
+#: glyph is deliberately not transliterated into an ASCII marker
+#: either: a marker in this column would invite a caller to decide
+#: the dangerous-publish partition by substring-scanning a
+#: description, and
+#: :func:`~strands_robots.tools.g1.g1_dangerous_publish_topics.g1_dangerous_publish_topic_admits`
+#: already decides it against a set.
+#:
+#: A neon-side widen or narrow of a description lands in the same PR
+#: as the neon table (the parity test surfaces the drift if the
+#: strings diverge).
 _DDS_TOPIC_DESCRIPTIONS: dict[str, str] = {
     # --- READ-ONLY: robot state ---
     "rt/lowstate": "IMU, joints, motors (~1kHz)",
@@ -91,15 +111,15 @@ _DDS_TOPIC_DESCRIPTIONS: dict[str, str] = {
     "rt/utlidar/lidar_state": "LiDAR sensor state",
     # --- READ-ONLY: joystick ---
     "rt/wirelesscontroller": "Remote joystick (silent unpaired)",
-    # --- CONTROL (WRITE) — dangerous ---
-    "rt/lowcmd": "Low-level motor cmd (\U0001f6a8)",
-    "rt/armsdk": "Arm SDK override (\U0001f6a8)",
-    "rt/user_lowcmd": "User low-level cmd (\U0001f6a8)",
-    "rt/bmscmd": "BMS cmd (\U0001f6a8 power/reboot)",
+    # --- CONTROL (WRITE): dangerous to publish ---
+    "rt/lowcmd": "Low-level motor cmd (drives every joint on the low-level control loop)",
+    "rt/armsdk": "Arm SDK override (the arm-SDK admission path a naive publish bypasses)",
+    "rt/user_lowcmd": "User low-level cmd (an alternative rt/lowcmd path with the same wire risk)",
+    "rt/bmscmd": "BMS cmd (battery-management command, admits a reboot or power-cycle payload)",
     # --- G1 HANDS (Inspire/Unitree 5/7-DoF hand) ---
     "rt/inspire/state": "Inspire hand state (joint pos/tau)",
-    "rt/inspire/cmd": "Inspire hand command (\U0001f6a8 write)",
-    # --- SLAM / Odometry (experimental — topic naming varies) ---
+    "rt/inspire/cmd": "Inspire hand command (5/7-DoF hand joint cmd, publishes to the hand controller)",
+    # --- SLAM / Odometry (experimental - topic naming varies) ---
     "rt/odom": "Robot odometry (nav_msgs)",
     "rt/unitree_slam/odom": "Unitree SLAM odometry",
     "rt/unitree_slam/global_map": "Unitree SLAM global map",
@@ -137,11 +157,10 @@ def g1_list_dds_topic_descriptions() -> dict[str, Any]:
 
     The envelope names twenty-two topics: nine on the read-side
     ``state`` partition, two on ``lidar``, one on ``joystick``, four
-    on the ``control`` write partition (each entry carries the
-    dangerous-publish marker the neon catalog uses to name the
-    refusal list), two on ``hand`` (the command topic also
-    dangerous-publish-marked),
-    three on ``slam``, and one on ``config``.
+    on the ``control`` write partition, two on ``hand``, three on
+    ``slam``, and one on ``config``. Which of them a publish path
+    must refuse is not answered here; ``g1_dangerous_publish_topics``
+    answers that against a set rather than by marking this column.
 
     Returns:
         A dict with ``status``; a ``count`` naming the number of

--- a/strands_robots/tools/g1/g1_dds_topic_descriptions.py
+++ b/strands_robots/tools/g1/g1_dds_topic_descriptions.py
@@ -9,7 +9,7 @@ first two positions; :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`
 names the fourth. The remaining third position - the plain-text
 description a caller reads to name what the topic decodes at the
 wire (e.g. ``"IMU, joints, motors (~1kHz)"`` for ``rt/lowstate`` or
-``"Low-level motor cmd (🚨)"`` for ``rt/lowcmd``) - is what this
+``"Low-level motor cmd (\\U0001f6a8)"`` for ``rt/lowcmd``) - is what this
 module surfaces.
 
 This module snapshots the twenty-two topic descriptions as a
@@ -68,9 +68,9 @@ from strands import tool
 
 #: Snapshot of the neon-catalog topic-description column, keyed by
 #: DDS topic name. Twenty-two entries: nine ``state``, two ``lidar``,
-#: one ``joystick``, four ``control`` (each entry carries the 🚨
-#: marker naming the dangerous-publish refusal list), two ``hand``
-#: (the command topic also carries 🚨), three ``slam``, and one
+#: one ``joystick``, four ``control`` (each entry carries the
+#: dangerous-publish marker naming the refusal list), two ``hand``
+#: (the command topic also carries the dangerous-publish marker), three ``slam``, and one
 #: ``config``. The strings are captured byte-for-byte from the neon
 #: catalog; a neon-side widen or narrow of a description lands in
 #: the same PR as the neon table (the parity test surfaces the
@@ -137,9 +137,10 @@ def g1_list_dds_topic_descriptions() -> dict[str, Any]:
 
     The envelope names twenty-two topics: nine on the read-side
     ``state`` partition, two on ``lidar``, one on ``joystick``, four
-    on the ``control`` write partition (each entry carries the 🚨
-    marker the neon catalog uses to name the dangerous-publish
-    refusal list), two on ``hand`` (the command topic also 🚨-marked),
+    on the ``control`` write partition (each entry carries the
+    dangerous-publish marker the neon catalog uses to name the
+    refusal list), two on ``hand`` (the command topic also
+    dangerous-publish-marked),
     three on ``slam``, and one on ``config``.
 
     Returns:

--- a/strands_robots/tools/g1/g1_dds_topic_descriptions.py
+++ b/strands_robots/tools/g1/g1_dds_topic_descriptions.py
@@ -1,0 +1,249 @@
+"""Agent-facing lookup for the DDS topic descriptions the neon catalog names.
+
+The neon bundle's ``_dds_engine.py``
+(``cagataycali/neon-the-g1/tools/_dds_engine.py``) carries a
+``TOPIC_CATALOG`` dict whose per-topic value tuple is
+``(idl_module, idl_class, description, category)``. The
+:mod:`~strands_robots.tools.g1.g1_dds_topic_idl_types` port names the
+first two positions; :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`
+names the fourth. The remaining third position - the plain-text
+description a caller reads to name what the topic decodes at the
+wire (e.g. ``"IMU, joints, motors (~1kHz)"`` for ``rt/lowstate`` or
+``"Low-level motor cmd (🚨)"`` for ``rt/lowcmd``) - is what this
+module surfaces.
+
+This module snapshots the twenty-two topic descriptions as a
+module-level constant and surfaces them as two agent-facing verbs
+(:func:`g1_list_dds_topic_descriptions` returns the whole envelope;
+:func:`g1_dds_topic_description_admits` decides one membership query
+against the topic-name key) so a caller planning a bus-side read or
+write names the intent of a topic decidably before a future
+driver-side wrapper for the neon ``g1_dds_snapshot`` /
+``g1_dds_subscribe`` verb dispatches. Refs strands-labs/robots#358.
+
+Two things this module is deliberately *not*:
+
+* An execution path. The neon bundle's generic DDS verbs open a
+  second DDS reader against arbitrary topics; that second reader
+  path is out of scope for this lookup, which only names the
+  read-only description string. A future verb that routes a
+  subscribe request through the driver's singleton reader is a
+  separate port; refs strands-labs/robots#358 for the DDS-facing
+  seam that would land on. This module ports the read-only lookup
+  half without also introducing a second reader path the driver
+  does not yet front.
+* An SDK or CycloneDDS re-import. The topic-description strings are
+  captured here as module-level constants snapshotted from the neon
+  ``TOPIC_CATALOG`` dict; the constants live here rather than being
+  re-imported from the neon module so ``import
+  strands_robots.tools.g1.g1_dds_topic_descriptions`` pulls no
+  ``unitree_sdk2py`` submodule (the import-hygiene contract every
+  other file in this package carries, refs strands-labs/robots#358).
+  A neon-side widen that adds or drops a topic description lands in
+  the same PR as the neon table, or the parity test in
+  ``tests/drivers/`` surfaces the drift.
+
+What this module does not decide.
+
+* Whether a topic is currently *live* on the bus. Topic liveness is a
+  DDS-layer discovery answer; the neon bundle's ``g1_dds_discover``
+  verb wraps ``cyclonedds ls`` for that. This lookup answers a static
+  question: which description string the neon catalog carries per
+  topic name, independent of whether the robot is powered on.
+* Which IDL class decodes the topic's payload. That belongs on
+  :mod:`~strands_robots.tools.g1.g1_dds_topic_idl_types`, which
+  already answers it. This module carries only the plain-text
+  description column.
+* Which category label partitions the topic. That belongs on
+  :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`, which
+  already answers it. A caller who wants both fields dispatches to
+  each verb separately.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+#: Snapshot of the neon-catalog topic-description column, keyed by
+#: DDS topic name. Twenty-two entries: nine ``state``, two ``lidar``,
+#: one ``joystick``, four ``control`` (each entry carries the 🚨
+#: marker naming the dangerous-publish refusal list), two ``hand``
+#: (the command topic also carries 🚨), three ``slam``, and one
+#: ``config``. The strings are captured byte-for-byte from the neon
+#: catalog; a neon-side widen or narrow of a description lands in
+#: the same PR as the neon table (the parity test surfaces the
+#: drift if the strings diverge).
+_DDS_TOPIC_DESCRIPTIONS: dict[str, str] = {
+    # --- READ-ONLY: robot state ---
+    "rt/lowstate": "IMU, joints, motors (~1kHz)",
+    "rt/lf/lowstate": "Low-freq LowState variant",
+    "rt/bmsstate": "Battery management",
+    "rt/lf/bmsstate": "Battery (low-freq)",
+    "rt/mainboardstate": "Fan / board temps",
+    "rt/pressuresensorstate": "Foot pressure sensors",
+    "rt/lf/sportmodestate": "Motion state (low-freq)",
+    "rt/lf/secondary_imu": "Secondary IMU",
+    "rt/multiplestate": "Combined state",
+    # --- READ-ONLY: LiDAR / SLAM ---
+    "rt/utlidar/cloud_livox_mid360": "Livox Mid-360 point cloud",
+    "rt/utlidar/lidar_state": "LiDAR sensor state",
+    # --- READ-ONLY: joystick ---
+    "rt/wirelesscontroller": "Remote joystick (silent unpaired)",
+    # --- CONTROL (WRITE) — dangerous ---
+    "rt/lowcmd": "Low-level motor cmd (\U0001f6a8)",
+    "rt/armsdk": "Arm SDK override (\U0001f6a8)",
+    "rt/user_lowcmd": "User low-level cmd (\U0001f6a8)",
+    "rt/bmscmd": "BMS cmd (\U0001f6a8 power/reboot)",
+    # --- G1 HANDS (Inspire/Unitree 5/7-DoF hand) ---
+    "rt/inspire/state": "Inspire hand state (joint pos/tau)",
+    "rt/inspire/cmd": "Inspire hand command (\U0001f6a8 write)",
+    # --- SLAM / Odometry (experimental — topic naming varies) ---
+    "rt/odom": "Robot odometry (nav_msgs)",
+    "rt/unitree_slam/odom": "Unitree SLAM odometry",
+    "rt/unitree_slam/global_map": "Unitree SLAM global map",
+    # --- WRITE: non-motion config ---
+    "rt/utlidar/switch": "LiDAR ON/OFF switch",
+}
+
+
+def _describe(topic: str) -> dict[str, Any]:
+    """Build the per-topic descriptor the verbs return.
+
+    Kept here rather than inlined in
+    :func:`g1_list_dds_topic_descriptions` so
+    :func:`g1_dds_topic_description_admits`'s admitted-path payload
+    names the same fields, and so a widen to the descriptor lands
+    in one place. Every field is a snapshot read; no bus is
+    touched.
+    """
+    return {
+        "topic": topic,
+        "description": _DDS_TOPIC_DESCRIPTIONS[topic],
+    }
+
+
+@tool
+def g1_list_dds_topic_descriptions() -> dict[str, Any]:
+    """Return the DDS topic descriptions the neon catalog names.
+
+    Read-only. No driver instance, no DDS, no SDK: every field is a
+    module-level constant. Useful before a future driver-side wrapper
+    for the neon ``g1_dds_snapshot`` / ``g1_dds_subscribe`` verb is
+    called, so a caller planning a bus-side read or write names what
+    the topic decodes at the wire decidably before the topic itself
+    is opened.
+
+    The envelope names twenty-two topics: nine on the read-side
+    ``state`` partition, two on ``lidar``, one on ``joystick``, four
+    on the ``control`` write partition (each entry carries the 🚨
+    marker the neon catalog uses to name the dangerous-publish
+    refusal list), two on ``hand`` (the command topic also 🚨-marked),
+    three on ``slam``, and one on ``config``.
+
+    Returns:
+        A dict with ``status``; a ``count`` naming the number of
+        topics; a ``descriptions`` list of descriptors (one per
+        topic, sorted lexicographically by ``topic``) carrying
+        ``topic`` and ``description``; and a ``topics`` field
+        listing the topic-name keys sorted lexicographically. Every
+        field is a snapshot of a neon-observed constant; no dynamic
+        decode runs here.
+    """
+    topics = sorted(_DDS_TOPIC_DESCRIPTIONS)
+    return {
+        "status": "success",
+        "count": len(_DDS_TOPIC_DESCRIPTIONS),
+        "descriptions": [_describe(topic) for topic in topics],
+        "topics": topics,
+    }
+
+
+@tool
+def g1_dds_topic_description_admits(topic: str = "") -> dict[str, Any]:
+    """Decide whether a topic name is inside the neon-catalog description table.
+
+    Read-only. Reads the module's snapshot of the neon bundle's
+    ``TOPIC_CATALOG`` topic-name keys and returns the same
+    membership answer a caller planning a bus-side read or write
+    against the catalog would compute. A caller with a topic
+    string resolves it against the catalog before a future
+    catalog-lookup verb dispatches, rather than triggering the
+    neon catalog's ``KeyError`` at wire time (an unknown topic
+    name is not on the neon table and the neon lookup returns
+    nothing for it).
+
+    A topic inside :data:`_DDS_TOPIC_DESCRIPTIONS` is a valid neon
+    catalog entry; a topic outside is either not carried by the
+    neon catalog (the neon generic ``g1_dds_snapshot`` verb still
+    accepts an arbitrary topic with ``type_module`` +
+    ``type_class`` overrides, but a caller relying on the neon
+    catalog's built-in decode resolves the miss decidably here).
+
+    Args:
+        topic: The DDS topic name to test. Must be a non-empty
+            ``str``; ``bool`` is refused (``True``/``False`` are
+            not valid topic names under any DDS convention) and
+            the empty string is refused as a shape error (no name
+            means no membership query to answer). Non-str inputs
+            are refused decidably rather than resolved through
+            Python's ``str()`` coercion.
+
+    Returns:
+        A dict with ``status``; a ``query`` sub-dict carrying the
+        supplied ``topic``; an ``admitted`` boolean naming whether
+        the topic is a member of the twenty-two-entry catalog; and
+        (when ``admitted`` is ``True``) a ``target`` sub-dict
+        carrying the same descriptor
+        :func:`g1_list_dds_topic_descriptions` returns for the
+        topic (``topic``, ``description``). On a not-admitted
+        query the dict carries a ``refusal_advice`` field naming
+        the neon-side note that the topic is not on the built-in
+        catalog and that a caller may still reach the bus via the
+        generic ``g1_dds_snapshot`` verb by supplying
+        ``type_module`` and ``type_class`` overrides. On a shape
+        error (``bool``, non-str, empty string) the dict carries
+        ``status="error"`` with a message naming the type refused.
+    """
+    if isinstance(topic, bool):
+        return {
+            "status": "error",
+            "message": (f"topic must be str, got bool ({topic!r}). Refs strands-labs/robots#358."),
+        }
+    if not isinstance(topic, str):
+        return {
+            "status": "error",
+            "message": (f"topic must be str, got {type(topic).__name__} ({topic!r}). Refs strands-labs/robots#358."),
+        }
+    if topic == "":
+        return {
+            "status": "error",
+            "message": (
+                "topic must be a non-empty str; an empty topic name has "
+                "no membership answer to compute. Refs "
+                "strands-labs/robots#358."
+            ),
+        }
+
+    admitted = topic in _DDS_TOPIC_DESCRIPTIONS
+    if not admitted:
+        return {
+            "status": "success",
+            "admitted": False,
+            "query": {"topic": topic},
+            "refusal_advice": (
+                f"topic {topic!r} is not on the neon catalog; the neon "
+                "g1_dds_snapshot verb still accepts an arbitrary topic "
+                "with type_module + type_class overrides, but a caller "
+                "relying on the catalog's built-in decode resolves the "
+                "miss here. Refs strands-labs/robots#358."
+            ),
+        }
+
+    return {
+        "status": "success",
+        "admitted": True,
+        "query": {"topic": topic},
+        "target": _describe(topic),
+    }

--- a/tests/drivers/test_g1_dds_topic_descriptions_reads_the_neon_catalog.py
+++ b/tests/drivers/test_g1_dds_topic_descriptions_reads_the_neon_catalog.py
@@ -1,0 +1,403 @@
+"""The DDS topic-description envelope tools name exactly what the neon catalog ships.
+
+The neon bundle's ``_dds_engine.py`` (``cagataycali/neon-the-g1/tools/_dds_engine.py``)
+carries a ``TOPIC_CATALOG`` dict whose per-topic value tuple's third
+position is a plain-text description string; the neon generic
+``g1_dds_list_topics`` verb returns those descriptors verbatim to a
+caller. The :mod:`strands_robots.tools.g1.g1_dds_topic_descriptions`
+module snapshots the twenty-two topic descriptions into a module-level
+constant and exposes two agent-facing verbs -
+:func:`g1_list_dds_topic_descriptions` (list the whole envelope) and
+:func:`g1_dds_topic_description_admits` (decide one membership query) -
+so a caller planning a bus-side read or write names what the topic
+decodes at the wire decidably before a future driver-side wrapper
+for the neon ``g1_dds_snapshot`` / ``g1_dds_subscribe`` verb lands.
+The tests here fix that contract without pulling the SDK: the module
+is loadable on a host without ``unitree_sdk2py`` (the same
+SDK-load-hygiene rule every other file under
+:mod:`strands_robots.tools.g1` carries, refs strands-labs/robots#358),
+and every membership answer is read off the module's own snapshot
+rather than restated in the tests, so a widen or narrow to the
+constant surfaces here as a shape change rather than as a diverging
+table this file would need to manually update.
+
+Two things this file's cells deliberately do not pin:
+
+* The neon bundle's own answer at wire time. The verbs answer against
+  the module-level snapshot, not against a live import of the neon
+  bundle's ``TOPIC_CATALOG`` value tuples (the whole point of the
+  port is that the snapshot lets a headless host answer without
+  pulling the neon module or the CycloneDDS bindings). A driver-side
+  wrapper for the neon catalog read that lands later will
+  re-validate against its own live table at wire time; testing the
+  snapshot vs the live table is a driver-side test, not a
+  lookup-side one.
+* Per-topic IDL type or category. The verb answers only the description
+  column of the neon catalog's per-topic tuple. Which IDL class decodes
+  the payload is answered by
+  :mod:`~strands_robots.tools.g1.g1_dds_topic_idl_types`, and which
+  category partitions the topic is answered by
+  :mod:`~strands_robots.tools.g1.g1_dds_topic_categories`. A caller
+  wanting both fields dispatches to each verb separately; this test
+  file does not cross that scope line.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+from strands_robots.tools.g1.g1_dds_topic_descriptions import (
+    _DDS_TOPIC_DESCRIPTIONS,
+    g1_dds_topic_description_admits,
+    g1_list_dds_topic_descriptions,
+)
+
+
+def _call(tool: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call a ``@tool``-decorated function and unwrap the payload.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process, but a caller cannot rely on
+    that: the wrapper's contract is that it returns the wrapped
+    function's return value verbatim. This helper is where a shape
+    drift would surface once, rather than at every call site.
+    """
+    return tool(**kwargs)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be importable
+    with the SDK absent; a module that pulled a submodule at import
+    time would break every headless CI runner and Thor before an
+    office bring-up. The driver enforces the same rule against
+    itself (:func:`~strands_robots.tools.g1._g1_common.ensure_dds` is
+    the only path that loads the SDK); this cell holds the
+    dds-topic-descriptions envelope verbs to it too (refs
+    strands-labs/robots#358).
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_dds_topic_descriptions")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_dds_topic_descriptions imports pulled "
+        f"SDK submodules: {leaked}. The rule for this package is that the "
+        "SDK loads only inside function bodies (refs "
+        "strands-labs/robots#358)."
+    )
+
+
+def test_the_snapshot_covers_the_neon_observed_catalog() -> None:
+    """The snapshot names every topic the neon catalog carries today.
+
+    The neon bundle's ``_dds_engine.TOPIC_CATALOG`` ships twenty-two
+    entries: nine ``state``, two ``lidar``, one ``joystick``, four
+    ``control``, two ``hand``, three ``slam``, one ``config``. A drift
+    on either side surfaces here: a driver-side generic-snapshot
+    wrapper (when it lands) will validate the same catalog at wire
+    time and its refusal string will quote the same membership test.
+    The count is pinned rather than listed value-by-value so a
+    caller widening the catalog on the neon side updates one number
+    here rather than 22 assertions.
+    """
+    assert len(_DDS_TOPIC_DESCRIPTIONS) == 22, (
+        f"expected 22 topic entries in the neon-observed snapshot, got "
+        f"{len(_DDS_TOPIC_DESCRIPTIONS)}: {sorted(_DDS_TOPIC_DESCRIPTIONS)}. A "
+        "neon-side widen or narrow would update this count; refs "
+        "strands-labs/robots#358."
+    )
+
+
+def test_every_snapshot_topic_carries_a_non_empty_description() -> None:
+    """Every topic key has a non-empty description string.
+
+    :data:`_DDS_TOPIC_DESCRIPTIONS` is the table both verbs read when
+    they build the returned descriptor. A neon-side widen must
+    supply a non-empty description string; an empty description
+    would leave a caller unable to name the intent of the topic at
+    the surface, which is the whole point of surfacing the
+    description column separately from the IDL-type and category
+    columns.
+    """
+    for topic, description in _DDS_TOPIC_DESCRIPTIONS.items():
+        assert isinstance(description, str) and description != "", (
+            f"description for topic {topic!r} must be a non-empty str; "
+            f"got {description!r}. Refs strands-labs/robots#358."
+        )
+
+
+def test_every_snapshot_topic_key_is_an_rt_prefixed_string() -> None:
+    """Every topic name follows the neon catalog's ``rt/`` prefix convention.
+
+    The neon ``_dds_engine.TOPIC_CATALOG`` names every G1 DDS topic
+    with the ``rt/`` prefix Unitree's SDK ships. A key without that
+    prefix would either be a caller mistake in the port or a neon
+    widen that broke the convention; either way, the drift surfaces
+    here so the assertion in a driver-side wrapper for the
+    ``g1_dds_snapshot`` verb (when it lands) does not silently pass
+    the un-prefixed key through.
+    """
+    for topic in _DDS_TOPIC_DESCRIPTIONS:
+        assert topic.startswith("rt/"), (
+            f"topic key {topic!r} does not start with 'rt/'; the neon "
+            "TOPIC_CATALOG names every G1 DDS topic with that prefix. Refs "
+            "strands-labs/robots#358."
+        )
+
+
+def test_the_control_topics_carry_the_dangerous_publish_marker() -> None:
+    """Every ``rt/lowcmd``-family control topic description carries 🚨.
+
+    The neon ``TOPIC_CATALOG`` marks every write-side low-level
+    command topic with the 🚨 emoji in its description so a caller
+    reading the raw catalog can see the dangerous-publish partition
+    at a glance. A neon-side widen that dropped the marker on one
+    of the four control topics would silently downgrade the caller's
+    visible refusal; pinning the marker here surfaces the drift.
+    Refs :mod:`~strands_robots.tools.g1.g1_dangerous_publish_topics`
+    for the sibling snapshot of the same partition as a bare set.
+    """
+    control_topics = (
+        "rt/lowcmd",
+        "rt/armsdk",
+        "rt/user_lowcmd",
+        "rt/bmscmd",
+    )
+    for topic in control_topics:
+        description = _DDS_TOPIC_DESCRIPTIONS[topic]
+        assert "\U0001f6a8" in description, (
+            f"description for control topic {topic!r} is {description!r}; "
+            "the neon catalog marks every write-side low-level command "
+            "topic with 🚨. Refs strands-labs/robots#358."
+        )
+
+
+def test_the_inspire_cmd_topic_carries_the_dangerous_publish_marker() -> None:
+    """The Inspire hand ``cmd`` write topic carries 🚨 too.
+
+    The neon ``DANGEROUS_PUB_TOPICS`` set is five entries: the four
+    ``control`` category topics plus ``rt/inspire/cmd`` (the Inspire
+    hand cmd, which sits in the ``hand`` category rather than
+    ``control``). The description column marks it as 🚨 too, which
+    a caller reading the raw catalog needs to see so the hand
+    partition does not silently look safer than the low-level
+    command partition.
+    """
+    description = _DDS_TOPIC_DESCRIPTIONS["rt/inspire/cmd"]
+    assert "\U0001f6a8" in description, (
+        f"description for rt/inspire/cmd is {description!r}; the neon "
+        "catalog marks the Inspire hand cmd write topic with 🚨 too. "
+        "Refs strands-labs/robots#358."
+    )
+
+
+def test_the_state_topics_do_not_carry_the_dangerous_publish_marker() -> None:
+    """No read-side ``state`` topic description carries 🚨.
+
+    The 🚨 marker names the write-side dangerous-publish partition
+    only; a read-side topic with the marker would misrepresent the
+    refusal surface to a caller scanning the catalog. This test
+    pins the marker's meaning against the read partition.
+    """
+    state_topics = (
+        "rt/lowstate",
+        "rt/lf/lowstate",
+        "rt/bmsstate",
+        "rt/lf/bmsstate",
+        "rt/mainboardstate",
+        "rt/pressuresensorstate",
+        "rt/lf/sportmodestate",
+        "rt/lf/secondary_imu",
+        "rt/multiplestate",
+    )
+    for topic in state_topics:
+        description = _DDS_TOPIC_DESCRIPTIONS[topic]
+        assert "\U0001f6a8" not in description, (
+            f"description for read-side state topic {topic!r} is "
+            f"{description!r}; the neon catalog marks only write-side "
+            "topics with 🚨. Refs strands-labs/robots#358."
+        )
+
+
+def test_list_returns_every_topic_in_sorted_order() -> None:
+    """The list verb returns descriptors sorted lexicographically by topic name.
+
+    The order is fixed so a caller comparing two returned envelopes
+    (before and after a widen, for instance) sees a stable diff
+    rather than a permutation. Sorting is done at the verb boundary
+    rather than in the snapshot so the underlying constant stays a
+    ``dict`` (order-free at the shape level) and the verb-time order
+    is a display concern.
+    """
+    payload = _call(g1_list_dds_topic_descriptions)
+    assert payload["status"] == "success", payload
+    topics = payload["topics"]
+    assert topics == sorted(topics), (
+        f"list verb returned topics {topics!r} out of sorted order; the "
+        "verb's contract is a stable lexicographic sort so a caller sees a "
+        "stable diff across widens. Refs strands-labs/robots#358."
+    )
+    descriptor_topics = [row["topic"] for row in payload["descriptions"]]
+    assert descriptor_topics == topics, (
+        f"descriptor list ordering {descriptor_topics!r} disagrees with "
+        f"topics field ordering {topics!r}; both must present in the same "
+        "sorted order. Refs strands-labs/robots#358."
+    )
+
+
+def test_list_names_every_snapshot_topic_and_no_others() -> None:
+    """The list verb surfaces exactly the membership set.
+
+    A drift here means the verb's returned envelope disagrees with
+    the module-level constant it is supposed to snapshot; the whole
+    point of the port is that the two agree by construction.
+    """
+    payload = _call(g1_list_dds_topic_descriptions)
+    assert payload["count"] == len(_DDS_TOPIC_DESCRIPTIONS), (
+        f"list verb count {payload['count']} disagrees with snapshot size "
+        f"{len(_DDS_TOPIC_DESCRIPTIONS)}. Refs strands-labs/robots#358."
+    )
+    surfaced = set(payload["topics"])
+    assert surfaced == set(_DDS_TOPIC_DESCRIPTIONS), (
+        f"list verb topics {sorted(surfaced)} disagree with the snapshot "
+        f"{sorted(_DDS_TOPIC_DESCRIPTIONS)}. A widen must update both "
+        "together; refs strands-labs/robots#358."
+    )
+
+
+def test_list_surfaces_every_descriptor_with_the_snapshot_description() -> None:
+    """Every descriptor carries the topic's snapshot description byte-for-byte.
+
+    The ``description`` field on each returned descriptor must match
+    the module's :data:`_DDS_TOPIC_DESCRIPTIONS` entry for that
+    topic byte-for-byte; a re-wording that only landed on one side
+    of the verb boundary would surface here.
+    """
+    payload = _call(g1_list_dds_topic_descriptions)
+    for row in payload["descriptions"]:
+        topic = row["topic"]
+        expected = _DDS_TOPIC_DESCRIPTIONS[topic]
+        assert row["description"] == expected, (
+            f"descriptor row for topic {topic!r} carries description "
+            f"{row['description']!r}; snapshot says {expected!r}. Refs "
+            "strands-labs/robots#358."
+        )
+
+
+def test_admits_returns_true_on_every_snapshot_topic() -> None:
+    """Every topic key in the snapshot admits.
+
+    Pins the round-trip: whatever the list verb returns as a valid
+    topic, the admits verb agrees is a member of the catalog. A
+    drift between the two would leave a caller unable to trust the
+    two verbs' answers together.
+    """
+    for topic in sorted(_DDS_TOPIC_DESCRIPTIONS):
+        payload = _call(g1_dds_topic_description_admits, topic=topic)
+        assert payload["status"] == "success", payload
+        assert payload["admitted"] is True, (
+            f"admits verb refused {topic!r} but it is a member of the "
+            f"catalog snapshot {sorted(_DDS_TOPIC_DESCRIPTIONS)}. Refs "
+            "strands-labs/robots#358."
+        )
+        assert payload["target"]["topic"] == topic, (
+            f"admits verb target topic {payload['target']['topic']!r} "
+            f"disagrees with the queried topic {topic!r}. Refs "
+            "strands-labs/robots#358."
+        )
+        assert payload["target"]["description"] == _DDS_TOPIC_DESCRIPTIONS[topic], (
+            f"admits verb target description for {topic!r} is "
+            f"{payload['target']['description']!r}; snapshot says "
+            f"{_DDS_TOPIC_DESCRIPTIONS[topic]!r}. Refs "
+            "strands-labs/robots#358."
+        )
+
+
+def test_admits_refuses_an_off_catalog_topic_with_snapshot_note() -> None:
+    """A topic outside the catalog returns ``admitted=False`` with the neon override note.
+
+    A caller relying on the neon catalog's built-in decode resolves
+    the miss decidably; the refusal names the neon-side override
+    path (``type_module`` + ``type_class``) the generic
+    ``g1_dds_snapshot`` verb accepts, so a caller reading the
+    refusal knows how to reach the bus for an off-catalog topic
+    without pretending the description snapshot carries it.
+    """
+    payload = _call(g1_dds_topic_description_admits, topic="rt/notacatalogtopic")
+    assert payload["status"] == "success", payload
+    assert payload["admitted"] is False, (
+        "admits verb admitted an off-catalog topic; catalog snapshot "
+        f"is {sorted(_DDS_TOPIC_DESCRIPTIONS)}. Refs "
+        "strands-labs/robots#358."
+    )
+    assert "'rt/notacatalogtopic'" in payload["refusal_advice"], (
+        f"admits verb refusal_advice {payload['refusal_advice']!r} must "
+        "name the queried topic verbatim. Refs strands-labs/robots#358."
+    )
+    assert "type_module" in payload["refusal_advice"], (
+        f"admits verb refusal_advice {payload['refusal_advice']!r} must "
+        "name the type_module override path a caller uses to reach the "
+        "bus for an off-catalog topic. Refs strands-labs/robots#358."
+    )
+
+
+def test_admits_refuses_a_bool_argument_as_a_shape_error() -> None:
+    """``bool`` is refused decidably, not resolved through ``str()`` coercion.
+
+    ``True``/``False`` are not valid topic names under any DDS
+    convention; a caller that passed a boolean is making a caller
+    mistake, and the verb surfaces it as an error rather than
+    resolving through Python's coercions.
+    """
+    for value in (True, False):
+        payload = _call(g1_dds_topic_description_admits, topic=value)
+        assert payload["status"] == "error", (
+            f"admits verb accepted bool topic {value!r}; the argument must be str. Refs strands-labs/robots#358."
+        )
+        assert "bool" in payload["message"], (
+            f"admits verb error message for bool topic {value!r} must "
+            f"name the refused type; got {payload['message']!r}. Refs "
+            "strands-labs/robots#358."
+        )
+
+
+def test_admits_refuses_a_non_str_argument_as_a_shape_error() -> None:
+    """Non-str inputs are refused decidably.
+
+    ``int``, ``float``, ``None``, ``list``, ``tuple`` are all not
+    valid topic names and the verb surfaces each as a shape error
+    rather than resolving through Python's coercions.
+    """
+    for value in (1, 1.5, None, ["rt/lowstate"], ("rt/lowstate",)):
+        payload = _call(g1_dds_topic_description_admits, topic=value)
+        assert payload["status"] == "error", (
+            f"admits verb accepted non-str topic {value!r}; the argument must be str. Refs strands-labs/robots#358."
+        )
+        assert type(value).__name__ in payload["message"], (
+            f"admits verb error message for non-str topic {value!r} must "
+            f"name the refused type; got {payload['message']!r}. Refs "
+            "strands-labs/robots#358."
+        )
+
+
+def test_admits_refuses_the_empty_string_as_a_shape_error() -> None:
+    """The empty string is refused decidably.
+
+    An empty topic name has no membership answer to compute; the
+    verb refuses it as a shape error rather than returning
+    ``admitted=False`` (which would let a caller silently pass the
+    empty string through as an off-catalog topic).
+    """
+    payload = _call(g1_dds_topic_description_admits, topic="")
+    assert payload["status"] == "error", (
+        "admits verb accepted an empty topic string; the argument must be non-empty. Refs strands-labs/robots#358."
+    )
+    assert "non-empty" in payload["message"], (
+        f"admits verb error message for the empty string must name the "
+        f"non-empty contract; got {payload['message']!r}. Refs "
+        "strands-labs/robots#358."
+    )

--- a/tests/drivers/test_g1_dds_topic_descriptions_reads_the_neon_catalog.py
+++ b/tests/drivers/test_g1_dds_topic_descriptions_reads_the_neon_catalog.py
@@ -48,6 +48,12 @@ import importlib
 import sys
 from typing import Any
 
+from strands_robots.tools.g1.g1_dangerous_publish_topics import (
+    _DANGEROUS_PUBLISH_TOPICS,
+)
+from strands_robots.tools.g1.g1_dangerous_publish_topics import (
+    _TOPIC_DESCRIPTIONS as _DANGEROUS_PUBLISH_DESCRIPTIONS,
+)
 from strands_robots.tools.g1.g1_dds_topic_descriptions import (
     _DDS_TOPIC_DESCRIPTIONS,
     g1_dds_topic_description_admits,
@@ -149,59 +155,59 @@ def test_every_snapshot_topic_key_is_an_rt_prefixed_string() -> None:
         )
 
 
-def test_the_control_topics_carry_the_dangerous_publish_marker() -> None:
-    """Every ``rt/lowcmd``-family control topic description carries 🚨.
+def test_the_dangerous_publish_topics_carry_the_sibling_spelling() -> None:
+    """The five write-side topics reuse the shipped plain-text descriptions.
 
-    The neon ``TOPIC_CATALOG`` marks every write-side low-level
-    command topic with the 🚨 emoji in its description so a caller
-    reading the raw catalog can see the dangerous-publish partition
-    at a glance. A neon-side widen that dropped the marker on one
-    of the four control topics would silently downgrade the caller's
-    visible refusal; pinning the marker here surfaces the drift.
-    Refs :mod:`~strands_robots.tools.g1.g1_dangerous_publish_topics`
-    for the sibling snapshot of the same partition as a bare set.
+    The neon ``TOPIC_CATALOG`` marks its five write-side topics with
+    an emoji glyph in the description column.
+    :mod:`~strands_robots.tools.g1.g1_dangerous_publish_topics` already
+    ported that same column for the same five topics with the glyph
+    expanded to plain text, so this snapshot reuses those strings
+    verbatim rather than inventing a second spelling: one neon
+    description resolves to one string on the tool surface, and a
+    re-wording lands in one file instead of drifting between two
+    verbs a caller may well call in the same turn.
+
+    Read off the sibling constant rather than restated here, so a
+    re-wording on either side surfaces as this cell failing instead
+    of as two verbs quietly disagreeing.
     """
-    control_topics = (
-        "rt/lowcmd",
-        "rt/armsdk",
-        "rt/user_lowcmd",
-        "rt/bmscmd",
+    assert _DANGEROUS_PUBLISH_TOPICS, (
+        "the sibling dangerous-publish snapshot is empty; this cell "
+        "compares against it and would pass vacuously. Refs "
+        "strands-labs/robots#358."
     )
-    for topic in control_topics:
-        description = _DDS_TOPIC_DESCRIPTIONS[topic]
-        assert "\U0001f6a8" in description, (
-            f"description for control topic {topic!r} is {description!r}; "
-            "the neon catalog marks every write-side low-level command "
-            "topic with 🚨. Refs strands-labs/robots#358."
+    for topic in sorted(_DANGEROUS_PUBLISH_TOPICS):
+        assert topic in _DDS_TOPIC_DESCRIPTIONS, (
+            f"write-side topic {topic!r} is named by "
+            "g1_dangerous_publish_topics but absent from the "
+            "description snapshot; the two ports read the same neon "
+            "catalog and must cover the same topic names. Refs "
+            "strands-labs/robots#358."
+        )
+        assert _DDS_TOPIC_DESCRIPTIONS[topic] == _DANGEROUS_PUBLISH_DESCRIPTIONS[topic], (
+            f"description for {topic!r} is "
+            f"{_DDS_TOPIC_DESCRIPTIONS[topic]!r} but "
+            "g1_dangerous_publish_topics spells the same neon column "
+            f"{_DANGEROUS_PUBLISH_DESCRIPTIONS[topic]!r}. One neon "
+            "description must have one spelling on the tool surface. "
+            "Refs strands-labs/robots#358."
         )
 
 
-def test_the_inspire_cmd_topic_carries_the_dangerous_publish_marker() -> None:
-    """The Inspire hand ``cmd`` write topic carries 🚨 too.
+def test_the_state_topics_are_not_in_the_dangerous_publish_set() -> None:
+    """The read partition is decided by the sibling set, not by prose.
 
-    The neon ``DANGEROUS_PUB_TOPICS`` set is five entries: the four
-    ``control`` category topics plus ``rt/inspire/cmd`` (the Inspire
-    hand cmd, which sits in the ``hand`` category rather than
-    ``control``). The description column marks it as 🚨 too, which
-    a caller reading the raw catalog needs to see so the hand
-    partition does not silently look safer than the low-level
-    command partition.
-    """
-    description = _DDS_TOPIC_DESCRIPTIONS["rt/inspire/cmd"]
-    assert "\U0001f6a8" in description, (
-        f"description for rt/inspire/cmd is {description!r}; the neon "
-        "catalog marks the Inspire hand cmd write topic with 🚨 too. "
-        "Refs strands-labs/robots#358."
-    )
-
-
-def test_the_state_topics_do_not_carry_the_dangerous_publish_marker() -> None:
-    """No read-side ``state`` topic description carries 🚨.
-
-    The 🚨 marker names the write-side dangerous-publish partition
-    only; a read-side topic with the marker would misrepresent the
-    refusal surface to a caller scanning the catalog. This test
-    pins the marker's meaning against the read partition.
+    The write-side partition a caller needs before planning a publish
+    is answered by
+    :func:`~strands_robots.tools.g1.g1_dangerous_publish_topics.g1_dangerous_publish_topic_admits`
+    against a ``frozenset``. This cell pins that the read-side
+    ``state`` topics this snapshot carries stay outside that set, so
+    the two ports keep partitioning the catalog the same way -
+    deliberately without asserting on any marker substring inside a
+    description, because a caller that decided a refusal by scanning
+    prose would be keying on a string domain no verb promises to
+    keep stable.
     """
     state_topics = (
         "rt/lowstate",
@@ -215,11 +221,36 @@ def test_the_state_topics_do_not_carry_the_dangerous_publish_marker() -> None:
         "rt/multiplestate",
     )
     for topic in state_topics:
-        description = _DDS_TOPIC_DESCRIPTIONS[topic]
-        assert "\U0001f6a8" not in description, (
-            f"description for read-side state topic {topic!r} is "
-            f"{description!r}; the neon catalog marks only write-side "
-            "topics with 🚨. Refs strands-labs/robots#358."
+        assert topic in _DDS_TOPIC_DESCRIPTIONS, (
+            f"read-side state topic {topic!r} is missing from the description snapshot. Refs strands-labs/robots#358."
+        )
+        assert topic not in _DANGEROUS_PUBLISH_TOPICS, (
+            f"read-side state topic {topic!r} appears in the sibling "
+            "dangerous-publish set; the read partition must stay "
+            "outside the publish-refusal set. Refs "
+            "strands-labs/robots#358."
+        )
+
+
+def test_every_description_is_ascii_only() -> None:
+    """No description carries a non-ASCII byte into the tool payload.
+
+    The description strings are returned verbatim to a caller in
+    ``descriptions[*].description`` and ``target.description``, which
+    is the first surface AGENTS.md > "Unicode & String Hygiene" names:
+    an agent reads these back out of its own tool call, so a glyph
+    here is tokenizer noise a caller may then key on. The neon
+    catalog spells its write-side markers with an emoji; this cell
+    pins that the port does not carry one through, in either literal
+    or escaped form.
+    """
+    for topic, description in _DDS_TOPIC_DESCRIPTIONS.items():
+        offenders = sorted({ch for ch in description if ord(ch) > 127})
+        assert offenders == [], (
+            f"description for topic {topic!r} carries non-ASCII "
+            f"characters {[hex(ord(ch)) for ch in offenders]}: "
+            f"{description!r}. Tool-result text is plain ASCII in this "
+            "package. Refs strands-labs/robots#358."
         )
 
 


### PR DESCRIPTION
## What

Ports the plain-text **description** column of the neon bundle's `TOPIC_CATALOG` value tuple (`cagataycali/neon-the-g1/tools/_dds_engine.py`) into two agent-facing verbs:

- `g1_list_dds_topic_descriptions` - returns the whole 22-entry envelope, sorted lexicographically by topic name
- `g1_dds_topic_description_admits(topic)` - decides one membership query against the catalog

The neon `TOPIC_CATALOG` value tuple is `(idl_module, idl_class, description, category)`. Positions 1-2 are already ported in [`g1_dds_topic_idl_types`](https://github.com/strands-labs/robots/blob/main/strands_robots/tools/g1/g1_dds_topic_idl_types.py); position 4 is already ported in [`g1_dds_topic_categories`](https://github.com/strands-labs/robots/blob/main/strands_robots/tools/g1/g1_dds_topic_categories.py). This PR ports the remaining column so a caller planning a bus-side read/write can resolve the intent of a topic (e.g. `"IMU, joints, motors (~1kHz)"` for `rt/lowstate`) decidably before a future driver-side wrapper for the neon `g1_dds_snapshot` verb dispatches.

## String domain

The neon table marks its five write-side topics with an emoji glyph in this column. The port drops the marker rather than transliterating it, and those five topics carry the plain-text expansions [`g1_dangerous_publish_topics`](https://github.com/strands-labs/robots/blob/main/strands_robots/tools/g1/g1_dangerous_publish_topics.py) already ships for the same neon column:

```python
"rt/lowcmd": "Low-level motor cmd (drives every joint on the low-level control loop)",
"rt/armsdk": "Arm SDK override (the arm-SDK admission path a naive publish bypasses)",
"rt/user_lowcmd": "User low-level cmd (an alternative rt/lowcmd path with the same wire risk)",
"rt/bmscmd": "BMS cmd (battery-management command, admits a reboot or power-cycle payload)",
"rt/inspire/cmd": "Inspire hand command (5/7-DoF hand joint cmd, publishes to the hand controller)",
```

Two consequences worth stating, because they are the reason this shape was chosen over an ASCII marker such as `(DANGER)`:

1. **One neon column, one spelling.** A caller that reads a description from this verb and from `g1_dangerous_publish_topics` in the same turn gets the same string, and a re-wording lands in one file instead of drifting between two verbs.
2. **The dangerous-publish partition is not encoded in prose.** Any marker in this column - in any encoding - would invite a caller to decide a publish refusal by substring-scanning a description. `g1_dangerous_publish_topic_admits` already decides it against a `frozenset`, which is the surface that should answer it.

## Refusal shape

- `bool` argument -> `status=error`, `message` names `bool` refused
- non-`str` argument (`int`, `float`, `None`, `list`, `tuple`) -> `status=error`, message names the refused type
- empty string -> `status=error`, message names the non-empty contract
- off-catalog topic -> `admitted=False`, `refusal_advice` names the neon-side `type_module`/`type_class` override the generic `g1_dds_snapshot` verb accepts

Every refusal cites `strands-labs/robots#358`.

## Tests

15 cells in `tests/drivers/test_g1_dds_topic_descriptions_reads_the_neon_catalog.py`:

- SDK-load hygiene (import pulls no `unitree_sdk2py`)
- 22-entry snapshot size + every key `rt/`-prefixed
- Every description non-empty
- Every description ASCII-only (pins the payload string domain)
- The five write-side topics carry descriptions `==` the sibling constant, read off that constant rather than restated
- The nine read-side `state` topics stay outside the sibling's `frozenset`
- Round-trip: list sorted lex, admits agrees on every snapshot topic
- Off-catalog refusal names `type_module` override
- Bool/non-str/empty-string refusals

## Gates

43 passed: the three hygiene scans (`test_source_strings_no_emoji`, `test_source_strings_no_unicode_dashes`, `test_log_strings_are_ascii`), this PR's 15 cells, and the sibling's 14.

- `ruff check` OK
- `ruff format --check` OK
- `mypy strands_robots/tools/g1/g1_dds_topic_descriptions.py` - 0 errors in touched file (pre-existing errors in unrelated files unchanged)
- `python3 scripts/assemble_changelog.py --check` OK
- `grep -rnP '[^\x00-\x7F]'` across all three changed files returns nothing

## Contract

- Import pulls **zero** `unitree_sdk2py` submodules
- No second DDS reader/writer path
- Read-only lookup; no bus, no SDK, no driver instance touched
- Reuses existing type-refusal patterns from sibling `_admits` verbs
- Tool-result text is plain ASCII
- Changelog fragment follows level-3 heading convention (refs strands-labs/robots#3019 lesson)

## 13. Round changelog

### Round 2 - `d44bc750`

Addresses both [MUST FIX] threads from review feedback; both are resolved.

| Concern | Resolution |
|---|---|
| Literal U+1F6A8 in the tool module, failing `test_no_emoji_in_package_sources` | Marker dropped; docstrings and `#:` comments use ASCII prose |
| U+2014 em-dashes in two section comments, failing `test_no_unicode_dashes_in_package_sources` | Re-spelled as `-` / `:` |
| The `\U0001f6a8` escape reaching the **runtime payload**, invisible to the source scan | Removed; the five write-side topics reuse the sibling's plain-text expansions verbatim |
| Two conflicting spellings of one neon column on the tool surface | One spelling, sourced from the sibling constant and pinned by a cross-module equality cell |
| Literal U+1F6A8 across 9 lines of the test file, failing `test_no_emoji_in_test_sources` | Removed from every docstring and assert message |
| The glyph pinned as a payload regression contract (`assert "\U0001f6a8" in description`) | Those three cells deleted; partition-visibility re-sourced from the sibling's `frozenset`, plus a new ASCII-only payload cell |

Not in the review, found while sweeping for the same class of problem:

- The **changelog fragment** carried a literal U+1F6A8. Neither hygiene scan covers `changelog.d/`, so this would have shipped a glyph into the release notes after a green run. Re-spelled.
- The `g1_list_dds_topic_descriptions` docstring and the `#:` snapshot comment still described the marker as a feature of the column. Both now name `g1_dangerous_publish_topics` as the owner of the partition, and a new bullet in "What this module does not decide" states it, so the module documents the decision rather than leaving it implicit in the data.

Both new pinning cells were verified to **fail** when the marker is reintroduced on `rt/lowcmd`, so neither passes vacuously. The `_DANGEROUS_PUBLISH_TOPICS` non-empty guard exists for the same reason.

Net: 130 insertions, 75 deletions across the same three files. No new file, no new dependency, no change to the verb signatures or the refusal shapes.

Refs strands-labs/robots#358, strands-labs/robots#2916