### PR TITLE
fix(drivers/g1): a DDS decoder publishes only fields its IDL declares

### DIFF
--- a/changelog.d/3098-g1-decoders-read-only-declared-idl-fields.md
+++ b/changelog.d/3098-g1-decoders-read-only-declared-idl-fields.md
@@ -1,0 +1,34 @@
+### Fixed: a G1 DDS decoder publishes only fields its IDL declares
+
+`G1Driver._on_bms` read `getattr(msg, "charge", 0)` into a `charging` flag, and
+`unitree_hg.msg.dds_.BmsState_` declares no charge field of any spelling
+(`version_high`, `version_low`, `fn`, `cell_vol`, `bmsvoltage`, `current`,
+`soc`, `soh`, `temperature`, `cycle`, `manufacturer_date`, `bmsstate`,
+`reserve`). `getattr` with a typed default cannot fail, and `False` is a
+well-formed answer to "is this pack charging", so every G1 reported
+`charging=False` - a claim no measurement backed, indistinguishable from a pack
+measured to be discharging, and published on the mesh health wire by
+`SensorMixin._read_health`.
+
+`_on_mainboard` had the same shape with the opposite symptom: it read
+`sys_state` and `tick`, which `MainBoardState_` does not declare either
+(`tick` is declared on `LowState_`), so both reported `None` forever, while the
+two vectors the message *does* declare - `value` (`float32[6]`) and `state`
+(`uint32[6]`) - were never read at all.
+
+Both decoders now read the names their IDL declares, and every field is read
+through `getattr(msg, name, None)` so an absent or renamed field lands `None`
+rather than a plausible `0` / `0.0` / `False`. `g1_battery` returns `pct` /
+`current` / `cycle` / `t` and no charge flag; `g1_mainboard` returns
+`fan_state` / `temperature` / `value` / `state` / `t`. The fleet-health reader
+sets `charging` only for a record that carries the reading, instead of
+defaulting an absent key to `False`.
+
+Three of the driver's six DDS decoders had a declared-fields grader; the BMS
+decoder was one of the two without, which is why the read went unnoticed. It
+has one now, in the same three-layer shape (faithful double, frozen
+declaration checked against the real SDK where importable, derivation over the
+decoder's source). The mainboard and pressure fidelity cells were also
+comparing the frozen copy to the SDK with `<=`, which sees only the drift that
+removes a field; both now assert equality, so a field declared but unread
+fails too.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -1353,14 +1353,31 @@ class G1Driver:
             logger.debug("%s: lowstate decode failed: %s", self._tool_name, exc)
 
     def _on_bms(self, msg: Any) -> None:
-        """Decode ``rt/lf/bmsstate`` into :attr:`_battery`."""
+        """Decode ``rt/lf/bmsstate`` into :attr:`_battery`.
+
+        Every field is read through ``getattr(msg, name, None)`` and coerced
+        by :func:`_to_float` / :func:`_to_int`, so a name the message does
+        not carry lands ``None`` in the record rather than a typed default.
+        That distinction is the whole contract here: ``getattr`` with a
+        ``0`` default cannot fail and ``0`` is a well-formed reading, so a
+        default-carrying read of a name the IDL never declared publishes a
+        constant shaped exactly like telemetry - a zero-amp pack, a
+        zero-cycle count - for as long as the robot runs.
+
+        ``BmsState_`` declares thirteen fields (``version_high``,
+        ``version_low``, ``fn``, ``cell_vol``, ``bmsvoltage``, ``current``,
+        ``soc``, ``soh``, ``temperature``, ``cycle``, ``manufacturer_date``,
+        ``bmsstate``, ``reserve``) and none of them is a charge flag, so
+        the record carries no ``charging`` key: a flag the message never
+        carries would be a guess with the shape of a reading.  A layout
+        that does declare one is one read here plus one key on the
+        ``g1_battery`` envelope.
+        """
         try:
-            soc = getattr(msg, "soc", None)
             self._battery = {
-                "pct": float(soc) if soc is not None else None,
-                "charging": bool(getattr(msg, "charge", 0)),
-                "current": float(getattr(msg, "current", 0.0)),
-                "cycle": int(getattr(msg, "cycle", 0)),
+                "pct": _to_float(getattr(msg, "soc", None)),
+                "current": _to_float(getattr(msg, "current", None)),
+                "cycle": _to_int(getattr(msg, "cycle", None)),
                 "t": time.time(),
             }
         except Exception as exc:  # noqa: BLE001
@@ -1426,28 +1443,31 @@ class G1Driver:
     def _on_mainboard(self, msg: Any) -> None:
         """Decode ``rt/mainboardstate`` into :attr:`_mainboard`.
 
-        ``MainBoardState_`` is a firmware-version-dependent envelope: the fan
-        state, board temperatures and system-state fields it declares vary
-        across G1 releases, so the fields read here are the ones that appear
-        on the layout the current firmware ships with and every one is read
-        through ``getattr`` with a default so a name a future firmware
-        renames yields ``None`` on this side rather than raising on the DDS
-        thread.  A missing field surfaces to the ``g1_mainboard`` verb as
-        ``None`` for that key, which is decidable, rather than as an
-        exception the DDS thread swallows silently.
+        ``MainBoardState_`` declares exactly four fields and all four are
+        six-element vectors: ``fan_state`` (``uint16``, one flag per fan),
+        ``temperature`` (``int16``, one per thermistor), ``value``
+        (``float32``) and ``state`` (``uint32``).  The IDL documents no
+        semantics for the last two, so they are published under the vendor's
+        own names rather than being renamed into a reading this side cannot
+        justify.
 
-        ``fan_state`` and ``temperature`` are vector fields on the message
-        (one entry per fan / thermistor); they are cast to a plain
-        ``list[int]`` / ``list[float]`` under the copy the ``_snapshot``
-        accessor returns, so a caller mutating the returned dict does not
-        race the DDS thread writing into it.
+        Each is read through ``getattr`` with a ``None`` default so a name a
+        future firmware renames surfaces to the ``g1_mainboard`` verb as
+        ``None`` for that key - decidable - rather than as an exception the
+        DDS thread swallows silently.  A *typed* default would not be
+        decidable: it looks like a reading, which is how a name the IDL never
+        declared publishes a constant forever.
+
+        All four are cast to a plain ``list[int]`` / ``list[float]`` under
+        the copy the ``_snapshot`` accessor returns, so a caller mutating the
+        returned dict does not race the DDS thread writing into it.
         """
         try:
             self._mainboard = {
                 "fan_state": _to_int_list(getattr(msg, "fan_state", None)),
                 "temperature": _to_float_list(getattr(msg, "temperature", None)),
-                "sys_state": _to_int(getattr(msg, "sys_state", None)),
-                "tick": _to_int(getattr(msg, "tick", None)),
+                "value": _to_float_list(getattr(msg, "value", None)),
+                "state": _to_int_list(getattr(msg, "state", None)),
                 "t": time.time(),
             }
         except Exception as exc:  # noqa: BLE001 - IDL message can be anything
@@ -1502,19 +1522,35 @@ class G1Driver:
 def _to_int(value: Any) -> int | None:
     """Coerce ``value`` to ``int``, or return ``None`` if it will not.
 
-    ``MainBoardState_``'s scalar fields (``sys_state``, ``tick``) are declared
-    integer on the layout the current firmware ships with, but the value
-    landing here comes from ``getattr(msg, name, None)`` at
-    :meth:`G1Driver._on_mainboard`, so a firmware that renames one of them
-    yields ``None`` at this call.  Returning ``None`` decidably rather than
-    raising keeps the DDS thread's decoder swallowing nothing silently, and
-    the ``g1_mainboard`` verb reports the missing field as ``None`` in the
-    envelope instead of dropping the whole reading.
+    ``BmsState_.cycle`` is declared integer, but the value landing here comes
+    from ``getattr(msg, name, None)`` at :meth:`G1Driver._on_bms`, so a
+    firmware that renames the field yields ``None`` at this call.  Returning
+    ``None`` decidably rather than raising keeps the DDS thread's decoder
+    swallowing nothing silently, and the ``g1_battery`` verb reports the
+    missing field as ``None`` in the envelope instead of dropping the whole
+    reading.  The same rule is why no caller passes a typed default: ``0``
+    would be indistinguishable from a real zero-cycle pack.
     """
     if value is None:
         return None
     try:
         return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_float(value: Any) -> float | None:
+    """Coerce ``value`` to ``float``, or return ``None`` if it will not.
+
+    The float counterpart of :func:`_to_int`, for ``BmsState_``'s ``soc`` and
+    ``current``.  Same rule: the caller passes ``getattr(msg, name, None)``
+    rather than a typed default, so a renamed or undeclared field reaches the
+    ``g1_battery`` envelope as ``None`` instead of a plausible ``0.0``.
+    """
+    if value is None:
+        return None
+    try:
+        return float(value)
     except (TypeError, ValueError):
         return None
 

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -420,7 +420,13 @@ class SensorLoopsMixin:
             if battery is not None:
                 if isinstance(battery, dict):
                     health["battery_pct"] = battery.get("pct", battery.get("percentage"))
-                    health["charging"] = battery.get("charging", False)
+                    if "charging" in battery:
+                        # Only a record that carries the reading gets to make
+                        # the claim.  Defaulting an absent key to False put a
+                        # charge state on the health wire that no driver had
+                        # reported, indistinguishable from a pack measured to
+                        # be discharging.
+                        health["charging"] = battery["charging"]
                 elif isinstance(battery, (int, float)):
                     health["battery_pct"] = float(battery)
                 has_data = True

--- a/strands_robots/tools/g1/g1_battery.py
+++ b/strands_robots/tools/g1/g1_battery.py
@@ -1,9 +1,9 @@
 """Agent-facing wrapper for the driver's cached ``rt/lf/bmsstate`` snapshot.
 
 ``G1Driver`` subscribes ``rt/lf/bmsstate`` at connect time and decodes each
-message into a small ``_battery`` dict carrying the SOC percentage, a
-charging flag, the pack current (A), the pack cycle count and the wall time
-the last message decoded at. ``G1Driver.get_status`` publishes ``battery_pct``
+message into a small ``_battery`` dict carrying the SOC percentage, the
+pack current, the pack cycle count and the wall time the last message
+decoded at. ``G1Driver.get_status`` publishes ``battery_pct``
 from that same dict on the mesh's status wire, which the ``g1_get_state``
 verb already surfaces to an agent; this verb is the *cached-snapshot*
 companion the ``g1_state`` docstring names, returning every field the
@@ -39,9 +39,10 @@ What this module does not do.
   ``_on_bms`` handler; adding a second subscriber path would compete for
   ``rt/lf/bmsstate`` and double the bus touch ``_DDS_INIT_LOCK`` is meant
   to prevent.
-* Rewrite the driver's decode. ``_on_bms`` names ``pct`` / ``charging`` /
-  ``current`` / ``cycle`` / ``t``; those are what this verb returns
-  verbatim. A neon-side ``g1_battery`` port additionally read ``soh``,
+* Rewrite the driver's decode. ``_on_bms`` names ``pct`` / ``current`` /
+  ``cycle`` / ``t``; those are what this verb returns verbatim.  It names
+  no charge flag because ``BmsState_`` declares none - see that decoder's
+  docstring.  A neon-side ``g1_battery`` port additionally read ``soh``,
   cell-level voltages and a per-cell temperature vector off ``BmsState_``
   directly - fields the driver's decoder does not carry today. Adding
   them here would be a second decoder for the same message, so those
@@ -89,15 +90,17 @@ def g1_battery(driver: Any) -> dict[str, Any]:
 
     Returns:
         A dict with ``status``, a ``present`` flag naming whether the
-        driver has a cached reading yet, and the five fields ``_on_bms``
+        driver has a cached reading yet, and the four fields ``_on_bms``
         writes: ``pct`` (SOC percentage, ``float`` or ``None``),
-        ``charging`` (``bool`` or ``None``), ``current`` (pack current in
-        amps, ``float`` or ``None``), ``cycle`` (integer cycle count or
-        ``None``) and ``t`` (the wall time the reading was decoded at,
-        seconds since epoch, ``float`` or ``None``).  On a driver whose
-        subscriber has not received a BMS message yet the returned dict
-        carries ``present=False`` and every field ``None`` - the verb
-        does not fabricate a reading the driver does not have.
+        ``current`` (pack current as ``BmsState_.current`` reports it,
+        ``float`` or ``None``), ``cycle`` (integer cycle count or ``None``)
+        and ``t`` (the wall time the reading was decoded at, seconds since
+        epoch, ``float`` or ``None``).  There is no charging flag:
+        ``BmsState_`` declares no charge field, so reporting one would be a
+        guess with the shape of a reading.  On a driver whose subscriber has
+        not received a BMS message yet the returned dict carries
+        ``present=False`` and every field ``None`` - the verb does not
+        fabricate a reading the driver does not have.
     """
     refusal = snapshot_handle_refusal("g1_battery", driver)
     if refusal is not None:
@@ -109,7 +112,6 @@ def g1_battery(driver: Any) -> dict[str, Any]:
             "status": "success",
             "present": False,
             "pct": None,
-            "charging": None,
             "current": None,
             "cycle": None,
             "t": None,
@@ -118,7 +120,6 @@ def g1_battery(driver: Any) -> dict[str, Any]:
         "status": "success",
         "present": True,
         "pct": snapshot.get("pct"),
-        "charging": snapshot.get("charging"),
         "current": snapshot.get("current"),
         "cycle": snapshot.get("cycle"),
         "t": snapshot.get("t"),

--- a/strands_robots/tools/g1/g1_mainboard.py
+++ b/strands_robots/tools/g1/g1_mainboard.py
@@ -42,14 +42,15 @@ What this module does not do.
   compete for ``rt/mainboardstate`` and double the bus touch
   ``_DDS_INIT_LOCK`` is meant to prevent.
 * Rewrite the driver's decode.  ``_on_mainboard`` names ``fan_state`` /
-  ``temperature`` / ``sys_state`` / ``tick`` / ``t``; those are what
-  this verb returns verbatim.  The neon-side ``g1_mainboard`` port
-  additionally read ``fan_speed`` / ``cpu_temperature`` / ``sys_bat_state``
-  / ``bms_state`` off ``MainBoardState_`` directly -- fields the current
-  firmware layout does not declare on every unit, and adding them on the
-  verb would be a second decoder for the same message that agrees with
-  the driver's writer only when both name the same fields.  Those fields
-  land (if at all) on the driver's ``_on_mainboard``, not this verb.
+  ``temperature`` / ``value`` / ``state`` / ``t``; those are what this
+  verb returns verbatim.  The neon-side ``g1_mainboard`` port additionally
+  read ``fan_speed`` / ``cpu_temperature`` / ``sys_state`` /
+  ``sys_bat_state`` / ``bms_state`` / ``tick`` off ``MainBoardState_``
+  directly, each behind a ``hasattr`` gate because the layout declares
+  none of them; adding them on the verb would be a second decoder for the
+  same message that agrees with the driver's writer only when both name
+  the same fields.  Those fields land (if at all) on the driver's
+  ``_on_mainboard``, not this verb.
 * Rewrite pressure-sensor readings.  ``rt/pressuresensorstate`` is a
   separate DDS topic with its own IDL (``PressSensorState_``); a
   ``g1_pressure`` port lands as its own verb once the driver caches
@@ -101,10 +102,12 @@ def g1_mainboard(driver: Any) -> dict[str, Any]:
         ``_on_mainboard`` writes: ``fan_state`` (a vector of integer
         fan flags as ``list[int]`` or ``None``), ``temperature`` (a
         vector of board-thermistor readings as ``list[float]`` or
-        ``None``), ``sys_state`` (the system-state code as integer or
-        ``None``), ``tick`` (the firmware tick counter as integer or
-        ``None``) and ``t`` (the wall time the reading was decoded at,
-        seconds since epoch, ``float`` or ``None``).  On a driver
+        ``None``), ``value`` and ``state`` (the two remaining vectors
+        ``MainBoardState_`` declares, as ``list[float]`` / ``list[int]``
+        or ``None``, under the vendor's own names because the IDL
+        documents no semantics for them) and ``t`` (the wall time the
+        reading was decoded at, seconds since epoch, ``float`` or
+        ``None``).  On a driver
         whose subscriber has not received a ``MainBoardState_``
         message yet the returned dict carries ``present=False`` and
         every field ``None`` -- the verb does not fabricate a reading
