### PR TITLE
fix(drivers/reachy): a body-only turn is held to the head-body coupling limit

### DIFF
--- a/changelog.d/3097-reachy-lone-body-yaw-coupling.md
+++ b/changelog.d/3097-reachy-lone-body-yaw-coupling.md
@@ -1,0 +1,46 @@
+### Fixed: a Reachy Mini body-only turn is held to the head-body coupling limit
+
+`HEAD_BODY_YAW_DELTA_LIMIT_DEG` bounds `head_yaw - body_yaw`, and
+`envelope_error` only reached it when one action carried both names. Every motion
+verb that sends one member routed around it: `reachy_body_turn` sends `body_yaw`
+alone, `reachy_look` omits `body_yaw` at its `None` default, and an action naming
+a head axis other than the yaw (`{"head_pitch": 10, "body_yaw": 160}`) commands
+the head yaw to zero without spelling it, so the gate did not see that pair
+either. `reachy_body_turn(yaw=160)` against a head at 0 reported `success` for a
+body that reaches 65 degrees and stops.
+
+The limit is the daemon's own. Its default kinematics solves a head pose through
+`inverse_kinematics_safe(pose, body_yaw, max_relative_yaw=65 deg,
+max_body_yaw=160 deg)` - the two figures this envelope carries - and it never
+refuses an over-twist: it keeps the twist inside the limit by moving the body,
+holding the head pose as the primary task. So an out-of-limit request does not
+fail, it succeeds with a body yaw the caller did not ask for, which is the silent
+substitution the envelope exists to refuse.
+
+That makes the two directions different events, and only one of them is a defect.
+A lone `head_yaw` of 180 is honored - the body turns to 115 under it, nothing of
+the caller's is substituted, and refusing it would refuse the head verb its own
+range. A lone `body_yaw` of 160 against a head target of 0 is replaced by one 95
+degrees short. `ReachyDriver.send_action` now checks the coupling on a body-only
+turn as well as on a pair, against the head yaw it last commanded - which is
+exactly what the daemon is still targeting, and known rather than estimated
+because the head command is a whole pose every time. The bound follows that
+target rather than being a fixed range, so a body turn to 160 with the head
+already round at 100 is 60 degrees of twist and still legal.
+
+Unknown is not guessed. Before any head pose is commanded, and after
+`play_move`, `wake_up`, `goto_sleep` or `set_motors` - the daemon re-pins its own
+head target to wherever the head physically is when torque returns - the target
+is forgotten and the coupling is skipped, because a turn refused against a stale
+target is a turn the robot could have made.
+
+`reachy_look` and `reachy_body_turn` said otherwise in the descriptions a model
+reads back out of its own schema: `reachy_look` promised a refusal "beyond 65
+deg" that its default path could not produce and said `body_yaw=None` "leaves the
+body alone" when a large head yaw turns the whole robot, and `reachy_body_turn`
+offered the full +/-160 with no mention of what bounds it. Both now state the
+coupling and how to ask for a bigger turn. The Device Connect driver's
+`_reject_unusable` no longer hands the pairwise limit to "`send_action`, which
+takes both": one member is enough where the counterpart is known, and that
+surface keeps no such record, so its `body` RPC stays per-axis only - graded now
+rather than asserted in prose.

--- a/changelog.d/3097-reachy-lone-body-yaw-coupling.md
+++ b/changelog.d/3097-reachy-lone-body-yaw-coupling.md
@@ -34,13 +34,15 @@ head target to wherever the head physically is when torque returns - the target
 is forgotten and the coupling is skipped, because a turn refused against a stale
 target is a turn the robot could have made.
 
