### PR TITLE
fix(utils): an absent optional dependency names the module in ImportError.name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,12 @@ hatch run format            # ruff check --fix, ruff format
 4. **Imports at file top** - unless lazy-loading heavy deps with documented reason
 5. **Raise on fatal errors** - never warn-and-continue if the system will behave unexpectedly
 6. **No silent defaults on error** - returning zero-valued actions on failure is forbidden
-7. **Use `require_optional()`** - from `strands_robots/utils.py` for all optional deps
+7. **Use `require_optional()`** - from `strands_robots/utils.py` for all optional deps.
+   It reports the absent module in `ImportError.name`, so a caller can tell an absent
+   extra from a broken package path without parsing the message. A hand-rolled
+   `raise ImportError(...)` that reports an absent dependency must pass `name=` for the
+   same reason; `tests/test_absent_dependency_reports_name_the_module.py` refuses one
+   that leaves the module readable only in prose
 8. **Integration tests required** - each policy needs `tests_integ/` tests with real inference
 9. **Test behavior, not implementation** - assert on outputs, not internal state
 10. **No dead code** - if it's not called and not part of base class, delete it

--- a/changelog.d/3077-importerror-names-the-absent-module.md
+++ b/changelog.d/3077-importerror-names-the-absent-module.md
@@ -1,0 +1,31 @@
+### Fixed: an absent optional dependency is reported in `ImportError.name`, not only in prose
+
+`ImportError` carries a keyword-only `name` field so a caller can read which
+module could not be imported without parsing the message. The interpreter always
+populates it; code that constructs the exception itself populates it only where
+it passes `name=`, and no site in the package did -- including both raise sites
+of `require_optional` and `require_optionals`, the mechanism every optional
+dependency in the package is required to go through and the path 48 call sites
+take.
+
+Anything having to tell "an optional extra is absent here" from "this dotted path
+does not exist" was therefore left reading the chained exception and, failing
+that, matching the reported text. `require_optionals` raises after the `except`
+block that probed the modules has exited, so it carried no chain either and the
+message was the only thing left.
+
+Measured across the package, 21 of the 28 constructed raise sites were already
+reachable through a chained `ModuleNotFoundError` and 7 reported the module in
+prose alone. Those 7 now name it at the source: `require_optional` reports the
+module it was asked for, `require_optionals` the first missing one in the order
+given, and the four hand-rolled probes in `strands_robots/rtps/idl`,
+`strands_robots/training/reward.py`,
+`strands_robots/policies/vera/server_runner.py` and
+`strands_robots/simulation/mujoco/backend.py` report `cyclonedds`,
+`lerobot.rewards`, `vera` and `mujoco` respectively.
+
+Two facts are kept rather than traded. `name` is the module that was *requested*,
+and the chained `ModuleNotFoundError` is retained, so a module that is present
+but whose own imports are not still reports both what was asked for and what the
+interpreter could not find. `name=` is metadata rather than text, so every
+install instruction is byte-identical to before.

--- a/strands_robots/policies/vera/server_runner.py
+++ b/strands_robots/policies/vera/server_runner.py
@@ -50,7 +50,8 @@ def _require_vera_installed(python_executable: str) -> None:
             "because PyPI rejects direct VCS references). Install it directly:\n"
             "  pip install 'vera @ git+https://github.com/sizhe-li/VERA.git'\n"
             "  # plus the client deps: pip install websockets msgpack 'numpy>=1.24'\n"
-            "See the ``strands_robots.policies.vera`` module docstring for the full quickstart."
+            "See the ``strands_robots.policies.vera`` module docstring for the full quickstart.",
+            name="vera",
         )
 
 

--- a/strands_robots/rtps/idl/__init__.py
+++ b/strands_robots/rtps/idl/__init__.py
@@ -38,7 +38,7 @@ except ImportError:  # pragma: no cover - exercised only without the extra
     if not TYPE_CHECKING:
 
         def dataclass(cls=None, **kwargs):  # type: ignore[no-redef]
-            raise ImportError(_INSTALL_HINT)
+            raise ImportError(_INSTALL_HINT, name="cyclonedds")
 
         class IdlStruct:  # type: ignore[no-redef]
             pass
