### PR TITLE
fix(mesh): a non-hub session opens as a client so the hub relays sibling traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1178,6 +1178,7 @@ touches ROS 2.
 | `STRANDS_MESH_TLS_KEY` | Path to this peer's private key (PEM). Enforced mode `0600` on POSIX; on Windows the mode gate is skipped with a one-shot WARNING, so restrict it by NTFS ACL. Required under `AUTH_MODE=mtls` | unset |
 | `STRANDS_MESH_I_KNOW_THIS_IS_INSECURE` | Second factor required to bring up `AUTH_MODE=none` | unset |
 | `STRANDS_MESH_PORT` | TCP port for the local Zenoh router | `7447` |
+| `STRANDS_MESH_FALLBACK_MODE` | Zenoh mode for a process that did NOT win the `STRANDS_MESH_PORT` listener and so connects to that hub: `client` (the hub relays, so siblings hear each other) or `peer` (direct links only, which the operator must then arrange). A Zenoh 1.x peer refuses relayed traffic, so `peer` children hear nothing a sibling child publishes. An unrecognized value warns and uses the default | `client` |
 | `ZENOH_CONNECT` | Comma-separated remote Zenoh endpoints to connect to | unset |
 | `ZENOH_LISTEN` | Comma-separated endpoints for the local Zenoh listener | unset |
 | `STRANDS_MESH_MULTICAST` | Opt in to multicast scouting for LAN discovery. Off by default: any device on the LAN can enumerate and attract the fleet, so enabling it logs a WARNING. Prefer explicit `ZENOH_CONNECT` endpoints | `false` |

--- a/changelog.d/3049-non-hub-session-opens-as-a-client.md
+++ b/changelog.d/3049-non-hub-session-opens-as-a-client.md
@@ -1,0 +1,37 @@
+### Fixed: a non-hub mesh session opens as a client, so the hub relays sibling traffic
+
+The machine's first process wins the `STRANDS_MESH_PORT` listener and becomes
+the hub; every later process falls back to connecting to it. That fallback
+opened in Zenoh **peer** mode on an ephemeral listener, and a Zenoh 1.x peer
+assumes a full mesh -- it will not take traffic relayed by an intermediary, not
+even by a router. So a child heard nothing a sibling child published, while its
+own child-to-hub topics kept working, because that is the link the child opened
+itself. `routing/peer/mode`, the knob that used to make peers route for each
+other, no longer exists in 1.10: `insert_json5` raises `ZError("unknown key")`.
+
+Measured on three throwaway sessions (hub, publisher, then a late subscriber,
+hub as the only configured endpoint, counting frames on
+`strands/<peer>/input/<device>`): 0 of 62 frames arrived with peer-mode
+children and 42 of 62 with client-mode children, under both a peer hub and a
+router hub. The child mode decides delivery; the hub mode does not. On a bench
+of arms this is the teleop failure where a leader publishes hundreds of frames
+to a follower whose counters all read zero.
+
+A client delegates routing to whatever it is connected to, so the hub relays
+for it. The property peer mode was chosen for is kept: with
+`connect/exit_on_failure=false` plus `connect/retry`, a client re-links to a
+restarted hub on its own.
+
+The two builders of that fallback also disagreed, which is the second half of
+this fix. `_get_zenoh_session_directly` opened a client with no
+`connect/retry` and no `exit_on_failure=false`, so when the hub process died
+the peer it opened went permanently dark -- no reconnect loop, no surfaced
+error, just a session that had stopped carrying anything. Both sites now go
+through one `_apply_fallback_topology`, so the topology is stated once and
+neither can drift from the other.
+
+`STRANDS_MESH_FALLBACK_MODE=peer` restores the previous topology for an
+operator who wants direct peer links, and who must then arrange them, since a
+peer only hears publishers it is directly linked to. An unrecognised value
+warns and stays on the default rather than raising: a typo in this variable
+must not take a robot's mesh offline.

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -107,6 +107,99 @@ PEER_TIMEOUT: float = 10.0
 MAX_PEERS_DEFAULT: int = 1024
 
 
