### PR TITLE
fix(simulation): an unreadable episode count is reported as no reading, not as zero

### DIFF
--- a/changelog.d/3128-episode-count-probe-reports-no-reading.md
+++ b/changelog.d/3128-episode-count-probe-reports-no-reading.md
@@ -1,0 +1,24 @@
+### Fixed: an unreadable episode count is reported as no reading, not as zero
+
+`stop_recording`'s parquet-truth gate read the dataset's canonical episode
+count as `int(getattr(ds_meta, "total_episodes", 0))`. A layout that exposes no
+such attribute is a failed probe, but the zero default turned it into the
+*measurement* `0` -- which the gate then trusted as ground truth and used to
+overwrite the count the recorder had actually measured. A session that really
+saved four episodes reported `episode_count: 0`, `parquet_episode_count: 0`,
+`episode_count_mismatch: True` in both the json and the human-readable payload,
+and logged a warning naming a parquet count nothing had read.
+
+Every other unavailability on this same path is already expressed as "skip",
+never as a zero: `recorder_dataset_fps` returns `None` when the attribute is
+absent and the comparison is skipped, and the missing-`dataset` branch leaves
+`parquet_episode_count` at `None` with the gate quiet -- the suite calls these
+the safe defaults and pins them. The third attribute in the same defensive
+chain was the only one substituting a zero-valued default for a failed probe.
+
+The probe now uses `None` and the gate is skipped when the attribute is absent,
+so only a count that was actually read can move the reported total. A layout
+that really reports zero episodes is still a reading and is still judged, so
+the silent-collapse gate keeps firing on the case it was written for.
+`stop_recording` also gained the `Returns:` block it never had, stating the
+contract for all three episode-count fields.

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -863,6 +863,17 @@ class DatasetRecordingMixin:
                 place). When no recording is open, syncs the last dataset this
                 sim finalized (errors if there is none).
             run_id: Optional subpath inside the bucket (defaults to dataset name).
