### PR TITLE
fix(simulation): a scene mutation swaps the live model under self._lock

### DIFF
--- a/changelog.d/3102-scene-mutation-swaps-under-the-lock.md
+++ b/changelog.d/3102-scene-mutation-swaps-under-the-lock.md
@@ -1,0 +1,38 @@
+### Fixed: a scene mutation swaps the live MuJoCo model under `self._lock`
+
+The MuJoCo backend's own module docstring declares `self._lock` as the "RLock
+serializing ALL model/data access", and the render path takes it with a comment
+explaining exactly why: "the recorder daemon calls render() on its own thread,
+so this path is NOT covered by the blanket dispatch lock". Seven scene-mutation
+verbs performed the swap outside that lock, relying on
+`_require_no_running_policy()` instead. The two guards cover different readers.
+The policy gate refuses a *policy* worker; the camera-recorder daemon has no
+policy, so the gate cannot see it, and the lock was the only thing that could
+have excluded it.
+
+`create_world`, `add_robot`, `add_object`, `remove_object`, `add_camera`,
+`remove_camera`, `patch_scene_mjcf` and `replace_scene_mjcf` now hold the lock
+across the swap, joining `load_scene` and `remove_robot`, which already did --
+`load_scene`'s existing comment names the hazard ("so a concurrent
+render/recorder thread never observes a half-built world"). Registration and
+rollback are inside the same critical section as the recompile, so a reader
+never sees an object registered against a model that does not contain it, nor a
+rolled-back registry against a recompiled model. `_compile_world` takes the lock
+itself rather than relying on its caller, keeping the invariant local to the
+function that performs the swap.
+
+The swap is two assignments wide: `scene_ops.install_compiled_model` rebinds
+`world._model` and then `world._data`, so an unexcluded reader can observe a
+model from after the swap paired with data from before it -- indexing the new
+model's body count into the old data's arrays, which MuJoCo dereferences
+natively.
+
+Measured with a reader of the recorder's shape, which takes the lock and renders
+twice without releasing it: before, an `add_object` on another thread landed
+between the two renders and 634 pixels changed inside one critical section;
+after, the two frames are byte-identical and the mutation waits. All ten verbs
+still return `success`. The regression test pins each verb, keeps `load_scene`
+and `remove_robot` as controls that were already correct, and closes the family
+with a check that derives the set of scene-recompiling helpers from
+`scene_ops` rather than listing it, so a new one is graded on the commit that
+introduces it.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -39,6 +39,24 @@ call does not work any better than narrowing through a bound method
 dedup).
 
 So: the split is honest about being for file-size, not for decoupling.
