### PR TITLE
fix(mesh/security): the teleop slew bound is sized on recorded teleop, and full scale does not size a speed

### DIFF
--- a/changelog.d/2935-teleop-speed-axis-not-full-scale.md
+++ b/changelog.d/2935-teleop-speed-axis-not-full-scale.md
@@ -1,0 +1,27 @@
+### Changed: the teleop slew bound's margin is stated against recorded teleop, and reach's per-unit table is not reused on the speed axis
+
+`input_value_abs_by_key` bounds how far one teleop command may *reach* in the
+unit the receiving follower declares for each joint, because full scale is where
+reach stops being addressable - lerobot clamps a command past it. The open
+question was whether the *speed* bound, `DEFAULT_INPUT_SLEW_ABS`, should be
+keyed on the same declaration. Measured, it must not be.
+
+Full scale is not a speed. A frame-unit speed converts to servo travel through
+the joint's *calibrated* range, which on a `RANGE_0_100` gripper is unrelated to
+its full scale of 100. Granting speed the same multiple of full scale that reach
+gets would bound a percent gripper at 400 units/s - below the ~406 units/s that
+recorded leader-follower teleop actually commands - so the tighter number would
+be bought by refusing real motion on the one joint a hand traverses full scale
+fastest, while leaving the degree joints untouched.
+
+The bound's own justification was also reasoning from the wrong ceiling. A
+leader arm is back-driven by hand, so the Feetech STS3215 no-load speed
+(~372 deg/s in the unit the frames carry) is a floor on what a real stream
+contains, not a limit on it: across 176,293 recorded action frames the fastest
+single commanded step is ~899 deg/s, 2.4x that figure. The default is unchanged
+and still clears every one of those frames, but by 1.6x rather than the ~3.9x
+the datasheet reading suggests, which is what a future retune has to spend.
+
+No production behaviour changes. The measured margins, and the counterfactual
+per-unit row that would refuse a recorded gripper step, are pinned by tests -
+including at the receiver, where such a row would take effect.

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -191,12 +191,29 @@ def _input_value_abs() -> float:
 #: neither bounds the distance between consecutive commands for one joint, so a
 #: stream inside both caps can still command a full-scale reversal every frame.
 #: The default is the full :data:`MAX_INPUT_VALUE_ABS` envelope traversed once
-#: per second (2 * 720), which is roughly 4x the no-load speed of the Feetech
-#: STS3215 servos on an SO-100 class arm -- ~6.5 rad/s at 12 V, and those frames
-#: arrive in degrees, so ~372 deg/s. Sized against the unit the frames carry, a
-#: physical leader arm cannot reach the bound and only a synthetic stream trips
-#: it. Operators whose actuators use a smaller unit (radians, or normalized
-#: -1..1) can narrow it via ``STRANDS_MESH_INPUT_SLEW_ABS``.
+#: per second (2 * 720), in the unit the frames carry. Operators whose actuators
+#: use a smaller unit (radians, or normalized -1..1) can narrow it via
+#: ``STRANDS_MESH_INPUT_SLEW_ABS``.
+#:
+#: The margin is measured against recorded teleop rather than against the servo
+#: datasheet, because a leader arm is back-driven by hand: its own servos' no-load
+#: speed (~6.5 rad/s at 12 V for the Feetech STS3215 on an SO-100 class arm, so
+#: ~372 deg/s in the unit the frames carry) is a floor on what a real stream
+#: contains, not a ceiling. Across 176,293 action frames of SO-100/SO-101
+#: leader-follower teleop the fastest single commanded step is ~899 deg/s, 2.4x
+#: that figure. The bound clears every one of those frames, but by 1.6x rather
+#: than the ~3.9x the datasheet figure alone suggests, so a retune has less room
+#: than the datasheet reading implies.
+#:
+#: This axis is deliberately *not* bounded per declared unit the way reach is
+#: (:func:`input_value_abs_by_key`): full scale bounds reach because a command
+#: past it is unaddressable, but full scale is not a speed. A frame-unit speed
+#: converts to servo travel through the joint's *calibrated* range, which on a
+#: ``RANGE_0_100`` gripper is unrelated to its full scale of 100. Applying the
+#: reach rule to this axis would bound a percent gripper at 400 units/s, below
+#: the ~406 units/s that recorded teleop actually commands, so the per-unit row
+#: would refuse real frames on the one joint a hand can traverse full scale
+#: fastest -- a tighter number bought by refusing the motion it exists to carry.
 DEFAULT_INPUT_SLEW_ABS: float = 1440.0  # frame units/second (2 * 720)
 MAX_INPUT_SLEW_ABS: float = _env_pos_float("STRANDS_MESH_INPUT_SLEW_ABS", DEFAULT_INPUT_SLEW_ABS)
 
