### PR TITLE
fix(simulation): an on-disk recording rate beyond the float range is unreadable, not an exception

### DIFF
--- a/changelog.d/3124-rate-guards-judge-every-fps-spelling.md
+++ b/changelog.d/3124-rate-guards-judge-every-fps-spelling.md
@@ -39,7 +39,8 @@ same module and catching `numpy.bool_`, which is not a `bool` subclass. The
 cross-ordering parametrization gains the numpy spellings, and each guard gains
 focused coverage asserting an in-domain rate is judged rather than passed through.
 
-No `try` is added around the `float(fps)` that follows either guard: both are
-asked only after the fps domain, which refuses a value beyond the float64 range
-with a reason of its own. That is the one respect in which they differ from
-`requested_rate_mismatch_reason`, which is asked before any domain and needs it.
+`rollout_rate_mismatch_reason` needs no `try` around the `float(fps)` that follows
+its guard: it is asked only after the fps domain, which refuses a value beyond the
+float64 range with a reason of its own. `recorder_dataset_fps` reads its rate off
+disk, where no domain has been asked, so it does need one -- see the entry for that
+guard below.

--- a/changelog.d/3129-on-disk-rate-beyond-float-range.md
+++ b/changelog.d/3129-on-disk-rate-beyond-float-range.md
@@ -1,0 +1,45 @@
+### Fixed: an on-disk recording rate beyond the float range is unreadable, not an exception
+
+`recorder_dataset_fps` reads a dataset's declared frame rate and is documented to
+answer `None` when the dataset "does not report a usable whole rate", so that "an
+unexpected LeRobot layout must not block a valid resume". It resolves the rate
+through `float`, because `numbers.Real` -- the predicate it classifies on, so every
+spelling the fps domain accepts is read -- carries no ordering against `int` and no
+`int()` overload. That conversion could raise, and the raise escaped the contract.
+
+The rate arrives off disk, where no domain has been asked. `meta/info.json` is
+JSON, whose integer literals are unbounded, and LeRobot's `fps` field is an
+unenforced dataclass annotation, so `LeRobotDataset` opens such a dataset without
+complaint and hands the value straight to the reader. Measured through
+`start_recording` against a recorded LeRobotDataset (SO-101 in MuJoCo, 1 episode,
+30 frames, 30 fps) whose on-disk `fps` was edited to a 401-digit integer:
+
+    on-disk fps      recorder_dataset_fps      start_recording
+    30                                 30     success
+    29.97                            None     success
+    0                                None     error: fps must be positive, got 0
+    1e400 (-> inf)                   None     success
+    10**400          raises OverflowError     error: Dataset init failed:
+                                              int too large to convert to float
+    -10**400         raises OverflowError     error: fps must be positive, got -1000...
+
+The dataset had opened -- LeRobot returned its metadata without complaint -- so the
+reported subject was wrong, and the message names neither the field nor a remedy,
+while the fractional and infinite rates beside it resumed as the unreadable
+layouts they are.
+
+Resolving the rate through `float` converts before the sign can be tested, so a
+negative rate of that magnitude reaches the conversion too. That sign does not
+change what `start_recording` reports -- LeRobot refuses it as it opens the dataset
+-- so it is a raise the reader owes its own callers rather than a verdict the
+surface got wrong, and it is pinned at the reader for that reason.
+
+The conversion is now made inside a `try` handling `OverflowError`, `TypeError`
+and `ValueError` -- the same exceptions, for the same reason, as
+`requested_rate_mismatch_reason`, the other guard in this module asked before any
+domain has classified its rate. A rate beyond the float64 range is reported as the
+unreadable layout it is, in either sign.
+
+The statement in #3124's fragment that neither guard needs a `try` is corrected in
+the same change: it holds for the guard asked after the domain, not for the one
+that reads its rate off disk.

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -222,7 +222,10 @@ def recorder_dataset_fps(recorder: Any) -> int | None:
     Returns:
         The dataset frame rate as an int, or ``None`` when the dataset does not
         report a usable whole rate (an unexpected LeRobot layout must not block
-        a valid resume).
+        a valid resume). A rate beyond the float64 range is reported that way
+        too: it is not a rate any recording can be written at, and raising the
+        conversion error out of this reader told the caller the dataset had
+        failed to open when it had opened fine.
     """
     dataset = getattr(recorder, "dataset", None)
     for value in (getattr(dataset, "fps", None), getattr(getattr(dataset, "meta", None), "fps", None)):
@@ -248,7 +251,24 @@ def recorder_dataset_fps(recorder: Any) -> int | None:
         # the three guards answering identically, which is the property the
         # cross-ordering test asserts. The conversion count is unchanged: the
         # previous spelling already called ``float`` to ask ``is_integer``.
-        declared = float(value)
+        try:
+            declared = float(value)
+        except (OverflowError, TypeError, ValueError):
+            # Reported as the unreadable layout it is, not raised. This rate
+            # arrives off disk, where no domain has been asked: ``meta/info.json``
+            # is JSON, whose integer literals are unbounded, and LeRobot's ``fps``
+            # is an unenforced dataclass annotation, so ``LeRobotDataset`` opens
+            # such a dataset without complaint and hands the value straight here.
+            # Letting the conversion raise escaped a reader documented to answer
+            # ``None`` for a rate it cannot read, and ``start_recording`` reported
+            # it as ``Dataset init failed: int too large to convert to float`` -
+            # a subject that had not failed, naming neither the field nor a
+            # remedy. Resolving the rate through ``float`` converts before the
+            # sign can be tested, so both signs reach the conversion and both are
+            # answered here. Same handled exceptions, and the same reason, as
+            # :func:`requested_rate_mismatch_reason`: it is the other guard in
+            # this module asked before any domain has classified its rate.
+            continue
         if declared > 0 and declared.is_integer():
             return int(declared)
     return None

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -257,6 +257,35 @@ class TestTheGuardHelperIsRobust:
         # asserted rather than left implied by the equality above.
         assert type(recorder_dataset_fps(_FakeRecorder(rate))) is int
 
+    @pytest.mark.parametrize("rate", [10**400, -(10**400)])
+    def test_a_rate_beyond_the_float_range_is_an_unreadable_layout_not_an_exception(self, rate):
+        """A rate no recording can be written at is reported, not raised.
+
+        This rate arrives off disk rather than from a caller, so no domain has
+        classified it: ``meta/info.json`` is JSON, whose integer literals are
+        unbounded, and LeRobot's ``fps`` field is an unenforced dataclass
+        annotation - so ``LeRobotDataset`` opens such a dataset without complaint
+        and hands the 401-digit ``int`` straight to this reader. Letting the
+        conversion raise escaped a function documented to answer ``None`` for a
+        layout it cannot read, and the caller reported it as the dataset having
+        failed to open, which it had not. Measured through ``start_recording``
+        against a recorded dataset whose on-disk ``fps`` was edited to that
+        value: ``error: Dataset init failed: int too large to convert to float``,
+        naming neither the field nor a remedy, while the fractional and infinite
+        rates beside it resumed as the unreadable layouts they are.
+
+        Both signs are asserted because resolving the rate through ``float`` -
+        which the typed spelling requires, ``numbers.Real`` carrying no ordering
+        against ``int`` - converts before it can test the sign, so a negative rate
+        reaches the conversion as well. Only the positive one changes what
+        ``start_recording`` reports: LeRobot refuses a negative rate as it opens
+        the dataset ("fps must be positive"), so that sign is a raise this reader
+        owes its own callers rather than a verdict the surface got wrong. It is
+        pinned here, where the contract is, for that reason.
+        """
+        assert recorder_dataset_fps(_FakeRecorder(rate)) is None
+        assert recorder_dataset_fps(_MetaOnlyRecorder(rate)) is None
+
 
 class TestTheRunnerLayerCarriesItsOwnGuarantee:
     """``PolicyRunner`` is driven directly, with the engine's guard off the path.


