### PR TITLE
fix(tools): a session reported stopped is one whose process is confirmed gone

### DIFF
--- a/changelog.d/3104-session-stop-confirms-the-process-exited.md
+++ b/changelog.d/3104-session-stop-confirms-the-process-exited.md
@@ -1,0 +1,31 @@
+### Fixed: a session reported stopped is one whose process is confirmed gone
+
+`lerobot_teleoperate` and `lerobot_train` both implement `action="stop"` as
+SIGTERM, a fixed two-second sleep, SIGKILL if the pid still exists - and then an
+unconditional `"**Session Stopped**"` plus an unconditional
+`remove_session(...)`. Sending SIGKILL is not the process exiting. The kernel
+delivers it asynchronously, and a task inside an uninterruptible wait (a serial
+ioctl on the teleoperation bus, a stalled CUDA or network call in a training
+step) stays in the process table until that wait returns.
+
+Driving the real verb against a real child that ignores SIGTERM, the process was
+still running at the moment the tool reported it stopped in 5 of 5 trials - and
+the record had already been dropped. That store is the only place a detached
+session's pid is written down, so the process kept driving the robot with no
+supported way left to stop it.
+
+Both verbs now capture the process identity before signalling anything, so the
+escalation is aimed at the process they found rather than at whatever holds the
+pid two seconds later, and they report the outcome they can establish: success
+with `stopped: true` once the process has left the table, an error with
+`stopped: false` when it is still there, and an error with `stopped: null` when
+this user may not inspect it and neither answer is available. The record is kept
+in both error cases, which is what keeps the session stoppable on the next
+attempt. The rule lives in one place (`strands_robots.tools._process_stop`) so
+the two verbs cannot drift apart on it.
+
+The confirmation replaces the fixed sleep, so a session whose process exits
+promptly now stops in 0.002s instead of 2.001s. The sibling teardowns this
+aligns with - `gr00t_inference._stop_service`, which rescans the port after the
+escalation, and `policies.vera.server_runner.stop`, which waits after each
+signal - are unchanged.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -75,6 +75,25 @@ serial port - is still listed and still stoppable when the tool is later invoked
 as the unprivileged user. Being kept is not a claim that it is running: `list`
 and `status` each derive that from the pid's existence at the moment you ask.
 
+`stop` is held to the same standard from the other side. It captures the process
+identity *before* it signals - so the SIGKILL escalation is aimed at the process
+it found, not at whatever holds the pid once the grace period is over - and then
+reports only what it can establish:
+
+| After SIGTERM, then SIGKILL | `stopped` | Result |
+|-----------------------------|-----------|--------|
+| the process left the process table | `true` | success, record dropped |
+| it was already gone when `stop` looked | `true` | success ("already stopped"), record dropped |
+| it is still there | `false` | error, record kept |
+| whether it exited could not be determined (`AccessDenied`) | `null` | error, record kept |
+
+Sending SIGKILL is not the same as the process exiting: the kernel delivers it
+asynchronously, and a task inside an uninterruptible wait - a serial ioctl on the
+teleop bus, a stalled CUDA call in a training step - stays in the table until that
+wait returns. So the record is kept in exactly the cases where the exit was not
+observed, because dropping it would leave the process running with nothing left
+recording its pid.
+
 ### A raw servo write is bounded by the register it encodes into
 
 `serial_tool` writes Feetech registers by masking the value into fixed-width

