### PR TITLE
fix(drivers): open the Booster T1's channels under the shared DDS lock

### DIFF
--- a/changelog.d/3068-booster-channels-under-the-shared-dds-lock.md
+++ b/changelog.d/3068-booster-channels-under-the-shared-dds-lock.md
@@ -1,0 +1,31 @@
+### Fixed: the Booster T1 driver opens its channels under the shared DDS lock
+
+`BoosterDriver.connect_eagerly` built ten DDS endpoints in a row - the channel
+factory, an RPC client and four subscriber/publisher channels - while holding no
+lock, in a process where `DDSSubscriberSet` constructs every subscriber under
+`_DDS_INIT_LOCK` on its own streaming, rollout and mesh-telemetry threads. The
+CycloneDDS bindings segfault on concurrent endpoint construction, and a segfault
+is not catchable by the driver's "return a reason and stay usable for reads"
+boundary: the process dies, possibly while a 1.2 m biped stands under its own
+controller.
+
+The whole construction block now runs under the shared lock, which is the shape
+`Go2Driver` and `G1Driver` already use. Measured on the engine with 40 subscribes
+against 40 opens, concurrent endpoint constructions go from 79 to 0, at a 9%
+wall-clock cost that is the serialisation rather than a regression.
+
+Two things stay outside the lock and are pinned there: the lazy SDK import, since
+an import creates no endpoint and holding the shared lock across one would stall
+every endpoint construction in the process for its duration; and the partial-set
+release, since a close creates no endpoint either and must not stall the process
+while the driver discards a set it is abandoning.
+
+Only two of the ten sites were reachable by the rule that grades endpoint
+construction over the source. That rule derives its vocabulary from the Unitree
+infrastructure modules, so it recognises `Init` and not the Booster SDK's
+`InitWithName`, `InitChannel`, `InitChannelWithName`, or its
+`B1LowStateSubscriber` / `B1LowCmdPublisher` / `B1BatteryStateSubscriber` /
+`B1FallDownStateSubscriber` constructors. Wrapping only the reported pair would
+have turned the rule green over eight identical hazards, so the regression pin
+grades the behaviour - was the shared lock held while each endpoint was built -
+which no vendor's choice of name can evade.

--- a/strands_robots/drivers/booster.py
+++ b/strands_robots/drivers/booster.py
@@ -53,6 +53,7 @@ import threading
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.utils import boolean_flag_error, dds_domain_id_error, finite_number_error
 
 if TYPE_CHECKING:
@@ -459,6 +460,22 @@ class BoosterDriver:
         A partially built channel set is released rather than kept: a driver
         holding a live subscriber and no publisher reads fine and refuses every
         write, which is the state hardest to diagnose from the outside.
