### PR TITLE
docs(AGENTS.md): a qualified role must not name a module that lives in an open PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ pip install -e ".[all,dev]"
 # Run tests
 hatch run test              # unit tests
 hatch run test-integ        # integration tests (needs GPU + model weights)
+hatch run whole-tree-check  # the graders whose input is the rest of the repo
 
 # Lint & format
 hatch run lint              # ruff check, ruff format --check, mypy
@@ -363,7 +364,14 @@ hatch run format            # ruff check --fix, ruff format
    why it belongs here and `--issue` belongs above. It still arrives early enough
    to matter - both claim-free pairs opened inside the same ~35-minute window every
    other observed collision shares, 14m 41s and 29m 26s apart.
-2. Make changes, run `hatch run format && hatch run lint && hatch run test`
+2. Make changes, run `hatch run format && hatch run lint && hatch run test`.
+   If you narrow the test run to the area you changed (`pytest tests/drivers/ -k g1`),
+   run `hatch run whole-tree-check` alongside it. A handful of graders take the
+   *rest of the repository* as their input rather than the file under change, so
+   no path or `-k` filter over your own area collects them - and a green narrow
+   run reads in a PR description exactly like a green full one. Two consecutive
+   verb ports cited such a run and both landed with the required check red on the
+   same grader (#2934, #2938, per #2940).
 3. Record the change as a news fragment: `changelog.d/<pr-number>-<slug>.md`
    (see [`changelog.d/README.md`](changelog.d/README.md)). **Never append to
    `## [Unreleased]` in `CHANGELOG.md` directly** - every branch inserts at the
@@ -2074,6 +2082,7 @@ which side the enum is on.
 - **`robot.py` is for the `Robot()` factory**, the user-facing entry point. Hardware-specific code lives in `hardware_robot.py`. Don't have two files both named "robot something" with different responsibilities.
 - **Reference module names, not filenames, in docstrings** - `strands_robots.hardware_robot` not `robot.py`. Filenames change; module paths are the public contract.
 - **Keep a cross-reference target on one line** - a `:class:`/`:func:`/`:meth:` path is only a dotted path while it is contiguous. Wrapping `:class:`~strands_robots.policies.protomotions.motion_utils.MotionPlayer`` over a line break leaves a token carrying a newline and the next line's indentation, which imports nowhere. Break the prose before the role and give the path its own line.
+- **Do not point a qualified role at a module that lives in an open PR** - in a series that adds one sibling module per PR, the target exists in the author's mental model of the series and not in the branch's tree, so the role looks correct while it is being written and is dead on arrival. Write the sibling as a literal (``g1_motion_gates``, ``EarthRoverDriver``) and add the role in the PR that lands the target, or in a later one. Landing the sibling first is not a remedy: CI checks out the pull request head rather than the merge ref (PR Workflow step 8), so the branch stays red until it also absorbs `main` - which costs a re-approval round and imposes a landing order on PRs that are otherwise independent. Demoting to a literal has been the resolution every time it has come up (#2934 and #2938, both naming a module in a still-open sibling; #3084, naming a driver class from #3081). Graded by `tests/test_docstring_xref_roles_resolve.py`, which is one of the graders a narrowed selector cannot collect - see PR Workflow step 2.
 - **A cross-reference in a test docstring is graded too** - the roles in `tests/` and `tests_integ/` are checked against the real API alongside the package's, because a test module's docstring is where a maintainer working on that subsystem starts reading. Name the seam a fixture actually patches (`strands_robots.mesh.core.get_session`), not a local import alias dressed up as a module path.
 
 ### Unicode & String Hygiene

--- a/changelog.d/3087-agents-inflight-sibling-xref-rule.md
+++ b/changelog.d/3087-agents-inflight-sibling-xref-rule.md
@@ -1,0 +1,18 @@
+### Changed
+
+- **Contributing**: `AGENTS.md` now names `hatch run whole-tree-check` in the
+  pre-push instructions, and the cross-reference conventions gained the rule for
+  a qualified role naming a sibling module that lives in a still-open PR: write
+  it as a literal until the target lands. Both halves close issue #2940. The
+  preflight script it points at already existed; the document a contributor reads
+  before pushing did not name it, so an author who narrowed the test run to the
+  area they changed had nothing pointing at the class of grader that narrowing
+  structurally cannot collect - and a green narrow run reads in a pull request
+  description exactly like a green full one. Landing the sibling first is not an
+  alternative remedy: the required check reads the pull request head rather than
+  the merge ref, so the branch stays red until it also absorbs `main`, which
+  costs a re-approval round and imposes a landing order on pull requests that
+  are otherwise independent. `tests/test_whole_tree_graders_roster_is_complete.py`
+  reads the hatch script's name out of `pyproject.toml` and requires `AGENTS.md`
+  to name it, so renaming the script fails that pin rather than leaving the
+  document pointing at a command that no longer exists. No source change.

--- a/tests/test_whole_tree_graders_roster_is_complete.py
+++ b/tests/test_whole_tree_graders_roster_is_complete.py
@@ -35,11 +35,20 @@ one line, this test's ``_ROSTERED_BY_ISSUE_2940`` set stays unchanged (its
 role is to pin the issue's roster, not to enumerate every future one), and
 ``scripts/check_whole_tree_graders.py``'s module docstring's list of graders
 grows alongside.
+
+A roster only helps a caller who knows to run it. Issue #2940's failure mode
+was a *green* narrow run, so the remedy is only reachable if the pre-push
+instructions a contributor reads name the command - which is why
+``test_agents_md_names_the_preflight_command`` reads the command's name out of
+``pyproject.toml`` and requires ``AGENTS.md`` to name it. Renaming the hatch
+script then fails here rather than leaving the document pointing at a command
+that no longer exists.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import tomllib
 from pathlib import Path
 
 _TESTS_ROOT = Path(__file__).resolve().parent
@@ -139,4 +148,52 @@ def test_script_has_no_arguments_beyond_the_program_name() -> None:
         "check_whole_tree_graders.py accepted an argument other than its "
         "program name. The roster is meant to be fixed; a caller-composed "
         "input set defeats the point of the preflight script."
+    )
+
+
+def _preflight_hatch_script_name() -> str:
+    """The hatch script name that runs the preflight, read from ``pyproject.toml``.
+
+    Derived rather than repeated so this pin grades the document against the
+    command that exists, not against a string a previous edit happened to
+    write down.
+    """
+    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    envs = pyproject.get("tool", {}).get("hatch", {}).get("envs", {})
+    script_path = _SCRIPT_PATH.relative_to(_REPO_ROOT).as_posix()
+    names = sorted(
+        {
+            name
+            for env in envs.values()
+            for name, command in (env.get("scripts") or {}).items()
+            if script_path in (command if isinstance(command, str) else " ".join(command))
+        }
+    )
+    assert len(names) == 1, (
+        f"expected exactly one hatch script to invoke {script_path!r}, found {names}. "
+        "This pin derives the documented command from pyproject.toml; with zero or "
+        "several it cannot say which name AGENTS.md should carry."
+    )
+    return names[0]
+
+
+def test_agents_md_names_the_preflight_command() -> None:
+    """The pre-push instructions name the command that runs these graders.
+
+    The graders in the roster are the ones a diff-scoped selector structurally
+    cannot collect, so an author who narrows the run to the area they changed
+    gets a green result that reads exactly like a green full run - the failure
+    mode issue #2940 documents, observed three times. A preflight command that
+    exists but is unnamed in the document a contributor reads before pushing
+    does not close it.
+    """
+    command = f"hatch run {_preflight_hatch_script_name()}"
+    agents_md = _REPO_ROOT / "AGENTS.md"
+    assert agents_md.is_file(), f"pin cannot locate {agents_md}"
+    assert command in agents_md.read_text(encoding="utf-8"), (
+        f"AGENTS.md does not name {command!r}. The roster in "
+        f"{_SCRIPT_PATH.relative_to(_REPO_ROOT).as_posix()} only helps a caller who "
+        "knows to run it, and the graders it collects are exactly the ones a "
+        "path-or-keyword selector over the changed area does not. Name it in the "
+        "pre-push instructions, or rename the hatch script and update both."
     )


### PR DESCRIPTION
## Problem

Issue #2940 documents a failure mode with two halves. **The first half shipped**: `scripts/check_whole_tree_graders.py` collects the graders whose input is the *rest of the repository* rather than the file under change, under `hatch run whole-tree-check`.

**The second half - the convention - was never written down.** The issue says so explicitly, and says why it was deferred:

> The AGENTS.md edit this implies is not filed yet on purpose: #2937 already carries an AGENTS.md change, and a second open PR touching the same file would create the merge-order coupling this issue is partly about.

#2937 merged on 2026-08-29. The coupling is clear: no open pull request touches `AGENTS.md`, `scripts/check_whole_tree_graders.py`, or the roster pin.

Meanwhile the class has now cost a third pull request:

| PR | dead pointer | target lived in | required check |
|---|---|---|---|
| #2934 | two `:mod:` + one `:func:` naming `tools.g1.g1_motion_gates` | then-open #2933 | red |
| #2938 | four qualified roles naming `tools.g1.g1_state` | then-open #2934 | red |
| **#3084** | `:class:` naming `drivers.earthrover.EarthRoverDriver` | **still-open #3081** | red |

All three were found by the grader or a reviewer, not the author, and all three were resolved the same way - by demoting the role to a literal. #3084 took that remedy in `ffba45e8f` while this pull request was being written, independently and for the third time, which is the argument for the rule being readable up front rather than rediscovered in review.

## Two gaps, measured on `main`

**1. `AGENTS.md` never named the preflight command.** The hatch script is declared (`pyproject.toml:777`) and the document does not mention it:

```
$ grep -c "whole-tree-check" pyproject.toml AGENTS.md
pyproject.toml:1
AGENTS.md:0
```

PR Workflow step 2 named only `format && lint && test`, so an author who narrowed the run to their own area - the cited command in both prior cases was `pytest tests/drivers/ -k g1` - had nothing pointing at the graders that narrowing structurally cannot collect. A green narrow run reads in a description exactly like a green full one.

**2. The cross-reference conventions had no bullet for the in-flight sibling.** The two neighbouring bullets cover a wrapped path and a role in a test docstring; neither covers a role whose target is in a sibling pull request, which is where a per-PR verb series naturally points.

Landing the sibling first is not an alternative remedy. The required check reads `pull_request.head.sha`, not the merge ref, so the branch stays red until it also absorbs `main` - which costs a re-approval round under `require_last_push_approval` and imposes a landing order on pull requests that are otherwise independent.

## Change

`AGENTS.md`, three edits: the command list gains `hatch run whole-tree-check`; PR Workflow step 2 says to run it alongside a narrowed selector and why; the cross-reference conventions gain the in-flight-sibling rule beside the two existing bullets.

The pin lands in `tests/test_whole_tree_graders_roster_is_complete.py` rather than a new file - that module already owns "the roster and the tree cannot drift", and this is the same drift one step out. It derives the command name from `pyproject.toml` instead of repeating it.

## Grading

Pre-fix / post-fix, with `AGENTS.md` at `b5aa45ed7`:

| tree | result |
|---|---|
| `AGENTS.md` from `upstream/main` | **1 failed**, 4 passed |
| this branch | 5 passed |

The 4 passing pre-fix are the module's pre-existing cells, so nothing was weakened. The refusal names the command and the remedy:

```
AssertionError: AGENTS.md does not name 'hatch run whole-tree-check'. The roster in
scripts/check_whole_tree_graders.py only helps a caller who knows to run it, and the
graders it collects are exactly the ones a path-or-keyword selector over the changed
area does not. Name it in the pre-push instructions, or rename the hatch script and
update both.
```

Why the name is derived rather than written down - `b2` is the alternative this rules out:

| mutation | fires |
|---|---|
| `b0` control | 0 of 5 |
| `b1` hatch script renamed, document stale | **1** |
| `b2` same rename, but the pin hardcodes the string | **0 - blind** |
| `b3` hatch script deleted | **1**, naming the ambiguity |

`b1` vs `b2` is the point: a hardcoded string passes on exactly the drift the pin exists to catch. `b3` fires the non-vacuity assertion, so a pin that can no longer identify one command says so rather than silently grading nothing.

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` (CI scope) | clean, 1802 files |
| `mypy strands_robots tests tests_integ` | `Success: no issues found in 1799 source files` |
| `hatch run whole-tree-check` (dogfooded) | 188 passed, 1 skipped |
| every test reading `AGENTS.md` + `tests/test_docs*.py` (88 files) | 3152 passed, 2 skipped |
| changelog graders | 91 passed |

One flake in that sweep, `test_rendering_pacers_survive_a_clock_step[forward_30s]` ("premise: only 6 frames captured"): it counts wall-clock frames, reproduces in isolation under load, and passes on a pristine `upstream/main` worktree at the same commit. This branch changes one Markdown file and one test module, neither on that path.

LOC delta: **+85 / -1** across 3 files, no source change.

Closes #2940.