--- a/strands_robots/tools/_process_stop.py
+++ b/strands_robots/tools/_process_stop.py
@@ -1,0 +1,99 @@
+"""Confirmation that a signalled session process has actually exited.
+
+A tool that stops a background session sends a signal and then has to answer a
+separate question: did the process go away? Sending SIGKILL is not the answer.
+The kernel delivers it asynchronously, and a task inside an uninterruptible
+wait - a serial ioctl on a teleoperation bus, a stalled CUDA or network call in
+a training step - stays in the process table until that wait returns. A stop
+that reports success on the strength of having *sent* the signal tells the
+caller the arm is released and the GPU is free when neither may be true.
+
+:func:`confirm_exit` is that answer and :func:`unstopped_result` is the report
+for when it is not affirmative, shared by every session ``stop`` verb so the
+rule is stated once rather than per verb.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psutil
+
+# How long to let a process wind itself down after SIGTERM before escalating.
+# The session processes this covers flush a dataset shard or a checkpoint on
+# the way out, so the grace period is real work, not politeness.
+SIGTERM_GRACE_S = 2.0
+
+# How long to wait for SIGKILL to take effect before reporting that it has not.
+# A process still present after this is in an uninterruptible wait; more waiting
+# does not change the verdict, and the caller needs the verdict.
+SIGKILL_CONFIRM_S = 2.0
+
+
+def confirm_exit(proc: psutil.Process, timeout: float) -> bool | None:
+    """Wait up to ``timeout`` seconds for ``proc`` to leave the process table.
+
+    Args:
+        proc: The process being stopped. It must have been constructed *before*
+            the signal was sent: psutil records the creation time at
+            construction, so every probe here is identity-checked and a PID that
+            was recycled in the meantime reads as exited rather than as the
+            original process still running.
+        timeout: Seconds to wait. Returns as soon as the process is gone.
+
+    Returns:
+        ``True`` when the process is known to have exited, ``False`` when it is
+        known to be still present, and ``None`` when neither could be
+        established - this user may not inspect the process
+        (:class:`psutil.AccessDenied`). ``None`` must not be read as either
+        answer: the PID existing already said it is not death, and being unable
+        to look is no evidence that it left.
+    """
+    try:
+        proc.wait(timeout=timeout)
+    except psutil.TimeoutExpired:
+        return False
+    except psutil.NoSuchProcess:
+        return True
+    except psutil.AccessDenied:
+        return None
+    return True
+
+
+def unstopped_result(session_name: str, pid: int, verdict: bool | None, doing: str) -> dict[str, Any]:
+    """Report a session whose process was not confirmed gone after SIGKILL.
+
+    The caller keeps the session record when it gets this: that store is the
+    only place a detached session's PID is written down, so dropping it would
+    leave the process running with no supported way left to stop it.
+
+    Args:
+        session_name: Name the session is tracked under.
+        pid: PID that was signalled.
+        verdict: The non-affirmative :func:`confirm_exit` answer being reported -
+            ``False`` (still present) or ``None`` (could not be determined).
+        doing: What the process is still doing, in the caller's terms
+            (``"driving the robot"``, ``"training"``).
+
+    Returns:
+        A tool error result whose ``json`` block carries ``stopped`` verbatim, so
+        an unknown outcome stays unknown to whoever reads it.
+    """
+    if verdict is None:
+        what = (
+            f"Session '{session_name}' (PID {pid}) was signalled with SIGTERM and SIGKILL, but whether it "
+            f"exited could not be determined: this user may not inspect it. A session started under sudo "
+            f"for device access and stopped as the invoking user reads this way."
+        )
+    else:
+        what = (
+            f"Session '{session_name}' (PID {pid}) is still present after SIGTERM and SIGKILL, so it is "
+            f"still {doing}. A process that outlives SIGKILL is in an uninterruptible wait."
+        )
+    return {
+        "status": "error",
+        "content": [
+            {"text": f"{what} Its record is kept so the session stays stoppable; inspect it with 'ps -p {pid}'."},
+            {"json": {"session_name": session_name, "pid": pid, "stopped": verdict}},
+        ],
+    }

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -23,6 +23,12 @@ from typing import Any
 import psutil
 from strands import tool
 
+from strands_robots.tools._process_stop import (
+    SIGKILL_CONFIRM_S,
+    SIGTERM_GRACE_S,
+    confirm_exit,
+    unstopped_result,
+)
 from strands_robots.utils import (
     boolean_flag_error,
     non_negative_whole_number_error,
@@ -766,7 +772,8 @@ def lerobot_teleoperate(
             - Recording mode (dataset_repo_id specified)
             - Background or foreground execution
 
-        stop: Stop a running session by name
+        stop: Stop a running session by name (SIGTERM, then SIGKILL), reported
+            successful only once the process has left the process table
 
         list: List all active teleoperation sessions
 
@@ -1167,13 +1174,23 @@ def lerobot_teleoperate(
 
             pid_int = int(pid)
             try:
-                # Try graceful termination first
-                os.kill(pid_int, signal.SIGTERM)
-                time.sleep(2)  # Grace period for process to flush buffers and exit cleanly
+                # Capture the process identity before signalling anything: psutil
+                # records the creation time here, so the escalation and the
+                # confirmation below are aimed at this process and not at
+                # whatever holds the PID once the grace period is over.
+                proc = psutil.Process(pid_int)
 
-                # Force kill if still running after grace period
-                if psutil.pid_exists(pid_int):
+                os.kill(pid_int, signal.SIGTERM)
+                if confirm_exit(proc, SIGTERM_GRACE_S) is not True:
                     os.kill(pid_int, signal.SIGKILL)
+                    verdict = confirm_exit(proc, SIGKILL_CONFIRM_S)
+                    if verdict is not True:
+                        # Sending SIGKILL is not the process exiting. Reporting
+                        # this stopped would also drop the record below, and that
+                        # store is the only place the detached PID is written
+                        # down, so the session would carry on with no supported
+                        # way left to stop it.
+                        return unstopped_result(session_name, pid_int, verdict, "driving the robot")
 
                 session_manager.remove_session(session_name)
 
@@ -1181,18 +1198,25 @@ def lerobot_teleoperate(
                     "status": "success",
                     "content": [
                         {"text": f"**Session Stopped**\nSession: `{session_name}`\nPID: {pid}"},
-                        {"json": {"session_name": session_name, "session_info": session_info}},
+                        {
+                            "json": {
+                                "session_name": session_name,
+                                "session_info": session_info,
+                                "stopped": True,
+                            }
+                        },
                     ],
                 }
 
-            except ProcessLookupError:
-                # Process already dead
+            except (ProcessLookupError, psutil.NoSuchProcess):
+                # Already gone before this verb reached it: os.kill reports that
+                # as ProcessLookupError, psutil.Process as NoSuchProcess.
                 session_manager.remove_session(session_name)
                 return {
                     "status": "success",
                     "content": [
                         {"text": f"Session '{session_name}' was already stopped"},
-                        {"json": {"session_name": session_name}},
+                        {"json": {"session_name": session_name, "stopped": True}},
                     ],
                 }
             except Exception as e:

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -29,6 +29,12 @@ from strands import tool
 from strands.types.tools import ToolContext
 
 from strands_robots.tools._hitl_audit import log_operator_response
+from strands_robots.tools._process_stop import (
+    SIGKILL_CONFIRM_S,
+    SIGTERM_GRACE_S,
+    confirm_exit,
+    unstopped_result,
+)
 from strands_robots.utils import (
     positive_count_error,
     step_cadence_error,
@@ -744,7 +750,8 @@ def lerobot_train(
     Actions:
         start: launch a new training run (default).
         status: report a run's PID, uptime, running flag, and recent log tail.
-        stop: terminate a running session by name (SIGTERM then SIGKILL).
+        stop: terminate a running session by name (SIGTERM then SIGKILL),
+            reported successful only once the process has exited.
         list: list tracked training sessions.
 
     Args:
@@ -957,25 +964,47 @@ def lerobot_train(
 
             pid_int = int(pid)
             try:
+                # Capture the process identity before signalling anything: psutil
+                # records the creation time here, so the escalation and the
+                # confirmation below are aimed at this process and not at
+                # whatever holds the PID once the grace period is over.
+                proc = psutil.Process(pid_int)
+
                 os.kill(pid_int, signal.SIGTERM)
-                time.sleep(2)
-                if psutil.pid_exists(pid_int):
+                if confirm_exit(proc, SIGTERM_GRACE_S) is not True:
                     os.kill(pid_int, signal.SIGKILL)
+                    verdict = confirm_exit(proc, SIGKILL_CONFIRM_S)
+                    if verdict is not True:
+                        # Sending SIGKILL is not the process exiting. Reporting
+                        # this stopped would also drop the record below, and that
+                        # store is the only place the detached PID is written
+                        # down, so the session would carry on with no supported
+                        # way left to stop it.
+                        return unstopped_result(session_name, pid_int, verdict, "training")
+
                 session_manager.remove_session(session_name)
                 return {
                     "status": "success",
                     "content": [
                         {"text": f"**Session Stopped**\nSession: `{session_name}`\nPID: {pid}"},
-                        {"json": {"session_name": session_name, "session_info": session_info}},
+                        {
+                            "json": {
+                                "session_name": session_name,
+                                "session_info": session_info,
+                                "stopped": True,
+                            }
+                        },
                     ],
                 }
-            except ProcessLookupError:
+            except (ProcessLookupError, psutil.NoSuchProcess):
+                # Already gone before this verb reached it: os.kill reports that
+                # as ProcessLookupError, psutil.Process as NoSuchProcess.
                 session_manager.remove_session(session_name)
                 return {
                     "status": "success",
                     "content": [
                         {"text": f"Session '{session_name}' was already stopped"},
-                        {"json": {"session_name": session_name}},
+                        {"json": {"session_name": session_name, "stopped": True}},
                     ],
                 }
 

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -653,18 +653,9 @@ def test_status_running_session_is_ascii(monkeypatch: pytest.MonkeyPatch) -> Non
     _assert_ascii(_texts(result))
 
 
-def test_stop_session_terminates_and_removes(monkeypatch: pytest.MonkeyPatch) -> None:
-    mgr = SessionManager()
-    live_pid = os.getpid()
-    mgr.add_session("kill", {"pid": live_pid, "start_time": 0.0})
-    killed: list[tuple[int, int]] = []
-    monkeypatch.setattr(tele_mod.os, "kill", lambda pid, sig: killed.append((pid, sig)))
-    monkeypatch.setattr(tele_mod.time, "sleep", lambda s: None)
-    result = lerobot_teleoperate(action="stop", session_name="kill")
-    assert result["status"] == "success"
-    assert killed and killed[0][0] == live_pid
-    assert SessionManager().get_session("kill") is None
-    _assert_ascii(_texts(result))
+# stop's own verdict - what it signals, what it confirms, and what it reports
+# when the process does not exit - is pinned across both session tools in
+# tests.tools.test_session_stop_confirms_the_process_exited.
 
 
 def test_stop_without_name_errors() -> None:

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -458,6 +458,10 @@ def test_session_lifecycle_round_trips(tmp_path: Path, monkeypatch: pytest.Monke
         def is_running(self) -> bool:
             return True
 
+        def wait(self, timeout: float | None = None) -> int:
+            # Exits as soon as it is signalled, so the stop below confirms it.
+            return 0
+
     monkeypatch.setattr(train_mod.psutil, "Process", _FakeProcess)
 
     start = lerobot_train(
@@ -486,8 +490,6 @@ def test_session_lifecycle_round_trips(tmp_path: Path, monkeypatch: pytest.Monke
     # Stop: capture the kill calls instead of touching a real process.
     killed: list[int] = []
     monkeypatch.setattr(train_mod.os, "kill", lambda pid, sig: killed.append(pid))
-    # After SIGTERM the process is gone.
-    monkeypatch.setattr(train_mod.psutil, "pid_exists", lambda pid: False)
 
     stop = lerobot_train(action="stop", dataset_root=str(root), session_name="t1")
     assert stop["status"] == "success"
@@ -687,8 +689,25 @@ def test_stop_unknown_session_errors(tmp_path: Path) -> None:
 
 
 def test_stop_already_dead_process_clears_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When the PID is already gone, stop reports success and drops the session."""