@@ -220,6 +237,9 @@ def _input_slew_abs() -> float:
 #: ``[-100, 100]`` / ``[0, 100]``), so a percent value past 100 is not a further
 #: reach - it is unaddressable. ``DEGREES`` is clamped in neither direction, and
 #: a full turn is the excursion the degree envelope has always been sized on.
+#:
+#: This table bounds *reach* only. It is not reused on the speed axis, for the
+#: reason recorded on :data:`DEFAULT_INPUT_SLEW_ABS`.
 INPUT_FULL_SCALE_BY_NORM_MODE: dict[str, float] = {
     "DEGREES": 360.0,
     "RANGE_M100_100": 100.0,

--- a/tests/mesh/test_input_envelope_units.py
+++ b/tests/mesh/test_input_envelope_units.py
@@ -24,6 +24,11 @@ full turns of reach, that envelope traversed once per second, comfortably above
 the leader's own servos) is asserted against the unit the frames carry, so a
 future retune must keep the relation rather than silently re-enter the mismatch.
 
+The datasheet is a floor on what a real stream contains, not a ceiling: a leader
+arm is back-driven by hand, so it outruns its own servos' no-load speed. The last
+class states the margin against recorded teleop instead, and why the per-joint
+reach table below is not reused on that axis.
+
 One frame carries more than one unit, which is the other half: the same arm that
 streams degrees for its five arm joints streams 0-100 percent for its gripper, so
 a single scalar bound has to be loose enough for the widest joint and is 7.2x full
@@ -64,6 +69,21 @@ STS3215_NO_LOAD_DEG_S = STS3215_NO_LOAD_RAD_S * 180.0 / math.pi  # ~372 deg/s
 
 #: A 50 Hz frame period - the rate ``InputPublisher`` streams at by default.
 FRAME_S = 1.0 / 50.0
+
+#: The fastest single step recorded teleop commands, per unit, in the unit that
+#: joint's frames carry: ``max |a[t+1] - a[t]| * fps`` within an episode, over
+#: 176,293 action frames / 295 episodes of SO-100 and SO-101 leader-follower
+#: teleop (``lerobot/svla_so100_pickplace``, ``lerobot/svla_so101_pickplace``,
+#: ``HashtagRobotics/tic-tac-toe-so101-block-a-clean-v1``). The degree figure is
+#: 2.4x :data:`STS3215_NO_LOAD_DEG_S`, which is what makes the datasheet a floor
+#: on a hand-driven stream rather than a ceiling.
+TELEOP_FASTEST_DEGREE_STEP = 899.3  # shoulder_lift, deg/s
+TELEOP_FASTEST_PERCENT_STEP = 405.7  # gripper, percent/s
+
+#: The largest magnitude those same frames command, per unit - the reach axis's
+#: counterpart to the two speeds above, measured the same way (``max |a[t]|``).
+TELEOP_FARTHEST_DEGREE_REACH = 137.8  # wrist_roll, deg
+TELEOP_FARTHEST_PERCENT_REACH = 46.7  # gripper, percent
 
 #: What a shipped SO-100 class arm declares, motor by motor. Restated here so
 #: the per-joint cells run with lerobot absent;
@@ -163,6 +183,95 @@ class TestAPhysicalLeaderAtFullSpeedIsNotRefused:
         assert reason is None, f"half the servo limit was refused: {reason}"
 
 
+class TestTheSpeedAxisIsSizedOnRecordedTeleop:
+    """What the bound clears, and why full scale does not size it.
+
+    Reach and speed are different axes on the same frame.
+    :func:`~strands_robots.mesh.security.input_value_abs_by_key` bounds reach per
+    declared unit because full scale is where reach stops being addressable -
+    lerobot clamps a command past it. A speed has no such ceiling in full scale:
+    a frame-unit speed converts to servo travel through the joint's *calibrated*
+    range, so the same rule applied here lands under real motion on the narrowest
+    unit. The slew bound therefore stays scalar, sized on what recorded teleop
+    commands.
+    """
+
+    @staticmethod
+    def _verdict(key: str, speed: float, max_slew: float | None = None) -> str | None:
+        """Whether one joint moving at *speed* frame units/second is refused."""
+        return input_frame_slew_violation({key: speed * FRAME_S}, _baseline({key: 0.0}), FRAME_S, FRAME_S, max_slew)
+
+    def test_a_hand_driven_leader_outruns_its_own_servo_datasheet(self):
+        """The premise the measured constants exist for."""
+        assert TELEOP_FASTEST_DEGREE_STEP > STS3215_NO_LOAD_DEG_S
+        assert TELEOP_FASTEST_DEGREE_STEP / STS3215_NO_LOAD_DEG_S == pytest.approx(2.4, abs=0.1)
+
+    @pytest.mark.parametrize(
+        ("key", "speed"),
+        [
+            ("shoulder_lift.pos", TELEOP_FASTEST_DEGREE_STEP),
+            ("gripper.pos", TELEOP_FASTEST_PERCENT_STEP),
+        ],
+    )
+    def test_the_bound_admits_the_fastest_recorded_step_in_every_unit(self, key, speed):
+        assert self._verdict(key, speed) is None, "recorded teleop was refused"
+
+    def test_the_real_margin_is_smaller_than_the_datasheet_reading(self):
+        """1.6x, not 3.9x - what a retune of the default actually has to spend."""
+        assert DEFAULT_INPUT_SLEW_ABS / TELEOP_FASTEST_DEGREE_STEP == pytest.approx(1.6, abs=0.1)
+
+    def test_the_reach_rule_applied_to_speed_would_refuse_recorded_teleop(self):
+        """Why :data:`INPUT_FULL_SCALE_BY_NORM_MODE` is not reused on this axis.
+
+        Reach grants each unit the same multiple of its own full scale. Granting
+        speed the same way gives a percent gripper 400 units/s - under the ~406
+        it is actually commanded at - while leaving the degree joints untouched,
+        so the tighter number is bought by refusing the motion the bound exists
+        to carry, on the one joint a hand traverses full scale fastest.
+        """
+        slew_per_reach = DEFAULT_INPUT_SLEW_ABS / DEFAULT_INPUT_VALUE_ABS
+        reach = input_value_abs_by_key(SO_ARM_NORM_MODES)
+        percent_row = reach["gripper.pos"] * slew_per_reach
+        degree_row = reach["shoulder_lift.pos"] * slew_per_reach
+
+        assert degree_row == pytest.approx(DEFAULT_INPUT_SLEW_ABS), "the degree joints see no change"
+        assert percent_row < TELEOP_FASTEST_PERCENT_STEP, "premise: the row lands under real motion"
+        assert self._verdict("gripper.pos", TELEOP_FASTEST_PERCENT_STEP, percent_row) is not None
+        assert self._verdict("gripper.pos", TELEOP_FASTEST_PERCENT_STEP) is None
+
+    def test_the_receiver_applies_a_percent_gripper_at_the_fastest_recorded_speed(self, monkeypatch):
+        """End to end, on a follower that declares the percent unit.
+
+        This is the cell a per-unit speed row turns red: the receiver reads the
+        gripper's declared unit for reach already, so a row keyed on that same
+        declaration would refuse the second frame here.
+
+        With the apply-rate cap off the interval charged to a move is the nominal
+        publish period, so two back-to-back frames are exactly one 50 Hz frame
+        apart in the bound's terms rather than microseconds apart.
+        """
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "0")
+        recv, applied = _receiver(SO_ARM_NORM_MODES)
+        step = TELEOP_FASTEST_PERCENT_STEP * FRAME_S
+        _send(recv, {"gripper.pos": 0.0})
+        _send(recv, {"gripper.pos": step})
+        assert applied == [{"gripper.pos": 0.0}, {"gripper.pos": step}]
+        assert recv.stats["slew_rejected"] == 0
+
+    @pytest.mark.parametrize(
+        ("key", "reach"),
+        [
+            ("wrist_roll.pos", TELEOP_FARTHEST_DEGREE_REACH),
+            ("gripper.pos", TELEOP_FARTHEST_PERCENT_REACH),
+        ],
+    )
+    def test_the_per_joint_reach_bound_admits_every_recorded_magnitude(self, key, reach):
+        """The axis that *is* bounded per unit still clears the same frames."""
+        bounds = input_value_abs_by_key(SO_ARM_NORM_MODES)
+        assert validate_input_frame({key: reach}, bounds) == {key: reach}
+        assert bounds[key] / reach > 3.0, "and not marginally"
+
+
 class TestTheEncodedPolicyIsStatedInTheFrameUnit:
     def test_reach_is_two_full_turns(self):
         assert DEFAULT_INPUT_VALUE_ABS == pytest.approx(2 * FULL_TURN_DEG)
