### PR TITLE
fix(simulation): a rollout runs for the wall clock it was asked for

### DIFF
--- a/changelog.d/3103-rollout-loop-deadline-pacing.md
+++ b/changelog.d/3103-rollout-loop-deadline-pacing.md
@@ -1,0 +1,34 @@
+### Fixed: a rollout runs for the wall clock it was asked for, whatever a step costs
+
+`duration` is documented as wall-clock seconds and `fast_mode=False` as
+real-time pacing. Both were false by the cost of one step: the three rollout
+loops slept `1 / control_frequency` AFTER each step, which is a delay where a
+rate needs a deadline, so the wall clock a step spent on inference, the physics
+substeps, a render for the video and the recorder's frame write was added to the
+period instead of subtracted from it and the loop ran at `1 / (period + work)`.
+
+Measured on a MuJoCo so101 rollout asking for 2.0s, before -> after:
+
+| case | achieved | achieved Hz | asked Hz |
+| --- | --- | --- | --- |
+| free policy, 50 Hz | 2.15s -> 2.00s | 46.4 -> 50.0 | 50 |
+| 10 ms inference, 50 Hz | 3.15s -> 2.00s | 31.8 -> 50.0 | 50 |
+| 30 ms inference, 30 Hz | 3.90s -> 2.00s | 15.4 -> 30.0 | 30 |
+
+Sim time was exact in every row (2.0s of integration), so neither the physics
+nor a recorded dataset's timebase was wrong - only the wall clock the caller was
+promised, and the rate anything watching the rollout saw.
+
+`PolicyRunner.run` and both backends' `run_multi_policy` now pace on
+`strands_robots.mesh.pacing.Ticker`, which the mesh's publish loops were
+converted to for this exact argument. A step whose work fits inside the period
+is fully absorbed; a step that overruns drops the missed deadlines rather than
+chasing them, so a slow step is followed by a gap instead of a burst of
+back-to-back setpoints. `fast_mode=True` is unchanged and unpaced.
+
+The mesh's pacing inventory scans for the `stop_event.wait(period)` spelling of a
+delay and so could not see these three: they paced with `time.sleep(period)`.
+`tests/simulation/test_rollout_loop_paces_on_a_deadline.py` covers that second
+spelling for the simulation package, deliberately without requiring the call to
+sit inside the loop body - the runner's pace lived in a per-step helper, and a
+loop-scoped version of the check named the two backends and missed the runner.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2442,7 +2442,10 @@ class SimEngine(ABC):
                 ``use_processor``, ``processor_overrides``, ``device``,
                 ...). Forwarded verbatim to ``create_policy``.
             instruction: Natural-language instruction for the policy.
-            duration: Wall-clock seconds to run. Used only when no ``n_steps``
+            duration: Wall-clock seconds to run, honored as such: the loop
+                paces on a deadline, so a step's own cost comes out of the
+                period rather than being added to it (``fast_mode=True``
+                removes the pacing entirely). Used only when no ``n_steps``
                 / ``max_steps`` is given (the step count wins and ``duration``
                 is recomputed from it). Must be a finite positive number; a
                 non-positive, non-finite, non-numeric, or bool value is
@@ -2469,7 +2472,11 @@ class SimEngine(ABC):
                 their own interval and ignore this entirely. Must be a
                 positive integer (>= 1); a non-positive or non-int value is
                 reported as a caller error.