+
+        Every channel is opened under
+        :data:`~strands_robots.tools.g1._g1_common._DDS_INIT_LOCK`, the one lock
+        the whole process serialises endpoint construction on. The bindings
+        segfault when two endpoints are constructed concurrently, and this
+        driver shares the process with
+        :class:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet`, which
+        builds every subscriber under that same lock on its own threads
+        (streaming, a policy rollout, mesh telemetry). A segfault is not
+        catchable by the "return a reason and stay usable" boundary above: the
+        process dies, possibly while a 1.2 m biped is standing under its own
+        controller.
+
+        The release path below runs *outside* the lock. It closes channels
+        rather than creating them, so it owes no serialisation, and a close that
+        blocks must not stall every endpoint construction in the process.
         """
         if self._connected:
             return None
@@ -476,23 +493,29 @@ class BoosterDriver:
         battery: Any | None = None
         fall: Any | None = None
         try:
-            sdk.ChannelFactory.Instance().Init(self._domain_id, self._port)
+            # Every line in here builds a DDS endpoint, so the whole block is
+            # one critical section. The lazy SDK import above stays outside it:
+            # it creates no endpoint, and holding the shared lock across an
+            # import would stall every endpoint construction in the process for
+            # its duration.
+            with _DDS_INIT_LOCK:
+                sdk.ChannelFactory.Instance().Init(self._domain_id, self._port)
 
-            client = sdk.B1LocoClient()
-            if self._robot_name is None:
-                client.Init()
-            else:
-                client.InitWithName(self._robot_name)
-
-            subscriber = sdk.B1LowStateSubscriber(self._on_low_state)
-            publisher = sdk.B1LowCmdPublisher()
-            battery = sdk.B1BatteryStateSubscriber(self._on_battery)
-            fall = sdk.B1FallDownStateSubscriber(self._on_fall_state)
-            for channel in (subscriber, publisher, battery, fall):
+                client = sdk.B1LocoClient()
                 if self._robot_name is None:
-                    channel.InitChannel()
+                    client.Init()
                 else:
-                    channel.InitChannelWithName(self._robot_name)
+                    client.InitWithName(self._robot_name)
+
+                subscriber = sdk.B1LowStateSubscriber(self._on_low_state)
+                publisher = sdk.B1LowCmdPublisher()
+                battery = sdk.B1BatteryStateSubscriber(self._on_battery)
+                fall = sdk.B1FallDownStateSubscriber(self._on_fall_state)
+                for channel in (subscriber, publisher, battery, fall):
+                    if self._robot_name is None:
+                        channel.InitChannel()
+                    else:
+                        channel.InitChannelWithName(self._robot_name)
         except (RuntimeError, OSError, ValueError) as exc:
             for channel in (subscriber, publisher, battery, fall):
                 if channel is not None:

--- a/tests/drivers/test_booster_channels_open_under_the_shared_dds_lock.py
+++ b/tests/drivers/test_booster_channels_open_under_the_shared_dds_lock.py
@@ -1,0 +1,262 @@
+"""Opening the Booster T1's channels holds the shared DDS lock.
+
+``_g1_common``'s module docstring states the contract graded here: "A
+``ChannelSubscriber`` and a ``ChannelPublisher`` cannot be constructed
+concurrently: the CycloneDDS bindings segfault. ``_DDS_INIT_LOCK`` is the
+*shared* lock the driver and the tools both hold while creating readers or
+writers. One lock; two consumers."
+
+:meth:`~strands_robots.drivers.booster.BoosterDriver.connect_eagerly` builds six
+endpoints in a row - the channel factory, an RPC client, and four
+subscriber/publisher channels - while
+:class:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet` constructs
+subscribers under that same lock on other threads in the same process
+(streaming, a policy rollout, mesh telemetry). A shared lock is only a guarantee
+where every caller takes it, and the caller that loses the race is the one
+holding nothing. The loss is a native segfault, which no ``except`` boundary can
+turn into an error envelope: the process dies, possibly while a 1.2 m biped is
+standing under its own controller.
+
+These cells grade the *behaviour* - was the shared lock held while each endpoint
+was built - rather than the source, and that is what this driver specifically
+needs. The package-wide source rule in
+``tests/tools/g1/test_every_dds_endpoint_is_created_under_the_shared_lock.py``
+derives its vocabulary of endpoint-creating operations from the Unitree
+infrastructure modules, so it recognises ``Init`` and nothing else here: the
+Booster SDK spells the identical operations ``InitWithName``, ``InitChannel``,
+``InitChannelWithName`` and ``B1LowStateSubscriber`` / ``B1LowCmdPublisher`` /
+``B1BatteryStateSubscriber`` / ``B1FallDownStateSubscriber``. Eight of this
+driver's ten construction sites are therefore invisible to that rule, and a
+behavioural pin cannot be evaded by a vendor's choice of name.
+
+:func:`TestTheLockIsTheSharedOneAndNotAPrivateOne.test_the_open_waits_for_a_competing_endpoint_construction`
+is the cell that makes the pin specific: a driver-private lock would satisfy
+"some lock was held" while excluding nothing the engine does.
+
+No cell here needs a T1, a DDS bus or ``booster_robotics_sdk_python``: the SDK is
+a recorder staged on :mod:`sys.modules`, which is the driver's lazy-import path.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.booster import BoosterDriver
+from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
+
+#: How long a cell waits for something that should already have happened, and
+#: how long it waits to conclude that something is correctly still blocked.
+_TIMEOUT_S = 5.0
+_BLOCKED_S = 0.2
+
+#: Every endpoint-creating operation the driver performs, by the name the vendor
+#: gives it. ``Init`` is the only one the package-wide source rule recognises.
+_UNNAMED_ROBOT_OPERATIONS = (
+    "ChannelFactory.Init",
+    "B1LocoClient",
+    "B1LocoClient.Init",
+    "B1LowStateSubscriber",
+    "B1LowCmdPublisher",
+    "B1BatteryStateSubscriber",
+    "B1FallDownStateSubscriber",
+) + ("InitChannel",) * 4
+_NAMED_ROBOT_OPERATIONS = (
+    "ChannelFactory.Init",
+    "B1LocoClient",
+    "B1LocoClient.InitWithName",
+    "B1LowStateSubscriber",
+    "B1LowCmdPublisher",
+    "B1BatteryStateSubscriber",
+    "B1FallDownStateSubscriber",
+) + ("InitChannelWithName",) * 4
+
+
+class _Recorder:
+    """Collects ``(operation, was the shared lock held)`` in call order."""
+
+    def __init__(self) -> None:
+        self.observed: list[tuple[str, bool]] = []
+        self.refuse: str | None = None
+
+    def note(self, operation: str) -> None:
+        self.observed.append((operation, _DDS_INIT_LOCK.locked()))
+        if self.refuse == operation:
+            raise RuntimeError(f"{operation}: channel busy")
+
+    def held(self, operation: str) -> list[bool]:
+        return [was_held for name, was_held in self.observed if name == operation]
+
+
+class _FakeChannel:
+    """A subscriber or publisher, recording when it was opened and closed."""
+
+    def __init__(self, recorder: _Recorder) -> None:
+        self._recorder = recorder
+
+    def InitChannel(self) -> None:  # noqa: N802 - the SDK's own spelling
+        self._recorder.note("InitChannel")
+
+    def InitChannelWithName(self, robot_name: str) -> None:  # noqa: N802
+        self._recorder.note("InitChannelWithName")
+
+    def CloseChannel(self) -> None:  # noqa: N802
+        self._recorder.note("CloseChannel")
+
+
+class _FakeLocoClient:
+    def __init__(self, recorder: _Recorder) -> None:
+        self._recorder = recorder
+
+    def Init(self) -> None:  # noqa: N802
+        self._recorder.note("B1LocoClient.Init")
+
+    def InitWithName(self, robot_name: str) -> None:  # noqa: N802
+        self._recorder.note("B1LocoClient.InitWithName")
+
+
+class _FakeSdk:
+    """The construction surface of ``booster_robotics_sdk_python``, recording."""
+
+    def __init__(self, recorder: _Recorder) -> None:
+        self._recorder = recorder
+        sdk = self
+
+        class _Factory:
+            @staticmethod
+            def Instance() -> Any:  # noqa: N802
+                return _Factory()
+
+            def Init(self, domain_id: int, ip: str) -> None:  # noqa: N802
+                sdk._recorder.note("ChannelFactory.Init")
+
+        self.ChannelFactory = _Factory
+
+    def B1LocoClient(self) -> _FakeLocoClient:  # noqa: N802
+        self._recorder.note("B1LocoClient")
+        return _FakeLocoClient(self._recorder)
+
+    def B1LowStateSubscriber(self, handler: Any) -> _FakeChannel:  # noqa: N802
+        self._recorder.note("B1LowStateSubscriber")
+        return _FakeChannel(self._recorder)
+
+    def B1LowCmdPublisher(self) -> _FakeChannel:  # noqa: N802
+        self._recorder.note("B1LowCmdPublisher")
+        return _FakeChannel(self._recorder)
+
+    def B1BatteryStateSubscriber(self, handler: Any) -> _FakeChannel:  # noqa: N802
+        self._recorder.note("B1BatteryStateSubscriber")
+        return _FakeChannel(self._recorder)
+
+    def B1FallDownStateSubscriber(self, handler: Any) -> _FakeChannel:  # noqa: N802
+        self._recorder.note("B1FallDownStateSubscriber")
+        return _FakeChannel(self._recorder)
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    """Stage the recording SDK under the name the driver imports."""
+    rec = _Recorder()
+    monkeypatch.setitem(sys.modules, "booster_robotics_sdk_python", _FakeSdk(rec))
+    return rec
+
+
+class TestEveryEndpointIsBuiltUnderTheSharedLock:
+    """The whole channel set is one critical section, not just the graded call."""
+
+    @pytest.mark.parametrize(
+        ("robot_name", "expected"),
+        [(None, _UNNAMED_ROBOT_OPERATIONS), ("t1_left", _NAMED_ROBOT_OPERATIONS)],
+    )
+    def test_no_endpoint_is_constructed_with_the_lock_free(
+        self, recorder: _Recorder, robot_name: str | None, expected: tuple[str, ...]
+    ) -> None:
+        """Both spellings of the open are graded: a named T1 takes the other branch."""
+        assert BoosterDriver(robot_name=robot_name).connect_eagerly() is None
+
+        assert [name for name, _ in recorder.observed] == list(expected), (
+            "the recorder did not see the construction sequence it grades, so "
+            "the assertion below would pass over an open that never happened"
+        )
+        unlocked = sorted({name for name, was_held in recorder.observed if not was_held})
+        assert not unlocked, (
+            f"these endpoints were constructed with the shared {_DDS_INIT_LOCK!r} "
+            f"free, so they race every other endpoint construction in the "
+            f"process and the loss is a native segfault: {unlocked}"
+        )
+
+    def test_the_lock_is_released_once_the_channels_are_open(self, recorder: _Recorder) -> None:
+        """The lock is a critical section, not something the driver keeps."""
+        assert BoosterDriver().connect_eagerly() is None
+        assert not _DDS_INIT_LOCK.locked(), (
+            "the shared lock is still held after the open returned, which would "
+            "stall every later endpoint construction in the process"
+        )
+
+    def test_a_refused_channel_releases_the_lock_on_the_way_out(self, recorder: _Recorder) -> None:
+        """The failure path is the one that leaks, and a leak deadlocks the process."""
+        recorder.refuse = "InitChannel"
+        reason = BoosterDriver().connect_eagerly()
+        assert reason is not None and "did not open" in reason
+        assert not _DDS_INIT_LOCK.locked(), (
+            "a channel that refused to open left the shared lock held, so every "
+            "later endpoint construction in the process would block forever"
+        )
+
+    def test_the_release_path_does_not_hold_the_lock(self, recorder: _Recorder) -> None:
+        """Closing creates no endpoint, so it owes no serialisation.
+
+        Pinned because the alternative is worse than redundant: a close that
+        blocks would stall every endpoint construction in the process while the
+        driver tidied up a set it is about to discard.
+        """
+        recorder.refuse = "InitChannel"
+        assert BoosterDriver().connect_eagerly() is not None
+        closes = recorder.held("CloseChannel")
+        assert closes, "no channel was released, so this cell grades nothing"
+        assert not any(closes), f"the partial channel set was released while holding the shared lock: {closes}"
+
+
+class TestTheLockIsTheSharedOneAndNotAPrivateOne:
+    """A driver-private lock would exclude nothing the engine does."""
+
+    def test_the_open_waits_for_a_competing_endpoint_construction(self, recorder: _Recorder) -> None:
+        opened = threading.Event()
+        release = threading.Event()
+
+        def hold_the_lock() -> None:
+            with _DDS_INIT_LOCK:
+                release.wait(_TIMEOUT_S)
+
+        holder = threading.Thread(target=hold_the_lock, daemon=True)
+        holder.start()
+        try:
+            # Wait for the competing holder to actually own the lock, so the
+            # assertion below cannot pass just because the race was not run.
+            while not _DDS_INIT_LOCK.locked():
+                threading.Event().wait(0.01)
+
+            def open_the_channels() -> None:
+                if BoosterDriver().connect_eagerly() is None:
+                    opened.set()
+
+            threading.Thread(target=open_the_channels, daemon=True).start()
+            assert not opened.wait(_BLOCKED_S), (
+                "the channels opened while another thread held the shared DDS "
+                "lock, so they are not serialised against the engine's endpoint "
+                "construction - a private lock excludes nothing"
+            )
+            assert not recorder.observed, (
+                "an endpoint was constructed before the competing holder let go, "
+                "so the lock the driver takes is not the one being held here"
+            )
+        finally:
+            release.set()
+            holder.join(_TIMEOUT_S)
+        assert opened.wait(_TIMEOUT_S), (
+            "the open never completed after the shared lock was released, so it "
+            "is blocked on something other than that lock"
+        )


