### PR TITLE
fix(simulation): a camera recording reported as stopped is one whose recorder thread has exited

### DIFF
--- a/changelog.d/3092-camera-recorder-stop-reports-the-join.md
+++ b/changelog.d/3092-camera-recorder-stop-reports-the-join.md
@@ -15,8 +15,15 @@ about that live thread.
 The join outcome is now read and reported. An expired join returns
 `status="error"` with `stopped=False` and the per-camera buffered frame counts,
 encodes nothing, and leaves the recording registered so a later
-`stop_cameras_recording()` re-joins the loop and flushes it. Both
-`start_cameras_recording` and `start_cameras_recording_synchronous` read the
-recorder thread's liveness rather than the `running` flag the loop outlives, and
-the status verb reports a `[stopping]` phase carrying `running` and
-`thread_alive` separately.
+`stop_cameras_recording()` re-joins the loop and flushes it.
+
+Both `start_cameras_recording` and `start_cameras_recording_synchronous` now key
+their refusal on the registration rather than on the `running` flag the loop
+outlives. Only a flush deregisters a recording, so a registered one always holds
+frames nothing has encoded -- including after an expired join's loop finally
+leaves `render` and exits, a state no liveness read can see. A `start` in that
+window used to replace the registration and discard those frames while reporting
+success, which is the recovery the expired-join error had just promised. The
+status verb names all four phases (`recording`, `stopping`, `unflushed`, `idle`)
+in its text and as `phase` in its JSON block, alongside `running` and
+`thread_alive`; `[idle]` now means only that no buffer is left to encode.

