### PR TITLE
docs(getting-started): the driver='strands' refusal example names a robot that has one

### DIFF
--- a/changelog.d/3038-native-driver-refusal-example.md
+++ b/changelog.d/3038-native-driver-refusal-example.md
@@ -1,0 +1,24 @@
+### Docs: the `driver='strands'` refusal example names a robot that has no native driver
+
+`docs/getting-started/robot-factory.md` shows the "no native driver is
+registered" refusal as a verbatim `>>>` transcript. It refused `so101`, which
+`FeetechDriver` has since come to serve, so the block asserted `No native driver
+is registered for 'so101'` while `Robot("so101", mode="real", driver="strands")`
+returns a driver and raises nothing.
+
+The list inside that transcript rotted the same way, naming two robots when
+fourteen are registered. An incomplete list reads as authoritative: a reader
+checking whether their robot is natively driven found `trossen_wxai`, `vx300s`,
+`wx250s` and `dynamixel_2r` absent and concluded no driver existed for them.
+
+The example now refuses `ur5e`, which has none, and shows the refusal the code
+raises. The section opener no longer implies the two driver paths are exclusive
+-- `so100`, `so101`, `koch`, `aloha`, `lekiwi` and `hope_jr` each have a native
+driver *and* a lerobot type -- and names `list_native_drivers()` as the live
+answer rather than the captured list.
+
+`TestTheNativeDriverRefusalExampleIsStillTrue` grades the names rather than the
+wording: the refused robot must have no driver, every robot the transcript calls
+natively driven must have one, and the refusal is checked by raising it.
+Correctness is graded and completeness deliberately is not, so a fifteenth
+driver leaves the capture older rather than wrong.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -81,8 +81,10 @@ the clamp disabled.
 
 `mode="real"` builds a driver. By default that is the lerobot one - it constructs a lerobot
 `RobotConfig` and wraps a lerobot driver, which is what most robots in the shipped registry
-use. A robot that lerobot cannot model declares a native driver instead; `list_native_drivers()`
-reports which robots those are.
+use. A robot lerobot cannot model needs a native driver, but the two are not exclusive - a
+robot lerobot *can* build may have one as well, and then `driver=` decides which is used.
+`list_native_drivers()` reports every robot that has one, and is the answer to "is my robot
+driven natively" - the refusal below lists them only as of the day it was captured.
 
 `driver=` selects a different one:
 
@@ -112,11 +114,12 @@ URL - because only the driver knows how to read it.
 Asking for a driver that is not there is refused, never quietly substituted:
 
 ```python
->>> Robot("so101", mode="real", driver="strands")
-ValueError: No native driver is registered for 'so101', so driver='strands' cannot build
-it. Robots with a native driver: reachy_mini, unitree_g1. Either use driver='lerobot'
-(today's default, which builds it through lerobot) or register one with
-strands_robots.drivers.register_native_driver().
+>>> Robot("ur5e", mode="real", driver="strands")
+ValueError: No native driver is registered for 'ur5e', so driver='strands' cannot build
+it. Robots with a native driver: aloha, dynamixel_2r, hope_jr, koch, lekiwi, microduck,
+open_duck_mini, reachy_mini, so100, so101, trossen_wxai, unitree_g1, vx300s, wx250s.
+Either use driver='lerobot' (today's default, which builds it through lerobot) or
+register one with strands_robots.drivers.register_native_driver().
 ```
 
 A robot may also declare its driver in the registry, so a caller needs no `driver=` at all:

--- a/tests/test_docs_robot_factory_reference.py
+++ b/tests/test_docs_robot_factory_reference.py
@@ -207,3 +207,121 @@ class TestTheMeshSectionNamesTheSpellingThatEnablesMesh:
             assert sim.mesh is None
         finally:
             sim.destroy()
