### PR TITLE
feat(mesh/security): bound each teleop joint in the unit its follower declares

### DIFF
--- a/changelog.d/3066-per-joint-teleop-input-envelope.md
+++ b/changelog.d/3066-per-joint-teleop-input-envelope.md
@@ -1,0 +1,43 @@
+### Fixed: a teleop frame's joints are bounded in the unit each one declares, not by one shared scalar
+
+`validate_input_frame` bounded every key in a teleop frame by a single scalar,
+`DEFAULT_INPUT_VALUE_ABS = 720.0`. One frame does not carry one unit: lerobot
+normalises Feetech positions per motor, so a shipped SO-100 class arm declares
+`DEGREES` for its five arm joints and `RANGE_0_100` for its gripper. A scalar
+therefore has to be loose enough for the widest joint, which leaves it slack on
+the narrowest - the gripper's fully-open command is `100` and it was bounded at
+`720`, seven times its own full scale. `validate_input_frame` already took a
+`value_abs_by_key` seam for exactly this and nothing populated it.
+
+This was slackness, not a false refusal: `720` is already degree-scaled, so real
+frames were accepted before and still are. Measured on that arm, the five degree
+joints stay at `720` and only the gripper tightens, to `200`.
+
+The unit is read from the robot the frame is about to be applied to, never from
+the frame - the bound that constrains a sender must not be chosen by that sender.
+New `bus_access.motor_norm_modes` reads `bus.motors[name].norm_mode` through the
+same wrapper-or-driver resolution as `joint_read_source`, and `InputReceiver`
+resolves the envelope once from its own follower on the first frame, so a frame
+carrying its own `norm_modes` or `unit` changes nothing.
+
+`INPUT_ENVELOPE_FULL_SCALES` is derived from the existing default rather than
+restated (`DEFAULT_INPUT_VALUE_ABS / 360.0`), so the degree row *is* the old
+default expressed through the new rule and a retune of the default moves every
+unit together. Two properties hold by construction: an unrecognised `norm_mode`
+is absent from the mapping and so keeps the scalar envelope instead of being
+widened to the most permissive row, and a per-joint row only ever tightens
+(`min(scalar, per_key)`), so an operator who narrows
+`STRANDS_MESH_INPUT_VALUE_ABS` is not handed the envelope back by a declared
+unit. Both frame spellings of one motor are bounded (`gripper` and the
+`<motor>.pos` action key lerobot publishes).
+
+`mesh/security.py` still imports nothing from lerobot - the mode spellings are
+held as plain strings, and the guard is an import-graph assertion rather than a
+check on the strings, so the module stays importable and testable with lerobot
+absent.
+
+`input_frame_slew_violation`'s `max_slew_by_key` seam is deliberately left
+unpopulated: it bounds a speed, and the same full-scale derivation would put a
+percent gripper's ceiling below what the leader's own servos produce across that
+joint's travel, which would be a false-refusal regression rather than a slack
+removal.

--- a/strands_robots/bus_access.py
+++ b/strands_robots/bus_access.py
@@ -284,3 +284,44 @@ def joint_read_source(robot: Any) -> Any | None:
         # No inner device: a native driver owns its telemetry directly.
         device = robot
     return device if _answers_a_joint_read(device) else None
