### PR TITLE
fix(simulation): the rate guards judge every fps spelling their own domain accepts

### DIFF
--- a/changelog.d/3124-rate-guards-judge-every-fps-spelling.md
+++ b/changelog.d/3124-rate-guards-judge-every-fps-spelling.md
@@ -1,0 +1,45 @@
+### Fixed: the recording rate guards judge every `fps` spelling their own domain accepts
+
+`recorder_dataset_fps` and `rollout_rate_mismatch_reason` classified `fps` with
+`isinstance(value, int | float)`. `numpy.int64` and `numpy.float32` are neither an
+`int` nor a `float` subclass, so both guards read a whole rate as "no readable
+rate" and returned `None` -- which their callers treat as "do not judge". The
+rate-disagreement refusal was therefore skipped and the episode was written on a
+timebase that mislabels it, with `start_recording` returning `status="success"`.
+
+The values were in domain, not out of it. `positive_whole_number_error` -- the
+domain `start_recording` runs `fps` through *before* either guard is asked --
+classifies on `numbers.Real` and accepts `np.int64(60)` and `np.float64(30.0)`,
+pinned by `tests/simulation/test_dataset_recording_fps_contract.py`. So the
+narrowing declined to judge a rate the surface had just accepted, which is the one
+case these guards exist for.
+
+Measured with `fps` spelled four ways against a rollout capturing at 50 Hz, the
+three orderings of this single disagreement split apart:
+
+    fps                recorder_dataset_fps   rollout    dataset    requested
+    30                                 30     REFUSED    REFUSED    REFUSED
+    np.int64(30)                     None     -          -          REFUSED
+    np.float32(30.0)                 None     -          -          REFUSED
+    np.float64(30.0)                   30     REFUSED    REFUSED    REFUSED
+
+`numpy.float64` IS a `float` subclass, so the narrowing held for one numpy
+spelling and not its siblings; `requested_rate_mismatch_reason` already classified
+on `numbers.Real`, which is why one of the three orderings was unaffected and the
+split went unnoticed.
+
+`tests/simulation/test_recording_rate_matches_control_frequency.py` already
+asserts the three orderings never disagree about a pair -- that invariant is what
+broke -- but its parametrization carried `fps` as a plain `int` only, so the
+disagreement sat outside its population.
+
+Both guards now classify on `numbers.Real` and route the boolean question to the
+shared `is_boolean` predicate, matching `requested_rate_mismatch_reason` in the
+same module and catching `numpy.bool_`, which is not a `bool` subclass. The
+cross-ordering parametrization gains the numpy spellings, and each guard gains
+focused coverage asserting an in-domain rate is judged rather than passed through.
+
+No `try` is added around the `float(fps)` that follows either guard: both are
+asked only after the fps domain, which refuses a value beyond the float64 range
+with a reason of its own. That is the one respect in which they differ from
+`requested_rate_mismatch_reason`, which is asked before any domain and needs it.

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -236,8 +236,21 @@ def recorder_dataset_fps(recorder: Any) -> int | None:
         # catches ``numpy.bool_`` (not a ``bool`` subclass).
         if is_boolean(value) or not isinstance(value, numbers.Real):
             continue
