### PR TITLE
feat(drivers): native Modbus TCP driver for the Robotiq 2F-85 gripper

### DIFF
--- a/changelog.d/3053-robotiq-2f85-modbus-driver.md
+++ b/changelog.d/3053-robotiq-2f85-modbus-driver.md
@@ -1,0 +1,34 @@
+### Added: a native Modbus TCP driver for the Robotiq 2F-85 gripper
+
+`robotiq_2f85` had no driver of either kind. lerobot registers no robot type for
+a gripper -- it is an end effector, not an arm -- and no native driver was
+registered against it, so `Robot("robotiq_2f85", mode="real")` could not reach
+the hardware by any route.
+
+`RobotiqDriver` speaks Modbus TCP directly: three registers out, three back, one
+socket, and no new dependency. The command path is wired end to end rather than
+deferred behind a "not wired yet" envelope, because a six-byte register map and
+a TCP socket is the whole protocol.
+
+Two behaviours the register map alone does not give a caller. Activation is part
+of connecting: a 2F-85 powers up unactivated and *ignores every position
+command* until it has run its open-close calibration stroke, reporting no error
+and simply not moving, so `connect_eagerly()` performs the sequence and waits
+for `gSTA` rather than returning on an open socket. And a grasp is distinguished
+from an empty close: `gOBJ` says whether the fingers stopped at the commanded
+position or because something is between them, and reading only "stopped"
+reports every empty close as a successful pick.
+
+Position counts run backwards to the aperture a caller measures -- `rPR=0` is
+fully open -- which is the protocol's one sign trap, so the inversion is written
+in exactly one place and pinned in both directions.
+
+Both registry entries now declare `hardware.driver="strands"`, because lerobot
+cannot build them and the native driver is the only thing that can, so
+`mode="real"` resolves here without naming a driver.
+
+The tests run against a scripted gripper that answers real MBAP frames over a
+real socket and enforces the hardware's own preconditions: a position lands only
+when the gripper is activated and the frame set `rGTO`. A driver that built a
+perfect frame but skipped activation returns identical envelopes and moves
+nothing, so the assertions read what reached the wire instead.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -117,7 +117,8 @@ Asking for a driver that is not there is refused, never quietly substituted:
 >>> Robot("ur5e", mode="real", driver="strands")
 ValueError: No native driver is registered for 'ur5e', so driver='strands' cannot build
 it. Robots with a native driver: aloha, dynamixel_2r, hope_jr, koch, lekiwi, microduck,