+
+
+def motor_norm_modes(robot: Any) -> dict[str, str]:
+    """The normalisation mode each of ``robot``'s motors declares.
+
+    A motor bus declares, per motor, the unit its positions are reported and
+    commanded in - lerobot spells them ``DEGREES``, ``RANGE_M100_100`` and
+    ``RANGE_0_100`` - and one arm mixes them: a shipped SO-100 class arm reports
+    degrees for its five arm joints and 0-100 percent for its gripper. A consumer
+    that bounds or scales joint values needs that declaration, and the robot it
+    is about to act on is the only trustworthy source of it.
+
+    Read through the same wrapper-or-driver resolution as
+    :func:`joint_read_source`, so a lerobot wrapper and a native driver answer
+    identically. Duck-typed, like the rest of this module: nothing is imported
+    from lerobot, and a bus that declares nothing is reported as such rather
+    than raising.
+
+    Args:
+        robot: A lerobot wrapper, a native driver, or anything else shaped like
+            one. Nothing on it is called and no bus traffic is generated: the
+            declaration is configuration, readable before ``connect()``.
+
+    Returns:
+        Motor name to the mode's own spelling (``getattr(mode, "name")`` for an
+        enum member, otherwise ``str(mode)``). Empty when the device exposes no
+        bus, no motors, or motors that declare no mode - "nothing declared",
+        which every caller must treat as "no per-motor knowledge" rather than as
+        a failure.
+    """
+    device = joint_read_source(robot) or robot
+    motors = getattr(getattr(device, "bus", None), "motors", None)
+    if not isinstance(motors, Mapping):
+        return {}
+    modes: dict[str, str] = {}
+    for name, motor in motors.items():
+        mode = getattr(motor, "norm_mode", None)
+        if mode is None:
+            continue
+        modes[str(name)] = str(getattr(mode, "name", None) or mode)
+    return modes

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -30,11 +30,12 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.bus_access import write_action
+from strands_robots.bus_access import motor_norm_modes, write_action
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.mesh.security import (
     ValidationError,
     input_frame_slew_violation,
+    input_value_abs_by_key,
     merge_slew_baseline,
     validate_input_frame,
     validate_mesh_identifier,
@@ -492,6 +493,15 @@ class InputReceiver:
         # merged rather than replaced, so a frame carrying a subset of the
         # joints cannot erase the baseline of the ones it omits.
         self._last_applied: dict[str, tuple[float, float]] = {}
+        # Per-joint magnitude bounds in the unit each of the FOLLOWER's joints
+        # declares, resolved once from its own bus. Read from the receiving
+        # robot rather than from the frame, because the bound that constrains a
+        # sender must not be chosen by that sender. Resolved on the first frame
+        # rather than here: a receiver may be constructed before the robot is
+        # connected, and the declaration is worth reading from the robot as it
+        # actually is when frames start arriving.
+        self._value_abs_by_key: dict[str, float] = {}
+        self._envelope_resolved = False
         self._start_mono = 0.0
 
     def __repr__(self) -> str:
@@ -711,8 +721,17 @@ class InputReceiver:
             # bounds key count, key charset, and clamps each value to a
             # finite magnitude. Rejected frames are counted + logged and
             # dropped (never applied) rather than crashing the receiver.
+            # One frame does not carry one unit: a shipped SO-100 class arm
+            # declares degrees for its five arm joints and 0-100 percent for its
+            # gripper, so a single scalar envelope has to be loose enough for the
+            # widest joint and is 7.2x full scale on the narrowest. The bound is
+            # therefore taken per joint, in the unit the FOLLOWER declares for
+            # it, and only ever tighter than the scalar envelope.
+            if not self._envelope_resolved:
+                self._value_abs_by_key = input_value_abs_by_key(motor_norm_modes(self.robot))
+                self._envelope_resolved = True
             try:
-                safe_action = validate_input_frame(action)
+                safe_action = validate_input_frame(action, self._value_abs_by_key)
             except ValidationError as verr:
                 self._refuse(
                     "invalid",

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -208,6 +208,98 @@ def _input_slew_abs() -> float:
     return _env_pos_float("STRANDS_MESH_INPUT_SLEW_ABS", DEFAULT_INPUT_SLEW_ABS)
 
 
+#: Largest magnitude one joint can reach, in frame units, under each
+#: normalisation mode a motor bus declares. Keyed by the mode's own spelling
+#: (:class:`~lerobot.motors.MotorNormMode` member names) but held as plain
+#: strings, so this module stays importable and testable with lerobot absent.
+#:
+#: The two percent modes share a row because they share a magnitude: lerobot's
+#: normaliser clamps both of them to the calibrated travel at full scale, on the
+#: way in (``_normalize`` bounds the raw count into ``[range_min, range_max]``
+#: before scaling) and on the way out (``_unnormalize`` bounds the command into
+#: ``[-100, 100]`` / ``[0, 100]``), so a percent value past 100 is not a further
+#: reach - it is unaddressable. ``DEGREES`` is clamped in neither direction, and
+#: a full turn is the excursion the degree envelope has always been sized on.
+INPUT_FULL_SCALE_BY_NORM_MODE: dict[str, float] = {
+    "DEGREES": 360.0,
+    "RANGE_M100_100": 100.0,
+    "RANGE_0_100": 100.0,
+}
+
+#: How many full excursions of reach a joint is granted, derived from the
+#: default rather than restated: :data:`DEFAULT_INPUT_VALUE_ABS` is two full
+#: turns of a ``DEGREES`` joint, so every other unit gets the same multiple of
+#: its own full scale and a retune of the default moves all of them together.
+INPUT_ENVELOPE_FULL_SCALES: float = DEFAULT_INPUT_VALUE_ABS / INPUT_FULL_SCALE_BY_NORM_MODE["DEGREES"]
+
+
+def input_value_abs_by_key(norm_modes: Mapping[str, str] | None) -> dict[str, float]:
+    """Per-joint magnitude bounds for the units a receiving robot declares.
+
+    One teleop frame does not carry one unit. A shipped SO-100 class arm
+    declares ``DEGREES`` for its five arm joints and ``RANGE_0_100`` for the
+    gripper, so a single scalar envelope has to be loose enough for the widest
+    joint: at :data:`DEFAULT_INPUT_VALUE_ABS` the gripper is bounded at 7.2x its
+    own full scale. Bounding each joint in its own unit removes that slack
+    without touching the joints the scalar was sized for.
+
+    The unit is read from the robot the frame is about to be applied to, never
+    from the frame: the bound that constrains a sender must not be chosen by
+    that sender. :func:`strands_robots.bus_access.motor_norm_modes` is what
+    reads it.
+
+    Args:
+        norm_modes: Motor name to the normalisation mode that motor declares
+            (``"DEGREES"``, ``"RANGE_0_100"``, ...), case-insensitive. ``None``
+            or empty means nothing was declared, so nothing is bounded per
+            joint and the scalar envelope stands alone.
+
+    Returns:
+        Frame key to magnitude bound, holding only the joints whose mode is
+        recognised. Both spellings a frame may use for one motor are present:
+        the bare motor name and lerobot's ``<motor>.pos`` action key. A joint
+        whose declared mode is unrecognised is absent rather than widened, so it
+        keeps the scalar envelope.
+    """
+    if not norm_modes:
+        return {}
+    bounds: dict[str, float] = {}
+    for motor, mode in norm_modes.items():
+        full_scale = INPUT_FULL_SCALE_BY_NORM_MODE.get(str(mode).upper())
+        if full_scale is None:
+            continue
+        bounds[str(motor)] = bounds[f"{motor}.pos"] = INPUT_ENVELOPE_FULL_SCALES * full_scale
+    return bounds
+
+
+def _resolve_input_value_abs(key: str, value_abs_by_key: Mapping[str, float] | None) -> float:
+    """The magnitude bound in force for one frame key.
+
+    A per-joint bound only ever *tightens* the scalar envelope. That is what
+    keeps :func:`_input_value_abs` authoritative: an operator who narrows
+    ``STRANDS_MESH_INPUT_VALUE_ABS`` for a fleet whose actuators use a smaller
+    unit stays narrowed, instead of having the declared-unit row widen the
+    envelope back out underneath them.
+
+    Args:
+        key: The frame key being bounded.
+        value_abs_by_key: Per-joint bounds, as built by
+            :func:`input_value_abs_by_key` from the receiving robot's declared
+            units. ``None``, empty, or missing this key means the scalar
+            envelope applies.
+
+    Returns:
+        The bound to compare ``abs(value)`` against.
+    """
+    scalar = _input_value_abs()
+    if not value_abs_by_key:
+        return scalar
+    per_key = value_abs_by_key.get(key)
+    if per_key is None:
+        return scalar
+    return min(scalar, float(per_key))
+
+
 #: Charset for teleop input-frame keys (motor/joint names like
 #: ``"motor.pos"``, ``"shoulder_pan"``, ``"j0"``). Printable, no
 #: whitespace, no shell metacharacters, no path separators.
@@ -1391,7 +1483,7 @@ def validate_device_rpc(function: str, params: Any = None) -> tuple[str, dict[st
     return function, dict(params)
 
 
-def validate_input_frame(action: Any) -> dict[str, float]:
+def validate_input_frame(action: Any, value_abs_by_key: Mapping[str, float] | None = None) -> dict[str, float]:
     """Validate and sanitise a teleop input frame, returning a clean copy.
 
     A teleop input frame is the flat ``{motor_name: float}`` payload
@@ -1421,15 +1513,28 @@ def validate_input_frame(action: Any) -> dict[str, float]:
       then refused explicitly: ``bool`` is an ``int`` subclass, so ``True``
       would otherwise reach an actuator as a ``1.0`` command.
     * Each value: **finite** (no ``nan`` / ``inf``) and within ``+/-``
-      :func:`_input_value_abs` (``STRANDS_MESH_INPUT_VALUE_ABS``).
+      :func:`_input_value_abs` (``STRANDS_MESH_INPUT_VALUE_ABS``), tightened
+      for that joint by *value_abs_by_key*.
 
     The envelope the last check applies is that resolver, not the import-time
     :data:`MAX_INPUT_VALUE_ABS` snapshot of it, so an operator who narrows the
     teleop envelope takes effect without a process restart. The two agree until
     the env var is set after import, and it is the resolver that refuses.
 
-    Returns a sanitised ``dict[str, float]`` containing only validated
-    entries. Raises :class:`ValidationError` on any violation.
+    Args:
+        action: The frame to validate.
+        value_abs_by_key: Per-joint magnitude bounds in the unit each joint
+            declares, as built by :func:`input_value_abs_by_key` from the
+            receiving robot. A joint listed here is bounded by the tighter of
+            its own bound and the scalar envelope; a joint absent from it keeps
+            the scalar envelope. ``None`` bounds every joint by the scalar,
+            which is what a caller with no bus to read declares.
+
+    Returns:
+        A sanitised ``dict[str, float]`` containing only validated entries.
+
+    Raises:
+        ValidationError: On any violation above.
     """
     if not isinstance(action, dict):
         raise ValidationError(f"input frame must be a dict (got {type(action).__name__})")
@@ -1466,7 +1571,7 @@ def validate_input_frame(action: Any) -> dict[str, float]:
         fval = float(value)
         if not math.isfinite(fval):
             raise ValidationError(f"input frame value for {key!r} must be finite, got {fval}")
-        _value_abs = _input_value_abs()
+        _value_abs = _resolve_input_value_abs(key, value_abs_by_key)
         if abs(fval) > _value_abs:
             raise ValidationError(
                 f"input frame value for {key!r} out of range: |{fval}| > {_value_abs}",
@@ -1642,6 +1747,9 @@ __all__ = [
     "is_safe_policy_provider",
     "is_safe_policy_type",
     "is_safe_server_address",
+    "INPUT_ENVELOPE_FULL_SCALES",
+    "INPUT_FULL_SCALE_BY_NORM_MODE",
+    "input_value_abs_by_key",
     "validate_command",
     "validate_device_rpc",
     "input_frame_slew_violation",

--- a/tests/mesh/test_input_envelope_units.py
+++ b/tests/mesh/test_input_envelope_units.py
@@ -23,19 +23,34 @@ These tests pin the unit, not a magnitude: the policy the constants encode (two
 full turns of reach, that envelope traversed once per second, comfortably above
 the leader's own servos) is asserted against the unit the frames carry, so a
 future retune must keep the relation rather than silently re-enter the mismatch.
+
+One frame carries more than one unit, which is the other half: the same arm that
+streams degrees for its five arm joints streams 0-100 percent for its gripper, so
+a single scalar bound has to be loose enough for the widest joint and is 7.2x full
+scale on the narrowest. The last classes pin the per-joint envelope
+:func:`~strands_robots.mesh.security.input_value_abs_by_key` builds from the
+units the RECEIVING robot declares.
 """
 
 from __future__ import annotations
 
 import math
+import time
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from strands_robots.bus_access import motor_norm_modes
 from strands_robots.mesh import security
+from strands_robots.mesh.input import InputReceiver
 from strands_robots.mesh.security import (
     DEFAULT_INPUT_SLEW_ABS,
     DEFAULT_INPUT_VALUE_ABS,
+    INPUT_ENVELOPE_FULL_SCALES,
+    INPUT_FULL_SCALE_BY_NORM_MODE,
     input_frame_slew_violation,
+    input_value_abs_by_key,
     validate_input_frame,
 )
 
@@ -49,6 +64,19 @@ STS3215_NO_LOAD_DEG_S = STS3215_NO_LOAD_RAD_S * 180.0 / math.pi  # ~372 deg/s
 
 #: A 50 Hz frame period - the rate ``InputPublisher`` streams at by default.
 FRAME_S = 1.0 / 50.0
+
+#: What a shipped SO-100 class arm declares, motor by motor. Restated here so
+#: the per-joint cells run with lerobot absent;
+#: :meth:`TestTheWireUnitIsDegrees.test_the_so_arm_declares_a_mixed_unit_frame`
+#: is what holds it to lerobot's own declaration.
+SO_ARM_NORM_MODES = {
+    "shoulder_pan": "DEGREES",
+    "shoulder_lift": "DEGREES",
+    "elbow_flex": "DEGREES",
+    "wrist_flex": "DEGREES",
+    "wrist_roll": "DEGREES",
+    "gripper": "RANGE_0_100",
+}
 
 
 def _baseline(pose: dict[str, float], t: float = 0.0) -> dict[str, tuple[float, float]]:
@@ -66,6 +94,29 @@ class TestTheWireUnitIsDegrees:
 
         defaults = {f.name: f.default for f in dataclasses.fields(SOFollowerRobotConfig)}
         assert defaults["use_degrees"] is True, "premise: the envelope is sized for the unit the SO driver defaults to"
+
+    def test_the_so_arm_declares_a_mixed_unit_frame(self):
+        """:data:`SO_ARM_NORM_MODES` is lerobot's declaration, not our guess."""
+        pytest.importorskip("lerobot")
+        from lerobot.robots.so_follower import SOFollower
+        from lerobot.robots.so_follower.config_so_follower import SOFollowerRobotConfig
+
+        arm = SOFollower(SOFollowerRobotConfig(port="/dev/null", id="unit-probe"))
+        assert motor_norm_modes(arm) == SO_ARM_NORM_MODES
+
+    def test_every_bounded_mode_is_one_lerobot_declares(self):
+        """The table may not carry a row for a mode no bus can declare.
+
+        The other direction is deliberately not pinned: a mode lerobot adds
+        later is absent from the table, and an absent mode keeps the scalar
+        envelope, which is the safe verdict rather than a broken one.
+        """
+        pytest.importorskip("lerobot")
+        from lerobot.motors import MotorNormMode
+
+        declarable = {mode.name for mode in MotorNormMode}
+        unknown = set(INPUT_FULL_SCALE_BY_NORM_MODE) - declarable
+        assert not unknown, f"bounded modes no bus can declare: {sorted(unknown)}"
 
 
 class TestAFullRangeLeaderFrameIsAdmitted:
@@ -147,3 +198,148 @@ class TestTheBoundStillRefusesARunaway:
         # A radian-valued or normalized fleet narrows rather than widens.
         monkeypatch.setenv("STRANDS_MESH_INPUT_VALUE_ABS", "3.2")
         assert security._input_value_abs() == pytest.approx(3.2)
+
+
+class TestEachJointIsBoundedInItsOwnDeclaredUnit:
+    """A degree shoulder and a percent gripper do not share one scalar bound."""
+
+    @pytest.mark.parametrize(
+        ("key", "value", "admitted"),
+        [
+            # The degree joints keep the envelope they were sized for.
+            ("shoulder_pan.pos", 110.0, True),
+            ("wrist_roll.pos", FULL_TURN_DEG + 90.0, True),
+            ("wrist_roll.pos", 3 * FULL_TURN_DEG, False),
+            # The gripper is RANGE_0_100: 100 is fully open, and the same
+            # 2x-full-scale margin the degree row carries admits 200.
+            ("gripper.pos", 100.0, True),
+            ("gripper.pos", 200.0, True),
+            # 300 is 3x a fully-open gripper. The scalar envelope admits it.
+            ("gripper.pos", 300.0, False),
+        ],
+    )
+    def test_a_mixed_unit_frame_is_bounded_per_joint(self, key, value, admitted):
+        bounds = input_value_abs_by_key(SO_ARM_NORM_MODES)
+        if admitted:
+            assert validate_input_frame({key: value}, bounds) == {key: value}
+        else:
+            with pytest.raises(security.ValidationError):
+                validate_input_frame({key: value}, bounds)
+
+    def test_the_bound_is_the_same_multiple_of_full_scale_in_every_unit(self):
+        """One rule, applied per unit - not a second hand-picked number.
+
+        The degree row is the scalar default restated through that rule, so the
+        joints the scalar was sized for are bounded exactly as before and a
+        retune of :data:`DEFAULT_INPUT_VALUE_ABS` moves every unit together.
+        """
+        bounds = input_value_abs_by_key(SO_ARM_NORM_MODES)
+        assert bounds["shoulder_pan.pos"] == pytest.approx(DEFAULT_INPUT_VALUE_ABS)
+        for mode, full_scale in INPUT_FULL_SCALE_BY_NORM_MODE.items():
+            per_joint = input_value_abs_by_key({"j": mode})["j"]
+            assert per_joint / full_scale == pytest.approx(INPUT_ENVELOPE_FULL_SCALES)
+
+    def test_the_percent_gripper_stops_being_bounded_at_7x_its_full_scale(self):
+        """The slack this exists to remove, measured in both directions."""
+        full_scale = INPUT_FULL_SCALE_BY_NORM_MODE["RANGE_0_100"]
+        scalar = security._input_value_abs()
+        assert scalar / full_scale == pytest.approx(7.2)
+        per_joint = input_value_abs_by_key(SO_ARM_NORM_MODES)["gripper.pos"]
+        assert per_joint / full_scale == pytest.approx(2.0)
+
+    @pytest.mark.parametrize("key", ["gripper", "gripper.pos"])
+    def test_both_spellings_of_one_motor_are_bounded(self, key):
+        """A frame keys a motor bare or as lerobot's ``<motor>.pos`` action."""
+        with pytest.raises(security.ValidationError):
+            validate_input_frame({key: 300.0}, input_value_abs_by_key(SO_ARM_NORM_MODES))
+
+    def test_an_unrecognised_mode_keeps_the_scalar_envelope(self):
+        """An unknown declaration must not widen anything, nor narrow blindly."""
+        bounds = input_value_abs_by_key({"gripper": "RANGE_M42_42"})
+        assert bounds == {}
+        validate_input_frame({"gripper.pos": DEFAULT_INPUT_VALUE_ABS}, bounds)
+        with pytest.raises(security.ValidationError):
+            validate_input_frame({"gripper.pos": DEFAULT_INPUT_VALUE_ABS * 1.5}, bounds)
+
+    def test_a_narrowed_operator_envelope_is_not_widened_by_a_declared_unit(self, monkeypatch):
+        """The per-joint row only ever tightens the scalar envelope.
+
+        A fleet whose actuators use a smaller unit narrows
+        ``STRANDS_MESH_INPUT_VALUE_ABS``; a degree row of 720 must not hand the
+        envelope back.
+        """
+        monkeypatch.setenv("STRANDS_MESH_INPUT_VALUE_ABS", "3.2")
+        bounds = input_value_abs_by_key(SO_ARM_NORM_MODES)
+        validate_input_frame({"shoulder_pan.pos": 3.0}, bounds)
+        with pytest.raises(security.ValidationError):
+            validate_input_frame({"shoulder_pan.pos": 45.0}, bounds)
+
+    def test_the_module_bounds_units_without_importing_lerobot(self):
+        """``mesh.security`` stays importable and testable with lerobot absent.
+
+        The mode spellings are plain strings for this reason, so the guard is on
+        the import graph rather than on the strings.
+        """
+        import ast
+
+        tree = ast.parse(Path(security.__file__).read_text(encoding="utf-8"))
+        imported = {
+            node.module.split(".")[0] for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module
+        } | {
+            alias.name.split(".")[0] for node in ast.walk(tree) if isinstance(node, ast.Import) for alias in node.names
+        }
+        assert "lerobot" not in imported
+
+
+class TestTheUnitComesFromTheReceiverNotTheFrame:
+    """The bound that constrains a sender must not be chosen by that sender."""
+
+    @staticmethod
+    def _receiver(norm_modes):
+        class _Bus:
+            motors = {name: SimpleNamespace(norm_mode=mode) for name, mode in norm_modes.items()}
+
+            def sync_read(self, *a, **k):  # what makes this the joint-read source
+                return {}
+
+        applied: list[dict] = []
+        recv = InputReceiver(
+            mesh=SimpleNamespace(
+                peer_id="follower-1",
+                subscribe=lambda *a, **k: "sub",
+                unsubscribe=lambda *a, **k: None,
+            ),
+            robot=SimpleNamespace(bus=_Bus()),
+            source_peer_id="leader-1",
+            apply_fn=lambda robot, action: applied.append(action),
+        )
+        recv._running = True
+        return recv, applied
+
+    def _send(self, recv, frame, **extra):
+        recv._on_input(recv.topic, {"action": frame, "seq": 0, "t": time.time(), **extra})
+
+    def test_the_follower_declaration_decides_the_verdict(self):
+        """One frame, two followers: the percent gripper is the one refused."""
+        percent, applied_percent = self._receiver(SO_ARM_NORM_MODES)
+        self._send(percent, {"gripper.pos": 300.0})
+        assert applied_percent == []
+        assert percent._rejected == 1
+
+        degrees, applied_degrees = self._receiver({"gripper": "DEGREES"})
+        self._send(degrees, {"gripper.pos": 300.0})
+        assert applied_degrees == [{"gripper.pos": 300.0}]
+
+    def test_a_unit_claimed_by_the_frame_cannot_widen_the_bound(self):
+        """A sender-supplied declaration is not consulted, so it changes nothing."""
+        recv, applied = self._receiver(SO_ARM_NORM_MODES)
+        self._send(recv, {"gripper.pos": 300.0}, norm_modes={"gripper": "DEGREES"}, unit="deg")
+        assert applied == []
+        assert recv._rejected == 1
+
+    def test_a_robot_that_declares_nothing_keeps_the_scalar_envelope(self):
+        """No bus to read is "no per-joint knowledge", not a refusal."""
+        recv, applied = self._receiver({})
+        self._send(recv, {"gripper.pos": 300.0})
+        assert applied == [{"gripper.pos": 300.0}]
+        assert recv._value_abs_by_key == {}


### PR DESCRIPTION
## The bound and the frame did not share a unit

`validate_input_frame` bounded every key in a teleop frame by one scalar, `DEFAULT_INPUT_VALUE_ABS = 720.0`. One frame does not carry one unit: lerobot normalises Feetech positions per motor, so a shipped SO-100 class arm declares `DEGREES` for its five arm joints and `RANGE_0_100` for its gripper. A single scalar therefore has to be loose enough for the widest joint, which leaves it slack on the narrowest -- the gripper's fully-open command is `100` and it was bounded at `720`.

This is slackness, not a false-refusal defect: `720` is already degree-scaled, so real frames were accepted before and still are. `validate_input_frame` already took a `value_abs_by_key` seam for exactly this; nothing populated it.

![per-unit input envelope](https://raw.githubusercontent.com/cagataycali/robots/assets/per-unit-input-envelope/envelope_per_unit.png)

Measured from the shipped constants: the five degree joints stay at `720`, the gripper moves to `200`, and every joint ends up at the same `2x` multiple of its own full scale.

## The unit is read from the receiver, never from the frame

`bus_access.motor_norm_modes(robot)` reads `bus.motors[name].norm_mode` through the same wrapper-or-driver resolution as `joint_read_source`, and `InputReceiver` resolves the envelope once from **its own follower** on the first frame. The bound that constrains a sender is not chosen by that sender: a frame may carry `norm_modes=...` / `unit=...` and it changes nothing.

`mesh/security.py` still imports nothing from lerobot -- the mode spellings are plain strings, pinned by an import-graph assertion rather than by the strings.

## One rule, not a second hand-picked number

`INPUT_ENVELOPE_FULL_SCALES` is *derived* (`DEFAULT_INPUT_VALUE_ABS / 360.0` = 2.0), so the degree row is the existing default restated through the rule and a retune of the default moves every unit together. Two safety properties hold by construction:

- **An unrecognised `norm_mode` is absent from the mapping**, so it keeps the scalar envelope rather than being widened to the most permissive row.
- **A per-joint row only ever tightens** (`min(scalar, per_key)`), so an operator who narrows `STRANDS_MESH_INPUT_VALUE_ABS` is not handed the envelope back by a declared unit.

## Behaviour, before and after

A real `InputReceiver` whose follower declares the mixed-unit bus above, one joint per frame:

| frame | before | after |
|---|---|---|
| `gripper.pos = 100` (fully open) | APPLIED | APPLIED |
| `gripper.pos = 200` (2x full scale, the margin kept) | APPLIED | APPLIED |
| `gripper.pos = 300` | APPLIED | **REFUSED** |
| `gripper.pos = 700` (7x full scale, still under 720) | APPLIED | **REFUSED** |
| `shoulder_pan.pos = 110` (ordinary degree pose) | APPLIED | APPLIED |
| `wrist_roll.pos = 450` (multi-turn wrist) | APPLIED | APPLIED |
| `wrist_roll.pos = 1080` (runaway) | REFUSED | REFUSED |

Every degree row is identical in both columns; only the percent gripper changes.

## Tests

`tests/mesh/test_input_envelope_units.py` grows by 196 lines and deletes none. Two cells read the premise off lerobot itself rather than restating it -- `motor_norm_modes(SOFollower(...))` must equal the mixed-unit declaration, and no row of the table may name a mode `MotorNormMode` does not define. The rest pin the mixed-unit verdicts, the derivation, both frame spellings of one motor (`gripper` and `gripper.pos`), the unrecognised-mode fallback, the tightening-only invariant, and the receiver-not-the-frame property. 31 pass; the 12 pre-existing cells are untouched.

## Not in scope

`input_frame_slew_violation`'s `max_slew_by_key` seam stays unpopulated. It bounds a *speed*, and the same `2x full scale` derivation would put a percent gripper's ceiling below what the leader's own servos can produce across that joint's travel -- a false-refusal regression rather than a slack removal. Wiring it needs a per-unit speed premise this change does not establish, so `#2935` is referenced rather than closed.

Refs #2935

## LOC

`5 files changed, 414 insertions(+), 7 deletions(-)` -- `strands_robots/` +175/-7, `tests/` +196/-0, changelog fragment +43/-0.