-        if value > 0 and float(value).is_integer():
-            return int(value)
+        # Judged and returned through ``float``, the same hop both sibling
+        # guards take (``declared = float(fps)`` ... ``fps_int = int(declared)``):
+        # ``numbers.Real`` carries no ordering against ``int`` and no ``int()``
+        # overload, so asking ``value > 0`` or truncating it directly is
+        # untypeable. Deliberately not ``math.trunc(value)``, which would keep
+        # a >2**53 rate exact but raises ``TypeError`` on ``numpy.int64`` - it
+        # defines ``__int__``, not ``__trunc__`` - and numpy spellings are the
+        # reason this classifies on ``Real`` at all. A rate that large is
+        # float-rounded by both siblings too, so routing through ``float`` keeps
+        # the three guards answering identically, which is the property the
+        # cross-ordering test asserts. The conversion count is unchanged: the
+        # previous spelling already called ``float`` to ask ``is_integer``.
+        declared = float(value)
+        if declared > 0 and declared.is_integer():
+            return int(declared)
     return None
 
 

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -226,7 +226,15 @@ def recorder_dataset_fps(recorder: Any) -> int | None:
     """
     dataset = getattr(recorder, "dataset", None)
     for value in (getattr(dataset, "fps", None), getattr(getattr(dataset, "meta", None), "fps", None)):
-        if isinstance(value, bool) or not isinstance(value, int | float):
+        # Classified on ``numbers.Real``, not ``int | float``: ``numpy.int64`` and
+        # ``numpy.float32`` are neither ``int`` nor ``float`` subclasses, so the
+        # narrower spelling read a whole rate this function calls "usable" as an
+        # unreadable layout and returned ``None`` - which the one caller treats as
+        # "do not judge", skipping the refusal. ``numpy.float64`` IS a ``float``
+        # subclass, so the narrowing failed for some numpy spellings and not
+        # others. The boolean question goes to the shared predicate, which also
+        # catches ``numpy.bool_`` (not a ``bool`` subclass).
+        if is_boolean(value) or not isinstance(value, numbers.Real):
             continue
         if value > 0 and float(value).is_integer():
             return int(value)
@@ -376,7 +384,10 @@ def rollout_rate_mismatch_reason(method: str, fps: Any, rates: Mapping[str, floa
         fps: Caller-supplied dataset frame rate. Validate it with
             :func:`dataset_recording_option_error` first; a value outside that
             domain returns ``None`` here so it is reported as the parameter
-            error it is rather than as a rate disagreement.
+            error it is rather than as a rate disagreement. Classified on
+            ``numbers.Real``, the predicate that domain uses, so every spelling
+            it accepts - a ``numpy.int64`` rate read out of a config included -
+            is judged here rather than silently passed through.
         rates: Capture rate in Hz per robot with a rollout in flight, as
             reported by
             :meth:`~strands_robots.simulation.base.SimEngine._active_rollout_rates`.
@@ -388,8 +399,19 @@ def rollout_rate_mismatch_reason(method: str, fps: Any, rates: Mapping[str, floa
     """
     if not rates:
         return None
-    if isinstance(fps, bool) or not isinstance(fps, int | float):
+    # ``numbers.Real``, the predicate ``positive_whole_number_error`` classifies
+    # this same ``fps`` with, so every spelling that domain accepts is judged
+    # here. The narrower ``int | float`` declined to judge ``numpy.int64(30)`` -
+    # a value that domain accepts, and is test-pinned as accepting - so the
+    # disagreement this function exists to refuse was skipped and the episode was
+    # written on a timebase that mislabels it. See the identical reasoning in
+    # :func:`requested_rate_mismatch_reason`.
+    if is_boolean(fps) or not isinstance(fps, numbers.Real):
         return None
