### PR TITLE
test(dds): a non-vacuity floor must not double as a surface inventory

### DIFF
--- a/changelog.d/3057-dds-domain-non-vacuity-floor.md
+++ b/changelog.d/3057-dds-domain-non-vacuity-floor.md
@@ -1,0 +1,11 @@
+### Fixed: a compliant new DDS domain surface no longer fails the shared-domain guard
+
+The structural sweep in `tests/test_dds_domain_id_domain.py` grades every
+surface taking a `domain_id` or `ros2_domain`: it must call
+`dds_domain_id_error` or forward the value to something that does. Its
+non-vacuity companion asserted set equality against a snapshot of the package,
+so a surface that obeyed the rule failed the module by existing, and the only
+remedy the failure suggested was appending a name to a list. It is now a floor
+over `KNOWN_SURFACES`, checked in the one direction that means the scan broke,
+and a new cell pins that a newcomer calling the shared guard reads as guarding
+while a hand-rolled range check is still named by the sweep.

--- a/tests/test_dds_domain_id_domain.py
+++ b/tests/test_dds_domain_id_domain.py
@@ -273,11 +273,27 @@ class TestEverySurfaceRoutesThroughTheSharedDomain:
     A surface that stores a caller-supplied domain id without either calling
     :func:`dds_domain_id_error` or handing the value to a surface that does is
     accepting a domain nothing can be reached on. Checked structurally so a
