### PR TITLE
fix(drivers/booster): construct the T1 DDS endpoints under the shared lock

### DIFF
--- a/changelog.d/3067-booster-dds-endpoints-under-shared-lock.md
+++ b/changelog.d/3067-booster-dds-endpoints-under-shared-lock.md
@@ -1,0 +1,27 @@
+### Fixed: the Booster T1 driver constructs its DDS endpoints under the shared lock
+
+`BoosterDriver.connect_eagerly` built the channel factory, the `B1LocoClient` and
+its four channels with no serialisation against the rest of the process.
+Constructing one CycloneDDS endpoint while another is under construction
+segfaults the bindings, and `DDSSubscriberSet.subscribe` creates every subscriber
+under `_DDS_INIT_LOCK`, so anything else in the process touching DDS raced this
+driver. That loss is not catchable by the surrounding "record the reason and stay
+usable for reads" boundary: the process dies, possibly while a 1.2 m biped is
+standing under its own controller. Measured with the real subscriber set on one
+thread and the real connect on the other, 40 against 40, there were 80
+overlapping construction pairs; there are now none.
+
+The construction block is wrapped in `_DDS_INIT_LOCK`, matching
+`Go2Driver._motion_switcher_client`. The lazy SDK import stays outside it - it
+creates no endpoint, and holding a process-wide lock across an import would stall
+every subscriber construction for its duration - and so does the teardown of a
+partial channel set, matching `DDSSubscriberSet.close`, which releases under its
+own bookkeeping lock: the shared lock serialises construction, not release. No
+lock is nested, so no new ordering is introduced.
+
+`tests/tools/g1/test_every_dds_endpoint_is_created_under_the_shared_lock.py`
+already refused the two call sites. Because it matches on the callee's name, and
+a call laundered through a lower-case local would evade it, the driver's own test
+module now also pins the behaviour: a competing holder of the shared lock makes
+`connect_eagerly` block with no endpoint constructed, which is what distinguishes
+taking the shared lock from taking a private one that would exclude nothing.

--- a/strands_robots/drivers/booster.py
+++ b/strands_robots/drivers/booster.py
@@ -53,6 +53,7 @@ import threading
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.utils import boolean_flag_error, dds_domain_id_error, finite_number_error
 
 if TYPE_CHECKING:
@@ -459,6 +460,24 @@ class BoosterDriver:
         A partially built channel set is released rather than kept: a driver
         holding a live subscriber and no publisher reads fine and refuses every
         write, which is the state hardest to diagnose from the outside.
