### PR TITLE
fix(simulation): an evaluation that lost a recording episode does not report a success rate over it

### DIFF
--- a/changelog.d/3109-eval-stops-on-a-lost-recording-episode.md
+++ b/changelog.d/3109-eval-stops-on-a-lost-recording-episode.md
@@ -1,0 +1,45 @@
+### Fixed: an evaluation that lost a recording episode does not report a success rate over it
+
+`PolicyRunner._finalize_recorder_episode` flushes the attached dataset recorder
+at the end of every eval rollout so the dataset records per-episode boundaries.
+A failed flush was turned into a `logger.warning` and the helper returned
+nothing, so both `evaluate` and `_evaluate_with_spec` ran their remaining
+episodes and reported a `success_rate` over all of them under
+`status="success"`.
+
+A failed flush is not the loss of an episode boundary. `DatasetRecorder`
+marks itself closed on one, because the LeRobot episode buffer is in an
+undefined state after a partial write - and `add_frame` returns on a closed
+recorder without writing a frame, without raising `RecordingFrameError`, and
+without counting a `dropped_frame_count`. Every later episode is therefore
+discarded in silence, leaving no trace even in the recorder's own accounting.
+Driving a real MuJoCo evaluation with a real recorder over a dataset root whose
+write permission is revoked at the end of episode 0, a four-episode run reported
+four completed episodes with `status="success"` while `meta/info.json` held zero
+and 18 of 24 `add_frame` calls had been dropped with `dropped_frame_count` still
+at 0. One warning line was the whole record of the run.
+
+The helper now returns the reason, and both loops stop at that episode and
+report it: `status` is `"error"`, the text names the lost episode, and the json
+payload carries `recording_save_error` - present and `None` on every healthy
+run. `episodes_completed` and the aggregates cover only the episodes that ran,
+so nothing is averaged over episodes whose frames reached no dataset. The
+failing episode's rollout MP4 is still closed and collected before the loop
+stops, since the dataset episode is gone and the video is the only remaining
+record of what the policy did on it.
+
+This is the rule every sibling flush already applies, each for the same stated
+reason: `stop_recording` and `SimEngine.save_episode` drop the poisoned recorder
+and return an error, `run_policy(n_episodes=...)` aborts its remaining episodes,
+and the MuJoCo backend's `reset` surfaces the failure rather than resetting into
+an undefined state. It also matches the level below, where `RecordingFrameError`
+exists precisely so a rollout driver cannot absorb a lost recording frame - a
+lost frame truncates one episode, while a lost episode truncated the whole run.
+
+The regression test drives a real `Simulation`, `PolicyRunner` and
+`DatasetRecorder`, standing in only for the `LeRobotDataset`, and closes the
+family with a scan that derives every `save_episode` call site in
+`strands_robots/simulation` from the source rather than listing them. Three
+existing tests asserted the previous posture and are evolved in place, since
+each still pins something real: the helper must report rather than raise, and
+the flush must be attempted per episode.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -772,6 +772,34 @@ recording: a failed write is counted in `dropped_frame_count`, warned about at
 `WARNING` (on the 1st, 2nd, 4th, 8th ... failure so a 50 Hz loop cannot flood the
 log), and the rollout continues.
 
+### An episode the recorder cannot flush stops a recorded evaluation
+
+`save_episode` is the episode-level counterpart, and a failed flush is worse than
+a lost frame rather than milder. The recorder marks itself closed, because the
+LeRobot episode buffer is in an undefined state after a partial write - and
+`add_frame` returns immediately on a closed recorder, without writing a frame,
+without raising `RecordingFrameError`, and without counting a
+`dropped_frame_count`. Every later episode is therefore discarded in silence,
+leaving no trace even in the recorder's own accounting.
+
+So every flush refuses rather than continues. `save_episode()` and
+`stop_recording()` drop the poisoned recorder and return `status="error"`,
+`run_policy(n_episodes=N)` aborts its remaining episodes, `reset()` surfaces the
+failure instead of resetting into an undefined state, and a recorded
+`eval_policy` / `evaluate_benchmark` - one driven with an `on_frame` hook that
+calls `add_frame`, which is the only way those two feed a recorder - stops at the
+episode whose flush failed and reports the reason:
+
+```python
+result = sim.eval_policy(robot_name="so100", n_episodes=20, on_frame=hook)
+payload = next(b["json"] for b in result["content"] if "json" in b)
+if payload["recording_save_error"]:      # None on every healthy evaluation
+    ...   # status is "error"; episodes_completed is the episode it stopped at
+```
+
+`episodes_completed` and `success_rate` then cover only the episodes that ran, so
+an aggregate is never reported over episodes whose frames reached no dataset.
+
 ## Instance methods
 
 | Method | What |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -3979,7 +3979,9 @@ class SimEngine(ABC):
 
             ``status`` reports whether the evaluation RAN, not whether the
             policy succeeded: an evaluation in which every episode failed is
-            still ``status="success"`` with ``success_rate=0.0``. Read
+            still ``status="success"`` with ``success_rate=0.0``. The one
+            thing that makes it ``"error"`` is a recording it could not keep:
+            see ``recording_save_error`` below. Read
             ``success_measured`` first - it is ``False`` when no
             ``success_fn`` / benchmark spec was supplied, in which case
             ``success_rate`` is ``0.0`` for every policy regardless of what it
@@ -3993,6 +3995,15 @@ class SimEngine(ABC):
 
             Horizon: ``n_episodes``, ``max_steps`` (the values the evaluation
             ran with) and ``stopped_early``.
