### PR TITLE
fix(tests): the emoji scan covers changelog.d, the surface that folds verbatim into CHANGELOG.md

### DIFF
--- a/changelog.d/2982-g1-dangerous-publish-topics-port.md
+++ b/changelog.d/2982-g1-dangerous-publish-topics-port.md
@@ -13,7 +13,7 @@
   `g1_dds_publish` verb refuses membership on the set unless the
   caller passes an explicit `unsafe=True` override. Each descriptor
   carries a `description` label (the neon bundle's own topic-catalog
-  description with the `🚨` marker stripped so the string domain is
+  description with the `U+1F6A8` marker stripped so the string domain is
   plain text) plus a `dangerous_to_publish` flag (always `True` on
   membership - the set itself is the danger contract, surfaced for
   shape parity with the neon bundle's own `list_topics` payload).

--- a/changelog.d/3022-emoji-scan-covers-changelog-fragments.md
+++ b/changelog.d/3022-emoji-scan-covers-changelog-fragments.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- `tests/test_source_strings_no_emoji.py` now scans `changelog.d/*.md`, closing
+  the one hygiene surface no scan covered. All three source-hygiene scans walk
+  `*.py` under the package and the test tree only, while
+  `scripts/assemble_changelog.py --apply` folds fragment text *verbatim* into
+  `CHANGELOG.md`, so a glyph in a fragment reached the released notes behind a
+  fully green run. The gap was not hypothetical: the `U+1F6A8` marker that
+  `changelog.d/2982-g1-dangerous-publish-topics-port.md` describes as *stripped*
+  was still sitting in that fragment's own prose, and is re-spelled here in the
+  `U+XXXX` notation AGENTS.md and the scan's own comments already use. Every
+  `*.md` in the directory is scanned with no reserved-name exemption, including
+  `README.md`: it documents the fragment convention and is what a contributor
+  copies a skeleton out of, so a glyph there propagates by construction. The
+  directory guard deliberately asserts the path still resolves rather than
+  counting files, because `--apply` unlinks every fragment it consumes and an
+  empty `changelog.d/` is the legitimate state of the tree on a release commit -
+  a count-based guard of the kind the package and test-tree cells use would turn
+  `main` red exactly there. The already-released `CHANGELOG.md:5090` glyph is
+  left alone and the scan is pointed at fragments only; rewriting shipped
+  release-note text is a separate decision. Refs #3022, #3020.

--- a/tests/test_source_strings_no_emoji.py
+++ b/tests/test_source_strings_no_emoji.py
@@ -1,4 +1,4 @@
-"""Regression: no ``strands_robots`` module or test module may embed emoji.
+"""Regression: no package module, test module, or changelog fragment may embed emoji.
 
 AGENTS.md forbids emoji in code, logs, and error messages: agents read these
 strings programmatically, emoji are tokenizer noise, and they render
@@ -102,3 +102,55 @@ def test_no_emoji_in_test_sources() -> None:
                     f"{path.relative_to(_TESTS_DIR.parent)}:{lineno}: U+{ord(cp[0]):04X} {line.strip()[:80]!r}"
                 )
     assert not offenders, "emoji found in test sources:\n" + "\n".join(offenders)
