### PR TITLE
fix(drivers): a LowCmd_ field a motor integrates must be a finite number

### DIFF
--- a/changelog.d/3101-unitree-lowcmd-fields-must-be-finite.md
+++ b/changelog.d/3101-unitree-lowcmd-fields-must-be-finite.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **drivers/g1, drivers/go2**: every field a ``LowCmd_`` carries to a motor - the
+  position target ``q``, the gains ``kp`` / ``kd``, the velocity feed-forward
+  ``dq`` and the effort ``tau`` - is now held to the shared
+  ``finite_number_error`` domain before it is written. Both builders coerced with
+  a bare ``float()``, which accepts ``nan``, ``inf``, the string ``"nan"`` and
+  ``True``, so a diverged policy published a fully populated frame with the slot
+  enabled and a valid CRC and the motor controller integrated an unrepresentable
+  target. Ten of the twelve native drivers already applied this domain to their
+  action values; these two applied it only to the constructor's
+  ``battery_floor_pct`` and ``run_policy``'s ``duration``. A non-finite action
+  now takes the control loop's existing ``exit_reason="policy"`` lane instead of
+  reaching the wire. NumPy scalars are still accepted.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -223,6 +223,15 @@ _LEG_KD: tuple[float, ...] = (1.0, 1.0, 1.0, 2.0, 1.0, 1.0)
 _WAIST_KD: tuple[float, ...] = (1.0, 1.0, 1.0)
 _ARM_KD: tuple[float, ...] = (1.0,) * 7
 _SDK_KD: tuple[float, ...] = _LEG_KD + _LEG_KD + _WAIST_KD + _ARM_KD + _ARM_KD
+# The per-joint fields a caller may put on a ``LowCmd_`` motor slot, and the
+# whole set this module reads off an action dict. Every one of them is a
+# physical quantity the frame carries to the motor controller verbatim, so each
+# is held to :func:`~strands_robots.utils.finite_number_error` before it is
+# written: a ``nan`` target serializes as a valid IEEE-754 float and the
+# controller integrates it, which poisons the pose rather than refusing the
+# command. Single-sourced so the fields accepted and the fields checked cannot
+# drift apart.
+_WIRE_FIELDS: tuple[str, ...] = ("q", "kp", "kd", "dq", "tau")
 
 
 class G1Driver:
@@ -1026,6 +1035,10 @@ class G1Driver:
            :meth:`run_policy` owns that loop today; this method is one frame.
         2. A safety filter.  The FSM and battery gates are the safety
            envelope; command-magnitude limits are the arm-SDK client's job.
+           Every commanded field is still required to be a finite number, which
+           is a different question from how large it may be: a ``nan`` target is
+           not a bold move the SDK can clamp, it is a value the motor controller
+           cannot honor at all.
 
         Scope is ``"arm"`` because ``send_action`` writes to ``rt/lowcmd`` for
         arm-SDK-shaped targets; base velocity is not a ``send_action`` verb.