+
+            Recording: ``recording_save_error`` - ``None`` on every healthy
+            evaluation, and the reason string when a per-episode dataset flush
+            failed. A failed flush closes the recorder, after which
+            ``add_frame`` writes nothing and counts no drop, so the evaluation
+            stops at that episode and ``status`` is ``"error"``:
+            ``episodes_completed`` is then the last episode attempted rather
+            than ``n_episodes``, and the aggregate covers only those episodes
+            instead of averaging over ones whose data does not exist.
 
             Video: ``video_paths`` (one MP4 per episode, empty when no
             recording was requested).
@@ -4226,6 +4237,12 @@ class SimEngine(ABC):
             reward + aggregate success_rate / avg_reward / avg_steps in the
             JSON payload, plus ``video_paths`` (the per-episode MP4s written
             when ``video`` is set).
+
+            ``recording_save_error`` is ``None`` on every healthy run and
+            carries the reason when a per-episode dataset flush failed, in
+            which case the benchmark stops at that episode and ``status`` is
+            ``"error"`` - see :meth:`eval_policy`, which reports it the same
+            way.
         """
         from strands_robots.policies import create_policy
         from strands_robots.simulation.benchmark import get_benchmark

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1137,38 +1137,58 @@ class PolicyRunner:
     # Calling this at the end of each policy-runner episode forces a per-
     # episode boundary in the recorded dataset. Skipped silently when no
     # recorder is attached (eval without recording is the common case).
-    def _finalize_recorder_episode(self) -> None:
+    def _finalize_recorder_episode(self) -> str | None:
         """Roll the attached dataset_recorder over to a new episode.
 
         Called at end of each rollout iteration in ``evaluate`` and
         ``_evaluate_with_spec``. No-op when no recorder is attached or when
         the episode buffer is empty (e.g. degenerate policy returned no
         actions and ``add_frame`` was never called).
+
+        Returns:
+            ``None`` when the episode was flushed, or when there was nothing
+            to flush. A reason string when the flush FAILED, for the caller to
+            stop on and report.
+
+            A failed flush is not telemetry. The recorder marks itself closed
+            because the LeRobot episode buffer is in an undefined state, and
+            :meth:`~strands_robots.dataset_recorder.DatasetRecorder.add_frame`
+            then returns on a closed recorder without writing a frame or
+            counting a drop - so a later episode's frames reach no dataset and
+            leave no trace in the recorder's own accounting either. An
+            evaluation that carried on would report a ``success_rate`` over
+            episodes whose data does not exist. Every sibling flush already
+            refuses the same way: ``stop_recording`` and
+            :meth:`~strands_robots.simulation.base.SimEngine.save_episode`
+            drop the poisoned recorder and return an error,
+            :meth:`~strands_robots.simulation.base.SimEngine.run_policy` with
+            ``n_episodes`` aborts its remaining episodes, and the MuJoCo
+            backend's ``reset``
+            surfaces the failure rather than resetting into an undefined
+            state.
         """
         try:
             world = getattr(self.sim, "_world", None)
             if world is None:
-                return
+                return None
             recorder = world._backend_state.get("dataset_recorder")
         except AttributeError:
-            return
+            return None
         if recorder is None:
-            return
+            return None
         # Don't flush an empty buffer - LeRobot raises on save_episode with
         # zero frames, and a degenerate rollout still counts as "no data" for
         # this episode rather than an error.
         pending = getattr(recorder, "episode_frame_count", 0)
         if pending <= 0:
-            return
+            return None
         try:
             result = recorder.save_episode()
-            if isinstance(result, dict) and result.get("status") != "success":
-                logger.warning(
-                    "Per-episode save_episode returned non-success: %s",
-                    result.get("message", result),
-                )
-        except Exception as e:  # noqa: BLE001 - recorder errors must not abort eval
-            logger.warning("Per-episode save_episode raised: %s", e)
+        except Exception as e:  # noqa: BLE001 - reported to the caller, not raised
+            return f"save_episode raised: {e}"
+        if isinstance(result, dict) and result.get("status") != "success":
+            return f"save_episode: {result.get('message', result)}"
+        return None
 
     # run(): blocking policy execution
     def run(
@@ -2623,6 +2643,13 @@ class PolicyRunner:
             the completed episodes: ``stopped_early=True`` and the aggregate
             metrics are computed over ``episodes_completed`` (which may be less
             than the requested ``n_episodes``).
+
+            ``recording_save_error`` is the third way an evaluation can cover
+            fewer episodes than asked for, and the only one that makes
+            ``status`` ``"error"``: it is ``None`` on every healthy run, and
+            the reason string when a per-episode dataset flush failed. See
+            :meth:`_finalize_recorder_episode` for why a lost episode stops
+            the evaluation instead of being averaged over.
         """
         # Refuse before any frame reaches the engine's open recording.
         self._reject_recording_rate_mismatch(control_frequency, "PolicyRunner.evaluate")
@@ -2854,6 +2881,7 @@ class PolicyRunner:
             global_step += 1
 
         stopped_early = False
+        recording_save_error: str | None = None
         try:
             for ep in range(n_episodes):
                 self.sim.reset()
@@ -2962,7 +2990,7 @@ class PolicyRunner:
                 # #708 - roll the attached recorder over to a new episode so the
                 # dataset records per-episode boundaries rather than collapsing
                 # every rollout into one mega-episode.
-                self._finalize_recorder_episode()
+                recording_save_error = self._finalize_recorder_episode()
 
                 if current_vwriter is not None:
                     current_vwriter.close()
