### PR TITLE
feat(tools/reachy): Reachy Mini tool surface - 14 verbs, consolidated shape

### DIFF
--- a/changelog.d/3082-reachy-tool-surface.md
+++ b/changelog.d/3082-reachy-tool-surface.md
@@ -46,3 +46,14 @@ shipped verb. The read now goes through an accessor whose return type says what
 the endpoint can answer, so the shape must be narrowed before it is indexed and
 this class of mistake is a type error at check time rather than an exception on
 a real daemon.
+
+`reachy_wake` selects one of two physical motions, so its `sleep` flag is
+checked against the shared `boolean_flag_error` domain rather than read by
+truthiness. Every non-empty string is truthy, so `'false'`, `'no'`, `'off'` and
+`'0'` - the spellings a caller reaches for to opt *out* - each commanded
+go-to-sleep and reported success. The check precedes the accessor because the
+accessor is derived from the flag: the same misread also decided which accessor
+the handle judgement required to be callable, so a handle that could wake but
+not sleep was refused for a request to wake. It is the domain
+`build_lerobot_command` already applies to its own flags, so a posture flag is
+refused identically wherever it is supplied rather than merely equivalently.

--- a/changelog.d/3082-reachy-tool-surface.md
+++ b/changelog.d/3082-reachy-tool-surface.md
@@ -1,0 +1,48 @@
+### Added: the Reachy Mini's agent tool surface, 14 verbs on the native driver
+
+`ReachyDriver` shipped in #2762 and could reach the hardware, but nothing on the
+agent surface could reach the driver. An agent asked to make the Mini look at
+something had `send_action` and a joint dict, which is the wire shape rather
+than the verb shape, and none of the daemon's expressive surface - recorded
+emotions, wake and sleep, the antennas, the speaker - was addressable at all.
+
+The surface is 12 execution verbs plus 2 read verbs, in the consolidated
+table-driven shape the g1 family locked (refs #3037, #3070): a `_VERBS` table
+names each verb's driver accessor, one shared handle judgement is worded from
+that table, and each `@tool` makes exactly one driver call and returns that
+envelope verbatim. So the tools add no second opinion about what the robot did -
+a refusal an agent reads is the driver's own refusal, including the motion
+envelope's travel limits and its head-body yaw *coupling* limit, which no
+per-axis check can see.
+
+Six `ReachyDriver` accessors landed with it, because a verb with no accessor is
+a verb that cannot be written: `play_move`, `list_moves`, `wake_up`,
+`goto_sleep`, `set_motors` and `state_snapshot`. `set_motors` admits
+`enabled` and `disabled` and refuses the SDK's third mode
+(`gravity_compensation`) *by name*, because that mode has no daemon-link
+command - mapping it silently onto one of the two that do would report success
+for a torque state the robot is not in. `state_snapshot` copies each cache
+under the lock it is written behind, so a caller mutating what it reads cannot
+reach the sensor state the mesh publishes.
+
+Move names are matched against a URL-safe alphabet before they reach the
+daemon's path template, which is the same guard the proven Device Connect
+driver ships: a name is interpolated into
+`/api/move/play/recorded-move-dataset/{dataset}/{move}`, so `../` in a name an
+agent chose would address a different endpoint than the one the verb documents.
+
+Four media verbs refuse rather than pretend. `ReachyDriver` has no accessor for
+them yet, and a verb that returned a plausible-looking envelope for a camera
+frame nothing captured would be worse than one that names the accessor still to
+be added.
+
+One wire shape is not the one the other endpoints use.
+`GET /api/move/recorded-move-datasets/list/{dataset}` is declared `-> list[str]`
+by the daemon and the transport returns the decoded body unreshaped, so a
+*successful* catalogue read is a JSON array while every failure is still the
+`{"error": ...}` dict. Reading an error key off that array raised
+`AttributeError` out through `reachy_list_emotions`, on the happy path of a
+shipped verb. The read now goes through an accessor whose return type says what
+the endpoint can answer, so the shape must be narrowed before it is indexed and
+this class of mistake is a type error at check time rather than an exception on
+a real daemon.

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -793,6 +793,35 @@ class ReachyDriver:
             return _refuse(f"set_motors: {error}")
         return {"status": "success", "content": [{"json": {"motors": mode}}]}
 
+    def state_snapshot(self) -> dict[str, Any]:
+        """Return the cached sensor state: joints, pose, IMU, battery.
+
+        A synchronous read off the caches the link thread fills - no daemon
+        round-trip, so it is cheap enough to call before and after every
+        motion. A ``None`` field means that stream has not delivered yet (IMU
+        and battery stay ``None`` forever on a Lite, which has neither).
+
+        Returns:
+            A success envelope carrying the four snapshots, or a refusal when
+            the driver was never connected (caches from a link that never ran
+            would be indistinguishable from a robot reporting nothing).
+        """
+        if not self._connected:
+            return _refuse("state_snapshot: not connected - call connect_eagerly() first")
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "json": {
+                        "joints": self._snapshot("_joints"),
+                        "pose": self._snapshot("_pose"),
+                        "imu": self._snapshot("_imu"),
+                        "battery": self._snapshot("_battery"),
+                    }
+                }
+            ],
+        }
+
     # ------------------------------------------------------------------ #
     # Link callbacks. Each runs on the loop thread; keep fast and pure.  #
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -726,17 +726,20 @@ class ReachyDriver:
             library: Which library, one of ``'emotions'`` or ``'dances'``.
 
         Returns:
-            A success envelope carrying the daemon's catalogue, or an error
-            envelope naming what refused.
+            A success envelope whose ``moves`` is the daemon's array of names,
+            or an error envelope naming what refused.
         """
         if not self._connected:
             return _refuse("list_moves: not connected - call connect_eagerly() first")
         dataset = _MOVE_LIBRARIES.get(library)
         if dataset is None:
             return _refuse(f"list_moves: unknown library {library!r}; expected one of {sorted(_MOVE_LIBRARIES)}")
-        result = self._daemon_get(_PATH_MOVE_LIST.format(dataset=dataset))
-        if (error := result.get("error")) is not None:
-            return _refuse(f"list_moves: daemon refused: {error}")
+        result = self._daemon_get_list(_PATH_MOVE_LIST.format(dataset=dataset))
+        # A catalogue read succeeds as a JSON array. The only dict this endpoint
+        # can produce is the transport's {"error": ...} envelope, so a dict here
+        # is a failure whatever key it carries.
+        if isinstance(result, dict):
+            return _refuse(f"list_moves: daemon refused: {result.get('error', result)}")
         return {"status": "success", "content": [{"json": {"library": library, "moves": result}}]}
 
     def wake_up(self) -> dict[str, Any]:
@@ -920,6 +923,34 @@ class ReachyDriver:
             return {"error": transport}
 
         result: dict[str, Any] = transport.api(self._host, self._api_port, path)
+        return result
+
+    def _daemon_get_list(self, path: str) -> list[Any] | dict[str, Any]:
+        """Call a daemon REST endpoint whose success body is a JSON array.
+
+        ``/api/move/recorded-move-datasets/list/{dataset}`` is declared
+        ``-> list[str]`` by the daemon, and
+        :func:`~strands_robots.device_connect.reachy_transport.api` hands the
+        decoded body back unreshaped, so a successful catalogue read is a
+        ``list`` while every failure is still the ``{"error": ...}`` dict.
+
+        Kept separate from :meth:`_daemon_get` rather than widening that
+        return type, so the union stays confined to the one endpoint that can
+        answer with an array and the dict-shaped callers keep narrowing for
+        free. Reading an error key off a catalogue is then a type error at
+        check time rather than an ``AttributeError`` on the happy path.
+
+        Args:
+            path: Request path, one of this module's ``_PATH_*`` constants.
+
+        Returns:
+            The decoded array on success, or ``{"error": ...}``.
+        """
+        transport = _resolve_transport()
+        if isinstance(transport, str):
+            return {"error": transport}
+
+        result: list[Any] | dict[str, Any] = transport.api(self._host, self._api_port, path)
         return result
 
     def _daemon_post(self, path: str, data: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import re
 import threading
 import time
 from collections.abc import AsyncGenerator
@@ -82,6 +83,23 @@ DEFAULT_API_PORT: int = 8000
 #: the same constants the driver sends.
 _PATH_STATUS = "/api/daemon/status"
 _PATH_STOP = "/api/move/stop"
+_PATH_WAKE = "/api/move/play/wake_up"
+_PATH_SLEEP = "/api/move/play/goto_sleep"
+_PATH_MOVE_PLAY = "/api/move/play/recorded-move-dataset/{dataset}/{move}"
+_PATH_MOVE_LIST = "/api/move/recorded-move-datasets/list/{dataset}"
+
+#: A recorded move's name goes into a URL path, so the admitted alphabet is the
+#: same one :mod:`strands_robots.device_connect.reachy_mini_driver` enforces -
+#: anything else is refused before a request is built from it.
+_MOVE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+#: The two recorded-move libraries the daemon serves, mapped to their
+#: HuggingFace dataset ids. A dict rather than string surgery so a refusal can
+#: name the admitted set.
+_MOVE_LIBRARIES: dict[str, str] = {
+    "emotions": "pollen-robotics/reachy-mini-emotions-library",
+    "dances": "pollen-robotics/reachy-mini-dances-library",
+}
 
 #: The module every daemon touch here goes through. It is a leaf that imports
 #: nothing but the standard library, and its parent package
@@ -665,6 +683,115 @@ class ReachyDriver:
             return _refuse(f"stop_task: daemon refused the stop: {error}")
         self._stopped = True
         return {"status": "success", "content": [{"text": "asked the daemon to stop any recorded move in progress"}]}
+
+    # ------------------------------------------------------------------ #
+    # Recorded-move and motor paths the reachy_* tools call.             #
+    # ------------------------------------------------------------------ #
+
+    def play_move(self, move_name: str, library: str = "emotions") -> dict[str, Any]:
+        """Play one recorded move (emotion or dance) by name through the daemon.
+
+        The Mini's expressive behaviour is a recorded head+antenna+body
+        choreography served by the daemon from a HuggingFace library - the same
+        rail :meth:`stop_task` halts. Three gates: connected, ``library`` in the
+        admitted set, ``move_name`` in the URL-safe alphabet.
+
+        Args:
+            move_name: The move's name in the library, e.g. ``'happy'``.
+            library: Which library, one of ``'emotions'`` or ``'dances'``.
+
+        Returns:
+            A success envelope naming the move, or an error envelope naming the
+            first gate that refused.
+        """
+        if not self._connected:
+            return _refuse("play_move: not connected - call connect_eagerly() first")
+        dataset = _MOVE_LIBRARIES.get(library)
+        if dataset is None:
+            return _refuse(f"play_move: unknown library {library!r}; expected one of {sorted(_MOVE_LIBRARIES)}")
+        if not _MOVE_NAME_RE.fullmatch(move_name or ""):
+            return _refuse(
+                f"play_move: invalid move_name {move_name!r}; expected 1-128 chars of [A-Za-z0-9._-] - "
+                "list_moves() names the library's catalogue"
+            )
+        result = self._daemon_post(_PATH_MOVE_PLAY.format(dataset=dataset, move=move_name))
+        if (error := result.get("error")) is not None:
+            return _refuse(f"play_move: daemon refused {move_name!r}: {error}")
+        return {"status": "success", "content": [{"json": {"played": move_name, "library": library}}]}
+
+    def list_moves(self, library: str = "emotions") -> dict[str, Any]:
+        """List the recorded moves one library serves.
+
+        Args:
+            library: Which library, one of ``'emotions'`` or ``'dances'``.
+
+        Returns:
+            A success envelope carrying the daemon's catalogue, or an error
+            envelope naming what refused.
+        """
+        if not self._connected:
+            return _refuse("list_moves: not connected - call connect_eagerly() first")
+        dataset = _MOVE_LIBRARIES.get(library)
+        if dataset is None:
+            return _refuse(f"list_moves: unknown library {library!r}; expected one of {sorted(_MOVE_LIBRARIES)}")
+        result = self._daemon_get(_PATH_MOVE_LIST.format(dataset=dataset))
+        if (error := result.get("error")) is not None:
+            return _refuse(f"list_moves: daemon refused: {error}")
+        return {"status": "success", "content": [{"json": {"library": library, "moves": result}}]}
+
+    def wake_up(self) -> dict[str, Any]:
+        """Play the daemon's built-in wake-up move (init pose, ears up).
+
+        Returns:
+            A success envelope, or an error envelope naming what refused.
+        """
+        if not self._connected:
+            return _refuse("wake_up: not connected - call connect_eagerly() first")
+        result = self._daemon_post(_PATH_WAKE)
+        if (error := result.get("error")) is not None:
+            return _refuse(f"wake_up: daemon refused: {error}")
+        return {"status": "success", "content": [{"text": "asked the daemon to play the wake-up move"}]}
+
+    def goto_sleep(self) -> dict[str, Any]:
+        """Play the daemon's built-in go-to-sleep move (head down, ears rest).
+
+        Returns:
+            A success envelope, or an error envelope naming what refused.
+        """
+        if not self._connected:
+            return _refuse("goto_sleep: not connected - call connect_eagerly() first")
+        result = self._daemon_post(_PATH_SLEEP)
+        if (error := result.get("error")) is not None:
+            return _refuse(f"goto_sleep: daemon refused: {error}")
+        return {"status": "success", "content": [{"text": "asked the daemon to play the go-to-sleep move"}]}
+
+    def set_motors(self, mode: str) -> dict[str, Any]:
+        """Set motor torque for all joints: ``'enabled'`` holds, ``'disabled'`` goes limp.
+
+        Sent on the real-time command link, the same rail
+        :meth:`send_action` writes. The SDK's third mode
+        (``gravity_compensation``) has no daemon-link command, so it is refused
+        by name rather than silently mapped to one of the two that do.
+
+        Args:
+            mode: ``'enabled'`` (torque on) or ``'disabled'`` (safe to move by
+                hand).
+
+        Returns:
+            A success envelope naming the mode, or an error envelope naming
+            what refused.
+        """
+        if not self._connected:
+            return _refuse("set_motors: not connected - call connect_eagerly() first")
+        torque = {"enabled": True, "disabled": False}.get(mode)
+        if torque is None:
+            return _refuse(
+                f"set_motors: unknown mode {mode!r}; expected 'enabled' or 'disabled' "
+                "(the SDK's gravity_compensation mode has no daemon-link command)"
+            )
+        if (error := self._send_cmd({"torque": torque, "ids": None})) is not None:
+            return _refuse(f"set_motors: {error}")
+        return {"status": "success", "content": [{"json": {"motors": mode}}]}
 
     # ------------------------------------------------------------------ #
     # Link callbacks. Each runs on the loop thread; keep fast and pure.  #

--- a/strands_robots/tools/reachy/__init__.py
+++ b/strands_robots/tools/reachy/__init__.py
@@ -14,23 +14,60 @@ Device Connect driver already ships and which
 re-implements. This package holds only what the *two* Reachy consumers must
 agree on and neither owns: the motion envelope.
 
-The agent ``@tool``s that will sit on the same daemon (``reachy_look``,
-``reachy_antennas``, ``reachy_express``, ...) are a separate change, and they
-import :func:`~strands_robots.tools.reachy._reachy_common.envelope_error` from
-here so a limit is defined once for the robot rather than once per caller.
+The agent ``@tool``s that sit on the same daemon live in two sibling modules -
+:mod:`~strands_robots.tools.reachy.reachy_actions` (the execution verbs) and
+:mod:`~strands_robots.tools.reachy.reachy_reads` (the read-only pair) - and are
+re-exported here lazily so importing the package costs nothing until a verb is
+actually used. They import
+:func:`~strands_robots.tools.reachy._reachy_common.envelope_error` machinery
+from here so a limit is defined once for the robot rather than once per caller.
 
 Nothing here imports a transport, a daemon client or the driver, so this package
 is importable and fully testable on a machine with no Reachy attached.
 """
 
+import importlib as _importlib
+
 from strands_robots.tools.reachy._reachy_common import (
     HEAD_BODY_YAW_DELTA_LIMIT_DEG,
     MOTION_ENVELOPE_DEG,
     envelope_error,
+    live_handle_refusal,
 )
+
+#: verb -> (relative module, attribute). Lazy so ``import strands_robots.tools.reachy``
+#: stays free of the ``strands`` import the verb modules need.
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "reachy_look": (".reachy_actions", "reachy_look"),
+    "reachy_antennas": (".reachy_actions", "reachy_antennas"),
+    "reachy_body_turn": (".reachy_actions", "reachy_body_turn"),
+    "reachy_home": (".reachy_actions", "reachy_home"),
+    "reachy_stop": (".reachy_actions", "reachy_stop"),
+    "reachy_wake": (".reachy_actions", "reachy_wake"),
+    "reachy_express": (".reachy_actions", "reachy_express"),
+    "reachy_motors": (".reachy_actions", "reachy_motors"),
+    "reachy_play_sound": (".reachy_actions", "reachy_play_sound"),
+    "reachy_volume": (".reachy_actions", "reachy_volume"),
+    "reachy_camera": (".reachy_actions", "reachy_camera"),
+    "reachy_look_at": (".reachy_actions", "reachy_look_at"),
+    "reachy_get_state": (".reachy_reads", "reachy_get_state"),
+    "reachy_list_emotions": (".reachy_reads", "reachy_list_emotions"),
+}
 
 __all__ = [
     "HEAD_BODY_YAW_DELTA_LIMIT_DEG",
     "MOTION_ENVELOPE_DEG",
     "envelope_error",
+    "live_handle_refusal",
+    *_LAZY_IMPORTS.keys(),
 ]