@@ -125,8 +128,8 @@ def g1_mainboard(driver: Any) -> dict[str, Any]:
             "present": False,
             "fan_state": None,
             "temperature": None,
-            "sys_state": None,
-            "tick": None,
+            "value": None,
+            "state": None,
             "t": None,
         }
     return {
@@ -134,7 +137,7 @@ def g1_mainboard(driver: Any) -> dict[str, Any]:
         "present": True,
         "fan_state": snapshot.get("fan_state"),
         "temperature": snapshot.get("temperature"),
-        "sys_state": snapshot.get("sys_state"),
-        "tick": snapshot.get("tick"),
+        "value": snapshot.get("value"),
+        "state": snapshot.get("state"),
         "t": snapshot.get("t"),
     }

--- a/tests/drivers/test_g1_battery_floor_reaches_with_wired_fsm.py
+++ b/tests/drivers/test_g1_battery_floor_reaches_with_wired_fsm.py
@@ -93,10 +93,9 @@ class _RecordingMotionSwitcherClient:
         return self._return
 
 
-def _pack(pct: float) -> dict[str, float | bool | int]:
+def _pack(pct: float) -> dict[str, float | int]:
     return {
         "pct": pct,
-        "charging": False,
         "current": 0.0,
         "cycle": 0,
         "t": 0.0,

--- a/tests/drivers/test_g1_battery_reads_the_driver_snapshot.py
+++ b/tests/drivers/test_g1_battery_reads_the_driver_snapshot.py
@@ -10,8 +10,8 @@ contract by handing a hand-rolled driver double to the verb and asserting
 the returned dict names each field ``_on_bms`` writes into ``_battery``.
 
 The cache field names are read here off the driver's own writer
-(:meth:`G1Driver._on_bms` names ``pct`` / ``charging`` / ``current`` /
-``cycle`` / ``t``) rather than being restated in the tests, so a widen
+(:meth:`G1Driver._on_bms` names ``pct`` / ``current`` / ``cycle`` /
+``t``) rather than being restated in the tests, so a widen
 or rename on the driver side moves both the write path and this verb
 together.  What the tests do restate is the SDK-load-hygiene contract
 every file under :mod:`strands_robots.tools.g1` carries: importing the
@@ -99,7 +99,6 @@ def test_a_driver_with_no_bms_message_yet_reports_absent() -> None:
     assert result["status"] == "success"
     assert result["present"] is False
     assert result["pct"] is None
-    assert result["charging"] is None
     assert result["current"] is None
     assert result["cycle"] is None
     assert result["t"] is None
@@ -107,18 +106,17 @@ def test_a_driver_with_no_bms_message_yet_reports_absent() -> None:
 
 
 def test_a_healthy_pack_reports_every_field_the_decoder_wrote() -> None:
-    """Each of the five ``_on_bms`` fields rides through unchanged.
+    """Each of the four ``_on_bms`` fields rides through unchanged.
 
-    ``_on_bms`` writes ``pct`` (SOC percent, float), ``charging`` (bool),
-    ``current`` (pack current in amps, float), ``cycle`` (integer cycle
-    count) and ``t`` (wall time of decode).  The verb is not the place
-    to reword or convert those - a caller comparing this reading against
-    the driver's ``_battery_floor_pct`` reads ``pct`` at the same units
-    the gate does.
+    ``_on_bms`` writes ``pct`` (SOC percent, float), ``current`` (pack
+    current as ``BmsState_.current`` reports it, float), ``cycle``
+    (integer cycle count) and ``t`` (wall time of decode).  The verb is
+    not the place to reword or convert those - a caller comparing this
+    reading against the driver's ``_battery_floor_pct`` reads ``pct`` at
+    the same units the gate does.
     """
     cache: dict[str, Any] = {
         "pct": 87.5,
-        "charging": False,
         "current": -1.25,
         "cycle": 42,
         "t": 1_700_000_000.0,
@@ -128,31 +126,9 @@ def test_a_healthy_pack_reports_every_field_the_decoder_wrote() -> None:
     assert result["status"] == "success"
     assert result["present"] is True
     assert result["pct"] == 87.5
-    assert result["charging"] is False
     assert result["current"] == -1.25
     assert result["cycle"] == 42
     assert result["t"] == 1_700_000_000.0
-
-
-def test_a_charging_pack_reports_charging_true() -> None:
-    """The ``charging`` flag round-trips from the driver's decode.
-
-    ``_on_bms`` writes ``bool(getattr(msg, "charge", 0))`` into
-    ``charging``; a firmware reporting a non-zero charge flag lands as
-    ``True`` in the cache, and this verb must not silently drop or
-    invert that.
-    """
-    cache: dict[str, Any] = {
-        "pct": 92.0,
-        "charging": True,
-        "current": 3.5,
-        "cycle": 100,
-        "t": 1_700_000_100.0,
-    }
-    result = _call(_StubG1Driver(cache=cache))
-
-    assert result["charging"] is True
-    assert result["current"] == 3.5
 
 
 def test_a_critical_pack_pct_is_reported_verbatim_not_clipped() -> None:
@@ -167,7 +143,6 @@ def test_a_critical_pack_pct_is_reported_verbatim_not_clipped() -> None:
     """
     cache: dict[str, Any] = {
         "pct": 5.0,
-        "charging": False,
         "current": -0.8,
         "cycle": 250,
         "t": 1_700_000_200.0,
@@ -179,7 +154,7 @@ def test_a_critical_pack_pct_is_reported_verbatim_not_clipped() -> None:
 
 
 def test_a_missing_field_in_the_cache_reports_none() -> None:
-    """A cache dict missing one of the five fields returns ``None`` for it.
+    """A cache dict missing one of the four fields returns ``None`` for it.
 
     ``_on_bms`` may in principle write a partial dict on a decode where
     one attribute was absent from the IDL message (the handler catches
@@ -190,14 +165,12 @@ def test_a_missing_field_in_the_cache_reports_none() -> None:
     """
     cache: dict[str, Any] = {
         "pct": 60.0,
-        "charging": False,
         # current / cycle / t missing
     }
     result = _call(_StubG1Driver(cache=cache))
 
     assert result["present"] is True
     assert result["pct"] == 60.0
-    assert result["charging"] is False
     assert result["current"] is None
     assert result["cycle"] is None
     assert result["t"] is None
@@ -215,7 +188,6 @@ def test_the_verb_reads_the_snapshot_exactly_once() -> None:
     driver = _StubG1Driver(
         cache={
             "pct": 75.0,
-            "charging": False,
             "current": -0.5,
             "cycle": 30,
             "t": 1_700_000_300.0,
@@ -239,7 +211,6 @@ def test_the_returned_dict_does_not_alias_the_cache() -> None:
     """
     original_cache: dict[str, Any] = {
         "pct": 80.0,
-        "charging": False,
         "current": -1.0,
         "cycle": 25,
         "t": 1_700_000_400.0,

--- a/tests/drivers/test_g1_bms_reads_the_declared_fields.py
+++ b/tests/drivers/test_g1_bms_reads_the_declared_fields.py
@@ -1,0 +1,348 @@
+"""The BMS decoder reads the field names ``BmsState_`` declares.
+
+``_on_bms`` reaches into the IDL message with ``getattr(msg, name, default)``.
+That call cannot fail: a name the message type does not declare yields the
+default, and a *typed* default is a well-formed value that lands in the
+published record looking exactly like a reading.  So a decoder that reads a
+name the IDL never had publishes a constant, and the fleet card shows a
+plausible reading forever.
+
+That is not hypothetical here.  ``_on_bms`` read ``getattr(msg, "charge", 0)``
+into a ``charging`` flag, and ``BmsState_`` declares no charge field of any
+spelling, so every G1 reported ``charging=False`` - indistinguishable from a
+pack measured to be discharging, and published on the mesh health wire by
+the health reader in :mod:`strands_robots.mesh.sensors`.  Three of the driver's
+six DDS decoders had a declared-fields grader like this one; this decoder was
+one of the two without, which is why the read went unnoticed.
+
+The suite has three layers because the SDK that owns the IDL is not on PyPI
+and so cannot be a test dependency:
+
+* A *faithful double* carrying exactly the declared field names and nothing
+  else.  Reading an undeclared name off it produces the default, which is
+  the defect, so these cells grade the decoder on any install.
+* :data:`_DECLARED_BMS_FIELDS`, a frozen copy of the declaration, and a cell
+  that checks it against the real ``BmsState_`` when the SDK *is*
+  importable.  That is what keeps the double faithful as the IDL moves.
+* A derivation over the decoder's own source, so a name added later is held
+  to the same rule without anyone remembering to add a case.
+
+Sibling files: :mod:`tests.drivers.test_g1_mainboard_reads_the_declared_fields`,
+:mod:`tests.drivers.test_g1_pressure_reads_the_declared_fields` and
+:mod:`tests.drivers.test_g1_lidar_state_reads_the_declared_fields`.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import inspect
+import textwrap
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.g1 import _TOPIC_BMS, G1Driver
+
+#: Every field ``unitree_hg.msg.dds_.BmsState_`` declares.  Frozen here
+#: because that SDK is installed from a git clone rather than PyPI, so it
+#: cannot be a test dependency; :func:`test_the_frozen_declaration_matches_the_sdk`
+#: proves this copy is still true wherever the SDK *is* importable.  The
+#: decoder reads three of these (``soc``, ``current``, ``cycle``); the rest
+#: are declared but uncached, which the ``g1_battery`` module docstring
+#: records as a decision that belongs to the decoder rather than the verb.
+_DECLARED_BMS_FIELDS: frozenset[str] = frozenset(
+    {
+        "version_high",
+        "version_low",
+        "fn",
+        "cell_vol",
+        "bmsvoltage",
+        "current",
+        "soc",
+        "soh",
+        "temperature",
+        "cycle",
+        "manufacturer_date",
+        "bmsstate",
+        "reserve",
+    }
+)
+
+
+def _bms_message(**overrides: Any) -> types.SimpleNamespace:
+    """Return a stand-in carrying exactly the declared BmsState fields.
+
+    Faithful in the one way that matters here: it declares the names the real
+    message declares and no others, so a decoder reaching for a name the IDL
+    does not have gets ``getattr``'s default from this object exactly as it
+    would from the real one.
+    """
+    fields: dict[str, Any] = {
+        "version_high": 1,
+        "version_low": 0,
+        "fn": 0,
+        "cell_vol": [4000] * 40,
+        "bmsvoltage": [50000, 0, 0],
+        "current": 0,
+        "soc": 100,
+        "soh": 100,
+        "temperature": [25] * 12,
+        "cycle": 0,
+        "manufacturer_date": 0,
+        "bmsstate": [0] * 5,
+        "reserve": [0] * 3,
+    }
+    fields.update(overrides)
+    # Sanity: reject overrides that widen the field set the double declares.
+    assert set(fields) == set(_DECLARED_BMS_FIELDS), (
+        f"stand-in got fields the IDL does not declare: {set(fields) - _DECLARED_BMS_FIELDS}"
+    )
+    return types.SimpleNamespace(**fields)
+
+
+def _getattr_names(func: Any) -> set[str]:
+    """Return every literal attribute name ``func`` reads with ``getattr``."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (isinstance(node.func, ast.Name) and node.func.id == "getattr"):
+            continue
+        if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+            value = node.args[1].value
+            if isinstance(value, str):
+                names.add(value)
+    return names
+
+
+def _decode(**overrides: Any) -> dict[str, Any]:
+    """Return the ``_battery`` record one decode of the double produces."""
+    driver = G1Driver(tool_name="g1", port="1.2.3.4")
+    driver._on_bms(_bms_message(**overrides))
+    assert driver._battery is not None, "the decoder wrote no record at all"
+    return driver._battery
+
+
+# =========================================================================
+# Premises - the absence this suite is about is real.                     #
+# =========================================================================
+
+
+class TestThePremisesHold:
+    """What makes an undeclared read silent, stated as checkable facts."""
+
+    def test_the_double_declares_the_fields_and_no_others(self) -> None:
+        """The stand-in is faithful in shape, which is what makes it useful."""
+        assert set(vars(_bms_message())) == set(_DECLARED_BMS_FIELDS)
+
+    @pytest.mark.parametrize("undeclared", ["charge", "charging", "status", "charge_state"])
+    def test_the_declaration_carries_no_charge_field(self, undeclared: str) -> None:
+        """No spelling of a charge flag is declared on this message.
+
+        ``charge`` is the name the decoder used to read.  ``status`` is the
+        near miss: it *is* declared on ``unitree_go.msg.dds_.BmsState_``, the
+        quadruped's BMS message, and this driver subscribes the humanoid's
+        ``unitree_hg`` one - so a reader who checked the wrong IDL would
+        conclude a status word was available here.
+        """
+        assert undeclared not in _DECLARED_BMS_FIELDS
+        assert not hasattr(_bms_message(), undeclared)
+
+    def test_an_undeclared_read_yields_a_plausible_false_not_an_error(self) -> None:
+        """This is the whole mechanism: the miss is silent, and it lies.
+
+        ``bool(getattr(msg, "charge", 0))`` on a message with no charge
+        field is ``False``, which is a perfectly well-formed answer to "is
+        this pack charging" - so nothing downstream can tell it apart from
+        a measurement.  That is why the defect survived: the read could not
+        raise and the value could not look wrong.
+        """
+        msg = _bms_message(soc=42)
+        assert bool(getattr(msg, "charge", 0)) is False
+        assert getattr(msg, "charge", 0.0) == 0.0
+
+
+# =========================================================================
+# The regression - the record carries readings and nothing else.          #
+# =========================================================================
+
+
+class TestTheRecordCarriesOnlyWhatTheMessageSaid:
+    """A key in the record has to trace back to a field on the wire."""
+
+    def test_the_record_carries_no_charge_flag(self) -> None:
+        """The defect, pinned: no charge key on a decode of a real layout.
+
+        Reporting one would mean answering a question the message does not
+        answer.  A firmware that does declare a charge field is one read in
+        ``_on_bms`` plus one key on the ``g1_battery`` envelope, and this
+        cell is where that decision gets recorded.
+        """
+        record = _decode()
+        assert "charging" not in record, (
+            f"_on_bms published {sorted(record)}; BmsState_ declares no charge field, so a "
+            "charging key can only be the getattr default dressed as a reading."
+        )
+
+    def test_the_record_names_exactly_the_readings_the_decoder_lifts(self) -> None:
+        """Three declared fields plus the decode timestamp, nothing more."""
+        assert set(_decode()) == {"pct", "current", "cycle", "t"}
+
+    def test_the_state_of_charge_reaches_the_record(self) -> None:
+        """``soc`` is the percentage the motion gates read as ``pct``."""
+        assert _decode(soc=77)["pct"] == pytest.approx(77.0)
+
+    def test_the_pack_current_reaches_the_record(self) -> None:
+        """``current`` is signed; the sign is the vendor's, not converted."""
+        assert _decode(current=-3210)["current"] == pytest.approx(-3210.0)
+
+    def test_the_cycle_count_reaches_the_record(self) -> None:
+        """``cycle`` is the pack's charge-cycle count as an integer."""
+        assert _decode(cycle=142)["cycle"] == 142
+
+    def test_the_wall_time_is_stamped(self) -> None:
+        """``t`` is the host clock at decode, not a field on the message.
+
+        ``BmsState_`` declares ``manufacturer_date`` and no clock, so the
+        decoder stamps ``time.time()``.  This is how the mesh's health chip
+        knows whether the reading is stale.
+        """
+        assert _decode()["t"] > 0.0
+
+    @pytest.mark.parametrize("renamed", ["soc", "current", "cycle"])
+    def test_a_missing_field_lands_none_not_a_plausible_zero(self, renamed: str) -> None:
+        """A firmware that renames a field yields ``None``, never ``0``.
+
+        ``0.0`` amps is a real reading (an idle pack) and ``0`` cycles is a
+        real reading (a new pack), so a typed default here is exactly as
+        undetectable as the charge flag was.  ``None`` is the one value that
+        cannot be mistaken for a measurement.
+        """
+        fields = {name: 1 for name in _DECLARED_BMS_FIELDS if name != renamed}
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_bms(types.SimpleNamespace(**fields))
+        assert driver._battery is not None
+        key = {"soc": "pct", "current": "current", "cycle": "cycle"}[renamed]
+        assert driver._battery[key] is None
+
+    def test_a_non_numeric_field_lands_none_rather_than_raising(self) -> None:
+        """A value that will not coerce is a miss, not a dead DDS thread."""
+        record = _decode(soc="n/a")
+        assert record["pct"] is None
+
+
+# =========================================================================
+# The derivation - a name added later is held to the same rule.           #
+# =========================================================================
+
+
+class TestEveryNameReadIsDeclared:
+    """Derived from the decoder's source, so a new read is graded on arrival."""
+
+    def test_the_decoder_reads_only_declared_fields(self) -> None:
+        """Any name here that the IDL does not declare is a silent constant."""
+        read = _getattr_names(G1Driver._on_bms)
+        assert read, "the derivation found no getattr reads to grade"
+        undeclared = read - _DECLARED_BMS_FIELDS
+        assert not undeclared, (
+            f"_on_bms reads {sorted(undeclared)} which BmsState_ does not declare. "
+            "Either add the field to _DECLARED_BMS_FIELDS (and to the double) or "
+            "drop the read; a read with a typed default publishes a constant."
+        )
+
+    def test_at_least_one_declared_field_is_read(self) -> None:
+        """Non-vacuity: the rule above is not satisfied by reading nothing."""
+        read = _getattr_names(G1Driver._on_bms)
+        assert read & _DECLARED_BMS_FIELDS, (
+            f"_on_bms reads none of the declared BmsState fields "
+            f"({sorted(_DECLARED_BMS_FIELDS)}). This would land a record of "
+            "all-None values on the mesh forever."
+        )
+
+
+# =========================================================================
+# Controls - a malformed message does not crash the DDS thread.           #
+# =========================================================================
+
+
+class TestTheDecoderIsResilient:
+    """The DDS thread has to survive a message it cannot read."""
+
+    def test_a_malformed_message_is_swallowed(self) -> None:
+        """The decoder catches, logs at debug, and moves on."""
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_bms("not a message")
+        driver._on_bms(None)
+        driver._on_bms(object())
+        # ``_battery`` may be None (no successful decode) or hold whatever the
+        # last coercion-tolerant read produced -- but the driver still runs.
+
+
+# =========================================================================
+# The subscription plan - the topic and IDL are wired.                    #
+# =========================================================================
+
+
+class TestTheDriverSubscribesTheTopic:
+    """Every cached record starts with a subscription: this one is wired."""
+
+    def test_the_topic_constant_names_the_bms_topic(self) -> None:
+        """``_TOPIC_BMS`` is the wire the firmware publishes the pack on."""
+        assert _TOPIC_BMS == "rt/lf/bmsstate"
+
+    def test_the_subscription_plan_wires_the_humanoid_idl(self) -> None:
+        """The plan names ``unitree_hg``, which is what fixes the field set.
+
+        ``unitree_go.msg.dds_.BmsState_`` is a different declaration under
+        the same class name, so the module the plan names is what decides
+        which fields exist.  A plan that pointed at the quadruped's IDL
+        would make the frozen declaration in this file wrong.
+        """
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        for topic, (idl_module, idl_class), decoder in driver._subscription_plan():
+            if topic == _TOPIC_BMS:
+                assert idl_module == "unitree_sdk2py.idl.unitree_hg.msg.dds_"
+                assert idl_class == "BmsState_"
+                assert decoder == driver._on_bms
+                break
+        else:  # pragma: no cover - the assertion below names the failure
+            raise AssertionError(f"{_TOPIC_BMS} is not in the subscription plan")
+
+
+# =========================================================================
+# Fidelity - the frozen declaration is checked where the SDK exists.      #
+# =========================================================================
+
+
+class TestTheFrozenDeclarationIsTrue:
+    """Without this the double could drift into agreeing with a bug."""
+
+    def test_the_frozen_declaration_matches_the_sdk(self) -> None:
+        """Compare the frozen copy against the real IDL when it is importable.
+
+        ``unitree_sdk2py`` is installed from a git clone rather than PyPI, so
+        it is absent on an ordinary contributor machine and in CI; skipping
+        there is the point of freezing the declaration in the first place.
+        On a host with the SDK present this cell holds the frozen copy honest
+        against the real message the firmware ships.
+
+        Equality, not containment: a subset check sees only the drift that
+        removes a field, and the other direction - a field declared that this
+        side never reads - is a reading dropped on the floor.  Both need a
+        decision before landing.
+        """
+        dds = pytest.importorskip(
+            "unitree_sdk2py.idl.unitree_hg.msg.dds_",
+            reason="unitree_sdk2py is installed from a git clone, not PyPI",
+        )
+        declared = {field.name for field in dataclasses.fields(dds.BmsState_)}
+        assert declared == set(_DECLARED_BMS_FIELDS), (
+            f"BmsState_ declares {sorted(declared)}; the frozen copy says "
+            f"{sorted(_DECLARED_BMS_FIELDS)}. Fields gone: "
+            f"{sorted(set(_DECLARED_BMS_FIELDS) - declared)}; fields added: "
+            f"{sorted(declared - set(_DECLARED_BMS_FIELDS))}. Update "
+            "_DECLARED_BMS_FIELDS, the double and _on_bms together."
+        )

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -180,20 +180,21 @@ def test_lowstate_populates_imu_and_mode_machine() -> None:
     assert isinstance(driver._imu["t"], float)
 
 
-def test_bms_populates_battery_with_pct_and_charging() -> None:
+def test_bms_populates_battery_with_the_fields_the_health_chip_reads() -> None:
     """``rt/lf/bmsstate`` yields the fields the mesh's health chip reads.
 
-    :mod:`strands_robots.mesh.sensors` reads ``battery.get("pct")`` and
-    ``battery.get("charging")`` - the names must match those keys or the
-    mesh publishes an empty health entry.
+    :mod:`strands_robots.mesh.sensors` reads ``battery.get("pct")`` - the
+    name must match that key or the mesh publishes an empty health entry.
+    A charge flag is deliberately absent from the record; see
+    :mod:`tests.drivers.test_g1_bms_reads_the_declared_fields`.
     """
     driver = G1Driver(tool_name="g1", port="1.2.3.4")
-    msg = types.SimpleNamespace(soc=87.5, charge=0, current=-1.2, cycle=42)
+    msg = types.SimpleNamespace(soc=87.5, current=-1.2, cycle=42)
     driver._on_bms(msg)
     assert driver._battery is not None
     assert driver._battery["pct"] == pytest.approx(87.5)
-    assert driver._battery["charging"] is False
     assert driver._battery["current"] == pytest.approx(-1.2)
+    assert driver._battery["cycle"] == 42
 
 
 def test_lidar_state_decodes_code() -> None:
@@ -396,7 +397,7 @@ def test_send_action_refuses_below_battery_floor() -> None:
     driver._connected = True
     driver._fsm_id = 501
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 12.0, "charging": False, "current": 0.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 12.0, "current": 0.0, "cycle": 0, "t": 0.0}
     result = driver.send_action({"any": 0.0})
     assert result["status"] == "error"
     assert "battery" in result["content"][0]["text"]
@@ -416,7 +417,7 @@ def test_send_action_reports_motion_not_wired_when_gates_pass() -> None:
     driver._connected = True
     driver._fsm_id = 501
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
     result = driver.send_action({"left_shoulder_pitch": 0.1})
     assert result["status"] == "error"
     assert "publisher not initialised" in result["content"][0]["text"]
@@ -443,7 +444,7 @@ def test_task_and_policy_paths_report_not_wired_when_gates_pass() -> None:
     driver._connected = True
     driver._fsm_id = 501  # in both HANDSHAKE_FSMS and WALK_FSMS
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
 
     start = driver.start_task("do X", policy_port=8000)
     assert start["status"] == "error"
@@ -499,7 +500,7 @@ def test_task_paths_refuse_below_battery_floor(verb: str) -> None:
     driver._connected = True
     driver._fsm_id = 501  # walkable
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 4.0, "charging": False, "current": 0.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 4.0, "current": 0.0, "cycle": 0, "t": 0.0}
     if verb == "start_task":
         result = driver.start_task("walk 1m")
     else:
@@ -524,7 +525,7 @@ def test_task_paths_refuse_outside_motion_fsm(verb: str) -> None:
     driver._connected = True
     driver._fsm_id = 0
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
     if verb == "start_task":
         result = driver.start_task("do X")
     else:
@@ -563,7 +564,7 @@ def test_send_action_admits_every_handshake_fsm(fsm: int) -> None:
     driver._connected = True
     driver._fsm_id = fsm
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
     result = driver.send_action({"any": 0.0})
     assert result["status"] == "error"
     text = result["content"][0]["text"]
@@ -591,7 +592,7 @@ def test_walk_fsms_has_a_consumer_and_a_documented_boundary() -> None:
     driver._connected = True
     driver._fsm_id = 500  # sitting: in HANDSHAKE_FSMS, not in WALK_FSMS
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
 
     # Arm-scoped write at 500 passes the gate (500 is in HANDSHAKE_FSMS).
     arm_result = driver.send_action({"any": 0.0})
@@ -661,7 +662,7 @@ def test_the_loco_gate_admits_every_walking_fsm(fsm: int) -> None:
     driver._connected = True
     driver._fsm_id = fsm
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
     assert driver._check_motion_gates("loco") is None
 
 
@@ -683,7 +684,7 @@ def test_motion_verbs_admit_a_literally_walkable_fsm(verb: str, fsm: int) -> Non
     driver._connected = True
     driver._fsm_id = fsm
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
     if verb == "start_task":
         result = driver.start_task("do X")
         expected_marker = "provider registry not wired yet"
@@ -955,7 +956,7 @@ def _gated_driver() -> tuple[G1Driver, _RecordingPublisher]:
     driver._connected = True
     driver._fsm_id = 501  # in HANDSHAKE_FSMS
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
     pub = _RecordingPublisher()
     driver._pubs = pub  # type: ignore[assignment]
     return driver, pub
@@ -1197,7 +1198,7 @@ def test_send_action_refuses_when_pubs_is_missing() -> None:
     driver._connected = True
     driver._fsm_id = 501
     driver._mode_machine = 9  # uint8 layout id echoed from lowstate
-    driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._battery = {"pct": 92.0, "current": 1.0, "cycle": 0, "t": 0.0}
     # _pubs left at its __init__ default (None).
     result = driver.send_action({"left_elbow": 0.1})
     assert result["status"] == "error"

--- a/tests/drivers/test_g1_driver_reaches_the_mesh_wire.py
+++ b/tests/drivers/test_g1_driver_reaches_the_mesh_wire.py
@@ -82,7 +82,7 @@ def _lowstate() -> Any:
 
 def _bms() -> Any:
     """An ``rt/lf/bmsstate`` sample, with the charge as a float32."""
-    return types.SimpleNamespace(soc=np.float32(87.5), charge=0, current=np.float32(-2.4), cycle=np.int64(42))
+    return types.SimpleNamespace(soc=np.float32(87.5), current=np.float32(-2.4), cycle=np.int64(42))
 
 
 def _lidar_state() -> Any:
@@ -170,10 +170,21 @@ class TestTheCriterionTopicsArriveEncoded:
         assert imu["rpy"] == pytest.approx([0.01, -0.02, 0.5], rel=1e-6)
         assert imu["accelerometer"] == pytest.approx([0.0, 0.0, 9.81], rel=1e-6)
 
-    def test_the_health_record_carries_the_battery_charge(self, capture: _Capture) -> None:
+    def test_the_health_record_carries_the_battery_percentage(self, capture: _Capture) -> None:
         health = _tick(_driver(), capture).wire[f"strands/{_PEER}/health"]
         assert health["battery_pct"] == pytest.approx(87.5, rel=1e-6)
-        assert health["charging"] is False
+
+    def test_the_health_record_claims_no_charge_state_the_pack_never_reported(self, capture: _Capture) -> None:
+        """``BmsState_`` declares no charge flag, so the wire carries none.
+
+        The reader used to default an absent ``charging`` key to ``False``,
+        which put a charge state on the health wire for every G1 - a claim
+        indistinguishable from a pack measured to be discharging.  An
+        absent key is the honest encoding of a reading the robot does not
+        publish.
+        """
+        health = _tick(_driver(), capture).wire[f"strands/{_PEER}/health"]
+        assert "charging" not in health
 
     def test_the_lidar_summary_carries_the_cloud_size(self, capture: _Capture) -> None:
         summary = _tick(_driver(), capture).wire[f"strands/{_PEER}/lidar/summary"]

--- a/tests/drivers/test_g1_mainboard_reads_the_declared_fields.py
+++ b/tests/drivers/test_g1_mainboard_reads_the_declared_fields.py
@@ -37,19 +37,20 @@ from strands_robots.drivers.g1 import (
     G1Driver,
 )
 
-#: Every field ``unitree_hg.msg.dds_.MainBoardState_`` declares on the layout
-#: the current firmware ships with.  Frozen here because that SDK is installed
-#: from a git clone rather than PyPI, so it cannot be a test dependency;
-#: :func:`test_the_frozen_declaration_matches_the_sdk` proves this copy is
-#: still true wherever the SDK *is* importable.  If a firmware update lands a
-#: field rename, the fidelity cell fails there first and the frozen copy is
-#: rewritten to match.
+#: Every field ``unitree_hg.msg.dds_.MainBoardState_`` declares, all four of
+#: them six-element vectors: ``fan_state`` (``uint16``), ``temperature``
+#: (``int16``), ``value`` (``float32``) and ``state`` (``uint32``).  Frozen
+#: here because that SDK is installed from a git clone rather than PyPI, so it
+#: cannot be a test dependency; :func:`test_the_frozen_declaration_matches_the_sdk`
+#: proves this copy is still true wherever the SDK *is* importable.  If a
+#: firmware update lands a field rename, the fidelity cell fails there first
+#: and the frozen copy is rewritten to match.
 _DECLARED_MAINBOARD_FIELDS: frozenset[str] = frozenset(
     {
         "fan_state",
         "temperature",
-        "sys_state",
-        "tick",
+        "value",
+        "state",
     }
 )
 
@@ -60,16 +61,16 @@ def _mainboard_message(**overrides: Any) -> types.SimpleNamespace:
     Faithful in the one way that matters here: it declares the names the
     real message declares and no others, so a decoder reaching for a name
     the IDL does not have gets ``getattr``'s default from this object
-    exactly as it would from the real one.  The default values are chosen
-    to be typed correctly (a list for the vector fields, an integer for
-    the scalars) so a decoder that reads them and coerces will succeed
-    end-to-end without needing a matching firmware on the box.
+    exactly as it would from the real one.  The defaults are six-element
+    vectors like the real declaration, so a decoder that reads them and
+    coerces will succeed end-to-end without needing a matching firmware
+    on the box.
     """
     fields: dict[str, Any] = {
-        "fan_state": [0, 0, 0, 0],
-        "temperature": [0.0, 0.0, 0.0],
-        "sys_state": 0,
-        "tick": 0,
+        "fan_state": [0] * 6,
+        "temperature": [0.0] * 6,
+        "value": [0.0] * 6,
+        "state": [0] * 6,
     }
     fields.update(overrides)
     return types.SimpleNamespace(**fields)
@@ -104,25 +105,31 @@ class TestThePremisesHold:
         msg = _mainboard_message()
         assert set(vars(msg)) == set(_DECLARED_MAINBOARD_FIELDS)
 
-    @pytest.mark.parametrize("undeclared", ["fan_speed", "cpu_temperature", "bms_state"])
+    @pytest.mark.parametrize(
+        "undeclared",
+        ["fan_speed", "cpu_temperature", "bms_state", "sys_bat_state", "sys_state", "tick"],
+    )
     def test_the_declaration_carries_no_such_field(self, undeclared: str) -> None:
         """The neon-side reads that are not on this firmware's layout.
 
-        The neon-the-g1 ``g1_mainboard`` port additionally read these fields
-        directly off the IDL.  On the layout the current firmware ships with
-        they are not declared, so a decoder reading them would land the
-        ``getattr`` default in the record forever.  If a future firmware
-        adds one back, this cell fires so the declaration and the decoder
-        can be updated together.
+        The neon-the-g1 ``g1_mainboard`` port read each of these off the IDL
+        behind a ``hasattr`` gate, so a name the message did not declare was
+        simply absent from its output.  ``sys_state`` and ``tick`` are the
+        two that reached this decoder without that gate, where an
+        undeclared read lands the ``getattr`` default in the record instead
+        (``tick`` is declared on ``LowState_``, not here).  If a future
+        firmware adds one back, this cell fires so the declaration and the
+        decoder can be updated together.
         """
         assert undeclared not in _DECLARED_MAINBOARD_FIELDS
         assert not hasattr(_mainboard_message(), undeclared)
 
     def test_an_undeclared_read_yields_the_default_rather_than_raising(self) -> None:
         """This is the whole mechanism: the miss is silent, not an error."""
-        msg = _mainboard_message(sys_state=1)
+        msg = _mainboard_message(state=[1] * 6)
         assert getattr(msg, "fan_speed", 0) == 0
         assert getattr(msg, "bms_state", 0) == 0
+        assert getattr(msg, "sys_state", 0) == 0
 
 
 # =========================================================================
@@ -147,26 +154,31 @@ class TestTheDecoderReadsTheDeclaredNames:
         assert driver._mainboard is not None
         assert driver._mainboard["temperature"] == pytest.approx([42.5, 44.0, 41.75])
 
-    def test_the_system_state_code_reaches_the_record(self) -> None:
-        """``sys_state`` is the firmware's system-state code as an integer."""
-        driver = G1Driver(tool_name="g1", port="1.2.3.4")
-        driver._on_mainboard(_mainboard_message(sys_state=2))
-        assert driver._mainboard is not None
-        assert driver._mainboard["sys_state"] == 2
+    def test_the_state_vector_reaches_the_record(self) -> None:
+        """``state`` is a ``uint32`` vector; the IDL gives it no semantics.
 
-    def test_the_firmware_tick_reaches_the_record(self) -> None:
-        """``tick`` is the firmware tick counter, monotonic within a boot."""
+        Published under the vendor's own name rather than interpreted, so
+        a caller reads what the board sent.  The decoder carrying it at
+        all is the point: a decoder that reads a name the IDL does not
+        declare drops this reading and reports a constant instead.
+        """
         driver = G1Driver(tool_name="g1", port="1.2.3.4")
-        driver._on_mainboard(_mainboard_message(tick=99999))
+        driver._on_mainboard(_mainboard_message(state=[2, 0, 0, 0, 0, 1]))
         assert driver._mainboard is not None
-        assert driver._mainboard["tick"] == 99999
+        assert driver._mainboard["state"] == [2, 0, 0, 0, 0, 1]
+
+    def test_the_value_vector_reaches_the_record(self) -> None:
+        """``value`` is a ``float32`` vector, likewise undocumented."""
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_mainboard(_mainboard_message(value=[1.5, 2.5, 3.5, 4.5, 5.5, 6.5]))
+        assert driver._mainboard is not None
+        assert driver._mainboard["value"] == pytest.approx([1.5, 2.5, 3.5, 4.5, 5.5, 6.5])
 
     def test_the_wall_time_is_stamped(self) -> None:
         """``t`` is the wall time of decode, not a field on the message.
 
-        The IDL does not carry a wall-time field (its ``tick`` is a
-        firmware counter, not a host clock), so the decoder stamps
-        ``time.time()`` on every message.  This is how the mesh's health
+        The IDL declares four vectors and no clock of any kind, so the
+        decoder stamps ``time.time()`` on every message.  This is how the mesh's health
         chip knows whether the reading is stale.
         """
         driver = G1Driver(tool_name="g1", port="1.2.3.4")
@@ -175,44 +187,26 @@ class TestTheDecoderReadsTheDeclaredNames:
         assert driver._mainboard["t"] is not None
         assert driver._mainboard["t"] > 0.0
 
-    def test_a_missing_scalar_field_lands_none_not_zero(self) -> None:
-        """A firmware that renames ``sys_state`` yields ``None`` on this side.
+    @pytest.mark.parametrize("renamed", sorted(_DECLARED_MAINBOARD_FIELDS))
+    def test_a_missing_field_lands_none_not_a_plausible_reading(self, renamed: str) -> None:
+        """A firmware that renames a field yields ``None`` for it here.
 
         ``_on_mainboard`` reads through ``getattr(msg, name, None)`` at
-        every field so a firmware rename does not silently write ``0``
-        into the record (which would look like a healthy system on the
-        current layout).  A message stand-in that omits the attribute
-        entirely models exactly that miss.
+        every field, so a rename does not write a typed default into the
+        record.  That matters because every plausible default is also a
+        real reading: ``0`` looks like a healthy system, ``[]`` looks like
+        a unit reporting no fans.  ``None`` is the one value that cannot
+        be mistaken for a measurement, and the ``g1_mainboard`` verb
+        passes it through.  A stand-in that omits one attribute models
+        exactly that miss, one field at a time.
         """
+        fields = {name: [1] * 6 for name in _DECLARED_MAINBOARD_FIELDS if name != renamed}
         driver = G1Driver(tool_name="g1", port="1.2.3.4")
-        msg = types.SimpleNamespace(
-            fan_state=[1, 1, 1, 1],
-            temperature=[40.0],
-            # sys_state / tick deliberately absent
-        )
-        driver._on_mainboard(msg)
+        driver._on_mainboard(types.SimpleNamespace(**fields))
         assert driver._mainboard is not None
-        assert driver._mainboard["sys_state"] is None
-        assert driver._mainboard["tick"] is None
-
-    def test_a_missing_vector_field_lands_none_not_empty(self) -> None:
-        """An undeclared ``fan_state`` lands ``None`` in the record.
-
-        An empty list would be a plausible reading (a build with no fans
-        declared), but is not the same as a firmware rename where the
-        field is absent entirely.  ``None`` is the decidable value for
-        the missing case; the ``g1_mainboard`` verb passes it through.
-        """
-        driver = G1Driver(tool_name="g1", port="1.2.3.4")
-        msg = types.SimpleNamespace(
-            temperature=[40.0],
-            sys_state=0,
-            tick=1,
-            # fan_state deliberately absent
-        )
-        driver._on_mainboard(msg)
-        assert driver._mainboard is not None
-        assert driver._mainboard["fan_state"] is None
+        assert driver._mainboard[renamed] is None
+        for present in fields:
+            assert driver._mainboard[present] is not None
 
 
 # =========================================================================
@@ -322,10 +316,15 @@ class TestTheFrozenDeclarationIsTrue:
             reason="unitree_sdk2py is installed from a git clone, not PyPI",
         )
         declared = {field.name for field in dataclasses.fields(dds.MainBoardState_)}
-        # The frozen set names the fields the driver reads; on a firmware
-        # that declares a superset this cell fails, so a rewriter has to
-        # decide which fields to lift into the cache before landing.
-        assert set(_DECLARED_MAINBOARD_FIELDS) <= declared, (
-            f"MainBoardState_ dropped fields: {sorted(set(_DECLARED_MAINBOARD_FIELDS) - declared)}. "
-            "Update _DECLARED_MAINBOARD_FIELDS to the real declaration."
+        # Equality, not containment.  A subset check sees only the half of
+        # the drift that removes a field; the other half is a firmware that
+        # declares one this side never reads, which is a reading dropped on
+        # the floor rather than a constant published - both need a decision
+        # before landing, so both fail here.
+        assert declared == set(_DECLARED_MAINBOARD_FIELDS), (
+            f"MainBoardState_ declares {sorted(declared)}; the frozen copy says "
+            f"{sorted(_DECLARED_MAINBOARD_FIELDS)}. Fields gone: "
+            f"{sorted(set(_DECLARED_MAINBOARD_FIELDS) - declared)}; fields the decoder "
+            f"does not read: {sorted(declared - set(_DECLARED_MAINBOARD_FIELDS))}. "
+            "Update _DECLARED_MAINBOARD_FIELDS and _on_mainboard together."
         )

--- a/tests/drivers/test_g1_mainboard_reads_the_driver_snapshot.py
+++ b/tests/drivers/test_g1_mainboard_reads_the_driver_snapshot.py
@@ -15,7 +15,7 @@ field ``_on_mainboard`` writes into ``_mainboard``.
 
 The cache field names are read here off the driver's own writer
 (:meth:`G1Driver._on_mainboard` names ``fan_state`` / ``temperature`` /
-``sys_state`` / ``tick`` / ``t``) rather than being restated in the
+``value`` / ``state`` / ``t``) rather than being restated in the
 tests, so a widen or rename on the driver side moves both the write
 path and this verb together.  What the tests do restate is the
 SDK-load-hygiene contract every file under
@@ -108,8 +108,8 @@ def test_a_driver_with_no_mainboard_message_yet_reports_absent() -> None:
     assert result["present"] is False
     assert result["fan_state"] is None
     assert result["temperature"] is None
-    assert result["sys_state"] is None
-    assert result["tick"] is None
+    assert result["value"] is None
+    assert result["state"] is None
     assert result["t"] is None
     assert driver.calls == ["_mainboard"], (
         f"g1_mainboard must read exactly _mainboard from the cache; got {driver.calls}"
@@ -121,17 +121,17 @@ def test_a_healthy_reading_reports_every_field_the_decoder_wrote() -> None:
 
     ``_on_mainboard`` writes ``fan_state`` (``list[int]``, one entry per
     fan flag), ``temperature`` (``list[float]``, one entry per board
-    thermistor in the units the firmware declares), ``sys_state`` (int),
-    ``tick`` (int) and ``t`` (wall time of decode).  The verb is not
-    the place to reword, convert or truncate those -- a caller reading
-    the values against a health chip on the mesh reads the same units
-    the driver wrote.
+    thermistor in the units the firmware declares), ``value``
+    (``list[float]``), ``state`` (``list[int]``) and ``t`` (wall time of
+    decode).  The verb is not the place to reword, convert or truncate
+    those -- a caller reading the values against a health chip on the
+    mesh reads the same units the driver wrote.
     """
     cache: dict[str, Any] = {
         "fan_state": [1, 1, 1, 0],
         "temperature": [42.5, 44.0, 41.75],
-        "sys_state": 0,
-        "tick": 12345,
+        "value": [1.5, 2.5, 3.5],
+        "state": [0, 1, 2],
         "t": 1_700_000_000.0,
     }
     result = _call(_StubG1Driver(cache=cache))
@@ -140,8 +140,8 @@ def test_a_healthy_reading_reports_every_field_the_decoder_wrote() -> None:
     assert result["present"] is True
     assert result["fan_state"] == [1, 1, 1, 0]
     assert result["temperature"] == [42.5, 44.0, 41.75]
-    assert result["sys_state"] == 0
-    assert result["tick"] == 12345
+    assert result["value"] == [1.5, 2.5, 3.5]
+    assert result["state"] == [0, 1, 2]
     assert result["t"] == 1_700_000_000.0
 
 
@@ -158,19 +158,19 @@ def test_a_hot_board_reading_is_returned_verbatim_not_clipped() -> None:
     cache: dict[str, Any] = {
         "fan_state": [1, 1, 1, 1],
         "temperature": [88.5, 91.25, 92.0],
-        "sys_state": 2,
-        "tick": 99999,
+        "value": [9.5, 9.75, 10.0],
+        "state": [2, 2, 2],
         "t": 1_700_000_100.0,
     }
     result = _call(_StubG1Driver(cache=cache))
 
     assert result["present"] is True
     assert result["temperature"] == [88.5, 91.25, 92.0]
-    assert result["sys_state"] == 2
+    assert result["state"] == [2, 2, 2]
 
 
 def test_a_missing_field_in_the_cache_reports_none() -> None:
-    """A cache dict missing one of the five fields returns ``None`` for it.
+    """A cache dict missing one of the five keys returns ``None`` for it.
 
     ``_on_mainboard`` reads through ``getattr(msg, name, None)`` at
     every field, so a firmware that renames one of the declared fields
@@ -183,15 +183,15 @@ def test_a_missing_field_in_the_cache_reports_none() -> None:
     cache: dict[str, Any] = {
         "fan_state": [1, 1, 1, 1],
         "temperature": [40.0],
-        # sys_state / tick / t deliberately absent
+        # value / state / t deliberately absent
     }
     result = _call(_StubG1Driver(cache=cache))
 
     assert result["present"] is True
     assert result["fan_state"] == [1, 1, 1, 1]
     assert result["temperature"] == [40.0]
-    assert result["sys_state"] is None
-    assert result["tick"] is None
+    assert result["value"] is None
+    assert result["state"] is None
     assert result["t"] is None
 
 
@@ -208,8 +208,8 @@ def test_the_verb_reads_the_snapshot_exactly_once() -> None:
         cache={
             "fan_state": [1, 1, 1, 1],
             "temperature": [40.0, 40.0, 40.0],
-            "sys_state": 0,
-            "tick": 1,
+            "value": [0.0, 0.0, 0.0],
+            "state": [0, 0, 0],
             "t": 1_700_000_300.0,
         }
     )
@@ -231,27 +231,26 @@ def test_mutating_the_result_does_not_alter_the_cache() -> None:
     cache: dict[str, Any] = {
         "fan_state": [1, 1, 1, 1],
         "temperature": [40.0, 40.0, 40.0],
-        "sys_state": 0,
-        "tick": 1,
+        "value": [0.0, 0.0, 0.0],
+        "state": [0, 0, 0],
         "t": 1_700_000_400.0,
     }
     driver = _StubG1Driver(cache=cache)
     result = _call(driver)
 
-    result["sys_state"] = 999
+    result["state"] = [999]
     result["injected"] = "should not appear in source"
 
-    assert cache["sys_state"] == 0, "mutating the verb's dict must not alter the driver's cache"
+    assert cache["state"] == [0, 0, 0], "mutating the verb's dict must not alter the driver's cache"
     assert "injected" not in cache
 
 
 def test_a_bare_zero_reading_is_still_present() -> None:
     """A cache carrying zero-valued fields still reports ``present=True``.
 
-    ``sys_state=0`` is the firmware's healthy-system code on the current
-    layout, ``tick=0`` is the firmware tick at boot before the first
-    increment, and an empty ``fan_state`` / ``temperature`` list is what
-    a build with no populated fans / thermistors would report.  Every
+    An all-zero ``state`` / ``value`` vector is what a board with nothing
+    latched reports, and an empty ``fan_state`` / ``temperature`` list is
+    what a build with no populated fans / thermistors would report.  Every
     one of those is a *reading*: ``_on_mainboard`` wrote something into
     ``_mainboard``, so ``_snapshot("_mainboard")`` returned a
     non-``None`` dict.  The verb reports the fact of the reading through
@@ -261,8 +260,8 @@ def test_a_bare_zero_reading_is_still_present() -> None:
     cache: dict[str, Any] = {
         "fan_state": [],
         "temperature": [],
-        "sys_state": 0,
-        "tick": 0,
+        "value": [0.0],
+        "state": [0],
         "t": 0.0,
     }
     result = _call(_StubG1Driver(cache=cache))
@@ -270,6 +269,6 @@ def test_a_bare_zero_reading_is_still_present() -> None:
     assert result["present"] is True
     assert result["fan_state"] == []
     assert result["temperature"] == []
-    assert result["sys_state"] == 0
-    assert result["tick"] == 0
+    assert result["value"] == [0.0]
+    assert result["state"] == [0]
     assert result["t"] == 0.0

--- a/tests/drivers/test_g1_pressure_reads_the_declared_fields.py
+++ b/tests/drivers/test_g1_pressure_reads_the_declared_fields.py
@@ -339,7 +339,7 @@ class TestTheFrozenDeclarationIsTrue:
         # The frozen set names the fields the driver reads; on a firmware
         # that declares a superset this cell fails, so a rewriter has to
         # decide which fields to lift into the cache before landing.
-        assert set(_DECLARED_PRESSURE_FIELDS) <= declared, (
+        assert declared == set(_DECLARED_PRESSURE_FIELDS), (
             f"PressSensorState_ dropped fields: "
             f"{sorted(set(_DECLARED_PRESSURE_FIELDS) - declared)}. "
             "Update _DECLARED_PRESSURE_FIELDS to the real declaration."

--- a/tests/mesh/test_sensor_readers.py
+++ b/tests/mesh/test_sensor_readers.py
@@ -391,6 +391,21 @@ def test_read_health_dict_battery_and_temps() -> None:
     assert health["temps"] == {"cpu": 55.0}
 
 
+def test_read_health_makes_no_charge_claim_a_record_did_not_carry() -> None:
+    """A record with no charge reading gets no charge key on the wire.
+
+    The reader used to default an absent ``charging`` key to ``False``, so
+    every driver whose battery record carries no charge flag - the G1's
+    ``BmsState_`` declares none - published a charge state indistinguishable
+    from a pack measured to be discharging.  Absence is the honest encoding
+    of a question the robot does not answer.
+    """
+    health = _host(_battery={"pct": 80})._read_health()
+    assert health is not None
+    assert health["battery_pct"] == 80
+    assert "charging" not in health
+
+
 def test_read_health_scalar_battery() -> None:
     health = _host(_battery=42)._read_health()
     assert health is not None


### PR DESCRIPTION
`G1Driver._on_bms` read `getattr(msg, "charge", 0)` into a `charging` flag. `unitree_hg.msg.dds_.BmsState_` declares no charge field of any spelling, so **every G1 reported `charging=False`** - a well-formed answer to "is this pack charging" that no measurement backed, published on the mesh health wire.

```mermaid
flowchart LR
  W["rt/lf/bmsstate<br/>BmsState_ declares<br/>13 fields, no charge"] --> D["_on_bms<br/>getattr(msg,'charge',0)"]
  D --> R["_battery record<br/>charging=False"]
  R --> V["g1_battery verb<br/>charging: false"]
  R --> H["mesh health wire<br/>charging: false"]
  style D fill:#ffdddd
  style R fill:#ffdddd
  style V fill:#ffdddd
  style H fill:#ffdddd
```

`getattr` with a typed default cannot fail, and the default is a well-formed value, so the read is invisible from both sides: nothing raises and nothing looks wrong. `_on_mainboard` had the same shape with the opposite symptom - it read `sys_state` and `tick`, which `MainBoardState_` does not declare either (`tick` is declared on `LowState_`), while the two vectors the message *does* declare were never read at all.

## What the IDL declares

| message | declared | the decoder read | verdict |
| --- | --- | --- | --- |
| `unitree_hg BmsState_` | `version_high` `version_low` `fn` `cell_vol` `bmsvoltage` `current` `soc` `soh` `temperature` `cycle` `manufacturer_date` `bmsstate` `reserve` | + `charge` | invented - `bool(0)` -> `False` forever |
| `unitree_hg MainBoardState_` | `fan_state` `uint16[6]`, `temperature` `int16[6]`, `value` `float32[6]`, `state` `uint32[6]` | `fan_state` `temperature` `sys_state` `tick` | 2 invented (`None` forever), 2 declared readings dropped |

`grep -rn 'charge\|sys_state' unitree_sdk2py/idl/` over the whole generated SDK returns nothing, and the `unitree_hg` IDL has a single commit - so these are not a firmware rename, they are names no layout ever had. `status` is the near miss: it is declared on `unitree_go.msg.dds_.BmsState_`, the quadruped's message, and this driver subscribes the humanoid's.

## Measured

One real `BmsState_` / `MainBoardState_` instance built from the installed SDK, driven through decoder -> verb -> health reader on both trees:

| surface | before | after |
| --- | --- | --- |
| wire `BmsState_` | `soc=77 current=-3210 cycle=142`, no charge field | same |
| `g1_battery` | `pct=77.0, charging=False, current=-3210.0, cycle=142` | `pct=77.0, current=-3210.0, cycle=142` |
| wire `MainBoardState_` | `fan_state=[1..6] temperature=[40..45] value=[1.5..6.5] state=[10..60]` | same |
| `g1_mainboard` | `fan_state=[1..6], temperature=[40..45], sys_state=None, tick=None` | `fan_state=[1..6], temperature=[40..45], value=[1.5..6.5], state=[10..60]` |
| mesh health wire | `battery_pct=77.0, charging=False` | `battery_pct=77.0` |

## The change

- Both decoders read the names their IDL declares. `_on_mainboard` publishes `value` / `state` under the vendor's own names, because the IDL documents no semantics for them and renaming them into a reading this side cannot justify would be a guess.
- Every field goes through `getattr(msg, name, None)` and a coercion that returns `None` (new `_to_float`, matching `_to_int`), so an absent or renamed field lands `None` and never a plausible `0` / `0.0` / `False`. `None` is the one value that cannot be mistaken for a measurement; `0.0` amps is a real idle pack and `0` cycles is a real new pack.
- The record carries no `charging` key. A layout that does declare a charge field is one read plus one envelope key away, and the cell that would change says so.
- `SensorLoopsMixin._read_health` sets `charging` only for a record that carries the reading, instead of defaulting an absent key to `False`.

## Why it went unnoticed, and what closes it

Three of the driver's six DDS decoders had a declared-fields grader (`lidar_state`, `mainboard`, `pressure`); the BMS decoder was one of the two without. Its grader is added here in the same three-layer shape - faithful double, frozen declaration checked against the real SDK where importable, derivation over the decoder's own source - so a future read is graded on arrival.

The mainboard grader did exist and stayed green because its frozen declaration *contained the invented names*: the oracle agreed with the bug. Its SDK-fidelity cell was also `frozen <= declared`, which only sees drift that removes a field, while the comment beside it claimed a superset would fail. Both that cell and the pressure one now assert equality, so a field declared but unread fails too.

## Verdicts

| selection | pre-fix (`upstream/main`, new pins copied in) | post-fix |
| --- | --- | --- |
| new + updated declared-fields graders | 13 failed / 32 passed | 45 passed |
| the two consumer pins (verb envelope, mesh wire) | 2 failed / 8 passed | 10 passed |
| `tests/drivers` + `tests/mesh/test_sensor_readers.py` | - | 2115 passed, 7 skipped |
| `scripts/check_whole_tree_graders.py` | - | 297 passed |

The 32 pre-fix passes are the controls: the unchanged happy paths, the subscription plan, the resilience cells and the fidelity cell all hold on both trees, so the failures name the mechanism rather than the file being new. `ruff check` / `ruff format --check` clean, `mypy` at the pinned version unchanged from base.

LOC: **+658 / -235**. Production is +110 / -64; 348 of the additions are the missing grader file, and the mainboard grader is net -1 (two miss cells consolidated into one table over the declaration).