### PR TITLE
fix(tools/g1): drop stale #3006 deferral in icp-fitness envelope docstring

### DIFF
--- a/changelog.d/3028-g1-icp-fitness-deferral-drop-stale-3006.md
+++ b/changelog.d/3028-g1-icp-fitness-deferral-drop-stale-3006.md
@@ -1,0 +1,19 @@
+### Fixed: the ICP fitness envelope docstring no longer defers to a change this repository already landed
+
+The module docstring on `strands_robots/tools/g1/g1_slam_icp_fitness_envelope.py`
+described its voxel-size twin as "open for review as strands-labs/robots#3006"
+and named that sibling as a literal rather than a cross-reference, on the
+premise that a Sphinx role promises an importable dotted path and this tree
+did not yet carry the module. PR #3006 has since landed and
+`strands_robots.tools.g1.g1_slam_relocalize_envelope` is now importable, so
+the deferral is stale in the same way `tests/test_deferral_strings_do_not_cite_a_landed_change.py`
+already grades against: a reader following `#3006` finds a merged change
+and cannot tell whether the sibling module is missing or the note is stale.
+
+The two references now use the Sphinx `:mod:` role that the sibling
+`g1_lidar_max_points_envelope` reference in the same paragraph already
+used, folding the twin into the same read shape. No behavioural code
+changes; only the docstring's forward-deferral references become
+backward Sphinx cross-refs.
+
+Refs #358.

--- a/strands_robots/tools/g1/g1_slam_icp_fitness_envelope.py
+++ b/strands_robots/tools/g1/g1_slam_icp_fitness_envelope.py
@@ -19,12 +19,8 @@ the refusal decidably before a future driver-side SLAM relocalise
 wrapper is called, rather than pinning the value inside the ICP
 path where the refusal is invisible to the planner.
 
-Twin of ``g1_slam_relocalize_envelope`` (the ICP *voxel-size*
-dimension on the same relocalise surface, open for review as
-strands-labs/robots#3006).  That sibling is named as a literal rather
-than cross-referenced, because a Sphinx role promises an importable
-dotted path and this tree does not carry that module until #3006
-lands.  Twin also of
+Twin of :mod:`~strands_robots.tools.g1.g1_slam_relocalize_envelope`
+(the ICP *voxel-size* dimension on the same relocalise surface).  Twin also of
 :mod:`~strands_robots.tools.g1.g1_lidar_max_points_envelope` (the
 *downsample cap* on the frame the ICP consumes).  The three modules
 stay separate because a fitness refusal is a *quality* judgement on
@@ -43,7 +39,7 @@ Two things this module is deliberately *not*:
   actual ICP against ``self._map_dedup`` and interpreted the
   ``result.fitness`` scalar; the write end of that pipeline is
   reached today by ``g1_slam_relocalize_envelope`` on the
-  caller-side subsample dimension (strands-labs/robots#3006) and by
+  caller-side subsample dimension (see :mod:`~strands_robots.tools.g1.g1_slam_relocalize_envelope`) and by
   future driver-side work on the ICP dispatch itself.  This module
   ports the read-only envelope half without also introducing a
   second ICP writer path the driver does not yet own.  Refs


### PR DESCRIPTION
PR #3006 landed and `strands_robots.tools.g1.g1_slam_relocalize_envelope` is now importable, but the docstring on `g1_slam_icp_fitness_envelope.py` still describes its voxel-size twin as "open for review as strands-labs/robots#3006" and names it as a literal rather than a Sphinx cross-reference on the premise that the module was not yet in the tree.

The two references now use `:mod:` roles, matching the sibling `g1_lidar_max_points_envelope` reference already in the same paragraph.

This unblocks `tests/test_deferral_strings_do_not_cite_a_landed_change.py` on main, which currently fails on every in-flight PR branched from main (#3009, #3025, #3026, #3027 all hit the same test).

Refs #358.

## Test evidence
- `grep -n '3006' strands_robots/tools/g1/g1_slam_icp_fitness_envelope.py` → 0 matches (was 3)
- `python -m py_compile` on the module: parse OK
- Changelog fragment: `changelog.d/3028-g1-icp-fitness-deferral-drop-stale-3006.md`