+
+
+def __getattr__(name: str):  # noqa: N807
+    if name in _LAZY_IMPORTS:
+        rel_module, attr_name = _LAZY_IMPORTS[name]
+        module = _importlib.import_module(rel_module, __name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/strands_robots/tools/reachy/_reachy_common.py
+++ b/strands_robots/tools/reachy/_reachy_common.py
@@ -114,3 +114,58 @@ def envelope_error(values: dict[str, Any], context: str) -> str | None:
                 f"head-body coupling limit of {HEAD_BODY_YAW_DELTA_LIMIT_DEG:g} deg"
             )
     return None
+
+
+def _handle_refusal_envelope(text: str) -> dict[str, Any]:
+    """Wrap a refusal sentence in the envelope every ``@tool`` owes a caller."""
+    return {"status": "error", "content": [{"text": text}]}
+
+
+def live_handle_refusal(
+    verb: str,
+    driver: Any,
+    *,
+    accessor: str,
+    reads: str,
+    expected: str,
+) -> dict[str, Any] | None:
+    """Return the refusal envelope for an unusable live-handle ``driver``, or ``None``.
+
+    The Reachy sibling of :func:`strands_robots.tools.g1._g1_common.live_handle_refusal`,
+    kept as a second copy because the two packages must not import each other
+    (each stays out of the other's SDK-load path). Every ``reachy_*`` verb that
+    takes a wired :class:`~strands_robots.drivers.reachy.ReachyDriver` reads it
+    through one accessor; the handle is a live Python object an agent cannot
+    synthesize, typed :class:`~typing.Any` so no type leaks into the tool schema.
+
+    The judgement keeps four invariants for every verb: the answer is an error
+    *envelope* and never an exception, it names the verb, it names ``driver``,
+    and it names the type it received. ``accessor`` must be *callable* on the
+    handle, not merely present — a namespace built from a cache dump carries the
+    name as data and would fail on the call.
+
+    Args:
+        verb: The tool name, opening the message so a transcript reader can
+            tell which verb refused.
+        driver: The handle to judge; a wrong handle is refused, not coerced.
+        accessor: The attribute the verb reads the handle through.
+        reads: Why an agent cannot supply the handle, completing "an agent
+            cannot synthesize it, because ...".
+        expected: What the handle failed to expose and what to pass instead,
+            completing "of type 'str' does not expose ...".
+
+    Returns:
+        ``None`` when ``driver`` exposes a callable ``accessor``, otherwise the
+        ``{"status": "error", "content": [...]}`` envelope.
+    """
+    if driver is None:
+        return _handle_refusal_envelope(
+            f"{verb}: `driver` is required. Pass the live ReachyDriver "
+            "handle the orchestrator constructed - an agent cannot "
+            f"synthesize it, because {reads}."
+        )
+    if not callable(getattr(driver, accessor, None)):
+        return _handle_refusal_envelope(
+            f"{verb}: `driver` of type {type(driver).__name__!r} does not expose {expected}"
+        )
+    return None

