### PR TITLE
fix(tests): a round trip that must complete is not timed by the budget for a read that must not

### DIFF
--- a/changelog.d/3117-round-trip-budget-is-not-the-parked-read-budget.md
+++ b/changelog.d/3117-round-trip-budget-is-not-the-parked-read-budget.md
@@ -1,0 +1,63 @@
+### Fixed: a round trip that must complete is not timed by the budget for a read that must not
+
+`tests/inference/test_a_failed_exchange_does_not_leave_the_connection_cached.py`
+built its fixture client with a single `REQUEST_TIMEOUT = 0.3`, whose comment
+stated two requirements without noticing they pull in opposite directions on one
+number: short enough that a parked reply misses its deadline promptly, long
+enough that an unparked round trip never does. Several scenarios in that file
+park a reply server-side and assert the read misses its deadline; the same client
+also serves the calls that have to *succeed*. One value cannot serve both, and it
+was resolved in favour of the requirement whose cost is visible -- suite speed --
+so `0.3` was a budget calibrated for the calls that must fail, applied silently
+to the calls that must succeed.
+
+That turned `main` red at `ee1fb7f`:
+`test_a_successful_handshake_is_cached` makes one ordinary `get_actions_sync`
+call and reported `TimeoutError: timed out in 0.3s`.
+
+The tension is not real, because only one of the two budgets is ever waited out.
+A successful call returns as soon as its reply lands -- the deadline is an upper
+bound it never reaches -- so a generous value there costs a passing run nothing.
+A missed read waits out its budget in full on every run, so that is the only one
+with a reason to be small. The single constant coupled a budget that is free to
+be generous to one that is not.
+
+Measured on the round trip the 0.3s budget had to cover: 2.4ms median idle
+(5% of the budget), 26.6ms median with cores oversubscribed 4x, and 654.6ms
+median / 1851ms max at 24x. The nominal cost sits ~125x inside the budget, so the
+failure is entirely tail latency under contention -- which is what a full suite
+creates, and why this reproduces in CI and not on an idle checkout. On the exact
+failing pattern under that load, the old budget breached 4 times in 40 trials;
+the new ones breached 0 in 40.
+
+`ROUND_TRIP_TIMEOUT` (5.0) now times the calls that must complete and
+`PARKED_READ_TIMEOUT` (0.3) the one read per scenario that must miss, narrowed
+around just that read and unwound in a `finally` -- callers keep using the client
+after the strand returns, so a failed assertion inside the window would otherwise
+leave the short deadline on it and relocate the flake into whichever test ran
+next. The round-trip budget is generous but bounded: a genuinely hung call must
+still report `TimeoutError` from the client rather than be killed by the suite's
+`--timeout=120`, which reports nothing useful.
+
+The concurrent-discard scenario keeps one shared budget
+(`SHARED_DISCARD_TIMEOUT`, 3.0), because thread A's completing call and thread
+B's missed read run on the same client and `_request` takes its deadline from
+instance state with no per-call override. It is bounded on both sides: above a
+round trip on a loaded runner, below the join that observes B time out.
+
+`PARK_HOLD` names the hold that makes a missed read deterministic rather than a
+race, and a new premise test pins the ordering the scenarios rest on:
+`PARKED_READ_TIMEOUT < SHARED_DISCARD_TIMEOUT < THREAD_JOIN_TIMEOUT <
+PARK_HOLD`. A budget that must expire but exceeds the hold gets its reply
+*delivered*, so the scenario passes having asserted nothing about the discard it
+names -- indistinguishable from a real pass. That relationship previously lived
+only in the arithmetic between two unrelated literals, and the motive that
+produced the original single budget applies just as well to shortening the hold,
+so the guard is on the relationship rather than on any one value. It pins the
+meaning of those scenarios, not their freedom from timing flakes: that a
+completing call fits inside its budget depends on the runner and is not
+statically assertable.
+
+Test-only. The library's 60s default is a sensible deadline; these tests needed a
+probe. Green-path cost is +2.76s, all of it the one concurrent test whose two
+budgets provably cannot be separated.

--- a/tests/inference/test_a_failed_exchange_does_not_leave_the_connection_cached.py
+++ b/tests/inference/test_a_failed_exchange_does_not_leave_the_connection_cached.py
@@ -49,9 +49,38 @@ from strands_robots.policies import MockPolicy
 
 pytest.importorskip("websockets")
 