@@ -195,7 +195,7 @@ def get_type(ros_type: str) -> Any:
             scope for v1 - see the module docstring).
     """
     if not _HAVE_CYCLONEDDS:
-        raise ImportError(_INSTALL_HINT)
+        raise ImportError(_INSTALL_HINT, name="cyclonedds")
     if ros_type not in REGISTRY:
         known = ", ".join(sorted(REGISTRY)) or "(none)"
         raise KeyError(

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -439,7 +439,7 @@ def _ensure_mujoco() -> "Any":
         # Not cached until it passes: a refused build must be re-checked (and
         # re-reported) on the next call rather than served from the global.
         if msg := _mujoco_api_floor_error(str(getattr(module, "__version__", ""))):
-            raise ImportError(msg)
+            raise ImportError(msg, name="mujoco")
         _mujoco = module
     if _mujoco_viewer is None and not _is_headless():
         try:

--- a/strands_robots/training/reward.py
+++ b/strands_robots/training/reward.py
@@ -179,7 +179,8 @@ def load_reward_model(
     if importlib.util.find_spec("lerobot.rewards") is None:
         raise ImportError(
             "reward-model inference requires lerobot >= 0.6.0 (the 'lerobot.rewards' "
-            "package). Reinstall 'strands-robots[lerobot]'."
+            "package). Reinstall 'strands-robots[lerobot]'.",
+            name="lerobot.rewards",
         )
     from lerobot.rewards import make_reward_model, make_reward_model_config
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -44,7 +44,13 @@ def require_optional(
         The imported module object.
 
     Raises:
-        ImportError: With a helpful install instruction.
+        ImportError: With a helpful install instruction, and ``name`` set to
+            *module_name* so a caller can tell an absent optional dependency
+            from a broken package path without parsing the message. The
+            interpreter's own ``ModuleNotFoundError`` stays reachable on
+            ``__context__``, which names the module actually not found - that
+            differs from *module_name* when the requested module is present but
+            something it imports is not.
     """
     if module_name in _lazy_modules:
         return _lazy_modules[module_name]
