### PR TITLE
fix(ci): the whole-tree preflight resolves a grader root passed as a parameter

### DIFF
--- a/changelog.d/3118-preflight-resolves-a-parameter-rooted-walk.md
+++ b/changelog.d/3118-preflight-resolves-a-parameter-rooted-walk.md
@@ -1,0 +1,39 @@
+### Fixed: the whole-tree preflight collects a grader whose walk root is a parameter
+
+`scripts/check_whole_tree_graders.py` derives its roster from the tree: a grader
+whose population is the rest of the repository walks the repository root or one
+of its top-level Python areas, so the walk's receiver is resolved to a concrete
+path and the module is selected on where it lands. The resolver read module-level
+bindings and, since #3113, an area held in a loop variable. It did not read a
+root that arrives as a **function parameter**.
+
+That is the spelling a grader reaches for as soon as it plants source for its own
+predicate: the sweep and the planted controls share one implementation, so the
+walk moves into a helper and the receiver is bound per call rather than at module
+scope.
+
+```python
+def _scan(root: Path) -> list[str]: ...   # root.rglob("*.py")
+_SURFACES = _scan(_PACKAGE_ROOT)          # the real sweep
+... _scan(tmp_path)                       # a planted control
+```
+
+Five graders were unrostered on it, and the absence is silent in the reassuring
+direction - a preflight run passes without having collected them:
+
+| grader | population | outcomes |
+| --- | --- | --- |
+| `tests/test_args_docstring_completeness.py` | every documented surface in the package | 545 |
+| `tests/test_attributes_docstring_completeness.py` | every dataclass in the package | 40 |
+| `tests/test_raises_docstring_completeness.py` | every raising surface in the package | 18 |
+| `tests/test_mujoco_render_assertions_are_gl_gated.py` | all of `tests/` | 13 |
+| `tests/simulation/test_no_import_cycle.py` | the package import graph | 6 |
+
+The parameter is resolvable from the module's *own* calls, which is what the fix
+reads: every argument a call in the same module passes for that parameter, plus
+any default the helper declares. The asymmetry that makes such a module a grader
+is visible there - the planted call passes a `tmp_path` and resolves to nothing,
+the real call passes the package root. Roster 70 -> 75 graders, 1910 -> 2532
+outcomes, with nothing dropped and the eight `tests/simulation` backend sweeps
+still excluded (a path-scoped run over the mirroring test directory collects
+them, so they are not in the class this script rescues).

--- a/scripts/check_whole_tree_graders.py
+++ b/scripts/check_whole_tree_graders.py
@@ -46,7 +46,7 @@ good reason: a subject test globbing its own fixture directory is
 shape-identical to one walking the repository. It is not value-identical -
 ``Path(__file__).parent / "fixtures"`` and ``tmp_path`` are neither the
 repository root nor a top-level area - so resolving the path separates them.
-Measured over this repository, the derivation selects 68 of 1426 test modules.
+Measured over this repository, the derivation selects 74 of 1461 test modules.
 
 Resolving the *value* is also why the area a grader walks may be held in a loop
 variable. The idiom here is a tuple of area names walked one at a time::
@@ -66,6 +66,25 @@ never having collected the grader that failed.
 :func:`_resolve_area_loop` contributes one candidate path per literal in the
 iterated tuple and leaves the membership question where it already was, which
 is what makes the change safe rather than merely wider.
+
+The root may also arrive as a *function parameter*. A grader that plants source
+for its own predicate factors the walk into a helper so the sweep and the
+planted cases share one implementation::
+
+    def _scan(root: Path) -> list[str]: ...       # root.rglob("*.py")
+    _SURFACES = _scan(_PACKAGE_ROOT)              # the real sweep
+    ... _scan(tmp_path)                           # a planted control
+
+The receiver is then an ``ast.Name`` bound per call rather than at module
+scope, so reading module-level bindings alone resolved it to nothing.
+:func:`_call_site_paths` resolves it from the module's *own* calls: every
+argument a call in the same module passes for that parameter, plus any default
+the helper carries. The planted call contributes nothing (``tmp_path`` resolves
+to no path) and the real one contributes the package root, which is exactly the
+asymmetry that makes the module a grader. Measured over this repository, five
+whole-tree graders were unrostered on this spelling - three docstring-
+completeness sweeps over the installed package, the package import-cycle graph,
+and the render-gating sweep over all of ``tests/``.
 
 A walk rooted *inside* a subpackage (``strands_robots/policies/``) is
 deliberately not selected: a path-scoped run over the mirroring test directory
