### PR TITLE
fix(ci): report a docstring role naming a module the other side deletes

### DIFF
--- a/changelog.d/3090-overlap-role-naming-a-deleted-module.md
+++ b/changelog.d/3090-overlap-role-naming-a-deleted-module.md
@@ -1,0 +1,42 @@
+### Fixed: a docstring role naming a module the other side deletes is now a reported overlap
+
+`scripts/check_merge_base_overlap.py` read two relations, and both read a *change*: the paths a
+branch and its base both edited, and the dotted module names the branch's tests write as string
+literals. `main` went red at `8d0298345` through neither of them. #3037 removed 96 g1 lookup
+modules; eight verb pull requests that had already merged cited those modules in docstring roles
+(``:mod:`strands_robots.tools.g1.g1_fsm_targets```). #3037 branched before the verbs landed, so no
+tree held both the role and the deletion until the squash, where
+`tests/test_docstring_xref_roles_resolve.py` - which resolves every role in the tree - reported 44
+offending docstrings across 15 files.
+
+Neither existing relation could reach it. Replayed from the real commits, with the branch forked at
+#3055's merge base and the base advanced to the tip carrying the four verbs: the changed-path
+intersection is empty in both directions, git merges the two sides with no conflict, and the check
+reported `No overlap` and exited 0.
+
+There is now a third relation, over the same merge base and one further input: the qualified
+cross-reference roles in the docstrings of one tree, resolved through the same
+`named_module_paths` the literal relation uses, intersected with the module files the other side
+removes. Both directions are read, because either side can land last - the branch deletes and the
+base cites, or the branch cites and the base deletes. On that replay it now exits 1 and names 29
+`(citing file, target)` rows, which is exactly the set of distinct file-and-target pairs the grader
+reports on the merged tree.
+
+Each side is read from a tree rather than from a diff, because a role only counts inside a
+docstring and a hunk cannot be parsed for that - so a role in a comment or a runtime string is not
+a finding here, and the population is identical to the grader's. Only contiguous fully-qualified
+targets are resolved; a wrapped or short-form role has no decidable module path, and the grader
+reports both on their own account. The relation is quiet where it cannot matter: a removal nobody
+cites, a role nothing removes, and a citing file the branch itself changes - that last one because
+the branch's own tree holds both halves, so its own suite run already reports it. It costs nothing
+on a branch that removes no package module, which is most of them: an empty key set short-circuits
+before git is asked anything, and a `git grep` for the removed modules' dotted names narrows the
+parse to the candidate files.
+
+Unlike the path relation, this one is not cleared by merging the base alone. That merge produces
+precisely the tree the report is about - a role and no module - and the suite is red on it, so the
+role must be dropped or repointed too, which is what the report's remedy sentence asks for.
+
+The relation is absent from `--all-open`, which is named in the sweep's own limits paragraph: the
+sweep reads patches and no checkout, so it cannot tell whether a role sits in a docstring, and
+grading a different population than the gate would be worse than naming the gap.

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -170,6 +170,44 @@ What stays out of reach is unchanged, and is still the walk. A population
 resolved by ``rglob`` names nothing, so it shares neither a path nor a literal
 with the siblings it grades, and the report says so unconditionally.
 
+A role naming a module the composition deletes
+----------------------------------------------
+The two relations above both read a *change*. This one reads a **removal**, and
+it is the direction that put ``main`` red at ``8d0298345``. #3037 removed 96 g1
+lookup modules; eight verb pull requests, each already merged, carried docstring
+roles citing them (``:mod:`strands_robots.tools.g1.g1_fsm_targets```). #3037
+branched before those verbs landed, so no tree ever held both the role and the
+deletion until the squash, where
+``tests/test_docstring_xref_roles_resolve.py`` -- which resolves every role in
+the tree -- reported 44 offending docstrings. git merged the two sides without a
+conflict, and the path intersection was empty: the branch deletes files no verb
+touches, and the verbs cite them from files the branch does not open.
+
+A role is a coupling stated by name, like the literals above, so the same
+resolver serves it: ``named_module_paths`` turns a dotted target into the module
+files it needs, and a target is dead when one of them is deleted by the other
+side. Both directions are read, because either side can land last:
+
+- the branch deletes the module and the base cites it, read from the base tip;
+- the branch cites the module and the base deleted it, read from the branch head.
+
+Each side is read from the tree rather than from a diff, which is what keeps the
+population identical to the grader's: a role only counts when it sits in a
+docstring, and a hunk cannot be parsed for that. Only *contiguous fully-qualified*
+targets are resolved -- a wrapped or short-form role has no decidable module path
+here, and the grader reports both on their own account.
+
+Two restrictions keep this quiet where it cannot matter. A base-side role in a
+file the branch itself changes is skipped: the branch's own tree holds both
+halves, so its own run of the grader already sees it. A base-side deletion of a
+file the branch also changes is skipped for the stronger reason that git reports
+that one as a conflict.
+
+This relation is absent from ``--all-open`` because it cannot be computed there.
+The sweep reads patches and no checkout, and a patch hunk does not say whether
+its role is inside a docstring -- so the sweep would have to either guess or
+grade a different population than the gate. It names the gap instead.
+
 Prose is reported but does not block
 ------------------------------------
 An overlap confined to ``.md`` / ``.rst`` / ``.txt`` cannot change what the test
