### PR TITLE
fix(ci): the whole-tree preflight resolves a grader area held in a loop variable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,15 +366,18 @@ hatch run format            # ruff check --fix, ruff format
    other observed collision shares, 14m 41s and 29m 26s apart.
 2. Make changes, run `hatch run format && hatch run lint && hatch run test`.
    If you narrow the test run to the area you changed (`pytest tests/drivers/ -k g1`),
-   run `hatch run whole-tree-check` alongside it. Around sixty graders take the
-   *rest of the repository* as their input rather than the file under change, so
-   no path or `-k` filter over your own area collects them - and a green narrow
+   run `hatch run whole-tree-check` alongside it. Just under seventy graders take
+   the *rest of the repository* as their input rather than the file under change,
+   so no path or `-k` filter over your own area collects them - and a green narrow
    run reads in a PR description exactly like a green full one. Two consecutive
    verb ports cited such a run and both landed with the required check red on the
    same grader (#2934, #2938, per #2940). That command derives its roster from
    the tree - a grader that walks the repository root or a top-level Python area
    is collected on arrival - so adding one needs no second edit to register it
-   (#3105).
+   (#3105). The area may be held in a loop variable (`for tree in _TREES`), which
+   is how most of them spell it; reading only a literal segment there left seven
+   graders invisible to the preflight while the roster's own pin stayed green
+   (#3111).
 3. Record the change as a news fragment: `changelog.d/<pr-number>-<slug>.md`
    (see [`changelog.d/README.md`](changelog.d/README.md)). **Never append to
    `## [Unreleased]` in `CHANGELOG.md` directly** - every branch inserts at the

--- a/changelog.d/3111-preflight-resolves-a-loop-variable-area.md
+++ b/changelog.d/3111-preflight-resolves-a-loop-variable-area.md
@@ -1,0 +1,47 @@
+### Fixed: the whole-tree grader preflight collects a grader whose area is a loop variable
+
+`scripts/check_whole_tree_graders.py` derives its roster by resolving each
+walk's receiver to a concrete path and keeping the modules whose walk lands on
+the repository root or a top-level Python area. It read a `/` segment only as a
+string constant, and the idiom most whole-tree graders in this tree use holds
+the area in a loop variable:
+
+```python
+_TREES = ("strands_robots", "tests", "tests_integ", "examples")
+sorted(p for tree in _TREES for p in (_REPO_ROOT / tree).rglob("*.py"))
+```
+
+`(_REPO_ROOT / tree)` has an `ast.Name` on the right, so the walk resolved to
+nothing and the module was skipped. Measured over the tree, 21 modules use that
+spelling and 15 were absent from the roster. The gap read as healthy because 5
+of the remaining 6 were rescued incidentally by a *second*, resolvable walk
+elsewhere in the same file -- including three the roster's own pin names, so
+`test_the_roster_covers_every_grader_the_issues_name` passed over a resolver
+that could not read their main walk.
+
+The live instance is #3108: a redundant `except` tuple member took the required
+`call-test-lint` red while this preflight passed, never having collected
+`tests/test_except_tuples_state_their_real_scope.py`. That is the failure mode
+#3105 documents, arriving one layer further down -- the roster is no longer
+hand-maintained, but the derivation feeding it could not see the file either.
+
+A loop variable iterating a tuple, list or set of string literals now
+contributes one candidate segment per literal, and `walk_targets` decides
+membership exactly as it already did for a literal segment. Keeping those two
+concerns apart is what makes the change safe rather than merely wider: the
+eight `tests/simulation` backend sweeps walk `_SIM_PACKAGE / backend`, so they
+resolve now and are still *not* selected, because a walk rooted inside a
+subpackage is collected by a path-scoped run over the mirroring test directory
+and is not in the class this preflight exists to rescue. They are the control
+the resolver is measured against, and a partially understood iterable resolves
+to nothing rather than to its string members -- a subset would read as a
+resolved walk while omitting areas the grader covers.
+
+Derived graders go 60 to 68 over this tree with nothing lost, collecting seven
+that were invisible. The `UNDERIVABLE_GRADERS` entry for
+`tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py` is dropped:
+its stated reason was this exact shape, and
+`test_each_explicitly_named_grader_is_invisible_to_the_derivation` requires the
+removal now that the derivation can see it. No behaviour changes for the
+required check -- all seven were already collected by a full `tests/` run; what
+changes is that the preflight is now faithful to it.

--- a/scripts/check_whole_tree_graders.py
+++ b/scripts/check_whole_tree_graders.py
@@ -46,11 +46,35 @@ good reason: a subject test globbing its own fixture directory is
 shape-identical to one walking the repository. It is not value-identical -
 ``Path(__file__).parent / "fixtures"`` and ``tmp_path`` are neither the
 repository root nor a top-level area - so resolving the path separates them.
-Measured over this repository, the derivation selects 60 of 1461 test modules.
+Measured over this repository, the derivation selects 68 of 1426 test modules.
+
+Resolving the *value* is also why the area a grader walks may be held in a loop
+variable. The idiom here is a tuple of area names walked one at a time::
+
+    _TREES = ("strands_robots", "tests", "tests_integ", "examples")
+    sorted(p for tree in _TREES for p in (_REPO_ROOT / tree).rglob("*.py"))
+
+The segment reaching ``/`` is an ``ast.Name`` bound per iteration, not a
+constant, so reading constants alone resolved this to nothing and skipped the
+module. Issue #3111 measured 21 modules on that spelling, 15 of them absent
+from the roster; the 5 that were present were rescued incidentally by a
+*second*, resolvable walk elsewhere in the same file, which is why the gap read
+as healthy from the roster's own pin. #3108 is the live instance - a redundant
+``except`` tuple took the required check red while this preflight passed,
+never having collected the grader that failed.
+
+:func:`_resolve_area_loop` contributes one candidate path per literal in the
+iterated tuple and leaves the membership question where it already was, which
+is what makes the change safe rather than merely wider.
 
 A walk rooted *inside* a subpackage (``strands_robots/policies/``) is
 deliberately not selected: a path-scoped run over the mirroring test directory
-does collect it, so it is not in the class this script exists to rescue.
+does collect it, so it is not in the class this script exists to rescue. The
+eight ``tests/simulation`` backend sweeps are the live measure of that rule
+holding across the loop-variable spelling - they walk ``_SIM_PACKAGE / backend``,
+so they resolve now and are still excluded. A resolver change that pulled them
+in would be over-selecting, so they are the control this one was measured
+against.
 
 :data:`UNDERIVABLE_GRADERS` carries the graders whose population is the tree
 but whose walk the derivation cannot resolve - one enumerates a package with
@@ -111,10 +135,6 @@ UNDERIVABLE_GRADERS: tuple[tuple[str, str], ...] = (
     (
         "tests/tools/test_agent_tool_parameter_descriptions.py",
         "enumerates the tool package with pkgutil.iter_modules, so it walks no path",
-    ),
-    (
-        "tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py",
-        "walks (_REPO_ROOT / area) for area in a tuple, so the walked path is a loop variable",
     ),
 )
 
@@ -294,6 +314,96 @@ def _module_bindings(tree: ast.Module, module_path: Path, root: Path) -> dict[st
     return bindings
 
 
+def _literal_segments(node: ast.expr, sequences: dict[str, tuple[str, ...]]) -> tuple[str, ...]:
+    """Return the path segments ``node`` enumerates, or ``()`` if it is not a literal set of them.
+
+    A tuple, list or set of string constants answers for itself; a name answers
+    from ``sequences``, which carries the module-level ones. A container with a
+    single non-string element resolves to ``()`` rather than to its string
+    members: a partially understood iterable would contribute *some* of the
+    areas walked, and a subset is the one answer worse than none here - it
+    reads as a resolved walk while omitting directories the grader covers.
+
+    :param node: The expression a loop iterates.
+    :param sequences: Module-level names already known to hold literal segments.
+    """
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        values = [
+            element.value
+            for element in node.elts
+            if isinstance(element, ast.Constant) and isinstance(element.value, str)
+        ]
+        return tuple(values) if values and len(values) == len(node.elts) else ()
+    if isinstance(node, ast.Name):
+        return sequences.get(node.id, ())
+    return ()
+
+
+def _segment_bindings(tree: ast.Module) -> dict[str, tuple[str, ...]]:
+    """Map every loop variable that iterates literal path segments to those segments.
+
+    Both loop forms are read - a ``for`` statement and a comprehension's
+    ``for`` clause - because the graders in this tree use each, and the
+    comprehension spelling is the more common of the two. A name bound by
+    two different loops accumulates both sets, which is the safe direction:
+    the union over-approximates the paths one walk can take, and membership is
+    then decided by intersection with :func:`walk_targets`, so an extra
+    candidate that is not a walk target changes no verdict.
+
+    :param tree: The parsed module.
+    :returns: Loop variable name to the segments it takes.
+    """
+    sequences: dict[str, tuple[str, ...]] = {}
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+            name, value = stmt.targets[0].id, stmt.value
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name) and stmt.value is not None:
+            name, value = stmt.target.id, stmt.value
+        else:
+            continue
+        found = _literal_segments(value, {})
+        if found:
+            sequences[name] = found
+
+    bindings: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)) and isinstance(node.target, ast.Name):
+            found = _literal_segments(node.iter, sequences)
+            if found:
+                bindings.setdefault(node.target.id, set()).update(found)
+    return {name: tuple(sorted(values)) for name, values in bindings.items()}
+
+
+def _resolve_area_loop(
+    receiver: ast.expr,
+    module_path: Path,
+    bindings: dict[str, Path],
+    segments: dict[str, tuple[str, ...]],
+    root: Path,
+) -> set[Path]:
+    """Return every path a walk of ``base / <loop variable>`` reaches.
+
+    Empty unless the receiver is exactly that shape with a resolvable base and
+    a loop variable known to iterate literal segments. Anything else stays
+    unresolved, which :data:`UNDERIVABLE_GRADERS` reports rather than this
+    silently counting as a whole-tree walk.
+
+    :param receiver: The expression the walk method is called on.
+    :param module_path: Where the module lives, so ``__file__`` resolves.
+    :param bindings: Module-level names resolved to paths.
+    :param segments: Loop variables resolved to literal segments.
+    :param root: The repository root.
+    """
+    if not (
+        isinstance(receiver, ast.BinOp) and isinstance(receiver.op, ast.Div) and isinstance(receiver.right, ast.Name)
+    ):
+        return set()
+    base = _resolve(receiver.left, module_path, bindings, root)
+    if not isinstance(base, Path):
+        return set()
+    return {base / segment for segment in segments.get(receiver.right.id, ())}
+
+
 def walked_paths(source: str, module_path: Path, root: Path) -> set[Path]:
     """Return every directory ``source`` walks that resolves to a concrete path.
 
@@ -303,12 +413,16 @@ def walked_paths(source: str, module_path: Path, root: Path) -> set[Path]:
     """
     tree = ast.parse(source)
     bindings = _module_bindings(tree, module_path, root)
+    segments = _segment_bindings(tree)
     targets: set[Path] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr in _WALK_METHODS:
-            resolved = _resolve(node.func.value, module_path, bindings, root)
+            receiver = node.func.value
+            resolved = _resolve(receiver, module_path, bindings, root)
             if isinstance(resolved, Path):
                 targets.add(resolved)
+                continue
+            targets.update(_resolve_area_loop(receiver, module_path, bindings, segments, root))
     return targets
 
 

--- a/tests/test_whole_tree_graders_roster_is_complete.py
+++ b/tests/test_whole_tree_graders_roster_is_complete.py
@@ -34,7 +34,15 @@ nothing reads exactly like a tree with nothing to select:
   was rejected because it could not tell those apart;
 - every entry in ``UNDERIVABLE_GRADERS`` is genuinely invisible to the
   derivation, so that list cannot quietly grow back into the hand roster this
-  replaced.
+  replaced;
+- an area held in a *loop variable* resolves, which issue #3111 records as the
+  third turn of the same screw. The derivation read a ``/`` segment only as a
+  string constant, and the idiom here is a tuple of area names walked one at a
+  time, so 15 of the 21 modules on that spelling were unrostered - while the
+  bullet above passed, because 5 of the remaining 6 were rescued incidentally
+  by a second, resolvable walk elsewhere in the same file. A pin that grades
+  only the graders an issue names cannot see a resolver gap that its own named
+  graders survive by accident, so the spellings are graded directly.
 
 A roster only helps a caller who knows to run it. Issue #2940's failure mode
 was a *green* narrow run, so the remedy is only reachable if the pre-push
@@ -67,9 +75,11 @@ _cwtg = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_cwtg)
 
 
-# The graders the two issues name by filename. #2940 named five; #3105 named
+# The graders the three issues name by filename. #2940 named five; #3105 named
 # the sixth, which a hand roster had omitted and which is the reason the roster
-# is derived rather than written down.
+# is derived rather than written down; #3111 named the seventh, which the
+# derivation itself could not see because it walks an area held in a loop
+# variable.
 _NAMED_BY_ISSUES: frozenset[str] = frozenset(
     {
         "tests/test_docstring_xref_roles_resolve.py",
@@ -78,6 +88,7 @@ _NAMED_BY_ISSUES: frozenset[str] = frozenset(
         "tests/tools/test_agent_tool_parameter_descriptions.py",
         "tests/test_parameter_deletes_precede_the_body_they_narrow.py",
         "tests/test_mesh_pacing_ticker.py",
+        "tests/test_except_tuples_state_their_real_scope.py",
     }
 )
 
@@ -123,7 +134,7 @@ def test_the_roster_covers_every_grader_the_issues_name(roster: tuple[str, ...])
 def test_the_derivation_is_not_vacuous(derived: tuple[str, ...]) -> None:
     """A derivation that selected nothing would report a clean sweep.
 
-    The floor is deliberately far below the measured count (60 at the time of
+    The floor is deliberately far below the measured count (68 at the time of
     writing): the point is to fail when the resolver breaks and selects
     almost nothing, not to pin a number that every added grader edits.
     """
@@ -187,6 +198,86 @@ def test_a_subject_scoped_walk_is_not_a_whole_tree_grader(label: str, walk: str)
         f"the derivation selected a module that only walks {label}. Every "
         "subject test that globs its own fixtures would join the preflight, "
         "which is the reason an earlier shape-based scan was rejected."
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "grader"),
+    [
+        (
+            "a module-level tuple walked in a comprehension",
+            "_TREES = ('strands_robots', 'tests')\n\nFILES = [p for tree in _TREES for p in (ROOT / tree).rglob('*.py')]",
+        ),
+        (
+            "a module-level tuple walked in a for statement",
+            "_TREES = ('strands_robots', 'tests')\n\nfor tree in _TREES:\n    for p in (ROOT / tree).rglob('*.py'):\n        pass",
+        ),
+        (
+            "a tuple written inline in the loop",
+            "for area in ('strands_robots', 'tests'):\n    for p in (ROOT / area).rglob('*.py'):\n        pass",
+        ),
+        (
+            "a module-level list",
+            "_AREAS = ['strands_robots']\n\nFILES = [p for a in _AREAS for p in (ROOT / a).rglob('*.py')]",
+        ),
+    ],
+)
+def test_an_area_held_in_a_loop_variable_resolves(label: str, grader: str) -> None:
+    """A grader that walks ``root / area`` for each name in a tuple is selected.
+
+    This is the spelling most whole-tree graders in this tree use, and #3111
+    measured 21 modules on it with 15 unrostered. The segment reaching ``/`` is
+    bound per iteration rather than written as a constant, so a resolver that
+    reads constants alone resolves the walk to nothing and skips the module -
+    silently, and in the reassuring direction. ``label`` names the spelling so a
+    failure says which one stopped resolving.
+    """
+    source = f"import pathlib\n\nimport strands_robots\n\nROOT = pathlib.Path(strands_robots.__file__).resolve().parents[1]\n\n{grader}\n"
+    assert _selects(source, _TESTS_ROOT / "test_planted.py"), (
+        f"the derivation cannot resolve an area spelled as {label}, so a grader "
+        "written that way is invisible to the preflight rather than merely "
+        "unrostered - which is the defect #3111 records."
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "grader"),
+    [
+        (
+            "a subpackage walked per backend",
+            "_BACKENDS = ('mujoco', 'newton', 'isaac')\n\nFILES = [p for b in _BACKENDS for p in (PKG / 'simulation' / b).rglob('*.py')]",
+        ),
+        (
+            "a loop over paths rather than name segments",
+            "_ROOTS = [PKG, PKG / 'policies']\n\nFILES = [p for r in _ROOTS for p in (PKG / r).rglob('*.py')]",
+        ),
+        (
+            "a loop whose iterable is computed at run time",
+            "_AREAS = os.environ['AREAS'].split(',')\n\nFILES = [p for a in _AREAS for p in (PKG / a).rglob('*.py')]",
+        ),
+    ],
+)
+def test_a_loop_variable_area_that_is_not_a_top_level_area_is_not_selected(label: str, grader: str) -> None:
+    """Resolving a loop variable must not widen *which* walks count as whole-tree.
+
+    The resolver contributes candidate paths; :func:`walk_targets` still decides
+    membership. The eight ``tests/simulation`` backend sweeps are the live
+    control - they walk ``_SIM_PACKAGE / backend``, so they resolve and are
+    still excluded, because a path-scoped run over the mirroring test directory
+    collects them. A loop over values that are not literal name segments stays
+    unresolved instead of contributing a partially understood walk.
+
+    The run-time case deliberately computes its areas from the environment
+    rather than from the tree. Spelling it ``sorted(PKG.iterdir())`` would not
+    grade this resolver at all: that walks ``PKG`` itself, which is a top-level
+    area, so the module is selected on the ``iterdir`` call alone and reads as
+    a pass here on ``main`` too.
+    """
+    source = f"import os\nimport pathlib\n\nimport strands_robots\n\nPKG = pathlib.Path(strands_robots.__file__).resolve().parent\n\n{grader}\n"
+    assert not _selects(source, _TESTS_ROOT / "simulation" / "test_planted.py"), (
+        f"the derivation selected a module walking {label}. Resolving a loop "
+        "variable is meant to read the same walks the tree already has, not to "
+        "widen the class of walk that counts as whole-tree."
     )
 
 


