### PR TITLE
fix(drivers): a stop() that could not halt the robot says so

### DIFF
--- a/changelog.d/3108-stop-hook-logs-the-halt-it-could-not-complete.md
+++ b/changelog.d/3108-stop-hook-logs-the-halt-it-could-not-complete.md
@@ -1,0 +1,24 @@
+### Fixed: a `stop()` that could not halt the robot says so
+
+`HardwareDriver.stop` is annotated `-> None` on all twelve shipped drivers, so it
+carries no verdict - which makes its log the only place a halt it could not
+complete can be recorded. Three drivers delegated to a verb that decides one and
+threw the answer away: `BoosterDriver.stop` and `EarthRoverDriver.stop` dropped
+`stop_task()`'s envelope, and `CrazyflieDriver.stop` dropped `land()`'s.
+
+For the two ground robots the refusal is an ordinary hardware failure -
+`BoosterDriver.move` reports a `RuntimeError` from `MoveCommand` as "the T1
+refused the twist", and `EarthRoverDriver.send_action` reports a `/control` POST
+that did not land. Because `stop` returns `None` and wrote nothing, a fleet
+teardown had no surface anywhere - envelope, flag or log - saying the robot had
+not stopped: a velocity-commanded rover holds its last command until another one
+arrives, so an unsent zero twist leaves it driving.
+
+Each hook now reads the envelope and logs a non-success naming what may still be
+moving. `strands_robots.drivers.halt_failure_detail` renders the reason, because
+the shipped halt verbs answer in two shapes - a refusal text, and a per-half
+outcome dict naming which half of the T1's two-part halt failed - and a failure
+it cannot parse still reports as a failure rather than as a landed halt. The
+`stop` contract now states the obligation it always had, and a regression test
+derives the rule over the whole fleet: a `stop` that calls one of its own
+envelope-returning verbs must read what that verb answered.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -130,6 +130,15 @@ members it is missing, so a half-built driver fails at the line that registers i
 than on the first agent call. `port=` stays polymorphic - a serial path, an IP address or a
 URL - because only the driver knows how to read it.
 
