### PR TITLE
fix(drivers/ur): a halt reported as done is a halt the rollout thread has left

### DIFF
--- a/changelog.d/3091-ur-stop-task-halt-outcome.md
+++ b/changelog.d/3091-ur-stop-task-halt-outcome.md
@@ -1,0 +1,25 @@
+### Fixed: a UR halt that reports success is a halt the rollout thread has left
+
+`URDriver.stop_task()` signals the rollout, waits for its thread and then
+decelerates the arm with `servoStop`. The wait is bounded at two seconds and a
+caller-supplied policy blocking on a remote inference call outlasts any bound, so
+the case that matters is the one where it expires. Two things were true of it.
+
+`_Rollout.join` was annotated `-> None` and swallowed the timeout, so the
+envelope carried `stopped=True` for a thread still inside the loop - while
+`get_task_status()` reported `running=True` in the same instant. One driver, two
+envelopes, opposite answers about whether the arm is under a task, on the one
+path an operator reaches to stop it.
+
+The loop also read its stop event at the top of a step and not again after the
+policy returned, so the setpoint that policy call was computing went out *after*
+the `servoStop`, measured landing 0.59 ms later. An arm an operator was told had
+stopped resumed moving.
+
+`join` now returns whether the thread left the loop, the step re-reads the stop
+event after the policy returns and before the setpoint goes out, and `stop_task`
+reports an error envelope with `stopped=False` and a reason naming the timeout
+when the thread is still in there. The arm is decelerated either way; what is
+gone is the claim. `G1Driver` and `Go2Driver` - the fleet's other two drivers that
+roll a policy out on a thread - already held both contracts, so the third one is
+now graded on the same relation rather than on its own weaker one.

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -130,6 +130,15 @@ command the way a servo bus does - it accepts the register and performs nothing:
   proximal joints are held to 120 deg/s - so the same policy cadence can be admitted on
   one arm and refused on the other.
 
+Stopping a rollout is reported rather than asserted. `stop_task()` signals the loop,
+waits up to two seconds for its thread and decelerates the arm with `servoStop`; a
+policy blocking on a remote inference call outlasts that budget, and the envelope then
+carries `status="error"` with `stopped=False` and a reason naming the timeout, matching
+what `get_task_status()` says about the same loop. The arm is decelerated either way,
+and no further setpoint reaches the controller - the loop re-reads the stop signal after
+the policy returns and before it writes. `stop()` carries no verdict (the driver protocol
+annotates it `-> None`); read `stop_task()` when the outcome matters.
+
 Joint keys are the arm's own names, in RTDE wire order, and the MuJoCo assets declare
 them identically - so an action dict recorded in simulation streams to the controller
 with no remap:

--- a/strands_robots/drivers/ur.py
+++ b/strands_robots/drivers/ur.py
@@ -702,7 +702,14 @@ class URDriver:
         }
 
     async def stop(self) -> None:
-        """Stop motion, leaving both interfaces connected."""
+        """Stop motion, leaving both interfaces connected.
+
+        Annotated ``-> None`` by the driver protocol, so it carries no verdict:
+        the rollout is signalled and not waited for, and the loop's own step
+        re-reads that signal before its next setpoint, which is what keeps a
+        servoJ from landing after this servoStop. A caller that needs the halt
+        outcome reads :meth:`stop_task`, which decides one.
+        """
         rollout = self._rollout
         if rollout is not None:
             rollout.request_stop()
@@ -717,7 +724,14 @@ class URDriver:
         self._drop_anchor()
 
     def cleanup(self) -> None:
-        """Stop the arm and release both interfaces. Idempotent."""
+        """Stop the arm and release both interfaces. Idempotent.
+
+        The join outcome is not reported - the protocol annotates this ``-> None``
+        - and it does not need to be: the interface handles are cleared under the
+        lock before either is disconnected, so a rollout thread that outlasted
+        the join finds ``None`` and refuses its own write rather than reaching a
+        disconnected interface.
+        """
         rollout = self._rollout
         if rollout is not None:
             rollout.request_stop()
@@ -1108,13 +1122,20 @@ class URDriver:
         """Stop the rollout and decelerate the arm.
 
         Returns:
-            A success envelope naming what was halted, or a refusal when the
-            controller declined the stop.
+            A success envelope naming what was halted when the rollout thread
+            left the loop, a refusal when the controller declined the stop, and
+            an *error* envelope carrying ``stopped=False`` when the thread is
+            still in the loop - a caller-supplied policy blocking on a remote
+            inference call is the ordinary case. The arm is decelerated either
+            way; what the third case refuses to do is claim a halt while
+            :meth:`get_task_status` would report ``running=True``.
         """
         rollout = self._rollout
