### PR TITLE
docs(tools/g1): drop the docstring roles that cite the removed lookup modules

### DIFF
--- a/strands_robots/tools/g1/g1_move_velocity.py
+++ b/strands_robots/tools/g1/g1_move_velocity.py
@@ -11,9 +11,9 @@ that walks the robot at the argument triple for the argument
 duration (seconds); the neon bundle's ``g1_move_velocity`` verb
 (``cagataycali/neon-the-g1/tools/g1_locomotion.py``) fronted the
 call under a single-writer lock, clamped the arguments to the
-observed envelope :mod:`~strands_robots.tools.g1.g1_velocity_envelope`
-already surfaces to an agent, and returned an rc envelope.  This
-module is the write-side companion of that read-only envelope (refs
+envelope it observed against the real robot on a gantry, and
+returned an rc envelope.  This module is the write-side companion
+of that envelope (refs
 strands-labs/robots#358, strands-labs/robots#2965 for the envelope,
 strands-labs/robots#2972 for the duration envelope,
 strands-labs/robots#3035 for the sibling ``g1_stop_move``), and it
@@ -72,12 +72,10 @@ verb clamped its arguments before dispatch; that decision belongs
 on the driver's own write path so a caller who reaches
 ``SetVelocity`` through a different entry point (a future
 ``use_unitree`` dispatcher, refs strands-labs/robots#3037) is held
-to the same envelope.  The read-only lookup
-:mod:`~strands_robots.tools.g1.g1_velocity_envelope` (refs
-strands-labs/robots#2965) surfaces the numbers to an agent so the
-refusal is decidable before the write is attempted, and
-:mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`
-(refs strands-labs/robots#2972) surfaces the duration bound.  The
+to the same envelope.  The magnitude numbers
+(refs strands-labs/robots#2965) and the duration bound (refs
+strands-labs/robots#2972) belong with that write path rather than
+with a lookup verb of their own.  The
 data-parameter refusals below cover the shapes the SDK's own
 handler would raise on
 (``None``, non-numeric, ``nan``, ``inf``, ``bool`` subclass which
@@ -116,10 +114,8 @@ What this module does not do.
   walking robot has exactly one legal velocity commander at a
   time (the SDK returns ``rc=7400`` on parallel writes).
 * Clamp the argument quadruple against the neon-observed envelope.
-  :mod:`~strands_robots.tools.g1.g1_velocity_envelope` and
-  :mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`
-  are the read-only sources of truth a caller consults before
-  the write; restating the clamps here would fork them.
+  The driver's own write path is the source of truth for those
+  numbers; restating the clamps here would fork them.
 * Handle the ``continuous`` variant of the neon verb.  The neon
   bundle exposed a ``continuous=True`` branch that reached the
   SDK's ``LocoClient.Move(..., continous_move=True)`` overload
@@ -191,9 +187,7 @@ def g1_move_velocity(
     subsequent :func:`g1_stop_move` halts it earlier.  A caller
     who commanded a walk longer than they intend to observe halts
     with the sibling stop verb; the two together are the loco
-    write side of the read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_velocity_envelope` already
-    surfaces.
+    write side of the neon-observed velocity envelope.
 
     Args:
         driver: An object with a callable
@@ -215,28 +209,24 @@ def g1_move_velocity(
             SDK-facing gate work in strands-labs/robots#358), the
             same call returns the driver's envelope verbatim.
         vx: Forward velocity component in m/s.  A signed finite
-            float; the read-only envelope
-            :mod:`~strands_robots.tools.g1.g1_velocity_envelope`
-            (refs strands-labs/robots#2965) surfaces the walkable
-            magnitude bound the driver's own write path will
-            clamp against.  The shared
+            float; the walkable magnitude bound the neon bundle
+            observed (refs strands-labs/robots#2965) is the
+            driver's own write path to clamp against.  The shared
             :func:`~strands_robots.utils.finite_number_error`
             validator refuses ``None``, non-numeric shapes,
             ``nan``, ``inf`` and the ``bool`` subclass which
             would coerce to ``0.0``/``1.0`` silently.
         vy: Lateral velocity component in m/s (positive = strafe
             left).  Same domain as ``vx`` - a signed finite float
-            the read-only envelope names the magnitude bound for.
+            the neon-observed envelope bounds the magnitude of.
         vyaw: Rotation rate in rad/s (positive = counter-clockwise
             about the up-axis).  Same signed-finite-float domain;
-            :mod:`~strands_robots.tools.g1.g1_velocity_envelope`
-            surfaces the walkable magnitude bound for the yaw
-            axis separately from the linear axes.
+            the neon-observed envelope bounds the yaw axis
+            separately from the linear axes.
         duration: Seconds to hold the velocity triple.  A positive
-            finite float; the read-only envelope
-            :mod:`~strands_robots.tools.g1.g1_locomotion_duration_envelope`
-            (refs strands-labs/robots#2972) surfaces the upper
-            bound the driver's own write path will clamp against.
+            finite float; the upper bound the neon bundle observed
+            (refs strands-labs/robots#2972) is the driver's own
+            write path to clamp against.
             The shared
             :func:`~strands_robots.utils.positive_finite_number_error`
             validator refuses ``None``, non-numeric shapes,

--- a/strands_robots/tools/g1/g1_safe_lie_to_stand.py
+++ b/strands_robots/tools/g1/g1_safe_lie_to_stand.py
@@ -11,16 +11,14 @@ over the same DDS singleton
 Damp preamble is the SDK's controller-to-controller handoff smoother
 - firing it against an unheld robot leaves it slumping toward the
 floor, so the driver's own path is where the FSM-set precondition
-gate (``{1, 702}`` - the read-only envelope
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` names
-that set, refs strands-labs/robots#358) is enforced.  The neon
+gate (``{1, 702}`` - the set the neon bundle's
+field notes name, refs strands-labs/robots#358) is enforced.  The neon
 bundle's ``g1_safe_lie_to_stand`` verb
 (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``) wrapped the
 call with an ``_assert_safe_for_damp`` FSM+pose guard that refused
 outside ``{1, 702}`` or when the average knee angle exceeded
-``1.4`` rad; the read-only half of that envelope already landed as
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` and
-:mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`, and
+``1.4`` rad; that FSM set and the transition
+preamble range are the driver's own path to enforce, and
 this module is the write-side companion that hands the target to
 the driver.
 
@@ -63,9 +61,8 @@ first-class access to the LowState cache.  A second gate call
 here would double the FSM read against the driver's cache, would
 refuse a preamble the driver's own path admits, and would fork
 the FSM-set precondition table into a second source of truth this
-module would then have to keep in sync with the envelope lookup
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` already
-carries.  Restating any of that on this side would fork the rule
+module would then have to keep in sync with the driver's own gate.
+Restating any of that on this side would fork the rule
 the driver's own path already enforces (refs
 strands-labs/robots#358, strands-labs/robots#2916).  ``import
 strands_robots.tools.g1.g1_safe_lie_to_stand`` still pulls no
@@ -90,10 +87,9 @@ the tests hand it a hand-rolled double.
 What this module does not do.
 
 * Refuse a ``preamble_s`` outside the neon-bundle-observed usable
-  range.  The neon bundle defaulted to ``0.5`` seconds and the
-  read-only envelope
-  :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-  names the observed range; refusing an unlisted duration here
+  range.  The neon bundle defaulted to ``0.5`` seconds and its
+  field notes name the observed range; refusing an unlisted
+  duration here
   would fork the neon bundle's admission set into a second source
   of truth this module would then have to keep in sync with the
   envelope lookup.  The driver's own path (once landed) is where a
@@ -172,9 +168,7 @@ def g1_safe_lie_to_stand(
     documented (refs the merged
     strands-labs/robots#2916), and the driver's own path (once
     landed) is where the FSM-set precondition gate ``{1, 702}``
-    (the read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates`
-    names that set) and the ``avg_knee <= 1.4`` rad pose gate
+    (the set the neon bundle's field notes name) and the ``avg_knee <= 1.4`` rad pose gate
     fire.  This verb's only job is the pass-through of one call
     and the envelope-shaped refusal on two shapes the driver's
     own path cannot format: a wrong-shape handle, and a
@@ -200,9 +194,8 @@ def g1_safe_lie_to_stand(
             before ``Lie2StandUp`` fires, in seconds.  The neon
             bundle defaulted to ``0.5`` seconds
             (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``)
-            and the read-only envelope
-            :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-            names the field-notes range against the real robot.
+            and its field notes name the observed range against
+            the real robot.
             Validated against
             :func:`~strands_robots.utils.positive_finite_number_error`
             because the caller-facing domain is a positive real

--- a/strands_robots/tools/g1/g1_safe_squat_to_stand.py
+++ b/strands_robots/tools/g1/g1_safe_squat_to_stand.py
@@ -11,16 +11,14 @@ over the same DDS singleton
 Damp preamble is the SDK's controller-to-controller handoff smoother
 - firing it against an unheld robot leaves it slumping toward the
 floor, so the driver's own path is where the FSM-set precondition
-gate (``{3, 4, 706}`` - the read-only envelope
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` names
-that set, refs strands-labs/robots#358) is enforced.  The neon
+gate (``{3, 4, 706}`` - the set the neon bundle's
+field notes name, refs strands-labs/robots#358) is enforced.  The neon
 bundle's ``g1_safe_squat_to_stand`` verb
 (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``) wrapped the
 call with an ``_assert_safe_for_damp`` FSM+pose guard that refused
 outside ``{3, 4, 706}`` or when the average knee angle exceeded
-``1.4`` rad; the read-only half of that envelope already landed as
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` and
-:mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`, and
+``1.4`` rad; that FSM set and the transition
+preamble range are the driver's own path to enforce, and
 this module is the write-side companion that hands the target to
 the driver.
 
@@ -63,9 +61,8 @@ first-class access to the LowState cache.  A second gate call
 here would double the FSM read against the driver's cache, would
 refuse a preamble the driver's own path admits, and would fork
 the FSM-set precondition table into a second source of truth this
-module would then have to keep in sync with the envelope lookup
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` already
-carries.  Restating any of that on this side would fork the rule
+module would then have to keep in sync with the driver's own gate.
+Restating any of that on this side would fork the rule
 the driver's own path already enforces (refs
 strands-labs/robots#358, strands-labs/robots#2916).  ``import
 strands_robots.tools.g1.g1_safe_squat_to_stand`` still pulls no
@@ -90,10 +87,9 @@ the tests hand it a hand-rolled double.
 What this module does not do.
 
 * Refuse a ``preamble_s`` outside the neon-bundle-observed usable
-  range.  The neon bundle defaulted to ``0.5`` seconds and the
-  read-only envelope
-  :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-  names the observed range; refusing an unlisted duration here
+  range.  The neon bundle defaulted to ``0.5`` seconds and its
+  field notes name the observed range; refusing an unlisted
+  duration here
   would fork the neon bundle's admission set into a second source
   of truth this module would then have to keep in sync with the
   envelope lookup.  The driver's own path (once landed) is where a
@@ -172,9 +168,7 @@ def g1_safe_squat_to_stand(
     documented (refs the merged
     strands-labs/robots#2916), and the driver's own path (once
     landed) is where the FSM-set precondition gate ``{3, 4, 706}``
-    (the read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates`
-    names that set) and the ``avg_knee <= 1.4`` rad pose gate
+    (the set the neon bundle's field notes name) and the ``avg_knee <= 1.4`` rad pose gate
     fire.  This verb's only job is the pass-through of one call
     and the envelope-shaped refusal on two shapes the driver's
     own path cannot format: a wrong-shape handle, and a
@@ -200,9 +194,8 @@ def g1_safe_squat_to_stand(
             before ``Squat2StandUp`` fires, in seconds.  The neon
             bundle defaulted to ``0.5`` seconds
             (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``)
-            and the read-only envelope
-            :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-            names the field-notes range against the real robot.
+            and its field notes name the observed range against
+            the real robot.
             Validated against
             :func:`~strands_robots.utils.positive_finite_number_error`
             because the caller-facing domain is a positive real

--- a/strands_robots/tools/g1/g1_safe_stand_to_squat.py
+++ b/strands_robots/tools/g1/g1_safe_stand_to_squat.py
@@ -11,15 +11,13 @@ over the same DDS singleton
 Damp preamble is the SDK's controller-to-controller handoff smoother
 - firing it against an unheld robot leaves it slumping toward the
 floor, so the driver's own path is where the FSM-set precondition
-gate (``{500, 501, 801}`` - the read-only envelope
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` names
-that set, refs strands-labs/robots#358) is enforced.  The neon
+gate (``{500, 501, 801}`` - the set the neon bundle's
+field notes name, refs strands-labs/robots#358) is enforced.  The neon
 bundle's ``g1_safe_stand_to_squat`` verb
 (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``) wrapped the
 call with an ``_assert_safe_for_damp`` FSM+pose guard that refused
-outside ``{500, 501, 801}`` ; the read-only half of that envelope already landed as
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` and
-:mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`, and
+outside ``{500, 501, 801}`` ; that FSM set and the transition
+preamble range are the driver's own path to enforce, and
 this module is the write-side companion that hands the target to
 the driver.
 
@@ -62,9 +60,8 @@ first-class access to the LowState cache.  A second gate call
 here would double the FSM read against the driver's cache, would
 refuse a preamble the driver's own path admits, and would fork
 the FSM-set precondition table into a second source of truth this
-module would then have to keep in sync with the envelope lookup
-:mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates` already
-carries.  Restating any of that on this side would fork the rule
+module would then have to keep in sync with the driver's own gate.
+Restating any of that on this side would fork the rule
 the driver's own path already enforces (refs
 strands-labs/robots#358, strands-labs/robots#2916).  ``import
 strands_robots.tools.g1.g1_safe_stand_to_squat`` still pulls no
@@ -89,10 +86,9 @@ the tests hand it a hand-rolled double.
 What this module does not do.
 
 * Refuse a ``preamble_s`` outside the neon-bundle-observed usable
-  range.  The neon bundle defaulted to ``0.5`` seconds and the
-  read-only envelope
-  :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-  names the observed range; refusing an unlisted duration here
+  range.  The neon bundle defaulted to ``0.5`` seconds and its
+  field notes name the observed range; refusing an unlisted
+  duration here
   would fork the neon bundle's admission set into a second source
   of truth this module would then have to keep in sync with the
   envelope lookup.  The driver's own path (once landed) is where a
@@ -171,9 +167,7 @@ def g1_safe_stand_to_squat(
     documented (refs the merged
     strands-labs/robots#2916), and the driver's own path (once
     landed) is where the FSM-set precondition gate ``{500, 501, 801}``
-    (the read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_safe_posture_fsm_gates`
-    names that set) and the upright FSM precondition
+    (the set the neon bundle's field notes name) and the upright FSM precondition
     fire.  This verb's only job is the pass-through of one call
     and the envelope-shaped refusal on two shapes the driver's
     own path cannot format: a wrong-shape handle, and a
@@ -199,9 +193,8 @@ def g1_safe_stand_to_squat(
             before ``SetFsmId(2)`` fires, in seconds.  The neon
             bundle defaulted to ``0.5`` seconds
             (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``)
-            and the read-only envelope
-            :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-            names the field-notes range against the real robot.
+            and its field notes name the observed range against
+            the real robot.
             Validated against
             :func:`~strands_robots.utils.positive_finite_number_error`
             because the caller-facing domain is a positive real

--- a/strands_robots/tools/g1/g1_set_fsm.py
+++ b/strands_robots/tools/g1/g1_set_fsm.py
@@ -9,10 +9,9 @@ call over the same DDS singleton :func:`ensure_dds` opens, waits for
 the transition to settle, and reads the driver's own live ``fsm_id``
 back to surface the fsm-before / fsm-after round-trip the neon bundle's
 ``g1_set_fsm`` verb documented (a transition the SDK refused silently
-still shows the fsm-after equal to fsm-before). The driver's
-:mod:`~strands_robots.tools.g1.g1_fsm_targets` lookup is the read-only
-half of this conversation: it lists the id set the SDK admits without
-opening a write path; this verb is the write half.
+still shows the fsm-after equal to fsm-before). The id set the SDK
+admits is named in this module's ``fsm_id`` docstring; this verb is the
+write half of that conversation.
 
 The driver's method itself is not yet plumbed on
 :class:`~strands_robots.drivers.g1.G1Driver` today (refs
@@ -69,12 +68,12 @@ double.
 
 What this module does not do.
 
-* Decide which FSM ids the SDK admits. The
-  :mod:`~strands_robots.tools.g1.g1_fsm_targets` lookup is the id-set
-  snapshot; a caller who wants to know whether the target is reachable
-  reads that verb first, and this verb writes the transition once the
-  target is known. A second admission table here would fork the source
-  of truth the lookup already owns and drift as the SDK's admissions
+* Decide which FSM ids the SDK admits. The driver's own ``set_fsm``
+  owns the admission set; a caller who wants to know whether the target
+  is reachable reads the snapshot in the ``fsm_id`` docstring below, and
+  this verb writes the transition once the target is known. A second
+  admission table here would fork that source
+  of truth and drift as the SDK's admissions
   change.
 * Decode ``rc=7302`` "Invalid FSM id" into a label. The
   :data:`~strands_robots.tools.g1._g1_common.ERR_CODES` table (surfaced
@@ -84,11 +83,9 @@ What this module does not do.
 * Warn about safety. The neon bundle's ``g1_set_fsm`` verb emitted a
   free-form "ZeroTorque collapses off-gantry" sentence into the
   message; the driver's own gate / dangerous-target set is where a
-  refusal for that shape belongs (refs
-  :mod:`~strands_robots.tools.g1.g1_fsm_targets`'s ``dangerous_ids``
-  envelope field). A caller running this verb from an agent that
-  already consulted the target lookup has been warned; a caller who
-  jumped past the lookup gets the driver's own admission wording
+  refusal for that shape belongs. A caller running this verb from an
+  agent that already read the id snapshot has been warned; a caller who
+  jumped past it gets the driver's own admission wording
   rather than a duplicate here.
 * Restate the driver's refusal wording. Whatever text the driver's
   method writes (a rc-decoded sentence, a gate refusal, a
@@ -142,19 +139,17 @@ def g1_set_fsm(
     can see whether the SDK admitted the write (the SDK's
     ``SetFsmId`` handler returns ``rc=7302`` for ids outside its
     admission set and can also silently discard an id it admits but
-    the physical state does not; the round-trip surfaces both, refs
-    :mod:`~strands_robots.tools.g1.g1_fsm_targets` for the id-set
-    lookup and :mod:`~strands_robots.tools.g1.g1_error_codes` for the
-    rc catalogue).
+    the physical state does not; the round-trip surfaces both, and
+    :mod:`~strands_robots.tools.g1.g1_error_codes` is the rc
+    catalogue).
 
     The transition is a loco-side write, not an arm-SDK write; the
     driver's :meth:`~strands_robots.drivers.g1.G1Driver._check_motion_gates`
     gate is the arm-write gate (``send_action`` / ``run_policy`` /
     ``start_task``) and does not admit or refuse this verb (refs
     strands-labs/robots#2916). A caller who wants to know whether the
-    target is reachable at all reads
-    :mod:`~strands_robots.tools.g1.g1_fsm_targets` first; this verb is
-    the write once the target is known.
+    target is reachable at all reads the id snapshot in the ``fsm_id``
+    entry below; this verb is the write once the target is known.
 
     Args:
         driver: An object with a callable ``set_fsm(fsm_id, wait=...)``
@@ -173,18 +168,17 @@ def g1_set_fsm(
             lands (the SDK-facing gate work in
             strands-labs/robots#358), the same call returns the
             driver's envelope verbatim.
-        fsm_id: An FSM id the SDK's ``SetFsmId`` handler admits (see
-            :mod:`~strands_robots.tools.g1.g1_fsm_targets` for the
-            snapshot: ``1`` Damp, ``500`` Start, ``501`` Walk, ``801``
+        fsm_id: An FSM id the SDK's ``SetFsmId`` handler admits (the
+            snapshot the neon bundle recorded: ``1`` Damp, ``500``
+            Start, ``501`` Walk, ``801``
             BalanceExpert, ``3`` Sit, ``0`` ZeroTorque, ``2``
             Squat2Stand, ``4`` Locomotion, ``706`` BalanceLie, ``802``
             DampToBalance). The driver's own ``set_fsm`` refuses ids
             outside that set at wire time with the SDK's own ``rc=7302``
             envelope; this verb refuses a ``None`` or non-int shape
             here rather than on the driver so the refusal names
-            ``fsm_id`` and the remedy. A caller who wants to know the
-            id set before issuing the write reads
-            :mod:`~strands_robots.tools.g1.g1_fsm_targets`.
+            ``fsm_id`` and the remedy. The id set a caller wants
+            before issuing the write is the snapshot above.
         wait: Seconds to wait after ``SetFsmId`` returns before reading
             ``fsm_after``. Defaults to ``3.0`` seconds - the neon
             bundle's own default, chosen to let the slowest documented

--- a/strands_robots/tools/g1/g1_shake_hand_loco.py
+++ b/strands_robots/tools/g1/g1_shake_hand_loco.py
@@ -14,11 +14,9 @@ hand, and ``-1`` asks the SDK to toggle the internal stage counter
 ``g1_shake_hand_loco`` verb
 (``cagataycali/neon-the-g1/tools/g1_locomotion.py``) wrapped the call
 under a single-writer lock and coerced the argument through
-:class:`int` before dispatch; the read-only half of that envelope
-already landed as
-:mod:`~strands_robots.tools.g1.g1_shake_hand_stage_envelope` (refs
-strands-labs/robots#358), and this module is the write-side companion
-that hands the target to the driver.
+:class:`int` before dispatch (refs strands-labs/robots#358), and this
+module is the write-side companion that hands the target to the
+driver.
 
 The driver's method itself is not yet plumbed on
 :class:`~strands_robots.drivers.g1.G1Driver` today (refs
@@ -85,11 +83,9 @@ double.
 What this module does not do.
 
 * Refuse a ``stage`` outside the SDK-observed admitted set
-  ``{-1, 0, 1}``. The read-only envelope
-  :mod:`~strands_robots.tools.g1.g1_shake_hand_stage_envelope` names
-  those three as the stages the SDK's dispatcher decodes against
-  its fixed internal table; refusing an unlisted stage here would
-  fork the envelope module's admission set into a second source
+  ``{-1, 0, 1}``. Those three are the stages the SDK's dispatcher
+  decodes against its fixed internal table; refusing an unlisted
+  stage here would fork that admission set into a second source
   of truth this module would then have to keep in sync with the
   envelope lookup.  The SDK's own handler returns ``rc=7303``
   ("Invalid task id (loco)") on a stage outside its programmed
@@ -172,12 +168,10 @@ def g1_shake_hand_loco(
     reach-out stage, a caller who passes ``1`` reaches the shake
     stage, and a caller who passes ``-1`` asks the SDK to toggle
     its internal stage counter (the SDK's own default reads through
-    the sentinel).  The read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_shake_hand_stage_envelope`
-    names all three variants and the SDK's ``rc=7303`` refusal on
-    any integer outside the set; a caller planning the write
-    reaches that lookup first and reaches this verb once the target
-    ``stage`` is decided.
+    the sentinel).  The ``stage`` entry below names all three
+    variants and the SDK's ``rc=7303`` refusal on any integer
+    outside the set; a caller planning the write reads it first and
+    reaches this verb once the target ``stage`` is decided.
 
     ``ShakeHand`` dispatches through ``SetTaskId`` rather than the
     arm-SDK path ``send_action`` / ``run_policy`` walk, so it does
@@ -222,9 +216,8 @@ def g1_shake_hand_loco(
             same call returns the driver's envelope verbatim.
         stage: The integer stage argument
             ``LocoClient.ShakeHand`` admits.  The SDK's internal
-            table decodes three values and the read-only envelope
-            :mod:`~strands_robots.tools.g1.g1_shake_hand_stage_envelope`
-            names them: ``0`` (reach out - extend the arm forward),
+            table decodes three values: ``0`` (reach out - extend
+            the arm forward),
             ``1`` (shake - move the extended hand), and ``-1``
             (toggle the SDK's internal stage counter, the sentinel
             the SDK's default reads through).  This verb does not
@@ -243,10 +236,8 @@ def g1_shake_hand_loco(
             bundle's own ``int(...)`` coercion silently
             transformed rather than declined.  Those are shape
             refusals, not domain refusals; the in-set admission
-            belongs on the driver's write path and the read-only
-            envelope module the same way ``g1_balance_stand``'s
-            ``{0, 3}`` admission belongs on
-            :mod:`~strands_robots.tools.g1.g1_balance_modes`.
+            belongs on the driver's write path the same way
+            ``g1_balance_stand``'s ``{0, 3}`` admission does.
 
     Returns:
         The envelope ``G1Driver.shake_hand_loco`` returned.  On the
@@ -299,8 +290,7 @@ def g1_shake_hand_loco(
 
     # ``stage`` is a data parameter the tool schema *does* describe
     # (an integer stage id, with the SDK-observed admitted set
-    # ``{-1, 0, 1}`` surfaced by
-    # :mod:`~strands_robots.tools.g1.g1_shake_hand_stage_envelope`),
+    # ``{-1, 0, 1}`` documented above),
     # so a model can synthesize the wrong shape here as easily as
     # it can reach the verb with the right one.  The refusals
     # below cover the shapes the driver's own ``shake_hand_loco``

--- a/strands_robots/tools/g1/g1_stop_move.py
+++ b/strands_robots/tools/g1/g1_stop_move.py
@@ -10,9 +10,9 @@ that zeroes the last-commanded ``(vx, vy, vyaw)`` velocity triple
 without changing the FSM the robot is in; the neon bundle's
 ``g1_stop_move`` verb (``cagataycali/neon-the-g1/tools/g1_locomotion.py``)
 fronted the call under a single-writer lock and returned an rc
-envelope. This module is the write-side companion of the read-only
-velocity envelope :mod:`~strands_robots.tools.g1.g1_velocity_envelope`
-that already landed (refs strands-labs/robots#358, #2965); every
+envelope. This module is the write-side companion of the velocity
+envelope the neon bundle observed on a gantry, which the driver's own
+write path owns (refs strands-labs/robots#358, #2965); every
 other locomotion verb the neon bundle exposes
 (``g1_move_velocity``, ``g1_walk_forward``, ``g1_turn``) hands the
 same ``LocoClient`` its argument triple, and this verb hands it the

--- a/strands_robots/tools/g1/g1_wave_hand_loco.py
+++ b/strands_robots/tools/g1/g1_wave_hand_loco.py
@@ -12,11 +12,9 @@ wave-and-turn-around task (the two variants the neon bundle observed
 in-hand).  The neon bundle's ``g1_wave_hand_loco`` verb
 (``cagataycali/neon-the-g1/tools/g1_locomotion.py``) wrapped the call
 under a single-writer lock and coerced the argument through
-:class:`bool` before dispatch; the read-only half of that envelope
-already landed as
-:mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope` (refs
-strands-labs/robots#358), and this module is the write-side
-companion that hands the target to the driver.
+:class:`bool` before dispatch (refs strands-labs/robots#358), and
+this module is the write-side companion that hands the target to the
+driver.
 
 The driver's method itself is not yet plumbed on
 :class:`~strands_robots.drivers.g1.G1Driver` today (refs
@@ -84,12 +82,11 @@ What this module does not do.
   saw the value, silently transforming ``1`` / ``"yes"`` / ``None``
   into an admitted task id; this verb refuses those shapes
   explicitly because the two admitted values (``False``,
-  ``True``) are the two data points the read-only envelope
-  :mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope`
-  names, and a caller passing ``1`` here is not naming a
-  turn-flag variant on purpose.  The in-set admission the
-  envelope module surfaces is the source of truth; the shape
-  refusal here mirrors the envelope's own ``turn_flag must be
+  ``True``) are the only two variants the neon bundle observed,
+  and a caller passing ``1`` here is not naming a
+  turn-flag variant on purpose.  The driver's own write path owns
+  the in-set admission; the shape
+  refusal here mirrors the neon verb's own ``turn_flag must be
   bool`` refusal so the two paths render the same shape a caller
   can grep for.
 * Encode the ``LocoClient.WaveHand`` dispatch.  The SDK's public
@@ -108,11 +105,9 @@ What this module does not do.
   registry-not-wired one) passes through this verb; a verbatim
   quote here would trap the verb to one release's prose (refs
   strands-labs/robots#2874).
-* Compose the ``SetTaskId`` payload id.  The read-only envelope
-  :mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope`
-  surfaces the ``composed_task_id`` a caller planning the write
-  wants on hand; the driver's own path is where the composition
-  lives, so a caller reaching this verb passes only the boolean.
+* Compose the ``SetTaskId`` payload id.  The driver's own path is
+  where the composition lives, so a caller reaching this verb
+  passes only the boolean.
 * Chain a companion FSM transition.  The neon bundle's docstring
   named ``WaveHand`` as an FSM-agnostic dispatch (``SetTaskId``
   admits from every FSM) but observed the behaviour varies with
@@ -156,10 +151,8 @@ def g1_wave_hand_loco(
     ``SetTaskId`` payload); a caller who passes ``False`` reaches
     the wave-in-place task the neon bundle observed and a caller
     who passes ``True`` reaches the wave-and-turn-around task.
-    The read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope`
-    names both variants and their composed task ids; a caller
-    planning the write reaches that lookup first and reaches this
+    The ``turn_flag`` entry below names both variants; a caller
+    planning the write reads it first and reaches this
     verb once the target ``turn_flag`` is decided.
 
     ``WaveHand`` dispatches through ``SetTaskId`` rather than the
@@ -195,9 +188,7 @@ def g1_wave_hand_loco(
             same call returns the driver's envelope verbatim.
         turn_flag: The boolean turn-flag argument
             ``LocoClient.WaveHand`` admits.  The neon bundle
-            observed two variants and the read-only envelope
-            :mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope`
-            names them: ``False`` (wave-in-place, the SDK's
+            observed two variants: ``False`` (wave-in-place, the SDK's
             wave-only ``SetTaskId`` composition) and ``True``
             (wave-and-turn-around).  A non-``bool`` payload is
             refused as a shape error rather than resolved through
@@ -279,10 +270,9 @@ def g1_wave_hand_loco(
     # the four invariants: envelope not exception, names the
     # verb, names the parameter, names the shape received.  The
     # in-set admission is not enforced here - both ``False`` and
-    # ``True`` are admitted today and the envelope module owns
-    # the admission set the same way ``g1_balance_stand``'s
-    # ``{0, 3}`` admission belongs on
-    # :mod:`~strands_robots.tools.g1.g1_balance_modes`.
+    # ``True`` are admitted today and the driver's own write path
+    # owns the admission set the same way ``g1_balance_stand``'s
+    # ``{0, 3}`` admission does.
     if turn_flag is None:
         return _refusal_envelope(
             "g1_wave_hand_loco: `turn_flag` is required. Pass a "
@@ -294,8 +284,7 @@ def g1_wave_hand_loco(
     # it, because a caller passing ``1`` (``int``) reaches the SDK's
     # dispatcher through the neon wrapper's silent ``bool()`` coercion
     # as an admitted task id.  Refusing the non-``bool`` shape
-    # explicitly matches the read-only envelope
-    # :mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope`'s
+    # explicitly matches the neon verb's
     # own ``turn_flag must be bool`` refusal, so both paths render the
     # same shape a caller can grep for and the boolean requirement is
     # decidable at the tool surface rather than at wire time.

--- a/tests/drivers/test_g1_move_velocity_writes_the_driver_envelope.py
+++ b/tests/drivers/test_g1_move_velocity_writes_the_driver_envelope.py
@@ -234,9 +234,9 @@ def test_the_verb_passes_the_argument_quadruple_through_verbatim() -> None:
 
     A reshape here (a rounding, a clamp, a sign flip) would fork
     the SDK's own contract into two sources of truth; a caller
-    reading :mod:`~strands_robots.tools.g1.g1_velocity_envelope`
-    for the walkable magnitude bound would decide the refusal
-    against a different envelope than the write actually reached.
+    reading the walkable magnitude bound off the driver's own
+    write path would decide the refusal against a different
+    envelope than the write actually reached.
     This cell pins the argument round-trip explicit: whatever
     finite-numeric quadruple the caller passed reaches the driver
     unchanged.
@@ -318,9 +318,8 @@ def test_a_bool_velocity_is_refused_before_silent_coercion() -> None:
     Python's ``bool`` is a subclass of ``int`` and coerces to
     ``0.0`` / ``1.0`` in every arithmetic context. A caller that
     reached the verb with ``True`` on ``vx`` would silently
-    command a 1 m/s forward walk (well outside the envelope
-    :mod:`~strands_robots.tools.g1.g1_velocity_envelope` names as
-    walkable); the shared
+    command a 1 m/s forward walk (well outside the envelope the
+    neon bundle observed as walkable); the shared
     :func:`~strands_robots.utils.finite_number_error` validator
     refuses the ``bool`` subclass before that silent coercion
     reaches the driver.

--- a/tests/drivers/test_g1_safe_lie_to_stand_writes_the_driver_envelope.py
+++ b/tests/drivers/test_g1_safe_lie_to_stand_writes_the_driver_envelope.py
@@ -233,9 +233,8 @@ def test_the_default_preamble_matches_the_neon_bundle_field_notes() -> None:
     The neon bundle's ``g1_safe_lie_to_stand`` verb defaulted to
     ``preamble_s=0.5`` seconds
     (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``); the
-    read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-    names the same value as the neon-observed default.  This cell
+    bundle's field notes name the same value as its observed
+    default.  This cell
     pins that the verb's own default matches, so a caller
     upgrading from the neon bundle reaches the driver with the
     same target the field notes against the real robot preferred.
@@ -405,9 +404,8 @@ def test_a_non_finite_preamble_is_refused_before_the_driver_is_called() -> None:
 def test_a_large_preamble_reaches_the_driver_unchanged() -> None:
     """A ``preamble_s=5.0`` reaches the driver: the verb does not domain-refuse.
 
-    The read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-    names the neon-bundle-observed usable range; the module
+    The neon bundle's field notes name the observed usable
+    range; the module
     docstring names "does not refuse a preamble_s outside the
     neon-bundle-observed usable range" as one of the things this
     verb does not do.  Refusing an unlisted duration here would

--- a/tests/drivers/test_g1_safe_squat_to_stand_writes_the_driver_envelope.py
+++ b/tests/drivers/test_g1_safe_squat_to_stand_writes_the_driver_envelope.py
@@ -235,9 +235,8 @@ def test_the_default_preamble_matches_the_neon_bundle_field_notes() -> None:
     The neon bundle's ``g1_safe_squat_to_stand`` verb defaulted to
     ``preamble_s=0.5`` seconds
     (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``); the
-    read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-    names the same value as the neon-observed default.  This cell
+    bundle's field notes name the same value as its observed
+    default.  This cell
     pins that the verb's own default matches, so a caller
     upgrading from the neon bundle reaches the driver with the
     same target the field notes against the real robot preferred.
@@ -407,9 +406,8 @@ def test_a_non_finite_preamble_is_refused_before_the_driver_is_called() -> None:
 def test_a_large_preamble_reaches_the_driver_unchanged() -> None:
     """A ``preamble_s=5.0`` reaches the driver: the verb does not domain-refuse.
 
-    The read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-    names the neon-bundle-observed usable range; the module
+    The neon bundle's field notes name the observed usable
+    range; the module
     docstring names "does not refuse a preamble_s outside the
     neon-bundle-observed usable range" as one of the things this
     verb does not do.  Refusing an unlisted duration here would

--- a/tests/drivers/test_g1_safe_stand_to_squat_writes_the_driver_envelope.py
+++ b/tests/drivers/test_g1_safe_stand_to_squat_writes_the_driver_envelope.py
@@ -234,9 +234,8 @@ def test_the_default_preamble_matches_the_neon_bundle_field_notes() -> None:
     The neon bundle's ``g1_safe_stand_to_squat`` verb defaulted to
     ``preamble_s=0.5`` seconds
     (``cagataycali/neon-the-g1/tools/g1_safe_posture.py``); the
-    read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-    names the same value as the neon-observed default.  This cell
+    bundle's field notes name the same value as its observed
+    default.  This cell
     pins that the verb's own default matches, so a caller
     upgrading from the neon bundle reaches the driver with the
     same target the field notes against the real robot preferred.
@@ -406,9 +405,8 @@ def test_a_non_finite_preamble_is_refused_before_the_driver_is_called() -> None:
 def test_a_large_preamble_reaches_the_driver_unchanged() -> None:
     """A ``preamble_s=5.0`` reaches the driver: the verb does not domain-refuse.
 
-    The read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_damp_transition_envelope`
-    names the neon-bundle-observed usable range; the module
+    The neon bundle's field notes name the observed usable
+    range; the module
     docstring names "does not refuse a preamble_s outside the
     neon-bundle-observed usable range" as one of the things this
     verb does not do.  Refusing an unlisted duration here would

--- a/tests/drivers/test_g1_set_fsm_writes_the_driver_envelope.py
+++ b/tests/drivers/test_g1_set_fsm_writes_the_driver_envelope.py
@@ -1,8 +1,8 @@
 """``g1_set_fsm`` returns exactly what ``G1Driver.set_fsm`` gives it.
 
-``g1_set_fsm`` is the write-side companion to the read-only lookup
-verb :mod:`strands_robots.tools.g1.g1_fsm_targets`: where that one
-lists the FSM ids the SDK's ``LocoClient.SetFsmId`` handler admits,
+``g1_set_fsm`` is the write side of the FSM-id conversation: its own
+``fsm_id`` docstring lists the ids the SDK's ``LocoClient.SetFsmId``
+handler admits, and
 this one hands one of those ids to the driver's own SetFsmId write
 path and reads back the fsm-before / fsm-after / rc round-trip the
 neon bundle's ``g1_set_fsm`` verb documented.  The driver's

--- a/tests/drivers/test_g1_shake_hand_loco_writes_the_driver_envelope.py
+++ b/tests/drivers/test_g1_shake_hand_loco_writes_the_driver_envelope.py
@@ -214,10 +214,8 @@ def test_the_verb_passes_the_argument_through_unchanged_reach() -> None:
     not ask for, and does not compose the ``SetTaskId`` payload
     itself.  This cell fixes that ``stage=0`` reaches the driver
     method verbatim - the reach-out stage the neon bundle
-    observed, and the ``composed_task_id`` the read-only
-    envelope
-    :mod:`~strands_robots.tools.g1.g1_shake_hand_stage_envelope`
-    surfaces to a caller planning the write.
+    observed, and the ``composed_task_id`` the driver's own
+    write path composes from it.
     """
     envelope = {"status": "success", "content": [{"json": {"rc": 0}}]}
     driver = _StubG1Driver(envelope=envelope)
@@ -231,10 +229,8 @@ def test_the_verb_passes_the_argument_through_unchanged_shake() -> None:
     """A ``stage=1`` reaches the driver: shake extended hand.
 
     The neon bundle observed the shake stage as the second
-    admitted target of ``LocoClient.ShakeHand`` and the read-only
-    envelope
-    :mod:`~strands_robots.tools.g1.g1_shake_hand_stage_envelope`
-    names it.  This cell pins that the verb reaches the driver
+    admitted target of ``LocoClient.ShakeHand``.  This cell pins
+    that the verb reaches the driver
     with ``1`` verbatim (no substitution to the reach-out
     default), so a caller upgrading from the neon bundle reaches
     the same behaviour.

--- a/tests/drivers/test_g1_wave_hand_loco_writes_the_driver_envelope.py
+++ b/tests/drivers/test_g1_wave_hand_loco_writes_the_driver_envelope.py
@@ -215,10 +215,8 @@ def test_the_verb_passes_the_argument_through_unchanged_false() -> None:
     not ask for, and does not compose the ``SetTaskId`` payload
     itself.  This cell fixes that ``turn_flag=False`` reaches the
     driver method verbatim - the wave-in-place variant the neon
-    bundle observed, and the ``composed_task_id`` the read-only
-    envelope
-    :mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope`
-    surfaces to a caller planning the write.
+    bundle observed, and the ``composed_task_id`` the driver's
+    own write path composes from it.
     """
     envelope = {"status": "success", "content": [{"json": {"rc": 0}}]}
     driver = _StubG1Driver(envelope=envelope)
@@ -232,10 +230,8 @@ def test_the_verb_passes_the_argument_through_unchanged_true() -> None:
     """A ``turn_flag=True`` reaches the driver: wave and turn around.
 
     The neon bundle observed the wave-and-turn-around variant as
-    the second admitted target of ``LocoClient.WaveHand`` and the
-    read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope`
-    names it.  This cell pins that the verb reaches the driver
+    the second admitted target of ``LocoClient.WaveHand``.  This
+    cell pins that the verb reaches the driver
     with ``True`` verbatim (no substitution to the in-place
     default), so a caller upgrading from the neon bundle reaches
     the same behaviour.
@@ -297,8 +293,7 @@ def test_an_int_turn_flag_is_refused_because_bool_coercion_would_be_silent() -> 
     turn around) and ``0`` into ``False`` (wave in place); a
     caller reaching this verb with ``1`` has not named a
     turn-flag variant on purpose.  Refusing the non-``bool``
-    shape explicitly matches the read-only envelope
-    :mod:`~strands_robots.tools.g1.g1_wave_hand_turn_flag_envelope`'s
+    shape explicitly matches the neon verb's
     own ``turn_flag must be bool`` refusal, so both paths render
     the same shape a caller can grep for.
     """


### PR DESCRIPTION
## Problem

`main` is red on the one required check, so every open pull request inherits the failure.

`tests/test_docstring_xref_roles_resolve.py::test_qualified_strands_robots_xref_roles_resolve` reports **30 offending docstrings** whose `:mod:` roles name eight lookup modules #3037 removed. Measured on `main` at `608ca434` (`Pull Request and Push Action` run `33381851116`):

```
tests/test_docstring_xref_roles_resolve.py::test_qualified_strands_robots_xref_roles_resolve FAILED
1 failed, 31176 passed, 226 skipped in 1124.94s
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
```

The run exits at the first failure, so the rest of the suite is unmeasured on `main` as well. `cc129d58a`, the commit before #3037, was the last green push.

## Why neither side could see it

The grader derives its population from the tree, so a citation has no file-path relationship to the module it cites - exactly the shape #3037's own description predicted ("this will recur for any envelope-citing verb that lands before this merges"):

```mermaid
graph LR
  A["#3037 forks<br/>removes 46 lookup modules"] --> M["main: 30 dead roles"]
  B["8 execution verbs land after the fork<br/>each :mod:-cites a lookup that still exists"] --> M
  A -.->|"green: the citing verbs<br/>were not on its base"| A
  B -.->|"green: the lookups<br/>were still there"| B
```

## Change

Repaired the way #3037 repaired the same shape for `g1_balance_modes`: **the dead role goes, every factual statement it carried stays** - the values were already stated inline in the same docstrings (`{-1, 0, 1}`, `{1, 702}`, `0.5` s, the FSM id snapshot). Docstrings and comments only; no code path, signature or behaviour is touched.

| removed module cited | roles dropped | citing files |
|---|---|---|
| `g1_damp_transition_envelope` | 15 | 3 verbs + 3 tests |
| `g1_safe_posture_fsm_gates` | 12 | 3 verbs |
| `g1_velocity_envelope` | 9 | 2 verbs + 1 test |
| `g1_wave_hand_turn_flag_envelope` | 9 | 1 verb + 1 test |
| `g1_fsm_targets` | 8 | 1 verb + 1 test |
| `g1_shake_hand_stage_envelope` | 7 | 1 verb + 1 test |
| `g1_locomotion_duration_envelope` | 3 | 1 verb |
| `g1_balance_modes` | 2 | 2 verbs |
| **total** | **65** | **8 verbs + 7 tests** |

LOC delta: **+142 / -216 = -74 net**, 15 files.

## Verification

The regression pin is the grader itself, which fails on the base and passes here:

| | `upstream/main` | this branch |
|---|---|---|
| `test_docstring_xref_roles_resolve.py` | **1 failed**, 24 passed | **25 passed** |
| dead `:mod:` roles into removed modules (`grep`) | 65 | 0 |

Everything else, on this branch and on pristine `main` (`git stash -u`) for comparison:

| gate | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | All checks passed |
| `ruff format --check strands_robots tests tests_integ` | 1778 files already formatted |
| `mypy strands_robots tests tests_integ` (1.20.2) | 20 errors in 6 files, **0 attributable** (all `examples/isaac_gs` + `simulation/ik.py`, identical to the base) |
| `pytest tests/tools/g1 tests/drivers` | 3 failed / 2240 passed here, **the same 3 failed on pristine `main`** - a locally installed `unitree_sdk2py` (`test_importing_use_unitree_pulls_no_sdk_submodule`, `MainBoardState_` field drift, the motion-switcher SDK recorder) |
| `test_docstrings_no_dangling_doc_refs`, `test_args_docstring_completeness`, `test_source_strings_no_emoji` | passed |
| `scripts/check_changelog_fragment.py` | no entry added; 91 changelog cells pass |

No changelog fragment: no behaviour, API or user-visible surface changes - the fragments that describe those lookup verbs are records of releases where they existed and are left as they are.

No visual artifact: this touches no policy, simulation, rendering, recording or asset behaviour.

Refs #3037, #2791.