--- a/changelog.d/3092-camera-recorder-stop-reports-the-join.md
+++ b/changelog.d/3092-camera-recorder-stop-reports-the-join.md
@@ -1,0 +1,22 @@
+### Fixed: a camera recording reported as stopped is one whose recorder thread has exited
+
+`Simulation.stop_cameras_recording` asked the daemon recorder loop to exit,
+joined it with a 5 s budget, and then discarded the outcome -- `Thread.join`
+returns `None` whether or not the thread finished. A loop still inside `render`
+when the budget expired therefore produced three answers that all read as
+success: the MP4 was encoded from a frame buffer the live loop was still
+appending to (the flush walks each buffer twice, so the encoded clip and the
+reported frame count could describe different lists), the recording was
+deregistered so no later call could re-join it, and `Already recording` no
+longer refused a second recorder on the same cameras -- putting two capture
+threads on one camera set. `get_cameras_recording_status` answered `[idle]`
+about that live thread.
+
+The join outcome is now read and reported. An expired join returns
+`status="error"` with `stopped=False` and the per-camera buffered frame counts,
+encodes nothing, and leaves the recording registered so a later
+`stop_cameras_recording()` re-joins the loop and flushes it. Both
+`start_cameras_recording` and `start_cameras_recording_synchronous` read the
+recorder thread's liveness rather than the `running` flag the loop outlives, and
+the status verb reports a `[stopping]` phase carrying `running` and
+`thread_alive` separately.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -471,10 +471,27 @@ if result["status"] == "error":
     result = sim.stop_cameras_recording()
 ```
 
-While that window is open, `get_cameras_recording_status` reports a third phase,
-`[stopping]`, with `running: False` and `thread_alive: True` in its JSON block,
-and both `start_cameras_recording` and `start_cameras_recording_synchronous`
-refuse a new recording rather than putting a second thread on the same cameras.
+Only a flush deregisters a recording, so being registered is exactly what "holds
+frames nobody has encoded" means -- and that is what both start verbs check.
+`start_cameras_recording` and `start_cameras_recording_synchronous` refuse a new
+recording for as long as the old one is registered, whether or not its thread is
+still alive: while it is, starting would put a second thread on the same cameras,
+and once it has exited, starting would silently discard the frames the failed
+stop just promised were recoverable. Retrying the stop is the remedy in both
+cases, and on a recording whose loop has exited it joins immediately and encodes.
+
+`get_cameras_recording_status` reports which of the four phases holds, in its
+text and as `phase` in its JSON block:
+
+| `phase` | `running` | `thread_alive` | Meaning |
+|---|---|---|---|
+| `recording` | `True` | `True` | Capturing normally. |
+| `stopping` | `False` | `True` | A stop's join expired; frames can still land. |
+| `unflushed` | `False` | `False` | The loop has exited, frames still unencoded -- stop again to flush. |
+| `idle` | - | - | Nothing registered; there is no buffer left to encode. |
+
+`[idle]` is therefore a promise that nothing is pending, which is why the
+settled-but-registered state gets its own name instead of borrowing it.
 
 `fps`, `width`, `height` and `max_frames_per_camera` on the plain-MP4 recorders
 must be positive whole numbers - the same domain `run_policy(video={...})`,

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -455,6 +455,27 @@ then only a lower bound, reported in the `unreadable_files` diagnostics.
 | `save_episode` | `[lerobot]` | Close current rollout as one episode (call once per `run_policy` for N episodes) |
 | `start_cameras_recording` / `stop_cameras_recording` | `[sim-mujoco]` alone | Plain MP4, no parquet |
 
+`stop_cameras_recording` returns a verdict, not just a report. The daemon
+recorder runs in its own thread, so the stop asks that loop to exit and waits
+5 s for it; if the loop is still inside `render` when the budget expires -- a
+wedged GL context, an EGL device that stopped answering -- the call is a
+structured **error** carrying `stopped: False` and the per-camera buffered frame
+counts, and no MP4 is written:
+
+```python
+result = sim.stop_cameras_recording()
+if result["status"] == "error":
+    # The loop is still capturing. Nothing was encoded (an MP4 read from a
+    # buffer that is still growing would not describe either frame list), and
+    # the recording is still registered -- call stop again to re-join it.
+    result = sim.stop_cameras_recording()
+```
+
+While that window is open, `get_cameras_recording_status` reports a third phase,
+`[stopping]`, with `running: False` and `thread_alive: True` in its JSON block,
+and both `start_cameras_recording` and `start_cameras_recording_synchronous`
+refuse a new recording rather than putting a second thread on the same cameras.
+
 `fps`, `width`, `height` and `max_frames_per_camera` on the plain-MP4 recorders
 must be positive whole numbers - the same domain `run_policy(video={...})`,
 `start_recording(fps=...)` and the shared encoder

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -117,6 +117,14 @@ def _max_render_bytes() -> int:
 # value read and the name quoted in a refusal cannot drift apart.
 _RENDER_ALLOW_ABS_ENV = "STRANDS_ROBOTS_RENDER_ALLOW_ABS"
 
+# How long ``stop_cameras_recording`` waits for the daemon recorder thread to
+# leave its capture loop. One owner for the value so the budget the join uses
+# and the number a refusal quotes cannot drift apart, matching
+# ``_TELEOP_JOIN_TIMEOUT_S`` and ``_FSM_REFRESHER_JOIN_S``. The loop checks
+# ``state["running"]`` once per camera, so the wait is one render call, not one
+# frame period -- the budget is sized for a slow render rather than a slow loop.
+_CAMS_REC_JOIN_TIMEOUT_S = 5.0
+
 
 def _validate_render_output_path(output_path: str) -> Path:
     """Validate an LLM-supplied render path, confined to the render sandbox.
@@ -1892,6 +1900,30 @@ class RenderingMixin:
     # background thread creates its own GL context. No shared state with
     # main dispatch thread.
 
+    def _capturing_cams_recording(self):
+        """The registered camera recording that is still capturing, or ``None``.
+
+        A recording is still capturing while its ``running`` flag is set OR
+        while its daemon recorder thread is alive, and the second half is not
+        implied by the first: :meth:`stop_cameras_recording` clears the flag
+        before it joins, so a loop wedged inside ``render`` outlives the flag
+        that describes it. Every read that took the flag alone as the answer
+        reported an idle recorder while that loop was still rendering into the
+        buffers -- which is what let a second recorder start beside it and what
+        made :meth:`get_cameras_recording_status` answer ``[idle]`` about a
+        live thread.
+
+        The synchronous recorder registers no thread, so for that variant this
+        reduces to the flag, which is the whole of its state.
+        """
+        state = getattr(self, "_cams_rec_state", None)
+        if not state:
+            return None
+        thread = state.get("thread")
+        if state.get("running") or (thread is not None and thread.is_alive()):
+            return state
+        return None
+
     def _active_camera_list(self, cameras):
         """Resolve cameras to concrete camera names currently in the world.
 
@@ -2087,8 +2119,12 @@ class RenderingMixin:
         width = None if width is None else int(width)
         height = None if height is None else int(height)
 
-        if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
-            cur = self._cams_rec_state["name"]
+        # Reads the recorder thread as well as the flag: a stop whose join
+        # expired leaves the daemon loop rendering, and starting a second
+        # recorder beside it puts two threads on the same cameras and replaces
+        # the state the first one is still writing into.
+        if (cur_state := self._capturing_cams_recording()) is not None:
+            cur = cur_state["name"]
             return {
                 "status": "error",
                 "content": [{"text": f"Already recording '{cur}'. Call stop_cameras_recording() first."}],
@@ -2348,16 +2384,62 @@ class RenderingMixin:
           ``on_frame`` is the preferred entry point but
           ``stop_cameras_recording`` works equivalently for callers that
           don't keep the closure handle.
+
+        The returned envelope reports the join outcome. ``Thread.join`` returns
+        ``None`` whether or not the thread finished, so the liveness read after
+        it is the only thing that tells a stopped recorder from one that
+        outlasted :data:`_CAMS_REC_JOIN_TIMEOUT_S` - a ``render`` call blocking
+        on a wedged GL context is the ordinary case. That outcome decides all
+        three of what happens next:
+
+        * ``status="error"`` with ``stopped=False``, so a caller cannot read
+          "success" while frames are still being captured.
+        * **Nothing is encoded.** The flush walks each buffer twice (once to
+          find the dominant frame shape, once to select it) and a live capture
+          loop appending between the two passes makes the encoded clip and the
+          reported counts describe different frame lists. An unflushed buffer is
+          recoverable; an MP4 encoded from a moving one is not.
+        * The recording stays registered, so a later call re-joins that loop
+          and flushes it, and :meth:`_capturing_cams_recording` can still see
+          the live thread - which is what keeps a second recorder from starting
+          on the same cameras.
         """
         state = getattr(self, "_cams_rec_state", None)
-        if not state or not state.get("running"):
-            # idempotent - 'already stopped' is a success, not an error.
+        if not state:
+            # idempotent - 'already stopped' is a success, not an error. A
+            # successful flush is what clears the registration, so a state that
+            # is still registered is still stoppable even with ``running``
+            # already cleared: that is precisely the recording whose join
+            # expired, and reading the flag here would refuse to re-join it and
+            # leave its buffers unflushed for good.
             return {"status": "success", "content": [{"text": "Was not recording cameras."}]}
 
         state["running"] = False
         thread = state.get("thread")
+        joined = True
         if thread is not None:
-            thread.join(timeout=5.0)
+            thread.join(timeout=_CAMS_REC_JOIN_TIMEOUT_S)
+            joined = not thread.is_alive()
+
+        if not joined:
+            cams = list(state["cameras"])
+            buffered = {cam: len(state["buffers"][cam]) for cam in cams}
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Camera recording '{state['name']}' did not stop within "
+                            f"{_CAMS_REC_JOIN_TIMEOUT_S:.1f}s: the recorder thread is still rendering "
+                            f"{cams}. Its render() call is most likely blocking. Nothing was encoded - "
+                            f"the buffers are left unflushed rather than read while that thread appends "
+                            f"to them - and the recording is left registered; call "
+                            f"stop_cameras_recording() again to re-join it."
+                        )
+                    },
+                    {"json": {"stopped": False, "recording": state["name"], "buffered_frames": buffered}},
+                ],
+            }
 
         result = self._flush_cameras_recording_state(state)
         self._cams_rec_state = None
@@ -2369,8 +2451,12 @@ class RenderingMixin:
         Shared by :meth:`stop_cameras_recording` (daemon-thread path) and
         the ``finalize`` callable returned by
         :meth:`start_cameras_recording_synchronous`. ``state`` is mutated
-        in place - ``running`` should already be ``False`` before this
-        runs, and the daemon thread (if any) already joined.
+        in place, and both callers must have established that no one else
+        is writing to it: ``running`` already ``False``, and the daemon
+        thread (if any) *observed* to have exited rather than merely asked
+        to. Reading a buffer a capture loop is still appending to is what
+        :meth:`stop_cameras_recording` refuses on an expired join rather
+        than encoding.
 
         Best-effort: per-camera flush failures are reported in the result
         dict's text + JSON (``frames`` / ``errors`` / ``size_kb``) but
@@ -2596,8 +2682,12 @@ class RenderingMixin:
         width = None if width is None else int(width)
         height = None if height is None else int(height)
 
-        if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
-            cur = self._cams_rec_state["name"]
+        # Reads the recorder thread as well as the flag: a stop whose join
+        # expired leaves the daemon loop rendering, and starting a second
+        # recorder beside it puts two threads on the same cameras and replaces
+        # the state the first one is still writing into.
+        if (cur_state := self._capturing_cams_recording()) is not None:
+            cur = cur_state["name"]
             return {
                 "status": "error",
                 "content": [{"text": f"Already recording '{cur}'. Call stop_cameras_recording() first."}],
@@ -2724,16 +2814,48 @@ class RenderingMixin:
         }
 
     def get_cameras_recording_status(self):
-        """Cheap introspection of an ongoing multi-camera recording."""
+        """Cheap introspection of an ongoing multi-camera recording.
+
+        Three phases, not two. ``[recording]`` is a live capture, ``[idle]`` is
+        no registered recorder, and ``[stopping]`` is the window between a stop
+        whose join expired and the recorder thread actually exiting - frames can
+        still land in that window, so answering ``[idle]`` there would
+        contradict the thread. The JSON block carries ``running`` and
+        ``thread_alive`` separately for the same reason: they differ for exactly
+        as long as a loop outlives the stop that asked it to exit.
+        """
         import time as _time
 
-        state = getattr(self, "_cams_rec_state", None)
-        if not state or not state.get("running"):
+        state = self._capturing_cams_recording()
+        if state is None:
             return {"status": "success", "content": [{"text": "[idle] No active camera recording."}]}
 
+        # ``running`` cleared with the thread still alive is the window a stop
+        # opened and could not close. Reporting it as ``[recording]`` would
+        # claim a capture nobody asked for, and as ``[idle]`` would contradict
+        # the thread, so it gets its own phase.
+        thread = state.get("thread")
+        stopping = not state.get("running") and thread is not None and thread.is_alive()
         elapsed = _time.monotonic() - state["started_mono"]
-        lines = [f"[recording] '{state['name']}' for {elapsed:.1f}s  @ {state['fps']} FPS"]
+        phase = "stopping" if stopping else "recording"
+        head = f"[{phase}] '{state['name']}' for {elapsed:.1f}s  @ {state['fps']} FPS"
+        if stopping:
+            head += "  (stop requested; the recorder thread has not exited)"
+        lines = [head]
         for cam in state["cameras"]:
             frames = len(state["buffers"][cam])
             lines.append(f"   {cam:20s} {frames:>5d} frames  ({state['errors'][cam]} errors)")
-        return {"status": "success", "content": [{"text": "\n".join(lines)}]}
+        return {
+            "status": "success",
+            "content": [
+                {"text": "\n".join(lines)},
+                {
+                    "json": {
+                        "recording": state["name"],
+                        "running": bool(state.get("running")),
+                        "thread_alive": thread is not None and thread.is_alive(),
+                        "frames": {cam: len(state["buffers"][cam]) for cam in state["cameras"]},
+                    }
+                },
+            ],
+        }

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1900,29 +1900,89 @@ class RenderingMixin:
     # background thread creates its own GL context. No shared state with
     # main dispatch thread.
 
-    def _capturing_cams_recording(self):
-        """The registered camera recording that is still capturing, or ``None``.
+    def _cams_recording_phase(self):
+        """The registered camera recording and the phase it is in.
 
-        A recording is still capturing while its ``running`` flag is set OR
-        while its daemon recorder thread is alive, and the second half is not
-        implied by the first: :meth:`stop_cameras_recording` clears the flag
-        before it joins, so a loop wedged inside ``render`` outlives the flag
-        that describes it. Every read that took the flag alone as the answer
-        reported an idle recorder while that loop was still rendering into the
-        buffers -- which is what let a second recorder start beside it and what
-        made :meth:`get_cameras_recording_status` answer ``[idle]`` about a
-        live thread.
+        Returns ``(None, "idle")`` when nothing is registered, else the state
+        and one of:
 
-        The synchronous recorder registers no thread, so for that variant this
-        reduces to the flag, which is the whole of its state.
+        * ``"recording"`` -- ``running`` set, the loop is capturing.
+        * ``"stopping"`` -- ``running`` cleared but the recorder thread is
+          still alive. :meth:`stop_cameras_recording` clears the flag before it
+          joins, so a loop wedged inside ``render`` outlives the flag that
+          describes it; reading the flag alone reported an idle recorder while
+          that loop was still rendering into the buffers.
+        * ``"unflushed"`` -- ``running`` cleared and the thread gone, but the
+          registration still standing. Only a flush deregisters, so this is a
+          buffer of captured frames that nothing has encoded: the state a stop
+          whose join expired decays into once the slow ``render`` returns and
+          the loop exits. Liveness cannot see it, and it is droppable, so every
+          read that decides whether a buffer may be replaced keys on the
+          registration instead.
+
+        Registration is the load-bearing half. ``_cams_rec_state`` is set by the
+        two start verbs and cleared only by a successful flush, so "registered"
+        means exactly "holds frames nobody has encoded" -- which is the question
+        the start guards are asking, and the reason they cannot ask about
+        liveness. The thread read only distinguishes the two registered phases
+        that are still moving from the one that has settled.
+
+        The synchronous recorder registers no thread, so its live phase is
+        ``"recording"`` on the flag alone and its ``finalize`` flushes and
+        deregisters in one step.
         """
         state = getattr(self, "_cams_rec_state", None)
         if not state:
-            return None
+            return None, "idle"
+        if state.get("running"):
+            return state, "recording"
         thread = state.get("thread")
-        if state.get("running") or (thread is not None and thread.is_alive()):
-            return state
-        return None
+        if thread is not None and thread.is_alive():
+            return state, "stopping"
+        return state, "unflushed"
+
+    def _refuse_replacing_cams_recording(self):
+        """The refusal a ``start_cameras_recording*`` verb owes a registered recording.
+
+        ``None`` when there is nothing registered and a start may proceed. Both
+        start verbs register into the same ``_cams_rec_state``, so both had the
+        same hole and both ask through here.
+
+        A start replaces that attribute, so on any registered phase it would
+        drop whatever the previous recording had buffered. While the previous
+        loop is alive that also puts two capture threads on one camera set; once
+        it has exited the damage is quieter and worse -- captured frames
+        discarded under ``status="success"``, with no warning and no flush,
+        which is the outcome :meth:`stop_cameras_recording` refuses to produce
+        on an expired join in the first place. Refusing every registered phase
+        is what makes the "call ``stop_cameras_recording()`` again" contract
+        that error advertises hold for the callers who hit it: a stop on a
+        settled recording joins immediately and encodes.
+        """
+        state, phase = self._cams_recording_phase()
+        if state is None:
+            return None
+        name = state["name"]
+        if phase == "unflushed":
+            buffered = {cam: len(state["buffers"][cam]) for cam in state["cameras"]}
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Camera recording '{name}' is still registered with frames no flush has "
+                            f"read: {buffered}. Its recorder thread has exited, so a stop now joins "
+                            f"immediately -- call stop_cameras_recording() first to encode them. "
+                            f"Starting a new recording here would discard them."
+                        )
+                    },
+                    {"json": {"phase": phase, "recording": name, "buffered_frames": buffered}},
+                ],
+            }
+        return {
+            "status": "error",
+            "content": [{"text": f"Already recording '{name}'. Call stop_cameras_recording() first."}],
+        }
 
     def _active_camera_list(self, cameras):
         """Resolve cameras to concrete camera names currently in the world.
@@ -2119,16 +2179,12 @@ class RenderingMixin:
         width = None if width is None else int(width)
         height = None if height is None else int(height)
 
-        # Reads the recorder thread as well as the flag: a stop whose join
-        # expired leaves the daemon loop rendering, and starting a second
-        # recorder beside it puts two threads on the same cameras and replaces
-        # the state the first one is still writing into.
-        if (cur_state := self._capturing_cams_recording()) is not None:
-            cur = cur_state["name"]
-            return {
-                "status": "error",
-                "content": [{"text": f"Already recording '{cur}'. Call stop_cameras_recording() first."}],
-            }
+        # Keyed on the registration, not on liveness: a start replaces
+        # ``_cams_rec_state``, so every registered phase has frames it would
+        # drop -- including the settled one a stop whose join expired decays
+        # into, which no liveness read can see.
+        if (refusal := self._refuse_replacing_cams_recording()) is not None:
+            return refusal
 
         names, unresolved = self._active_camera_list(cameras)
         # Strict validation: if user specified cameras, error on any unresolved names
@@ -2400,9 +2456,12 @@ class RenderingMixin:
           reported counts describe different frame lists. An unflushed buffer is
           recoverable; an MP4 encoded from a moving one is not.
         * The recording stays registered, so a later call re-joins that loop
-          and flushes it, and :meth:`_capturing_cams_recording` can still see
-          the live thread - which is what keeps a second recorder from starting
-          on the same cameras.
+          and flushes it. The registration is also what keeps a second recorder
+          from starting on the same cameras, and it keeps doing so after the
+          slow ``render`` returns and the loop exits: the start guards read the
+          registration rather than the thread, because that settled state still
+          holds the frames this refusal promised were recoverable. See
+          :meth:`_cams_recording_phase`.
         """
         state = getattr(self, "_cams_rec_state", None)
         if not state:
@@ -2682,16 +2741,12 @@ class RenderingMixin:
         width = None if width is None else int(width)
         height = None if height is None else int(height)
 
-        # Reads the recorder thread as well as the flag: a stop whose join
-        # expired leaves the daemon loop rendering, and starting a second
-        # recorder beside it puts two threads on the same cameras and replaces
-        # the state the first one is still writing into.
-        if (cur_state := self._capturing_cams_recording()) is not None:
-            cur = cur_state["name"]
-            return {
-                "status": "error",
-                "content": [{"text": f"Already recording '{cur}'. Call stop_cameras_recording() first."}],
-            }
+        # Keyed on the registration, not on liveness: a start replaces
+        # ``_cams_rec_state``, so every registered phase has frames it would
+        # drop -- including the settled one a stop whose join expired decays
+        # into, which no liveness read can see.
+        if (refusal := self._refuse_replacing_cams_recording()) is not None:
+            return refusal
 
         names, unresolved = self._active_camera_list(cameras)
         if cameras is not None and unresolved:
@@ -2816,31 +2871,34 @@ class RenderingMixin:
     def get_cameras_recording_status(self):
         """Cheap introspection of an ongoing multi-camera recording.
 
-        Three phases, not two. ``[recording]`` is a live capture, ``[idle]`` is
-        no registered recorder, and ``[stopping]`` is the window between a stop
-        whose join expired and the recorder thread actually exiting - frames can
-        still land in that window, so answering ``[idle]`` there would
-        contradict the thread. The JSON block carries ``running`` and
-        ``thread_alive`` separately for the same reason: they differ for exactly
-        as long as a loop outlives the stop that asked it to exit.
+        Four phases, and only one of them is ``[idle]``. ``[recording]`` is a
+        live capture; ``[stopping]`` is the window between a stop whose join
+        expired and the recorder thread actually exiting, where frames can still
+        land; ``[unflushed]`` is that window after the thread has gone, holding
+        frames no flush has read; and ``[idle]`` means nothing is registered at
+        all. The last distinction is the one worth stating: only a flush
+        deregisters a recording, so ``[idle]`` promises there is no buffer left
+        to encode, and answering it about a settled-but-registered state would
+        report captured frames as if they had never existed.
+
+        The JSON block carries ``phase`` alongside ``running`` and
+        ``thread_alive`` because the three registered phases need two booleans
+        to tell apart, and re-deriving them is the reading this verb exists to
+        hand over rather than leave to the caller.
         """
         import time as _time
 
-        state = self._capturing_cams_recording()
+        state, phase = self._cams_recording_phase()
         if state is None:
             return {"status": "success", "content": [{"text": "[idle] No active camera recording."}]}
 
-        # ``running`` cleared with the thread still alive is the window a stop
-        # opened and could not close. Reporting it as ``[recording]`` would
-        # claim a capture nobody asked for, and as ``[idle]`` would contradict
-        # the thread, so it gets its own phase.
         thread = state.get("thread")
-        stopping = not state.get("running") and thread is not None and thread.is_alive()
         elapsed = _time.monotonic() - state["started_mono"]
-        phase = "stopping" if stopping else "recording"
         head = f"[{phase}] '{state['name']}' for {elapsed:.1f}s  @ {state['fps']} FPS"
-        if stopping:
+        if phase == "stopping":
             head += "  (stop requested; the recorder thread has not exited)"
+        elif phase == "unflushed":
+            head += "  (stopped, not encoded; call stop_cameras_recording() to flush)"
         lines = [head]
         for cam in state["cameras"]:
             frames = len(state["buffers"][cam])
@@ -2852,6 +2910,7 @@ class RenderingMixin:
                 {
                     "json": {
                         "recording": state["name"],
+                        "phase": phase,
                         "running": bool(state.get("running")),
                         "thread_alive": thread is not None and thread.is_alive(),
                         "frames": {cam: len(state["buffers"][cam]) for cam in state["cameras"]},

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2918,11 +2918,16 @@ class MuJoCoSimEngine(
         base["methods"]["stop_cameras_recording"] = (
             "() -> dict  # stop start_cameras_recording, flush each camera's "
             "buffer to an MP4, and report per-camera frame counts + paths; "
-            "idempotent. The inverse of start_cameras_recording"
+            "idempotent. The inverse of start_cameras_recording. status='error' "
+            "with stopped=False means the recorder thread outlived the join "
+            "budget: nothing was encoded and the recording is still registered, "
+            "so call it again to re-join that loop"
         )
         base["methods"]["get_cameras_recording_status"] = (
             "() -> dict  # inspect an in-progress start_cameras_recording "
-            "(elapsed time, per-camera frame counts); reports idle when none is active"
+            "(elapsed time, per-camera frame counts, running vs thread_alive); "
+            "reports idle when none is active and stopping while a loop outlives "
+            "the stop that asked it to exit"
         )
 
         # Physics-introspection / grounding surface. The discovery surface

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2926,8 +2926,9 @@ class MuJoCoSimEngine(
         base["methods"]["get_cameras_recording_status"] = (
             "() -> dict  # inspect an in-progress start_cameras_recording "
             "(elapsed time, per-camera frame counts, running vs thread_alive); "
-            "reports idle when none is active and stopping while a loop outlives "
-            "the stop that asked it to exit"
+            "phase is recording, stopping while a loop outlives the stop that "
+            "asked it to exit, unflushed once that loop has gone but its frames "
+            "are still unencoded, or idle only when no buffer is left to encode"
         )
 
         # Physics-introspection / grounding surface. The discovery surface

--- a/tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py
+++ b/tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py
@@ -1,0 +1,257 @@
+"""A camera-recorder stop that cannot join its thread says so, and encodes nothing.
+
+``stop_cameras_recording`` asks the daemon recorder loop to exit, waits
+:data:`~strands_robots.simulation.mujoco.rendering._CAMS_REC_JOIN_TIMEOUT_S` for
+it, and then has to decide what to report. ``Thread.join`` returns ``None``
+whether or not the thread finished, so the liveness read after it is the only
+thing that distinguishes a stopped recorder from one still inside ``render`` -
+and that one reading decides three separate answers: the envelope's verdict,
+whether the buffers may be encoded, and whether the recording stays registered.
+
+The window is ordinary rather than exotic: ``render`` on a wedged GL context, an
+EGL device that stops answering, or a frame large enough that one encode outlasts
+the budget. What made it worth pinning is that the *consequences* of getting the
+verdict wrong all read as success - an MP4 encoded from a frame list that is
+still growing, a status verb answering ``[idle]`` about a live thread, and a
+second recorder started on the same cameras because the guard that should have
+refused it reads a flag the first loop already outlived.
+
+Each cell drives a real daemon thread and wedges it inside ``render``, mirroring
+``test_daemon_camera_recording.py``'s fake-render harness so no GL context is
+needed. The join budget is monkeypatched down so a cell costs a fraction of a
+second rather than the production wait.
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+mujoco = pytest.importorskip("mujoco", reason="mujoco not installed - pip install strands-robots[sim-mujoco]")
+imageio = pytest.importorskip("imageio", reason="imageio not installed - pip install imageio imageio-ffmpeg")
+
+from strands_robots.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.mujoco import rendering  # noqa: E402
+
+# Short enough that a cell's failed join is not felt, long enough that the
+# capture loop reaches the wedge on a loaded box.
+_TEST_JOIN_BUDGET_S = 0.5
+
+
+def _render_result(width: int, height: int) -> dict[str, Any]:
+    """A ``render()`` envelope carrying a real PNG the recorder can decode.
+
+    A gradient rather than a flat fill: the recorder's warmup discards frames
+    whose per-column standard deviation reads as a cold GL gradient.
+    """
+    from PIL import Image
+
+    row = np.linspace(0, 255, width, dtype=np.uint8)
+    arr = np.repeat(row[None, :], height, axis=0)
+    arr = np.stack([arr, arr[::-1], arr], axis=-1).astype(np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")
+    return {
+        "status": "success",
+        "content": [
+            {"text": f"{width}x{height}"},
+            {"image": {"format": "png", "source": {"bytes": buf.getvalue()}}},
+        ],
+    }
+
+
+class _WedgeableRecorder:
+    """A sim whose recorder thread can be parked inside ``render`` on demand.
+
+    ``arm()`` makes the next ``render`` block until ``release()``, so a test can
+    let real frames buffer first and only then produce the state the join budget
+    cannot clear. Without the two-phase shape the wedge lands during the warmup
+    loop instead, and the buffers a stop would have flushed are empty - which is
+    a different situation with the same symptom.
+    """
+
+    def __init__(self) -> None:
+        self.sim = Simulation()
+        self.sim.create_world()
+        self.sim.add_robot("arm", data_config="so101", position=[0.0, 0.0, 0.0])
+        self.sim.add_camera("cam_a", position=[-0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+        self._armed = threading.Event()
+        self._released = threading.Event()
+        self.wedged = threading.Event()
+        self.sim.render = self._render  # type: ignore[assignment,method-assign]
+
+    def _render(self, camera_name: str, width: int | None = None, height: int | None = None, **_kw: Any) -> dict:
+        if self._armed.is_set():
+            self.wedged.set()
+            self._released.wait(timeout=30)
+        return _render_result(width or 32, height or 24)
+
+    def buffered(self, camera: str = "cam_a") -> int:
+        state = self.sim._cams_rec_state
+        return 0 if state is None else len(state["buffers"][camera])
+
+    def wedge(self) -> threading.Thread:
+        """Buffer a few real frames, then park the loop inside ``render``."""
+        deadline = time.monotonic() + 30.0
+        while self.buffered() < 3 and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert self.buffered() >= 3, "premise: the recorder buffers frames before it is wedged"
+        thread = self.sim._cams_rec_state["thread"]
+        self._armed.set()
+        assert self.wedged.wait(timeout=30), "premise: the recorder thread reaches the blocking render"
+        return thread
+
+    def release(self) -> None:
+        self._armed.clear()
+        self._released.set()
+
+
+@pytest.fixture
+def recorder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A started daemon recording whose thread is released at teardown."""
+    monkeypatch.setattr(rendering, "_CAMS_REC_JOIN_TIMEOUT_S", _TEST_JOIN_BUDGET_S)
+    rec = _WedgeableRecorder()
+    started = rec.sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="wedge")
+    assert started["status"] == "success", started
+    try:
+        yield rec
+    finally:
+        rec.release()
+        thread = (rec.sim._cams_rec_state or {}).get("thread")
+        if thread is not None:
+            thread.join(timeout=10)
+
+
+def _json_block(envelope: dict) -> dict:
+    """The single JSON payload of a tool envelope."""
+    blocks = [c["json"] for c in envelope["content"] if "json" in c]
+    assert len(blocks) == 1, envelope
+    return blocks[0]
+
+
+class TestAStopWhoseJoinExpires:
+    """The recorder thread outlives the budget: one reading, four consequences."""
+
+    def test_the_stop_refuses_instead_of_reporting_a_stop_that_did_not_happen(self, recorder) -> None:
+        """A caller cannot read success while the loop is still capturing."""
+        thread = recorder.wedge()
+
+        result = recorder.sim.stop_cameras_recording()
+
+        assert thread.is_alive(), "premise: the wedged thread outlives the join budget"
+        assert result["status"] == "error", result
+        payload = _json_block(result)
+        assert payload["stopped"] is False
+        assert payload["recording"] == "wedge"
+        # The frames it did capture are reported, so the refusal says what is
+        # pending rather than only that something went wrong.
+        assert payload["buffered_frames"]["cam_a"] >= 3
+        text = result["content"][0]["text"]
+        assert f"{_TEST_JOIN_BUDGET_S:.1f}s" in text, text
+        assert "cam_a" in text
+
+    def test_no_mp4_is_encoded_from_a_buffer_the_loop_is_still_appending_to(self, recorder, tmp_path) -> None:
+        """The flush reads each buffer twice; a live appender makes the two disagree."""
+        recorder.wedge()
+
+        recorder.sim.stop_cameras_recording()
+
+        assert list(tmp_path.glob("*.mp4")) == []
+
+    def test_the_recording_stays_registered_so_a_later_call_re_joins_and_flushes_it(self, recorder, tmp_path) -> None:
+        """The unflushed buffers are recoverable: the second stop writes the MP4."""
+        recorder.wedge()
+        first = recorder.sim.stop_cameras_recording()
+        assert first["status"] == "error"
+        assert recorder.sim._cams_rec_state is not None, "the handle is the only route back to the loop"
+
+        recorder.release()
+        second = recorder.sim.stop_cameras_recording()
+
+        assert second["status"] == "success", second
+        artifact = _json_block(second)["artifacts"][0]
+        assert artifact["frames"] >= 3
+        mp4 = Path(artifact["path"])
+        assert mp4.exists()
+        # Round-trip: what was written is a readable clip, not a sealed stub.
+        with imageio.v2.get_reader(str(mp4)) as reader:
+            assert sum(1 for _ in reader) == artifact["frames"]
+        assert recorder.sim._cams_rec_state is None, "a real stop deregisters the recording"
+
+    def test_the_status_verb_reports_the_loop_that_has_not_exited(self, recorder) -> None:
+        """``running`` and ``thread_alive`` differ exactly across this window."""
+        recorder.wedge()
+        recorder.sim.stop_cameras_recording()
+
+        status = recorder.sim.get_cameras_recording_status()
+
+        assert status["status"] == "success"
+        text = status["content"][0]["text"]
+        assert text.startswith("[stopping]"), text
+        assert "[idle]" not in text
+        payload = _json_block(status)
+        assert payload["running"] is False
+        assert payload["thread_alive"] is True
+
+    def test_a_second_recorder_cannot_start_beside_the_live_one(self, recorder, tmp_path) -> None:
+        """Two threads on one camera set is what the start guard exists to refuse."""
+        recorder.wedge()
+        recorder.sim.stop_cameras_recording()
+
+        again = recorder.sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="second")
+
+        assert again["status"] == "error", again
+        assert "Already recording 'wedge'" in again["content"][0]["text"]
+
+    def test_the_synchronous_variant_is_refused_for_the_same_reason(self, recorder, tmp_path) -> None:
+        """Both start verbs share one registration, so both read the same liveness."""
+        recorder.wedge()
+        recorder.sim.stop_cameras_recording()
+
+        again = recorder.sim.start_cameras_recording_synchronous(
+            cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="second"
+        )
+
+        assert again["status"] == "error", again
+        assert "Already recording 'wedge'" in again["content"][0]["text"]
+
+
+class TestARecorderThatExitsIsUnaffected:
+    """Controls: the ordinary paths keep their existing answers."""
+
+    def test_a_joined_recorder_reports_success_and_writes_its_mp4(self, recorder) -> None:
+        """The whole point is a verdict, not a refusal - an exiting loop still flushes."""
+        deadline = time.monotonic() + 30.0
+        while recorder.buffered() < 2 and time.monotonic() < deadline:
+            time.sleep(0.02)
+
+        result = recorder.sim.stop_cameras_recording()
+
+        assert result["status"] == "success", result
+        artifact = _json_block(result)["artifacts"][0]
+        assert artifact["frames"] >= 2
+        assert Path(artifact["path"]).exists()
+        assert recorder.sim._cams_rec_state is None
+
+    def test_nothing_registered_is_still_the_idempotent_no_op(self, recorder) -> None:
+        """A second stop after a real one is a success, not an error."""
+        recorder.sim.stop_cameras_recording()
+
+        again = recorder.sim.stop_cameras_recording()
+
+        assert again["status"] == "success"
+        assert "Was not recording cameras." in again["content"][0]["text"]
+
+    def test_status_is_idle_once_the_recording_is_deregistered(self, recorder) -> None:
+        """``[stopping]`` is a third phase, not a replacement for ``[idle]``."""
+        recorder.sim.stop_cameras_recording()
+
+        status = recorder.sim.get_cameras_recording_status()
+
+        assert "[idle]" in status["content"][0]["text"]

--- a/tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py
+++ b/tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py
@@ -16,6 +16,12 @@ still growing, a status verb answering ``[idle]`` about a live thread, and a
 second recorder started on the same cameras because the guard that should have
 refused it reads a flag the first loop already outlived.
 
+The refusal it settles on promises the buffered frames are recoverable through a
+second stop, which makes every read *between* the two calls part of the same
+defect: the state decays -- the slow ``render`` returns, the loop exits -- into
+one that no liveness read can see but that still holds those frames, so a guard
+keyed on liveness would let a `start` drop them under ``status="success"``.
+
 Each cell drives a real daemon thread and wedges it inside ``render``, mirroring
 ``test_daemon_camera_recording.py``'s fake-render harness so no GL context is
 needed. The join budget is monkeypatched down so a cell costs a fraction of a
@@ -110,6 +116,23 @@ class _WedgeableRecorder:
     def release(self) -> None:
         self._armed.clear()
         self._released.set()
+
+    def settle(self) -> int:
+        """Let the wedged ``render`` return so the loop exits, and count what it left.
+
+        The state a failed stop decays into on the ordinary recovery path: the
+        budget is sized for a slow render, i.e. one that does return, just late.
+        ``running`` is already clear, so the loop appends the frame that render
+        was holding and then leaves -- and the registration outlives it, because
+        only a flush deregisters.
+        """
+        thread = self.sim._cams_rec_state["thread"]
+        self.release()
+        thread.join(timeout=30)
+        assert not thread.is_alive(), "premise: the released render lets the loop exit"
+        buffered = self.buffered()
+        assert buffered >= 3, "premise: the settled state still holds the captured frames"
+        return buffered
 
 
 @pytest.fixture
@@ -220,6 +243,87 @@ class TestAStopWhoseJoinExpires:
 
         assert again["status"] == "error", again
         assert "Already recording 'wedge'" in again["content"][0]["text"]
+
+
+class TestASettledRecordingIsNotDroppable:
+    """The failed stop decays: thread gone, buffers still registered and unencoded.
+
+    This is where the recovery contract is kept or broken. The refusal tells the
+    caller the frames are recoverable via a second stop, so nothing between the
+    two calls may discard them -- and a guard that reads liveness stops seeing
+    this state the moment the slow ``render`` returns, which is precisely when
+    the caller is most likely to retry. Reading the registration instead makes
+    the same caller sequence answer the same way whether or not the wedge
+    cleared in between.
+    """
+
+    def test_a_start_cannot_discard_the_frames_the_failed_stop_promised_were_recoverable(
+        self, recorder, tmp_path
+    ) -> None:
+        """The frames survive the refused start, so the second stop can still encode them."""
+        recorder.wedge()
+        assert recorder.sim.stop_cameras_recording()["status"] == "error"
+        buffered = recorder.settle()
+
+        again = recorder.sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="second")
+
+        assert again["status"] == "error", again
+        text = again["content"][0]["text"]
+        assert "stop_cameras_recording() first" in text, text
+        assert str(buffered) in text, text
+        assert _json_block(again)["phase"] == "unflushed"
+        # The refusal is only worth anything if the buffer it protected is intact.
+        assert recorder.sim._cams_rec_state["name"] == "wedge"
+        assert recorder.buffered() == buffered
+
+    def test_the_synchronous_start_reads_the_same_registration(self, recorder, tmp_path) -> None:
+        """Both start verbs replace one attribute, so one guard answers for both."""
+        recorder.wedge()
+        assert recorder.sim.stop_cameras_recording()["status"] == "error"
+        buffered = recorder.settle()
+
+        again = recorder.sim.start_cameras_recording_synchronous(
+            cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="second"
+        )
+
+        assert again["status"] == "error", again
+        assert "stop_cameras_recording() first" in again["content"][0]["text"]
+        assert recorder.sim._cams_rec_state["name"] == "wedge"
+        assert recorder.buffered() == buffered
+
+    def test_the_status_verb_does_not_call_an_unencoded_buffer_idle(self, recorder) -> None:
+        """``[idle]`` promises nothing is left to encode; here something is."""
+        recorder.wedge()
+        recorder.sim.stop_cameras_recording()
+        buffered = recorder.settle()
+
+        status = recorder.sim.get_cameras_recording_status()
+
+        text = status["content"][0]["text"]
+        assert text.startswith("[unflushed]"), text
+        assert "[idle]" not in text
+        payload = _json_block(status)
+        assert payload["phase"] == "unflushed"
+        # Neither boolean is set here, which is why the phase had to be carried:
+        # a caller reading only these two cannot tell this from a stale handle.
+        assert payload["running"] is False
+        assert payload["thread_alive"] is False
+        assert payload["frames"]["cam_a"] == buffered
+
+    def test_the_second_stop_still_encodes_the_settled_buffer(self, recorder) -> None:
+        """The advertised remedy: a stop on a settled recording joins at once and flushes."""
+        recorder.wedge()
+        assert recorder.sim.stop_cameras_recording()["status"] == "error"
+        buffered = recorder.settle()
+
+        second = recorder.sim.stop_cameras_recording()
+
+        assert second["status"] == "success", second
+        artifact = _json_block(second)["artifacts"][0]
+        assert artifact["frames"] == buffered
+        with imageio.v2.get_reader(str(artifact["path"])) as reader:
+            assert sum(1 for _ in reader) == buffered
+        assert recorder.sim._cams_rec_state is None
 
 
 class TestARecorderThatExitsIsUnaffected:


### PR DESCRIPTION
`stop_cameras_recording` asks the daemon recorder loop to exit, joins it with a 5 s budget, and then **discarded the outcome** -- `Thread.join` returns `None` whether or not the thread finished, so the liveness read after it is the only thing that tells a stopped recorder from one still inside `render`.

That one discarded reading decides three separate answers, and all three failed as *success*.

## Measured, same probe on both trees

A real daemon recorder buffers 3 frames, then parks inside `render` (a wedged GL context, an EGL device that stopped answering) so the join budget cannot clear it.

| | before | after |
|---|---|---|
| `stop()` status | `success` | **`error`** |
| `stop()` json | `artifacts: [{frames: 4, size_kb: 1.6}]` | **`{stopped: False, buffered_frames: {cam_a: 4}}`** |
| recorder thread alive after stop | `True` | `True` |
| MP4 encoded while the loop is live | **`True`** | `False` |
| recording still registered | `False` | **`True`** |
| `get_cameras_recording_status()` | `[idle]` | **`[stopping]`** |
| second `start_cameras_recording()` | `success` | **`error`** |
| non-main threads alive | **2** | 1 |
| re-join `stop()` flushed | `'second'`, 12 frames | **`'wedge'`, 5 frames** |
| MP4 reopens with | 4 frames | **5 frames** |

The encoded MP4 is the sharp edge: the flush walks each buffer twice, once to find the dominant frame shape and once to select it, so a live appender makes the encoded clip and the reported count describe different frame lists. An unflushed buffer is recoverable; an MP4 sealed from a moving one is not -- and `before` sealed a 4-frame clip and deregistered the recording, so the frames captured after it were unreachable. The `before` re-join column shows the rest of the damage: the later stop flushed `'second'`, a recording that only exists because the start guard read a flag the first loop had already outlived, and its 12 frames came off two capture threads sharing one camera.

## The change

```
state["running"] = False
thread.join(timeout=_CAMS_REC_JOIN_TIMEOUT_S)
joined = not thread.is_alive()     # <- the reading that was missing
```

An expired join returns `status="error"` with `stopped=False` and the per-camera buffered counts, **encodes nothing**, and leaves the recording registered so a later `stop_cameras_recording()` re-joins that loop and flushes it.

That registration is the whole contract, so it is also what the other three verbs read. **Only a flush deregisters a recording**, which makes "registered" mean exactly "holds frames nobody has encoded" -- the question a `start` is asking, since a start replaces the registration. `_cams_recording_phase()` returns the state plus one of four phases, and one shared refusal (`_refuse_replacing_cams_recording`) answers for both `start_cameras_recording*` verbs, which register into the same state and so had the same hole.

```mermaid
stateDiagram-v2
    [*] --> recording: start_cameras_recording()
    recording --> idle: stop() joined -> flush, deregister
    recording --> stopping: stop() join expired -> refuse, encode nothing
    stopping --> idle: stop() again -> re-join, flush
    stopping --> unflushed: the slow render returns, the loop exits
    unflushed --> idle: stop() -> joins at once, flush
    stopping --> stopping: start() refused, status reports thread_alive
    unflushed --> unflushed: start() refused, status reports the buffered counts