+    # ``float()`` cannot overflow here: this guard is asked only after
+    # ``dataset_recording_option_error``, whose domain refuses an ``fps`` beyond
+    # the float64 range with a reason of its own. That is why it needs no
+    # ``try`` - unlike ``requested_rate_mismatch_reason``, which is asked first.
     declared = float(fps)
     if declared <= 0 or not declared.is_integer():
         return None

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -251,6 +251,11 @@ class TestTheGuardHelperIsRobust:
         """
         assert recorder_dataset_fps(_FakeRecorder(rate)) == 30
         assert recorder_dataset_fps(_MetaOnlyRecorder(rate)) == 30
+        # A built-in ``int``, not the numpy scalar passed through: the annotation
+        # says ``int``, and the value is handed to ``1.0 / fps`` and into a reason
+        # string. ``== 30`` holds for a numpy scalar too, so the identity is
+        # asserted rather than left implied by the equality above.
+        assert type(recorder_dataset_fps(_FakeRecorder(rate))) is int
 
 
 class TestTheRunnerLayerCarriesItsOwnGuarantee:

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -50,6 +50,7 @@ import contextlib
 import time
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 pytest.importorskip("mujoco")
@@ -61,6 +62,7 @@ from strands_robots.simulation.policy_runner import PolicyRunner  # noqa: E402
 from strands_robots.simulation.recording import (  # noqa: E402
     dataset_rate_mismatch_error,
     dataset_rate_mismatch_reason,
+    dataset_recording_option_error,
     rate_mismatch_explanation,
     recorder_dataset_fps,
     requested_rate_mismatch_reason,
@@ -234,6 +236,21 @@ class TestTheGuardHelperIsRobust:
 
     def test_a_boolean_rate_is_not_read_as_one(self):
         assert recorder_dataset_fps(_FakeRecorder(True)) is None
+        assert recorder_dataset_fps(_FakeRecorder(np.bool_(True))) is None
+
+    @pytest.mark.parametrize("rate", [np.int64(30), np.int32(30), np.float32(30.0), np.float64(30.0)])
+    def test_a_numpy_rate_is_read_rather_than_treated_as_an_unreadable_layout(self, rate):
+        """A whole rate is a whole rate whichever scalar type carries it.
+
+        ``numpy.int64`` and ``numpy.float32`` are not ``int``/``float``
+        subclasses, so classifying on ``int | float`` reported them as "no
+        readable rate" - and the one caller reads that as "do not judge", so the
+        mismatch refusal was skipped and the episode was written on a timebase
+        that mislabels it. ``numpy.float64`` IS a ``float`` subclass, so the
+        narrowing held for one numpy spelling and not its siblings.
+        """
+        assert recorder_dataset_fps(_FakeRecorder(rate)) == 30
+        assert recorder_dataset_fps(_MetaOnlyRecorder(rate)) == 30
 
 
 class TestTheRunnerLayerCarriesItsOwnGuarantee:
@@ -585,6 +602,21 @@ class TestTheRolloutRateGuardHelperIsRobust:
         assert rollout_rate_mismatch_reason("start_recording", 50.0, {"arm": 50.0}) is None
         assert rollout_rate_mismatch_reason("start_recording", 30.0, {"arm": 50.0}) is not None
 
+    @pytest.mark.parametrize("fps", [np.int64(30), np.int32(30), np.float32(30.0), np.float64(30.0)])
+    def test_a_numpy_fps_the_domain_accepts_is_judged_and_not_passed_through(self, fps):
+        """Declining to judge an in-domain rate is the distortion, not a nicety.
+
+        ``positive_whole_number_error`` - the domain ``start_recording`` runs
+        ``fps`` through before this guard is asked - accepts every one of these
+        (pinned by ``tests/simulation/test_dataset_recording_fps_contract.py``).
+        So an ``int | float`` narrowing here refuses nothing and reports nothing:
+        ``start_recording`` returns ``status="success"`` and the episode declares
+        30 fps for frames captured at 50 Hz.
+        """
+        assert dataset_recording_option_error("start_recording", fps) is None, "precondition: in domain"
+        assert rollout_rate_mismatch_reason("start_recording", fps, {"arm": 50.0}) is not None
+        assert rollout_rate_mismatch_reason("start_recording", fps, {"arm": 30.0}) is None, "agreeing rate"
+
     def test_a_fractional_capture_rate_offers_only_the_remedy_it_can(self):
         """``fps`` must be whole, so 33.3 Hz has no rate to advise recording at."""
         reason = rollout_rate_mismatch_reason("start_recording", 30, {"arm": 33.3})
@@ -613,7 +645,25 @@ class TestTheRolloutRateGuardHelperIsRobust:
 
 @pytest.mark.parametrize(
     ("fps", "rate"),
-    [(30, 50.0), (50, 30.0), (30, 30.0), (50, 50.0), (25, 25.0), (30, 33.3), (60, 50.0)],
+    [
+        (30, 50.0),
+        (50, 30.0),
+        (30, 30.0),
+        (50, 50.0),
+        (25, 25.0),
+        (30, 33.3),
+        (60, 50.0),
+        # The same pairs with ``fps`` carried by a numpy scalar. An ``fps`` read
+        # out of a config or computed from array shape arrives spelled this way,
+        # the fps domain accepts all of them, and two of the three orderings
+        # classified on ``int | float`` - so the orderings disagreed about a pair
+        # every one of them accepts, which is exactly what this test forbids.
+        (np.int64(30), 50.0),
+        (np.int32(30), 50.0),
+        (np.float32(30.0), 50.0),
+        (np.float64(30.0), 50.0),
+        (np.int64(50), 50.0),
+    ],
 )
 def test_every_ordering_reaches_the_same_verdict_and_explanation(fps, rate):
     """One disagreement, so its orderings may not disagree about it.


