### PR TITLE
docs(AGENTS.md): convention 7's rule is recoverability, and name= is one of three shapes that satisfy it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,21 @@ hatch run format            # ruff check --fix, ruff format
 7. **Use `require_optional()`** - from `strands_robots/utils.py` for all optional deps.
    It reports the absent module in `ImportError.name`, so a caller can tell an absent
    extra from a broken package path without parsing the message. A hand-rolled
-   `raise ImportError(...)` that reports an absent dependency must pass `name=` for the
-   same reason; `tests/test_absent_dependency_reports_name_the_module.py` refuses one
-   that leaves the module readable only in prose
+   `raise ImportError(...)` that reports an absent dependency must leave that module
+   recoverable from the exception for the same reason, and
+   `tests/test_absent_dependency_reports_name_the_module.py` refuses one that leaves it
+   readable only in prose. Three shapes satisfy it and the test grades them one by one:
+   `name=`, `raise ... from exc`, or raising lexically inside the `except` handler, which
+   sets `__context__` - `from None` suppresses the *rendering* of that chain but not the
+   attribute. `name=` is the only shape left once the raise moves out of the handler,
+   which is why `require_optionals` passes it explicitly. So this is not "every site
+   spells `name=`". Measured over the package with that test's own AST grader: 28
+   constructed sites, 7 spelling `name=`, 19 carrying the module on the chain instead
+   (18 `from exc`, one raising inside the handler), 2 exempt because they report a
+   rejected argument rather than an absent install, 0 blind. Adding the keyword to the
+   19 is not a compliance fix. Reach for the grader and not `grep -v name=` when
+   auditing this: `name=` on a continuation line of a multi-line `raise` is invisible to
+   a line-oriented grep, which reports those 7 as 5 and the 19 as 23
 8. **Integration tests required** - each policy needs `tests_integ/` tests with real inference
 9. **Test behavior, not implementation** - assert on outputs, not internal state
 10. **No dead code** - if it's not called and not part of base class, delete it


### PR DESCRIPTION
Convention 7 states two rules and they are not the same rule.

> A hand-rolled `raise ImportError(...)` that reports an absent dependency **must pass `name=`** for the same reason; `tests/test_absent_dependency_reports_name_the_module.py` refuses one **that leaves the module readable only in prose**

The tree follows the second. The cited test grades `names_the_module or chains_a_cause or inside_a_handler`, and its `TestTheRuleIsNotVacuous` table pins all six raise shapes individually - so `raise ... from exc` and raising lexically inside the `except` handler both satisfy the gate without `name=`.

I wrote this wording in #3077 and it overstated what that PR's own test enforces.

## Measured

With that test's own AST grader rather than grep (`_package_sites()` on the shipped package):

| bucket | sites |
|---|---|
| total constructed `raise ImportError(...)` | **28** |
| spells `name=` | 7 |
| carries the module on the chain instead | **19** (18 `from exc`, 1 raising inside the handler) |
| exempt - reports a rejected argument, not an absent install | 2 |
| blind, would fail the gate | **0** |

So the absolute as written was contradicted at 19 in-rule sites while the gate was green, and the test suite is 17 passed either way.

## Why it is worth a diff

The cost is an audit, not a crash. A contributor who reads "must pass `name=`" and greps for compliance finds a long list of apparent violations and either files them or "fixes" them - both unrequested work on a tree that already passes. The grep is the natural next step precisely because the test's own docstring publishes it.

And that grep is the wrong instrument twice over: `name=` on a continuation line of a multi-line `raise` is invisible to a line-oriented match, so `grep -rn "raise ImportError(" strands_robots/ | grep -v name=` reports the 7 as **5** and the 19 as **23**. I hit this while drafting the fix - my first draft of this very paragraph said 23, and the AST grader corrected it. That is now written down beside the rule.

## The change

The wording states the property the gate actually enforces, names the three shapes that satisfy it, records the measured breakdown, and says why `name=` is still mandatory for `require_optionals` specifically: it raises after its handler has exited, so `__context__` is `None` there and no chain is left to carry the name. That last point is the one fact the absolute got right, and it now has its reason attached rather than being generalised to every site.

## Scope

`AGENTS.md` only, **+15 / -3**, one convention entry. Confirmed the single copy of the claim (`AGENTS.md:77`) - no `docs/` duplicate. No test parses `AGENTS.md`; the 20 test modules that mention it cite it in prose. The graded test is untouched and still **17 passed**. No changelog fragment: no shipped behaviour differs.

Deliberately *not* in this diff: `TestTheRuleIsNotVacuous`'s sibling assertion is named `test_every_absent_dependency_report_names_its_module`, which reads as the same overstatement. Renaming it is a test-file change on a different axis from the doc drift, so it is left for a separate diff rather than bundled here.

Refs #3077.