@@ -2975,6 +3003,16 @@ class PolicyRunner:
                             current_vwriter.path,
                         )
                     current_vwriter = None
+
+                if recording_save_error is not None:
+                    # This episode's frames did not reach the dataset and the
+                    # recorder is now closed, so every later episode would run
+                    # into a recorder that drops frames without counting them.
+                    # Stop here and report, rather than measure a success_rate
+                    # over episodes whose data is gone. This episode's video is
+                    # already closed and collected above, so it is kept.
+                    recording_save_error = f"episode {ep}: {recording_save_error}"
+                    break
 
         except CooperativeStop:
             # A user/backend on_frame hook requested a graceful stop (the
@@ -3004,12 +3042,17 @@ class PolicyRunner:
         }
 
         return {
-            "status": "success",
+            "status": "error" if recording_save_error is not None else "success",
             "content": [
                 {
                     "text": (
                         f"Evaluation: {type(policy).__name__} on '{robot_name}'\n"
-                        f"Episodes: {n_completed}"
+                        + (
+                            f"Stopped after a lost recording episode - {recording_save_error}\n"
+                            if recording_save_error is not None
+                            else ""
+                        )
+                        + f"Episodes: {n_completed}"
                         + (f" of {n_episodes} (stopped early)" if stopped_early else "")
                         + f" | Success: {n_success}/{n_completed} ({success_rate:.1%})"
                         + ("" if success_measured else " [no success criterion - not measured]")
@@ -3024,6 +3067,7 @@ class PolicyRunner:
                         "n_episodes": n_episodes,
                         "episodes_completed": n_completed,
                         "stopped_early": stopped_early,
+                        "recording_save_error": recording_save_error,
                         "n_success": n_success,
                         "avg_steps": round(avg_steps, 1),
                         "max_steps": max_steps,
@@ -3180,6 +3224,7 @@ class PolicyRunner:
         current_vwriter: _RolloutVideoWriter | None = None
 
         stopped_early = False
+        recording_save_error: str | None = None
         try:
             for ep in range(n_episodes):
                 self.sim.reset()
@@ -3410,7 +3455,7 @@ class PolicyRunner:
                     }
                 )
                 # #708 - same per-episode recorder boundary as evaluate().
-                self._finalize_recorder_episode()
+                recording_save_error = self._finalize_recorder_episode()
 
                 if current_vwriter is not None:
                     current_vwriter.close()
@@ -3423,6 +3468,12 @@ class PolicyRunner:
                             current_vwriter.path,
                         )
                     current_vwriter = None
+
+                if recording_save_error is not None:
+                    # Same rule as evaluate(): a lost episode stops the
+                    # benchmark instead of being averaged over.
+                    recording_save_error = f"episode {ep}: {recording_save_error}"
+                    break
 
         except CooperativeStop:
             # A user/backend on_frame hook requested a graceful stop (the
@@ -3444,12 +3495,17 @@ class PolicyRunner:
         avg_reward = sum(r["cumulative_reward"] for r in results) / max(n_completed, 1)
 
         return {
-            "status": "success",
+            "status": "error" if recording_save_error is not None else "success",
             "content": [
                 {
                     "text": (
                         f"Benchmark: {spec_name} | policy {type(policy).__name__} on '{robot_name}'\n"
-                        f"Episodes: {n_completed}"
+                        + (
+                            f"Stopped after a lost recording episode - {recording_save_error}\n"
+                            if recording_save_error is not None
+                            else ""
+                        )
+                        + f"Episodes: {n_completed}"
                         + (f" of {n_episodes} (stopped early)" if stopped_early else "")
                         + f" | Success: {n_success} | Failure: {n_failure} ({success_rate:.1%} success)\n"
                         f"Avg reward: {avg_reward:.2f} | Avg steps: {avg_steps:.0f}/{max_steps}"
@@ -3462,6 +3518,7 @@ class PolicyRunner:
                         "n_episodes": n_episodes,
                         "episodes_completed": n_completed,
                         "stopped_early": stopped_early,
+                        "recording_save_error": recording_save_error,
                         "n_success": n_success,
                         "n_failure": n_failure,
                         "avg_steps": round(avg_steps, 1),

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import base64
 import inspect
 import io
-import logging
 import os
 import sys
 import threading
@@ -887,16 +886,22 @@ class TestChunkNotTruncatedBelowActionsPerStep:
 
 
 #
-# evaluate(): per-episode recorder finalize is fault-tolerant (issue #708)
+# evaluate(): a per-episode recorder finalize that fails stops the eval
 #
 # `_finalize_recorder_episode` rolls the attached LeRobot dataset_recorder over
 # to a fresh episode at the end of each eval rollout so the dataset records
 # per-episode boundaries instead of collapsing every rollout into one
-# mega-episode. A recorder failure at that boundary (a non-success status dict,
-# or an exception from `save_episode`) must NOT abort the eval: the rollouts
-# already happened, and losing the episode-split is strictly better than losing
-# the whole eval summary. These pin that fault-tolerance contract through the
-# public `evaluate()` API.
+# mega-episode (issue #708). A failure at that boundary (a non-success status
+# dict, or an exception from `save_episode`) is not the loss of an episode
+# split: the recorder closes itself because the LeRobot episode buffer is in an
+# undefined state, and `add_frame` then returns on a closed recorder without
+# writing a frame, raising `RecordingFrameError`, or counting a
+# `dropped_frame_count` - so the remaining episodes are discarded in silence
+# and the whole dataset is lost, not just its boundaries. The eval therefore
+# stops at that episode and reports the reason in `recording_save_error`, the
+# same refusal every sibling flush makes. These pin that contract through the
+# public `evaluate()` API; the loop-level behaviour is pinned in
+# tests/simulation/test_recording_episode_loss_is_not_tolerated.py.
 
 
 class _FailingRecorder:
@@ -928,12 +933,13 @@ def _attach_recorder(sim: FakeSim, recorder: Any) -> None:
 
 
 @pytest.mark.parametrize("mode", ["non_success", "raise"])
-def test_evaluate_survives_per_episode_recorder_save_failure(mode, caplog):
-    """A failing per-episode recorder finalize must not abort the eval.
+def test_evaluate_reports_a_per_episode_recorder_save_failure(mode):
+    """A failing per-episode recorder finalize stops the eval and is reported.
 
     Whether `save_episode` returns a non-success status or raises, `evaluate`
-    still completes every requested episode and returns a success summary; the
-    failure is logged, not propagated.
+    ends after the episode whose flush failed and returns an error carrying the
+    reason - rather than measuring the remaining episodes into a closed recorder
+    and reporting a success summary over data that does not exist.
     """
     sim = FakeSim()
     recorder = _FailingRecorder(mode)
@@ -942,16 +948,16 @@ def test_evaluate_survives_per_episode_recorder_save_failure(mode, caplog):
     policy = MockPolicy()
     policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
 
-    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.policy_runner"):
-        result = PolicyRunner(sim).evaluate("fake_robot", policy, n_episodes=2, max_steps=3)
+    result = PolicyRunner(sim).evaluate("fake_robot", policy, n_episodes=2, max_steps=3)
 
-    # Eval survives and reports a normal summary despite the recorder failing.
-    assert result["status"] == "success"
+    assert result["status"] == "error"
     payload = next(c["json"] for c in result["content"] if isinstance(c, dict) and "json" in c)
-    assert payload["episodes_completed"] == 2
+    # Episode 0 ran; episode 1 was never measured into the closed recorder.
+    assert payload["episodes_completed"] == 1
     assert payload["stopped_early"] is False
+    assert recorder.save_calls == 1
 
-    # The finalize was attempted once per episode (not silently skipped).
-    assert recorder.save_calls == 2
-    # The failure surfaced as a warning rather than an exception.
-    assert any("save_episode" in rec.message for rec in caplog.records)
+    # The reason reaches the caller in the payload, not only a log line.
+    reason = payload["recording_save_error"]
+    assert reason.startswith("episode 0: ")
+    assert ("simulated recorder disk failure" if mode == "raise" else "disk full") in reason

--- a/tests/simulation/test_policy_runner_recorder_episode_boundary.py
+++ b/tests/simulation/test_policy_runner_recorder_episode_boundary.py
@@ -181,11 +181,17 @@ class TestRecorderEpisodeBoundary:
         # After save, buffer is reset.
         assert rec.episode_frame_count == 0
 
-    def test_finalize_helper_tolerates_save_exception(self, sim_with_robot):
-        """Recorder.save_episode raising must not abort the eval.
+    def test_finalize_helper_reports_a_save_exception_instead_of_raising(self, sim_with_robot):
+        """A failed flush reaches the caller as a reason, not as an exception.
 
-        Eval is the dominant use case; recording is opportunistic. Log and
-        continue — matches the existing on_frame failure handling pattern.
+        The helper still must not raise - the eval loop reports outcomes in an
+        envelope - but it no longer swallows the failure either. Continuing was
+        not the milder option: the recorder closes itself on a failed flush and
+        every later ``add_frame`` then writes nothing and counts no drop, so the
+        evaluation would report a ``success_rate`` over episodes whose data does
+        not exist. See
+        ``tests/simulation/test_recording_episode_loss_is_not_tolerated.py``,
+        which pins what the loops do with this reason.
         """
         rec = _attach_recorder(sim_with_robot)
         rec.episode_frame_count = 5  # non-empty buffer
@@ -196,5 +202,7 @@ class TestRecorderEpisodeBoundary:
         rec.save_episode = boom  # type: ignore[method-assign]
 
         runner = PolicyRunner(sim_with_robot)
-        # Must not raise.
-        runner._finalize_recorder_episode()
+        reason = runner._finalize_recorder_episode()  # must not raise
+
+        assert reason is not None
+        assert "simulated lerobot crash" in reason

--- a/tests/simulation/test_recording_episode_loss_is_not_tolerated.py
+++ b/tests/simulation/test_recording_episode_loss_is_not_tolerated.py
@@ -1,0 +1,461 @@
+"""A dataset episode the recorder could not flush must stop a recorded evaluation.
+
+``tests/simulation/test_recording_frame_loss_is_not_tolerated.py`` pins the rule
+one level down: a lost recording *frame* is fatal, because continuing past it
+leaves a short episode whose surviving frames are re-timestamped from the
+declared ``fps`` while the rollout still reports success. Its
+``test_the_eval_loop_does_not_swallow_it_either`` pins that the eval loop
+specifically must surface a lost frame rather than absorb it as telemetry.
+
+The *episode* flush had the opposite rule, and it sits on the worse failure. A
+failed ``save_episode`` closes the recorder - the LeRobot episode buffer is in
+an undefined state after a partial write - and ``add_frame`` then returns on a
+closed recorder without writing a frame, without raising
+``RecordingFrameError``, and without counting a ``dropped_frame_count``. So one
+failed flush discards every remaining episode of the evaluation in total
+silence, and the eval reported a ``success_rate`` over all of them under
+``status="success"``. A lost frame truncates an episode; a lost episode
+truncated the whole run and took the recorder's own accounting with it.
+
+These tests pin the episode-level rule: the evaluation stops at the episode
+whose flush failed and reports the reason in ``recording_save_error``, matching
+what every sibling flush already does - ``stop_recording`` and
+``SimEngine.save_episode`` drop the poisoned recorder and return an error,
+``run_policy(n_episodes=...)`` aborts its remaining episodes, and the MuJoCo
+backend's ``reset`` surfaces the failure rather than resetting into an
+undefined state. :class:`TestEveryFlushVerdictIsRead` derives that population
+from the source, so a new flush cannot go back to discarding its verdict.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import random
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.dataset_recorder import DatasetRecorder
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.benchmark import BenchmarkProtocol, StepInfo
+from strands_robots.simulation.mujoco.backend import _can_render
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+_FEATURES: dict[str, Any] = {
+    "observation.state": {"dtype": "float32", "names": ["1", "2", "3", "4", "5", "6"]},
+    "action": {"dtype": "float32", "names": ["1", "2", "3", "4", "5", "6"]},
+}
+
+
+class _Dataset:
+    """Stand-in ``LeRobotDataset`` whose flush fails from a chosen episode on.
+
+    Stands in for the dataset, not for the recorder: the real
+    :class:`~strands_robots.dataset_recorder.DatasetRecorder` runs unmodified,
+    so the poisoning this suite is about is the production one.
+    """
+
+    def __init__(self, *, fail_from_episode: int | None = 0) -> None:
+        self.repo_id = "local/episode-loss"
+        self.root = "/tmp/local-episode-loss"
+        self.features = _FEATURES
+        self.fail_from_episode = fail_from_episode
+        self.written = 0
+        self.saved = 0
+        self.save_attempts = 0
+
+    def add_frame(self, frame: dict[str, Any]) -> None:
+        self.written += 1
+
+    def save_episode(self) -> None:
+        attempt = self.save_attempts
+        self.save_attempts += 1
+        if self.fail_from_episode is not None and attempt >= self.fail_from_episode:
+            # Deliberately does NOT say "episode": the episode the reason names
+            # has to come from the loop, not from the underlying message.
+            raise RuntimeError(f"simulated parquet write failure (flush attempt {attempt})")
+        self.saved += 1
+
+
+class _NoopSpec(BenchmarkProtocol):
+    """Minimal always-running spec: fixed horizon, never succeeds or fails."""
+
+    max_steps = 3
+
+    @property
+    def supported_robots(self) -> list[str]:
+        return ["so100"]
+
+    @property
+    def default_robot(self) -> str:
+        return "arm"
+
+    def on_episode_start(self, sim: Any, rng: random.Random) -> None:
+        return None
+
+    def on_step(self, sim: Any, obs: dict[str, Any], action: dict[str, Any]) -> StepInfo:
+        return StepInfo(reward=0.0)
+
+    def is_success(self, sim: Any) -> bool:
+        return False
+
+    def is_failure(self, sim: Any) -> bool:
+        return False
+
+
+def _recording_sim(recorder: Any) -> Simulation:
+    """A one-robot sim with ``recorder`` attached as the live session's writer."""
+    sim = Simulation(tool_name="episode_loss", mesh=False)
+    sim.create_world()
+    sim.add_robot(name="arm", data_config="so100")
+    assert sim._world is not None
+    sim._world._backend_state["recording"] = True
+    sim._world._backend_state["trajectory"] = []
+    sim._world._backend_state["dataset_recorder"] = recorder
+    return sim
+
+
+requires_gl = pytest.mark.skipif(not _can_render(), reason="No OpenGL context (EGL/OSMesa) for offscreen rendering")
+
+
+def _policy(sim: Simulation) -> MockPolicy:
+    policy = MockPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    return policy
+
+
+def _payload(result: dict[str, Any]) -> dict[str, Any]:
+    """The json block, scanned for rather than indexed (the documented read)."""
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+def _feed(recorder: Any) -> Any:
+    """An ``on_frame`` hook that records - the only way an eval feeds a recorder."""
+
+    def hook(_step: int, observation: dict[str, Any], action: dict[str, Any]) -> None:
+        recorder.add_frame(observation, action, camera_keys=[])
+
+    return hook
+
+
+class TestALostRecordingEpisodeStopsTheEvaluation:
+    """The regression: the run stops at the lost episode and says so."""
+
+    def test_evaluate_stops_at_the_episode_whose_flush_failed(self) -> None:
+        """Pre-fix all 3 episodes ran, 2 of them into a closed recorder."""
+        ds = _Dataset(fail_from_episode=0)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        sim = _recording_sim(recorder)
+        try:
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_episodes=3,
+                max_steps=2,
+                control_frequency=50.0,
+                on_frame=_feed(recorder),
+            )
+        finally:
+            sim.cleanup()
+
+        payload = _payload(result)
+        assert result["status"] == "error", result
+        assert payload["episodes_completed"] == 1, payload
+        assert payload["n_episodes"] == 3
+        # Only episode 0's frames were ever offered to the dataset: the two
+        # later episodes did not run into the closed recorder at all.
+        assert ds.written == 2
+        assert ds.save_attempts == 1
+
+    def test_the_report_names_the_episode_and_the_underlying_cause(self) -> None:
+        """A reason the caller can act on, not a log line they never see."""
+        ds = _Dataset(fail_from_episode=0)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        sim = _recording_sim(recorder)
+        try:
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_episodes=2,
+                max_steps=2,
+                control_frequency=50.0,
+                on_frame=_feed(recorder),
+            )
+        finally:
+            sim.cleanup()
+
+        payload = _payload(result)
+        reason = payload["recording_save_error"]
+        assert reason is not None
+        assert reason.startswith("episode 0: "), reason
+        assert "simulated parquet write failure" in reason
+        assert "recorder closed" in reason
+        # The same fact reaches a reader of the text block.
+        assert "lost recording episode" in result["content"][0]["text"]
+
+    def test_a_later_episode_is_the_one_that_stops_it(self) -> None:
+        """The first episodes are kept; the aggregate covers exactly those."""
+        ds = _Dataset(fail_from_episode=2)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        sim = _recording_sim(recorder)
+        try:
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_episodes=5,
+                max_steps=2,
+                control_frequency=50.0,
+                on_frame=_feed(recorder),
+            )
+        finally:
+            sim.cleanup()
+
+        payload = _payload(result)
+        assert result["status"] == "error"
+        assert payload["episodes_completed"] == 3
+        assert len(payload["episodes"]) == 3
+        assert payload["recording_save_error"].startswith("episode 2: ")
+        assert ds.saved == 2
+
+    @requires_gl
+    def test_the_lost_episode_keeps_the_video_that_shows_what_it_did(self, tmp_path) -> None:
+        """Stopping must not also discard the rollout footage.
+
+        The dataset episode is gone; the MP4 is the only remaining record of
+        what the policy did on it, so the video is closed and collected before
+        the loop stops rather than after.
+        """
+        ds = _Dataset(fail_from_episode=1)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        sim = _recording_sim(recorder)
+        try:
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_episodes=4,
+                max_steps=2,
+                control_frequency=50.0,
+                on_frame=_feed(recorder),
+                video={"path": str(tmp_path / "rollout.mp4"), "fps": 25, "width": 64, "height": 64},
+            )
+        finally:
+            sim.cleanup()
+
+        payload = _payload(result)
+        assert result["status"] == "error"
+        assert payload["episodes_completed"] == 2
+        # One MP4 per episode that ran, including the one whose flush failed.
+        assert len(payload["video_paths"]) == 2, payload["video_paths"]
+        assert all(pathlib.Path(v).is_file() for v in payload["video_paths"])
+
+    def test_the_benchmark_path_stops_and_reports_the_same_way(self) -> None:
+        """``_evaluate_with_spec`` shares the rule, not just the schema."""
+        ds = _Dataset(fail_from_episode=0)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        sim = _recording_sim(recorder)
+        try:
+            result = PolicyRunner(sim).evaluate(
+                robot_name="arm",
+                policy=_policy(sim),
+                spec=_NoopSpec(),
+                n_episodes=3,
+                control_frequency=50.0,
+                on_frame=_feed(recorder),
+            )
+        finally:
+            sim.cleanup()
+
+        payload = _payload(result)
+        assert result["status"] == "error", result
+        assert payload["episodes_completed"] == 1
+        assert payload["recording_save_error"].startswith("episode 0: ")
+        assert ds.save_attempts == 1
+
+
+class TestAHealthyEvaluationIsNotRefused:
+    """No evaluation reports a lost episode where there is not one.
+
+    These fail pre-fix only because the key did not exist. Their point is the
+    other direction: they are what a fix cannot pass by simply reporting a
+    reason unconditionally, and they pin the key as PRESENT and ``None`` on a
+    healthy run rather than absent - an absent key read with ``.get()`` is not
+    the same fact as a key that says nothing went wrong.
+    """
+
+    def test_a_flushed_episode_reports_the_key_as_none(self) -> None:
+        """Present and ``None``, so an absent key is never read as "fine"."""
+        ds = _Dataset(fail_from_episode=None)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        sim = _recording_sim(recorder)
+        try:
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_episodes=3,
+                max_steps=2,
+                control_frequency=50.0,
+                on_frame=_feed(recorder),
+            )
+        finally:
+            sim.cleanup()
+
+        payload = _payload(result)
+        assert result["status"] == "success", result
+        assert "recording_save_error" in payload
+        assert payload["recording_save_error"] is None
+        assert payload["episodes_completed"] == 3
+        assert ds.saved == 3
+
+    def test_an_evaluation_with_no_recorder_runs_every_episode(self) -> None:
+        """The common case: no recording session, nothing to flush."""
+        sim = Simulation(tool_name="episode_loss_norec", mesh=False)
+        sim.create_world()
+        sim.add_robot(name="arm", data_config="so100")
+        try:
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_episodes=3,
+                max_steps=2,
+                control_frequency=50.0,
+            )
+        finally:
+            sim.cleanup()
+
+        payload = _payload(result)
+        assert result["status"] == "success", result
+        assert payload["recording_save_error"] is None
+        assert payload["episodes_completed"] == 3
+
+    def test_an_empty_buffer_is_not_a_lost_episode(self) -> None:
+        """A recorder nothing fed has no episode to lose, so no flush is tried."""
+        ds = _Dataset(fail_from_episode=0)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        sim = _recording_sim(recorder)
+        try:
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_episodes=3,
+                max_steps=2,
+                control_frequency=50.0,
+            )
+        finally:
+            sim.cleanup()
+
+        payload = _payload(result)
+        assert result["status"] == "success", result
+        assert payload["recording_save_error"] is None
+        assert payload["episodes_completed"] == 3
+        assert ds.save_attempts == 0
+
+
+class TestTheClosedRecorderIsWhyItStops:
+    """The premise, measured on the real recorder rather than asserted.
+
+    Both cells hold before and after the fix: they describe why continuing is
+    not a milder outcome than stopping, which is the reason the evaluation
+    stops rather than averaging over the episodes that follow.
+    """
+
+    def test_a_failed_flush_closes_the_recorder_and_reports_it(self) -> None:
+        ds = _Dataset(fail_from_episode=0)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        recorder.add_frame({"1": 0.0}, {"1": 0.0}, camera_keys=[])
+        assert recorder.episode_frame_count == 1
+
+        verdict = recorder.save_episode()
+
+        assert verdict["status"] == "error"
+        assert recorder._closed is True
+
+    def test_add_frame_on_a_closed_recorder_writes_nothing_and_counts_no_drop(self) -> None:
+        """The silence: no frame, no ``RecordingFrameError``, no counted drop."""
+        ds = _Dataset(fail_from_episode=0)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+        recorder.add_frame({"1": 0.0}, {"1": 0.0}, camera_keys=[])
+        recorder.save_episode()
+        assert recorder._closed is True
+
+        before = (recorder.frame_count, recorder.dropped_frame_count, ds.written)
+        for _ in range(5):
+            recorder.add_frame({"1": 0.0}, {"1": 0.0}, camera_keys=[])
+
+        assert (recorder.frame_count, recorder.dropped_frame_count, ds.written) == before
+        assert recorder.strict is True  # even fail-fast mode raises nothing here
+
+
+def _discarded_flush_verdicts(source: str) -> list[int]:
+    """Line numbers of ``save_episode()`` calls whose verdict is thrown away."""
+    discarded: list[int] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+            continue
+        func = node.value.func
+        if isinstance(func, ast.Attribute) and func.attr == "save_episode":
+            discarded.append(node.lineno)
+    return discarded
+
+
+def _flush_call_sites(source: str) -> list[int]:
+    """Line numbers of every ``save_episode()`` call, discarded or not."""
+    return [
+        node.lineno
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "save_episode"
+    ]
+
+
+def _simulation_modules() -> list[pathlib.Path]:
+    root = pathlib.Path(inspect.getfile(Simulation)).parent.parent
+    assert root.name == "simulation", root
+    return sorted(root.rglob("*.py"))
+
+
+class TestEveryFlushVerdictIsRead:
+    """No flush in ``strands_robots/simulation`` discards its verdict.
+
+    This class passes before and after the fix, and that is the point: the
+    verdict was never thrown away at the call, it was bound and then only
+    logged - which no source scan can see. It is a guard for the next flush
+    rather than a pin of this one, derived from the source so a call site added
+    later is held to the same rule without being listed here.
+
+    Scoped to the simulation package: ``transforms`` has its own caller chain
+    and its own reporting, and is not what this change is about.
+    """
+
+    def test_no_save_episode_call_discards_its_verdict(self) -> None:
+        offenders = [
+            f"{path}:{line}"
+            for path in _simulation_modules()
+            for line in _discarded_flush_verdicts(path.read_text(encoding="utf-8"))
+        ]
+        assert not offenders, (
+            f"these flushes throw away a verdict that reports whether the episode reached the dataset: {offenders}"
+        )
+
+    def test_the_scan_reaches_the_call_sites_it_grades(self) -> None:
+        """Non-vacuity: an empty population would report clean forever."""
+        sites = [
+            f"{path.name}:{line}"
+            for path in _simulation_modules()
+            for line in _flush_call_sites(path.read_text(encoding="utf-8"))
+        ]
+        assert len(sites) >= 4, sites
+        assert {path.name for path in _simulation_modules()} >= {
+            "recording.py",
+            "base.py",
+            "policy_runner.py",
+        }
+
+    def test_a_discarded_verdict_is_reported(self) -> None:
+        """Non-vacuity: the scan rejects the shape this change replaced."""
+        assert _discarded_flush_verdicts("recorder.save_episode()\n") == [1]
+        assert _discarded_flush_verdicts("verdict = recorder.save_episode()\n") == []
+        assert _discarded_flush_verdicts("if recorder.save_episode()['status']: pass\n") == []