+A driver has **two** ways to halt its robot and they are not the same contract. `stop_task()`
+returns a status envelope and decides an outcome, so that is what a caller reads. `stop()` is
+the lifecycle hook and is annotated `-> None`, so it carries no verdict at all - which makes
+its log the only place a halt it could not complete can be recorded. A `stop()` that
+delegates to a halt verb must therefore read that verb's envelope and log a non-success,
+naming what may still be moving; `strands_robots.drivers.halt_failure_detail` reads the
+reason out of one. Discarding it returns from shutdown reporting the robot as stopped on the
+one surface that has no way to say otherwise.
+
 Asking for a driver that is not there is refused, never quietly substituted:
 
 ```python

--- a/strands_robots/drivers/__init__.py
+++ b/strands_robots/drivers/__init__.py
@@ -21,6 +21,7 @@ from strands_robots.drivers.base import (
     DRIVER_CHOICES,
     DRIVER_SURFACE,
     HardwareDriver,
+    halt_failure_detail,
     missing_driver_members,
 )
 from strands_robots.drivers.registry import (
@@ -128,6 +129,7 @@ __all__ = [
     "HardwareDriver",
     "driver_choice_error",
     "get_native_driver_class",
+    "halt_failure_detail",
     "list_driver_coverage",
     "list_native_drivers",
     "missing_driver_members",

--- a/strands_robots/drivers/base.py
+++ b/strands_robots/drivers/base.py
@@ -183,7 +183,17 @@ class HardwareDriver(Protocol):
         """
 
     async def stop(self) -> None:
-        """Stop motion and any background loop, leaving the robot connected."""
+        """Stop motion and any background loop, leaving the robot connected.
+
+        Annotated ``-> None``, so it carries no verdict: a caller that needs the
+        halt outcome reads :meth:`stop_task`, which decides one. That is exactly
+        what makes the log the *only* place a halt this hook could not complete
+        can be recorded, so an implementation that delegates to a halt verb must
+        read that verb's envelope and log a non-success, naming what may still be
+        moving. Discarding it returns from shutdown reporting a robot as stopped
+        on the one surface that carries no way to say otherwise.
+        :func:`halt_failure_detail` reads the reason out of such an envelope.
+        """
 
     def cleanup(self) -> None:
         """Release the device and every background resource held for it."""
@@ -226,3 +236,37 @@ def missing_driver_members(candidate: object) -> tuple[str, ...]:
         satisfies the whole surface.
     """
     return tuple(name for name in DRIVER_SURFACE if not hasattr(candidate, name))
+
+
+def halt_failure_detail(envelope: dict[str, Any]) -> str | None:
+    """Read why a halt did not complete, or ``None`` when it did.
+
+    :meth:`HardwareDriver.stop` carries no verdict, so the envelope of the halt
+    verb it delegates to is the only one there is and the log is the only place
+    it survives. This renders that envelope as the detail such a log line
+    quotes, in one place rather than once per driver, because the shipped halt
+    verbs answer in two shapes: a refusal *text*, and a per-half *outcome* dict
+    naming which half of a two-part halt failed.
+
+    Args:
+        envelope: The halt verb's own status envelope.
+
+    Returns:
+        The reason, or ``None`` when ``envelope`` reports success. A non-success
+        envelope always yields a string - a failure whose content this cannot
+        parse still reports as a failure, because returning ``None`` there would
+        read as "the halt landed".
+    """
+    if envelope.get("status") == "success":
+        return None
+    blocks = [block for block in envelope.get("content") or [] if isinstance(block, dict)]
+    if texts := [str(block["text"]).strip() for block in blocks if block.get("text")]:
+        return " ".join(texts)
+    if payloads := [block["json"] for block in blocks if "json" in block]:
+        return "; ".join(
+            ", ".join(f"{key}={value!r}" for key, value in sorted(payload.items()))
+            if isinstance(payload, dict)
+            else repr(payload)
+            for payload in payloads
+        )
+    return "no detail reported"

--- a/strands_robots/drivers/booster.py
+++ b/strands_robots/drivers/booster.py
@@ -53,6 +53,7 @@ import threading
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import halt_failure_detail
 from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.utils import boolean_flag_error, dds_domain_id_error, finite_number_error
 
@@ -630,8 +631,21 @@ class BoosterDriver:
         }
 
     async def stop(self) -> None:
-        """Halt locomotion and hand the upper body back. Never raises."""
-        self.stop_task()
+        """Halt locomotion and hand the upper body back. Never raises.
+
+        Annotated ``-> None`` by the driver protocol, so it carries no verdict:
+        a caller that needs the halt outcome reads :meth:`stop_task`, which
+        decides one for each half. Both halves are attempted either way, and a
+        halt that did not complete is logged - the T1 walks under its own
+        controller, so a refused twist leaves it walking, and a refused release
+        leaves the host holding the arms.
+        """
+        if (detail := halt_failure_detail(self.stop_task())) is not None:
+            logger.error(
+                "%s.stop(): the halt did not complete, and the T1 may still be walking or holding the upper body: %s",
+                self._tool_name,
+                detail,
+            )
 
     def cleanup(self) -> None:
         """Release the SDK channels. Idempotent, and stops first."""

--- a/strands_robots/drivers/crazyflie.py
+++ b/strands_robots/drivers/crazyflie.py
@@ -98,6 +98,7 @@ import threading
 from collections.abc import AsyncGenerator, Mapping
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import halt_failure_detail
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.utils import (
     finite_number_error,
@@ -1082,10 +1083,15 @@ class CrazyflieDriver:
         the ground. So this **lands**; it never cuts the motors. Cutting them is
         :meth:`emergency_stop`, which a caller has to name.
         """
-        if self.is_connected:
-            self.land()
-        else:
+        if not self.is_connected:
             self._halt_repeater()
+            return
+        if (detail := halt_failure_detail(self.land())) is not None:
+            logger.error(
+                "%s.stop(): the descent was refused, and the aircraft may still be flying: %s",
+                self._tool_name,
+                detail,
+            )
 
     def cleanup(self) -> None:
         """Land, stop the log block and close the radio link.

--- a/strands_robots/drivers/earthrover.py
+++ b/strands_robots/drivers/earthrover.py
@@ -38,6 +38,7 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import halt_failure_detail
 from strands_robots.utils import finite_number_error, positive_finite_number_error
 
 if TYPE_CHECKING:
@@ -332,8 +333,21 @@ class EarthRoverDriver:
         }
 
     async def stop(self) -> None:
-        """Command a zero twist, leaving the rover connected. Never raises."""
-        self.stop_task()
+        """Command a zero twist, leaving the rover connected. Never raises.
+
+        Annotated ``-> None`` by the driver protocol, so it carries no verdict:
+        a caller that needs the halt outcome reads :meth:`stop_task`, which
+        decides one. A zero twist that did not reach the SDK is logged, because
+        a velocity-commanded base holds its last command until another one
+        arrives - so an unsent halt leaves the rover driving.
+        """
+        if (detail := halt_failure_detail(self.stop_task())) is not None:
+            logger.error(
+                "%s.stop(): the zero twist did not reach the rover, which may still be "
+                "driving at the commanded velocity: %s",
+                self._tool_name,
+                detail,
+            )
 
     def cleanup(self) -> None:
         """Stop the wheels, then release the session. Idempotent.

--- a/tests/drivers/test_stop_hook_logs_the_halt_it_could_not_complete.py
+++ b/tests/drivers/test_stop_hook_logs_the_halt_it_could_not_complete.py
@@ -101,7 +101,7 @@ def _envelope_verbs(cls: type) -> set[str]:
     for name, _ in inspect.getmembers(cls, predicate=inspect.isfunction):
         try:
             node = _method_ast(cls, name)
-        except (OSError, TypeError, SyntaxError, IndentationError):  # pragma: no cover - C or builtin
+        except (OSError, TypeError, SyntaxError):  # pragma: no cover - C or builtin
             continue
         returns = getattr(node, "returns", None)
         if returns is not None and ast.unparse(returns) == _ENVELOPE_RETURN:

--- a/tests/drivers/test_stop_hook_logs_the_halt_it_could_not_complete.py
+++ b/tests/drivers/test_stop_hook_logs_the_halt_it_could_not_complete.py
@@ -1,0 +1,408 @@
+"""The verdict-free ``stop`` hook logs a halt it could not complete.
+
+:data:`~strands_robots.drivers.base.DRIVER_SURFACE` carries two ways to halt a
+robot and only one of them can answer. ``stop_task`` returns an envelope and
+*decides*; ``stop`` is annotated ``-> None`` on every shipped driver, so it
+carries no verdict at all. ``tests/drivers/test_agent_stop_verb_reports_the_halt_outcome``
+grades the first consequence of that asymmetry - the agent-facing verb must hand
+back ``stop_task``'s envelope rather than build one beside the hook - and its own
+premise names the second: ``stop`` is verdict-free *because* it logs, "the
+Microduck ... logs an ``OSError`` from robotd, the Mini logs a daemon that
+declined".
+
+That premise was never graded, and three drivers did not hold it. Each one's
+``stop`` delegated to a verb that returns an envelope and dropped it on the
+floor:
+
+======================  ====================  ==================================
+driver                  discarded envelope    what a refusal leaves running
+======================  ====================  ==================================
+``BoosterDriver``       ``stop_task()``       the T1 walking, or the host still
+                                              holding the upper body
+``EarthRoverDriver``    ``stop_task()``       the rover driving at the last
+                                              commanded velocity
+``CrazyflieDriver``     ``land()``            the aircraft flying
+======================  ====================  ==================================
+
+For the two ground robots the refusal is an ordinary hardware failure -
+``BoosterDriver.move`` reports a ``RuntimeError`` from ``MoveCommand`` as
+``"the T1 refused the twist"``, and ``EarthRoverDriver.send_action`` reports a
+``/control`` POST that did not land. Because ``stop`` returns ``None`` and wrote
+nothing, a fleet teardown that called it had **no** surface anywhere - envelope,
+flag or log - saying the robot had not stopped. ``CrazyflieDriver.land`` re-checks
+the link that ``stop`` just checked, so its refusal needs a disconnect racing the
+two, which makes it a latent hole rather than a reproduced field failure; it is
+fixed here because the rule below is derived from the code and does not have a
+category for "discards a verdict, but only rarely".
+
+The relation is what makes the next driver graded on arrival, and it is derived
+rather than listed: *a ``stop`` that calls one of its own envelope-returning
+verbs must read what that verb answered.* Nine of the twelve shipped drivers
+already satisfied it - seven log the failure directly at the wire and two read a
+delegated envelope first - so this pins the shape they already have.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import logging
+import sys
+import textwrap
+import types
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers as drivers_pkg
+from strands_robots.drivers.base import halt_failure_detail
+from strands_robots.drivers.registry import get_native_driver_class
+
+# Reused wholesale from each driver's own suite: the SDK doubles and the
+# connected-driver helpers. Every name imported here is a plain class or
+# function, never a fixture, so importing them binds no fixture name.
+from tests.drivers.test_booster_driver import _FakeSdk
+from tests.drivers.test_booster_driver import _live_driver as _live_booster
+from tests.drivers.test_earthrover_driver import _FakeResponse, _FakeSession
+from tests.drivers.test_earthrover_driver import _live_driver as _live_rover
+
+#: The annotated return type that makes a driver method a status envelope.
+_ENVELOPE_RETURN = "dict[str, Any]"
+
+
+# --------------------------------------------------------------------------- #
+# The derived relation.                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _driver_classes() -> dict[str, type]:
+    """Every distinct native driver class the registry can build."""
+    return {
+        cls.__name__: cls
+        for cls in (get_native_driver_class(robot) for robot in drivers_pkg.list_native_drivers())
+        if cls is not None
+    }
+
+
+def _method_ast(cls: type, name: str) -> ast.AST:
+    """Parse one method of ``cls`` into an AST node."""
+    return ast.parse(textwrap.dedent(inspect.getsource(getattr(cls, name)))).body[0]
+
+
+def _envelope_verbs(cls: type) -> set[str]:
+    """Which of ``cls``'s own methods answer with a status envelope.
+
+    Read from the annotation rather than from a name list, so a halt verb spelled
+    something other than ``stop_task`` - the aircraft's ``land`` - is in scope
+    without being named here.
+    """
+    verbs = set()
+    for name, _ in inspect.getmembers(cls, predicate=inspect.isfunction):
+        try:
+            node = _method_ast(cls, name)
+        except (OSError, TypeError, SyntaxError, IndentationError):  # pragma: no cover - C or builtin
+            continue
+        returns = getattr(node, "returns", None)
+        if returns is not None and ast.unparse(returns) == _ENVELOPE_RETURN:
+            verbs.add(name)
+    return verbs
+
+
+def _discarded_envelopes(node: ast.AST, verbs: set[str]) -> list[str]:
+    """Envelope verbs this body calls as a bare statement, throwing the answer away."""
+    discarded = []
+    for stmt in ast.walk(node):
+        if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+            continue
+        func = stmt.value.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "self"
+            and func.attr in verbs
+        ):
+            discarded.append(func.attr)
+    return sorted(discarded)
+
+
+class TestThePremise:
+    """The hook cannot answer, so the log is the only place a failure survives."""
+
+    def test_the_census_reaches_the_whole_shipped_fleet(self) -> None:
+        classes = _driver_classes()
+        assert len(classes) >= 10, f"the driver census went blind: {sorted(classes)}"
+        assert {"BoosterDriver", "CrazyflieDriver", "EarthRoverDriver"} <= set(classes)
+
+    @pytest.mark.parametrize("name", sorted(_driver_classes()))
+    def test_the_hook_carries_no_verdict(self, name: str) -> None:
+        node = _method_ast(_driver_classes()[name], "stop")
+        assert isinstance(node, ast.AsyncFunctionDef)
+        assert node.returns is not None, f"{name}.stop must annotate its return"
+        assert ast.unparse(node.returns) == "None", f"{name}.stop must be the verdict-free hook"
+
+    def test_the_halt_verbs_that_can_refuse_really_do(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The verdict exists on both ground robots; the hook simply dropped it.
+        sdk = _FakeSdk()
+        monkeypatch.setitem(sys.modules, "booster_robotics_sdk_python", sdk)
+        booster = _live_booster(sdk)
+        sdk.client.refuse.add("MoveCommand")
+        assert booster.stop_task()["status"] == "error"
+
+        session = _install_requests(monkeypatch)
+        rover = _live_rover(session)
+        session.post_response = OSError("no route to host")
+        assert rover.stop_task()["status"] == "error"
+
+
+class TestEveryStopHookReadsTheHaltItDelegated:
+    """The relation, over the derived fleet."""
+
+    def test_no_stop_hook_discards_an_envelope(self) -> None:
+        offenders = {}
+        for name, cls in sorted(_driver_classes().items()):
+            discarded = _discarded_envelopes(_method_ast(cls, "stop"), _envelope_verbs(cls))
+            if discarded:
+                offenders[name] = discarded
+        assert offenders == {}, (
+            "these stop hooks call a verb that decides a halt verdict and then discard it. "
+            "stop() returns None, so nothing anywhere records that the robot did not stop: "
+            f"{offenders}"
+        )
+
+    @pytest.mark.parametrize("name", ["BoosterDriver", "CrazyflieDriver", "EarthRoverDriver"])
+    def test_the_halt_verb_is_in_scope_by_its_annotation(self, name: str) -> None:
+        # The relation finds ``land`` for the same reason it finds ``stop_task``:
+        # both answer with an envelope. Neither is named by the predicate.
+        verbs = _envelope_verbs(_driver_classes()[name])
+        assert "stop_task" in verbs
+        assert "land" in verbs if name == "CrazyflieDriver" else True
+
+
+class TestTheRelationIsNotVacuous:
+    """Graded on constructed sources, so a clean tree is not the only evidence."""
+
+    _COMPLIANT = """
+        async def stop(self) -> None:
+            if (detail := halt_failure_detail(self.stop_task())) is not None:
+                logger.error("%s.stop(): it did not stop: %s", self._tool_name, detail)
+    """
+    _VIOLATING = """
+        async def stop(self) -> None:
+            self.stop_task()
+    """
+
+    def test_a_hook_that_reads_the_envelope_is_accepted(self) -> None:
+        node = ast.parse(textwrap.dedent(self._COMPLIANT)).body[0]
+        assert _discarded_envelopes(node, {"stop_task"}) == []
+
+    def test_a_hook_that_drops_the_envelope_is_refused(self) -> None:
+        node = ast.parse(textwrap.dedent(self._VIOLATING)).body[0]
+        assert _discarded_envelopes(node, {"stop_task"}) == ["stop_task"]
+
+    def test_a_call_to_something_that_answers_nothing_is_not_a_violation(self) -> None:
+        # ``_halt_repeater`` returns None: there is no verdict to read, so a bare
+        # call to it is not the shape this relation is about.
+        node = ast.parse("async def stop(self) -> None:\n    self._halt_repeater()\n").body[0]
+        assert _discarded_envelopes(node, {"stop_task", "land"}) == []
+
+
+# --------------------------------------------------------------------------- #
+# Regression - a refused halt is logged, naming what may still be moving.      #
+# --------------------------------------------------------------------------- #
+
+
+def _install_requests(monkeypatch: pytest.MonkeyPatch) -> _FakeSession:
+    """Install a fake ``requests`` whose ``Session()`` is one shared recorder."""
+    session = _FakeSession()
+    module = types.ModuleType("requests")
+    module.Session = lambda: session  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "requests", module)
+    return session
+
+
+def _errors(caplog: pytest.LogCaptureFixture) -> str:
+    """Every ERROR-or-worse message captured, joined for substring assertions."""
+    return " ".join(record.getMessage() for record in caplog.records if record.levelno >= logging.ERROR)
+
+
+def _refusing_booster(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A T1 whose halting twist the locomotion controller refuses."""
+    sdk = _FakeSdk()
+    monkeypatch.setitem(sys.modules, "booster_robotics_sdk_python", sdk)
+    driver = _live_booster(sdk)
+    sdk.client.refuse.add("MoveCommand")
+    return driver
+
+
+def _refusing_rover(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A rover whose zero twist cannot leave the host."""
+    session = _install_requests(monkeypatch)
+    driver = _live_rover(session)
+    session.post_response = OSError("no route to host")
+    return driver
+
+
+def _refusing_rover_http(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A second door to the same failure: the SDK answered, and refused."""
+    session = _install_requests(monkeypatch)
+    driver = _live_rover(session)
+    session.post_response = _FakeResponse(503, None, "controller busy")
+    return driver
+
+
+def _refusing_aircraft(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """An aircraft whose descent is refused.
+
+    Stubbed rather than driven: ``land`` re-checks the link ``stop`` just
+    checked, so reaching its refusal for real needs a disconnect racing the two.
+    What is under test is that the hook reads the answer it is given.
+    """
+    driver = _flying(monkeypatch)
+    monkeypatch.setattr(
+        driver, "land", lambda **_: {"status": "error", "content": [{"text": "land: the link went away"}]}
+    )
+    return driver
+
+
+def _flying(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A Crazyflie driver that reports an open link."""
+    from strands_robots.drivers import crazyflie as module
+
+    driver = module.CrazyflieDriver()
+    monkeypatch.setattr(driver, "_connected", True)
+    monkeypatch.setattr(driver, "_cf", object())
+    assert driver.is_connected
+    return driver
+
+
+def _healthy_booster(monkeypatch: pytest.MonkeyPatch) -> Any:
+    sdk = _FakeSdk()
+    monkeypatch.setitem(sys.modules, "booster_robotics_sdk_python", sdk)
+    return _live_booster(sdk)
+
+
+def _healthy_rover(monkeypatch: pytest.MonkeyPatch) -> Any:
+    return _live_rover(_install_requests(monkeypatch))
+
+
+def _healthy_aircraft(monkeypatch: pytest.MonkeyPatch) -> Any:
+    driver = _flying(monkeypatch)
+    monkeypatch.setattr(driver, "land", lambda **_: {"status": "success", "content": []})
+    return driver
+
+
+class TestARefusedHaltIsLoggedNamingWhatMayStillMove:
+    """The regression: on ``main`` every one of these logged nothing at all."""
+
+    @pytest.mark.parametrize(
+        ("label", "build", "expected"),
+        [
+            ("the T1 refused the halting twist", _refusing_booster, ("may still be walking",)),
+            # The T1's halt has two halves and the envelope reports each, so an
+            # operator learns it was the locomotion half that did not land.
+            ("the failing half is named", _refusing_booster, ("locomotion_halted=False",)),
+            (
+                "the rover's zero twist could not send",
+                _refusing_rover,
+                ("may still be driving at the commanded velocity", "no route to host"),
+            ),
+            ("the rover's SDK answered and refused", _refusing_rover_http, ("may still be driving", "HTTP 503")),
+            ("the descent was refused", _refusing_aircraft, ("may still be flying", "the link went away")),
+        ],
+    )
+    def test_the_hook_logs_an_error(
+        self,
+        label: str,
+        build: Any,
+        expected: tuple[str, ...],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        driver = build(monkeypatch)
+        with caplog.at_level(logging.DEBUG):
+            assert asyncio.run(driver.stop()) is None, "the hook still carries no verdict"
+        errors = _errors(caplog)
+        for fragment in expected:
+            assert fragment in errors, f"{label}: {fragment!r} not in {errors!r}"
+
+    @pytest.mark.parametrize(
+        ("label", "build"),
+        [
+            ("the T1 halted", _healthy_booster),
+            ("the rover halted", _healthy_rover),
+            ("the aircraft is descending", _healthy_aircraft),
+        ],
+    )
+    def test_a_halt_that_landed_logs_no_error(
+        self, label: str, build: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        driver = build(monkeypatch)
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(driver.stop())
+        assert _errors(caplog) == "", label
+
+    def test_the_healthy_halt_still_reaches_the_wire(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Reading a verdict must not have replaced sending the command.
+        sdk = _FakeSdk()
+        monkeypatch.setitem(sys.modules, "booster_robotics_sdk_python", sdk)
+        asyncio.run(_live_booster(sdk).stop())
+        assert ("MoveCommand", (0.0, 0.0, 0.0)) in sdk.client.calls
+
+        session = _install_requests(monkeypatch)
+        asyncio.run(_live_rover(session).stop())
+        assert session.posts, "the zero twist must still reach /control"
+
+    def test_a_disconnected_aircraft_still_only_halts_the_repeater(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The branch with nothing to descend is unchanged, and silent: there is
+        # no halt to report on an aircraft that is not flying.
+        from strands_robots.drivers import crazyflie as module
+
+        driver = module.CrazyflieDriver()
+        monkeypatch.setattr(driver, "land", lambda **_: pytest.fail("a disconnected aircraft must not be landed"))
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(driver.stop())
+        assert _errors(caplog) == ""
+
+
+# --------------------------------------------------------------------------- #
+# The shared detail reader.                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class TestTheDetailReader:
+    """One reader, because the shipped halt verbs answer in two shapes."""
+
+    @pytest.mark.parametrize(
+        ("label", "envelope", "expected"),
+        [
+            ("success is not a failure", {"status": "success", "content": [{"text": "halted"}]}, None),
+            (
+                "a refusal text is quoted",
+                {"status": "error", "content": [{"text": "move: the T1 refused the twist: code = 100"}]},
+                "move: the T1 refused the twist: code = 100",
+            ),
+            (
+                "a per-half outcome names the half",
+                {"status": "error", "content": [{"json": {"locomotion_halted": False, "upper_body_released": True}}]},
+                "locomotion_halted=False, upper_body_released=True",
+            ),
+            ("an unparsable failure is still a failure", {"status": "error", "content": []}, "no detail reported"),
+            ("a missing status is not success", {"content": [{"text": "who knows"}]}, "who knows"),
+        ],
+    )
+    def test_it_renders_the_shape_it_was_given(
+        self, label: str, envelope: dict[str, Any], expected: str | None
+    ) -> None:
+        assert halt_failure_detail(envelope) == expected, label
+
+    def test_it_never_reads_a_failure_as_a_landed_halt(self) -> None:
+        # ``None`` means "the halt landed", so no non-success envelope may yield
+        # it - including the malformed ones a caller cannot anticipate.
+        malformed: list[Any] = [[], [{}], [{"json": {}}], ["not a block"], None]
+        for content in malformed:
+            assert halt_failure_detail({"status": "error", "content": content}) is not None


### PR DESCRIPTION
`HardwareDriver.stop` is annotated `-> None` on all twelve shipped drivers, so it carries no verdict. That is exactly what makes its **log the only place a halt it could not complete can be recorded** - and three drivers delegated to a verb that decides one, then threw the answer away.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/stop-hook-halt-report/stop_hook_halt_report.png)

## What was discarded

| driver | discarded | reachable via | what a refusal leaves running |
| --- | --- | --- | --- |
| `BoosterDriver` | `stop_task()` | `MoveCommand` raising -> `move` reports "the T1 refused the twist" | the T1 walking, or the host still holding the upper body |
| `EarthRoverDriver` | `stop_task()` | a `/control` POST that does not land (`OSError`, or non-200) | the rover driving at the last commanded velocity |
| `CrazyflieDriver` | `land()` | a disconnect racing `stop`'s own `is_connected` check | the aircraft flying |

For the two ground robots this is an ordinary hardware failure. Because `stop` returns `None` and wrote nothing, a fleet teardown that called it had **no** surface anywhere - envelope, flag or log - saying the robot had not stopped. A velocity-commanded base holds its last command until another one arrives, so an unsent zero twist leaves the rover driving.

The aircraft's refusal is narrow (`land` re-checks the link `stop` just checked), so it is a latent hole rather than a reproduced field failure. It is fixed here because the rule below is derived from the code and has no category for "discards a verdict, but only rarely".

## Measured

Same probe on `main` `4dce4c01` and on this branch, driving each refusal above and counting what `stop()` reported:

| driver | before | after |
| --- | --- | --- |
| `BoosterDriver` | 0 ERROR records | 1, naming `locomotion_halted=False, upper_body_released=True` |
| `EarthRoverDriver` | 0 ERROR records | 1, quoting `POST .../control did not reach the SDK: no route to host` |
| `CrazyflieDriver` | 0 ERROR records | 1, quoting `land: the link went away` |

`stop()` still returns `None` in every row - the hook's signature is unchanged, only its silence is.

## Change

Each hook reads the envelope and logs a non-success naming what may still be moving, in the shape its nine compliant siblings already use (`"%s.stop(): ..."`). `strands_robots.drivers.halt_failure_detail` renders the reason, because the shipped halt verbs answer in **two** shapes - a refusal *text*, and a per-half *outcome* dict naming which half of the T1's two-part halt failed - and a failure it cannot parse still reports as a failure rather than as a landed halt.

The `stop` contract docstring now states the obligation it always had, which is the root cause: nothing told a driver author that the log is the only record.

## Why nothing caught it

`tests/drivers/test_agent_stop_verb_reports_the_halt_outcome` owns this population and grades two directions - the hook is verdict-free, and the *agent* verb reports the verdict. Its own docstring cites the third as the reason the second is acceptable: `stop` is verdict-free *because* it logs, "the Microduck ... logs an `OSError` from robotd, the Mini logs a daemon that declined". That premise was never asserted, and it was false for three of the twelve.

So the new grader derives the rule over the whole fleet rather than listing members: **a `stop` that calls one of its own envelope-returning verbs must read what that verb answered.** Verbs are found by their annotated return type, so the aircraft's `land` is in scope without being named; a call to something returning `None` (`_halt_repeater`) is not a violation. Both directions are pinned on planted sources.

Pre-fix, with only the helper ported so the import resolves and the three hooks left exactly as `main` has them: **6 failed / 31 passed**, every message assertion reading `not in ''`. After: **37 passed**.

## Gate

- `ruff check` + `ruff format --check` clean; `mypy` at the CI pin unchanged from baseline (20 pre-existing, 0 attributable).
- `tests/drivers`: 2178 passed vs 2141 on pristine `main` (+37 = exactly the new cells). One pre-existing failure (`test_g1_actions_write_the_driver_envelope::test_the_import_pulls_no_sdk_module`) reproduces on pristine `main` and passes in isolation - order-dependent, and present only where the vendor SDK is installed.
- `scripts/check_whole_tree_graders.py`: 297 passed.

LOC delta **+529 / -8** across 8 files: +88 source/docs/changelog, +405 the derived grader and its regression table. The additions are a fix plus the guard that keeps the next driver from repeating it.

---

## Review changelog

| Round | Concern | Fix commit | Pin test path |
|---|---|---|---|
| R1 | `IndentationError` is a subclass of `SyntaxError`, so the except tuple at line 104 names a class a sibling already covers - the repo's own grader refuses that shape and takes the required check red | `43b060e0abc03ba24d5f7e66e6fd20f626806e84` | existing `tests/test_except_tuples_state_their_real_scope.py::test_no_tuple_names_a_class_a_sibling_already_covers` (grader already pins this) |