### PR DESCRIPTION
## The defect

`BoosterDriver.connect_eagerly` builds **ten DDS endpoints** in a row - the channel factory, an RPC client, and four subscriber/publisher channels - while holding **no lock**.

It shares the process with `DDSSubscriberSet`, which constructs every subscriber under `_DDS_INIT_LOCK` on its own streaming, rollout and mesh-telemetry threads. `_g1_common` states the contract those threads honour: *"A `ChannelSubscriber` and a `ChannelPublisher` cannot be constructed concurrently: the CycloneDDS bindings segfault. `_DDS_INIT_LOCK` is the shared lock the driver and the tools both hold."*

A shared lock is only a guarantee where every caller takes it, and the caller that loses the race is the one holding nothing. The loss is a **native segfault**, which the driver's "return a reason and stay usable" boundary cannot turn into an error envelope: the process dies, possibly while a 1.2 m biped stands under its own controller.

## Measured

40 engine subscribes against 40 driver opens (440 endpoint constructions, 11 per open), both sides running the shipped code with only the two vendor SDKs stood in:

| | cross-side concurrent constructions | wall clock |
|---|---|---|
| before | **79** | 0.9136 s |
| after | **0** | 0.9959 s (+9.0%) |

The +9.0% is the cost of serialising and is the point rather than a regression: the two lanes are no longer allowed to overlap.