-`reachy_look` and `reachy_body_turn` said otherwise in the descriptions a model
-reads back out of its own schema: `reachy_look` promised a refusal "beyond 65
-deg" that its default path could not produce and said `body_yaw=None` "leaves the
-body alone" when a large head yaw turns the whole robot, and `reachy_body_turn`
-offered the full +/-160 with no mention of what bounds it. Both now state the
-coupling and how to ask for a bigger turn. The Device Connect driver's
-`_reject_unusable` no longer hands the pairwise limit to "`send_action`, which
-takes both": one member is enough where the counterpart is known, and that
-surface keeps no such record, so its `body` RPC stays per-axis only - graded now
-rather than asserted in prose.
+The descriptions a model reads back out of its own schema follow the same split.
+`reachy_look` can omit `body_yaw`, so it states that the pairwise limit applies
+only when both are sent, and now says why a lone large `yaw` is not an unchecked
+twist: the body turns under the head to serve it. `reachy_body_turn` sends
+`body_yaw` alone, where the limit *is* applied, so it names the counterpart it is
+measured against instead of claiming an exemption. The suite grades those two
+obligations separately, derived per verb from what one call actually carries, so
+a stale exemption fails as loudly as an unqualified promise. The Device Connect
+`_reject_unusable` keeps its scope paragraph but no longer says the coverage is
+absent: the native driver has it, and this surface's `body` RPC stays per-axis
+because keeping no record of the pose its `look` RPC commanded is the invariant
+that puts the limit out of reach there.

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -151,10 +151,16 @@ def _motion_domain_error(rpc_name: str, values: dict[str, Any]) -> dict[str, str
     own checks.
 
     The head-body yaw coupling limit the envelope also carries is not reachable
-    from here: it bounds ``head_yaw - body_yaw`` and needs both values in one
-    call, where this surface splits them across :meth:`ReachyMiniDriver.look`
-    and :meth:`ReachyMiniDriver.body`. Per-axis travel is the half that
-    transfers; the pairwise limit stays with ``send_action``, which takes both.
+    from here: it bounds ``head_yaw - body_yaw``, and this surface splits the
+    pair across :meth:`ReachyMiniDriver.look` and :meth:`ReachyMiniDriver.body`,
+    so neither RPC ever holds both. Per-axis travel is the half that transfers.
+    The other half needs the head yaw the daemon is targeting while a lone
+    ``body`` turn is carried out, and this driver keeps no record of what it
+    last commanded - so a ``body`` RPC is per-axis only, where
+    :meth:`~strands_robots.drivers.reachy.ReachyDriver.send_action` checks the
+    coupling on a pair and on a body-only turn alike. Keeping no such record is
+    the invariant: were one added here, the limit would become reachable and
+    this exclusion would have to go with it.
 
     Args:
         rpc_name: The RPC that received the values, used as the message prefix.

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -234,6 +234,15 @@ class ReachyDriver:
         self._battery: dict[str, Any] | None = None
         self._joints: dict[str, Any] | None = None
 
+        # The head yaw, in degrees, this driver last put on the wire, and so the
+        # one the daemon is still targeting. Not a sensor reading: no telemetry
+        # carries it, because the head IMU measures the head's orientation and
+        # nothing reports body yaw back. ``None`` means unknown - never
+        # commanded, or a path that re-pins the daemon's target has run since.
+        # Guarded by ``_cache_lock`` with the sensor caches: same kind of
+        # cross-thread read, same lock rather than a second one.
+        self._head_yaw_target: float | None = None
+
         # Connection state. ``None`` link on a machine that never connected is
         # a valid state for tests and for a peer built ahead of a bring-up.
         self._link: Any = None
@@ -524,6 +533,7 @@ class ReachyDriver:
         self._loop = None
         self._loop_thread = None
         self._connected = False
+        self._remember_head_yaw_target(None)
 
     # ------------------------------------------------------------------ #
     # Command path.                                                      #
@@ -543,7 +553,13 @@ class ReachyDriver:
         2. Every numeric value is finite, and every bounded axis is inside the
            envelope - both from the shared
            :func:`~strands_robots.tools.reachy.envelope_error`, so this driver
-           and the ``reachy_*`` tools cannot disagree about the same robot.
+           and the ``reachy_*`` tools cannot disagree about the same robot. An
+           action carrying ``body_yaw`` and no head pose is checked against the
+           head yaw this driver last commanded, so the head-body coupling limit
+           applies to a body-only turn as well as to a pair: the daemon holds
+           the head pose and turns the body no further than the limit, so a
+           lone body yaw beyond it would report success and stop short. The
+           limit is skipped, not guessed, while that target is unknown.
         3. The action names at least one thing this driver can send. An action
            dict of unknown keys is refused rather than reported as a successful
            no-op.
@@ -578,7 +594,9 @@ class ReachyDriver:
         for name, value in action.items():
             if (reason := finite_number_error(value, name, "send_action")) is not None:
                 return _refuse(reason)
-        if (reason := envelope_error(action, "send_action")) is not None:
+        commanded_head_yaw = _head_yaw_of(action)
+        held_head_yaw = commanded_head_yaw if commanded_head_yaw is not None else self._read_head_yaw_target()
+        if (reason := envelope_error(action, "send_action", head_yaw_target=held_head_yaw)) is not None:
             return _refuse(reason)
 
         commands = _wire_commands(action)
@@ -593,6 +611,8 @@ class ReachyDriver:
         for command in commands:
             if (error := self._send_cmd(command)) is not None:
                 return _refuse(f"send_action: {error}")
+        if commanded_head_yaw is not None:
+            self._remember_head_yaw_target(commanded_head_yaw)
         return {
             "status": "success",
             "content": [{"json": {"sent": [sorted(c) for c in commands], "robot": self._tool_name}}],
@@ -717,6 +737,7 @@ class ReachyDriver:
         result = self._daemon_post(_PATH_MOVE_PLAY.format(dataset=dataset, move=move_name))
         if (error := result.get("error")) is not None:
             return _refuse(f"play_move: daemon refused {move_name!r}: {error}")
+        self._remember_head_yaw_target(None)
         return {"status": "success", "content": [{"json": {"played": move_name, "library": library}}]}
 
     def list_moves(self, library: str = "emotions") -> dict[str, Any]:
@@ -753,6 +774,7 @@ class ReachyDriver:
         result = self._daemon_post(_PATH_WAKE)
         if (error := result.get("error")) is not None:
             return _refuse(f"wake_up: daemon refused: {error}")
+        self._remember_head_yaw_target(None)
         return {"status": "success", "content": [{"text": "asked the daemon to play the wake-up move"}]}
 
     def goto_sleep(self) -> dict[str, Any]:
@@ -766,6 +788,7 @@ class ReachyDriver:
         result = self._daemon_post(_PATH_SLEEP)
         if (error := result.get("error")) is not None:
             return _refuse(f"goto_sleep: daemon refused: {error}")
+        self._remember_head_yaw_target(None)
         return {"status": "success", "content": [{"text": "asked the daemon to play the go-to-sleep move"}]}
 
     def set_motors(self, mode: str) -> dict[str, Any]:
@@ -794,6 +817,7 @@ class ReachyDriver:
             )
         if (error := self._send_cmd({"torque": torque, "ids": None})) is not None:
             return _refuse(f"set_motors: {error}")
+        self._remember_head_yaw_target(None)
         return {"status": "success", "content": [{"json": {"motors": mode}}]}
 
     def state_snapshot(self) -> dict[str, Any]:
@@ -987,6 +1011,29 @@ class ReachyDriver:
             return f"link refused the command: {exc}"
         return None
 
+    def _remember_head_yaw_target(self, yaw: float | None) -> None:
+        """Record the head yaw the daemon is targeting, or ``None`` for unknown.
+
+        Called with a value after :meth:`send_action` puts a head pose on the
+        wire, and with ``None`` by every path that moves the head without one:
+        :meth:`play_move`, :meth:`wake_up` and :meth:`goto_sleep` hand the
+        daemon a whole choreography, :meth:`set_motors` lets it re-pin its own
+        target to wherever the head physically is when torque comes back, and
+        :meth:`cleanup` ends the session that knew. Forgetting is the safe
+        direction: an unknown target skips the coupling check, where a stale one
+        would refuse a turn the robot could make.
+
+        Args:
+            yaw: Degrees, or ``None`` to mark the target unknown.
+        """
+        with self._cache_lock:
+            self._head_yaw_target = yaw
+
+    def _read_head_yaw_target(self) -> float | None:
+        """The head yaw the daemon is targeting, or ``None`` when unknown."""
+        with self._cache_lock:
+            return self._head_yaw_target
+
     def _snapshot(self, attr: str) -> dict[str, Any] | None:
         """Return a copy of one cached sensor dict, or ``None``.
 
@@ -1023,6 +1070,29 @@ _ACTION_KEYS: frozenset[str] = frozenset(
 _HEAD_KEYS: tuple[str, ...] = ("head_pitch", "head_roll", "head_yaw", "head_x", "head_y", "head_z")
 
 
+def _head_yaw_of(action: dict[str, Any]) -> float | None:
+    """The head yaw, in degrees, ``action`` puts on the wire - ``None`` for no head pose.
+
+    The daemon's head command is a whole pose, so naming any one head key
+    commands all six: an action that moves the pitch and says nothing about the
+    yaw commands the yaw to zero. That makes the head yaw of a head-bearing
+    action knowable exactly, which is what the coupling limit needs, and it is
+    why this returns ``0.0`` rather than ``None`` for ``{"head_pitch": 10}``.
+    The single owner of that rule - :func:`_wire_commands` builds the pose from
+    it, and :meth:`ReachyDriver.send_action` checks the coupling against it.
+
+    Args:
+        action: An action dict; see :meth:`ReachyDriver.send_action`.
+
+    Returns:
+        The commanded head yaw in degrees, or ``None`` when the action names no
+        head axis and so leaves the head pose alone.
+    """
+    if not any(key in action for key in _HEAD_KEYS):
+        return None
+    return float(action.get("head_yaw", 0.0))
+
+
 def _wire_commands(action: dict[str, Any]) -> list[dict[str, Any]] | str:
     """Translate a degrees-and-millimetres action into link commands.
 
@@ -1050,13 +1120,14 @@ def _wire_commands(action: dict[str, Any]) -> list[dict[str, Any]] | str:
         return transport
 
     commands: list[dict[str, Any]] = []
-    if any(key in action for key in _HEAD_KEYS):
+    head_yaw = _head_yaw_of(action)
+    if head_yaw is not None:
         commands.append(
             {
                 "head_pose": transport.rpy_to_pose(
                     float(action.get("head_pitch", 0.0)),
                     float(action.get("head_roll", 0.0)),
-                    float(action.get("head_yaw", 0.0)),
+                    head_yaw,
                     float(action.get("head_x", 0.0)),
                     float(action.get("head_y", 0.0)),
                     float(action.get("head_z", 0.0)),

--- a/strands_robots/tools/reachy/_reachy_common.py
+++ b/strands_robots/tools/reachy/_reachy_common.py
@@ -14,6 +14,35 @@ matter of taste, and they are not all of one kind:
   -60 are each individually legal and together ask for a 120-degree twist the
   neck cannot make.
 
+What the coupling limit refuses is a substitution, not an impossibility. The
+daemon's default kinematics solves the head pose through
+``inverse_kinematics_safe(pose, body_yaw, max_relative_yaw=65 deg,
+max_body_yaw=160 deg)``, and those two figures are
+:data:`HEAD_BODY_YAW_DELTA_LIMIT_DEG` and ``MOTION_ENVELOPE_DEG["body_yaw"]``.
+So the twist can never be mechanically violated: the solver keeps it inside the
+limit by *moving the body*, and the head pose is its primary task. A pair
+outside the limit therefore does not fail - it succeeds with a body yaw the
+caller did not ask for, which is the silent substitution this module exists to
+refuse.
+
+That makes the two directions of a lone yaw value different things, and the
+difference is why one of them is checked and the other is not:
+
+* A lone ``head_yaw`` is honored. Asking the head to face 180 degrees turns the
+  body to 115 so the twist lands at exactly the limit. Nothing is substituted,
+  because the caller named no body yaw - so this is legal motion and refusing it
+  would refuse the verb its own point.
+* A lone ``body_yaw`` is honored only within the limit *of the head yaw the
+  daemon is already targeting*. With the head target at 0, a body yaw of 160
+  reaches 65 and stops: the caller's own explicit value is substituted. That is
+  the same failure as an out-of-limit pair, and :func:`envelope_error` refuses it
+  when the caller can say what the head target is - see ``head_yaw_target``.
+
+The head pose is absolute, which is what makes the difference a difference: the
+daemon's IK sets the requested pose as the head's world frame and drives
+``body_yaw`` as a separate joint, so ``head_yaw - body_yaw`` really is the twist
+and a full-turn head bound is only coherent because the body carries it round.
+
 Kept in one module because two consumers need the same answer:
 :class:`~strands_robots.drivers.reachy.ReachyDriver` (the ``mode="real"``
 seam driver) and the agent ``@tool``s that will sit on the same daemon. A
@@ -57,10 +86,10 @@ HEAD_BODY_YAW_DELTA_LIMIT_DEG: float = 65.0
 _YAW_PAIR: tuple[str, str] = ("head_yaw", "body_yaw")
 
 
-def envelope_error(values: dict[str, Any], context: str) -> str | None:
+def envelope_error(values: dict[str, Any], context: str, head_yaw_target: float | None = None) -> str | None:
     """Report why ``values`` cannot be commanded, or ``None`` when they can.
 
-    Three checks, in this order, because each depends on the previous one
+    Four checks, in this order, because each depends on the previous one
     having passed:
 
     1. Each bounded axis that is present carries a finite number. A ``nan``
@@ -76,6 +105,12 @@ def envelope_error(values: dict[str, Any], context: str) -> str | None:
        only meaningful once both values are known to be finite and individually
        legal - otherwise a caller would be told about a coupling when the real
        problem is one value.
+    4. If ``body_yaw`` is present *without* ``head_yaw`` and the caller supplied
+       ``head_yaw_target``, the same limit applies against that target. Same
+       check, one value of which the caller rather than the action supplies:
+       the daemon holds the head pose and turns the body no further than the
+       limit, so a lone body yaw outside it is substituted exactly as an
+       out-of-limit pair is.
 
     A key this envelope does not know is ignored entirely - not bounded and not
     even checked for finiteness. The driver's action dict also carries antenna
@@ -90,6 +125,14 @@ def envelope_error(values: dict[str, Any], context: str) -> str | None:
             :data:`MOTION_ENVELOPE_DEG` are bounded; others are ignored.
         context: Calling surface to quote in the reason, so a caller can tell
             which of several verbs refused.
+        head_yaw_target: The head yaw, in degrees, the robot will be holding
+            while ``values`` is carried out, for the case where ``values``
+            names no ``head_yaw`` of its own. ``None`` means the caller cannot
+            know it - the coupling is then left unchecked rather than guessed
+            against a default, because refusing a body turn the robot could
+            actually have made is worse than the substitution it prevents.
+            Ignored when ``values`` carries ``head_yaw``, which is the stronger
+            answer to the same question.
 
     Returns:
         A reason naming the limit that refused, or ``None`` when every value in
@@ -105,14 +148,31 @@ def envelope_error(values: dict[str, Any], context: str) -> str | None:
             return f"{context}: {axis} {value:g} deg is outside the envelope +/-{limit:g} deg"
 
     head_key, body_key = _YAW_PAIR
-    if head_key in values and body_key in values:
-        delta = float(values[head_key]) - float(values[body_key])
+    if body_key not in values:
+        return None
+    body = float(values[body_key])
+    if head_key in values:
+        delta = float(values[head_key]) - body
         if abs(delta) > HEAD_BODY_YAW_DELTA_LIMIT_DEG:
             return (
                 f"{context}: {head_key} {float(values[head_key]):g} deg and {body_key} "
-                f"{float(values[body_key]):g} deg differ by {delta:g} deg, which exceeds the "
+                f"{body:g} deg differ by {delta:g} deg, which exceeds the "
                 f"head-body coupling limit of {HEAD_BODY_YAW_DELTA_LIMIT_DEG:g} deg"
             )
+        return None
+    if head_yaw_target is None:
+        return None
+    if (reason := finite_number_error(head_yaw_target, "head_yaw_target", context)) is not None:
+        return reason
+    delta = abs(float(head_yaw_target) - body)
+    if delta > HEAD_BODY_YAW_DELTA_LIMIT_DEG:
+        return (
+            f"{context}: {body_key} {body:g} deg is {delta:g} deg from the head yaw the daemon "
+            f"is targeting ({float(head_yaw_target):g} deg), which exceeds the head-body coupling "
+            f"limit of {HEAD_BODY_YAW_DELTA_LIMIT_DEG:g} deg - the head pose is the daemon's "
+            f"primary task, so it turns the body no further than the limit; name {head_key} in "
+            f"the same action to turn the head with the body"
+        )
     return None
 
 

--- a/strands_robots/tools/reachy/reachy_actions.py
+++ b/strands_robots/tools/reachy/reachy_actions.py
@@ -170,9 +170,12 @@ def reachy_look(
 
     Calls ``ReachyDriver.send_action(...)`` once with a whole head pose: the
     daemon's head command is a pose, not a delta, so an absent axis means zero
-    (level), not "leave as it was". The driver refuses non-finite values, any
+    (level), not "leave as it was". The driver refuses non-finite values and any
     axis outside the motion envelope (pitch/roll +/-40 deg, yaw +/-180 deg,
-    body +/-160 deg) and a head-body yaw twist beyond 65 deg.
+    body +/-160 deg). A ``yaw`` beyond 65 deg is reached by the body turning
+    under the head, so it moves the whole robot even when ``body_yaw`` is left
+    alone; giving both refuses the pair if they differ by more than 65 deg,
+    because the daemon would override the body yaw asked for.
 
     Args:
         driver: The live ReachyDriver handle the orchestrator constructed.
@@ -182,7 +185,8 @@ def reachy_look(
         x: Head translation forward, millimetres (small, ~[-20, 20]).
         y: Head translation left, millimetres.
         z: Head translation up, millimetres.
-        body_yaw: Body rotation, degrees; ``None`` leaves the body alone.
+        body_yaw: Body rotation, degrees; ``None`` lets the daemon turn the body
+            as far as the head yaw needs, and no further.
         antenna_left: Left antenna angle, degrees; ``None`` leaves it alone.
         antenna_right: Right antenna angle, degrees; ``None`` leaves it alone.
 
@@ -236,12 +240,17 @@ def reachy_body_turn(driver: Any, yaw: float = 0.0) -> dict[str, Any]:
     """Rotate the Mini's body around the vertical axis, in degrees.
 
     Calls ``ReachyDriver.send_action(...)`` once with only ``body_yaw``; the
-    driver refuses values outside +/-160 deg. Use it to turn toward a speaker
-    or scan the room while the head stays put.
+    driver refuses values outside +/-160 deg. Use it to turn toward a speaker or
+    scan the room while the head stays put - which is what bounds it: the head
+    pose is the daemon's primary task, so the body turns no further than 65 deg
+    from the head's own yaw and a bigger turn is refused. To turn the whole robot
+    further, call ``reachy_look`` with ``yaw`` and ``body_yaw`` together so the
+    head comes round with the body.
 
     Args:
         driver: The live ReachyDriver handle the orchestrator constructed.
-        yaw: Body yaw, degrees, envelope +/-160.
+        yaw: Body yaw, degrees, envelope +/-160, and within 65 deg of the head's
+            current yaw target.
 
     Returns:
         The driver's envelope, success or refusal, unreshaped.

--- a/tests/drivers/test_reachy_driver.py
+++ b/tests/drivers/test_reachy_driver.py
@@ -474,10 +474,37 @@ class TestTheEnvelopeRefusesWhatTheNeckCannotDo:
         assert f"{HEAD_BODY_YAW_DELTA_LIMIT_DEG:g}" in _text(result)
         assert link.commands == []
 
-    def test_each_half_of_a_refused_pair_is_legal_on_its_own(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        driver, _, _ = _connected(monkeypatch)
+    def test_each_half_of_a_refused_pair_is_legal_against_a_robot_it_does_not_twist(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The discriminator: the pair is refused for being a pair, not for its values.
+
+        One driver each, so neither half is judged against the other. Without
+        this the coupling tests would pass against a driver that refuses 60
+        degrees of yaw outright.
+        """
+        head_only, _, _ = _connected(monkeypatch)
+        body_only, _, _ = _connected(monkeypatch)
+        assert head_only.send_action({"head_yaw": 60.0})["status"] == "success"
+        assert body_only.send_action({"body_yaw": -60.0})["status"] == "success"
+
+    def test_the_two_halves_in_sequence_are_still_the_pair(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Splitting a refused pair across two calls does not make it legal.
+
+        The head pose the first call commands is the one the daemon holds while
+        the second is carried out, so the twist is the same 120 degrees whether
+        the two values arrive together or apart. Owned by
+        ``tests/test_reachy_a_lone_body_yaw_is_bounded_by_the_head_target.py``.
+        """
+        driver, _, link = _connected(monkeypatch)
         assert driver.send_action({"head_yaw": 60.0})["status"] == "success"
-        assert driver.send_action({"body_yaw": -60.0})["status"] == "success"
+        link.commands.clear()
+
+        result = driver.send_action({"body_yaw": -60.0})
+
+        assert result["status"] == "error"
+        assert f"{HEAD_BODY_YAW_DELTA_LIMIT_DEG:g}" in _text(result)
+        assert link.commands == []
 
     def test_the_coupling_limit_is_inclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         driver, _, _ = _connected(monkeypatch)

--- a/tests/test_reachy_a_lone_body_yaw_is_bounded_by_the_head_target.py
+++ b/tests/test_reachy_a_lone_body_yaw_is_bounded_by_the_head_target.py
@@ -1,0 +1,263 @@
+"""A body-only turn is held to the head-body coupling limit, not just to its axis.
+
+:data:`~strands_robots.tools.reachy.HEAD_BODY_YAW_DELTA_LIMIT_DEG` bounds
+``head_yaw - body_yaw``, and ``envelope_error`` only reached it when one action
+carried both names. Every motion verb that sends one member routed around it:
+``reachy_body_turn`` sends ``body_yaw`` alone, ``reachy_look`` omits ``body_yaw``
+at its ``None`` default, and an action naming a head axis other than the yaw
+(``{"head_pitch": 10, "body_yaw": 160}``) commands the head yaw to zero without
+spelling it, so the gate did not see that pair either.
+
+What the limit is. The daemon's default kinematics solves a head pose through
+``inverse_kinematics_safe(pose, body_yaw, max_relative_yaw=65 deg,
+max_body_yaw=160 deg)`` - the same two figures the envelope carries. It never
+refuses an over-twist and it cannot mechanically make one: it keeps the twist
+inside the limit by moving the body, holding the head pose as the primary task.
+Driving that solver over its own shipped kinematics data:
+
+    requested head_yaw   requested body_yaw   body joint out   twist
+                   180                    0           115.00   65.00
+                    90                    0            25.00   65.00
+                     0                  160            65.00  -65.00
+                     0                   66            65.00  -65.00
+                    65                    0            -0.00   65.00
+
+So the two directions of a lone value are not the same event, and that asymmetry
+is what this file pins:
+
+* A lone ``head_yaw`` of 180 is honored - the body turns to 115 under it. The
+  caller named no body yaw, so nothing of theirs is substituted, and refusing it
+  would refuse the head verb its own range. Accepted, and pinned as accepted.
+* A lone ``body_yaw`` of 160 against a head target of 0 reaches 65 and stops.
+  The caller's own explicit value is replaced by one 95 degrees short of it,
+  which is the silent substitution ``_reachy_common`` exists to refuse, and the
+  same event as an out-of-limit pair. Refused.
+
+Which head yaw to check against. Not a sensor reading - no telemetry carries
+body yaw, and the head IMU measures the head's orientation rather than the twist.
+It is the head pose the driver last commanded, which is exactly what the daemon
+is still targeting, and it is known exactly rather than estimated because
+``_wire_commands`` sends a whole pose every time. When the driver has not
+commanded one, or a path that re-pins the daemon's own target has run since
+(``play_move``, ``wake_up``, ``goto_sleep``, ``set_motors`` - the vendor's
+``enable_motors`` re-pins ``target_head_pose`` to wherever the head physically
+is), the target is unknown and the coupling is skipped rather than guessed: a
+turn refused against a stale target would be a turn the robot could have made.
+``TestAnUnknownTargetRefusesNothing`` holds that direction, because it is the
+one a fix to this defect could plausibly break.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.reachy import ReachyDriver, _head_yaw_of
+from strands_robots.tools.reachy import HEAD_BODY_YAW_DELTA_LIMIT_DEG, MOTION_ENVELOPE_DEG, envelope_error
+
+#: Comfortably outside the coupling limit while inside the body axis itself, so
+#: a refusal here can only be the coupling and never per-axis travel.
+_BEYOND_COUPLING = MOTION_ENVELOPE_DEG["body_yaw"]
+
+#: Comfortably inside both.
+_WITHIN_COUPLING = HEAD_BODY_YAW_DELTA_LIMIT_DEG - 25.0
+
+
+def _native() -> tuple[ReachyDriver, list[dict[str, Any]]]:
+    """A connected driver that records what it would put on the wire."""
+    driver = ReachyDriver.__new__(ReachyDriver)
+    driver._tool_name = "reachy_mini"
+    driver._connected = True
+    driver._cache_lock = threading.Lock()
+    driver._head_yaw_target = None
+    sent: list[dict[str, Any]] = []
+
+    def _send(command: dict[str, Any]) -> str | None:
+        sent.append(command)
+        return None
+
+    driver._send_cmd = _send  # type: ignore[method-assign]
+    driver._daemon_post = lambda *a, **k: {}  # type: ignore[method-assign]
+    return driver, sent
+
+
+def _head_pose(**overrides: float) -> dict[str, Any]:
+    """A whole head pose action, as ``reachy_look`` builds one."""
+    action = {"head_pitch": 0.0, "head_roll": 0.0, "head_yaw": 0.0, "head_x": 0.0, "head_y": 0.0, "head_z": 0.0}
+    action.update(overrides)
+    return action
+
+
+def _body_on_wire(sent: list[dict[str, Any]]) -> float | None:
+    """The body yaw that reached the link, in degrees, or ``None`` if none did."""
+    for command in sent:
+        if "body_yaw" in command:
+            return math.degrees(command["body_yaw"])
+    return None
+
+
+def _text(envelope: dict[str, Any]) -> str:
+    return " ".join(block["text"] for block in envelope.get("content", []) if "text" in block)
+
+
+class TestALoneBodyTurnBeyondTheCouplingIsRefused:
+    """The defect: a body-only turn the daemon would serve only in part."""
+
+    def test_a_body_turn_beyond_the_limit_from_the_head_target_is_refused(self) -> None:
+        driver, sent = _native()
+        driver.send_action(_head_pose())
+        sent.clear()
+
+        result = driver.send_action({"body_yaw": _BEYOND_COUPLING})
+
+        assert result["status"] == "error"
+        assert _body_on_wire(sent) is None
+
+    def test_the_refusal_names_the_limit_the_head_target_and_the_way_to_ask(self) -> None:
+        """A refusal teaches the envelope, per this module's own contract."""
+        driver, _sent = _native()
+        driver.send_action(_head_pose())
+
+        reason = _text(driver.send_action({"body_yaw": _BEYOND_COUPLING}))
+
+        assert f"{HEAD_BODY_YAW_DELTA_LIMIT_DEG:g} deg" in reason
+        assert "head yaw the daemon is targeting (0 deg)" in reason
+        assert "name head_yaw in the same action" in reason
+
+    def test_a_body_turn_within_the_limit_still_reaches_the_robot(self) -> None:
+        """The control: this is a bound, not a ban on turning the body."""
+        driver, sent = _native()
+        driver.send_action(_head_pose())
+        sent.clear()
+
+        result = driver.send_action({"body_yaw": _WITHIN_COUPLING})
+
+        assert result["status"] == "success"
+        assert _body_on_wire(sent) == pytest.approx(_WITHIN_COUPLING)
+
+    def test_the_bound_follows_the_head_target_rather_than_being_a_fixed_range(self) -> None:
+        """With the head already round at 100, a body turn to 160 is 60 away - legal.
+
+        The case a stateless rule would get wrong. Refusing every lone body yaw
+        beyond the coupling limit would refuse this, and the robot can make it.
+        """
+        driver, sent = _native()
+        driver.send_action(_head_pose(head_yaw=100.0))
+        sent.clear()
+
+        result = driver.send_action({"body_yaw": _BEYOND_COUPLING})
+
+        assert result["status"] == "success"
+        assert _body_on_wire(sent) == pytest.approx(_BEYOND_COUPLING)
+
+    def test_a_body_yaw_beside_a_head_axis_that_is_not_the_yaw_is_checked_too(self) -> None:
+        """No state needed here: naming any head key commands the yaw to zero."""
+        driver, sent = _native()
+
+        result = driver.send_action({"head_pitch": 10.0, "body_yaw": _BEYOND_COUPLING})
+
+        assert result["status"] == "error"
+        assert sent == [], "the head pose must not go out either when the pair is refused"
+
+    def test_the_head_yaw_an_action_commands_is_read_from_the_one_rule(self) -> None:
+        """``_head_yaw_of`` is what makes the previous case state-free."""
+        assert _head_yaw_of({"head_pitch": 10.0}) == 0.0
+        assert _head_yaw_of({"head_yaw": 33.0}) == 33.0
+        assert _head_yaw_of({"body_yaw": 33.0}) is None
+        assert _head_yaw_of({"antenna_left": 10.0}) is None
+
+
+class TestALoneHeadYawIsHonoredNotRefused:
+    """The other direction, which measurement says is legal motion."""
+
+    def test_a_full_turn_of_the_head_alone_is_accepted(self) -> None:
+        driver, sent = _native()
+
+        result = driver.send_action(_head_pose(head_yaw=MOTION_ENVELOPE_DEG["head_yaw"]))
+
+        assert result["status"] == "success"
+        assert [sorted(command) for command in sent] == [["head_pose"]]
+
+    def test_a_head_pose_records_the_target_the_next_body_turn_is_checked_against(self) -> None:
+        """The pair (180, 0) is refused whether it arrives in one action or two.
+
+        Two actions is the shape the tool surface produces: ``reachy_look``
+        followed by ``reachy_body_turn``.
+        """
+        one_action, _sent = _native()
+        together = one_action.send_action({"head_yaw": 180.0, "body_yaw": 0.0})
+
+        two_actions, sent = _native()
+        two_actions.send_action(_head_pose(head_yaw=180.0))
+        sent.clear()
+        apart = two_actions.send_action({"body_yaw": 0.0})
+
+        assert together["status"] == "error"
+        assert apart["status"] == "error"
+        assert _body_on_wire(sent) is None
+
+
+class TestAnUnknownTargetRefusesNothing:
+    """Forgetting is the safe direction, so nothing is refused against a guess."""
+
+    def test_a_body_turn_before_any_head_pose_is_not_refused(self) -> None:
+        driver, sent = _native()
+
+        result = driver.send_action({"body_yaw": _BEYOND_COUPLING})
+
+        assert result["status"] == "success"
+        assert _body_on_wire(sent) == pytest.approx(_BEYOND_COUPLING)
+
+    @pytest.mark.parametrize(
+        ("verb", "args"),
+        [
+            ("play_move", ("happy",)),
+            ("wake_up", ()),
+            ("goto_sleep", ()),
+            ("set_motors", ("enabled",)),
+        ],
+    )
+    def test_a_path_that_moves_the_head_without_a_pose_forgets_the_target(
+        self, verb: str, args: tuple[Any, ...]
+    ) -> None:
+        driver, sent = _native()
+        driver.send_action(_head_pose())
+        assert driver.send_action({"body_yaw": _BEYOND_COUPLING})["status"] == "error"
+
+        assert getattr(driver, verb)(*args)["status"] == "success"
+        sent.clear()
+
+        assert driver.send_action({"body_yaw": _BEYOND_COUPLING})["status"] == "success"
+        assert _body_on_wire(sent) == pytest.approx(_BEYOND_COUPLING)
+
+    def test_a_lone_body_yaw_the_envelope_is_given_no_target_for_is_unchecked(self) -> None:
+        """The shared envelope's own half of that decision."""
+        assert envelope_error({"body_yaw": _BEYOND_COUPLING}, "look") is None
+        assert envelope_error({"body_yaw": _BEYOND_COUPLING}, "look", head_yaw_target=0.0) is not None
+
+    def test_a_target_that_is_not_a_usable_number_is_named_rather_than_compared(self) -> None:
+        """``abs(nan) <= 65`` is ``False``, so an unordered target must not read as travel."""
+        reason = envelope_error({"body_yaw": 10.0}, "look", head_yaw_target=float("nan"))
+
+        assert reason is not None
+        assert "head_yaw_target" in reason
+
+
+class TestTheActionsOwnHeadYawWinsOverTheRecordedTarget:
+    """An action that says where the head is going is the stronger answer."""
+
+    def test_a_pair_is_judged_on_its_own_two_values(self) -> None:
+        driver, sent = _native()
+        driver.send_action(_head_pose(head_yaw=180.0))
+        sent.clear()
+
+        result = driver.send_action({"head_yaw": 60.0, "body_yaw": 30.0})
+
+        assert result["status"] == "success", "the action moves the head too, so the old target is stale"
+        assert _body_on_wire(sent) == pytest.approx(30.0)
+
+    def test_a_recorded_target_is_ignored_when_the_action_carries_a_head_yaw(self) -> None:
+        assert envelope_error({"head_yaw": 10.0, "body_yaw": 0.0}, "look", head_yaw_target=180.0) is None

--- a/tests/test_reachy_motion_envelope_is_shared_with_the_native_driver.py
+++ b/tests/test_reachy_motion_envelope_is_shared_with_the_native_driver.py
@@ -32,13 +32,18 @@ and reports no error. :data:`_ENVELOPE_AXIS_BY_PARAM` is that mapping, and
 axis added to the envelope cannot be silently unmapped.
 
 Scope. Per-axis travel is the half that transfers. The envelope's head-body yaw
-coupling limit bounds ``head_yaw - body_yaw`` and needs both values in one call,
-which this RPC surface does not offer - ``look`` carries the head yaw and
-``body`` the body yaw. ``TestTheCouplingLimitIsNotReachableHere`` pins that as a
-property of the mapping rather than leaving it implied. The millimetre offsets
-and the antenna angles carry no envelope entry and stay finiteness-only, which
-``TestWhatTheEnvelopeDoesNotBound`` holds from both sides so this change cannot
-grow into a bound the envelope never declared.
+coupling limit bounds ``head_yaw - body_yaw`` and no single RPC here carries both
+values - ``look`` carries the head yaw and ``body`` the body yaw.
+``TestTheCouplingLimitIsNotReachableHere`` pins that as a property of the mapping
+rather than leaving it implied, and grades the one-member case rather than
+assuming it: the native driver reaches the limit on a lone ``body_yaw`` too, by
+checking it against the head yaw it last commanded, and this surface keeps no
+such record, so its ``body`` RPC stays per-axis only. Both halves of that are
+asserted, so the difference between the two consumers is a measured property and
+not a paragraph. The millimetre offsets and the antenna angles carry no envelope
+entry and stay finiteness-only, which ``TestWhatTheEnvelopeDoesNotBound`` holds
+from both sides so this change cannot grow into a bound the envelope never
+declared.
 """
 
 from __future__ import annotations
@@ -48,6 +53,7 @@ import asyncio
 import inspect
 import pathlib
 import textwrap
+import threading
 from typing import Any
 
 import pytest
@@ -111,10 +117,17 @@ def _device_connect(rmd: Any) -> tuple[Any, _RecordingLink]:
 
 
 def _native() -> tuple[ReachyDriver, list[dict[str, Any]]]:
-    """A native driver reporting connected, recording what it would send."""
+    """A native driver reporting connected, recording what it would send.
+
+    Carries the cache lock and the head yaw target as well as the connection
+    flag: ``send_action`` reads the target when an action names no head pose, so
+    a stand-in without it could not reach the coupling check at all.
+    """
     driver = ReachyDriver.__new__(ReachyDriver)
     driver._tool_name = "reachy_mini"
     driver._connected = True
+    driver._cache_lock = threading.Lock()
+    driver._head_yaw_target = None
     sent: list[dict[str, Any]] = []
 
     def _send(command: dict[str, Any]) -> str | None:
@@ -286,11 +299,14 @@ class TestWhatTheEnvelopeDoesNotBound:
 
 
 class TestTheCouplingLimitIsNotReachableHere:
-    """Scope, pinned rather than implied: the pairwise limit needs both values.
+    """Scope, pinned rather than implied: no RPC here carries both values.
 
     Holds before and after the change. It records why the envelope's second
     limit is not part of it, so a reader does not take the omission for an
-    oversight.
+    oversight - and grades the one-member case, because "no RPC maps both" is
+    not on its own a reason the limit cannot apply. The native driver does apply
+    it to a lone ``body_yaw``, against the head yaw it last commanded; this
+    surface keeps no record of what it commanded, so it cannot.
     """
 
     def test_no_single_rpc_carries_both_members_of_the_yaw_pair(self, rmd: Any) -> None:
@@ -307,6 +323,39 @@ class TestTheCouplingLimitIsNotReachableHere:
         assert result["status"] == "error"
         assert sent == []
         assert "coupling" in _text(result)
+
+    def test_the_native_driver_reaches_it_on_a_lone_body_yaw_as_well(self) -> None:
+        """One member is enough there, because that driver knows the other one.
+
+        ``tests/test_reachy_a_lone_body_yaw_is_bounded_by_the_head_target.py``
+        owns this behaviour; asserted here so the difference between the two
+        consumers is measured on the same page that documents it.
+        """
+        driver, sent = _native()
+        driver.send_action({"head_pitch": 0.0, "head_yaw": 0.0})
+        sent.clear()
+
+        result = driver.send_action({"body_yaw": MOTION_ENVELOPE_DEG["body_yaw"]})
+
+        assert result["status"] == "error"
+        assert sent == []
+        assert "coupling" in _text(result)
+
+    def test_this_surface_keeps_no_record_of_the_head_yaw_it_commanded(self, rmd: Any) -> None:
+        """Why it cannot do the same: the ``look`` RPC stores nothing.
+
+        Measured on the driver's own state rather than asserted in prose, so a
+        driver that grows such a record fails here and is told to apply the
+        limit rather than leaving this file's scope paragraph stale.
+        """
+        driver, link = _device_connect(rmd)
+        before = set(vars(driver))
+
+        _call(driver, "look", pitch=0.0, roll=0.0, yaw=_inside(MOTION_ENVELOPE_DEG["head_yaw"]))
+
+        assert link.commands, "the look RPC did reach the link"
+        assert set(vars(driver)) == before, "a new attribute here would be that record"
+        assert _call(driver, "body", yaw=MOTION_ENVELOPE_DEG["body_yaw"])["status"] == "success"
 
 
 class TestThePremisesThisRestsOn:

--- a/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
+++ b/tests/tools/reachy/test_the_consolidated_reachy_surface_holds.py
@@ -91,6 +91,7 @@ def _bare_driver(connected: bool = True) -> ReachyDriver:
     driver = ReachyDriver.__new__(ReachyDriver)
     driver._connected = connected
     driver._cache_lock = threading.Lock()
+    driver._head_yaw_target = None
     driver._joints = None
     driver._pose = None
     driver._imu = None


### PR DESCRIPTION
Closes #3094. Builds on #3095, which narrowed the claims and left the enforcement open because one fact was not in the tree.

#3094 could not pick between its three candidates without knowing **which frame the daemon reads `head_pose` in**, because that changes the shape of the fix. It is the world frame, and the vendor solver settles it twice over: the IK sets the requested pose as the head's world frame and drives `body_yaw` as a separate joint, and its FK returns `T_world_platform`. So `head_yaw - body_yaw` really is the twist, and the full-turn head bound is coherent only because the body carries it round.

![measured](https://raw.githubusercontent.com/cagataycali/robots/assets/reachy-lone-body-yaw-coupling/reachy_coupling.png)

## The limit substitutes rather than refuses, which is what makes the two directions different

The default kinematics engine solves a head pose through `inverse_kinematics_safe(pose, body_yaw, max_relative_yaw=65 deg, max_body_yaw=160 deg)` - the same two figures this envelope carries. It never refuses an over-twist and cannot mechanically make one: it keeps the twist inside the limit **by moving the body**, holding the head pose as the primary task. Driving that solver over its own shipped kinematics data:

| requested `head_yaw` | requested `body_yaw` | body joint out | twist |
| --- | --- | --- | --- |
| 180 | 0 | **115.00** | 65.00 |
| 90 | 0 | 25.00 | 65.00 |
| 65 | 0 | -0.00 | 65.00 |
| 0 | **160** | **65.00** | -65.00 |
| 0 | 66 | 65.00 | -65.00 |
| 0 | 0 | -0.00 | 0.00 |

An out-of-limit request therefore does not fail - it succeeds with a body yaw the caller did not ask for, the silent substitution the envelope exists to refuse. And the two lone directions are not the same event:

| lone value | what happens | verdict |
| --- | --- | --- |
| `head_yaw` 180 | body turns to 115 under it, twist lands at the limit | **honored** - the caller named no body yaw, so nothing of theirs is substituted, and refusing it would refuse the head verb its own range |
| `body_yaw` 160, head target 0 | body reaches 65 and stops | **substituted** - the caller's own explicit value is replaced by one 95 deg short |

That asymmetry is why candidate 1 in the issue is right for one member only: checking a lone `head_yaw` against a remembered body yaw would refuse legal motion.

## The fix

`send_action` applies the coupling to a body-only turn as well as to a pair, against the head yaw it last commanded - what the daemon is still targeting, and known rather than estimated because the head command is a whole pose every time. So the bound **follows that target** instead of being a fixed range:

| sequence | before | after | body on the wire |
| --- | --- | --- | --- |
| `body_turn(160)`, head target 0 | success | **error** | none |
| `body_turn(66)`, head target 0 | success | **error** | none |
| `body_turn(40)`, head target 0 | success | success | 40 |
| `look(yaw=100)` then `body_turn(160)` | success | success | 160 (twist 60) |
| `look(yaw=180)` then `body_turn(0)` | success | **error** | none |
| `{head_pitch: 10, body_yaw: 160}` | success | **error** | none |
| `look(yaw=180)` alone | success | success | none |

Row 4 is why this is not a fixed +/-65 rule: that turn is 60 degrees of twist and the robot can make it. Row 6 needs no state at all - naming any head key commands the yaw to zero, so the pair was there all along and unseen; `_head_yaw_of` is now the single owner of that whole-pose rule, read by both the wire builder and the check.

**Unknown is not guessed.** Before any head pose is commanded, and after `play_move`, `wake_up`, `goto_sleep` or `set_motors` (`enable_motors` re-pins the daemon's own `target_head_pose` to wherever the head physically is), the target is forgotten and the coupling is skipped - a turn refused against a stale target is a turn the robot could have made. The envelope takes the counterpart as an argument, so a surface that does not know one passes nothing: Device Connect's `body` RPC stays per-axis, and keeping no such record is now stated as the invariant that puts the limit out of reach there.

## What this changes in #3095's work

#3095's two single-member rows carried the note that they are "the assertion that has to change" once #3094 is answered, so they are edited rather than replaced: a lone `head_yaw` still clears, on its own stated terms, and a lone `body_yaw` clears only while no counterpart is known. Its fact-family-5 grader had one obligation for both verbs; the obligations have diverged, so it now branches on which member a call can carry alone - `reachy_look` (can omit `body_yaw`) must still say the limit applies only when both are sent, `reachy_body_turn` (sends `body_yaw` alone, where the limit now applies) must name the counterpart instead of claiming an exemption. A cell pins that the two obligations land on different verbs, so one phrase cannot satisfy both by accident.

## Tests

Reverting only the wiring, every new symbol left defined: **10 failed / 59 passed**, each failure a coupling cell, the 59 greens the controls - including every "unknown target refuses nothing" positive and the lone-head acceptance.

One existing cell asserted the old fact and was a contradiction rather than a bystander: `test_each_half_of_a_refused_pair_is_legal_on_its_own` sent both halves to **one** driver, which is exactly the 120-degree twist. Split into a per-driver discriminator (still proving the pair is refused for being a pair, not for its values) plus a cell pinning that splitting a refused pair across two calls does not make it legal. Three shared `ReachyDriver` test doubles gained the head-yaw-target dimension - without it no stand-in could reach the check at all.

## Gate

`ruff check` / `ruff format --check` clean. mypy at the CI pin: 20 errors in 6 files, identical on pristine main, 0 attributable. `scripts/check_whole_tree_graders.py` 297 passed + the known `qpsolvers`-absent failure. All 733 reachy-selected tests pass. Full `tests/` suite before the merge: 60 failed / 45,033 passed / 54 errors, and running that failing-id set on a pristine `upstream/main` worktree reproduced the same 112 environment failures (absent `awsiot`/`webauthn`, lerobot drift), the one residual id passing in isolation on both trees.

LOC +628 / -78 across 9 files. 263 of the additions are the new regression file and 48 the changelog; production is +177 / -41, most of it the docstring that now states what the limit is, why it substitutes rather than refuses, and why one direction of a lone value is checked and the other is not.