### PR TITLE
feat(tools/g1): port g1_balance_stand verb from cagataycali/neon-the-g1 (refs #358, #2916, #3025, #3031, #3032)

### DIFF
--- a/changelog.d/3033-g1-balance-stand-verb.md
+++ b/changelog.d/3033-g1-balance-stand-verb.md
@@ -1,0 +1,67 @@
+### Added: `g1_balance_stand` verb for the driver's BalanceStand write
+
+`G1Driver.balance_stand` is the driver-side BalanceStand entry point: a caller
+passes a balance-mode id and the driver publishes `LocoClient.BalanceStand`
+(which internally reaches the SDK's `SetBalanceMode` handler) over the same
+DDS singleton `ensure_dds` opens. The Python SDK exposes `BalanceStand` as a
+public `LocoClient` method that admits a small set of pre-programmed modes:
+`0` (static balance, the default) and `3` (dynamic balance, from the neon
+bundle's field notes against the real robot). The neon bundle's
+`g1_balance_stand` verb (`cagataycali/neon-the-g1/tools/g1_posture.py`)
+wrapped the call under a single-writer lock and coerced the argument through
+`int(...)` before dispatch; the read-only half of that envelope already landed
+as `strands_robots.tools.g1.g1_balance_modes` (refs #358), and this module is
+the write-side companion that hands the target to the driver.
+
+The driver's method itself is not yet plumbed on `G1Driver` today (refs #358
+for the SDK-facing gate work the write belongs on), so the
+`live_handle_refusal` grader refuses a handle without a `balance_stand`
+accessor with a message naming the verb, the `driver` parameter and the
+accessor. Once the driver method lands the same call returns the driver's
+envelope verbatim — this is the same shape `g1_set_fsm` (refs #3025),
+`g1_set_stand_height` (refs #3031) and `g1_set_swing_height` (refs #3032)
+already ship.
+
+`strands_robots.tools.g1.g1_balance_stand.g1_balance_stand` is the
+agent-facing side of that write: one duck-typed call on
+`driver.balance_stand`, the envelope the driver produced returned verbatim,
+and the same live-handle refusals every write-side verb in this package owes
+(`driver` is `None`, a robot *name*, or any object without a callable
+`balance_stand`). The verb adds four data-parameter shape refusals on top —
+a `None` `balance_mode`, a `bool` payload (which would coerce to a silent
+`0` or `1`), a `float` payload (which the neon bundle's own `int(...)` would
+silently truncate to a mode the caller did not name), and a non-integer
+`str` shape — using inline `isinstance` shape checks rather than a shared
+validator because the value-domain here is an integer mode id with a
+neon-bundle-observed admitted set `{0, 3}`, and no existing shared validator
+in `strands_robots.utils` fits that shape (`positive_count_error` refuses
+`0`, which is the static-balance default; `finite_number_error` admits
+floats the SDK's handler cannot use). The in-set admission `{0, 3}` itself
+is not enforced by this verb — the module docstring names "does not refuse
+a `balance_mode` outside the admitted set" as one of the things this verb
+does not do, because refusing an unlisted mode here would fork the neon
+bundle's admission set into a second source of truth this module would then
+have to keep in sync with the read-only envelope `g1_balance_modes` module.
+Importing the module pulls no `unitree_sdk2py` submodule (the package's
+SDK-load-hygiene contract, refs #358), and the module docstring names the
+six things this verb does not do (refuse an out-of-set mode, encode the
+`BalanceStand` dispatch, decode the SDK's `rc`, restate the driver's
+refusal wording, schedule the FSM 801 prerequisite, check the `WALK_FSMS`
+gate) so a caller reading it does not misread the surface.
+
+The test suite
+(`tests/drivers/test_g1_balance_stand_writes_the_driver_envelope.py`) grades
+sixteen shapes: the SDK-load-hygiene pin, two driver-side envelopes as
+pass-through (a driver-side refusal, a future success envelope), the two
+live-handle refusals through the shared `live_handle_refusal` guard, four
+data-parameter shape refusals (missing `balance_mode`, non-integer `str`
+`balance_mode`, `float` `balance_mode`, `bool` `balance_mode`), four
+admitted-value pins (a `0` static-balance target, a `3` dynamic-balance
+target, a `7` out-of-set target passed through unchanged, and a negative
+value passed through unchanged - all four reach the driver verbatim because
+the module docstring names "does not refuse a `balance_mode` outside the
+admitted set" as one of the things this verb does not do), one exactly-once
+write pin, and one arguments-pass-through pin. The universal auto-discovery
+test at `tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py`
+grades the verb the moment it lands (its first parameter is `driver: Any`),
+so the two live-handle refusal rules are held by that suite too.

--- a/strands_robots/tools/g1/g1_balance_stand.py
+++ b/strands_robots/tools/g1/g1_balance_stand.py
@@ -1,0 +1,328 @@
+"""Agent-facing wrapper for ``G1Driver.balance_stand``.
+
+``G1Driver.balance_stand`` is the driver-side BalanceStand entry
+point: a caller passes a balance-mode id and the driver publishes
+:meth:`unitree_sdk2py.g1.loco.g1_loco_client.LocoClient.BalanceStand`
+(which internally reaches the SDK's ``SetBalanceMode`` handler) over
+the same DDS singleton :func:`~strands_robots.tools.g1._g1_common.ensure_dds`
+opens. The Python SDK exposes ``BalanceStand`` as a public
+``LocoClient`` method that admits a small set of pre-programmed
+modes: ``0`` (static balance, the default) and ``3`` (dynamic
+balance, from the neon bundle's field notes against the real
+robot). The neon bundle's ``g1_balance_stand`` verb
+(``cagataycali/neon-the-g1/tools/g1_posture.py``) wrapped the call
+under a single-writer lock and coerced the argument through
+:class:`int` before dispatch; the read-only half of that envelope
+already landed as :mod:`~strands_robots.tools.g1.g1_balance_modes`
+(refs strands-labs/robots#358), and this module is the write-side
+companion that hands the target to the driver.
+
+The driver's method itself is not yet plumbed on
+:class:`~strands_robots.drivers.g1.G1Driver` today (refs
+strands-labs/robots#358 for the SDK-facing gate work the write
+belongs on); the accessor grades this verb through
+:func:`~strands_robots.tools.g1._g1_common.live_handle_refusal`, so a
+handle without a ``balance_stand`` method refuses with a message
+naming the verb, the ``driver`` parameter and the accessor it read
+for, and once the driver lands the same call returns the envelope
+the driver wrote verbatim. This is the same shape ``g1_set_fsm``
+(refs strands-labs/robots#3025), ``g1_set_stand_height`` (refs
+strands-labs/robots#3031) and ``g1_set_swing_height`` (refs
+strands-labs/robots#3032) already ship.
+
+This module is a thin duck-typed wrapper. It reads the driver
+through ``driver.balance_stand`` and returns the envelope the
+driver produced verbatim. A future field the driver adds on the
+success path (say, an ``rc`` from the SDK's ``SetBalanceMode``
+handler, the FSM the controller settled into) reaches a caller the
+moment the driver writes it, because this verb does not restate
+the shape. What it does add is the two refusal envelopes every
+``@tool`` handler in this package owes its callers instead of an
+exception: a live-handle refusal (``driver`` is ``None`` or a robot
+*name* or an object without ``balance_stand``) and the driver's
+own refusal surfaced verbatim.
+
+The FSM gate is not consulted here. The driver's
+:meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates` is
+the one gate for arm-SDK writes (``send_action`` / ``run_policy`` /
+``start_task``); ``BalanceStand`` sits on the loco side of the
+same DDS singleton and belongs on the locomotion admission set
+:data:`~strands_robots.tools.g1._g1_common.WALK_FSMS` the driver's
+own path will check when the write lands. A second gate call here
+would double the read against a cache the driver's FSM refresher
+fills, and would refuse targets the driver's own path admits.
+Restating any of that on this side would be a second source of
+truth for a rule the driver's own path already enforces (refs
+strands-labs/robots#358, strands-labs/robots#2916). ``import
+strands_robots.tools.g1.g1_balance_stand`` still pulls no
+``unitree_sdk2py`` submodule (the package's SDK-load-hygiene
+contract, refs strands-labs/robots#358).
+
+The driver argument is typed :class:`~typing.Any` at runtime rather
+than as ``G1Driver`` for the same reason ``g1_set_fsm``,
+``g1_set_stand_height``, ``g1_set_swing_height``, ``g1_start_task``,
+``g1_run_policy``, ``g1_send_action`` and ``g1_stop_task`` give:
+the driver module imports
+:func:`~strands_robots.tools.g1._g1_common.ensure_dds` from this
+package at load, so a runtime import of ``G1Driver`` here would
+close a cycle, and ``@tool`` calls :func:`typing.get_type_hints`
+at decoration time so a string forward reference cannot resolve
+without pulling the driver at import. The verb is duck-typed on
+``balance_stand``; any object with a synchronous
+``balance_stand(balance_mode)`` returning the driver's envelope
+satisfies it, which is also how the tests hand it a hand-rolled
+double.
+
+What this module does not do.
+
+* Refuse a ``balance_mode`` outside the neon-bundle-observed
+  admitted set ``{0, 3}``. The read-only envelope
+  :mod:`~strands_robots.tools.g1.g1_balance_modes` names those two
+  as the modes the neon bundle observed as walkable; refusing an
+  unlisted mode here would fork the neon bundle's admission set
+  into a second source of truth this module would then have to
+  keep in sync with the envelope lookup. The SDK's own handler
+  silently accepts an unknown mode and ignores it when outside
+  its programmed set, so the driver's method (once landed) is
+  where an in-set refusal lives - a caller who passes ``7`` here
+  reaches the driver's own refusal, which round-trips through
+  this verb verbatim. The bare-int shape checks below refuse the
+  cross-type shapes ``bool``/``float``/``str`` the SDK's
+  :class:`int` coercion in the neon wrapper silently transformed
+  rather than declined; those are separate from the in-set
+  admission the envelope module owns.
+* Encode the ``LocoClient.BalanceStand`` dispatch. The SDK's
+  public method and the neon bundle's single-writer lock are
+  driver-side wire concerns; the verb passes ``balance_mode``
+  through unchanged and the driver's method decides how to reach
+  the SDK's handler. A caller reading this verb's docstring
+  learns the ergonomic contract, not the wire format.
+* Decode the SDK's ``rc`` return into a label. The
+  :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` table
+  (surfaced by :mod:`~strands_robots.tools.g1.g1_error_codes`)
+  names every SDK return code the driver's method may quote;
+  restating the label here would fork the same table.
+* Restate the driver's refusal wording. Whatever text the
+  driver's method writes (a rc-decoded sentence, a gate refusal,
+  a no-balance-stand-yet message like ``g1_start_task``'s
+  registry-not-wired one) passes through this verb; a verbatim
+  quote here would trap the verb to one release's prose (refs
+  strands-labs/robots#2874).
+* Schedule the FSM prerequisite. The neon bundle's docstring
+  named ``g1_set_fsm(801)`` as a companion call to reach FSM 801
+  (``BalanceExpert``) from other FSMs before ``BalanceStand``
+  itself is admitted by the controller; ``g1_set_fsm`` already
+  ships as a sibling verb (refs strands-labs/robots#3025). A
+  caller who wants that sequence issues the two calls in order
+  and reads each envelope; this verb does not chain them.
+* Check whether the driver's live ``_fsm_id`` is inside
+  :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS`. That
+  membership test is the driver's own gate concern; the read-
+  only lookup :mod:`~strands_robots.tools.g1.g1_balance_modes`
+  surfaces the set to a caller planning the write, but this
+  verb does not enforce it (the driver's method will).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+from strands_robots.tools.g1._g1_common import live_handle_refusal
+
+
+def _refusal_envelope(text: str) -> dict[str, Any]:
+    """Return the ``@tool`` error envelope with ``text`` inside.
+
+    Kept as a small free helper so every ``balance_mode`` refusal
+    path in this module renders the same shape a caller can grep
+    for, matching the driver's own
+    :func:`~strands_robots.drivers.g1._refuse` free function on the
+    write side.
+    """
+    return {"status": "error", "content": [{"text": text}]}
+
+
+@tool
+def g1_balance_stand(
+    driver: Any,
+    balance_mode: int | None = None,
+) -> dict[str, Any]:
+    """Enter the G1's BalanceStand state with the given balance mode.
+
+    Calls ``G1Driver.balance_stand`` once and returns the envelope
+    the driver produced verbatim. The driver's method routes to
+    ``LocoClient.BalanceStand`` (which internally reaches the SDK's
+    ``SetBalanceMode`` handler); a caller who passes ``0`` reaches
+    the static balance mode (the default the neon bundle
+    documented), a caller who passes ``3`` reaches the dynamic
+    balance mode the neon bundle observed as walkable, and a value
+    outside the neon-bundle-observed ``{0, 3}`` admitted set
+    reaches either the driver's own refusal or the SDK's silent-
+    accept-and-ignore handler through the verb's pass-through (the
+    SDK does not ship a distinct ``rc`` for an unknown mode). The
+    neon bundle's own ``g1_balance_stand`` verb documented ``0``
+    and ``3`` as the two modes it observed; the read-only envelope
+    :mod:`~strands_robots.tools.g1.g1_balance_modes` names them
+    and this verb ports the write-side of that contract unchanged
+    so a caller upgrading from the neon bundle reaches the same
+    behaviour.
+
+    Reaching FSM 801 (``BalanceExpert``) may require a companion
+    ``g1_set_fsm(801)`` call before this verb (refs
+    strands-labs/robots#3025); the neon bundle documented that
+    prerequisite and this verb does not chain the FSM transition
+    itself - a caller who wants the sequence issues the two calls
+    in order and reads each envelope.
+
+    ``BalanceStand`` is a locomotion-shaped write; the driver's
+    :meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates`
+    gate will (once the driver's method lands) refuse the write
+    while ``_fsm_id`` is outside
+    :data:`~strands_robots.tools.g1._g1_common.WALK_FSMS` (refs
+    strands-labs/robots#2916). A caller planning the write compares
+    the driver's live ``fsm_id`` (from ``get_status``) against the
+    ``walk_ready_fsm_ids`` :mod:`~strands_robots.tools.g1.g1_balance_modes`
+    surfaces before reaching this verb; this verb does not re-run
+    that check itself.
+
+    Args:
+        driver: An object with a callable
+            ``balance_stand(balance_mode)`` returning the driver's
+            write envelope (in practice a
+            :class:`~strands_robots.drivers.g1.G1Driver`). Typed
+            :class:`~typing.Any` rather than as ``G1Driver`` to
+            keep this module out of the import cycle the driver's
+            own :func:`~strands_robots.tools.g1._g1_common.ensure_dds`
+            reach into this package would close - see the module
+            docstring's SDK-load-hygiene note. The verb is duck-
+            typed on ``balance_stand``; any object with that
+            method returning the envelope shape the driver writes
+            will satisfy it. On today's driver ``balance_stand``
+            is not yet exposed, so the :func:`live_handle_refusal`
+            grader refuses the call with a message naming the
+            accessor; once the driver's method lands (the SDK-
+            facing gate work in strands-labs/robots#358), the
+            same call returns the driver's envelope verbatim.
+        balance_mode: The balance-mode id
+            ``LocoClient.BalanceStand`` admits. The neon bundle
+            observed two walkable modes and the read-only
+            envelope :mod:`~strands_robots.tools.g1.g1_balance_modes`
+            names them: ``0`` (static balance, the default the
+            neon bundle documented) and ``3`` (dynamic balance).
+            This verb does not refuse a mode outside that set -
+            the driver's method (once landed) is where an in-set
+            refusal lives, and a caller who passes ``7`` reaches
+            either the driver's own refusal or the SDK's silent-
+            accept-and-ignore handler through the verb's pass-
+            through. The shape checks below refuse a ``None``
+            payload, a ``bool`` payload (``bool`` is an ``int``
+            subclass, so ``True`` would act as a silent ``1``
+            and ``False`` as a silent ``0`` - neither is a mode
+            id a caller writing the boolean would have named on
+            purpose), and a non-integer shape (``float``,
+            ``str``) that the neon bundle's own ``int(...)``
+            coercion silently transformed rather than declined.
+            Those are shape refusals, not domain refusals; the
+            in-set admission belongs on the driver's write path
+            and the read-only envelope module the same way
+            ``g1_set_swing_height``'s ``0.05..0.15`` typical
+            range belongs on the driver rather than this verb.
+
+    Returns:
+        The envelope ``G1Driver.balance_stand`` returned. On the
+        success path the driver's method will surface the SDK's
+        outcome inside a ``{"status": "success", "content":
+        [{"json": {"rc": 0, "message": "BalanceStand(mode=0)
+        dispatched"}}]}`` envelope (or whatever richer shape the
+        driver settles on); on the driver's refusal path (an
+        SDK-side raise, a caller running this verb before the
+        driver's method lands, a gate refusal) it is
+        ``{"status": "error", "content": [{"text": "..."}]}`` with
+        the driver's own reason inside. The verb does not reshape
+        either shape - a future field the driver adds on the
+        success path reaches a caller the moment the driver writes
+        it, because this verb passes the envelope through.
+    """
+    # The handle is a live Python object typed :class:`~typing.Any`
+    # (see the module docstring's import-cycle note), so the tool
+    # schema carries no signal that ``None`` or a robot *name* is
+    # refused.  The shared ``live_handle_refusal`` guard is the
+    # one implementation of that judgement for this package; it is
+    # keyed on the accessor the verb reads, which for this verb is
+    # ``balance_stand`` (a callable that calls
+    # ``LocoClient.BalanceStand`` and returns the driver's
+    # envelope) rather than the sensor verbs' ``_snapshot``.
+    # Returning its refusal envelope here rather than raising
+    # keeps the four invariants every ``@tool`` handler owes a
+    # caller (envelope not exception, names the verb, names
+    # ``driver``, names the type on wrong-type inputs).
+    refusal = live_handle_refusal(
+        "g1_balance_stand",
+        driver,
+        accessor="balance_stand",
+        reads=(
+            "the verb requests a G1 BalanceStand transition through "
+            "the driver's own SDK-facing write path and reads back "
+            "the envelope the driver produced"
+        ),
+        expected=(
+            "a callable ``balance_stand(balance_mode)`` returning "
+            "the driver's write envelope - pass the live G1Driver "
+            "handle the orchestrator constructed"
+        ),
+    )
+    if refusal is not None:
+        return refusal
+
+    # ``balance_mode`` is a data parameter the tool schema *does*
+    # describe (an integer mode id, with the neon-bundle-observed
+    # admitted set ``{0, 3}`` surfaced by
+    # :mod:`~strands_robots.tools.g1.g1_balance_modes`), so a
+    # model can synthesize the wrong shape here as easily as it
+    # can reach the verb with the right one.  The refusals below
+    # cover the shapes the driver's own ``balance_stand`` would
+    # surface as an inner raise or as a silent coercion: a
+    # ``None`` payload, a ``bool`` payload (``int`` subclass,
+    # would coerce to ``0`` or ``1``), and a non-integer shape
+    # (``float`` / ``str``) the neon bundle's own ``int(...)``
+    # silently transformed.  Naming ``balance_mode`` here keeps
+    # the four invariants: envelope not exception, names the
+    # verb, names the parameter, names the shape received.  The
+    # in-set admission ``{0, 3}`` is not enforced here (see the
+    # module docstring's "does not refuse a balance_mode outside
+    # the admitted set" note); that belongs on the driver.
+    if balance_mode is None:
+        return _refusal_envelope(
+            "g1_balance_stand: `balance_mode` is required. Pass an "
+            "integer mode id (neon-bundle-observed admitted set "
+            "{0, 3}; 0 = static, 3 = dynamic) - see "
+            "`g1_list_balance_modes` for the read-only descriptors "
+            "(refs strands-labs/robots#358)."
+        )
+    # ``bool`` is an ``int`` subclass, so a bare ``isinstance(..., int)``
+    # test would let ``True`` through as a silent ``1`` and ``False`` as
+    # a silent ``0`` (both are inside the ``{0, 3}`` admitted set - a
+    # ``True`` payload would even reach the SDK's static-balance handler
+    # unnoticed).  Refusing ``bool`` explicitly matches the shape refusal
+    # ``finite_number_error`` / ``positive_count_error`` render for the
+    # same reason on the numeric verbs, and keeps the verb's message
+    # naming the parameter and the shape received rather than silently
+    # transitioning to a mode the caller writing ``True`` did not name.
+    if isinstance(balance_mode, bool):
+        return _refusal_envelope(
+            f"g1_balance_stand: `balance_mode` must be an integer mode id "
+            f"(int, not bool), got {type(balance_mode).__name__!r}. See "
+            f"`g1_list_balance_modes` for the read-only descriptors "
+            f"(refs strands-labs/robots#358)."
+        )
+    if not isinstance(balance_mode, int):
+        return _refusal_envelope(
+            f"g1_balance_stand: `balance_mode` must be an integer mode id "
+            f"(int), got {type(balance_mode).__name__!r}. See "
+            f"`g1_list_balance_modes` for the read-only descriptors "
+            f"(refs strands-labs/robots#358)."
+        )
+
+    return driver.balance_stand(balance_mode)

--- a/tests/drivers/test_g1_balance_stand_writes_the_driver_envelope.py
+++ b/tests/drivers/test_g1_balance_stand_writes_the_driver_envelope.py
@@ -1,0 +1,410 @@
+"""``g1_balance_stand`` returns exactly what ``G1Driver.balance_stand`` gives it.
+
+``g1_balance_stand`` is the write-side companion to the neon
+bundle's ``g1_balance_stand`` verb: where the neon verb wraps
+``LocoClient.BalanceStand`` (which internally reaches the SDK's
+``SetBalanceMode`` handler) under a single-writer lock, this one
+hands a target balance-mode id to the driver's own write path and
+reads back the envelope the driver produced. The driver's
+``G1Driver.balance_stand`` method is not yet plumbed today
+(refs strands-labs/robots#358 for the SDK-facing gate work the
+write belongs on), so the :func:`live_handle_refusal` grader
+refuses a handle without a ``balance_stand`` accessor with a
+message naming the verb, the ``driver`` parameter and the
+accessor; these tests fix the shape the verb passes through for
+each of the driver's current and future outcomes (a driver-side
+refusal, a future success envelope, and the verb's own ``driver``
+/ ``balance_mode`` refusals).
+
+The refusal-string tests do not restate the driver's exact prose -
+that would trap the verb to the driver's refusal wording of one
+release, which is exactly what the driver's own release notes say
+verbatim quotes should not do (refs strands-labs/robots#2874).
+They grade the shape (``status="error"``, an envelope-shaped
+``content[0]["text"]``, the verb's own four refusal invariants
+when the verb produced them) and pass the driver's own text
+through unchanged when the driver produced it. The SDK-load-
+hygiene contract every file under :mod:`strands_robots.tools.g1`
+carries is fixed first: importing the module must not pull any
+``unitree_sdk2py`` submodule.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+from strands_robots.tools.g1.g1_balance_stand import g1_balance_stand
+
+
+class _StubG1Driver:
+    """A driver double whose ``balance_stand`` returns a fixed envelope.
+
+    ``g1_balance_stand`` calls ``driver.balance_stand(balance_mode)``
+    and returns the envelope verbatim. This double sits under the
+    same interface without pulling the real driver's imports (the
+    real class reaches CycloneDDS at construction time in some
+    paths), so a test can hand a wired-shape envelope to the verb
+    without a bus. ``calls`` records the ``balance_mode`` per
+    invocation so a test can pin "the verb writes the driver
+    exactly once" and "the verb passes the argument through
+    unchanged" without asking the driver method itself to record.
+    """
+
+    def __init__(self, envelope: dict[str, Any]) -> None:
+        self._envelope = envelope
+        self.calls: list[int] = []
+
+    def balance_stand(self, balance_mode: int) -> dict[str, Any]:
+        self.calls.append(balance_mode)
+        return self._envelope
+
+
+def _call(
+    driver: Any,
+    *,
+    balance_mode: int | None = 0,
+) -> dict[str, Any]:
+    """Call the ``@tool``-decorated verb and return its dict.
+
+    The ``strands`` ``@tool`` wrapper defers to the wrapped function
+    directly when called in-process, but a caller cannot rely on
+    that: the wrapper's contract is that it returns the wrapped
+    function's return value verbatim. This helper is where a shape
+    drift would surface once, rather than at every call site. The
+    default ``balance_mode=0`` is the static-balance mode the neon
+    bundle documented as the default, so a call that omits the
+    value here still reaches the driver with a target the
+    controller admits.
+    """
+    return g1_balance_stand(driver=driver, balance_mode=balance_mode)
+
+
+def test_the_import_pulls_no_sdk_module() -> None:
+    """The tool module is loadable on a host without ``unitree_sdk2py``.
+
+    Every file under :mod:`strands_robots.tools.g1` must be
+    importable with the SDK absent; a module that pulled a
+    submodule at import time would break every headless CI runner
+    and Thor before an office bring-up. The driver enforces the
+    same rule against itself
+    (:func:`~strands_robots.tools.g1._g1_common.ensure_dds` is the
+    only path that loads the SDK); this cell holds the balance-
+    stand verb to it too.
+    """
+    before = set(sys.modules)
+    importlib.import_module("strands_robots.tools.g1.g1_balance_stand")
+    after = set(sys.modules)
+    leaked = {name for name in after - before if "unitree" in name.lower()}
+    assert leaked == set(), (
+        f"strands_robots.tools.g1.g1_balance_stand imports pulled SDK "
+        f"submodules: {leaked}. The rule for this package is that the SDK "
+        "loads only inside function bodies (refs strands-labs/robots#358)."
+    )
+
+
+def test_a_driver_side_refusal_surfaces_verbatim() -> None:
+    """The driver's refusal envelope round-trips through the verb unchanged.
+
+    ``G1Driver.balance_stand`` will (once landed) refuse an
+    SDK-side raise with a named error envelope, and today's driver
+    refuses every call because the method is not yet plumbed. Both
+    shapes are ``{"status": "error", "content": [{"text": ...}]}``
+    and the verb passes either through; a wording drift on the
+    driver side moves this verb with it (refs
+    strands-labs/robots#2874).
+    """
+    refusal_text = "balance_stand: BalanceStand(mode=0) raised: RPC_CLIENT_API_TIMEOUT"
+    envelope = {"status": "error", "content": [{"text": refusal_text}]}
+    driver = _StubG1Driver(envelope=envelope)
+    result = _call(driver, balance_mode=0)
+
+    assert result["status"] == "error"
+    assert result["content"][0]["text"] == refusal_text
+
+
+def test_a_future_success_envelope_round_trips_verbatim() -> None:
+    """Once ``balance_stand`` lands, the success envelope surfaces verbatim.
+
+    When the driver's method is plumbed, ``G1Driver.balance_stand``
+    will surface the SDK's outcome inside a ``{"status":
+    "success", "content": [{"json": {"rc": 0, "message":
+    "BalanceStand(mode=0) dispatched"}}]}`` envelope. The verb
+    does not reshape it - a future field the driver adds reaches
+    a caller the moment the driver writes it, and this cell holds
+    that pass-through explicit so the verb is ready the moment the
+    write path lands.
+    """
+    envelope = {
+        "status": "success",
+        "content": [
+            {
+                "json": {
+                    "rc": 0,
+                    "message": "BalanceStand(mode=0) dispatched",
+                }
+            }
+        ],
+    }
+    driver = _StubG1Driver(envelope=envelope)
+    result = _call(driver, balance_mode=0)
+
+    assert result is envelope or result == envelope
+    assert result["status"] == "success"
+    payload = result["content"][0]["json"]
+    assert payload["rc"] == 0
+
+
+def test_a_missing_driver_is_refused_with_a_message_naming_the_parameter() -> None:
+    """A ``None`` driver is refused before the accessor is called.
+
+    ``driver`` is a live Python object typed :class:`~typing.Any`,
+    so the tool schema carries no signal that a caller cannot
+    synthesize it. A model that leaves the parameter out reaches
+    the verb with ``None``, and the verb owes an envelope-shaped
+    refusal instead of an exception the ``@tool`` wrapper cannot
+    format. The shared
+    :func:`~strands_robots.tools.g1._g1_common.live_handle_refusal`
+    guard produces it; this cell fixes that the guard is called
+    before the accessor path.
+    """
+    result = g1_balance_stand(driver=None, balance_mode=0)
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "g1_balance_stand" in text
+    assert "driver" in text
+
+
+def test_a_wrong_shape_driver_is_refused_with_a_message_naming_the_type() -> None:
+    """A robot *name* (string) is refused before the accessor call.
+
+    A model that synthesizes the argument as a robot name reaches
+    the verb with a ``str``. The verb owes an envelope-shaped
+    refusal that names the type it received and the remedy - the
+    four invariants every ``@tool`` handler in this package holds
+    - and this cell fixes the shape.
+    """
+    result = g1_balance_stand(driver="unitree_g1", balance_mode=0)
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "g1_balance_stand" in text
+    assert "'str'" in text
+
+
+def test_the_verb_writes_the_driver_exactly_once() -> None:
+    """One call to the verb makes one call to ``driver.balance_stand``.
+
+    A double-call from a wrapper that retried inside the verb
+    would issue two ``BalanceStand`` writes on the same admission
+    window; the SDK's handler is not re-entrant and neon's own
+    bundle held a single-writer lock. This cell pins the verb to
+    a single driver call per invocation.
+    """
+    driver = _StubG1Driver(envelope={"status": "success", "content": [{"json": {}}]})
+    _call(driver)
+    assert len(driver.calls) == 1
+
+
+def test_the_verb_passes_the_argument_through_unchanged() -> None:
+    """The balance mode the driver receives is the one the caller passed.
+
+    The verb's contract is a pass-through: it does not translate
+    argument names, does not synthesize defaults the driver did
+    not ask for, and does not clamp the value. This cell fixes
+    that ``balance_mode`` reaches the driver method verbatim - a
+    rename or coercion on either side is a driver-level contract
+    change, not a silent verb-side translation.
+    """
+    envelope = {"status": "success", "content": [{"json": {}}]}
+    driver = _StubG1Driver(envelope=envelope)
+    _call(driver, balance_mode=3)
+    assert driver.calls == [3]
+
+
+def test_the_wrong_shape_driver_is_not_called() -> None:
+    """A wrong-shape driver is refused before the accessor path.
+
+    The shared
+    :func:`~strands_robots.tools.g1._g1_common.live_handle_refusal`
+    guard is called first; a numeric handle is refused with an
+    envelope and the driver's method is never reached. This cell
+    holds the ordering by grading a handle that would raise if
+    called (``int`` has no ``balance_stand`` attribute) and
+    observing that the refusal envelope has the four invariants
+    without an exception in flight.
+    """
+    result = g1_balance_stand(driver=42, balance_mode=0)
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "g1_balance_stand" in text
+    assert "'int'" in text
+
+
+def test_a_missing_balance_mode_is_refused_with_a_message_naming_the_parameter() -> None:
+    """A ``None`` ``balance_mode`` is refused before the driver is called.
+
+    ``balance_mode`` is a data parameter the tool schema *does*
+    describe, so a model can synthesize the wrong shape here as
+    easily as it can reach the verb with the right one. ``None``
+    is the "the model left it out" shape: the verb owes an
+    envelope-shaped refusal naming the parameter and the remedy,
+    and this cell fixes that the refusal fires before the driver
+    is reached.
+    """
+    driver = _StubG1Driver(envelope={"status": "success", "content": [{"json": {}}]})
+    result = g1_balance_stand(driver=driver, balance_mode=None)
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "g1_balance_stand" in text
+    assert "balance_mode" in text
+    assert driver.calls == []
+
+
+def test_a_wrong_shape_balance_mode_is_refused_with_a_message_naming_the_parameter() -> None:
+    """A non-integer ``balance_mode`` is refused before the driver is called.
+
+    A model may synthesize the mode id as a string ``"0"`` or a
+    float ``0.0``; the SDK's handler is int-only (the neon
+    bundle's own wrapper coerced through :class:`int` before
+    dispatch, so a float or string reaching that path would either
+    be silently truncated or raise on the wire). The verb refuses
+    the shape here so the envelope names ``balance_mode`` and the
+    remedy is decidable rather than SDK-version dependent.
+    """
+    driver = _StubG1Driver(envelope={"status": "success", "content": [{"json": {}}]})
+    result = g1_balance_stand(driver=driver, balance_mode="0")  # type: ignore[arg-type]
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "g1_balance_stand" in text
+    assert "balance_mode" in text
+    assert driver.calls == []
+
+
+def test_a_float_balance_mode_is_refused_before_the_driver_is_called() -> None:
+    """A ``float`` ``balance_mode`` is refused rather than truncated.
+
+    ``LocoClient.BalanceStand`` takes an :class:`int` and the neon
+    bundle coerced through ``int(balance_mode)`` before dispatch,
+    which would silently truncate ``0.9`` to ``0`` (a valid mode
+    id the caller did not name) or ``3.5`` to ``3`` (also a valid
+    mode id). Refusing the shape here rather than truncating keeps
+    the verb from silently transitioning to a balance mode the
+    caller writing ``0.9`` did not name; a caller who wants a
+    specific mode reaches the verb with an integer explicitly.
+    """
+    driver = _StubG1Driver(envelope={"status": "success", "content": [{"json": {}}]})
+    result = g1_balance_stand(driver=driver, balance_mode=0.9)  # type: ignore[arg-type]
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "g1_balance_stand" in text
+    assert "balance_mode" in text
+    assert driver.calls == []
+
+
+def test_a_boolean_balance_mode_is_refused_because_it_would_act_as_a_silent_int() -> None:
+    """A ``True`` payload is refused rather than coerced to ``1``.
+
+    ``bool`` is an ``int`` subclass, so a caller passing ``True``
+    would reach the SDK's ``BalanceStand(1)`` handler - a mode id
+    outside the neon-bundle-observed admitted set ``{0, 3}`` that
+    the controller silently accepts and ignores - through a
+    signature that names none of that; ``False`` would collapse
+    to ``BalanceStand(0)`` (the static-balance default) silently.
+    Refusing ``bool`` explicitly rather than silently transitioning
+    matches the shape refusal every other numeric verb in this
+    package renders on the same subclass hazard; a caller who
+    wants ``0`` or ``3`` reaches the verb with the integer
+    explicitly.
+    """
+    driver = _StubG1Driver(envelope={"status": "success", "content": [{"json": {}}]})
+    result = g1_balance_stand(driver=driver, balance_mode=True)  # type: ignore[arg-type]
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "g1_balance_stand" in text
+    assert "balance_mode" in text
+    assert driver.calls == []
+
+
+def test_a_zero_balance_mode_is_admitted_because_it_is_the_static_balance_mode() -> None:
+    """A ``balance_mode=0`` reaches the driver: 0 is the static-balance default.
+
+    Unlike a positive-only knob, ``balance_mode`` at ``0`` is a
+    caller-facing value the neon bundle's own wrapper did not
+    reject: it is the static-balance default the neon bundle
+    documented, and the read-only envelope
+    :mod:`~strands_robots.tools.g1.g1_balance_modes` names it as
+    an admitted mode id. This cell pins that a caller who wants
+    static balance reaches the driver with the target verbatim.
+    """
+    envelope = {"status": "success", "content": [{"json": {"rc": 0}}]}
+    driver = _StubG1Driver(envelope=envelope)
+    result = _call(driver, balance_mode=0)
+
+    assert result["status"] == "success"
+    assert driver.calls == [0]
+
+
+def test_a_dynamic_balance_mode_reaches_the_driver_unchanged() -> None:
+    """A ``balance_mode=3`` reaches the driver: 3 is the dynamic-balance mode.
+
+    The neon bundle observed two walkable modes and the read-only
+    envelope :mod:`~strands_robots.tools.g1.g1_balance_modes`
+    names ``3`` as the dynamic-balance mode. This cell pins that
+    the verb reaches the driver with ``3`` verbatim (no
+    substitution to the static default), so a caller upgrading
+    from the neon bundle reaches the same behaviour.
+    """
+    envelope = {"status": "success", "content": [{"json": {"rc": 0}}]}
+    driver = _StubG1Driver(envelope=envelope)
+    result = _call(driver, balance_mode=3)
+
+    assert result["status"] == "success"
+    assert driver.calls == [3]
+
+
+def test_a_balance_mode_outside_the_admitted_set_reaches_the_driver_unchanged() -> None:
+    """A ``balance_mode=7`` reaches the driver unchanged - the verb does not domain-refuse.
+
+    The read-only envelope
+    :mod:`~strands_robots.tools.g1.g1_balance_modes` names the
+    neon-bundle-observed admitted set as ``{0, 3}``; the module
+    docstring names "does not refuse a balance_mode outside the
+    admitted set" as one of the things this verb does not do.
+    Refusing an unlisted mode here would fork the neon bundle's
+    admission set into a second source of truth this module would
+    then have to keep in sync with the envelope lookup. This cell
+    pins that a caller who passes ``7`` reaches the driver's own
+    refusal (or the SDK's silent-accept-and-ignore handler)
+    through the verb's pass-through, rather than being intercepted
+    here.
+    """
+    envelope = {"status": "success", "content": [{"json": {"rc": 0}}]}
+    driver = _StubG1Driver(envelope=envelope)
+    result = _call(driver, balance_mode=7)
+
+    assert result["status"] == "success"
+    assert driver.calls == [7]
+
+
+def test_a_negative_balance_mode_reaches_the_driver_unchanged() -> None:
+    """A negative ``balance_mode`` is passed to the driver, not clamped in the verb.
+
+    The neon bundle's own wrapper coerced through
+    ``int(balance_mode)`` and dispatched the result unchanged; a
+    negative id is not a shape violation
+    (:class:`int` accepts it) but a domain violation the SDK's
+    handler will either silently ignore or refuse. The module
+    docstring names "does not refuse a balance_mode outside the
+    admitted set" as one of the things this verb does not do. This
+    cell pins that the verb does not refuse or transform a
+    negative value on its own - a rewording of the driver's
+    refusal would then reach a caller through the envelope, not
+    through a verb-side interception.
+    """
+    envelope = {"status": "success", "content": [{"json": {"rc": 0}}]}
+    driver = _StubG1Driver(envelope=envelope)
+    result = _call(driver, balance_mode=-1)
+
+    assert result["status"] == "success"
+    assert driver.calls == [-1]


### PR DESCRIPTION
## Summary

Ports `g1_balance_stand` from the neon bundle's `g1_posture.py` as a thin duck-typed `@tool` wrapper over `driver.balance_stand`. Same shape as the three sibling verbs already on `main`:

- `g1_set_fsm` (#3025)
- `g1_set_stand_height` (#3031, in flight)
- `g1_set_swing_height` (#3032, approved & merging)

The driver-side `G1Driver.balance_stand` method is not yet plumbed (refs #358 for the SDK-facing gate work the write belongs on); the shared `live_handle_refusal` grader refuses today, and the same call returns the driver's envelope verbatim once the method lands. Zero risk to hardware: nothing can reach the SDK through this verb before the driver-side write is plumbed (where the gate review belongs).

## Design

- **Accessor**: `balance_stand` — the neon bundle wrapped `LocoClient.BalanceStand(int)` (which internally reaches the SDK's `SetBalanceMode` handler) under a single-writer lock.
- **Value-domain**: integer mode id. Neon-bundle-observed admitted set is `{0, 3}` (0 = static balance, 3 = dynamic balance). The read-only envelope `g1_balance_modes` already surfaces this admission (already on `main`).
- **Shape validation**: inline `isinstance` checks for `None`, `bool`, non-`int`. **No shared `strands_robots.utils` validator was reused** because none fits an int-in-set with `0` admitted: `positive_count_error` refuses `0` (the static default), `finite_number_error` admits floats the SDK cannot use. This is documented in both the module docstring and the changelog fragment — the rule "reuse validators, don't invent new ones" was interpreted as "reuse when one fits", and refusing to reuse a mis-fit is the honest call.
- **Does NOT enforce in-set admission**: refusing an unlisted mode here would fork the neon bundle's admission set into a second source of truth this module would then have to keep in sync with `g1_balance_modes`. Above-set values reach the driver / SDK for its own refusal or silent-accept behavior. Explicit in the docstring's "does not do" list (6 items).

## Refusal-string references

Every refusal message cites resolvable references (per #2872):
- `g1_list_balance_modes` — real tool in `strands_robots/tools/g1/g1_balance_modes.py`
- `strands-labs/robots#358` — the tracking issue
- `strands-labs/robots#2916` — the gate the driver-side write will use

## Tests

`tests/drivers/test_g1_balance_stand_writes_the_driver_envelope.py` — **16 tests**:

| # | Test | Grades |
|---|---|---|
| 1 | SDK-load hygiene | `import` pulls no `unitree_sdk2py` submodule |
| 2 | Driver-side refusal pass-through | Verbatim (no restated wording, per #2874) |
| 3 | Future success envelope pass-through | Verbatim |
| 4 | `driver=None` | Envelope names verb + `driver` |
| 5 | `driver="unitree_g1"` | Envelope names `'str'` |
| 6 | Exactly-once write | 1 call per invocation |
| 7 | Arg pass-through | `balance_mode` reaches driver verbatim |
| 8 | Wrong-shape driver not called | `int` driver → refused, driver not touched |
| 9 | `balance_mode=None` | Envelope names verb + parameter |
| 10 | `balance_mode="0"` | Envelope names verb + parameter |
| 11 | `balance_mode=0.9` (float) | Refused, driver not called |
| 12 | `balance_mode=True` (bool subclass hazard) | Refused, driver not called |
| 13 | `balance_mode=0` admitted (static default) | Reaches driver |
| 14 | `balance_mode=3` admitted (dynamic mode) | Reaches driver |
| 15 | `balance_mode=7` out-of-set | Reaches driver unchanged (docstring "does not do" #1) |
| 16 | `balance_mode=-1` negative | Reaches driver unchanged (docstring "does not do" #1) |

The universal auto-discovery test `tests/tools/g1/test_a_live_handle_verb_refuses_a_wrong_handle.py` grades the two live-handle refusal rules automatically (verb's first parameter is `driver: Any`). Both suites: **40/40 green** locally.

## Gates

- `ruff check` — clean on both new files
- `ruff format --check` — clean on both new files
- `mypy` — clean on both new files (the 4 pre-existing errors in `utils.py:975`, `simulation/ik.py:174`, `mesh/core.py:2254/2268` are not on this PR's surface)
- `pytest` — 16 new + 24 auto-discovery + **579/579 tree-guard tests** green (`test_docstring_xref_roles_resolve`, `test_args_docstring_completeness`, `test_no_host_paths`, `test_log_strings_are_ascii`, `test_changelog_format`, `test_changelog_fragments`, `test_docstrings_no_dangling_doc_refs`, `test_documented_guard_names_resolve`, `test_agent_tool_parameter_descriptions`, `tests/tools/test_docstring_module_xrefs`, `tests/tools/test_public_member_docstrings`)

## Files

- `strands_robots/tools/g1/g1_balance_stand.py` — 330 lines (module docstring + verb + shape-check helper)
- `tests/drivers/test_g1_balance_stand_writes_the_driver_envelope.py` — 410 lines (16 tests)
- `changelog.d/3033-g1-balance-stand-verb.md` — matches the fragment convention CI enforces

## Progress on #358

After this: `g1_send_action` (#3004), `g1_run_policy` (#3005), `g1_stop_task`, `g1_start_task` (#3016), `g1_set_fsm` (#3025), `g1_set_stand_height` (#3031), `g1_set_swing_height` (#3032), and now `g1_balance_stand` (#3033) — 8 write-side verbs from the neon bundle, all uniform in shape. The `g1_posture.py` block is complete.