![DDS endpoint construction overlap, before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/booster-dds-lock/dds_overlap.png)

## Why the fix covers the whole block, not the two reported lines

`tests/tools/g1/test_every_dds_endpoint_is_created_under_the_shared_lock.py` reports exactly two sites here:

```
{'drivers/booster.py': [('Init', 479), ('Init', 483)]}
```

That rule derives its vocabulary of endpoint-creating operations from the Unitree infrastructure modules, which gives `{ChannelFactoryInitialize, ChannelPublisher, ChannelSubscriber, Init}`. The Booster SDK spells the identical operations differently, so **eight of the ten sites are invisible to it**:

| operation | seen by the source rule |
|---|---|
| `ChannelFactory...Init`, `B1LocoClient.Init` | yes |
| `InitWithName`, `InitChannel`, `InitChannelWithName` | no |
| `B1LocoClient`, `B1LowStateSubscriber`, `B1LowCmdPublisher`, `B1BatteryStateSubscriber`, `B1FallDownStateSubscriber` | no |

Wrapping only the two reported lines would turn the check green and leave eight identical hazards behind it. The whole construction block is therefore one critical section, which is also the smaller edit.

Two things stay **outside** the lock, deliberately and pinned: the lazy SDK import (it creates no endpoint, and holding the shared lock across an import would stall every endpoint construction in the process for its duration) and the partial-set release (a close creates no endpoint either, and must not stall the process while the driver discards a set it is abandoning).

