### PR TITLE
fix(dashboard/auth): a passkey ceremony is verified against the connection, not the caller's claim

### DIFF
--- a/changelog.d/3080-ceremony-origin-is-the-connection.md
+++ b/changelog.d/3080-ceremony-origin-is-the-connection.md
@@ -1,0 +1,38 @@
+### Fixed: a passkey ceremony is verified against the connection, not the caller's claim
+
+`_derive_origin` returned the request's own `Origin` header whenever
+`STRANDS_DASH_AUTH_ORIGIN` was unset, which is the default. That value was handed
+to `verify_registration_response` and `verify_authentication_response` as
+`expected_origin`, so the WebAuthn library was told to expect whatever the caller
+said and the comparison could not fail. `expected_rp_id` still came from the
+stashed challenge record, and a browser will not sign for an rpId that is not a
+registrable suffix of the page origin, so this was never cross-origin credential
+theft -- what was lost is the binding *within* one registrable domain: an
+`http://` downgrade and a sibling subdomain both passed a check whose only
+purpose is to refuse them. The scheme half was caller-controlled even when no
+`Origin` header was sent, because `x-forwarded-proto` was read with no
+trusted-proxy allowlist.
+
+The expectation is now a fact about the connection: the transport's own scheme
+plus the `Host` header that `rp_id_verdict` already binds, so the two
+expectations a ceremony is verified against agree by construction. A socket
+scheme is mapped to the page origin it belongs to -- a `wss` socket belongs to an
+`https` page, and that page's `Origin` is spelled `https://` -- and an `Origin`
+header that contradicts the connection is refused by the new `origin_verdict`,
+which names both origins, rather than being adopted.
+
+A TLS-terminating proxy is still honoured, by the server under the trusted-proxy
+allowlist the operator configured there (uvicorn's `--proxy-headers` with
+`--forwarded-allow-ips`), which rewrites the scheme before the app is reached; a
+deployment that cannot do that sets `STRANDS_DASH_AUTH_ORIGIN`, which is now
+documented and normalised, and which still outranks every header. The installs
+that need that pin are the ones whose proxy rewrites `Host` and `Origin`, so
+consulting either header when it is set would refuse exactly the deployment it
+exists for.
+
+`status()` reads a new `_served_origin` seam instead of the ceremony
+expectation: its advisory reports where the dashboard is served, so a mismatched
+`Origin` cannot remove the login screen's hints exactly when a misconfigured
+proxy makes them worth reading. One case changes in the permissive direction: a
+dashboard reached over https that receives no `Origin` header used to
+reconstruct `http://<host>` and would have refused a legitimate browser.

--- a/strands_robots/dashboard/auth.py
+++ b/strands_robots/dashboard/auth.py
@@ -1,5 +1,24 @@
 """WebAuthn (passkey) authentication for the dashboard. Why this exists: the dashboard commands
 real hardware (SO-101 arms).
+
+A ceremony is verified against two expectations, and neither may come from the
+caller: ``expected_rp_id`` from the challenge record this process stashed, and
+``expected_origin`` from the connection the request actually arrived on (see
+:func:`origin_verdict`). What the request ASSERTS about itself -- its ``Origin``
+header, ``x-forwarded-proto``, ``x-forwarded-for`` -- is a claim, and a claim is
+only ever compared against an expectation, never promoted into one.
+
+Configuration:
+    ``STRANDS_DASH_AUTH_ORIGIN``: the origin the dashboard is served at, e.g.
+        ``https://robots.example``. Unset by default, in which case it is read off
+        the connection: the transport's own scheme plus the ``Host`` header. Set
+        it when a proxy rewrites ``Host`` or ``Origin``, or when TLS is terminated
+        upstream and the server is not configured to forward that fact (uvicorn's
+        ``--proxy-headers`` with ``--forwarded-allow-ips``, which is where the
+        trusted-proxy decision belongs). WebAuthn compares origins byte-for-byte,
+        so it must carry the scheme and any non-default port.
+    ``STRANDS_DASH_AUTH_RP_ID``: pins the relying-party id when the hostname
+        legitimately changed. See :func:`rp_id_verdict`.
 """
 
 from __future__ import annotations
@@ -356,17 +375,113 @@ def _derive_rp_id(request_or_ws: Any) -> str:
     return cast(str, rp_id)
 
 