### PR DESCRIPTION
Fixes #3111

## What was wrong

`scripts/check_whole_tree_graders.py` derives its roster by resolving each walk's receiver to a concrete path and keeping the modules whose walk lands on the repository root or a top-level Python area. It read a `/` segment only as an `ast.Constant` string. The idiom most whole-tree graders in this tree use holds the area in a **loop variable**:

```python
# tests/test_except_tuples_state_their_real_scope.py
_TREES = ("strands_robots", "tests", "tests_integ", "examples")

def _scanned_files() -> list[Path]:
    return sorted(p for tree in _TREES for p in (_REPO_ROOT / tree).rglob("*.py"))
```

`(_REPO_ROOT / tree)` has an `ast.Name` on the right, so `_resolve` returned `None`, `walked_paths` yielded the empty set, and the module was skipped.

## Why it stayed hidden

| population | count |
|---|---|
| modules using the loop-variable idiom | 21 |
| of those, **absent from the roster** | **15** |
| rescued incidentally by a *second*, resolvable walk in the same file | 5 |
| hand-named in `UNDERIVABLE_GRADERS` | 1 |

The 5 rescued ones are why this read as healthy: `tests/test_dependency_audit.py`, `tests/test_no_host_paths.py` and `tests/test_parameter_deletes_precede_the_body_they_narrow.py` are all in the pin's `_NAMED_BY_ISSUES` and all passed it -- not because the idiom resolved, but because each also walks a root directly somewhere else in the file. So `test_the_roster_covers_every_grader_the_issues_name` was green over a resolver that could not read their main walk. A pin that grades only the graders an issue names cannot see a resolver gap its own named graders survive by accident.

