### PR TITLE
fix(drivers): open the motion-switcher client under the shared DDS lock

### DIFF
--- a/changelog.d/3064-motion-switcher-open-under-the-shared-dds-lock.md
+++ b/changelog.d/3064-motion-switcher-open-under-the-shared-dds-lock.md
@@ -1,0 +1,22 @@
+### Fixed: both native Unitree drivers open their motion-switcher client under the shared DDS lock
+
+`Init()` on a Unitree RPC client builds its DDS request/response endpoints, and
+the CycloneDDS bindings segfault when an endpoint is constructed concurrently
+with another -- the pair `_DDS_INIT_LOCK` exists to serialise. Neither
+`G1Driver` nor `Go2Driver` held that lock while opening the client, while both
+construct subscribers under it on their own streaming, rollout and
+mesh-telemetry threads, so a single driver instance raced itself. The loss is a
+native segfault, which the drivers' "record the error and stay usable for reads"
+boundary cannot turn into an error envelope: the process dies, possibly while
+the robot stands under its own controller.
+
+Both open paths, injected factory included, now hold the shared lock; the lazy
+SDK import stays outside it, because an import creates no endpoint. Measured on
+the engine with 40 subscribes against 40 opens on one driver, concurrent
+endpoint constructions go from 79 to 0.
+
+The G1 site was additionally invisible to a rule grading endpoint construction
+over the source, because it called through a lower-case local binding
+(`init = getattr(client, "Init", None); init()`); it is now spelled
+`client.Init()`, and the regression pin grades the behaviour rather than the
+spelling.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -52,6 +52,7 @@ from typing import TYPE_CHECKING, Any, cast
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.tools.g1 import HANDSHAKE_FSMS, WALK_FSMS, decode_code
 from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
