### PR TITLE
fix(mesh): validate the command envelope's routing fields, which are key-expression segments

### DIFF
--- a/changelog.d/3085-mesh-command-envelope-routing-identifiers.md
+++ b/changelog.d/3085-mesh-command-envelope-routing-identifiers.md
@@ -1,0 +1,27 @@
+### Fixed: a command envelope's routing fields are validated as key-expression segments
+
+`Mesh` answers a command on
+`strands/{sender_id}/response/{responder}/{turn_id}`, built from two fields read
+straight off the wire. Zenoh accepts a wildcard on a `put` and routes it by
+intersection, so an envelope carrying `sender_id="**"` produced a reply key that
+every peer's `strands/{peer}/response/**` subscription matched -- the answering
+robot's dispatch result (task status, battery, pose) reached the whole fleet
+instead of the peer that asked. Measured with two live Zenoh sessions: both
+bystander peers received a reply to a command neither of them sent.
+
+`validate_command` already type-checked, length-bounded and charset-validated a
+`turn_id` / `sender_id` carried inside the *command* dict, and said in its
+docstring that those were the fields `Mesh` correlates a turn and keys its
+command-replay cache on. They were not: routing reads the enclosing envelope's
+own copies, which reached the key expression unchecked. The routing pair is now
+held to `validate_mesh_identifier` -- the same `[A-Za-z0-9_.-]+`, at most 128
+characters rule the teleop identifiers follow, because printable ASCII is not a
+sufficient bound when `*` and `/` are printable and are what widen a key.
+
+An envelope that breaks the rule is refused whole: nothing is dispatched, nothing
+is published, and one audit record is written. The refusal cannot forge a log
+record either -- the warning names the field and the rule but never the rejected
+value, so a line break in it cannot split the record, while the structured audit
+record carries a bounded `repr` for forensics. An **absent** `sender_id` is
+unchanged and still means fire-and-forget: the command runs and no reply is
+published.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -118,7 +118,7 @@ a loop. Every attempt, granted or refused, is written to the safety audit log.
 | `strands/{peer_id}/presence` | 2 Hz | heartbeat / peer discovery |
 | `strands/{peer_id}/state` | 10 Hz | joints, sim time, task status, which robots are running a policy, degraded probes |
 | `strands/{peer_id}/cmd` | on demand | incoming RPC commands |
-| `strands/{peer_id}/response/{id}` | on demand | RPC replies (turn_id correlated) |
+| `strands/{requester}/response/{responder}/{turn_id}` | on demand | RPC replies (turn_id correlated) |
 | `strands/{peer_id}/stream` | on demand | VLA execution steps |
 | `strands/{peer_id}/pose` | on demand | SE(3) from SLAM/odom/VIO |
 | `strands/{peer_id}/imu` | on demand | orientation, gyro, accel |
@@ -126,6 +126,20 @@ a loop. Every attempt, granted or refused, is written to the safety audit log.
 | `strands/broadcast` | on demand | fan-out RPC |
 
 Sensor topics only publish when the robot exposes the attribute. Zero cost when unused.
+
+**A reply key is built from the request envelope, so its routing fields are
+identifiers.** A command carries `sender_id` (where to answer) and `turn_id`
+(which turn is being answered), and the reply is published on
+`strands/{sender_id}/response/{responder}/{turn_id}`. Both fields must match
+`[A-Za-z0-9_.-]+` and be at most 128 characters -- the same rule the teleop
+identifiers follow -- because Zenoh routes a wildcard by intersection, so a
+segment holding one would address the reply at every peer's
+`strands/{peer}/response/**` subscription instead of at the peer that asked. A
+command whose envelope breaks the rule is refused whole: nothing is dispatched,
+nothing is published, and the refusal is written to the safety audit log.
+Omitting `sender_id` is unchanged and still means fire-and-forget -- the command
+runs and no reply is published.
+
 
 **A sensor record's identity is the publisher's too.** A reader seeds each record
 with what this process decided, merges the robot's provider mapping over it, and

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1774,6 +1774,54 @@ class Mesh(SensorLoopsMixin):
         # could observe the response topic. D1 closed the outbound side;
         # this closes the symmetric receive-side surface.
         turn = data.get("turn_id") or uuid.uuid4().hex