@@ -404,6 +423,144 @@ def _resolve_area_loop(
     return {base / segment for segment in segments.get(receiver.right.id, ())}
 
 
+def _function_owners(tree: ast.Module) -> dict[ast.AST, ast.AST | None]:
+    """Map every node to the innermost function definition whose body holds it.
+
+    A walk receiver spelled as a bare name may be a parameter, and *which*
+    function's parameter it is decides what the module's own calls bind it to.
+    Nested definitions override, so a helper defined inside a test method
+    answers for its own parameters rather than for the method's.
+
+    :param tree: The parsed module.
+    :returns: Node to its innermost enclosing function, or ``None`` for a node
+        at module scope.
+    """
+    owners: dict[ast.AST, ast.AST | None] = {}
+
+    def visit(node: ast.AST, owner: ast.AST | None) -> None:
+        inner = node if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)) else owner
+        for child in ast.iter_child_nodes(node):
+            owners[child] = inner
+            visit(child, inner)
+
+    visit(tree, None)
+    return owners
+
+
+def _call_site_paths(
+    tree: ast.Module, module_path: Path, bindings: dict[str, Path], root: Path
+) -> dict[tuple[str, str], set[Path]]:
+    """Map ``(function name, parameter name)`` to the paths this module binds it to.
+
+    A grader that plants source for its own predicate factors the walk into a
+    helper taking the root as a parameter, then calls it once with the real
+    area and once per planted case. The parameter is resolvable from the
+    module's own calls, so those are read: every argument a call in this module
+    passes for that parameter, plus any default the helper declares.
+
+    A name matched as an attribute (``self._scan(root)``) is the same helper
+    reached another way, so both spellings are read - the alternative is being
+    blind to whichever spelling a grader happened to choose, which is the
+    defect this resolver keeps being widened for. Two definitions sharing a
+    name contribute to one entry; the union over-approximates the paths one
+    call can pass, and membership is then decided by intersection with
+    :func:`walk_targets`, so a candidate that is not a walk target changes no
+    verdict. A helper imported from a ``conftest`` stays unresolved, which
+    :data:`UNDERIVABLE_GRADERS` reports rather than this guessing.
+
+    :param tree: The parsed module.
+    :param module_path: Where the module lives, so ``__file__`` resolves.
+    :param bindings: Module-level names already resolved to paths.
+    :param root: The repository root.
+    """
+    definitions: dict[str, list[ast.FunctionDef | ast.AsyncFunctionDef]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            definitions.setdefault(node.name, []).append(node)
+
+    found: dict[tuple[str, str], set[Path]] = {}
+
+    def record(name: str, parameter: str, value: ast.expr) -> None:
+        resolved = _resolve(value, module_path, bindings, root)
+        if isinstance(resolved, Path):
+            found.setdefault((name, parameter), set()).add(resolved)
+
+    for name, overloads in definitions.items():
+        for definition in overloads:
+            args = definition.args
+            positional = [*args.posonlyargs, *args.args]
+            # Defaults align with the *last* positional parameters.
+            for parameter, default in zip(positional[len(positional) - len(args.defaults) :], args.defaults):
+                record(name, parameter.arg, default)
+            for parameter, keyword_default in zip(args.kwonlyargs, args.kw_defaults):
+                if keyword_default is not None:
+                    record(name, parameter.arg, keyword_default)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        called = node.func
+        called_name = called.attr if isinstance(called, ast.Attribute) else getattr(called, "id", "")
+        for definition in definitions.get(called_name, ()):
+            signature = definition.args
+            names = [parameter.arg for parameter in [*signature.posonlyargs, *signature.args]]
+            for index, value in enumerate(node.args):
+                if index < len(names):
+                    record(called_name, names[index], value)
+            accepted = {*names, *(parameter.arg for parameter in signature.kwonlyargs)}
+            for keyword in node.keywords:
+                if keyword.arg is not None and keyword.arg in accepted:
+                    record(called_name, keyword.arg, keyword.value)
+    return found
+
+
+def _parameter_scopes(
+    call: ast.Call,
+    owners: dict[ast.AST, ast.AST | None],
+    parameters: dict[tuple[str, str], set[Path]],
+    bindings: dict[str, Path],
+) -> list[dict[str, Path]]:
+    """Return ``bindings`` extended with one path a parameter in scope can take.
+
+    One scope per ``(parameter, candidate path)`` pair, so a helper called with
+    both a real area and a planted directory is read as reaching each in turn.
+    Empty for a walk at module scope, and for one inside a ``lambda``, which
+    has no name for a call site to name.
+
+    :param call: The walk call whose receiver did not resolve.
+    :param owners: Node to its innermost enclosing function.
+    :param parameters: What the module's own calls bind each parameter to.
+    :param bindings: Module-level names resolved to paths.
+    """
+    owner = owners.get(call)
+    if not isinstance(owner, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return []
+    args = owner.args
+    scopes = []
+    for parameter in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
+        for candidate in sorted(parameters.get((owner.name, parameter.arg), ())):
+            scopes.append({**bindings, parameter.arg: candidate})
+    return scopes
+
+
+def _receiver_targets(
+    receiver: ast.expr,
+    module_path: Path,
+    bindings: dict[str, Path],
+    segments: dict[str, tuple[str, ...]],
+    root: Path,
+) -> set[Path]:
+    """Return every directory a walk on ``receiver`` reaches under ``bindings``.
+
+    Both receiver shapes a grader uses: a name or expression resolving straight
+    to a path, and ``base / <loop variable>`` over literal area names.
+    """
+    resolved = _resolve(receiver, module_path, bindings, root)
+    if isinstance(resolved, Path):
+        return {resolved}
+    return _resolve_area_loop(receiver, module_path, bindings, segments, root)
+
+
 def walked_paths(source: str, module_path: Path, root: Path) -> set[Path]:
     """Return every directory ``source`` walks that resolves to a concrete path.
 
@@ -414,15 +571,18 @@ def walked_paths(source: str, module_path: Path, root: Path) -> set[Path]:
     tree = ast.parse(source)
     bindings = _module_bindings(tree, module_path, root)
     segments = _segment_bindings(tree)
+    parameters = _call_site_paths(tree, module_path, bindings, root)
+    owners = _function_owners(tree)
     targets: set[Path] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr in _WALK_METHODS:
             receiver = node.func.value
-            resolved = _resolve(receiver, module_path, bindings, root)
-            if isinstance(resolved, Path):
-                targets.add(resolved)
+            found = _receiver_targets(receiver, module_path, bindings, segments, root)
+            if found:
+                targets.update(found)
                 continue
-            targets.update(_resolve_area_loop(receiver, module_path, bindings, segments, root))
+            for scope in _parameter_scopes(node, owners, parameters, bindings):
+                targets.update(_receiver_targets(receiver, module_path, scope, segments, root))
     return targets
 
 

--- a/tests/test_whole_tree_graders_roster_is_complete.py
+++ b/tests/test_whole_tree_graders_roster_is_complete.py
@@ -43,6 +43,15 @@ nothing reads exactly like a tree with nothing to select:
   by a second, resolvable walk elsewhere in the same file. A pin that grades
   only the graders an issue names cannot see a resolver gap that its own named
   graders survive by accident, so the spellings are graded directly.
+- a root held in a *function parameter* resolves. This is the fourth turn of
+  the same screw and the one the previous three make predictable: a grader that
+  plants source for its own predicate factors the walk into a helper taking the
+  root as an argument, so the receiver is bound per call rather than at module
+  scope. Five graders were unrostered on it - three docstring-completeness
+  sweeps over the installed package, the package import-cycle graph, and the
+  render-gating sweep over all of ``tests/``. The asymmetry that makes such a
+  module a grader is visible in its own calls: the planted call passes a
+  ``tmp_path`` and resolves to nothing, the real one passes the package root.
 
 A roster only helps a caller who knows to run it. Issue #2940's failure mode
 was a *green* narrow run, so the remedy is only reachable if the pre-push
@@ -278,6 +287,108 @@ def test_a_loop_variable_area_that_is_not_a_top_level_area_is_not_selected(label
         f"the derivation selected a module walking {label}. Resolving a loop "
         "variable is meant to read the same walks the tree already has, not to "
         "widen the class of walk that counts as whole-tree."
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "grader"),
+    [
+        (
+            "a helper called at module scope with the package root",
+            "def _scan(root):\n    return [p for p in root.rglob('*.py')]\n\nFILES = _scan(PKG)",
+        ),
+        (
+            "a helper called with the root as a keyword",
+            "def _scan(root):\n    return [p for p in root.rglob('*.py')]\n\nFILES = _scan(root=PKG)",
+        ),
+        (
+            "a helper declaring the root as its default",
+            "def _scan(root=PKG):\n    return [p for p in root.rglob('*.py')]",
+        ),
+        (
+            "a helper reached as an attribute",
+            "def _scan(root):\n    return [p for p in root.rglob('*.py')]\n\n\nclass TestIt:\n"
+            "    def test_it(self):\n        assert self._scan(PKG)\n",
+        ),
+        (
+            "a parameter root combined with a loop-variable area",
+            "def _scan(root):\n    for area in ('strands_robots', 'tests'):\n"
+            "        for p in (root / area).rglob('*.py'):\n            pass\n\nFILES = _scan(PKG.parent)",
+        ),
+        (
+            "a helper the module calls with a tmp_path as well as the real root",
+            "def _scan(root):\n    return [p for p in root.rglob('*.py')]\n\nFILES = _scan(PKG)\n\n\n"
+            "def test_planted(tmp_path):\n    assert not _scan(tmp_path)\n",
+        ),
+    ],
+)
+def test_a_root_that_arrives_as_a_parameter_resolves(label: str, grader: str) -> None:
+    """A grader whose walk root is a function argument is selected.
+
+    The last case is the shape every real instance takes: the helper exists so
+    the sweep and the module's planted controls share one implementation, and
+    the real call is what makes the module a grader. Reading module-level
+    bindings alone resolved the receiver to nothing and skipped all six - in the
+    reassuring direction, exactly as #3105 and #3111 describe one spelling
+    each. ``label`` names the spelling so a failure says which one stopped
+    resolving.
+    """
+    source = f"import pathlib\n\nimport strands_robots\n\nPKG = pathlib.Path(strands_robots.__file__).resolve().parent\n\n{grader}\n"
+    assert _selects(source, _TESTS_ROOT / "test_planted.py"), (
+        f"the derivation cannot resolve a root spelled as {label}, so a grader "
+        "written that way is invisible to the preflight rather than merely "
+        "unrostered."
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "grader"),
+    [
+        (
+            "a parameter no call in the module binds",
+            "def _scan(root):\n    return [p for p in root.rglob('*.py')]",
+        ),
+        (
+            "a parameter bound only to a tmp_path",
+            "def _scan(root):\n    return [p for p in root.rglob('*.py')]\n\n\n"
+            "def test_it(tmp_path):\n    assert not _scan(tmp_path)\n",
+        ),
+        (
+            "a parameter bound only to a fixture directory beside the test",
+            "def _scan(root):\n    return [p for p in root.rglob('*.py')]\n\n"
+            "FILES = _scan(pathlib.Path(__file__).parent / 'fixtures')",
+        ),
+        (
+            "a parameter bound only to a subpackage",
+            "def _scan(root):\n    return [p for p in root.rglob('*.py')]\n\nFILES = _scan(PKG / 'policies')",
+        ),
+        (
+            "an inner helper's parameter, where only the outer one takes the root",
+            "def _outer(root):\n    def _inner(root):\n        return [p for p in root.rglob('*.py')]\n\n"
+            "    return _inner(root / 'policies')\n\nFILES = _outer(PKG)",
+        ),
+    ],
+)
+def test_a_parameter_the_module_does_not_bind_to_an_area_is_not_selected(label: str, grader: str) -> None:
+    """Resolving a parameter must not widen *which* walks count as whole-tree.
+
+    The resolver contributes candidate paths; :func:`walk_targets` still
+    decides membership, so a helper the module only ever hands a fixture
+    directory, a ``tmp_path`` or a subpackage stays out. The unbound case is
+    the safe direction stated directly: a helper whose caller lives in a
+    ``conftest`` resolves to nothing rather than to a guess.
+
+    The inner-helper case grades the attribution rather than the resolution.
+    ``_outer`` is handed the package root and ``_inner`` is handed a subpackage
+    of it; the walk sits in ``_inner``, so reading the *innermost* enclosing
+    function is what keeps the outer call from lending its root to a walk that
+    never sees it.
+    """
+    source = f"import pathlib\n\nimport strands_robots\n\nPKG = pathlib.Path(strands_robots.__file__).resolve().parent\n\n{grader}\n"
+    assert not _selects(source, _TESTS_ROOT / "subject" / "test_planted.py"), (
+        f"the derivation selected a module whose walk root is only ever {label}. "
+        "Resolving a parameter is meant to read the same walks the tree already "
+        "has, not to widen the class of walk that counts as whole-tree."
     )
 
 


### PR DESCRIPTION
![preflight coverage before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/preflight-param-root/roster_param_root.png)

## The gap

`scripts/check_whole_tree_graders.py` derives its roster from the tree rather than from a hand list: a grader whose population is the rest of the repository walks the repository root or a top-level Python area, so membership is decided by resolving the walk's *receiver* to a concrete path. The resolver reads module-level bindings, and since #3113 an area held in a loop variable. It did not read a root that arrives as a **function parameter**.

That is the spelling a grader reaches for as soon as it plants source for its own predicate - the sweep and the planted controls share one implementation, so the walk moves into a helper and the receiver is bound per call:

```python
def _scan(root: Path) -> list[str]: ...   # root.rglob("*.py")
_SURFACES = _scan(_PACKAGE_ROOT)          # the real sweep
...       = _scan(tmp_path)               # a planted control
```

Five graders were unrostered on it, and the absence is silent in the reassuring direction - the preflight passes because it never collects them:

| grader | population | outcomes | in the roster |
| --- | --- | --- | --- |
| `tests/test_args_docstring_completeness.py` | every documented surface in the package | 545 | before: no |
| `tests/test_attributes_docstring_completeness.py` | every dataclass in the package | 40 | before: no |
| `tests/test_raises_docstring_completeness.py` | every raising surface in the package | 18 | before: no |
| `tests/test_mujoco_render_assertions_are_gl_gated.py` | all of `tests/` | 13 | before: no |
| `tests/simulation/test_no_import_cycle.py` | the package import graph | 6 | before: no |

## The change

The parameter *is* resolvable, from the module's own calls, and that is what is now read: every argument a call in the same module passes for that parameter, plus any default the helper declares. The asymmetry that makes such a module a grader lives right there - the planted call passes a `tmp_path` and resolves to nothing, the real call passes the package root.

Three helpers, and `walked_paths` retries an unresolved receiver once per `(parameter, candidate path)` pair, so the same code path also reads a parameter root combined with the loop-variable area spelling (`(root / area).rglob(...)`).

| | measured |
| --- | --- |
| roster | **70 -> 75** graders (69 -> 74 derived, 1 named explicitly) |
| outcomes the preflight collects | **1910 -> 2532** (+622) |
| +622 accounted for | 545 + 40 + 18 + 13 + 6 = **622**, exactly the five files |
| graders dropped | **0** |
| the eight `tests/simulation` backend sweeps | still excluded (control) |
| preflight result, `main` | 5 failed / 1855 passed |
| preflight result, this branch | 5 failed / **2477** passed, **same five node ids** |

The five failures are environment drift on this machine, identical on both trees and unrelated to this change: absent `qpsolvers` metadata, two lerobot 0.6.2 symbol-drift cells, and two `websockets` floor cells (16.0 installed against the declared `>=17.0`).

## Not widening what counts as whole-tree

The resolver contributes candidate paths; `walk_targets` still decides membership. So the negative half is graded too, five planted cases: a parameter no call in the module binds (a helper whose caller lives in a `conftest` stays unresolved rather than guessed), one bound only to a `tmp_path`, one bound only to a fixture directory, one bound only to a subpackage, and - grading attribution rather than resolution - an inner helper handed a subpackage while only the *outer* one is handed the package root. Reading the *innermost* enclosing function is what keeps the outer call from lending its root to a walk that never sees it.

## Tests

`tests/test_whole_tree_graders_roster_is_complete.py` gains 11 cells in two parametrized sets. Six positive spellings - module-scope call, keyword argument, the helper's own default, a helper reached as an attribute (`self._scan(root)`), a parameter root combined with a loop-variable area, and the real shape of one real call plus one planted call - and the five negative controls above.

Pre-fix reading, the new test file against unmodified `main`:

```
6 failed, 27 passed
```

Every one of the six positive spellings fails, every negative control passes. After the fix: `33 passed`.

## LOC

| file | raw | executable (docstrings/comments excluded) |
| --- | --- | --- |
| `scripts/check_whole_tree_graders.py` | 536 -> 696 (+160) | 260 -> 342 (+82) |
| `tests/test_whole_tree_graders_roster_is_complete.py` | 405 -> 516 (+111) | 142 -> 156 (+14) |

Net-positive and justified: +96 executable lines buy 622 grader outcomes that a preflight run could not previously see. The 11 new cells are two parametrized tables rather than eleven files.

Refs #3105, #3111, #2940.