--- a/strands_robots/tools/reachy/_reachy_common.py
+++ b/strands_robots/tools/reachy/_reachy_common.py
@@ -141,7 +141,7 @@ def live_handle_refusal(
     The judgement keeps four invariants for every verb: the answer is an error
     *envelope* and never an exception, it names the verb, it names ``driver``,
     and it names the type it received. ``accessor`` must be *callable* on the
-    handle, not merely present — a namespace built from a cache dump carries the
+    handle, not merely present - a namespace built from a cache dump carries the
     name as data and would fail on the call.
 
     Args:

--- a/strands_robots/tools/reachy/reachy_actions.py
+++ b/strands_robots/tools/reachy/reachy_actions.py
@@ -29,6 +29,7 @@ from typing import Any
 from strands import tool
 
 from strands_robots.tools.reachy._reachy_common import live_handle_refusal
+from strands_robots.utils import boolean_flag_error
 
 
 def _refusal(text: str) -> dict[str, Any]:
@@ -307,13 +308,30 @@ def reachy_wake(driver: Any, sleep: bool = False) -> dict[str, Any]:
     Calls ``ReachyDriver.wake_up()`` or ``ReachyDriver.goto_sleep()`` once -
     the daemon's two built-in recorded moves.
 
+    ``sleep`` selects which of two physical motions is commanded, so it is
+    checked against the shared
+    :func:`~strands_robots.utils.boolean_flag_error` domain rather than read by
+    truthiness - the domain
+    :func:`~strands_robots.tools.lerobot_teleoperate.build_lerobot_command`
+    already applies to its own flags. Every non-empty string is truthy, so
+    ``'false'``, ``'no'`` and ``'0'`` - the spellings a caller reaches for to
+    opt *out* - would otherwise command go-to-sleep and report success.
+
+    The check precedes the accessor because the accessor is derived from the
+    flag: a misread ``sleep`` also decides which accessor the handle gate
+    requires to be callable, so it would refuse a handle that can wake but not
+    sleep for a request to wake.
+
     Args:
         driver: The live ReachyDriver handle the orchestrator constructed.
-        sleep: ``True`` plays go-to-sleep instead of wake-up.
+        sleep: ``True`` plays go-to-sleep instead of wake-up. Checked, not
+            parsed - a truthy spelling of off is refused, never honoured.
 
     Returns:
         The driver's envelope, success or refusal, unreshaped.
     """
+    if error := boolean_flag_error(sleep, "sleep", "reachy_wake"):
+        return _refusal(error)
     accessor = "goto_sleep" if sleep else "wake_up"
     refusal = _handle_refusal("reachy_wake", driver, accessor=accessor)
     if refusal is not None:

--- a/strands_robots/tools/reachy/reachy_actions.py
+++ b/strands_robots/tools/reachy/reachy_actions.py
@@ -1,0 +1,471 @@
+"""reachy_actions - the Reachy Mini's driver-gated execution verbs, one table-driven module.
+
+Twelve ``@tool`` verbs ported from ``cagataycali/tiny-the-reachy`` in the
+consolidated shape the g1 family proved (refs #3037, #3070): each makes exactly
+one call on a live :class:`~strands_robots.drivers.reachy.ReachyDriver` handle
+and returns the driver's envelope verbatim. The driver owns the safety
+judgement - the motion envelope, the finite-number gates and the connected
+check all live on its write path - so a verb never re-validates what the
+driver already refuses.
+
+Every verb holds the package's four ``@tool`` invariants (envelope not
+exception; names the verb; names the parameter; names the received type) via
+:func:`~strands_robots.tools.reachy._reachy_common.live_handle_refusal`, worded
+per verb from the ``_ACTIONS`` table. The ``driver`` parameter is typed
+:class:`~typing.Any` so no live-object type leaks into the generated tool
+schema.
+
+Four verbs (``reachy_play_sound``, ``reachy_volume``, ``reachy_camera``,
+``reachy_look_at``) name driver accessors that do not exist yet - the Mini's
+media rail is SDK-client-side and has no daemon REST path in this repository -
+so today they refuse by naming the accessor to plumb, exactly as
+``g1_move_velocity`` did before ``G1Driver.move_velocity`` landed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+from strands_robots.tools.reachy._reachy_common import live_handle_refusal
+
+
+def _refusal(text: str) -> dict[str, Any]:
+    """Wrap ``text`` in the ``{"status": "error"}`` envelope every verb owes."""
+    return {"status": "error", "content": [{"text": text}]}
+
+
+# verb -> (accessor, reads, expected) for live_handle_refusal. One row per verb
+# because the refusal prose names the remedy, which differs per accessor.
+_ACTIONS: dict[str, tuple[str, str, str]] = {
+    "reachy_look": (
+        "send_action",
+        "the verb sends one whole head-pose command on the driver's real-time "
+        "link and reads back the envelope the driver produced",
+        "a callable ``send_action(action)`` returning the driver's write "
+        "envelope - pass the live ReachyDriver handle the orchestrator "
+        "constructed",
+    ),
+    "reachy_antennas": (
+        "send_action",
+        "the verb sends one antenna command on the driver's real-time link "
+        "and reads back the envelope the driver produced",
+        "a callable ``send_action(action)`` returning the driver's write "
+        "envelope - pass the live ReachyDriver handle the orchestrator "
+        "constructed",
+    ),
+    "reachy_body_turn": (
+        "send_action",
+        "the verb sends one body-yaw command on the driver's real-time link "
+        "and reads back the envelope the driver produced",
+        "a callable ``send_action(action)`` returning the driver's write "
+        "envelope - pass the live ReachyDriver handle the orchestrator "
+        "constructed",
+    ),
+    "reachy_home": (
+        "send_action",
+        "the verb sends the neutral whole-pose command on the driver's "
+        "real-time link and reads back the envelope the driver produced",
+        "a callable ``send_action(action)`` returning the driver's write "
+        "envelope - pass the live ReachyDriver handle the orchestrator "
+        "constructed",
+    ),
+    "reachy_stop": (
+        "stop_task",
+        "the verb asks the daemon to halt any recorded move in progress "
+        "through the driver's own stop path and reads back the envelope the "
+        "driver produced",
+        "a callable ``stop_task()`` returning the driver's envelope - pass "
+        "the live ReachyDriver handle the orchestrator constructed",
+    ),
+    "reachy_wake": (
+        "wake_up",
+        "the verb plays the daemon's built-in wake-up or go-to-sleep move "
+        "through the driver's recorded-move path and reads back the envelope "
+        "the driver produced",
+        "callables ``wake_up()`` and ``goto_sleep()`` returning the driver's "
+        "envelope - pass the live ReachyDriver handle the orchestrator "
+        "constructed",
+    ),
+    "reachy_express": (
+        "play_move",
+        "the verb plays one recorded emotion or dance through the driver's "
+        "recorded-move path and reads back the envelope the driver produced",
+        "a callable ``play_move(move_name, library)`` returning the driver's "
+        "envelope - pass the live ReachyDriver handle the orchestrator "
+        "constructed",
+    ),
+    "reachy_motors": (
+        "set_motors",
+        "the verb sets motor torque on the driver's real-time link and reads back the envelope the driver produced",
+        "a callable ``set_motors(mode)`` returning the driver's envelope - "
+        "pass the live ReachyDriver handle the orchestrator constructed",
+    ),
+    "reachy_play_sound": (
+        "play_sound",
+        "the verb plays one sound file through the driver's media path and reads back the envelope the driver produced",
+        "a callable ``play_sound(sound_file)`` returning the driver's "
+        "envelope - the Mini's media rail is not plumbed into ReachyDriver "
+        "yet, so this names the accessor to add",
+    ),
+    "reachy_volume": (
+        "set_volume",
+        "the verb sets the speaker volume through the driver's media path "
+        "and reads back the envelope the driver produced",
+        "a callable ``set_volume(level)`` returning the driver's envelope - "
+        "the Mini's media rail is not plumbed into ReachyDriver yet, so this "
+        "names the accessor to add",
+    ),
+    "reachy_camera": (
+        "capture_frame",
+        "the verb captures one frame from the head camera through the "
+        "driver's media path and reads back the envelope the driver produced",
+        "a callable ``capture_frame(save_path)`` returning the driver's "
+        "envelope - the Mini's media rail is not plumbed into ReachyDriver "
+        "yet, so this names the accessor to add",
+    ),
+    "reachy_look_at": (
+        "look_at_image",
+        "the verb servos the head toward a camera pixel through the driver's "
+        "media path and reads back the envelope the driver produced",
+        "a callable ``look_at_image(u, v)`` returning the driver's envelope - "
+        "the Mini's media rail is not plumbed into ReachyDriver yet, so this "
+        "names the accessor to add",
+    ),
+}
+
+
+def _handle_refusal(verb: str, driver: Any, accessor: str | None = None) -> dict[str, Any] | None:
+    """The shared live-handle judgement, worded from the ``_ACTIONS`` row.
+
+    Args:
+        verb: The ``_ACTIONS`` key.
+        driver: The handle to judge.
+        accessor: Override for a verb that picks its accessor at call time
+            (``reachy_wake`` reads ``wake_up`` or ``goto_sleep``).
+
+    Returns:
+        ``None`` or the refusal envelope.
+    """
+    row_accessor, reads, expected = _ACTIONS[verb]
+    return live_handle_refusal(verb, driver, accessor=accessor or row_accessor, reads=reads, expected=expected)
+
+
+@tool
+def reachy_look(
+    driver: Any,
+    pitch: float = 0.0,
+    roll: float = 0.0,
+    yaw: float = 0.0,
+    x: float = 0.0,
+    y: float = 0.0,
+    z: float = 0.0,
+    body_yaw: float | None = None,
+    antenna_left: float | None = None,
+    antenna_right: float | None = None,
+) -> dict[str, Any]:
+    """Move the Mini's head to a pose - the primary gesture verb.
+
+    Calls ``ReachyDriver.send_action(...)`` once with a whole head pose: the
+    daemon's head command is a pose, not a delta, so an absent axis means zero
+    (level), not "leave as it was". The driver refuses non-finite values, any
+    axis outside the motion envelope (pitch/roll +/-40 deg, yaw +/-180 deg,
+    body +/-160 deg) and a head-body yaw twist beyond 65 deg.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        pitch: Head pitch, degrees (positive = up).
+        roll: Head roll, degrees.
+        yaw: Head yaw, degrees (positive = left).
+        x: Head translation forward, millimetres (small, ~[-20, 20]).
+        y: Head translation left, millimetres.
+        z: Head translation up, millimetres.
+        body_yaw: Body rotation, degrees; ``None`` leaves the body alone.
+        antenna_left: Left antenna angle, degrees; ``None`` leaves it alone.
+        antenna_right: Right antenna angle, degrees; ``None`` leaves it alone.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_look", driver)
+    if refusal is not None:
+        return refusal
+    action: dict[str, Any] = {
+        "head_pitch": pitch,
+        "head_roll": roll,
+        "head_yaw": yaw,
+        "head_x": x,
+        "head_y": y,
+        "head_z": z,
+    }
+    if body_yaw is not None:
+        action["body_yaw"] = body_yaw
+    if antenna_left is not None:
+        action["antenna_left"] = antenna_left
+    if antenna_right is not None:
+        action["antenna_right"] = antenna_right
+    return driver.send_action(action)
+
+
+@tool
+def reachy_antennas(driver: Any, right: float = 0.0, left: float = 0.0) -> dict[str, Any]:
+    """Move just the two antennas (the Mini's 'ears'), in degrees.
+
+    Calls ``ReachyDriver.send_action(...)`` once with only the antenna keys,
+    so head and body stay where they are. Both up reads alert, both down
+    reads sad, asymmetric reads quizzical.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        right: Right antenna angle, degrees (~[-90, 90]).
+        left: Left antenna angle, degrees (~[-90, 90]).
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_antennas", driver)
+    if refusal is not None:
+        return refusal
+    return driver.send_action({"antenna_right": right, "antenna_left": left})
+
+
+@tool
+def reachy_body_turn(driver: Any, yaw: float = 0.0) -> dict[str, Any]:
+    """Rotate the Mini's body around the vertical axis, in degrees.
+
+    Calls ``ReachyDriver.send_action(...)`` once with only ``body_yaw``; the
+    driver refuses values outside +/-160 deg. Use it to turn toward a speaker
+    or scan the room while the head stays put.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        yaw: Body yaw, degrees, envelope +/-160.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_body_turn", driver)
+    if refusal is not None:
+        return refusal
+    return driver.send_action({"body_yaw": yaw})
+
+
+@tool
+def reachy_home(driver: Any) -> dict[str, Any]:
+    """Return the Mini to the neutral pose: head centred, body forward, ears rest.
+
+    Calls ``ReachyDriver.send_action(...)`` once with every axis at zero.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_home", driver)
+    if refusal is not None:
+        return refusal
+    return driver.send_action(
+        {
+            "head_pitch": 0.0,
+            "head_roll": 0.0,
+            "head_yaw": 0.0,
+            "head_x": 0.0,
+            "head_y": 0.0,
+            "head_z": 0.0,
+            "body_yaw": 0.0,
+            "antenna_left": 0.0,
+            "antenna_right": 0.0,
+        }
+    )
+
+
+@tool
+def reachy_stop(driver: Any) -> dict[str, Any]:
+    """Halt any recorded move the daemon is playing.
+
+    Calls ``ReachyDriver.stop_task()`` once - the Mini's closest thing to a
+    task is a recorded move, and this is its stop.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_stop", driver)
+    if refusal is not None:
+        return refusal
+    return driver.stop_task()
+
+
+@tool
+def reachy_wake(driver: Any, sleep: bool = False) -> dict[str, Any]:
+    """Wake the Mini up (init pose, ears up) or put it to sleep.
+
+    Calls ``ReachyDriver.wake_up()`` or ``ReachyDriver.goto_sleep()`` once -
+    the daemon's two built-in recorded moves.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        sleep: ``True`` plays go-to-sleep instead of wake-up.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    accessor = "goto_sleep" if sleep else "wake_up"
+    refusal = _handle_refusal("reachy_wake", driver, accessor=accessor)
+    if refusal is not None:
+        return refusal
+    return getattr(driver, accessor)()
+
+
+@tool
+def reachy_express(driver: Any, emotion: str = "", library: str = "emotions") -> dict[str, Any]:
+    """Play a named emotion or dance from the Mini's recorded-move library.
+
+    Calls ``ReachyDriver.play_move(emotion, library)`` once. This is the
+    Mini's personality rail - a full head+antenna+body choreography served by
+    the daemon; :func:`~strands_robots.tools.reachy.reachy_reads.reachy_list_emotions`
+    names the live catalogue.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        emotion: The move's name, e.g. ``'happy'``, ``'curious'``, ``'no'``.
+        library: ``'emotions'`` (default) or ``'dances'``.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_express", driver)
+    if refusal is not None:
+        return refusal
+    if not emotion:
+        return _refusal(
+            "reachy_express: `emotion` is required. Pass a recorded move's name "
+            "like 'happy' or 'curious' - reachy_list_emotions names the live catalogue."
+        )
+    return driver.play_move(emotion, library)
+
+
+@tool
+def reachy_motors(driver: Any, mode: str = "") -> dict[str, Any]:
+    """Set the Mini's motor torque: ``'enabled'`` holds pose, ``'disabled'`` goes limp.
+
+    Calls ``ReachyDriver.set_motors(mode)`` once. Disabled is the safe-to-
+    move-by-hand state; the driver refuses any other word by naming the
+    admitted set.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        mode: ``'enabled'`` or ``'disabled'``.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_motors", driver)
+    if refusal is not None:
+        return refusal
+    if not mode:
+        return _refusal("reachy_motors: `mode` is required. Pass 'enabled' (torque on) or 'disabled' (limp).")
+    return driver.set_motors(mode)
+
+
+@tool
+def reachy_play_sound(driver: Any, sound_file: str = "") -> dict[str, Any]:
+    """Play a sound file through the Mini's speaker.
+
+    Calls ``ReachyDriver.play_sound(sound_file)`` once. The media rail is not
+    plumbed into the driver yet, so today this refuses by naming the accessor
+    to add - the same shape ``g1_move_velocity`` had before its driver method
+    landed.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        sound_file: Path or builtin name of the audio file the daemon can read.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_play_sound", driver)
+    if refusal is not None:
+        return refusal
+    if not sound_file:
+        return _refusal("reachy_play_sound: `sound_file` is required. Pass a path or builtin name like 'wake_up.wav'.")
+    return driver.play_sound(sound_file)
+
+
+@tool
+def reachy_volume(driver: Any, level: int | None = None) -> dict[str, Any]:
+    """Set the Mini's speaker volume, 0-100.
+
+    Calls ``ReachyDriver.set_volume(level)`` once. The media rail is not
+    plumbed into the driver yet, so today this refuses by naming the accessor
+    to add.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        level: Volume, an integer from 0 to 100.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_volume", driver)
+    if refusal is not None:
+        return refusal
+    if level is None:
+        return _refusal("reachy_volume: `level` is required. Pass an integer from 0 to 100.")
+    if isinstance(level, bool) or not isinstance(level, int):
+        return _refusal(f"reachy_volume: `level` must be an integer 0-100, got {type(level).__name__!r}.")
+    if not 0 <= level <= 100:
+        return _refusal(f"reachy_volume: `level` must be within 0-100, got {level}.")
+    return driver.set_volume(level)
+
+
+@tool
+def reachy_camera(driver: Any, save_path: str = "") -> dict[str, Any]:
+    """Capture a frame from the Mini's head camera and save it to disk.
+
+    Calls ``ReachyDriver.capture_frame(save_path)`` once. The media rail is
+    not plumbed into the driver yet, so today this refuses by naming the
+    accessor to add.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        save_path: Where to write the JPEG; empty means the driver's default.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_camera", driver)
+    if refusal is not None:
+        return refusal
+    return driver.capture_frame(save_path)
+
+
+@tool
+def reachy_look_at(driver: Any, u: int | None = None, v: int | None = None) -> dict[str, Any]:
+    """Servo the Mini's head toward pixel ``(u, v)`` in its camera frame.
+
+    Calls ``ReachyDriver.look_at_image(u, v)`` once. The media rail is not
+    plumbed into the driver yet, so today this refuses by naming the accessor
+    to add.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        u: Pixel column in the camera frame.
+        v: Pixel row in the camera frame.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_look_at", driver)
+    if refusal is not None:
+        return refusal
+    for name, value in (("u", u), ("v", v)):
+        if value is None:
+            return _refusal(f"reachy_look_at: `{name}` is required. Pass the pixel coordinate in the camera frame.")
+        if isinstance(value, bool) or not isinstance(value, int):
+            return _refusal(f"reachy_look_at: `{name}` must be an integer pixel, got {type(value).__name__!r}.")
+    return driver.look_at_image(u, v)

--- a/strands_robots/tools/reachy/reachy_reads.py
+++ b/strands_robots/tools/reachy/reachy_reads.py
@@ -1,0 +1,81 @@
+"""reachy_reads - the Reachy Mini's read-only verbs, off the driver's caches and catalogue.
+
+Two ``@tool`` verbs, the read half of the port from ``cagataycali/tiny-the-reachy``
+(the write half is :mod:`~strands_robots.tools.reachy.reachy_actions`). Same
+contract: one call on a live :class:`~strands_robots.drivers.reachy.ReachyDriver`
+handle, envelope back verbatim, live-handle refusals via
+:func:`~strands_robots.tools.reachy._reachy_common.live_handle_refusal`.
+Both are safe to call at any time - neither moves the robot.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands import tool
+
+from strands_robots.tools.reachy._reachy_common import live_handle_refusal
+
+# verb -> (accessor, reads, expected), the same table shape reachy_actions uses.
+_READS: dict[str, tuple[str, str, str]] = {
+    "reachy_get_state": (
+        "state_snapshot",
+        "the verb reads the joint, pose, IMU and battery caches the driver's link thread fills",
+        "a callable ``state_snapshot()`` returning the driver's envelope - "
+        "pass the live ReachyDriver handle the orchestrator constructed",
+    ),
+    "reachy_list_emotions": (
+        "list_moves",
+        "the verb asks the daemon for a recorded-move library's catalogue through the driver's REST path",
+        "a callable ``list_moves(library)`` returning the driver's envelope - "
+        "pass the live ReachyDriver handle the orchestrator constructed",
+    ),
+}
+
+
+def _handle_refusal(verb: str, driver: Any) -> dict[str, Any] | None:
+    """The shared live-handle judgement, worded from the ``_READS`` row."""
+    accessor, reads, expected = _READS[verb]
+    return live_handle_refusal(verb, driver, accessor=accessor, reads=reads, expected=expected)
+
+
+@tool
+def reachy_get_state(driver: Any) -> dict[str, Any]:
+    """Read the Mini's live state: joints, head pose, IMU, battery.
+
+    Calls ``ReachyDriver.state_snapshot()`` once - a cache read, no daemon
+    round-trip, so call it freely before and after motion to verify. A
+    ``None`` field means that stream has not delivered yet; IMU and battery
+    stay ``None`` on a Lite, which has neither.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_get_state", driver)
+    if refusal is not None:
+        return refusal
+    return driver.state_snapshot()
+
+
+@tool
+def reachy_list_emotions(driver: Any, library: str = "emotions") -> dict[str, Any]:
+    """List the recorded moves the Mini's daemon can play.
+
+    Calls ``ReachyDriver.list_moves(library)`` once. The names it returns are
+    what :func:`~strands_robots.tools.reachy.reachy_actions.reachy_express`
+    accepts.
+
+    Args:
+        driver: The live ReachyDriver handle the orchestrator constructed.
+        library: ``'emotions'`` (default) or ``'dances'``.
+
+    Returns:
+        The driver's envelope, success or refusal, unreshaped.
+    """
+    refusal = _handle_refusal("reachy_list_emotions", driver)
+    if refusal is not None:
+        return refusal
+    return driver.list_moves(library)

--- a/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
+++ b/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
@@ -139,10 +139,11 @@ class TestEveryVerbMakesExactlyOneDriverCall:
         assert len(handle.calls) == 1
         assert handle.calls[0][0] == VERB_ACCESSOR[verb]
 
-    def test_reachy_wake_sleep_flag_picks_goto_sleep(self) -> None:
+    @pytest.mark.parametrize("sleep,accessor", [(False, "wake_up"), (True, "goto_sleep")])
+    def test_reachy_wake_commands_the_motion_its_flag_names(self, sleep: bool, accessor: str) -> None:
         handle = _RecordingHandle()
-        reachy_actions.reachy_wake(driver=handle, sleep=True)
-        assert handle.calls == [("goto_sleep", (), {})]
+        reachy_actions.reachy_wake(driver=handle, sleep=sleep)
+        assert handle.calls == [(accessor, (), {})]
 
     def test_reachy_look_omits_axes_the_caller_left_alone(self) -> None:
         handle = _RecordingHandle()
@@ -186,7 +187,14 @@ PARAM_REFUSALS: list[tuple[str, dict[str, Any], str]] = [
     ("reachy_look_at", {"u": 4}, "`v` is required"),
     ("reachy_look_at", {"u": 4.5, "v": 4}, "got 'float'"),
     ("reachy_look_at", {"u": True, "v": 4}, "got 'bool'"),
+    ("reachy_wake", {"sleep": "false"}, "sleep must be a boolean"),
+    ("reachy_wake", {"sleep": 1}, "sleep must be a boolean"),
 ]
+
+#: Spellings a caller reaches for to opt *out* of sleep. Every one is truthy, so
+#: a ``sleep`` read by truthiness commands go-to-sleep for each of them - the
+#: opposite physical motion of the one asked for.
+TRUTHY_SPELLINGS_OF_OFF: list[Any] = ["false", "no", "off", "0", "False"]
 
 
 class TestTheVerbsOwnDataGates:
@@ -203,6 +211,50 @@ class TestTheVerbsOwnDataGates:
         assert text.startswith(f"{verb}: ")
         assert fragment in text
         assert handle.calls == []  # the refusal happened before any driver call
+
+
+class TestTheWakeFlagSelectsAPostureRatherThanScalingAQuantity:
+    """Fact family 3b: ``sleep`` picks one of two physical motions.
+
+    It is therefore checked against
+    :func:`~strands_robots.utils.boolean_flag_error` rather than read by
+    truthiness. :class:`TestTheVerbsOwnDataGates` already grades the refusal's
+    wording from :data:`PARAM_REFUSALS`; what these rows add is the *motion*,
+    which is the part a wrong answer moves.
+    """
+
+    @pytest.mark.parametrize("spelling", TRUTHY_SPELLINGS_OF_OFF)
+    def test_a_truthy_spelling_of_off_commands_nothing(self, spelling: Any) -> None:
+        handle = _RecordingHandle()
+        result = reachy_actions.reachy_wake(driver=handle, sleep=spelling)
+        assert result["status"] == "error"
+        # The point of the row: go-to-sleep was not commanded for a caller
+        # spelling "do not go to sleep".
+        assert handle.calls == []
+
+    def test_the_flag_is_judged_before_the_accessor_it_selects(self) -> None:
+        """A handle that can wake but not sleep still serves a request to wake.
+
+        ``accessor`` is derived from ``sleep``, so a flag read by truthiness
+        also decides which accessor the handle gate requires to be callable: a
+        misread ``'false'`` made this handle unusable for the very motion it
+        can perform.
+        """
+
+        class _WakeOnlyHandle:
+            def wake_up(self) -> dict[str, Any]:
+                return {"status": "success", "content": [{"text": "wake_up"}]}
+
+        assert reachy_actions.reachy_wake(driver=_WakeOnlyHandle(), sleep=False)["status"] == "success"
+        # Read from the table rather than written inline: the value is off-type
+        # on purpose - that is the property under test - and the table's ``Any``
+        # keeps the annotation mypy would enforce from hiding what a live caller
+        # can still supply.
+        refusal = reachy_actions.reachy_wake(driver=_WakeOnlyHandle(), sleep=TRUTHY_SPELLINGS_OF_OFF[0])
+        assert refusal["status"] == "error"
+        # The flag is named, not the handle - the handle was never the problem.
+        assert "sleep must be a boolean" in refusal["content"][0]["text"]
+        assert "does not expose" not in refusal["content"][0]["text"]
 
 
 class TestThePackageSurfaceHolds:

--- a/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
+++ b/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
@@ -15,7 +15,9 @@ by a file per fact. Four fact families:
    shipped once and now pins against.
 
 Plus the new ``ReachyDriver`` accessor gates (connected-first, admitted sets,
-URL-safe move names) exercised on a bare instance with no daemon.
+URL-safe move names) exercised on a bare instance with no daemon, and the move
+catalogue's wire shape, which is an array rather than a dict and so cannot be
+read the way every other endpoint's body is.
 """
 
 from __future__ import annotations
@@ -25,6 +27,7 @@ from typing import Any
 
 import pytest
 
+import strands_robots.drivers.reachy as reachy_driver_module
 import strands_robots.tools.reachy as reachy_package
 from strands_robots.drivers.reachy import ReachyDriver
 from strands_robots.tools.reachy import reachy_actions, reachy_reads
@@ -94,6 +97,8 @@ def _bare_driver(connected: bool = True) -> ReachyDriver:
     driver._battery = None
     driver._link = None
     driver._loop = None
+    driver._host = "localhost"
+    driver._api_port = 8080
     return driver
 
 
@@ -275,3 +280,78 @@ class TestTheDriverAccessorGates:
         assert payload["imu"] is None and payload["pose"] is None
         payload["joints"]["body_yaw"] = 99  # a caller's mutation must not reach the cache
         assert driver._joints["body_yaw"] == 0.5
+
+
+class _FakeTransport:
+    """A transport double that answers ``api`` with one canned body."""
+
+    def __init__(self, body: Any) -> None:
+        self.body = body
+        self.paths: list[str] = []
+
+    def api(self, host: str, port: int, path: str, method: str = "GET", data: Any = None) -> Any:
+        self.paths.append(path)
+        return self.body
+
+
+class TestTheMoveCatalogueIsReadAsAnArray:
+    """Regression: the daemon's catalogue endpoint answers a JSON array.
+
+    ``GET /api/move/recorded-move-datasets/list/{dataset}`` is declared
+    ``-> list[str]`` by the daemon (pollen-robotics/reachy_mini,
+    ``daemon/app/routers/move.py::list_recorded_move_dataset``) and
+    ``reachy_transport.api`` returns the decoded body unreshaped, so on a
+    *successful* read ``list_moves`` holds a ``list``. Reading ``.get("error")``
+    off it raised ``AttributeError`` out through ``reachy_list_emotions``,
+    breaking both halves of the surface's standing contract at once - an
+    envelope back, and never an exception. The gates above could not see it
+    because ``_RecordingHandle`` never returns a list, so these rows drive the
+    transport seam with the shapes the daemon actually produces.
+    """
+
+    @staticmethod
+    def _driver_answering(monkeypatch: pytest.MonkeyPatch, body: Any) -> tuple[ReachyDriver, _FakeTransport]:
+        transport = _FakeTransport(body)
+        monkeypatch.setattr(reachy_driver_module, "_resolve_transport", lambda: transport)
+        return _bare_driver(), transport
+
+    def test_a_catalogue_read_returns_the_array_verbatim(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, transport = self._driver_answering(monkeypatch, ["happy", "sad", "curious"])
+        result = driver.list_moves("emotions")
+        assert result["status"] == "success"
+        assert result["content"][0]["json"] == {
+            "library": "emotions",
+            "moves": ["happy", "sad", "curious"],
+        }
+        assert transport.paths == ["/api/move/recorded-move-datasets/list/pollen-robotics/reachy-mini-emotions-library"]
+
+    def test_an_empty_catalogue_is_a_success_not_a_refusal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, _ = self._driver_answering(monkeypatch, [])
+        result = driver.list_moves("dances")
+        assert result["status"] == "success"
+        assert result["content"][0]["json"]["moves"] == []
+
+    def test_each_library_reads_its_own_dataset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, transport = self._driver_answering(monkeypatch, [])
+        driver.list_moves("dances")
+        assert transport.paths == ["/api/move/recorded-move-datasets/list/pollen-robotics/reachy-mini-dances-library"]
+
+    def test_an_error_body_is_still_refused_naming_the_cause(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, _ = self._driver_answering(monkeypatch, {"error": "daemon said no"})
+        result = driver.list_moves()
+        assert result["status"] == "error"
+        assert "daemon said no" in result["content"][0]["text"]
+
+    def test_an_unexpected_dict_is_refused_rather_than_served_as_a_catalogue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        driver, _ = self._driver_answering(monkeypatch, {"unexpected": "shape"})
+        result = driver.list_moves()
+        assert result["status"] == "error"
+        assert "list_moves: daemon refused" in result["content"][0]["text"]
+
+    def test_the_read_verb_carries_the_array_out_without_raising(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, _ = self._driver_answering(monkeypatch, ["happy"])
+        result = reachy_reads.reachy_list_emotions(driver=driver)
+        assert result["status"] == "success"
+        assert result["content"][0]["json"]["moves"] == ["happy"]

--- a/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
+++ b/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
@@ -1,0 +1,277 @@
+"""The consolidated Reachy tool surface holds - one table-driven suite.
+
+Facts x verbs, in the shape the g1 family's consolidation locked (refs #3037,
+#3070): the whole ``reachy_*`` surface is judged by rows in tables rather than
+by a file per fact. Four fact families:
+
+1. Every verb refuses an unusable ``driver`` handle with an envelope that
+   names the verb, the parameter and the received type - never an exception.
+2. Every verb makes exactly one call on a wired handle, through exactly the
+   accessor its table row names, and returns that envelope object verbatim.
+3. A data parameter a verb gates itself (the driver cannot see a missing
+   ``emotion``) is refused with prose naming the parameter.
+4. The package surface holds: every ``@tool`` the two verb modules define is
+   lazily importable from the package - the drift the g1 family actually
+   shipped once and now pins against.
+
+Plus the new ``ReachyDriver`` accessor gates (connected-first, admitted sets,
+URL-safe move names) exercised on a bare instance with no daemon.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.reachy as reachy_package
+from strands_robots.drivers.reachy import ReachyDriver
+from strands_robots.tools.reachy import reachy_actions, reachy_reads
+
+ALL_VERBS: dict[str, Any] = {
+    **{name: getattr(reachy_actions, name) for name in reachy_actions._ACTIONS},
+    **{name: getattr(reachy_reads, name) for name in reachy_reads._READS},
+}
+
+#: verb -> the accessor its table row says it reads the handle through.
+VERB_ACCESSOR: dict[str, str] = {
+    **{name: row[0] for name, row in reachy_actions._ACTIONS.items()},
+    **{name: row[0] for name, row in reachy_reads._READS.items()},
+}
+
+#: The arguments that carry each verb past its own data gates, so the call
+#: reaches the driver accessor.
+VERB_ARGS: dict[str, dict[str, Any]] = {
+    "reachy_look": {"pitch": 10.0, "yaw": -5.0},
+    "reachy_antennas": {"right": 30.0, "left": -30.0},
+    "reachy_body_turn": {"yaw": 45.0},
+    "reachy_home": {},
+    "reachy_stop": {},
+    "reachy_wake": {},
+    "reachy_express": {"emotion": "happy"},
+    "reachy_motors": {"mode": "enabled"},
+    "reachy_play_sound": {"sound_file": "wake_up.wav"},
+    "reachy_volume": {"level": 40},
+    "reachy_camera": {},
+    "reachy_look_at": {"u": 320, "v": 240},
+    "reachy_get_state": {},
+    "reachy_list_emotions": {},
+}
+
+
+class _RecordingHandle:
+    """A handle that answers any accessor and records the calls it served."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+        self.envelope = {"status": "success", "content": [{"json": {"from": "stub"}}]}
+
+    def __getattr__(self, name: str) -> Any:
+        def _call(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append((name, args, kwargs))
+            return self.envelope
+
+        return _call
+
+
+class _AccessorIsData:
+    """Carries every accessor name as *data* - a cache dump, not a driver."""
+
+    def __init__(self) -> None:
+        for accessor in set(VERB_ACCESSOR.values()):
+            setattr(self, accessor, "a string, not a callable")
+
+
+def _bare_driver(connected: bool = True) -> ReachyDriver:
+    """A ReachyDriver with no daemon: caches empty, link absent."""
+    driver = ReachyDriver.__new__(ReachyDriver)
+    driver._connected = connected
+    driver._cache_lock = threading.Lock()
+    driver._joints = None
+    driver._pose = None
+    driver._imu = None
+    driver._battery = None
+    driver._link = None
+    driver._loop = None
+    return driver
+
+
+class TestEveryVerbRefusesAWrongHandle:
+    """Fact family 1: the live-handle judgement, uniform across the surface."""
+
+    @pytest.mark.parametrize("verb", sorted(ALL_VERBS))
+    def test_a_none_driver_is_refused_naming_the_verb_and_parameter(self, verb: str) -> None:
+        result = ALL_VERBS[verb](driver=None)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith(f"{verb}: ")
+        assert "`driver` is required" in text
+
+    @pytest.mark.parametrize("verb", sorted(ALL_VERBS))
+    def test_a_string_handle_is_refused_naming_the_received_type(self, verb: str) -> None:
+        result = ALL_VERBS[verb](driver="reachy-mini")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith(f"{verb}: ")
+        assert "'str'" in text
+
+    @pytest.mark.parametrize("verb", sorted(ALL_VERBS))
+    def test_an_accessor_present_as_data_is_still_refused(self, verb: str) -> None:
+        result = ALL_VERBS[verb](driver=_AccessorIsData())
+        assert result["status"] == "error"
+        assert result["content"][0]["text"].startswith(f"{verb}: ")
+
+
+class TestEveryVerbMakesExactlyOneDriverCall:
+    """Fact family 2: one call, through the table's accessor, envelope verbatim."""
+
+    @pytest.mark.parametrize("verb", sorted(ALL_VERBS))
+    def test_the_tables_accessor_serves_the_call_and_the_envelope_returns_verbatim(self, verb: str) -> None:
+        handle = _RecordingHandle()
+        result = ALL_VERBS[verb](driver=handle, **VERB_ARGS[verb])
+        assert result is handle.envelope
+        assert len(handle.calls) == 1
+        assert handle.calls[0][0] == VERB_ACCESSOR[verb]
+
+    def test_reachy_wake_sleep_flag_picks_goto_sleep(self) -> None:
+        handle = _RecordingHandle()
+        reachy_actions.reachy_wake(driver=handle, sleep=True)
+        assert handle.calls == [("goto_sleep", (), {})]
+
+    def test_reachy_look_omits_axes_the_caller_left_alone(self) -> None:
+        handle = _RecordingHandle()
+        reachy_actions.reachy_look(driver=handle, pitch=15.0)
+        (accessor, args, _) = handle.calls[0]
+        action = args[0]
+        assert accessor == "send_action"
+        assert action["head_pitch"] == 15.0
+        assert "body_yaw" not in action
+        assert "antenna_left" not in action and "antenna_right" not in action
+
+    def test_reachy_home_sends_every_axis_at_zero(self) -> None:
+        handle = _RecordingHandle()
+        reachy_actions.reachy_home(driver=handle)
+        action = handle.calls[0][1][0]
+        assert set(action) == {
+            "head_pitch",
+            "head_roll",
+            "head_yaw",
+            "head_x",
+            "head_y",
+            "head_z",
+            "body_yaw",
+            "antenna_left",
+            "antenna_right",
+        }
+        assert all(value == 0.0 for value in action.values())
+
+
+#: (verb, kwargs, fragment the refusal must contain) - the data gates the
+#: verbs own because the driver cannot judge an absent value.
+PARAM_REFUSALS: list[tuple[str, dict[str, Any], str]] = [
+    ("reachy_express", {}, "`emotion` is required"),
+    ("reachy_motors", {}, "`mode` is required"),
+    ("reachy_play_sound", {}, "`sound_file` is required"),
+    ("reachy_volume", {}, "`level` is required"),
+    ("reachy_volume", {"level": True}, "got 'bool'"),
+    ("reachy_volume", {"level": 101}, "within 0-100"),
+    ("reachy_volume", {"level": -1}, "within 0-100"),
+    ("reachy_look_at", {"v": 4}, "`u` is required"),
+    ("reachy_look_at", {"u": 4}, "`v` is required"),
+    ("reachy_look_at", {"u": 4.5, "v": 4}, "got 'float'"),
+    ("reachy_look_at", {"u": True, "v": 4}, "got 'bool'"),
+]
+
+
+class TestTheVerbsOwnDataGates:
+    """Fact family 3: a bad data parameter is refused naming the parameter."""
+
+    @pytest.mark.parametrize(
+        "verb,kwargs,fragment", PARAM_REFUSALS, ids=[f"{v}-{f[:20]}" for v, _, f in PARAM_REFUSALS]
+    )
+    def test_the_refusal_names_the_parameter(self, verb: str, kwargs: dict[str, Any], fragment: str) -> None:
+        handle = _RecordingHandle()
+        result = ALL_VERBS[verb](driver=handle, **kwargs)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith(f"{verb}: ")
+        assert fragment in text
+        assert handle.calls == []  # the refusal happened before any driver call
+
+
+class TestThePackageSurfaceHolds:
+    """Fact family 4: the lazy surface and the modules cannot drift apart."""
+
+    def test_every_lazy_name_resolves(self) -> None:
+        for name in reachy_package._LAZY_IMPORTS:
+            assert getattr(reachy_package, name) is not None
+
+    def test_every_tool_the_modules_define_is_on_the_package(self) -> None:
+        defined = set(reachy_actions._ACTIONS) | set(reachy_reads._READS)
+        assert defined == set(reachy_package._LAZY_IMPORTS)
+
+    def test_the_tables_cover_every_tool_decorated_function(self) -> None:
+        for module, table in ((reachy_actions, reachy_actions._ACTIONS), (reachy_reads, reachy_reads._READS)):
+            tools = {
+                name for name in dir(module) if not name.startswith("_") and hasattr(getattr(module, name), "tool_spec")
+            }
+            assert tools == set(table)
+
+
+#: (method invocation, fragment) rows for the driver's own gates, judged on a
+#: bare instance - no daemon, no link.
+DRIVER_GATES: list[tuple[str, dict[str, Any], str]] = [
+    ("play_move", {"move_name": "happy"}, "not connected"),
+    ("list_moves", {}, "not connected"),
+    ("wake_up", {}, "not connected"),
+    ("goto_sleep", {}, "not connected"),
+    ("set_motors", {"mode": "enabled"}, "not connected"),
+    ("state_snapshot", {}, "not connected"),
+]
+
+
+class TestTheDriverAccessorGates:
+    """The new ReachyDriver accessors refuse in envelopes, connected-first."""
+
+    @pytest.mark.parametrize("method,kwargs,fragment", DRIVER_GATES, ids=[m for m, _, _ in DRIVER_GATES])
+    def test_disconnected_is_refused(self, method: str, kwargs: dict[str, Any], fragment: str) -> None:
+        driver = _bare_driver(connected=False)
+        result = getattr(driver, method)(**kwargs)
+        assert result["status"] == "error"
+        assert fragment in result["content"][0]["text"]
+
+    @pytest.mark.parametrize(
+        "kwargs,fragment",
+        [
+            ({"move_name": "../evil"}, "invalid move_name"),
+            ({"move_name": ""}, "invalid move_name"),
+            ({"move_name": "ok", "library": "gestures"}, "unknown library"),
+        ],
+        ids=["path-escape", "empty-name", "unknown-library"],
+    )
+    def test_play_move_refuses_bad_input_before_any_request(self, kwargs: dict[str, Any], fragment: str) -> None:
+        result = _bare_driver().play_move(**kwargs)
+        assert result["status"] == "error"
+        assert fragment in result["content"][0]["text"]
+
+    def test_set_motors_refuses_the_sdk_only_mode_by_name(self) -> None:
+        result = _bare_driver().set_motors("gravity_compensation")
+        assert result["status"] == "error"
+        assert "gravity_compensation" in result["content"][0]["text"]
+
+    def test_set_motors_without_a_link_reports_the_link(self) -> None:
+        result = _bare_driver().set_motors("disabled")
+        assert result["status"] == "error"
+        assert "link is not running" in result["content"][0]["text"]
+
+    def test_state_snapshot_returns_cache_copies(self) -> None:
+        driver = _bare_driver()
+        driver._joints = {"body_yaw": 0.5}
+        driver._battery = {"pct": 88}
+        payload = driver.state_snapshot()["content"][0]["json"]
+        assert payload["joints"] == {"body_yaw": 0.5}
+        assert payload["battery"] == {"pct": 88}
+        assert payload["imu"] is None and payload["pose"] is None
+        payload["joints"]["body_yaw"] = 99  # a caller's mutation must not reach the cache
+        assert driver._joints["body_yaw"] == 0.5


### PR DESCRIPTION
Ports the Reachy Mini tool surface from `cagataycali/tiny-the-reachy` in the consolidated shape the g1 family locked (#3037, #3070): **no per-verb modules** — one table-driven execution module + one read module + one table-driven test suite.

## Shape

```
tools/reachy/
├── reachy_actions.py   12 execution verbs · _ACTIONS table (accessor + refusal prose)
├── reachy_reads.py      2 read verbs      · _READS table
└── _reachy_common.py   +live_handle_refusal (g1's judgement, deliberate sibling copy)
drivers/reachy.py       +6 accessors: play_move · list_moves · wake_up · goto_sleep · set_motors · state_snapshot
```

## Verb → driver call (always exactly one)

| verb | accessor | rail |
|---|---|---|
| reachy_look / antennas / body_turn / home | `send_action` | RT link (driver owns envelope gates) |
| reachy_stop | `stop_task` | `POST /api/move/stop` |
| reachy_wake(sleep=) | `wake_up` / `goto_sleep` | daemon built-in moves |
| reachy_express / reachy_list_emotions | `play_move` / `list_moves` | recorded-move library (emotions + dances) |
| reachy_motors | `set_motors` | torque on RT link |
| reachy_get_state | `state_snapshot` | cache read, no round-trip |
| reachy_play_sound / volume / camera / look_at | *named accessor, not plumbed* | refuse today naming the accessor — the `g1_move_velocity` precedent |

Every daemon REST path is one already proven in `device_connect/reachy_mini_driver.py`; move names keep its URL-safe alphabet.

## Not ported, on purpose
`reachy_say` (HF-space TTS = voice-agent glue), `vision.py` (bidi context injection + OpenAI-realtime monkey-patch), all non-robot tools (telegram/dispatch/memory).

## Tests
One suite, facts × verbs: 3 wrong-handle facts × 14 verbs, one-call/envelope-verbatim × 14, 13 param-refusal rows, package-surface drift pins (the `_LAZY_IMPORTS` drift g1 actually shipped once), driver gates on a bare instance, and the move catalogue's wire shape. **100 tests, 0 per-fact files.** ruff + format clean.

LOC: +1321/−4 — driver lane (exempt, grows) +187; the 14-verb tool surface lands at ~1/6 the per-verb cadence this replaced (refs the #3055 correction).

## Round changelog

### Round 2 — one blocker, one red gate, one missing fragment

**`0a9f260` — the move catalogue is a JSON array, not a dict.** Review feedback caught a real defect on the happy path of a shipped verb: `GET /api/move/recorded-move-datasets/list/{dataset}` is declared `-> list[str]` by the daemon and `reachy_transport.api` returns `json.loads(...)` unreshaped, so on a *successful* read `list_moves` held a `list` and `result.get("error")` raised `AttributeError` out through `reachy_list_emotions` — breaking both halves of the contract this PR states for every verb (envelope back verbatim, never an exception).

The read now goes through a `_daemon_get_list` accessor annotated `list[Any] | dict[str, Any]`, so `list_moves` must narrow before it indexes and a dict body is refused whatever key it carries. Kept separate from `_daemon_get` rather than widening that return type, for two reasons: it makes the mistake unrepeatable (with `_daemon_get` still `dict[str, Any]`, the next array-returning endpoint reads `.get` with mypy's blessing — which is how this one got through), and it keeps the union off `connect_eagerly`'s three uses of the status body, a proven path this diff has no reason to touch.

The existing rows could not see it: `_RecordingHandle` answers every accessor with a canned dict, so nothing in the suite could produce a list, and only the `not connected` gate was driven. Six new rows drive the transport seam with the shapes the daemon actually produces — array, empty array, `{"error": ...}`, an unexpected dict, per-library dataset paths, and the same read through `reachy_list_emotions`. **Five of the six fail with the reported `AttributeError` on `92f97cf`**, so the pin fails on the old behaviour rather than merely passing on the new one.

**`f9d0c11` — the red required check was one codepoint.** `tests/test_source_strings_no_unicode_dashes.py` scans every line of every module under `strands_robots`, docstrings included, and the `U+2014` at `_reachy_common.py:144` was the only offender in the package. That was the whole of `call-test-lint`'s failure (`1 failed, 36116 passed`).

**`8e25518` — changelog fragment the branch was missing.** AGENTS.md step 3 makes a `changelog.d/` fragment part of the contribution workflow, and this branch shipped 14 agent verbs without one. `changelog-fragment.yml` reads only the fragments a branch *adds*, so an absent fragment passes it silently — which is why CI never flagged it.

Verified at this head: `tests/tools/reachy/` + the dash gate are 93 passed, `tests/test_changelog_fragments.py` + `tests/test_changelog_format.py` 32 passed, `assemble_changelog.py --check` OK, `ruff check` and `ruff format --check` clean across `strands_robots tests tests_integ`, and mypy clean on the changed driver. The upstream `reachy_transport.api` annotation (`-> dict[str, Any]` over an unreshaped `json.loads`) is the root cause but is pre-existing with dict-only callers elsewhere, so it stays out of this diff.

### Round 3 - a posture flag read by truthiness

**`9907c95` - `reachy_wake`'s `sleep` selects a physical motion, so it is checked.** Review feedback caught the documented class in AGENTS.md > Review Learnings (#86): `accessor = "goto_sleep" if sleep else "wake_up"` reads the flag by truthiness, and every non-empty string is truthy, so `'false'`, `'no'`, `'off'` and `'0'` - the spellings a caller reaches for to opt *out* - each commanded go-to-sleep and reported success.

| `sleep` | motion commanded | status | motion asked for |
|---|---|---|---|
| `False` | `wake_up` | success | `wake_up` |
| `True` | `goto_sleep` | success | `goto_sleep` |
| `"false"` / `"no"` / `"0"` | `goto_sleep` | success | `wake_up` **inverted** |

The flag now goes through the shared `strands_robots.utils.boolean_flag_error` domain - the one `build_lerobot_command` already applies to its own flags, so a posture flag is refused identically wherever it is supplied rather than merely equivalently - and it goes there *ahead of the accessor it selects*. That ordering is forced, not stylistic: the misread flag also decided which accessor `live_handle_refusal` required to be callable, so a handle that could wake but not sleep was refused for a request to wake.

The existing rows could not see it: the suite's only `sleep` row drove `sleep=True`, and the flag-domain pins elsewhere in `tests/` are per-surface, so nothing would have caught this verb after merge. Eight rows now do - two on the refusal's wording, five on the *motion* (for every truthy spelling of off, no accessor is called at all), one on the ordering - and the single-value `sleep` cell is folded into a parametrized one covering both postures, in fewer lines than it replaced. **All eight fail with the guard reverted (8 failed / 92 passed) and pass with it (100 passed)**; the 92 that hold both ways include the canonical-boolean cell, which is the control.

An AST scan puts the population at 1 of 1: `sleep` is the only caller-supplied posture flag across the three tool modules. `ReachyDriver._build_link(is_lite=)` is the only other `bool` in the diff and is out of scope - keyword-only, private, and derived from the daemon's own status.

Verified at this head: `ruff check` and `ruff format --check` clean; mypy clean over 1801 source files; `scripts/check_whole_tree_graders.py` 188 passed, 1 skipped; `tests/tools/reachy/` 100 passed; the three changelog suites 91 passed with the fragment present in `assemble_changelog.py --print`. Attribution on a 536-file selection of every suite that walks the tree, run with and without these two files: identical failing sets both sides, and `+9` collected localizing exactly to the rows above.