### PR TITLE
fix(dashboard): a WebAuthn challenge's TTL is measured on a clock a correction cannot move

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1848,9 +1848,16 @@ which side the enum is on.
   `time.time()`; the mesh keeps `_last_estop_mono` beside `_last_estop_ts` for the same
   reason. If one value is used both to decide and to report, split it rather than picking
   a compromise clock.
-- Pinned by `tests/tools/test_tool_wait_budgets_survive_a_clock_step.py` (a scan over the
-  agent-callable tools, no exemption list) and, for the safety subsystem, by
-  `tests/mesh/test_replay_cache_monotonic.py` and
+- **A scan whose walk root is one subsystem grades one subsystem.** The source scan for
+  this idiom walked `strands_robots/tools` alone and read clean while the one offender in
+  the tree sat in `dashboard/auth.py`, where a WebAuthn challenge's TTL was measured on the
+  wall clock. Same predicate, wider root, found it at once: a walk root narrower than the
+  shape being graded reports a clean tree, not an ungraded one.
+- Pinned by `tests/test_expiry_gates_survive_a_clock_step.py` (a scan over the whole
+  package, no exemption list), by `tests/tools/test_tool_wait_budgets_survive_a_clock_step.py`
+  for the real `spin_for` behaviour, by
+  `tests/test_dashboard_challenge_expiry_survives_a_clock_step.py` for the challenge store,
+  and, for the safety subsystem, by `tests/mesh/test_replay_cache_monotonic.py` and
   `tests/mesh/test_corroboration_clock_domain.py`. The frame pacer named above is pinned
   by `tests/simulation/test_rollout_durations_survive_a_clock_step.py`, which asserts the
   *achieved* frame interval across a clock step rather than the value the pacer computed,

--- a/changelog.d/3115-challenge-expiry-on-a-monotonic-clock.md
+++ b/changelog.d/3115-challenge-expiry-on-a-monotonic-clock.md
@@ -1,0 +1,27 @@
+### Fixed: a WebAuthn challenge's TTL is measured on a clock a correction cannot move
+
+`_stash_challenge` stamped each challenge record with `time.time()` and three
+decisions read that stamp back: the TTL gate in `_pop_challenge`, the sweep the
+next stash performs on the way in, and the order `_evict_oldest` drops entries
+in when the table hits its cap. All three are durations this process decides on
+its own -- it writes the stamp and it reads it -- so one NTP correction,
+`date -s` or resume from suspend moved every one of them.
+
+Measured against the real store with the default 300s TTL: a challenge 301
+seconds old was **accepted** across a `-1h` step, extending the window that
+nonce stays replayable by the size of the step, while a challenge one second old
+was **refused** across a `+1h` step and then swept out of the table by the next
+caller's request -- so an unrelated client's arriving login ended the operator's
+in-flight ceremony. Across a backward step the cap also inverted: an entry
+stamped *after* the correction sorts oldest, so "drop the oldest" dropped a newer
+challenge and kept a staler one.
+
+The stamp is now `time.monotonic()`, under a `t_mono` key that names its clock
+domain the way the safety subsystem does. The absolute stamps in the same module
+are deliberately unchanged: a session token's `iat`/`exp` and a credential's
+`created` name a point in time that a browser or an operator correlates with
+something off this process, and belong on the wall clock.
+
+The source scan that grades this idiom walked `strands_robots/tools` alone,
+which is a root narrower than the shape it grades -- it read clean while the one
+offender in the tree sat in the dashboard. It now walks the whole package.

--- a/strands_robots/dashboard/auth.py
+++ b/strands_robots/dashboard/auth.py
@@ -500,6 +500,17 @@ logger = logging.getLogger(__name__)
 _challenges: dict[str, dict[str, Any]] = {}
 _chal_lock = threading.Lock()
 _CHAL_TTL = 300.0
+# : A challenge's age is a DURATION this process decides on its own -- it stamps
+# : the record and it reads it back -- so it is measured on ``time.monotonic()``,
+# : under the ``_mono`` name the safety subsystem uses for the same distinction.
+# : ``time.time()`` is not a clock but the current opinion about the date, and an
+# : NTP correction, a ``date -s`` or a resume from suspend moves it by an
+# : arbitrary amount: backwards, an expired challenge stays replayable for the
+# : size of the step, and the cap's "drop the oldest" drops a newer entry;
+# : forwards, an in-flight ceremony is refused and the next stash sweeps it out.
+# : The absolute stamps in this module -- a session token's ``iat``/``exp``, a
+# : credential's ``created`` -- name a point in time a browser or an operator
+# : correlates with something off this process, and stay on the wall clock.
 
 # : Caps on the challenge table. Both are per-process and generous: a challenge : measures
 # ~0.5KB, so 512 of them is ~256KB.
