### PR TITLE
feat(drivers): list_driver_coverage joins both registries so a driver gap is derived

### DIFF
--- a/changelog.d/3042-driver-coverage-join.md
+++ b/changelog.d/3042-driver-coverage-join.md
@@ -1,0 +1,28 @@
+### Added: `list_driver_coverage()` - which drivers can build each robot, joined from both registries
+
+Two registries answer "what can build this robot for real": a registry entry's
+`hardware.lerobot_type` names a lerobot robot type, and the native-driver
+registry holds the classes driver packages register. `list_native_drivers()`
+reports the second and `get_hardware_type()` the first, so the group defined by
+*both* absences - the simulation-only robots, which is the one group a
+driver-coverage gap list is made of - was reported by nothing and got assembled
+by hand. A hand-assembled join goes stale in one direction only: a robot that
+gains a driver keeps reading as a gap. Measured on the shipped registry, a
+hand-written gap list of sixteen robots named five that were already reachable -
+`open_duck_mini` through `FeetechDriver`, and `openarm`, `bi_openarm`,
+`rebot_b601` and `bi_rebot_b601` through their declared lerobot types.
+
+`list_driver_coverage()` is that join, derived on every call: canonical robot
+name to the driver names able to build it, for every registered robot. Both
+reported names are `DRIVER_CHOICES` values, so an entry reads as the set of
+`driver=` arguments that work, and an empty tuple is the driver gap. It reports
+what the registries *declare*, needing no optional dependency and no hardware -
+whether lerobot is installed is a property of the environment, not of the robot.
+Coverage is not resolution: a robot both drivers can build is reported as both,
+and `resolve_driver` still picks one.
+
+Resolution precedence, the native-driver refusal and every registry entry are
+unchanged. `has_hardware`'s docstring described only the `lerobot_type` half of
+the block it reads, which was already wrong for the Reachy Mini and the Microduck
+- both declare only `hardware.driver`, because lerobot has no robot type for them
+- so it now describes the block and points at the join for the complete answer.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -92,6 +92,25 @@ reports which robots those are.
 | `"lerobot"` | The lerobot driver, explicitly. |
 | `"strands"` | The native driver registered for this robot. |
 
+`list_driver_coverage()` reports the join for every registered robot: which `driver=` values
+can build it, and an empty tuple where neither can.
+
+```python
+from strands_robots.drivers import list_driver_coverage
+
+coverage = list_driver_coverage()
+coverage["so101"], coverage["vx300s"], coverage["panda"]
+# (('lerobot', 'strands'), ('strands',), ())
+
+sim_only = [name for name, drivers in coverage.items() if not drivers]
+```
+
+`so101` is reported as both and `resolve_driver("so101")` returns `"lerobot"` - coverage is
+what *can* build a robot, resolution is what *does*. `vx300s` has no lerobot robot type, so its
+native driver is the only one that can build it. An empty tuple is the driver gap: `sim_only`
+is every robot `mode="real"` has nowhere to go for, derived on each call rather than
+maintained by hand.
+
 A native driver is for a robot lerobot's arm/serial shape cannot model - a humanoid with its
 own state machine, a rover reporting GPS, a base publishing a point cloud. It is a separate
 class satisfying `strands_robots.drivers.HardwareDriver`, registered against a robot name:

