### PR TITLE
test: a test module name must state the behaviour, not the tracker item

### DIFF
--- a/changelog.d/2861-g1-send-action-success-acceptance-criterion.md
+++ b/changelog.d/2861-g1-send-action-success-acceptance-criterion.md
@@ -7,7 +7,7 @@ by a mocked test passing, so it has read as complete thirteen times. The
 existing pin grades the *un*-reachability (the refusal must name the FSM, not
 the battery); nothing graded the positive outcome.
 
-`tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py`
+`tests/drivers/test_g1_send_action_succeeds_on_a_healthy_wired_driver.py`
 adds it as `pytest.mark.xfail(strict=True)`: today it xfails against the shipped
 `FSM id unknown` refusal, and the day a motion-switcher decoder gives `_fsm_id`
 a producer it XPASSes, which `strict=True` turns into a failure the wiring

--- a/changelog.d/2873-xpass-reason-matches-shipped-refusal.md
+++ b/changelog.d/2873-xpass-reason-matches-shipped-refusal.md
@@ -1,7 +1,7 @@
 ### Tests: the harness#361 XPASS marker cites the refusal the driver actually returns
 
 The strict-xfail cell in
-`tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py`
+`tests/drivers/test_g1_send_action_succeeds_on_a_healthy_wired_driver.py`
 documented its deferral by quoting the shipped refusal.  When #2865 tightened
 that refusal (dropping the parenthetical `(harness#361 PR-C)` because the PR
 had landed and the issue reference alone is the resolvable pointer), the test

