### PR TITLE
docs(tools/reachy): a verb states the coupling limit only where its own action can reach it

### DIFF
--- a/changelog.d/3094-reachy-coupling-limit-scope-is-stated-where-it-is-promised.md
+++ b/changelog.d/3094-reachy-coupling-limit-scope-is-stated-where-it-is-promised.md
@@ -1,0 +1,53 @@
+### Fixed: two Reachy verbs no longer promise a head-body twist limit they do not reach
+
+`envelope_error` carries two kinds of limit, and only one of them is a property
+of a single value. Per-axis travel is checked whenever the axis is present; the
+head-body yaw *coupling* limit bounds `head_yaw - body_yaw`, so it is checked
+only when one action carries both members. While `send_action` was the only
+surface taking both, that was a clean split, and
+`reachy_mini_driver._reject_unusable` documented it as one: "the pairwise limit
+stays with `send_action`, which takes both".
+
+The Reachy tool surface (#3082) put two verbs on `send_action` that send one
+member. `reachy_body_turn` sends `body_yaw` alone, and `reachy_look` omits
+`body_yaw` whenever the caller leaves it at its `None` default. So the
+delegation above no longer names a surface that covers the pair, and the two
+descriptions an agent reads promised a check that does not run on the path they
+take:
+
+* `reachy_look` said the driver refuses "a head-body yaw twist beyond 65 deg",
+  unconditionally, on a verb whose default omits the body value;
+* `reachy_body_turn` recommended itself for turning "while the head stays put",
+  which is precisely the case whose twist is `head_current - body_new` and
+  which nothing compares.
+
+A tool description is the only thing the model driving the verb reads, so a
+promised refusal is one it plans against - and here it moves a real head on a
+real neck. Measured against a counterpart at 0, `reachy_body_turn(yaw=160)` asks
+for 2.46x the 65 deg limit and `reachy_look(yaw=180)` for 2.77x, and both report
+`success`.
+
+Each of the three surfaces now states the scope it actually enforces:
+`envelope_error`'s docstring says the check is a property of one action rather
+than of the robot, `_reject_unusable` says its exclusion is a scope and not a
+delegation, and the two verb descriptions state the condition (`reachy_look`
+names passing `body_yaw` as the way to get the limit applied, which the suite
+now grades as a real remedy).
+
+**No behaviour changed, and the gap is not closed.** Which surface should own the
+missing half is #3094, and it turns on a fact not in this tree: whether the
+daemon reads `head_pose` in the world frame or relative to the platform's base.
+On the first reading the gate is bypassed by two verbs; on the second the
+`+/-180 deg` head-yaw bound is itself 2.77x the mechanical limit and the fix has
+a different shape. Picking one here would have been a guess about hardware.
+
+What the change does buy, beyond the honest descriptions, is that the gap is
+graded rather than assumed. `TestTheCouplingLimitIsNotReachableHere` previously
+asserted that no Device Connect RPC maps both members and that `send_action`
+refuses when given both - nothing anywhere exercised one member, which is the
+shape the new verbs send, and is why the suite was green over this. Two rows now
+pin the single-member behaviour at the envelope and through the native driver, so
+whichever answer #3094 takes arrives as an edited expectation. A fifth fact
+family on the consolidated surface suite derives, per verb and by calling it,
+which members of the pair reach one action, and refuses a description that quotes
+the coupling limit without saying when it applies.

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -154,7 +154,14 @@ def _motion_domain_error(rpc_name: str, values: dict[str, Any]) -> dict[str, str
     from here: it bounds ``head_yaw - body_yaw`` and needs both values in one
     call, where this surface splits them across :meth:`ReachyMiniDriver.look`
     and :meth:`ReachyMiniDriver.body`. Per-axis travel is the half that
-    transfers; the pairwise limit stays with ``send_action``, which takes both.
+    transfers.
+
+    That is a scope and not a delegation. ``send_action`` applies the pairwise
+    limit only to an action carrying both members, and the agent verbs on that
+    seam split the pair as well - so there are paths on which it is checked by
+    nobody (#3094). This RPC is not where that is fixed, having one member per
+    call by construction, but the coverage this paragraph used to attribute to
+    ``send_action`` is not there to lean on.
 
     Args:
         rpc_name: The RPC that received the values, used as the message prefix.

--- a/strands_robots/tools/reachy/_reachy_common.py
+++ b/strands_robots/tools/reachy/_reachy_common.py
@@ -77,6 +77,17 @@ def envelope_error(values: dict[str, Any], context: str) -> str | None:
        legal - otherwise a caller would be told about a coupling when the real
        problem is one value.
 
+    Check (3) is a property of one *action* rather than of the robot: it needs
+    both members in the same ``values`` mapping, so an action carrying one of
+    them alone passes it however far that member is from the counterpart the
+    robot is holding. This module cannot close that on its own - it is handed a
+    mapping and has no robot to ask for the other half - and the gap is on paths
+    agents take rather than on an edge one, since ``reachy_body_turn`` sends
+    ``body_yaw`` alone and ``reachy_look`` omits ``body_yaw`` whenever the caller
+    leaves it at its default. Which surface should own the missing half is
+    #3094; until that is decided, a caller who needs the coupling enforced has
+    to supply both values in one action.
+
     A key this envelope does not know is ignored entirely - not bounded and not
     even checked for finiteness. The driver's action dict also carries antenna
     positions and other pass-through values, and refusing a name this module has

--- a/strands_robots/tools/reachy/reachy_actions.py
+++ b/strands_robots/tools/reachy/reachy_actions.py
@@ -170,9 +170,12 @@ def reachy_look(
 
     Calls ``ReachyDriver.send_action(...)`` once with a whole head pose: the
     daemon's head command is a pose, not a delta, so an absent axis means zero
-    (level), not "leave as it was". The driver refuses non-finite values, any
+    (level), not "leave as it was". The driver refuses non-finite values and any
     axis outside the motion envelope (pitch/roll +/-40 deg, yaw +/-180 deg,
-    body +/-160 deg) and a head-body yaw twist beyond 65 deg.
+    body +/-160 deg). It also refuses a head-body yaw twist beyond 65 deg, but
+    only when ``body_yaw`` is sent in the same call: left at its default,
+    ``body_yaw`` is omitted from the action and the twist against the body's
+    current heading is not checked. Pass ``body_yaw`` when that limit matters.
 
     Args:
         driver: The live ReachyDriver handle the orchestrator constructed.
@@ -237,7 +240,10 @@ def reachy_body_turn(driver: Any, yaw: float = 0.0) -> dict[str, Any]:
 
     Calls ``ReachyDriver.send_action(...)`` once with only ``body_yaw``; the
     driver refuses values outside +/-160 deg. Use it to turn toward a speaker
-    or scan the room while the head stays put.
+    or scan the room while the head stays put. Because the action carries no
+    head yaw, the 65 deg head-body twist limit is not checked on this call:
+    turning the body away from where the head is pointing can ask for a twist
+    past it. Send both values through ``reachy_look`` when the pair matters.
 
     Args:
         driver: The live ReachyDriver handle the orchestrator constructed.

--- a/tests/test_reachy_motion_envelope_is_shared_with_the_native_driver.py
+++ b/tests/test_reachy_motion_envelope_is_shared_with_the_native_driver.py
@@ -291,6 +291,10 @@ class TestTheCouplingLimitIsNotReachableHere:
     Holds before and after the change. It records why the envelope's second
     limit is not part of it, so a reader does not take the omission for an
     oversight.
+
+    "Needs both values" is the whole scope, and it is not a fact about this
+    surface: the two rows added last grade what ``send_action`` does with one
+    member, which is the shape the agent verbs send (#3094).
     """
 
     def test_no_single_rpc_carries_both_members_of_the_yaw_pair(self, rmd: Any) -> None:
@@ -307,6 +311,31 @@ class TestTheCouplingLimitIsNotReachableHere:
         assert result["status"] == "error"
         assert sent == []
         assert "coupling" in _text(result)
+
+    def test_one_member_of_the_pair_alone_clears_the_check(self) -> None:
+        """The single-member case, graded rather than left to be assumed.
+
+        The row above pins that no Device Connect RPC carries both members. That
+        is a property of the *pair*, not of that surface, so an action reaching
+        ``send_action`` with one member does not reach the check either - which
+        is what ``reachy_body_turn`` (``body_yaw`` alone) and ``reachy_look``
+        (``body_yaw`` omitted at its default) send. Whichever surface #3094
+        gives the missing half to, this is the assertion that has to change, so
+        the answer arrives as an edited expectation rather than as silence.
+        """
+        far = HEAD_BODY_YAW_DELTA_LIMIT_DEG + 20.0
+        assert envelope_error({"head_yaw": far}, "reachy_look") is None
+        assert envelope_error({"body_yaw": far}, "reachy_body_turn") is None
+        # The same head value paired with a counterpart is refused, so what
+        # decides the verdict is the action's key set and not the angle.
+        assert envelope_error({"head_yaw": far, "body_yaw": 0.0}, "send_action") is not None
+
+    def test_a_lone_member_reaches_the_wire_through_the_native_driver(self) -> None:
+        """End to end: the envelope is consulted by a driver, not obeyed by one."""
+        driver, sent = _native()
+        result = driver.send_action({"body_yaw": HEAD_BODY_YAW_DELTA_LIMIT_DEG + 20.0})
+        assert result["status"] == "success", result
+        assert len(sent) == 1
 
 
 class TestThePremisesThisRestsOn:

--- a/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
+++ b/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
@@ -2,7 +2,7 @@
 
 Facts x verbs, in the shape the g1 family's consolidation locked (refs #3037,
 #3070): the whole ``reachy_*`` surface is judged by rows in tables rather than
-by a file per fact. Four fact families:
+by a file per fact. Five fact families:
 
 1. Every verb refuses an unusable ``driver`` handle with an envelope that
    names the verb, the parameter and the received type - never an exception.
@@ -13,6 +13,10 @@ by a file per fact. Four fact families:
 4. The package surface holds: every ``@tool`` the two verb modules define is
    lazily importable from the package - the drift the g1 family actually
    shipped once and now pins against.
+5. No verb's description promises the head-body yaw coupling limit unless the
+   action that verb sends can reach it. That limit needs both members of the
+   pair in one action, so a verb sending one member is not refused by it - and
+   the description is the only thing the model driving the verb reads.
 
 Plus the new ``ReachyDriver`` accessor gates (connected-first, admitted sets,
 URL-safe move names) exercised on a bare instance with no daemon, and the move
@@ -274,6 +278,66 @@ class TestThePackageSurfaceHolds:
                 name for name in dir(module) if not name.startswith("_") and hasattr(getattr(module, name), "tool_spec")
             }
             assert tools == set(table)
+
+
+def _yaw_keys_one_call_carries(verb: str, kwargs: dict[str, Any]) -> set[str]:
+    """The members of the yaw pair ``verb`` puts in one action, from a live call.
+
+    Derived by calling the verb rather than read from a table, so a verb that
+    starts or stops sending a member is graded without this file being edited.
+    """
+    handle = _RecordingHandle()
+    ALL_VERBS[verb](driver=handle, **kwargs)
+    for accessor, args, _kwargs in handle.calls:
+        if accessor == "send_action" and args and isinstance(args[0], dict):
+            return {"head_yaw", "body_yaw"} & set(args[0])
+    return set()
+
+
+class TestNoVerbPromisesACouplingLimitItsOwnActionCannotReach:
+    """Fact family 5: the twist limit is a property of one action, not the robot.
+
+    ``envelope_error`` compares ``head_yaw - body_yaw``, so it needs both in the
+    same action and an action carrying one member is not refused however far the
+    counterpart is. Which surface should own that missing half is open (#3094);
+    what is not open is what the verbs may claim while it is. A tool description
+    is the only thing the model driving the verb reads, so a limit promised
+    there is a limit the model plans against - and a promise of a refusal that
+    does not happen is worse than no promise, because it moves a real robot.
+
+    Derived from the tool specs and from what each verb actually sends, so
+    re-adding the unqualified sentence fails here rather than shipping.
+    """
+
+    #: Either phrasing states the condition. The wording stays the author's;
+    #: only the presence of a stated condition is graded.
+    SCOPE_PHRASES: tuple[str, ...] = ("only when", "not checked")
+
+    @pytest.mark.parametrize("verb", sorted(reachy_actions._ACTIONS))
+    def test_a_verb_that_can_send_one_member_states_the_condition(self, verb: str) -> None:
+        limit = f"{reachy_package.HEAD_BODY_YAW_DELTA_LIMIT_DEG:g} deg"
+        description = ALL_VERBS[verb].tool_spec["description"]
+        if limit not in description:
+            return  # says nothing about the coupling, so it promises nothing
+        yaw_keys = _yaw_keys_one_call_carries(verb, VERB_ARGS[verb])
+        if yaw_keys == {"head_yaw", "body_yaw"}:
+            return  # every call carries the pair, so the limit does apply
+        assert any(phrase in description for phrase in self.SCOPE_PHRASES), (
+            f"{verb} sends {sorted(yaw_keys) or 'no yaw key'} in one action and quotes the "
+            f"{limit} coupling limit without stating when it applies"
+        )
+
+    def test_the_two_verbs_that_can_send_a_lone_member_are_the_documented_pair(self) -> None:
+        """The premise the rows above rest on, measured from the verbs."""
+        lone = {verb for verb in reachy_actions._ACTIONS if len(_yaw_keys_one_call_carries(verb, VERB_ARGS[verb])) == 1}
+        assert lone == {"reachy_look", "reachy_body_turn"}
+
+    def test_passing_body_yaw_puts_the_pair_in_one_action(self) -> None:
+        """``reachy_look``'s description offers this remedy, so it must exist."""
+        assert _yaw_keys_one_call_carries("reachy_look", {"yaw": 80.0, "body_yaw": 0.0}) == {
+            "head_yaw",
+            "body_yaw",
+        }
 
 
 #: (method invocation, fragment) rows for the driver's own gates, judged on a


### PR DESCRIPTION
## What

`_reachy_common.envelope_error` carries two kinds of limit, and only one is a property of a single value:

* **per-axis travel**, checked whenever the axis is present;
* the **head-body yaw coupling limit** (`HEAD_BODY_YAW_DELTA_LIMIT_DEG = 65.0`), a bound on `head_yaw - body_yaw` that the module docstring calls mechanical - "a head at +60 and a body at -60 are each individually legal and together ask for a 120-degree twist the neck cannot make".

The coupling check is guarded by `if head_key in values and body_key in values`, so it is a property of one **action**, not of the robot. While `send_action` was the only surface taking both values that split was clean, and `reachy_mini_driver._reject_unusable` documented it as a delegation:

> Per-axis travel is the half that transfers; **the pairwise limit stays with `send_action`, which takes both.**

The tool surface added in #3082 put two verbs on `send_action` that send one member. `reachy_body_turn` sends `body_yaw` alone; `reachy_look` omits `body_yaw` whenever the caller leaves it at its `None` default. So the delegation above no longer names a surface that covers the pair, and the two descriptions an agent reads promised a refusal that does not happen on the path they take.

This PR makes the three surfaces state the scope they enforce, and grades the gap. **It changes no behaviour and does not close the gap** - see "What this deliberately does not do".

## Why it costs something today

A `@tool` description is the only thing the model driving the verb reads, so a promised refusal is one it plans against - on a real neck.

* `reachy_look` said: "The driver refuses non-finite values, any axis outside the motion envelope (...) **and a head-body yaw twist beyond 65 deg**" - unconditionally, on a verb whose default omits the body value.
* `reachy_body_turn` said: "Use it to turn toward a speaker or scan the room **while the head stays put**" - which is precisely the case whose twist is `head_current - body_new`, and nothing compares it.

Measured at `f9f7249`, through `ReachyDriver` with the link stubbed and `_connected = True`:

```
call                                          status   on the wire
reachy_body_turn(yaw=160)   body alone        success  body_yaw 2.7925 rad = 160 deg
reachy_look(yaw=180)        head alone        success  head_pose (4x4)
reachy_look(yaw=180, body_yaw=0)   both       error    send_action: ... coupling limit of 65 deg
```

Only the last row reaches the gate. Against a counterpart at 0 the first asks for 2.46x the limit and the second for 2.77x, and both report `success`.

## Change

Three docstrings and two test files.

| surface | before | after |
|---|---|---|
| `envelope_error` | listed check (3) with no scope | states the check is a property of one action, names the two verbs that route around it, points the enforcement question at #3094 |
| `_reject_unusable` | "the pairwise limit stays with `send_action`, which takes both" | "that is a scope and not a delegation" - there are paths on which it is checked by nobody |
| `reachy_look` | quotes 65 deg unconditionally | quotes it "only when `body_yaw` is sent in the same call", and names passing `body_yaw` as the remedy |
| `reachy_body_turn` | "while the head stays put" | adds that the 65 deg limit is not checked on this call, because the action carries no head yaw |

## Why the suite was green over this

`TestTheCouplingLimitIsNotReachableHere` pinned the *assumption*: no Device Connect RPC maps both members, and `send_action` refuses when given **both**. Nothing anywhere exercised **one** member - which is the shape the new verbs send.

Two rows added there now pin the single-member behaviour, at the envelope and end-to-end through the native driver. So whichever answer #3094 takes, it arrives as an edited expectation rather than as silence.

A fifth fact family on the consolidated surface suite derives, **per verb and by calling it**, which members of the yaw pair reach one action, and refuses a description quoting the coupling limit without stating when it applies. Verified load-bearing by restoring the old `reachy_look` sentence:

```
FAILED ...::test_a_verb_that_can_send_one_member_states_the_condition[reachy_look]
AssertionError: reachy_look sends ['head_yaw'] in one action and quotes the 65 deg
                coupling limit without stating when it applies
```

It also grades the premise (`{reachy_look, reachy_body_turn}` are exactly the verbs that can send a lone member, derived from the tree) and the remedy (`reachy_look(yaw=..., body_yaw=...)` really does put the pair in one action).

## What this deliberately does not do

It does not enforce the coupling on a lone member, and it does not close #3094. That decision turns on a fact not in this tree: **which frame the daemon interprets `head_pose` in**. On the world-frame reading the gate is bypassed by two verbs; on the body-frame reading `head_yaw` *is* the twist, the `+/-180 deg` head-yaw bound is itself 2.77x the mechanical limit, and the fix has a different shape. Choosing here would be a guess about hardware, so #3094 stays open for it and this PR claims no close.

What is not decision-dependent is what the verbs may claim while it is open, and that a gap on the default path of two shipped verbs should be graded rather than assumed. Both are what #3094's closing paragraph asked for.

## Verification

```
hatch run test -- tests/test_reachy_motion_envelope_is_shared_with_the_native_driver.py \
                  tests/tools/reachy/ tests/drivers/test_reachy_driver.py \
                  tests/test_reachy_mini_driver.py tests/test_reachy_motion_domain.py
=> 397 passed

hatch run lint              => Success: no issues found in 1812 source files
hatch run whole-tree-check  => 298 passed, 1 skipped
python scripts/assemble_changelog.py --check => changelog fragments OK
```

`whole-tree-check` was run alongside the narrowed run, per AGENTS.md step 2 - the graders that take the rest of the repository as input are not collected by a path filter over the changed area.

Refs #3094, #3082.

## §13 Round changelog

**Round 0 (opening):** initial submission. Changelog fragment `changelog.d/3094-...md` is in the first push, so no second push is needed and no approval can be dismissed by one.