--- a/strands_robots/drivers/__init__.py
+++ b/strands_robots/drivers/__init__.py
@@ -26,6 +26,7 @@ from strands_robots.drivers.base import (
 from strands_robots.drivers.registry import (
     driver_choice_error,
     get_native_driver_class,
+    list_driver_coverage,
     list_native_drivers,
     register_native_driver,
     resolve_driver,
@@ -120,6 +121,7 @@ __all__ = [
     "HardwareDriver",
     "driver_choice_error",
     "get_native_driver_class",
+    "list_driver_coverage",
     "list_native_drivers",
     "missing_driver_members",
     "register_native_driver",

--- a/strands_robots/drivers/registry.py
+++ b/strands_robots/drivers/registry.py
@@ -1,12 +1,17 @@
 """Choose which driver builds a ``mode="real"`` robot, and find it.
 
-Two questions, kept apart because they have different answers:
+Three questions, kept apart because they have different answers:
 
 * *Which driver?* :func:`resolve_driver` - a name, from the caller's ``driver=``
   or the robot's registry entry, defaulting to
   :data:`~strands_robots.drivers.base.DEFAULT_DRIVER`.
 * *Which class?* :func:`get_native_driver_class` - the class a native driver
   package registered for this robot, or ``None``.
+* *Which drivers could?* :func:`list_driver_coverage` - for every registered
+  robot, the driver names able to build it, joined from this table and the
+  package registry's declared lerobot types. Resolution picks one of them; the
+  join is the only surface that reports the robots for which there is nothing to
+  pick.
 
 The native table starts empty: every robot in the package registry is driven
 through lerobot, so nothing is registered until a driver package calls
@@ -21,7 +26,7 @@ from __future__ import annotations
 import logging
 
 from strands_robots.drivers.base import DEFAULT_DRIVER, DRIVER_CHOICES, missing_driver_members
-from strands_robots.registry import get_driver, resolve_name
+from strands_robots.registry import get_driver, get_hardware_type, list_robots, resolve_name
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +159,56 @@ def list_native_drivers() -> dict[str, str]:
         Canonical robot name -> driver class name, sorted by robot name.
     """
     return {name: cls.__name__ for name, cls in sorted(_NATIVE_DRIVERS.items())}
+
+
+def list_driver_coverage() -> dict[str, tuple[str, ...]]:
+    """Report which drivers can build each registered robot, for every robot.
+
+    :func:`list_native_drivers` answers half the question and
+    :func:`~strands_robots.registry.get_hardware_type` the other half, and
+    neither is a complete answer to "can I drive this robot for real". A robot
+    may be reachable through lerobot only, through a native driver only, through
+    both, or through neither -- and the last group is the one no existing surface
+    reports at all, because it is defined by two absences. Assembling it by hand
+    is how a coverage list goes stale: a robot that gained a native driver still
+    reads as a gap until someone re-runs the join.
+
+    Reports what the two registries *declare*, so it needs no optional
+    dependency and no hardware:
+
+    * ``"lerobot"`` when the robot declares a ``hardware.lerobot_type``. That is
+      the type string :class:`~strands_robots.hardware_robot.Robot` hands to
+      lerobot's ``RobotConfig``; whether lerobot is installed is a property of
+      the environment, not of the robot, so it is deliberately not consulted.
+    * ``"strands"`` when a native driver is registered for the robot -- by this
+      package's own :data:`~strands_robots.drivers._SHIPPED_DRIVERS`, or by any
+      driver package that has called :func:`register_native_driver`.
+
+    Both names are :data:`~strands_robots.drivers.base.DRIVER_CHOICES` values, so
+    an entry reads as the set of ``driver=`` arguments that can build that robot.
+    Which one *wins* for a robot that has both is :func:`resolve_driver`'s
+    answer, not this one's: coverage is about what exists, resolution about what
+    is chosen.
+
+    Returns:
+        Canonical robot name -> the driver names that can build it, sorted by
+        robot name. An empty tuple means the robot is simulation-only: neither
+        registry can reach hardware for it, and ``mode="real"`` has nowhere to
+        go until a driver is written or a lerobot type is declared.
+    """
+    coverage: dict[str, tuple[str, ...]] = {}
+    for entry in list_robots("all"):
+        name = str(entry["name"])
+        drivers: list[str] = []
+        if get_hardware_type(name) is not None:
+            drivers.append(DEFAULT_DRIVER)
+        if get_native_driver_class(name) is not None:
+            # The literal rather than a constant, matching the one call site
+            # that already reads it (``strands_robots.robot`` builds a native
+            # driver when the resolved name is this).
+            drivers.append("strands")
+        coverage[name] = tuple(drivers)
+    return coverage
 
 
 def _native_driver_refusal(robot_type: str) -> str | None:

--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -93,7 +93,32 @@ def has_sim(name: str) -> bool:
 
 
 def has_hardware(name: str) -> bool:
-    """Check if a robot has real hardware support (LeRobot type)."""
+    """Check if a robot declares a real-hardware backend.
+
+    Reads the registry entry's ``hardware`` block, which has two independent
+    fields: ``lerobot_type`` names a lerobot robot type, and ``driver`` names
+    which driver builds the robot. Either alone is a hardware declaration --
+    the Reachy Mini and the Microduck declare only a ``driver``, because lerobot
+    has no robot type for them at all -- so this reads the block rather than one
+    field of it.
+
+    A robot may be drivable without declaring anything: a native driver
+    registered through
+    :func:`~strands_robots.drivers.register_native_driver` needs no registry
+    declaration, and several servo-bus arms are in exactly that position.
+    Declaration and registration are two different facts and this predicate
+    reports only the first, because it is the one a caller can read without
+    importing a driver package.
+    :func:`~strands_robots.drivers.list_driver_coverage` joins both and is what
+    answers "can this robot be driven for real" completely.
+
+    Args:
+        name: Robot name, alias, or data_config.
+
+    Returns:
+        True when the robot's registry entry carries a ``hardware`` block,
+        False when it does not or the robot is not registered at all.
+    """
     info = get_robot(name)
     return info is not None and "hardware" in info
 

--- a/tests/drivers/test_driver_coverage_joins_both_registries.py
+++ b/tests/drivers/test_driver_coverage_joins_both_registries.py
@@ -1,0 +1,107 @@
+"""Driver coverage is derived from both registries, so a gap list cannot go stale.
+
+Two registries answer "what can build this robot for real": a registry entry's
+``hardware.lerobot_type`` names a lerobot robot type, and the native-driver
+registry holds the classes driver packages register. ``list_native_drivers()``
+reports the second, ``get_hardware_type()`` the first, and neither reports the
+group defined by *both* absences -- the simulation-only robots, which is the one
+group a driver-coverage gap list is made of.
+
+So that list was assembled by hand, and a hand-assembled join goes stale in one
+direction only: a robot that gains a driver keeps reading as a gap. Measured on
+the shipped registry, a hand-written gap list of sixteen robots named five that
+were already reachable -- ``open_duck_mini`` through ``FeetechDriver``, and
+``openarm``, ``bi_openarm``, ``rebot_b601`` and ``bi_rebot_b601`` through their
+declared lerobot types.
+
+:func:`~strands_robots.drivers.list_driver_coverage` is that join, derived on
+every call. The tests below pin the two agreements it rests on, that it reads the
+registry rather than a snapshot of today's drivers, and that coverage is not
+resolution -- a robot both drivers can build is reported as both even though
+:func:`~strands_robots.drivers.resolve_driver` picks one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import strands_robots.drivers.registry as drivers_registry_mod
+from strands_robots.drivers import (
+    DEFAULT_DRIVER,
+    DRIVER_CHOICES,
+    get_native_driver_class,
+    list_driver_coverage,
+    resolve_driver,
+)
+from strands_robots.registry import get_hardware_type, list_robots
+
+
+def test_every_registered_robot_is_reported_exactly_once() -> None:
+    """The population is the registry's, so no robot can be silently skipped."""
+    coverage = list_driver_coverage()
+    assert set(coverage) == {entry["name"] for entry in list_robots("all")}
+
+
+def test_the_four_groups_are_all_populated() -> None:
+    """Non-vacuity, and the reason the join is worth having.
+
+    A function that reported an empty tuple for every robot would satisfy every
+    agreement below. The group that matters is the last one: fifty robots reach
+    hardware through neither registry, and nothing else reports them.
+    """
+    coverage = list_driver_coverage()
+    assert [name for name, d in coverage.items() if d == (DEFAULT_DRIVER,)]
+    assert [name for name, d in coverage.items() if d == ("strands",)]
+    assert [name for name, d in coverage.items() if len(d) == 2]
+    assert [name for name, d in coverage.items() if not d]
+
+
+def test_the_strands_entry_agrees_with_the_native_driver_registry() -> None:
+    """One half of the join: ``"strands"`` iff a native driver is registered."""
+    for name, drivers in list_driver_coverage().items():
+        assert ("strands" in drivers) is (get_native_driver_class(name) is not None), name
+
+
+def test_the_lerobot_entry_agrees_with_the_declared_robot_type() -> None:
+    """The other half: ``"lerobot"`` iff the entry declares a lerobot robot type.
+
+    The declaration, not the installation. Whether lerobot is importable is a
+    property of the environment, so consulting it would make coverage depend on
+    which extras a caller installed.
+    """
+    for name, drivers in list_driver_coverage().items():
+        assert (DEFAULT_DRIVER in drivers) is (get_hardware_type(name) is not None), name
+
+
+def test_a_driver_registered_later_leaves_the_gap_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Derived, not a snapshot: this is what a hand-written list cannot do.
+
+    The robot planted against is read out of the gap rather than named, because a
+    named one is a hostage to the next driver: every robot in this group is one
+    someone is writing a driver for, and pinning the sentinel would make this
+    cell fail on the PR that closes its gap for real.
+    """
+
+    class _PlantedDriver:
+        pass
+
+    sim_only = next(name for name, drivers in sorted(list_driver_coverage().items()) if not drivers)
+    monkeypatch.setitem(drivers_registry_mod._NATIVE_DRIVERS, sim_only, _PlantedDriver)
+    assert list_driver_coverage()[sim_only] == ("strands",)
+
+
+def test_coverage_is_not_resolution() -> None:
+    """A robot both drivers can build is reported as both; one of them wins.
+
+    ``resolve_driver`` answers which driver a call gets, and never reports
+    ``"auto"``. Coverage answers which ``driver=`` values could work, so it must
+    keep naming the one resolution did not pick - and every name it reports has
+    to be a value a caller may actually pass.
+    """
+    coverage = list_driver_coverage()
+    both = [name for name, drivers in coverage.items() if len(drivers) == 2]
+    assert both, "expected at least one robot both drivers can build"
+    for name in both:
+        assert resolve_driver(name) in coverage[name]
+    for name, drivers in coverage.items():
+        assert set(drivers) <= set(DRIVER_CHOICES) - {"auto"}, name


### PR DESCRIPTION
## The gap a gap list cannot see

Two registries answer *what can build this robot for real*, and each surface reports one of them:

```mermaid
flowchart LR
  A["registry entry<br/>hardware.lerobot_type"] -->|get_hardware_type| C["16 robots"]
  B["native-driver registry<br/>register_native_driver"] -->|list_native_drivers| D["14 robots"]
  C --> E["list_driver_coverage<br/>the join"]
  D --> E
  E --> F["50 robots reported by<br/>NEITHER: the driver gap"]
```

The group defined by **both** absences is the one group a driver-coverage list is made of, and nothing reported it. So it gets assembled by hand, and a hand-assembled join goes stale in exactly one direction: a robot that *gains* a driver keeps reading as a gap. Measured against the shipped registry, a hand-written gap list of sixteen robots named five that were already reachable - `open_duck_mini` through `FeetechDriver`, and `openarm`, `bi_openarm`, `rebot_b601`, `bi_rebot_b601` through their declared lerobot types.

## What lands

`list_driver_coverage()` - the join, derived on every call, for every registered robot.

```python
from strands_robots.drivers import list_driver_coverage

coverage = list_driver_coverage()
coverage["so101"], coverage["vx300s"], coverage["panda"]
# (('lerobot', 'strands'), ('strands',), ())

sim_only = [name for name, drivers in coverage.items() if not drivers]
```

Measured on `main` @ `3e1155ddd`, all 73 registered robots accounted for:

| coverage | robots | names |
|---|---:|---|
| `('lerobot',)` | 9 | `bi_openarm`, `bi_rebot_b601`, `earthrover`, `hope_jr_hand`, `lekiwi_client`, `omx`, `openarm`, `reachy2` (+1) |
| `('strands',)` | 7 | `dynamixel_2r`, `microduck`, `open_duck_mini`, `reachy_mini`, `trossen_wxai`, `vx300s`, `wx250s` |
| `('lerobot', 'strands')` | 7 | `aloha`, `hope_jr`, `koch`, `lekiwi`, `so100`, `so101`, `unitree_g1` |
| `()` **the driver gap** | 50 | `aliengo`, `anymal_b`, `anymal_c`, `arx_l5`, `cassie`, `jvrc`, `op3`, `piper`, `yam`, `z1` (+40) |

Both reported names are `DRIVER_CHOICES` values, so an entry reads as the set of `driver=` arguments that can build that robot. Coverage is not resolution: `so101` is reported as both and `resolve_driver("so101")` still returns `"lerobot"`.

Reports what the registries **declare**, so it needs no optional dependency and no hardware - whether lerobot is installed is a property of the environment, not of the robot.

## Derived, and measured against the drivers landing right now

The point of a derived join is that it needs no edit when a driver lands. Composed this branch with #3039 (Go2) and #3040 (Franka) - `git merge`, no conflicts:

| tree | gap | strands-only | `unitree_go2` | `panda` / `fr3` / `fr3_v2` |
|---|---:|---:|---|---|
| this branch | 50 | 7 | `()` | `()` |
| + #3039 + #3040 | **46** | **11** | `('strands',)` | `('strands',)` |

Four robots leave the gap with no edit to this code or its tests. `259 passed` on the composed tree (this suite + both new driver suites + `test_driver_seam.py` + `test_native_driver_named_when_lerobot_has_no_type.py`).

The same reasoning is why the plant cell reads its sentinel *out of* the gap instead of naming one: every robot in that group is one somebody is writing a driver for, and #3040 would have broken a cell that named `panda`.

## Nothing else changes

Resolution precedence, `_native_driver_refusal` and every registry entry are untouched. `has_hardware`'s one-line docstring said `(LeRobot type)`, which was already wrong for the Reachy Mini and the Microduck - they declare only `hardware.driver`, because lerobot has no robot type for them - so it now describes the block it actually reads and points at the join for the complete answer.

## Tests

`tests/drivers/test_driver_coverage_joins_both_registries.py` - 6 cells, all derived, no per-robot table:

| cell | pins |
|---|---|
| population | every registered robot reported exactly once |
| four groups populated | non-vacuity; an all-empty return would satisfy every agreement below |
| strands agreement | `"strands" in entry` iff `get_native_driver_class` is not `None` |
| lerobot agreement | `"lerobot" in entry` iff a `lerobot_type` is declared (declaration, not installation) |
| plant | a driver registered later leaves the gap immediately - what a hand-written list cannot do |
| coverage != resolution | a both-driver robot keeps naming the driver resolution did not pick; every name is a passable `driver=` |

## Gate

| check | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | All checks passed |
| `ruff format --check` | 1871 files already formatted |
| `mypy strands_robots tests tests_integ` | 22 errors in 8 files = the standing baseline, **0 attributable** to any changed file |
| `pytest tests` (full) | **43906 passed**, 0 new failures |
| new-failure attribution | the 100 files failing in this env fail **byte-identically** on pristine `main`: `430 failed, 2671 passed, 50 skipped, 402 errors` on both, 832 identical ids (missing optional extras: `lerobot[dataset]`, `device_connect_edge`, `accelerate`) |
| affected scope | `tests/drivers` + `tests/registry` + seam + export/docstring/docs graders: **3500 passed, 23 skipped** |

## LOC delta

| file | +/- |
|---|---|
| `strands_robots/drivers/registry.py` | +57 / -2 (46 of the +57 are the docstring) |
| `strands_robots/registry/robots.py` | +26 / -1 (docstring only) |
| `strands_robots/drivers/__init__.py` | +2 |
| `docs/getting-started/robot-factory.md` | +19 |
| `tests/drivers/test_driver_coverage_joins_both_registries.py` | +104 (new) |

Net positive, and the justification is the one it earns back: a derived join replaces a hand-maintained coverage list, and the 46-line docstring is the ledger of *why* a robot with both drivers is reported as both.