@@ -511,7 +522,7 @@ _CHAL_MAX_PER_IP = int(os.getenv("STRANDS_DASH_AUTH_CHAL_MAX_PER_IP", "16"))
 
 def _evict_oldest(where: dict[str, dict[str, Any]], keep: int, ip: str | None = None) -> int:
     """Drop the oldest entries (optionally only one ip's) until ``keep`` remain."""
-    pool = [(v["t"], k) for k, v in where.items() if ip is None or v.get("ip") == ip]
+    pool = [(v["t_mono"], k) for k, v in where.items() if ip is None or v.get("ip") == ip]
     dropped = 0
     for _t, k in sorted(pool)[: max(0, len(pool) - keep)]:
         where.pop(k, None)
@@ -526,9 +537,9 @@ def _stash_challenge(
     ip: str | None = None,
 ) -> str:
     cid = secrets.token_urlsafe(16)
-    now = time.time()
+    now = time.monotonic()
     with _chal_lock:
-        for k in [k for k, v in _challenges.items() if now - v["t"] > _CHAL_TTL]:
+        for k in [k for k, v in _challenges.items() if now - v["t_mono"] > _CHAL_TTL]:
             _challenges.pop(k, None)
         # Evict the flooder's OWN oldest entries first, so one noisy client
         # cannot cost anybody else their in-flight ceremony.