### PR DESCRIPTION
## 1. What is wrong

`recorder_dataset_fps` and `rollout_rate_mismatch_reason` — two of the three guards that refuse a dataset frame rate disagreeing with the rate frames are really captured at — classified `fps` with `isinstance(value, int | float)`.

`numpy.int64` and `numpy.float32` are neither an `int` nor a `float` subclass. Both guards therefore read a perfectly good whole rate as "no readable rate" and returned `None` — which their callers treat as **"do not judge"**, not as "acceptable". The refusal was skipped, `start_recording` returned `status="success"`, and the episode was written on a timebase that mislabels it.

This is the exact distortion the module's own docstring quantifies: `fps=30` against `control_frequency=50.0` saved 81 frames captured 0.0200 s apart and declared them 0.0333 s apart — a 2.6667 s episode for a 1.62 s capture, with `start_policy`, `start_recording` and `stop_recording` all reporting success.

## 2. The values are in domain, not out of it

This is not a guard correctly declining an invalid rate. `positive_whole_number_error` — the domain `start_recording` runs `fps` through **before** either guard is asked — classifies on `numbers.Real` and accepts numpy scalars. That acceptance is already test-pinned:

```python
# tests/simulation/test_dataset_recording_fps_contract.py
@pytest.mark.parametrize("fps", [1, 30, 30.0, np.int64(60), np.float64(30.0)])
def test_positive_whole_rate_is_accepted(self, fps):
    assert dataset_recording_option_error("start_recording", fps) is None
```

So the surface accepted the rate and the guard then declined to judge it — which is the one case these guards exist for.

## 3. Measured

`fps` spelled four ways, against a rollout capturing at 50 Hz. Every value is in domain (`dataset_recording_option_error` returns `None` for all four):

| `fps` | `recorder_dataset_fps` | rollout ordering | dataset ordering | requested ordering |
| --- | --- | --- | --- | --- |
| `30` | `30` | REFUSED | REFUSED | REFUSED |
| `np.int64(30)` | `None` | **no verdict** | **no verdict** | REFUSED |
| `np.float32(30.0)` | `None` | **no verdict** | **no verdict** | REFUSED |
| `np.float64(30.0)` | `30` | REFUSED | REFUSED | REFUSED |

Two things kept this hidden:

- `numpy.float64` **is** a `float` subclass, so the narrowing held for one numpy spelling and broke for its siblings.
- `requested_rate_mismatch_reason` already classified on `numbers.Real`, so one of the three orderings always answered correctly.

## 4. The invariant that broke

`tests/simulation/test_recording_rate_matches_control_frequency.py` already asserts the three orderings never disagree about a pair:

> One disagreement, so its orderings may not disagree about it. […] a caller who reverses the order of two calls, or supplies both rates at once, must not be told the pair is acceptable in one direction and not the other.

That is precisely what happened. The test did not catch it because its parametrization carried `fps` as a plain `int` only, so the numpy spellings were outside its population.

## 5. The fix

Both guards now classify on `numbers.Real` and route the boolean question to the shared `is_boolean` predicate — matching `requested_rate_mismatch_reason` in the same module, whose inline comment already documents why the narrow form is wrong:

> `numpy.int64` and `numpy.float32` are neither `int` nor `float` subclasses, so an `isinstance(int | float)` narrowing here would have passed a colliding pair read out of a config straight through.

`is_boolean` rather than `isinstance(value, bool)` also catches `numpy.bool_`, which is not a `bool` subclass.

## 6. Why no `try` around the following `float(fps)`

`requested_rate_mismatch_reason` wraps its coercion in `except (OverflowError, TypeError, ValueError)` because it is asked *before* either rate has been through a domain. These two guards are asked only *after* the fps domain, which refuses a value beyond the float64 range with a reason of its own — so `float(fps)` cannot overflow here. Adding the `try` would suggest a reachable path that does not exist. Both sites now carry a comment stating this, so the asymmetry with the sibling reads as a decision rather than an omission.

## 7. Scope

Two predicate expressions, their explanatory comments, one docstring clause, and test coverage. No behaviour change for any rate spelling that already worked — verified below.

