### PR TITLE
fix(ci): the whole-tree preflight resolves a grader root bound inside the function

### DIFF
--- a/changelog.d/3120-preflight-resolves-a-grader-root-bound-in-the-function.md
+++ b/changelog.d/3120-preflight-resolves-a-grader-root-bound-in-the-function.md
@@ -1,0 +1,44 @@
+### Fixed: the whole-tree preflight collects a grader whose walk root is bound inside the function
+
+`scripts/check_whole_tree_graders.py` derives its roster from the tree: a grader
+whose population is the rest of the repository walks the repository root or one
+of its top-level Python areas, so the walk's receiver is resolved to a concrete
+path and the module is selected on where it lands. The resolver read module-level
+bindings, an area held in a loop variable (#3113) and a root arriving as a
+function parameter (#3118). It did not read a root **assigned on a line of the
+function that walks it** - the plainest spelling of all, and the one a grader
+reaches for when it keeps its sweep beside the assertion it feeds:
+
+```python
+def test_no_publish_loop_still_paces_on_an_inflated_wait() -> None:
+    root = Path(__file__).resolve().parent.parent / "strands_robots"
+    for path in sorted(root.rglob("*.py")):
+```
+
+Eight graders were unrostered on it, and the absence is silent in the reassuring
+direction - a preflight run passes without having collected them:
+
+| grader | population | outcomes |
+| --- | --- | --- |
+| `tests/tools/test_gr00t_numeric_option_guards.py` | every port-taking tool in the package | 148 |
+| `tests/test_repr_survives_partial_construction.py` | every class in the package | 49 |
+| `tests/mesh/test_gateway_mesh_kill_switch.py` | every module in the package | 36 |
+| `tests/tools/test_rosbridge_transport_port_limit.py` | every transport tool in the package | 24 |
+| `tests/drivers/test_booster_refuses_a_vendor_enum_member_it_cannot_read.py` | every module in the package | 22 |
+| `tests/test_episode_frame_range_is_one_row_read.py` | every module in the package | 20 |
+| `tests/test_mesh_state_loop_rate.py` | every pacing loop in the package | 17 |
+| `tests/mesh/test_acl_cache_docstring_matches_the_cache.py` | every module in the package | 13 |
+
+`_enclosing_assignments` reads the root from the assignments the functions
+enclosing the walk own, outermost first so a name rebound closer to the walk wins,
+as Python resolves it. Scoping is the whole of the fix's safety, and the tree
+carries a live measure of it: `tests/policies/curobo/test_action_horizon_domain.py`
+binds the repository root in one test method - to *read* a file, not to walk one -
+and walks a subpackage in another. Reading every assignment in the module would
+let the first lend its root to the second and select the file; reading only the
+assignments the enclosing functions own leaves it out, which is correct, because a
+path-scoped run over `tests/policies/` collects it already.
+
+Roster 76 -> 84 graders, 2542 -> 2871 outcomes - the increase is exactly the 329
+cells those eight files hold - with nothing dropped and the eight
+`tests/simulation` backend sweeps still excluded.

--- a/scripts/check_whole_tree_graders.py
+++ b/scripts/check_whole_tree_graders.py
@@ -46,7 +46,7 @@ good reason: a subject test globbing its own fixture directory is
 shape-identical to one walking the repository. It is not value-identical -
 ``Path(__file__).parent / "fixtures"`` and ``tmp_path`` are neither the
 repository root nor a top-level area - so resolving the path separates them.
-Measured over this repository, the derivation selects 74 of 1461 test modules.
+Measured over this repository, the derivation selects 83 of 1479 test modules.
 
 Resolving the *value* is also why the area a grader walks may be held in a loop
 variable. The idiom here is a tuple of area names walked one at a time::
@@ -85,6 +85,31 @@ asymmetry that makes the module a grader. Measured over this repository, five
 whole-tree graders were unrostered on this spelling - three docstring-
 completeness sweeps over the installed package, the package import-cycle graph,
 and the render-gating sweep over all of ``tests/``.
+
+The root may also be bound *inside the function that walks it*. A grader that
+keeps its sweep beside the assertion it feeds has no reason to hoist the root
+to module scope::
+
+    def test_no_publish_loop_still_paces_on_an_inflated_wait() -> None:
+        root = Path(__file__).resolve().parent.parent / "strands_robots"
+        for path in sorted(root.rglob("*.py")):
+
+The receiver is an ``ast.Name`` again, bound by a statement in a function body
+that neither the module-level pass nor the call-site pass reads.
+:func:`_enclosing_assignments` reads it from the assignments the functions
+enclosing the walk own, outermost first so a name rebound closer to the walk
+wins, as Python resolves it. Eight whole-tree graders were unrostered on this
+spelling - among them the sweep that grades every pacing loop in the package
+and three whose root is the installed package reached through an imported
+module's ``__file__``.
+
+Scoping is what keeps that from over-selecting, and there is a live measure of
+it: ``tests/policies/curobo/test_action_horizon_domain.py`` binds the
+repository root in one test method - to *read* a file, not to walk one - and
+walks a subpackage in another. Reading every assignment in the module would let
+the first lend its root to the second and select the file; reading only the
+assignments the enclosing functions own leaves it out, which is correct,
+because a path-scoped run over ``tests/policies/`` collects it already.
 
 A walk rooted *inside* a subpackage (``strands_robots/policies/``) is
 deliberately not selected: a path-scoped run over the mirroring test directory
@@ -543,6 +568,92 @@ def _parameter_scopes(
     return scopes
 
 
+def _enclosing_assignments(
+    call: ast.Call,
+    owners: dict[ast.AST, ast.AST | None],
+    scope: dict[str, Path],
+    module_path: Path,
+    root: Path,
+) -> dict[str, Path]:
+    """Return ``scope`` extended with the local names the functions around ``call`` bind to paths.
+
+    A grader that keeps its sweep beside the assertion it feeds binds the root
+    on a line of the test itself::
+
+        def test_no_loop_still_paces_on_an_inflated_wait() -> None:
+            root = Path(__file__).resolve().parent.parent / "strands_robots"
+            for path in sorted(root.rglob("*.py")):
+
+    The receiver is an ``ast.Name`` bound inside a function body, so reading
+    module-level names and call-site arguments alone resolved it to nothing.
+
+    Only the assignments the enclosing functions *own* are read, walking that
+    chain outermost first so a name rebound closer to the walk wins, exactly as
+    Python resolves it. A name assigned in some unrelated function is therefore
+    not in scope and lends nothing - that separation is the point, since a
+    module holding both a fixture-directory glob and a package sweep must not
+    have the one borrow the other's root.
+
+    :param call: The walk call whose receiver did not resolve.
+    :param owners: Node to its innermost enclosing function.
+    :param scope: The names already resolved, which the locals extend.
+    :param module_path: Where the module lives, so ``__file__`` resolves.
+    :param root: The repository root.
+    """
+    chain: list[ast.AST] = []
+    owner = owners.get(call)
+    while owner is not None:
+        chain.append(owner)
+        owner = owners.get(owner)
+    extended = dict(scope)
+    for function in reversed(chain):
+        # The loop repeats so a local defined in terms of an earlier one
+        # resolves regardless of how many steps the grader spells it in.
+        for _ in range(3):
+            for statement in ast.walk(function):
+                if owners.get(statement) is not function:
+                    continue
+                if (
+                    isinstance(statement, ast.Assign)
+                    and len(statement.targets) == 1
+                    and isinstance(statement.targets[0], ast.Name)
+                ):
+                    name, value = statement.targets[0].id, statement.value
+                elif (
+                    isinstance(statement, ast.AnnAssign)
+                    and isinstance(statement.target, ast.Name)
+                    and statement.value is not None
+                ):
+                    name, value = statement.target.id, statement.value
+                else:
+                    continue
+                resolved = _resolve(value, module_path, extended, root)
+                if isinstance(resolved, Path):
+                    extended[name] = resolved
+    return extended
+
+
+def _walk_scopes(
+    call: ast.Call,
+    owners: dict[ast.AST, ast.AST | None],
+    parameters: dict[tuple[str, str], set[Path]],
+    bindings: dict[str, Path],
+    module_path: Path,
+    root: Path,
+) -> list[dict[str, Path]]:
+    """Return every scope a walk receiver that did not resolve may be read under.
+
+    The module's own bindings first, then one per ``(parameter, candidate)``
+    pair, and each of those extended with the locals in scope at the call - so
+    a root assembled from a parameter (``root = base / "strands_robots"``)
+    resolves without either resolver needing to know about the other.
+    """
+    return [
+        _enclosing_assignments(call, owners, scope, module_path, root)
+        for scope in [bindings, *_parameter_scopes(call, owners, parameters, bindings)]
+    ]
+
+
 def _receiver_targets(
     receiver: ast.expr,
     module_path: Path,
@@ -581,7 +692,7 @@ def walked_paths(source: str, module_path: Path, root: Path) -> set[Path]:
             if found:
                 targets.update(found)
                 continue
-            for scope in _parameter_scopes(node, owners, parameters, bindings):
+            for scope in _walk_scopes(node, owners, parameters, bindings, module_path, root):
                 targets.update(_receiver_targets(receiver, module_path, scope, segments, root))
     return targets
 

--- a/tests/test_whole_tree_graders_roster_is_complete.py
+++ b/tests/test_whole_tree_graders_roster_is_complete.py
@@ -52,6 +52,13 @@ nothing reads exactly like a tree with nothing to select:
   render-gating sweep over all of ``tests/``. The asymmetry that makes such a
   module a grader is visible in its own calls: the planted call passes a
   ``tmp_path`` and resolves to nothing, the real one passes the package root.
+- a root bound *inside the function that walks it* resolves. This is the fifth
+  turn, and the plainest of the five: a grader that keeps its sweep beside the
+  assertion it feeds binds the root where it is used. Eight graders were
+  unrostered on it. Both directions are graded, because reading locals is the
+  first of these widenings that could over-select - a name assigned in one
+  function must not stand in for a receiver in another, and the tree carries a
+  live instance of exactly that pair.
 
 A roster only helps a caller who knows to run it. Issue #2940's failure mode
 was a *green* narrow run, so the remedy is only reachable if the pre-push
@@ -389,6 +396,118 @@ def test_a_parameter_the_module_does_not_bind_to_an_area_is_not_selected(label: 
         f"the derivation selected a module whose walk root is only ever {label}. "
         "Resolving a parameter is meant to read the same walks the tree already "
         "has, not to widen the class of walk that counts as whole-tree."
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "grader"),
+    [
+        (
+            "a local bound to a module constant",
+            "def test_it():\n    root = PKG\n    for p in root.rglob('*.py'):\n        pass\n",
+        ),
+        (
+            "a local assembled from the installed package's file",
+            "def test_it():\n    root = pathlib.Path(strands_robots.__file__).parent\n"
+            "    for p in root.rglob('*.py'):\n        pass\n",
+        ),
+        (
+            "a local returned by a zero-argument module helper",
+            "def _package_root():\n    return PKG\n\n\ndef test_it():\n    root = _package_root()\n"
+            "    for p in root.rglob('*.py'):\n        pass\n",
+        ),
+        (
+            "a local defined in terms of an earlier local",
+            "def test_it():\n    own = pathlib.Path(strands_robots.__file__).resolve()\n    root = own.parent\n"
+            "    for p in root.rglob('*.py'):\n        pass\n",
+        ),
+        (
+            "a local inside a test method on a class",
+            "class TestIt:\n    def test_it(self):\n        root = PKG\n"
+            "        for p in root.rglob('*.py'):\n            pass\n",
+        ),
+        (
+            "an enclosing function's local read by a nested one",
+            "def test_it():\n    root = PKG\n\n    def _sweep():\n        return [p for p in root.rglob('*.py')]\n\n"
+            "    assert _sweep() is not None\n",
+        ),
+        (
+            "a local assembled from a parameter the module binds",
+            "def _scan(base):\n    root = base / 'strands_robots'\n    return [p for p in root.rglob('*.py')]\n\n"
+            "FILES = _scan(PKG.parent)",
+        ),
+    ],
+)
+def test_a_root_bound_inside_the_function_resolves(label: str, grader: str) -> None:
+    """A grader whose walk root is assigned on a line of the function is selected.
+
+    This is the fifth turn of the same screw, and the plainest: a grader that
+    keeps its sweep beside the assertion it feeds has no reason to hoist the
+    root to module scope, so it binds it where it is used. Reading module-level
+    names and call-site arguments alone resolved the receiver to nothing, and
+    eight graders were unrostered on it - among them the sweep in
+    ``tests/test_mesh_state_loop_rate.py`` that grades every pacing loop in the
+    package, and three sweeps whose walk is the installed package root reached
+    through an imported module's ``__file__``.
+
+    The last case is the one neither resolver settles alone: the root is
+    *assembled* from a parameter, so the local and the argument have to compose.
+
+    ``label`` names the spelling so a failure says which one stopped resolving.
+    """
+    source = f"import pathlib\n\nimport strands_robots\n\nPKG = pathlib.Path(strands_robots.__file__).resolve().parent\n\n{grader}\n"
+    assert _selects(source, _TESTS_ROOT / "test_planted.py"), (
+        f"the derivation cannot resolve a root spelled as {label}, so a grader "
+        "written that way is invisible to the preflight rather than merely "
+        "unrostered."
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "grader"),
+    [
+        (
+            "a local in a different function than the walk",
+            "def test_reads_the_tree():\n    root = PKG\n    assert root.is_dir()\n\n\n"
+            "def test_walks_a_fixture(tmp_path):\n    root = tmp_path\n"
+            "    for p in root.rglob('*.py'):\n        pass\n",
+        ),
+        (
+            "a local rebound to a subpackage closer to the walk",
+            "def test_it():\n    root = PKG\n\n    def _sweep():\n        root = PKG / 'policies'\n"
+            "        return [p for p in root.rglob('*.py')]\n\n    assert _sweep() is not None\n",
+        ),
+        (
+            "a local bound to a fixture directory beside the test",
+            "def test_it():\n    root = pathlib.Path(__file__).parent / 'fixtures'\n"
+            "    for p in root.rglob('*.py'):\n        pass\n",
+        ),
+        (
+            "a local bound to a subpackage",
+            "def test_it():\n    root = PKG / 'policies'\n    for p in root.rglob('*.py'):\n        pass\n",
+        ),
+    ],
+)
+def test_a_local_the_walk_cannot_see_lends_nothing(label: str, grader: str) -> None:
+    """Reading locals must not lend a name across functions that do not share it.
+
+    The first case is the live shape this separation is measured against.
+    ``tests/policies/curobo/test_action_horizon_domain.py`` binds the repository
+    root in one test method - to *read* a file, not to walk one - and walks a
+    subpackage in another. Reading every assignment in the module would let the
+    first method's root stand in for the second method's receiver and select the
+    file; reading only the assignments the enclosing functions own leaves it
+    out, which is correct, because a path-scoped run over
+    ``tests/policies/`` does collect it.
+
+    The second case grades the same attribution one scope in: a nested function
+    that rebinds the name resolves to its own value, as Python does.
+    """
+    source = f"import pathlib\n\nimport strands_robots\n\nPKG = pathlib.Path(strands_robots.__file__).resolve().parent\n\n{grader}\n"
+    assert not _selects(source, _TESTS_ROOT / "subject" / "test_planted.py"), (
+        f"the derivation selected a module whose walk root is only ever {label}. "
+        "Resolving a local is meant to read the same walks the tree already has, "
+        "not to widen the class of walk that counts as whole-tree."
     )
 
 


### PR DESCRIPTION
![roster](https://raw.githubusercontent.com/cagataycali/robots/assets/preflight-locals/roster_locals.png)

`scripts/check_whole_tree_graders.py` derives its roster from the tree: a grader whose population is the rest of the repository walks the repository root or a top-level Python area, so the walk's receiver is resolved to a concrete path and the module is selected on where it lands.

The resolver read module-level bindings, an area held in a loop variable (#3113) and a root arriving as a function parameter (#3118). It did not read a root **assigned on a line of the function that walks it** - the plainest spelling of all, and the one a grader uses when it keeps its sweep beside the assertion it feeds:

```python
def test_no_publish_loop_still_paces_on_an_inflated_wait() -> None:
    root = Path(__file__).resolve().parent.parent / "strands_robots"
    for path in sorted(root.rglob("*.py")):
```

Eight graders were unrostered on it. Each walks all of `strands_robots` (or the repository root), and the absence is silent in the *reassuring* direction - a preflight run passes without ever collecting them:

| grader | population | cells |
| --- | --- | --- |
| `tests/tools/test_gr00t_numeric_option_guards.py` | every port-taking tool in the package | 148 |
| `tests/test_repr_survives_partial_construction.py` | every class in the package | 49 |
| `tests/mesh/test_gateway_mesh_kill_switch.py` | every module in the package | 36 |
| `tests/tools/test_rosbridge_transport_port_limit.py` | every transport tool in the package | 24 |
| `tests/drivers/test_booster_refuses_a_vendor_enum_member_it_cannot_read.py` | every module in the package | 22 |
| `tests/test_episode_frame_range_is_one_row_read.py` | every module in the package | 20 |
| `tests/test_mesh_state_loop_rate.py` | every pacing loop in the package | 17 |
| `tests/mesh/test_acl_cache_docstring_matches_the_cache.py` | every module in the package | 13 |

`tests/test_mesh_state_loop_rate.py` is the sharpest of the eight: its own docstring says it "scans for the SHAPE rather than for one spelling" of a pacing loop, and no preflight run had ever collected it.

## The change

`_enclosing_assignments` resolves the receiver from the assignments the functions *enclosing the walk* own, walking that chain outermost first so a name rebound closer to the walk wins, as Python resolves it. `_walk_scopes` composes it with the existing parameter resolver, so a root **assembled** from a parameter (`root = base / "strands_robots"`) resolves without either resolver knowing about the other.

Scoping is the whole of the fix's safety, and the tree carries a live measure of it. `tests/policies/curobo/test_action_horizon_domain.py` binds the repository root in one test method - to *read* a file, not to walk one - and walks a subpackage in another. Reading every assignment in the module would let the first lend its root to the second and select the file; reading only the assignments the enclosing functions own leaves it out, which is correct, because a path-scoped run over `tests/policies/` collects it already. A first draft of this patch did read every assignment, and that file is what caught it.

## Measured

Same tree, both resolvers:

| | before | after |
| --- | --- | --- |
| graders derived | 75 | 83 |
| roster (derived + explicitly named) | 76 | 84 |
| preflight outcomes | 2542 | 2871 |
| dropped | - | **0** |

The `+329` is exactly the 329 cells those eight files hold. The eight `tests/simulation` backend sweeps stay excluded (they walk `_SIM_PACKAGE / backend`, and a path-scoped run over the mirroring test directory collects them, so they are not in the class this script rescues) - they are the control this resolver was measured against.

## Tests

`tests/test_whole_tree_graders_roster_is_complete.py` gains two parametrized families in the file's existing planted-source shape, graded in both directions:

- `test_a_root_bound_inside_the_function_resolves` - 7 spellings: a local bound to a module constant, one assembled from an imported module's `__file__`, one returned by a zero-argument helper, one defined in terms of an earlier local, one inside a test method on a class, an enclosing function's local read by a nested one, and one assembled from a parameter.
- `test_a_local_the_walk_cannot_see_lends_nothing` - 4 negative controls: a local in a different function than the walk (the curobo shape), a local rebound to a subpackage closer to the walk, a fixture directory, and a subpackage.

Pre-fix reading, new test file only against unmodified `main`: **7 failed, 4 passed** - every positive spelling fails, every negative control passes, as a control must.

## Gate

- `ruff check` / `ruff format --check` clean; `mypy` clean on both changed files, and the repository-scope run is unchanged at its existing 20 errors in 6 files (none attributable).
- `tests/test_whole_tree_graders_roster_is_complete.py`: **44 passed**.
- Full preflight, base vs branch: `5 failed / 2487 passed` -> `5 failed / 2809 passed`, the five failures set-identical and all environment (this box has no `qpsolvers` metadata and carries `lerobot` 0.5.1 / `websockets` 16.0, both below the floors `pyproject.toml` declares). The branch additionally *reports* 4 errors, all in `TestAgainstARealDataset` in `tests/test_episode_frame_range_is_one_row_read.py` - one of the newly collected graders. Running that file directly on unmodified `main` gives the identical `16 passed, 4 errors` from the same stale `lerobot`, so the verdict is pre-existing; this change makes it *visible*, which is the point.

## LOC

`+276 / -2` raw. By executable statements (docstrings excluded): script `254 -> 277`, test `70 -> 76` - **+29 executable**, the rest being the narrative both files keep for why the resolver has been widened five times.
