### PR TITLE
fix(dashboard/auth): the first enrollment is limited to the machine, not just the damaged-store one

### DIFF
--- a/changelog.d/3078-first-enrollment-is-limited-to-the-machine.md
+++ b/changelog.d/3078-first-enrollment-is-limited-to-the-machine.md
@@ -1,0 +1,33 @@
+### Fixed: a stranger can no longer seize a fresh dashboard by enrolling the first passkey
+
+`auth_enabled()` IS `has_credentials()`, so the first passkey enrolled decides who
+owns the fleet - every later caller is locked out of a dashboard that commands real
+hardware. Three branches could gate that request and only two did: a bootstrap token
+was checked when one was configured, and a loopback check applied when the credential
+store was *unreadable* and no token was set. A fresh install with an intact empty
+store and no token configured matched neither.
+
+```
+fresh store,   peer 203.0.113.9  ->  ACCEPTED   (challenge issued)
+damaged store, peer 203.0.113.9  ->  refused    (403)
+```
+
+The guard was on the weaker case. A damaged store needs a disk error to happen first;
+a fresh install is every install's first minute, and it is where seizing enrollment
+costs an attacker nothing.
+
+Both routes are now gated on the one predicate. The refusal wording still varies by
+cause, because one that blamed a disk error where none occurred would send the reader
+looking for a backup file that does not exist; both name the same two ways forward.
+The decision reads the socket peer rather than `_client_ip`, whose own contract says
+it is for the per-ip cap and never for trust, so a `CF-Connecting-IP: 127.0.0.1` from
+a stranger does not manufacture locality, and a connection with no peer address is
+not treated as local either.
+
+Two boundaries are deliberate. The gate lifts once a credential exists, since an
+owner adding a second passkey remotely is the route's session decision and a gate
+that never lifted would be a lockout rather than a guard. And it runs after the rp_id
+usability check, so a caller on a bare IP is still told that passkeys cannot work
+there at all instead of being sent to a console where the same refusal awaits. A
+configured `STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN` remains the route for a headless
+robot, so its owner is not locked out.