-    sixth surface cannot ship without joining the rule.
+    sixth surface cannot ship without joining the rule: the population is the
+    scan, so a surface joins the sweep by existing rather than by being listed.
     """
 
     #: Parameter names that carry a DDS domain id.
     DOMAIN_PARAMS = frozenset({"domain_id", "ros2_domain"})
+
+    #: The domain surfaces the sweep is known to reach, as ``file::function``.
+    #: A floor for the scan, not an inventory of what may exist: a scan that
+    #: stopped reaching these would report a clean sweep over nothing.
+    KNOWN_SURFACES = frozenset(
+        {
+            "hardware_robot.py::__init__",
+            "hardware_robot.py::_init_ros_bridge",
+            "hardware_ros_bridge.py::__init__",
+            "hardware_rtps_bridge.py::__init__",
+            "ros_telemetry.py::__init__",
+            "simulation/base.py::_init_ros_bridge",
+            "simulation/mujoco/simulation.py::__init__",
+        }
+    )
 
     @staticmethod
     def _package_root() -> pathlib.Path:
@@ -316,17 +332,17 @@ class TestEverySurfaceRoutesThroughTheSharedDomain:
                 surfaces[f"{path.relative_to(self._package_root())}::{name}"] = verdict
         return surfaces
 
-    def test_the_scan_finds_every_known_domain_surface(self) -> None:
-        """Non-vacuity: a scan rooted elsewhere would report a clean sweep."""
-        assert set(self._surfaces()) == {
-            "hardware_robot.py::__init__",
-            "hardware_robot.py::_init_ros_bridge",
-            "hardware_ros_bridge.py::__init__",
-            "hardware_rtps_bridge.py::__init__",
-            "ros_telemetry.py::__init__",
-            "simulation/base.py::_init_ros_bridge",
-            "simulation/mujoco/simulation.py::__init__",
-        }
+    def test_the_scan_reaches_every_surface_the_sweep_is_known_to_grade(self) -> None:
+        """Non-vacuity: a scan rooted elsewhere would report a clean sweep.
+
+        A floor, checked in the one direction that means the scan broke. The
+        other direction is not a defect: a new domain surface is graded by the
+        sweep below the moment it exists, so failing it for also being absent
+        from a list here would fail correct code and teach its author that
+        appending a name is the remedy, when the remedy is calling the guard.
+        """
+        missing = self.KNOWN_SURFACES - set(self._surfaces())
+        assert not missing, f"the scan no longer reaches {sorted(missing)}, so the sweep passes over nothing"
 
     def test_every_domain_surface_guards_or_forwards_the_value(self) -> None:
         adrift = {name for name, (guards, forwards) in self._surfaces().items() if not (guards or forwards)}
@@ -336,3 +352,28 @@ class TestEverySurfaceRoutesThroughTheSharedDomain:
         """A scanner that matched nothing would pass the sweep vacuously."""
         planted = "def brand_new_bridge(self, *, domain_id: int = 0) -> None:\n    self._domain = domain_id\n"
         assert self._classify(planted) == {"brand_new_bridge": (False, False)}
+
+    def test_the_scanner_recognises_a_new_surface_that_joins_the_rule(self) -> None:
+        """The other answer a new surface can give, so the floor is safe.
+
+        The sweep's population is whatever the scan finds, so growth needs no
+        edit here - but only if a compliant newcomer is actually read as
+        compliant. Both answers are pinned: a surface that calls the shared
+        guard clears the sweep, and one that hand-rolls its own range check is
+        named by it, which is the disagreement the shared domain exists to
+        prevent.
+        """
+        joins = (
+            "def __init__(self, *, domain_id: int = 0) -> None:\n"
+            "    if reason := dds_domain_id_error(domain_id, 'domain_id', 'NewBridge'):\n"
+            "        raise ValueError(reason)\n"
+            "    self._domain = domain_id\n"
+        )
+        hand_rolled = (
+            "def __init__(self, *, domain_id: int = 0) -> None:\n"
+            "    if domain_id < 0:\n"
+            "        raise ValueError('bad domain')\n"
+            "    self._domain = domain_id\n"
+        )
+        assert self._classify(joins) == {"__init__": (True, False)}
+        assert self._classify(hand_rolled) == {"__init__": (False, False)}


### PR DESCRIPTION
## What fails today

`TestEverySurfaceRoutesThroughTheSharedDomain` grades every domain-taking surface structurally: it must call `dds_domain_id_error` or forward the value on to something that does. Its *non-vacuity* cell, though, asserted set **equality** against a seven-name snapshot of the package - so a surface that obeys the rule perfectly fails the module simply by existing.

Measured by planting one native driver that takes `domain_id` and calls the shared guard:

| tree | non-vacuity cell | `test_every_domain_surface_guards_or_forwards_the_value` | result |
| --- | --- | --- | --- |
| `main` | **FAIL** - `Extra items in the left set: 'drivers/_plant_dds.py::__init__'` | pass | `1 failed, 78 passed` |
| this PR | pass | pass | `80 passed` |

The failure blames the newcomer for existing, and its only remedy - append a name to a list - is not the rule the class is about. The cell that *is* about the rule already grades whoever the scan finds, newcomer included. A driver currently in review that takes a `domain_id` (#3045) trips both cells; with this change only the actionable one fires: `2 failed` -> `1 failed`, `these surfaces neither validate nor forward the domain id: ['drivers/booster.py::__init__']`.

## Change

- The non-vacuity cell becomes a floor over a named `KNOWN_SURFACES`, checked in the one direction that means the scan broke, and it says so: `the scan no longer reaches [...], so the sweep passes over nothing`.
- One new cell pins the other answer a newcomer can give, which is what makes widening the floor safe: a surface calling the shared guard reads as guarding, and a hand-rolled range check reads as neither guarding nor forwarding, so the sweep names it.

## Nothing was weakened

Each row is a plant or mutation, run in turn, source restored after each:

| mutation | expected | measured |
| --- | --- | --- |
| plant a surface that hand-rolls `domain_id < 0` | the sweep names it | `1 failed` - `these surfaces neither validate nor forward the domain id: ['drivers/_plant_dds.py::__init__']` |
| root the scan at a subdirectory holding no surfaces | the floor bites, naming what went missing | `1 failed` - `the scan no longer reaches [7 surfaces], so the sweep passes over nothing` |
| plant a surface that calls the shared guard | nothing fails | `80 passed` |

A hand-rolled `domain_id < 0` accepts 300 - a domain whose RTPS discovery ports overflow the 16-bit port space, which every other surface refuses - and that is precisely the disagreement the shared domain exists to prevent. That check still fires. Only the inventory pin stops.

## Gate

`ruff check` and `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` reports the same 24 errors in 9 files as `main`, none in this file; `tests/test_dds_domain_id_domain.py` 80 passed; `scripts/check_whole_tree_graders.py` 181 passed, 1 failed (`test_declared_qp_backends_are_real_qpsolvers_extras`, `qpsolvers` absent from the local environment, reproduces unchanged on `main`).

LOC delta `+53 / -12` in the test file (`+64 / -12` with the changelog fragment). The additions are the floor's reason stated where a future reader will need it, a named constant replacing an inline literal of the same length, and the one positive-control cell the file lacked; the pin that was removed graded nothing the following cell does not grade better.
