### PR TITLE
fix(ci): the whole-tree grader preflight derives its roster from the tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,12 +366,15 @@ hatch run format            # ruff check --fix, ruff format
    other observed collision shares, 14m 41s and 29m 26s apart.
 2. Make changes, run `hatch run format && hatch run lint && hatch run test`.
    If you narrow the test run to the area you changed (`pytest tests/drivers/ -k g1`),
-   run `hatch run whole-tree-check` alongside it. A handful of graders take the
+   run `hatch run whole-tree-check` alongside it. Around sixty graders take the
    *rest of the repository* as their input rather than the file under change, so
    no path or `-k` filter over your own area collects them - and a green narrow
    run reads in a PR description exactly like a green full one. Two consecutive
    verb ports cited such a run and both landed with the required check red on the
-   same grader (#2934, #2938, per #2940).
+   same grader (#2934, #2938, per #2940). That command derives its roster from
+   the tree - a grader that walks the repository root or a top-level Python area
+   is collected on arrival - so adding one needs no second edit to register it
+   (#3105).
 3. Record the change as a news fragment: `changelog.d/<pr-number>-<slug>.md`
    (see [`changelog.d/README.md`](changelog.d/README.md)). **Never append to
    `## [Unreleased]` in `CHANGELOG.md` directly** - every branch inserts at the

--- a/changelog.d/3107-whole-tree-grader-roster-derived.md
+++ b/changelog.d/3107-whole-tree-grader-roster-derived.md
@@ -1,0 +1,23 @@
+### Fixed: the whole-tree grader preflight derives its roster from the tree
+
+`hatch run whole-tree-check` runs the graders whose input is the *rest* of the
+repository, the class a `-k` keyword or a `tests/drivers/` path does not
+collect. Its roster was a hand-written tuple of seven, so a grader added later
+was absent from it by default - and the absence read in the reassuring
+direction, because the preflight passed by never collecting the grader that
+would have failed. A branch cited a green preflight while the required check
+went red on `tests/test_mesh_pacing_ticker.py`, which walks the installed
+package and was never named (#3105).
+
+The roster is now read off the tree: a grader that walks the repository root or
+one of its top-level Python areas is collected on arrival, so adding one needs
+no second edit to register it. Membership is decided by the walk's resolved
+*value* rather than its AST shape, which is what separates a repository walk
+from a subject test globbing its own fixture directory - the reason an earlier
+shape-based scan was rejected. All three spellings of the package root in use
+here resolve, including `inspect.getfile(strands_robots)` and a root bound
+under an alias.
+
+The preflight now collects 62 graders instead of 7 (60 derived plus 2 that walk
+no resolvable path and stay named explicitly, each with its reason). A run over
+this tree goes from 298 to 1763 test outcomes and from 35s to 3m43s.

--- a/scripts/check_whole_tree_graders.py
+++ b/scripts/check_whole_tree_graders.py
@@ -4,23 +4,10 @@
 Why this exists
 ---------------
 Several tests in this repository derive their expectation from the whole tree
-rather than from any single file under change:
-
-- ``tests/test_docstring_xref_roles_resolve.py`` -- every fully-qualified
-  ``strands_robots.*`` cross-reference role must resolve against the real API.
-- ``tests/test_no_host_paths.py`` -- no source file may hard-code a per-machine
-  host path (``/Users/<name>``, ``/home/<user>/...`` and siblings).
-- ``tests/test_dependency_audit.py`` -- every declared dependency is either
-  imported or explicitly documented.
-- ``tests/tools/test_agent_tool_parameter_descriptions.py`` -- every
-  ``@tool``-decorated verb pins a parameter description for each argument.
-- ``tests/test_parameter_deletes_precede_the_body_they_narrow.py`` -- a
-  ``del <param>`` inside a function must precede the block it narrows, not
-  trail the return.
-- ``tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py`` -- no
-  test module may be named after the tracker item that birthed it.
-- ``tests/tools/test_agent_tool_parameters_reach_the_body.py`` -- no ``@tool``
-  may advertise a parameter its body never reads.
+rather than from any single file under change: every declared dependency is
+imported or documented, no source file hard-codes a host path, every
+``strands_robots.*`` cross-reference role resolves, no log string carries a
+non-ASCII character, and so on.
 
 These have one property in common: their input is the *rest* of the repository,
 not the file under change. A path- or ``-k``-scoped pytest run collects none of
@@ -37,17 +24,40 @@ series and dead on arrival in the branch's tree. Both were caught by a
 reviewer, not by CI on the branch (``call-test-lint`` reads the head alone, so
 being behind ``main`` does not update the graders' input).
 
-What this does
---------------
-Collects and runs exactly the whole-tree graders, by their fully-qualified
-node ids, so a preflight step cannot silently skip one by keyword or path
-selection. The roster is a single ``WHOLE_TREE_GRADERS`` tuple below; every
-entry is a test file this script guarantees to collect. The tuple is *pinned*
-by ``tests/test_whole_tree_graders_roster_is_complete.py`` so that a new
-whole-tree grader added to ``tests/`` without an entry here fails a required
-check -- which is what keeps the two artifacts (the grader itself and the
-preflight command) from drifting the way the two PRs above drifted from
-``main``.
+How the roster is built
+-----------------------
+The roster is *derived from the tree*, not written down. A grader whose input
+is the rest of the repository has a structural signature: it walks a directory
+that is the repository root or one of its top-level Python areas (including the
+installed ``strands_robots`` package root), then grades every file the walk
+yields. :func:`derive_graders` finds those by resolving each walk's receiver to
+a concrete path and keeping the modules whose walk lands on such an area.
+
+A hand-maintained list was tried first and is what this derivation replaces.
+Its failure mode is that a whole-tree grader added later is absent from it *by
+default*, and the absence is silent in the reassuring direction: the preflight
+passes because it never collected the grader that would have failed. Issue
+#3105 records that arriving in review - a branch cited a green preflight over a
+roster that did not name the grader the required check then failed on.
+
+Deciding membership by the walk's resolved *value* is what makes the derivation
+usable. An earlier attempt keyed on the AST shape alone and was rejected for a
+good reason: a subject test globbing its own fixture directory is
+shape-identical to one walking the repository. It is not value-identical -
+``Path(__file__).parent / "fixtures"`` and ``tmp_path`` are neither the
+repository root nor a top-level area - so resolving the path separates them.
+Measured over this repository, the derivation selects 60 of 1461 test modules.
+
+A walk rooted *inside* a subpackage (``strands_robots/policies/``) is
+deliberately not selected: a path-scoped run over the mirroring test directory
+does collect it, so it is not in the class this script exists to rescue.
+
+:data:`UNDERIVABLE_GRADERS` carries the graders whose population is the tree
+but whose walk the derivation cannot resolve - one enumerates a package with
+``pkgutil.iter_modules`` and so walks no path at all. Each entry states its
+reason, because a list that grows without one is the hand-maintained roster
+returning under a new name; ``tests/test_whole_tree_graders_roster_is_complete``
+refuses an entry the derivation *can* see.
 
 Exit codes
 ----------
@@ -71,31 +81,41 @@ Usage
     # Via hatch (installs the test extras first)
     hatch run whole-tree-check
 
-Neither form takes arguments. This is deliberate: the whole point of the
-script is that its input set is fixed, not composed by a caller.
+Neither form takes arguments. This is deliberate: the input set is a property
+of the tree, not something a caller composes.
 """
 
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 from pathlib import Path
 
-# The roster of whole-tree graders. Every entry is a path relative to the
-# repository root that ``pytest`` collects as a test module. Order is only
-# cosmetic (pytest resolves each independently), and duplicates are refused by
-# the roster-completeness pin, not by this script.
-#
-# Add a new grader here when you add one to ``tests/``. The roster-completeness
-# pin will fail a required check otherwise.
-WHOLE_TREE_GRADERS: tuple[str, ...] = (
-    "tests/test_docstring_xref_roles_resolve.py",
-    "tests/test_no_host_paths.py",
-    "tests/test_dependency_audit.py",
-    "tests/tools/test_agent_tool_parameter_descriptions.py",
-    "tests/test_parameter_deletes_precede_the_body_they_narrow.py",
-    "tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py",
-    "tests/tools/test_agent_tool_parameters_reach_the_body.py",
+#: The package whose root counts as a whole-tree walk target.
+PACKAGE = "strands_robots"
+
+#: Directory-walking calls. ``ast.walk`` shares the ``walk`` name and is not a
+#: false positive: its receiver is the ``ast`` module, which resolves to no
+#: path, so it is dropped for want of a target rather than by a name exception.
+_WALK_METHODS = frozenset({"rglob", "glob", "iterdir", "walk"})
+
+#: Callables that answer "the file this module was loaded from".
+_MODULE_FILE_FUNCS = frozenset({"getfile", "getsourcefile"})
+
+#: Graders whose input is the tree but whose walk :func:`derive_graders`
+#: cannot resolve, each with the reason it is invisible. The roster pin refuses
+#: an entry here that the derivation can already see, so this stays a list of
+#: genuine blind spots rather than growing back into a hand-maintained roster.
+UNDERIVABLE_GRADERS: tuple[tuple[str, str], ...] = (
+    (
+        "tests/tools/test_agent_tool_parameter_descriptions.py",
+        "enumerates the tool package with pkgutil.iter_modules, so it walks no path",
+    ),
+    (
+        "tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py",
+        "walks (_REPO_ROOT / area) for area in a tuple, so the walked path is a loop variable",
+    ),
 )
 
 
@@ -110,8 +130,228 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def walk_targets(root: Path) -> frozenset[Path]:
+    """Return the directories whose walk means "the rest of the repository".
+
+    The repository root plus each of its top-level Python areas, derived by
+    listing the root rather than naming them, so an area added later counts on
+    arrival.
+
+    :param root: The repository root.
+    :returns: The set of paths a whole-tree grader may walk.
+    """
+    targets = {root}
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir() and not entry.name.startswith(".") and any(entry.rglob("*.py")):
+            targets.add(entry)
+    return frozenset(targets)
+
+
+def _module_file(dotted: str, root: Path) -> Path | None:
+    """Return the file a first-party dotted module name loads from, if any.
+
+    Third-party modules resolve to ``None``: a grader walking somebody else's
+    installed package is not grading this tree.
+    """
+    if dotted != PACKAGE and not dotted.startswith(f"{PACKAGE}."):
+        return None
+    relative = Path(*dotted.split("."))
+    for candidate in (root / relative / "__init__.py", root / relative.with_suffix(".py")):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _imported_module_files(tree: ast.Module, root: Path) -> dict[str, Path]:
+    """Map each locally bound name of a first-party module to its file.
+
+    Both import forms and any ``as`` alias are read, so a package reached under
+    a local name (``from strands_robots import tools as tools_pkg``) resolves
+    the same as one imported plainly. The alias matters: binding under another
+    name is the ordinary way to avoid shadowing, and a scan that keyed on the
+    imported spelling would be blind to exactly the modules that took care.
+    """
+    bindings: dict[str, Path] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                # ``import a.b`` binds ``a``; ``import a.b as c`` binds ``c``.
+                dotted = alias.name if alias.asname else alias.name.split(".")[0]
+                found = _module_file(dotted, root)
+                if found is not None:
+                    bindings[alias.asname or dotted] = found
+        elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
+            for alias in node.names:
+                found = _module_file(f"{node.module}.{alias.name}", root)
+                if found is not None:
+                    bindings[alias.asname or alias.name] = found
+    return bindings
+
+
+def _resolve(node: ast.AST, module_path: Path, bindings: dict[str, Path], root: Path) -> Path | tuple[str, Path] | None:
+    """Resolve a path expression to a concrete path, or ``None`` if unknown.
+
+    Handles the spellings this repository's graders actually use: ``Path`` of a
+    module file, ``.resolve()``, ``.parent``, ``.parents[n]``, ``/`` with a
+    literal segment, a module-level name, and a zero-argument module-level
+    helper. Anything else is unresolved, which is the safe direction - an
+    unresolved walk is reported by :data:`UNDERIVABLE_GRADERS`, never silently
+    counted as a whole-tree walk.
+
+    :returns: The resolved path, a ``("parents", base)`` marker awaiting a
+        subscript, or ``None``.
+    """
+    if isinstance(node, ast.Name):
+        return bindings.get(node.id)
+    if isinstance(node, ast.Call):
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name == "Path" and node.args:
+            return _resolve_module_file(node.args[0], module_path, bindings, root)
+        if name in {"resolve", "absolute"} and isinstance(func, ast.Attribute):
+            return _resolve(func.value, module_path, bindings, root)
+        if isinstance(func, ast.Name) and not node.args:
+            return bindings.get(f"{func.id}()")
+        return None
+    if isinstance(node, ast.Attribute):
+        if node.attr == "parent":
+            base = _resolve(node.value, module_path, bindings, root)
+            return base.parent if isinstance(base, Path) else None
+        if node.attr == "parents":
+            base = _resolve(node.value, module_path, bindings, root)
+            return ("parents", base) if isinstance(base, Path) else None
+        return None
+    if isinstance(node, ast.Subscript):
+        base = _resolve(node.value, module_path, bindings, root)
+        index = node.slice
+        if (
+            isinstance(base, tuple)
+            and isinstance(index, ast.Constant)
+            and isinstance(index.value, int)
+            and not isinstance(index.value, bool)
+        ):
+            try:
+                return base[1].parents[index.value]
+            except IndexError:
+                return None
+        return None
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        base = _resolve(node.left, module_path, bindings, root)
+        segment = node.right
+        if isinstance(base, Path) and isinstance(segment, ast.Constant) and isinstance(segment.value, str):
+            return base / segment.value
+        return None
+    return None
+
+
+def _resolve_module_file(node: ast.AST, module_path: Path, bindings: dict[str, Path], root: Path) -> Path | None:
+    """Resolve the argument of ``Path(...)`` to a file on disk.
+
+    Three spellings reach the same fact and all are read, because a scan that
+    knew only one would report a clean sweep over a tree using another:
+    ``__file__`` (this module), ``<module>.__file__``, and
+    ``inspect.getfile(<module>)``.
+    """
+    if isinstance(node, ast.Name) and node.id == "__file__":
+        return module_path
+    if isinstance(node, ast.Attribute) and node.attr == "__file__" and isinstance(node.value, ast.Name):
+        return bindings.get(node.value.id)
+    if isinstance(node, ast.Call):
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name in _MODULE_FILE_FUNCS and len(node.args) == 1 and isinstance(node.args[0], ast.Name):
+            return bindings.get(node.args[0].id)
+    resolved = _resolve(node, module_path, bindings, root)
+    return resolved if isinstance(resolved, Path) else None
+
+
+def _module_bindings(tree: ast.Module, module_path: Path, root: Path) -> dict[str, Path]:
+    """Resolve every module-level name and zero-argument helper to a path.
+
+    Graders spell their root as a module constant (``_REPO_ROOT``) or as a
+    helper (``def _package_root() -> Path``); both are read. The loop repeats
+    so a constant defined in terms of an earlier one resolves regardless of
+    the order the module happens to declare them in.
+    """
+    bindings = _imported_module_files(tree, root)
+    for _ in range(3):
+        for stmt in tree.body:
+            candidates: list[tuple[str, ast.expr]] = []
+            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+                candidates = [(stmt.targets[0].id, stmt.value)]
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name) and stmt.value is not None:
+                candidates = [(stmt.target.id, stmt.value)]
+            elif isinstance(stmt, ast.FunctionDef) and not stmt.args.args:
+                returned = [n.value for n in ast.walk(stmt) if isinstance(n, ast.Return) and n.value is not None]
+                # One return is the whole helper's answer; several would need
+                # a branch analysis this does not attempt.
+                if len(returned) == 1:
+                    candidates = [(f"{stmt.name}()", returned[0])]
+            for name, value in candidates:
+                resolved = _resolve(value, module_path, bindings, root)
+                if isinstance(resolved, Path):
+                    bindings[name] = resolved
+    return bindings
+
+
+def walked_paths(source: str, module_path: Path, root: Path) -> set[Path]:
+    """Return every directory ``source`` walks that resolves to a concrete path.
+
+    :param source: The module's source text.
+    :param module_path: Where the module lives, so ``__file__`` resolves.
+    :param root: The repository root.
+    """
+    tree = ast.parse(source)
+    bindings = _module_bindings(tree, module_path, root)
+    targets: set[Path] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr in _WALK_METHODS:
+            resolved = _resolve(node.func.value, module_path, bindings, root)
+            if isinstance(resolved, Path):
+                targets.add(resolved)
+    return targets
+
+
+def derive_graders(root: Path) -> tuple[str, ...]:
+    """Return the test modules that walk the tree, as repo-relative posix paths.
+
+    :param root: The repository root.
+    :returns: Sorted paths of every module whose walk lands on a
+        :func:`walk_targets` directory.
+    """
+    targets = walk_targets(root)
+    found: set[str] = set()
+    for path in (root / "tests").rglob("test_*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            walked = walked_paths(source, path, root)
+        except SyntaxError:
+            # A module pytest itself cannot collect is not this script's to
+            # report; the run that collects it will say so.
+            continue
+        if walked & targets:
+            found.add(path.relative_to(root).as_posix())
+    return tuple(sorted(found))
+
+
+def roster(root: Path) -> tuple[str, ...]:
+    """Return every grader a preflight run collects.
+
+    The derived set plus :data:`UNDERIVABLE_GRADERS`, deduplicated and sorted
+    so the invocation is stable between runs on the same tree.
+
+    :param root: The repository root.
+    """
+    return tuple(sorted({*derive_graders(root), *(path for path, _reason in UNDERIVABLE_GRADERS)}))
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Run every entry in :data:`WHOLE_TREE_GRADERS` as a pytest invocation.
+    """Run every grader :func:`roster` derives as a single pytest invocation.
 
     :param argv: The command-line arguments this script received. Only the
         program name is honored; any additional argument prints usage on
@@ -123,8 +363,8 @@ def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv
     if len(args) > 1:
         sys.stderr.write(
-            "check_whole_tree_graders.py takes no arguments; "
-            "the grader roster is fixed by design (see module docstring).\n"
+            "check_whole_tree_graders.py takes no arguments; the grader roster "
+            "is derived from the tree (see module docstring).\n"
         )
         return 2
 
@@ -136,25 +376,28 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    # Verify each grader path exists before invoking pytest. A missing path
-    # would make pytest exit 4 ("usage error"), which reads to a caller like
-    # the script itself is broken; the earlier check names the missing file
-    # instead.
-    missing = [p for p in WHOLE_TREE_GRADERS if not (root / p).is_file()]
+    graders = roster(root)
+    # An entry naming a file that is gone can only come from
+    # UNDERIVABLE_GRADERS -- the derived half is read off the tree. Naming it
+    # beats pytest's exit 4 ("usage error"), which reads like this script is
+    # broken rather than like one hand-written entry is stale.
+    missing = [path for path in graders if not (root / path).is_file()]
     if missing:
-        sys.stderr.write("check_whole_tree_graders.py: the following graders in the roster do not exist on disk:\n")
+        sys.stderr.write("check_whole_tree_graders.py: the following graders do not exist on disk:\n")
         for path in missing:
             sys.stderr.write(f"  - {path}\n")
         sys.stderr.write(
-            "Either the grader was moved or renamed and the roster in this "
-            "script needs the matching update, or the working tree is stale. "
-            "The roster-completeness pin at "
-            "tests/test_whole_tree_graders_roster_is_complete.py grades the "
-            "opposite direction (a grader present in tests/ that is absent "
-            "from the roster).\n"
+            "Each is named in this script's UNDERIVABLE_GRADERS. Either the "
+            "grader was moved or renamed and that entry needs the matching "
+            "update, or it is gone and the entry should be dropped.\n"
         )
         return 1
 
+    sys.stderr.write(
+        f"check_whole_tree_graders.py: {len(graders)} graders "
+        f"({len(graders) - len(UNDERIVABLE_GRADERS)} derived from the tree, "
+        f"{len(UNDERIVABLE_GRADERS)} named explicitly)\n"
+    )
     cmd = [
         sys.executable,
         "-m",
@@ -169,7 +412,7 @@ def main(argv: list[str] | None = None) -> int:
         # ``.pytest_cache`` that a subsequent full run would then respect.
         "-p",
         "no:cacheprovider",
-        *WHOLE_TREE_GRADERS,
+        *graders,
     ]
     result = subprocess.run(cmd, cwd=root, check=False)
     return 0 if result.returncode == 0 else 1

--- a/tests/test_whole_tree_graders_roster_is_complete.py
+++ b/tests/test_whole_tree_graders_roster_is_complete.py
@@ -1,8 +1,8 @@
-"""Pin: the whole-tree graders named in strands-labs/robots#2940 are in the roster.
+"""Pin: the preflight roster is derived from the tree, so a new grader joins it.
 
 Why this exists
 ---------------
-``scripts/check_whole_tree_graders.py`` names the tests whose input is the
+``scripts/check_whole_tree_graders.py`` runs the tests whose input is the
 *rest* of the repository rather than the file under change - the class of
 check a diff-scoped ``pytest`` selector (a ``-k`` keyword, a
 ``tests/drivers/`` path) does not collect. Issue #2940 documents the failure
@@ -11,30 +11,30 @@ mode: two consecutive verb-port PRs (#2934, #2938) cited a green
 with ``call-test-lint`` red on the exact class of grader a narrow selector
 skipped.
 
-The remedy in ``scripts/check_whole_tree_graders.py`` is a fixed roster. This
-pin refuses if:
+That remedy was first written as a hand-maintained roster, and issue #3105
+records the second-order failure: a grader added later is absent from a hand
+list *by default*, and its absence is silent in the reassuring direction. A
+branch cited a green preflight over a roster of seven while the required check
+went red on ``tests/test_mesh_pacing_ticker.py``, which walks the installed
+package and was never named. The preflight could not have said otherwise - it
+never collected the file that failed.
 
-- an entry the roster names does not exist on disk (a rename that dropped the
-  script out of sync with the tree), or
-- one of the five graders named in issue #2940 is absent from the roster (the
-  five the issue documents by name, which are the minimum guarantee this
-  script offers a preflight caller).
+So the roster is now derived: a grader whose population is the tree is one that
+walks the repository root or a top-level Python area. This module grades that
+derivation, in both directions, because a derivation that silently selects
+nothing reads exactly like a tree with nothing to select:
 
-The pin does *not* try to auto-discover further whole-tree graders. That was
-tried and rejected: any test module that imports ``pathlib`` and calls
-``.glob(...)`` on a subject subtree looks structurally identical to one that
-walks the whole repository, so an AST-shape scan flags several hundred tests
-whose input is a single fixture directory. Enumerating that boundary is a
-maintainer-scoped decision - which tests are the ones a *narrow* selector
-cannot see - and belongs in the roster's own edits, not in an auto-scan that
-would demand an "add to exemptions" step every time a subject test uses
-``rglob``.
-
-If a new whole-tree grader is added later, the roster in the script grows by
-one line, this test's ``_ROSTERED_BY_ISSUE_2940`` set stays unchanged (its
-role is to pin the issue's roster, not to enumerate every future one), and
-``scripts/check_whole_tree_graders.py``'s module docstring's list of graders
-grows alongside.
+- the roster covers the graders the two issues name, including #3105's live
+  instance;
+- the derivation is not vacuous, and each spelling of "the package root" a
+  grader in this tree actually uses resolves (a resolver blind to one spelling
+  is the defect #3105 describes, one layer down);
+- a walk of a fixture directory or a ``tmp_path`` is *not* selected, which is
+  the property that makes deriving viable at all - an earlier AST-shape scan
+  was rejected because it could not tell those apart;
+- every entry in ``UNDERIVABLE_GRADERS`` is genuinely invisible to the
+  derivation, so that list cannot quietly grow back into the hand roster this
+  replaced.
 
 A roster only helps a caller who knows to run it. Issue #2940's failure mode
 was a *green* narrow run, so the remedy is only reachable if the pre-push
@@ -51,6 +51,8 @@ import importlib.util
 import tomllib
 from pathlib import Path
 
+import pytest
+
 _TESTS_ROOT = Path(__file__).resolve().parent
 _REPO_ROOT = _TESTS_ROOT.parent
 
@@ -65,89 +67,202 @@ _cwtg = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_cwtg)
 
 
-# The five graders issue #2940 names by filename. Reproduced verbatim from the
-# issue body so the diagnostic can point back at the source of the guarantee.
-_ROSTERED_BY_ISSUE_2940: frozenset[str] = frozenset(
+# The graders the two issues name by filename. #2940 named five; #3105 named
+# the sixth, which a hand roster had omitted and which is the reason the roster
+# is derived rather than written down.
+_NAMED_BY_ISSUES: frozenset[str] = frozenset(
     {
         "tests/test_docstring_xref_roles_resolve.py",
         "tests/test_no_host_paths.py",
         "tests/test_dependency_audit.py",
         "tests/tools/test_agent_tool_parameter_descriptions.py",
         "tests/test_parameter_deletes_precede_the_body_they_narrow.py",
+        "tests/test_mesh_pacing_ticker.py",
     }
 )
 
 
-def test_every_grader_named_in_issue_2940_is_in_the_roster() -> None:
-    """The five graders issue #2940 names are all rostered in the script.
+@pytest.fixture(scope="module")
+def roster() -> tuple[str, ...]:
+    """Every grader a preflight run of this tree collects."""
+    return _cwtg.roster(_REPO_ROOT)
 
-    The preflight script exists to run *these* five graders under a single
-    command; if one is missing from the roster, a preflight run silently
-    skips it and the issue's failure mode returns unreported.
+
+@pytest.fixture(scope="module")
+def derived() -> tuple[str, ...]:
+    """The half of the roster read off the tree."""
+    return _cwtg.derive_graders(_REPO_ROOT)
+
+
+def _selects(source: str, module_path: Path) -> bool:
+    """Whether the derivation would call a module with ``source`` a whole-tree grader.
+
+    :param source: Planted module source.
+    :param module_path: Where the module would live, so ``__file__`` resolves.
     """
-    rostered = set(_cwtg.WHOLE_TREE_GRADERS)
-    missing = _ROSTERED_BY_ISSUE_2940 - rostered
+    walked = _cwtg.walked_paths(source, module_path, _REPO_ROOT)
+    return bool(walked & _cwtg.walk_targets(_REPO_ROOT))
+
+
+def test_the_roster_covers_every_grader_the_issues_name(roster: tuple[str, ...]) -> None:
+    """The graders #2940 and #3105 name are all collected by a preflight run.
+
+    #3105's instance is the one that matters here: it was absent from the hand
+    roster, so a preflight run over that roster passed while the required
+    check failed on it.
+    """
+    missing = _NAMED_BY_ISSUES - set(roster)
     assert not missing, (
-        "the preflight script's WHOLE_TREE_GRADERS roster is missing "
-        "graders that issue #2940 names by filename; add each of them to "
-        "scripts/check_whole_tree_graders.py so a `hatch run "
-        "whole-tree-check` collects the class of test the issue documents:\n"
-        + "\n".join(f"  - {p!r}," for p in sorted(missing))
+        "a preflight run does not collect graders that issues #2940 and #3105 "
+        "name by filename. Each walks the tree, so a diff-scoped pytest "
+        "selector does not collect it either, and the failure mode both issues "
+        "document returns unreported:\n" + "\n".join(f"  - {path}" for path in sorted(missing))
     )
 
 
-def test_every_roster_entry_points_at_a_real_grader_file() -> None:
-    """Every entry in the script's roster is a file that exists.
+def test_the_derivation_is_not_vacuous(derived: tuple[str, ...]) -> None:
+    """A derivation that selected nothing would report a clean sweep.
 
-    The preflight script already refuses at runtime when a rostered path is
-    missing on disk, but the required call-test-lint check runs this test at
-    review time - catching a stale roster before a preflight run that would
-    exit 1 on the same tree.
+    The floor is deliberately far below the measured count (60 at the time of
+    writing): the point is to fail when the resolver breaks and selects
+    almost nothing, not to pin a number that every added grader edits.
     """
-    missing = [entry for entry in _cwtg.WHOLE_TREE_GRADERS if not (_REPO_ROOT / entry).is_file()]
-    assert not missing, (
-        "the preflight script's WHOLE_TREE_GRADERS roster names files that "
-        "do not exist on disk; either the grader was moved/renamed and the "
-        "roster needs the matching update, or the entry was added in "
-        "error:\n" + "\n".join(f"  - {p!r}" for p in missing)
+    assert len(derived) >= 20, (
+        f"the derivation selected only {len(derived)} whole-tree graders. It "
+        "resolves each walk's receiver to a concrete path, so a change that "
+        "stops resolving the spellings this tree uses makes the preflight "
+        "silently collect almost nothing."
     )
 
 
-def test_roster_has_no_duplicate_entries() -> None:
-    """A duplicate entry would silently run one grader twice.
+@pytest.mark.parametrize(
+    ("label", "root_expression"),
+    [
+        ("__file__ ancestry", "ROOT = pathlib.Path(__file__).resolve().parents[1]"),
+        ("module __file__", "ROOT = pathlib.Path(strands_robots.__file__).resolve().parent"),
+        ("inspect.getfile", "ROOT = pathlib.Path(inspect.getfile(strands_robots)).parent"),
+        ("helper returning the root", "def _root():\n    return pathlib.Path(inspect.getfile(strands_robots)).parent"),
+    ],
+)
+def test_every_spelling_of_the_root_a_grader_uses_resolves(label: str, root_expression: str) -> None:
+    """Each way this tree names the repository or package root is selected.
 
-    Enforced separately so the diagnostic names the duplicate rather than
-    trying to explain a set-equality failure.
+    Graders reach the same directory three ways, and a resolver that knew only
+    one would report a clean sweep over a tree using another - which is the
+    shape of defect #3105 describes, one layer down. ``label`` names the
+    spelling under test so a failure says which one stopped resolving.
     """
-    roster = list(_cwtg.WHOLE_TREE_GRADERS)
-    seen: set[str] = set()
-    duplicates: list[str] = []
-    for entry in roster:
-        if entry in seen:
-            duplicates.append(entry)
-        else:
-            seen.add(entry)
+    walker = "_root()" if root_expression.startswith("def ") else "ROOT"
+    source = f"import inspect\nimport pathlib\n\nimport strands_robots\n\n{root_expression}\n\nfor p in {walker}.rglob('*.py'):\n    pass\n"
+    assert _selects(source, _TESTS_ROOT / "test_planted.py"), (
+        f"the derivation cannot resolve a root spelled as {label}, so a grader "
+        "written that way is invisible to the preflight rather than merely "
+        "unrostered."
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "walk"),
+    [
+        ("a fixture directory beside the test", "(pathlib.Path(__file__).parent / 'fixtures').rglob('*.py')"),
+        ("a tmp_path handed in by pytest", "tmp_path.rglob('*.py')"),
+        (
+            "a subpackage of the installed package",
+            "(pathlib.Path(strands_robots.__file__).parent / 'policies').rglob('*.py')",
+        ),
+    ],
+)
+def test_a_subject_scoped_walk_is_not_a_whole_tree_grader(label: str, walk: str) -> None:
+    """Walking a fixture directory, a tmp_path or a subpackage is not selected.
+
+    This is the property that makes deriving viable. An AST-shape scan was
+    tried and rejected because a fixture glob is shape-identical to a
+    repository walk; it is not value-identical, and resolving the path is what
+    separates them. The subpackage case is excluded on its own merit: a
+    path-scoped run over the mirroring test directory does collect it, so it
+    is not in the class the preflight exists to rescue.
+    """
+    source = f"import pathlib\n\nimport strands_robots\n\ndef test_it(tmp_path):\n    for p in {walk}:\n        pass\n"
+    assert not _selects(source, _TESTS_ROOT / "subject" / "test_planted.py"), (
+        f"the derivation selected a module that only walks {label}. Every "
+        "subject test that globs its own fixtures would join the preflight, "
+        "which is the reason an earlier shape-based scan was rejected."
+    )
+
+
+def test_each_explicitly_named_grader_is_invisible_to_the_derivation(derived: tuple[str, ...]) -> None:
+    """``UNDERIVABLE_GRADERS`` holds only graders the derivation cannot see.
+
+    An entry the derivation already selects is a hand-maintained roster
+    growing back one line at a time, which is the thing #3105 asks to end.
+    """
+    redundant = [path for path, _reason in _cwtg.UNDERIVABLE_GRADERS if path in set(derived)]
+    assert not redundant, (
+        "these graders are named explicitly in UNDERIVABLE_GRADERS but the "
+        "derivation already selects them; drop the entries so the list stays "
+        "a record of genuine blind spots:\n" + "\n".join(f"  - {path}" for path in redundant)
+    )
+
+
+def test_each_explicitly_named_grader_states_why_it_is_invisible() -> None:
+    """Every explicit entry carries a reason.
+
+    A path with no reason cannot be re-examined later: a reader cannot tell
+    whether the derivation still misses it or whether the entry outlived the
+    blind spot it was added for.
+    """
+    unexplained = [path for path, reason in _cwtg.UNDERIVABLE_GRADERS if not reason.strip()]
+    assert not unexplained, (
+        "these UNDERIVABLE_GRADERS entries carry no reason, so a later reader "
+        "cannot tell whether the derivation still misses them:\n" + "\n".join(f"  - {path}" for path in unexplained)
+    )
+
+
+def test_every_roster_entry_points_at_a_real_grader_file(roster: tuple[str, ...]) -> None:
+    """Every entry in the roster is a file that exists.
+
+    Only ``UNDERIVABLE_GRADERS`` can go stale this way - the derived half is
+    read off the tree - and the preflight script already refuses at runtime.
+    This pin runs under the required check, catching a stale entry at review
+    time rather than at the preflight run that would exit 1 on the same tree.
+    """
+    missing = [entry for entry in roster if not (_REPO_ROOT / entry).is_file()]
+    assert not missing, (
+        "the preflight roster names files that do not exist on disk; either the "
+        "grader was moved or renamed and scripts/check_whole_tree_graders.py's "
+        "UNDERIVABLE_GRADERS needs the matching update, or the entry was added "
+        "in error:\n" + "\n".join(f"  - {entry!r}" for entry in missing)
+    )
+
+
+def test_the_roster_runs_each_grader_once(roster: tuple[str, ...]) -> None:
+    """No grader is collected twice.
+
+    The derived half and the explicit half are separate sources for one list,
+    so an entry could appear in both; a duplicate would run the grader twice
+    against the same tree for no added signal.
+    """
+    duplicates = sorted({entry for entry in roster if list(roster).count(entry) > 1})
     assert not duplicates, (
-        "the preflight script's WHOLE_TREE_GRADERS roster carries duplicate "
-        "entries; each grader should appear exactly once so a preflight run "
-        "does not repeat the work of one against the same tree:\n" + "\n".join(f"  - {p!r}" for p in duplicates)
+        "the preflight roster carries duplicate entries, so these graders run "
+        "twice against the same tree:\n" + "\n".join(f"  - {entry!r}" for entry in duplicates)
     )
 
 
 def test_script_has_no_arguments_beyond_the_program_name() -> None:
     """The preflight script's ``main`` refuses extra arguments.
 
-    The whole point of the roster is that the input set is fixed rather than
-    composed by a caller. A future edit that accepted an argument would break
-    that guarantee silently for any caller who happened not to pass one; this
-    pin makes such an edit a required-check failure.
+    The input set is a property of the tree, not something a caller composes.
+    A future edit that accepted an argument would break that guarantee
+    silently for any caller who happened not to pass one; this pin makes such
+    an edit a required-check failure.
     """
     # A ``main`` that returns 2 on any extra arg is the guarantee; check
     # the behaviour directly instead of an AST scan for signatures.
     assert _cwtg.main(["prog", "--anything"]) == 2, (
         "check_whole_tree_graders.py accepted an argument other than its "
-        "program name. The roster is meant to be fixed; a caller-composed "
-        "input set defeats the point of the preflight script."
+        "program name. The input set is derived from the tree; a "
+        "caller-composed one defeats the point of the preflight script."
     )
 
 


### PR DESCRIPTION
Closes #3105.

`hatch run whole-tree-check` runs the graders whose input is the *rest* of the repository -- the class a `-k` keyword or a `tests/drivers/` path does not collect. Its roster was a hand-written tuple of seven, so a grader added later was absent from it **by default**, and the absence read in the reassuring direction: the preflight passed because it never collected the grader that would have failed.

| | roster | collects `test_mesh_pacing_ticker.py` | outcomes | wall |
|---|---|---|---|---|
| before | 7 hand-written | **no** | 298 | 35s |
| after | **62** (60 derived + 2 explicit) | **yes** | 1763 | 3m43s |

```mermaid
graph LR
  subgraph before
    A["tuple of 7 filenames"] --> B["pytest"]
    N["grader added later"] -.->|"absent by default"| A
  end
  subgraph after
    T["tests/**/test_*.py (1461)"] --> R{"walk resolves to<br/>repo root or a<br/>top-level area?"}
    R -->|"yes: 60"| S["pytest"]
    R -->|"no"| X["not a whole-tree grader"]
    E["UNDERIVABLE_GRADERS (2)<br/>walks no resolvable path"] --> S
  end
```

## The change

A grader whose population is the tree walks the repository root or one of its top-level Python areas. So resolve each walk's receiver to a concrete path and select the modules whose walk lands there.

Deciding on the resolved **value** rather than the AST shape is what makes this viable. An earlier shape-based scan was tried and rejected for a good reason -- a subject test globbing its own fixture directory is shape-identical to a repository walk. It is not value-identical: `Path(__file__).parent / "fixtures"` and `tmp_path` are neither the repository root nor a top-level area. Measured, the derivation selects **60 of 1461** test modules.

All three spellings of the root in use here resolve, including a module bound under an alias -- a resolver that knew one spelling would be blind to exactly the modules that took care to avoid shadowing:

```python
ROOT = Path(__file__).resolve().parents[1]                 # __file__ ancestry
ROOT = Path(strands_robots.__file__).resolve().parent      # <module>.__file__
ROOT = Path(inspect.getfile(strands_robots)).parent        # inspect.getfile
```

That third one is how `test_mesh_pacing_ticker.py` -- #3105's live instance -- spells it.

A walk rooted *inside* a subpackage (`strands_robots/policies/`) is deliberately not selected: a path-scoped run over the mirroring test directory does collect it, so it is not in the class this script exists to rescue.

`UNDERIVABLE_GRADERS` holds the two graders that walk no resolvable path (one enumerates a package with `pkgutil.iter_modules`), each with its reason. It cannot quietly become the old roster again: the pin refuses an entry the derivation already sees, and refuses one carrying no reason.

## Regression test

Pre-fix reading taken by reverting **only the mechanism** -- `roster()` returns the old seven-entry tuple while every new helper stays defined, so the module still imports and the derivation controls remain real controls:

```
before:  1 failed, 14 passed
after:  15 passed

FAILED test_the_roster_covers_every_grader_the_issues_name
E   a preflight run does not collect graders that issues #2940 and #3105 name by filename...
E       - tests/test_mesh_pacing_ticker.py
```

The 14 that pass pre-fix are the controls. Beyond the completeness cell the pin grades the derivation in both directions, because one that silently selects nothing reads exactly like a tree with nothing to select: non-vacuity, each root spelling resolving (parametrized, so a failure names which one broke), and -- the other direction -- that a fixture-directory walk, a `tmp_path` walk and a subpackage walk are each **not** selected.

## Gate

- `ruff check strands_robots tests tests_integ` clean; `ruff format --check` clean.
- `mypy strands_robots tests tests_integ`: 20 errors in 6 files, unchanged from `main` and none in the changed files. `mypy scripts/check_whole_tree_graders.py`: clean.
- `tests/test_whole_tree_graders_roster_is_complete.py`: 15 passed. `tests/test_changelog_fragments.py`: 28 passed.
- `python scripts/check_whole_tree_graders.py`: `62 graders (60 derived from the tree, 2 named explicitly)`, 1760 passed / 50 skipped / 3 failed in 3m43s. The three failures -- absent `qpsolvers` metadata and two `lerobot` symbol-drift assertions (`reanchor_relative_rtc_prefix`) -- reproduce identically on pristine `main`, so they are environment-dependent and pre-existing rather than introduced here.

## LOC

+520 / -136 across 4 files, net **+384** -- an addition, so: 304 of the added lines are `scripts/check_whole_tree_graders.py`, of which roughly half is the module docstring recording why deriving is safe and why the shape-based attempt was not. The mechanism replaces a 7-line list with coverage of 60 graders, and the pin's growth (+188/-73) is the two-directional grading that keeps the derivation honest. No behaviour in `strands_robots` is touched.