-#: Short enough that a parked reply misses the deadline promptly, long enough
-#: that an unparked round trip on loopback never does.
-REQUEST_TIMEOUT = 0.3
+#: Seconds the server holds a parked reply before giving up on it. This is what
+#: makes a missed read *deterministic* rather than a race: the reply is provably
+#: still withheld when the client's deadline expires, so every budget below that
+#: has to expire must stay well under this.
+PARK_HOLD = 10.0
+
+#: Deadline for a call that must *complete*. A successful call returns as soon as
+#: its reply lands, so this budget is never waited out on a passing run and a
+#: generous value costs one nothing - it buys immunity from the scheduling stalls
+#: a loaded runner adds to a loopback round trip, which are what a tight budget
+#: here measures instead of the behaviour under test. Generous but bounded: a
+#: genuinely hung call must still report ``TimeoutError`` from this client rather
+#: than be killed by the suite's ``--timeout=120``, which reports nothing useful.
+ROUND_TRIP_TIMEOUT = 5.0
+
+#: Deadline for the one read per scenario that must *miss* its reply. Unlike
+#: ``ROUND_TRIP_TIMEOUT`` this one is waited out in full on every run, so it is
+#: the budget that costs wall clock and the only reason to keep a value small.
+PARKED_READ_TIMEOUT = 0.3
+
+#: The concurrent-discard scenario cannot separate the two budgets above: thread
+#: A's completing call and thread B's missed read share one client, and
+#: ``_request`` takes its deadline from instance state with no per-call override,
+#: so one value serves both. Bounded on both sides - above a round trip on a
+#: loaded runner (A must finish), below ``THREAD_JOIN_TIMEOUT`` (B must be seen
+#: to time out).
+SHARED_DISCARD_TIMEOUT = 3.0
+
+#: How long to wait for a thread in that scenario to finish. Exceeds the deadline
+#: the thread is waiting out, and stays under ``PARK_HOLD`` so a join cannot
+#: outlive the park it depends on.
+THREAD_JOIN_TIMEOUT = 9.0
 
 
 class TaggedPolicy(MockPolicy):  # type: ignore[misc]
@@ -79,7 +108,7 @@ class TaggedPolicy(MockPolicy):  # type: ignore[misc]
             # every later request promptly.
             self.park.clear()
             self.parked.set()
-            self.release.wait(timeout=10.0)
+            self.release.wait(timeout=PARK_HOLD)
         return [{"tag": marker}]
 
 
@@ -88,7 +117,7 @@ def tagged() -> Any:
     """A live server whose policy tags chunks, plus a client pointed at it."""
     policy = TaggedPolicy()
     server = PolicyServer(policy=policy, host="127.0.0.1", port=0).start()
-    client = RemotePolicy(host="127.0.0.1", port=server.port, request_timeout=REQUEST_TIMEOUT)
+    client = RemotePolicy(host="127.0.0.1", port=server.port, request_timeout=ROUND_TRIP_TIMEOUT)
     try:
         yield policy, server, client
     finally:
@@ -102,12 +131,28 @@ def _strand(client: RemotePolicy, policy: TaggedPolicy) -> Any:
 
     Returns the connection the client was using when the read timed out, so a
     caller can ask what became of it.