--- a/changelog.d/3076-test-module-names-state-the-behaviour.md
+++ b/changelog.d/3076-test-module-names-state-the-behaviour.md
@@ -1,0 +1,25 @@
+### Tests: a test module name states the behaviour, not the tracker item that birthed it
+
+`tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py`
+named the item it was filed against rather than what it grades, so its failure
+line told a reader nothing about the broken behaviour, and the coordinate it
+carried - `harness#361` - is an unowned slug that resolves to nothing, the same
+shape `tests/test_source_strings_resolve_their_issue_references.py` already
+refuses in an operator-facing string.
+
+The file is now `test_g1_send_action_succeeds_on_a_healthy_wired_driver.py`,
+which is what it verifies, and its docstrings state the two contracts they
+always carried - the publisher must be populated, and the wire must be exercised
+rather than the status alone believed - without the review history around them.
+
+`tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py` keeps the
+shape out of the tree. A module name spells a coordinate when a word is followed
+by a standalone run of digits (`..._for_harness_361` is `harness#361` written
+for a filesystem), and whether that coordinate resolves is decided by the
+predicate that already grades the string surface, so the two guards cannot drift
+apart. The rule needs no exemption list: a vendor model or version number is
+spelled attached to the word it qualifies (`so101`, `gr00t`, `n17`, `cosmos3`,
+`go2`, `ipv6`, `moveit2`, `ros2`, `molmoact2`), so all eleven digit-bearing
+tokens across the 1,500 test modules pass. The grader joins the roster in
+`scripts/check_whole_tree_graders.py`, since its input is the tree rather than
+the file under change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -769,7 +769,8 @@ format = ["ruff check --fix strands_robots tests tests_integ", "ruff format stra
 # Whole-tree graders a diff-scoped selector cannot see. Runs the tests whose
 # input is the rest of the repository rather than the file under change
 # (docstring xref roles, host-path literals, dependency audit, agent-tool
-# parameter descriptions, del-precedes-body). Fixed roster, no arguments -
+# parameter descriptions, del-precedes-body, test-module names). Fixed roster,
+# no arguments -
 # the script is the safety net for a narrow local pytest run that would
 # otherwise ship a defect one of these graders would catch on CI. See
 # scripts/check_whole_tree_graders.py and issue #2940.

--- a/scripts/check_whole_tree_graders.py
+++ b/scripts/check_whole_tree_graders.py
@@ -17,6 +17,8 @@ rather than from any single file under change:
 - ``tests/test_parameter_deletes_precede_the_body_they_narrow.py`` -- a
   ``del <param>`` inside a function must precede the block it narrows, not
   trail the return.
+- ``tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py`` -- no
+  test module may be named after the tracker item that birthed it.
 
 These have one property in common: their input is the *rest* of the repository,
 not the file under change. A path- or ``-k``-scoped pytest run collects none of
@@ -90,6 +92,7 @@ WHOLE_TREE_GRADERS: tuple[str, ...] = (
     "tests/test_dependency_audit.py",
     "tests/tools/test_agent_tool_parameter_descriptions.py",
     "tests/test_parameter_deletes_precede_the_body_they_narrow.py",
+    "tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py",
 )
 
 

--- a/tests/drivers/test_g1_fsm_refresh_is_off_the_control_loop_thread.py
+++ b/tests/drivers/test_g1_fsm_refresh_is_off_the_control_loop_thread.py
@@ -36,9 +36,9 @@ made it unsafe:
    quietly move it off ``send_action`` / ``run_policy`` too: those pay one round
    trip so the decision that opens the wire is made on a fresh reading.
 
-The sibling files stay where they were: the acceptance criterion
-(``test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361``)
-grades that a healthy driver reaches the wire, and
+The sibling files stay where they were:
+``test_g1_send_action_succeeds_on_a_healthy_wired_driver`` grades that a healthy
+driver reaches the wire, and
 ``test_g1_battery_floor_reaches_with_wired_fsm`` grades the flipped
 reachability.  Neither can see a cadence property, because neither runs the
 loop against a slow wire.  This file is the one that does.

--- a/tests/drivers/test_g1_send_action_succeeds_on_a_healthy_wired_driver.py
+++ b/tests/drivers/test_g1_send_action_succeeds_on_a_healthy_wired_driver.py
@@ -1,47 +1,30 @@
-"""The acceptance criterion for harness#361 is a positive outcome, not a body.
+"""``send_action`` reaches the wire on a healthy, fully wired driver.
 
-harness#361 has closed early thirteen times because every box on it is
-satisfied by a body existing or by a mocked test passing. A checklist of
-bodies closes early forever. The gap the peer reviewer named directly on
-that issue is one line long:
+A refusal test proves the motion gate closes; it does not prove the gate ever
+opens.  This file grades the positive outcome: a driver whose every field is
+what a real, healthy G1 produces -- a completed ``connect_eagerly``, a decoded
+``LowState_``, a healthy pack, and an ``_fsm_id`` read through the
+motion-switcher wire -- reaches ``send_action`` and gets ``status="success"``.
 
-    ``send_action`` returns ``status="success"`` on a connected driver with a
-    decoded ``LowState_`` and a healthy pack.
+Two boundary contracts keep that verdict honest:
 
-The predecessor of this file (same path, before this PR) added that cell as
-a strict :func:`pytest.mark.xfail` documented against the shipped refusal --
-``FSM id unknown - motion-switcher source has not been wired`` -- so the day
-a producer landed for ``_fsm_id`` the xfail would XPASS and the wiring commit
-would delete the marker in the same change.
+1. The publisher is populated.  A driver whose ``_pubs is None`` refuses for a
+   second reason ("publisher not initialised"), which would leave the success
+   path unreachable for a cause other than the FSM.  The fixture uses a
+   recording publisher whose ``.publish`` returns ``None``, matching production
+   shape.
+2. The wire is actually exercised.  ``result["status"] == "success"`` is
+   necessary but not sufficient; a return that skipped the write would satisfy
+   it silently.  The publisher records its call count, and that count is one
+   after ``send_action`` returns.
 
-That day is this PR.  The xfail is gone, the criterion is a passing cell, and
-the surface still grades what the predecessor promised: a driver whose every
-field is what a real, healthy G1 produces (a completed ``connect_eagerly``,
-a decoded ``LowState_``, a healthy pack) reaches ``send_action`` and gets
-``status="success"``.  The one thing that changed is the FSM producer: the
-driver now takes an injectable ``motion_switcher_client_factory`` and
-:meth:`_refresh_fsm_id` reads through it on every motion-gate check.  The
-fixture below hands in a recording client so the wire runs without the SDK.
+The FSM producer is injectable: the driver takes a
+``motion_switcher_client_factory`` and :meth:`_refresh_fsm_id` reads through it
+on every motion-gate check, so the fixture hands in a recording client and the
+wire runs without the SDK.
 
-Two contracts survive from the predecessor file so the boundary does not
-silently drift:
-
-1. The publisher is populated.  A driver whose ``_pubs is None`` would refuse
-   for a second reason ("publisher not initialised") and the acceptance
-   contract would be unreachable for a cause other than the FSM.  The
-   fixture uses a recording publisher whose ``.publish`` returns ``None``,
-   matching production shape.
-
-2. The wire is actually exercised.  ``result["status"] == "success"`` is a
-   necessary but not sufficient condition; a return that skipped the wire
-   would satisfy it silently.  The publisher records its call count, and
-   that count is one after ``send_action`` returns.
-
-The un-reachability sibling
-(:mod:`test_g1_battery_floor_reaches_with_wired_fsm`) is where the reverse
-reachability -- battery-floor reaches through the gate now -- is graded.  The
-two files complement each other: this file says "success on a healthy pack",
-that one says "refuses for battery on a critical pack".
+:mod:`test_g1_battery_floor_reaches_with_wired_fsm` grades the flipped
+reachability -- the same wired gate refusing for battery on a critical pack.
 """
 
 from __future__ import annotations
@@ -187,9 +170,8 @@ def _healthy_driver(motion_switcher_client: Any | None = None) -> G1Driver:
     """Return a driver whose every field is what a real, healthy G1 produces.
 
     If ``motion_switcher_client`` is supplied the driver's FSM producer runs
-    through it; otherwise the driver is constructed with no factory (which
-    the predecessor xfail was written against, and which the un-reachability
-    sibling grades).
+    through it; otherwise the driver is constructed with no factory, which is
+    the shape the un-wired refusal below is graded against.
     """
     factory: Any = None
     if motion_switcher_client is not None:
@@ -229,7 +211,7 @@ def _healthy_driver(motion_switcher_client: Any | None = None) -> G1Driver:
 def test_send_action_returns_success_on_a_healthy_driver_that_has_a_decoded_lowstate(
     monkeypatch: Any,
 ) -> None:
-    """The one line the harness#361 checklist has been missing -- now passing.
+    """A healthy, wired driver reaches the wire and reports success.
 
     Every field is populated the way a real, healthy G1 populates it:
 
@@ -269,20 +251,19 @@ def test_send_action_returns_success_on_a_healthy_driver_that_has_a_decoded_lows
 
 
 def test_send_action_still_refuses_when_no_motion_switcher_factory_is_configured() -> None:
-    """The predecessor's un-wired refusal survives when no factory is passed.
+    """A driver with no FSM producer configured still refuses, by name.
 
     A driver constructed without ``motion_switcher_client_factory`` (the
     default) on a box with no ``unitree_sdk2py`` falls back to the shipped
     refusal, because :meth:`_open_motion_switcher_client` cannot import the
-    SDK.  The wording is unchanged, so a mesh peer that expected the exact
-    string still gets it.
+    SDK.  Both phrases a mesh peer reads off that refusal are pinned here, so
+    the wording cannot drift silently.
     """
     # No factory, no monkeypatch: the SDK import genuinely fails on CI.
     driver = _healthy_driver(motion_switcher_client=None)
     result = driver.send_action({"left_shoulder_pitch": 0.0})
     assert result["status"] == "error"
     text = result["content"][0]["text"]
-    # Both phrases the predecessor's xfail reason cited.
     assert "FSM id unknown" in text
     assert "motion-switcher" in text
 
@@ -292,9 +273,9 @@ def test_the_publisher_is_populated_and_the_driver_is_otherwise_healthy(
 ) -> None:
     """The success path uses a real publisher; hold the boundary.
 
-    A future refactor that made the driver skip publisher setup on
-    ``_fsm_id is None`` would trip this cell, and the fix is to preserve
-    the current shape rather than to silence the assertion.
+    A refactor that made the driver skip publisher setup on ``_fsm_id is None``
+    would trip this cell, and the fix is to preserve the current shape rather
+    than to silence the assertion.
     """
     _install_lowcmd_stub(monkeypatch)
     client = _RecordingMotionSwitcherClient(fsm_id=_HEALTHY_FSM_ID)

--- a/tests/test_source_strings_resolve_their_issue_references.py
+++ b/tests/test_source_strings_resolve_their_issue_references.py
@@ -20,6 +20,11 @@ a real repository), and a maintainer reading a docstring has the git history and
 the sibling checkouts to hand. An operator holding a refusal envelope has
 neither, so the rule applies where the text reaches them.
 