+        unjoined: _Rollout | None = None
         if rollout is not None and rollout.is_running:
             rollout.request_stop()
-            rollout.join()
+            if not rollout.join():
+                unjoined = rollout
         halted = 0 if rollout is None else rollout.steps
         with self._lock:
             control = self._control
@@ -1125,6 +1146,21 @@ class URDriver:
         except (OSError, RuntimeError) as exc:
             return _refuse(f"stop_task: the controller refused servoStop: {exc}")
         self._drop_anchor()
+        if unjoined is not None:
+            # The thread is still in the loop. It will not write another
+            # setpoint - the step re-reads the stop event before sending - but it
+            # holds the rollout, so reporting success here would hand a caller
+            # that reads only ``status`` a halt the payload's own ``running``
+            # contradicts.
+            snapshot = unjoined.snapshot()
+            snapshot["stopped"] = False
+            snapshot["robot"] = self._tool_name
+            snapshot["reason"] = (
+                "stop_task: the rollout thread did not join within its budget; the policy is "
+                "likely blocking - the arm is decelerated and the loop writes no further "
+                "setpoint, but the task is still holding the arm"
+            )
+            return {"status": "error", "content": [{"json": snapshot}]}
         return {
             "status": "success",
             "content": [{"json": {"stopped": True, "steps": halted, "robot": self._tool_name}}],
@@ -1224,17 +1260,26 @@ class _Rollout:
         """Ask the loop to exit at its next tick."""
         self._stop.set()
 
-    def join(self, timeout: float = 2.0) -> None:
-        """Wait for the loop to exit.
+    def join(self, timeout: float = 2.0) -> bool:
+        """Wait for the loop to exit, reporting whether it did.
 
         Args:
             timeout: Seconds to wait. The loop checks the stop event once per
-                period, so a bound a few periods long is enough; exceeding it is
-                reported through the snapshot rather than raised.
+                period, so a bound a few periods long is enough.
+
+        Returns:
+            ``True`` when the thread is out of the loop - which is what makes a
+            halt claim true, because the loop cannot write another setpoint once
+            it has left. ``False`` when it is still in there: a caller-supplied
+            policy blocking on a remote inference call outlasts any join budget,
+            and :meth:`URDriver.stop_task` needs that fact rather than a
+            ``stopped`` claim its own ``running`` flag contradicts.
         """
         thread = self._thread
-        if thread is not None:
-            thread.join(timeout)
+        if thread is None:
+            return True
+        thread.join(timeout)
+        return not thread.is_alive()
 
     def snapshot(self) -> dict[str, Any]:
         """The counters and exit reason, as one dict for the status envelope."""
@@ -1274,6 +1319,16 @@ class _Rollout:
                     return
                 if not isinstance(action, dict) or not action:
                     self._finish("policy", f"the policy returned {action!r}, expected a joint-keyed action dict")
+                    return
+
+                if self._stop.is_set():
+                    # Re-read after the policy returns and before the setpoint
+                    # goes out. A policy call is the longest thing in a step, so
+                    # a stop signalled during one would otherwise be answered by
+                    # one more servoJ - landing after the servoStop the halt
+                    # verb just issued, and moving an arm an operator was told
+                    # had stopped.
+                    self._finish("stopped")
                     return
 
                 envelope = self._driver.send_action(action)

--- a/tests/drivers/ur/test_ur_stop_task_reports_the_rollout_halt_outcome.py
+++ b/tests/drivers/ur/test_ur_stop_task_reports_the_rollout_halt_outcome.py
@@ -1,0 +1,247 @@
+"""A halt this driver reports as done is a halt the rollout thread has left.
+
+:meth:`~strands_robots.drivers.ur.URDriver.stop_task` signals the rollout, waits
+for its thread and then decelerates the arm with ``servoStop``.  The wait is
+bounded, and a caller-supplied policy blocking on a remote inference call
+outlasts any bound - so the interesting case is not the happy one.  Two things
+were true of it:
+
+* ``_Rollout.join`` was annotated ``-> None`` and swallowed the timeout, so the
+  envelope reported ``stopped=True`` for a thread still inside the loop, while
+  :meth:`~strands_robots.drivers.ur.URDriver.get_task_status` reported
+  ``running=True`` in the same instant.  One driver, two envelopes, opposite
+  answers about whether the arm is under a task.
+* the loop read its stop event at the top of a step and not again after the
+  policy returned, so the setpoint that policy call was computing went out
+  *after* the ``servoStop`` - measured landing 0.5 ms later.  An arm an operator
+  was told had stopped resumed moving.
+
+:class:`~strands_robots.drivers.g1.G1Driver` and
+:class:`~strands_robots.drivers.go2.Go2Driver` are the fleet's other two drivers
+that roll a policy out on a thread, and both already report this: their loop's
+``stop`` returns whether it joined, ``stop_task`` puts that in ``stopped`` and
+returns an error envelope when it is false, and the G1 loop re-reads the stop
+signal once more after the policy returns and before the frame publishes.  This
+driver now holds the same two contracts, so the third rollout driver is graded on
+the same relation rather than on its own weaker one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.ur import JOINT_NAMES, URDriver, _Rollout
+from tests.mocks.ur_rtde import MEASURED_Q, FakeRTDE, json_of, text_of
+
+HOST = "192.168.1.10"
+
+#: Tight enough that a blocked-policy cell costs milliseconds rather than the
+#: 2 s production budget, which is sized for a real controller's period.
+FAST_JOIN_S = 0.05
+
+
+def _reachable_setpoint() -> dict[str, float]:
+    """A setpoint one step off the measured pose, so the step gate admits it."""
+    return {name: q + 0.001 for name, q in zip(JOINT_NAMES, MEASURED_Q, strict=True)}
+
+
+def _fast_join(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shrink the join budget without patching over the decision it feeds."""
+    original = _Rollout.join
+
+    def fast(self: _Rollout, timeout: float = FAST_JOIN_S) -> bool:
+        return original(self, timeout=timeout)
+
+    monkeypatch.setattr(_Rollout, "join", fast)
+
+
+@pytest.fixture
+def blocked_rollout(fake_rtde: FakeRTDE, monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[URDriver, threading.Event]]:
+    """A connected arm whose rollout is stuck inside one policy call.
+
+    The policy returns a *reachable* setpoint once released, so a write that
+    escapes the halt reaches ``servoJ`` rather than being turned away by the step
+    gate - the cell would otherwise pass for the wrong reason.
+    """
+    driver = URDriver(tool_name="ur5e", port=HOST, control_frequency=200.0)
+    assert driver.connect_eagerly() is None
+    _fast_join(monkeypatch)
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def policy(observation: dict[str, Any]) -> dict[str, float]:
+        entered.set()
+        release.wait(10.0)
+        return _reachable_setpoint()
+
+    assert driver.run_policy(policy, instruction="hold", duration=30.0)["status"] == "success"
+    assert entered.wait(5.0), "the rollout never reached the policy"
+    try:
+        yield driver, release
+    finally:
+        release.set()
+        driver.cleanup()
+
+
+def _await_exit(rollout: _Rollout) -> None:
+    """Wait for the rollout thread to leave the loop, polling its own flag.
+
+    Deliberately not ``join`` - the cells below that grade ``join``'s verdict
+    would otherwise share a helper with the ones that grade the setpoints, and a
+    tree where the verdict is missing would fail them all for the same reason.
+    """
+    deadline = time.monotonic() + 5.0
+    while rollout.is_running and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not rollout.is_running, "the rollout thread never exited"
+
+
+def _drain(driver: URDriver, release: threading.Event) -> None:
+    """Release the policy and wait for the rollout thread to leave the loop."""
+    release.set()
+    rollout = driver._rollout
+    assert rollout is not None
+    _await_exit(rollout)
+
+
+class TestAHaltIsNotClaimedWhileTheThreadIsStillInTheLoop:
+    """The envelope agrees with the driver's own task status."""
+
+    def test_a_rollout_that_did_not_join_is_reported_as_not_stopped(
+        self, blocked_rollout: tuple[URDriver, threading.Event]
+    ) -> None:
+        driver, _release = blocked_rollout
+        envelope = driver.stop_task()
+        assert envelope["status"] == "error"
+        payload = json_of(envelope)
+        assert payload["stopped"] is False
+        assert payload["running"] is True
+        assert "did not join" in str(payload["reason"])
+
+    def test_the_two_envelopes_do_not_contradict_each_other(
+        self, blocked_rollout: tuple[URDriver, threading.Event]
+    ) -> None:
+        driver, _release = blocked_rollout
+        stopped = json_of(driver.stop_task())["stopped"]
+        running = json_of(driver.get_task_status())["running"]
+        assert stopped is not running, f"stop_task said stopped={stopped} while the task ran"
+
+
+class TestNoSetpointOutlivesTheHalt:
+    """The stop signal wins over a policy call that was already in flight."""
+
+    def test_stop_task_is_the_last_thing_the_controller_hears(
+        self, blocked_rollout: tuple[URDriver, threading.Event]
+    ) -> None:
+        driver, release = blocked_rollout
+        control = driver._control
+        assert control is not None
+        driver.stop_task()
+        assert control.servo_stops == 1
+        commanded = len(control.servoj_calls)
+        _drain(driver, release)
+        assert len(control.servoj_calls) == commanded, "a setpoint reached the arm after the halt"
+
+    def test_the_verdictless_stop_hook_holds_the_same_line(
+        self, blocked_rollout: tuple[URDriver, threading.Event]
+    ) -> None:
+        # ``stop`` is annotated ``-> None`` so it cannot report anything; the
+        # property has to hold by construction there rather than be reported.
+        driver, release = blocked_rollout
+        control = driver._control
+        assert control is not None
+        asyncio.run(driver.stop())
+        commanded = len(control.servoj_calls)
+        _drain(driver, release)
+        assert len(control.servoj_calls) == commanded, "a setpoint reached the arm after stop()"
+
+    def test_the_loop_records_the_caller_as_the_reason_it_exited(
+        self, blocked_rollout: tuple[URDriver, threading.Event]
+    ) -> None:
+        driver, release = blocked_rollout
+        driver.stop_task()
+        _drain(driver, release)
+        assert json_of(driver.get_task_status())["exit_reason"] == "stopped"
+
+
+class TestTheJoinReportsWhatItObserved:
+    """``_Rollout.join`` is the single source of the halt verdict."""
+
+    def test_a_thread_still_in_the_loop_is_not_joined(self, blocked_rollout: tuple[URDriver, threading.Event]) -> None:
+        driver, _release = blocked_rollout
+        rollout = driver._rollout
+        assert rollout is not None
+        rollout.request_stop()
+        assert rollout.join(timeout=FAST_JOIN_S) is False
+
+    def test_a_thread_that_left_the_loop_is_joined(self, blocked_rollout: tuple[URDriver, threading.Event]) -> None:
+        driver, release = blocked_rollout
+        driver.stop_task()
+        _drain(driver, release)
+        assert driver._rollout is not None
+        assert driver._rollout.join(timeout=FAST_JOIN_S) is True
+
+    def test_a_rollout_that_never_started_is_trivially_joined(self) -> None:
+        # ``cleanup`` joins without checking ``is_running``, and a rollout is
+        # published to the driver just before its thread starts, so this is the
+        # state that race can observe.
+        rollout = _Rollout(
+            driver=URDriver(tool_name="ur5e", port=HOST),
+            policy=lambda observation: _reachable_setpoint(),
+            instruction="",
+            duration=1.0,
+            n_steps=1,
+            period=0.01,
+        )
+        assert rollout.join(timeout=FAST_JOIN_S) is True
+
+
+class TestWhatTheHappyPathStillReports:
+    """Recorded because they pass before and after: only the unjoined case moved."""
+
+    def test_a_rollout_that_finished_its_budget_reports_a_clean_stop(self, fake_rtde: FakeRTDE) -> None:
+        driver = URDriver(tool_name="ur5e", port=HOST, control_frequency=200.0)
+        assert driver.connect_eagerly() is None
+        assert driver.run_policy(lambda _obs: _reachable_setpoint(), n_steps=2)["status"] == "success"
+        assert driver._rollout is not None
+        _await_exit(driver._rollout)
+        payload = json_of(driver.stop_task())
+        assert payload["stopped"] is True
+        assert payload["steps"] == 2
+
+    def test_stopping_an_idle_arm_is_a_success(self, fake_rtde: FakeRTDE) -> None:
+        driver = URDriver(tool_name="ur5e", port=HOST)
+        assert driver.connect_eagerly() is None
+        assert json_of(driver.stop_task()) == {"stopped": True, "steps": 0, "robot": "ur5e"}
+
+    def test_stopping_a_disconnected_arm_is_still_refused(self) -> None:
+        envelope = URDriver(tool_name="ur5e", port=HOST).stop_task()
+        assert envelope["status"] == "error"
+        assert "not connected" in text_of(envelope)
+
+
+class TestTeardownDoesNotDisconnectUnderALiveWrite:
+    """``cleanup`` carries no verdict, so the property holds by construction."""
+
+    def test_a_late_write_finds_no_interface_rather_than_a_disconnected_one(
+        self, blocked_rollout: tuple[URDriver, threading.Event]
+    ) -> None:
+        driver, release = blocked_rollout
+        control = driver._control
+        assert control is not None
+        driver.cleanup()
+        assert control.disconnected is True
+        commanded = len(control.servoj_calls)
+        release.set()
+        rollout = driver._rollout
+        assert rollout is not None
+        _await_exit(rollout)
+        assert len(control.servoj_calls) == commanded
+        assert json_of(driver.get_task_status())["exit_reason"] == "stopped"


### PR DESCRIPTION
## The case that matters is the one where the wait expires

`URDriver.stop_task()` signals the rollout, waits **2 s** for its thread, then decelerates the arm with `servoStop`. A caller-supplied policy blocking on a remote inference call outlasts any bound, so the expiry is the ordinary path, not a pathological one. Two things were true of it.

![stop_task timeline, before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/ur-stop-task-halt-outcome/ur_stop_task_timeline.png)

*One controller double, one blocked policy, the same probe run against `main` and against this branch. Timestamps are measured at the SDK boundary.*

| | `main` | this PR |
|---|---|---|
| `stop_task()` envelope | `success`, `stopped=True` | `error`, `stopped=False` + reason |
| `get_task_status()` at the same instant | `running=True` | `running=True` |
| the two agree | **no** | yes |
| `servoJ` after the `servoStop` | **1**, at +0.59 ms | **0** |

**1. The verdict was discarded.** `_Rollout.join` was annotated `-> None` and swallowed the timeout, so the envelope claimed `stopped=True` for a thread still inside the loop — while the driver's own `get_task_status()` said `running=True`. One driver, two envelopes, opposite answers about whether the arm is under a task, on the one path an operator reaches to stop it.

**2. A setpoint outlived the halt.** The loop read its stop event at the top of a step and not again after the policy returned, so the setpoint that call was computing went out *after* the `servoStop`. An arm an operator was told had stopped resumed moving.

## Change

- `_Rollout.join(timeout) -> bool` — returns whether the thread left the loop.
- `_Rollout._run` re-reads the stop event **after the policy returns and before the setpoint goes out**, so a stop signalled mid-inference costs no further `servoJ`. This is also what makes the verdictless `stop()` hook (`-> None` per the driver protocol) safe, since it cannot report anything.
- `stop_task()` reports the outcome: success with `stopped=True` when the thread left, and an error envelope carrying the loop snapshot, `stopped=False` and a reason naming the timeout when it did not. **The arm is decelerated either way** — what is gone is the claim.

`G1Driver` and `Go2Driver` — the fleet's other two drivers that roll a policy out on a thread — already hold both contracts (`_ControlLoop.stop() -> bool`, `snap["stopped"] = joined`, error envelope when false, and the G1 loop's second stop read after the policy returns). This brings the third one onto the same relation rather than its own weaker one; `tests/drivers/test_agent_stop_verb_reports_the_halt_outcome.py` already argues the principle for the agent `stop` verb.

## Tests

`tests/drivers/ur/test_ur_stop_task_reports_the_rollout_halt_outcome.py`, 12 cells over a rollout blocked inside one policy call. Against `main`: **8 failed / 4 passed**, each failure naming its own contract.

| pre-fix | cell |
|---|---|
| `assert 'success' == 'error'` | an unjoined rollout is reported as not stopped |
| `stopped=True while the task ran` | the two envelopes do not contradict each other |
| `a setpoint reached the arm after the halt` | `stop_task` is the last thing the controller hears |
| `a setpoint reached the arm after stop()` | the verdictless hook holds the same line |
| `assert None is False` / `is True` (×3) | `join` reports what it observed |
| `assert 'refused' == 'stopped'` | a late write finds no interface, and the loop exits `stopped` not `refused` |

The 4 pre-fix passes are the controls: a rollout that spent its budget still reports `stopped=True` with its step count, an idle arm still returns `{"stopped": True, "steps": 0, "robot": "ur5e"}`, a disconnected arm is still refused, and the loop still records `stopped` as its exit reason.

The setpoint cells deliberately do **not** use `join` to wait — a tree where the verdict is missing would otherwise fail them for that reason instead of for the setpoint. The blocked policy returns a *reachable* setpoint so an escaping write reaches `servoJ` rather than being turned away by the step gate.

`strands_robots/drivers/ur.py` coverage **80% -> 86%** (90 -> 63 missing lines), measured on the same tree with and without the new file.

## Gate

`ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ`; mypy at the pinned version 20 errors in 6 files, identical on a pristine `main` worktree; `scripts/check_whole_tree_graders.py` 199 passed; `tests/drivers` 1988 passed with the same 2 environment-specific failures a pristine `main` worktree produces (0 attributable). Docs: the RTDE section of `docs/robots/arms.md` now states the halt contract.

**LOC delta: +347 / -11 across 4 files** — +247 test, +66 production (of which ~40 are the two docstrings stating the contracts), +25 changelog, +9 docs.