### PR DESCRIPTION
## The problem

A recorded evaluation whose per-episode dataset flush fails reports a `success_rate` over episodes whose data does not exist.

`PolicyRunner._finalize_recorder_episode` called `recorder.save_episode()` at the end of every eval rollout and turned a failure into a `logger.warning`, returning `None`. Both eval loops discarded that and kept going. But a failed flush is not the loss of an episode boundary: `DatasetRecorder.save_episode` marks the recorder **closed** on failure, because "the LeRobot episode buffer is in undefined state after a failed save" - and `add_frame` on a closed recorder does a bare `return`, so a later episode's frames are not written, do not raise `RecordingFrameError`, and are **not counted in `dropped_frame_count`**. One failed flush therefore discards every remaining episode in silence, and the evaluation reported a full N-episode result under `status="success"`.

![reported vs on disk](https://raw.githubusercontent.com/cagataycali/robots/assets/eval-episode-loss/eval_episode_loss.png)

Measured on a real MuJoCo `so101` evaluation with a real `DatasetRecorder`/`LeRobotDataset`, made to fail by revoking write permission on the dataset root at the end of episode 0 (what a full disk, a revoked permission or a read-only mount looks like to LeRobot's parquet writer). Same script, same scenario, both trees:

| | `main` | this change |
|---|---|---|
| `status` | `success` | `error` |
| `episodes_completed` | 4 of 4 | 1 of 4 |
| `success_rate` computed over | 4 episodes | 1 episode |
| `recording_save_error` | key absent | `episode 0: save_episode: ... [Errno 13] Permission denied` |
| `total_episodes` in `meta/info.json` | 0 | 0 |
| `add_frame` calls | 24 | 6 |
| frames written | 6 | 6 |
| **frames silently dropped** | **18** | **0** |
| `recorder.dropped_frame_count` | 0 | 0 |

`dropped_frame_count` stays 0 in both runs: on `main` those 18 frames leave no trace even in the recorder's own accounting, and one `logger.warning` is the entire record of the run.

## Why refusing is the established rule here

Every other flush in the tree already refuses, and each says why:

| flush site | on a failed `save_episode` |
|---|---|
| `stop_recording` (`recording.py`) | clears the recorder, returns `status="error"` |
| `SimEngine.save_episode` (`recording.py`) | drops the poisoned recorder "so callers do not keep appending into a poisoned recorder" |
| `run_policy(n_episodes=...)` (`base.py`) | records `save_episode_error` and **aborts the remaining episodes** |
| MuJoCo `reset()` | "Surface the failure rather than resetting into an undefined state" |
| the eval loops | `logger.warning`, keep going |

The one level down is already decided the same way. `RecordingFrameError` exists precisely so a rollout driver cannot absorb a lost recording frame: "granting that tolerance to a lost recording frame truncates the dataset while the rollout still reports success", and `test_recording_frame_loss_is_not_tolerated.py::test_the_eval_loop_does_not_swallow_it_either` pins that the eval loop specifically must surface it. The episode level had the opposite rule while sitting on the strictly worse failure - a lost frame truncates one episode, a lost episode truncated the whole run and took the recorder's accounting with it.

## The change

`_finalize_recorder_episode` returns `str | None` - the reason on failure, `None` when the episode was flushed or there was nothing to flush. Both `evaluate` and `_evaluate_with_spec` stop at that episode and report it:

* `status` becomes `"error"`, and the text block names the lost episode.
* the json payload carries `recording_save_error`, present and `None` on every healthy run.
* `episodes_completed` and the aggregates cover only the episodes that ran, so nothing is averaged over episodes whose frames reached no dataset.
* the failing episode's rollout MP4 is still closed and collected before the loop stops - the dataset episode is gone, so the video is the only remaining record of what the policy did.

Docs: a new `docs/recording.md` section beside the frame-level one, plus the `eval_policy` / `evaluate_benchmark` / `evaluate` return contracts (`eval_policy`'s "`status` reports whether the evaluation RAN" now names its one exception).

## Tests

`tests/simulation/test_recording_episode_loss_is_not_tolerated.py` (13 cells), named after and cross-referencing the frame-level suite. Real `Simulation`, real `PolicyRunner`, real `MockPolicy`, real `DatasetRecorder`; only the `LeRobotDataset` is stood in, so the poisoning under test is the production one.

Pre-fix, run from a pristine `upstream/main` worktree: **8 failed / 9 passed**. The 9 that pass are the premise cells (`a failed flush closes the recorder`, `add_frame on a closed recorder writes nothing and counts no drop` - both measured on the real recorder and true either way), the derived flush scan, and the untouched episode-boundary cells.

Break table over 10 mutations, control 0, `collected` stable at 18, and 0 in the frame-level sibling suite on every row:

| mutation | cells firing |
|---|---|
| control (no mutation) | 0 |
| helper returns `None` on a non-success envelope | 5 |
| helper returns `None` on a raising flush | 1 |
| `evaluate` captures the reason but does not stop | 4 |
| `_evaluate_with_spec` captures the reason but does not stop | 1 |
| `evaluate` reports the reason but keeps `status="success"` | 3 |
| benchmark path reports the reason but keeps `status="success"` | 1 |
| `evaluate` omits the key from its payload | 5 |
| the reason drops the episode it names | 2 |
| `evaluate` stops before collecting the episode's video | 1 |

Three existing tests asserted the old posture and are evolved in place rather than deleted, since each still pins something real (the helper must not raise; the finalize must be attempted per episode). Their docstrings stated the decision being changed - "recording is opportunistic. Log and continue", and "losing the episode-split is strictly better than losing the whole eval summary" - which the measurement above refutes: the whole dataset is lost, not just its boundaries.

## Gate

* `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean (1826 files).
* `mypy strands_robots tests tests_integ`: `Success: no issues found in 1823 source files`.
* `scripts/check_whole_tree_graders.py`: 298 passed, 1 skipped.
* `MUJOCO_GL=egl pytest tests/simulation/`: **1 failed, 14079 passed, 13 skipped**. The one failure is `newton/test_multi_camera.py::test_bad_position_shape_rejected`, reproduced byte-identically on a pristine `upstream/main` worktree (it asserts `'3 elements'` against `"must be a 3-element vector"`). Zero attributable failures.
* Healthy path end to end, same rig: 3 of 3 episodes, `recording_save_error=None`, three per-episode MP4s, `stop_recording` success, `verify_dataset_episodes` `expected=3 actual=3 info_total_episodes=3 sources_agree=True`, and the dataset reopens through `LeRobotDataset` with 60 frames, `observation.images.cam` at `(3, 128, 128)` and action dim `(6,)`. [Episode-0 rollout MP4](https://raw.githubusercontent.com/cagataycali/robots/assets/eval-episode-loss/healthy_eval_ep0.mp4).

LOC: +623 / -46 across 6 files, of which +461 is the new test file.

## Out of scope

`transforms/base.py:917` is the other `save_episode()` consumer that discards its verdict. It is a different subsystem with its own caller chain and its own reporting, so it is left alone here; the new derived scan is deliberately scoped to `strands_robots/simulation` and says so.