```

`unflushed` is the phase a failed stop *decays into*, and it is the one liveness cannot see: `running` is clear and the thread is gone, but the frames are still there. Keying the start guards on registration rather than liveness is what makes the recovery the error advertises hold for the callers who actually hit it -- otherwise the same sequence (`stop` -> error -> `start`) is refused or silently lossy depending only on whether the wedge cleared in between. `[idle]` now carries a promise: nothing is left to encode.

The status JSON carries `phase` alongside `running` and `thread_alive`, because the three registered phases take two booleans to tell apart and handing over the reading rather than leaving it to be re-derived is the point of the whole change.

The join budget moves from a bare `5.0` into `_CAMS_REC_JOIN_TIMEOUT_S`, so the value the wait uses and the number the refusal quotes cannot drift -- the shape `_TELEOP_JOIN_TIMEOUT_S` and `_FSM_REFRESHER_JOIN_S` already use for the same decision.

## The happy path, recorded through the fixed code

A 4 s mock-policy rollout on `so101` captured by the daemon recorder, MuJoCo headless (`MUJOCO_GL=egl`), 480x360 @ 30 fps: `start` -> `[recording] 'recorder_join' for 0.8s @ 30 FPS` -> `stop` `success`, **124 frames / 519 KB / 0 errors**, and the clip reopens with 124 frames == the count it reported. Status after the stop: `[idle]`.

![daemon recorder rollout](https://raw.githubusercontent.com/cagataycali/robots/assets/camera-recorder-stop-reports-the-join/recorder_join.gif)

[recorder_join__scene.mp4](https://raw.githubusercontent.com/cagataycali/robots/assets/camera-recorder-stop-reports-the-join/recorder_join__scene.mp4) (531 KB, the encoder's own output)

## Tests

`tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py`, **13 cells** driving a real daemon thread with the fake-render harness `test_daemon_camera_recording.py` established, with the join budget monkeypatched down so the file runs in 11 s.

Against the pre-PR mechanism (the join outcome discarded and every read back on the `running` flag alone, the new symbols left defined so the module still imports): **10 failed / 3 passed**. The three greens are the controls -- a recorder that does exit still reports success and writes its MP4, a second stop is still the idempotent `Was not recording cameras.`, and `[idle]` still means idle. Post-fix: **13 passed**.

Against the round-1 intermediate (the join reading present but the start guards and the status verb keyed on liveness): **3 failed / 10 passed** -- the two start verbs and the status verb, i.e. exactly the reads that could not see a settled registration. The fourth new cell passes there because the stop path was already right on that state, which is what makes it the remedy the refusal points at; it fails against pre-PR only because pre-PR no settled state could exist at all.

Two cells are recovery round-trips end to end, one per route back: the second stop re-joining a loop that is still alive, and a stop on a loop that has already exited. Both end `success`, MP4 written, reopened, frame count equal to the reported one.

## Gate

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy` over the same scope: **18 errors in 16 files**, all `import-not-found` for extras absent from this env plus two pre-existing errors in `training/rl/gym_env.py` / `doctor.py`; **none in any file this PR touches**, 0 attributable.
- `MUJOCO_GL=osmesa pytest tests/simulation`: **13,559 passed, 278 skipped, 12 failed in 10m57s**. All 12 are the LeRobot/`pyav` extra paths (`start_recording`, `save_episode`, `verify_dataset`), and the same 12 fail identically on a pristine `d584cbaf` worktree against the same interpreter -- 0 attributable.
- Whole-tree graders: 139 passed, 1 skipped for the five that do not need the absent `lerobot` extra, including `test_docstring_xref_roles_resolve.py`, which covers the new `:meth:` cross-references.
- `scripts/assemble_changelog.py --check`: OK.

