### PR TITLE
fix(drivers/feetech): the two-byte word order is an STS/SMS property, so say so and decide it once

### DIFF
--- a/changelog.d/3074-feetech-word-order-is-a-series-property.md
+++ b/changelog.d/3074-feetech-word-order-is-a-series-property.md
@@ -1,0 +1,28 @@
+### Fixed: the Feetech word order and position full scale are named as STS/SMS-series properties, and decided once
+
+`Goal_Position`'s 12-bit full scale and the low-byte-first order the package
+frames it in belong to the STS/SMS **series**, not to the register and not to
+Feetech. The vendor SDK reverses that order on a per-model protocol number, so
+an SCS-series servo reads the same two bytes as the byte-swapped value:
+`position=1023`, which is full scale on an `scs0009`, reaches it as 65283.
+
+Every surface that stated one of those numbers while naming only the
+manufacturer now names the series -- `serial_tool`'s `position` and `velocity`
+schema entries (which is the whole of what a model planning a call knows about
+the domain), the refusal that quotes the ceiling back, and
+`FeetechDriver.tool_spec`'s description, which described itself as an
+"SCS protocol" driver while framing STS/SMS words.
+
+Both numbers are now decided in the codec that frames the register:
+`MAX_GOAL_POSITION`, `encode_word` and `decode_word` in
+`strands_robots.drivers.feetech.protocol`, with the order named rather than
+spelled as shifts. The bus, `serial_tool` and `pose_tool` read them; previously
+the two-byte split appeared 6 times across those three modules and the full
+scale 8 times, so a correction for a different series could move one and leave
+the rest behind. `encode_word` also refuses a value two bytes cannot carry
+instead of masking it into a different, reachable command.
+
+No byte this package puts on the wire changes for an STS/SMS servo, and cells
+graded against `scservo_sdk` under both protocol numbers pin that. Addressing an
+SCS-series servo remains out of scope: it needs a second word order and a second
+full scale, not a scale option, which is why no surface offers one.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -107,7 +107,7 @@ disagree about which address is a servo and which is the whole bus.
 | Option | Accepted | Why the bound is where it is |
 |--------|----------|------------------------------|
 | `motor_id` | integer in `[1, 254]`, or `[1, 253]` for an action that reads a reply | the frame carries the ID in one byte, of which `0xfd` is the highest a servo may hold and `0xfe` is the broadcast, while `0xff` is the header value |
-| `position` | integer in `[0, 4095]` | `Goal_Position` is a 12-bit register - the same full scale the reported angle divides by |
+| `position` | integer in `[0, 4095]` | `Goal_Position` is 12-bit on the STS/SMS series - the same full scale the reported angle divides by |
 | `velocity` | integer in `[0, 32767]` | `Goal_Velocity` is sign-magnitude with bit 15 the direction bit, so a larger magnitude commands the opposite direction |
 | `baudrate` | positive integer | pyserial coerces rather than checks, so `2.7` opens the port at 2 baud |
 | `read_bytes` | positive integer | pyserial's read loop is `while len(read) < size`, so a non-positive size returns no bytes and looks like a timeout |
@@ -121,6 +121,21 @@ own "required" message rather than as an unusable value.
 `pose_tool` writes the same `Goal_Position` register through the same mask and
 needs no bound of its own - it clamps to each motor's declared range before
 encoding, so the mask only ever sees a value that fits.
+
+Both bounds and the reported angle are STS/SMS-series properties, not properties
+of the register or of Feetech generally, and so is the two-byte order the value
+is encoded into. Feetech publishes one framing document for the whole family and
+ships one SDK for it, but that SDK's `PacketHandler` takes a per-model protocol
+number and reverses the word order on it: protocol 0 (STS3215, STS3250, SM8512BL)
+puts the low byte first, protocol 1 (the SCS series) puts the high byte first.
+A position framed for one series is therefore a *different position* on the
+other, not a mis-scaled one - `position=1023`, which is full scale on an
+`scs0009`, is read by it as 65283. `strands_robots.drivers.feetech.protocol`
+decides that order once (`encode_word` / `decode_word`) and holds the full scale
+once (`MAX_GOAL_POSITION`), and every Feetech write path in the package - this
+tool, `pose_tool`, and the native `FeetechDriver` bus - reads both from there.
+Addressing an SCS-series servo needs a second word order and a second full scale
+rather than a scale option, so no surface here offers one.
 
 ### A mesh wait budget is bounded where the command body cannot carry it
 

--- a/strands_robots/drivers/feetech/__init__.py
+++ b/strands_robots/drivers/feetech/__init__.py
@@ -1,4 +1,4 @@
-"""Feetech STS/SCS-series native driver package.
+"""Feetech STS/SMS-series native driver package.
 
 Three layers, each usable alone: the wire codec (:mod:`.protocol`), the serial
 bus that puts those frames on a port and converts units (:mod:`.bus`), and the