+        # Both fields become key-expression segments: ``rkey`` below interpolates
+        # them into ``strands/{sender}/response/{responder}/{turn}``, and Zenoh
+        # accepts a wildcard on a ``put`` and routes it by intersection -- so a
+        # ``sender_id`` of ``**`` addresses the response at every peer's
+        # ``strands/{peer}/response/**`` subscription rather than at the one peer
+        # that asked, and this robot's dispatch result reaches the whole fleet.
+        # ``validate_command`` already type-checks, length-bounds and
+        # charset-validates a ``turn_id`` / ``sender_id`` carried INSIDE the
+        # command dict, but routing reads the envelope's own copy, which reached
+        # the key expression unchecked. So validate the pair that routes, with
+        # the rule this library already applies to the teleop identifiers it
+        # interpolates into a key expression -- printable ASCII is not enough
+        # here, because ``*`` and ``/`` are printable and are what widen a key.
+        #
+        # An ABSENT sender stays supported and means something else: "no response
+        # route" (``rkey`` is None below), the documented fire-and-forget shape.
+        # An invalid one names no peer this robot could answer, so the envelope
+        # is refused whole rather than executed with its routing fields dropped.
+        for field, value in (("sender_id", sender), ("turn_id", turn)):
+            if field == "sender_id" and value == "":
+                continue
+            try:
+                _security.validate_mesh_identifier(value, f"command envelope {field}")
+            except _security.ValidationError as exc:
+                # No wire bytes on the log line: the message names the field and
+                # the rule, never the rejected value, so a line break in it
+                # cannot split this record in two. The audit record carries a
+                # bounded ``repr`` instead -- a structured sink can hold the
+                # shape forensics wants without a line-oriented reader seeing a
+                # record this process never wrote. ``sender`` is recorded only
+                # once it has itself passed: the loop checks it first, so a
+                # ``turn_id`` rejection carries a sender known to be an
+                # identifier, and a sender rejection carries only the repr.
+                logger.warning("[mesh] %s: refused cmd with unroutable %s -- %s", self.peer_id, field, exc)
+                try:
+                    log_safety_event(
+                        "command_rejected",
+                        self.peer_id,
+                        {
+                            "sender": sender if field != "sender_id" else None,
+                            "field": field,
+                            "reason": str(exc),
+                            "value": repr(value)[: _security.MAX_PEER_ID_LEN],
+                        },
+                    )
+                except (TypeError, ValueError, OSError) as audit_exc:
+                    logger.debug("[mesh] %s: audit log unavailable: %s", self.peer_id, audit_exc)
+                return
         # require an explicit ``command`` key.
         # Earlier the fallback ``data.get("command", data)`` allowed a
         # peer to publish a flat-shape envelope (sender_id, turn_id,

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -987,13 +987,20 @@ def validate_mesh_identifier(value: Any, param: str) -> str:
     ``peer_id`` or a teleop ``device_name`` interpolated into
     ``strands/{peer_id}/input/{device_name}`` by
     :class:`~strands_robots.mesh.input.InputPublisher` and
-    :class:`~strands_robots.mesh.input.InputReceiver`.
+    :class:`~strands_robots.mesh.input.InputReceiver`, or the ``sender_id`` and
+    ``turn_id`` of an inbound command envelope, which
+    :class:`~strands_robots.mesh.core.Mesh` interpolates into
+    ``strands/{sender_id}/response/{responder}/{turn_id}`` to answer it.
 
     Zenoh treats ``*`` and ``**`` as key-expression wildcards, so an
     unvalidated segment silently widens a point-to-point subscription into a
     match-any one: a receiver built with ``source_peer_id="**"`` subscribes to
     ``strands/**/input/leader`` and applies joint commands from *every* peer on