+
+
+# Changelog news fragments are the third graded surface. ``changelog.d/*.md`` is
+# folded *verbatim* into ``CHANGELOG.md`` by ``scripts/assemble_changelog.py
+# --apply``, so a glyph in a fragment is a glyph in the released notes - and
+# neither scan above can see it, because both walk ``*.py`` only. That is not
+# hypothetical: the ``U+1F6A8`` marker this directory's ``2982-`` fragment
+# describes as *stripped* was still sitting in the fragment prose, and would
+# have folded into the log on the next release, behind a fully green run.
+#
+# Every ``*.md`` in the directory is scanned, with no reserved-name exemption.
+# ``README.md`` documents the fragment convention and is the file a contributor
+# copies a skeleton out of, so holding it to the same bar is the point rather
+# than an oversight.
+_FRAGMENT_DIR = Path(__file__).resolve().parents[1] / "changelog.d"
+
+
+def _fragment_sources() -> list[Path]:
+    return sorted(_FRAGMENT_DIR.glob("*.md"))
+
+
+def test_fragment_dir_still_resolves() -> None:
+    """Guard: the scan points at the fragment directory rather than at nothing.
+
+    Deliberately *not* a file-count assertion, unlike the two guards above.
+    ``assemble_changelog.py --apply`` ``unlink``s every fragment it consumes, so
+    an empty ``changelog.d/`` is the legitimate state of the tree immediately
+    after a release, and a ``len(...) > N`` guard would turn ``main`` red on the
+    release commit itself. The failure actually worth catching is the scan
+    walking a path the fragments have moved out of; the convention doc lives
+    alongside them, so its presence is what proves the path still resolves.
+    """
+    assert _FRAGMENT_DIR.is_dir(), f"fragment directory is missing: {_FRAGMENT_DIR}"
+    assert (_FRAGMENT_DIR / "README.md").is_file(), (
+        f"{_FRAGMENT_DIR / 'README.md'} is absent - the fragment directory was moved or renamed "
+        "and this scan is now walking the wrong path"
+    )
+
+
+def test_no_emoji_in_changelog_fragments() -> None:
+    """No news fragment may embed emoji: its text is folded verbatim into the log."""
+    offenders: list[str] = []
+    for path in _fragment_sources():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in _EMOJI.finditer(line):
+                cp = match.group()
+                offenders.append(
+                    f"{path.relative_to(_FRAGMENT_DIR.parent)}:{lineno}: U+{ord(cp[0]):04X} {line.strip()[:80]!r}"
+                )
+    assert not offenders, "emoji found in changelog fragments (folded verbatim into CHANGELOG.md):\n" + "\n".join(
+        offenders
+    )


### PR DESCRIPTION
Closes #3022. Refs #3020, #358.

## Problem

All three source-hygiene scans walk `*.py` under the package and the test tree only:

```
tests/test_source_strings_no_emoji.py:47          _PACKAGE_DIR.rglob("*.py")
tests/test_source_strings_no_emoji.py:83          _TESTS_DIR.rglob("*.py")
tests/test_source_strings_no_unicode_dashes.py:33 _PACKAGE_DIR.rglob("*.py")
tests/test_log_strings_are_ascii.py:60            _PACKAGE_DIR.rglob("*.py")
```

`changelog.d/` sits outside every one of them, and `scripts/assemble_changelog.py --apply` folds fragment text **verbatim** into `CHANGELOG.md` (then `unlink`s what it consumed). So a glyph in a fragment ships into the generated release notes after a fully green run.

The gap was live, not hypothetical. `changelog.d/2982-g1-dangerous-publish-topics-port.md:16` carried the `U+1F6A8` marker **in the very sentence describing that marker as stripped**, and would have folded into the log on the next `--apply`.

## Change

Three files:

1. **`tests/test_source_strings_no_emoji.py`** - a third scanned surface (`changelog.d/*.md`) reusing the existing `_EMOJI` range and offender-report format, plus a directory guard.
2. **`changelog.d/2982-g1-dangerous-publish-topics-port.md`** - the one pending offender re-spelled `U+1F6A8`, the notation AGENTS.md and this scan's own range comments already use. One line.
3. **`changelog.d/3022-...md`** - fragment for this change.

## Two design calls that differ from the issue's sketch

**The guard does not count files.** The issue proposed carrying the `assert len(sources) > 50` pattern across from the package and test-tree cells. That would be a latent break: `--apply` unlinks every fragment it consumes, so an empty `changelog.d/` is the *legitimate* state of the tree on a release commit, and a count guard would turn `main` red exactly there. Verified against a simulated post-release tree (evidence below). The failure actually worth catching is the scan walking a path the fragments moved out of, so the guard asserts the directory resolves and that the convention doc still lives beside them.