@@ -1650,6 +1663,15 @@ def _build_lowcmd_from_action(
       are optional.  An unknown key inside the inner dict is refused for the
       same reason as an unknown joint name: silent drop is worse than a
       caller-facing error.
+    * Every field a caller supplies is held to
+      :func:`~strands_robots.utils.finite_number_error` before it is written -
+      the same domain the other native drivers put their action values through.
+      A ``nan`` or ``inf`` survives a bare ``float()`` and serializes onto the
+      wire as a valid IEEE-754 float, so the motor controller integrates it
+      instead of rejecting it; ``True`` would land as a silent ``1.0`` rad. This
+      is not a magnitude limit - it is the gate that keeps an unrepresentable
+      target off the wire, and refusing the whole action is the same posture an
+      unknown joint name gets, for the same reason.
 
     Wire-frame contract:
 
@@ -1687,7 +1709,7 @@ def _build_lowcmd_from_action(
     cmd.mode_pr = 0
     if mode_machine is not None:
         cmd.mode_machine = int(mode_machine)
-    known_inner = {"q", "kp", "kd", "dq", "tau"}
+    known_inner = set(_WIRE_FIELDS)
     for name, value in action.items():
         slot = _G1_JOINT_INDEX.get(name)
         if slot is None:
@@ -1707,16 +1729,16 @@ def _build_lowcmd_from_action(
             kd = value.get("kd", _SDK_KD[slot])
             dq = value.get("dq", 0.0)
             tau = value.get("tau", 0.0)
+            supplied = {key: value[key] for key in _WIRE_FIELDS if key in value}
         else:
             q, kp, kd, dq, tau = value, _SDK_KP[slot], _SDK_KD[slot], 0.0, 0.0
-        try:
-            q_f = float(q)
-            kp_f = float(kp)
-            kd_f = float(kd)
-            dq_f = float(dq)
-            tau_f = float(tau)
-        except (TypeError, ValueError) as exc:
-            return None, f"joint {name!r} carries a non-numeric target: {exc}"
+            supplied = {"q": value}
+        for key, raw in supplied.items():
+            reason = finite_number_error(raw, f"{name}.{key}", "send_action")
+            if reason is not None:
+                return None, reason
+        q_f, kp_f, kd_f = float(q), float(kp), float(kd)
+        dq_f, tau_f = float(dq), float(tau)
         motor = cmd.motor_cmd[slot]
         motor.mode = 1  # Enable - a Disable slot commands nothing regardless of CRC.
         motor.q = q_f

--- a/strands_robots/drivers/go2.py
+++ b/strands_robots/drivers/go2.py
@@ -153,6 +153,15 @@ _LEG_KD: tuple[float, float, float] = (5.0, 5.0, 5.0)
 #: is the default gain for a joint.
 _SDK_KP: tuple[float, ...] = _LEG_KP * 4
 _SDK_KD: tuple[float, ...] = _LEG_KD * 4
+# The per-joint fields a caller may put on a ``LowCmd_`` motor slot, and the
+# whole set this module reads off an action dict. Every one of them is a
+# physical quantity the frame carries to the motor controller verbatim, so each
+# is held to :func:`~strands_robots.utils.finite_number_error` before it is
+# written: a ``nan`` target serializes as a valid IEEE-754 float and the
+# controller integrates it, which poisons the pose rather than refusing the
+# command. Single-sourced so the fields accepted and the fields checked cannot
+# drift apart.
+_WIRE_FIELDS: tuple[str, ...] = ("q", "kp", "kd", "dq", "tau")
 
 #: Joint name -> ``LowCmd_.motor_cmd`` slot.
 #:
@@ -326,6 +335,15 @@ def build_lowcmd_from_action(action: dict[str, Any]) -> tuple[Any, str | None]:
     * A dict value must carry ``"q"``; ``"kp"``, ``"kd"``, ``"dq"`` and
       ``"tau"`` are optional. An unknown inner key is refused for the same
       reason an unknown joint name is.
+    * Every field a caller supplies is held to
+      :func:`~strands_robots.utils.finite_number_error` before it is written -
+      the same domain the other native drivers put their action values through.
+      A ``nan`` or ``inf`` survives a bare ``float()`` and serializes onto the
+      wire as a valid IEEE-754 float, so the motor controller integrates it
+      instead of rejecting it; ``True`` would land as a silent ``1.0`` rad. This
+      is not a magnitude limit - it is the gate that keeps an unrepresentable
+      target off the wire, and refusing the whole action is the same posture an
+      unknown joint name gets, for the same reason.
 
     Wire-frame contract: the header and ``level_flag`` come from
     :func:`_new_lowcmd`; ``motor_cmd[i].mode`` is set to
@@ -347,7 +365,7 @@ def build_lowcmd_from_action(action: dict[str, Any]) -> tuple[Any, str | None]:
     cmd, err = _new_lowcmd()
     if err is not None:
         return None, err
-    known_inner = {"q", "kp", "kd", "dq", "tau"}
+    known_inner = set(_WIRE_FIELDS)
     for name, value in action.items():
         slot = GO2_JOINT_INDEX.get(name)
         if slot is None:
@@ -367,12 +385,16 @@ def build_lowcmd_from_action(action: dict[str, Any]) -> tuple[Any, str | None]:
             kd = value.get("kd", _SDK_KD[slot])
             dq = value.get("dq", 0.0)
             tau = value.get("tau", 0.0)
+            supplied = {key: value[key] for key in _WIRE_FIELDS if key in value}
         else:
             q, kp, kd, dq, tau = value, _SDK_KP[slot], _SDK_KD[slot], 0.0, 0.0
-        try:
-            q_f, kp_f, kd_f, dq_f, tau_f = float(q), float(kp), float(kd), float(dq), float(tau)
-        except (TypeError, ValueError) as exc:
-            return None, f"joint {name!r} carries a non-numeric target: {exc}"
+            supplied = {"q": value}
+        for key, raw in supplied.items():
+            reason = finite_number_error(raw, f"{name}.{key}", "send_action")
+            if reason is not None:
+                return None, reason
+        q_f, kp_f, kd_f = float(q), float(kp), float(kd)
+        dq_f, tau_f = float(dq), float(tau)
         motor = cmd.motor_cmd[slot]
         motor.mode = _MOTOR_MODE_SERVO
         motor.q = q_f
@@ -968,11 +990,14 @@ class Go2Driver:
         supplies either ``{joint_name: target_position_radians}`` to take the
         reference gains, or ``{joint_name: {"q": ..., "kp": ..., "kd": ...,
         "dq": ..., "tau": ...}}`` for per-joint control; a missing ``q`` refuses
-        the whole action so a silently-zeroed target cannot reach the wire.
+        the whole action so a silently-zeroed target cannot reach the wire, and
+        every field the caller does supply must be a finite number for the same
+        reason - see :func:`build_lowcmd_from_action`.
 
         Two things this deliberately is not: a control loop (a caller wanting
         500 Hz calls this on their own timer, or uses :meth:`run_policy`), and a
-        command-magnitude filter (the gates are the safety envelope).
+        command-magnitude filter (the gates are the safety envelope). Requiring
+        a field to be finite is not a magnitude limit: ``nan`` names no pose.
 
         Args:
             action: Joint-name-keyed targets.

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -1151,13 +1151,19 @@ def test_send_action_refuses_unknown_per_joint_key() -> None:
 
 
 @pytest.mark.usefixtures("_stub_unitree_sdk")
-def test_send_action_refuses_non_numeric_target() -> None:
-    """A non-numeric target is refused with the joint name in the reason."""
+def test_send_action_refuses_a_target_that_is_not_a_finite_number() -> None:
+    """A target outside the finite-number domain is refused, naming the field.
+
+    The reason comes from the shared
+    :func:`~strands_robots.utils.finite_number_error` domain, so it names the
+    joint *and* the field it was wrong on - a caller commanding five fields per
+    joint needs to know which one.
+    """
     driver, pub = _gated_driver()
     result = driver.send_action({"left_elbow": "hold"})
     assert result["status"] == "error"
-    assert "left_elbow" in result["content"][0]["text"]
-    assert "non-numeric" in result["content"][0]["text"]
+    assert "left_elbow.q" in result["content"][0]["text"]
+    assert "must be a finite number" in result["content"][0]["text"]
     assert pub.writes == []
 
 

--- a/tests/drivers/test_go2_driver.py
+++ b/tests/drivers/test_go2_driver.py
@@ -373,7 +373,8 @@ def test_per_joint_gains_override_the_reference_gains(stub_unitree_sdk: None) ->
         pytest.param({"elbow": 0.0}, "unknown joint name", id="unknown-joint"),
         pytest.param({"FL_hip_joint": {"kp": 1.0}}, "missing required key 'q'", id="missing-q"),
         pytest.param({"FL_hip_joint": {"q": 0.0, "kx": 1.0}}, "unknown per-joint keys", id="unknown-inner-key"),
-        pytest.param({"FL_hip_joint": "forward"}, "non-numeric target", id="non-numeric"),
+        pytest.param({"FL_hip_joint": "forward"}, "must be a finite number", id="not-a-number"),
+        pytest.param({"FL_hip_joint": float("nan")}, "must be a finite number", id="nan-target"),
     ],
 )
 def test_an_unusable_action_is_refused_and_nothing_reaches_the_wire(

--- a/tests/drivers/test_unitree_lowcmd_fields_are_finite.py
+++ b/tests/drivers/test_unitree_lowcmd_fields_are_finite.py
@@ -383,5 +383,15 @@ def test_a_policy_that_diverges_stops_the_loop_instead_of_publishing_nan() -> No
         for slot in range(len(cmd.motor_cmd)):
             motor = cmd.motor_cmd[slot]
             for field in _WIRE_FIELDS:
+                # ``math.isfinite`` and deliberately not the builder's own
+                # :func:`finite_number_error`, which this module reaches for
+                # everywhere else: a scan has to be able to fail when the
+                # shared domain is the thing that regressed, and asking that
+                # helper would make the oracle circular - gate and scan would
+                # then regress together and the wire would read clean with a
+                # ``nan`` on it. Finiteness is the whole domain here anyway,
+                # because only ``float`` can reach a field: the ``float()``
+                # coercion sits downstream of the gate, and a value with no
+                # float64 form makes the builder raise before it writes.
                 value = getattr(motor, field)
                 assert math.isfinite(value), f"a non-finite {field}={value!r} reached the wire"

--- a/tests/drivers/test_unitree_lowcmd_fields_are_finite.py
+++ b/tests/drivers/test_unitree_lowcmd_fields_are_finite.py
@@ -1,0 +1,387 @@
+"""Every field a Unitree low-command carries to a motor must be a finite number.
+
+The two Unitree drivers build one ``LowCmd_`` per control step from a
+joint-name-keyed action dict, and each commanded slot carries five physical
+quantities: the position target ``q``, the gains ``kp`` / ``kd``, the velocity
+feed-forward ``dq`` and the effort ``tau``. Both builders coerced every one of
+them with a bare ``float()``, which is a *type* check and not a *domain* check:
+``float()`` accepts ``nan``, ``inf``, the string ``"nan"`` and ``True``.
+
+Measured on the real ``unitree_sdk2py`` IDL before this gate existed, on
+``G1Driver`` and ``Go2Driver`` alike, every row below produced a fully populated
+frame with the slot's enable byte set and a valid CRC:
+
+===========================================  =========================
+action                                       what reached ``motor_cmd``
+===========================================  =========================
+``{"left_shoulder_pitch": float("nan")}``    ``q=nan``
+``{"left_shoulder_pitch": float("inf")}``    ``q=inf``
+``{"left_shoulder_pitch": "nan"}``           ``q=nan``
+``{... {"q": 0.1, "kp": float("inf")}}``     ``kp=inf``
+``{... {"q": 0.1, "tau": float("nan")}}``    ``tau=nan``
+``{"left_shoulder_pitch": True}``            ``q=1.0``
+===========================================  =========================
+
+A ``nan`` is the dangerous spelling rather than merely an odd one, for the same
+reason it was on this driver's battery floor (see
+``tests.drivers.test_g1_battery_floor_is_a_finite_percentage``): it survives the
+coercion and then serializes onto the wire as a perfectly valid IEEE-754 float,
+so the firmware accepts the frame, the CRC matches, and the motor controller
+integrates an unrepresentable target into its own state. Nothing in any log says
+why. A refusal is not available at that point - the frame is already gone.
+
+The realistic route is not a hand-written action but a policy: an inference
+server that diverges, a checkpoint with a ``NaN`` weight, or a normalisation
+that divides by a zero-variance statistic all return a ``nan`` action while
+reporting success. The control loop already owns a lane for that -
+``exit_reason="policy"``, detail ``"policy returned an unusable action"`` - and
+``nan`` simply was not in the definition of unusable, so the frame published
+instead of taking it.
+
+The domain itself is not new and is not defined here: ten of the twelve native
+drivers already put their action values through
+:func:`~strands_robots.utils.finite_number_error` (UR per joint in
+``targets_from_action``, Booster per field in ``send_action``, Franka, Reachy,
+Microduck, Earthrover, Crazyflie, and Feetech / Robotiq through their own wire
+layers). The two Unitree builders were the exception, and both *imported* that
+helper already - for the constructor's ``battery_floor_pct`` and for
+``run_policy``'s ``duration``, but not for the values that move the robot.
+
+Scope, deliberately: this is not a magnitude limit. How far a joint may be
+commanded is the arm-SDK client's question and both drivers say so; whether a
+value names a pose at all is this one.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from strands_robots.drivers.g1 import (
+    _G1_JOINT_INDEX,
+    _WIRE_FIELDS,
+    _build_lowcmd_from_action,
+    _ControlLoop,
+)
+from strands_robots.drivers.go2 import _WIRE_FIELDS as _GO2_WIRE_FIELDS
+from strands_robots.drivers.go2 import GO2_JOINT_INDEX, build_lowcmd_from_action
+from strands_robots.utils import finite_number_error
+
+# One joint per driver is enough: the builders loop over the action dict, so the
+# gate is per-value and not per-slot. These two are named rather than derived so
+# a reader can see which joint the messages below are about.
+G1_JOINT = "left_shoulder_pitch"
+GO2_JOINT = "FL_hip_joint"
+
+#: ``(label, builder, joint_name, slot_index)`` for each driver, so every domain
+#: cell below grades both without being written twice.
+BUILDERS = (
+    pytest.param("g1", _build_lowcmd_from_action, G1_JOINT, _G1_JOINT_INDEX[G1_JOINT], id="g1"),
+    pytest.param("go2", build_lowcmd_from_action, GO2_JOINT, GO2_JOINT_INDEX[GO2_JOINT], id="go2"),
+)
+
+#: Values outside the domain, each with the reason it is not merely unusual.
+OUTSIDE_THE_DOMAIN = (
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(float("-inf"), id="-inf"),
+    pytest.param("nan", id="nan-as-a-string"),
+    pytest.param("0.25", id="a-numeric-string"),
+    pytest.param(True, id="bool-true-would-be-one-radian"),
+    pytest.param(None, id="none"),
+    pytest.param([0.25], id="a-list"),
+    pytest.param(10**400, id="past-the-float64-range"),
+)
+
+#: Real scalars a policy legitimately produces. NumPy is the case that matters:
+#: an action read off a policy tensor arrives as ``np.float32``, and refusing it
+#: would break every inference path. Same acceptance the battery floor has.
+INSIDE_THE_DOMAIN = (
+    pytest.param(0.25, id="float"),
+    pytest.param(0, id="int-zero"),
+    pytest.param(-1.5, id="negative"),
+    pytest.param(np.float32(0.25), id="numpy-float32"),
+    pytest.param(np.float64(-0.25), id="numpy-float64"),
+)
+
+
+# ---------------------------------------------------------------------------
+# One stub for both IDL namespaces. The builders import the SDK inside their
+# bodies, so registering the modules on sys.modules drives the same production
+# lane hardware drives - and puts these cells in front of CI, which has no SDK.
+# ---------------------------------------------------------------------------
+
+
+class _StubMotorCmd:
+    """One ``motor_cmd`` slot: the five wire fields plus the enable byte."""
+
+    def __init__(self) -> None:
+        self.mode: int = 0
+        self.q: float = 0.0
+        self.dq: float = 0.0
+        self.tau: float = 0.0
+        self.kp: float = 0.0
+        self.kd: float = 0.0
+
+
+class _StubLowCmd:
+    """Stand-in for a ``LowCmd_`` default instance, carrying both headers.
+
+    The slot width is per-subclass because it is not decoration: the Go2 builder
+    refuses an IDL whose ``motor_cmd`` is not exactly 20 wide, and the G1's is
+    35. One stub class serving both would be caught by that check - which is the
+    driver doing its job.
+    """
+
+    _SLOTS = 0
+
+    def __init__(self) -> None:
+        self.mode_pr: int = 0
+        self.mode_machine: int = 0
+        self.head: list[int] = [0, 0]
+        self.level_flag: int = 0
+        self.gpio: int = 0
+        self.motor_cmd: list[_StubMotorCmd] = [_StubMotorCmd() for _ in range(self._SLOTS)]
+        self.crc: int = 0
+
+
+class _StubHgLowCmd(_StubLowCmd):
+    """The G1's ``unitree_hg`` width, which the builder asserts is wide enough."""
+
+    _SLOTS = 35
+
+
+class _StubGoLowCmd(_StubLowCmd):
+    """The Go2's ``unitree_go`` width, which its builder requires exactly."""
+
+    _SLOTS = 20
+
+
+class _StubCRC:
+    """Stand-in for ``unitree_sdk2py.utils.crc.CRC``; ``42`` is a live marker."""
+
+    def Crc(self, _cmd: Any) -> int:
+        return 42
+
+
+@pytest.fixture(autouse=True)
+def _stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register both IDL namespaces the two builders import.
+
+    ``monkeypatch.setitem`` restores the previous entries on teardown, so a box
+    that does have the real SDK installed is left as it was.
+    """
+    modules = {
+        name: types.ModuleType(name)
+        for name in (
+            "unitree_sdk2py",
+            "unitree_sdk2py.idl",
+            "unitree_sdk2py.idl.default",
+            "unitree_sdk2py.idl.unitree_hg",
+            "unitree_sdk2py.idl.unitree_hg.msg",
+            "unitree_sdk2py.idl.unitree_hg.msg.dds_",
+            "unitree_sdk2py.idl.unitree_go",
+            "unitree_sdk2py.idl.unitree_go.msg",
+            "unitree_sdk2py.idl.unitree_go.msg.dds_",
+            "unitree_sdk2py.utils",
+            "unitree_sdk2py.utils.crc",
+        )
+    }
+    modules["unitree_sdk2py.idl.default"].unitree_hg_msg_dds__LowCmd_ = _StubHgLowCmd  # type: ignore[attr-defined]
+    modules["unitree_sdk2py.idl.default"].unitree_go_msg_dds__LowCmd_ = _StubGoLowCmd  # type: ignore[attr-defined]
+    modules["unitree_sdk2py.idl.unitree_hg.msg.dds_"].LowCmd_ = _StubHgLowCmd  # type: ignore[attr-defined]
+    modules["unitree_sdk2py.idl.unitree_go.msg.dds_"].LowCmd_ = _StubGoLowCmd  # type: ignore[attr-defined]
+    modules["unitree_sdk2py.utils.crc"].CRC = _StubCRC  # type: ignore[attr-defined]
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+# ---------------------------------------------------------------------------
+# The domain, on every field of both builders.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("label", "build", "joint", "slot"), BUILDERS)
+@pytest.mark.parametrize("field", _WIRE_FIELDS)
+@pytest.mark.parametrize("value", OUTSIDE_THE_DOMAIN)
+def test_a_field_outside_the_domain_refuses_the_whole_frame(
+    label: str, build: Any, joint: str, slot: int, field: str, value: Any
+) -> None:
+    """No frame is built at all - not a frame with the bad field dropped.
+
+    Refusing whole is the same posture an unknown joint name gets: silently
+    dropping a field the caller believed was commanded is worse than an error,
+    because the slot would then take a default the caller never chose.
+    """
+    del label, slot
+    cmd, reason = build({joint: {"q": 0.1, field: value}} if field != "q" else {joint: {"q": value}})
+    assert cmd is None, f"{field}={value!r} built a frame that would reach the wire"
+    assert reason is not None
+    assert f"{joint}.{field}" in reason, "the reason must name the joint and the field"
+
+
+@pytest.mark.parametrize(("label", "build", "joint", "slot"), BUILDERS)
+@pytest.mark.parametrize("value", OUTSIDE_THE_DOMAIN)
+def test_a_scalar_action_outside_the_domain_refuses_the_whole_frame(
+    label: str, build: Any, joint: str, slot: int, value: Any
+) -> None:
+    """The scalar spelling is the position target, and takes the same domain."""
+    del label, slot
+    cmd, reason = build({joint: value})
+    assert cmd is None
+    assert reason is not None and f"{joint}.q" in reason
+
+
+@pytest.mark.parametrize(("label", "build", "joint", "slot"), BUILDERS)
+@pytest.mark.parametrize("value", INSIDE_THE_DOMAIN)
+def test_a_real_scalar_still_reaches_the_slot(label: str, build: Any, joint: str, slot: int, value: Any) -> None:
+    """The controls. A gate that refused these would break every policy.
+
+    ``np.float32`` is the row that matters: an action read off a policy tensor
+    arrives as a NumPy scalar, not a Python float.
+    """
+    del label
+    cmd, reason = build({joint: value})
+    assert reason is None, f"{value!r} is a usable target and must not be refused"
+    assert cmd is not None
+    assert cmd.motor_cmd[slot].q == pytest.approx(float(value))
+    assert cmd.motor_cmd[slot].mode != 0, "a commanded slot must be enabled"
+
+
+@pytest.mark.parametrize(("label", "build", "joint", "slot"), BUILDERS)
+def test_every_field_the_builder_accepts_is_a_field_it_checks(label: str, build: Any, joint: str, slot: int) -> None:
+    """The vocabulary accepted and the vocabulary checked are one list.
+
+    A sixth wire field added to ``_WIRE_FIELDS`` later is graded on arrival: it
+    becomes an accepted inner key *and* a checked one in the same edit, so the
+    two cannot drift into a field that is written without being judged.
+    """
+    del slot
+    assert _WIRE_FIELDS == _GO2_WIRE_FIELDS, "both drivers frame the same five fields"
+    for field in _WIRE_FIELDS:
+        action = {joint: {"q": 0.1, field: float("nan")}} if field != "q" else {joint: {"q": float("nan")}}
+        cmd, reason = build(action)
+        assert cmd is None and reason is not None, f"{label}: {field} is accepted but not checked"
+    # An unknown inner key is still refused, so the accepted set is exactly this.
+    cmd, reason = build({joint: {"q": 0.1, "torque": 1.0}})
+    assert cmd is None and reason is not None and "unknown per-joint keys" in reason
+
+
+@pytest.mark.parametrize(("label", "build", "joint", "slot"), BUILDERS)
+def test_the_reason_is_the_shared_domain_verbatim(label: str, build: Any, joint: str, slot: int) -> None:
+    """Neither driver carries its own copy of the domain or of its wording.
+
+    Compared against the helper's own output rather than a fragment, so a
+    private re-implementation that happened to refuse ``nan`` would still fail
+    here - the point is one domain, not two that agree today.
+    """
+    del label, slot
+    _, reason = build({joint: float("nan")})
+    assert reason == finite_number_error(float("nan"), f"{joint}.q", "send_action")
+
+
+# ---------------------------------------------------------------------------
+# The realistic route: a policy that returns a non-finite action.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingPublisher:
+    """Records every ``publish``; returns ``None`` like the real one on success."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+        self.closed = False
+
+    def publish(self, topic: str, klass: Any, cmd: Any) -> str | None:
+        self.calls.append((topic, klass, cmd))
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fake_driver(publisher: _RecordingPublisher) -> Any:
+    """A driver good enough for :class:`_ControlLoop`, with gates that admit."""
+    import threading
+
+    driver = MagicMock(
+        spec=[
+            "_mode_machine",
+            "_fsm_id",
+            "_battery",
+            "_imu",
+            "_pubs",
+            "_check_motion_gates",
+            "_loop",
+            "_task_admission",
+            "_tool_name",
+            "_refresh_fsm_id",
+            "_fsm_read_at",
+            "_motion_switcher_lock",
+        ]
+    )
+    driver._mode_machine = 9
+    driver._fsm_id = 500
+    driver._tool_name = "g1"
+    driver._refresh_fsm_id = MagicMock(side_effect=lambda: setattr(driver, "_fsm_read_at", time.monotonic()))
+    driver._fsm_read_at = time.monotonic()
+    driver._motion_switcher_lock = threading.Lock()
+    driver._battery = {"pct": 80.0}
+    driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+    driver._pubs = publisher
+    driver._check_motion_gates = MagicMock(return_value=None)
+    driver._loop = None
+    driver._task_admission = threading.Lock()
+    return driver
+
+
+def test_a_policy_that_diverges_stops_the_loop_instead_of_publishing_nan() -> None:
+    """The money case: a diverged policy takes the loop's own refusal lane.
+
+    Two good steps, then ``nan``. The loop already reports an unusable action as
+    ``exit_reason="policy"``; what this pins is that a ``nan`` action *is*
+    unusable, so the frame carrying it is never published. Every position frame
+    on the wire holds finite targets, and the loop still soft-stops on the way
+    out - a refusal must not leave the motors hot.
+    """
+    publisher = _RecordingPublisher()
+    driver = _fake_driver(publisher)
+    steps = {"n": 0}
+
+    def policy(_obs: Any) -> dict[str, float]:
+        steps["n"] += 1
+        if steps["n"] > 2:
+            return {G1_JOINT: float("nan")}
+        return {G1_JOINT: 0.1}
+
+    # Bounded by ``n_steps`` so the loop terminates whether or not the gate
+    # exists: without it a published ``nan`` is simply the next setpoint and the
+    # loop runs its full duration, which would make this cell fail on a timeout
+    # rather than on the claim it is here to make.
+    loop = _ControlLoop(driver=driver, policy=policy, duration=60.0, n_steps=6)
+    loop.start()
+    deadline = time.monotonic() + 10.0
+    while loop.is_running and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not loop.is_running, "loop did not finish"
+
+    snap = loop.snapshot()
+    assert snap["exit_reason"] == "policy"
+    assert "unusable action" in (snap["exit_detail"] or "")
+    assert "must be a finite number" in (snap["exit_detail"] or "")
+
+    published = [cmd for _topic, _klass, cmd in publisher.calls]
+    assert published, "the two good steps must have reached the wire"
+    for cmd in published:
+        for slot in range(len(cmd.motor_cmd)):
+            motor = cmd.motor_cmd[slot]
+            for field in _WIRE_FIELDS:
+                value = getattr(motor, field)
+                assert value == value, f"a nan {field} reached the wire"
+                assert abs(value) != float("inf"), f"an inf {field} reached the wire"

--- a/tests/drivers/test_unitree_lowcmd_fields_are_finite.py
+++ b/tests/drivers/test_unitree_lowcmd_fields_are_finite.py
@@ -54,6 +54,7 @@ value names a pose at all is this one.
 
 from __future__ import annotations
 
+import math
 import sys
 import time
 import types
@@ -383,5 +384,4 @@ def test_a_policy_that_diverges_stops_the_loop_instead_of_publishing_nan() -> No
             motor = cmd.motor_cmd[slot]
             for field in _WIRE_FIELDS:
                 value = getattr(motor, field)
-                assert value == value, f"a nan {field} reached the wire"
-                assert abs(value) != float("inf"), f"an inf {field} reached the wire"
+                assert math.isfinite(value), f"a non-finite {field}={value!r} reached the wire"


### PR DESCRIPTION
## A diverged policy published 4 nan setpoints and the rollout reported success

![nan on the wire](https://raw.githubusercontent.com/cagataycali/robots/assets/unitree-lowcmd-fields-must-be-finite/nan_on_the_wire.png)

Same run on both trees: the real `_ControlLoop`, gates admitting, a 6-step budget, a policy that returns `nan` from step 3. Left is `main`, right is this branch.

| | frames published | `q=nan` on the wire | `exit_reason` |
| --- | --- | --- | --- |
| before | 7 | **4** | `n_steps`, no detail |
| after | 3 | **0** | `policy`, naming `left_shoulder_pitch.q` |

## What was wrong

Both Unitree builders coerced every commanded field with a bare `float()`. That is a *type* check, not a *domain* check. Measured against the real `unitree_sdk2py` IDL on `G1Driver` and `Go2Driver` alike - every row produced a fully populated frame, slot enable byte set, valid CRC:

| action | reached `motor_cmd` |
| --- | --- |
| `{"left_shoulder_pitch": float("nan")}` | `q=nan` |
| `{"left_shoulder_pitch": float("inf")}` | `q=inf` |
| `{"left_shoulder_pitch": "nan"}` | `q=nan` |
| `{... {"q": 0.1, "kp": float("inf")}}` | `kp=inf` |
| `{... {"q": 0.1, "tau": float("nan")}}` | `tau=nan` |
| `{"left_shoulder_pitch": True}` | `q=1.0` |

`nan` is the dangerous spelling rather than merely an odd one: it survives the coercion and then serializes as a perfectly valid IEEE-754 float, so firmware accepts the frame, the CRC matches, and the motor controller integrates an unrepresentable target. No refusal is available at that point - the frame is gone.

The realistic route is not a hand-written action. An inference server that diverges, a checkpoint with a `NaN` weight, or a normalisation dividing by a zero-variance statistic all return a `nan` action while reporting success. The loop already owns a lane for that - `exit_reason="policy"`, `"policy returned an unusable action"` - and `nan` was simply not in the definition of unusable.

## Why these two

The domain is not new. `finite_number_error` already documents this exact pathology, and 10 of the 12 native drivers apply it to their action values:

| driver | action value gated | where |
| --- | --- | --- |
| ur | yes | `finite_number_error` per joint in `targets_from_action` |
| booster | yes | per field in `send_action` |
| franka | yes | `send_action` |
| reachy / microduck / earthrover / crazyflie | yes | `send_action` |
| feetech / robotiq | yes | own wire layer |
| dynamixel | n/a | not wired |
| **g1** | **no** | bare `float()` |
| **go2** | **no** | bare `float()` |

Both already *imported* the helper - for the constructor's `battery_floor_pct` and `run_policy`'s `duration`, but not for the values that move the robot. On the G1 the asymmetry was stark: `tests/drivers/test_g1_battery_floor_is_a_finite_percentage.py` argues the `nan` case at length for the battery floor, and the tool verbs refuse a `nan` `vx` and `height` - only `motor_cmd[i].q` was ungraded.

## The change

`_WIRE_FIELDS = ("q", "kp", "kd", "dq", "tau")` is now the one vocabulary each builder both accepts and checks, so the two cannot drift into a field written without being judged. Every field the caller supplies goes through `finite_number_error(value, f"{joint}.{field}", "send_action")` - the same shape Booster uses - and the refusal names the joint and the field. Refusing whole matches the posture an unknown joint name already gets.

NumPy scalars still pass: an action read off a policy tensor arrives as `np.float32`, and the shared domain accepts any real scalar. That is pinned, alongside the reverse.

Scope, deliberately: this is not a magnitude limit. How far a joint may be commanded is the arm-SDK client's question and both drivers say so; whether a value names a pose at all is this one. The docstrings that claimed "not a safety filter" now draw that distinction instead of implying no value check exists.

## Tests

`tests/drivers/test_unitree_lowcmd_fields_are_finite.py` - 123 cells, table-driven over both drivers rather than one file per value: the domain on all 5 fields in both spellings, the controls that must keep passing, the vocabulary-is-one-list pin, a cell asserting the reason equals the shared helper's own output verbatim (so a private re-implementation that happened to refuse `nan` still fails), and the control-loop cell above.

Against `main` with only the gate reverted and every new symbol left defined: **113 failed / 10 passed**; after, **123 passed**. The 10 pre-fix greens are the controls. The two existing `"non-numeric target"` assertions are evolved in place to the shared wording, and a `nan` row is added to the Go2 refusal table.

The SDK is stubbed on `sys.modules` for both IDL namespaces, so these run in CI. The stub widths are per-driver on purpose - the Go2 builder refuses an IDL whose `motor_cmd` is not exactly 20 wide, which caught a single shared 35-slot stub.

The published-frame scan asks `math.isfinite` once rather than restating finiteness as `value == value` plus an `abs(value) != inf` test. Verdict-equivalent - only `float` can reach a wire field, because the `float()` coercion sits downstream of the gate - and deliberately not the builder's own `finite_number_error`, since a scan has to be able to fail when the shared domain is what regressed.

Local gate: `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ` (1820 files); `mypy` no issues in 1817 source files; `scripts/check_whole_tree_graders.py` 298 passed / 1 skipped; `tests/drivers` + `tests/tools/g1` 2333 passed / 25 skipped / 0 failed.

LOC delta +486/-21, of which the test file is +397.


## §13 Round changelog

**Round 1** -- one static-analysis finding, addressed in `fbf7644` and `4866018`.

- *`assert value == value` in the control-loop cell is a comparison of identical values (CodeQL `py/comparison-of-identical-expressions`); use an explicit nan test.* Correct on the reading that matters: the self-comparison is the nan idiom, but it is spelled as the tautology static analysis exists to catch, so a reader has to recognise the trick before the line says anything. It was also half a check -- the infinities needed the separate `abs(value) != float("inf")` line beside it, leaving the pair's exhaustiveness for the reader to verify.
  Both lines collapse into `assert math.isfinite(value)`. That is the predicate this PR is *about* -- the same domain `finite_number_error` applies on the production side -- and the spelling the rest of the tree already uses for it (`tests/policies/vera`, `tests/training`, `tests/policies/lerobot_local` and others). One call covers nan and both infinities, and the message now names the offending value rather than only its field. Cell count is unchanged at 123: this is one assertion inside the existing control-loop cell, so the reverted-gate measurement above still holds.
  `4866018` records why this one scan is spelled by hand in a module that argues for the shared domain everywhere else: routing it through `finite_number_error` is the obvious next refactor and it would make the oracle circular. With that helper mutated to stop refusing non-finite values, a `nan` reaches the wire and a `finite_number_error`-based scan reads clean, while `math.isfinite` still catches it - gate and scan must not be able to regress together. Finiteness is also the whole domain at this point, since only a `float` can reach a field: the `float()` coercion sits downstream of the gate, and a value with no float64 form makes the builder raise before it writes.