This is the shape `Go2Driver` and `G1Driver` already use - both import `_DDS_INIT_LOCK` and hold it across their client open.

## Tests

New `tests/drivers/test_booster_channels_open_under_the_shared_dds_lock.py`, a sibling of `test_motion_switcher_open_is_under_the_shared_dds_lock.py`. It grades the **behaviour** - was the shared lock held while each endpoint was built - so no vendor's choice of name can evade it.

Pre-fix, with only `strands_robots/` reverted:

```
3 failed, 3 passed
```

- both spellings of the open (`robot_name=None` and a named T1) fail, each naming **8 operations** constructed with the lock free
- `test_the_open_waits_for_a_competing_endpoint_construction` fails - the open completed while another thread held the shared lock, which is what distinguishes the shared lock from a driver-private one
- the 3 passing cells are the leak controls; they hold both ways by construction (a lock never taken is a lock never leaked), which is what makes them controls rather than regression cells

The package-wide source rule fails pre-fix too (`1 failed, 9 passed`) and passes after, so both halves of the pin move.

## Gate

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1778 source files`
- `tests/drivers/` + `tests/tools/g1/`: `1755 passed, 23 skipped`
- `test_docstring_xref_roles_resolve`, `test_source_strings_no_review_archaeology`, `test_no_host_paths`, `test_dependency_audit`: `122 passed, 1 skipped`
- registry scenes unaffected: this touches one driver's connect path and no scene loader

No T1, DDS bus or `booster_robotics_sdk_python` is needed by any cell: the SDK is a recorder staged on `sys.modules`, which is the driver's own lazy-import path.
