### PR TITLE
fix(tests): whole-tree guards locate the tree they grade, not the working directory

### DIFF
--- a/changelog.d/3119-guards-locate-the-tree-they-grade.md
+++ b/changelog.d/3119-guards-locate-the-tree-they-grade.md
@@ -1,0 +1,9 @@
+### Fixed: whole-tree guards locate the tree they grade instead of the working directory
+
+Four guards walked the repository through a path relative to the process working
+directory (`Path("tests")`, `Path("docs")`), so they graded whichever tree the run
+started in. Two then reported that tree clean - including the guard that refuses a
+test calling `pose_tool(action="emergency_stop")` with no explicit `port`, whose
+hazard is de-energizing an arm plugged into the machine running the suite. Each
+root is now derived from `Path(__file__)` or from a package symbol, the two sweeps
+refuse a vacuous scan, and a new inventory refuses the next relative locator.

--- a/tests/simulation/test_gripper_mount_vocabulary_is_shared.py
+++ b/tests/simulation/test_gripper_mount_vocabulary_is_shared.py
@@ -261,15 +261,16 @@ class TestTheVocabularyHasOneOwner:
     def test_no_backend_defines_a_gripper_vocabulary_of_its_own(self) -> None:
         """A per-backend copy is the shape that drifted; refuse a second one."""
         owners = []
-        for path in sorted(Path("strands_robots/simulation").rglob("*.py")):
+        package = Path(inspect.getfile(ik)).parent
+        for path in sorted(package.rglob("*.py")):
             for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
                 if not isinstance(node, ast.Assign):
                     continue
                 for target in node.targets:
                     if isinstance(target, ast.Name) and target.id.upper().endswith("GRIPPER_BODY_HINTS"):
-                        owners.append(f"{path}:{node.lineno} {target.id}")
+                        owners.append(f"{path.relative_to(package)}:{node.lineno} {target.id}")
         assert len(owners) == 1, owners
-        assert owners[0].startswith("strands_robots/simulation/ik.py"), owners
+        assert owners[0].startswith("ik.py"), owners
 
     def test_the_shipped_vocabulary_is_the_one_this_file_expects(self) -> None:
         """The single cell that couples this file to the shipped constant."""

--- a/tests/simulation/test_recording_dataset_home_across_backends.py
+++ b/tests/simulation/test_recording_dataset_home_across_backends.py
@@ -284,6 +284,13 @@ _START_RECORDING_BACKENDS = (
     "strands_robots/simulation/newton/recording.py",
 )
 
+#: This repository, located from this file. Every path below is joined onto it:
+#: a relative literal resolves against the working directory, so the reads here
+#: raised ``FileNotFoundError`` and the sweep above graded nothing at all when
+#: the suite ran from anywhere but the repository root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCS_TREE = _REPO_ROOT / "docs"
+
 
 def _method_node(module: str, method: str) -> ast.FunctionDef:
     """The ``def method`` node in ``module``, or fail naming what was not found.
@@ -292,7 +299,7 @@ def _method_node(module: str, method: str) -> ast.FunctionDef:
     no method would assert nothing at all - so a missing name fails the test
     rather than yielding an empty set.
     """