-            fast_mode: Skip real-time sleep between steps.
+            fast_mode: Skip the real-time pacing and run as fast as inference
+                and physics allow. When False (default) the loop is paced on a
+                deadline at ``control_frequency``, so the wall clock a step
+                spends working is subtracted from the period rather than added
+                to it and ``duration`` is honored whatever a step costs.
             video: Optional video-recording config dict. Accepted keys:
                 ``path`` (str, output MP4 - required to enable recording),
                 ``fps`` (int, default 30), ``camera`` (str, default backend

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -4281,98 +4281,98 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         # than chased, so a slow step does not fire a burst of back-to-back
         # actions at the robots. ``_validate_positive_frequency`` above has
         # already refused a non-positive rate, so the period is always usable and
-        # the pace is unconditional. Constructed inside the try so the finally
-        # always closes it (it owns a selector and a socketpair).
-        ticker = None
+        # the pace is unconditional. Acquired with ``with``: the ticker owns a
+        # selector and a socketpair, so releasing it is the language's job rather
+        # than this loop's to remember - ``tests/test_mesh_pacing_ticker.py``
+        # grades every paced loop in the package on exactly that.
         try:
             from strands_robots.mesh.pacing import Ticker
 
-            ticker = Ticker(1.0 / control_frequency)
-            while step_count < total_steps:
-                # --- 1. Observe every robot (one main-thread hop). No lock is
-                # held across the marshal (#1896); get_observation takes it.
-                per_robot_obs, camera_imgs = self.run_on_main(_observe_all)
+            with Ticker(1.0 / control_frequency) as ticker:
+                while step_count < total_steps:
+                    # --- 1. Observe every robot (one main-thread hop). No lock is
+                    # held across the marshal (#1896); get_observation takes it.
+                    per_robot_obs, camera_imgs = self.run_on_main(_observe_all)
 
-                # --- 2. Resolve each robot's action for THIS step, off the
-                # main thread. Re-query a policy ONLY when its buffered chunk
-                # drains (open-loop chunk execution).
-                per_robot_action: dict[str, dict[str, Any]] = {}
-                for rname, pol in policies.items():
-                    # Cooperative stop check.
-                    if not self._robots[rname].policy_running:
-                        raise CooperativeStop(f"Policy stopped on '{rname}'")
-                    if not action_queues[rname]:
-                        pol_obs = dict(per_robot_obs[rname])
-                        pol_obs.update(camera_imgs)
-                        coro = pol.get_actions(pol_obs, instr_map[rname])
-                        acts = _resolve_coroutine(coro)
-                        # Size the chunk via the shared ChunkedPolicy rule so a
-                        # chunk-emitting policy keeps its full trained chunk
-                        # here exactly as the single-policy runner does.
-                        _chunk = resolve_chunk_length(pol, horizon_map[rname])
-                        for a in acts[:_chunk]:
-                            action_queues[rname].append(a)
-                    if not action_queues[rname]:
-                        # Emitting a zero-valued substitute here would advance
-                        # a trajectory no policy commanded. Fail loudly
-                        # instead (Key Conventions #6).
-                        raise RuntimeError(
-                            f"Policy for robot '{rname}' returned an empty action chunk; "
-                            "cannot advance the synchronized loop. Check the policy's "
-                            "get_actions() output."
+                    # --- 2. Resolve each robot's action for THIS step, off the
+                    # main thread. Re-query a policy ONLY when its buffered chunk
+                    # drains (open-loop chunk execution).
+                    per_robot_action: dict[str, dict[str, Any]] = {}
+                    for rname, pol in policies.items():
+                        # Cooperative stop check.
+                        if not self._robots[rname].policy_running:
+                            raise CooperativeStop(f"Policy stopped on '{rname}'")
+                        if not action_queues[rname]:
+                            pol_obs = dict(per_robot_obs[rname])
+                            pol_obs.update(camera_imgs)
+                            coro = pol.get_actions(pol_obs, instr_map[rname])
+                            acts = _resolve_coroutine(coro)
+                            # Size the chunk via the shared ChunkedPolicy rule so a
+                            # chunk-emitting policy keeps its full trained chunk
+                            # here exactly as the single-policy runner does.
+                            _chunk = resolve_chunk_length(pol, horizon_map[rname])
+                            for a in acts[:_chunk]:
+                                action_queues[rname].append(a)
+                        if not action_queues[rname]:
+                            # Emitting a zero-valued substitute here would advance
+                            # a trajectory no policy commanded. Fail loudly
+                            # instead (Key Conventions #6).
+                            raise RuntimeError(
+                                f"Policy for robot '{rname}' returned an empty action chunk; "
+                                "cannot advance the synchronized loop. Check the policy's "
+                                "get_actions() output."
+                            )
+                        per_robot_action[rname] = action_queues[rname].popleft()
+
+                    # --- 3+4. Apply ALL robots' targets, then step physics ONCE
+                    # (one main-thread hop; the hop takes self._lock itself).
+                    self.run_on_main(lambda acts=per_robot_action: _apply_all_and_step(acts))
+
+                    # --- 5. Record ONE merged frame (all robots + all cameras),
+                    # off the main thread: add_frame writes to LeRobot's
+                    # image-writer queue and parquet buffer, never to Kit/USD, and
+                    # the consistent state snapshot was already taken inside the
+                    # two hops above.
+                    if recording and recorder is not None:
+                        merged_obs: dict[str, Any] = {}
+                        merged_act: dict[str, Any] = {}
+                        # The schema declares a state column for every robot in the
+                        # scene, and ``policies`` need only name robots that exist -
+                        # not all of them. A robot this call does not drive is a
+                        # readable measurement, so its columns are filled from the
+                        # engine at this step rather than left to add_frame's 0.0
+                        # fill, which records them as a zero pose the robot is not
+                        # in. Merged first, so driven keys win any collision.
+                        merged_obs.update(undriven_robot_state(self, policies, self._robots))
+                        for rname in policies:
+                            if multi_robot:
+                                for k, v in per_robot_obs[rname].items():
+                                    merged_obs[f"{rname}__{k}"] = v
+                                for k, v in per_robot_action[rname].items():
+                                    merged_act[f"{rname}__{k}"] = v
+                            else:
+                                merged_obs.update(per_robot_obs[rname])
+                                merged_act.update(per_robot_action[rname])
+                        # Cameras are scene-global: rename raw -> schema-safe and
+                        # drop any outside the start_recording(cameras=...) scope.
+                        for k, v in camera_imgs.items():
+                            safe = raw_to_safe.get(k)
+                            if safe is not None:
+                                merged_obs[safe] = v
+                        # LeRobot stores ONE task per frame: the first robot's
+                        # instruction (the shared normalizer already warned when
+                        # per-robot instructions are distinct).
+                        recorder.add_frame(
+                            observation=merged_obs,
+                            action=merged_act,
+                            task=instr_map[next(iter(policies))],
+                            required_action_keys=merged_required_action_keys,
                         )
-                    per_robot_action[rname] = action_queues[rname].popleft()
 
-                # --- 3+4. Apply ALL robots' targets, then step physics ONCE
-                # (one main-thread hop; the hop takes self._lock itself).
-                self.run_on_main(lambda acts=per_robot_action: _apply_all_and_step(acts))
-
-                # --- 5. Record ONE merged frame (all robots + all cameras),
-                # off the main thread: add_frame writes to LeRobot's
-                # image-writer queue and parquet buffer, never to Kit/USD, and
-                # the consistent state snapshot was already taken inside the
-                # two hops above.
-                if recording and recorder is not None:
-                    merged_obs: dict[str, Any] = {}
-                    merged_act: dict[str, Any] = {}
-                    # The schema declares a state column for every robot in the
-                    # scene, and ``policies`` need only name robots that exist -
-                    # not all of them. A robot this call does not drive is a
-                    # readable measurement, so its columns are filled from the
-                    # engine at this step rather than left to add_frame's 0.0
-                    # fill, which records them as a zero pose the robot is not
-                    # in. Merged first, so driven keys win any collision.
-                    merged_obs.update(undriven_robot_state(self, policies, self._robots))
+                    step_count += 1
                     for rname in policies:
-                        if multi_robot:
-                            for k, v in per_robot_obs[rname].items():
-                                merged_obs[f"{rname}__{k}"] = v
-                            for k, v in per_robot_action[rname].items():
-                                merged_act[f"{rname}__{k}"] = v
-                        else:
-                            merged_obs.update(per_robot_obs[rname])
-                            merged_act.update(per_robot_action[rname])
-                    # Cameras are scene-global: rename raw -> schema-safe and
-                    # drop any outside the start_recording(cameras=...) scope.
-                    for k, v in camera_imgs.items():
-                        safe = raw_to_safe.get(k)
-                        if safe is not None:
-                            merged_obs[safe] = v
-                    # LeRobot stores ONE task per frame: the first robot's
-                    # instruction (the shared normalizer already warned when
-                    # per-robot instructions are distinct).
-                    recorder.add_frame(
-                        observation=merged_obs,
-                        action=merged_act,
-                        task=instr_map[next(iter(policies))],
-                        required_action_keys=merged_required_action_keys,
-                    )
+                        self._robots[rname].policy_steps = step_count
 
-                step_count += 1
-                for rname in policies:
-                    self._robots[rname].policy_steps = step_count
-
-                if ticker is not None:
                     ticker.wait()
 
             completed_cleanly = True
@@ -4381,8 +4381,6 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             stopped_early = True
             completed_cleanly = True
         finally:
-            if ticker is not None:
-                ticker.close()
             for rname in policies:
                 if registered(self._robots, rname):
                     self._robots[rname].policy_running = False

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -4283,8 +4283,9 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         # already refused a non-positive rate, so the period is always usable and
         # the pace is unconditional. Acquired with ``with``: the ticker owns a
         # selector and a socketpair, so releasing it is the language's job rather
-        # than this loop's to remember - ``tests/test_mesh_pacing_ticker.py``
-        # grades every paced loop in the package on exactly that.
+        # than this loop's to remember. Every paced loop in the package is held
+        # to that, so constructing a bare ``Ticker(...)`` here is a suite failure
+        # rather than one leaked descriptor pair per rollout.
         try:
             from strands_robots.mesh.pacing import Ticker
 

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -4225,7 +4225,6 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         physics_dt = float(getattr(self._config, "physics_dt", 0.0) or 0.0)
 
         total_steps = int(duration * control_frequency)
-        action_sleep = 1.0 / control_frequency if control_frequency > 0 else 0.0
 
         # Mark all robots as running so a cooperative stop can interrupt the
         # loop, and so a concurrent driver is refused by the busy check above.
@@ -4274,7 +4273,21 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         # must discard so the next recording starts at frame 0 rather than
         # appending to a half-episode (MuJoCo parity).
         completed_cleanly = False
+        # Pace on a DEADLINE, not a delay (MuJoCo parity): ``time.sleep(1 /
+        # control_frequency)`` added each step's work - N policy queries, the
+        # main-thread observe hop, the recorder's frame write - to the period, so
+        # the loop ran at ``1 / (period + work)`` while ``duration`` is
+        # documented in wall-clock seconds. Missed deadlines are dropped rather
+        # than chased, so a slow step does not fire a burst of back-to-back
+        # actions at the robots. ``_validate_positive_frequency`` above has
+        # already refused a non-positive rate, so the period is always usable and
+        # the pace is unconditional. Constructed inside the try so the finally
+        # always closes it (it owns a selector and a socketpair).
+        ticker = None
         try:
+            from strands_robots.mesh.pacing import Ticker
+
+            ticker = Ticker(1.0 / control_frequency)
             while step_count < total_steps:
                 # --- 1. Observe every robot (one main-thread hop). No lock is
                 # held across the marshal (#1896); get_observation takes it.
@@ -4359,8 +4372,8 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 for rname in policies:
                     self._robots[rname].policy_steps = step_count
 
-                if action_sleep:
-                    time.sleep(action_sleep)
+                if ticker is not None:
+                    ticker.wait()
 
             completed_cleanly = True
         except CooperativeStop:
@@ -4368,6 +4381,8 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             stopped_early = True
             completed_cleanly = True
         finally:
+            if ticker is not None:
+                ticker.close()
             for rname in policies:
                 if registered(self._robots, rname):
                     self._robots[rname].policy_running = False

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5642,7 +5642,6 @@ class MuJoCoSimEngine(
         skip_images = not (any_needs_images or recording)
 
         total_steps = int(duration * control_frequency)
-        action_sleep = 1.0 / control_frequency if control_frequency > 0 else 0.0
 
         # Mark all robots as running so stop_policy can interrupt the loop.
         for rname in policies:
@@ -5666,7 +5665,23 @@ class MuJoCoSimEngine(
         # chunk) leaves a dangling partial episode we must discard so the next
         # recording starts at frame 0 rather than appending to a half-episode.
         completed_cleanly = False
+        # Pace on a DEADLINE, not a delay: ``time.sleep(1 / control_frequency)``
+        # added each step's work - N policy queries, one camera render, the
+        # recorder's frame write - to the period, so the loop ran at ``1 /
+        # (period + work)`` while ``duration`` is documented in wall-clock
+        # seconds. Missed deadlines are dropped rather than chased, so a slow
+        # step does not fire a burst of back-to-back actions at the robots.
+        # ``_validate_positive_frequency`` above has already refused a
+        # non-positive rate, so the period is always usable and the pace is
+        # unconditional. Constructed inside the try so the finally always closes
+        # it (it owns a selector and a socketpair). Local import: the mesh
+        # package __init__ pulls the fleet stack, the same reason
+        # ``init_mesh`` is imported at its point of use in this module.
+        ticker = None
         try:
+            from strands_robots.mesh.pacing import Ticker
+
+            ticker = Ticker(1.0 / control_frequency)
             while step_count < total_steps:
                 # --- 1. Observe every robot + render cameras ONCE (under lock).
                 # get_observation renders ALL cameras, so we only need to fetch
@@ -5792,8 +5807,8 @@ class MuJoCoSimEngine(
                 for rname in policies:
                     self._world.robots[rname].policy_steps = step_count
 
-                if action_sleep:
-                    time.sleep(action_sleep)
+                if ticker is not None:
+                    ticker.wait()
 
             completed_cleanly = True
         except CooperativeStop:
@@ -5802,6 +5817,8 @@ class MuJoCoSimEngine(
             stopped_early = True
             completed_cleanly = True
         finally:
+            if ticker is not None:
+                ticker.close()
             for rname in policies:
                 if registered(self._world.robots, rname):
                     self._world.robots[rname].policy_running = False

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5673,141 +5673,141 @@ class MuJoCoSimEngine(
         # step does not fire a burst of back-to-back actions at the robots.
         # ``_validate_positive_frequency`` above has already refused a
         # non-positive rate, so the period is always usable and the pace is
-        # unconditional. Constructed inside the try so the finally always closes
-        # it (it owns a selector and a socketpair). Local import: the mesh
-        # package __init__ pulls the fleet stack, the same reason
-        # ``init_mesh`` is imported at its point of use in this module.
-        ticker = None
+        # unconditional. Acquired with ``with``: the ticker owns a selector and a
+        # socketpair, so releasing it is the language's job rather than this
+        # loop's to remember - ``tests/test_mesh_pacing_ticker.py`` grades every
+        # paced loop in the package on exactly that. Local import: the mesh
+        # package __init__ pulls the fleet stack, the same reason ``init_mesh``
+        # is imported at its point of use in this module.
         try:
             from strands_robots.mesh.pacing import Ticker
 
-            ticker = Ticker(1.0 / control_frequency)
-            while step_count < total_steps:
-                # --- 1. Observe every robot + render cameras ONCE (under lock).
-                # get_observation renders ALL cameras, so we only need to fetch
-                # the camera images once (from any robot's observation); per-robot
-                # we keep the scalar joint values.
-                per_robot_obs: dict[str, dict[str, Any]] = {}
-                camera_imgs: dict[str, Any] = {}
-                first = True
-                for rname in policies:
-                    obs = self.get_observation(robot_name=rname, skip_images=(skip_images or not first))
-                    # Split scalars (joints) from ndarrays (camera images).
-                    scal = {k: v for k, v in obs.items() if not isinstance(v, np.ndarray)}
-                    per_robot_obs[rname] = scal
-                    if first:
-                        camera_imgs = {k: v for k, v in obs.items() if isinstance(v, np.ndarray)}
-                        first = False
-
-                # --- 2. Get each robot's action for THIS step.
-                # Re-query a policy ONLY when its action queue is empty (open-loop
-                # chunk execution). Between re-queries we replay the buffered
-                # chunk - so an expensive VLA runs inference once per horizon
-                # steps, not every step. Observation is still gathered every step
-                # (cheap) so recorded frames carry live state, and the chunk's
-                # first action is computed from a fresh observation.
-                per_robot_action: dict[str, dict[str, Any]] = {}
-                for rname, pol in policies.items():
-                    # Cooperative stop check.
-                    if not self._world.robots[rname].policy_running:
-                        raise CooperativeStop(f"Policy stopped on '{rname}'")
-                    if not action_queues[rname]:
-                        pol_obs = dict(per_robot_obs[rname])
-                        # Give the policy this robot's camera view(s) too.
-                        pol_obs.update(camera_imgs)
-                        coro = pol.get_actions(pol_obs, instr_map[rname])
-                        acts = _resolve_coroutine(coro)
-                        # Buffer the policy's chunk; re-query only when drained.
-                        # Size the chunk via the shared ChunkedPolicy rule so a
-                        # chunk-emitting policy (actions_per_step == N) keeps its
-                        # full trained chunk here exactly as the single-policy
-                        # runner does - clamping to action_horizon alone would
-                        # drop the chunk tail and force an out-of-distribution
-                        # re-query for one driver but not the other.
-                        _chunk = resolve_chunk_length(pol, horizon_map[rname])
-                        for a in acts[:_chunk]:
-                            action_queues[rname].append(a)
-                    if not action_queues[rname]:
-                        # A policy yielded no actions (empty chunk) -- emitting an
-                        # empty action dict here would remap downstream to all-zero
-                        # ctrl, silently corrupting the recording with dead frames.
-                        # Fail loudly instead (Key Conventions #6: no silent
-                        # zero-valued action on failure).
-                        raise RuntimeError(
-                            f"Policy for robot '{rname}' returned an empty action chunk; "
-                            "cannot advance the synchronized loop. Check the policy's "
-                            "get_actions() output."
-                        )
-                    per_robot_action[rname] = action_queues[rname].popleft()
-
-                # --- 3. Apply ALL robots' ctrl, then step physics ONCE.
-                with self._lock:
-                    mj = self._mj
-                    for rname, act in per_robot_action.items():
-                        # write ctrl only (no per-robot mj_step) - we step once
-                        # after every robot's ctrl is set.
-                        robot = self._world.robots[rname]
-                        pfx = robot.namespace or ""
-                        self._apply_action_by_name(self._world._model, self._world._data, act, pfx, mj)
-                    mj.mj_step(self._world._model, self._world._data)
-                    # Kinematic attachments (attach_bodies mode="kinematic")
-                    # follow their parent every physics step, on this
-                    # synchronized loop as much as on the single-robot policy
-                    # path. Fast no-op when none are registered.
-                    self._apply_kinematic_attachments()
-                    self._world.sim_time = self._world._data.time
-                    self._world.step_count += 1
-                    if hasattr(self, "_viewer_handle") and self._viewer_handle is not None:
-                        self._viewer_handle.sync()
-
-                # --- 4. Record ONE merged frame (all robots + all cameras).
-                # ``recording`` already implies ``recorder is not None`` (see its
-                # definition), but the explicit check narrows the Optional for the
-                # type checker at the add_frame call below.
-                if recording and recorder is not None:
-                    merged_obs: dict[str, Any] = {}
-                    merged_act: dict[str, Any] = {}
-                    # The schema declares a state column for every robot in the
-                    # scene, and ``policies`` need only name robots that exist -
-                    # not all of them. A robot this call does not drive is a
-                    # readable measurement, so its columns are filled from the
-                    # engine at this step rather than left to add_frame's 0.0
-                    # fill, which records them as a zero pose the robot is not
-                    # in. Merged first, so driven keys win any collision.
-                    merged_obs.update(undriven_robot_state(self, policies, self._world.robots))
+            with Ticker(1.0 / control_frequency) as ticker:
+                while step_count < total_steps:
+                    # --- 1. Observe every robot + render cameras ONCE (under lock).
+                    # get_observation renders ALL cameras, so we only need to fetch
+                    # the camera images once (from any robot's observation); per-robot
+                    # we keep the scalar joint values.
+                    per_robot_obs: dict[str, dict[str, Any]] = {}
+                    camera_imgs: dict[str, Any] = {}
+                    first = True
                     for rname in policies:
-                        if multi_robot:
-                            for k, v in per_robot_obs[rname].items():
-                                merged_obs[f"{rname}__{k}"] = v
-                            for k, v in per_robot_action[rname].items():
-                                merged_act[f"{rname}__{k}"] = v
-                        else:
-                            merged_obs.update(per_robot_obs[rname])
-                            merged_act.update(per_robot_action[rname])
-                    # Cameras are scene-global (already namespaced if injected
-                    # per-robot); keep ndarray keys as-is, minus any the caller
-                    # excluded via start_recording(cameras=...).
-                    rec_cams = self._world._backend_state.get("recording_cameras")
-                    merged_obs.update(_drop_unrecorded_cameras(camera_imgs, rec_cams))
-                    task = instr_map[next(iter(policies))]
-                    # add_frame writes to LeRobot's image-writer queue and parquet
-                    # buffer; it does not touch MuJoCo model/data. The consistent
-                    # state snapshot was already taken under self._lock in steps 1
-                    # and 3, and merged_obs/merged_act are plain copies, so holding
-                    # the physics lock across frame writeout would needlessly starve
-                    # other lock holders (viewer sync, concurrent tool reads).
-                    recorder.add_frame(
-                        observation=merged_obs,
-                        action=merged_act,
-                        task=task,
-                        required_action_keys=merged_required_action_keys,
-                    )
+                        obs = self.get_observation(robot_name=rname, skip_images=(skip_images or not first))
+                        # Split scalars (joints) from ndarrays (camera images).
+                        scal = {k: v for k, v in obs.items() if not isinstance(v, np.ndarray)}
+                        per_robot_obs[rname] = scal
+                        if first:
+                            camera_imgs = {k: v for k, v in obs.items() if isinstance(v, np.ndarray)}
+                            first = False
 
-                step_count += 1
-                for rname in policies:
-                    self._world.robots[rname].policy_steps = step_count
+                    # --- 2. Get each robot's action for THIS step.
+                    # Re-query a policy ONLY when its action queue is empty (open-loop
+                    # chunk execution). Between re-queries we replay the buffered
+                    # chunk - so an expensive VLA runs inference once per horizon
+                    # steps, not every step. Observation is still gathered every step
+                    # (cheap) so recorded frames carry live state, and the chunk's
+                    # first action is computed from a fresh observation.
+                    per_robot_action: dict[str, dict[str, Any]] = {}
+                    for rname, pol in policies.items():
+                        # Cooperative stop check.
+                        if not self._world.robots[rname].policy_running:
+                            raise CooperativeStop(f"Policy stopped on '{rname}'")
+                        if not action_queues[rname]:
+                            pol_obs = dict(per_robot_obs[rname])
+                            # Give the policy this robot's camera view(s) too.
+                            pol_obs.update(camera_imgs)
+                            coro = pol.get_actions(pol_obs, instr_map[rname])
+                            acts = _resolve_coroutine(coro)
+                            # Buffer the policy's chunk; re-query only when drained.
+                            # Size the chunk via the shared ChunkedPolicy rule so a
+                            # chunk-emitting policy (actions_per_step == N) keeps its
+                            # full trained chunk here exactly as the single-policy
+                            # runner does - clamping to action_horizon alone would
+                            # drop the chunk tail and force an out-of-distribution
+                            # re-query for one driver but not the other.
+                            _chunk = resolve_chunk_length(pol, horizon_map[rname])
+                            for a in acts[:_chunk]:
+                                action_queues[rname].append(a)
+                        if not action_queues[rname]:
+                            # A policy yielded no actions (empty chunk) -- emitting an
+                            # empty action dict here would remap downstream to all-zero
+                            # ctrl, silently corrupting the recording with dead frames.
+                            # Fail loudly instead (Key Conventions #6: no silent
+                            # zero-valued action on failure).
+                            raise RuntimeError(
+                                f"Policy for robot '{rname}' returned an empty action chunk; "
+                                "cannot advance the synchronized loop. Check the policy's "
+                                "get_actions() output."
+                            )
+                        per_robot_action[rname] = action_queues[rname].popleft()
 
-                if ticker is not None:
+                    # --- 3. Apply ALL robots' ctrl, then step physics ONCE.
+                    with self._lock:
+                        mj = self._mj
+                        for rname, act in per_robot_action.items():
+                            # write ctrl only (no per-robot mj_step) - we step once
+                            # after every robot's ctrl is set.
+                            robot = self._world.robots[rname]
+                            pfx = robot.namespace or ""
+                            self._apply_action_by_name(self._world._model, self._world._data, act, pfx, mj)
+                        mj.mj_step(self._world._model, self._world._data)
+                        # Kinematic attachments (attach_bodies mode="kinematic")
+                        # follow their parent every physics step, on this
+                        # synchronized loop as much as on the single-robot policy
+                        # path. Fast no-op when none are registered.
+                        self._apply_kinematic_attachments()
+                        self._world.sim_time = self._world._data.time
+                        self._world.step_count += 1
+                        if hasattr(self, "_viewer_handle") and self._viewer_handle is not None:
+                            self._viewer_handle.sync()
+
+                    # --- 4. Record ONE merged frame (all robots + all cameras).
+                    # ``recording`` already implies ``recorder is not None`` (see its
+                    # definition), but the explicit check narrows the Optional for the
+                    # type checker at the add_frame call below.
+                    if recording and recorder is not None:
+                        merged_obs: dict[str, Any] = {}
+                        merged_act: dict[str, Any] = {}
+                        # The schema declares a state column for every robot in the
+                        # scene, and ``policies`` need only name robots that exist -
+                        # not all of them. A robot this call does not drive is a
+                        # readable measurement, so its columns are filled from the
+                        # engine at this step rather than left to add_frame's 0.0
+                        # fill, which records them as a zero pose the robot is not
+                        # in. Merged first, so driven keys win any collision.
+                        merged_obs.update(undriven_robot_state(self, policies, self._world.robots))
+                        for rname in policies:
+                            if multi_robot:
+                                for k, v in per_robot_obs[rname].items():
+                                    merged_obs[f"{rname}__{k}"] = v
+                                for k, v in per_robot_action[rname].items():
+                                    merged_act[f"{rname}__{k}"] = v
+                            else:
+                                merged_obs.update(per_robot_obs[rname])
+                                merged_act.update(per_robot_action[rname])
+                        # Cameras are scene-global (already namespaced if injected
+                        # per-robot); keep ndarray keys as-is, minus any the caller
+                        # excluded via start_recording(cameras=...).
+                        rec_cams = self._world._backend_state.get("recording_cameras")
+                        merged_obs.update(_drop_unrecorded_cameras(camera_imgs, rec_cams))
+                        task = instr_map[next(iter(policies))]
+                        # add_frame writes to LeRobot's image-writer queue and parquet
+                        # buffer; it does not touch MuJoCo model/data. The consistent
+                        # state snapshot was already taken under self._lock in steps 1
+                        # and 3, and merged_obs/merged_act are plain copies, so holding
+                        # the physics lock across frame writeout would needlessly starve
+                        # other lock holders (viewer sync, concurrent tool reads).
+                        recorder.add_frame(
+                            observation=merged_obs,
+                            action=merged_act,
+                            task=task,
+                            required_action_keys=merged_required_action_keys,
+                        )
+
+                    step_count += 1
+                    for rname in policies:
+                        self._world.robots[rname].policy_steps = step_count
+
                     ticker.wait()
 
             completed_cleanly = True
@@ -5817,8 +5817,6 @@ class MuJoCoSimEngine(
             stopped_early = True
             completed_cleanly = True
         finally:
-            if ticker is not None:
-                ticker.close()
             for rname in policies:
                 if registered(self._world.robots, rname):
                     self._world.robots[rname].policy_running = False

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5742,8 +5742,9 @@ class MuJoCoSimEngine(
         # non-positive rate, so the period is always usable and the pace is
         # unconditional. Acquired with ``with``: the ticker owns a selector and a
         # socketpair, so releasing it is the language's job rather than this
-        # loop's to remember - ``tests/test_mesh_pacing_ticker.py`` grades every
-        # paced loop in the package on exactly that. Local import: the mesh
+        # loop's to remember. Every paced loop in the package is held to that, so
+        # constructing a bare ``Ticker(...)`` here is a suite failure rather than
+        # one leaked descriptor pair per rollout. Local import: the mesh
         # package __init__ pulls the fleet stack, the same reason ``init_mesh``
         # is imported at its point of use in this module.
         try:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -57,6 +57,7 @@ from strands_robots.utils import (
 )
 
 if TYPE_CHECKING:
+    from strands_robots.mesh.pacing import Ticker
     from strands_robots.policies.base import Policy
     from strands_robots.simulation.base import SimEngine
     from strands_robots.simulation.benchmark import BenchmarkProtocol
@@ -1225,7 +1226,16 @@ class PolicyRunner:
                 never asked for - or leaks a bare conversion error out of the
                 first inference, so it is refused here exactly as
                 ``run_policy`` refuses it.
-            fast_mode: If True, skip real-time ``time.sleep`` between steps.
+            fast_mode: If True, run unpaced - as fast as inference and physics
+                allow. If False (default) the loop is paced on a DEADLINE at
+                ``control_frequency``: the wall clock a step spends on
+                inference, physics substeps, rendering and recording is
+                subtracted from the period rather than added to it, so a
+                rollout of ``n`` steps takes ``n / control_frequency`` seconds
+                whatever a step costs, as long as it fits inside one period. A
+                step that overruns its period drops the missed deadlines
+                instead of chasing them, so a slow step is followed by a gap
+                rather than by a burst of back-to-back actions.
             video: Optional :class:`VideoConfig` - set ``video.path`` to enable
                 MP4 recording via :meth:`SimEngine.render`.
             on_frame: Optional hook ``(step_idx, obs, action) -> None`` called
@@ -1580,6 +1590,9 @@ class PolicyRunner:
         # future reader does not reach for ``time.time()`` again.
         start_mono = time.monotonic()
         step_count = 0
+        # Bound before the try so the finally below can close it whatever the
+        # rollout did, the same reason ``start_mono`` is bound above.
+        ticker: Ticker | None = None
         try:
             # Prefer an explicit integer step count when the caller resolved one
             # from ``n_steps`` (or the legacy ``max_steps`` alias). Recomputing
@@ -1591,7 +1604,29 @@ class PolicyRunner:
                 total_steps = n_steps
             else:
                 total_steps = int(duration * control_frequency)
-            action_sleep = 1.0 / control_frequency
+            # Pace the loop on a DEADLINE, not a delay. ``time.sleep(1 /
+            # control_frequency)`` after each step ADDS that step's work -
+            # inference, the physics substeps, a render for the video, the
+            # recorder's frame write - to the period instead of subtracting it,
+            # so the loop runs at ``1 / (period + work)``. Measured on a MuJoCo
+            # so101 rollout asking for 2.0s: 2.15s with a free policy, 3.15s
+            # with 10ms of inference at 50Hz, and 3.90s at 30Hz with 30ms of
+            # inference - 15.4Hz achieved where 30Hz was asked for. ``duration``
+            # is documented as wall-clock seconds and ``fast_mode=False`` as
+            # real-time pacing, so both claims were false by the cost of a step.
+            # Ticker also DROPS missed deadlines rather than chasing them, so one
+            # slow step does not fire a burst of back-to-back actions at the arm.
+            #
+            # Imported here rather than at module scope: importing any
+            # ``strands_robots.mesh`` submodule executes the mesh package
+            # ``__init__``, which pulls the fleet stack (measured: 14 mesh
+            # modules plus boto3) - a cost a local rollout must not pay for a
+            # pure-timing helper. Same reason as the local imports in the MuJoCo
+            # backend and ``TeleopMixin._teleop_apply_loop``.
+            if not fast_mode:
+                from strands_robots.mesh.pacing import Ticker as _Ticker
+
+                ticker = _Ticker(1.0 / control_frequency)
 
             # Control-rate substepping: a position-servo robot needs the physics
             # to advance for the FULL control period (1/control_frequency) after
@@ -1737,8 +1772,12 @@ class PolicyRunner:
                 if vwriter is not None:
                     vwriter.capture(step_count)
 
-                if not fast_mode:
-                    time.sleep(action_sleep)
+                if ticker is not None:
+                    # ``wait()`` returns the stop verdict of the event a Ticker
+                    # was given; this one has none - the runner's cooperative
+                    # stop arrives as an exception out of the on_frame hook
+                    # above - so there is no verdict here to read.
+                    ticker.wait()
 
             def _stop_when_fired() -> bool:
                 """Evaluate the caller's ``stop_when`` clause against the live sim.
@@ -1980,6 +2019,12 @@ class PolicyRunner:
                     {"json": {**_rtc_telemetry(), "stopped_reason": "error", "steps_used": step_count}},
                 ],
             }
+        finally:
+            # The Ticker owns a selector and a socketpair, so an unclosed one
+            # leaks two descriptors per rollout - which an eval loop repeats
+            # once per episode.
+            if ticker is not None:
+                ticker.close()
 
         # Either finished all steps, hit the stop_when condition, or was
         # cooperatively stopped.

--- a/tests/simulation/test_rollout_loop_paces_on_a_deadline.py
+++ b/tests/simulation/test_rollout_loop_paces_on_a_deadline.py
@@ -1,0 +1,295 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""A rollout runs for the wall clock it was asked for, whatever a step costs.
+
+``duration`` is documented as wall-clock seconds and ``fast_mode=False`` as
+real-time pacing, and both were false by the cost of one step: the loop slept
+``1 / control_frequency`` AFTER each step, which is a delay where a rate needs a
+deadline. The wall clock a step spends on inference, the physics substeps, a
+render for the video and the recorder's frame write was added to the period
+instead of subtracted from it, so the loop ran at ``1 / (period + work)``.
+Measured on a MuJoCo so101 rollout asking for 2.0 s, before and after:
+
+============================  =========  ========  =======  =========
+case                          requested  achieved  Hz       asked Hz
+============================  =========  ========  =======  =========
+free policy, 50 Hz (before)      2.0 s     2.15 s    46.4      50
+free policy, 50 Hz (after)       2.0 s     2.00 s    49.97     50
+10 ms inference, 50 Hz (b)       2.0 s     3.15 s    31.8      50
+10 ms inference, 50 Hz (a)       2.0 s     2.00 s    49.98     50
+30 ms inference, 30 Hz (b)       2.0 s     3.90 s    15.4      30
+30 ms inference, 30 Hz (a)       2.0 s     2.00 s    29.98     30
+============================  =========  ========  =======  =========
+
+Sim time was exact throughout (2.0 s of integration in every row), so nothing
+about the physics or the recorded timebase was wrong - only the wall clock the
+caller was promised, and the rate anything watching the rollout saw.
+
+:mod:`strands_robots.mesh.pacing` already owned this argument and the fix: its
+``Ticker`` is a deadline, and it DROPS missed deadlines rather than chasing them,
+so an overrunning step is followed by a gap rather than by a burst of
+back-to-back actions at the arm. The mesh's publish loops were converted for the
+same reason (see ``tests/test_mesh_state_loop_rate.py``, whose inventory scans
+for the ``stop_event.wait(period)`` spelling of a delay); the rollout loops paced
+with the other spelling, ``time.sleep(period)``, and that inventory could not see
+them. The source-level cells below cover that second spelling for the simulation
+package, because the timing cells - being timing cells - could in principle be
+met by luck on a heavily loaded machine.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.policy_runner import PolicyRunner
+from tests.simulation.test_policy_runner import FakeSim
+
+_PACKAGE = Path(__file__).resolve().parents[2] / "strands_robots"
+
+#: The rollout loops that must pace on a deadline, as (module path, qualified
+#: function). Read from source rather than imported: the Isaac backend needs
+#: ``isaacsim``, which no CI runner has, and its loop is exactly the same shape.
+_ROLLOUT_LOOPS = (
+    ("simulation/policy_runner.py", "PolicyRunner.run"),
+    ("simulation/mujoco/simulation.py", "MuJoCoSimEngine.run_multi_policy"),
+    ("simulation/isaac/simulation.py", "IsaacSimulation.run_multi_policy"),
+)
+
+
+def _busy_wait(seconds: float) -> None:
+    """Burn ``seconds`` of wall clock without sleeping.
+
+    A ``time.sleep`` would let the pacer's own wait overlap the work on some
+    platforms, and is itself inflated on a host that taxes blocking waits (the
+    cost :func:`strands_robots.mesh.pacing.sleep_penalty_s` measures), so the
+    step's cost is spent on the CPU exactly as inference spends it.
+    """
+    deadline = time.perf_counter() + seconds
+    while time.perf_counter() < deadline:
+        pass
+
+
+def _run(*, n_steps: int, frequency: float, on_frame: Any = None, fast_mode: bool = False) -> float:
+    """Drive the real ``PolicyRunner.run`` loop; return the wall clock it took."""
+    sim = FakeSim()
+    policy = MockPolicy()
+    start = time.perf_counter()
+    result = PolicyRunner(sim).run(
+        "fake_robot",
+        policy,
+        n_steps=n_steps,
+        control_frequency=frequency,
+        fast_mode=fast_mode,
+        on_frame=on_frame,
+    )
+    elapsed = time.perf_counter() - start
+    assert result["status"] == "success", result
+    return elapsed
+
+
+class TestARolloutTakesTheWallClockItWasAskedFor:
+    """The headline behaviour: a step's own cost comes out of the period."""
+
+    def test_the_work_of_a_step_comes_out_of_the_period_not_on_top_of_it(self) -> None:
+        """32 ms of per-step work inside a 40 ms period still ticks at 25 Hz.
+
+        The median step gap rather than the total elapsed, for the reason the
+        mesh's equivalent cell gives: a median is unmoved by the odd 100 ms of
+        descheduling a loaded CI host will hand any thread, while the regression
+        it grades is every gap. On the delay pacing this gap was ``period +
+        work`` = 72 ms; a deadline pacer absorbs the work and gives 40 ms.
+        """
+        frequency, n_steps, work_s = 25.0, 20, 0.032
+        period = 1.0 / frequency
+        stamps: list[float] = []
+
+        def on_frame(_idx: int, _obs: Any, _act: Any) -> None:
+            _busy_wait(work_s)
+            stamps.append(time.perf_counter())
+
+        _run(n_steps=n_steps, frequency=frequency, on_frame=on_frame)
+        gaps = sorted(b - a for a, b in zip(stamps, stamps[1:], strict=False))
+        assert gaps, "no steps to measure"
+        median_gap = gaps[len(gaps) // 2]
+        assert median_gap < period * 1.5, (
+            f"median step gap {median_gap * 1000:.1f}ms against a {period * 1000:.0f}ms period with "
+            f"{work_s * 1000:.0f}ms of work per step - the work is being added to the period instead "
+            "of subtracted from it, so the loop runs at 1 / (period + work). Use mesh.pacing.Ticker."
+        )
+
+    def test_a_free_step_still_takes_the_period(self) -> None:
+        """The pace is a floor as well as a ceiling: 25 steps at 50 Hz is 0.5 s.
+
+        Without this, "fast" would be an equally passing answer to the cell
+        above, and ``fast_mode=False`` would no longer mean anything.
+        """
+        frequency, n_steps = 50.0, 25
+        requested = n_steps / frequency
+        elapsed = _run(n_steps=n_steps, frequency=frequency)
+        assert elapsed >= requested * 0.9, (
+            f"a paced rollout of {n_steps} steps at {frequency:.0f}Hz returned in {elapsed:.3f}s, "
+            f"under the {requested:.3f}s its own rate implies - it is not pacing at all."
+        )
+
+    def test_fast_mode_is_still_unpaced(self) -> None:
+        """``fast_mode=True`` must pay no pace at all, deadline or otherwise."""
+        frequency, n_steps = 50.0, 25
+        elapsed = _run(n_steps=n_steps, frequency=frequency, fast_mode=True)
+        assert elapsed < (n_steps / frequency) * 0.5, (
+            f"fast_mode=True took {elapsed:.3f}s for {n_steps} steps at {frequency:.0f}Hz - "
+            "it is being paced despite asking not to be."
+        )
+
+
+class TestAnOverrunningStepIsFollowedByAGapNotABurst:
+    """A dropped deadline must not be chased.
+
+    Chasing fires several steps back to back to pay off the debt, which on a
+    robot means a burst of setpoints microseconds apart - a worse lie about what
+    the controller did than the stall itself. This is a property of the chosen
+    pacer rather than a regression from the delay, and it is what stops the
+    obvious alternative fix (accumulate the debt and sleep the remainder) from
+    passing.
+    """
+
+    def test_one_slow_step_does_not_fire_a_burst_of_catch_up_steps(self) -> None:
+        frequency, n_steps, period = 50.0, 20, 0.02
+        stamps: list[float] = []
+
+        def on_frame(step_idx: int, _obs: Any, _act: Any) -> None:
+            if step_idx == 5:  # one step worth about five periods
+                _busy_wait(period * 5)
+            stamps.append(time.perf_counter())
+
+        _run(n_steps=n_steps, frequency=frequency, on_frame=on_frame)
+        gaps = [b - a for a, b in zip(stamps, stamps[1:], strict=False)]
+        instant = [g for g in gaps if g < 0.002]
+        assert len(instant) <= 1, (
+            f"{len(instant)} of {len(gaps)} step gaps were under 2ms at a {period * 1000:.0f}ms "
+            "period - the loop is chasing the deadlines it missed during the slow step."
+        )
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="/proc/self/fd is Linux-only")
+def test_a_paced_rollout_releases_the_pacers_descriptors() -> None:
+    """A Ticker owns a selector and a socketpair, so an unclosed one leaks two.
+
+    An eval loop builds one rollout per episode, so a leak here is a file
+    descriptor exhaustion over a long evaluation rather than a one-off.
+    """
+    fds = Path("/proc/self/fd")
+    before = len(os.listdir(fds))
+    for _ in range(5):
+        _run(n_steps=2, frequency=200.0)
+    after = len(os.listdir(fds))
+    assert after <= before + 1, (
+        f"{after - before} descriptors outlived 5 paced rollouts (before {before}, after {after}) - "
+        "the pacer is not being closed."
+    )
+
+
+def _function_source(rel_path: str, qualified: str) -> str:
+    """Return the CODE of ``qualified`` in ``rel_path`` - no comments, no docstring.
+
+    Read through :mod:`ast` rather than ``inspect`` because one graded module
+    imports ``isaacsim``, and unparsed rather than sliced out of the file because
+    a converted loop explains in prose what it stopped doing: the first version
+    of this scanner failed on the very comment documenting the fix. A scanner
+    that reads its own documentation punishes documenting.
+    """
+    path = _PACKAGE / rel_path
+    tree = ast.parse(path.read_text())
+    cls_name, _, fn_name = qualified.rpartition(".")
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != cls_name:
+            continue
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef) and item.name == fn_name:
+                body = list(item.body)
+                if ast.get_docstring(item) is not None:
+                    body = body[1:]
+                return "\n".join(ast.unparse(stmt) for stmt in body)
+    raise AssertionError(f"{qualified} not found in {rel_path}")
+
+
+@pytest.mark.parametrize(("rel_path", "qualified"), _ROLLOUT_LOOPS, ids=[q for _, q in _ROLLOUT_LOOPS])
+def test_every_rollout_loop_paces_through_the_shared_ticker(rel_path: str, qualified: str) -> None:
+    """All three rollout loops pace in one place, so one cannot regress alone.
+
+    A loop that quietly kept ``time.sleep(period)`` while its siblings were
+    converted is harder to notice than all three being slow, because the one
+    that is late looks like the backend that is genuinely slower.
+    """
+    source = _function_source(rel_path, qualified)
+    assert "Ticker(" in source, f"{qualified} does not pace on mesh.pacing.Ticker"
+    assert "time.sleep(" not in source, (
+        f"{qualified} sleeps a period again - that delay adds the step's work to the period, "
+        "so the loop runs at 1 / (period + work). Use mesh.pacing.Ticker."
+    )
+
+
+def test_no_loop_in_the_simulation_package_paces_on_a_rate_derived_sleep() -> None:
+    """The inventory: this is only cured if no pacer was missed.
+
+    Scans for the SHAPE - ``time.sleep(x)`` where ``x`` is a name assigned from a
+    division by a rate and never from a subtraction - rather than for the one
+    spelling that was fixed. Two exclusions carry the whole rule.
+
+    The subtraction: a sleep computed as ``interval - elapsed`` has already taken
+    the body's cost off the period, which is what the two rendering pacers do.
+
+    The loop: this does NOT require the call to sit inside a ``while``/``for``,
+    and that is the correction that makes it see the site this change fixes. The
+    runner's pace lived in a per-step helper called from the loop rather than in
+    the loop body, so a version of this check that walked loops named the two
+    backends and missed the runner - the same near miss as the mesh inventory,
+    which looked for one attribute name and missed the teleop loop whose event is
+    spelled differently.
+
+    Scoped to the rollout/render loops of the simulation package. The same shape
+    exists in the bounded publish bursts of ``use_rtps`` / ``use_rosbridge``,
+    where ``rate`` is an inter-message spacing for a fixed ``count`` rather than
+    a control loop promising a duration; those are a separate surface with their
+    own contract and are deliberately out of this check's scope.
+    """
+    offenders: dict[tuple[str, int], str] = {}
+    for path in sorted((_PACKAGE / "simulation").rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for fn in ast.walk(tree):
+            if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            # Names bound in this function (nested helpers included) to a
+            # quotient with no subtraction in it - i.e. a bare 1 / rate period.
+            rate_derived: set[str] = set()
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                    continue
+                target = node.targets[0]
+                if not isinstance(target, ast.Name):
+                    continue
+                dumped = ast.dump(node.value)
+                if "Div()" in dumped and "Sub()" not in dumped:
+                    rate_derived.add(target.id)
+            for call in ast.walk(fn):
+                if not isinstance(call, ast.Call) or getattr(call.func, "attr", "") != "sleep":
+                    continue
+                if len(call.args) != 1 or not isinstance(call.args[0], ast.Name):
+                    continue
+                if call.args[0].id in rate_derived:
+                    rel = str(path.relative_to(_PACKAGE))
+                    offenders[rel, call.lineno] = (
+                        f"{rel}:{call.lineno}: sleeps {call.args[0].id}, a period derived from a rate"
+                    )
+    assert not offenders, (
+        "these sleeps pace a loop, so the body's work is added to the period and the loop runs at "
+        f"1 / (period + work); pace them on mesh.pacing.Ticker: {sorted(offenders.values())}"
+    )


### PR DESCRIPTION
![requested vs achieved wall clock, and the interval between consecutive actions](https://raw.githubusercontent.com/cagataycali/robots/assets/rollout-pacing/pace_before_after.png)

`duration` is documented as wall-clock seconds and `fast_mode=False` as real-time pacing. Both were false by the cost of one step: the three rollout loops slept `1 / control_frequency` **after** each step, which is a delay where a rate needs a deadline, so the wall clock a step spent on inference, the physics substeps, a render for the video and the recorder's frame write was added to the period instead of subtracted from it and the loop ran at `1 / (period + work)`.

Measured on a MuJoCo so101 rollout (headless) asking for 2.0 s:

| case | achieved | achieved Hz | asked Hz | sim time |
| --- | --- | --- | --- | --- |
| free policy, 50 Hz | 2.15 s -> **2.00 s** | 46.4 -> **50.0** | 50 | 2.00 s both |
| 10 ms inference, 50 Hz | 3.15 s -> **2.00 s** | 31.8 -> **50.0** | 50 | 2.00 s both |
| 30 ms inference, 30 Hz | 3.90 s -> **2.00 s** | 15.4 -> **30.0** | 30 | 2.04 s both |

Sim time was exact in every row, so neither the physics nor a recorded dataset's timebase was wrong - only the wall clock the caller was promised, and the rate anything watching the rollout saw. Even a free policy ran 7.7% late; at 30 Hz with 30 ms of inference the loop delivered 51% of the rate it announced.

## Change

`PolicyRunner.run` and both backends' `run_multi_policy` pace on `strands_robots.mesh.pacing.Ticker`, which the mesh's publish loops were converted to for this exact argument (#2601). A step whose work fits inside the period is fully absorbed; a step that overruns drops the missed deadlines rather than chasing them, so a slow step is followed by a gap instead of a burst of back-to-back setpoints. `fast_mode=True` is unchanged and unpaced. The `control_frequency > 0` branch the old `action_sleep` carried is gone from both backends: `_validate_positive_frequency` already refuses a non-positive rate before the loop, so the pace is unconditional there.

Both backends acquire the ticker with `with` (see R1 below); the runner's is conditional on `fast_mode` and still releases in a `finally`.

## Guard

The mesh's pacing inventory scans for the `stop_event.wait(period)` spelling of a delay and so could not see these three - they paced with `time.sleep(period)`. `tests/simulation/test_rollout_loop_paces_on_a_deadline.py` covers that second spelling for the simulation package, and deliberately does **not** require the call to sit inside the loop body: the runner's pace lived in a per-step helper, so a loop-scoped version of the check named the two backends and missed the runner. The compensated `interval - elapsed` sleeps of the two rendering pacers are excluded by the same rule that catches a bare `1 / rate`.

On `main` the file is **5 failed / 4 passed**; on this branch **9 passed**. The four that pass either way are the controls (a paced rollout is not free, `fast_mode` is still unpaced, no catch-up burst, no leaked descriptor). The headline cell grades the *median* step gap rather than total elapsed, so a loaded CI host handing one thread 100 ms of descheduling cannot flake it: 72 ms against a 40 ms period before, 40 ms after.

## Gate

`ruff check` / `ruff format --check` clean; mypy at the CI pin unchanged from `main` (20 pre-existing errors in 6 files, none in these paths); `MUJOCO_GL=egl pytest tests/simulation tests/rendering` = 14,646 passed / 1 failed, that one (`test_pose_vector_rule_parity::test_a_numpy_array_pose_is_accepted_by_both`) reproduced on a pristine `main` worktree.

`scripts/check_whole_tree_graders.py` reported 297 passed and that is not evidence about this branch's package-wide graders: its roster is the hand-maintained 7-entry `WHOLE_TREE_GRADERS` tuple, and `tests/test_mesh_pacing_ticker.py` - which `rglob`s the whole package and is a whole-tree grader by construction - is not on it. So the sweep was green while the required check was red, which is the failure shape AGENTS.md step 2 describes ("a green narrow run reads in a PR description exactly like a green full one") arriving through the roster rather than through a `-k` filter. Tracked as #3105.

LOC: **+128 / -26** in `strands_robots/` and `changelog.d/`, plus a 295-line test file - the behavioural pins, the three-loop parity pin and the inventory that keeps the class from returning.

## S13 Review Rounds

| Round | Concern | Fix commit | Pin |
|---|---|---|---|
| R1 | Both backends constructed their `Ticker` outside a `with`, so the required check was red on `tests/test_mesh_pacing_ticker.py::TestEveryPacedLoopAcquiresItsTickerWithWith` - the ticker owns a selector and a self-pipe, and that grader exists because a hand-rolled `try/finally` release is a discipline each loop must remember | `49f55fd` | `tests/test_mesh_pacing_ticker.py` 1 failed / 80 passed -> **81 passed** |
| R1 | `Detect an untested overlap with the base branch` went red: #3102 changed `mujoco/simulation.py` on `main` after this branch diverged, so no run had compiled the two together | `3e51273` | composition run, see below |
| R2 | The required check was red on `tests/test_docstrings_no_dangling_doc_refs.py::test_no_reference_to_test_files_by_name`: the comment R1 added to explain the `with` acquisition pointed at the grader **by filename**, and the published wheel ships no test tree, so that pointer is a dead end for a package reader and it rots the moment the test is renamed | `f0aee97` | `tests/test_docstrings_no_dangling_doc_refs.py` 1 failed / 5 passed -> **6 passed** |

### R1 notes

The grader's own docstring predicted this exact arrival: "the kind of rule six loops get right and the seventh does not". The two backends were the seventh and eighth.

Wrapping each step loop in `with Ticker(...) as ticker:` also retires the `ticker = None` sentinel and both `if ticker is not None` guards, which were unreachable as written - the constructor is the statement immediately before the loop. `Ticker.__enter__` returns `self` and `__exit__` calls `close()`, so the release is byte-for-byte the previous behaviour, only structural. Net real change **+10 / -14** (`git diff -w`); the remainder of the line count is one level of re-indentation on the two loop bodies, so review with `-w`.

`tests/simulation` is unchanged at **441 failed / 12890 passed / 418 skipped / 34 errors**, byte-identical pre- and post-change on a host with only software OSMesa and no GPU - read as a delta, not an absolute, per AGENTS.md.

The base merge is a pure one: `git show --cc` is 0 lines and this branch's own diff is unchanged, so it carries no unreviewed text. #3102's ten hunks all land before line 4320 and the pacing change is at 5670-5830, so there is no textual adjacency - but #3102 is a locking change in the same file, so the composition was run rather than assumed. `tests/simulation/mujoco/test_scene_mutation_swaps_under_the_lock.py` is **2 failed / 8 passed on a pristine `origin/main` worktree and 2 failed / 8 passed composed** - the two are asset-dependent cells needing a robot this host cannot fetch - and `tests/test_mesh_pacing_ticker.py` is **81 passed** on the composition.

**Not fixed here, and deliberately.** `PolicyRunner.run` imports the ticker as `_Ticker` (the module already binds `Ticker` under `TYPE_CHECKING` for the annotation), and the grader matches `ast.Name` with `id == "Ticker"` - so the runner's construction is invisible to it and passes by omission rather than by compliance. Closing that hole makes the runner fail the rule, and the runner's ticker is consumed inside a closure spanning both step loops, so its live region is the whole 431-line `try`: `with` there needs `contextlib.ExitStack` plus a widening of a mesh-owned grader to accept `enter_context` as structural acquisition. That is a change to the pacing rule itself and wants its own review rather than a round on this branch. Its release is correct today (`finally`, on every path including the error-dict return) and is covered by this branch's descriptor-leak control. Tracked as #3106.

### R2 notes

Comment-only, +6 / -4 across the two backends, no behaviour touched.

Worth recording because of where it came from: **R1's fix introduced it.** Wrapping the two loops in `with Ticker(...)` needed a sentence saying why, and the shortest true sentence named the grader that enforces the rule -- which is exactly the citation this repo refuses in shipped source. One round's explanation became the next round's failure, in a file the round never otherwise touched.

Both comments now state the invariant instead of its enforcer: every paced loop in the package is held to acquiring the ticker with `with`, so a bare construction there is a suite failure rather than one leaked descriptor pair per rollout. That is the part a reader of an installed wheel can act on, and it survives a rename.

The full required check was **1 failed / 32247 passed / 224 skipped** on the previous head, so this was its single red cell. Paired reading on the grader, taken by reverting only the two comments: **1 failed / 5 passed -> 6 passed**; the 5 that pass either way are the controls for the other two dangling-reference classes. `tests/test_mesh_pacing_ticker.py` with the rollout deadline pin is **90 passed / 1 skipped**, so R1's rule still holds. `ruff check` and `ruff format --check` clean on both files.