+:mod:`test_test_module_names_do_not_spell_a_tracker_coordinate` applies this
+module's :func:`_unresolvable_references` to the *other* surface a coordinate
+gets written on -- a test module's own name -- so the two guards cannot drift to
+two definitions of "resolvable".
+
 It would have failed while ``G1Driver._check_motion_gates`` refused every write
 with "FSM id unknown - motion-switcher source has not been wired (harness#361
 PR-C); see #2765 for the wire-side decision". That refusal is the one every real

--- a/tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py
+++ b/tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py
@@ -1,0 +1,135 @@
+"""Regression: a test module's name must name the behaviour, not a tracker item.
+
+A test module name is the whole diagnosis a reader gets from a failure line, and
+it is the index a maintainer scans when asking "is this behaviour already
+graded?".  A name that encodes the issue or pull request that birthed the file
+answers neither question: the reader still has to open the file to learn what
+broke, and the coordinate ages out of usefulness the moment the item is closed.
+
+The shape this refuses is a *tracker coordinate written with an underscore where
+the ``#`` would be*.  ``..._for_harness_361`` is ``harness#361`` spelled for a
+filesystem, and it is unresolvable for exactly the reason
+:mod:`test_source_strings_resolve_their_issue_references` documents for the
+operator-facing string it grades: an unowned slug names a repository with no
+owner, so the reader has no coordinate to open.  That module owns the predicate
+and this one reuses it, so the two surfaces cannot drift to two definitions of
+"resolvable".
+
+The rule needs no exemption list, which is what makes it derivable rather than
+curated.  A vendor model or version number is spelled *attached* to the word it
+qualifies -- ``so101``, ``gr00t``, ``n17``, ``cosmos3``, ``go2``, ``ipv6`` --
+and every one of those is a single token with no underscore before its digits,
+so none of them matches.  A bare run of digits standing as its own token is
+either a tracker coordinate or a magic number, and neither is a behaviour.
+
+It would have failed while ``tests/drivers/`` carried
+``test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py``,
+whose behaviour -- ``send_action`` reaching the wire on a healthy, fully wired
+driver -- is now what its name says.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests.test_source_strings_resolve_their_issue_references import _unresolvable_references
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: The two test trees a merge gates on.
+_TEST_ROOTS = ("tests", "tests_integ")
+
+#: A word, an underscore, then a run of digits standing as its own token: the
+#: filesystem spelling of ``<slug>#<number>``.  ``so101`` and ``gr00t`` do not
+#: match (no underscore before the digits) and neither does ``2fa`` (the digits
+#: are not the whole token).
+_NAME_COORDINATE = re.compile(r"([A-Za-z][A-Za-z0-9]*)_(\d+)(?=_|$)")
+
+
+def _test_modules() -> list[Path]:
+    """Every Python module under the test trees, ``__pycache__`` excluded."""
+    return sorted(
+        path for root in _TEST_ROOTS for path in (_REPO_ROOT / root).rglob("*.py") if "__pycache__" not in path.parts
+    )
+
+
+def _coordinates_in_name(stem: str) -> list[str]:
+    """Tracker coordinates ``stem`` spells, rendered as ``<slug>#<number>``.
+
+    Args:
+        stem: A module name without its ``.py`` suffix.
+
+    Returns:
+        The unresolvable coordinates the name spells, in the same
+        ``<slug>#<number>`` form :func:`_unresolvable_references` grades, so
+        both surfaces answer to one definition of "resolvable".
+    """
+    return [
+        reference
+        for word, number in _NAME_COORDINATE.findall(stem)
+        for reference in _unresolvable_references(f"{word}#{number}")
+    ]
+
+
+def test_test_modules_discovered() -> None:
+    """Guard: the scan walked both test trees, not one subtree."""
+    modules = _test_modules()
+    assert len(modules) > 1000, f"only {len(modules)} test modules found; the scan is too narrow"
+    roots = {path.relative_to(_REPO_ROOT).parts[0] for path in modules}
+    assert set(_TEST_ROOTS) <= roots, roots
+
+
+def test_no_test_module_name_spells_a_tracker_coordinate() -> None:
+    """A test module name must state a behaviour, not a tracker coordinate."""
+    offenders = [
+        f"{path.relative_to(_REPO_ROOT)}: {', '.join(coordinates)}"
+        for path in _test_modules()
+        if (coordinates := _coordinates_in_name(path.stem))
+    ]
+    assert not offenders, (
+        "A test module name encodes a tracker coordinate rather than the "
+        "behaviour it grades. Rename the file after what it verifies - the name "
+        "is the whole diagnosis a reader gets from a failure line, and the "
+        "coordinate resolves to nothing:\n" + "\n".join(offenders)
+    )
+
+
+def test_an_underscored_coordinate_in_a_name_is_flagged() -> None:
+    """The predicate flags the shape this guard exists to keep out."""
+    assert _coordinates_in_name("test_g1_send_action_is_the_criterion_for_harness_361") == ["harness#361"]
+    assert _coordinates_in_name("test_mesh_acl_scoping_issue_2935") == ["issue#2935"]
+
+
+def test_a_name_cannot_spell_an_owner_which_is_why_the_rule_is_absolute() -> None:
+    """A module name has no ``/``, so every coordinate it spells is unowned.
+
+    The sibling's predicate accepts an owner-qualified coordinate as resolvable.
+    A module name cannot produce one, because the separator that completes a
+    slug is not a path token -- which is why this guard admits no spelling of a
+    coordinate in a name where the string guard admits two.
+    """
+    assert _unresolvable_references("strands-labs/robots#2765") == []
+    assert "/" not in Path("test_g1_criterion_for_harness_361.py").stem
+    assert _coordinates_in_name("test_strands_labs_robots_2765") == ["robots#2765"]
+
+
+def test_a_model_or_version_number_in_a_name_is_not_flagged() -> None:
+    """Domain numbers must pass, or the rule is blanket strictness about digits."""
+    accepted = [
+        "test_examples_so101_pick_lifts",  # robot model
+        "test_gr00t_container_hardening",  # policy family
+        "test_n17_live_server",  # policy version
+        "test_cosmos3_lifecycle",  # policy provider
+        "test_go2_driver",  # robot model
+        "test_server_address_port_ipv6",  # protocol version
+        "test_dashboard_auth_2fa_ceremony",  # digits are not the whole token
+    ]
+    for stem in accepted:
+        assert _coordinates_in_name(stem) == [], f"should not be flagged: {stem!r}"
+
+
+def test_the_predicate_separates_the_two_shapes() -> None:
+    """Non-vacuity: the predicate answers both ways over the exemplars."""
+    outcomes = {bool(_coordinates_in_name(stem)) for stem in ("test_a_for_harness_361", "test_examples_so101_pick")}
+    assert outcomes == {True, False}


### PR DESCRIPTION
## The name

| | |
|---|---|
| before | `tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py` |
| after | `tests/drivers/test_g1_send_action_succeeds_on_a_healthy_wired_driver.py` |

The old name said which item the file was filed against, so a failure line named
a coordinate instead of a behaviour, and the coordinate does not resolve:
`harness#361` is an unowned slug, exactly the shape
`tests/test_source_strings_resolve_their_issue_references.py` already refuses in
an operator-facing string. Its docstrings carried the matching archaeology - a
predecessor xfail, a checklist, "that day is this PR" - none of which a reader
can open.

## The guard, and why it needs no exemption list

A module name spells a coordinate when a word is followed by a standalone run of
digits: `..._for_harness_361` is `harness#361` written for a filesystem. Whether
that coordinate resolves is decided by
`test_source_strings_resolve_their_issue_references._unresolvable_references` -
the predicate that already grades the string surface - so the two guards cannot
drift to two definitions of "resolvable".

A vendor model or version number is spelled *attached* to the word it qualifies,
so it is a single token with no underscore before its digits. Measured over all
1,500 test modules on this branch:

| token | modules | verdict |
|---|---|---|
| `g1` | 41 | passes |
| `gr00t` | 10 | passes |
| `e2e` | 5 | passes |
| `cosmos3` | 2 | passes |
| `go2` | 2 | passes |
| `molmoact2` | 2 | passes |
| `so101` | 2 | passes |
| `ipv6` | 1 | passes |
| `moveit2` | 1 | passes |
| `n17` | 1 | passes |
| `ros2` | 1 | passes |
| **total flagged** | **0** | |

A name can never spell an owner - `/` is not a path token - so unlike the string
rule, which admits a bare `#2765` and an owner-qualified
`strands-labs/robots-sim#46`, this one admits no spelling of a coordinate at all.
That asymmetry is pinned rather than assumed.

## Pre-fix / post-fix

`tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py`, run with the
old filename restored and then with the new one:

```
old name in tree:  1 failed, 5 passed
                   tests/drivers/test_g1_send_action_success_is_the_acceptance_criterion_for_harness_361.py: harness#361
new name in tree:  6 passed
```

The five cells that pass either way are the controls: they are what shows the
predicate discriminates rather than refusing every digit.

## What the rename kept

Both contracts the old docstring stated survive verbatim in behaviour, only
without the history around them:

1. **The publisher is populated** - a driver whose `_pubs is None` refuses for a
   second reason, which would leave the success path unreachable for a cause
   other than the FSM.
2. **The wire is exercised** - `result["status"] == "success"` is necessary but
   not sufficient, so the publisher's call count is asserted at one.

Four cells, unchanged assertions: 18 passed across the renamed file and the
sibling whose docstring referenced it.

## Local gate

| check | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | All checks passed |
| `ruff format --check` (same scope) | 1799 files already formatted |
| `mypy strands_robots tests tests_integ` (1.20.2) | 20 errors in 6 files - 0 attributable, identical on `main` |
| `scripts/check_whole_tree_graders.py` | 187 passed (was 181), 1 failed: `qpsolvers` absent locally |
| `pytest tests/drivers tests/tools/g1` | 3 failed, 2055 passed - the same 3 on a pristine `upstream/main` worktree (a real `unitree_sdk2py` is importable here) |
| changelog graders | 91 passed, fragments OK (1051 pending) |

## LOC

| path | +/- |
|---|---|
| renamed g1 test (docstring distilled) | +36 / -55 |
| new grader | +135 |
| roster, xref, `pyproject` comment, two fragment paths | +10 / -6 |
| changelog fragment | +25 |
| **total** | **+211 / -61, 9 files** |

The grader is the only real addition: 135 lines that retire a naming class
across 1,500 modules and are wired into the whole-tree preflight roster, since
its input is the tree rather than the file under change.