@@ -542,7 +553,7 @@ def _stash_challenge(
         _challenges[cid] = {
             "kind": kind,
             "challenge": challenge,
-            "t": now,
+            "t_mono": now,
             "extra": extra or {},
             "ip": ip,
         }
@@ -582,7 +593,7 @@ def _pop_challenge(cid: str, kind: str) -> dict[str, Any]:
         rec = _challenges.pop(cid, None)
     if not rec or rec["kind"] != kind:
         raise HTTPException(400, "invalid or expired challenge")
-    if time.time() - rec["t"] > _CHAL_TTL:
+    if time.monotonic() - rec["t_mono"] > _CHAL_TTL:
         raise HTTPException(400, "challenge expired")
     return rec
 

--- a/tests/test_dashboard_auth_edges.py
+++ b/tests/test_dashboard_auth_edges.py
@@ -44,8 +44,11 @@ def isolated_store(tmp_path, monkeypatch):
 
 
 def test_expired_challenge_refused_at_pop():
+    # Age is faked by rewriting the stamp, so this cell says nothing about which
+    # clock measures it; that is graded by moving the clock instead, in
+    # tests/test_dashboard_challenge_expiry_survives_a_clock_step.py.
     cid = auth._stash_challenge("auth", b"chal", ip="1.2.3.4")
-    auth._challenges[cid]["t"] = time.time() - auth._CHAL_TTL - 1
+    auth._challenges[cid]["t_mono"] = time.monotonic() - auth._CHAL_TTL - 1
     with pytest.raises(HTTPException) as e:
         auth._pop_challenge(cid, "auth")
     assert e.value.status_code == 400

--- a/tests/test_dashboard_auth_rpid_and_challenge_caps.py
+++ b/tests/test_dashboard_auth_rpid_and_challenge_caps.py
@@ -156,13 +156,6 @@ def test_a_stashed_challenge_still_pops_normally():
     assert rec["challenge"] == b"secret" and rec["extra"]["rp_id"] == "localhost"
 
 
-def test_expired_entries_are_still_pruned(monkeypatch):
-    cid = auth._stash_challenge("auth", b"old", {}, ip="192.0.2.5")
-    auth._challenges[cid]["t"] -= auth._CHAL_TTL + 1
-    auth._stash_challenge("auth", b"new", {}, ip="192.0.2.6")
-    assert cid not in auth._challenges
-
-
 def test_the_client_ip_prefers_a_forwarded_header_for_fairness_only():
     """Attacker-settable, so it is used to SPREAD the cap, never to grant trust."""
     assert auth._client_ip(_req(**{"cf-connecting-ip": "198.51.100.7"})) == "198.51.100.7"

--- a/tests/test_dashboard_challenge_expiry_survives_a_clock_step.py
+++ b/tests/test_dashboard_challenge_expiry_survives_a_clock_step.py
@@ -1,0 +1,230 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""A WebAuthn challenge's five-minute life is measured on a clock that cannot step.
+
+``_stash_challenge`` stamps a challenge record and ``_pop_challenge`` reads that
+stamp back to decide whether the ceremony is still open. Both readings are this
+process's own, so the age between them is a *duration* -- local bookkeeping, and
+the tree's thrice-settled boundary puts it on ``time.monotonic()``. It was
+measured against ``time.time()``, which is not a clock but the current opinion
+about the date, and one NTP correction, ``date -s`` or resume from suspend moved
+all three decisions the stamp feeds. Driving the real store through a clock
+double that takes one step, with the default 300s TTL::
+
+    pop a challenge                              before        after
+    10s old, no step (control)                  accepted    accepted
+    301s old, no step (control)                  refused     refused
+    301s old, wall clock steps -1h              accepted     refused
+    1s old, wall clock steps +1h                 refused    accepted
+
+    a 1s-old ceremony, next stash after a +1h step   swept out by the GC    kept
+    the cap drops, entries either side of a -1h step       a newer entry  the oldest
+
+Backwards, a challenge whose window has closed is accepted for the size of the
+step: the TTL is the only thing bounding how long that nonce stays replayable.
+Forwards, an operator mid-login is refused with "challenge expired", and the next
+caller's ``_stash_challenge`` sweeps the record out of the table on the way in --
+so one client's arriving request ends another's ceremony. The third row is the
+per-client cap: ``_evict_oldest`` orders the pool by that stamp, and across a
+backward step the entry stamped *after* the correction sorts oldest, so "drop the
+oldest" drops a newer challenge and keeps a staler one -- inverting the fairness
+property the cap exists for.
+
+Neither direction was observable from the existing suite, because both cells that
+covered expiry simulated age by rewriting the stored stamp
+(``_challenges[cid]["t"] = time.time() - _CHAL_TTL - 1``) rather than by moving
+the clock. A stamp rewritten in the code's own clock domain agrees with the code
+whichever clock that is, so those cells were green either way; the cells here
+move the clock instead and leave the store alone.
+
+The other half of the boundary is pinned too: a session token's ``iat``/``exp``
+are absolute stamps that a browser and ``renewal_verdict`` correlate, so they stay
+on the wall clock and this module must not be swept clock-blind.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import jwt
+import pytest
+from fastapi import HTTPException
+
+import strands_robots.dashboard.auth as auth
+
+
+class SteppableClock:
+    """A wall clock that can be corrected, beside a monotonic one that cannot.
+
+    ``advance`` is real time passing: both clocks move together. ``step_wall`` is
+    the correction -- an NTP slew, a ``date -s``, a resume from suspend -- and
+    moves only :meth:`time`. Correct code reads :meth:`monotonic` and is
+    therefore immune to any number of steps.
+    """
+
+    def __init__(self, *, wall_base: float = 1_700_000_000.0, mono_base: float = 1000.0) -> None:
+        self._elapsed = 0.0
+        self._offset = 0.0
+        self._wall_base = wall_base
+        self._mono_base = mono_base
+
+    def advance(self, seconds: float) -> None:
+        self._elapsed += seconds
+
+    def step_wall(self, seconds: float) -> None:
+        self._offset += seconds
+
+    def monotonic(self) -> float:
+        return self._mono_base + self._elapsed
+
+    def time(self) -> float:
+        return self._wall_base + self._elapsed + self._offset
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> Iterator[SteppableClock]:
+    """The real challenge store, reading the clock double, empty before and after."""
+    double = SteppableClock()
+    # Annotated Any: the real attribute is the `time` module, and the double
+    # answers the two readings this module makes of it.
+    stand_in: Any = double
+    monkeypatch.setattr(auth, "time", stand_in)
+    auth._challenges.clear()
+    try:
+        yield double
+    finally:
+        auth._challenges.clear()
+
+
+def _pop(cid: str) -> str:
+    """``"accepted"``, or the refusal the caller is given."""
+    try:
+        auth._pop_challenge(cid, "auth")
+    except HTTPException as exc:
+        return f"refused: {exc.detail}"
+    return "accepted"
+
+
+# ---------------------------------------------------------------------------
+# The double itself, so that a clean run below means something
+# ---------------------------------------------------------------------------
+def test_the_double_advance_moves_both_clocks(clock: SteppableClock) -> None:
+    wall, mono = clock.time(), clock.monotonic()
+    clock.advance(7.0)
+    assert clock.time() == pytest.approx(wall + 7.0)
+    assert clock.monotonic() == pytest.approx(mono + 7.0)
+
+
+@pytest.mark.parametrize("step", [30.0, 3600.0, -30.0, -3600.0])
+def test_the_double_step_moves_only_the_wall_clock(clock: SteppableClock, step: float) -> None:
+    wall, mono = clock.time(), clock.monotonic()
+    clock.step_wall(step)
+    assert clock.time() == pytest.approx(wall + step), "the double must really hand out the step"
+    assert clock.monotonic() == pytest.approx(mono), "monotonic must not move on a wall-clock step"
+
+
+# ---------------------------------------------------------------------------
+# The TTL gate at pop
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("aged", "expected"),
+    [(10.0, "accepted"), (auth._CHAL_TTL + 1.0, "refused: challenge expired")],
+)
+def test_the_ttl_is_enforced_when_the_clock_does_not_step(clock: SteppableClock, aged: float, expected: str) -> None:
+    """Control: absent a correction, a challenge lives exactly its TTL."""
+    cid = auth._stash_challenge("auth", b"operator", {}, ip="192.0.2.5")
+    clock.advance(aged)
+    assert _pop(cid) == expected
+
+
+def test_a_live_challenge_still_pops_after_the_clock_jumps_forward(clock: SteppableClock) -> None:
+    """A correction must not refuse the ceremony the operator is in the middle of."""
+    cid = auth._stash_challenge("auth", b"operator", {}, ip="192.0.2.5")
+    clock.advance(1.0)
+    clock.step_wall(+3600.0)
+    assert _pop(cid) == "accepted", (
+        "a +1h wall-clock step expired a challenge one second old, so an operator "
+        "mid-login is told the ceremony timed out"
+    )
+
+
+def test_an_expired_challenge_is_refused_after_the_clock_jumps_back(clock: SteppableClock) -> None:
+    """A correction must not extend the window a nonce stays replayable in."""
+    cid = auth._stash_challenge("auth", b"operator", {}, ip="192.0.2.5")
+    clock.advance(auth._CHAL_TTL + 1.0)
+    clock.step_wall(-3600.0)
+    assert _pop(cid) == "refused: challenge expired", (
+        "a -1h wall-clock step accepted a challenge past its TTL, extending the replay window by the size of the step"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The sweep the next stash performs on the way in
+# ---------------------------------------------------------------------------
+def test_the_stash_sweep_keeps_a_live_challenge_after_a_forward_step(clock: SteppableClock) -> None:
+    """One caller's arriving request must not end another's ceremony."""
+    mine = auth._stash_challenge("auth", b"operator", {}, ip="192.0.2.5")
+    clock.advance(1.0)
+    clock.step_wall(+3600.0)
+    auth._stash_challenge("auth", b"other", {}, ip="198.51.100.7")
+    assert mine in auth._challenges, (
+        "after a +1h step the next stash swept out a challenge one second old, so "
+        "an unrelated caller's request ended the operator's in-flight login"
+    )
+
+
+def test_the_stash_sweep_still_prunes_a_genuinely_expired_challenge(clock: SteppableClock) -> None:
+    """Control: the sweep is still a sweep. Age simulated by moving the clock."""
+    stale = auth._stash_challenge("auth", b"old", {}, ip="192.0.2.5")
+    clock.advance(auth._CHAL_TTL + 1.0)
+    auth._stash_challenge("auth", b"new", {}, ip="192.0.2.6")
+    assert stale not in auth._challenges, "an expired challenge must not survive the next stash"
+
+
+# ---------------------------------------------------------------------------
+# Which entry the cap evicts
+# ---------------------------------------------------------------------------
+def test_the_cap_evicts_the_challenge_stashed_first_across_a_backward_step(
+    clock: SteppableClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "Drop the oldest" must mean the one stashed first, however the date moves."""
+    monkeypatch.setattr(auth, "_CHAL_MAX", 3)
+    monkeypatch.setattr(auth, "_CHAL_MAX_PER_IP", 100)  # isolate the global cap
+    first = auth._stash_challenge("auth", b"first", {}, ip="192.0.2.5")
+    clock.advance(1.0)
+    clock.step_wall(-3600.0)
+    second = auth._stash_challenge("auth", b"second", {}, ip="192.0.2.6")
+    clock.advance(1.0)
+    third = auth._stash_challenge("auth", b"third", {}, ip="192.0.2.7")
+    clock.advance(1.0)
+    auth._stash_challenge("auth", b"trigger", {}, ip="192.0.2.8")  # crosses the cap
+    dropped = [
+        name for name, cid in (("first", first), ("second", second), ("third", third)) if cid not in auth._challenges
+    ]
+    assert dropped == ["first"], (
+        f"the cap dropped {dropped or ['nothing']}: across a -1h step an entry stashed "
+        "after the correction sorts oldest, so a newer challenge is evicted and a "
+        "staler one survives"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The other half of the boundary: an absolute stamp is not a duration
+# ---------------------------------------------------------------------------
+def test_a_session_tokens_stamps_stay_on_the_wall_clock(clock: SteppableClock, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``iat``/``exp`` name a date a browser reads, so they must not move to monotonic.
+
+    This fails if the module is swept clock-blind rather than per value: seconds of
+    process uptime in ``exp`` is a token that expired 55 years ago.
+    """
+    secret = "a-secret-long-enough-for-HS256-in-this-test"
+    monkeypatch.setattr(auth, "_jwt_secret", lambda: secret)
+    token = auth.issue_token("operator")
+    # verify_exp off: the assertions below are about which clock stamped the
+    # token, and the double's date is deliberately not today's.
+    claims = jwt.decode(token, secret, algorithms=["HS256"], options={"verify_exp": False})
+    assert claims["iat"] == int(clock.time()), (
+        f"a token's iat is {claims['iat']}, not the wall clock's {int(clock.time())}"
+    )
+    assert claims["iat"] != int(clock.monotonic()), "iat must not be seconds of process uptime"
+    assert claims["exp"] > claims["iat"], "a freshly minted token must not already be expired"

--- a/tests/test_expiry_gates_survive_a_clock_step.py
+++ b/tests/test_expiry_gates_survive_a_clock_step.py
@@ -1,0 +1,127 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""No module in the package lets a steppable clock decide whether to keep waiting.
+
+``time.time()`` is not a clock: it is the current opinion about the date, and an
+NTP correction, a ``date -s`` or a resume from suspend moves it by an arbitrary
+amount. A gate built on it therefore moves with the correction -- a forward step
+ends a wait early with the work still in flight, a backward step runs past the
+budget by the size of the step -- and the tree settled that boundary several
+times over, each time the same way: a *duration* this process decides on its own
+belongs on ``time.monotonic()``, while an *absolute stamp* that something off
+this machine correlates stays on the wall clock.
+
+This scan is the package-wide half of that contract. It used to live beside the
+tool wait-budget tests and walk ``strands_robots/tools`` alone, which is a root
+narrower than the shape it grades: it read clean while the one offender in the
+tree sat in ``strands_robots/dashboard/auth.py``, where a WebAuthn challenge's
+five-minute TTL was measured on the wall clock. Running the same predicate over
+the whole package found it immediately, so the predicate was never the problem
+and the walk root was. It now walks the package, with no exemption list, so a
+new *subsystem* cannot reintroduce the idiom either -- not just a new tool.
+
+What the shape does and does not carry, stated so it is not mistaken for a
+complete guard. A wall-clock read inside the test of a ``while`` or of an ``if``
+that leaves the wait is a decision and is reported. Two things are deliberately
+not: a read that only *reports* (a record's timestamp, a logged duration), and a
+read hoisted into a local before the comparison (``now = time.time()`` compared
+further down). The subsystem grader owning each surface pins the rest on
+behaviour, which is stronger than any source shape -- see
+``tests/test_dashboard_challenge_expiry_survives_a_clock_step.py``,
+``tests/mesh/test_mesh_durations_survive_a_clock_step.py``,
+``tests/test_control_loop_budgets_survive_a_clock_step.py`` and the rendering,
+rollout and RTC members of the same family.
+
+Two wall-clock comparisons in ``mesh/core.py`` are correct and must stay: the
+estop and resume freshness windows measure ``now - envelope_t`` against a
+timestamp a *peer* put on the wire, which is the one place a stamp crosses a
+machine boundary (``docs/mesh.md``). They are not reported here because the read
+is hoisted, but a future widening of this scan must keep clearing them.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import strands_robots
+
+_PACKAGE_ROOT = pathlib.Path(strands_robots.__file__).parent
+
+
+def _reads_wall_clock(node: ast.AST) -> bool:
+    """True if ``node`` contains a ``time.time()`` / ``time.time_ns()`` read."""
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr in ("time", "time_ns")
+            and isinstance(sub.func.value, ast.Name)
+            and sub.func.value.id == "time"
+        ):
+            return True
+    return False
+
+
+def _wall_clock_wait_decisions(source: str) -> list[tuple[int, str]]:
+    """Sites in ``source`` where a wall-clock read decides whether to keep waiting.
+
+    Two shapes carry that decision: a ``while`` whose test reads the wall clock,
+    and an ``if`` that reads it to leave a wait (``raise`` / ``break`` /
+    ``return`` / ``continue``). A wall-clock read that only *reports* -- a
+    record's timestamp, a logged duration -- is not a decision and is not
+    reported.
+    """
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.While) and _reads_wall_clock(node.test):
+            found.append((node.lineno, "while-gate"))
+        elif isinstance(node, ast.If) and _reads_wall_clock(node.test):
+            exits = {type(sub).__name__ for sub in ast.walk(ast.Module(body=node.body, type_ignores=[]))}
+            if exits & {"Raise", "Break", "Return", "Continue"}:
+                found.append((node.lineno, "wait-abort"))
+    return found
+
+
+def test_no_module_lets_a_steppable_clock_decide_whether_to_keep_waiting() -> None:
+    """No module under ``strands_robots`` gates a wait or an expiry on ``time.time()``."""
+    offenders: list[str] = []
+    scanned = 0
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        scanned += 1
+        for lineno, shape in _wall_clock_wait_decisions(path.read_text(encoding="utf-8")):
+            offenders.append(f"{path.relative_to(_PACKAGE_ROOT.parent)}:{lineno} ({shape})")
+    assert scanned >= 100, f"premise: the scan reached only {scanned} modules, so the walk root is wrong"
+    assert not offenders, (
+        "these gates let the wall clock decide whether to keep waiting, so an NTP "
+        "step moves the deadline by the size of the step: "
+        f"{offenders}. Measure a duration on time.monotonic(); the wall clock is "
+        "for absolute stamps something off this machine correlates."
+    )
+
+
+def test_the_scan_detects_a_planted_wall_clock_wait() -> None:
+    """A clean sweep means the package is right, not that the scan sees nothing."""
+    planted = (
+        "import time\n"
+        "def wait(timeout):\n"
+        "    deadline = time.time() + timeout\n"
+        "    while time.time() < deadline:\n"
+        "        pass\n"
+        "def abort(deadline):\n"
+        "    if time.time() >= deadline:\n"
+        "        raise TimeoutError\n"
+    )
+    shapes = {shape for _, shape in _wall_clock_wait_decisions(planted)}
+    assert shapes == {"while-gate", "wait-abort"}, f"the scan missed a planted wait: {shapes}"
+
+
+def test_a_reported_wall_clock_stamp_is_not_read_as_a_wait_decision() -> None:
+    """Reporting the date is not deciding how long to wait, and stays allowed."""
+    reporting_only = (
+        "import time\n"
+        "def record(chunk):\n"
+        "    return {'timestamp': time.time(), 'data': chunk}\n"
+        "def log(start):\n"
+        "    print(time.time() - start)\n"
+    )
+    assert _wall_clock_wait_decisions(reporting_only) == []

--- a/tests/tools/test_tool_wait_budgets_survive_a_clock_step.py
+++ b/tests/tools/test_tool_wait_budgets_survive_a_clock_step.py
@@ -21,15 +21,16 @@ something off this machine correlates it. That boundary is why
 ``timestamp`` in the records it returns does not, and it is pinned below in both
 directions.
 
-The scan is repository-wide over ``strands_robots/tools`` with no exemption
-list, so a new tool cannot reintroduce the idiom, and a meta-test plants a
-wall-clock wait to prove a clean result means the tools are right rather than
-that the scan sees nothing.
+The source scan that grades the idiom lives in
+``tests/test_expiry_gates_survive_a_clock_step.py``, which walks the whole
+package: its walk root used to be ``strands_robots/tools`` alone, which is
+narrower than the shape it grades, and it read clean while the one offender in
+the tree sat in the dashboard's challenge store. What remains here is the
+behaviour, driven through the real ``spin_for``.
 """
 
 from __future__ import annotations
 
-import ast
 import pathlib
 import time
 from typing import Any
@@ -38,90 +39,6 @@ import pytest
 
 import strands_robots.tools.serial_tool as serial_mod
 import strands_robots.tools.use_ros as ros_mod
-
-_TOOLS_DIR = pathlib.Path(ros_mod.__file__).parent
-
-
-# ---------------------------------------------------------------------------
-# The scan
-# ---------------------------------------------------------------------------
-def _reads_wall_clock(node: ast.AST) -> bool:
-    """True if ``node`` contains a ``time.time()`` / ``time.time_ns()`` read."""
-    for sub in ast.walk(node):
-        if (
-            isinstance(sub, ast.Call)
-            and isinstance(sub.func, ast.Attribute)
-            and sub.func.attr in ("time", "time_ns")
-            and isinstance(sub.func.value, ast.Name)
-            and sub.func.value.id == "time"
-        ):
-            return True
-    return False
-
-
-def _wall_clock_wait_decisions(source: str) -> list[tuple[int, str]]:
-    """Sites in ``source`` where a wall-clock read decides whether to keep waiting.
-
-    Two shapes carry that decision: a ``while`` whose test reads the wall clock,
-    and an ``if`` that reads it to leave a wait (``raise`` / ``break`` /
-    ``return`` / ``continue``). A wall-clock read that only *reports* -- a
-    record's timestamp, a logged duration -- is not a decision and is not
-    reported.
-    """
-    found: list[tuple[int, str]] = []
-    for node in ast.walk(ast.parse(source)):
-        if isinstance(node, ast.While) and _reads_wall_clock(node.test):
-            found.append((node.lineno, "while-gate"))
-        elif isinstance(node, ast.If) and _reads_wall_clock(node.test):
-            exits = {type(sub).__name__ for sub in ast.walk(ast.Module(body=node.body, type_ignores=[]))}
-            if exits & {"Raise", "Break", "Return", "Continue"}:
-                found.append((node.lineno, "wait-abort"))
-    return found
-
-
-def test_no_tool_lets_a_steppable_clock_decide_whether_to_keep_waiting() -> None:
-    """No module under ``strands_robots/tools`` gates a wait on ``time.time()``."""
-    offenders: list[str] = []
-    scanned = 0
-    for path in sorted(_TOOLS_DIR.rglob("*.py")):
-        scanned += 1
-        for lineno, shape in _wall_clock_wait_decisions(path.read_text(encoding="utf-8")):
-            offenders.append(f"{path.name}:{lineno} ({shape})")
-    assert scanned >= 10, f"premise: the scan reached only {scanned} tool modules"
-    assert not offenders, (
-        "these waits let the wall clock decide whether to keep waiting, so an NTP "
-        "step mid-wait moves the deadline by the size of the step: "
-        f"{offenders}. Measure a duration on time.monotonic(); the wall clock is "
-        "for absolute stamps something off this machine correlates."
-    )
-
-
-def test_the_scan_detects_a_planted_wall_clock_wait() -> None:
-    """A clean sweep means the tools are right, not that the scan sees nothing."""
-    planted = (
-        "import time\n"
-        "def wait(timeout):\n"
-        "    deadline = time.time() + timeout\n"
-        "    while time.time() < deadline:\n"
-        "        pass\n"
-        "def abort(deadline):\n"
-        "    if time.time() >= deadline:\n"
-        "        raise TimeoutError\n"
-    )
-    shapes = {shape for _, shape in _wall_clock_wait_decisions(planted)}
-    assert shapes == {"while-gate", "wait-abort"}, f"the scan missed a planted wait: {shapes}"
-
-
-def test_a_reported_wall_clock_stamp_is_not_read_as_a_wait_decision() -> None:
-    """Reporting the date is not deciding how long to wait, and stays allowed."""
-    reporting_only = (
-        "import time\n"
-        "def record(chunk):\n"
-        "    return {'timestamp': time.time(), 'data': chunk}\n"
-        "def log(start):\n"
-        "    print(time.time() - start)\n"
-    )
-    assert _wall_clock_wait_decisions(reporting_only) == []
 
 
 def test_every_deadline_in_the_ros_tool_is_built_on_one_clock() -> None:


### PR DESCRIPTION
## The defect

`_stash_challenge` stamps each challenge record with the wall clock, and **three** decisions read that stamp back: the TTL gate in `_pop_challenge`, the sweep the next stash performs on the way in, and the order `_evict_oldest` drops entries in at the cap. All three are durations this process decides on its own -- it writes the stamp and it reads it -- so one NTP correction, `date -s` or resume from suspend moves every one of them.

![challenge TTL across one clock correction](https://raw.githubusercontent.com/cagataycali/robots/assets/challenge-ttl-clock-step/challenge_ttl_clock_step.png)

Swept the challenge age in 0.5s steps over 0..600s against the real store, default 300s TTL, one correction at age 150s:

| | before (`upstream/main`) | after |
|---|---|---|
| clock steps **-1h** | **never refused** -- 1201/1201 ages accepted | refused from 300.5s (last accepted 300.0s) |
| clock steps **+1h** | refused from **150.0s** -- the instant of the correction, 150s early | refused from 300.5s (last accepted 300.0s) |
| a 1s-old ceremony, next stash after a +1h step | **swept out of the table** | kept |
| the cap drops, entries either side of a -1h step | a **newer** entry (`second`) | the oldest (`first`) |

Backwards, the TTL is the only thing bounding how long that nonce stays replayable, and it is gone for the size of the step. Forwards, an operator mid-login is refused with `challenge expired`, and because the sweep runs on the way *in*, an unrelated client's arriving request is what ends the ceremony. The cap row inverts the fairness property the per-client cap exists for: an entry stamped after the correction sorts oldest, so "drop the oldest" keeps the staler challenge.

## The change

The stamp is `time.monotonic()`, under a `t_mono` key that names its clock domain the way `_last_estop_mono` already does beside `_last_estop_ts` in the safety subsystem. **Zero executable lines added** to the module (565 -> 565 by an AST count); the `+16/-5` is the comment stating the boundary.

The absolute stamps in the same module are deliberately unchanged, and now pinned so a later clock-blind sweep cannot move them: a session token's `iat`/`exp` and a credential's `created` name a point in time a browser and `renewal_verdict` correlate with something off this process. Seconds of process uptime in `exp` is a token that expired 55 years ago.

## Why no test caught it

Both cells that covered expiry simulated age by rewriting the stored stamp:

```python
auth._challenges[cid]["t"] = time.time() - auth._CHAL_TTL - 1
```

A stamp rewritten in the code's own clock domain agrees with the code whichever clock that is, so those cells were green either way. The new cells move the clock and leave the store alone. `test_expired_entries_are_still_pruned` is deleted as subsumed -- the same fact, graded honestly, is `test_the_stash_sweep_still_prunes_a_genuinely_expired_challenge`.

The source scan for this idiom walked `strands_robots/tools` alone. A walk root narrower than the shape it grades reports a **clean tree**, not an ungraded one -- the same predicate over all 304 package modules named `dashboard/auth.py:585` immediately and nothing else. It now walks the package with no exemption list, so a new *subsystem* cannot reintroduce it either; the roster derivation picks the file up on its own (62 -> 63 whole-tree graders, no roster edit). The tools file keeps its real-`spin_for` behaviour cells and points at the new owner.

Two wall-clock comparisons in `mesh/core.py` are correct and stay: the estop/resume freshness windows measure against a `t` a *peer* put on the wire, which is the one place a stamp crosses a machine boundary. The new grader's docstring says so, so a future widening keeps clearing them.

## Verification

**Pre-fix: 5 failed / 11 passed. Post-fix: 16 passed.** The five that fail on `upstream/main`:

```
test_a_live_challenge_still_pops_after_the_clock_jumps_forward
test_an_expired_challenge_is_refused_after_the_clock_jumps_back
test_the_stash_sweep_keeps_a_live_challenge_after_a_forward_step
test_the_cap_evicts_the_challenge_stashed_first_across_a_backward_step
test_no_module_lets_a_steppable_clock_decide_whether_to_keep_waiting
   -> ['strands_robots/dashboard/auth.py:585 (wait-abort)']
```

Every control passes pre-fix (the clock double, the TTL with no step in both directions, the sweep still pruning, the token's stamps, both scan meta-cells).

| gate | result |
|---|---|
| `ruff check` / `ruff format --check` (`strands_robots tests tests_integ`) | clean |
| `mypy` 1.20.2, same scope | 20 errors in 6 files, byte-identical to `main` (19 `examples/isaac_gs`, 1 `simulation/ik.py`) |
| `pytest -k dashboard` | 287 passed / 1 failed; the 1 (`..._store_cache_is_keyed_on_the_file::test_a_re_read_after_an_outside_change_does_not_accumulate_entries`) fails identically on pristine `main`. 275 -> 287 = +13 new cells - 1 subsumed |
| `scripts/check_whole_tree_graders.py` | 1763 passed / 3 failed, all 3 environmental on `main` too (absent `qpsolvers` metadata, lerobot 0.6.2 dropping `reanchor_relative_rtc_prefix`). 1760 -> 1763 = exactly the 3 new scan cells |
| `pytest -k docs` | 1271 passed / 1 failed, the 1 an unrelated `rebot_b601` registry/lerobot drift present on `main` |

## LOC

| file | +/- |
|---|---|
| `strands_robots/dashboard/auth.py` | +16 / -5 (0 executable) |
| `tests/test_dashboard_challenge_expiry_survives_a_clock_step.py` | +230 (new: 13 cells, 5 of them the regression) |
| `tests/test_expiry_gates_survive_a_clock_step.py` | +127 (89 of them moved from the tools file) |
| `tests/tools/test_tool_wait_budgets_survive_a_clock_step.py` | +6 / -89 |
| `tests/test_dashboard_auth_rpid_and_challenge_caps.py` | -7 (subsumed cell) |
| `tests/test_dashboard_auth_edges.py` | +4 / -1 |
| `AGENTS.md` | +10 / -3 (the rule, and the walk-root lesson) |

Net test growth is +264 for a security-relevant regression with five pre-fix-failing cells plus a package-wide guard; the scan relocation is +31 net for a root that is now wider than the class it grades.