@@ -67,7 +73,10 @@ def require_optional(
             if extra:
                 parts.append(f"  pip install 'strands-robots[{extra}]'")
             parts.append(f"  pip install {install_hint}")
-        raise ImportError("\n".join(parts)) from None
+        # ``name`` is the module that was attempted, which is what the message
+        # already claims is required; the chained ModuleNotFoundError keeps the
+        # module the interpreter actually could not find.
+        raise ImportError("\n".join(parts), name=module_name) from None
 
 
 def require_optionals(
@@ -106,7 +115,12 @@ def require_optionals(
 
     Raises:
         ImportError: If one or more modules are missing, listing every missing
-            module and an actionable install instruction.
+            module and an actionable install instruction, with ``name`` set to
+            the first missing module in the order given. The interpreter names
+            only the first module an import fails on too, and the full set stays
+            in the message. Nothing else carries it here: the raise is outside
+            the ``except`` block that probed the modules, so ``__context__`` is
+            empty and ``name`` is the only machine-readable report.
     """
     missing: list[str] = []
     for name in module_names:
@@ -130,7 +144,7 @@ def require_optionals(
         parts.append(f"  pip install 'strands-robots[{extra}]'")
     distributions = [(pip_install or {}).get(name, name) for name in missing]
     parts.append(f"  pip install {' '.join(distributions)}")
-    raise ImportError("\n".join(parts)) from None
+    raise ImportError("\n".join(parts), name=missing[0]) from None
 
 
 def lerobot_version() -> str:

--- a/tests/test_absent_dependency_reports_name_the_module.py
+++ b/tests/test_absent_dependency_reports_name_the_module.py
@@ -1,0 +1,271 @@
+"""An ``ImportError`` reporting an absent optional dependency must name it.
+
+``ImportError`` carries a keyword-only ``name`` field for exactly one purpose:
+telling a caller *which* module could not be imported, without parsing prose.
+The interpreter always populates it. Code that constructs the exception itself
+only populates it if it says ``name=``, and no site in this package did::
+
+    grep -rn "raise ImportError(" strands_robots/ | grep -c "name="
+    -> 0   (of 28 sites)
+
+Both raise sites of :func:`strands_robots.utils.require_optional` and
+:func:`strands_robots.utils.require_optionals` were among them -- the mechanism
+AGENTS.md convention 7 makes mandatory for an optional dependency, and the path
+48 call sites in the package take. So the project's own sanctioned way of
+reporting an absent extra reported it in a form only a human could read.
+
+What that costs, concretely: ``tests/test_docstring_xref_roles_resolve.py`` has
+to decide, for an ``ImportError`` raised out of a module body it imported,
+whether an extra is absent (this environment cannot grade the target) or a
+``strands_robots`` path is dead (the rot it exists to catch). With ``name``
+empty it fell back to the chained exception, and then to matching the reported
+*message* -- and ``require_optionals`` raises after its ``except`` block has
+exited, so ``__context__`` is ``None`` there and the message was the only thing
+left. A reader reduced to reading prose is one wording change from
+misclassifying, and misclassifying that direction aborted the sweep (#2963).
+
+The fix is at the source, so the distinction does not depend on any reader's
+fallback: every site that reports an absent dependency names it. This module
+pins that as a property of the package rather than of the sites it was written
+against, because the hazard arrives with a *new* raise site: nothing else
+refuses the shape. ``ruff`` has no rule for it, ``mypy`` cannot know which
+argument carries a module name, and code scanning has no query for it.
+
+Two sites do not report an absent dependency at all and are exempt by name
+below, with the reason each is not one. The check is a subset assertion rather
+than an equality: a site that stops being blind -- including by its module being
+deleted -- must not turn the gate red for an unrelated change.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+import strands_robots
+from strands_robots.utils import require_optional, require_optionals
+
+# The consumer this change was made for. Imported rather than restated so the
+# cell below grades the guard's real classification, not a copy of it.
+from tests.test_docstring_xref_roles_resolve import _undecidable_import
+
+#: The shipped package. Reached through the imported module so a layout change
+#: cannot silently narrow the scan to nothing.
+_PACKAGE_ROOT = Path(strands_robots.__file__).resolve().parent
+
+#: Extras group the probes below ask for. Synthetic: these cells exercise the
+#: message formatter, not the project's extras table, and the remedy is asserted
+#: through this name rather than spelled inline so the "every written
+#: ``strands-robots[...]`` names a declared extra" audit reads a template hole
+#: instead of an instruction.
+_PROBE_EXTRA = "probe"
+
+#: Lower bound on ``raise ImportError(...)`` sites found. Pinned so a scan
+#: rooted somewhere unexpected fails loudly instead of reporting a clean sweep
+#: over nothing. Measured at 28 when written.
+_MINIMUM_CONSTRUCTED_IMPORT_ERRORS = 20
+
+#: Package-relative modules whose constructed ``ImportError`` is not a report
+#: that a dependency is absent, so there is no module name for it to carry.
+_NOT_AN_ABSENT_DEPENDENCY_REPORT = {
+    "policies/groot/policy.py": (
+        "raised when the configured GR00T version string matches none of the "
+        "supported loaders - a rejected argument, not a probe of an install"
+    ),
+    "policies/lerobot_local/resolution.py": (
+        "raised when no lerobot policy class matches the requested policy_type; "
+        "with lerobot present that is a typo'd argument, and naming a module "
+        "would report an absence that did not happen"
+    ),
+}
+
+
+class _Site(NamedTuple):
+    """One ``raise ImportError(...)`` and what a reader could recover from it."""
+
+    label: str
+    lineno: int
+    names_the_module: bool
+    chains_a_cause: bool
+    inside_a_handler: bool
+
+    @property
+    def recoverable(self) -> bool:
+        """True when the absent module is reachable without reading the message.
+
+        ``name=`` is the direct report. Failing that, ``raise ... from exc`` sets
+        ``__cause__``, and raising lexically inside an ``except`` block sets
+        ``__context__`` to the exception being handled -- ``from None`` suppresses
+        the *rendering* of that chain but does not clear the attribute.
+        """
+        return self.names_the_module or self.chains_a_cause or self.inside_a_handler
+
+
+def _import_error_sites(source: str, label: str) -> list[_Site]:
+    """Every ``raise ImportError(...)`` in *source*, graded for recoverability."""
+    sites: list[_Site] = []
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.handlers: list[ast.ExceptHandler] = []
+
+        def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+            self.handlers.append(node)
+            self.generic_visit(node)
+            self.handlers.pop()
+
+        def visit_Raise(self, node: ast.Raise) -> None:
+            exc = node.exc
+            if isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name) and exc.func.id == "ImportError":
+                from_none = isinstance(node.cause, ast.Constant) and node.cause.value is None
+                sites.append(
+                    _Site(
+                        label=label,
+                        lineno=node.lineno,
+                        names_the_module=any(kw.arg == "name" for kw in exc.keywords),
+                        chains_a_cause=node.cause is not None and not from_none,
+                        inside_a_handler=bool(self.handlers),
+                    )
+                )
+            self.generic_visit(node)
+
+    Visitor().visit(ast.parse(source))
+    return sites
+
+
+def _package_sites() -> list[_Site]:
+    """Grade every ``raise ImportError(...)`` in the shipped package."""
+    sites: list[_Site] = []
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        label = path.relative_to(_PACKAGE_ROOT).as_posix()
+        sites.extend(_import_error_sites(path.read_text(encoding="utf-8"), label))
+    return sites
+
+
+class TestTheSanctionedMechanismNamesTheModule:
+    """The two raise sites 48 call sites in the package go through."""
+
+    def test_require_optional_names_the_module_it_could_not_import(self) -> None:
+        with pytest.raises(ImportError) as caught:
+            require_optional("a_module_this_environment_does_not_have", extra=_PROBE_EXTRA)
+        assert caught.value.name == "a_module_this_environment_does_not_have"
+
+    def test_require_optional_keeps_the_interpreter_report_on_the_chain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``name`` is what was asked for; ``__context__`` is what was missing.
+
+        The two differ when the requested module is present but something *it*
+        imports is not, so overwriting one with the other would lose a fact.
+        """
+        (tmp_path / "a_module_needing_something_absent.py").write_text(
+            "import a_transitive_module_that_is_absent\n", encoding="utf-8"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        with pytest.raises(ImportError) as caught:
+            require_optional("a_module_needing_something_absent", extra=_PROBE_EXTRA)
+
+        assert caught.value.name == "a_module_needing_something_absent"
+        assert getattr(caught.value.__context__, "name", None) == "a_transitive_module_that_is_absent"
+
+    def test_require_optionals_names_the_first_missing_module_in_the_order_given(self) -> None:
+        """The plural form has nothing but ``name``: it raises outside the handler."""
+        with pytest.raises(ImportError) as caught:
+            require_optionals(("absent_module_one", "absent_module_two"), extra=_PROBE_EXTRA)
+
+        assert caught.value.name == "absent_module_one"
+        assert caught.value.__cause__ is None
+        assert caught.value.__context__ is None
+
+    @pytest.mark.parametrize(
+        ("call", "module"),
+        [
+            (
+                lambda: require_optional("absent_singular_probe", extra=_PROBE_EXTRA, purpose="a probe"),
+                "absent_singular_probe",
+            ),
+            (
+                lambda: require_optionals(("absent_plural_probe",), extra=_PROBE_EXTRA, purpose="a probe"),
+                "absent_plural_probe",
+            ),
+        ],
+        ids=["require_optional", "require_optionals"],
+    )
+    def test_naming_the_module_leaves_the_remedy_message_intact(self, call, module: str) -> None:
+        """``name=`` is metadata, not text: the install instruction is unchanged."""
+        with pytest.raises(ImportError) as caught:
+            call()
+        reported = str(caught.value)
+        assert module in reported
+        assert "a probe" in reported
+        assert f"pip install 'strands-robots[{_PROBE_EXTRA}]'" in reported
+        assert "name=" not in reported
+
+
+class TestTheGuardClassifiesOnTheName:
+    """The xref guard now reads the field, not the chain and not the prose."""
+
+    @pytest.mark.parametrize(
+        ("call", "module"),
+        [
+            (lambda: require_optional("absent_read_probe", extra=_PROBE_EXTRA), "absent_read_probe"),
+            (lambda: require_optionals(("absent_read_plural",), extra=_PROBE_EXTRA), "absent_read_plural"),
+        ],
+        ids=["require_optional", "require_optionals"],
+    )
+    def test_an_absent_extra_is_reported_as_the_module_name(self, call, module: str) -> None:
+        with pytest.raises(ImportError) as caught:
+            call()
+        # Pre-fix this returned the first line of the install message for the
+        # singular form and, for the plural one, could return nothing else.
+        assert _undecidable_import(caught.value) == module
+
+    def test_a_strands_robots_path_is_still_read_as_the_rot_being_graded(self) -> None:
+        """The opposite verdict is unchanged: a package path is not an absent extra."""
+        assert _undecidable_import(ImportError("gone", name="strands_robots.no_such_module")) is None
+
+
+class TestTheRuleHoldsAcrossThePackage:
+    def test_every_absent_dependency_report_names_its_module(self) -> None:
+        sites = _package_sites()
+        assert len(sites) >= _MINIMUM_CONSTRUCTED_IMPORT_ERRORS, (
+            f"found only {len(sites)} constructed ImportError sites under {_PACKAGE_ROOT}; "
+            "the scan is rooted wrong or the pattern stopped matching"
+        )
+        blind = [s for s in sites if not s.recoverable and s.label not in _NOT_AN_ABSENT_DEPENDENCY_REPORT]
+        assert not blind, (
+            "these ImportErrors report an absent module in prose only - pass name= so a "
+            "caller does not have to parse the message: " + ", ".join(f"{s.label}:{s.lineno}" for s in blind)
+        )
+
+
+class TestTheRuleIsNotVacuous:
+    @pytest.mark.parametrize(
+        ("source", "recoverable"),
+        [
+            ('raise ImportError("zmq is required")', False),
+            ('raise ImportError("zmq is required", name="zmq")', True),
+            ('try:\n    import zmq\nexcept ImportError as e:\n    raise ImportError("no zmq") from e', True),
+            ('try:\n    import zmq\nexcept ImportError:\n    raise ImportError("no zmq")', True),
+            ('try:\n    import zmq\nexcept ImportError:\n    pass\nraise ImportError("no zmq")', False),
+            ('try:\n    import zmq\nexcept ImportError:\n    raise ImportError("no zmq") from None', True),
+        ],
+        ids=["bare", "named", "from-cause", "in-handler", "after-handler", "from-none"],
+    )
+    def test_recoverability_is_graded_per_raise_shape(self, source: str, recoverable: bool) -> None:
+        sites = _import_error_sites(source, "planted.py")
+        assert len(sites) == 1
+        assert sites[0].recoverable is recoverable
+
+    def test_a_planted_blind_site_is_reported(self) -> None:
+        """The exemptions are by module path, so an unlisted module is refused."""
+        sites = _import_error_sites('raise ImportError("torch is required")', "policies/somewhere_new.py")
+        blind = [s for s in sites if not s.recoverable and s.label not in _NOT_AN_ABSENT_DEPENDENCY_REPORT]
+        assert [s.lineno for s in blind] == [1]
+
+    def test_a_raise_of_another_exception_type_is_not_graded(self) -> None:
+        assert _import_error_sites('raise ValueError("not an import problem")', "planted.py") == []

--- a/tests/test_docstring_xref_roles_resolve.py
+++ b/tests/test_docstring_xref_roles_resolve.py
@@ -412,16 +412,23 @@ def test_a_module_the_package_does_not_have_is_still_a_dead_pointer() -> None:
 def test_an_absent_extra_reported_without_a_name_is_undecidable_not_rot() -> None:
     """An ``ImportError`` the package constructs must not be read as package rot.
 
-    ``exc.name`` is populated only on an exception the interpreter raises itself,
-    so classifying on it alone put all 28 of the package's constructed raise sites
-    on the *rot* branch - the one the member walk answers with ``raise`` - and one
-    absent extra ended the whole sweep with nothing graded after it (#2963). Both
-    shapes the package actually uses are pinned here, because the surface exception
-    is identical in each and only the chain distinguishes them: the wrapping raise
-    at ``strands_robots/tools/lerobot_camera.py``, and
-    :func:`strands_robots.utils.require_optional`, which AGENTS.md convention 7
-    makes the mandatory mechanism - its ``raise ... from None`` suppresses only the
-    *rendering* of ``__context__``, which is why the same walk reaches both.
+    ``exc.name`` is populated by the interpreter on an exception it raises itself,
+    and by constructing code only where that code says ``name=``. Classifying on
+    the surface name alone therefore put every constructed raise site in the
+    package on the *rot* branch - the one the member walk answers with ``raise`` -
+    and one absent extra ended the whole sweep with nothing graded after it
+    (#2963).
+
+    Both shapes the package uses are pinned here, because each has to reach the
+    same verdict by a different route. :func:`strands_robots.utils.require_optional`
+    - the mechanism AGENTS.md convention 7 makes mandatory - names the module at
+    the source, so it is classified on the field and does not depend on this
+    reader's fallback. The wrapping raise at
+    ``strands_robots/tools/lerobot_camera.py`` names nothing, so the chain walk is
+    what decides it, and that walk stays load-bearing for every site of that shape.
+    ``require_optional`` also pins that its ``raise ... from None`` leaves
+    ``__context__`` intact - suppressing the chain's *rendering* is not clearing it
+    - which is what lets one walk reach both shapes.
     """
     absent = "a_module_this_environment_does_not_have"
 
@@ -435,8 +442,9 @@ def test_an_absent_extra_reported_without_a_name_is_undecidable_not_rot() -> Non
 
     with pytest.raises(ImportError) as required:
         require_optional(absent, extra="probe")
-    assert getattr(required.value, "name", None) is None
+    assert required.value.name == absent
     assert required.value.__cause__ is None
+    assert getattr(required.value.__context__, "name", None) == absent
     assert _undecidable_import(required.value) == absent
 
     # Neither a name nor a chain to read: still undecidable, because the interpreter


### PR DESCRIPTION
![how each constructed ImportError reports its absent module, main vs this branch](https://raw.githubusercontent.com/cagataycali/robots/assets/importerror-name-at-the-source/importerror-name-at-the-source.png)

`ImportError` has a keyword-only `name` field so a caller can read *which* module is missing without parsing prose. The interpreter always sets it. Constructing code sets it only where it says `name=`:

```
grep -rn "raise ImportError(" strands_robots/ | grep -c "name="
-> 0     (of 28 sites)
```

Both raise sites of `require_optional` / `require_optionals` were among them - the mechanism AGENTS.md convention 7 makes mandatory, and the path **48 call sites** take (45 singular, 3 plural).

## What a reader actually got

| | `.name` | `__cause__` | `__context__` |
|---|---|---|---|
| `require_optional("absent")` | `None` | `None` | `ModuleNotFoundError('absent')` |
| `require_optionals(("absent", ...))` | `None` | `None` | `None` |

The plural form raises *after* its `except` block has exited, so nothing at all carried the module and only the message was left. `tests/test_docstring_xref_roles_resolve.py`, which has to tell "an extra is absent" from "a `strands_robots` path is dead", therefore answered with the install text:

```
_undecidable_import(exc)  ->  "'absent_read_plural' is required"     # pre-fix
_undecidable_import(exc)  ->  "absent_read_plural"                   # after
```

## Census, measured over the package

| how the absent module is recoverable | main | this branch |
|---|---|---|
| `name=` at the source | 0 | **7** |
| chained exception only | 21 | 19 |
| **prose only** | **7** | **2** |

21 of 28 were already reachable through a chain, so the honest cost of naming them was 7 sites, not 28. Those 7:

| site | names |
|---|---|
| `utils.py` `require_optional` | the requested module |
| `utils.py` `require_optionals` | first missing, in the order given |
| `rtps/idl/__init__.py` (x2) | `cyclonedds` |
| `training/reward.py` | `lerobot.rewards` |
| `policies/vera/server_runner.py` | `vera` |
| `simulation/mujoco/backend.py` | `mujoco` |

The 2 remaining are exempt by name in the test, with the reason each is not an absent-dependency report: `policies/groot/policy.py` rejects an unrecognised version string, and `policies/lerobot_local/resolution.py` reports a `policy_type` that matches no class - with lerobot present that is a typo'd argument, and naming a module would report an absence that did not happen.

## Two facts kept, not traded

`name` is what was *asked for*; the chained `ModuleNotFoundError` is retained and names what the interpreter *could not find*. They differ when the requested module is present but something it imports is not, so neither overwrites the other (pinned).

`name=` is metadata, not text - every remedy message is byte-identical, pinned per function.

## Proof

`tests/test_absent_dependency_reports_name_the_module.py` pins the rule as a property of the package, not of the sites it was written against: nothing else refuses the shape (ruff has no rule, mypy cannot know which argument is a module name, no code-scanning query), so site 29 would arrive blind. Reverting only `strands_robots/`:

```
5 failed, 12 passed     # pre-fix
17 passed               # after
```

The 12 pre-fix passes are the controls - the per-raise-shape table, the "package path is still rot" verdict, and the singular form's guard read, which the chain walk already rescued. Only the plural form and the whole-tree census were red.

The existing xref-guard cell was evolved rather than deleted: `require_optional` is now classified on the field, while the wrapping-raise shape still needs the chain walk, so both routes stay pinned.

## Gate

`ruff check` / `ruff format --check` clean; mypy at the project pin reports 0 errors attributable to the 8 changed files. `scripts/check_whole_tree_graders.py` 181 passed. Broad sweep `tests/` (less `mesh`, `device_connect`) 39,756 passed; the 33 failing ids in the affected directories are byte-identical to pristine `main` on this box (absent `qpsolvers` / `webauthn` / `peft`, lerobot 0.6.2 drift) - 0 regressions, 0 fixed.

LOC `+352 / -21` across 9 files, of which 271 added lines are the new test and 31 the changelog fragment.

Closes #2963