+
+
+class TestTheNativeDriverRefusalExampleIsStillTrue:
+    """The ``driver="strands"`` refusal example must name a robot that has no driver.
+
+    The page shows the refusal verbatim, as a ``>>>`` transcript, so it reads as
+    something the reader could paste. That makes it the one block on the page
+    whose *premise* can rot without a word of it changing: a robot named here
+    because it had no native driver acquires one the day a driver package
+    registers it, and the transcript then shows an error that no longer happens
+    for a robot that now builds fine.
+
+    It did rot. The example named ``so101``, and ``FeetechDriver`` came to serve
+    it - so the block asserted "no native driver is registered for 'so101'"
+    while ``Robot("so101", mode="real", driver="strands")`` returned a driver.
+    The enumerated list rotted with it, naming two robots when fourteen were
+    registered, which is worse than saying nothing: a reader looking up whether
+    their robot is natively driven found a list that omitted it and concluded no
+    driver existed.
+
+    So the names are graded, not the wording. Every robot the transcript claims
+    is natively driven must be, the robot it refuses must have no driver at all,
+    and the refusal must still be the one the code raises - checked by raising
+    it.
+
+    Correctness is graded, deliberately not completeness. A transcript is a
+    capture, and a fifteenth driver leaves it merely older rather than wrong, so
+    requiring the list to be exhaustive would fail this page on every driver that
+    lands - and the page names ``list_native_drivers()`` as the live answer for
+    that reason. A name that is *listed and has no driver* is the failure worth
+    catching, because that is the one that sends a reader looking for a driver
+    that does not exist.
+    """
+
+    @staticmethod
+    def _transcript() -> str:
+        """Return the fenced block holding the ``driver="strands"`` refusal.
+
+        Returns:
+            The block's text.
+
+        Raises:
+            AssertionError: If the page ships no such block - the guard would
+                otherwise report clean having read nothing.
+        """
+        text = _DOC.read_text(encoding="utf-8")
+        blocks = [
+            block
+            for block in re.findall(r"```[a-z]*\n(.*?)```", text, re.DOTALL)
+            if 'driver="strands"' in block and "No native driver is registered" in block
+        ]
+        assert len(blocks) == 1, (
+            f"expected exactly one transcript of the driver='strands' refusal, found {len(blocks)}. "
+            "This guard grades that block; without it a clean run proves nothing."
+        )
+        return blocks[0]
+
+    def test_the_refused_robot_really_has_no_native_driver(self) -> None:
+        """The premise the transcript rests on, and the one that rotted before."""
+        from strands_robots.drivers import get_native_driver_class
+
+        transcript = self._transcript()
+        match = re.search(r">>>\s*Robot\(\s*[\"']([^\"']+)[\"']", transcript)
+        assert match is not None, f"the transcript shows no Robot(...) call:\n{transcript}"
+        name = match.group(1)
+        driver_cls = get_native_driver_class(name)
+        assert driver_cls is None, (
+            f"The page refuses driver='strands' for {name!r} to show what happens when no native "
+            f"driver is registered, but {driver_cls.__name__} now serves it: "
+            f"Robot({name!r}, mode='real', driver='strands') builds a driver. "
+            "Name a robot that still has none, or drop the example."
+        )
+
+    def test_the_transcript_is_the_refusal_the_code_raises(self) -> None:
+        """Graded by raising it, so a reworded refusal cannot leave the page stale."""
+        from strands_robots import Robot
+
+        transcript = self._transcript()
+        match = re.search(r">>>\s*Robot\(\s*[\"']([^\"']+)[\"']", transcript)
+        assert match is not None
+        with pytest.raises(ValueError) as excinfo:
+            Robot(match.group(1), mode="real", driver="strands")
+        raised = str(excinfo.value)
+        for sentence in (
+            "No native driver is registered for",
+            "so driver='strands' cannot build",
+            "Robots with a native driver:",
+            "strands_robots.drivers.register_native_driver()",
+        ):
+            assert sentence in raised, f"the code no longer says {sentence!r}; the page still shows it"
+            assert sentence in transcript, f"the page dropped {sentence!r}, which the refusal still says"
+
+    def test_every_robot_the_page_calls_natively_driven_really_is(self) -> None:
+        """A name in the list must have a driver, or it sends a reader to a dead end."""
+        from strands_robots.drivers import get_native_driver_class, list_native_drivers
+
+        transcript = self._transcript()
+        listed = re.search(r"Robots with a native driver:\s*(.*?)\.\s", transcript, re.DOTALL)
+        assert listed is not None, f"the transcript shows no list of natively driven robots:\n{transcript}"
+        names = [
+            candidate
+            for candidate in re.findall(r"[A-Za-z_][A-Za-z0-9_]*", listed.group(1))
+            # The elision marker and any prose in the tail are not robot names.
+            if candidate in set(list_native_drivers()) or get_native_driver_class(candidate) is None
+        ]
+        assert names, f"no robot name was read out of {listed.group(1)!r}; the guard would prove nothing"
+        wrong = [name for name in names if get_native_driver_class(name) is None]
+        assert not wrong, (
+            f"The page lists {wrong} among robots with a native driver, but none is registered for them. "
+            "A reader checking whether their robot is natively driven is told yes and finds nothing."
+        )
+
+    def test_the_page_names_the_live_listing_helper(self) -> None:
+        """A captured list is only honest if the page says where the live one is."""
+        assert "list_native_drivers()" in _DOC.read_text(encoding="utf-8"), (
+            "The transcript's list of natively driven robots is a capture, so the page must name "
+            "list_native_drivers() as the way to get the current one."
+        )