-def _derive_origin(request_or_ws: Any) -> str:
+#: How a connection scheme is spelled by the page origin it belongs to. An operator
+#: page served over https opens its sockets as ``wss``, and the browser still spells
+#: that page's ``Origin`` ``https://`` -- so the socket spelling is never the answer.
+_PAGE_SCHEME = {"http": "http", "https": "https", "ws": "http", "wss": "https"}
+
+
+def origin_verdict(offered: str, expected: str) -> tuple:
+    """Decide the origin a ceremony is verified against: ``(origin, reason)``, or ``(None, reason)``.
+
+    ``expected`` is where this deployment is reachable, which is a fact about the
+    connection (or a value the operator configured). ``offered`` is the request's
+    own ``Origin`` header, which is the caller's claim about itself and therefore
+    never the answer: handing it to the WebAuthn library as ``expected_origin``
+    tells the library to expect whatever the caller said, and a comparison
+    against the caller's own claim cannot fail. What that comparison exists to
+    refuse -- an ``http://`` downgrade, a sibling subdomain -- is precisely what
+    adopting the header lets through, because ``rp_id`` binds the registrable
+    domain but nothing below it.
+
+    Args:
+        offered: The request's ``Origin`` header, or ``""`` when it sent none.
+        expected: The origin this deployment is actually reachable at.
+
+    Returns:
+        ``(origin, reason)`` with the origin to verify against, or
+        ``(None, reason)`` when the header contradicts the connection.
+    """
+    if not offered:
+        # A browser sends Origin on the ceremony POSTs, so its absence is odd --
+        # but absence is not a reason to widen the expectation. The connection's
+        # own origin stands, and the authenticator's signed clientData still has
+        # to match it, which is the check that was being bypassed.
+        return (expected, "no Origin header; the connection's own origin stands")
+    if offered.rstrip("/") == expected:
+        return (expected, "Origin matches the connection")
+    return (None, f"Origin {offered!r} is not this deployment's origin {expected!r}")
+
+
+def _connection_scheme(request_or_ws: Any) -> str:
+    """The scheme this deployment was actually reached over, spelled as a page origin.
+
+    Read off the ASGI connection rather than from ``x-forwarded-proto``, for the
+    same reason :func:`_socket_peer` ignores ``x-forwarded-for``: that header is
+    set by whoever is calling, so a stranger can spell it ``https`` and choose
+    the scheme half of an expectation that grants a session. A TLS-terminating
+    proxy is still honoured -- by the SERVER, under the trusted-proxy allowlist
+    the operator configured there (uvicorn's ``--proxy-headers`` with
+    ``--forwarded-allow-ips``), which rewrites the scheme before the app is
+    reached. A deployment that cannot do that sets ``STRANDS_DASH_AUTH_ORIGIN``.
+
+    Raises:
+        HTTPException: 400 when the transport reports no usable scheme, so an
+            expectation is refused rather than guessed.
+    """
+    scheme = str(getattr(getattr(request_or_ws, "url", None), "scheme", "")).lower()
+    page = _PAGE_SCHEME.get(scheme)
+    if page is None:
+        logger.warning("refused WebAuthn ceremony: transport reported scheme %r", scheme)
+        raise HTTPException(
+            400,
+            {
+                "error": "this connection cannot be used for a passkey ceremony",
+                "detail": f"the transport reported no usable scheme ({scheme!r}), so the origin "
+                "a ceremony must be verified against cannot be determined",
+                "hint": "set STRANDS_DASH_AUTH_ORIGIN to the origin the dashboard is served at",
+            },
+        )
+    return page
+
+
+def _served_origin(request_or_ws: Any) -> str:
+    """The origin this deployment is reachable at: configured, or the connection's own.
+
+    The ``Host`` header supplies the authority half, which is the same source
+    :func:`_derive_rp_id` already binds through :func:`rp_id_verdict` -- so the two
+    expectations agree by construction, and a host a stranger made up is refused
+    there rather than reappearing here as a different answer.
+    """
     forced = _forced_origin()
     if forced:
-        return forced
-    headers = _headers(request_or_ws)
-    origin = headers.get("origin")
-    if origin:
-        return cast(str, origin.rstrip("/"))
-    host = headers.get("host", "localhost:8090")
-    scheme = "https" if headers.get("x-forwarded-proto") == "https" else "http"
-    return f"{scheme}://{host}"
+        # Normalised because WebAuthn compares origins byte-for-byte: a trailing
+        # slash in the env var would otherwise fail every ceremony.
+        return forced.rstrip("/")
+    return f"{_connection_scheme(request_or_ws)}://{_headers(request_or_ws).get('host', 'localhost:8090')}"
+
+
+def _derive_origin(request_or_ws: Any) -> str:
+    """The origin a ceremony is verified against, refusing a caller that claims another."""
+    expected = _served_origin(request_or_ws)
+    if _forced_origin():
+        # The operator decided it, and the installs that need this pin are the ones
+        # whose proxy rewrites Host/Origin -- so consulting either header here would
+        # refuse exactly the deployment the pin exists for.
+        return expected
+    origin, reason = origin_verdict(_headers(request_or_ws).get("origin", ""), expected)
+    if origin is None:
+        logger.warning("refused WebAuthn ceremony: %s", reason)
+        raise HTTPException(
+            400,
+            {
+                "error": "this Origin cannot be used for a passkey ceremony",
+                "detail": reason,
+                "hint": "reach the dashboard on the origin it is served at, or set "
+                "STRANDS_DASH_AUTH_ORIGIN if a proxy rewrites Host or Origin",
+            },
+        )
+    return cast(str, origin)
 
 
 def _rpid_error(rp_id: str) -> HTTPException:
@@ -782,7 +897,11 @@ def status(request: Any = None) -> dict[str, Any]:
     }
     if request is not None:
         # The rp_id block is advisory: it tells the login screen which relying-party
-        # id this origin can use and why it might not work. It is derived from the
+        # id this origin can use and why it might not work. It reports the origin the
+        # dashboard is SERVED at rather than the one a ceremony would accept, because
+        # a diagnostic that refuses a mismatched Origin would remove the login
+        # screen's hints exactly when a misconfigured proxy makes them worth
+        # reading. It is derived from the
         # request, so any transport that answers `headers` or `url` differently than
         # expected can make it raise - and a diagnostic that raises would take the
         # login screen down with it, which is strictly worse than a screen missing
@@ -795,7 +914,7 @@ def status(request: Any = None) -> dict[str, Any]:
         advisory: dict[str, Any] = {}
         try:
             host = _host_only(request.headers.get("host", ""))
-            origin = _derive_origin(request)
+            origin = _served_origin(request)
             forced = _forced_rp_id()
             advisory["rp_id"] = forced or host
             advisory["secure_context"] = origin.startswith("https://") or host == "localhost"