## LOC

`+639 / -24` across 5 files. The mechanism is ~20 lines (the join reading, the phase read, one shared refusal); the rest is the 13-cell regression file (+361) that pins it, the docstrings stating what each reading decides, and the `docs/recording.md` phase table a caller needs to read the new error. `describe()` advertises the verdict and the phases on both verbs so the refusals are discoverable without reading the source.

## §13 Round changelog

**Round 1** -- one MUST FIX, addressed in `5c9428f7`.

- *A `start` could silently discard the frames the expired-join error promised were recoverable.* Correct, and the sharp part was **when**: the guards keyed on liveness, so they stopped seeing the state the moment the slow `render` returned and the loop exited -- which is exactly the window a caller retries in. The state still held the frames, and a start replaces the registration, so `stop` -> error -> `start` was refused or lossy depending only on timing, and `get_cameras_recording_status` called that unencoded buffer `[idle]`.
  Both start guards now key on the registration (`_refuse_replacing_cams_recording`, shared by the two verbs rather than duplicated), since only a flush deregisters and therefore registration *is* the "frames nobody has encoded" predicate. The settled phase gets its own refusal naming the buffered counts and the stop that recovers them, `[unflushed]` joins the status phases so `[idle]` keeps its promise, and `phase` is carried in the status JSON. 4 cells added; 3 fail against the round-0 mechanism, and the 4th pins the remedy -- the stop path was already right on a settled recording, which is precisely why refusing the `start` is enough to keep the contract.