--- a/strands_robots/dashboard/auth.py
+++ b/strands_robots/dashboard/auth.py
@@ -658,23 +658,36 @@ def begin_registration(request: Any, label: str = "passkey", bootstrap: str = ""
         if not secrets.compare_digest(bootstrap or "", required):
             raise HTTPException(403, "bootstrap token required for first enrollment")
 
-    # A first enrollment that exists only because the store was unreadable is a DIFFERENT event
-    # from a genuinely new dashboard: nobody chose it, and a stranger must not be able to seize
-    # the dashboard on the strength of a disk error.
-    damage = store_corruption()
-    if first_time and damage and not required:
-        if not client_is_loopback(_socket_peer(request)):
-            raise HTTPException(
-                403,
-                "the credential store was unreadable and has been kept as "
-                f"{damage['backup'] or 'a backup'} ({damage['reason']}). Enrolling a new passkey "
-                "is limited to the machine itself until one exists again - open the dashboard on "
-                "that machine, or set STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN and pass it.",
-            )
-
     rp_id = _derive_rp_id(request)
     if not rpid_is_usable(rp_id):
         raise _rpid_error(rp_id)
+
+    # The first enrollment seals the dashboard, so it is the one request that hands out
+    # ownership of the fleet rather than merely using it. With no bootstrap token configured
+    # there is nothing to check it against, so it is limited to the machine itself: whoever is
+    # at the keyboard is the only party who can be presumed to be the owner. A disk error is
+    # one way to arrive here and a genuinely new install is the other; the second is the
+    # commoner one and the more valuable to seize, so both are gated and only the wording
+    # differs. The socket peer is deliberate -- see _socket_peer, and note that an unknown
+    # peer is NOT the machine.
+    damage = store_corruption()
+    if first_time and not required:
+        if not client_is_loopback(_socket_peer(request)):
+            if damage:
+                raise HTTPException(
+                    403,
+                    "the credential store was unreadable and has been kept as "
+                    f"{damage['backup'] or 'a backup'} ({damage['reason']}). Enrolling a new passkey "
+                    "is limited to the machine itself until one exists again - open the dashboard on "
+                    "that machine, or set STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN and pass it.",
+                )
+            raise HTTPException(
+                403,
+                "the first passkey enrolled becomes the owner of this dashboard, and no "
+                "STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN is set for it to be checked against, so it is "
+                "limited to the machine itself - open the dashboard on that machine, or set "
+                "STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN and pass it.",
+            )
 
     user_id = store.get("user_id")
     if not user_id:

--- a/tests/test_dashboard_auth_ceremony_finish.py
+++ b/tests/test_dashboard_auth_ceremony_finish.py
@@ -24,8 +24,12 @@ from strands_robots.dashboard import auth
 
 
 class FakeRequest:
-    def __init__(self, headers=None):
+    # A socket peer is modelled because the first-enrollment gate reads it: with no bootstrap
+    # token set, only the machine itself may enroll the passkey that seals the dashboard. These
+    # cells are the owner at the machine, so the peer is loopback.
+    def __init__(self, headers=None, client_host="127.0.0.1"):
         self.headers = headers or {"host": "localhost:8090"}
+        self.client = type("C", (), {"host": client_host})()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_dashboard_auth_corrupt_store.py
+++ b/tests/test_dashboard_auth_corrupt_store.py
@@ -103,11 +103,21 @@ def test_bootstrap_token_still_works_from_anywhere(tmp_path, monkeypatch):
     assert opts.get("challenge_id")
 
 
-def test_a_genuinely_new_dashboard_is_unaffected(tmp_path):
-    # No corruption: first enrollment from anywhere keeps working exactly as before, so this
-    # change narrows an accident rather than adding a gate to the normal path.
-    opts = auth.begin_registration(FakeRequest(client_host="203.0.113.9"), label="fresh")
-    assert opts.get("challenge_id")
+def test_a_genuinely_new_dashboard_is_gated_too_and_says_so_differently(tmp_path):
+    """The fresh-install case is gated on the same predicate, with its own wording.
+
+    This cell used to assert the opposite -- that a first enrollment from anywhere kept
+    working -- which was this file's scope discipline rather than a finding that the normal
+    path was safe. It is not: a fresh store is the case an attacker most wants, because
+    nothing has to break first. Both routes into a first enrollment now refuse a caller who
+    is not at the machine; only the diagnosis differs, and neither mentions the other's cause.
+    """
+    with pytest.raises(HTTPException) as e:
+        auth.begin_registration(FakeRequest(client_host="203.0.113.9"), label="fresh")
+    assert e.value.status_code == 403
+    # The wording must fit the cause: no disk error happened here, so it must not claim one.
+    assert "unreadable" not in e.value.detail and "corrupt-" not in e.value.detail
+    assert "BOOTSTRAP_TOKEN" in e.value.detail
     assert auth.store_corruption() is None
 
 

--- a/tests/test_dashboard_auth_module.py
+++ b/tests/test_dashboard_auth_module.py
@@ -19,8 +19,11 @@ from strands_robots.dashboard import auth
 
 
 class FakeRequest:
-    def __init__(self, headers=None):
+    # Carries a loopback socket peer: the first-enrollment gate reads it, and these cells are
+    # the owner enrolling at the machine.
+    def __init__(self, headers=None, client_host="127.0.0.1"):
         self.headers = headers or {"host": "localhost:8090"}
+        self.client = type("C", (), {"host": client_host})()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_dashboard_first_enrollment_is_limited_to_the_machine.py
+++ b/tests/test_dashboard_first_enrollment_is_limited_to_the_machine.py
@@ -1,0 +1,202 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pin: the passkey that seals the dashboard can only be enrolled from the machine.
+
+``auth_enabled()`` IS ``has_credentials()``, so the FIRST enrollment is the request
+that decides who owns the fleet: once it succeeds, every later caller is locked out
+and ``rp_id_verdict`` plus the last-passkey rule are built around the store that
+enrollment created. It is a one-way door.
+
+Three branches could gate it and only two did. A bootstrap token is checked when one
+is configured, and a loopback check applied when the store was *unreadable* and no
+token was set. The ordinary case -- a fresh install, an intact empty store, no token
+configured -- matched neither, so it was ungated. Measured on ``main`` at ``19329cd``:
+
+    fresh store,   peer 203.0.113.9  ->  ACCEPTED   (challenge issued)
+    damaged store, peer 203.0.113.9  ->  refused    (403)
+
+That is backwards. The damaged store is the rarer route and needs a disk error to
+happen first; the fresh install is every install's first minute, and it is the one
+where seizing enrollment costs an attacker nothing. So the weaker case carried the
+guard and the stronger case did not.
+
+The gate is now the one predicate ``first_time and not required`` for both routes,
+and these cells pin each way through it. The wording still differs per cause, because
+a refusal that blames a disk error where none occurred sends the reader to the wrong
+place; that split is asserted here rather than left to prose.
+
+Scope note: this bounds the *first* enrollment only. Later enrollments are a session
+decision belonging to the route, and the last cell pins that this gate stops applying
+once a credential exists -- an owner adding a phone from their sofa is not this
+threat, and a gate that never lifted would be a lockout rather than a guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from strands_robots.dashboard import auth
+
+# Headers _client_ip reads ahead of the socket peer, and which a caller can therefore set.
+_SPOOFABLE = ["cf-connecting-ip", "x-forwarded-for", "x-real-ip"]
+
+_STRANGER = "203.0.113.9"  # TEST-NET-3, never a real peer
+
+
+class FakeRequest:
+    """A request whose socket peer, headers and Host can be set independently."""
+
+    def __init__(
+        self,
+        client_host: str | None = _STRANGER,
+        headers: dict[str, str] | None = None,
+        host: str = "localhost:8090",
+    ) -> None:
+        self.headers = {"host": host, **(headers or {})}
+        # client_host=None models a connection with no peer address, which is what an
+        # ASGI scope carries for a unix socket or a broken transport.
+        self.client = None if client_host is None else type("C", (), {"host": client_host})()
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.setenv("STRANDS_DASH_AUTH_STORE", str(tmp_path / "auth.json"))
+    for k in ("STRANDS_DASH_AUTH_ENABLED", "STRANDS_DASH_AUTH_RP_ID", "STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN"):
+        monkeypatch.delenv(k, raising=False)
+    auth._cache = {}
+    auth._corrupt = None
+    yield
+    auth._corrupt = None
+
+
+class TestTheFirstEnrollmentOnAFreshStore:
+    """No disk error, no token configured: the case that was ungated."""
+
+    def test_a_stranger_cannot_seize_a_fresh_dashboard(self) -> None:
+        with pytest.raises(HTTPException) as e:
+            auth.begin_registration(FakeRequest(), label="attacker")
+        assert e.value.status_code == 403
+
+    def test_the_refusal_names_the_two_ways_forward(self) -> None:
+        """A 403 an operator cannot act on is a support ticket, so both remedies are named."""
+        with pytest.raises(HTTPException) as e:
+            auth.begin_registration(FakeRequest(), label="attacker")
+        detail = e.value.detail
+        assert "the machine itself" in detail
+        assert "STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN" in detail
+
+    def test_the_refusal_does_not_blame_a_disk_error_that_did_not_happen(self) -> None:
+        with pytest.raises(HTTPException) as e:
+            auth.begin_registration(FakeRequest(), label="attacker")
+        assert "unreadable" not in e.value.detail
+        assert "corrupt-" not in e.value.detail
+        assert auth.store_corruption() is None, "no damage was staged, so none may be reported"
+
+    def test_nothing_is_written_by_a_refused_enrollment(self) -> None:
+        """A refusal must not leave the store half-created; auth stays off, not sealed-by-nobody."""
+        with pytest.raises(HTTPException):
+            auth.begin_registration(FakeRequest(), label="attacker")
+        assert auth.auth_enabled() is False
+        assert auth._load().get("credentials") == []
+
+    def test_the_person_at_the_machine_still_enrolls_with_no_configuration(self) -> None:
+        """The zero-config local path is the common one and must stay frictionless."""
+        opts = auth.begin_registration(FakeRequest(client_host="127.0.0.1"), label="owner")
+        assert opts.get("challenge_id")
+
+    @pytest.mark.parametrize("peer", ["127.0.0.1", "127.0.0.53", "::1", "localhost"])
+    def test_every_spelling_of_the_machine_itself_is_accepted(self, peer: str) -> None:
+        opts = auth.begin_registration(FakeRequest(client_host=peer), label="owner")
+        assert opts.get("challenge_id")
+
+
+class TestWhatCountsAsTheMachine:
+    """The gate grants ownership, so it reads only facts about the connection."""
+
+    @pytest.mark.parametrize("header", _SPOOFABLE)
+    def test_a_forwarded_header_cannot_manufacture_loopback(self, header: str) -> None:
+        """_client_ip's own contract: best-effort identity, NEVER for trust.
+
+        The damaged-store route was already pinned against this. The fresh route is the
+        one an attacker reaches without needing a disk error first, so it is pinned too.
+        """
+        request = FakeRequest(client_host=_STRANGER, headers={header: "127.0.0.1"})
+        with pytest.raises(HTTPException) as e:
+            auth.begin_registration(request, label="attacker")
+        assert e.value.status_code == 403
+
+    def test_a_connection_with_no_peer_is_not_the_machine(self) -> None:
+        """Fail closed on an unknown peer: absence of evidence is not evidence of locality."""
+        with pytest.raises(HTTPException) as e:
+            auth.begin_registration(FakeRequest(client_host=None), label="unknown")
+        assert e.value.status_code == 403
+
+
+class TestTheBootstrapTokenIsTheRemoteRoute:
+    """A headless robot has no browser on it, so the token is how its owner enrolls."""
+
+    def test_the_right_token_enrolls_from_anywhere(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN", "let-me-in")
+        opts = auth.begin_registration(FakeRequest(), label="remote-owner", bootstrap="let-me-in")
+        assert opts.get("challenge_id"), "the documented remote path must not be closed by this gate"
+
+    def test_a_wrong_token_is_refused_from_anywhere(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN", "let-me-in")
+        with pytest.raises(HTTPException) as e:
+            auth.begin_registration(FakeRequest(), label="attacker", bootstrap="guess")
+        assert e.value.status_code == 403
+
+    def test_a_configured_token_is_required_even_at_the_machine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loopback does not waive a token the operator deliberately set."""
+        monkeypatch.setenv("STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN", "let-me-in")
+        with pytest.raises(HTTPException):
+            auth.begin_registration(FakeRequest(client_host="127.0.0.1"), label="owner")
+
+
+class TestTheGateIsBoundedToTheFirstEnrollment:
+    """It guards a one-way door, not the dashboard's ongoing use."""
+
+    def test_once_a_credential_exists_the_gate_no_longer_applies(self) -> None:
+        """An owner adding a second passkey remotely is the route's decision, not this one.
+
+        Pinned because a gate on ``first_time`` that leaked into later enrollments would
+        lock an operator out of their own dashboard from anywhere but the console.
+        """
+        auth._save({"credentials": [{"id": "AAAA", "name": "existing"}]})
+        auth._cache = {}
+        assert auth.auth_enabled() is True
+
+        opts = auth.begin_registration(FakeRequest(), label="second-key")
+        assert opts.get("challenge_id")
+
+
+class TestWhichRefusalTheCallerGets:
+    """Two gates can refuse the same request; the report has to be the useful one."""
+
+    def test_an_unusable_rp_id_is_reported_as_such_not_as_an_ownership_refusal(self) -> None:
+        """A bare IP cannot host passkeys at all, so that is the diagnosis worth giving.
+
+        Pins the ordering: the rp_id check runs first, because a caller refused for an
+        unusable rp_id would not be able to enroll from the machine either, and telling
+        them to move to the console would send them somewhere that also fails.
+        """
+        with pytest.raises(HTTPException) as e:
+            auth.begin_registration(FakeRequest(host="192.168.1.166:8090"), label="lan")
+        assert e.value.status_code == 400
+        assert "BOOTSTRAP_TOKEN" not in e.value.detail
+
+    def test_a_damaged_store_still_reports_the_damage_and_where_the_bytes_went(self, tmp_path: Path) -> None:
+        """The more specific cause keeps its more specific message."""
+        (tmp_path / "auth.json").write_text('{"credentials": [{"id": "AAA')  # truncated JSON
+        auth._cache = {}
+        auth._corrupt = None
+        auth._load()
+
+        with pytest.raises(HTTPException) as e:
+            auth.begin_registration(FakeRequest(), label="attacker")
+        assert e.value.status_code == 403
+        assert "unreadable" in e.value.detail and "corrupt-" in e.value.detail


### PR DESCRIPTION
`auth_enabled()` IS `has_credentials()`, so the **first** passkey enrolled decides who owns the fleet: once it succeeds every later caller is locked out, and `rp_id_verdict` plus the last-passkey rule are then built around the store that enrollment created. It is a one-way door in front of hardware.

Three branches could gate that request and only two did.

| arriving at a first enrollment | gated on `main` |
|---|---|
| a bootstrap token is configured | yes, `secrets.compare_digest` |
| the credential store was unreadable, no token | yes, loopback |
| **fresh install, intact empty store, no token** | **no** |

Measured at `19329cd`, same peer, same call:

```
fresh store,   peer 203.0.113.9  ->  ACCEPTED   (challenge issued)
damaged store, peer 203.0.113.9  ->  refused    (403)
```

That is inverted. The damaged store needs a disk error to happen first; the fresh install is every install's first minute, and it is the case where seizing enrollment costs an attacker nothing. The weaker case carried the guard and the stronger one did not.

## The change

One predicate for both routes, `first_time and not required`. Production diff is `+18 / -12` in one function.

The wording still varies by cause. A refusal that blames a disk error where none occurred sends the reader looking for a backup file that does not exist, so the fresh case gets its own sentence; both name the same two ways forward, and the new test asserts that neither claims the other's cause.

The socket peer is read, not `_client_ip`, whose own docstring says it is for the per-ip cap and *never* for trust. The damaged-store route was already pinned against a forwarded header spelling itself `127.0.0.1`; the fresh route -- the one reachable without a disk error -- now is too. An unknown peer (`request.client is None`, e.g. a unix socket) is not the machine, and fails closed.

## Two boundaries, both deliberate and both pinned

**It lifts once a credential exists.** An owner adding a phone from their sofa is the route's session decision, not this one. A gate on `first_time` that leaked into later enrollments would be a lockout rather than a guard.

**It runs after the rp_id usability check.** A caller on a bare IP is told that passkeys cannot work there at all, which is the actionable diagnosis; telling them to move to the console would send them somewhere the same refusal awaits. This ordering is why `test_begin_registration_rejects_raw_ip` still reports 400.

A configured bootstrap token remains the route for a headless robot, so its owner is not locked out. That path is pinned rather than assumed.

## The test that asserted the old behaviour

`test_a_genuinely_new_dashboard_is_unaffected` asserted exactly what this changes. Its comment is the useful record: *"first enrollment from anywhere keeps working exactly as before, so this change narrows an accident rather than adding a gate to the normal path."* That was the corrupt-store PR's scope discipline, not a finding that the normal path was safe. It is rewritten to state what is now true rather than deleted.

## Why the suite stayed green over this

The fakes in three auth suites carried no `client` attribute at all, so `_socket_peer` returned `None` for every cell and no test could observe a gate that reads it. They now model the loopback peer those cells always meant. That is a fixture gap rather than a fix, and it is part of the answer to how an ungated ownership path survived review.

## Proof

`tests/test_dashboard_first_enrollment_is_limited_to_the_machine.py` pins each way through the gate. Reverting only `strands_robots/`:

```
8 failed, 11 passed     # pre-fix
19 passed               # after
```

The 11 pre-fix passes are the controls -- the loopback path, both token paths, the bounded-to-first-enrollment cell and the rp_id ordering all held before the change and must keep holding, so the file is not merely restating the new branch.

## Gate

All 12 dashboard suites: **174 passed**. `ruff check` / `ruff format --check` clean on the 5 touched files. mypy at the project pin reports 0 errors in `dashboard/auth.py`. Whole-tree graders (issue #2940's class) 132 passed / 1 skipped; the single failure is `test_declared_qp_backends_are_real_qpsolvers_extras`, absent `qpsolvers` in this environment and identical on pristine `main`. `test_no_host_paths` 26 passed, ASCII/emoji/dash string graders 16 passed.

LOC `+263 / -31` across 5 files, of which 208 added lines are the new test.

## Provenance

This is the auth half of the #2977 decomposition, and it answers the `auth.py:561` thread on draft #2848 against merged code rather than against a 477-file diff. The other half of that finding -- both enrollment endpoints sitting in `PUBLIC_PATHS`, so the middleware returns early for them -- lives in `server.py`, which is not yet sliced onto `main`; it stays a precondition of that slice, and this gate is what makes it survivable when it lands, since the route-level `PUBLIC_PATHS` mistake no longer reaches an ungated ownership decision.

Refs #2977, #2848.