--- a/tests/test_dashboard_auth_ceremony_finish.py
+++ b/tests/test_dashboard_auth_ceremony_finish.py
@@ -24,8 +24,17 @@ from strands_robots.dashboard import auth
 
 
 class FakeRequest:
-    def __init__(self, headers=None):
+    """A request as it arrived: over a SCHEME, carrying headers.
+
+    The scheme is a property of the connection, not of a header, so a stand-in
+    that answers headers alone cannot represent one -- and an expectation
+    derived from it would look right here while being caller-controlled in
+    production.
+    """
+
+    def __init__(self, headers=None, scheme="http"):
         self.headers = headers or {"host": "localhost:8090"}
+        self.url = SimpleNamespace(scheme=scheme)
 
 
 @pytest.fixture(autouse=True)
@@ -253,8 +262,8 @@ def test_status_warns_on_insecure_context():
 
 
 def test_status_warns_on_unusable_rpid():
-    # https via proxy headers, but the host is an IP: rpId can never work.
-    out = auth.status(FakeRequest({"host": "192.168.1.50:8090", "x-forwarded-proto": "https"}))
+    # Reached over https, but the host is an IP: rpId can never work.
+    out = auth.status(FakeRequest({"host": "192.168.1.50:8090"}, scheme="https"))
     assert out["rpid_usable"] is False
     assert "rpId" in out.get("warning", "")
 

--- a/tests/test_dashboard_auth_corrupt_store.py
+++ b/tests/test_dashboard_auth_corrupt_store.py
@@ -12,6 +12,7 @@ machine re-enroll while a stranger who merely benefited from a disk error cannot
 
 import json
 import logging
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -20,9 +21,18 @@ from strands_robots.dashboard import auth
 
 
 class FakeRequest:
-    def __init__(self, headers=None, client_host="127.0.0.1"):
+    """A request as it arrived: over a SCHEME, carrying headers.
+
+    The scheme is a property of the connection, not of a header, so a stand-in
+    that answers headers alone cannot represent one -- and an expectation
+    derived from it would look right here while being caller-controlled in
+    production.
+    """
+
+    def __init__(self, headers=None, client_host="127.0.0.1", scheme="http"):
         self.headers = headers or {"host": "localhost:8090"}
         self.client = type("C", (), {"host": client_host})()
+        self.url = SimpleNamespace(scheme=scheme)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_dashboard_auth_edges.py
+++ b/tests/test_dashboard_auth_edges.py
@@ -7,10 +7,10 @@ that are security behaviour rather than IO error tolerance).
 2. begin_authentication refuses to run a ceremony whose rp_id is a raw IP,
    even when the operator pinned that IP - browsers reject an IP rpId before
    the ceremony starts, so proceeding would mint challenges nothing can answer.