-open_duck_mini, reachy_mini, so100, so101, trossen_wxai, unitree_g1, vx300s, wx250s.
+open_duck_mini, reachy_mini, robotiq_2f85, robotiq_2f85_v4, so100, so101, trossen_wxai,
+unitree_g1, vx300s, wx250s.
 Either use driver='lerobot' (today's default, which builds it through lerobot) or
 register one with strands_robots.drivers.register_native_driver().
 ```

--- a/docs/robots/hands.md
+++ b/docs/robots/hands.md
@@ -47,6 +47,42 @@ _Robotiq 2F-85 Gripper (2-finger adaptive)_
 
 _Shadow Dexterous Hand (24-DOF)_
 
+## Hardware control
+
+Every entry above builds in simulation. One of them also drives real hardware:
+the Robotiq 2F-85 has a native Modbus TCP driver, so `mode="real"` reaches the
+gripper itself.
+
+```python
+from strands_robots import Robot
+
+gripper = Robot("robotiq_2f85", mode="real", port="192.168.1.11")
+gripper.connect_eagerly()          # opens the socket AND activates the gripper
+
+gripper.send_action({"gripper": 1.0})        # 0.0 fully open, 1.0 fully closed
+gripper.send_action({"aperture_mm": 40.0})   # or millimetres between the fingertips
+gripper.read_status()                        # aperture, grasp detection, faults
+```
+
+`driver="strands"` is the default for this robot (its registry entry declares
+it), because lerobot has no robot type for a gripper.
+
+Two things worth knowing about the hardware:
+
+- **Activation is not optional.** A 2F-85 powers up unactivated and *ignores*
+  every position command until it has run a calibration stroke - it reports no
+  error, it simply does not move. `connect_eagerly()` performs the activation
+  sequence and waits for it to finish, so a successful connect means a gripper
+  that will actually move.
+- **A grasp is not the same as a stop.** `read_status()` reports `holding`,
+  derived from the gripper's `gOBJ` field: the fingers stopping because they
+  reached the commanded position is a different outcome from stopping because
+  something is between them. Reading only "stopped" reports every empty close
+  as a successful pick.
+
+The 2F-140 and Hand-E answer the same register map with a different stroke; pass
+`stroke_mm=` to drive one.
+
 ## See also
 
 - [Arms](arms.md) - pair a hand with an arm via `add_robot`.

--- a/strands_robots/drivers/__init__.py
+++ b/strands_robots/drivers/__init__.py
@@ -54,6 +54,7 @@ _SHIPPED_DRIVERS: tuple[tuple[str, str, tuple[str, ...] | str], ...] = (
     ("strands_robots.drivers.g1", "G1Driver", ("g1", "unitree_g1")),
     ("strands_robots.drivers.reachy", "ReachyDriver", ("reachy_mini",)),
     ("strands_robots.drivers.microduck", "MicroduckDriver", ("microduck",)),
+    ("strands_robots.drivers.robotiq.driver", "RobotiqDriver", "SUPPORTED_ROBOTS"),
 )
 
 

--- a/strands_robots/drivers/robotiq/__init__.py
+++ b/strands_robots/drivers/robotiq/__init__.py
@@ -1,0 +1,68 @@
+"""Native Modbus TCP driver for the Robotiq 2F-85 adaptive gripper.
+
+``Robot("robotiq_2f85", mode="real", port="192.168.1.11")`` builds
+:class:`RobotiqDriver` and the fingers move: unlike the servo-bus drivers whose
+transport is still deferred, the command path here is wired end to end, because
+Modbus TCP needs a socket and a six-byte register map and nothing else.
+
+Two modules, the same split the sibling driver packages use:
+
+* :mod:`strands_robots.drivers.robotiq.protocol` - the register map and Modbus
+  TCP framing, pure functions, no I/O, importable on any host.
+* :mod:`strands_robots.drivers.robotiq.driver` - :class:`RobotiqDriver`, which
+  owns the socket and the power-on activation sequence.
+
+The 2F-140 and the Hand-E answer the same registers with a different stroke,
+which is why :func:`~strands_robots.drivers.robotiq.protocol.counts_to_aperture_mm`
+and the driver both take ``stroke_mm``; only the 2F-85 entries are registered,
+because those are the ones the package registry knows.
+"""
+
+from strands_robots.drivers.robotiq.driver import SUPPORTED_ROBOTS, RobotiqDriver
+from strands_robots.drivers.robotiq.protocol import (
+    DEFAULT_TCP_PORT,
+    DEFAULT_UNIT_ID,
+    INPUT_BASE,
+    OUTPUT_BASE,
+    REGISTER_COUNT,
+    STROKE_MM,
+    ActivationStatus,
+    Fault,
+    FunctionCode,
+    ObjectStatus,
+    ProtocolError,
+    aperture_mm_to_counts,
+    closed_fraction_to_counts,
+    command_payload,
+    command_registers,
+    counts_to_aperture_mm,
+    parse_status,
+    read_input_registers_frame,
+    read_registers_payload,
+    write_registers_frame,
+)
+
+__all__ = [
+    "DEFAULT_TCP_PORT",
+    "DEFAULT_UNIT_ID",
+    "INPUT_BASE",
+    "OUTPUT_BASE",
+    "REGISTER_COUNT",
+    "STROKE_MM",
+    "SUPPORTED_ROBOTS",
+    "ActivationStatus",
+    "Fault",
+    "FunctionCode",
+    "ObjectStatus",
+    "ProtocolError",
+    "RobotiqDriver",
+    "aperture_mm_to_counts",
+    "closed_fraction_to_counts",
+    "command_payload",
+    "command_registers",
+    "counts_to_aperture_mm",
+    "parse_status",
+    "read_input_registers_frame",
+    "read_registers_payload",
+    "write_registers_frame",
+]

--- a/strands_robots/drivers/robotiq/driver.py
+++ b/strands_robots/drivers/robotiq/driver.py
@@ -1,0 +1,702 @@
+"""Native Modbus TCP driver for the Robotiq 2F-85, satisfying :class:`HardwareDriver`.
+
+``Robot("robotiq_2f85", mode="real", port="192.168.1.11")`` builds one of these
+and the fingers move. The driver owns its socket, so unlike a lerobot-shaped
+robot there is no inner device: it answers the joint read itself (see
+:func:`strands_robots.bus_access.joint_read_source`), which is what puts the
+gripper's aperture on the mesh state topic.
+
+Why a native driver: lerobot has no robot type for a Robotiq gripper - it is an
+end effector, not an arm - and the gripper does not speak a servo bus. It speaks
+Modbus, three registers each way, and the honest client speaks Modbus. The
+codec is :mod:`strands_robots.drivers.robotiq.protocol`; only the socket and the
+activation sequence live here.
+
+The activation sequence is the one piece of behaviour a caller cannot skip. A
+2F-85 powers up unactivated and *ignores every position command* until it has
+been told to activate and has finished its open-close calibration stroke - it
+does not report an error, it simply does not move. So :meth:`connect_eagerly`
+activates and waits for ``gSTA == ACTIVE`` rather than returning as soon as the
+socket opens, and :meth:`send_action` refuses while the gripper is not activated
+instead of writing a frame that would be silently dropped.
+
+What this driver does not do: run a policy. A 1-DOF end effector has no
+rollout of its own - it is commanded as one dimension of the arm's action, by
+whichever driver owns that arm - so :meth:`start_task` and :meth:`run_policy`
+refuse and name the path that does work. That is a design fact about a gripper,
+not a deferred feature.
+
+``mode="real"`` on this robot resolves here by default: the registry entries
+declare ``hardware.driver = "strands"``, because the alternative
+(:data:`~strands_robots.drivers.base.DEFAULT_DRIVER`) cannot build a robot
+lerobot has no type for.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import socket
+import struct
+import threading
+import time
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any, cast
+
+from strands_robots.drivers.robotiq.protocol import (
+    DEFAULT_TCP_PORT,
+    DEFAULT_UNIT_ID,
+    INPUT_BASE,
+    MAX_COUNTS,
+    MBAP_SIZE,
+    OUTPUT_BASE,
+    REGISTER_COUNT,
+    STROKE_MM,
+    ActivationStatus,
+    FunctionCode,
+    ObjectStatus,
+    ProtocolError,
+    aperture_mm_to_counts,
+    closed_fraction_to_counts,
+    command_registers,
+    counts_to_aperture_mm,
+    parse_response,
+    parse_status,
+    read_input_registers_frame,
+    read_registers_payload,
+    write_registers_frame,
+)
+from strands_robots.utils import (
+    finite_number_error,
+    positive_finite_number_error,
+    tcp_port_error,
+)
+
+if TYPE_CHECKING:
+    from strands.types.tools import ToolSpec, ToolUse
+
+    from strands_robots.policies import Policy
+
+logger = logging.getLogger(__name__)
+
+
+SUPPORTED_ROBOTS: tuple[str, ...] = ("robotiq_2f85", "robotiq_2f85_v4")
+"""Robots this driver registers for. Both registry entries are the same
+gripper - ``robotiq_2f85_v4`` is the newer simulation model of the same
+hardware - and the register map is identical, so one driver serves both."""
+
+_NORMALISED_KEYS: tuple[str, ...] = ("gripper", "gripper.pos")
+"""``send_action`` keys carrying a closed fraction, ``0.0`` open to ``1.0``
+closed. Both spellings because a policy action dict names the joint
+``gripper.pos`` while a hand-written call says ``gripper``, and a caller should
+not have to discover which one this driver happens to read."""
+
+_APERTURE_KEYS: tuple[str, ...] = ("position", "aperture_mm")
+"""``send_action`` keys carrying a fingertip aperture in millimetres."""
+
+_MODIFIER_KEYS: tuple[str, ...] = ("speed", "force")
+"""``send_action`` keys scaling the motion, ``0.0``..``1.0`` of the gripper's
+maximum. Absent means keep the driver's configured default."""
+
+_NO_POLICY = (
+    "a 2F-85 is a 1-DOF end effector with no rollout of its own - command it as "
+    "one dimension of the arm's action through send_action({'gripper': ...}), or "
+    "run the policy against the arm that carries it"
+)
+
+
+class _ModbusTcpClient:
+    """One Modbus TCP connection: framed reads, serialised writes.
+
+    Modbus TCP runs over a byte stream, so a reply must be read by its declared
+    length rather than by whatever one ``recv`` returns - a short read that is
+    parsed as a whole frame decodes a position the gripper never sent. The
+    header is read first, its length field consulted, then exactly that many
+    further bytes.
+
+    Writes and their replies are serialised under one lock so two threads
+    cannot interleave request and response on the same socket; the transaction
+    id is checked on top of that, which catches a desynchronised stream rather
+    than trusting the lock alone.
+    """
+
+    def __init__(self, host: str, port: int, unit_id: int, timeout: float) -> None:
+        self._host = host
+        self._port = port
+        self._unit_id = unit_id
+        self._timeout = timeout
+        self._sock: socket.socket | None = None
+        self._lock = threading.Lock()
+        self._transaction = 0
+
+    @property
+    def alive(self) -> bool:
+        """Whether the socket is open."""
+        return self._sock is not None
+
+    def connect(self) -> None:
+        """Open the TCP connection. Raises on failure so the caller names it."""
+        self._sock = socket.create_connection((self._host, self._port), timeout=self._timeout)
+        self._sock.settimeout(self._timeout)
+
+    def _next_transaction(self) -> int:
+        self._transaction = (self._transaction + 1) % 0x10000
+        return self._transaction
+
+    def _read_exactly(self, sock: socket.socket, count: int) -> bytes:
+        """Read exactly ``count`` bytes, or raise naming what arrived."""
+        chunks: list[bytes] = []
+        remaining = count
+        while remaining > 0:
+            chunk = sock.recv(remaining)
+            if not chunk:
+                raise ProtocolError(f"gripper closed the connection after {count - remaining} of {count} bytes")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _exchange(self, request: bytes) -> bytes:
+        """Send one frame and read its whole reply."""
+        sock = self._sock
+        if sock is None:
+            raise ProtocolError("gripper socket is not connected")
+        with self._lock:
+            sock.sendall(request)
+            header = self._read_exactly(sock, MBAP_SIZE)
+            # The MBAP length counts the unit id plus the PDU, and the unit id
+            # is the last header byte already in hand.
+            (length,) = struct.unpack(">H", header[4:6])
+            body = self._read_exactly(sock, length - 1)
+        return header + body
+
+    def write_registers(self, address: int, values: tuple[int, ...]) -> None:
+        """Write ``values`` at ``address`` and validate the acknowledgement.
+
+        Raises:
+            ProtocolError: If the gripper answers an exception or a frame that
+                does not match the request.
+            OSError: If the socket fails.
+        """
+        transaction = self._next_transaction()
+        reply = self._exchange(write_registers_frame(transaction, self._unit_id, address, values))
+        parse_response(reply, transaction, FunctionCode.WRITE_MULTIPLE_REGISTERS)
+
+    def read_input_registers(self, address: int, count: int) -> bytes:
+        """Read ``count`` registers at ``address`` and return their bytes.
+
+        Raises:
+            ProtocolError: If the reply is malformed or an exception response.
+            OSError: If the socket fails.
+        """
+        transaction = self._next_transaction()
+        reply = self._exchange(read_input_registers_frame(transaction, self._unit_id, address, count))
+        return read_registers_payload(reply, transaction, count)
+
+    def close(self) -> None:
+        """Close the socket. Idempotent."""
+        sock, self._sock = self._sock, None
+        if sock is None:
+            return
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass  # already half-closed; a shutdown race here is not actionable
+        try:
+            sock.close()
+        except OSError:
+            pass  # closing a socket that is already gone is fine
+
+
+class RobotiqDriver:
+    """Native Modbus TCP driver for the grippers in :data:`SUPPORTED_ROBOTS`.
+
+    Satisfies :class:`~strands_robots.drivers.base.HardwareDriver` structurally;
+    the surface check in
+    :func:`~strands_robots.drivers.register_native_driver` pins the contract at
+    registration.
+    """
+
+    tool_type = "robot"
+
+    def __init__(
+        self,
+        tool_name: str = "robotiq_2f85",
+        cameras: dict[str, dict[str, Any]] | None = None,
+        data_config: str | None = None,
+        *,
+        port: str | None = None,
+        tcp_port: int = DEFAULT_TCP_PORT,
+        unit_id: int = DEFAULT_UNIT_ID,
+        timeout: float = 2.0,
+        activation_timeout: float = 10.0,
+        stroke_mm: float = STROKE_MM,
+        speed: float = 1.0,
+        force: float = 1.0,
+        **kwargs: Any,
+    ) -> None:
+        """Record configuration; :meth:`connect_eagerly` opens the socket.
+
+        Args:
+            tool_name: Name the agent invokes the driver by, and the mesh peer id.
+            cameras: Accepted for parity with the other drivers; a gripper
+                addresses no camera of its own.
+            data_config: Accepted for parity; unused.
+            port: The gripper's host - an IP address or hostname. ``port`` is the
+                factory's polymorphic device keyword (a serial path for a servo
+                bus, a host here), which is why the TCP port is a separate
+                ``tcp_port``.
+            tcp_port: Modbus TCP port; :data:`DEFAULT_TCP_PORT` unless the
+                gripper is behind a controller that remaps it.
+            unit_id: Modbus slave id. :data:`DEFAULT_UNIT_ID` is what Robotiq
+                ships; a gripper behind a Universal Robots controller often
+                answers on ``0``.
+            timeout: Socket and reply timeout in seconds.
+            activation_timeout: How long :meth:`connect_eagerly` waits for the
+                power-on calibration stroke to finish. The manual's sequence has
+                no faster completion signal than ``gSTA``.
+            stroke_mm: Aperture at position count ``0``. Defaults to the
+                2F-85's; a 2F-140 is the same protocol with a wider stroke.
+            speed: Default speed, ``0.0``..``1.0`` of maximum.
+            force: Default force, ``0.0``..``1.0`` of maximum.
+            **kwargs: Ignored; accepted so the factory can forward extras.
+
+        Raises:
+            ValueError: If a numeric knob is outside its domain. Raised here
+                rather than returned from :meth:`connect_eagerly`, which is
+                declared ``-> str | None``: a value the transport cannot use is
+                not a connection this driver can degrade to reporting.
+        """
+        del cameras, data_config
+        if kwargs:
+            logger.debug("RobotiqDriver ignoring extra kwargs: %s", sorted(kwargs))
+
+        # Each of these reaches a consumer that cannot report what it was
+        # handed: the timeouts go to socket.settimeout and to a deadline
+        # comparison, tcp_port and unit_id are packed into a frame, and
+        # speed/force are scaled into a byte. A nan or a string surfaces from
+        # inside the socket call or from struct.pack, naming neither this
+        # driver nor the parameter.
+        for value, name, check in (
+            (timeout, "timeout", positive_finite_number_error),
+            (activation_timeout, "activation_timeout", positive_finite_number_error),
+            (stroke_mm, "stroke_mm", positive_finite_number_error),
+        ):
+            if reason := check(value, name, "RobotiqDriver"):
+                raise ValueError(reason)
+        if reason := tcp_port_error(tcp_port, "tcp_port", "RobotiqDriver"):
+            raise ValueError(reason)
+        for value, name in ((speed, "speed"), (force, "force")):
+            if reason := finite_number_error(value, name, "RobotiqDriver"):
+                raise ValueError(reason)
+            if not 0.0 <= float(value) <= 1.0:
+                raise ValueError(f"RobotiqDriver: {name} must be in 0.0..1.0, got {value}")
+        if not isinstance(unit_id, int) or isinstance(unit_id, bool) or not 0 <= unit_id <= MAX_COUNTS:
+            raise ValueError(f"RobotiqDriver: unit_id must be an int in 0..{MAX_COUNTS}, got {unit_id!r}")
+
+        self._tool_name = tool_name
+        self._host = str(port) if port else "127.0.0.1"
+        self._tcp_port = int(tcp_port)
+        self._unit_id = int(unit_id)
+        self._timeout = float(timeout)
+        self._activation_timeout = float(activation_timeout)
+        self._stroke_mm = float(stroke_mm)
+        self._speed = closed_fraction_to_counts(speed)
+        self._force = closed_fraction_to_counts(force)
+
+        self._client: _ModbusTcpClient | None = None
+        self._connected = False
+        self._connect_error: str | None = None
+        self._cache_lock = threading.Lock()
+        self._last_status: dict[str, Any] | None = None
+
+    # ------------------------------------------------------------------ #
+    # Agent tool surface.                                                #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def tool_name(self) -> str:
+        """The name the Strands agent invokes this driver by."""
+        return self._tool_name
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the Modbus connection is live, for the mesh joint read."""
+        return self._connected and self._client is not None and self._client.alive
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        """The verbs an agent may ask of a gripper.
+
+        Every declared verb works. ``open`` and ``close`` are named separately
+        from a position command because they are what an agent actually plans
+        with, and making it compute a count for "let go" is a worse surface.
+        """
+        return cast(
+            "ToolSpec",
+            {
+                "name": self._tool_name,
+                "description": (
+                    "Robotiq 2F-85 native driver over Modbus TCP. Opens and closes the gripper, "
+                    "reports fingertip aperture, grasp detection and faults."
+                ),
+                "inputSchema": {
+                    "json": {
+                        "type": "object",
+                        "properties": {
+                            "action": {
+                                "type": "string",
+                                "description": (
+                                    "open: release to full aperture; "
+                                    "close: grasp at the configured force; "
+                                    "sensors: aperture, grasp state and current; "
+                                    "status: connection and activation state; "
+                                    "stop: halt the fingers where they are"
+                                ),
+                                "enum": ["open", "close", "sensors", "status", "stop"],
+                                "default": "sensors",
+                            },
+                        },
+                        "required": ["action"],
+                    }
+                },
+            },
+        )
+
+    async def stream(
+        self,
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        **kwargs: Any,
+    ) -> AsyncGenerator[Any, None]:
+        """Handle one agent invocation and yield exactly one tool result."""
+        del kwargs, invocation_state
+        tool_use_id = tool_use.get("toolUseId", "")
+        action = (tool_use.get("input") or {}).get("action", "sensors")
+        envelope: dict[str, Any]
+        if action == "open":
+            envelope = self.send_action({"gripper": 0.0})
+        elif action == "close":
+            envelope = self.send_action({"gripper": 1.0})
+        elif action == "sensors":
+            envelope = self.read_status()
+        elif action == "status":
+            envelope = await self.get_status()
+        else:  # "stop"
+            # Delegate rather than re-derive: stop_task decides whether the halt
+            # reached the gripper, and an agent that read a restated success here
+            # would be told the fingers stopped when the write failed.
+            envelope = self.stop_task()
+        yield {"toolUseId": tool_use_id, **envelope}
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle.                                                          #
+    # ------------------------------------------------------------------ #
+
+    def connect_eagerly(self) -> str | None:
+        """Open the socket and activate the gripper.
+
+        Activation is part of connecting, not a separate call, because an
+        unactivated 2F-85 accepts a position command and does not move. A
+        driver that returned success on an open socket alone would report a
+        healthy gripper that silently ignores every action.
+
+        Returns:
+            ``None`` when the gripper is connected and activated, or a reason
+            naming what failed.
+        """
+        client = _ModbusTcpClient(self._host, self._tcp_port, self._unit_id, self._timeout)
+        try:
+            client.connect()
+        except OSError as exc:
+            self._connect_error = f"cannot reach the gripper at {self._host}:{self._tcp_port} - {exc}"
+            client.close()
+            return self._connect_error
+        self._client = client
+        try:
+            reason = self._activate()
+        except (OSError, ProtocolError) as exc:
+            reason = f"activation failed: {exc}"
+        if reason is not None:
+            client.close()
+            self._client = None
+            self._connect_error = reason
+            return reason
+        self._connected = True
+        self._connect_error = None
+        return None
+
+    def _activate(self) -> str | None:
+        """Run the manual's activation sequence. Returns a reason or ``None``."""
+        status = self._read_status_raw()
+        if status["activation"] is ActivationStatus.ACTIVE and status["activated"]:
+            return None
+        # A reset first: the manual requires rACT be cleared before a fresh
+        # activation, and a gripper holding a fault will not activate without it.
+        self._write_command(activate=False, go_to=False)
+        self._write_command(activate=True, go_to=False)
+        deadline = time.monotonic() + self._activation_timeout
+        while time.monotonic() < deadline:
+            status = self._read_status_raw()
+            if status["activation"] is ActivationStatus.ACTIVE:
+                return None
+            time.sleep(0.1)
+        return (
+            f"gripper did not finish activating within {self._activation_timeout}s "
+            f"(gSTA={status['activation'].name}, gFLT={status['fault']!r})"
+        )
+
+    async def get_status(self) -> dict[str, Any]:
+        """Report the driver's connection and the gripper's activation state."""
+        payload: dict[str, Any] = {
+            "tool_name": self._tool_name,
+            "tool_type": self.tool_type,
+            "connected": self.is_connected,
+            "connect_error": self._connect_error,
+            "host": self._host,
+            "tcp_port": self._tcp_port,
+            "unit_id": self._unit_id,
+            "stroke_mm": self._stroke_mm,
+            "supported_robots": list(SUPPORTED_ROBOTS),
+            # Part of the tool_name/connected/battery_pct triple every shipped
+            # driver reports, so a mesh consumer reads one shape for every peer.
+            # Always None here: the gripper is powered from the arm's controller
+            # and reports no state of charge, and inventing one would be worse
+            # than an honest absence.
+            "battery_pct": None,
+        }
+        with self._cache_lock:
+            cached = self._last_status
+        if cached is not None:
+            payload["gripper"] = _readable(cached)
+        return {"status": "success", "content": [{"json": payload}]}
+
+    async def stop(self) -> None:
+        """Halt the fingers where they are, leaving the gripper activated.
+
+        Clearing ``rGTO`` stops motion without dropping the activation, so the
+        next :meth:`send_action` moves immediately rather than paying for
+        another calibration stroke. A stop on a disconnected gripper is a no-op
+        rather than an error - there is nothing moving to halt.
+        """
+        if not self.is_connected:
+            return
+        try:
+            self._write_command(activate=True, go_to=False)
+        except (OSError, ProtocolError) as exc:
+            logger.debug("stop could not reach the gripper: %s", exc)
+
+    def cleanup(self) -> None:
+        """Close the socket. Leaves the gripper activated and holding position."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+        self._connected = False
+
+    # ------------------------------------------------------------------ #
+    # Command path.                                                       #
+    # ------------------------------------------------------------------ #
+
+    def send_action(self, action: dict[str, Any], robot_name: str | None = None) -> dict[str, Any]:
+        """Command an aperture.
+
+        Gates, in order: this driver fronts this robot; it is connected and
+        activated; the action names exactly one aperture spelling; the values
+        are finite. A refusal is an envelope, never an exception, so the mesh
+        command path handles a bad action the same way it handles a dead socket.
+
+        Args:
+            action: One of :data:`_NORMALISED_KEYS` carrying a closed fraction
+                (``0.0`` open, ``1.0`` closed), or one of
+                :data:`_APERTURE_KEYS` carrying a fingertip aperture in
+                millimetres. Optionally :data:`_MODIFIER_KEYS` to scale speed
+                and force for this command.
+            robot_name: Which robot to command; ``None`` or this driver's own
+                name. A gripper fronts exactly one device.
+
+        Returns:
+            A success envelope naming the commanded count and aperture, or an
+            error envelope naming the reason.
+        """
+        if robot_name is not None and robot_name != self._tool_name:
+            return _refuse(f"send_action: this driver fronts {self._tool_name!r} only, not {robot_name!r}")
+        if not self.is_connected or self._client is None:
+            return _refuse("send_action: not connected - call connect_eagerly() first")
+
+        normalised = [key for key in _NORMALISED_KEYS if key in action]
+        aperture = [key for key in _APERTURE_KEYS if key in action]
+        if normalised and aperture:
+            return _refuse(
+                f"send_action: {sorted(normalised + aperture)} are two spellings of the same command - "
+                f"pass a closed fraction ({' or '.join(_NORMALISED_KEYS)}) or millimetres "
+                f"({' or '.join(_APERTURE_KEYS)}), not both"
+            )
+        if not normalised and not aperture:
+            return _refuse(
+                f"send_action: nothing to command - none of {sorted(action)} names an aperture; "
+                f"expected one of {sorted(_NORMALISED_KEYS + _APERTURE_KEYS)}"
+            )
+
+        key = (normalised or aperture)[0]
+        for name in (key, *(m for m in _MODIFIER_KEYS if m in action)):
+            if reason := finite_number_error(action[name], name, "send_action"):
+                return _refuse(reason)
+
+        try:
+            counts = (
+                closed_fraction_to_counts(action[key])
+                if normalised
+                else aperture_mm_to_counts(action[key], self._stroke_mm)
+            )
+            speed = closed_fraction_to_counts(action["speed"]) if "speed" in action else self._speed
+            force = closed_fraction_to_counts(action["force"]) if "force" in action else self._force
+            self._write_command(activate=True, go_to=True, position=counts, speed=speed, force=force)
+        except ProtocolError as exc:
+            return _refuse(f"send_action: {exc}")
+        except OSError as exc:
+            return _refuse(f"send_action: writing to the gripper failed: {exc}")
+
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "json": {
+                        "robot": self._tool_name,
+                        "commanded_key": key,
+                        "position": counts,
+                        "aperture_mm": counts_to_aperture_mm(counts, self._stroke_mm),
+                        "speed": speed,
+                        "force": force,
+                    }
+                }
+            ],
+        }
+
+    def read_status(self) -> dict[str, Any]:
+        """Read the gripper's live status.
+
+        Returns:
+            A success envelope carrying the decoded status, or an error
+            envelope naming why the read failed.
+        """
+        if not self.is_connected:
+            return _refuse("read_status: not connected - call connect_eagerly() first")
+        try:
+            status = self._read_status_raw()
+        except ProtocolError as exc:
+            return _refuse(f"read_status: {exc}")
+        except OSError as exc:
+            return _refuse(f"read_status: reading the gripper failed: {exc}")
+        return {"status": "success", "content": [{"json": _readable(status)}]}
+
+    def get_observation(self) -> dict[str, float]:
+        """Report the gripper's one joint, for the mesh state topic.
+
+        The key is ``gripper.pos`` because that is the name a policy action
+        dict uses for this degree of freedom, so an observation and the action
+        that answers it agree.
+
+        Returns:
+            The closed fraction under ``gripper.pos``, or an empty mapping when
+            the gripper cannot be read - "no joints" is not a failure.
+        """
+        if not self.is_connected:
+            return {}
+        try:
+            status = self._read_status_raw()
+        except (OSError, ProtocolError) as exc:
+            logger.debug("joint read failed: %s", exc)
+            return {}
+        return {"gripper.pos": status["position"] / MAX_COUNTS}
+
+    # ------------------------------------------------------------------ #
+    # Task and policy paths - a gripper has no rollout, so these refuse.  #
+    # ------------------------------------------------------------------ #
+
+    def start_task(
+        self,
+        instruction: str,
+        policy_port: int | None = None,
+        policy_host: str = "localhost",
+        policy_provider: str = "groot",
+        duration: float = 30.0,
+        **policy_kwargs: Any,
+    ) -> dict[str, Any]:
+        """Refuse: see :data:`_NO_POLICY`."""
+        del instruction, policy_port, policy_host, policy_provider, duration, policy_kwargs
+        return _refuse(f"start_task: {_NO_POLICY}")
+
+    def run_policy(
+        self,
+        policy_object: Policy,
+        instruction: str = "",
+        duration: float = 30.0,
+        n_steps: int | None = None,
+    ) -> dict[str, Any]:
+        """Refuse: see :data:`_NO_POLICY`."""
+        del policy_object, instruction, duration, n_steps
+        return _refuse(f"run_policy: {_NO_POLICY}")
+
+    def get_task_status(self) -> dict[str, Any]:
+        """Report that no task runs, which is always true for a gripper."""
+        return {"status": "success", "content": [{"json": {"in_flight": False, "reason": _NO_POLICY}}]}
+
+    def stop_task(self) -> dict[str, Any]:
+        """Halt the fingers. There is no task, but a caller asking to stop means it."""
+        if not self.is_connected:
+            return {"status": "success", "content": [{"text": "stop_task: not connected, nothing to stop"}]}
+        try:
+            self._write_command(activate=True, go_to=False)
+        except (OSError, ProtocolError) as exc:
+            return _refuse(f"stop_task: {exc}")
+        return {"status": "success", "content": [{"text": f"stop_task: {self._tool_name} fingers halted"}]}
+
+    # ------------------------------------------------------------------ #
+    # Wire helpers.                                                       #
+    # ------------------------------------------------------------------ #
+
+    def _write_command(self, **fields: Any) -> None:
+        """Write one output frame. Raises ``OSError``/``ProtocolError``."""
+        if self._client is None:
+            raise ProtocolError("gripper socket is not connected")
+        self._client.write_registers(OUTPUT_BASE, command_registers(**fields))
+
+    def _read_status_raw(self) -> dict[str, Any]:
+        """Read and decode the input registers, caching the result."""
+        if self._client is None:
+            raise ProtocolError("gripper socket is not connected")
+        payload = self._client.read_input_registers(INPUT_BASE, REGISTER_COUNT)
+        status = parse_status(payload)
+        status["aperture_mm"] = counts_to_aperture_mm(status["position"], self._stroke_mm)
+        status["holding"] = status["object"] in (ObjectStatus.CONTACT_OPENING, ObjectStatus.CONTACT_CLOSING)
+        with self._cache_lock:
+            self._last_status = status
+        return status
+
+
+def _readable(status: dict[str, Any]) -> dict[str, Any]:
+    """Render a decoded status with its enums as names, for an envelope.
+
+    An ``IntEnum`` serialises as a bare integer, so a consumer reading
+    ``object: 2`` off the wire has to own a copy of the map to know it means a
+    grasp. Naming it in the payload keeps the reading self-describing.
+
+    Args:
+        status: A :func:`~strands_robots.drivers.robotiq.protocol.parse_status`
+            result.
+
+    Returns:
+        A copy with the enum members replaced by their names.
+    """
+    rendered = dict(status)
+    for field in ("activation", "object", "fault"):
+        value = rendered.get(field)
+        # An undocumented fault arrives as a plain int and is passed through, so
+        # this cannot assume every field is an enum member.
+        if isinstance(value, enum.Enum):
+            rendered[field] = value.name
+    return rendered
+
+
+def _refuse(message: str) -> dict[str, Any]:
+    """Return an error envelope carrying ``message``."""
+    return {"status": "error", "content": [{"text": message}]}

--- a/strands_robots/drivers/robotiq/driver.py
+++ b/strands_robots/drivers/robotiq/driver.py
@@ -524,7 +524,7 @@ class RobotiqDriver:
 
         normalised = [key for key in _NORMALISED_KEYS if key in action]
         aperture = [key for key in _APERTURE_KEYS if key in action]
-        if normalised and aperture:
+        if len(normalised) + len(aperture) > 1:
             return _refuse(
                 f"send_action: {sorted(normalised + aperture)} are two spellings of the same command - "
                 f"pass a closed fraction ({' or '.join(_NORMALISED_KEYS)}) or millimetres "

--- a/strands_robots/drivers/robotiq/protocol.py
+++ b/strands_robots/drivers/robotiq/protocol.py
@@ -1,0 +1,526 @@
+"""Robotiq 2F-85 register map and Modbus TCP wire format. Pure, no I/O.
+
+The 2F-85 is commanded through three 16-bit registers and reports through
+three more. Everything a caller can ask of the gripper - activate, go to a
+position, how hard, how fast - is six bytes wide, and everything it reports
+back is another six. That map is the whole protocol, and it is shared with the
+2F-140 and the Hand-E; only the stroke differs.
+
+Wire frame (Modbus TCP, MBAP header then PDU):
+
+.. code-block:: text
+
+    TRANSACTION  PROTOCOL  LENGTH  UNIT  FUNCTION  ...
+    <2 bytes>    0x0000    <2>     <1>   <1>       <function payload>
+
+- ``LENGTH`` counts the bytes that follow it, i.e. ``UNIT`` + the PDU.
+- There is **no checksum**. Modbus TCP delegates integrity to TCP; the CRC-16
+  in :rfc:`Modbus RTU <0>` framing applies to the serial transport only, which
+  is why none is computed here. A caller reaching the same gripper over RS-485
+  needs RTU framing around the *same* register payloads
+  (:func:`command_registers` / :func:`parse_status`), not a different map.
+- A server reporting a problem answers with the function code ORed with
+  ``0x80`` and a one-byte exception code, so a refusal is a *parse* outcome
+  rather than a timeout. :func:`parse_response` raises
+  :class:`ProtocolError` naming the code.
+
+Register layout, from Robotiq's *2F-85 & 2F-140 Instruction Manual*, section
+"Modbus RTU/TCP". The robot writes three registers at
+:data:`OUTPUT_BASE` and reads three at :data:`INPUT_BASE`; each register is a
+big-endian pair of the byte-oriented map:
+
+.. code-block:: text
+
+    write (0x03E8..0x03EA)        read (0x07D0..0x07D2)
+    byte 0  ACTION REQUEST        byte 0  GRIPPER STATUS
+    byte 1  reserved              byte 1  reserved
+    byte 2  reserved              byte 2  FAULT STATUS
+    byte 3  rPR position          byte 3  rPR echo
+    byte 4  rSP speed             byte 4  gPO actual position
+    byte 5  rFR force             byte 5  gCU motor current
+
+Position is a *count*, not a length: ``0`` is fully open and ``255`` fully
+closed, so it runs backwards to the aperture a caller measures in millimetres.
+:func:`counts_to_aperture_mm` and :func:`aperture_mm_to_counts` are the only
+place that inversion is written down, because a sign error here closes a
+gripper that was asked to open.
+
+Nothing here opens a socket. The transport lives in
+:mod:`strands_robots.drivers.robotiq.driver`, so this module imports on any
+host and the codec is gradeable without a gripper.
+"""
+
+from __future__ import annotations
+
+import enum
+import math
+import struct
+from typing import Any, Final
+
+# --------------------------------------------------------------------------- #
+# Framing and addressing.                                                     #
+# --------------------------------------------------------------------------- #
+
+MBAP_SIZE: Final[int] = 7
+"""Bytes before the function code: transaction (2), protocol (2), length (2), unit (1)."""
+
+PROTOCOL_ID: Final[int] = 0
+"""The only protocol id Modbus TCP defines. A frame carrying anything else is not Modbus."""
+
+DEFAULT_UNIT_ID: Final[int] = 9
+"""Slave id Robotiq ships the gripper with (0x09), documented in the manual's
+Modbus section. A gripper behind a Universal Robots controller commonly answers
+on ``0`` instead, so the driver keeps this a parameter."""
+
+DEFAULT_TCP_PORT: Final[int] = 502
+"""The registered Modbus TCP port."""
+
+OUTPUT_BASE: Final[int] = 0x03E8
+"""First register the robot writes: the action request."""
+
+INPUT_BASE: Final[int] = 0x07D0
+"""First register the robot reads: the gripper status."""
+
+REGISTER_COUNT: Final[int] = 3
+"""Registers in each direction. Six bytes, and the map defines no more."""
+
+PAYLOAD_SIZE: Final[int] = REGISTER_COUNT * 2
+"""Bytes in one command or one status payload."""
+
+MAX_COUNTS: Final[int] = 0xFF
+"""Widest value the position, speed and force fields hold."""
+
+STROKE_MM: Final[float] = 85.0
+"""2F-85 stroke: the aperture at position count ``0``. The 2F-140 shares this
+codec with a 140 mm stroke, which is why the conversions take it as a default
+rather than baking it in."""
+
+
+class FunctionCode(enum.IntEnum):
+    """The two Modbus functions the gripper needs.
+
+    Reading uses input registers (``0x04``) and writing uses the multiple-register
+    write (``0x10``), which is what the manual specifies; the single-register
+    write is not used because the three output registers must land together for
+    ``rGTO`` to act on the position in the same frame.
+    """
+
+    READ_INPUT_REGISTERS = 0x04
+    WRITE_MULTIPLE_REGISTERS = 0x10
+
+
+class ActivationStatus(enum.IntEnum):
+    """``gSTA``: where the gripper is in its activation sequence.
+
+    There is no ``2``. The manual defines three states and leaves the fourth
+    encoding unused, so a gripper reporting ``2`` is not answering this map.
+    """
+
+    RESET = 0
+    ACTIVATING = 1
+    ACTIVE = 3
+
+
+class ObjectStatus(enum.IntEnum):
+    """``gOBJ``: why the fingers stopped, which is how a grasp is detected.
+
+    The distinction that matters to a caller: :attr:`AT_REQUEST` means the
+    fingers reached the commanded position and therefore hold *nothing*, while
+    :attr:`CONTACT_CLOSING` means they stopped early because something is in
+    the way - a successful grasp. Reading "stopped" without reading which kind
+    reports every empty close as a pick.
+    """
+
+    MOVING = 0
+    CONTACT_OPENING = 1
+    CONTACT_CLOSING = 2
+    AT_REQUEST = 3
+
+
+class Fault(enum.IntEnum):
+    """``gFLT`` values the manual names. Only the codes it documents appear here."""
+
+    NONE = 0x00
+    ACTION_DELAYED_REACTIVATION_NEEDED = 0x05
+    ACTIVATION_BIT_NOT_SET = 0x07
+    OVER_TEMPERATURE = 0x08
+    NO_COMMUNICATION = 0x09
+    UNDER_VOLTAGE = 0x0A
+    AUTOMATIC_RELEASE_IN_PROGRESS = 0x0B
+    INTERNAL_FAULT = 0x0C
+    ACTIVATION_FAULT = 0x0D
+    OVERCURRENT = 0x0E
+    AUTOMATIC_RELEASE_COMPLETE = 0x0F
+
+
+class ProtocolError(ValueError):
+    """A frame does not answer this map, or the gripper reported an exception.
+
+    A :class:`ValueError` because a frame is a value that fails to parse. The
+    driver catches it to build a refusal envelope, so a malformed reply is
+    reported rather than mistaken for a position.
+    """
+
+
+# --------------------------------------------------------------------------- #
+# Bounds. Written once: every field in the map is a byte, and a caller handing
+# a float or a numpy integer to struct.pack gets an opaque struct.error that
+# names neither the field nor this gripper.
+# --------------------------------------------------------------------------- #
+def _validate_byte(value: Any, field: str) -> int:
+    """Return ``value`` as a byte, or raise naming the field and its range.
+
+    Args:
+        value: The candidate. A float is refused rather than truncated, because
+            ``0.9`` of a position count is a caller error and rounding it hides
+            which end of the stroke they meant. A ``bool`` is refused for the
+            same reason: ``True`` is not a position.
+        field: Field name to quote in the reason.
+
+    Returns:
+        The value as an :class:`int`.
+
+    Raises:
+        ProtocolError: If ``value`` is not an integer in ``0..255``.
+    """
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ProtocolError(f"{field} must be an int in 0..{MAX_COUNTS}, got {value!r}")
+    if not 0 <= value <= MAX_COUNTS:
+        raise ProtocolError(f"{field} must be in 0..{MAX_COUNTS}, got {value}")
+    return int(value)
+
+
+def _validate_finite(value: Any, field: str) -> float:
+    """Return ``value`` as a finite float, or raise naming the field.
+
+    Args:
+        value: The candidate. A ``bool`` is refused: ``True`` is not an
+            aperture, and accepting it as ``1.0`` mm would move the fingers
+            almost shut for a caller who meant "open".
+        field: Field name to quote in the reason.
+
+    Returns:
+        The value as a :class:`float`.
+
+    Raises:
+        ProtocolError: If ``value`` is not a finite real number.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ProtocolError(f"{field} must be a number, got {value!r}")
+    if not math.isfinite(value):
+        raise ProtocolError(f"{field} must be finite, got {value!r}")
+    return float(value)
+
+
+def command_payload(
+    *,
+    activate: bool = True,
+    go_to: bool = False,
+    auto_release: bool = False,
+    position: int = 0,
+    speed: int = MAX_COUNTS,
+    force: int = MAX_COUNTS,
+) -> bytes:
+    """Build the six output bytes.
+
+    Args:
+        activate: ``rACT``. Held ``True`` for every normal command: clearing it
+            resets the gripper, which drops the activation and requires the
+            whole sequence again.
+        go_to: ``rGTO``. The gripper only moves on a frame that sets it, so a
+            position written with ``go_to=False`` is staged and not executed.
+        auto_release: ``rATR``. Emergency release; the manual requires the
+            gripper be reactivated afterwards, so it is not a stop.
+        position: ``rPR`` count, ``0`` fully open to ``255`` fully closed.
+        speed: ``rSP`` count. Full speed by default.
+        force: ``rFR`` count. Full force by default.
+
+    Returns:
+        Exactly :data:`PAYLOAD_SIZE` bytes, in the manual's byte order.
+
+    Raises:
+        ProtocolError: If a byte-valued field is out of range.
+    """
+    action = (0x01 if activate else 0x00) | (0x08 if go_to else 0x00) | (0x10 if auto_release else 0x00)
+    return struct.pack(
+        ">BBBBBB",
+        action,
+        0,
+        0,
+        _validate_byte(position, "position"),
+        _validate_byte(speed, "speed"),
+        _validate_byte(force, "force"),
+    )
+
+
+def command_registers(**kwargs: Any) -> tuple[int, ...]:
+    """Build the three register values a write frame carries.
+
+    The registers are the :func:`command_payload` bytes paired big-endian,
+    which is the one place that packing is written down.
+
+    Args:
+        **kwargs: Passed through to :func:`command_payload`.
+
+    Returns:
+        :data:`REGISTER_COUNT` register values.
+    """
+    payload = command_payload(**kwargs)
+    return tuple(int(value) for value in struct.unpack(">HHH", payload))
+
+
+def parse_status(payload: bytes) -> dict[str, Any]:
+    """Decode the six input bytes into named fields.
+
+    Args:
+        payload: Exactly :data:`PAYLOAD_SIZE` bytes, as read from
+            :data:`INPUT_BASE`.
+
+    Returns:
+        The decoded status. ``activation`` and ``object`` are the
+        :class:`ActivationStatus` / :class:`ObjectStatus` members; ``fault`` is
+        a :class:`Fault` when the code is one the manual names and the raw
+        integer otherwise, because an undocumented fault is still worth
+        reporting verbatim rather than dropping. ``position`` and
+        ``position_request`` are counts; ``aperture_mm`` is the position
+        converted for a caller who thinks in millimetres.
+
+    Raises:
+        ProtocolError: If ``payload`` is the wrong length, or reports a
+            ``gSTA`` outside the three states the map defines.
+    """
+    if len(payload) != PAYLOAD_SIZE:
+        raise ProtocolError(f"status payload must be {PAYLOAD_SIZE} bytes, got {len(payload)}")
+    status, _reserved, fault_byte, request, position, current = struct.unpack(">BBBBBB", payload)
+    activation_bits = (status >> 4) & 0x03
+    try:
+        activation = ActivationStatus(activation_bits)
+    except ValueError as exc:
+        raise ProtocolError(
+            f"gSTA={activation_bits} is not one of "
+            f"{[member.value for member in ActivationStatus]} - this is not a 2F status word"
+        ) from exc
+    fault_code = fault_byte & 0x0F
+    return {
+        "activated": bool(status & 0x01),
+        "go_to": bool(status & 0x08),
+        "activation": activation,
+        "object": ObjectStatus((status >> 6) & 0x03),
+        "fault": Fault(fault_code) if fault_code in _FAULT_VALUES else fault_code,
+        "position_request": request,
+        "position": position,
+        "aperture_mm": counts_to_aperture_mm(position),
+        "current_ma": current * 10,
+    }
+
+
+_FAULT_VALUES: Final[frozenset[int]] = frozenset(member.value for member in Fault)
+"""Codes :class:`Fault` names, so :func:`parse_status` can pass an undocumented
+one through as an integer rather than raising on a gripper firmware that grew a
+new code."""
+
+
+# --------------------------------------------------------------------------- #
+# Position conversions. The one inversion in the protocol.                     #
+# --------------------------------------------------------------------------- #
+def counts_to_aperture_mm(counts: int, stroke_mm: float = STROKE_MM) -> float:
+    """Convert a position count to the aperture between the fingertips.
+
+    Args:
+        counts: ``0`` (fully open) to ``255`` (fully closed).
+        stroke_mm: Aperture at count ``0``. Defaults to the 2F-85's.
+
+    Returns:
+        The aperture in millimetres.
+
+    Raises:
+        ProtocolError: If ``counts`` is not a byte.
+    """
+    return stroke_mm * (MAX_COUNTS - _validate_byte(counts, "counts")) / MAX_COUNTS
+
+
+def aperture_mm_to_counts(aperture_mm: float, stroke_mm: float = STROKE_MM) -> int:
+    """Convert a fingertip aperture to the position count that commands it.
+
+    The inverse of :func:`counts_to_aperture_mm`, clamped to the stroke: a
+    caller asking for 200 mm on an 85 mm gripper means "all the way open", and
+    refusing that is less useful than opening.
+
+    Args:
+        aperture_mm: Requested aperture in millimetres.
+        stroke_mm: Aperture at count ``0``. Defaults to the 2F-85's.
+
+    Returns:
+        The position count, ``0..255``.
+
+    Raises:
+        ProtocolError: If ``aperture_mm`` is not a finite number, or
+            ``stroke_mm`` is not positive.
+    """
+    _validate_finite(aperture_mm, "aperture_mm")
+    if stroke_mm <= 0:
+        raise ProtocolError(f"stroke_mm must be positive, got {stroke_mm!r}")
+    clamped = min(max(float(aperture_mm), 0.0), stroke_mm)
+    return int(round(MAX_COUNTS * (stroke_mm - clamped) / stroke_mm))
+
+
+def closed_fraction_to_counts(fraction: float) -> int:
+    """Convert a normalised close command to a position count.
+
+    Args:
+        fraction: ``0.0`` fully open to ``1.0`` fully closed. Clamped, for the
+            same reason :func:`aperture_mm_to_counts` clamps.
+
+    Returns:
+        The position count, ``0..255``.
+
+    Raises:
+        ProtocolError: If ``fraction`` is not a finite number.
+    """
+    _validate_finite(fraction, "fraction")
+    return int(round(MAX_COUNTS * min(max(float(fraction), 0.0), 1.0)))
+
+
+# --------------------------------------------------------------------------- #
+# Modbus TCP framing.                                                          #
+# --------------------------------------------------------------------------- #
+def _validate_transaction_id(transaction_id: int) -> int:
+    if not isinstance(transaction_id, int) or isinstance(transaction_id, bool):
+        raise ProtocolError(f"transaction_id must be an int, got {transaction_id!r}")
+    if not 0 <= transaction_id <= 0xFFFF:
+        raise ProtocolError(f"transaction_id must be in 0..65535, got {transaction_id}")
+    return transaction_id
+
+
+def _frame(transaction_id: int, unit_id: int, pdu: bytes) -> bytes:
+    """Wrap ``pdu`` in an MBAP header."""
+    header = struct.pack(
+        ">HHHB",
+        _validate_transaction_id(transaction_id),
+        PROTOCOL_ID,
+        len(pdu) + 1,  # the unit id travels inside the counted length
+        _validate_byte(unit_id, "unit_id"),
+    )
+    return header + pdu
+
+
+def write_registers_frame(
+    transaction_id: int,
+    unit_id: int,
+    address: int,
+    values: tuple[int, ...],
+) -> bytes:
+    """Build a function-16 frame writing ``values`` at ``address``.
+
+    Args:
+        transaction_id: Echoed by the server, so a reply can be matched to its
+            request.
+        unit_id: Modbus slave id; see :data:`DEFAULT_UNIT_ID`.
+        address: First register to write, e.g. :data:`OUTPUT_BASE`.
+        values: Register values, each ``0..65535``.
+
+    Returns:
+        The complete frame, MBAP header included.
+
+    Raises:
+        ProtocolError: If ``values`` is empty or a value is out of range.
+    """
+    if not values:
+        raise ProtocolError("write_registers_frame: values must not be empty")
+    for value in values:
+        if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 0xFFFF:
+            raise ProtocolError(f"register value must be an int in 0..65535, got {value!r}")
+    pdu = struct.pack(
+        ">BHHB",
+        FunctionCode.WRITE_MULTIPLE_REGISTERS,
+        address,
+        len(values),
+        len(values) * 2,
+    ) + struct.pack(f">{len(values)}H", *values)
+    return _frame(transaction_id, unit_id, pdu)
+
+
+def read_input_registers_frame(transaction_id: int, unit_id: int, address: int, count: int) -> bytes:
+    """Build a function-4 frame reading ``count`` registers at ``address``.
+
+    Args:
+        transaction_id: Echoed by the server.
+        unit_id: Modbus slave id.
+        address: First register to read, e.g. :data:`INPUT_BASE`.
+        count: How many registers to read.
+
+    Returns:
+        The complete frame, MBAP header included.
+
+    Raises:
+        ProtocolError: If ``count`` is not positive.
+    """
+    if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+        raise ProtocolError(f"count must be a positive int, got {count!r}")
+    pdu = struct.pack(">BHH", FunctionCode.READ_INPUT_REGISTERS, address, count)
+    return _frame(transaction_id, unit_id, pdu)
+
+
+def parse_response(raw: bytes, expected_transaction_id: int, expected_function: int) -> bytes:
+    """Validate a reply frame and return its PDU body after the function code.
+
+    Args:
+        raw: The whole frame, MBAP header included.
+        expected_transaction_id: The id the request carried. A mismatch is a
+            reply to a *different* request, which on a shared connection would
+            otherwise be read as this one's answer.
+        expected_function: The function code the request used.
+
+    Returns:
+        Everything after the function code. For a read that is the byte count
+        followed by the data; for a write, the echoed address and count.
+
+    Raises:
+        ProtocolError: If the frame is truncated, carries the wrong protocol
+            id or transaction id, or is an exception response.
+    """
+    if len(raw) < MBAP_SIZE + 1:
+        raise ProtocolError(f"response must be at least {MBAP_SIZE + 1} bytes, got {len(raw)}")
+    transaction_id, protocol_id, length, _unit_id = struct.unpack(">HHHB", raw[:MBAP_SIZE])
+    if protocol_id != PROTOCOL_ID:
+        raise ProtocolError(f"protocol id must be {PROTOCOL_ID}, got {protocol_id} - this is not Modbus TCP")
+    if transaction_id != expected_transaction_id:
+        raise ProtocolError(f"response is for transaction {transaction_id}, expected {expected_transaction_id}")
+    body = raw[MBAP_SIZE:]
+    if len(body) + 1 != length:
+        raise ProtocolError(f"MBAP length says {length} bytes follow, got {len(body) + 1}")
+    function = body[0]
+    if function == (expected_function | 0x80):
+        code = body[1] if len(body) > 1 else 0
+        raise ProtocolError(f"gripper refused function {expected_function:#04x} with Modbus exception {code:#04x}")
+    if function != expected_function:
+        raise ProtocolError(f"response function is {function:#04x}, expected {expected_function:#04x}")
+    return body[1:]
+
+
+def read_registers_payload(raw: bytes, expected_transaction_id: int, count: int) -> bytes:
+    """Validate a function-4 reply and return the register bytes it carries.
+
+    Args:
+        raw: The whole reply frame.
+        expected_transaction_id: The id the request carried.
+        count: Registers the request asked for.
+
+    Returns:
+        ``count * 2`` data bytes.
+
+    Raises:
+        ProtocolError: If the frame is malformed or carries the wrong amount of
+            data. A short read is raised rather than padded: half a status word
+            decodes to a position the gripper never reported.
+    """
+    body = parse_response(raw, expected_transaction_id, FunctionCode.READ_INPUT_REGISTERS)
+    if not body:
+        raise ProtocolError("read response carries no byte count")
+    byte_count = body[0]
+    data = body[1:]
+    if byte_count != count * 2:
+        raise ProtocolError(f"read response declares {byte_count} bytes, expected {count * 2}")
+    if len(data) != byte_count:
+        raise ProtocolError(f"read response declares {byte_count} bytes but carries {len(data)}")
+    return data

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -533,7 +533,10 @@
       },
       "aliases": [
         "robotiq"
-      ]
+      ],
+      "hardware": {
+        "driver": "strands"
+      }
     },
     "robotiq_2f85_v4": {
       "description": "Robotiq 2F-85 v4 Gripper (updated model)",
@@ -544,6 +547,9 @@
         "model_xml": "2f85.xml",
         "scene_xml": "scene.xml",
         "robot_descriptions_module": "robotiq_2f85_v4_mj_description"
+      },
+      "hardware": {
+        "driver": "strands"
       }
     },
     "shadow_dexee": {

--- a/tests/drivers/robotiq/conftest.py
+++ b/tests/drivers/robotiq/conftest.py
@@ -1,0 +1,266 @@
+"""A scripted Robotiq 2F-85 speaking Modbus TCP, shared by the driver tests.
+
+A hardware-shaped fake rather than a mock: it accepts a real TCP connection,
+reads real MBAP-framed requests and answers with real register payloads, and it
+enforces the two behaviours that make a 2F-85 different from a register file -
+it ignores a position command until it has been activated, and it only moves on
+a frame that sets ``rGTO``. A driver that skipped the activation sequence would
+pass against a mock that just stored bytes; against this it reports a gripper
+that never moves, which is exactly what the hardware does.
+
+The fake is the oracle for the codec too: it decodes with :mod:`struct` off the
+manual's byte layout rather than by calling the codec under test, so a frame the
+driver builds wrongly is not un-built by the same mistake.
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+from collections.abc import Callable, Iterator
+from types import TracebackType
+
+import pytest
+
+from strands_robots.drivers.robotiq import RobotiqDriver
+
+INPUT_BASE = 0x07D0
+OUTPUT_BASE = 0x03E8
+READ_INPUT_REGISTERS = 0x04
+WRITE_MULTIPLE_REGISTERS = 0x10
+
+
+class FakeGripper:
+    """A 2F-85 that answers Modbus TCP on an ephemeral localhost port.
+
+    Attributes:
+        port: The port the server bound to; pass it to the driver as ``tcp_port``.
+        commanded: Every ``rPR`` the gripper was told to go to, in order, for a
+            test to assert what actually reached the wire.
+        writes: Every decoded output payload, for asserting the flag bits.
+    """
+
+    def __init__(
+        self,
+        *,
+        activation_reads: int = 1,
+        object_status: int = 3,
+        fault: int = 0,
+        current: int = 0,
+        exception_code: int | None = None,
+        starts_activated: bool = False,
+        never_activates: bool = False,
+    ) -> None:
+        """Configure the gripper's scripted behaviour.
+
+        Args:
+            activation_reads: Status reads the calibration stroke takes before
+                ``gSTA`` reports ACTIVE.
+            object_status: ``gOBJ`` to report - ``2`` is a grasp, ``3`` is "at
+                the requested position, holding nothing".
+            fault: ``gFLT`` to report.
+            current: ``gCU`` to report, in units of 10 mA.
+            exception_code: When set, every request is answered with a Modbus
+                exception carrying this code.
+            starts_activated: Begin already activated, as a gripper that was
+                left powered would.
+            never_activates: Stay in ACTIVATING forever, so a driver's
+                activation timeout can be exercised.
+        """
+        self._activation_reads = activation_reads
+        self._object_status = object_status
+        self._fault = fault
+        self._current = current
+        self._exception_code = exception_code
+        self._never_activates = never_activates
+
+        self.activated = starts_activated
+        self.go_to = False
+        self.activation = 3 if starts_activated else 0
+        self.position = 0
+        self.requested = 0
+        self.speed = 0
+        self.force = 0
+        self.commanded: list[int] = []
+        self.writes: list[dict[str, int]] = []
+        self._reads_since_activate = 0
+
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(("127.0.0.1", 0))
+        self._server.listen(1)
+        self.port: int = self._server.getsockname()[1]
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, name="fake-2f85", daemon=True)
+        self._thread.start()
+
+    def __enter__(self) -> FakeGripper:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Stop serving and release the listening socket."""
+        self._stop.set()
+        try:
+            self._server.close()
+        except OSError:
+            pass
+        self._thread.join(timeout=2.0)
+
+    # ---------------------------------------------------------------- #
+    # Wire handling.                                                    #
+    # ---------------------------------------------------------------- #
+
+    def _serve(self) -> None:
+        try:
+            conn, _addr = self._server.accept()
+        except OSError:
+            return  # closed before a client arrived
+        with conn:
+            while not self._stop.is_set():
+                header = self._read_exactly(conn, 7)
+                if header is None:
+                    return
+                (length,) = struct.unpack(">H", header[4:6])
+                body = self._read_exactly(conn, length - 1)
+                if body is None:
+                    return
+                transaction, _protocol, _length, unit = struct.unpack(">HHHB", header)
+                try:
+                    conn.sendall(self._answer(transaction, unit, body))
+                except OSError:
+                    return
+
+    @staticmethod
+    def _read_exactly(conn: socket.socket, count: int) -> bytes | None:
+        chunks: list[bytes] = []
+        remaining = count
+        while remaining > 0:
+            try:
+                chunk = conn.recv(remaining)
+            except OSError:
+                return None
+            if not chunk:
+                return None
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _answer(self, transaction: int, unit: int, body: bytes) -> bytes:
+        function = body[0]
+        if self._exception_code is not None:
+            return _frame(transaction, unit, struct.pack(">BB", function | 0x80, self._exception_code))
+        if function == WRITE_MULTIPLE_REGISTERS:
+            address, count, _byte_count = struct.unpack(">HHB", body[1:6])
+            self._apply(body[6 : 6 + count * 2])
+            return _frame(transaction, unit, struct.pack(">BHH", function, address, count))
+        if function == READ_INPUT_REGISTERS:
+            address, count = struct.unpack(">HH", body[1:5])
+            assert address == INPUT_BASE, f"read at {address:#06x}, expected {INPUT_BASE:#06x}"
+            payload = self._status_payload()[: count * 2]
+            return _frame(transaction, unit, struct.pack(">BB", function, len(payload)) + payload)
+        return _frame(transaction, unit, struct.pack(">BB", function | 0x80, 0x01))
+
+    def _apply(self, payload: bytes) -> None:
+        """Absorb an output payload the way the gripper's firmware would."""
+        action, _r1, _r2, position, speed, force = struct.unpack(">BBBBBB", payload)
+        activate = bool(action & 0x01)
+        self.go_to = bool(action & 0x08)
+        self.writes.append(
+            {
+                "activate": int(activate),
+                "go_to": int(self.go_to),
+                "auto_release": int(bool(action & 0x10)),
+                "position": position,
+                "speed": speed,
+                "force": force,
+            }
+        )
+        if activate and not self.activated:
+            # rACT rising edge starts the calibration stroke.
+            self.activation = 1
+            self._reads_since_activate = 0
+        if not activate:
+            self.activation = 0
+        self.activated = activate
+        self.requested = position
+        self.speed = speed
+        self.force = force
+        # THE BEHAVIOUR THAT MATTERS: a position only lands when the gripper is
+        # activated and the frame set rGTO. Anything else is silently dropped,
+        # which is what the hardware does and why a driver must activate first.
+        if self.activated and self.activation == 3 and self.go_to:
+            self.position = position
+            self.commanded.append(position)
+
+    def _status_payload(self) -> bytes:
+        if self.activation == 1 and not self._never_activates:
+            self._reads_since_activate += 1
+            if self._reads_since_activate >= self._activation_reads:
+                self.activation = 3
+        status = (
+            (0x01 if self.activated else 0x00)
+            | (0x08 if self.go_to else 0x00)
+            | ((self.activation & 0x03) << 4)
+            | ((self._object_status & 0x03) << 6)
+        )
+        return struct.pack(">BBBBBB", status, 0, self._fault, self.requested, self.position, self._current)
+
+
+def _frame(transaction: int, unit: int, pdu: bytes) -> bytes:
+    return struct.pack(">HHHB", transaction, 0, len(pdu) + 1, unit) + pdu
+
+
+@pytest.fixture
+def gripper() -> Iterator[Callable[..., FakeGripper]]:
+    """Yield a factory for scripted grippers, each closed at teardown.
+
+    A factory rather than a single instance because most behaviours here need a
+    gripper configured differently - already activated, reporting a grasp,
+    answering only exceptions - and a test that had to remember to close its own
+    server would leak a listening socket on every failure.
+
+    Yields:
+        A callable taking :class:`FakeGripper`'s keyword arguments.
+    """
+    built: list[FakeGripper] = []
+
+    def _build(**kwargs: object) -> FakeGripper:
+        made = FakeGripper(**kwargs)  # type: ignore[arg-type]
+        built.append(made)
+        return made
+
+    yield _build
+    for made in built:
+        made.close()
+
+
+@pytest.fixture
+def connected(gripper: Callable[..., FakeGripper]) -> Iterator[Callable[..., tuple[RobotiqDriver, FakeGripper]]]:
+    """Yield a factory for drivers already connected to a scripted gripper.
+
+    Yields:
+        A callable taking :class:`FakeGripper`'s keyword arguments and returning
+        the connected driver paired with the gripper it drives. Asserts the
+        connection succeeded, so a test body starts from a working gripper.
+    """
+    drivers: list[RobotiqDriver] = []
+
+    def _build(**kwargs: object) -> tuple[RobotiqDriver, FakeGripper]:
+        fake = gripper(**kwargs)
+        driver = RobotiqDriver(tool_name="robotiq_2f85", port="127.0.0.1", tcp_port=fake.port, timeout=2.0)
+        drivers.append(driver)
+        assert driver.connect_eagerly() is None
+        return driver, fake
+
+    yield _build
+    for driver in drivers:
+        driver.cleanup()

--- a/tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py
+++ b/tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py
@@ -293,3 +293,31 @@ def test_real_mode_reaches_this_driver_without_naming_it(name: str, gripper: Cal
     assert built.send_action({"gripper": 1.0})["status"] == "success"
     assert fake.commanded == [255]
     built.cleanup()
+
+
+# ---------- regression: intra-category duplicate keys ----------
+
+
+class TestSendActionRefusesIntraCategoryDuplicateKeys:
+    """Pin the guard widened to ``len(normalised) + len(aperture) > 1``.
+
+    Two keys inside *one* category (e.g. ``{"gripper": 0.0, "gripper.pos": 1.0}``)
+    are contradictory.  Before the fix, the guard checked only for cross-category
+    conflicts and the first tuple element won silently -- a close command could be
+    dropped while the driver reported success.
+    """
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            pytest.param({"gripper": 0.0, "gripper.pos": 1.0}, id="two-normalised"),
+            pytest.param({"position": 85.0, "aperture_mm": 0.0}, id="two-aperture"),
+        ],
+    )
+    def test_intra_category_duplicate_keys_are_refused(self, connected: Connected, action: dict[str, float]) -> None:
+        driver, _fake = connected()
+        result = driver.send_action(action)
+        assert result["status"] == "error", (
+            f"Intra-category duplicate keys {sorted(action)} must be refused; got {result}"
+        )
+        assert "two spellings" in result["content"][0]["text"].lower()

--- a/tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py
+++ b/tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py
@@ -1,0 +1,295 @@
+"""The 2F-85 driver's command path, graded against a scripted gripper.
+
+Every case here runs over a real TCP socket to a fake that enforces the
+gripper's own preconditions (see :class:`FakeGripper`): a position lands only
+when the gripper is activated and the frame set ``rGTO``. So these are
+behaviour pins, not envelope pins - a driver that built a perfect frame but
+skipped activation would produce the same envelopes and move nothing, and the
+assertions read what reached the wire.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from strands_robots import Robot
+from strands_robots.drivers.robotiq import STROKE_MM, RobotiqDriver
+from strands_robots.drivers.robotiq.protocol import ObjectStatus
+from tests.drivers.robotiq.conftest import FakeGripper
+
+if TYPE_CHECKING:
+    from strands_robots.policies import Policy
+
+Connected = Callable[..., tuple[RobotiqDriver, FakeGripper]]
+
+
+def test_connecting_activates_the_gripper_before_reporting_success(connected: Connected) -> None:
+    """An unactivated 2F-85 ignores positions, so connecting must activate it.
+
+    The gripper is the authority: it only records a commanded position once
+    ``gSTA`` reads ACTIVE. If ``connect_eagerly`` returned on an open socket
+    alone, the first ``send_action`` would be dropped and this would see an
+    empty ``commanded``.
+    """
+    driver, fake = connected()
+
+    assert driver.is_connected
+    assert fake.activation == 3, "gripper should have finished its calibration stroke"
+    # The manual's sequence: clear rACT, then set it. Both frames must be sent,
+    # because a gripper holding a fault will not activate without the reset.
+    assert [write["activate"] for write in fake.writes[:2]] == [0, 1]
+
+    assert driver.send_action({"gripper": 1.0})["status"] == "success"
+    assert fake.commanded == [255], "the commanded position did not reach the gripper"
+
+
+def test_an_already_activated_gripper_is_not_reset(connected: Connected) -> None:
+    """Re-activating costs a calibration stroke, so a live gripper is left alone."""
+    driver, fake = connected(starts_activated=True)
+
+    assert driver.is_connected
+    assert fake.writes == [], "an activated gripper needs no activation frames"
+
+
+def test_activation_that_never_completes_is_reported_not_hidden(gripper: Callable[..., FakeGripper]) -> None:
+    """A gripper stuck mid-calibration yields a reason naming the state."""
+    fake = gripper(never_activates=True)
+    driver = RobotiqDriver(port="127.0.0.1", tcp_port=fake.port, timeout=1.0, activation_timeout=0.3)
+
+    reason = driver.connect_eagerly()
+
+    assert reason is not None
+    assert "did not finish activating" in reason
+    assert "ACTIVATING" in reason, f"the reason should name the state it was stuck in: {reason}"
+    assert not driver.is_connected
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_counts", "expected_mm"),
+    [
+        # The direction pin. rPR runs backwards to aperture, so a sign error
+        # here closes a gripper that was asked to open - and it would still
+        # look like a working driver.
+        ({"gripper": 0.0}, 0, STROKE_MM),
+        ({"gripper": 1.0}, 255, 0.0),
+        ({"gripper": 0.5}, 128, pytest.approx(42.3, abs=0.3)),
+        # The same command in the spelling a policy action dict uses.
+        ({"gripper.pos": 0.0}, 0, STROKE_MM),
+        ({"gripper.pos": 1.0}, 255, 0.0),
+        # Millimetres of fingertip aperture, both spellings.
+        ({"position": STROKE_MM}, 0, STROKE_MM),
+        ({"position": 0.0}, 255, 0.0),
+        ({"aperture_mm": 40.0}, 135, pytest.approx(40.0, abs=0.4)),
+        # Out of stroke means "as far as it goes", not a refusal.
+        ({"aperture_mm": 500.0}, 0, STROKE_MM),
+        ({"gripper": -3.0}, 0, STROKE_MM),
+        ({"gripper": 7.0}, 255, 0.0),
+    ],
+)
+def test_an_aperture_command_lands_the_position_it_names(
+    connected: Connected,
+    action: dict[str, float],
+    expected_counts: int,
+    expected_mm: float,
+) -> None:
+    """Each accepted spelling reaches the gripper as the position it means."""
+    driver, fake = connected()
+
+    envelope = driver.send_action(action)
+
+    assert envelope["status"] == "success", envelope
+    reported = envelope["content"][0]["json"]
+    assert reported["position"] == expected_counts
+    assert reported["aperture_mm"] == expected_mm
+    assert fake.commanded == [expected_counts], "the gripper received a different position"
+    assert fake.position == expected_counts
+
+
+def test_the_two_command_spellings_agree_on_the_wire(connected: Connected) -> None:
+    """A closed fraction and the millimetres it equals produce one position.
+
+    Pinned because the two paths convert through different functions, and a
+    caller switching spelling must not silently change where the fingers go.
+    """
+    driver, fake = connected()
+
+    driver.send_action({"gripper": 1.0})
+    driver.send_action({"aperture_mm": 0.0})
+
+    assert fake.commanded[0] == fake.commanded[1] == 255
+
+
+def test_speed_and_force_scale_from_a_fraction(connected: Connected) -> None:
+    """Per-command speed and force reach the gripper as counts."""
+    driver, fake = connected()
+
+    driver.send_action({"gripper": 1.0, "speed": 0.0, "force": 0.5})
+
+    assert fake.speed == 0
+    assert fake.force == 128
+
+
+def test_a_grasp_is_distinguished_from_an_empty_close(connected: Connected) -> None:
+    """``gOBJ`` says whether the fingers stopped on an object or on the target.
+
+    Reading "stopped" without reading which kind reports every empty close as a
+    successful pick, which is the difference between a grasp check that works
+    and one that always says yes.
+    """
+    holding_driver, _holding = connected(object_status=ObjectStatus.CONTACT_CLOSING)
+    empty_driver, _empty = connected(object_status=ObjectStatus.AT_REQUEST)
+
+    holding = holding_driver.read_status()["content"][0]["json"]
+    empty = empty_driver.read_status()["content"][0]["json"]
+
+    assert holding["object"] == "CONTACT_CLOSING"
+    assert holding["holding"] is True
+    assert empty["object"] == "AT_REQUEST"
+    assert empty["holding"] is False
+
+
+def test_the_observation_reports_the_one_joint_a_gripper_has(connected: Connected) -> None:
+    """``get_observation`` is what puts the gripper on the mesh state topic.
+
+    The driver owns its bus, so it answers the joint read itself rather than
+    through an inner device - see
+    :func:`strands_robots.bus_access.joint_read_source`.
+    """
+    from strands_robots.bus_access import joint_read_source
+
+    driver, _fake = connected()
+    driver.send_action({"gripper": 1.0})
+
+    assert joint_read_source(driver) is driver, "the mesh must resolve this driver as its own joint source"
+    assert driver.get_observation() == {"gripper.pos": 1.0}
+
+    driver.send_action({"gripper": 0.0})
+    assert driver.get_observation() == {"gripper.pos": 0.0}
+
+
+def test_a_disconnected_gripper_reports_no_joints_rather_than_failing() -> None:
+    """ "No joints" is not an error; the mesh publishes no section for it."""
+    driver = RobotiqDriver(port="127.0.0.1", tcp_port=1)
+
+    assert driver.get_observation() == {}
+
+
+@pytest.mark.parametrize(
+    ("action", "robot_name", "expected"),
+    [
+        ({"gripper": 0.0, "position": 10.0}, None, "two spellings of the same command"),
+        ({"wrist_flex": 0.2}, None, "none of ['wrist_flex'] names an aperture"),
+        ({}, None, "nothing to command"),
+        ({"gripper": float("nan")}, None, "gripper"),
+        ({"gripper": "shut"}, None, "gripper"),
+        ({"gripper": 0.0}, "so101", "fronts 'robotiq_2f85' only"),
+    ],
+)
+def test_a_command_it_cannot_honour_is_refused_in_an_envelope(
+    connected: Connected,
+    action: dict[str, object],
+    robot_name: str | None,
+    expected: str,
+) -> None:
+    """A bad action is an error envelope, never an exception past the boundary.
+
+    The mesh command path and the agent tool dispatch both read the envelope, so
+    a raise here would escape as a traceback where a reason was expected.
+    """
+    driver, fake = connected()
+
+    envelope = driver.send_action(action, robot_name=robot_name)
+
+    assert envelope["status"] == "error", envelope
+    assert expected in envelope["content"][0]["text"]
+    assert fake.commanded == [], "a refused command must not reach the gripper"
+
+
+def test_a_modbus_exception_reply_becomes_a_reason(gripper: Callable[..., FakeGripper]) -> None:
+    """A gripper refusing the write is reported with its exception code."""
+    fake = gripper(exception_code=0x02, starts_activated=True)
+    driver = RobotiqDriver(port="127.0.0.1", tcp_port=fake.port, timeout=1.0)
+
+    reason = driver.connect_eagerly()
+
+    assert reason is not None
+    assert "0x02" in reason, reason
+
+
+def test_stopping_halts_the_fingers_without_dropping_activation(connected: Connected) -> None:
+    """Clearing ``rGTO`` stops motion; clearing ``rACT`` would cost a re-stroke."""
+    driver, fake = connected()
+
+    envelope = driver.stop_task()
+
+    assert envelope["status"] == "success"
+    assert fake.writes[-1]["go_to"] == 0, "rGTO must be cleared to halt"
+    assert fake.writes[-1]["activate"] == 1, "rACT must stay set to keep the gripper activated"
+    assert fake.activation == 3
+
+
+@pytest.mark.parametrize("verb", ["start_task", "run_policy"])
+def test_a_gripper_refuses_a_policy_rollout_and_names_the_path_that_works(verb: str) -> None:
+    """A 1-DOF end effector has no rollout, so the refusal points at send_action.
+
+    A refusal that only said "unsupported" would leave a caller guessing; naming
+    the working path is what makes it actionable.
+    """
+    driver = RobotiqDriver()
+
+    envelope = (
+        driver.start_task("pick up the cube") if verb == "start_task" else driver.run_policy(cast("Policy", object()))
+    )
+
+    assert envelope["status"] == "error"
+    text = envelope["content"][0]["text"]
+    assert verb in text
+    assert "send_action" in text
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"timeout": 0}, "timeout"),
+        ({"timeout": float("nan")}, "timeout"),
+        ({"activation_timeout": -1.0}, "activation_timeout"),
+        ({"stroke_mm": 0.0}, "stroke_mm"),
+        ({"tcp_port": 0}, "tcp_port"),
+        ({"tcp_port": "502"}, "tcp_port"),
+        ({"unit_id": 300}, "unit_id"),
+        ({"unit_id": True}, "unit_id"),
+        ({"speed": 1.5}, "speed"),
+        ({"force": float("inf")}, "force"),
+    ],
+)
+def test_a_knob_the_transport_cannot_use_is_refused_at_construction(kwargs: dict[str, object], expected: str) -> None:
+    """Each of these reaches a consumer that cannot report what it was handed.
+
+    Raised from ``__init__`` rather than returned from ``connect_eagerly``,
+    which is declared ``-> str | None``: a value the socket cannot use is not a
+    connection the driver can degrade to reporting.
+    """
+    with pytest.raises(ValueError, match=expected):
+        RobotiqDriver(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("name", ["robotiq_2f85", "robotiq_2f85_v4", "robotiq"])
+def test_real_mode_reaches_this_driver_without_naming_it(name: str, gripper: Callable[..., FakeGripper]) -> None:
+    """``mode="real"`` alone resolves here, which is what the registry buys.
+
+    The entries declare ``hardware.driver = "strands"`` because lerobot has no
+    robot type for a gripper, so the default resolution must land here rather
+    than on a lerobot driver that cannot build it. Without that declaration a
+    caller would need ``driver="strands"`` and the documented call would fail.
+    """
+    fake = gripper(starts_activated=True)
+    built = Robot(name, mode="real", port="127.0.0.1", tcp_port=fake.port, timeout=1.0)
+
+    assert isinstance(built, RobotiqDriver)
+    assert built.connect_eagerly() is None
+    assert built.send_action({"gripper": 1.0})["status"] == "success"
+    assert fake.commanded == [255]
+    built.cleanup()

--- a/tests/drivers/robotiq/test_robotiq_protocol_frames.py
+++ b/tests/drivers/robotiq/test_robotiq_protocol_frames.py
@@ -1,0 +1,209 @@
+"""The Robotiq register map and Modbus TCP framing, byte for byte.
+
+The frames are pinned as literal bytes rather than rebuilt from the codec's own
+constants: a golden frame derived from the thing under test moves whenever the
+thing under test moves, which is the one case a wire-format test exists to
+catch. Every literal below is the layout in Robotiq's *2F-85 & 2F-140
+Instruction Manual*, Modbus RTU/TCP section.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from strands_robots.drivers.robotiq.protocol import (
+    INPUT_BASE,
+    MAX_COUNTS,
+    OUTPUT_BASE,
+    REGISTER_COUNT,
+    STROKE_MM,
+    ActivationStatus,
+    Fault,
+    FunctionCode,
+    ObjectStatus,
+    ProtocolError,
+    aperture_mm_to_counts,
+    closed_fraction_to_counts,
+    command_payload,
+    command_registers,
+    counts_to_aperture_mm,
+    parse_response,
+    parse_status,
+    read_input_registers_frame,
+    read_registers_payload,
+    write_registers_frame,
+)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        # rACT alone: the activation frame.
+        ({"activate": True}, "01 00 00 00 ff ff"),
+        # rACT cleared: the reset that must precede a fresh activation.
+        ({"activate": False}, "00 00 00 00 ff ff"),
+        # rACT|rGTO with a position: the frame that actually moves the fingers.
+        ({"activate": True, "go_to": True, "position": 255}, "09 00 00 ff ff ff"),
+        ({"activate": True, "go_to": True, "position": 0}, "09 00 00 00 ff ff"),
+        # rATR is bit 4, and sits alongside rACT.
+        ({"activate": True, "auto_release": True}, "11 00 00 00 ff ff"),
+        # Speed and force are the last two bytes, in that order.
+        ({"activate": True, "speed": 0x10, "force": 0x20}, "01 00 00 00 10 20"),
+    ],
+)
+def test_the_command_payload_is_the_manual_byte_layout(kwargs: dict[str, object], expected: str) -> None:
+    """Each output byte carries the field the manual assigns it."""
+    assert command_payload(**kwargs).hex(" ") == expected  # type: ignore[arg-type]
+
+
+def test_the_command_registers_pair_the_payload_big_endian() -> None:
+    """Three registers carry six bytes, high byte first."""
+    assert command_registers(activate=True, go_to=True, position=0xFF) == (0x0900, 0x00FF, 0xFFFF)
+
+
+@pytest.mark.parametrize(
+    ("frame", "expected"),
+    [
+        (
+            write_registers_frame(1, 9, OUTPUT_BASE, command_registers(activate=True, go_to=True, position=255)),
+            # transaction 0001 | protocol 0000 | length 000d | unit 09 |
+            # fc 10 | addr 03e8 | 3 registers | 6 bytes | payload
+            "00 01 00 00 00 0d 09 10 03 e8 00 03 06 09 00 00 ff ff ff",
+        ),
+        (
+            read_input_registers_frame(1, 9, INPUT_BASE, REGISTER_COUNT),
+            # transaction 0001 | protocol 0000 | length 0006 | unit 09 |
+            # fc 04 | addr 07d0 | 3 registers
+            "00 01 00 00 00 06 09 04 07 d0 00 03",
+        ),
+    ],
+)
+def test_a_request_frame_is_byte_exact(frame: bytes, expected: str) -> None:
+    """The MBAP header and PDU match the wire, including the counted length."""
+    assert frame.hex(" ") == expected
+
+
+def test_the_mbap_length_counts_the_unit_id_and_the_pdu() -> None:
+    """The one field a hand-built frame gets wrong, so it is pinned on its own."""
+    frame = write_registers_frame(7, 2, OUTPUT_BASE, (1, 2, 3))
+    (length,) = struct.unpack(">H", frame[4:6])
+
+    assert length == len(frame) - 6, "length must count every byte after itself"
+
+
+def test_a_status_word_decodes_the_documented_bit_fields() -> None:
+    """``gACT``/``gGTO``/``gSTA``/``gOBJ`` are packed in one byte; read each."""
+    # 0xb9 = rACT | rGTO | gSTA=ACTIVE(3)<<4 | gOBJ=CONTACT_CLOSING(2)<<6
+    status = parse_status(bytes.fromhex("b9 00 00 c8 be 05"))
+
+    assert status["activated"] is True
+    assert status["go_to"] is True
+    assert status["activation"] is ActivationStatus.ACTIVE
+    assert status["object"] is ObjectStatus.CONTACT_CLOSING
+    assert status["fault"] is Fault.NONE
+    assert status["position_request"] == 200
+    assert status["position"] == 190
+    assert status["current_ma"] == 50, "gCU is reported in units of 10 mA"
+
+
+def test_an_undocumented_fault_is_reported_verbatim_not_dropped() -> None:
+    """A firmware that grew a new code should still surface it to an operator."""
+    status = parse_status(bytes.fromhex("31 00 03 00 00 00"))
+
+    assert status["fault"] == 0x03
+    assert not isinstance(status["fault"], Fault)
+
+
+def test_a_status_word_that_is_not_a_2f_is_refused() -> None:
+    """``gSTA=2`` is undefined, so the payload is not this gripper's."""
+    with pytest.raises(ProtocolError, match="not a 2F status word"):
+        parse_status(bytes.fromhex("21 00 00 00 00 00"))
+
+
+@pytest.mark.parametrize("payload", [b"", b"\x00" * 5, b"\x00" * 7])
+def test_a_short_status_payload_is_refused_rather_than_padded(payload: bytes) -> None:
+    """Half a status word decodes to a position the gripper never reported."""
+    with pytest.raises(ProtocolError, match="must be 6 bytes"):
+        parse_status(payload)
+
+
+@pytest.mark.parametrize(
+    ("counts", "aperture"),
+    [(0, STROKE_MM), (MAX_COUNTS, 0.0), (128, pytest.approx(42.35, abs=0.05))],
+)
+def test_position_counts_run_backwards_to_aperture(counts: int, aperture: float) -> None:
+    """Count 0 is fully OPEN. The inversion is the protocol's one sign trap."""
+    assert counts_to_aperture_mm(counts) == aperture
+
+
+@pytest.mark.parametrize("aperture", [0.0, 10.0, 42.5, 85.0])
+def test_the_aperture_conversions_round_trip(aperture: float) -> None:
+    """Millimetres to counts and back lands within one count of the stroke."""
+    counts = aperture_mm_to_counts(aperture)
+
+    assert counts_to_aperture_mm(counts) == pytest.approx(aperture, abs=STROKE_MM / MAX_COUNTS)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(-5.0, 0), (0.0, 0), (1.0, MAX_COUNTS), (99.0, MAX_COUNTS)],
+)
+def test_a_closed_fraction_outside_the_unit_range_clamps(value: float, expected: int) -> None:
+    """ "More than fully closed" means fully closed, not a refusal."""
+    assert closed_fraction_to_counts(value) == expected
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), "half", None, True])
+def test_a_position_that_is_not_a_finite_number_is_refused(value: object) -> None:
+    """These reach ``struct.pack``, which cannot say which field was wrong."""
+    with pytest.raises(ProtocolError):
+        aperture_mm_to_counts(value)  # type: ignore[arg-type]
+    with pytest.raises(ProtocolError):
+        closed_fraction_to_counts(value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("position", [-1, 256, 1.5, True, "255"])
+def test_a_position_count_outside_a_byte_is_refused(position: object) -> None:
+    """A float count hides which end of the stroke the caller meant."""
+    with pytest.raises(ProtocolError, match="position"):
+        command_payload(position=position)  # type: ignore[arg-type]
+
+
+def test_an_exception_reply_is_raised_with_its_code() -> None:
+    """The gripper answers a refusal with the function ORed with 0x80."""
+    exception = struct.pack(">HHHBBB", 1, 0, 3, 9, FunctionCode.READ_INPUT_REGISTERS | 0x80, 0x02)
+
+    with pytest.raises(ProtocolError, match="Modbus exception 0x02"):
+        parse_response(exception, 1, FunctionCode.READ_INPUT_REGISTERS)
+
+
+def test_a_reply_to_a_different_request_is_not_read_as_this_one() -> None:
+    """On a shared connection a stale reply would otherwise become the answer."""
+    reply = read_input_registers_frame(4, 9, INPUT_BASE, 3)
+
+    with pytest.raises(ProtocolError, match="response is for transaction 4, expected 5"):
+        parse_response(reply, 5, FunctionCode.READ_INPUT_REGISTERS)
+
+
+def test_a_non_modbus_protocol_id_is_refused() -> None:
+    """Protocol id 0 is the only one Modbus TCP defines."""
+    frame = bytearray(read_input_registers_frame(1, 9, INPUT_BASE, 3))
+    frame[2:4] = b"\x00\x07"
+
+    with pytest.raises(ProtocolError, match="not Modbus TCP"):
+        parse_response(bytes(frame), 1, FunctionCode.READ_INPUT_REGISTERS)
+
+
+def test_a_read_reply_declaring_the_wrong_byte_count_is_refused() -> None:
+    """A truncated register block must not be decoded as a whole status.
+
+    The MBAP length is kept consistent with the body on purpose, so the frame
+    passes the framing check and the byte-count check is the one under test.
+    """
+    body = struct.pack(">BB", FunctionCode.READ_INPUT_REGISTERS, 2) + b"\x00\x00"
+    short = struct.pack(">HHHB", 1, 0, len(body) + 1, 9) + body
+
+    with pytest.raises(ProtocolError, match="declares 2 bytes, expected 6"):
+        read_registers_payload(short, 1, REGISTER_COUNT)

--- a/tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py
+++ b/tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py
@@ -69,7 +69,7 @@ NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE = (
 #: lerobot's robot types is the right answer and must survive. Two grippers and
 #: two arms: every one is a real registry entry with a simulation asset and no
 #: real-mode support of any kind.
-NO_DRIVER_OF_EITHER_KIND = ("robotiq_2f85", "robotiq_2f85_v4", "ur5e", "panda")
+NO_DRIVER_OF_EITHER_KIND = ("shadow_hand", "allegro_hand", "ur5e", "panda")
 
 #: The generic listing's own words, which must be absent from a refusal that has
 #: a better answer and present from one that does not.
@@ -243,7 +243,7 @@ class TestTheHelperReportsRatherThanRaises:
 
     def test_a_robot_with_no_native_driver_gets_no_reason(self) -> None:
         """``None`` is how the caller keeps its own listing."""
-        assert _native_driver_refusal("robotiq_2f85") is None
+        assert _native_driver_refusal("shadow_hand") is None
 
     def test_a_name_no_registry_knows_gets_no_reason(self) -> None:
         assert _native_driver_refusal("no-such-robot-anywhere") is None


### PR DESCRIPTION
## The gap

`robotiq_2f85` had **no driver of either kind**. lerobot registers no robot type for a gripper (it is an end effector, not an arm), and no native driver was registered, so `mode="real"` could not reach it at all.

```mermaid
flowchart LR
  A["Robot('robotiq_2f85', mode='real')"] --> B{driver?}
  B -->|"lerobot"| C["no robot type<br/>for a gripper"]
  B -->|"strands"| D["nothing registered"]
  C --> E["unreachable"]
  D --> E
```

## What lands

`RobotiqDriver` speaks Modbus TCP directly: three registers each way, one socket, **no new dependency** (stdlib `socket` + `struct`). The command path is wired end to end rather than deferred, because that is all the protocol needs.

```python
gripper = Robot("robotiq_2f85", mode="real", port="192.168.1.11")
gripper.connect_eagerly()                     # opens the socket AND activates
gripper.send_action({"gripper": 1.0})         # 0.0 open, 1.0 closed
gripper.send_action({"aperture_mm": 40.0})    # or millimetres
gripper.read_status()                         # aperture, grasp, faults
```

`driver="strands"` is not needed: both registry entries now declare `hardware.driver="strands"`, since lerobot cannot build them.

## The position count runs backwards to the aperture

That inversion is the protocol's one sign trap - `rPR=0` is fully **open** - so it lives in exactly one place and is pinned in both directions. Below, the count the driver put on the Modbus wire, applied to Robotiq's own MuJoCo model (its `fingers_actuator` range is `0..255`, the same domain), rendered headless:

![2F-85 at the counts the driver commanded](https://raw.githubusercontent.com/cagataycali/robots/pr-assets-robotiq-2f85/pr-assets/robotiq_2f85_aperture.png)

| `send_action` | rPR on the wire | driver reports | sim pad-centre separation |
|---|---:|---:|---:|
| `{"gripper": 0.0}` | 0 | 85.0 mm | 98.4 mm |
| `{"aperture_mm": 42.5}` | 128 | 42.3 mm | 58.0 mm |
| `{"gripper": 1.0}` | 255 | 0.0 mm | 15.0 mm |

Full-open to full-closed travel in sim is **83.4 mm** against the datasheet's 85 mm stroke - an independent corroboration of the mapping from the manufacturer's model rather than from this codec.

## Two behaviours the register map alone does not give you

**Activation is part of connecting.** A 2F-85 powers up unactivated and *ignores every position command* until it has run its open-close calibration stroke - it reports no error, it simply does not move. So `connect_eagerly()` runs the sequence and waits for `gSTA`, and a successful connect means a gripper that will actually move.

```mermaid
sequenceDiagram
  participant D as RobotiqDriver
  participant G as 2F-85
  D->>G: read gSTA
  G-->>D: RESET
  D->>G: rACT=0 (reset)
  D->>G: rACT=1 (activate)
  loop until ACTIVE or timeout
    D->>G: read gSTA
  end
  Note over D,G: only now will a position land
```

**A grasp is not the same as a stop.** `gOBJ` distinguishes "stopped at the commanded position" from "stopped because something is between the fingers". Reading only "stopped" reports every empty close as a successful pick, so `read_status()` reports `holding` derived from it.

## Tests

Against a **scripted gripper**, not a mock: it accepts a real TCP connection, parses real MBAP frames with `struct` off the manual's layout (not by calling the codec under test), and enforces the hardware's own preconditions - a position lands only when the gripper is activated *and* the frame set `rGTO`. A driver that built a perfect frame but skipped activation produces identical envelopes and moves nothing; these assertions read what reached the wire, so it fails them.

85 cells: byte-exact golden frames, the `gSTA`/`gOBJ`/`gFLT` bit fields, the aperture inversion both ways, refusals as envelopes (never an exception past the tool boundary), a Modbus exception reply becoming a reason, the factory resolving `mode="real"` without `driver=`, and the intra-category duplicate-key regression.

## LOC delta

`+2143 / -5`, net **+2138** - additions, justified as driver growth:

| | LOC |
|---|---:|
| `drivers/robotiq/` (codec 526, driver 702, exports 68) | +1296 |
| tests (scripted gripper 266, driver 324, codec 209) | +799 |
| docs (`robots/hands.md`, `robot-factory.md`) | +38 |
| seam + registry entries | +10 / -3 |

## Notes

- The register map is shared with the 2F-140 and Hand-E; pass `stroke_mm=`. Only the 2F-85 entries are registered, because those are the ones the registry knows.
- Modbus **TCP** only. RTU's CRC-16 framing is a different transport around the *same* register payloads, so no checksum is computed here and none is implied.
- Not yet exercised against a physical 2F-85 - the codec is graded against the published register map and the whole socket path against the scripted gripper.
- Two control robots in `test_native_driver_named_when_lerobot_has_no_type.py` used `robotiq_2f85` as an example of a robot with *no* driver; they move to `shadow_hand`/`allegro_hand`, which still have none.
- `tests/drivers/test_g1_mainboard_reads_the_declared_fields.py` fails on `main` today (`MainBoardState_` dropped `sys_state`/`tick`) - unrelated to this change and untouched here.

---

## Review Changelog

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R1 | Intra-category duplicate keys (`{"gripper": 0, "gripper.pos": 1}`) silently dropped one command on the actuation path | `a21499d` | `tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py::TestSendActionRefusesIntraCategoryDuplicateKeys` |