```
 strands_robots/simulation/recording.py                            | 28 ++++++--
 tests/simulation/test_recording_rate_matches_control_frequency.py | 52 +++++++++++-
 changelog.d/3124-rate-guards-judge-every-fps-spelling.md          | new
```

Deliberately **not** included, to keep this one concern:

- `recorder_dataset_fps`'s `float(value)` can still overflow on an outsized plain `int` read off a drifted LeRobot layout. That path exists identically on `main` (a huge `int` passes `isinstance(int | float)` today) and numpy scalars are bounded, so this change neither widens nor narrows it.
- A separate finding in the same file — `stop_recording`'s parquet probe defaulting a missing `total_episodes` to `0` and then reporting that zero as the canonical episode count — is filed separately rather than folded in here.

## 8. Verification

The added assertions run against both trees. 9 fail before the change, 0 after, and every pre-existing case stays green:

**Before (on `main`):**
```
FAIL  recorder_dataset_fps reads int64: got None
FAIL  recorder_dataset_fps reads int32: got None
FAIL  recorder_dataset_fps reads float32: got None
PASS  recorder_dataset_fps reads float64
FAIL  rollout guard judges int64: not judged
FAIL  rollout guard judges int32: not judged
FAIL  rollout guard judges float32: not judged
PASS  rollout guard judges float64
PASS  orderings agree fps=int(30) rate=50.0      <- all 7 pre-existing pairs pass
FAIL  orderings agree fps=int64(30) rate=50.0: orderings disagree: only ['requested'] refused
FAIL  orderings agree fps=int32(30) rate=50.0: orderings disagree: only ['requested'] refused
FAIL  orderings agree fps=float32(30.0) rate=50.0: orderings disagree: only ['requested'] refused
PASS  orderings agree fps=float64(30.0) rate=50.0
PASS  orderings agree fps=int64(50) rate=50.0
>>> 9 FAILING
```

**After:** `>>> 0 FAILING` (all 20 pass).

Out-of-domain values are still left to their own guard, so no refusal moved to the wrong reporter — `True`, `np.bool_(True)`, `2.7`, `"30"` and `0` all still return no verdict from all three orderings. An agreeing numpy rate (`np.int64(50)` against 50 Hz) correctly returns no verdict rather than becoming a false refusal.

`ruff check` and `ruff format --check` clean on both touched files.

## 9. Round changelog

**Round 1** — initial submission.

**Round 2** — `mypy` failure on the new `numbers.Real` classification (lint job red, review already approved). One commit.

- `recorder_dataset_fps` left the comparison and the truncation on the `Real` itself, which does not type-check: no ordering against `int` (`recording.py:239`) and no `int()` overload for `Real` (`recording.py:240`). Resolved with the hop **both sibling guards in this module already take** — `declared = float(...)` then `int(declared)` — rather than a new idiom.
- Deliberately **not** `math.trunc(value)`. It keeps a `>2**53` rate exact and `mypy` accepts it, but it raises `TypeError` on `numpy.int64`, which defines `__int__` and not `__trunc__` — i.e. it type-checks and then crashes on the exact values this PR exists to support. Caught by differential testing, not by the type checker.
- The one remaining difference from the previous spelling is that an odd integer above `2**53` is float-rounded. Both siblings already round it identically, so routing through `float` keeps the three guards answering the same — the property `test_every_ordering_reaches_the_same_verdict_and_explanation` asserts. Stated here rather than left implicit.
- Equivalence verified against the pre-change function across **37 `fps` spellings** (every numpy int/uint/float width, `bool`/`np.bool_`, `Fraction`, `Decimal`, `str`, `bytes`, `ndarray`, `nan`/`inf`, `10**20`), on the `dataset.fps` path, the `meta.fps` path, and the fallback order between them: **zero divergences**, return type `int` in every reading case.
- The numpy parametrization now also pins `type(...) is int`. `== 30` holds for a numpy scalar too, so the pass-through the conversion exists to prevent was not actually asserted against.

Why §8 above did not catch this: it verified `ruff check` and `ruff format --check` on the touched files but never ran `mypy`, which is the third command in the same `hatch run lint` sequence. `mypy strands_robots` is now part of the local gate for this branch.