+from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.tools.g1._motion_switcher import FSMReading, read_fsm_id
 from strands_robots.utils import (
     finite_number_error,
@@ -748,6 +749,25 @@ class G1Driver:
         would open two clients and leak one.  :meth:`_refresh_fsm_id` is the
         only caller and holds the lock across both the open and the read.
 
+        The open itself additionally holds
+        :data:`~strands_robots.tools.g1._g1_common._DDS_INIT_LOCK`, the lock
+        this driver's own :class:`DDSSubscriberSet` holds while constructing
+        every subscriber.  ``Init()`` builds the client's DDS
+        request/response endpoints and the CycloneDDS bindings segfault on a
+        concurrent endpoint construction, so the two sides of that pair - the
+        streaming subscribers and this open, both driven by one driver
+        instance - must not overlap.  ``_motion_switcher_lock`` cannot supply
+        that: a lock the engine does not take excludes nothing.  The
+        acquisition order is ``_motion_switcher_lock`` then the shared lock,
+        and nothing in the package acquires a driver lock while holding the
+        shared one, so the pair carries no cycle.
+
+        The lock covers the injected-factory branch too: the driver cannot
+        know whether a factory builds a real client, and one that does owes
+        the same serialisation.  A factory must construct its client directly
+        rather than reaching back through the engine, which would deadlock on
+        the non-reentrant shared lock.
+
         Returns:
             The open client, or ``None`` if the factory raised or refused.
         """
@@ -755,7 +775,8 @@ class G1Driver:
             return self._motion_switcher_client
         try:
             if self._motion_switcher_client_factory is not None:
-                client = self._motion_switcher_client_factory(self._network_interface)
+                with _DDS_INIT_LOCK:
+                    client = self._motion_switcher_client_factory(self._network_interface)
             else:
                 # Default: lazy-import the SDK and open a client against the
                 # driver's own NIC.  ``ChannelFactoryInitialize`` has already
@@ -770,18 +791,25 @@ class G1Driver:
                 # room for a domain-id kwarg if the SDK adds one.
                 import importlib
 
+                # The import creates no endpoint, so it stays outside the lock:
+                # holding the shared lock across a lazy SDK import would stall
+                # every subscriber construction in the process for its duration.
                 module = importlib.import_module("unitree_sdk2py.comm.motion_switcher.motion_switcher_client")
                 client_cls = module.MotionSwitcherClient
-                client = client_cls()
-                # ``Init`` is the SDK's own bring-up hook; every G1 example
-                # calls it right after construction.  A client that never
-                # ran ``Init`` returns ``(status != 0, {})`` from
-                # ``CheckMode``, which decodes to a named refusal in
-                # :func:`read_fsm_id` -- so a missing ``Init`` is a
-                # diagnosable failure, not a silent one.
-                init = getattr(client, "Init", None)
-                if callable(init):
-                    init()
+                with _DDS_INIT_LOCK:
+                    client = client_cls()
+                    # ``Init`` is the SDK's own bring-up hook; every G1 example
+                    # calls it right after construction.  A client that never
+                    # ran ``Init`` returns ``(status != 0, {})`` from
+                    # ``CheckMode``, which decodes to a named refusal in
+                    # :func:`read_fsm_id` -- so a missing ``Init`` is a
+                    # diagnosable failure, not a silent one.  Spelled as a
+                    # direct ``client.Init()`` rather than through a local
+                    # alias: a rule that grades endpoint construction over the
+                    # source reads the *callee's* name, and calling through a
+                    # lower-case binding hides this site from it.
+                    if callable(getattr(client, "Init", None)):
+                        client.Init()
         except Exception as exc:  # noqa: BLE001 - the SDK's failures are opaque
             self._motion_switcher_open_error = (
                 f"motion-switcher client could not be opened: {type(exc).__name__}: {exc}"

--- a/strands_robots/drivers/go2.py
+++ b/strands_robots/drivers/go2.py
@@ -75,6 +75,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
+from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.utils import (
     finite_number_error,
     positive_count_error,
@@ -798,6 +799,22 @@ class Go2Driver:
         :attr:`_sport_mode_client_error` and surfaced by :meth:`get_status`
         rather than raised: the driver stays usable for reads, and the write gate
         refuses on its own terms.
+
+        The client is opened under
+        :data:`~strands_robots.tools.g1._g1_common._DDS_INIT_LOCK`. ``Init()``
+        builds the client's DDS request/response endpoints, and the CycloneDDS
+        bindings segfault when an endpoint is constructed concurrently with
+        another - which this driver does on its own threads, because
+        :class:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet` creates
+        every subscriber under that same lock. A segfault is not catchable by the
+        "record the error and stay usable for reads" boundary above: the process
+        dies, possibly while the robot stands under its own controller.
+
+        The lock covers the injected-factory branch too. The driver cannot know
+        whether a factory builds a real client, and one that does owes the same
+        serialisation; a factory that instead reaches back through the engine
+        would deadlock, since the shared lock is not reentrant, so a factory must
+        construct its client directly.
         """
         if self._msc is not None:
             return self._msc
@@ -806,12 +823,17 @@ class Go2Driver:
             if factory is None:
                 from strands_robots.tools.g1._motion_switcher import _load_motion_switcher_client
 
+                # The import stays outside the lock: it creates no endpoint, and
+                # holding the shared lock across a lazy SDK import would stall
+                # every subscriber construction in the process for its duration.
                 msc_class = _load_motion_switcher_client()
-                client = msc_class()
-                client.SetTimeout(3.0)
-                client.Init()
+                with _DDS_INIT_LOCK:
+                    client = msc_class()
+                    client.SetTimeout(3.0)
+                    client.Init()
             else:
-                client = factory(self._network_interface)
+                with _DDS_INIT_LOCK:
+                    client = factory(self._network_interface)
         except Exception as exc:  # noqa: BLE001 - any SDK/transport failure is one reason
             self._sport_mode_client_error = f"cannot open MotionSwitcherClient: {exc}"
             logger.debug("%s: %s", self._tool_name, self._sport_mode_client_error, exc_info=True)

--- a/tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock.py
+++ b/tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock.py
@@ -1,0 +1,200 @@
+"""Opening a motion-switcher client holds the shared DDS lock, in every driver.
+
+``_g1_common``'s module docstring states the contract graded here: "A
+``ChannelSubscriber`` and a ``ChannelPublisher`` cannot be constructed
+concurrently: the CycloneDDS bindings segfault. ``_DDS_INIT_LOCK`` is the
+*shared* lock the driver and the tools both hold while creating readers or
+writers. One lock; two consumers."
+
+An RPC client's ``Init()`` is an endpoint construction - it builds the client's
+DDS request/response channels - so it belongs on the same lock. Both native
+Unitree drivers opened one without it while
+:class:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet` constructed
+subscribers under it on the *same driver instance's* streaming, rollout and
+mesh-telemetry threads. A shared-device lock is only a guarantee where every
+caller takes it, and the caller that loses the race is the one holding nothing,
+so the unconverted side is the side that breaks. The loss is a native segfault,
+which no ``except`` boundary can turn into an error envelope: the process dies,
+possibly while the robot stands under its own controller.
+
+These cells grade the *behaviour* - was the shared lock held while the client
+was built - rather than the source. That matters here, because the same
+violation is invisible to a source rule when the call is laundered through a
+lower-case local binding (``init = getattr(client, "Init"); init()``), which is
+exactly how the G1 driver spelled it. A behavioural pin cannot be evaded by
+renaming the callee.
+
+:func:`test_the_open_waits_for_a_competing_endpoint_construction` is the cell
+that makes the pin specific: a driver-private lock would satisfy "some lock was
+held" while excluding nothing the engine does, so the pin insists the open
+actually blocks behind a competing holder of the shared lock.
+
+No test here needs a robot, a DDS bus or ``unitree_sdk2py``: the SDK client is a
+recorder staged on :mod:`sys.modules` (the G1's lazy-import path) or behind the
+loader the Go2 imports.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.g1 import G1Driver
+from strands_robots.drivers.go2 import Go2Driver
+from strands_robots.tools.g1 import _motion_switcher
+from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
+
+#: How long a cell waits for something that should already have happened, and
+#: how long it waits to conclude that something is correctly still blocked.
+_TIMEOUT_S = 5.0
+_BLOCKED_S = 0.2
+
+_SDK_MODULE = "unitree_sdk2py.comm.motion_switcher.motion_switcher_client"
+
+
+class _RecordingClient:
+    """An SDK-shaped client that records whether the shared lock was held.
+
+    Both moments are recorded separately because they are separate endpoint
+    touches: the constructor and ``Init``, which is what actually builds the
+    request/response channels.
+    """
+
+    def __init__(self) -> None:
+        self.held_at_construct = _DDS_INIT_LOCK.locked()
+        self.held_at_init: bool | None = None
+
+    def SetTimeout(self, timeout: float) -> None:  # noqa: N802 - the SDK's spelling
+        """Accept the timeout the Go2 driver sets; the value is not the subject."""
+
+    def Init(self) -> None:  # noqa: N802 - the SDK's spelling
+        """Record the lock state at the moment the endpoints are built."""
+        self.held_at_init = _DDS_INIT_LOCK.locked()
+
+
+def _open_g1_over_the_sdk(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Open a G1 client through the driver's lazy ``importlib`` path."""
+    for name in (
+        "unitree_sdk2py",
+        "unitree_sdk2py.comm",
+        "unitree_sdk2py.comm.motion_switcher",
+        _SDK_MODULE,
+    ):
+        module = types.ModuleType(name)
+        module.__path__ = []  # type: ignore[attr-defined] - a stand-in package
+        monkeypatch.setitem(sys.modules, name, module)
+    monkeypatch.setattr(sys.modules[_SDK_MODULE], "MotionSwitcherClient", _RecordingClient, raising=False)
+    driver = G1Driver()
+    with driver._motion_switcher_lock:
+        return driver._open_motion_switcher_client()
+
+
+def _open_go2_over_the_sdk(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Open a Go2 client through the loader the driver imports."""
+    monkeypatch.setattr(_motion_switcher, "_load_motion_switcher_client", lambda: _RecordingClient)
+    return Go2Driver()._open_motion_switcher_client()
+
+
+def _open_g1_over_a_factory(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Open a G1 client through the injected factory seam."""
+    driver = G1Driver(motion_switcher_client_factory=lambda _nic: _RecordingClient())
+    with driver._motion_switcher_lock:
+        return driver._open_motion_switcher_client()
+
+
+def _open_go2_over_a_factory(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Open a Go2 client through the injected factory seam."""
+    return Go2Driver(motion_switcher_client_factory=lambda _nic: _RecordingClient())._open_motion_switcher_client()
+
+
+#: Every way either driver can open a motion-switcher client. The factory rows
+#: are graded too: the driver cannot know whether an injected factory builds a
+#: real client, and one that does owes the same serialisation.
+_OPENERS = {
+    "g1-over-the-sdk": _open_g1_over_the_sdk,
+    "g1-over-a-factory": _open_g1_over_a_factory,
+    "go2-over-the-sdk": _open_go2_over_the_sdk,
+    "go2-over-a-factory": _open_go2_over_a_factory,
+}
+
+
+class TestTheOpenHoldsTheSharedLock:
+    """Every open path constructs its client under the shared DDS lock."""
+
+    @pytest.mark.parametrize("opener", sorted(_OPENERS))
+    def test_the_client_is_built_under_the_shared_lock(self, opener: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _OPENERS[opener](monkeypatch)
+        assert isinstance(client, _RecordingClient), (
+            f"{opener}: the open returned {client!r} instead of the recorder, so this cell graded nothing"
+        )
+        assert client.held_at_construct, (
+            f"{opener}: the client was constructed without holding the shared "
+            "DDS lock, so it races every subscriber the engine builds on this "
+            "driver's own threads and the loss is a native segfault"
+        )
+
+    def test_the_sdk_init_that_builds_the_endpoints_is_under_the_lock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``Init`` is the endpoint construction, so it is the moment that counts."""
+        for opener in ("g1-over-the-sdk", "go2-over-the-sdk"):
+            client = _OPENERS[opener](monkeypatch)
+            assert client.held_at_init is True, (
+                f"{opener}: Init() ran with the shared lock state "
+                f"{client.held_at_init!r}; Init builds the client's DDS "
+                "request/response endpoints, which is exactly what must not "
+                "overlap another endpoint construction"
+            )
+
+    def test_the_lock_is_released_once_the_client_is_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The lock is a critical section, not something the driver keeps."""
+        _open_go2_over_a_factory(monkeypatch)
+        assert not _DDS_INIT_LOCK.locked(), (
+            "the shared lock is still held after the open returned, which would "
+            "stall every later subscriber construction in the process"
+        )
+
+
+class TestTheLockIsTheSharedOneAndNotAPrivateOne:
+    """A driver-private lock would exclude nothing the engine does."""
+
+    @pytest.mark.parametrize("opener", ["g1-over-a-factory", "go2-over-a-factory"])
+    def test_the_open_waits_for_a_competing_endpoint_construction(
+        self, opener: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        opened = threading.Event()
+        release = threading.Event()
+
+        def hold_the_lock() -> None:
+            with _DDS_INIT_LOCK:
+                release.wait(_TIMEOUT_S)
+
+        holder = threading.Thread(target=hold_the_lock, daemon=True)
+        holder.start()
+        try:
+            # Wait for the competing holder to actually own the lock, so the
+            # assertion below cannot pass just because the race was not run.
+            deadline = threading.Event()
+            while not _DDS_INIT_LOCK.locked():
+                deadline.wait(0.01)
+
+            def open_the_client() -> None:
+                _OPENERS[opener](monkeypatch)
+                opened.set()
+
+            opener_thread = threading.Thread(target=open_the_client, daemon=True)
+            opener_thread.start()
+            assert not opened.wait(_BLOCKED_S), (
+                f"{opener}: the open completed while another thread held the "
+                "shared DDS lock, so it is not serialised against the engine's "
+                "endpoint construction - a private lock excludes nothing"
+            )
+        finally:
+            release.set()
+            holder.join(_TIMEOUT_S)
+        assert opened.wait(_TIMEOUT_S), (
+            f"{opener}: the open never completed after the shared lock was "
+            "released, so it is blocked on something other than that lock"
+        )

--- a/tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock.py
+++ b/tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock.py
@@ -85,7 +85,9 @@ def _open_g1_over_the_sdk(monkeypatch: pytest.MonkeyPatch) -> Any:
         _SDK_MODULE,
     ):
         module = types.ModuleType(name)
-        module.__path__ = []  # type: ignore[attr-defined] - a stand-in package
+        # A stand-in package: ``importlib.import_module`` walks the parents of a
+        # dotted name, and a parent without ``__path__`` is not importable.
+        module.__path__ = []  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, name, module)
     monkeypatch.setattr(sys.modules[_SDK_MODULE], "MotionSwitcherClient", _RecordingClient, raising=False)
     driver = G1Driver()


### PR DESCRIPTION
## What breaks

![endpoint-construction overlap, measured before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/dds-lock-overlap/dds_lock_overlap.png)

`Init()` on a Unitree RPC client builds its DDS request/response endpoints. The
CycloneDDS bindings segfault when an endpoint is constructed concurrently with
another, which is what `_DDS_INIT_LOCK` exists to prevent -- "One lock; two
consumers", per `_g1_common`'s module docstring. Neither native driver held it
while opening its motion-switcher client.

The race is inside **one object**, which is what makes it reachable: the same
driver instance builds subscribers *under* the lock on its streaming, rollout
and mesh-telemetry threads, and opens the client holding **nothing** from the
write path. A shared lock is only a guarantee where every caller takes it, and
the caller that loses is the one holding nothing. The loss is a native
segfault, so the drivers' "record the error and stay usable for reads" boundary
cannot catch it: the process dies, possibly while the robot stands under its own
controller.

Measured on the real engine, 40 `DDSSubscriberSet.subscribe` calls against 40
client opens on one driver:

| | concurrent endpoint constructions | wall time |
|---|---|---|
| before | **79** | 82.7 ms |
| after | **0** | 165.7 ms |

The serialisation is the point, and it is not free: bring-up costs the sum
rather than the max. That is the trade the lock already makes for every
subscriber.

## Two sites, and one of them no rule could see

| driver | how it was spelled | visible to a rule over the source? |
|---|---|---|
| `drivers/go2.py` | `client.Init()` | yes |
| `drivers/g1.py` | `init = getattr(client, "Init", None); init()` | **no** -- the callee is a lower-case local |

A rule that grades endpoint construction reads the *callee's* name, so the G1
site was invisible to it while being the same defect. Measured on this tree
before the change, all six open paths ran unlocked:

```
g1/factory  g1/sdk-construct  g1/sdk-Init  go2/factory  go2/sdk-construct  go2/sdk-Init
False       False             False        False        False              False
```

The G1 call is now spelled `client.Init()` so a source rule can grade it, and
the regression pin grades the **behaviour** -- was the shared lock held while
the client was built -- which no renaming can evade.

## Decisions this required

**The factory branch is locked too.** The driver cannot know whether an injected
factory builds a real client, and one that does owes the same serialisation. The
corollary is documented on both methods: a factory must construct its client
directly rather than reaching back through the engine, which would deadlock on a
non-reentrant lock.

**The lazy SDK import stays outside the lock.** An import creates no endpoint,
and holding the shared lock across it would stall every subscriber construction
in the process for the import's duration.

**No cycle.** The order is `_motion_switcher_lock` then the shared lock. Nothing
in the package acquires a driver lock while holding the shared one -- the engine
takes only its own bookkeeping lock there, and releases it before the block.

## Tests

`tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock.py`, 8
cells over both drivers x both branches:

- the client is built under the shared lock (4 rows: g1/go2 x sdk/factory)
- `Init` -- the call that builds the endpoints -- is under it
- the lock is released once the client is open
- **the open blocks behind a competing holder of the shared lock** (2 rows).
  This is what makes the pin specific: a driver-private lock would satisfy "some
  lock was held" while excluding nothing the engine does.

Pre-fix, with the same test file against unchanged sources: **7 failed, 1
passed**. The one pass is the "lock released afterwards" control, which holds on
both trees -- so the pin discriminates rather than merely failing.

## Gate

`ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`
clean, the last one verified against the pinned `mypy>=1.0.0,<2.0.0` rather than
a newer local one: 1.20.2 rejects a `type: ignore[code]` comment that carries
trailing prose after the bracket, and a 2.x run does not. `tests/drivers`
+ `tests/tools/g1`: 2566 passed, 1 pre-existing failure
(`test_g1_mainboard_reads_the_declared_fields`, an SDK field drift that
reproduces unchanged on `main`). Full `tests/` failure-set diffed against the
same selection on `main`: **identical, 0 regressions**.

LOC: +289 / -15 across 4 files -- `g1.py` +39/-11 and `go2.py` +26/-4 (most of it the docstrings recording the contract), +200 for the pin, +22 the changelog fragment.

Fixes #3062