+
+        Every endpoint is constructed under
+        :data:`~strands_robots.tools.g1._g1_common._DDS_INIT_LOCK`. The channel
+        factory, the loco client's ``Init()`` and each of the four channels build
+        DDS readers and writers, and the CycloneDDS bindings segfault when one
+        endpoint is constructed concurrently with another - which happens as soon
+        as anything else in the process touches DDS, because
+        :class:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet` creates
+        every subscriber under that same lock. A segfault is not catchable by the
+        "record the reason and stay usable for reads" boundary below: the process
+        dies, possibly while the robot is standing under its own controller.
+
+        The lazy SDK import stays outside the lock - it creates no endpoint, and
+        holding the shared lock across it would stall every subscriber
+        construction in the process for its duration. So does the teardown of a
+        partial set, matching
+        :meth:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet.close`:
+        the lock serialises construction, not release.
         """
         if self._connected:
             return None
@@ -476,23 +495,24 @@ class BoosterDriver:
         battery: Any | None = None
         fall: Any | None = None
         try:
-            sdk.ChannelFactory.Instance().Init(self._domain_id, self._port)
+            with _DDS_INIT_LOCK:
+                sdk.ChannelFactory.Instance().Init(self._domain_id, self._port)
 
-            client = sdk.B1LocoClient()
-            if self._robot_name is None:
-                client.Init()
-            else:
-                client.InitWithName(self._robot_name)
-
-            subscriber = sdk.B1LowStateSubscriber(self._on_low_state)
-            publisher = sdk.B1LowCmdPublisher()
-            battery = sdk.B1BatteryStateSubscriber(self._on_battery)
-            fall = sdk.B1FallDownStateSubscriber(self._on_fall_state)
-            for channel in (subscriber, publisher, battery, fall):
+                client = sdk.B1LocoClient()
                 if self._robot_name is None:
-                    channel.InitChannel()
+                    client.Init()
                 else:
-                    channel.InitChannelWithName(self._robot_name)
+                    client.InitWithName(self._robot_name)
+
+                subscriber = sdk.B1LowStateSubscriber(self._on_low_state)
+                publisher = sdk.B1LowCmdPublisher()
+                battery = sdk.B1BatteryStateSubscriber(self._on_battery)
+                fall = sdk.B1FallDownStateSubscriber(self._on_fall_state)
+                for channel in (subscriber, publisher, battery, fall):
+                    if self._robot_name is None:
+                        channel.InitChannel()
+                    else:
+                        channel.InitChannelWithName(self._robot_name)
         except (RuntimeError, OSError, ValueError) as exc:
             for channel in (subscriber, publisher, battery, fall):
                 if channel is not None:

--- a/tests/drivers/test_booster_driver.py
+++ b/tests/drivers/test_booster_driver.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import math
 import sys
+import threading
 from typing import Any
 
 import pytest
@@ -39,6 +40,7 @@ from strands_robots.drivers.booster import (
     parse_low_state,
     resolve_targets,
 )
+from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.utils import MAX_DDS_DOMAIN_ID
 
 # The width a T1 reports. Every frame the driver builds is bounded by what the
@@ -680,3 +682,60 @@ class TestTheJointTableMatchesTheVendorEnum:
         for name in CMD_TYPE_STATE_FIELD:
             assert hasattr(sdk.LowCmdType, name.upper())
         assert {mode for mode in dir(sdk.RobotMode) if mode.startswith("k")} >= {"kCustom", "kWalking"}
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint construction is serialised against the rest of the process.         #
+# --------------------------------------------------------------------------- #
+
+
+class TestEndpointsAreBuiltUnderTheSharedDdsLock:
+    """The channel set is constructed under the lock every DDS user shares.
+
+    Constructing one CycloneDDS endpoint while another is being constructed
+    segfaults the bindings, and the loss is not catchable: the process dies,
+    possibly while a 1.2 m biped is standing under its own controller. The
+    subscriber set in MODULE ``strands_robots.tools.g1._dds_engine`` builds every
+    subscriber under ``_DDS_INIT_LOCK``, so this driver has to take the *same*
+    lock rather than one of its own - a private lock would exclude nothing.
+
+    That is what these cells measure: the connect blocks while a competing
+    holder owns the shared lock, and no endpoint is built until it is released.
+    """
+
+    @staticmethod
+    def _connect_in_a_thread(driver: BoosterDriver) -> tuple[threading.Thread, threading.Event, list[str | None]]:
+        done = threading.Event()
+        result: list[str | None] = []
+
+        def run() -> None:
+            result.append(driver.connect_eagerly())
+            done.set()
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        return thread, done, result
+
+    def test_connect_waits_for_a_competing_holder_of_the_shared_lock(self, sdk: _FakeSdk) -> None:
+        """Held elsewhere, the connect makes no progress and builds no endpoint."""
+        driver = BoosterDriver()
+        with _DDS_INIT_LOCK:
+            thread, done, result = self._connect_in_a_thread(driver)
+            assert not done.wait(0.5), "connect_eagerly did not wait for the shared DDS lock"
+            assert sdk.factory_init is None, "the channel factory was initialised while another holder had the lock"
+            assert sdk.subscriber is None, "a subscriber was constructed while another holder had the lock"
+            assert not driver.is_connected
+
+        assert done.wait(5.0), "connect_eagerly never completed after the lock was released"
+        thread.join(timeout=5.0)
+        assert result == [None]
+        assert sdk.factory_init is not None
+        assert sdk.subscriber is not None
+        assert driver.is_connected
+
+    def test_the_lock_is_released_for_the_next_endpoint_user(self, sdk: _FakeSdk) -> None:
+        """A connect that owns the lock must not keep it: DDS is process-wide."""
+        driver = BoosterDriver()
+        assert driver.connect_eagerly() is None
+        assert _DDS_INIT_LOCK.acquire(timeout=1.0), "connect_eagerly held the shared DDS lock past its own use"
+        _DDS_INIT_LOCK.release()


### PR DESCRIPTION
## `main` is red on this

`tests/tools/g1/test_every_dds_endpoint_is_created_under_the_shared_lock.py` fails on `main` at `2f19fb6a6`, so every open PR inherits the failure:

```
AssertionError: these call sites construct a DDS endpoint without holding the
shared _DDS_INIT_LOCK, so they race every other endpoint construction in the
process and the loss is a native segfault:
{'drivers/booster.py': [('Init', 479), ('Init', 483)]}
```

The guard and the driver landed from branches that had forked before each other, so both were green in isolation: the grader's population is the whole tree, so a new unguarded call site and the rule that forbids it only meet at `main`.

## The hazard

`connect_eagerly` built the channel factory, the loco client and four channels with no serialisation. Constructing one CycloneDDS endpoint while another is under construction segfaults the bindings, and `DDSSubscriberSet.subscribe` creates every subscriber under `_DDS_INIT_LOCK` -- so anything else in the process touching DDS races this driver. The loss is not catchable by the surrounding "record the reason and stay usable for reads" boundary: the process dies, possibly while a 1.2 m biped is standing under its own controller.

![booster DDS endpoint race](https://raw.githubusercontent.com/cagataycali/robots/assets/booster-dds-lock/booster_dds_race.png)

Measured with the real `DDSSubscriberSet.subscribe` on one thread and the real `connect_eagerly` on another, each SDK constructor occupying a 2 ms window, 40 connects against 40 subscribes:

| | overlapping construction pairs | wall |
|---|---|---|
| before | **80** | 500.3 ms |
| after | **0** | 585.9 ms |

The 86 ms is the cost of serialising, and it is the point -- endpoint construction is not concurrent work.

## The change

`with _DDS_INIT_LOCK:` around the construction block, matching `Go2Driver._motion_switcher_client`. Two things stay deliberately outside it:

- **the lazy SDK import** -- it creates no endpoint, and holding the process-wide lock across it would stall every subscriber construction for its duration;
- **the teardown of a partial channel set** -- matching `DDSSubscriberSet.close`, which closes under its own bookkeeping lock rather than the shared one. The lock serialises construction, not release.

No new lock is introduced and no lock is nested, so there is no new ordering to reason about.

## Tests

The whole-tree grader is the regression pin and goes `1 failed, 9 passed` -> `10 passed`. It matches on the callee's name, though, so a call laundered through a lower-case local would evade it -- `TestEndpointsAreBuiltUnderTheSharedDdsLock` in the driver's own module pins the **behaviour** instead, and specifically that the lock is the *shared* one rather than a private one that would exclude nothing: a competing holder makes `connect_eagerly` block, and no endpoint is constructed until it is released (`sdk.factory_init is None`, `sdk.subscriber is None`). A second cell pins that the connect does not keep the lock. Pre-fix that is `1 failed, 1 passed` -- the failing cell is the discriminating one, the passing one is the control.

`tests/drivers` + `tests/tools/g1`: 1766 passed, and a failure-set diff against `main` over the same selection is **0 new, 1 fixed** (the grader).

Closes the `main` breakage introduced by #3045.

## LOC

`3 files changed, 121 insertions(+), 15 deletions(-)` -- driver +35/-15 (mostly the docstring paragraph and the re-indent), tests +59/-0, changelog fragment +27/-0.