+
+        Returns:
+            The standard agent-tool envelope. Its json block reports the episode
+            bookkeeping as three fields: ``episode_count`` (the canonical count -
+            the dataset's own when that could be read, else the recorder's),
+            ``parquet_episode_count`` (the dataset's ``meta.total_episodes``, or
+            ``None`` when the recorder exposes no dataset handle, that layout
+            carries no such attribute, or the value cannot be read as an int -
+            an unreadable count is reported as no reading, never as a zero) and
+            ``episode_count_mismatch`` (the two counts were both read and
+            disagreed, so the on-disk one won).
         """
         # ``push_to_hub`` selects whether the finished dataset is published, so
         # it is checked before it is read - by the idle path just below and by
@@ -963,8 +974,18 @@ class DatasetRecordingMixin:
         episode_count_mismatch_orig: int = episode_count
         try:
             ds_meta = getattr(getattr(recorder, "dataset", None), "meta", None)
-            if ds_meta is not None:
-                parquet_episode_count = int(getattr(ds_meta, "total_episodes", 0))
+            # A layout that exposes no ``total_episodes`` is a FAILED PROBE, not
+            # a dataset holding zero episodes. Reading it with a zero default
+            # would hand that zero to the gate below as ground truth and
+            # overwrite the episode count the recorder actually measured, so a
+            # session that saved N episodes would report 0 with the mismatch
+            # flag raised. Probe with ``None`` and skip the gate when the
+            # attribute is absent - the same "unavailable means skip" the
+            # missing-``dataset`` branch above and ``recorder_dataset_fps``
+            # already use on this path.
+            raw_total_episodes = getattr(ds_meta, "total_episodes", None) if ds_meta is not None else None
+            if raw_total_episodes is not None:
+                parquet_episode_count = int(raw_total_episodes)
                 if parquet_episode_count != episode_count:
                     episode_count_mismatch = True
                     logger.warning(

--- a/tests/simulation/mujoco/test_stop_recording_finalize.py
+++ b/tests/simulation/mujoco/test_stop_recording_finalize.py
@@ -484,3 +484,43 @@ class TestStopRecordingParquetTruthGate:
         # Probe failed before assigning -> stays at the safe defaults.
         assert payload["parquet_episode_count"] is None
         assert payload["episode_count_mismatch"] is False
+
+    def test_meta_without_total_episodes_reports_no_reading_not_a_zero(self, recording_sim):
+        # ``meta`` present but exposing no ``total_episodes`` (a drifted or
+        # stubbed LeRobot layout) is a FAILED PROBE, not a dataset holding zero
+        # episodes. Read with a zero default it became the gate's ground truth
+        # and overwrote the count the recorder measured, so a session that saved
+        # 4 episodes reported episode_count=0 with the mismatch flag raised.
+        # Unavailable means skip, exactly as for a missing ``dataset`` handle.
+        rec = _FakeRecorder(meta_total_episodes=1)
+        del rec.dataset.meta.total_episodes
+        rec.episode_count = 4
+        assert not hasattr(rec.dataset.meta, "total_episodes")
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+        assert result["status"] == "success"
+        assert "finalize" in rec.calls
+        payload = result["content"][1]["json"]
+        assert payload["parquet_episode_count"] is None
+        assert payload["episode_count_mismatch"] is False
+        # The recorder's own count stands - in the payload and in the text.
+        assert payload["episode_count"] == 4
+        text = result["content"][0]["text"]
+        assert "4 episode(s)" in text
+        assert "#708 gate" not in text
+
+    def test_a_parquet_count_of_zero_is_still_judged(self, recording_sim):
+        # The control that gives the cell above its meaning: a layout that
+        # really reports zero episodes IS a reading, so the gate must still
+        # fire on it - collapsing an author-side count of 4 to the on-disk 0.
+        # Only an ABSENT attribute is the unreadable case.
+        rec = _FakeRecorder(meta_total_episodes=0)
+        rec.episode_count = 4
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+        assert result["status"] == "success"
+        payload = result["content"][1]["json"]
+        assert payload["parquet_episode_count"] == 0
+        assert payload["episode_count"] == 0
+        assert payload["episode_count_mismatch"] is True
+        assert "parquet has 0" in result["content"][0]["text"]


### PR DESCRIPTION
Closes #3125.

`stop_recording`'s parquet-truth gate read the dataset's canonical episode count as `int(getattr(ds_meta, "total_episodes", 0))`. A layout that exposes no such attribute is a **failed probe**, but the zero default turned it into the *measurement* `0` — which the gate then trusted as ground truth and used to overwrite the count the recorder had actually measured.

![probe matrix](https://raw.githubusercontent.com/cagataycali/robots/assets/episode-count-probe/episode_count_probe.png)

Measured by driving the real `stop_recording` on both trees with a recorder that saved **4** episodes (`meta` layout is the only variable):

| `recorder.dataset.meta` layout | `episode_count` | `parquet_episode_count` | `episode_count_mismatch` | gate banner in text |
|---|---|---|---|---|
| no `.dataset` handle | 4 → 4 | `None` → `None` | False → False | no → no |
| `total_episodes=4` (agrees) | 4 → 4 | 4 → 4 | False → False | no → no |
| `total_episodes=0` (a real zero) | 0 → 0 | 0 → 0 | True → True | yes → yes |
| **present, no `total_episodes`** | **0 → 4** | **0 → `None`** | **True → False** | **yes → no** |

Before, the unreadable layout was indistinguishable from a dataset that really holds zero episodes, and `stop_recording` logged `recorder.episode_count=4 but dataset.meta.total_episodes=0` — naming a parquet count nothing had read. After, it is indistinguishable from the missing-`dataset` case: skip the gate, the recorder's own count stands. A real `0` is still a reading and is still judged.

## Why skip, not zero

Every other unavailability on this same path is already expressed as "skip", never as a zero:

- `recorder_dataset_fps` returns `None` when the attribute is absent and the comparison is skipped;
- the missing-`dataset` branch leaves `parquet_episode_count = None` and the gate quiet — the suite calls these "the safe defaults" and pins them (`test_missing_dataset_handle_skips_gate`);
- `test_parquet_probe_failure_never_aborts_finalize` pins the same for a `total_episodes` that cannot be `int()`-ed.

The third attribute in the same defensive chain was the only one substituting a zero-valued default for a failed probe, which AGENTS.md Key Convention 6 forbids ("No silent defaults on error").

## Reachability, honestly stated

This needs `recorder.dataset.meta` to exist while carrying no `total_episodes` — a drifted or stubbed LeRobot layout. On the versions this repo targets the attribute is present (it is a property reading `info["total_episodes"]`, so a truncated `info.json` raises and already lands on the safe defaults). So it is latent rather than a live-path defect; it is fixed because the tests beside it already pin the intended behaviour for its two siblings, which makes the intent unambiguous and the change mechanical.

## The live path is unchanged

A full round-trip in MuJoCo (headless) on the fixed tree — `start_recording` → 2 × `run_policy` → `save_episode` → `stop_recording` → reopen:

<img src="https://raw.githubusercontent.com/cagataycali/robots/assets/episode-count-probe/rollout.gif" width="420" />

```
STOP PAYLOAD: {"repo_id": "local/probe_roundtrip", "frame_count": 90, "episode_count": 2,
               "parquet_episode_count": 2, "episode_count_mismatch": false, "root": "/tmp/art/ds"}
REOPENED total_episodes: 2  num_frames: 90  fps: 30
```

The reported count, the parquet count and the reopened dataset all agree. ([rollout.mp4](https://raw.githubusercontent.com/cagataycali/robots/assets/episode-count-probe/rollout.mp4), 45 frames @ 30 fps, 640×480.)

## Tests

`test_meta_without_total_episodes_reports_no_reading_not_a_zero` — a recorder that saved 4 episodes whose `meta` carries no `total_episodes`: the safe defaults stand, `episode_count` stays 4 in both payloads, and no gate banner is emitted. Pre-fix it fails with `assert 0 is None`, with the fabricated warning captured in the log.

`test_a_parquet_count_of_zero_is_still_judged` — the control that gives the cell above its meaning: a layout that really reports `0` IS a reading, so the gate must still fire and collapse an author-side 4 to the on-disk 0. Only an *absent* attribute is the unreadable case. (Passes pre-fix, as a control must.)

```
tests/simulation/mujoco/test_stop_recording_finalize.py
  pre-fix (pristine module + new tests):  1 failed, 28 passed
  post-fix:                                       29 passed
```

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` (`strands_robots tests tests_integ`) | clean |
| `mypy` | 20 errors in 6 files — all pre-existing (`examples/isaac_gs`, `simulation/ik.py`), none attributable |
| `pytest tests/simulation` (`MUJOCO_GL=egl`) | 13867 passed, 1 failed, 248 skipped — the 1 (`test_pose_vector_rule_parity::test_a_numpy_array_pose_is_accepted_by_both`) reproduces on pristine `main` |
| `scripts/check_whole_tree_graders.py` | 2890 passed / 5 failed / 4 errors, **set-identical** to `main` on the same box (stale interpreter: `lerobot` 0.5.1, `websockets` 16.0, absent `qpsolvers` metadata) |

## LOC

| file | diff | executable statements |
|---|---|---|
| `strands_robots/simulation/recording.py` | +23 / -2 | 321 → **322** (+1) |
| `tests/.../test_stop_recording_finalize.py` | +40 / -0 | 274 → 301 (2 new cells) |

The product change is one statement; the rest of that file's diff is the boundary comment plus a `Returns:` block for `stop_recording`, which had none — it now states the contract for all three episode-count fields, including that `parquet_episode_count` is `None` when the count could not be read.

## Not in this PR

`simulation/base.py` reads the same attribute with a zero default in two places (`_multi_policy_payload`, `_episode_count_fields`), but there the value feeds `dataset_episode_indices`, a list-shaped field with no way to express "unknown" and no measured count to overwrite. Changing that is a payload-contract decision, not this mechanical fix, so it is left out to hold this to one concern.