@@ -173,7 +282,9 @@ class TestTheEncodedPolicyIsStatedInTheFrameUnit:
 
     def test_slew_clears_the_leader_servo_speed_in_the_frame_unit(self):
         assert DEFAULT_INPUT_SLEW_ABS > STS3215_NO_LOAD_DEG_S
-        # The docstring's own margin: "roughly 4x the no-load speed".
+        # ~3.9x the datasheet speed. That ratio is not the margin against a real
+        # stream, which a hand outruns; TestTheSpeedAxisIsSizedOnRecordedTeleop
+        # pins the measured one.
         assert DEFAULT_INPUT_SLEW_ABS / STS3215_NO_LOAD_DEG_S == pytest.approx(3.87, abs=0.1)
 
 
@@ -291,55 +402,58 @@ class TestEachJointIsBoundedInItsOwnDeclaredUnit:
         assert "lerobot" not in imported
 
 
+def _receiver(norm_modes):
+    """A receiver whose follower declares *norm_modes*, and the frames it applies."""
+
+    class _Bus:
+        motors = {name: SimpleNamespace(norm_mode=mode) for name, mode in norm_modes.items()}
+
+        def sync_read(self, *a, **k):  # what makes this the joint-read source
+            return {}
+
+    applied: list[dict] = []
+    recv = InputReceiver(
+        mesh=SimpleNamespace(
+            peer_id="follower-1",
+            subscribe=lambda *a, **k: "sub",
+            unsubscribe=lambda *a, **k: None,
+        ),
+        robot=SimpleNamespace(bus=_Bus()),
+        source_peer_id="leader-1",
+        apply_fn=lambda robot, action: applied.append(action),
+    )
+    recv._running = True
+    return recv, applied
+
+
+def _send(recv, frame, **extra):
+    recv._on_input(recv.topic, {"action": frame, "seq": 0, "t": time.time(), **extra})
+
+
 class TestTheUnitComesFromTheReceiverNotTheFrame:
     """The bound that constrains a sender must not be chosen by that sender."""
 