### PR DESCRIPTION
## Problem

`docs/getting-started/robot-factory.md` shows the `driver="strands"` refusal as a verbatim `>>>` transcript, so it reads as something a reader can paste. Its premise rotted without a word of it changing.

```python
>>> Robot("so101", mode="real", driver="strands")   # what the page claimed
ValueError: No native driver is registered for 'so101' ...
```

Measured on `main`:

```
>>> Robot('so101', mode='real', driver='strands')
<strands_robots.drivers.feetech.driver.FeetechDriver object>   # builds; raises nothing
```

`FeetechDriver` came to serve `so101`, so the page documents an error that cannot happen for a robot that now builds fine.

## The list rotted with it

The transcript enumerated the natively driven robots as `reachy_mini, unitree_g1`. `list_native_drivers()` reports **14**:

| | robots |
|---|---|
| page said | `reachy_mini`, `unitree_g1` |
| actually registered | `aloha`, `dynamixel_2r`, `hope_jr`, `koch`, `lekiwi`, `microduck`, `open_duck_mini`, `reachy_mini`, `so100`, `so101`, `trossen_wxai`, `unitree_g1`, `vx300s`, `wx250s` |

An incomplete list reads as authoritative. A reader checking whether their robot is natively driven found `trossen_wxai`, `vx300s`, `wx250s` and `dynamixel_2r` absent and concluded no driver existed — while `Robot("trossen_wxai", mode="real", driver="strands")` returns a `DynamixelDriver` that satisfies the whole `HardwareDriver` surface (`missing_driver_members()` is empty).

The section opener also implied the two paths are exclusive ("a robot that lerobot cannot model declares a native driver instead"). Six robots have a native driver **and** a lerobot type, so that framing is what makes the captured list look complete.

## Change

- The example refuses `ur5e`, which has no native driver, and shows the refusal the code raises.
- The opener states the paths are not exclusive and names `list_native_drivers()` as the live answer, so the transcript's list is read as a capture.
- `TestTheNativeDriverRefusalExampleIsStillTrue` grades the **names**, not the wording: the refused robot must have no driver, every robot the transcript calls natively driven must have one, and the refusal is checked by raising it.

Correctness is graded and completeness deliberately is not — a fifteenth driver leaves the capture older rather than wrong, and failing this page on every driver that lands would be a treadmill. That is written into the test docstring so the omission is not read as an oversight.

## Verification

Guard against the unfixed page vs. the fixed page, test file held constant:

| tree | result |
|---|---|
| `main` doc + new guard | `2 failed, 2 passed` — `DID NOT RAISE ValueError`, and `FeetechDriver now serves it` |
| fixed doc + new guard | `4 passed` |

Gate: `ruff check` / `ruff format --check` clean on both changed files; `mypy` reports nothing attributable to either (the 4 it finds are the standing baseline in `mesh/core.py` and `simulation/mujoco/rendering.py`). `tests/test_docs_robot_factory_reference.py` `10 passed, 1 skipped`; the driver/registry/changelog scope `2267 passed`; all `tests/test_docs*.py` `199 passed`. Four failures in that sweep (`mujoco`, `psutil`, `msgpack` `ModuleNotFoundError`) reproduce identically on pristine `main` and are missing optional dependencies in this environment.

No visual artifact: this changes a documentation page and a test, no policy, asset or rendering behaviour.

## LOC delta

`+128 / -7`. The additions are one guard class over a page whose existing guard reads the parameter table and the Mesh section but never this transcript, which is how it went stale.
