### PR TITLE
fix(simulation): the Isaac preview cadence refuses an infinite period

### DIFF
--- a/changelog.d/3116-isaac-idle-render-period-finiteness.md
+++ b/changelog.d/3116-isaac-idle-render-period-finiteness.md
@@ -1,0 +1,17 @@
+### Fixed: an infinite `SO101_IDLE_RENDER_PERIOD` no longer freezes the Isaac live preview
+
+The Isaac backend resolved its idle preview cadence with `float()` behind a
+`v > 0` bound, and `inf > 0` is `True`, so `inf`, `Infinity` and an overflowing
+`1e999` all became the period. The gate that reads it is
+`now_mono - last_render_mono >= period`, which no elapsed span satisfies against
+an infinite period: driving the real loop for 6 s of virtual time, the preview
+refreshed once at `t=0` and never again while `pump()` kept draining the app - a
+viewport frozen for the life of the process, indistinguishable from a stalled
+simulation. Finiteness is now decided by the shared numeric domain
+(`utils.finite_number_error`), and every fallback is logged so a misconfigured
+knob is not mistaken for a stall.
+
+The rule already existed and was already swept - but the sweep was rooted at
+`strands_robots/mesh`, so a resolver anywhere else read as absent rather than as
+unguarded. That sweep now walks the whole package, which is the scope of the rule
+it enforces.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -53,6 +53,7 @@ from strands_robots.utils import (
     coerce_rgba,
     coerce_size_vector,
     entity_name_error,
+    finite_number_error,
     name_list_error,
     non_negative_whole_number_error,
     partial_construction_repr,
@@ -116,12 +117,51 @@ def _env_int(name: str, default: int) -> int:
 
 
 def _env_float(name: str, default: float) -> float:
-    """Read a positive float from the environment (fallback to ``default``)."""
-    try:
-        v = float(os.environ.get(name, ""))
-        return v if v > 0 else default
-    except (TypeError, ValueError):
+    """Read a positive finite float from the environment (fallback to ``default``).
+
+    Finiteness is decided by the shared numeric domain
+    (:func:`~strands_robots.utils.finite_number_error`) rather than left to the
+    positivity bound, which cannot express it: ``inf > 0`` is ``True``, so
+    ``inf``, ``Infinity`` and an overflowing ``1e999`` all resolved to a knob no
+    consumer can honor. ``nan`` was refused only incidentally - ``nan > 0`` is
+    ``False`` - so it reached the default by the route a typo takes.
+
+    That mattered here because the one knob this resolver serves is
+    :attr:`IsaacSimulation._idle_render_period`, read by the idle live-preview
+    gate in :meth:`IsaacSimulation.run_pump_forever` as
+    ``now_mono - last_render_mono >= period``. No elapsed span satisfies that
+    comparison against an infinite period, so the preview refreshed once on the
+    first iteration and then never again while ``pump()`` kept draining the app -
+    a frozen viewport that reads as a stalled simulation rather than as a
+    misconfigured variable.
+
+    Every rejection is reported for that reason, as the analogous mesh resolver
+    :func:`~strands_robots.mesh.core._parse_positive_float_env` reports its own:
+    substituting the default in silence leaves the operator's model of the
+    cadence wrong with nothing to correct it against.
+
+    Args:
+        name: Environment variable to read. Unset, empty or unusable falls back.
+        default: Value applied when the variable names no usable period.
+
+    Returns:
+        The override when it is a positive finite number, else ``default``.
+    """
+    raw = os.environ.get(name, "")
+    if raw.strip() == "":
         return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("%s=%r is not a number; using %r", name, raw, default)
+        return default
+    reason = finite_number_error(value, name, "Isaac simulation")
+    if reason is None and value <= 0:
+        reason = f"Isaac simulation: {name} must be > 0, got {value!r}."
+    if reason is not None:
+        logger.warning("%s; using %r", reason, default)
+        return default
+    return value
 
 
 def _to_float_list(value: Any, n: int) -> list[float] | None:

--- a/tests/mesh/test_env_float_knobs_reject_non_finite.py
+++ b/tests/mesh/test_env_float_knobs_reject_non_finite.py
@@ -21,8 +21,14 @@ The rule is not new to the package. Three of its five env-float resolvers
 already applied it, and :func:`strands_robots.mesh.security._env_pos_float`
 both documents it ("Non-numeric / non-positive / NaN / inf values fall back
 to the default") and names ``mesh.core._parse_positive_float_env`` as its
-analogue. So this pins the two that did not, the parity between them, and -
-structurally - that a sixth resolver cannot ship without the test.
+analogue. So this pins the two that did not and the parity between them.
+
+The structural half - that no resolver may ship without the test - is not a mesh
+property and is graded package-wide rather than here. A sweep rooted at this
+package reads a resolver anywhere else as absent rather than as unguarded, which
+is how the Isaac preview-cadence resolver came to admit ``inf``;
+``tests/test_env_float_knobs_resolve_to_a_finite_value.py`` walks the whole
+package, which is the scope of the rule.
 
 Deliberately out of scope: the ``0`` floor. ``_parse_positive_float_env``
 admits it (its ``minimum`` defaults to ``0.0``) while ``_env_pos_float``
@@ -42,7 +48,6 @@ keep naming the resolver.
 
 from __future__ import annotations
 
-import ast
 import inspect
 import math
 import pathlib
@@ -240,101 +245,6 @@ class TestTheZeroFloorIsUnchanged:
             assert core_mod._parse_positive_float_env("ZERO_PROBE", "60") == 60.0
         messages = [r.getMessage() for r in caplog.records]
         assert any("must be >=" in m for m in messages), messages
-
-
-# --- structural guard: no sixth resolver may ship without the test --------
-
-#: Every env-float resolver in the mesh package, as ``module::function``.
-EXPECTED_ENV_FLOAT_RESOLVERS = frozenset(
-    {
-        "_zenoh_config.py::_float_env",
-        "core.py::_parse_positive_float_env",
-        "security.py::_env_pos_float",
-        "session.py::hz_from_env",
-        "transport/bridge_transport.py::_resolve_dedup_ttl",
-    }
-)
-
-
-def _mesh_root() -> pathlib.Path:
-    """Derive the scanned package from an imported symbol, not a path literal."""
-    return pathlib.Path(inspect.getfile(core_mod)).parent
-
-
-def _reads_the_environment(fn: ast.AST) -> bool:
-    """True when *fn* really reads ``os.environ`` / ``os.getenv``.
-
-    Structural rather than textual: the safety handlers mention ``os.getenv``
-    in a comment explaining why they cache their knobs, and a text scan reads
-    that as an env-float site.
-    """
-    for node in ast.walk(fn):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            value = node.func.value
-            if node.func.attr == "getenv" and isinstance(value, ast.Name) and value.id == "os":
-                return True
-            if node.func.attr == "get" and isinstance(value, ast.Attribute) and value.attr == "environ":
-                return True
-        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Attribute) and node.value.attr == "environ":
-            return True
-    return False
-
-
-def _calls(fn: ast.AST, name: str) -> bool:
-    for node in ast.walk(fn):
-        if isinstance(node, ast.Call):
-            func = node.func
-            if isinstance(func, ast.Name) and func.id == name:
-                return True
-            if isinstance(func, ast.Attribute) and func.attr == name:
-                return True
-    return False
-
-
-def _scan(root: pathlib.Path) -> dict[str, bool]:
-    """Map ``module::function`` to whether it tests finiteness."""
-    found: dict[str, bool] = {}
-    for path in sorted(root.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            if _calls(node, "float") and _reads_the_environment(node):
-                found[f"{path.relative_to(root)}::{node.name}"] = _calls(node, "isfinite")
-    return found
-
-
-class TestEveryEnvFloatResolverTestsFiniteness:
-    """A structural guard, because the divergence is what let this happen."""
-
-    def test_the_scan_finds_exactly_the_known_resolvers(self):
-        """Non-vacuity: a scan rooted elsewhere, or a detector that stopped
-        matching, would report a clean sweep over nothing.
-        """
-        assert set(_scan(_mesh_root())) == set(EXPECTED_ENV_FLOAT_RESOLVERS)
-
-    def test_no_resolver_omits_the_finiteness_test(self):
-        adrift = sorted(name for name, guarded in _scan(_mesh_root()).items() if not guarded)
-        assert adrift == [], f"env-float resolvers with no finiteness test: {adrift}"
-
-    def test_the_scan_detects_a_planted_omission(self, tmp_path):
-        planted = tmp_path / "planted.py"
-        planted.write_text(
-            'import os\n\n\ndef _resolve(name: str) -> float:\n    return float(os.getenv(name, "1"))\n',
-            encoding="utf-8",
-        )
-        assert _scan(tmp_path) == {"planted.py::_resolve": False}
-
-    def test_the_scan_ignores_a_comment_mentioning_getenv(self, tmp_path):
-        """The detector must not re-acquire the text scan's false positive."""
-        planted = tmp_path / "commented.py"
-        planted.write_text(
-            "def _f(raw: str) -> float:\n"
-            "    # Reading them per-use parsed os.getenv on every reference.\n"
-            "    return float(raw)\n",
-            encoding="utf-8",
-        )
-        assert _scan(tmp_path) == {}
 
 
 @pytest.fixture(scope="module")

--- a/tests/simulation/isaac/test_idle_render_period_is_a_finite_span.py
+++ b/tests/simulation/isaac/test_idle_render_period_is_a_finite_span.py
@@ -1,0 +1,213 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``SO101_IDLE_RENDER_PERIOD`` cannot resolve to a period no refresh satisfies.
+
+The Isaac idle live-preview gate in :meth:`IsaacSimulation.run_pump_forever` is
+``now_mono - last_render_mono >= self._idle_render_period``, and
+:func:`~strands_robots.simulation.isaac.simulation._env_float` resolved that
+period with ``float()`` behind a ``v > 0`` bound. ``inf > 0`` is ``True``, so
+every infinite spelling passed through as the period - and no elapsed span
+satisfies the gate against it. Driving the real loop for 120 idle iterations
+(6.0 s of virtual time at the loop's own 0.05 s granularity):
+
+===================================  ==========  =========================
+``SO101_IDLE_RENDER_PERIOD``         refreshes   at (s)
+===================================  ==========  =========================
+``inf`` / ``Infinity`` / ``1e999``   1 (was)     0.0 - then never again
+``inf`` / ``Infinity`` / ``1e999``   6 (now)     0.0, 1.0, 2.0, ... 5.0
+``nan`` / ``-inf``                   6           unchanged: ``nan > 0`` and
+                                                 ``-inf > 0`` are both False
+``2.5``                              3           unchanged: 0.0, 2.5, 5.0
+unset                                6           unchanged: the 1.0 default
+===================================  ==========  =========================
+
+One refresh at t=0 and none after is a viewport frozen on the first frame for
+the life of the process, while ``pump()`` keeps draining the app - which reads as
+a stalled simulation rather than as a misconfigured variable. That is why the
+fallback is now reported: the operator has to be able to tell those apart.
+
+``nan`` reaching the default before this change was not the bound working, it was
+``nan > 0`` being ``False`` - the same route a typo takes. The assertions below
+are stated over the *achieved refresh timeline* rather than over the resolved
+number wherever the timeline is what the caller observes, so none of them can be
+satisfied by renaming a call.
+
+Solver-free: the engine is the skeleton ``__new__`` shape
+``test_isaac_durations_survive_a_clock_step.py`` uses and ``pump`` is faked on the
+instance, so no Isaac Sim Kit runtime, GL context or GPU is touched.
+"""
+
+from __future__ import annotations
+
+import queue
+import time
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.isaac import simulation as isaac_module
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _env_float
+
+#: The knob under test and the default its resolver falls back to.
+IDLE_PERIOD_ENV = "SO101_IDLE_RENDER_PERIOD"
+DEFAULT_PERIOD = 1.0
+
+#: Idle iterations to drive. At the loop's 0.05 s sleep this is 6.0 s of virtual
+#: time - long enough that a large *finite* period still refreshes more than
+#: once, so "refreshed once" identifies an infinite period rather than a slow one.
+PUMP_ITERATIONS = 120
+IDLE_SLEEP = 0.05
+
+#: Spellings ``float()`` accepts and the ``> 0`` bound cannot refuse.
+INFINITE_SPELLINGS = ["inf", "Inf", "Infinity", "  inf  ", "1e999"]
+
+#: Spellings the positivity bound already sent to the default. Kept as controls:
+#: they must keep resolving to the default, and now for a stated reason.
+ALREADY_REFUSED = ["nan", "NaN", "-inf", "-1e999", "-1", "0", "junk", ""]
+
+
+class _VirtualClock:
+    """A ``time`` double whose sleeps advance a virtual clock instead of blocking.
+
+    The gate reads ``monotonic()`` once per idle iteration; ``sleep`` moves the
+    clock by the requested span, so the achieved refresh timeline is exact and
+    the case runs in milliseconds. Every other attribute delegates to real
+    :mod:`time`.
+    """
+
+    def __init__(self, start: float = 1_000_000.0) -> None:
+        self._virtual = start
+        self.start = start
+
+    def monotonic(self) -> float:
+        return self._virtual
+
+    def time(self) -> float:
+        return self._virtual
+
+    def sleep(self, seconds: float) -> None:
+        if seconds > 0:
+            self._virtual += seconds
+
+    def elapsed(self) -> float:
+        """Virtual seconds since the start, as the test's own instrumentation."""
+        return self._virtual - self.start
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(time, name)
+
+
+class _StopAfter:
+    """A ``threading.Event``-shaped flag ending the loop after ``n`` checks."""
+
+    def __init__(self, n: int) -> None:
+        self.n = n
+        self.checks = 0
+
+    def is_set(self) -> bool:
+        self.checks += 1
+        return self.checks > self.n
+
+
+def _refresh_timeline(monkeypatch: pytest.MonkeyPatch, iterations: int = PUMP_ITERATIONS) -> list[float]:
+    """Drive the real idle gate and return the virtual times it refreshed at.
+
+    The period is resolved exactly as ``__init__`` resolves it, from the
+    environment through ``_env_float``, so the timeline is the consequence of the
+    resolver rather than of a number the test chose.
+    """
+    clock = _VirtualClock()
+    monkeypatch.setattr(isaac_module, "time", clock)
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._idle_render_period = _env_float(IDLE_PERIOD_ENV, DEFAULT_PERIOD)
+    engine._main_jobs = queue.Queue()
+    engine._action_q = queue.Queue()
+    engine._pump_running = False
+
+    refreshes: list[float] = []
+
+    def _pump(render: bool = True) -> None:
+        if render:
+            refreshes.append(round(clock.elapsed(), 3))
+
+    engine.pump = _pump  # type: ignore[method-assign]
+    engine.run_pump_forever(_StopAfter(iterations))
+    return refreshes
+
+
+@pytest.fixture(autouse=True)
+def _no_inherited_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The knob must not be inherited from the runner running these tests."""
+    monkeypatch.delenv(IDLE_PERIOD_ENV, raising=False)
+
+
+class TestAnInfinitePeriodDoesNotBecomeThePreviewCadence:
+    """The defect: a period the gate can never satisfy, applied in silence."""
+
+    @pytest.mark.parametrize("raw", INFINITE_SPELLINGS)
+    def test_the_preview_keeps_refreshing(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        """The timeline, not the number: one refresh is a frozen viewport."""
+        monkeypatch.setenv(IDLE_PERIOD_ENV, raw)
+        refreshes = _refresh_timeline(monkeypatch)
+        assert refreshes == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0], f"{raw!r} gave {refreshes}"
+
+    @pytest.mark.parametrize("raw", INFINITE_SPELLINGS)
+    def test_the_resolved_period_is_the_default(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        monkeypatch.setenv(IDLE_PERIOD_ENV, raw)
+        assert _env_float(IDLE_PERIOD_ENV, DEFAULT_PERIOD) == DEFAULT_PERIOD
+
+    @pytest.mark.parametrize("raw", INFINITE_SPELLINGS)
+    def test_the_fallback_names_the_variable_and_the_reason(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, raw: str
+    ) -> None:
+        """A frozen preview and a stalled simulation look identical; only the
+        log distinguishes them, so a silent substitution is not a fix.
+        """
+        monkeypatch.setenv(IDLE_PERIOD_ENV, raw)
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            _env_float(IDLE_PERIOD_ENV, DEFAULT_PERIOD)
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(IDLE_PERIOD_ENV in m and "finite" in m for m in messages), messages
+
+
+class TestTheAcceptedDomainIsUnchanged:
+    """Over-reach controls: only the non-finite verdict moved."""
+
+    @pytest.mark.parametrize(("raw", "expected"), [("0.5", 0.5), ("2.5", 2.5), ("1e-3", 0.001)])
+    def test_a_finite_positive_period_is_honored(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str, expected: float
+    ) -> None:
+        monkeypatch.setenv(IDLE_PERIOD_ENV, raw)
+        assert _env_float(IDLE_PERIOD_ENV, DEFAULT_PERIOD) == expected
+
+    def test_a_large_finite_period_still_refreshes_more_than_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Separates "refreshed once" from "was configured slowly"."""
+        monkeypatch.setenv(IDLE_PERIOD_ENV, "2.5")
+        assert _refresh_timeline(monkeypatch) == [0.0, 2.5, 5.0]
+
+    @pytest.mark.parametrize("raw", ALREADY_REFUSED)
+    def test_a_value_the_bound_already_refused_still_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str
+    ) -> None:
+        monkeypatch.setenv(IDLE_PERIOD_ENV, raw)
+        assert _env_float(IDLE_PERIOD_ENV, DEFAULT_PERIOD) == DEFAULT_PERIOD
+
+    def test_an_unset_variable_resolves_to_the_default_without_a_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Not setting a knob is not a misconfiguration, so it must stay quiet."""
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            assert _env_float(IDLE_PERIOD_ENV, DEFAULT_PERIOD) == DEFAULT_PERIOD
+        assert [r.getMessage() for r in caplog.records] == []
+
+    def test_the_unset_default_cadence_is_the_documented_one_second(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert _refresh_timeline(monkeypatch) == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+
+
+class TestTheIntResolverNeedsNoSuchBound:
+    """The control: ``int()`` refuses every non-finite spelling itself."""
+
+    @pytest.mark.parametrize("raw", ["inf", "Infinity", "1e999", "nan"])
+    def test_the_int_resolver_already_falls_back(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        monkeypatch.setenv("SO101_IDLE_CONVERGE", raw)
+        assert isaac_module._env_int("SO101_IDLE_CONVERGE", 4) == 4

--- a/tests/test_env_float_knobs_resolve_to_a_finite_value.py
+++ b/tests/test_env_float_knobs_resolve_to_a_finite_value.py
@@ -1,0 +1,202 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""No environment variable resolves to a non-finite float anywhere in the package.
+
+``float()`` accepts ``"nan"``, ``"inf"``, ``"Infinity"`` and an overflowing
+``"1e999"``, and no comparison-based bound recovers from that: a ``> 0`` floor is
+``True`` for ``inf`` and ``False`` for ``nan``, so a positivity test lets the
+first through as a resolved knob and refuses the second only by accident. Every
+resolver that reads a float out of the environment therefore has to test
+finiteness itself, and the library states that rule in two shapes - a direct
+:func:`math.isfinite`, as :func:`strands_robots.mesh.security._env_pos_float`
+does, or the shared numeric domain
+:func:`strands_robots.utils.finite_number_error`, as
+:func:`strands_robots.tools.robot_mesh._gateway_discovery_wait_s` does.
+
+The rule is package-wide but was graded per package: ``tests/mesh`` held a sweep
+rooted at ``strands_robots/mesh`` whose docstring said "a sixth resolver cannot
+ship without the test". A resolver rooted anywhere else was not a sixth resolver
+that failed the sweep - it was invisible to it, so the sweep read as a clean
+tree. ``simulation/isaac/simulation.py::_env_float`` was exactly that, and it
+admitted ``inf`` for the Isaac idle live-preview period. This sweep replaces the
+mesh-rooted one and walks the whole package, so its root is the scope of the rule
+it enforces.
+
+The population is derived, never listed: a function that both reads the
+environment and coerces with ``float()``. Only the exemptions are named, each
+with the reason it is not a resolver-level domain, and
+:meth:`TestEveryEnvFloatResolverIsFinitenessBounded.test_every_exemption_is_still_discovered`
+fails when one stops matching, so an exemption cannot outlive the code it
+describes and quietly cover a new site.
+
+The detector is structural rather than textual because the safety handlers
+mention ``os.getenv`` in comments explaining why they cache their knobs, and a
+text scan reads those comments as env-float sites.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+import strands_robots
+
+#: The two spellings of "this resolver tested finiteness". ``isfinite`` is the
+#: direct form; ``finite_number_error`` is the shared numeric domain, which
+#: decides numeric-ness and finiteness together and returns the operator-facing
+#: reason. A resolver satisfying either has the bound.
+FINITENESS_GUARDS = frozenset({"isfinite", "finite_number_error"})
+
+#: Sites that read a float out of the environment but are not the place its
+#: domain is decided, each with the reason. Kept as small as the tree allows: an
+#: exemption is a promise that some *other* named surface refuses the value.
+NOT_A_RESOLVER_DOMAIN = {
+    # Returns the raw value to a single caller, ``VeraConfig.__post_init__``,
+    # which refuses a non-finite ``motion_plan_scale`` on the *effective* value
+    # through utils.positive_finite_number_error - deliberately there, because
+    # that funnel is also the only place a keyword-supplied value can be
+    # refused. Pinned behaviourally by
+    # tests/policies/vera/test_vera_motion_plan_scale_domain.py.
+    "policies/vera/config.py::_env_float": "checked on the effective value at the VeraConfig funnel",
+}
+
+#: Resolvers the sweep must keep finding, one per top-level area, so a scan that
+#: silently stopped matching - or one rooted at a single package again - fails
+#: here rather than passing over nothing.
+LANDMARK_RESOLVERS = (
+    "mesh/core.py::_parse_positive_float_env",
+    "simulation/isaac/simulation.py::_env_float",
+    "tools/robot_mesh.py::_gateway_discovery_wait_s",
+)
+
+#: Non-vacuity floor, well below the count measured on this tree, so a resolver
+#: added or removed does not send a contributor to edit a number.
+MINIMUM_RESOLVERS = 6
+
+
+#: The scanned tree, derived from the imported package rather than from a path
+#: literal, and bound at module level rather than returned from a helper so that
+#: ``scripts/check_whole_tree_graders.py`` can resolve this module's walk root
+#: and collect it in the preflight - a grader whose root is only reachable
+#: through a call argument is invisible to that derivation.
+PACKAGE_ROOT = pathlib.Path(inspect.getfile(strands_robots)).parent
+
+
+def _reads_the_environment(fn: ast.AST) -> bool:
+    """True when *fn* really reads ``os.environ`` / ``os.getenv``."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            value = node.func.value
+            if node.func.attr == "getenv" and isinstance(value, ast.Name) and value.id == "os":
+                return True
+            if node.func.attr == "get" and isinstance(value, ast.Attribute) and value.attr == "environ":
+                return True
+        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Attribute) and node.value.attr == "environ":
+            return True
+    return False
+
+
+def _calls_any(fn: ast.AST, names: frozenset[str] | set[str]) -> bool:
+    """True when *fn* calls any function in *names*, bare or as an attribute."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in names:
+                return True
+            if isinstance(func, ast.Attribute) and func.attr in names:
+                return True
+    return False
+
+
+def _classify(paths: list[pathlib.Path], root: pathlib.Path) -> dict[str, bool]:
+    """Map ``module::function`` to whether it tests finiteness."""
+    found: dict[str, bool] = {}
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if _calls_any(node, {"float"}) and _reads_the_environment(node):
+                found[f"{path.relative_to(root).as_posix()}::{node.name}"] = _calls_any(node, FINITENESS_GUARDS)
+    return found
+
+
+def _resolvers() -> dict[str, bool]:
+    """Every env-float resolver in the package, and whether each is bounded."""
+    return _classify(sorted(PACKAGE_ROOT.rglob("*.py")), PACKAGE_ROOT)
+
+
+def _scan(root: pathlib.Path) -> dict[str, bool]:
+    """The same classification over an arbitrary tree, for planted source."""
+    return _classify(sorted(root.rglob("*.py")), root)
+
+
+class TestEveryEnvFloatResolverIsFinitenessBounded:
+    """The rule holds over the package, not over one of its subpackages."""
+
+    def test_no_resolver_admits_a_non_finite_value(self) -> None:
+        adrift = sorted(
+            name for name, guarded in _resolvers().items() if not guarded and name not in NOT_A_RESOLVER_DOMAIN
+        )
+        assert adrift == [], (
+            "these read a float out of the environment and test neither math.isfinite nor the shared "
+            f"utils.finite_number_error domain, so nan/inf/1e999 resolve to a knob no consumer can honor: {adrift}. "
+            "Test finiteness there, or add the site to NOT_A_RESOLVER_DOMAIN naming the surface that does."
+        )
+
+    def test_every_exemption_is_still_discovered(self) -> None:
+        """An exemption for code that moved would silently cover a new site."""
+        stale = sorted(set(NOT_A_RESOLVER_DOMAIN) - set(_resolvers()))
+        assert stale == [], f"exemptions matching no discovered resolver: {stale}"
+
+    @pytest.mark.parametrize("landmark", LANDMARK_RESOLVERS)
+    def test_the_scan_still_finds_each_landmark(self, landmark: str) -> None:
+        """One landmark per area: a scan rooted at one package fails here."""
+        assert landmark in _resolvers()
+
+    def test_the_scan_is_not_vacuous(self) -> None:
+        found = _resolvers()
+        assert len(found) >= MINIMUM_RESOLVERS, f"only {len(found)} resolvers discovered: {sorted(found)}"
+
+
+class TestTheDetectorAnswersOnPlantedSource:
+    """A sweep that cannot fail, or cannot pass, proves nothing."""
+
+    def test_an_unguarded_resolver_is_reported(self, tmp_path: pathlib.Path) -> None:
+        (tmp_path / "planted.py").write_text(
+            'import os\n\n\ndef _resolve(name: str) -> float:\n    return float(os.getenv(name, "1"))\n',
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {"planted.py::_resolve": False}
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("isfinite", "    value = float(os.environ[name])\n    return value if math.isfinite(value) else 1.0\n"),
+            (
+                "shared_domain",
+                "    value = float(os.environ[name])\n"
+                '    return 1.0 if finite_number_error(value, name, "planted") else value\n',
+            ),
+        ],
+    )
+    def test_either_guard_spelling_is_accepted(self, tmp_path: pathlib.Path, label: str, body: str) -> None:
+        """Both forms the library uses count; neither is privileged."""
+        (tmp_path / "planted.py").write_text(
+            f"import math\nimport os\n\n\ndef _resolve(name: str) -> float:\n{body}",
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {"planted.py::_resolve": True}, label
+
+    def test_a_comment_mentioning_getenv_is_not_a_resolver(self, tmp_path: pathlib.Path) -> None:
+        """The detector must not re-acquire the text scan's false positive."""
+        (tmp_path / "commented.py").write_text(
+            "def _f(raw: str) -> float:\n"
+            "    # Reading them per-use parsed os.getenv on every reference.\n"
+            "    return float(raw)\n",
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {}


### PR DESCRIPTION
`SO101_IDLE_RENDER_PERIOD=inf` resolved to `inf` and the idle live-preview gate `now_mono - last_render_mono >= period` is satisfied by no elapsed span, so the preview refreshed once and froze. Driving the real `run_pump_forever` loop for 120 iterations (6.0 s of virtual time), each tick one `pump(render=True)`:

![idle preview cadence before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/isaac-idle-preview-cadence/idle_preview_cadence.png)

| `SO101_IDLE_RENDER_PERIOD` | resolved before | refreshes before | resolved after | refreshes after |
|---|---|---|---|---|
| `inf` / `Inf` / `Infinity` | `inf` | **1** (t=0 only) | `1.0` | 6 (t=0..5) |
| `1e999` (overflows) | `inf` | **1** (t=0 only) | `1.0` | 6 (t=0..5) |
| `2.5` (control) | `2.5` | 3 | `2.5` | 3 |
| unset (control) | `1.0` | 6 | `1.0` | 6 |

One refresh at t=0 and none after is a viewport frozen for the life of the process while `pump()` keeps draining the app - which reads as a stalled simulation, not as a misconfigured variable. So the fallback is now logged too: `SO101_IDLE_RENDER_PERIOD must be a finite number, got inf.; using 1.0`.

## Cause

`_env_float` decided the domain with `float()` behind `v if v > 0 else default`. `inf > 0` is `True`, so every infinite spelling passed through as the period. `nan` reached the default only *incidentally* - `nan > 0` is `False` - i.e. by the route a typo takes, not by a bound.

Finiteness is now decided by the shared numeric domain `utils.finite_number_error`, the same way `tools/robot_mesh._gateway_discovery_wait_s` decides its own sleep span. `_env_int` beside it needs no such bound and gets none: `int("inf")` raises, so the value is unrepresentable there (pinned as a control).

## Why nothing caught it

The rule was already stated and already swept - `tests/mesh/test_env_float_knobs_reject_non_finite.py` said "a sixth resolver cannot ship without the test" - but the sweep was rooted at `strands_robots/mesh`. A resolver anywhere else is not a sixth resolver that fails the sweep; it is invisible to it, so the sweep reads as a **clean tree**. Running that sweep's own predicate over all 304 package modules names exactly one adrift site, this one.

That structural half is not a mesh property, so it moves to `tests/test_env_float_knobs_resolve_to_a_finite_value.py` and walks the whole package - the scope of the rule it enforces. The mesh file keeps its behavioural cells and now points at it. One sweep, not two.

The replacement derives its population (a function that reads the environment *and* coerces with `float()`) and names only exemptions, each with the surface that refuses the value instead - `policies/vera/config.py::_env_float`, whose single caller `VeraConfig.__post_init__` refuses a non-finite `motion_plan_scale` on the effective value. `test_every_exemption_is_still_discovered` fails when an exemption stops matching, so it cannot outlive the code it describes and quietly cover a new site. It also accepts **both** spellings the library uses (`math.isfinite` and `finite_number_error`), each pinned on planted source, so neither is privileged.

One extra detail: its walk root is a module-level binding rather than a call argument, so `scripts/check_whole_tree_graders.py` can resolve it and the preflight collects it (roster 69 -> 70).

## Tests

`tests/simulation/isaac/test_idle_render_period_is_a_finite_span.py` (33 cells) asserts the **achieved refresh timeline** wherever the timeline is what the caller observes, so nothing passes by renaming a call. It drives the real gate through a virtual clock with the engine's `__new__` skeleton and a faked `pump` - the shape `test_isaac_durations_survive_a_clock_step.py` uses - so no Isaac Sim Kit runtime, GL context or GPU is touched. A 6.0 s window is deliberate: it lets a large *finite* period (`2.5` -> 3 refreshes) separate "refreshed once" from "configured slowly".

Pre-fix, both new files against this base: **16 failed / 27 passed**; the grader names the site (`['simulation/isaac/simulation.py::_env_float']`). Post-fix: **43 passed**. The 27 passing pre-fix are the controls - over-reach, planted source, landmarks, the int resolver.

Local gate: `ruff check` + `ruff format --check` clean; mypy 20 errors in 6 files, unchanged from this base and none in the touched files; `tests/simulation/isaac tests/mesh` + the new grader = 6715 passed with a failure set **identical** to this base (21, all `awsiot`-absent IoT transport); whole-tree preflight 1863 passed / 3 failed, those 3 also failing on this base (absent `qpsolvers` metadata + lerobot import drift).

## LOC

| file | executable lines |
|---|---|
| `simulation/isaac/simulation.py` | +11 |
| `tests/mesh/test_env_float_knobs_reject_non_finite.py` | **-64** (sweep moved out) |
| `tests/test_env_float_knobs_resolve_to_a_finite_value.py` | +102 (new, package-wide) |
| `tests/simulation/isaac/test_idle_render_period_is_a_finite_span.py` | +101 (new) |
| net | **+150** |

Net-positive, and the additions are the two things the defect showed were missing: a behavioural pin on the cadence, and a sweep at the scope of the rule. The mesh file shrinks by the sweep that moved.