-    @staticmethod
-    def _receiver(norm_modes):
-        class _Bus:
-            motors = {name: SimpleNamespace(norm_mode=mode) for name, mode in norm_modes.items()}
-
-            def sync_read(self, *a, **k):  # what makes this the joint-read source
-                return {}
-
-        applied: list[dict] = []
-        recv = InputReceiver(
-            mesh=SimpleNamespace(
-                peer_id="follower-1",
-                subscribe=lambda *a, **k: "sub",
-                unsubscribe=lambda *a, **k: None,
-            ),
-            robot=SimpleNamespace(bus=_Bus()),
-            source_peer_id="leader-1",
-            apply_fn=lambda robot, action: applied.append(action),
-        )
-        recv._running = True
-        return recv, applied
-
-    def _send(self, recv, frame, **extra):
-        recv._on_input(recv.topic, {"action": frame, "seq": 0, "t": time.time(), **extra})
-
     def test_the_follower_declaration_decides_the_verdict(self):
         """One frame, two followers: the percent gripper is the one refused."""
-        percent, applied_percent = self._receiver(SO_ARM_NORM_MODES)
-        self._send(percent, {"gripper.pos": 300.0})
+        percent, applied_percent = _receiver(SO_ARM_NORM_MODES)
+        _send(percent, {"gripper.pos": 300.0})
         assert applied_percent == []
         assert percent._rejected == 1
 