@@ -25,10 +25,14 @@ from strands_robots.drivers.feetech.driver import FeetechDriver
 from strands_robots.drivers.feetech.protocol import (
     BROADCAST_ID,
     HEADER,
+    MAX_GOAL_POSITION,
     MAX_UNICAST_ID,
+    WORD_LENGTH,
     Instruction,
     ProtocolError,
     build_packet,
+    decode_word,
+    encode_word,
     parse_status_packet,
     ping_packet,
     read_packet,
@@ -42,12 +46,16 @@ __all__ = [
     "FeetechDriver",
     "HEADER",
     "Instruction",
+    "MAX_GOAL_POSITION",
     "MAX_UNICAST_ID",
+    "WORD_LENGTH",
     "MotorSpec",
     "ProtocolError",
     "READABLE_REGISTERS",
     "SO_ARM_MOTORS",
     "build_packet",
+    "decode_word",
+    "encode_word",
     "parse_status_packet",
     "ping_packet",
     "read_packet",

--- a/strands_robots/drivers/feetech/bus.py
+++ b/strands_robots/drivers/feetech/bus.py
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""The SCS/STS serial bus :class:`FeetechDriver` writes through.
+"""The Feetech serial bus :class:`FeetechDriver` writes through.
 
-:mod:`~strands_robots.drivers.feetech.protocol` builds and parses the frames;
-this module puts them on a wire and turns the two byte values a servo speaks
+:mod:`~strands_robots.drivers.feetech.protocol` builds and parses the frames -
+including the two-byte word order, which is a property of the STS/SMS series and
+not of the family, so it is read from there rather than spelled again here. This
+module puts those frames on a wire and turns the two byte values a servo speaks
 into the units a caller uses. It is the half :issue:`360` scope 1 named as
 deferred when the driver landed as a stub.
 
@@ -32,10 +34,13 @@ import time
 from typing import Any, Final
 
 from strands_robots.drivers.feetech.protocol import (
+    MAX_GOAL_POSITION,
     Instruction,
     ProtocolError,
     Register,
     build_packet,
+    decode_word,
+    encode_word,
     parse_status_packet,
     read_packet,
     sync_write_packet,
@@ -52,12 +57,15 @@ class MotorSpec:
         motor_id: The servo's ID on the shared half-duplex bus.
         low: Lowest caller value, in the joint's own unit.
         high: Highest caller value, in the joint's own unit.
-        resolution: Encoder counts spanning ``low``..``high``.
+        resolution: Encoder counts spanning ``low``..``high``. Defaults to
+            :data:`~strands_robots.drivers.feetech.protocol.MAX_GOAL_POSITION`,
+            the STS/SMS full scale - an SCS-series servo spans a quarter of it
+            and must be given its own.
     """
 
     __slots__ = ("high", "low", "motor_id", "resolution")
 
-    def __init__(self, motor_id: int, low: float, high: float, resolution: int = 4095) -> None:
+    def __init__(self, motor_id: int, low: float, high: float, resolution: int = MAX_GOAL_POSITION) -> None:
         self.motor_id = motor_id
         self.low = low
         self.high = high
@@ -135,16 +143,21 @@ _REPLY_SETTLE_S: Final[float] = 0.01
 
 
 def _decode(raw: bytes, sign_bit: int | None) -> int:
-    """Turn two little-endian reply bytes into a signed integer.
+    """Turn a two-byte reply into a signed integer.
+
+    The byte order comes from
+    :func:`~strands_robots.drivers.feetech.protocol.decode_word`; only the sign
+    convention is applied here, because which bit carries direction is a
+    per-register property the codec deliberately leaves to its caller.
 
     Args:
-        raw: The register's parameter bytes, low byte first.
+        raw: The register's parameter bytes, in the order the servo sent them.
         sign_bit: Bit carrying direction, or ``None`` when unsigned.
 
     Returns:
         The register value, negative when ``sign_bit`` is set.
     """
-    value = raw[0] | (raw[1] << 8)
+    value = decode_word(raw)
     if sign_bit is None:
         return value
     magnitude = value & ((1 << sign_bit) - 1)
@@ -152,7 +165,7 @@ def _decode(raw: bytes, sign_bit: int | None) -> int:
 
 
 class FeetechBus:
-    """A half-duplex SCS bus carrying one SO-arm's servos.
+    """A half-duplex Feetech bus carrying one SO-arm's servos.
 
     Args:
         port: Serial device path. ``None`` is accepted so a driver can be
@@ -316,7 +329,7 @@ class FeetechBus:
             if not math.isfinite(number):
                 raise ValueError(f"FeetechBus: {name} target must be finite, got {value!r}")
             counts = spec.to_counts(number)
-            motor_data.append((spec.motor_id, bytes([counts & 0xFF, (counts >> 8) & 0xFF])))
+            motor_data.append((spec.motor_id, encode_word(counts)))
         conn.write(sync_write_packet(Register.GOAL_POSITION, _REGISTER_WIDTH, motor_data))
 
     def set_torque(self, enabled: bool) -> list[str]:

--- a/strands_robots/drivers/feetech/driver.py
+++ b/strands_robots/drivers/feetech/driver.py
@@ -1,4 +1,4 @@
-"""Native Feetech STS/SCS-series driver satisfying :class:`HardwareDriver`.
+"""Native Feetech STS/SMS-series driver satisfying :class:`HardwareDriver`.
 
 This driver drives the arm. :mod:`~strands_robots.drivers.feetech.bus` opens
 the SCS serial port, so ``send_action`` writes goal positions and the joints
@@ -88,7 +88,14 @@ _NO_POLICY_LOOP = "not wired yet (the policy control loop)"
 
 
 class FeetechDriver:
-    """Native SCS-protocol driver for the arms in :data:`SUPPORTED_ROBOTS`.
+    """Native Feetech driver for the arms in :data:`SUPPORTED_ROBOTS`.
+
+    The bus writes STS/SMS-series frames: that series' two-byte word order and
+    its 12-bit ``Goal_Position`` full scale both come from
+    :mod:`~strands_robots.drivers.feetech.protocol`. An SCS-series servo reads
+    the same two bytes in the opposite order, so a bus of that series is not
+    addressed by this driver - which is why the one SCS-series robot the registry
+    declares, ``hope_jr_hand``, is absent from :data:`SUPPORTED_ROBOTS`.
 
     Constructor contract matches :class:`~strands_robots.drivers.base.HardwareDriver`
     - the factory builds every native driver as ``driver_cls(tool_name=...,
@@ -174,7 +181,7 @@ class FeetechDriver:
         return {
             "name": self._tool_name,
             "description": (
-                f"Feetech-native driver for {self._tool_name} (SCS protocol). Joint targets are degrees; "
+                f"Feetech-native driver for {self._tool_name} (STS/SMS series). Joint targets are degrees; "
                 "gripper is percent open."
             ),
             "inputSchema": {

--- a/strands_robots/drivers/feetech/protocol.py
+++ b/strands_robots/drivers/feetech/protocol.py
@@ -1,4 +1,4 @@
-"""Feetech STS/SCS-series wire format. Pure, no I/O.
+"""Feetech STS/SMS-series wire format. Pure, no I/O.
 
 The STS3215 and its SCS/SMS siblings share a Protocol 1-shaped bus that is
 close to Dynamixel's older Protocol 1 but not identical to Protocol 2. This
@@ -7,6 +7,27 @@ PyPI); as with :mod:`~strands_robots.drivers.dynamixel.protocol`, the point of
 extracting it is not dependency avoidance but grading, since the SDK's own
 parser lives inside :meth:`PacketHandler.readTxRx` and cannot be exercised
 without a serial port.
+
+**Framing is shared across the family; the two-byte word order is not.** Feetech
+publishes one framing document for the whole family (`SCS Communication`_ below,
+which is where the frame above comes from), and the vendor SDK is one package for
+all of it - but that SDK carries a global end-ness its ``PacketHandler`` sets
+from a per-model protocol number, and the two orders are the reverse of each
+other:
+
+.. code-block:: text
+
+    protocol 0  STS3215, STS3250, SM8512BL   low byte first
+    protocol 1  SCS0009 and the SCS series   high byte first
+
+So a two-byte register value framed for one series is a *different value* on the
+other, not a mis-scaled one: 1023 written low-byte-first is read as 65283 by an
+SCS-series servo. This module implements protocol 0 - :func:`encode_word` and
+:func:`decode_word` are that order, named so the whole package reads it from one
+place, and :data:`MAX_GOAL_POSITION` is the STS/SMS full scale (the SCS series is
+10-bit, a quarter of it). Supporting an SCS-series servo is therefore a second
+word order and a second full scale rather than a parameter, and nothing here
+claims to do it; see :issue:`2812`.
 
 Wire frame (from the Feetech STS3215 datasheet, `SCS Communication`_):
 
@@ -49,7 +70,7 @@ the datasheet page it comes from.
 from __future__ import annotations
 
 import enum
-from typing import Final
+from typing import Final, Literal
 
 # ---------------------------------------------------------------------------
 # Framing constants. Two bytes named because the manual talks about them by
@@ -72,6 +93,86 @@ _MAX_PARAM_COUNT: Final[int] = 0xFA
 """``LEN`` is one byte, and it must carry ``params + 2``. Anything above
 ``0xFA`` (250) params would overflow ``LEN`` past ``0xFC`` and collide with
 the reserved range; the SDK caps writes below this and so does this codec."""
+
+MAX_GOAL_POSITION: Final[int] = 4095
+"""Highest index ``Goal_Position`` addresses on the STS/SMS series, and so the
+divisor that turns a count into a fraction of a full turn.
+
+12-bit, i.e. 4096 counts. This is a property of the *series*, not of the
+register: lerobot's ``MODEL_RESOLUTION`` gives 4096 counts for ``sts3215``,
+``sts3250`` and ``sm8512bl`` and 1024 for ``scs0009``, so on an SCS-series servo
+the ceiling and the divisor are both 1023. Every surface in this package that
+bounds or reports a Feetech position reads this name, so the series the number
+belongs to is stated once."""
+
+WORD_LENGTH: Final[int] = 2
+"""Bytes a two-byte register field occupies on the wire."""
+
+_MAX_WORD: Final[int] = (1 << (8 * WORD_LENGTH)) - 1
+
+_WORD_ORDER: Final[Literal["little"]] = "little"
+"""The STS/SMS (protocol 0) byte order, named rather than spelled as shifts so
+the one place it is decided reads as the property it is. The SCS series is
+``"big"``; nothing here emits that order."""
+
+
+def encode_word(value: int) -> bytes:
+    """Encode ``value`` as the two bytes an STS/SMS-series servo reads.
+
+    Low byte first - the vendor SDK's protocol 0 order, which its
+    ``SCS_LOBYTE`` / ``SCS_HIBYTE`` pair produces while its global end-ness is
+    0. The SCS series sets that global to 1 and reads the same two bytes in the
+    opposite order, so this encoder is series-specific by construction and is
+    not portable to it (see the module docstring).
+
+    Args:
+        value: The register value, ``0..0xFFFF``. A field narrower than the word
+            - ``Goal_Position`` at :data:`MAX_GOAL_POSITION`, ``Goal_Velocity``
+            at its direction bit - is bounded by the caller that owns the field's
+            meaning; this refuses only what the two bytes cannot carry at all.
+
+    Returns:
+        Exactly :data:`WORD_LENGTH` bytes, low byte first.
+
+    Raises:
+        TypeError: If ``value`` is not an :class:`int`. A :class:`bool` is
+            refused with it, since ``True`` would silently encode as 1.
+        ValueError: If ``value`` does not fit two bytes. Masking it instead
+            would put a different, reachable command on the wire and report the
+            number the caller asked for.
+    """
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"word value must be int, got {type(value).__name__}")
+    if not 0 <= value <= _MAX_WORD:
+        raise ValueError(f"word value out of range 0..{_MAX_WORD}: {value}")
+    return value.to_bytes(WORD_LENGTH, _WORD_ORDER)
+
+
+def decode_word(raw: bytes) -> int:
+    """Read the two bytes an STS/SMS-series servo replied with.
+
+    The inverse of :func:`encode_word`, and the same protocol 0 order. Sign
+    handling is deliberately absent: which bit carries direction is a
+    per-register property (bit 15 on the goal and present pairs, bit 10 on
+    ``Present_Load``, and nothing at all on the SCS series), so it belongs to
+    the caller that knows which register it read.
+
+    Args:
+        raw: Exactly :data:`WORD_LENGTH` bytes, low byte first.
+
+    Returns:
+        The unsigned register value.
+
+    Raises:
+        TypeError: If ``raw`` is not bytes-like.
+        ValueError: If ``raw`` is not exactly :data:`WORD_LENGTH` bytes - a
+            short read decoded anyway reports a position the servo never sent.
+    """
+    if not isinstance(raw, (bytes, bytearray)):
+        raise TypeError(f"raw must be bytes, got {type(raw).__name__}")
+    if len(raw) != WORD_LENGTH:
+        raise ValueError(f"a register word is {WORD_LENGTH} bytes, got {len(raw)}")
+    return int.from_bytes(raw, _WORD_ORDER)
 
 
 class Instruction(enum.IntEnum):
@@ -112,7 +213,7 @@ class Register(enum.IntEnum):
     # SRAM
     TORQUE_ENABLE = 0x28
     ACCELERATION = 0x29
-    GOAL_POSITION = 0x2A  # 2 bytes, 0..4095 for STS3215
+    GOAL_POSITION = 0x2A  # 2 bytes, 0..MAX_GOAL_POSITION on the STS/SMS series
     GOAL_TIME = 0x2C  # 2 bytes
     GOAL_VELOCITY = 0x2E  # 2 bytes, sign-magnitude on bit 15
     LOCK = 0x37

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -22,6 +22,7 @@ import serial
 import serial.tools.list_ports
 from strands import tool
 
+from strands_robots.drivers.feetech.protocol import MAX_GOAL_POSITION, decode_word, encode_word
 from strands_robots.tools._path_validation import resolve_output_path, validate_save_path
 from strands_robots.utils import finite_number_error, positive_count_error, positive_finite_number_error
 
@@ -221,13 +222,18 @@ class MotorConfig(TypedDict):
 # that conversion could not represent. A second copy of these bounds could
 # disagree with the one the servo is actually driven from, which is the failure
 # the guard exists to prevent.
+#
+# ``resolution`` is the STS/SMS full scale for every joint, which is what an
+# SO-101's servos are; it is read from the codec that decides the wire format
+# rather than restated, so a bus of a different series cannot be described here
+# by changing one number and leaving the byte order behind.
 _DEFAULT_MOTOR_CONFIGS: dict[str, MotorConfig] = {
-    "shoulder_pan": {"id": 1, "range": (-180, 180), "resolution": 4095},
-    "shoulder_lift": {"id": 2, "range": (-90, 90), "resolution": 4095},
-    "elbow_flex": {"id": 3, "range": (-150, 150), "resolution": 4095},
-    "wrist_flex": {"id": 4, "range": (-90, 90), "resolution": 4095},
-    "wrist_roll": {"id": 5, "range": (-180, 180), "resolution": 4095},
-    "gripper": {"id": 6, "range": (0, 100), "resolution": 4095},
+    "shoulder_pan": {"id": 1, "range": (-180, 180), "resolution": MAX_GOAL_POSITION},
+    "shoulder_lift": {"id": 2, "range": (-90, 90), "resolution": MAX_GOAL_POSITION},
+    "elbow_flex": {"id": 3, "range": (-150, 150), "resolution": MAX_GOAL_POSITION},
+    "wrist_flex": {"id": 4, "range": (-90, 90), "resolution": MAX_GOAL_POSITION},
+    "wrist_roll": {"id": 5, "range": (-180, 180), "resolution": MAX_GOAL_POSITION},
+    "gripper": {"id": 6, "range": (0, 100), "resolution": MAX_GOAL_POSITION},
 }
 
 
@@ -572,7 +578,9 @@ class MotorController:
         # Clamp to range
         degrees = max(min_deg, min(max_deg, degrees))
 
-        # Convert to position (0-4095 for most servos)
+        # Convert to encoder counts. Each config's resolution is the STS/SMS
+        # full scale, which is the series every motor in
+        # ``_DEFAULT_MOTOR_CONFIGS`` is.
         if motor_name == "gripper":
             # Gripper uses 0-100 percentage
             return int((degrees / 100.0) * config["resolution"])
@@ -605,7 +613,7 @@ class MotorController:
             position = self.degrees_to_position(motor_name, position_degrees)
 
             # Feetech position command: INST_WRITE (0x03), Goal_Position address (0x2A)
-            params = [0x2A, position & 0xFF, (position >> 8) & 0xFF]
+            params = [0x2A, *encode_word(position)]
             packet = self.build_feetech_packet(motor_id, 0x03, params)
             self.serial_conn.write(packet)
             return True
@@ -687,7 +695,7 @@ class MotorController:
                     response.hex(" ") if response else "an empty read",
                 )
                 return None
-            position = reply[0] | (reply[1] << 8)
+            position = decode_word(bytes(reply))
             return self.position_to_degrees(motor_name, position)
         except Exception as e:
             logger.error(f"Failed to read motor {motor_name}: {e}")

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -1,4 +1,4 @@
-"""Raw serial-bus access: port discovery, byte-level I/O, and Feetech servo writes.
+"""Raw serial-bus access: port discovery, byte-level I/O, and STS/SMS servo writes.
 
 Every numeric option an action consumes is checked here, before the port is
 opened, because none of them is refused by the layer that finally consumes it.
@@ -51,7 +51,12 @@ import serial
 import serial.tools.list_ports
 from strands import tool
 
-from strands_robots.drivers.feetech.protocol import BROADCAST_ID, MAX_UNICAST_ID
+from strands_robots.drivers.feetech.protocol import (
+    BROADCAST_ID,
+    MAX_GOAL_POSITION,
+    MAX_UNICAST_ID,
+    encode_word,
+)
 from strands_robots.utils import (
     finite_number_error,
     non_negative_count_error,
@@ -68,15 +73,6 @@ _DIRECTION_BIT = 15
 # Largest magnitude either register carries with ``_DIRECTION_BIT`` still clear.
 _MAX_MAGNITUDE = (1 << _DIRECTION_BIT) - 1
 
-# Largest index ``Goal_Position`` addresses, and the divisor that turns a count
-# into the reported angle. One name carries both because the ceiling's own reason
-# below claims the two are "the same full scale": while they were separate
-# literals that claim was asserted rather than enforced, so a correction to
-# either was invisible to the other. See issue #2812, which reports that the
-# right full scale is model-dependent -- the registry declares SCS-series servos
-# at a quarter of this -- and that the choice is still open.
-_MAX_POSITION = 4095
-
 # Inclusive bounds and the reason for each ceiling, keyed by the parameter that
 # carries the field. The floor and the type are delegated to the shared count
 # domains so an off-type or negative value is reported in the words every other
@@ -91,8 +87,9 @@ _REGISTER_FIELDS: dict[str, tuple[int, int, str]] = {
     ),
     "position": (
         0,
-        _MAX_POSITION,
-        "Goal_Position is a 12-bit register, the same full scale the reported angle divides by",
+        MAX_GOAL_POSITION,
+        "Goal_Position is 12-bit on the STS/SMS series, the same full scale the reported angle "
+        "divides by; the SCS series is 10-bit and this module does not address it",
     ),
     "velocity": (
         0,
@@ -258,9 +255,9 @@ def serial_tool(
         - "send": Send data to serial port
         - "read": Read data from serial port
         - "send_read": Send data and read response
-        - "feetech_position": Control Feetech servo position
-        - "feetech_velocity": Control Feetech servo velocity
-        - "feetech_ping": Ping Feetech servo motor
+        - "feetech_position": Control STS/SMS servo position
+        - "feetech_velocity": Control STS/SMS servo velocity
+        - "feetech_ping": Ping a Feetech servo motor
         - "monitor": Monitor serial port (continuous read)
 
     Args:
@@ -274,10 +271,15 @@ def serial_tool(
         motor_id: Motor ID for Feetech commands; an integer in [1, 254], of
             which 254 (0xfe) is the broadcast every servo receives. An action
             that reads a reply back accepts only a single servo, [1, 253]
-        position: Target position for Feetech motors; an integer in [0, 4095]
-        velocity: Target velocity for Feetech motors; an integer in [0, 32767].
-            Goal_Velocity is sign-magnitude, so a magnitude reaching bit 15
-            commands the opposite direction instead of a faster move
+        position: Target position for STS/SMS-series motors; an integer in
+            [0, 4095]. That full scale and the two-byte order this tool encodes
+            into are both STS/SMS properties: the SCS series is 10-bit and reads
+            the same two bytes in the opposite order, so an SCS-series servo is
+            not addressed by this action at all
+        velocity: Target velocity for STS/SMS-series motors; an integer in
+            [0, 32767]. Goal_Velocity is sign-magnitude on that series, so a
+            magnitude reaching bit 15 commands the opposite direction instead of
+            a faster move
         read_bytes: Number of bytes to read; a positive integer
 
     Validation:
@@ -410,7 +412,7 @@ def serial_tool(
                 return {"status": "error", "content": [{"text": "motor_id and position required"}]}
 
             # Feetech position command: INST_WRITE (0x03), Goal_Position address (0x2A)
-            params = [0x2A, position & 0xFF, (position >> 8) & 0xFF]
+            params = [0x2A, *encode_word(position)]
             packet = build_feetech_packet(motor_id, 0x03, params)
             ser.write(packet)
             ser.close()
@@ -419,7 +421,8 @@ def serial_tool(
                 "status": "success",
                 "content": [
                     {
-                        "text": f"Feetech Motor {motor_id} -> Position {position} ({position / _MAX_POSITION * 360:.1f} deg)"
+                        "text": f"Feetech Motor {motor_id} -> Position {position} "
+                        f"({position / MAX_GOAL_POSITION * 360:.1f} deg)"
                     }
                 ],
             }
@@ -430,7 +433,7 @@ def serial_tool(
                 return {"status": "error", "content": [{"text": "motor_id and velocity required"}]}
 
             # Feetech velocity command: Goal_Velocity address (0x2E)
-            params = [0x2E, velocity & 0xFF, (velocity >> 8) & 0xFF]
+            params = [0x2E, *encode_word(velocity)]
             packet = build_feetech_packet(motor_id, 0x03, params)
             ser.write(packet)
             ser.close()

--- a/tests/drivers/test_feetech_protocol.py
+++ b/tests/drivers/test_feetech_protocol.py
@@ -24,17 +24,23 @@ this suite grades only the codec.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+from pathlib import Path
 
 import pytest
 
 from strands_robots.drivers.feetech.protocol import (
     BROADCAST_ID,
     HEADER,
+    MAX_GOAL_POSITION,
     MAX_UNICAST_ID,
+    WORD_LENGTH,
     Instruction,
     ProtocolError,
     build_packet,
+    decode_word,
+    encode_word,
     parse_status_packet,
     ping_packet,
     read_packet,
@@ -319,6 +325,38 @@ class TestParseStatusPacket:
 # skips only this class's 2 cells.
 _scservo_sdk_available = importlib.util.find_spec("scservo_sdk") is not None
 
+#: Repository root, so the source-level cells read the shipped file rather than
+#: an ``inspect.getsource`` of an already-imported module.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Values spanning the word: both bytes zero, low byte only, high byte only, the
+#: STS/SMS position full scale, and the two-byte maximum.
+_WORD_VALUES = (0, 1, 255, 256, 511, 1023, 2048, MAX_GOAL_POSITION, 0xFFFF)
+
+
+def _sdk_word(sdk, value: int, *, protocol: int) -> list[int]:  # type: ignore[no-untyped-def]
+    """The two bytes the vendor SDK frames ``value`` as under ``protocol``.
+
+    ``SCS_LOBYTE`` / ``SCS_HIBYTE`` read a module-global end-ness rather than
+    taking it as an argument, and ``PacketHandler`` is what sets it. Selecting
+    protocol 0 again in a ``finally`` keeps that global from leaking into any
+    later cell.
+    """
+    try:
+        sdk.PacketHandler(protocol)
+        return [sdk.SCS_LOBYTE(value), sdk.SCS_HIBYTE(value)]
+    finally:
+        sdk.PacketHandler(0)
+
+
+def _sdk_make_word(sdk, low: int, high: int, *, protocol: int) -> int:  # type: ignore[no-untyped-def]
+    """The value a servo speaking ``protocol`` reads from the pair ``low, high``."""
+    try:
+        sdk.PacketHandler(protocol)
+        return int(sdk.SCS_MAKEWORD(low, high))
+    finally:
+        sdk.PacketHandler(0)
+
 
 @pytest.mark.skipif(
     not _scservo_sdk_available,
@@ -375,3 +413,184 @@ class TestTheVendorAgreesOnFraming:
         checksum = (~sum(payload)) & 0xFF
         expected = bytes([0xFF, 0xFF] + payload + [checksum])
         assert write_packet(motor_id, address, bytes(data)) == expected
+
+    @pytest.mark.parametrize("value", _WORD_VALUES)
+    def test_encode_word_matches_the_sdk_protocol_0_order(self, sdk, value: int) -> None:  # type: ignore[no-untyped-def]
+        # The SDK's LOBYTE/HIBYTE pair reads a module-global end-ness that
+        # ``PacketHandler`` sets, so select protocol 0 - the STS/SMS order - and
+        # restore it afterwards rather than leaving a global behind for whichever
+        # cell runs next.
+        assert encode_word(value) == bytes(_sdk_word(sdk, value, protocol=0))
+
+    @pytest.mark.parametrize("value", _WORD_VALUES)
+    def test_the_scs_series_reads_the_same_bytes_as_a_different_value(self, sdk, value: int) -> None:  # type: ignore[no-untyped-def]
+        """Why :func:`encode_word` is series-specific rather than mis-scaled.
+
+        ``PacketHandler(1)`` - the SCS series - reverses the pair, so the bytes
+        this package puts on the wire are read by an SCS-series servo as the
+        byte-swapped value. For every value whose two bytes differ that is a
+        different position, which is what makes covering the SCS series a second
+        word order rather than a scale option.
+        """
+        low, high = _sdk_word(sdk, value, protocol=0)
+        assert _sdk_word(sdk, value, protocol=1) == [high, low]
+
+        as_scs_reads_it = _sdk_make_word(sdk, low, high, protocol=1)
+        if low == high:
+            assert as_scs_reads_it == value, "a palindrome word is the one case both series agree on"
+        else:
+            assert as_scs_reads_it != value, (
+                f"position {value} is framed as {[low, high]} and read by an SCS-series servo as {as_scs_reads_it}"
+            )
+
+
+class TestTheRegisterWordIsTheStsSeriesOrder:
+    """A two-byte register value is framed low byte first, and only there.
+
+    The order is a property of the servo *series*, not of the register or of
+    Feetech generally: the vendor SDK reverses it on a per-model protocol number.
+    These cells state the protocol 0 order this codec implements from the
+    datasheet's own examples, so the SDK-graded cells above confirm rather than
+    define it.
+    """
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0, b"\x00\x00"),
+            (1, b"\x01\x00"),
+            (255, b"\xff\x00"),
+            (256, b"\x00\x01"),
+            (1023, b"\xff\x03"),  # full scale on an SCS-series servo
+            (2048, b"\x00\x08"),  # mid-travel on an STS3215
+            (MAX_GOAL_POSITION, b"\xff\x0f"),
+            (0xFFFF, b"\xff\xff"),
+        ],
+    )
+    def test_a_word_is_framed_low_byte_first(self, value: int, expected: bytes) -> None:
+        assert encode_word(value) == expected
+        assert len(encode_word(value)) == WORD_LENGTH
+        assert decode_word(expected) == value
+
+    @pytest.mark.parametrize("value", _WORD_VALUES)
+    def test_a_word_survives_the_round_trip(self, value: int) -> None:
+        assert decode_word(encode_word(value)) == value
+
+    @pytest.mark.parametrize("value", [-1, 0x10000, 70000])
+    def test_a_value_the_word_cannot_carry_is_refused_not_masked(self, value: int) -> None:
+        # Masking would put a different, reachable command on the wire while the
+        # caller is told the number they asked for went out.
+        with pytest.raises(ValueError, match="out of range"):
+            encode_word(value)
+
+    @pytest.mark.parametrize("value", [True, 2.0, "2048", None])
+    def test_a_non_integer_word_is_refused(self, value: object) -> None:
+        # ``True`` is refused with the rest: it would silently encode as 1.
+        with pytest.raises(TypeError, match="must be int"):
+            encode_word(value)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("raw", [b"", b"\x01", b"\x01\x02\x03"])
+    def test_a_reply_that_is_not_one_word_is_refused(self, raw: bytes) -> None:
+        # A short read decoded anyway reports a position the servo never sent.
+        with pytest.raises(ValueError, match="bytes"):
+            decode_word(raw)
+
+    def test_a_bytearray_reply_decodes(self) -> None:
+        # The bus reads into whatever pyserial hands back; both shapes decode.
+        assert decode_word(bytearray(b"\xff\x03")) == 1023
+
+    def test_a_reply_that_is_not_bytes_is_refused(self) -> None:
+        with pytest.raises(TypeError, match="must be bytes"):
+            decode_word([0xFF, 0x03])  # type: ignore[arg-type]
+
+
+class TestTheWireFormatIsDecidedInOnePlace:
+    """Every Feetech write path reads the word order and the full scale from here.
+
+    Both are series properties, and the package spelled each of them several
+    times: the two-byte split appeared as ``value & 0xFF, (value >> 8) & 0xFF``
+    in the bus, in ``serial_tool`` (twice) and in ``pose_tool``, with the joining
+    shift in two more places, and the STS/SMS full scale appeared as eight
+    integer literals. A second spelling is what lets one of them be corrected for
+    a different series while the others stay behind, which is the arrangement
+    :issue:`2812` reports.
+    """
+
+    #: The modules that frame or read a Feetech register word.
+    _WRITE_PATH = (
+        "strands_robots/drivers/feetech/bus.py",
+        "strands_robots/drivers/feetech/driver.py",
+        "strands_robots/tools/serial_tool.py",
+        "strands_robots/tools/pose_tool.py",
+    )
+
+    @staticmethod
+    def _shift_by_eight_sites(source: str) -> list[int]:
+        """Lines spelling a byte-order shift, i.e. ``<< 8`` or ``>> 8``."""
+        tree = ast.parse(source)
+        return sorted(
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.BinOp)
+            and isinstance(node.op, (ast.LShift, ast.RShift))
+            and isinstance(node.right, ast.Constant)
+            and node.right.value == 8
+        )
+
+    @pytest.mark.parametrize("module_path", _WRITE_PATH)
+    def test_no_consumer_spells_the_byte_order_itself(self, module_path: str) -> None:
+        source = (_REPO_ROOT / module_path).read_text(encoding="utf-8")
+
+        assert self._shift_by_eight_sites(source) == [], (
+            f"{module_path} shifts a byte into place on lines "
+            f"{self._shift_by_eight_sites(source)}; the order belongs to "
+            "encode_word / decode_word so a servo series with the opposite order "
+            "is one edit rather than six"
+        )
+
+    def test_the_codec_names_the_order_rather_than_shifting(self) -> None:
+        source = (_REPO_ROOT / "strands_robots/drivers/feetech/protocol.py").read_text(encoding="utf-8")
+
+        assert self._shift_by_eight_sites(source) == []
+        assert '"little"' in source, "the order the codec implements is named, not encoded in shifts"
+
+    @pytest.mark.parametrize("module_path", _WRITE_PATH)
+    def test_no_consumer_restates_the_full_scale(self, module_path: str) -> None:
+        tree = ast.parse((_REPO_ROOT / module_path).read_text(encoding="utf-8"))
+        literals = sorted(
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and node.value.__class__ is int and node.value == MAX_GOAL_POSITION
+        )
+
+        assert literals == [], (
+            f"{module_path} spells the STS/SMS full scale {MAX_GOAL_POSITION} on lines "
+            f"{literals}; it is a series property and MAX_GOAL_POSITION is where it is decided"
+        )
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("lerobot") is None,
+    reason="lerobot not installed on this box",
+)
+class TestLerobotAgreesOnWhichSeriesTheFullScaleBelongsTo:
+    """lerobot's motor tables are the oracle for the resolution and the protocol.
+
+    Skipped where lerobot is absent, like the vendor-SDK class above: the codec's
+    own cells do not need it, and its tables are what let this package state that
+    4096 counts is the STS/SMS number rather than the Feetech number.
+    """
+
+    def test_the_full_scale_is_the_sts_series_resolution(self) -> None:
+        tables = pytest.importorskip("lerobot.motors.feetech.tables")
+
+        for model in ("sts3215", "sts3250", "sm8512bl"):
+            assert tables.MODEL_RESOLUTION[model] - 1 == MAX_GOAL_POSITION, model
+            assert tables.MODEL_PROTOCOL[model] == 0, f"{model} is the low-byte-first order"
+
+    def test_the_scs_series_is_a_different_scale_and_a_different_order(self) -> None:
+        tables = pytest.importorskip("lerobot.motors.feetech.tables")
+
+        assert tables.MODEL_RESOLUTION["scs0009"] - 1 != MAX_GOAL_POSITION
+        assert tables.MODEL_RESOLUTION["scs0009"] == 1024, "10-bit, a quarter of the STS/SMS scale"
+        assert tables.MODEL_PROTOCOL["scs0009"] == 1, "the high-byte-first order this codec does not emit"

--- a/tests/drivers/test_feetech_refusals_are_documented_and_catchable.py
+++ b/tests/drivers/test_feetech_refusals_are_documented_and_catchable.py
@@ -73,6 +73,10 @@ _REFUSALS: tuple[tuple[str, tuple[Any, ...], type[BaseException]], ...] = (
     ("parse_status_packet", ("notbytes", 1, 0), TypeError),
     ("parse_status_packet", (_WELL_FORMED, 0x1FF, 0), ValueError),
     ("parse_status_packet", (b"\x00\x00", 1, 0), protocol.ProtocolError),
+    ("encode_word", (True,), TypeError),
+    ("encode_word", (0x10000,), ValueError),
+    ("decode_word", ([0xFF, 0x03],), TypeError),
+    ("decode_word", (b"\x01",), ValueError),
 )
 
 

--- a/tests/tools/test_serial_tool_documented_bounds.py
+++ b/tests/tools/test_serial_tool_documented_bounds.py
@@ -34,10 +34,16 @@ the divisor to be single-sourced whichever way the model question is settled.
 This module pins that, so the correction is one edit rather than two that can
 disagree.
 
-Deliberately out of scope: which full scale is right. Choosing between naming the
-model, reporting counts only, and narrowing the claim to the STS series is the
-open decision in #2812 and needs hardware this suite does not have. These cells
-grade only that the number is stated once and reported honestly.
+Which full scale is right was left open by that change and is settled here: it is
+the STS/SMS one, because the two-byte order this tool encodes a position into is
+itself an STS/SMS property. The vendor SDK reverses that order on a per-model
+protocol number, so an SCS-series servo reads the same two bytes as the
+byte-swapped value -- ``position=1023``, full scale on an ``scs0009``, reaches it
+as 65283. Covering that series is therefore a second word order and a second full
+scale, not a scale option on this action, and the number and the order now come
+from :mod:`strands_robots.drivers.feetech.protocol`, which decides both once.
+These cells grade that the bound is honest, that it is not restated here, and
+that the schema says which series it belongs to.
 """
 
 from __future__ import annotations
@@ -51,6 +57,7 @@ import pytest
 import serial
 
 import strands_robots.tools.serial_tool as serial_mod
+from strands_robots.drivers.feetech.protocol import MAX_GOAL_POSITION
 
 #: The bound a field's schema entry declares, as the model reads it. ``motor_id``
 #: carries a second interval for the reply-expecting actions, so the *first*
@@ -138,12 +145,58 @@ class TestTheDocumentedBoundIsTheEnforcedBound:
         assert str(ceiling) in _text(refused)
 
 
+class TestTheSchemaNamesTheSeriesTheBoundBelongsTo:
+    """A model reading the schema is told which servos the bound is true of.
+
+    ``[0, 4095]`` and the degrees the tool reports back are true of the STS/SMS
+    series and of nothing else on this bus: an ``scs0009`` addresses a quarter of
+    that range and reads the two bytes in the opposite order, so the same call
+    commands a different position. A schema entry that names the manufacturer and
+    not the series tells the model the action covers servos it cannot address,
+    and the refusal it would rather have -- the one this suite exists to keep
+    honest -- never comes, because the value is in range for the series the tool
+    does speak.
+    """
+
+    @pytest.mark.parametrize("field", ["position", "velocity"])
+    def test_the_schema_entry_names_the_series(self, field: str) -> None:
+        properties = serial_mod.serial_tool.tool_spec["inputSchema"]["json"]["properties"]
+        description = " ".join(properties[field]["description"].split())
+
+        assert "STS/SMS" in description, (
+            f"{field}: the schema tells the model {description!r}, which names the "
+            "manufacturer rather than the series the bound and the encoding belong to"
+        )
+
+    def test_the_position_reason_says_which_series_the_full_scale_is(self) -> None:
+        # The reason is what a refusal quotes back, so it is the one place a
+        # caller who was refused learns why the ceiling is where it is.
+        _floor, _ceiling, why = serial_mod._REGISTER_FIELDS["position"]
+
+        assert "STS/SMS" in why and "SCS" in why, (
+            f"the position ceiling's reason reads {why!r}; it states a 12-bit scale "
+            "without saying which series is 12-bit, and the family has a 10-bit half"
+        )
+
+    def test_a_refusal_names_the_series_alongside_the_ceiling(self, opened: list[_FakeSerial]) -> None:
+        ceiling = serial_mod._REGISTER_FIELDS["position"][1]
+
+        refused = _call(action="feetech_position", motor_id=1, position=ceiling + 1)
+
+        assert refused["status"] == "error"
+        assert "STS/SMS" in _text(refused), _text(refused)
+
+
 class TestTheFullScaleIsSingleSourced:
     """The ceiling and the report divisor are one number, not two that agree."""
 
-    def test_the_full_scale_appears_as_one_literal_in_the_module(self) -> None:
+    def test_the_full_scale_is_not_spelled_in_this_module_at_all(self) -> None:
         # Taken from the enforced ceiling rather than from the constant that now
         # holds it, so this cell states the property and not the fix's spelling.
+        # It is a property of the servo series, decided by the codec that frames
+        # the register, so this module reads it and never restates it: the
+        # ceiling, the reported angle's divisor and the byte order a correction
+        # would have to move together all read one name.
         full_scale = serial_mod._REGISTER_FIELDS["position"][1]
         tree = ast.parse(inspect.getsource(serial_mod))
         literals = [
@@ -152,12 +205,14 @@ class TestTheFullScaleIsSingleSourced:
             if isinstance(node, ast.Constant) and node.value.__class__ is int and node.value == full_scale
         ]
 
-        assert len(literals) == 1, (
+        assert literals == [], (
             f"the position full scale {full_scale} is spelled as {len(literals)} "
-            f"integer literals, on lines {[node.lineno for node in literals]}; the "
-            "ceiling and the reported angle's divisor must read one name so a "
-            "correction to either cannot leave the other behind"
+            f"integer literals, on lines {[node.lineno for node in literals]}; it is "
+            "an STS/SMS-series property and MAX_GOAL_POSITION is where it is decided"
         )
+
+    def test_the_ceiling_is_the_codec_full_scale(self) -> None:
+        assert serial_mod._REGISTER_FIELDS["position"][1] == MAX_GOAL_POSITION
 
     def test_the_reported_angle_divides_by_the_enforced_ceiling(self, opened: list[_FakeSerial]) -> None:
         _floor, ceiling, _reason = serial_mod._REGISTER_FIELDS["position"]


### PR DESCRIPTION
`Goal_Position`'s 12-bit full scale and the low-byte-first order the package frames it in are properties of the STS/SMS **series**, not of the register and not of Feetech. Surfaces that state one of those numbers named the manufacturer, and each number was spelled in several modules at once.

![feetech word order](https://raw.githubusercontent.com/cagataycali/robots/assets/feetech-word-order/feetech_word_order.png)

## Measured

The vendor SDK reverses the pair on a per-model protocol number: `PacketHandler(protocol_end)` sets a module-global end-ness that `SCS_LOBYTE` / `SCS_HIBYTE` read. lerobot's `MODEL_PROTOCOL` gives 0 for `sts3215` / `sts3250` / `sm8512bl` and 1 for `scs0009`. Bytes below are from `encode_word`, decoded by `scservo_sdk.SCS_MAKEWORD` under each protocol:

| `position=` | bytes on the wire | STS/SMS reads | SCS reads |
|---|---|---|---|
| 1 | `01 00` | 1 | 256 |
| 511 | `ff 01` | 511 | 65281 |
| **1023** (full scale on an `scs0009`) | `ff 03` | 1023 | **65283** |
| 2048 | `00 08` | 2048 | 8 |
| 4095 | `ff 0f` | 4095 | 65295 |

So covering the SCS series is a second word order and a second full scale, not a scale option on the action. That settles the question #2812 left open without needing the fact it deliberately did not guess (what an `scs0009` does with 4095): it never reaches one as 4095.

## Before / after

Probe driving the shipped `serial_tool` and `FeetechDriver` against a fake port, on `main` and on this branch:

| | `main` | this branch |
|---|---|---|
| word-order spellings outside the codec | 6 | **0** |
| full-scale literals outside the codec | 8 | **0** |
| `position` / `velocity` schema entries name the series | no | **yes** |
| the refusal quoting the ceiling names the series | no | **yes** |
| `FeetechDriver` describes itself as | `so101 (SCS protocol)` | `so101 (STS/SMS series)` |

The refusal a model reads went from `Goal_Position is a 12-bit register, the same full scale the reported angle divides by` to `Goal_Position is 12-bit on the STS/SMS series ...; the SCS series is 10-bit and this module does not address it`.

## Changed

- `drivers/feetech/protocol.py` decides both once: `MAX_GOAL_POSITION`, `encode_word`, `decode_word`. The order is *named* (`"little"`) rather than spelled as shifts, and the module docstring separates the framing the whole family shares from the word order it does not.
- `feetech/bus.py`, `tools/serial_tool.py` and `tools/pose_tool.py` read them instead of spelling them. `encode_word` refuses a value two bytes cannot carry rather than masking it into a different reachable command.
- Series named where a series-specific number is stated: the two schema entries, the ceiling's reason, `FeetechDriver.tool_spec`, the module titles, `docs/hardware/tools.md`. Deliberately *not* a sweep of the word "SCS" - Feetech's own framing document is titled `SCS Communication Protocol` and covers the whole family, so "SCS bus" is not wrong where it means the bus.
- No behaviour change for an STS/SMS servo: every byte this package puts on the wire is unchanged, and the SDK-agreement cells pin that.

## Tests

`tests/drivers/test_feetech_protocol.py` 47 -> 105 cells, `tests/tools/test_serial_tool_documented_bounds.py` 9 -> 13. No new file: the word order belongs with the codec's own suite and the claim belongs with the documented-bounds suite. The existing "the full scale is one literal" cell became "it is not spelled in this module at all".

Two cells run the SDK under both protocols (skipped where `scservo_sdk` is absent, restoring its global in a `finally`), two read lerobot's tables as the oracle for which series 4096 counts belongs to, and the source-level cells hold every consumer to zero spellings of either number.

Mutation matrix, 220 baseline cells across the four affected suites:

| mutation | result | cells that caught it |
|---|---|---|
| `_WORD_ORDER` -> `"big"` (the SCS order) | 24 failed | SDK agreement, the datasheet table, and the bus / `pose_tool` round-trips - which is what shows the consolidation really feeds those paths |
| `MAX_GOAL_POSITION` -> 1023 | 21 failed | the lerobot oracle, the documented bound, every unit conversion |
| a consumer spells the split itself again | 1 failed | `test_no_consumer_spells_the_byte_order_itself` |
| the ceiling stops naming its series | 2 failed | the reason pin and the refusal pin |

The new cells cannot collect against pre-fix production (the codec has no word encoder), so the pre/post evidence is the probe table above rather than a red pytest run.

## Gate

`ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` (1.20.2) unchanged at 20 pre-existing errors in 6 files, 0 in any file touched here; `scripts/check_whole_tree_graders.py` 181 passed. `tests/drivers tests/tools` = 5139 passed, with the same 10 environment-specific failures (`unitree_sdk2py` present locally, lerobot-from-source drift) that pristine `main` produces in a detached worktree - 0 attributable.

LOC delta +520 / -59 over 11 files (the changelog fragment is +28); production alone +189 / -49, of which the codec's two functions and their docstrings are +104.

Refs #2812.