+
+    Only the parked read is put on the short budget. The warm call above it has
+    to *complete* - it is what caches the connection this helper returns - so it
+    keeps the fixture's round-trip budget, and the narrowing is unwound in a
+    ``finally`` because callers go on using this client after the strand: a
+    failed assertion inside the window would otherwise leave the short deadline
+    on it and relocate this flake into whichever test ran next.
     """
     client.get_actions_sync({"marker": "warm"}, "")
     stranded = client._ws
     policy.park.set()
-    with pytest.raises(TimeoutError):
-        client.get_actions_sync({"marker": "OBS-A"}, "")
+    client.request_timeout = PARKED_READ_TIMEOUT
+    try:
+        started = time.monotonic()
+        with pytest.raises(TimeoutError):
+            client.get_actions_sync({"marker": "OBS-A"}, "")
+        # The read expired on its own deadline, not because the server stopped
+        # parking: past PARK_HOLD the reply is delivered and there is no missed
+        # read left for these scenarios to be about.
+        assert time.monotonic() - started < PARK_HOLD, "the parked reply was released before the read gave up"
+    finally:
+        client.request_timeout = ROUND_TRIP_TIMEOUT
     policy.release.set()
     # Give the server time to finish producing the reply nobody read.
     time.sleep(0.5)
@@ -166,6 +211,38 @@ class TestThePremisesThisRestsOn:
         except Exception:  # noqa: BLE001 - pre-fix this call reads a stale reply
             pass
         assert policy.seen == ["warm", "OBS-A", "OBS-B"]
+
+    def test_every_budget_that_must_expire_does_so_while_the_reply_is_still_parked(self) -> None:
+        """The ordering that makes a missed read deterministic rather than a race.
+
+        These scenarios need one read to *not* arrive, and what withholds it is
+        the server parking the reply for ``PARK_HOLD``. So each budget that has
+        to expire must expire inside that window: past it the reply is delivered,
+        the read succeeds, and the test goes green while asserting nothing about
+        the discard it names. That failure is silent - a delivered reply is
+        indistinguishable from a passing test - which is why it is pinned here
+        rather than left to the arithmetic between two unrelated literals.
+
+        The motive that produced the original single budget (keep the suite
+        quick) applies just as well to shortening ``PARK_HOLD``, so the guard is
+        on the relationship, not on any one value.
+
+        This pins the *meaning* of the parked scenarios. It cannot pin their
+        freedom from timing flakes: that a completing call fits inside
+        ``ROUND_TRIP_TIMEOUT`` depends on the runner and is not statically
+        assertable, which is the separate reason that budget is generous.
+        """
+        assert PARKED_READ_TIMEOUT < PARK_HOLD, "the strand's read would be answered instead of missed"
+        assert SHARED_DISCARD_TIMEOUT < PARK_HOLD, "thread B would be answered instead of timing out"
+
+        # A join has to outlast the deadline whose expiry it is waiting to
+        # observe, or B is still blocked when its result is read; and it has to
+        # stay inside the park, or it outlives what holds the reply back.
+        assert SHARED_DISCARD_TIMEOUT < THREAD_JOIN_TIMEOUT < PARK_HOLD
+
+        # The two budgets are separate so that the one paid on every run stays
+        # small while the one that is never waited out can be generous.
+        assert PARKED_READ_TIMEOUT < ROUND_TRIP_TIMEOUT
 
     def test_the_wire_lock_is_not_reentrant(self) -> None:
         """Which is why the discard is inlined instead of routed through ``close``.
@@ -446,6 +523,12 @@ class TestAConcurrentCallerSurvivesADiscardByAnotherThread:
         # Warm the connection so _ensure_connected's fast path passes for both.
         client.get_actions_sync({"marker": "warm"}, "")
 
+        # One deadline has to serve both threads here - B must miss its reply and
+        # A must complete on the same client, concurrently - so it is set once,
+        # after the warm call, and not restored: nothing runs on this client
+        # afterwards, and the fixture is per-test.
+        client.request_timeout = SHARED_DISCARD_TIMEOUT
+
         # Park one reply so thread B times out.
         policy.park.set()
 
@@ -453,10 +536,10 @@ class TestAConcurrentCallerSurvivesADiscardByAnotherThread:
         t_a = threading.Thread(target=thread_a)
         t_b.start()
         t_a.start()
-        t_b.join(timeout=5.0)
+        t_b.join(timeout=THREAD_JOIN_TIMEOUT)
         # Release the parked reply so the server can serve thread A's request.
         policy.release.set()
-        t_a.join(timeout=5.0)
+        t_a.join(timeout=THREAD_JOIN_TIMEOUT)
 
         # Thread B timed out (expected).
         assert "B" in errors, f"thread B should have timed out, got result: {results.get('B')}"


### PR DESCRIPTION
## What broke

`main` is red at `ee1fb7f`. One test failed out of 2163:

```
FAILED tests/inference/test_a_failed_exchange_does_not_leave_the_connection_cached.py::
  TestWhatAFailedExchangeDoesNotMean::test_a_successful_handshake_is_cached
  - TimeoutError: timed out in 0.3s
```

That test does one ordinary call and asserts the connection was cached:

```python
def test_a_successful_handshake_is_cached(self, tagged):
    _policy, _server, client = tagged
    client.get_actions_sync({"marker": "warm"}, "")
```

Nothing about it is supposed to time out. It timed out because it was being measured against a budget that was never calibrated for it.

## The defect: one constant, two contradictory requirements

```python
#: Short enough that a parked reply misses the deadline promptly, long enough
#: that an unparked round trip on loopback never does.
REQUEST_TIMEOUT = 0.3
```

The comment states both requirements and does not notice they pull in opposite directions on a single number:

- **must be small** - several scenarios park a reply server-side and assert the read misses its deadline. That wait is paid in full on every run, so a large value is dead suite time.
- **must be large** - the same fixture client serves the calls that have to *succeed*. A small value measures runner scheduling latency instead of the behaviour under test.

One number cannot satisfy both, and it was resolved in favour of the requirement with the visible cost (suite speed). So `0.3` is a budget calibrated for the calls that must **fail**, silently applied to the calls that must **succeed**.

## Why the tension is not real

Only one of those budgets is ever actually waited out.