**No reserved-name exemption.** The issue's sketch referenced a `_DOC_FILES` set; no such name exists in that module, and the only non-fragment file is `changelog.d/README.md` (`RESERVED_NAMES` in the assembler). Rather than import or duplicate that exclusion, every `*.md` is scanned including `README.md`: it documents the convention and is the file a contributor copies a skeleton out of, so a glyph there propagates by construction. It is ASCII-clean today, so this costs nothing and removes an exclusion that would need maintaining. Scanning a superset also means a *misnamed* fragment is still emoji-checked, while naming stays the assembler's and `test_changelog_fragments.py`'s job - the hygiene scan never fails for a non-hygiene reason.

## Evidence

**The new cell is non-vacuous, and it proves the gap.** Reintroducing the glyph into the fragment:

```
FAILED tests/test_source_strings_no_emoji.py::test_no_emoji_in_changelog_fragments
  changelog.d/2982-g1-dangerous-publish-topics-port.md:16: U+1F6A8 'description with the `[glyph]` marker stripped so the string domain is'
1 failed, 5 passed
```

`1 failed, 5 passed` is the load-bearing part: both pre-existing emoji cells stayed **green** with a glyph in the tree. That is the merges-green failure mode, reproduced.

**An emptied `changelog.d/` (post-release) stays green** - and the count guard would not have:

```
fragments visible now (post-release sim): 1
issue-proposed guard  assert len(sources) > 50  -> FAIL (main goes red on the release commit)
$ pytest tests/test_source_strings_no_emoji.py
6 passed
```

**A moved/renamed directory fires the guard:**

```
$ mv changelog.d changelog.d.moved && pytest -k fragment
FAILED ...::test_fragment_dir_still_resolves - fragment directory is missing: /tmp/robots/changelog.d
1 failed, 1 passed
```

**Whole-tree graders** (per #2940 - a diff-scoped selector cannot see these). Every `.md`-reading and fragment-aware grader, including `test_duplicate_work_described_change_key`, `test_duplicate_work_added_path_key`, `test_markdown_links_resolve`, `test_changelog_fragment_gate`, `test_changelog_format`, `test_changelog_fragments`:

```
373 passed, 20 skipped
```

The 2 remaining failures in that selection (`test_dependency_audit`: `No module named 'strands'`, `No package metadata for qpsolvers`) are missing-package errors in the minimal local env and reproduce **identically on clean `main`** - verified by stashing.

```
$ python3 scripts/assemble_changelog.py --check
changelog fragments OK (1011 pending)
$ ruff check / ruff format --check
All checks passed! / 1 file already formatted
```

## Deliberately out of scope

- **`CHANGELOG.md:5090`** already carries `U+26A0 U+FE0F` in *released* text. The scan is pointed at fragments only and that line is left alone; rewriting shipped release-note text is a separate decision, and pointing the scan at `CHANGELOG.md` would need that decision made first.
- **The unicode-dash scan is not extended.** 25 fragments carry an em/en dash. That rule exists for tool-result and log text an agent reads back programmatically, and AGENTS.md already carves out that semantic Unicode documenting the source stays. Prose dashes in Markdown release notes are a different question; bundling 25 files of prose churn into an emoji fix would be scope creep.

## Acceptance (from #3022)

- [x] `tests/test_source_strings_no_emoji.py` covers `changelog.d/*.md`, with a walked-the-tree guard
- [x] The cell is verified to fail on a fragment with a glyph reintroduced (not vacuous)
- [x] `changelog.d/2982-g1-dangerous-publish-topics-port.md` re-spelled in ASCII
- [x] `python3 scripts/assemble_changelog.py --check` still OK

## Round changelog

**Round 0** (initial): emoji scan extended to `changelog.d/*.md` with a resolves-not-counts directory guard; one pending offender re-spelled `U+1F6A8`. Two documented departures from the issue sketch (no count guard, no reserved-name exemption), each with evidence above.