-    the mesh, not just the configured leader. The remaining rejected shapes
+    the mesh, not just the configured leader. Publishing is exposed the same way,
+    because Zenoh accepts a wildcard on a ``put`` and routes it by intersection:
+    a reply key holding one is delivered to every peer's
+    ``strands/{peer}/response/**`` subscription rather than to the peer that
+    asked. The remaining rejected shapes
     (whitespace, NULs, C0 controls, shell metacharacters, ``/``) keep an
     identifier from smuggling extra key segments or corrupting the log lines
     and per-device state keys it also lands in.
@@ -1037,10 +1044,14 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
       action, not per-action: each must be a str of at most
       :data:`MAX_PASSTHROUGH_LEN` characters, printable ASCII only (no C0/DEL
       or non-printable byte). They are wire-routing fields rather than action
-      payload -- ``Mesh`` correlates an RPC turn on ``turn_id`` and keys its
-      command-replay cache on ``(sender_id, turn_id)`` -- so a publisher
-      minting them needs the bound, and a control byte must not reach the
-      audit trail through either. Any other unvalidated key is dropped from
+      payload, so a publisher minting them needs the bound and a control byte
+      must not reach the audit trail through either. These are the *command's*
+      copies: what :class:`~strands_robots.mesh.core.Mesh` routes on is the
+      enclosing envelope's own ``sender_id`` / ``turn_id`` one level up, which it
+      correlates a turn on, keys its command-replay cache on, and interpolates
+      into the reply key -- so those are held to the stricter
+      :func:`validate_mesh_identifier` charset where they are read, and this
+      check is not the routing gate. Any other unvalidated key is dropped from
       the sanitised copy rather than refused.
     * ``execute`` and ``start`` actions require:
         - ``instruction``: non-empty str up to :data:`MAX_INSTRUCTION_LEN`,

--- a/tests/mesh/test_command_envelope_routing_identifiers.py
+++ b/tests/mesh/test_command_envelope_routing_identifiers.py
@@ -1,0 +1,135 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The command envelope's routing fields must be identifiers, not key expressions.
+
+``Mesh._exec_cmd`` answers a command on
+``strands/{sender_id}/response/{responder}/{turn_id}``, where ``sender_id`` and
+``turn_id`` are read straight off the wire. Zenoh accepts a wildcard on a ``put``
+and routes it by intersection, so a ``sender_id`` of ``**`` produces a key that
+every peer's ``strands/{peer}/response/**`` subscription matches: the response,
+which carries this robot's dispatch result, goes to the whole fleet instead of to
+the peer that asked.
+
+``validate_command`` guards a ``turn_id`` / ``sender_id`` found inside the
+*command* dict (see ``test_security_control_char_gates.py``), but routing reads
+the envelope's own copy. These cells pin the envelope pair, and the companion
+file ``test_response_topic_scope.py`` pins the shape of the key they build.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh.core import Mesh
+from strands_robots.mesh.security import MAX_PEER_ID_LEN
+
+#: Envelope values that must never reach a key expression. Wildcards widen the
+#: routing; ``/`` adds segments; whitespace, control bytes and a non-string are
+#: refused by the same identifier rule the teleop seams already use.
+UNROUTABLE = [
+    pytest.param("**", id="zenoh-recursive-wildcard"),
+    pytest.param("*", id="zenoh-single-wildcard"),
+    pytest.param("op/extra", id="extra-key-segment"),
+    pytest.param("op id", id="whitespace"),
+    pytest.param("op\nid", id="line-break"),
+    pytest.param("x" * (MAX_PEER_ID_LEN + 1), id="over-length"),
+    pytest.param(7, id="non-string"),
+]
+
+
+class _Robot:
+    """Records whether dispatch reached the robot at all.
+
+    ``get_task_status`` is the first branch ``Mesh._dispatch`` takes for the
+    ``status`` action, so the counter answers "did the command execute", and its
+    return value is the operator-visible state a leaked response would carry.
+    """
+
+    def __init__(self) -> None:
+        self.status_calls = 0
+
+    def get_observation(self) -> dict[str, Any]:
+        return {}
+
+    def get_task_status(self) -> dict[str, Any]:
+        self.status_calls += 1
+        return {"status": "idle", "battery": 41}
+
+
+def _mesh() -> tuple[Mesh, _Robot, list[tuple[str, dict]]]:
+    robot = _Robot()
+    mesh = Mesh(robot, peer_id="robot-a")
+    puts: list[tuple[str, dict]] = []
+    mesh.publish = lambda key, payload, **kw: puts.append((key, payload))  # type: ignore[method-assign]
+    return mesh, robot, puts
+
+
+@pytest.mark.parametrize("sender", UNROUTABLE)
+def test_unroutable_sender_is_refused_before_it_can_address_a_response(sender: object) -> None:
+    mesh, robot, puts = _mesh()
+    mesh._exec_cmd({"sender_id": sender, "turn_id": "t1", "command": {"action": "status"}})
+    assert puts == [], puts
+    assert robot.status_calls == 0
+
+
+@pytest.mark.parametrize("turn", UNROUTABLE)
+def test_unroutable_turn_id_is_refused_before_it_can_address_a_response(turn: object) -> None:
+    mesh, robot, puts = _mesh()
+    mesh._exec_cmd({"sender_id": "operator-1", "turn_id": turn, "command": {"action": "status"}})
+    assert puts == [], puts
+    assert robot.status_calls == 0
+
+
+def test_a_valid_envelope_still_answers_the_one_peer_that_asked() -> None:
+    mesh, robot, puts = _mesh()
+    mesh._exec_cmd({"sender_id": "operator-1", "turn_id": "turn-xyz", "command": {"action": "status"}})
+    assert [k for k, _ in puts] == ["strands/operator-1/response/robot-a/turn-xyz"], puts
+    assert robot.status_calls == 1
+
+
+def test_an_absent_sender_still_dispatches_without_a_response() -> None:
+    """The documented fire-and-forget shape: no route asked for, none built."""
+    mesh, robot, puts = _mesh()
+    mesh._exec_cmd({"sender_id": "", "command": {"action": "status"}})
+    assert puts == [], puts
+    assert robot.status_calls == 1
+
+
+def test_an_absent_turn_id_still_routes_on_the_generated_one() -> None:
+    mesh, robot, puts = _mesh()
+    mesh._exec_cmd({"sender_id": "operator-1", "command": {"action": "status"}})
+    assert len(puts) == 1, puts
+    key = puts[0][0]
+    assert key.startswith("strands/operator-1/response/robot-a/")
+    assert robot.status_calls == 1
+
+
+def test_the_refusal_names_the_field_without_putting_wire_bytes_on_the_log_line(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refusal is auditable, and cannot itself forge a second log record."""
+    events: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        "strands_robots.mesh.core.log_safety_event",
+        lambda event, peer, payload: events.append((event, peer, payload)),
+    )
+    mesh, _robot, puts = _mesh()
+    forging = "victim\n2026-01-01 00:00:00 CRITICAL mesh: estop cleared by operator"
+    with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+        mesh._exec_cmd({"sender_id": forging, "turn_id": "t1", "command": {"action": "status"}})
+
+    assert puts == [], puts
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, caplog.records
+    assert all("\n" not in m and "\r" not in m for m in warnings), warnings
+    assert any("sender_id" in m for m in warnings), warnings
+
+    assert [e[0] for e in events] == ["command_rejected"], events
+    payload = events[0][2]
+    assert payload["field"] == "sender_id"
+    assert payload["sender"] is None  # the offending value is not echoed as an identity
+    assert len(payload["value"]) <= MAX_PEER_ID_LEN
+    assert "\n" not in payload["value"]  # repr, so a structured reader sees the shape safely


### PR DESCRIPTION
## A reply key is a Zenoh key expression, and it is built from the request envelope

![response fan-out, measured](https://raw.githubusercontent.com/cagataycali/robots/assets/mesh-command-envelope-routing-identifiers/response_fanout.png)

`Mesh` answers a command on `strands/{sender_id}/response/{responder}/{turn_id}`,
where `sender_id` and `turn_id` come straight off the wire. Zenoh accepts a
wildcard on a `put` and routes it by **intersection**, so `sender_id="**"` yields
a key that every peer's `strands/{peer}/response/**` subscription matches.

Measured with two live Zenoh sessions over a TCP link, driving the real
`Mesh._exec_cmd` on each tree (`action: "status"`, so no lockout, no replay dedup
and no authorization step is involved):

| envelope `sender_id` | published key | peers that received the reply |
|---|---|---|
| `alice` (control) | `strands/alice/response/bob/turn-7` | `['alice']` — both trees |
| `**` on `main` | `strands/**/response/bob/turn-7` | `['alice', 'carol']` |
| `**` with this PR | *nothing published* | `[]` |

`alice` and `carol` never sent the command. The reply body carries `_dispatch`'s
result — task status, battery, pose.

## The check existed; it was on the copy that does not route

| field | before | after |
|---|---|---|
| `command["sender_id"]` / `command["turn_id"]` | `validate_command`: str, ≤128, printable ASCII | unchanged |
| envelope `sender_id` / `turn_id` (**what routes**) | nothing | `validate_mesh_identifier` → `[A-Za-z0-9_.-]+`, ≤128 |

Printable ASCII is not enough for the routing pair: `*` and `/` are printable and
are exactly what widen a key. `validate_mesh_identifier` is the rule the teleop
seams already apply for this reason, and its docstring already documented the
subscribe direction of the hazard — this adds the publish direction and the third
interpolation site. `validate_command`'s docstring claimed *its* copies were the
ones `Mesh` correlates a turn and keys its replay cache on; corrected, since the
code reads the envelope.

An envelope that breaks the rule is refused whole — no dispatch, no publish, one
audit record. An **absent** `sender_id` is unchanged and still means
fire-and-forget (the command runs, no reply is published); an *invalid* one names
no peer this robot could answer.

The refusal cannot forge a log record either: the warning names the field and the
rule and never the rejected value, so a line break in it cannot split the record;
the audit record (JSON, structured) carries a bounded `repr` for forensics.

## Tests

`tests/mesh/test_command_envelope_routing_identifiers.py`, 18 cells, table-driven
over `**`, `*`, `op/extra`, whitespace, a line break, over-length and a
non-string, for each of the two fields.

| tree | result |
|---|---|
| `upstream/main` | **15 failed**, 3 passed |
| this PR | **18 passed** |

The 3 that pass pre-fix are the controls — honest requester routed
point-to-point, absent `sender_id` dispatches without a reply, absent `turn_id`
routes on the generated one — so the refusals are new and nothing was narrowed.

## Gate

`ruff check` / `ruff format --check` clean · `mypy` 1.20.2 no new errors ·
`pytest tests/mesh` 4776 passed with a failing-id set identical to `upstream/main`
(0 attributable) · `pytest tests/ -k "mesh or envelope"` 6204 passed, same ·
`scripts/check_whole_tree_graders.py` 187 passed.

LOC: `+242 / −7` over 5 files — `+80 / −7` production+docs (48 additions are the
comment stating the measured hazard), `+135` test, `+27` changelog fragment.