A **successful** call returns as soon as its reply lands - the deadline is an upper bound it never reaches - so a generous value costs a passing run *nothing*. A **missed** read waits out its full budget every single run, so that is the only one with a reason to be small.

The single constant coupled a budget that is free to be generous to one that is not. Splitting them dissolves the tradeoff rather than re-tuning it.

## Measurements

Cost of the happy-path round trip the 0.3s budget had to cover (`connect` + handshake + RTT, loopback):

| condition | median | max | max as % of 300ms |
|---|---|---|---|
| idle | 2.4ms | 14.4ms | 5% |
| cores oversubscribed 4x | 26.6ms | 111.7ms | 37% |
| cores oversubscribed 24x | 654.6ms | 1851.0ms | **617%** |

So the nominal cost is ~125x inside the budget and the flake is entirely *tail latency* under contention - which is exactly the condition a full CI suite creates, and why this reproduces on `main` and not locally.

Reproduced and certified on the exact failing pattern, 40 trials under the 24x load:

| budget | happy-path breaches |
|---|---|
| old single `0.3s` | **4/40** (10% flake rate) |
| new `ROUND_TRIP_TIMEOUT` `5.0s` | **0/40** |
| new `SHARED_DISCARD_TIMEOUT` `3.0s` | **0/40** |

## The change (test-only)

| constant | value | waited out? | role |
|---|---|---|---|
| `ROUND_TRIP_TIMEOUT` | 5.0 | never, on green | deadline for a call that must complete - on the fixture client |
| `PARKED_READ_TIMEOUT` | 0.3 | every run | deadline for the one read per scenario that must miss |
| `SHARED_DISCARD_TIMEOUT` | 3.0 | once | the concurrent case, where one client serves both requirements |
| `THREAD_JOIN_TIMEOUT` | 9.0 | no | join that must outlast the deadline it observes |
| `PARK_HOLD` | 10.0 | no | names the existing hold that makes a missed read deterministic |

`ROUND_TRIP_TIMEOUT` is generous **but bounded**: a genuinely hung call must still report `TimeoutError` from this client rather than be killed by the suite's `--timeout=120`, which reports nothing useful.

`_strand()` narrows to `PARKED_READ_TIMEOUT` around only the read that must miss, and unwinds it in a `finally` - callers keep using that client after the strand returns, so a failed assertion inside the window would otherwise leave the short deadline on it and *relocate* this flake into whichever test ran next.

The concurrent-discard scenario keeps a single shared budget, because thread A's completing call and thread B's missed read run on the same client and `_request` takes its deadline from instance state with no per-call override. It is bounded on both sides: above a round trip on a loaded runner, below the join that observes B time out.

## Pinned invariant

A new premise test in the existing `TestThePremisesThisRestsOn` pins the ordering the parked scenarios depend on:

```
PARKED_READ_TIMEOUT  <  SHARED_DISCARD_TIMEOUT  <  THREAD_JOIN_TIMEOUT  <  PARK_HOLD
```

If a budget that must expire ever exceeds `PARK_HOLD`, the reply is *delivered* and the scenario goes green having asserted nothing about the discard it names - a silent failure, since a delivered reply is indistinguishable from a passing test. That relationship previously lived only in the arithmetic between two unrelated literals (`0.3` and `10.0`). The motive that produced the original single budget - keep the suite quick - applies just as well to shortening `PARK_HOLD`, so the guard is on the relationship rather than on any one value.

The guard is deliberately scoped: it pins the *meaning* of the parked scenarios. It cannot pin their freedom from timing flakes, because "5.0s exceeds the loaded tail" is not statically assertable. Two defects, two mechanisms.

## Verification

- `tests/inference/` - **165 passed, 1 skipped**
- target file - **31 passed** (30 + the new premise test)
- `ruff check`, `ruff format --check`, `mypy` - clean
- audited all 15 fixture consumers: 7 park via `_strand`, 1 parks directly, 7 are happy-path only. No negative assertion exists outside those 8 sites, which is what makes the generous budget free.

**Green-path cost: +2.76s** (6.20s -> 8.96s), entirely attributable to the one concurrent test going 0.3 -> 3.0. The 7 `_strand` tests are unchanged, as the cost model predicts. Reporting this rather than claiming "no change": it is the single site where the two budgets provably cannot be separated.

## Scope

No production code touched. The library's 60s default is a sensible *deadline*; these tests needed a *probe*. That is a test-calibration defect, not a library one.

Worth recording rather than fixing here: `RemotePolicy` exposes its timeout only as instance state with no per-call override, which is what made it easy to use one knob as two tools and is the reason the concurrent case cannot be split. An ergonomics gap, not a defect - noted so the decision not to touch `client.py` is a judgement rather than an omission.