**Live instance:** #3108. A redundant `except` tuple member took the required `call-test-lint` red while this preflight passed -- it never collected `tests/test_except_tuples_state_their_real_scope.py`. That is #3105's failure mode one layer further down: the roster is no longer hand-maintained, but the derivation feeding it could not see the file either.

## The change

A loop variable iterating a tuple, list or set of string literals contributes one candidate segment per literal (`_literal_segments`, `_segment_bindings`, `_resolve_area_loop`). `walk_targets` decides membership exactly as it already did for a literal segment.

Keeping those two concerns apart is what keeps this from widening *which* walks count as whole-tree, and there is a live control for it: the eight `tests/simulation` backend sweeps walk `_SIM_PACKAGE / backend`, so they **resolve now and are still excluded**, because a walk rooted inside a subpackage is collected by a path-scoped run over the mirroring test directory. A partially understood iterable resolves to `()` rather than to its string members -- a subset would read as a resolved walk while omitting areas the grader covers.

### Measured over this tree

| | before | after |
|---|---|---|
| derived graders | 60 | 68 |
| roster (derived + explicit) | 62 | 69 |
| lost | -- | **0** |

Seven graders that were invisible are now collected:

- `tests/test_except_tuples_state_their_real_scope.py` (the #3108 instance)
- `tests/test_mujoco_enum_comparisons_are_value_based.py`
- `tests/test_optional_dependency_skips_bind_their_names.py`
- `tests/test_sys_modules_removal_leaves_no_orphan.py`
- `tests/test_test_case_names_describe_behaviour.py`
- `tests/tools/test_lazy_tool_name_is_not_read_as_a_module.py`
- `tests/simulation/mujoco/test_suite_patch_ops_use_accepted_keys.py`

The `UNDERIVABLE_GRADERS` entry for `tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py` is **dropped**: its stated reason was this exact shape ("walks (_REPO_ROOT / area) for area in a tuple, so the walked path is a loop variable"), and `test_each_explicitly_named_grader_is_invisible_to_the_derivation` requires the removal now that the derivation can see it. That entry being the *second* copy of this shape is what made the pattern evidence rather than an exception.

**No behaviour change for the required check.** All seven were already collected by a full `tests/` run; what changes is that the preflight is now faithful to it.

## Regression pins

Added to `tests/test_whole_tree_graders_roster_is_complete.py`:

- `test_an_area_held_in_a_loop_variable_resolves` -- four spellings (module-level tuple via comprehension, module-level tuple via `for` statement, inline tuple, module-level list).
- `test_a_loop_variable_area_that_is_not_a_top_level_area_is_not_selected` -- three over-selection controls (subpackage per backend, a loop over paths rather than name segments, a run-time-computed iterable).
- The #3108 instance joins `_NAMED_BY_ISSUES`, so the existing coverage pin now grades it directly.

**Verified the pins fail without the fix.** With the branch's tests and `main`'s script, 5 fail / 17 pass; with the branch's script, 22 pass:

```
FAILED test_the_roster_covers_every_grader_the_issues_name
FAILED test_an_area_held_in_a_loop_variable_resolves[a module-level tuple walked in a comprehension]
FAILED test_an_area_held_in_a_loop_variable_resolves[a module-level tuple walked in a for statement]
FAILED test_an_area_held_in_a_loop_variable_resolves[a tuple written inline in the loop]
FAILED test_an_area_held_in_a_loop_variable_resolves[a module-level list]
```

One of the over-selection controls initially failed and the *test* was wrong, not the code: spelled `sorted(PKG.iterdir())`, it walks `PKG` itself -- a top-level area -- so the module is selected on the `iterdir` call alone and reads as a pass on `main` too. Confirmed against `main` and replaced with an iterable computed from the environment, which isolates the new resolver; the docstring records why.

## Verification

```
pytest tests/test_whole_tree_graders_roster_is_complete.py         22 passed
pytest tests/test_changelog_fragments.py tests/test_changelog_format.py
       tests/test_docstring_xref_roles_resolve.py
       tests/test_test_case_names_describe_behaviour.py
       tests/test_test_module_names_do_not_spell_a_tracker_coordinate.py
       tests/test_except_tuples_state_their_real_scope.py           114 passed
ruff check / ruff format --check                                    clean
mypy scripts/check_whole_tree_graders.py                            clean
```

The seven newly collected graders were run directly; the only failures were missing optional extras in the ad-hoc env (`lerobot`, `cv2`), not grader failures, and each file is already collected by today's required check unchanged.

## Doc drift

`AGENTS.md` PR Workflow step 2 said "Around sixty graders" and described the derivation as reading an area walk without qualification. Updated to "just under seventy" and to name the loop-variable spelling, since that step is the only place a contributor is told to run the preflight at all.

---

> [!NOTE]
> This pull request was created by an AI contributor (Strands Agents).