+
+Scene mutation and ``self._lock``
+
+A verb that swaps the live scene must hold ``self._lock`` across the swap, not
+merely pass ``_require_no_running_policy()``. The two guards cover different
+readers: the policy gate refuses a *policy* worker, while the camera-recorder
+daemon renders on its own thread and is serialised only by the lock (see
+:mod:`strands_robots.simulation.mujoco.rendering`, whose render path takes the
+lock precisely because it "is NOT covered by the blanket dispatch lock").
+
+The swap is not atomic either. ``scene_ops.install_compiled_model`` rebinds
+``world._model`` and ``world._data`` in two separate assignments, so a reader
+that is not excluded can observe a model from after the swap paired with data
+from before it -- and MuJoCo dereferences that pair natively, indexing the new
+model's body count into the old data's arrays. Holding the lock over the swap is
+what makes the pair a reader observes always a matching one. The lock is an
+``RLock``, so the acquisition is a reentrant no-op on the dispatch path and the
+real guard when the verb is called directly as a Python API.
 """
 
 import contextlib
@@ -939,23 +957,30 @@ class MuJoCoSimEngine(
                 return cast("dict[str, Any]", gravity_error)
             _gravity = normalized
 
-        self._world = SimWorld(
-            timestep=float(effective_timestep),
-            gravity=_gravity,
-            ground_plane=ground_plane,
-            terrain=terrain,
-            terrain_difficulty=float(difficulty),
-        )
+        # Rebinding self._world and compiling a model into it are one
+        # critical section (see "Scene mutation and self._lock" in the module
+        # docstring): a recorder thread still running against the previous
+        # world would otherwise observe the new SimWorld while its ``_model``
+        # is still None. No asset resolution happens here, so the lock is held
+        # only across the spec build and compile.
+        with self._lock:
+            self._world = SimWorld(
+                timestep=float(effective_timestep),
+                gravity=_gravity,
+                ground_plane=ground_plane,
+                terrain=terrain,
+                terrain_difficulty=float(difficulty),
+            )
 
-        self._world.cameras["default"] = SimCamera(
-            name="default",
-            position=[1.5, 1.5, 1.2],
-            target=[0.0, 0.0, 0.3],
-            width=self.default_width,
-            height=self.default_height,
-        )
+            self._world.cameras["default"] = SimCamera(
+                name="default",
+                position=[1.5, 1.5, 1.2],
+                target=[0.0, 0.0, 0.3],
+                width=self.default_width,
+                height=self.default_height,
+            )
 
-        self._compile_world()
+            self._compile_world()
 
         return {
             "status": "success",
@@ -1090,7 +1115,11 @@ class MuJoCoSimEngine(
             return err
 
         try:
-            replace_scene_mjcf(self._world, xml)
+            # Swap the live model under the lock (see "Scene mutation and
+            # self._lock" above): the recorder thread is not covered by the
+            # policy gate, and the rebind is two assignments wide.
+            with self._lock:
+                replace_scene_mjcf(self._world, xml)
         except (ValueError, RuntimeError) as e:
             return {"status": "error", "content": [{"text": f"MJCF compile failed: {e}"}]}
 
@@ -1193,7 +1222,9 @@ class MuJoCoSimEngine(
             return err
 
         try:
-            applied = patch_scene_mjcf(self._world, ops)
+            # Swap the live model under the lock (see the module docstring).
+            with self._lock:
+                applied = patch_scene_mjcf(self._world, ops)
         except (ValueError, RuntimeError) as e:
             return {"status": "error", "content": [{"text": f"MJCF patch failed: {e}"}]}
 
@@ -1229,13 +1260,19 @@ class MuJoCoSimEngine(
         self._world._backend_state["spec"] = spec
         with filter_mujoco_attach_noise():
             model = spec.compile()
-        install_compiled_model(self._world, model, mj.MjData(model))
-        # Forward the freshly-allocated MjData so derived state
-        # (xpos / xquat / xmat) is populated - same rationale as in
-        # ``load_scene`` (#168). Without this, the first
-        # render after ``_compile_world`` returns the skybox-only
-        # gradient because body transforms are zero-initialised.
-        mj.mj_forward(self._world._model, self._world._data)
+        # This function swaps the live model, so it holds the lock itself
+        # rather than relying on its caller (see "Scene mutation and
+        # self._lock" in the module docstring). RLock, so this is a reentrant
+        # no-op under ``create_world``'s acquisition, and it keeps the
+        # invariant local to the function that performs the swap.
+        with self._lock:
+            install_compiled_model(self._world, model, mj.MjData(model))
+            # Forward the freshly-allocated MjData so derived state
+            # (xpos / xquat / xmat) is populated - same rationale as in
+            # ``load_scene`` (#168). Without this, the first
+            # render after ``_compile_world`` returns the skybox-only
+            # gradient because body transforms are zero-initialised.
+            mj.mj_forward(self._world._model, self._world._data)
         try:
             with filter_mujoco_attach_noise():
                 self._world._backend_state["xml"] = spec.to_xml()
@@ -1897,24 +1934,31 @@ class MuJoCoSimEngine(
                 if kf_err is not None:
                     return kf_err
 
-            # Register the robot BEFORE attach so scene_ops can re-discover
-            # its joint/actuator IDs inside the merged model.
-            self._world.robots[name] = robot
-            # Track robot base path for asset path resolution.
-            if not self._world._backend_state.get("robot_base_xml"):
-                self._world._backend_state["robot_base_xml"] = resolved_path
+            # Registration, swap and rollback are one critical section (see
+            # "Scene mutation and self._lock" in the module docstring): the
+            # recorder thread is not covered by the policy gate above, so
+            # outside the lock it can observe the robot registered against a
+            # model that does not contain it. The asset is already resolved to
+            # ``resolved_path``, so no download happens under the lock.
+            with self._lock:
+                # Register the robot BEFORE attach so scene_ops can
+                # re-discover its joint/actuator IDs inside the merged model.
+                self._world.robots[name] = robot
+                # Track robot base path for asset path resolution.
+                if not self._world._backend_state.get("robot_base_xml"):
+                    self._world._backend_state["robot_base_xml"] = resolved_path
 
-            # Compose into the live spec via spec.attach(). The helper sets
-            # robot.joint_names from the source spec (pre-namespacing) and
-            # then scene_ops._recompile_preserving_state resolves the
-            # post-attach joint/actuator IDs on the compiled model.
-            ok = inject_robot_into_scene(self._world, robot, resolved_path)
-            if not ok:
-                del self._world.robots[name]
-                return {
-                    "status": "error",
-                    "content": [{"text": f"Failed to inject robot '{name}' into scene."}],
-                }
+                # Compose into the live spec via spec.attach(). The helper sets
+                # robot.joint_names from the source spec (pre-namespacing) and
+                # then scene_ops._recompile_preserving_state resolves the
+                # post-attach joint/actuator IDs on the compiled model.
+                ok = inject_robot_into_scene(self._world, robot, resolved_path)
+                if not ok:
+                    del self._world.robots[name]
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"Failed to inject robot '{name}' into scene."}],
+                    }
 
             # Discover cameras that the robot's source MJCF declared. The
             # compiled model already has them namespaced under
@@ -3722,21 +3766,28 @@ class MuJoCoSimEngine(
             material=material,
             is_static=is_static,
         )
-        self._world.objects[name] = obj
-
         # Every scene mutation goes through spec.recompile() - no branching
         # on robots / scene_loaded, and no XML round-trip. MjSpec preserves
         # existing joint state automatically on recompile.
+        #
+        # Registration, swap and rollback are one critical section (see "Scene
+        # mutation and self._lock" in the module docstring): the recorder thread
+        # is not covered by the policy gate, so outside the lock it can observe
+        # the object registered against a model that does not contain it, or a
+        # rolled-back registry against the recompiled model.
         try:
-            if not inject_object_into_scene(self._world, obj):
-                # Injection returned False (compile error). Clean up.
-                self._world.objects.pop(name, None)
-                return {
-                    "status": "error",
-                    "content": [{"text": f"Failed to inject '{name}': spec recompile refused."}],
-                }
+            with self._lock:
+                self._world.objects[name] = obj
+                if not inject_object_into_scene(self._world, obj):
+                    # Injection returned False (compile error). Clean up.
+                    self._world.objects.pop(name, None)
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"Failed to inject '{name}': spec recompile refused."}],
+                    }
         except (ValueError, RuntimeError) as e:
-            self._world.objects.pop(name, None)
+            with self._lock:
+                self._world.objects.pop(name, None)
             return {
                 "status": "error",
                 "content": [{"text": f"Failed to inject '{name}' into live scene: {e}"}],
@@ -3809,10 +3860,15 @@ class MuJoCoSimEngine(
                     }
                 ],
             }
-        del self._world.objects[name]
-        # spec-based path: eject_body_from_scene looks up the body in the
-        # live MjSpec, deletes it, and recompiles preserving remaining state.
-        eject_body_from_scene(self._world, name)
+        # Deregistration and the recompile are one critical section (see the
+        # module docstring): outside the lock a recorder thread can observe the
+        # object already gone from the registry while the model it renders
+        # still contains the body.
+        with self._lock:
+            del self._world.objects[name]
+            # spec-based path: eject_body_from_scene looks up the body in the
+            # live MjSpec, deletes it, and recompiles preserving remaining state.
+            eject_body_from_scene(self._world, name)
         return {"status": "success", "content": [{"text": f"'{name}' removed."}]}
 
     def move_object(
@@ -4159,19 +4215,24 @@ class MuJoCoSimEngine(
             height=height,
             parent_body=parent_body or "",
         )
-        self._world.cameras[name] = cam
-
         # Spec-based path: inject_camera_into_scene adds the camera to the
-        # live spec and recompiles preserving state.
+        # live spec and recompiles preserving state. Registration, swap and
+        # rollback are one critical section (see the module docstring): a
+        # recorder thread resolves camera names against the registry and then
+        # renders them against the model, so outside the lock it can pick up a
+        # camera this recompile has not installed yet.
         try:
-            if not inject_camera_into_scene(self._world, cam):
-                self._world.cameras.pop(name, None)
-                return {
-                    "status": "error",
-                    "content": [{"text": f"Failed to inject camera '{name}': spec recompile refused."}],
-                }
+            with self._lock:
+                self._world.cameras[name] = cam
+                if not inject_camera_into_scene(self._world, cam):
+                    self._world.cameras.pop(name, None)
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"Failed to inject camera '{name}': spec recompile refused."}],
+                    }
         except (ValueError, RuntimeError) as e:
-            self._world.cameras.pop(name, None)
+            with self._lock:
+                self._world.cameras.pop(name, None)
             return {
                 "status": "error",
                 "content": [{"text": f"Failed to inject camera '{name}' into live scene: {e}"}],
@@ -4224,24 +4285,30 @@ class MuJoCoSimEngine(
             return err
         cam = self._world.cameras[name]
 
-        if self._world._backend_state.get("spec") is not None:
-            # Use the namespaced MuJoCo name if we have it (camera came from
-            # a robot's URDF), else the short name.
-            if not eject_camera_from_scene(self._world, cam.name or name):
-                return {
-                    "status": "error",
-                    "content": [
-                        {
-                            "text": (
-                                f"Camera '{name}' was not removed: the scene would not "
-                                "recompile without it. The camera is still registered and "
-                                "the scene is unchanged; the compiler's reason is logged."
-                            )
-                        }
-                    ],
-                }
+        # The recompile and the deregistration are one critical section (see
+        # "Scene mutation and self._lock" in the module docstring): outside the
+        # lock a recorder thread can resolve this camera from the registry and
+        # then render it against the model the eject has already recompiled
+        # without it.
+        with self._lock:
+            if self._world._backend_state.get("spec") is not None:
+                # Use the namespaced MuJoCo name if we have it (camera came
+                # from a robot's URDF), else the short name.
+                if not eject_camera_from_scene(self._world, cam.name or name):
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"Camera '{name}' was not removed: the scene would not "
+                                    "recompile without it. The camera is still registered and "
+                                    "the scene is unchanged; the compiler's reason is logged."
+                                )
+                            }
+                        ],
+                    }
 
-        del self._world.cameras[name]
+            del self._world.cameras[name]
         return {"status": "success", "content": [{"text": f"Camera '{name}' removed."}]}
 
     # Simulation Control

--- a/tests/simulation/mujoco/test_scene_mutation_swaps_under_the_lock.py
+++ b/tests/simulation/mujoco/test_scene_mutation_swaps_under_the_lock.py
@@ -1,0 +1,251 @@
+"""A scene mutation swaps the live model under ``self._lock``.
+
+``Simulation._lock`` is declared by the backend's own module docstring as the
+"RLock serializing ALL model/data access", and the render path takes it because
+"the recorder daemon calls render() on its own thread, so this path is NOT
+covered by the blanket dispatch lock". Seven scene-mutation verbs performed the
+swap outside it and relied on ``_require_no_running_policy()`` instead - a guard
+that refuses a *policy* worker and cannot see the recorder thread, which has no
+policy.
+
+The swap is also two assignments wide:
+``scene_ops.install_compiled_model`` rebinds ``world._model`` and then
+``world._data``, so a reader that is not excluded can observe a model from after
+the swap paired with data from before it, and MuJoCo dereferences that pair
+natively.
+
+Measured with a reader of the recorder's shape - it takes the lock and, while
+still holding it, re-reads ``(nq, qpos.size, nbody, ncam)``:
+
+| verb | swap seen under lock (pre) | (post) |
+| --- | --- | --- |
+| ``replace_scene_mjcf`` | yes | no |
+| ``patch_scene_mjcf`` | yes | no |
+| ``add_object`` | yes | no |
+| ``add_robot`` | yes | no |
+| ``remove_object`` | yes | no |
+| ``add_camera`` | yes | no |
+| ``remove_camera`` | yes | no |
+| ``load_scene`` (control) | no | no |
+| ``remove_robot`` (control) | no | no |
+
+The two controls already swapped under the lock and are unchanged by this
+module's fix; they are what distinguishes the pin from "every mutation fails".
+"""
+
+import ast
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import strands_robots.simulation.mujoco as mujoco_pkg
+from strands_robots.simulation import create_simulation
+
+# The reader holds the lock for this long. Every unlocked swap measured well
+# under 0.25 s, so a writer that waits is unambiguous at this hold.
+HOLD_S = 1.0
+
+_ONE_BODY_SCENE = """<mujoco>
+  <worldbody>
+    <body name="a" pos="0 0 1"><joint type="free"/><geom type="box" size=".1 .1 .1"/></body>
+  </worldbody>
+</mujoco>"""
+
+
+@pytest.fixture(scope="module")
+def scene_file(tmp_path_factory):
+    """An MJCF on disk for the ``load_scene`` control row."""
+    path = tmp_path_factory.mktemp("scenes") / "one_body.xml"
+    path.write_text(_ONE_BODY_SCENE)
+    return str(path)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _warm_robot_assets():
+    """Resolve both robot descriptions once, before anything is timed.
+
+    ``add_robot`` may fetch a robot description on first use. That fetch inside
+    a timed row would be indistinguishable from a writer waiting on the lock,
+    so it happens here instead.
+    """
+    sim = create_simulation("mujoco")
+    try:
+        sim.create_world()
+        sim.add_robot(name="so100")
+        sim.add_robot(name="so101", position=[1, 0, 0])
+    finally:
+        sim.destroy()
+
+
+# (label, call, already_locked_before_this_fix)
+MUTATIONS = [
+    ("replace_scene_mjcf", lambda s, scene: s.replace_scene_mjcf(_ONE_BODY_SCENE), False),
+    (
+        "patch_scene_mjcf",
+        lambda s, scene: s.patch_scene_mjcf(
+            [{"op": "add_body", "parent": "world", "name": "patched", "pos": [0, 0, 3]}]
+        ),
+        False,
+    ),
+    ("add_object", lambda s, scene: s.add_object(name="crate", shape="box", position=[0.4, 0, 0.1]), False),
+    ("add_robot", lambda s, scene: s.add_robot(name="so101", position=[1, 0, 0]), False),
+    ("remove_object", lambda s, scene: s.remove_object("box0"), False),
+    ("add_camera", lambda s, scene: s.add_camera(name="side", position=[0, -1, 0.5], target=[0, 0, 0.2]), False),
+    ("remove_camera", lambda s, scene: s.remove_camera("side"), False),
+    # Controls: these two already held the lock across the swap.
+    ("load_scene", lambda s, scene: s.load_scene(scene), True),
+    ("remove_robot", lambda s, scene: s.remove_robot("so100"), True),
+]
+
+
+def _observe_swap_under_lock(sim, call, scene):
+    """Run ``call`` while a reader holds ``sim._lock``; report what it saw.
+
+    Returns:
+        A dict with ``status`` (the verb's envelope status), ``swapped`` (did the
+        live scene change while the reader held the lock) and ``writer_waited``
+        (did the verb block until the reader let go).
+    """
+    entered, writer_done = threading.Event(), threading.Event()
+    seen: dict[str, object] = {}
+
+    def reader() -> None:
+        # The shape of the recorder daemon: it renders under this same lock.
+        with sim._lock:
+            model, data = sim._world._model, sim._world._data
+            before = (model.nq, data.qpos.size, model.nbody, model.ncam)
+            entered.set()
+            writer_done.wait(timeout=HOLD_S)
+            model, data = sim._world._model, sim._world._data
+            after = (model.nq, data.qpos.size, model.nbody, model.ncam)
+            seen["swapped"] = before != after
+            # A torn pair: the model was rebound but its data was not.
+            seen["pair_torn"] = model.nq != data.qpos.size
+
+    thread = threading.Thread(target=reader)
+    thread.start()
+    try:
+        assert entered.wait(timeout=10), "reader never acquired the lock"
+        started = time.monotonic()
+        result = call(sim, scene)
+        elapsed = time.monotonic() - started
+    finally:
+        writer_done.set()
+        thread.join(timeout=10)
+
+    return {
+        "status": result.get("status"),
+        "swapped": seen.get("swapped"),
+        "pair_torn": seen.get("pair_torn"),
+        "writer_waited": elapsed > HOLD_S * 0.8,
+    }
+
+
+@pytest.mark.parametrize(("label", "call", "already_locked"), MUTATIONS, ids=[m[0] for m in MUTATIONS])
+def test_a_scene_mutation_is_not_visible_to_a_thread_holding_the_lock(label, call, already_locked, scene_file):
+    """No scene swap becomes visible to a reader that holds ``sim._lock``.
+
+    ``already_locked`` marks the two control verbs, which behaved this way
+    before the fix. Both groups must pass: the verb still succeeds, and the
+    reader's view of the live scene is stable for as long as it holds the lock.
+    """
+    sim = create_simulation("mujoco")
+    try:
+        sim.create_world()
+        sim.add_robot(name="so100")
+        sim.add_object(name="box0", shape="box", position=[0.3, 0, 0.1])
+        if label == "remove_camera":
+            sim.add_camera(name="side", position=[0, -1, 0.5], target=[0, 0, 0.2])
+
+        observed = _observe_swap_under_lock(sim, call, scene_file)
+    finally:
+        sim.destroy()
+
+    assert observed["status"] == "success", f"{label} did not succeed: {observed}"
+    assert observed["swapped"] is False, (
+        f"{label} swapped the live scene while a reader held sim._lock; "
+        f"the recorder daemon renders under that lock and is not covered by "
+        f"_require_no_running_policy()"
+    )
+    assert observed["pair_torn"] is False, f"{label} left model/data mismatched for a lock holder"
+    assert observed["writer_waited"] is True, f"{label} did not wait for the lock holder"
+
+
+def _live_model_swappers() -> set[str]:
+    """Every ``scene_ops`` function that (transitively) swaps the live model.
+
+    Derived rather than listed, so a new helper that recompiles the scene joins
+    the graded set on the commit that introduces it.
+    """
+    source = Path(mujoco_pkg.__file__).parent / "scene_ops.py"
+    tree = ast.parse(source.read_text())
+    functions = {n.name: n for n in tree.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    calls = {
+        name: {
+            node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call) and isinstance(node.func, (ast.Name, ast.Attribute))
+        }
+        for name, fn in functions.items()
+    }
+    swappers = {"install_compiled_model"}
+    changed = True
+    while changed:
+        changed = False
+        for name, called in calls.items():
+            if name not in swappers and called & swappers:
+                swappers.add(name)
+                changed = True
+    return swappers
+
+
+def _lock_covered_lines(fn: ast.AST) -> list[tuple[int, int]]:
+    """Line ranges inside ``fn`` that a ``with <...>lock<...>:`` statement covers."""
+    ranges = []
+    for node in ast.walk(fn):
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            header = " ".join(ast.unparse(item.context_expr) for item in node.items)
+            if "lock" in header.lower():
+                ranges.append((node.body[0].lineno, node.end_lineno or node.body[0].lineno))
+    return ranges
+
+
+def test_every_call_that_swaps_the_live_model_holds_the_lock():
+    """No caller in the MuJoCo backend recompiles the live scene unlocked.
+
+    The behaviour pins above cover today's verbs one by one. This closes the
+    family: an eighth verb that recompiles the scene outside ``self._lock`` is
+    reported here rather than waiting for someone to record while it runs.
+    """
+    swappers = _live_model_swappers()
+    assert "replace_scene_mjcf" in swappers, "swapper derivation found nothing to grade"
+
+    unlocked = []
+    for path in sorted(Path(mujoco_pkg.__file__).parent.glob("*.py")):
+        tree = ast.parse(path.read_text())
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            # Skip the swappers' own definitions, which live in scene_ops and
+            # take no lock by design (the lock belongs to Simulation, and they
+            # call each other). Keyed on the FILE, not the function name: the
+            # backend's ``replace_scene_mjcf`` / ``patch_scene_mjcf`` verbs share
+            # a name with the scene_ops helper they delegate to, so a name-only
+            # skip would silently exempt the two verbs most in need of grading.
+            if path.name == "scene_ops.py" and fn.name in swappers:
+                continue
+            covered = _lock_covered_lines(fn)
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+                if name in swappers and not any(lo <= node.lineno <= hi for lo, hi in covered):
+                    unlocked.append(f"{path.name}:{node.lineno} {fn.name}() -> {name}()")
+
+    assert not unlocked, (
+        "these call sites recompile the live scene without holding self._lock, so the "
+        "recorder thread can render a half-swapped scene:\n  " + "\n  ".join(unlocked)
+    )


### PR DESCRIPTION
Seven MuJoCo scene-mutation verbs swapped the live model **outside** `self._lock`, relying on `_require_no_running_policy()` instead. The two guards cover different readers: the policy gate refuses a *policy* worker, while the **camera-recorder daemon renders on its own thread** and has no policy, so the gate cannot see it. The lock was the only thing that could have excluded it.

The backend's own module docstring already declares the contract, and the render path already states the reason:

> `self._lock` - RLock serializing **ALL** model/data access

> the recorder daemon calls `render()` on its own thread, so this path is **NOT** covered by the blanket dispatch lock

## The measurement

A reader of the recorder's shape takes the lock and renders **twice without releasing it**, while an `add_object` runs on another thread. Two renders inside one critical section must show the same scene.

![two renders inside one critical section](https://raw.githubusercontent.com/cagataycali/robots/assets/scene-swap-under-lock/scene_swap_under_lock.png)

| | 2nd render vs 1st | verdict |
| --- | --- | --- |
| before | **634 px changed** | the green box appeared mid-critical-section |
| after | **0 px, byte-identical** | the mutation waits for the lock |

## Verb coverage

| verb | swap seen by a lock holder (before) | (after) |
| --- | --- | --- |
| `create_world` / `_compile_world` | yes | no |
| `add_robot` | yes | no |
| `add_object` | yes | no |
| `remove_object` | yes | no |
| `add_camera` | yes | no |
| `remove_camera` | yes | no |
| `patch_scene_mjcf` | yes | no |
| `replace_scene_mjcf` | yes | no |
| `load_scene` (control) | no | no |
| `remove_robot` (control) | no | no |

`load_scene` and `remove_robot` already held the lock — `load_scene`'s existing comment names the hazard exactly ("so a concurrent render/recorder thread never observes a half-built world"). They are kept as controls: they were already correct and are unchanged, which is what distinguishes the pin from "every mutation fails".

## Why the swap is not atomic

`scene_ops.install_compiled_model` rebinds `world._model` and **then** `world._data` — two separate assignments. An unexcluded reader can hold a model from *after* the swap paired with data from *before* it, indexing the new model's body count into the old data's arrays, which MuJoCo dereferences natively.

## The change

All eight sites now hold the lock across the swap. Registration and rollback share the critical section with the recompile, so a reader never sees an entity registered against a model that does not contain it, nor a rolled-back registry against a recompiled model. `_compile_world` takes the lock **itself** rather than relying on its caller, keeping the invariant local to the function that performs the swap.

The lock is an `RLock`, so every acquisition is a reentrant no-op on the dispatch path and the real guard when a verb is called directly as a Python API. No asset resolution happens inside any critical section (`add_robot` resolves its description first), so the recorder is never blocked on a download. The rationale is single-sourced in the module docstring; each site carries a one-line pointer.

## Tests

`tests/simulation/mujoco/test_scene_mutation_swaps_under_the_lock.py` — table-driven over all ten verbs, plus a grader that closes the family. The grader **derives** the set of scene-recompiling helpers from `scene_ops` (transitive callers of `install_compiled_model`, 14 today) rather than listing it, so a new one is graded on the commit that introduces it. It keys the skip on the *file* rather than the function name, because the backend's `replace_scene_mjcf` / `patch_scene_mjcf` verbs share a name with the `scene_ops` helper they delegate to — a name-only skip silently exempts the two verbs most in need of grading.

**Pre-fix 8 failed / 2 passed** (the 2 passes are exactly the two controls) → **post-fix 10 passed**. Pre-fix the grader names all 8 unlocked call sites with file and line.

Local gate: `ruff check strands_robots tests tests_integ` clean; `ruff format --check` clean; mypy at the CI pin unchanged from main (20 errors in 6 files, all pre-existing in `examples/isaac_gs` + `simulation/ik.py`); `scripts/check_whole_tree_graders.py` 297 passed; `tests/simulation` 13,809 passed with 1 failure reproduced on pristine `main` (`test_pose_vector_rule_parity`); `tests/rendering` + `tests/tools` failure set identical to pristine `main`.

**LOC: +439 / −83** across 3 files (+150/−83 in `simulation.py`, +251 test, +38 changelog).