-        degrees, applied_degrees = self._receiver({"gripper": "DEGREES"})
-        self._send(degrees, {"gripper.pos": 300.0})
+        degrees, applied_degrees = _receiver({"gripper": "DEGREES"})
+        _send(degrees, {"gripper.pos": 300.0})
         assert applied_degrees == [{"gripper.pos": 300.0}]
 
     def test_a_unit_claimed_by_the_frame_cannot_widen_the_bound(self):
         """A sender-supplied declaration is not consulted, so it changes nothing."""
-        recv, applied = self._receiver(SO_ARM_NORM_MODES)
-        self._send(recv, {"gripper.pos": 300.0}, norm_modes={"gripper": "DEGREES"}, unit="deg")
+        recv, applied = _receiver(SO_ARM_NORM_MODES)
+        _send(recv, {"gripper.pos": 300.0}, norm_modes={"gripper": "DEGREES"}, unit="deg")
         assert applied == []
         assert recv._rejected == 1
 
     def test_a_robot_that_declares_nothing_keeps_the_scalar_envelope(self):
         """No bus to read is "no per-joint knowledge", not a refusal."""
-        recv, applied = self._receiver({})
-        self._send(recv, {"gripper.pos": 300.0})
+        recv, applied = _receiver({})
+        _send(recv, {"gripper.pos": 300.0})
         assert applied == [{"gripper.pos": 300.0}]
         assert recv._value_abs_by_key == {}

--- a/tests/mesh/test_input_slew_bound.py
+++ b/tests/mesh/test_input_slew_bound.py
@@ -52,8 +52,11 @@ FRAME_S = 1.0 / mesh_input.INPUT_HZ_DEFAULT
 FRAME_UNITS_PER_RADIAN = 180.0 / math.pi
 
 #: Feetech STS3215 no-load speed at 12 V is ~6.5 rad/s, so a leader arm on an
-#: SO-100 class follower cannot travel more than this in one 50 Hz frame. Any
-#: bound that refuses it would refuse legitimate teleoperation.
+#: SO-100 class follower travels at least this far in one 50 Hz frame, and any
+#: bound that refuses it would refuse legitimate teleoperation. It is a floor,
+#: not a ceiling - the leader is back-driven by hand, and recorded teleop reaches
+#: 2.4x it (``TestTheSpeedAxisIsSizedOnRecordedTeleop`` in
+#: ``tests/mesh/test_input_envelope_units.py``).
 LEADER_MAX_STEP = 6.5 * FRAME_UNITS_PER_RADIAN * FRAME_S
 
 