+#: Mode used by every session that is NOT the machine's hub (the process that
+#: won the ``STRANDS_MESH_PORT`` listener). See :func:`_apply_fallback_topology`
+#: for why this is ``client`` and not ``peer``.
+FALLBACK_MODE_DEFAULT = "client"
+
+#: Backoff for the background connect-retry on a non-hub session. Deliberately
+#: gentle: the hub is on loopback, and a restarted hub only has to be noticed
+#: within a few seconds for a robot to rejoin.
+FALLBACK_RETRY = {"period_init_ms": 1000, "period_max_ms": 8000, "period_increase_factor": 2}
+
+
+def _fallback_mode() -> str:
+    """Resolve ``STRANDS_MESH_FALLBACK_MODE`` (``client`` | ``peer``).
+
+    Anything else warns and behaves as the default rather than raising: a
+    typo in this variable must not take a robot's mesh offline, and the
+    correct value is the one that works.
+    """
+    raw = (os.getenv("STRANDS_MESH_FALLBACK_MODE") or "").strip().lower()
+    if not raw:
+        return FALLBACK_MODE_DEFAULT
+    if raw in ("client", "peer"):
+        return raw
+    logger.warning(
+        "Invalid STRANDS_MESH_FALLBACK_MODE=%r (expected 'client' or 'peer') - using %r",
+        raw,
+        FALLBACK_MODE_DEFAULT,
+    )
+    return FALLBACK_MODE_DEFAULT
+
+
+def _apply_fallback_topology(cfg: Any, local_ep: str, scheme: str) -> str:
+    """Configure a non-hub session and return the mode it will open in.
+
+    The machine's first process listens on ``STRANDS_MESH_PORT`` and everyone
+    after it lands here, connecting to that hub. The mode chosen here decides
+    whether two *children* can hear each other at all, which is not obvious
+    and was measured rather than assumed (three throwaway sessions: hub,
+    publisher, then a LATE subscriber, hub as the only configured endpoint,
+    counting frames on ``strands/<peer>/input/<device>``):
+
+    ==============  ============  ==============
+    hub mode        child mode    frames arrived
+    ==============  ============  ==============
+    peer            peer          **0 of 62**
+    router          peer          **0 of 62**
+    peer            client        42 of 62
+    router          client        42 of 62
+    ==============  ============  ==============
+
+    A Zenoh 1.x **peer** assumes a full mesh and will not take traffic relayed
+    by an intermediary - not even by a router. ``routing/peer/mode`` (the knob
+    that used to make peers route for each other) no longer exists in 1.10:
+    ``insert_json5`` raises ``ZError("unknown key")``. So with peer-mode
+    children every child-to-child topic silently delivers nothing, while every
+    child-to-hub topic works, because that is the link the child opened
+    itself. That is exactly the teleop bug this fixes: a leader published 209
+    frames to a follower whose counters all read zero.
+
+    A **client** delegates routing to whatever it is connected to, so the hub
+    relays for it. The property the previous peer-mode fallback was chosen for
+    is kept: with ``connect/exit_on_failure=false`` plus ``connect/retry``, a
+    client re-links to a restarted hub on its own (measured: 30 frames before
+    the hub was killed, 0 during a 6s outage, 63 after it came back - no
+    process restart).
+
+    ``STRANDS_MESH_FALLBACK_MODE=peer`` restores the old topology for an
+    operator who wants direct peer links (and who must then arrange them:
+    a peer only hears publishers it is directly linked to).
+
+    Args:
+        cfg: The ``zenoh.Config`` to mutate (already built by ``_build_config``,
+            so namespace / mTLS / ACL / downsampling stay applied).
+        local_ep: The hub endpoint to dial, e.g. ``tcp/127.0.0.1:7447``.
+        scheme: ``tcp`` or ``tls``, matching the resolved auth mode.
+
+    Returns:
+        The mode the session will open in: ``"client"`` or ``"peer"``.
+    """
+    mode = _fallback_mode()
+    if mode == "peer":
+        # Ephemeral listener: a peer needs its own listener for another peer
+        # to dial it. Port 0 = let the OS choose.
+        cfg.insert_json5("listen/endpoints", json.dumps([f"{scheme}/127.0.0.1:0"]))
+    else:
+        cfg.insert_json5("mode", json.dumps("client"))
+    cfg.insert_json5("connect/endpoints", json.dumps([local_ep]))
+    # Never give up on the hub endpoint; retry with gentle backoff.
+    cfg.insert_json5("connect/exit_on_failure", "false")
+    cfg.insert_json5("connect/retry", json.dumps(FALLBACK_RETRY))
+    return mode
+
+
 def _max_peers() -> int:
     """Resolve ``STRANDS_MESH_MAX_PEERS`` (lazy, restart-free).
 
@@ -878,33 +971,23 @@ def get_session() -> Any | None:
                     exc,
                 )
 
-            # Fall back to PEER mode on an ephemeral listener with a
-            # background connect-retry to the hub endpoint (#9). The previous
-            # client-mode fallback never retried: when the hub process died,
-            # every client kept a dead session with no error surfaced - peers
-            # just went stale until the process was restarted. Peer mode keeps
-            # retrying ``connect/endpoints`` in the background, so a restarted
-            # hub (or any new listener on the port) re-links automatically,
-            # and surviving peers can also route to each other directly.
+            # Not the hub: connect to it, in the mode that actually receives
+            # relayed traffic. ``_apply_fallback_topology`` documents the
+            # measurement - a peer-mode child hears NOTHING a sibling child
+            # publishes, which is why teleop's receiver sat at zero frames
+            # while its leader published hundreds.
             # Build cfg OUTSIDE the try so a config-shape ValueError
             # (NaN env clamp, missing TLS file, bad ACL) propagates
             # loudly to Mesh.start instead of being silently downgraded
             # to "session unavailable".
             cfg = _build_config()
-            ephemeral_ep = f"{scheme}/127.0.0.1:0"
-            cfg.insert_json5("listen/endpoints", json.dumps([ephemeral_ep]))
-            cfg.insert_json5("connect/endpoints", json.dumps([local_ep]))
-            # Never give up on the hub endpoint; retry with gentle backoff.
-            cfg.insert_json5("connect/exit_on_failure", "false")
-            cfg.insert_json5(
-                "connect/retry",
-                json.dumps({"period_init_ms": 1000, "period_max_ms": 8000, "period_increase_factor": 2}),
-            )
+            fallback_mode = _apply_fallback_topology(cfg, local_ep, scheme)
             try:
                 _SESSION = zenoh.open(cfg)
                 _SESSION_REFS = 1
                 logger.info(
-                    "Zenoh mesh session opened (peer, ephemeral listener, retrying -> %s)",
+                    "Zenoh mesh session opened (%s, retrying -> %s)",
+                    fallback_mode,
                     local_ep,
                 )
                 return _SESSION
@@ -912,7 +995,7 @@ def get_session() -> Any | None:
                 # Narrow tuple per AGENTS.md > Review Learnings (#86):
                 # transport-level failures only; config-shape ValueError
                 # propagates to caller so misconfigured mTLS surfaces loudly.
-                logger.warning("Zenoh session open failed (peer fallback): %s", exc)
+                logger.warning("Zenoh session open failed (%s fallback): %s", fallback_mode, exc)
                 return None
 
         # Explicit endpoints provided via env vars.
@@ -1015,16 +1098,27 @@ def _get_zenoh_session_directly() -> Any | None:
                     exc,
                 )
 
+            # Same topology as ``get_session`` upstairs, through the one
+            # helper. Before this, the two fallbacks disagreed: this site
+            # opened a client with no ``connect/retry`` and no
+            # ``exit_on_failure=false``, so when the hub process died the
+            # bridge-transport peer went permanently dark - no reconnect
+            # loop, no surfaced error. Both now retry the hub endpoint in
+            # the background (measured for client mode: delivery resumed
+            # after a 6s hub outage with no process restart).
             cfg = _build_config()
-            cfg.insert_json5("mode", '"client"')
-            cfg.insert_json5("connect/endpoints", json.dumps([local_ep]))
+            fallback_mode = _apply_fallback_topology(cfg, local_ep, scheme)
             try:
                 _SESSION = zenoh.open(cfg)
                 _SESSION_REFS = 1
-                logger.info("Zenoh mesh session opened (client -> %s)", local_ep)
+                logger.info(
+                    "Zenoh mesh session opened (%s, retrying -> %s)",
+                    fallback_mode,
+                    local_ep,
+                )
                 return _SESSION
             except zenoh_error_types() as exc:
-                logger.warning("Zenoh session open failed (client mode): %s", exc)
+                logger.warning("Zenoh session open failed (%s fallback): %s", fallback_mode, exc)
                 return None
 
         cfg = _build_config()

--- a/tests/mesh/test_non_hub_session_topology.py
+++ b/tests/mesh/test_non_hub_session_topology.py
@@ -1,0 +1,130 @@
+"""A non-hub mesh session opens in the mode that receives relayed traffic.
+
+The machine's first process wins the ``STRANDS_MESH_PORT`` listener and becomes
+the hub; every later process falls back to connecting to it. Two entry points
+build that fallback -- :func:`~strands_robots.mesh.session.get_session` and
+:func:`~strands_robots.mesh.session._get_zenoh_session_directly` -- and both
+must produce the same topology, because a Zenoh 1.x *peer* refuses traffic
+relayed by an intermediary. A peer-mode child therefore hears nothing a sibling
+child publishes, which is the teleop failure where a leader published frames to
+a follower whose counters stayed at zero.
+
+These pin the config the fallback hands to ``zenoh.open`` rather than a live
+session, so they run without the ``zenoh`` extra installed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import strands_robots.mesh.session as mod
+
+#: The two fallback builders, driven identically. Both are reached only after
+#: the hub-listener attempt fails, so ``zenoh.open`` raises once then succeeds.
+ENTRY_POINTS = ("get_session", "_get_zenoh_session_directly")
+
+
+def _drive_fallback(entry: str, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Run one fallback builder and return the config keys it set.
+
+    Args:
+        entry: Attribute name of the session builder on the session module.
+        monkeypatch: Used to clear explicit-endpoint env and stub the config.
+
+    Returns:
+        The ``insert_json5`` key -> value mapping the builder produced.
+    """
+    for var in ("ZENOH_LISTEN", "ZENOH_CONNECT", "STRANDS_MESH_BACKEND"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(mod, "_SESSION", None)
+    monkeypatch.setattr(mod, "_SESSION_REFS", 0)
+
+    # One dict per built config: the hub-listener attempt builds its own
+    # before the fallback does, and only the LAST one is the topology here.
+    configs: list[dict[str, str]] = []
+
+    def _build() -> MagicMock:
+        recorded: dict[str, str] = {}
+        configs.append(recorded)
+        cfg = MagicMock()
+        cfg.insert_json5.side_effect = lambda key, val: recorded.__setitem__(key, val)
+        return cfg
+
+    monkeypatch.setattr(mod, "_build_config", _build)
+
+    zenoh = MagicMock()
+    # First open() is the hub-listener attempt; it must fail so the caller
+    # takes the fallback branch under test. The second is the fallback itself.
+    zenoh.open.side_effect = [RuntimeError("port already bound"), MagicMock()]
+
+    with patch.dict("sys.modules", {"zenoh": zenoh}):
+        session: Any = getattr(mod, entry)()
+
+    assert session is not None, f"{entry} did not open the fallback session"
+    assert len(configs) == 2, f"{entry} built {len(configs)} configs, expected hub then fallback"
+    return configs[-1]
+
+
+@pytest.mark.parametrize("entry", ENTRY_POINTS)
+def test_non_hub_session_opens_as_client_so_the_hub_relays(entry: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fallback is a client, not a peer, at both sites.
+
+    A peer would also need its own listener, so the presence of
+    ``listen/endpoints`` here is the tell for the topology that drops
+    sibling-to-sibling traffic.
+    """
+    recorded = _drive_fallback(entry, monkeypatch)
+
+    assert recorded.get("mode") == json.dumps("client"), recorded
+    assert "listen/endpoints" not in recorded, recorded
+
+
+@pytest.mark.parametrize("entry", ENTRY_POINTS)
+def test_non_hub_session_retries_the_hub_at_both_sites(entry: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither site may give up on the hub endpoint.
+
+    Without the retry a child whose hub process dies keeps a dead session with
+    no error surfaced: the peer just goes dark until it is restarted.
+    """
+    recorded = _drive_fallback(entry, monkeypatch)
+
+    assert recorded.get("connect/exit_on_failure") == "false", recorded
+    assert json.loads(recorded["connect/retry"]) == mod.FALLBACK_RETRY, recorded
+    assert json.loads(recorded["connect/endpoints"]) == ["tcp/127.0.0.1:7447"], recorded
+
+
+@pytest.mark.parametrize("entry", ENTRY_POINTS)
+def test_fallback_mode_peer_restores_direct_peer_links(entry: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``STRANDS_MESH_FALLBACK_MODE=peer`` opts back into the old topology.
+
+    An operator who arranges direct peer links keeps them, and gets the
+    ephemeral listener a peer needs in order to be dialled.
+    """
+    monkeypatch.setenv("STRANDS_MESH_FALLBACK_MODE", "peer")
+    recorded = _drive_fallback(entry, monkeypatch)
+
+    assert json.loads(recorded["listen/endpoints"]) == ["tcp/127.0.0.1:0"], recorded
+    assert "mode" not in recorded, recorded
+    # The retry property is not what peer mode trades away.
+    assert recorded.get("connect/exit_on_failure") == "false", recorded
+
+
+@pytest.mark.parametrize("bad", ["router", "PEERS", " "])
+def test_unrecognised_fallback_mode_warns_and_stays_client(
+    bad: str, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A typo must not take a robot's mesh offline, and must not be silent."""
+    monkeypatch.setenv("STRANDS_MESH_FALLBACK_MODE", bad)
+
+    with caplog.at_level("WARNING", logger=mod.logger.name):
+        assert mod._fallback_mode() == mod.FALLBACK_MODE_DEFAULT
+
+    if bad.strip():
+        assert "STRANDS_MESH_FALLBACK_MODE" in caplog.text
+    else:
+        # An empty value is "unset", not a typo, so it warrants no warning.
+        assert caplog.text == ""


### PR DESCRIPTION
## Problem

The machine's first process wins the `STRANDS_MESH_PORT` listener and becomes the hub. Every later process falls back to connecting to it — and that fallback opened in Zenoh **peer** mode on an ephemeral listener. A Zenoh 1.x peer assumes a full mesh and will not take traffic relayed by an intermediary, not even by a router. So a child heard **nothing** a sibling child published, while its own child-to-hub topics worked, because that is the link the child opened itself.

```mermaid
graph LR
  subgraph BEFORE["BEFORE - children are peers"]
    L1[leader child]:::p -. "209 frames published" .-> H1((hub))
    H1 -. "relay REFUSED by peer" .x F1[follower child]:::p
    F1 -->|"counters: 0"| X1[ ]:::hide
  end
  subgraph AFTER["AFTER - children are clients"]
    L2[leader child]:::c --> H2((hub))
    H2 -->|"hub relays"| F2[follower child]:::c
  end
  classDef p fill:#fdd,stroke:#c00
  classDef c fill:#dfd,stroke:#0a0
  classDef hide fill:none,stroke:none
```

`routing/peer/mode` — the knob that used to make peers route for each other — no longer exists in 1.10; `insert_json5` raises `ZError("unknown key")`.

Measured on three throwaway sessions (hub, publisher, then a **late** subscriber; hub as the only configured endpoint; counting frames on `strands/<peer>/input/<device>`):

| hub mode | child mode | frames arrived |
|---|---|---|
| peer | peer | **0 of 62** |
| router | peer | **0 of 62** |
| peer | client | 42 of 62 |
| router | client | 42 of 62 |

The child mode decides delivery; the hub mode does not.

## Second defect: the two fallbacks disagreed

Two builders construct that fallback, and only one retried the hub:

| builder | mode | `connect/retry` | `exit_on_failure=false` |
|---|---|---|---|
| `get_session` | peer + ephemeral listener | yes | yes |
| `_get_zenoh_session_directly` | client | **no** | **no** |

So when the hub process died, a peer opened by the second path went permanently dark — no reconnect loop, no surfaced error.

## Change

Both sites now go through one `_apply_fallback_topology`, so the topology is stated once and neither can drift. A **client** delegates routing to what it is connected to, so the hub relays for it; the property peer mode was chosen for is kept, because `connect/exit_on_failure=false` plus `connect/retry` let a client re-link to a restarted hub on its own (measured: 30 frames before the hub was killed, 0 during a 6s outage, 63 after it came back, no process restart).

`STRANDS_MESH_FALLBACK_MODE=peer` restores the old topology for an operator who arranges direct peer links. An unrecognized value warns and stays on the default — a typo here must not take a robot's mesh offline.

## Tests

`tests/mesh/test_non_hub_session_topology.py` pins the config handed to `zenoh.open` rather than a live session, so it runs without the `[mesh]` extra installed. Table-driven over both builders, so neither site can regress alone.

Pre-fix (`main`'s `session.py` + this test file): **7 failed, 2 passed**, naming both defects exactly:

| site | recorded fallback config pre-fix | verdict |
|---|---|---|
| `get_session` | `listen/endpoints: ["tcp/127.0.0.1:0"]`, no `mode` | a peer |
| `_get_zenoh_session_directly` | `mode: "client"`, no `connect/retry`, no `exit_on_failure` | goes dark |

Post-fix: **9 passed**.

The 2 that pass pre-fix are the pairs each site already satisfied (`_get_zenoh_session_directly` was already a client; `get_session` was already a peer under the opt-in), which is what makes the table-driven shape worth having.

## Gate

| check | result |
|---|---|
| `ruff check` (both changed files) | All checks passed |
| `ruff format --check` (both changed files) | 2 files already formatted |
| `mypy strands_robots/mesh/session.py` | 4 errors in 3 files, **0 in the changed file** (pre-existing, in `mesh/core.py`) |
| `pytest tests/mesh` paired, identical selection | **113 failed / 4564 passed / 33 skipped / 24 errors on BOTH sides** — 0 attributable (the failures are `awsiot` / `awscrt` absent in this environment) |
| changelog + host-path + docstring gates | 587 passed |

## LOC

| file | delta |
|---|---|
| `strands_robots/mesh/session.py` | +117 / -23 |
| `tests/mesh/test_non_hub_session_topology.py` | +129 (new) |
| `README.md` | +1 |

Net +224. The additions are one shared topology helper replacing two divergent inline blocks, its measured rationale, and the regression pin; the net-negative target does not apply to a defect fix that removes a silent-delivery-failure class.

Extracted from #2848 as a self-contained slice: this touches only `strands_robots/mesh/session.py` and stands alone on `main` with no dashboard code.
