### PR TITLE
test(drivers/booster): grade every endpoint construction against the shared DDS lock

### DIFF
--- a/changelog.d/3068-booster-endpoint-lock-coverage.md
+++ b/changelog.d/3068-booster-endpoint-lock-coverage.md
@@ -1,0 +1,24 @@
+### Fixed: a Booster T1 endpoint opened outside the shared DDS lock is now named
+
+The channel set is constructed under `_DDS_INIT_LOCK` (#3067). What graded that
+was a pair of cells driving the *start* of the construction - the open blocks
+while a competing holder owns the lock, and the lock is free once the open
+returns - plus the package-wide source rule over endpoint-creating calls.
+
+Neither sees *which* constructions the lock actually covers. Moving only the four
+channel opens out of the critical section, the plausible shape of a later
+refactor, leaves both cells green because the block still begins under the lock,
+and leaves the source rule green because that rule derives its vocabulary of
+endpoint-creating operations from the Unitree infrastructure modules: it knows
+`Init` and not the Booster SDK's `InitChannel`, `InitChannelWithName`,
+`InitWithName`, or its `B1LowStateSubscriber` / `B1LowCmdPublisher` /
+`B1BatteryStateSubscriber` / `B1FallDownStateSubscriber` constructors. Eight of
+the ten construction sites are outside what it can report.
+
+The lock state is now recorded at every one of them, for both the unnamed and the
+named-robot spelling, so an endpoint opened outside the critical section is named
+whatever the vendor calls it. Two further cells cover the failure path, which is
+the one that leaks: a lock still held after a channel refused to open deadlocks
+every later endpoint construction in the process, and the release of a partial
+set is pinned as happening outside the lock, which is what the driver's docstring
+already claims and nothing measured.

--- a/changelog.d/3068-booster-endpoint-lock-coverage.md
+++ b/changelog.d/3068-booster-endpoint-lock-coverage.md
@@ -12,8 +12,8 @@ and leaves the source rule green because that rule derives its vocabulary of
 endpoint-creating operations from the Unitree infrastructure modules: it knows
 `Init` and not the Booster SDK's `InitChannel`, `InitChannelWithName`,
 `InitWithName`, or its `B1LowStateSubscriber` / `B1LowCmdPublisher` /
-`B1BatteryStateSubscriber` / `B1FallDownStateSubscriber` constructors. Eight of
-the ten construction sites are outside what it can report.
+`B1BatteryStateSubscriber` / `B1FallDownStateSubscriber` constructors. Nine of
+the eleven constructions this method performs are outside what it can report.
 
 The lock state is now recorded at every one of them, for both the unnamed and the
 named-robot spelling, so an endpoint opened outside the critical section is named

--- a/tests/drivers/test_booster_channels_open_under_the_shared_dds_lock.py
+++ b/tests/drivers/test_booster_channels_open_under_the_shared_dds_lock.py
@@ -1,0 +1,214 @@
+"""Opening the Booster T1's channels holds the shared DDS lock.
+
+``_g1_common``'s module docstring states the contract graded here: "A
+``ChannelSubscriber`` and a ``ChannelPublisher`` cannot be constructed
+concurrently: the CycloneDDS bindings segfault. ``_DDS_INIT_LOCK`` is the
+*shared* lock the driver and the tools both hold while creating readers or
+writers. One lock; two consumers."
+
+:meth:`~strands_robots.drivers.booster.BoosterDriver.connect_eagerly` builds six
+endpoints in a row - the channel factory, an RPC client, and four
+subscriber/publisher channels - while
+:class:`~strands_robots.tools.g1._dds_engine.DDSSubscriberSet` constructs
+subscribers under that same lock on other threads in the same process
+(streaming, a policy rollout, mesh telemetry). A shared lock is only a guarantee
+where every caller takes it, and the caller that loses the race is the one
+holding nothing. The loss is a native segfault, which no ``except`` boundary can
+turn into an error envelope: the process dies, possibly while a 1.2 m biped is
+standing under its own controller.
+
+#3067 put that construction under the lock and pins two properties of it: that
+the open blocks while a competing holder owns the shared lock, and that the lock
+is free again once the open returns. These cells grade what neither that pair nor
+the source rule can see - *which* constructions the lock covers, and what happens
+to it when a channel refuses.
+
+The distinction is not academic. Moving only the four channel opens out of the
+critical section - the plausible shape of a later refactor - leaves both of
+#3067's cells green and the source rule green, because the block still *starts*
+under the lock and because the rule cannot see the names those four calls use.
+The package-wide source rule in
+``tests/tools/g1/test_every_dds_endpoint_is_created_under_the_shared_lock.py``
+derives its vocabulary of endpoint-creating operations from the Unitree
+infrastructure modules, so it recognises ``Init`` and nothing else here: the
+Booster SDK spells the identical operations ``InitWithName``, ``InitChannel``,
+``InitChannelWithName`` and ``B1LowStateSubscriber`` / ``B1LowCmdPublisher`` /
+``B1BatteryStateSubscriber`` / ``B1FallDownStateSubscriber``. Eight of this
+driver's ten construction sites are therefore invisible to that rule, and a
+behavioural pin cannot be evaded by a vendor's choice of name.
+
+The failure path is graded separately because it is the one that leaks: a lock
+still held after a channel refused deadlocks every later endpoint construction
+in the process, and #3067's release cell drives the success path only.
+
+No cell here needs a T1, a DDS bus or ``booster_robotics_sdk_python``: the SDK is
+a recorder staged on :mod:`sys.modules`, which is the driver's lazy-import path.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.booster import BoosterDriver
+from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
+
+#: Every endpoint-creating operation the driver performs, by the name the vendor
+#: gives it. ``Init`` is the only one the package-wide source rule recognises.
+_UNNAMED_ROBOT_OPERATIONS = (
+    "ChannelFactory.Init",
+    "B1LocoClient",
+    "B1LocoClient.Init",
+    "B1LowStateSubscriber",
+    "B1LowCmdPublisher",
+    "B1BatteryStateSubscriber",
+    "B1FallDownStateSubscriber",
+) + ("InitChannel",) * 4
+_NAMED_ROBOT_OPERATIONS = (
+    "ChannelFactory.Init",
+    "B1LocoClient",
+    "B1LocoClient.InitWithName",
+    "B1LowStateSubscriber",
+    "B1LowCmdPublisher",
+    "B1BatteryStateSubscriber",
+    "B1FallDownStateSubscriber",
+) + ("InitChannelWithName",) * 4
+
+
+class _Recorder:
+    """Collects ``(operation, was the shared lock held)`` in call order."""
+
+    def __init__(self) -> None:
+        self.observed: list[tuple[str, bool]] = []
+        self.refuse: str | None = None
+
+    def note(self, operation: str) -> None:
+        self.observed.append((operation, _DDS_INIT_LOCK.locked()))
+        if self.refuse == operation:
+            raise RuntimeError(f"{operation}: channel busy")
+
+    def held(self, operation: str) -> list[bool]:
+        return [was_held for name, was_held in self.observed if name == operation]
+
+
+class _FakeChannel:
+    """A subscriber or publisher, recording when it was opened and closed."""
+
+    def __init__(self, recorder: _Recorder) -> None:
+        self._recorder = recorder
+
+    def InitChannel(self) -> None:  # noqa: N802 - the SDK's own spelling
+        self._recorder.note("InitChannel")
+
+    def InitChannelWithName(self, robot_name: str) -> None:  # noqa: N802
+        self._recorder.note("InitChannelWithName")
+
+    def CloseChannel(self) -> None:  # noqa: N802
+        self._recorder.note("CloseChannel")
+
+
+class _FakeLocoClient:
+    def __init__(self, recorder: _Recorder) -> None:
+        self._recorder = recorder
+
+    def Init(self) -> None:  # noqa: N802
+        self._recorder.note("B1LocoClient.Init")
+
+    def InitWithName(self, robot_name: str) -> None:  # noqa: N802
+        self._recorder.note("B1LocoClient.InitWithName")
+
+
+class _FakeSdk:
+    """The construction surface of ``booster_robotics_sdk_python``, recording."""
+
+    def __init__(self, recorder: _Recorder) -> None:
+        self._recorder = recorder
+        sdk = self
+
+        class _Factory:
+            @staticmethod
+            def Instance() -> Any:  # noqa: N802
+                return _Factory()
+
+            def Init(self, domain_id: int, ip: str) -> None:  # noqa: N802
+                sdk._recorder.note("ChannelFactory.Init")
+
+        self.ChannelFactory = _Factory
+
+    def B1LocoClient(self) -> _FakeLocoClient:  # noqa: N802
+        self._recorder.note("B1LocoClient")
+        return _FakeLocoClient(self._recorder)
+
+    def B1LowStateSubscriber(self, handler: Any) -> _FakeChannel:  # noqa: N802
+        self._recorder.note("B1LowStateSubscriber")
+        return _FakeChannel(self._recorder)
+
+    def B1LowCmdPublisher(self) -> _FakeChannel:  # noqa: N802
+        self._recorder.note("B1LowCmdPublisher")
+        return _FakeChannel(self._recorder)
+
+    def B1BatteryStateSubscriber(self, handler: Any) -> _FakeChannel:  # noqa: N802
+        self._recorder.note("B1BatteryStateSubscriber")
+        return _FakeChannel(self._recorder)
+
+    def B1FallDownStateSubscriber(self, handler: Any) -> _FakeChannel:  # noqa: N802
+        self._recorder.note("B1FallDownStateSubscriber")
+        return _FakeChannel(self._recorder)
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    """Stage the recording SDK under the name the driver imports."""
+    rec = _Recorder()
+    monkeypatch.setitem(sys.modules, "booster_robotics_sdk_python", _FakeSdk(rec))
+    return rec
+
+
+class TestEveryEndpointIsBuiltUnderTheSharedLock:
+    """The whole channel set is one critical section, not just the graded call."""
+
+    @pytest.mark.parametrize(
+        ("robot_name", "expected"),
+        [(None, _UNNAMED_ROBOT_OPERATIONS), ("t1_left", _NAMED_ROBOT_OPERATIONS)],
+    )
+    def test_no_endpoint_is_constructed_with_the_lock_free(
+        self, recorder: _Recorder, robot_name: str | None, expected: tuple[str, ...]
+    ) -> None:
+        """Both spellings of the open are graded: a named T1 takes the other branch."""
+        assert BoosterDriver(robot_name=robot_name).connect_eagerly() is None
+
+        assert [name for name, _ in recorder.observed] == list(expected), (
+            "the recorder did not see the construction sequence it grades, so "
+            "the assertion below would pass over an open that never happened"
+        )
+        unlocked = sorted({name for name, was_held in recorder.observed if not was_held})
+        assert not unlocked, (
+            f"these endpoints were constructed with the shared {_DDS_INIT_LOCK!r} "
+            f"free, so they race every other endpoint construction in the "
+            f"process and the loss is a native segfault: {unlocked}"
+        )
+
+    def test_a_refused_channel_releases_the_lock_on_the_way_out(self, recorder: _Recorder) -> None:
+        """The failure path is the one that leaks, and a leak deadlocks the process."""
+        recorder.refuse = "InitChannel"
+        reason = BoosterDriver().connect_eagerly()
+        assert reason is not None and "did not open" in reason
+        assert not _DDS_INIT_LOCK.locked(), (
+            "a channel that refused to open left the shared lock held, so every "
+            "later endpoint construction in the process would block forever"
+        )
+
+    def test_the_release_path_does_not_hold_the_lock(self, recorder: _Recorder) -> None:
+        """Closing creates no endpoint, so it owes no serialisation.
+
+        Pinned because the alternative is worse than redundant: a close that
+        blocks would stall every endpoint construction in the process while the
+        driver tidied up a set it is about to discard.
+        """
+        recorder.refuse = "InitChannel"
+        assert BoosterDriver().connect_eagerly() is not None
+        closes = recorder.held("CloseChannel")
+        assert closes, "no channel was released, so this cell grades nothing"
+        assert not any(closes), f"the partial channel set was released while holding the shared lock: {closes}"

--- a/tests/drivers/test_booster_channels_open_under_the_shared_dds_lock.py
+++ b/tests/drivers/test_booster_channels_open_under_the_shared_dds_lock.py
@@ -33,9 +33,9 @@ derives its vocabulary of endpoint-creating operations from the Unitree
 infrastructure modules, so it recognises ``Init`` and nothing else here: the
 Booster SDK spells the identical operations ``InitWithName``, ``InitChannel``,
 ``InitChannelWithName`` and ``B1LowStateSubscriber`` / ``B1LowCmdPublisher`` /
-``B1BatteryStateSubscriber`` / ``B1FallDownStateSubscriber``. Eight of this
-driver's ten construction sites are therefore invisible to that rule, and a
-behavioural pin cannot be evaded by a vendor's choice of name.
+``B1BatteryStateSubscriber`` / ``B1FallDownStateSubscriber``. Nine of the
+eleven constructions this method performs are therefore invisible to that
+rule, and a behavioural pin cannot be evaded by a vendor's choice of name.
 
 The failure path is graded separately because it is the one that leaks: a lock
 still held after a channel refused deadlocks every later endpoint construction


### PR DESCRIPTION
`main` is correct today: #3067 wraps the T1's whole channel set in one `_DDS_INIT_LOCK` acquisition. This adds the coverage that keeps it that way, because what grades it now cannot see a partial regression.

## What is currently graded

`TestEndpointsAreBuiltUnderTheSharedDdsLock` (#3067) drives the *start* of the construction: the open blocks while a competing holder owns the lock, and the lock is free once the open returns. The package-wide source rule in `tests/tools/g1/test_every_dds_endpoint_is_created_under_the_shared_lock.py` grades endpoint-creating calls by callee name.

## What neither sees

Measured on `f95bfa0f0` by mutating `connect_eagerly` and running both, `-k SharedDdsLock` and the source rule, against each mutation:

| mutation to the merged fix | #3067's cells | source rule | cells added here |
|---|---|---|---|
| none (control) | 0 | 0 | 0 |
| the four channel opens moved out of the locked block | **0** | **0** | **2** |
| only the channel factory left inside the block | 0 | 1 | 2 |
| `with` replaced by a manual acquire released on the success path only | **0** | 1 | **2** |

Row 2 is the plausible shape of a later refactor and **nothing fails**. `#3067`'s cells stay green because the block still *begins* under the lock, so "no endpoint exists yet while a competing holder waits" is still true. The source rule stays green because it cannot see those four calls at all: it derives its vocabulary from the infrastructure modules that own the lock, which speak `unitree_sdk2py` only, so it knows `Init` and not `InitChannel` / `InitChannelWithName`. Of the eleven constructions this method performs it reports two.

Row 4 is the leak direction. A lock still held after a channel refused to open deadlocks **every later endpoint construction in the process**, and the existing release cell drives the success path, so it never reaches it.

That the source rule's reach is the systemic half of this is tracked separately in #3069; this PR is the per-driver half, which is what row 2 shows is not yet covered for the T1.

## The cells

`tests/drivers/test_booster_channels_open_under_the_shared_dds_lock.py`, a sibling of `test_motion_switcher_open_is_under_the_shared_dds_lock.py`. A recording stand-in for `booster_robotics_sdk_python` notes `_DDS_INIT_LOCK.locked()` at **every** construction, so the pin is on behaviour and no vendor's choice of name can evade it.

- `test_no_endpoint_is_constructed_with_the_lock_free`, parametrized over `robot_name=None` and a named T1, so the `Init`/`InitChannel` and the `InitWithName`/`InitChannelWithName` branches are both driven. It first asserts the exact construction sequence it observed, so it cannot pass over an open that never happened.
- `test_a_refused_channel_releases_the_lock_on_the_way_out` - the failure path.
- `test_the_release_path_does_not_hold_the_lock` - the driver's docstring says the partial-set teardown is deliberately outside the lock; this measures it.

The two properties #3067 already pins are deliberately **not** repeated here.

## Gate

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1778 source files`
- `tests/drivers/` + `tests/tools/g1/`: `1755 passed, 23 skipped`
- changelog, docstring-xref, source-string and host-path gates: `146 passed`
- no production file changes: `+238 / -0` across one test file and one fragment

No T1, DDS bus or `booster_robotics_sdk_python` is needed by any cell: the SDK is staged on `sys.modules`, which is the driver's own lazy-import path.

## Context: what the lock is worth

Driving the real `DDSSubscriberSet.subscribe` on one thread against the real `connect_eagerly` on another, 40 rounds each, and counting overlapping construction intervals - before and after #3067's fix:

| | concurrent cross-side constructions | wall clock |
|---|---|---|
| unlocked | 79 | 0.9136 s |
| locked | 0 | 0.9959 s |

![endpoint construction overlap](https://raw.githubusercontent.com/cagataycali/robots/assets/booster-dds-lock/dds_overlap.png)

The +9% is the serialisation, and it is what row 2 above would quietly give back.

Refs #3067, #3069