### PR DESCRIPTION
## The open question, and what settles it

`input_value_abs_by_key` bounds how far one teleop command may **reach** in the unit each joint declares (#3066). The half left open in #2935 was whether the **speed** bound, `DEFAULT_INPUT_SLEW_ABS`, should be keyed on that same declaration. Measured against recorded teleop, it must not be - and the bound's own justification was reasoning from the wrong ceiling.

![recorded teleop, both axes](https://raw.githubusercontent.com/cagataycali/robots/assets/teleop-speed-axis-recorded-teleop/teleop_axes.png)

176,293 action frames / 295 episodes of SO-100 and SO-101 leader-follower teleop (`lerobot/svla_so100_pickplace`, `lerobot/svla_so101_pickplace`, `HashtagRobotics/tic-tac-toe-so101-block-a-clean-v1`), scored as `max |a[t+1] - a[t]| * fps` within an episode.

## Full scale is not a speed

Reach is bounded per unit because full scale is where reach stops being addressable - lerobot's `_unnormalize` clamps a percent command into `[0, 100]` on the way out, so 101 is not a further reach. A speed has no such ceiling in full scale. `_unnormalize` converts a percent command through the joint's **calibrated** range (`(val / 100) * (range_max - range_min) + range_min`), not its full scale of 100, while a `DEGREES` command converts through a fixed `max_res / 360`. So the same frame-unit number means a different amount of servo travel per second on the two units.

Granting speed the same multiple of full scale that reach gets:

| declared unit | reach bound in force | reach rule applied to speed | fastest recorded step | verdict |
|---|---|---|---|---|
| `DEGREES` | 720 | 1440 u/s (unchanged) | 899.3 deg/s | admitted, 1.60x |
| `RANGE_0_100` | 200 | **400 u/s** | **405.7 u/s** | **refused** |

The tighter number is bought by refusing real motion, on the one joint a hand traverses full scale fastest, while the degree joints see no change at all. The bound stays scalar.

## The margin was quoted off the datasheet

The comment sized the default at "roughly 4x the no-load speed of the Feetech STS3215" and concluded "a physical leader arm cannot reach the bound". A leader arm is back-driven **by hand**, so its own servos' no-load speed (~372 deg/s in the unit the frames carry) is a floor on what a real stream contains, not a limit on it: the fastest recorded step is 899.3 deg/s, **2.4x** that figure. The default is unchanged and still clears every recorded frame, but by **1.60x**, not ~3.9x - which is what a future retune actually has to spend. The reach axis is confirmed healthy in the same pass: 0 of 176,293 frames refused, min headroom 4.3x (right panel).

## Proof

No production behaviour changes, so the pin is graded by implementing the change this PR refuses - a per-declared-unit speed row mirroring the reach rule, wired at the receiver:

| tree | result |
|---|---|
| as shipped | **89 passed** |
| with the per-unit speed row | **1 failed, 88 passed** - `TestTheSpeedAxisIsSizedOnRecordedTeleop::test_the_receiver_applies_a_percent_gripper_at_the_fastest_recorded_speed`, the receiver dropping a frame at the fastest recorded gripper speed |

The 88 green cells are the controls: every degree-joint cell is untouched by the row, which is the asymmetry itself. `LEADER_MAX_STEP`'s comment in `test_input_slew_bound.py` claimed the datasheet speed was a ceiling; it is corrected to a floor, and the magnitude it guards is unchanged.

## Gate

`ruff check` clean, `ruff format` clean (254 files), mypy at the pinned version 20 errors == 20 on `main` (0 attributable), `tests/mesh` 45 failing ids == 45 on a pristine `main` worktree (0 attributable; `awsiot` absent locally), whole-tree graders 187 passed, changelog fragment gate and `assemble_changelog.py --check` OK.

LOC delta +206 / -42 across 4 files; the only production change is 26 added / 6 removed lines of comment on `strands_robots/mesh/security.py`.

Closes #2935.