-3. STRANDS_DASH_AUTH_ORIGIN outranks every header (tunnel installs where the
-   proxy rewrites Host/Origin).
-4. Without the pin, the Origin header wins over Host reconstruction, and a
-   trailing slash is normalised - WebAuthn compares origins byte-for-byte.
+
+Expected-origin derivation used to be items 3 and 4 here. It is now a matrix of
+its own in test_dashboard_auth_expected_origin_is_the_connection.py, which needs
+a real Request to observe the transport scheme these edge cases never had.
 """
 
 from __future__ import annotations
@@ -86,26 +86,6 @@ def test_begin_authentication_needs_enrollment_first():
     with pytest.raises(HTTPException) as e:
         auth.begin_authentication(FakeRequest())
     assert "no credentials" in str(e.value.detail)
-
-
-# --- 3+4. expected-origin derivation ------------------------------------------
-
-
-def test_forced_origin_outranks_every_header(monkeypatch):
-    monkeypatch.setenv("STRANDS_DASH_AUTH_ORIGIN", "https://robots.cagatay.my")
-    req = FakeRequest({"host": "evil.example", "origin": "https://evil.example"})
-    assert auth._derive_origin(req) == "https://robots.cagatay.my"
-
-
-def test_origin_header_wins_and_is_normalised():
-    req = FakeRequest({"host": "localhost:8090", "origin": "https://robots.example/"})
-    assert auth._derive_origin(req) == "https://robots.example"
-
-
-def test_origin_falls_back_to_host_with_forwarded_proto():
-    req = FakeRequest({"host": "robots.example", "x-forwarded-proto": "https"})
-    assert auth._derive_origin(req) == "https://robots.example"
-    assert auth._derive_origin(FakeRequest({"host": "localhost:8090"})) == "http://localhost:8090"
 
 
 # --- bonus: a garbage TOKEN_TTL cannot break token minting --------------------

--- a/tests/test_dashboard_auth_expected_origin_is_the_connection.py
+++ b/tests/test_dashboard_auth_expected_origin_is_the_connection.py
@@ -35,6 +35,7 @@ from strands_robots.dashboard import auth
 SERVED_AT = "https://dash.example.com"
 CRED_ID = b"\x03" * 16
 CRED_ID_B64 = bytes_to_base64url(CRED_ID)
+BOOTSTRAP = "a-token-for-a-remote-first-enrollment"
 
 
 def request(scheme: str = "https", **headers: str) -> Request:
@@ -203,6 +204,13 @@ def _enrolled_credential() -> None:
 
 def _finish_registration(monkeypatch, begin_on: Request, finish_on: Request) -> dict:
     seen: dict = {}
+    # The first enrollment seals the dashboard, so it is limited to the machine itself
+    # unless a bootstrap token is configured to check it against. These cells model a
+    # REMOTE browser reaching a served origin -- that is the scenario under test -- so
+    # the socket peer is deliberately not loopback, and the token is what holds that
+    # gate constant and leaves the origin the only variable. Without it the enrollment
+    # gate refuses first, and a test about an origin reports on enrollment instead.
+    monkeypatch.setenv("STRANDS_DASH_AUTH_BOOTSTRAP_TOKEN", BOOTSTRAP)
     monkeypatch.setattr(
         auth,
         "verify_registration_response",
@@ -210,7 +218,7 @@ def _finish_registration(monkeypatch, begin_on: Request, finish_on: Request) -> 
             seen.update(kw) or SimpleNamespace(credential_id=CRED_ID, credential_public_key=b"\x02" * 32, sign_count=1)
         ),
     )
-    begun = auth.begin_registration(begin_on, label="phone")
+    begun = auth.begin_registration(begin_on, label="phone", bootstrap=BOOTSTRAP)
     auth.finish_registration(finish_on, begun["challenge_id"], {"id": CRED_ID_B64})
     return seen
 

--- a/tests/test_dashboard_auth_expected_origin_is_the_connection.py
+++ b/tests/test_dashboard_auth_expected_origin_is_the_connection.py
@@ -261,11 +261,27 @@ def test_a_ceremony_is_verified_against_the_served_origin(label, run, monkeypatc
     assert seen["expected_rp_id"] == "dash.example.com"
 
 
-@pytest.mark.parametrize(("label", "run"), CEREMONIES, ids=[c[0] for c in CEREMONIES])
-def test_a_ceremony_finished_from_a_claimed_origin_is_refused(label, run, monkeypatch):
+#: Every ceremony crossed with every claim the served origin contradicts. The claim
+#: is the FINISHING request's, so these rows grade the ceremony path rather than
+#: :func:`auth._derive_origin` on its own: a finish that decided the expectation
+#: from the credential's stored ``rp_id`` -- which is a HOST -- still refuses the
+#: rows whose host differs, and admits the two that share ``dash.example.com``. A
+#: single differing-host row cannot tell those two situations apart, however the
+#: refusal it does get is compared.
+REFUSED_CEREMONIES = [
+    (f"{ceremony}/{shape}", run, claimed) for ceremony, run in CEREMONIES for shape, claimed in CONTRADICTING
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "run", "claimed"),
+    REFUSED_CEREMONIES,
+    ids=[row[0] for row in REFUSED_CEREMONIES],
+)
+def test_a_ceremony_finished_from_a_claimed_origin_is_refused(label, run, claimed, monkeypatch):
     served = request(host="dash.example.com", origin=SERVED_AT)
-    claimed = request(host="dash.example.com", origin=ELSEWHERE)
+    finished_from = request(host="dash.example.com", origin=claimed)
     with pytest.raises(HTTPException) as e:
-        run(monkeypatch, served, claimed)
+        run(monkeypatch, served, finished_from)
     assert e.value.status_code == 400
-    assert e.value.detail["detail"] == contradiction(ELSEWHERE)
+    assert e.value.detail["detail"] == contradiction(claimed)

--- a/tests/test_dashboard_auth_expected_origin_is_the_connection.py
+++ b/tests/test_dashboard_auth_expected_origin_is_the_connection.py
@@ -33,9 +33,22 @@ from webauthn.helpers import bytes_to_base64url
 from strands_robots.dashboard import auth
 
 SERVED_AT = "https://dash.example.com"
+ELSEWHERE = "https://evil.example.com"
 CRED_ID = b"\x03" * 16
 CRED_ID_B64 = bytes_to_base64url(CRED_ID)
 BOOTSTRAP = "a-token-for-a-remote-first-enrollment"
+
+
+def contradiction(offered: str) -> str:
+    """The refusal an operator has to be able to read: which two origins disagreed.
+
+    Spelled whole, and compared whole. For a URL the POSITION carries the
+    meaning, so a substring assertion is satisfied by a message that names the
+    two origins the wrong way round, or that carries one inside the other's
+    query string -- neither of which tells an operator behind a proxy which end
+    to fix.
+    """
+    return f"Origin {offered!r} is not this deployment's origin {SERVED_AT!r}"
 
 
 def request(scheme: str = "https", **headers: str) -> Request:
@@ -101,7 +114,7 @@ def isolated_store(tmp_path, monkeypatch):
 #: refusal names the remedy rather than silently trusting the claim.
 CONTRADICTING = [
     ("http downgrade", "http://dash.example.com"),
-    ("sibling subdomain", "https://evil.example.com"),
+    ("sibling subdomain", ELSEWHERE),
     ("unrelated origin", "https://anything.at.all"),
     ("port swapped", "https://dash.example.com:8443"),
 ]
@@ -114,8 +127,7 @@ def test_an_origin_that_contradicts_the_connection_is_refused(label, claimed):
     assert e.value.status_code == 400
     # Attributable: an operator behind a proxy must be able to tell which two
     # origins disagreed, and be pointed at the pin that settles it.
-    assert claimed in e.value.detail["detail"]
-    assert SERVED_AT in e.value.detail["detail"]
+    assert e.value.detail["detail"] == contradiction(claimed)
     assert "STRANDS_DASH_AUTH_ORIGIN" in e.value.detail["hint"]
 
 
@@ -252,8 +264,8 @@ def test_a_ceremony_is_verified_against_the_served_origin(label, run, monkeypatc
 @pytest.mark.parametrize(("label", "run"), CEREMONIES, ids=[c[0] for c in CEREMONIES])
 def test_a_ceremony_finished_from_a_claimed_origin_is_refused(label, run, monkeypatch):
     served = request(host="dash.example.com", origin=SERVED_AT)
-    claimed = request(host="dash.example.com", origin="https://evil.example.com")
+    claimed = request(host="dash.example.com", origin=ELSEWHERE)
     with pytest.raises(HTTPException) as e:
         run(monkeypatch, served, claimed)
     assert e.value.status_code == 400
-    assert "evil.example.com" in e.value.detail["detail"]
+    assert e.value.detail["detail"] == contradiction(ELSEWHERE)

--- a/tests/test_dashboard_auth_expected_origin_is_the_connection.py
+++ b/tests/test_dashboard_auth_expected_origin_is_the_connection.py
@@ -1,0 +1,251 @@
+"""The origin a passkey ceremony is verified against is the connection's, not the caller's claim.
+
+``expected_origin`` is what the WebAuthn library compares the authenticator's
+SIGNED ``clientDataJSON.origin`` against, so it decides whether an assertion
+minted for one origin may mint a session at another. Deriving it from the
+request's own ``Origin`` header makes that comparison a tautology: the library
+is told to expect whatever the caller said. ``rp_id`` still binds the
+registrable domain -- a browser will not sign for an rpId that is not a
+registrable suffix of the page -- so what a tautology loses is the binding
+WITHIN one domain: an ``http://`` downgrade and a sibling subdomain both pass a
+check whose only purpose is to refuse them.
+
+These use real :class:`starlette.requests.Request` / :class:`WebSocket` objects
+rather than a stand-in with a ``headers`` dict, because the two facts under test
+-- the transport's own scheme, and that a websocket reports ``wss`` where its
+page origin says ``https`` -- exist only on the real object. A fake that answers
+headers alone cannot observe either, which is why an expectation taken from a
+header could look correct in a test.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+from starlette.websockets import WebSocket
+from webauthn.helpers import bytes_to_base64url
+
+from strands_robots.dashboard import auth
+
+SERVED_AT = "https://dash.example.com"
+CRED_ID = b"\x03" * 16
+CRED_ID_B64 = bytes_to_base64url(CRED_ID)
+
+
+def request(scheme: str = "https", **headers: str) -> Request:
+    """A request that really arrived over ``scheme`` carrying ``headers``."""
+    return Request(
+        {
+            "type": "http",
+            "scheme": scheme,
+            "method": "POST",
+            "path": "/",
+            "query_string": b"",
+            "server": ("10.0.0.1", 443),
+            "client": ("203.0.113.9", 51234),
+            "headers": [(k.replace("_", "-").encode(), v.encode()) for k, v in headers.items()],
+        }
+    )
+
+
+async def _never_receives() -> Any:
+    raise AssertionError("deciding an origin must not read from the socket")
+
+
+async def _never_sends(message: Any) -> None:
+    raise AssertionError("deciding an origin must not write to the socket")
+
+
+def websocket(scheme: str, **headers: str) -> WebSocket:
+    """A websocket that really arrived over ``scheme``.
+
+    Its receive/send channels refuse: the decision under test reads the
+    connection's scope, and must not depend on talking to the peer.
+    """
+    return WebSocket(
+        {
+            "type": "websocket",
+            "scheme": scheme,
+            "path": "/ws",
+            "query_string": b"",
+            "server": ("10.0.0.1", 443),
+            "headers": [(k.replace("_", "-").encode(), v.encode()) for k, v in headers.items()],
+        },
+        receive=_never_receives,
+        send=_never_sends,
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("STRANDS_DASH_AUTH_STORE", str(tmp_path / "auth.json"))
+    for key in ("ENABLED", "RP_ID", "ORIGIN", "BOOTSTRAP_TOKEN", "TOKEN_TTL"):
+        monkeypatch.delenv("STRANDS_DASH_AUTH_" + key, raising=False)
+    auth._cache = {}
+    auth._challenges.clear()
+    yield
+    auth._challenges.clear()
+
+
+# --- the expectation is never the caller's claim -------------------------------
+
+#: Each row is a claim a caller can make that the served origin contradicts. The
+#: first is not an attack shape but a MISCONFIGURATION with the same signature (a
+#: TLS-terminating proxy that speaks http to the app): both are refused, and the
+#: refusal names the remedy rather than silently trusting the claim.
+CONTRADICTING = [
+    ("http downgrade", "http://dash.example.com"),
+    ("sibling subdomain", "https://evil.example.com"),
+    ("unrelated origin", "https://anything.at.all"),
+    ("port swapped", "https://dash.example.com:8443"),
+]
+
+
+@pytest.mark.parametrize(("label", "claimed"), CONTRADICTING, ids=[r[0] for r in CONTRADICTING])
+def test_an_origin_that_contradicts_the_connection_is_refused(label, claimed):
+    with pytest.raises(HTTPException) as e:
+        auth._derive_origin(request(host="dash.example.com", origin=claimed))
+    assert e.value.status_code == 400
+    # Attributable: an operator behind a proxy must be able to tell which two
+    # origins disagreed, and be pointed at the pin that settles it.
+    assert claimed in e.value.detail["detail"]
+    assert SERVED_AT in e.value.detail["detail"]
+    assert "STRANDS_DASH_AUTH_ORIGIN" in e.value.detail["hint"]
+
+
+def test_the_origin_the_dashboard_is_served_at_is_accepted_and_normalised():
+    for claimed in (SERVED_AT, SERVED_AT + "/"):
+        assert auth._derive_origin(request(host="dash.example.com", origin=claimed)) == SERVED_AT
+    # Local development is the common case and must not need configuring.
+    assert (
+        auth._derive_origin(request("http", host="localhost:8090", origin="http://localhost:8090"))
+        == "http://localhost:8090"
+    )
+
+
+def test_a_missing_origin_header_leaves_the_connection_standing():
+    # Not a licence to widen it: the authenticator's signed clientData still has
+    # to match this, which is the comparison a header-derived value bypassed.
+    assert auth._derive_origin(request(host="dash.example.com")) == SERVED_AT
+
+
+def test_a_forwarded_proto_header_cannot_choose_the_scheme():
+    # x-forwarded-proto is set by whoever is calling. A proxy the operator trusts
+    # is honoured by the SERVER (uvicorn --proxy-headers --forwarded-allow-ips),
+    # which rewrites the connection scheme before the app sees the request.
+    reached_over_http = request("http", host="dash.example.com", x_forwarded_proto="https")
+    assert auth._derive_origin(reached_over_http) == "http://dash.example.com"
+
+
+def test_a_websocket_scheme_is_read_as_the_page_origin_it_belongs_to():
+    # A page served over https opens wss sockets, and the browser still spells
+    # that page's Origin https:// - so the socket spelling is never the answer.
+    assert auth._derive_origin(websocket("wss", host="dash.example.com", origin=SERVED_AT)) == SERVED_AT
+    assert (
+        auth._derive_origin(websocket("ws", host="localhost:8090", origin="http://localhost:8090"))
+        == "http://localhost:8090"
+    )
+
+
+def test_a_transport_with_no_scheme_is_refused_rather_than_guessed():
+    with pytest.raises(HTTPException) as e:
+        auth._derive_origin(SimpleNamespace(headers={"host": "dash.example.com"}))
+    assert e.value.status_code == 400
+    assert "no usable scheme" in e.value.detail["detail"]
+
+
+def test_the_configured_origin_outranks_the_headers_and_is_normalised(monkeypatch):
+    # The installs that need this pin are the ones whose proxy rewrites Host and
+    # Origin, so consulting either here would refuse the deployment it exists for.
+    monkeypatch.setenv("STRANDS_DASH_AUTH_ORIGIN", "https://robots.example/")
+    rewritten = request("http", host="internal.local", origin="http://internal.local")
+    assert auth._derive_origin(rewritten) == "https://robots.example"
+
+
+VERDICTS = [
+    ("matching", "https://a.example", "https://a.example", "https://a.example"),
+    ("trailing slash", "https://a.example/", "https://a.example", "https://a.example"),
+    ("absent", "", "https://a.example", "https://a.example"),
+    ("downgraded", "http://a.example", "https://a.example", None),
+    ("sibling", "https://b.a.example", "https://a.example", None),
+]
+
+
+@pytest.mark.parametrize(("label", "offered", "expected", "decided"), VERDICTS, ids=[r[0] for r in VERDICTS])
+def test_origin_verdict_reports_the_decision_and_its_reason(label, offered, expected, decided):
+    origin, reason = auth.origin_verdict(offered, expected)
+    assert origin == decided
+    assert reason
+
+
+# --- the call sites: what the library is actually told to expect ---------------
+
+
+def _enrolled_credential() -> None:
+    store = auth._load()
+    store["credentials"] = [
+        {
+            "id": CRED_ID_B64,
+            "public_key": bytes_to_base64url(b"\x02" * 32),
+            "sign_count": 0,
+            "name": "phone",
+            "rp_id": "dash.example.com",
+            "created": time.time(),
+        }
+    ]
+    auth._save(store)
+
+
+def _finish_registration(monkeypatch, begin_on: Request, finish_on: Request) -> dict:
+    seen: dict = {}
+    monkeypatch.setattr(
+        auth,
+        "verify_registration_response",
+        lambda **kw: (
+            seen.update(kw) or SimpleNamespace(credential_id=CRED_ID, credential_public_key=b"\x02" * 32, sign_count=1)
+        ),
+    )
+    begun = auth.begin_registration(begin_on, label="phone")
+    auth.finish_registration(finish_on, begun["challenge_id"], {"id": CRED_ID_B64})
+    return seen
+
+
+def _finish_authentication(monkeypatch, begin_on: Request, finish_on: Request) -> dict:
+    seen: dict = {}
+    _enrolled_credential()
+    monkeypatch.setattr(
+        auth,
+        "verify_authentication_response",
+        lambda **kw: seen.update(kw) or SimpleNamespace(new_sign_count=2),
+    )
+    begun = auth.begin_authentication(begin_on)
+    auth.finish_authentication(finish_on, begun["challenge_id"], {"id": CRED_ID_B64})
+    return seen
+
+
+CEREMONIES = [("registration", _finish_registration), ("authentication", _finish_authentication)]
+
+
+@pytest.mark.parametrize(("label", "run"), CEREMONIES, ids=[c[0] for c in CEREMONIES])
+def test_a_ceremony_is_verified_against_the_served_origin(label, run, monkeypatch):
+    served = request(host="dash.example.com", origin=SERVED_AT)
+    seen = run(monkeypatch, served, served)
+    assert seen["expected_origin"] == SERVED_AT
+    # The rp_id half comes from the stashed challenge, not the request - both
+    # expectations have to be facts for the pair to mean anything.
+    assert seen["expected_rp_id"] == "dash.example.com"
+
+
+@pytest.mark.parametrize(("label", "run"), CEREMONIES, ids=[c[0] for c in CEREMONIES])
+def test_a_ceremony_finished_from_a_claimed_origin_is_refused(label, run, monkeypatch):
+    served = request(host="dash.example.com", origin=SERVED_AT)
+    claimed = request(host="dash.example.com", origin="https://evil.example.com")
+    with pytest.raises(HTTPException) as e:
+        run(monkeypatch, served, claimed)
+    assert e.value.status_code == 400
+    assert "evil.example.com" in e.value.detail["detail"]

--- a/tests/test_dashboard_auth_module.py
+++ b/tests/test_dashboard_auth_module.py
@@ -11,6 +11,7 @@ import json
 import os
 import stat
 import time
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -19,8 +20,17 @@ from strands_robots.dashboard import auth
 
 
 class FakeRequest:
-    def __init__(self, headers=None):
+    """A request as it arrived: over a SCHEME, carrying headers.
+
+    The scheme is a property of the connection, not of a header, so a stand-in
+    that answers headers alone cannot represent one -- and an expectation
+    derived from it would look right here while being caller-controlled in
+    production.
+    """
+
+    def __init__(self, headers=None, scheme="http"):
         self.headers = headers or {"host": "localhost:8090"}
+        self.url = SimpleNamespace(scheme=scheme)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
`_derive_origin` returned the request's own `Origin` header when `STRANDS_DASH_AUTH_ORIGIN` was unset, which is the default. That value is what `verify_registration_response` / `verify_authentication_response` are given as `expected_origin`, so the library was told to expect whatever the caller said and the comparison could not fail.

![expected_origin before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/ceremony-origin/expected_origin_before_after.png)

Measured by calling `_derive_origin` with real `starlette` requests on `19329cd` and on this branch. 4 of 8 rows change; the 4 that do not are the deployments that must keep working.

## What was lost

`expected_rp_id` still comes from the stashed challenge record, and a browser will not sign for an rpId that is not a registrable suffix of the page origin, so this was not cross-origin credential theft. What a tautology loses is the binding *within* one registrable domain: an `http://` downgrade and a sibling subdomain passed a check whose only purpose is to refuse them. The scheme half was caller-controlled even with no `Origin` header, since `x-forwarded-proto` was read with no trusted-proxy allowlist (row 5).

## The change

```mermaid
flowchart LR
  A["Origin header<br/>x-forwarded-proto"] -->|before: promoted| E[expected_origin]
  A -->|after: compared| V{origin_verdict}
  C["transport scheme<br/>+ Host header"] --> V
  P["STRANDS_DASH_AUTH_ORIGIN"] --> V
  V -->|matches| E
  V -->|contradicts| R[400, naming both origins]
```

| | |
|---|---|
| **expectation** | the transport's own scheme + the `Host` header the `rp_id` decision already binds through `rp_id_verdict`, so the two expectations agree by construction |
| **websockets** | a `wss` socket belongs to an `https` page, and that page's `Origin` is spelled `https://` - so the socket spelling is mapped, not used. This is why `request.base_url` alone is not the answer: it yields `wss://host` |
| **a contradicting `Origin`** | refused by `origin_verdict` with both origins named and the remedy in the hint, rather than adopted |
| **proxies** | a TLS-terminating proxy is honoured by the **server**, under the trusted-proxy allowlist the operator configured there (uvicorn `--proxy-headers --forwarded-allow-ips`), which rewrites the scheme before the app is reached. This puts the trust decision where the allowlist lives and adds no env var |
| **`STRANDS_DASH_AUTH_ORIGIN`** | still outranks every header, and is now normalised (WebAuthn compares byte-for-byte, so a trailing slash in the env var would have failed every ceremony). The installs that need it are the ones whose proxy rewrites `Host` and `Origin`, so consulting either there would refuse exactly the deployment the pin exists for |
| **`status()`** | reads a new `_served_origin` seam: the advisory reports where the dashboard *is served*, so a mismatched `Origin` cannot remove the login screen's hints exactly when a misconfigured proxy makes them worth reading |

Row 6 of the figure is a fix in the other direction: reached over https with no `Origin` header, the old `Host` reconstruction produced `http://...` and would have refused a legitimate browser.

## Tests

`tests/test_dashboard_auth_expected_origin_is_the_connection.py`, 19 cells. Pre-fix (production file reverted, tests kept) **15 failed, 4 passed**; after, **19 passed**. The 4 that pass both ways are the controls - the served origin is accepted, and both ceremonies already verified against it when the caller told the truth.

| pre-fix | cell |
|---|---|
| FAILED x4 | `an_origin_that_contradicts_the_connection_is_refused` (downgrade, sibling subdomain, unrelated origin, swapped port) |
| FAILED | `a_missing_origin_header_leaves_the_connection_standing` |
| FAILED | `a_forwarded_proto_header_cannot_choose_the_scheme` |
| FAILED | `a_transport_with_no_scheme_is_refused_rather_than_guessed` |
| FAILED | `the_configured_origin_outranks_the_headers_and_is_normalised` |
| FAILED x5 | `origin_verdict_reports_the_decision_and_its_reason` |
| FAILED x2 | `a_ceremony_finished_from_a_claimed_origin_is_refused` (registration, authentication) |
| PASSED | `the_origin_the_dashboard_is_served_at_is_accepted_and_normalised` |
| PASSED | `a_websocket_scheme_is_read_as_the_page_origin_it_belongs_to` |
| PASSED x2 | `a_ceremony_is_verified_against_the_served_origin` |

The last pair is the assertion whose absence let this stay green: it captures the kwargs the library is actually called with, at both call sites. The file uses real `Request` / `WebSocket` objects because the two facts under test - the transport's scheme, and `wss` belonging to an `https` page - exist only on the real object.

The stand-in requests in the existing suite answered headers alone, which is exactly why an expectation taken from a header looked correct there; they now carry the scheme they arrived over. Three cells in `test_dashboard_auth_edges.py` asserted the header could *be* the expectation - every fact they pinned (the pin outranking headers, trailing-slash normalisation, the localhost default) is pinned in the new file against a request that can report a scheme, so they are removed rather than duplicated, and that file's docstring points at its successor.

## Gate

`ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ`. `mypy` at the pinned version: 1 error in 1 file (`simulation/ik.py`), identical on a pristine `main` worktree - 0 attributable. `pytest tests/ -k dashboard`: **269 passed, 7 skipped**, plus one failure (`test_a_re_read_after_an_outside_change_does_not_accumulate_entries`) reproduced on a pristine `main` worktree (253 passed, 7 skipped, the same 1 failed), so not from this change. `scripts/check_whole_tree_graders.py`: 187 passed (plus the `qpsolvers`-absent cell, which skips the extra rather than the rule).

**LOC: +479 / -45 across 7 files** (+130/-11 production, the rest tests and the changelog fragment).

Refs #3079.

---

## Round 1 - composition with the open sibling #3078

One concern, from a merge-base overlap sweep rather than from a thread. `scripts/check_merge_base_overlap.py --all-open` pairs this branch with **#3078** on four shared paths, `strands_robots/dashboard/auth.py` among them. Neither branch's checks have compiled the other's changes and neither can: each ran against a base containing neither.

`auth.py` itself **auto-merges with no conflict marker**, which is what made this worth measuring rather than assuming. The interaction is a precedence one. #3078 adds a first-enrollment gate to `begin_registration` that refuses a non-loopback socket peer when no bootstrap token is configured - and it refuses *ahead of* the origin verification these cells assert on. The cells here deliberately model a **remote** browser (`203.0.113.9`) reaching a served origin, because that is the scenario under test, so they are exactly what that gate turns away.

Measured over the dashboard auth suite, same command on each tree:

| tree | result |
|---|---|
| `main` (`276b798`) baseline | 72 passed |
| #3078 alone (`b6237aa`) | 91 passed |
| this branch alone | 88 passed |
| composition, before this round | **2 failed**, 105 passed |
| composition, after this round | **107 passed** |

Both failures were the `[registration]` parametrizations: `403` (enrollment) where the cell asserts `400` (a claimed origin), and the positive cell never reaching its `expected_origin` assertion at all. The `[authentication]` half is unaffected - a credential already exists by then, so the gate does not apply.

**Fix (`c647834`, tests only, +9/-1):** configure the bootstrap token and pass it in `_finish_registration`, which is what an operator does for a remote first enrollment. That holds the enrollment gate constant and leaves the origin the only variable, which is what these cells are about. `begin_registration` has accepted `bootstrap=` and read `_bootstrap_token()` since before either branch, so the change is inert on the current base and load-bearing once the sibling lands - 88 passed here unchanged, 107 passed composed. No production file moved and the changelog fragment is unchanged, since no shipped behaviour differs.

**Merge order:** #3078 first (it is approved). This branch then absorbs `main` and resolves a content conflict in two shared stand-in classes - `test_dashboard_auth_ceremony_finish.py` and `test_dashboard_auth_module.py` - whose resolution is the **union**, not either side: after composition one gate reads `url.scheme` and the other reads `client.host`, so a stand-in answering only one leaves the other reading a default. **Landed.** #3078 merged as `1b07f62`, and `main` is absorbed here: `auth.py` auto-merged, and the two shared stand-in classes conflicted exactly as predicted and were resolved as the union - one docstring stating both facts, `__init__(headers=None, scheme="http", client_host="127.0.0.1")`. Composed result measured above: **269 passed** against **253** on pristine `main`, +16 being this file's 19 cells less the 3 removed from `test_dashboard_auth_edges.py`.

## Round 2 - the refusal is compared whole, not by substring

Code scanning raised `py/incomplete-url-substring-sanitization` on the ceremony cell's `assert "evil.example.com" in detail["detail"]`. On a test asserting a refusal that is not a sanitization bypass - but the rule's point holds regardless: for a URL a membership test does not establish *where* in the message the origin sits, so the assertion is weaker than it reads. It was measured rather than suppressed.

Both refusal cells now compare the whole message, through one `contradiction(offered)` helper that spells it once. Run against a mutated `origin_verdict` message, the two forms disagree:

![substring versus whole-message assertion](https://raw.githubusercontent.com/cagataycali/robots/assets/ceremony-origin/substring_vs_whole_message.png)

The substring form passes all 19 cells against a refusal that names the two origins the wrong way round, and against one that mentions the offered origin only inside a help link. Both are useless to the operator the message exists for - which end do they fix? The whole-message form fails 6 of 19 on each: the 4 contradicting-origin rows and both ceremonies. The 13 that stay green are the controls, so this is not "refuse every message".

A tree-wide AST sweep for the same shape in production found two scheme-presence checks (`'://' in s` in `mesh/security.py` and `policies/lerobot_async/policy.py`) and no host-substring comparison anywhere, so nothing else needed changing.

Tests only, **+17/-5**, no production line moved this round - `git diff --stat` against the merge base is still the same `130/11` in `auth.py`, and the changelog fragment is unchanged since no shipped behaviour differs. The sibling-subdomain origin is now a named `ELSEWHERE` constant shared by the table and the ceremony cell. `main` (#3077) absorbed in the same push.