-    tree = ast.parse(Path(module).read_text())
+    tree = ast.parse((_REPO_ROOT / module).read_text())
     found = next(
         (node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == method),
         None,
@@ -457,10 +464,13 @@ class TestStartRecordingDocumentsWhereTheDatasetLands:
         The three were independent copies, which is why fixing one left two, so
         the property is asserted over the whole doc tree rather than per page.
         """
+        pages = sorted(_DOCS_TREE.rglob("*.md"))
+        assert len(pages) > 20, (
+            f"the sweep read {len(pages)} pages, so it graded almost nothing - it is rooted at "
+            f"{_DOCS_TREE}, which is not this repository's doc tree"
+        )
         offenders = [
-            path.as_posix()
-            for path in sorted(Path("docs").rglob("*.md"))
-            if "strands_robots/datasets" in path.read_text()
+            path.relative_to(_REPO_ROOT).as_posix() for path in pages if "strands_robots/datasets" in path.read_text()
         ]
         assert not offenders, (
             f"{', '.join(offenders)} names ~/.strands_robots/datasets as a dataset location; "

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -27,6 +27,11 @@ from strands_robots.registry.user_registry import (
     register_robot,
 )
 
+#: This repository, located from this file: a relative literal resolves against
+#: the working directory, so the example read below raised ``FileNotFoundError``
+#: whenever the suite ran from anywhere but the repository root.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
 _MINIMAL_MJCF = '<mujoco><worldbody><body><geom size="0.1"/></body></worldbody></mujoco>'
 
 
@@ -809,7 +814,7 @@ class TestTheDirectoryResolverCanDeclineTheSameFetch:
         """
         import ast
 
-        source = Path("examples/so101_curobo/planner.py").read_text()
+        source = (_REPO_ROOT / "examples/so101_curobo/planner.py").read_text()
         helper = next(
             node
             for node in ast.walk(ast.parse(source))

--- a/tests/test_graders_locate_the_tree_they_grade.py
+++ b/tests/test_graders_locate_the_tree_they_grade.py
@@ -1,0 +1,189 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A whole-tree guard locates the tree it grades, not the directory it started in.
+
+Many tests here assert a property over the whole repository - no host paths, no
+emoji in a shipped string, no ``emergency_stop`` without an explicit port - by
+walking the tree and collecting offenders. Such a sweep has one failure mode
+worse than any offender it looks for: rooted at a path that does not exist, it
+collects nothing, and "no offenders" is exactly what a clean tree looks like.
+
+``Path("tests")`` and ``Path("docs")`` resolve against the process working
+directory, not against the repository, so four guards graded whichever tree the
+run happened to start in. Two of them then reported that tree clean. Measured by
+planting a real offender in the tree under test and running the same guard twice,
+changing only the working directory:
+
+=========================================== ================== ==================
+guard                                        cwd = repo root    cwd = elsewhere
+=========================================== ================== ==================
+``emergency_stop`` on the default port       FAILED (caught it)  **1 passed**
+a doc page naming a dataset home            FAILED (caught it)  **1 passed**
+=========================================== ================== ==================
+
+The first of those is a safety guard: ``pose_tool``'s ``port`` defaults to
+``/dev/ttyACM0``, so the hazard it exists to refuse is a test that de-energizes
+whatever arm is plugged into the machine running the suite. It passed with that
+hazard present.
+
+Two spellings of the same mistake are graded here, because both were in the tree
+and only one is silent:
+
+* the sweep root - ``Path("docs").rglob(...)`` - which yields nothing and reads
+  as compliant;
+* the individual read - ``Path("strands_robots/.../recording.py").read_text()`` -
+  which raises ``FileNotFoundError``. Loud, so it costs a confusing failure
+  rather than a false pass, and it is still wrong: the guard names a file it did
+  not read.
+
+The rule is therefore about the *locator*, not about the failure it happens to
+produce: a relative literal must not reach the filesystem. Roots derived from
+``Path(__file__)`` or from a symbol the package defines
+(``Path(inspect.getfile(...)).parent``) are the convention the rest of the suite
+already keeps, and they answer the same whatever the working directory is.
+
+A relative ``Path`` literal that never touches the disk is not in scope, and the
+tree carries three - ``Path("out")`` compared for equality, ``Path("bare_id")``
+returned by a resolver, ``Path("test_x.py").stem`` read for its name. Keying on
+the filesystem call rather than on the literal is what distinguishes them, so
+they need no exemption entry that could later go stale.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+#: The test tree, located from this file - the rule this module states, applied
+#: to the module that states it.
+_TEST_TREE = pathlib.Path(__file__).resolve().parent
+
+#: Attribute calls that take a path to the filesystem. ``resolve`` and ``stem``
+#: are deliberately absent: neither reads anything, so neither turns a relative
+#: literal into a claim about a tree.
+_FILESYSTEM_CALLS = frozenset(
+    {
+        "glob",
+        "rglob",
+        "iterdir",
+        "walk",
+        "read_text",
+        "read_bytes",
+        "open",
+        "exists",
+        "is_file",
+        "is_dir",
+        "stat",
+    }
+)
+
+
+def _is_relative_path_literal(node: ast.AST) -> str | None:
+    """The literal of a ``Path("relative/thing")`` call, or ``None``.
+
+    An absolute literal names one tree wherever it runs from, so it is a
+    different question and not this one.
+    """
+    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Path"):
+        return None
+    if len(node.args) != 1 or not isinstance(node.args[0], ast.Constant):
+        return None
+    value = node.args[0].value
+    if not isinstance(value, str) or not value or value.startswith(("/", "~")):
+        return None
+    return value
+
+
+def _cwd_relative_locators(source: str) -> list[str]:
+    """Every relative path literal in ``source`` that reaches the filesystem.
+
+    Both spellings are resolved: the literal used directly as the receiver of a
+    filesystem call, and one bound to a name that is then used as that receiver.
+
+    Args:
+        source: Python source text.
+
+    Returns:
+        ``"<line>: <literal>.<call>"`` per locator, in source order.
+    """
+    tree = ast.parse(source)
+    bound: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        literal = _is_relative_path_literal(node.value)
+        if isinstance(target, ast.Name) and literal is not None:
+            bound[target.id] = literal
+
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr not in _FILESYSTEM_CALLS:
+            continue
+        receiver = node.func.value
+        literal = _is_relative_path_literal(receiver)
+        if literal is None and isinstance(receiver, ast.Name):
+            literal = bound.get(receiver.id)
+        if literal is not None:
+            found.append((node.lineno, f"{literal!r}.{node.func.attr}()"))
+    return [f"{line}: {what}" for line, what in sorted(found)]
+
+
+class TestNoGuardIsRootedAtTheWorkingDirectory:
+    """The inventory, over the test tree rather than over a list of files."""
+
+    def test_no_test_module_reaches_the_filesystem_through_a_relative_literal(self) -> None:
+        offenders: dict[str, list[str]] = {}
+        scanned = 0
+        for path in sorted(_TEST_TREE.rglob("*.py")):
+            scanned += 1
+            locators = _cwd_relative_locators(path.read_text(encoding="utf-8"))
+            if locators:
+                offenders[path.relative_to(_TEST_TREE).as_posix()] = locators
+        assert scanned > 100, (
+            f"the sweep read {scanned} modules, so it graded almost nothing - it is rooted at "
+            f"{_TEST_TREE}, which is not this repository's test tree"
+        )
+        assert not offenders, (
+            "these locate a tree by a path relative to the working directory, so they grade "
+            "whichever tree the run started in - and a sweep that finds nothing reports the tree "
+            f"clean: {offenders}. Derive the root from Path(__file__) or from a package symbol."
+        )
+
+
+class TestTheScannerIsCalibrated:
+    """Both spellings caught, and a literal that never reads is not one."""
+
+    @pytest.mark.parametrize(
+        ("label", "source"),
+        [
+            ("sweep root", 'for p in sorted(Path("docs").rglob("*.md")):\n    pass\n'),
+            ("single read", 'source = Path("strands_robots/x.py").read_text()\n'),
+            ("bound to a name", '_DOCS = Path("docs")\n\n\ndef f():\n    return list(_DOCS.glob("*.md"))\n'),
+            ("existence probe", 'if Path("examples/demo.py").exists():\n    pass\n'),
+        ],
+    )
+    def test_a_relative_locator_is_reported(self, label: str, source: str) -> None:
+        assert _cwd_relative_locators(source), f"the {label} spelling is no longer caught"
+
+    @pytest.mark.parametrize(
+        ("label", "source"),
+        [
+            (
+                "derived from this file",
+                'ROOT = Path(__file__).resolve().parents[2]\nlist((ROOT / "docs").rglob("*.md"))\n',
+            ),
+            ("derived from a symbol", 'p = Path(inspect.getfile(ik)).parent\nlist(p.rglob("*.py"))\n'),
+            ("absolute literal", 'Path("/etc/hosts").read_text()\n'),
+            ("compared, never read", 'assert cfg(result_dir=Path("out")) == cfg(result_dir="out")\n'),
+            ("returned, never read", 'assert resolve("bare_id") == Path("bare_id")\n'),
+            ("read for its name", 'assert "/" not in Path("test_x.py").stem\n'),
+        ],
+    )
+    def test_a_path_that_grades_nothing_is_not_reported(self, label: str, source: str) -> None:
+        """Over-reach control: the rule is about reaching the disk, not about the literal."""
+        assert _cwd_relative_locators(source) == [], f"the {label} case is wrongly flagged"

--- a/tests/tools/test_pose_tool_emergency_stop.py
+++ b/tests/tools/test_pose_tool_emergency_stop.py
@@ -34,6 +34,11 @@ from strands_robots.tools.pose_tool import MotorController, pose_tool
 
 from .conftest import FakeSerial
 
+#: This repository's test tree, located from this file rather than from the
+#: working directory. ``Path("tests")`` named whichever directory the process
+#: happened to start in, so the hazard sweep below graded a tree that was not
+#: there and reported it clean.
+_TEST_TREE = Path(__file__).resolve().parents[2] / "tests"
 _PORT = "/dev/ttyTEST"
 _TORQUE_ENABLE_ADDR = 0x28
 _MOTOR_IDS = {"shoulder_pan": 1, "shoulder_lift": 2, "elbow_flex": 3, "wrist_flex": 4, "wrist_roll": 5, "gripper": 6}
@@ -173,9 +178,17 @@ def test_no_test_calls_emergency_stop_on_the_default_port():
     it silently passes on a developer box with nothing plugged in and drops a
     live arm on one that has hardware. Walk the whole test tree by AST so the
     hazard cannot be reintroduced in a file nobody thinks to check.
+
+    The tree is located from this file rather than from the working directory.
+    ``Path("tests")`` resolved against wherever the process started, so a run
+    from any other directory swept zero files and reported the tree clean - the
+    one direction a safety guard must never fail in. ``scanned`` carries that
+    proof: a sweep that saw nothing fails here instead of passing.
     """
     offenders = []
-    for path in sorted(Path("tests").rglob("*.py")):
+    scanned = 0
+    for path in sorted(_TEST_TREE.rglob("*.py")):
+        scanned += 1
         for node in ast.walk(ast.parse(path.read_text())):
             if not isinstance(node, ast.Call):
                 continue
@@ -191,4 +204,8 @@ def test_no_test_calls_emergency_stop_on_the_default_port():
             if action == "emergency_stop" and "port" not in kwargs:
                 offenders.append(f"{path}:{node.lineno}")
 
+    assert scanned > 100, (
+        f"the sweep read {scanned} test modules, so it graded almost nothing - it is rooted at "
+        f"{_TEST_TREE}, which is not this repository's test tree"
+    )
     assert not offenders, f"emergency_stop called without an explicit port: {offenders}"


### PR DESCRIPTION
![before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/cwd-rooted-guards/cwd_rooted_guards.png)

Four whole-tree guards walked the repository through a path relative to the process working directory (`Path("tests")`, `Path("docs")`), so they graded whichever tree the run started in. A sweep rooted at a path that does not exist collects nothing, and "no offenders" is exactly what a clean tree looks like.

Measured by planting a **real** offender in the tree under test and running the same guard twice, changing only the working directory:

| guard | cwd = repo root | cwd = elsewhere |
| --- | --- | --- |
| `emergency_stop` on the default port | FAILED (caught it) | **1 passed** |
| a doc page naming a dataset home nothing writes | FAILED (caught it) | **1 passed** |

The first is a safety guard: `pose_tool`'s `port` defaults to `/dev/ttyACM0`, so the hazard it exists to refuse is a test that de-energizes whatever arm is plugged into the machine running the suite. It passed with that hazard present.

### The same literal had a second consequence

The whole-tree preflight (`scripts/check_whole_tree_graders.py`) derives each grader's walk root to decide what to collect. A bare relative literal resolves to nothing, so the arm-safety guard was never collected by the preflight either:

| | before | after |
| --- | --- | --- |
| graders in the roster | 71 | 73 |
| cells of the arm-safety guard the preflight runs | 0 | 9 |

One cause, two independent blind spots: the guard could not see the tree, and the preflight could not see the guard.

### Change

Every root is derived from `Path(__file__)` or from a package symbol (`Path(inspect.getfile(ik)).parent`) — the convention the rest of the suite already keeps. The two sweeps additionally assert they read a non-trivial number of files, so a root that is re-broken later fails loudly instead of reporting a clean tree.

Two spellings are graded, because both were present and only one is silent:

- the **sweep root** — `Path("docs").rglob(...)` — yields nothing and reads as compliant;
- the **individual read** — `Path("strands_robots/.../recording.py").read_text()` — raises `FileNotFoundError`. Loud, so it costs a confusing failure rather than a false pass, and still wrong: the guard names a file it did not read.

The rule is therefore about the *locator*, not the failure it happens to produce.

### Scope boundary

A relative `Path` literal that never touches the disk is **not** in scope, and the tree carries three: `Path("out")` compared for equality, `Path("bare_id")` returned by a resolver, `Path("test_x.py").stem` read for its name. Keying on the filesystem call rather than on the literal separates them by construction, so no exemption list exists to go stale. All three are pinned as over-reach controls.

### Tests

`tests/test_graders_locate_the_tree_they_grade.py` — one inventory over the test tree plus 10 calibration cells (4 spellings that must be caught, 6 that must not be). Pre-fix reading, the new file alone against `main`:

```
1 failed, 10 passed
E  AssertionError: ... clean: {
  'simulation/test_gripper_mount_vocabulary_is_shared.py': ["264: 'strands_robots/simulation'.rglob()"],
  'simulation/test_recording_dataset_home_across_backends.py': ["462: 'docs'.rglob()"],
  'test_asset_manager.py': ["812: 'examples/so101_curobo/planner.py'.read_text()"],
  'tools/test_pose_tool_emergency_stop.py': ["178: 'tests'.rglob()"]}
```

All 10 controls pass pre-fix, as controls must. Post-fix: 11 passed.

Behavioural confirmation that the fix reaches the reported case — planted offender, `cwd = elsewhere`: both guards now `1 failed` (caught). Clean tree, `cwd = elsewhere`, the four touched files: `130 passed` (pre-fix that run gave 28 `FileNotFoundError`).

### Gate

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy` over the same scope: 20 errors in 6 files, identical to `main` (19 `examples/isaac_gs`, 1 `simulation/ik.py`) — 0 attributable.
- Touched files from the repo root: **141 passed**.
- Whole-tree preflight, both trees: `main` 5 failed / 1865 passed → branch 5 failed / **1885** passed. Failure set **identical** and all five are pre-existing environment floors on this runner (absent `qpsolvers` metadata, installed `lerobot` below the declared floor ×2, installed `websockets` 16.0 below the declared `>=17.0` ×2). The `+20` is exactly `11` new cells `+ 9` cells of the arm-safety guard that the preflight now collects.

### LOC

`+240 / -9` raw; executable lines (docstrings and comments excluded) `1042 -> 1148` (`+106`). Of that, `+12` fixes the four guards and `+94` is the inventory that refuses the next one.