+    """A process that exits just before the signal lands: success, session dropped.
+
+    ``os.kill`` reports that as ``ProcessLookupError``; the sibling spelling -
+    gone before the identity capture, which raises ``psutil.NoSuchProcess`` - is
+    pinned in ``tests.tools.test_session_stop_confirms_the_process_exited``. The
+    process is alive for every probe here so the exit is decided by the signal
+    and not by whether PID 5555 happens to exist on the host.
+    """
     SessionManager().add_session("gone", {"pid": 5555, "action": "train"})
+    monkeypatch.setattr(train_mod.psutil, "pid_exists", lambda pid: True)
+
+    class _LiveProcess:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+        def is_running(self) -> bool:
+            return True
+
+    monkeypatch.setattr(train_mod.psutil, "Process", _LiveProcess)
 
     def _raise_no_such(pid: int, sig: int) -> None:
         raise ProcessLookupError
@@ -779,26 +798,8 @@ def test_start_autogenerates_session_name_and_clears_stale_empty_output(
     assert str(out) in rmtree_calls
 
 
-def test_stop_escalates_to_sigkill_when_sigterm_ignored(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A process still alive after SIGTERM gets SIGKILL, then the session clears."""
-    SessionManager().add_session("stubborn", {"pid": 8888, "action": "train"})
-    monkeypatch.setattr(train_mod.psutil, "pid_exists", lambda pid: True)
-
-    class _RunningProcess:
-        def __init__(self, pid: int) -> None:
-            self.pid = pid
-
-        def is_running(self) -> bool:
-            return True
-
-    monkeypatch.setattr(train_mod.psutil, "Process", _RunningProcess)
-    monkeypatch.setattr(train_mod.time, "sleep", lambda s: None)
-    signals: list[int] = []
-    monkeypatch.setattr(train_mod.os, "kill", lambda pid, sig: signals.append(sig))
-    result = lerobot_train(action="stop", dataset_root="/x", session_name="stubborn")
-    assert result["status"] == "success"
-    assert train_mod.signal.SIGTERM in signals
-    assert train_mod.signal.SIGKILL in signals
+# The SIGTERM -> SIGKILL escalation, and the verdict each outcome earns, are
+# pinned for both session tools in tests.tools.test_session_stop_confirms_the_process_exited.
 
 
 def test_stop_session_without_pid_errors(tmp_path: Path) -> None:

--- a/tests/tools/test_session_stop_confirms_the_process_exited.py
+++ b/tests/tools/test_session_stop_confirms_the_process_exited.py
@@ -1,0 +1,296 @@
+"""A session reported stopped must be one whose process is known to be gone.
+
+``lerobot_teleoperate`` and ``lerobot_train`` both expose ``action="stop"``, and
+both used to escalate SIGTERM -> SIGKILL and then report ``"**Session
+Stopped**"`` on the strength of having *sent* the signals:
+
+    os.kill(pid, SIGTERM); time.sleep(2)
+    if psutil.pid_exists(pid): os.kill(pid, SIGKILL)
+    session_manager.remove_session(name)   # <- unconditional
+    return {"status": "success", ...}      # <- unconditional
+
+Sending SIGKILL is not the same as the process exiting. The kernel delivers it
+asynchronously, and a task inside an uninterruptible wait - a serial ioctl on a
+teleoperation bus, a stalled CUDA or network call in a training step - stays in
+the process table until that wait returns. Two things then go wrong at once:
+the caller is told the arm is released and the GPU is free, and the record is
+dropped. That store is the only place a detached session's PID is written down
+(``SessionManager._load_sessions`` says so, and
+``tests.tools.test_teleop_session_store_keeps_a_live_pid`` pins it), so the
+process carries on driving the robot with no supported way left to stop it.
+
+The sibling teardown in the same package already refuses to do this:
+``gr00t_inference._stop_service`` rescans the port after the escalation and
+returns an error when anything still holds it, because "reporting success there
+would tell the caller the port is free when the next bind is about to fail".
+``policies.vera.server_runner.stop`` likewise waits after each signal. These
+tests hold the two session verbs to the same standard, on both modules, and
+additionally pin the identity half: the escalation is aimed at the process that
+was captured before the first signal, so a PID recycled during the grace period
+is not signalled a second time.
+"""
+
+from __future__ import annotations
+
+import signal
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.lerobot_teleoperate as tele_mod
+import strands_robots.tools.lerobot_train as train_mod
+from strands_robots.tools import _process_stop
+
+# Every recorded PID below is fake and every signal is captured, so nothing here
+# can reach a real process.
+FAKE_PID = 424242
+
+# Both stop verbs are the same shape over their own session store, so each
+# behaviour is pinned on both. ``kwargs`` carries the argument the tool needs
+# beyond the action.
+MODULES = [
+    pytest.param(tele_mod, "lerobot_teleoperate", {}, id="teleoperate"),
+    pytest.param(train_mod, "lerobot_train", {"dataset_root": "/x"}, id="train"),
+]
+
+_SIGNAMES = {signal.SIGTERM: "SIGTERM", signal.SIGKILL: "SIGKILL"}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect both session stores to a temp dir so no test touches the tree."""
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(tele_mod, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(train_mod, "SESSION_DIR", session_dir)
+    return session_dir
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    module: Any,
+    *,
+    survives_waits: int = 0,
+    wait_exc: type[Exception] | None = None,
+    missing_after: int | None = None,
+) -> list[str]:
+    """Stand in for the process being stopped and record what reaches it.
+
+    Args:
+        monkeypatch: pytest patcher.
+        module: The tool module whose ``psutil``/``os`` seams to patch.
+        survives_waits: How many confirmation waits time out before the process
+            is reported gone. ``0`` exits within the SIGTERM grace period, ``1``
+            exits only once SIGKILL lands, ``2`` outlives both.
+        wait_exc: Raised by every wait instead of timing out, for the cases the
+            probe itself reports (``NoSuchProcess`` for a recycled PID,
+            ``AccessDenied`` for a process this user may not inspect).
+        missing_after: Number of successful ``Process()`` constructions before
+            the next one raises ``NoSuchProcess``. ``1`` models the real race:
+            alive when the session store probes it, gone by the time the stop
+            verb captures it.
+
+    Returns:
+        The event log: ``"wait"`` per confirmation and ``"kill:<SIGNAME>"`` per
+        signal, in the order they happened.
+    """
+    events: list[str] = []
+    real_psutil = module.psutil
+    constructed = {"n": 0}
+
+    class _Proc:
+        def __init__(self, pid: int) -> None:
+            constructed["n"] += 1
+            if missing_after is not None and constructed["n"] > missing_after:
+                raise real_psutil.NoSuchProcess(pid)
+            self.pid = pid
+            self._waits = 0
+
+        def is_running(self) -> bool:
+            # The session store's own liveness probe; keeps the record visible.
+            return True
+
+        def wait(self, timeout: float | None = None) -> int:
+            self._waits += 1
+            events.append("wait")
+            if wait_exc is not None:
+                raise wait_exc(self.pid)
+            if self._waits <= survives_waits:
+                raise real_psutil.TimeoutExpired(timeout)
+            return 0
+
+    monkeypatch.setattr(real_psutil, "Process", _Proc)
+    monkeypatch.setattr(real_psutil, "pid_exists", lambda pid: True)
+    monkeypatch.setattr(module.os, "kill", lambda pid, sig: events.append(f"kill:{_SIGNAMES[sig]}"))
+    # The pre-fix implementation paced itself with a bare sleep; keep the suite
+    # fast if it is ever reintroduced.
+    monkeypatch.setattr(module.time, "sleep", lambda s: None)
+    return events
+
+
+def _stop(module: Any, tool_name: str, kwargs: dict[str, Any], name: str) -> dict[str, Any]:
+    tool = getattr(module, tool_name)
+    return tool(action="stop", session_name=name, **kwargs)
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _json(result: dict[str, Any]) -> dict[str, Any]:
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+def _add(module: Any, name: str) -> None:
+    module.SessionManager().add_session(name, {"pid": FAKE_PID, "start_time": 0.0, "action": "train"})
+
+
+# ---------------------------------------------------------------------------
+# The report must be true.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(("module", "tool_name", "kwargs"), MODULES)
+def test_a_process_that_outlives_sigkill_is_reported_as_an_error(
+    module: Any, tool_name: str, kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Survived both signals: an error, and the record is kept so it stays stoppable."""
+    _add(module, "stubborn")
+    events = _install(monkeypatch, module, survives_waits=2)
+
+    result = _stop(module, tool_name, kwargs, "stubborn")
+
+    assert result["status"] == "error", "a process still in the table has not stopped"
+    assert str(FAKE_PID) in _texts(result), "the report must name the PID that is still there"
+    assert _json(result)["stopped"] is False
+    assert module.SessionManager().get_session("stubborn") is not None, (
+        "dropping the record loses the only note of the PID, so the session becomes unstoppable"
+    )
+    # The escalation itself is unchanged: both signals are still sent.
+    assert events.count("kill:SIGTERM") == 1
+    assert events.count("kill:SIGKILL") == 1
+
+
+@pytest.mark.parametrize(("module", "tool_name", "kwargs"), MODULES)
+def test_a_process_that_exits_in_the_grace_period_is_not_escalated(
+    module: Any, tool_name: str, kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SIGTERM was enough: success, record dropped, and no SIGKILL is sent."""
+    _add(module, "polite")
+    events = _install(monkeypatch, module, survives_waits=0)
+
+    result = _stop(module, tool_name, kwargs, "polite")
+
+    assert result["status"] == "success"
+    assert _json(result)["stopped"] is True
+    assert module.SessionManager().get_session("polite") is None
+    assert events == ["kill:SIGTERM", "wait"], "a process that exited must not also be SIGKILLed"
+
+
+@pytest.mark.parametrize(("module", "tool_name", "kwargs"), MODULES)
+def test_a_process_that_exits_only_after_sigkill_is_reported_stopped(
+    module: Any, tool_name: str, kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The escalation still works: SIGTERM ignored, SIGKILL lands, stop succeeds."""
+    _add(module, "stubborn_but_mortal")
+    events = _install(monkeypatch, module, survives_waits=1)
+
+    result = _stop(module, tool_name, kwargs, "stubborn_but_mortal")
+
+    assert result["status"] == "success"
+    assert module.SessionManager().get_session("stubborn_but_mortal") is None
+    assert events == ["kill:SIGTERM", "wait", "kill:SIGKILL", "wait"]
+
+
+@pytest.mark.parametrize(("module", "tool_name", "kwargs"), MODULES)
+def test_a_process_that_cannot_be_inspected_is_not_reported_stopped(
+    module: Any, tool_name: str, kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``AccessDenied`` is not death - the PID existing already said that.
+
+    A session started under ``sudo`` for serial-port access and stopped as the
+    invoking user reads this way. Not being allowed to look is no evidence the
+    process left, so the verb must not claim it did.
+    """
+    _add(module, "sudo_session")
+    _install(monkeypatch, module, wait_exc=module.psutil.AccessDenied)
+
+    result = _stop(module, tool_name, kwargs, "sudo_session")
+
+    assert result["status"] == "error"
+    assert _json(result)["stopped"] is None, "unknown must stay unknown, not become False"
+    assert module.SessionManager().get_session("sudo_session") is not None
+
+
+# ---------------------------------------------------------------------------
+# The escalation must be aimed at the process that was captured.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(("module", "tool_name", "kwargs"), MODULES)
+def test_a_pid_recycled_during_the_grace_period_is_not_signalled_again(
+    module: Any, tool_name: str, kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The captured process is gone, so nothing is escalated at its old PID.
+
+    The probe reports ``NoSuchProcess`` (the captured process exited) while the
+    PID still exists, which is what PID reuse looks like from here. Deciding the
+    escalation on bare existence would send SIGKILL to whatever inherited the
+    number; deciding it on the captured identity does not.
+    """
+    _add(module, "recycled")
+    events = _install(monkeypatch, module, wait_exc=module.psutil.NoSuchProcess)
+
+    result = _stop(module, tool_name, kwargs, "recycled")
+
+    assert result["status"] == "success"
+    assert "kill:SIGKILL" not in events, "SIGKILL at a recycled PID hits an unrelated process"
+    assert module.SessionManager().get_session("recycled") is None
+
+
+@pytest.mark.parametrize(("module", "tool_name", "kwargs"), MODULES)
+def test_a_process_that_exits_before_the_capture_is_reported_already_stopped(
+    module: Any, tool_name: str, kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Alive at the store's liveness probe, gone at the capture: no signal is sent."""
+    _add(module, "raced")
+    events = _install(monkeypatch, module, missing_after=1)
+
+    result = _stop(module, tool_name, kwargs, "raced")
+
+    assert result["status"] == "success", "premise: the record must still be found"
+    assert "already stopped" in _texts(result)
+    assert events == [], "a process known to be gone must not be signalled at all"
+    assert module.SessionManager().get_session("raced") is None
+
+
+# ---------------------------------------------------------------------------
+# The shared rule both verbs read.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("outcome", "expected", "why"),
+    [
+        pytest.param(None, True, "wait() returned, so the process is gone", id="returned"),
+        pytest.param("timeout", False, "still in the process table", id="still-present"),
+        pytest.param("no-such-process", True, "identity-checked disappearance", id="gone"),
+        pytest.param("access-denied", None, "not inspectable is neither answer", id="unknown"),
+    ],
+)
+def test_confirm_exit_reports_gone_present_and_unknown_apart(
+    outcome: str | None, expected: bool | None, why: str
+) -> None:
+    """One rule, stated once, so both stop verbs cannot disagree about it.
+
+    The third answer matters: collapsing "could not look" into either bool makes
+    the caller state something it has no evidence for, in one direction or the
+    other.
+    """
+    import psutil
+
+    class _Proc:
+        def wait(self, timeout: float | None = None) -> int:
+            if outcome == "timeout":
+                raise psutil.TimeoutExpired(timeout)
+            if outcome == "no-such-process":
+                raise psutil.NoSuchProcess(1)
+            if outcome == "access-denied":
+                raise psutil.AccessDenied(1)
+            return 0
+
+    assert _process_stop.confirm_exit(_Proc(), 0.01) is expected, why

--- a/tests/tools/test_teleop_session_store_keeps_a_live_pid.py
+++ b/tests/tools/test_teleop_session_store_keeps_a_live_pid.py
@@ -54,13 +54,22 @@ def _live_pid() -> int:
 
 
 def _raise_on_probe(monkeypatch: pytest.MonkeyPatch, module: Any, exc: type[Exception]) -> None:
-    """Make ``is_running()`` raise ``exc`` while ``pid_exists`` stays truthful."""
+    """Make every probe of the process raise ``exc`` while ``pid_exists`` stays truthful.
+
+    ``stop`` confirms the exit with ``Process.wait()``, so a stand-in for an
+    uninspectable process has to refuse that the same way it refuses
+    ``is_running()``; answering one and not the other would model a process no
+    kernel produces.
+    """
 
     class _Probe:
         def __init__(self, pid: int) -> None:
             self._pid = pid
 
         def is_running(self) -> bool:
+            raise exc(self._pid)
+
+        def wait(self, timeout: float | None = None) -> int:
             raise exc(self._pid)
 
     monkeypatch.setattr(module.psutil, "Process", _Probe)
@@ -116,7 +125,15 @@ def test_adding_a_session_does_not_erase_an_uninspectable_sibling(monkeypatch: p
 
 
 def test_stop_can_still_reach_a_session_it_could_not_inspect(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The operator-visible point: such a session stays stoppable."""
+    """The operator-visible point: such a session stays stoppable.
+
+    Reaching it is the property being pinned - the record survives the load and
+    the signals go to the recorded PID. The *verdict* cannot be affirmative
+    here: the same ``AccessDenied`` that hid the process from the store also
+    hides whether it exited, and ``stop`` reports that as unknown rather than
+    claiming an exit it could not observe. The record is kept either way, which
+    is what keeps the session stoppable on the next attempt.
+    """
     pid = _live_pid()
     SessionManager().add_session("arm_teleop", {"pid": pid, "action": "teleoperate", "start_time": 0.0})
     _raise_on_probe(monkeypatch, tele_mod, tele_mod.psutil.AccessDenied)
@@ -126,8 +143,10 @@ def test_stop_can_still_reach_a_session_it_could_not_inspect(monkeypatch: pytest
 
     result = lerobot_teleoperate(action="stop", session_name="arm_teleop")
 
-    assert result["status"] == "success", "a live session the tool started must remain stoppable"
     assert signalled and signalled[0][0] == pid, "stop must signal the recorded PID"
+    verdict = next(block["json"] for block in result["content"] if "json" in block)["stopped"]
+    assert verdict is None, "an exit that could not be observed is unknown, not reported either way"
+    assert "arm_teleop" in _stored(SessionManager()), "the record must survive so the session stays stoppable"
 
 
 def test_retaining_the_record_is_reported(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
![stop before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/session-stop-confirms-exit/session_stop.png)

Measured by driving the real `stop` verb against real child processes, `main` vs this branch:

| real child | `main` | this branch |
|---|---|---|
| exits on SIGTERM | success in **2.001 s** | success in **0.002 s** |
| ignores SIGTERM | success, and the child was **still running when the report was published - 5/5 trials**, record already dropped | success, child gone first - **0/5** |

## The defect

`lerobot_teleoperate` and `lerobot_train` both implement `action="stop"` the same way:

```python
os.kill(pid, SIGTERM); time.sleep(2)
if psutil.pid_exists(pid): os.kill(pid, SIGKILL)
session_manager.remove_session(name)   # unconditional
return {"status": "success", ...}       # unconditional "**Session Stopped**"
```

Sending SIGKILL is not the process exiting. The kernel delivers it asynchronously, and a task inside an uninterruptible wait - a serial ioctl on the teleoperation bus, a stalled CUDA or network call in a training step - stays in the process table until that wait returns. Two things then go wrong at once: the caller is told the arm is released and the GPU is free, and the record is dropped. That store is the only place a detached session's pid is written down - `SessionManager._load_sessions` says so in as many words ("a pruned record leaves the teleoperation process running with no supported way to stop it") and `tests/tools/test_teleop_session_store_keeps_a_live_pid.py` pins it - so the process carries on driving the robot with nothing left recording its pid.

The escalation also aimed at a bare pid: `pid_exists` two seconds after the SIGTERM cannot tell the original process from whatever inherited the number, so a SIGKILL could land on an unrelated process. `_load_sessions` already knows this ("`Process(pid).is_running()` refines that - it also rules out PID reuse"); the knowledge was applied to the read path and not to the path that sends signals.

## The reference it is aligned with

Two of the four process-teardown paths in the package already refuse to report an unverified stop:

| teardown | confirms after SIGKILL? |
|---|---|
| `gr00t_inference._stop_service` | yes - rescans the port, errors if still held ("reporting success there would tell the caller the port is free when the next bind is about to fail") |
| `policies.vera.server_runner.stop` | yes - `proc.wait()` after each signal, logs "unresponsive to SIGKILL" |
| `lerobot_teleoperate` `stop` | **no** |
| `lerobot_train` `stop` | **no** |

## The change

Both verbs capture the process identity *before* signalling (psutil records the creation time at construction, so every later probe is identity-checked and a recycled pid reads as exited rather than as the original process), then report only what they can establish:

| after SIGTERM, then SIGKILL | `stopped` | result |
|---|---|---|
| left the process table | `true` | success, record dropped |
| already gone when `stop` looked | `true` | success ("already stopped"), no signal sent at all |
| still there | `false` | error, record kept |
| could not be determined (`AccessDenied`) | `null` | error, record kept |

The third answer is deliberate: collapsing "could not look" into either boolean makes the caller state something it has no evidence for, in one direction or the other. `AccessDenied` is how a session started under `sudo` for serial-port access and stopped as the invoking user reads, and the pid existing already told us that is not death.

The rule and the refusal report live once in `strands_robots/tools/_process_stop.py` so the two verbs cannot drift apart on it. Waiting for the exit also replaces the fixed `sleep(2)`, which is where the 2.001 s -> 0.002 s comes from.

## Tests

`tests/tools/test_session_stop_confirms_the_process_exited.py` - 16 cells, each behaviour pinned on **both** modules. Against `main` with the new helper module present and the verbs unchanged: **12 failed / 4 passed**. All 12 integration cells fail, each on its own contract (`assert 'success' == 'error'`, `SIGKILL at a recycled PID hits an unrelated process`, `KeyError: 'stopped'`, the missing confirmation waits); the 4 passes are the shared-rule cells, which are the controls - the rule was correct on its own, nothing consulted it. After: 16/16.

Four existing cells had premises this falsifies and were evolved rather than left:

- `test_stop_escalates_to_sigkill_when_sigterm_ignored` modelled a process that survives **both** signals and asserted `status == "success"` - it pinned the fabrication. Removed; the escalation and each outcome's verdict are now pinned for both modules in the new file.
- `test_stop_session_terminates_and_removes` is the same happy path as the new file's grace-period cell. Removed, with a pointer at the site.
- `test_stop_can_still_reach_a_session_it_could_not_inspect` conflated "reachable" with "confirmed stopped". It keeps its real claim (the record survives, the signals reach the recorded pid) and now pins the verdict as unknown. Its stand-in refused `is_running()` but answered `wait()`, which is a process no kernel produces - fixed.
- `test_stop_already_dead_process_clears_session` decided its outcome by whether pid 5555 happened to exist on the host. Made deterministic, and it now documents that it pins the `ProcessLookupError` spelling while the new file pins the `psutil.NoSuchProcess` one.

Local gate: `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; mypy 20 errors in 6 files, identical to `main` and none in the touched files; `scripts/check_whole_tree_graders.py` 297 passed; `tests/tools` 3707 passed / 8 failed, the same 8 ids as `main` on this host (lerobot-version drift plus one sdk-presence test).

## LOC

+563 / -54. Production is +168 / -16 with the rule single-sourced instead of copied into both verbs; the rest is the 296-line grader (16 cells over two modules), a 31-line changelog fragment and 19 lines of docs. The additions are the pins for a safety verdict that had none - the only existing grader over this code asserted the wrong answer.