@@ -227,6 +265,7 @@ whatever it is wired to.
 from __future__ import annotations
 
 import argparse
+import ast
 import dataclasses
 import itertools
 import json
@@ -302,6 +341,20 @@ def changed_paths(start: str, end: str, repo: Path | None = None) -> frozenset[s
     check whose failure mode is a missed overlap.
     """
     output = _git("diff", "--name-only", "--no-renames", f"{start}..{end}", repo=repo)
+    return frozenset(line for line in output.splitlines() if line)
+
+
+def deleted_paths(start: str, end: str, repo: Path | None = None) -> frozenset[str]:
+    """Return the paths that exist at ``start`` and not at ``end``.
+
+    The input to the role relation, which is the one relation here that reads a
+    removal rather than a change. ``--no-renames`` for the reason
+    :func:`changed_paths` gives, and it matters more here: with rename detection a
+    module moved to a new path is not reported as deleted at all, while a role
+    citing its old dotted name is dead in the merged tree exactly as if it had
+    been removed.
+    """
+    output = _git("diff", "--name-only", "--no-renames", "--diff-filter=D", f"{start}..{end}", repo=repo)
     return frozenset(line for line in output.splitlines() if line)
 
 
@@ -446,6 +499,161 @@ def named_module_paths(names: Iterable[str]) -> frozenset[str]:
 def named_module_overlaps(literals: Iterable[str], paths: Iterable[str]) -> tuple[str, ...]:
     """Return the sorted module files named by ``literals`` and changed in ``paths``."""
     return tuple(sorted(named_module_paths(literals) & frozenset(paths)))
+
+
+#: Sphinx cross-reference roles that name a dotted Python target, restricted to a
+#: contiguous fully-qualified :data:`PACKAGE_ROOT` path. The grader this predicts
+#: (``tests/test_docstring_xref_roles_resolve.py``) deliberately admits any
+#: non-backtick character, so it can report a role whose long path wrapped over a
+#: line break; that role has no decidable module path, and reporting it here would
+#: name a file this branch may not have touched for a defect the grader already
+#: describes better. Short-form targets (``Cls.method``) are out for the same
+#: reason: their head resolves against the citing module, which is not a path.
+_DOCSTRING_ROLE = re.compile(
+    r":(?:mod|class|func|meth|attr|data|obj|exc):`~?(?P<target>" + PACKAGE_ROOT + r"(?:\.[A-Za-z_][A-Za-z0-9_]*)+)`"
+)
+
+
+def dotted_module_names(paths: Iterable[str]) -> frozenset[str]:
+    """Return the dotted names under which a set of deleted module files were imported.
+
+    The narrowing key for :func:`orphaned_roles`: a role can only be orphaned by a
+    deletion whose dotted name the citing file spells, so this turns the deleted
+    paths into the strings to search for. Non-package and non-module paths drop
+    out, because no role can name them.
+
+    Names shallower than :data:`MIN_NAMED_MODULE_SEGMENTS` drop out too. That is
+    the bare package root, which :func:`named_module_paths` cannot resolve either,
+    so it could never produce a finding -- and as a search key it matches every
+    citing file in the tree, which is the one input that would make this relation
+    expensive.
+    """
+    found: set[str] = set()
+    for path in paths:
+        if not path.endswith(".py") or not path.startswith(f"{PACKAGE_ROOT}/"):
+            continue
+        stem = path[: -len("/__init__.py")] if path.endswith("/__init__.py") else path[: -len(".py")]
+        name = stem.replace("/", ".")
+        if len(name.split(".")) >= MIN_NAMED_MODULE_SEGMENTS:
+            found.add(name)
+    return frozenset(found)
+
+
+def role_targets(source: str) -> frozenset[str]:
+    """Return the qualified role targets named by the docstrings in one module's source.
+
+    Docstrings only, which is the population the grader reads. A role in a comment
+    or in a runtime string is a dead pointer on its own account and is not what
+    makes the suite red, and this check exists to predict the suite.
+
+    A file that does not parse yields nothing rather than raising: the tree side
+    this reads is a committed one, and refusing to report the other 43 findings
+    because one unrelated file is mid-refactor would trade a whole result for a
+    file nobody asked about.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return frozenset()
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        text = ast.get_docstring(node, clean=False)
+        if text:
+            found.update(match.group("target") for match in _DOCSTRING_ROLE.finditer(text))
+    return frozenset(found)
+
+
+def files_naming(rev: str, names: Iterable[str], pathspecs: Sequence[str], repo: Path | None = None) -> tuple[str, ...]:
+    """Return the ``.py`` files at ``rev`` whose text contains one of ``names``.
+
+    A narrowing step, not the verdict: ``git grep`` finds the candidates cheaply so
+    only those files are parsed. An empty name set searches for nothing and returns
+    nothing without invoking git, which is the common case -- most branches delete
+    no module at all.
+
+    ``git grep`` exits 1 to mean "no match", which is a result and not a failure,
+    so that status is read rather than raised. Any other non-zero status is a
+    ``GitError`` for the reason :class:`GitError` gives: a relation that reports
+    nothing because it could not look is the failure mode this file is written
+    against.
+    """
+    keys = sorted(names)
+    if not keys or not pathspecs:
+        return ()
+    command = ["git"] + (["-C", str(repo)] if repo is not None else [])
+    command += ["grep", "--files-with-matches", "-I", "--fixed-strings"]
+    for key in keys:
+        command += ["-e", key]
+    command += [rev, "--", *pathspecs]
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    if completed.returncode == 1 and not completed.stdout:
+        return ()
+    if completed.returncode != 0:
+        raise GitError(f"{' '.join(command)} exited {completed.returncode}: {completed.stderr.strip()}")
+    prefix = f"{rev}:"
+    return tuple(
+        sorted(
+            line[len(prefix) :]
+            for line in completed.stdout.splitlines()
+            if line.startswith(prefix) and line.endswith(".py")
+        )
+    )
+
+
+def orphaned_roles(
+    rev: str,
+    deleted: Iterable[str],
+    pathspecs: Sequence[str],
+    repo: Path | None = None,
+) -> tuple[tuple[str, str], ...]:
+    """Return ``(citing file, target)`` for every docstring role at ``rev`` that ``deleted`` breaks.
+
+    One side of the role relation. ``rev`` is the tree the roles are read from and
+    ``deleted`` the paths the *other* side removes, so both directions are this
+    function with its two inputs swapped.
+
+    The verdict is :func:`named_module_paths`, the same resolver the literal
+    relation uses: a target names a module file, every prefix included, and the
+    role is dead when the other side deletes one of them.
+    """
+    removed = frozenset(deleted)
+    found: set[tuple[str, str]] = set()
+    for path in files_naming(rev, dotted_module_names(removed), pathspecs, repo=repo):
+        source = _git("show", f"{rev}:{path}", repo=repo)
+        for target in role_targets(source):
+            if named_module_paths({target}) & removed:
+                found.add((path, target))
+    return tuple(sorted(found))
+
+
+def orphaned_role_overlaps(
+    *,
+    base: str,
+    head: str,
+    branch_deletions: Iterable[str],
+    base_deletions: Iterable[str],
+    branch_paths: Iterable[str],
+    repo: Path | None = None,
+) -> tuple[tuple[str, str], ...]:
+    """Return every ``(citing file, target)`` the merged tree would leave unresolvable.
+
+    Both directions, because either side can land last, and both restricted to
+    what the merge would actually keep -- see the module docstring. Sorted and
+    de-duplicated so a role reachable from both directions is one row.
+    """
+    edits = frozenset(branch_paths)
+    from_base = tuple(
+        row for row in orphaned_roles(base, branch_deletions, ("*.py",), repo=repo) if row[0] not in edits
+    )
+    from_head = orphaned_roles(
+        head,
+        frozenset(base_deletions) - edits,
+        tuple(sorted(path for path in edits if path.endswith(".py"))),
+        repo=repo,
+    )
+    return tuple(sorted(frozenset(from_base) | frozenset(from_head)))
 
 
 API_ROOT = "https://api.github.com"
@@ -975,7 +1183,9 @@ def render_sweep(
         + "and no name with the siblings it grades, and no row above can describe that "
         + "composition. Widening the path set to the walked root was measured and rejected as "
         + "unselective; only composing the branches and running the grader settles those, and "
-        + "that needs a checkout this mode does not have. See #2561."
+        + "that needs a checkout this mode does not have. See #2561. The role relation the "
+        + "single-branch mode carries - a docstring citing a module the other side deletes - is "
+        + "absent here for the same reason: it reads two trees, and this mode reads patches."
     )
     lines.append(limits)
     return "\n".join(lines) + "\n"
@@ -1030,6 +1240,7 @@ def render_report(
     blocking: Sequence[str],
     prose: Sequence[str],
     named: Sequence[str],
+    orphaned: Sequence[tuple[str, str]],
     base_change_count: int,
 ) -> str:
     """Render the Markdown report written to stdout and the CI job summary.
@@ -1043,7 +1254,7 @@ def render_report(
     """
     lines = ["## Merge-base overlap check", ""]
 
-    if not blocking and not prose and not named:
+    if not blocking and not prose and not named and not orphaned:
         no_overlap = (
             f"No overlap. This branch edits nothing that `{base_ref}` has changed since "
             + f"the two diverged at `{merge_base_sha[:8]}` "
@@ -1105,8 +1316,36 @@ def render_report(
         lines.append("")
         lines.append(named_remedy)
 
-    if prose:
+    if orphaned:
         if blocking or named:
+            lines.append("")
+        orphaned_heading = (
+            f"This branch and `{base_ref}` compose to a tree carrying **{len(orphaned)}** "
+            + "docstring cross-reference role(s) that name a module the composition does not "
+            + "contain:"
+        )
+        orphaned_why = (
+            "One side removes the module and the other cites it, so neither branch is wrong on "
+            + "its own and neither one's checks can see it: the role and the deletion are never in "
+            + "the same tree until the merge. `tests/test_docstring_xref_roles_resolve.py` "
+            + "resolves every role in the tree, so the composition is red - with no conflict for "
+            + "git to report, because no file was written by both sides."
+        )
+        orphaned_remedy = (
+            f"**To clear this:** merge `{base_ref}` into this branch, then drop or repoint the "
+            + "role(s) above. This is the relation `main` needed at `8d0298345`, where a branch "
+            + "removing 96 lookup modules and eight branches citing them were each green."
+        )
+        lines.append(orphaned_heading)
+        lines.append("")
+        lines += [f"- `{path}` cites `{target}`" for path, target in orphaned]
+        lines.append("")
+        lines.append(orphaned_why)
+        lines.append("")
+        lines.append(orphaned_remedy)
+
+    if prose:
+        if blocking or named or orphaned:
             lines.append("")
         prose_heading = (
             f"Also overlapping, not blocking ({len(prose)} documentation path(s)) - "
@@ -1181,6 +1420,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         pr_paths = changed_paths(fork_point, head, repo=repo)
         base_paths = changed_paths(fork_point, base, repo=repo)
         literals = module_literals(diff_entries(fork_point, head, repo=repo))
+        orphaned = orphaned_role_overlaps(
+            base=base,
+            head=head,
+            branch_deletions=deleted_paths(fork_point, head, repo=repo),
+            base_deletions=deleted_paths(fork_point, base, repo=repo),
+            branch_paths=pr_paths,
+            repo=repo,
+        )
     except GitError as error:
         # Loud and non-zero: a check that cannot compute its answer must not
         # report the reassuring one.
@@ -1198,6 +1445,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         blocking=blocking,
         prose=prose,
         named=named,
+        orphaned=orphaned,
         base_change_count=len(base_paths),
     )
 
@@ -1222,7 +1470,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         print(annotation)
 
-    return 1 if blocking or named else 0
+    for path, target in orphaned:
+        annotation = (
+            f"::error file={path}::{path} cites {target} in a docstring, and this branch and "
+            + f"{args.base_ref} compose to a tree without that module; every role in the tree is "
+            + "resolved by the suite, so the composition is red with no conflict to resolve."
+        )
+        print(annotation)
+
+    return 1 if blocking or named or orphaned else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -331,6 +331,7 @@ def test_report_names_every_blocking_path_and_the_remedy() -> None:
         blocking=[_SHARED],
         prose=["CHANGELOG.md"],
         named=[],
+        orphaned=[],
         base_change_count=5,
     )
     assert _SHARED in report
@@ -347,6 +348,7 @@ def test_report_says_so_when_there_is_no_overlap() -> None:
         blocking=[],
         prose=[],
         named=[],
+        orphaned=[],
         base_change_count=0,
     )
     assert "No overlap" in report
@@ -1470,3 +1472,309 @@ def test_the_walk_blind_spot_is_still_named_now_that_a_name_is_reachable(
     report = capsys.readouterr().out
     assert "resolves its population from a filesystem walk" in report
     assert "#2561" in report
+
+
+# --- the role relation, over a removal -------------------------------------------
+#
+# `main` went red at `8d0298345` from a ninth pull request and eight that had
+# already landed. #3037 removed 96 g1 lookup modules; the eight verbs cited them
+# in docstring roles. The path intersection was empty in both directions - the
+# removal touches no verb, the verbs cite from files the removal does not open -
+# and git merged the two sides with no conflict, so the first tree holding both
+# the role and the deletion was `main`, where
+# `tests/test_docstring_xref_roles_resolve.py` reported 44 offending docstrings.
+#
+# The relation these pin reads a removal rather than a change, and reads both
+# trees rather than a diff, because a role only counts inside a docstring and a
+# hunk cannot be parsed for that. Issues #2791, #3065.
+
+#: The lookup module #3037 removed, standing for all 96.
+_CITED_MODULE = "strands_robots/tools/g1/g1_fsm_targets.py"
+
+#: Its dotted name, which is what a role spells.
+_CITED_TARGET = "strands_robots.tools.g1.g1_fsm_targets"
+
+#: The verb whose docstring cites it, standing for all eight.
+_CITING_VERB = "strands_robots/tools/g1/g1_set_fsm.py"
+
+#: The report heading the relation renders, used to tell "reported by this
+#: relation" from "reported by the path relation on the same run".
+_ROLE_HEADING = "compose to a tree carrying"
+
+
+def _module_citing(target: str, *, in_docstring: bool = True) -> str:
+    """Source for a verb whose module docstring - or a comment - cites ``target``."""
+    citation = f"See :mod:`{target}` for the admitted set."
+    head = f'"""One verb.\n\n{citation}\n"""' if in_docstring else f"# {citation}"
+    return f"{head}\n\nvalue = 1\n"
+
+
+def _land_the_cited_module(repo: Path) -> None:
+    """Put the lookup module on ``main``, so both sides fork with it present."""
+    _write(repo, _CITED_MODULE, '"""The admitted FSM targets."""\n\nTARGETS = (1, 2)\n')
+    _commit(repo, "the lookup module both sides know about")
+
+
+def _branch_deleting_the_cited_module(repo: Path) -> None:
+    """Branch off ``main`` and remove the lookup module, as #3037 did."""
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _git(repo, "rm", "-q", _CITED_MODULE)
+    _commit(repo, "consolidate the lookup modules into the dispatcher")
+
+
+def _land_on_main_citing(repo: Path, *, in_docstring: bool = True) -> None:
+    """Land a verb on ``main`` whose docstring cites the module, as the eight did."""
+    _git(repo, "checkout", "-q", "main")
+    _write(repo, _CITING_VERB, _module_citing(_CITED_TARGET, in_docstring=in_docstring))
+    _commit(repo, "port a verb that cites the lookup module")
+    _git(repo, "checkout", "-q", "pr")
+
+
+def test_a_branch_deleting_a_module_the_base_cites_is_flagged(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The #3037 topology: the branch removes what the base went on to cite.
+
+    Neither side is wrong alone, and neither side's checks can see it - the role
+    and the deletion are in different trees until the merge. The report has to
+    name the citing file and the target, because the remedy is an edit to that
+    docstring rather than a merge.
+    """
+    _land_the_cited_module(repo)
+    _branch_deleting_the_cited_module(repo)
+    _land_on_main_citing(repo)
+
+    assert _run(repo) == 1
+
+    report = capsys.readouterr().out
+    assert _ROLE_HEADING in report
+    assert _CITING_VERB in report
+    assert _CITED_TARGET in report
+
+
+def test_the_role_finding_shares_no_path_and_no_literal_with_the_base(repo: Path) -> None:
+    """Premise: neither relation that already existed can reach this composition.
+
+    Without this the test above would pass on a tree where the two sides happen to
+    share a file, and the finding would be attributable to the path relation. The
+    literal relation is empty too: a docstring role is not a quoted whole-string
+    name, and the citing file is not under ``tests/``.
+    """
+    _land_the_cited_module(repo)
+    _branch_deleting_the_cited_module(repo)
+    _land_on_main_citing(repo)
+
+    fork_point = check.merge_base("main", "HEAD", repo=repo)
+    branch_paths = check.changed_paths(fork_point, "HEAD", repo=repo)
+    base_paths = check.changed_paths(fork_point, "main", repo=repo)
+    assert check.overlapping_paths(branch_paths, base_paths) == ()
+    literals = check.module_literals(check.diff_entries(fork_point, "HEAD", repo=repo))
+    assert check.named_module_overlaps(literals, base_paths) == ()
+    assert _CITED_MODULE in branch_paths
+    assert _CITING_VERB in base_paths
+
+
+def test_the_composition_merges_without_a_text_conflict(repo: Path) -> None:
+    """Non-vacuity: git has nothing to report, which is why a check is needed.
+
+    A removal on one side and a new file on the other is the cleanest merge there
+    is. The merge gate reports ``CLEAN`` and the merged tree carries a role
+    naming a module that is not in it.
+    """
+    _land_the_cited_module(repo)
+    _branch_deleting_the_cited_module(repo)
+    _land_on_main_citing(repo)
+
+    _git(repo, "merge", "--no-edit", "-q", "main")  # raises CalledProcessError on conflict
+    assert not (repo / _CITED_MODULE).exists()
+    assert _CITED_TARGET in (repo / _CITING_VERB).read_text(encoding="utf-8")
+
+
+def test_a_branch_citing_a_module_the_base_deleted_is_flagged(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The mirror direction, because either side can land last.
+
+    Same composition with the roles of the two branches swapped: here the branch
+    writes the docstring and the base removes the module. Reading only the
+    direction the incident arrived from would leave the citing author's own branch
+    unguarded, which is the half that is easiest to fix.
+    """
+    _land_the_cited_module(repo)
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _write(repo, _CITING_VERB, _module_citing(_CITED_TARGET))
+    _commit(repo, "port a verb that cites the lookup module")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "rm", "-q", _CITED_MODULE)
+    _commit(repo, "consolidate the lookup modules into the dispatcher")
+    _git(repo, "checkout", "-q", "pr")
+
+    assert _run(repo) == 1
+    report = capsys.readouterr().out
+    assert _ROLE_HEADING in report
+    assert _CITED_TARGET in report
+
+
+def test_merging_the_base_is_not_enough_and_editing_the_role_clears_it(repo: Path) -> None:
+    """This relation is not self-clearing, and it must not pretend to be.
+
+    The path relation clears on a merge because the merge is the whole remedy.
+    Here the merge produces exactly the tree the report is about: a role and no
+    module. The suite is red on that tree, so a check that went quiet would be
+    disagreeing with the thing it predicts. Dropping the role is what clears it,
+    which is what the remedy sentence asks for.
+    """
+    _land_the_cited_module(repo)
+    _branch_deleting_the_cited_module(repo)
+    _land_on_main_citing(repo)
+    assert _run(repo) == 1
+
+    _git(repo, "merge", "-q", "--no-edit", "main")
+    assert _run(repo) == 1
+
+    _write(repo, _CITING_VERB, '"""One verb."""\n\nvalue = 1\n')
+    _commit(repo, "drop the role that cited the removed module")
+    assert _run(repo) == 0
+
+
+def test_a_removal_nobody_cites_does_not_block(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Quiet where it cannot matter: removing a module is not itself a finding.
+
+    Consolidation is routine, and a relation that fired on any deletion would fire
+    on most refactors in the tree.
+    """
+    _land_the_cited_module(repo)
+    _branch_deleting_the_cited_module(repo)
+    _git(repo, "checkout", "-q", "main")
+    _write(repo, "strands_robots/unrelated.py", "value = 1\n")
+    _commit(repo, "an unrelated commit on main")
+    _git(repo, "checkout", "-q", "pr")
+
+    assert _run(repo) == 0
+    assert _ROLE_HEADING not in capsys.readouterr().out
+
+
+def test_a_role_the_composition_keeps_does_not_block(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The other half of quiet: citing a module is the normal way to reference one.
+
+    The base adds the same citing verb, and nothing removes the module. Every
+    docstring role in the tree would be a row if the relation keyed on the role
+    alone.
+    """
+    _land_the_cited_module(repo)
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _edit_line(repo, _SHARED, 40, "line 40  # edited by the pull request")
+    _commit(repo, "the pull request's commit")
+    _land_on_main_citing(repo)
+
+    assert _run(repo) == 0
+    assert _ROLE_HEADING not in capsys.readouterr().out
+
+
+def test_a_role_outside_a_docstring_is_not_this_relations_business(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The population is the grader's: docstrings, not every line mentioning a name.
+
+    A role in a comment is a dead pointer on its own account, and it is not what
+    turns the suite red. Reporting it here would block a merge for something no
+    test grades, and the ``git grep`` narrowing step finds such a file - so this
+    pins the parse, not the search.
+    """
+    _land_the_cited_module(repo)
+    _branch_deleting_the_cited_module(repo)
+    _land_on_main_citing(repo, in_docstring=False)
+
+    assert _run(repo) == 0
+    assert _ROLE_HEADING not in capsys.readouterr().out
+
+
+def test_a_citing_file_the_branch_changes_is_left_to_the_branch_s_own_suite_run(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """One tree, one report: a branch holding both halves is graded by its own suite.
+
+    When the branch itself changes the citing file, the role and the deletion are
+    already in the same tree, so ``call-test-lint`` on that head reports it. A
+    second row here would spend a reader's attention describing a composition
+    that is not a composition.
+    """
+    _land_the_cited_module(repo)
+    _write(repo, _CITING_VERB, _module_citing(_CITED_TARGET))
+    _commit(repo, "a verb citing the lookup module, on main before either side")
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _git(repo, "rm", "-q", _CITED_MODULE)
+    _write(repo, _CITING_VERB, _module_citing(_CITED_TARGET) + "# touched by this branch\n")
+    _commit(repo, "remove the module and edit the citing verb")
+
+    assert _run(repo) == 0
+    assert _ROLE_HEADING not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        pytest.param(f'"""Head.\n\n:mod:`{_CITED_TARGET}`\n"""\n', {_CITED_TARGET}, id="module-docstring"),
+        pytest.param(f'class C:\n    """:class:`{_CITED_TARGET}.T`"""\n', {f"{_CITED_TARGET}.T"}, id="class"),
+        pytest.param(f'def f():\n    """:func:`{_CITED_TARGET}.g`"""\n', {f"{_CITED_TARGET}.g"}, id="function"),
+        pytest.param(f"# :mod:`{_CITED_TARGET}`\n", set(), id="comment"),
+        pytest.param(f'X = ":mod:`{_CITED_TARGET}`"\n', set(), id="runtime-string"),
+        pytest.param(f'""":mod:`~{_CITED_TARGET}`"""\n', {_CITED_TARGET}, id="display-tilde"),
+        pytest.param('""":mod:`.protocol`"""\n', set(), id="relative-target"),
+        pytest.param('""":meth:`Cls.method`"""\n', set(), id="short-form"),
+        pytest.param('"""not a docstring below"""\nif True:\n    pass\n', set(), id="no-role"),
+        pytest.param("def f(:\n", set(), id="unparseable"),
+    ],
+)
+def test_role_targets_reads_the_docstrings_a_grader_would(source: str, expected: set[str]) -> None:
+    """Which spellings this relation can decide, and which it leaves to the grader.
+
+    A wrapped or short-form target has no module path to intersect, so admitting it
+    would mean guessing at a file. The grader reports both on their own account;
+    this relation only claims the contiguous qualified form.
+    """
+    assert check.role_targets(source) == expected
+
+
+@pytest.mark.parametrize(
+    ("paths", "expected"),
+    [
+        pytest.param([_CITED_MODULE], {_CITED_TARGET}, id="module"),
+        pytest.param(["strands_robots/tools/g1/__init__.py"], {"strands_robots.tools.g1"}, id="package"),
+        pytest.param(["strands_robots/__init__.py"], set(), id="bare-root"),
+        pytest.param(["strands_robots/one.py"], {"strands_robots.one"}, id="shallowest-resolvable"),
+        pytest.param(["tests/drivers/test_x.py"], set(), id="outside-the-package"),
+        pytest.param(["docs/guide.md"], set(), id="prose"),
+    ],
+)
+def test_a_deleted_path_becomes_a_search_key_only_when_a_role_could_name_it(
+    paths: list[str], expected: set[str]
+) -> None:
+    """The bare package root is excluded, for cost as well as for correctness.
+
+    ``named_module_paths`` cannot resolve a one-segment name, so such a key could
+    never produce a finding - and as a search key it matches every citing file in
+    the tree, which is the one input that would make this relation expensive.
+    """
+    assert check.dotted_module_names(paths) == expected
+
+
+def test_a_branch_deleting_no_module_asks_git_nothing(repo: Path) -> None:
+    """The relation costs nothing on the branches that are not about a removal.
+
+    Pinned through a revision that does not exist: reaching git at all would raise
+    rather than return an empty result, so an empty key set provably short-circuits
+    before the search.
+    """
+    assert check.files_naming("no-such-revision", (), ("*.py",), repo=repo) == ()
+    assert check.orphaned_roles("no-such-revision", (), ("*.py",), repo=repo) == ()
+
+
+def test_a_name_is_resolved_to_a_path_by_one_resolver() -> None:
+    """Both name relations answer "which files does this name need" the same way.
+
+    A role and a string literal are different spellings of one coupling, and the
+    prefix rule is the subtle part of resolving either: importing ``a.b.c`` runs
+    ``a/b/__init__.py``. Two resolvers would drift, and the drift would show up as
+    a relation that misses a package-level removal.
+    """
+    assert "named_module_paths(" in inspect.getsource(check.orphaned_roles)
+    resolved = check.named_module_paths({f"{_CITED_TARGET}.g1_fsm_target_admits"})
+    assert _CITED_MODULE in resolved
+    assert "strands_robots/tools/g1/__init__.py" in resolved


### PR DESCRIPTION
## The composition no relation could see

`main` went red at `8d0298345`. Nine pull requests, every one green on its own head, no conflict for git to report.

```mermaid
graph LR
  M["M<br/>merge base<br/>lookup modules present"]
  B1["#3055 #3025 #3059 #3061<br/>4 verbs land on main<br/>docstrings cite the lookup modules"]
  B2["#3037 branch<br/>removes 96 lookup modules"]
  X["merge<br/>role kept, module gone<br/>44 offending docstrings"]
  M --> B1 --> X
  M --> B2 --> X
  B1 -. "shared paths: none" .- B2
```

The branch removes files no verb touches; the verbs cite them from files the branch never opens. So the two existing relations are structurally silent - the path intersection is empty, and a docstring role is not a quoted whole-string literal in a test.

## Measured, replayed from the real commits

Branch forked at #3055's merge base, `main` advanced to the tip carrying the four verbs, branch removes the 96 paths #3037 removed.

| | before | after |
|---|---|---|
| `Detect an untested overlap with the base branch` | **exit 0**, `No overlap` | **exit 1**, 29 rows + 29 annotations |
| changed-path intersection | `[]` | `[]` (unchanged - it is not what finds this) |
| `git merge` | clean, no conflict | clean, no conflict |
| `test_docstring_xref_roles_resolve.py` on the merged tree | **1 failed**, 44 offending docstrings | same tree, same verdict |
| gate rows vs grader's distinct `(file, target)` pairs | - | **29 == 29, set-identical** |

The last row is the point: the gate does not approximate the grader, it reports exactly the pairs the grader will.

## The relation

Same merge base, one further input: the qualified cross-reference roles in the docstrings of one tree, resolved through the **same `named_module_paths`** the literal relation uses, intersected with the module files the other side removes. Both directions, because either side can land last.

Read from a **tree**, not a diff - a role only counts inside a docstring and a hunk cannot be parsed for that, so the population is identical to the grader's and a role in a comment or a runtime string is not a finding. Only contiguous fully-qualified targets are claimed; a wrapped or short-form role has no decidable module path and the grader reports those on their own account.

Quiet where it cannot matter, and cheap: a removal nobody cites, a role nothing removes, and a citing file the branch itself changes (that tree holds both halves, so the branch's own suite run reports it). An empty key set short-circuits before git is asked anything - **123 ms on a branch that deletes nothing** with the base 146 paths ahead, 961 ms on the 96-deletion finding case.

One property deliberately unlike its siblings: **merging the base does not clear this one.** That merge produces precisely the tree the report describes - a role and no module - and the suite is red on it, so the role must be dropped or repointed too. A check that went quiet there would be disagreeing with the thing it predicts. The remedy sentence says so and a cell pins all three steps.

Absent from `--all-open`, stated in the sweep's own limits paragraph: that mode reads patches and no checkout, so it cannot tell whether a role sits in a docstring, and grading a different population than the gate is worse than naming the gap.

## Pins

`tests/test_merge_base_overlap.py`: **70 -> 97 cells**. Pre-fix, with the relation's helpers still defined and only its wiring reverted: **3 failed / 94 passed** - both directions plus the not-self-clearing cell go red, and the 94 greens are the controls showing the file is not "refuse everything".

Three premise cells keep the topology cells non-vacuous: the path intersection really is `[]`, the literal relation really is `()`, and `git merge` really succeeds.

## Gate

`ruff check` + `ruff format --check` clean; `mypy` 20 errors in 6 files, all pre-existing in `examples/isaac_gs` + `simulation/ik.py`, **0 attributable**; `scripts/check_whole_tree_graders.py` 199 passed; `tests/test_docstring_xref_roles_resolve.py` + `tests/test_changelog_fragments.py` 53 passed; the `workflow or changelog or docstring or emoji or ascii or grader` slice 1316 passed.

**LOC: +610 / -4, 3 files** - a net addition, justified as a gate closing a class that has put `main` red three times (#2762 + #2774, #2938 + #2947 + #2948, and this one). 260 lines of it are the script, 308 the pins, 42 the changelog entry.

`.github/workflows/merge-base-overlap.yml` is untouched: it delegates entirely to the script, so the relation needs no workflow change, and the header's self-clearing sentence is scoped to the path overlap it describes.

Refs #2791, #3065.