### PR DESCRIPTION
`recorder_dataset_fps` reads a dataset's declared frame rate. Its docstring states the contract:

> The dataset frame rate as an int, or `None` when the dataset does not report a usable whole rate (an unexpected LeRobot layout must not block a valid resume).

It resolves the rate through `float`, because `numbers.Real` — the predicate it classifies on, so that every spelling the fps domain accepts is read — carries no ordering against `int` and no `int()` overload. That conversion can raise, and the raise escaped the contract.

![on-disk rate beyond the float range](https://raw.githubusercontent.com/cagataycali/robots/assets/on-disk-rate-v2/on-disk-rate-beyond-float-range.png)

## The rate arrives off disk, where no domain has been asked

`meta/info.json` is JSON, whose integer literals are unbounded, and LeRobot's `fps` is an unenforced dataclass annotation (`DatasetInfo.fps: int`), so `LeRobotDataset` opens such a dataset without complaint and hands the value straight to this reader. Measured against a recorded LeRobotDataset — SO-101 in MuJoCo, 1 episode, 30 frames, `fps 30`, three `observation.images.*` at `(3, 256, 256)` — copied per case with only `meta/info.json` `"fps"` rewritten, then resumed through `start_recording(root=..., fps=30)`:

| on-disk `"fps"` | `recorder_dataset_fps` | `start_recording` |
|---|---|---|
| `30` | `30` | success |
| `29.97` | `None` | success |
| `0` | `None` | error: `fps must be positive, got 0` (LeRobot's own) |
| `1e400` → `inf` | `None` | success |
| `10**400` | **raises `OverflowError`** | **error: `Dataset init failed: int too large to convert to float`** |
| `-10**400` | **raises `OverflowError`** | error: `fps must be positive, got -1000...` (LeRobot's own) |

The dataset had opened — LeRobot returned its metadata without complaint, `meta.fps` a 401-digit `int` — so the reported subject was wrong, and the message names neither the field nor a remedy. The fractional and infinite rates beside it resumed as the unreadable layouts they are; this one spelling raised instead.

The frame is unambiguous:

```
strands_robots/simulation/recording.py:251 in recorder_dataset_fps
    declared = float(value)
OverflowError: int too large to convert to float
```

## Why a `try`, when the sibling needs none

`rollout_rate_mismatch_reason` already documents that it needs no `try` around the same hop, and that is correct — it is asked only after the fps domain, which refuses a rate beyond the float64 range with a reason of its own. `recorder_dataset_fps` is not in that position. It is the other guard in this module asked before any domain has classified its rate, which is exactly why `requested_rate_mismatch_reason` handles `(OverflowError, TypeError, ValueError)`; the same exceptions, for the same reason, are handled here.

## Both signs, labelled by reachability

Resolving the rate through `float` converts before the sign can be tested, so a negative rate of that magnitude reaches the conversion too. Only the positive one changes what `start_recording` reports: LeRobot refuses a negative rate as it opens the dataset, so that sign is a raise the reader owes its own callers rather than a verdict the surface got wrong. It is pinned at the reader, where the contract is, for that reason.

## Tests

`test_a_rate_beyond_the_float_range_is_an_unreadable_layout_not_an_exception`, parametrized over both signs and asserted on both LeRobot layouts (`dataset.fps` and `dataset.meta.fps`, the on-disk route).

```
main's mechanism, new cell present   ->  2 failed, 107 passed
this change                          ->  109 passed
```

Both failures are the `OverflowError` at `recording.py:251`, naming the defect.

## Size

| file | +/- | note |
|---|---|---|
| `strands_robots/simulation/recording.py` | +22 / -2 | **+2 executable statements** (`try:` / `continue`); the rest is the comment and the `Returns:` contract |
| `tests/simulation/.../test_recording_rate_matches_control_frequency.py` | +29 / -0 | one parametrized cell |
| `changelog.d/3124-...md` | +5 / -4 | corrects a statement this change makes false |
| `changelog.d/3129-...md` | +45 / -0 | news fragment |

#3124's fragment says "No `try` is added around the `float(fps)` that follows either guard: both are asked only after the fps domain". That holds for the guard asked after the domain, not for the one that reads its rate off disk; it is corrected in the same change rather than left to contradict the code.

## Gate

- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ` (1837 files).
- `mypy strands_robots tests tests_integ` → `Success: no issues found in 1834 source files`.
- `tests/simulation/` → 1 pre-existing failure (`newton/test_multi_camera.py::test_bad_position_shape_rejected`), reproduced identically on `d83593610`.
- `scripts/check_whole_tree_graders.py` → 7 failed / 4212 passed, the 7 set-identical on `d83593610` (5 assert `rclpy` is absent where it resolves; 2 read the installed `websockets` against the declared floor).
