### PR TITLE
fix(simulation): a rollout duration that resolves to no control step is refused

### DIFF
--- a/changelog.d/3130-rollout-duration-must-produce-a-control-step.md
+++ b/changelog.d/3130-rollout-duration-must-produce-a-control-step.md
@@ -1,0 +1,14 @@
+### Fixed: a rollout `duration` that resolves to no control step is refused instead of reporting an empty success
+
+`duration` is one factor of the rollout horizon - with no `n_steps` the loop runs
+`int(duration * control_frequency)` control steps - and the guard judged the factor rather
+than the product, so every span shorter than one control period was positive, finite, and
+resolved to zero steps. Across 32 MuJoCo rollouts (4 rates x 8 spans, `video=` requested on
+each), all 16 sub-period rows reported `status="success"` with `0 steps`, `sim_t=0.000s` and
+no MP4 on disk, including `duration=1.9` at 0.5 Hz.
+
+`SimEngine._validate_duration` now takes the rate and refuses a horizon of no steps, naming
+both factors and the minimum span. One guard covers all four surfaces that resolve a duration
+horizon: `run_policy`, MuJoCo `start_policy`, and `run_multi_policy` on the MuJoCo and Isaac
+backends. A fractional duration that does produce steps is unaffected - the boundary is only
+at zero - and the value-domain message is unchanged.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1852,6 +1852,15 @@ class Robot(TeleopMixin, AgentTool):
         so the same budget cannot be refused for a digital twin and accepted
         for the arm it mirrors.
 
+        That parity is over the value domain, and it stops one control period
+        short of zero. In sim ``duration`` is a FACTOR of the step count
+        (``int(duration * control_frequency)``), so the sim guard additionally
+        refuses a duration below one control period - it resolves to no steps
+        there. Here it is a deadline the loop compares elapsed time against, so
+        the first iteration always runs and any positive budget commands the arm
+        at least once. The difference is in what the parameter means, not in the
+        values the two layers consider usable.
+
         Args:
             duration: The caller-supplied value to validate.
             method: Public entry point name, used to prefix the message.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2126,7 +2126,7 @@ class SimEngine(ABC):
         return components, None
 
     @staticmethod
-    def _validate_duration(duration: Any, method: str) -> dict[str, Any] | None:
+    def _validate_duration(duration: Any, method: str, control_frequency: float) -> dict[str, Any] | None:
         """Reject a rollout ``duration`` that cannot produce a single control step.
 
         ``duration`` is the default horizon knob: when no ``n_steps`` /
@@ -2151,9 +2151,34 @@ class SimEngine(ABC):
         are rejected before the ``<= 0`` comparison so a ``nan`` - which is
         never ``<= 0`` - cannot slip through.
 
+        **The horizon is a product, so one factor's sign does not decide
+        whether a step can be produced.** ``positive_finite_number_error`` reads
+        ``duration`` alone, and at the default ``control_frequency=50.0`` every
+        duration below ``0.02`` is positive, finite, and resolves to ``int(duration
+        * control_frequency) == 0`` control steps - the empty rollout described
+        above, reported as ``status="success"`` with ``0 steps`` and, with a
+        ``video`` requested, "Video requested but 0 frames captured" and no MP4 on
+        disk. Measured on a MuJoCo ``so101`` rollout: ``duration=0.01`` at 50 Hz,
+        ``duration=0.5`` at 1 Hz and ``duration=1.0`` at 0.5 Hz all reported a
+        successful rollout that never queried the policy. Which side of the line a
+        duration falls on is not a property of the duration, so the rate has to be
+        passed in.
+
+        Refused rather than floored to one step, for the reason
+        :meth:`_resolve_horizon` gives for the ``n_steps`` path: a horizon that
+        cannot be honored as asked is a caller error, not a value to silently
+        substitute. A fractional duration that does produce steps stays perfectly
+        usable (``2.5`` seconds at 62.5 Hz is 156 of them) - the boundary is only
+        at zero.
+
         Args:
             duration: The caller-supplied value to validate.
             method: Public method name, used to prefix the error message.
+            control_frequency: Rate the rollout will step at, the other factor of
+                the horizon. Validate it with
+                :meth:`_validate_positive_frequency` first, so a non-finite rate
+                is reported as the parameter error it is rather than as an
+                unreachable horizon.
 
         Returns:
             An error dict naming the offending parameter, or ``None`` when the
@@ -2162,6 +2187,26 @@ class SimEngine(ABC):
         error = positive_finite_number_error(duration, "duration", method)
         if error:
             return {"status": "error", "content": [{"text": error}]}
+        # Compared as floats rather than through the consumer's ``int(...)``:
+        # both factors are bounded only by the float64 range, so their product
+        # can be ``inf`` and ``int(inf)`` raises ``OverflowError`` out of the
+        # guard that exists so a horizon never raises. For a non-negative
+        # product the two tests are equivalent - ``int(p) < 1`` iff ``p < 1``.
+        if float(duration) * float(control_frequency) < 1.0:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"{method}: duration={float(duration):g} at "
+                            f"control_frequency={float(control_frequency):g} resolves to 0 control "
+                            f"steps, so the rollout would query no policy and step no physics. "
+                            f"Raise duration to at least {1.0 / float(control_frequency):g}, or "
+                            f"pass n_steps to give the horizon as a step count."
+                        )
+                    }
+                ],
+            }
         return None
 
     @staticmethod
@@ -2450,7 +2495,9 @@ class SimEngine(ABC):
                 is recomputed from it). Must be a finite positive number; a
                 non-positive, non-finite, non-numeric, or bool value is
                 reported as a structured caller error rather than running a
-                zero-step rollout that reports success.
+                zero-step rollout that reports success - as is a span shorter
+                than one control period (``1 / control_frequency``), which
+                resolves to no steps at that rate.
             control_frequency: Target Hz for policy queries. Must be a
                 positive number; a non-positive, non-numeric, or bool value
                 is reported as a structured caller error.
@@ -2768,7 +2815,7 @@ class SimEngine(ABC):
         # an ``n_steps`` the resolution above recomputes it - so validate the
         # value the rollout will actually run on, and only then.
         if n_steps is None:
-            if err := self._validate_duration(duration, "run_policy"):
+            if err := self._validate_duration(duration, "run_policy", control_frequency):
                 return err
 
         if err := self._validate_positive_int(n_episodes, "n_episodes", "run_policy"):
@@ -3007,7 +3054,8 @@ class SimEngine(ABC):
                 ``{robot_name: instruction}`` mapping (see contract above).
             duration: Episode length in seconds (steps = duration x freq).
                 Used only when no ``n_steps`` / ``max_steps`` is given. Must
-                be a finite positive number.
+                be a finite positive number of at least one control period, so
+                that product is at least one step.
             control_frequency: Target Hz for policy queries / physics. Must
                 be a positive number.
             action_horizon: Actions consumed from each policy's chunk before

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -4211,7 +4211,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         if horizon_error is not None:
             return horizon_error
         if n_steps is None:
-            if err := self._validate_duration(duration, "run_multi_policy"):
+            if err := self._validate_duration(duration, "run_multi_policy", control_frequency):
                 return err
 
         # Normalize action_horizon to a per-robot mapping on the shared

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5223,7 +5223,8 @@ class MuJoCoSimEngine(
 
         # Validate the step horizon synchronously, before submitting to the
         # executor. run_policy runs on a background thread, so a malformed
-        # horizon (duration <= 0, n_steps <= 0, control_frequency <= 0) would
+        # horizon (a duration resolving to no steps, n_steps <= 0,
+        # control_frequency <= 0) would
         # otherwise be reported only inside the future - the caller would
         # receive a false "started" success and the robot would be left marked
         # as running. Both horizon knobs are covered: the step count via
@@ -5240,7 +5241,7 @@ class MuJoCoSimEngine(
         if horizon_error is not None:
             return horizon_error
         if resolved_n_steps is None:
-            if err := self._validate_duration(resolved_duration, "start_policy"):
+            if err := self._validate_duration(resolved_duration, "start_policy", control_frequency):
                 return err
         if err := self._validate_action_horizon(action_horizon, "start_policy"):
             return err
@@ -5674,7 +5675,7 @@ class MuJoCoSimEngine(
         if horizon_error is not None:
             return horizon_error
         if n_steps is None:
-            if err := self._validate_duration(duration, "run_multi_policy"):
+            if err := self._validate_duration(duration, "run_multi_policy", control_frequency):
                 return err
 
         # Normalize action_horizon to a per-robot mapping through the shared

--- a/tests/simulation/isaac/test_run_multi_policy_no_recording.py
+++ b/tests/simulation/isaac/test_run_multi_policy_no_recording.py
@@ -416,7 +416,7 @@ def test_run_multi_policy_rejects_a_duration_it_cannot_honor(sim_two_robots, bad
     sim = sim_two_robots
     result = sim.run_multi_policy(policies=_both(), duration=bad, control_frequency=500.0)
 
-    assert result == IsaacSimulation._validate_duration(bad, "run_multi_policy")
+    assert result == IsaacSimulation._validate_duration(bad, "run_multi_policy", 500.0)
     assert result["status"] == "error"
     _cost_nothing(sim)
 

--- a/tests/simulation/test_input_validators_refuse_a_boolean.py
+++ b/tests/simulation/test_input_validators_refuse_a_boolean.py
@@ -539,6 +539,16 @@ _NOT_AN_INPUT_DOMAIN = {
     # tests/simulation/test_ik_bridge_numeric_parameter_domains.py fails when
     # the delegation is dropped or the shared domain stops refusing a boolean.
     "_damping_error": "coerces only a value finite_number_error accepted",
+    # Both float() calls here read a factor its OWN domain has already accepted:
+    # ``duration`` by the positive_finite_number_error immediately above (which
+    # refuses bool and numpy.bool_ by name), and ``control_frequency`` by
+    # _validate_positive_frequency, which every call site runs first and which
+    # this guard's Args entry requires. So a boolean is answered with its own
+    # reason and never reaches the product. Pinned behaviourally rather than only
+    # claimed here:
+    # tests/simulation/test_rollout_duration_must_produce_a_control_step.py fails
+    # when either delegation is dropped.
+    "_validate_duration": "coerces only factors their own domains accepted",
 }
 
 _GUARDED_VALIDATORS = {

--- a/tests/simulation/test_rollout_duration_must_produce_a_control_step.py
+++ b/tests/simulation/test_rollout_duration_must_produce_a_control_step.py
@@ -1,0 +1,210 @@
+"""A rollout ``duration`` that resolves to no control step is refused.
+
+``duration`` is one factor of the horizon: with no ``n_steps`` the rollout runs
+``int(duration * control_frequency)`` control steps. ``_validate_duration``
+judged the factor rather than the product - it delegated to
+``positive_finite_number_error``, which reads ``duration`` alone - so every
+duration shorter than one control period was positive, finite, and resolved to
+zero steps. Measured on a MuJoCo ``so101`` rollout before the fix, at the
+library default ``control_frequency=50.0``:
+
+    run_policy(duration=0.01)  ->  status="success", "0 steps", sim_t=0.000s
+                                   "Video requested but 0 frames captured"
+
+That is verbatim the outcome ``_validate_duration``'s own docstring says it
+exists to prevent ("reported as ``status="success"`` for a rollout that never
+queried the policy and never stepped physics - and, when a ``video`` was
+requested, wrote no MP4 while still claiming success"). The guard prevented it
+only for the half of the domain visible in one factor's sign, and which side of
+the line a duration falls on is not a property of the duration:
+``duration=1.0`` is a full second and still resolves to no step at 0.5 Hz.
+
+The same reading error is already recorded one parameter over, on the step-count
+path: ``_resolve_horizon``'s docstring notes that "a bare ``<= 0`` test only saw
+the sign", which let ``n_steps=2.7`` run two steps. This is that error on the
+duration path, where the sign belongs to only one of the two factors.
+
+Refused rather than floored to one step, for the reason ``_resolve_horizon``
+gives: a horizon that cannot be honored as asked is a caller error, not a value
+to substitute silently. A fractional duration that does produce steps stays
+usable - the boundary is only at zero - which is what the accepted rows below
+pin.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.base import SimEngine  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+#: Minimal single-hinge arm, so the behavioural rows below run a real rollout
+#: without depending on a packaged robot description.
+ARM_XML = """
+<mujoco model="one_joint_arm">
+  <worldbody>
+    <body name="link" pos="0 0 0.1">
+      <joint name="hinge" type="hinge" axis="0 1 0"/>
+      <geom name="rod" type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="hinge_act" joint="hinge" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+#: ``(duration, control_frequency)`` pairs whose product is under one step.
+#: Every one is a positive finite number the value domain accepts, and the last
+#: two are whole seconds - a duration is not short in isolation.
+NO_STEP = [
+    pytest.param(0.01, 50.0, id="0.01s-at-50Hz"),
+    pytest.param(0.019, 50.0, id="0.019s-just-under-one-period"),
+    pytest.param(0.5, 1.0, id="half-a-second-at-1Hz"),
+    pytest.param(1.0, 0.5, id="a-whole-second-at-0.5Hz"),
+    pytest.param(2.0, 0.25, id="two-seconds-at-0.25Hz"),
+]
+
+#: ``(duration, control_frequency, steps)`` triples that DO produce a horizon,
+#: including the exact boundary (one period) and a fractional duration that
+#: truncates without emptying.
+SOME_STEPS = [
+    pytest.param(0.02, 50.0, 1, id="exactly-one-period"),
+    pytest.param(0.021, 50.0, 1, id="a-hair-over-one-period"),
+    pytest.param(2.0, 0.5, 1, id="one-step-at-0.5Hz"),
+    pytest.param(2.5, 62.5, 156, id="fractional-and-truncating"),
+    pytest.param(10.0, 50.0, 500, id="the-library-defaults"),
+]
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+@pytest.fixture
+def arm_path(tmp_path):
+    path = tmp_path / "one_joint_arm.xml"
+    path.write_text(ARM_XML)
+    return str(path)
+
+
+@pytest.fixture
+def sim(arm_path):
+    s = Simulation(tool_name="test_rollout_duration_must_produce_a_control_step", mesh=False)
+    assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+    assert s.add_robot("arm", urdf_path=arm_path)["status"] == "success"
+    yield s
+    s.cleanup(policy_stop_timeout=2.0)
+
+
+class TestTheGuardJudgesTheProduct:
+    """The verdict follows ``duration * control_frequency``, not the sign."""
+
+    @pytest.mark.parametrize("duration, rate", NO_STEP)
+    def test_a_horizon_of_no_steps_is_refused(self, duration: float, rate: float) -> None:
+        assert SimEngine._validate_duration(duration, "run_policy", rate) is not None
+
+    @pytest.mark.parametrize("duration, rate, steps", SOME_STEPS)
+    def test_a_horizon_of_at_least_one_step_is_accepted(self, duration: float, rate: float, steps: int) -> None:
+        assert int(duration * rate) == steps, "the row states the horizon the consumer will run"
+        assert SimEngine._validate_duration(duration, "run_policy", rate) is None
+
+    def test_the_refusal_names_both_factors_and_the_remedy(self) -> None:
+        """The caller cannot act on a message naming only the value they passed."""
+        refusal = SimEngine._validate_duration(0.01, "run_policy", 50.0)
+
+        assert refusal is not None
+        assert _text(refusal) == (
+            "run_policy: duration=0.01 at control_frequency=50 resolves to 0 control steps, "
+            "so the rollout would query no policy and step no physics. Raise duration to at "
+            "least 0.02, or pass n_steps to give the horizon as a step count."
+        )
+
+    def test_the_value_domain_keeps_its_own_message(self) -> None:
+        """A value no rate could rescue is still refused as the value error it is.
+
+        The hardware guard pins this exact text as the shared one
+        (``tests/test_hardware_task_duration_guard.py``), so the horizon
+        condition must sit after the value domain rather than in front of it.
+        """
+        refusal = SimEngine._validate_duration(0, "run_policy", 50.0)
+
+        assert refusal is not None
+        assert _text(refusal) == "run_policy: duration must be > 0, got 0."
+
+
+class TestABooleanNeverReachesTheProduct:
+    """Each factor is answered by its own domain before the multiplication.
+
+    The horizon test coerces with ``float()``, and ``float(True)`` is ``1.0`` - a
+    silent one-second span or a silent 1 Hz rate. Neither is reachable: the value
+    domain above refuses a boolean ``duration`` by name, and the rate is refused
+    one call earlier by ``_validate_positive_frequency``, which every rollout
+    entry point runs first. ``tests/simulation/test_input_validators_refuse_a_boolean.py``
+    exempts this guard from its ``float()`` sweep on exactly that basis, so these
+    two rows are what that exemption stands on.
+    """
+
+    @pytest.mark.parametrize("spelling", [True, np.True_], ids=["bool", "numpy-bool"])
+    def test_a_boolean_duration_is_refused_as_a_value(self, spelling: Any) -> None:
+        refusal = SimEngine._validate_duration(spelling, "run_policy", 50.0)
+
+        assert refusal is not None
+        assert _text(refusal) == f"run_policy: duration must be > 0, got {spelling!r}."
+
+    @pytest.mark.parametrize("spelling", [True, np.True_], ids=["bool", "numpy-bool"])
+    def test_a_boolean_rate_is_refused_before_this_guard_is_reached(self, spelling: Any) -> None:
+        assert SimEngine._validate_positive_frequency(spelling, "run_policy") is not None
+
+
+class TestTheRolloutSurfacesRefuseIt:
+    """The refusal reaches the caller of a real rollout, not just the guard.
+
+    Asserted on what the caller receives rather than by comparing against the
+    guard's own envelope, so these rows fail on the outcome - a success reported
+    for an empty rollout - on any tree where the horizon is not judged.
+    """
+
+    def test_run_policy_refuses_it_and_writes_no_video(self, sim, tmp_path) -> None:
+        """The empty rollout used to be reported as a success with no MP4."""
+        video = tmp_path / "rollout.mp4"
+        result = sim.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            duration=0.01,
+            control_frequency=50.0,
+            video={"path": str(video), "fps": 30, "width": 64, "height": 48},
+        )
+
+        assert result["status"] == "error", _text(result)
+        assert "0 control steps" in _text(result)
+        assert "control_frequency=50" in _text(result), "the other factor has to be named"
+        assert not video.exists()
+
+    def test_run_policy_still_runs_the_shortest_honorable_horizon(self, sim, tmp_path) -> None:
+        """One control period is one step, and its frame reaches the MP4."""
+        video = tmp_path / "one_step.mp4"
+        result = sim.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            duration=0.02,
+            control_frequency=50.0,
+            video={"path": str(video), "fps": 30, "width": 64, "height": 48},
+        )
+
+        assert result["status"] == "success"
+        assert "1 steps" in _text(result)
+        assert video.exists() and video.stat().st_size > 0
+
+    def test_start_policy_refuses_it_before_the_thread_is_submitted(self, sim) -> None:
+        """The background surface resolves the same horizon, so it shares the guard."""
+        result = sim.start_policy(robot_name="arm", policy_provider="mock", duration=0.01, control_frequency=50.0)
+
+        assert result["status"] == "error", _text(result)
+        assert "start_policy" in _text(result) and "0 control steps" in _text(result)
+        assert sim._active_policy_robots() == [], "no rollout may be left running behind a refusal"

--- a/tests/test_hardware_task_duration_guard.py
+++ b/tests/test_hardware_task_duration_guard.py
@@ -266,19 +266,33 @@ class TestDomainMatchesSimulation:
     ``SimEngine._validate_duration`` and the hardware guard both delegate to
     ``positive_finite_number_error``; this pins that they cannot diverge, so a
     budget rehearsed in sim is honored on the arm and vice versa.
+
+    The parity is over that shared value domain, and it stops one control period
+    short of zero: in sim ``duration`` is a FACTOR of the step count
+    (``int(duration * control_frequency)``), so a duration below one control
+    period resolves to no steps and is refused, while on the arm it is an
+    elapsed-time DEADLINE (``time.monotonic() - start < duration``) that still
+    admits the first iteration. Both budgets are checked here at a rate under
+    which every usable one is many steps, so the horizon condition cannot mask a
+    value-domain disagreement.
     """
+
+    #: Rate for the sim side of the comparison. Every entry in
+    #: ``USABLE_DURATIONS`` is >= 0.25s, so all of them are >= 12 control steps
+    #: here and the verdicts under test are the value domain's alone.
+    RATE = 50.0
 
     @pytest.mark.parametrize("duration", UNUSABLE_DURATIONS + USABLE_DURATIONS)
     def test_both_layers_agree(self, hw: Any, duration: Any):
         """Refused by one layer if and only if refused by the other."""
-        sim_refuses = SimEngine._validate_duration(duration, "run_policy") is not None
+        sim_refuses = SimEngine._validate_duration(duration, "run_policy", self.RATE) is not None
         hw_refuses = hw._duration_error(duration, "run_policy") is not None
 
         assert hw_refuses == sim_refuses, f"verdicts differ for duration={duration!r}"
 
     def test_the_message_is_the_shared_one(self, hw: Any):
         """Both layers name the parameter identically."""
-        sim_error = SimEngine._validate_duration(0, "run_policy")
+        sim_error = SimEngine._validate_duration(0, "run_policy", self.RATE)
         hw_error = hw._duration_error(0, "run_policy")
 
         assert sim_error is not None and hw_error is not None

--- a/tests/test_reachy_motion_domain.py
+++ b/tests/test_reachy_motion_domain.py
@@ -299,7 +299,7 @@ class TestTheDelegationIsReal:
         driver._sim = _Sim()
         asyncio.run(driver.execute("task", duration=value, robot_name="arm"))
         assert recorded == [value], "the value must reach the guarded consumer verbatim"
-        assert SimEngine._validate_duration(value, "start_policy") is not None
+        assert SimEngine._validate_duration(value, "start_policy", 50.0) is not None
 
 
 def _exported_names(init_py: Path) -> list[str]:

--- a/tests/test_teleop_rate_and_duration_guards.py
+++ b/tests/test_teleop_rate_and_duration_guards.py
@@ -154,17 +154,30 @@ class TestARefusedRateNeverReachesTheMeshPublisher:
 
 
 class TestOneDomainForEveryRateAndDurationKnob:
-    """The shared helper and the sim's rollout knobs cannot diverge."""
+    """The shared helper and the sim's rollout knobs cannot diverge.
+
+    The parity is over the VALUE domain: which durations and rates are usable at
+    all. ``_validate_duration`` then applies one further condition the shared
+    helper cannot express, because it is not a property of the value - a
+    duration shorter than one control period resolves to zero steps at that
+    rate. Every value below is checked at a rate that can execute it, so this
+    class pins the shared domain alone; the rate-dependent refusal is pinned in
+    ``tests/simulation/test_rollout_duration_must_produce_a_control_step.py``.
+    """
+
+    #: A rate at which every usable duration below is many control steps, so
+    #: the horizon condition cannot mask a value-domain disagreement.
+    RATE = 50.0
 
     @pytest.mark.parametrize("value", UNUSABLE + [1, 50.0, 62.5, np.float32(2.5)])
     def test_the_sim_rollout_knobs_agree_with_the_shared_domain(self, value):
         shared_rejects = positive_finite_number_error(value, "x", "m") is not None
-        assert (SimEngine._validate_duration(value, "run_policy") is not None) is shared_rejects
+        assert (SimEngine._validate_duration(value, "run_policy", self.RATE) is not None) is shared_rejects
         assert (SimEngine._validate_positive_frequency(value, "run_policy") is not None) is shared_rejects
 
     def test_the_sim_rollout_messages_are_unchanged(self):
         """Callers (and tests) pin this exact text."""
-        assert SimEngine._validate_duration(0, "run_policy")["content"][0]["text"] == (
+        assert SimEngine._validate_duration(0, "run_policy", self.RATE)["content"][0]["text"] == (
             "run_policy: duration must be > 0, got 0."
         )
         assert SimEngine._validate_positive_frequency(math.nan, "eval_policy")["content"][0]["text"] == (


### PR DESCRIPTION
`duration` is one **factor** of the rollout horizon: with no `n_steps` the loop runs `int(duration * control_frequency)` control steps. `_validate_duration` judged the factor rather than the product - it delegates to `positive_finite_number_error`, which reads `duration` alone - so every span shorter than one control period was positive, finite, and resolved to zero steps.

32 real MuJoCo rollouts, 4 control rates x 8 spans, `video=` requested on every one:

![rollout horizon boundary](https://raw.githubusercontent.com/cagataycali/robots/assets/rollout-horizon-boundary/rollout_horizon_boundary.png)

| spans | before | after |
|---|---|---|
| under one period (16 rows) | 16x `status="success"`, **0 steps**, `sim_t=0.000s`, **0 MP4s written** | 16x `status="error"` |
| at or above one period (16 rows) | 16x success, 16 MP4s, steps `1,1,2,3` per rate | **identical** |

The refused rows are not exotic short spans. `duration=1.9` at 0.5 Hz and `duration=0.95` at 1 Hz are the same cell: which side of the line a duration falls on is not a property of the duration, which is why the guard now takes the rate.

That outcome is verbatim what the guard's own docstring says it exists to prevent - "reported as `status="success"` for a rollout that never queried the policy and never stepped physics - and, when a `video` was requested, wrote no MP4 while still claiming success". It prevented it only for the half of the domain visible in one factor's sign.

## Change

`_validate_duration(duration, method, control_frequency)` now also refuses a horizon of no steps, after the value domain:

```
run_policy: duration=0.01 at control_frequency=50 resolves to 0 control steps, so the
rollout would query no policy and step no physics. Raise duration to at least 0.02, or
pass n_steps to give the horizon as a step count.
```

Refused rather than floored to one step, for the reason `_resolve_horizon` gives on the step-count path: a horizon that cannot be honored as asked is a caller error, not a value to substitute silently. A fractional duration that does produce steps is untouched - the boundary is only at zero (`2.5s` at 62.5 Hz is still 156 steps).

One guard, so all four surfaces that resolve a duration horizon are covered with one `if`: `run_policy` (shared, both backends), MuJoCo `start_policy`, and `run_multi_policy` on the MuJoCo and Isaac backends. Every one of them already validated `control_frequency` immediately before, so the rate is in hand and validated at each call site.

The product is compared as floats rather than through the consumer's `int(...)`: both factors are bounded only by the float64 range, so their product can be `inf` and `int(inf)` raises `OverflowError` out of the guard that exists so a horizon never raises. For a non-negative product the two tests are equivalent.

The value-domain message is unchanged, which is what keeps `hardware_robot._duration_error`'s shared-text parity intact.

## Why nothing caught it

`TestOneDomainForEveryRateAndDurationKnob` asserted `_validate_duration` refuses **exactly** what `positive_finite_number_error` refuses - i.e. it pinned the guard as the sign domain and nothing more, which is the hole. Its parity is real but it is over the *value* domain, so it now says so and passes a rate; the rate-dependent condition is pinned in the new file.

The hardware parity test needed the same qualification, and the asymmetry is worth stating because both sides are right: in sim `duration` is a factor of a step count, on the arm it is an elapsed-time deadline (`time.monotonic() - start < duration`) that always admits the first iteration. So the arm honors a 0.01s budget and the sim cannot rehearse it at 50 Hz. Both class docstrings and `_duration_error`'s now name that boundary.

## Tests

`tests/simulation/test_rollout_duration_must_produce_a_control_step.py` (19 cells): the boundary table-driven over `(duration, rate)` including the exact one-period row; the refusal text; the unchanged value-domain text; and behavioural rows driving a real MuJoCo rollout. Those are asserted on **what the caller receives**, not against the guard's own envelope, so they fail on the outcome on any tree where the horizon is not judged - pre-fix against this base they fail with `AssertionError: Policy complete on 'arm'` and `AssertionError: Policy started on 'arm' (async)`. Its control row (one period -> 1 step, MP4 written) passes pre-fix, as a control must.

`tests/simulation/test_input_validators_refuse_a_boolean.py` caught the new `float()` coercion in its package sweep. Resolved the way its list already resolves `_kwarg_domain_error` and `_damping_error` - each factor is refused by its own domain before the multiplication - plus the behavioural pin that exemption stands on (a `bool` / `numpy.bool_` duration answered by the value domain, a boolean rate refused one call earlier), since `float(True)` would otherwise be a silent 1-second span or 1 Hz rate.

Local gate: `ruff check` + `ruff format --check` clean; mypy 20 errors in 6 files, unchanged from this base and none in the touched files; `tests/simulation` **13917 passed / 1 failed**, that one (`mujoco/test_pose_vector_rule_parity::test_a_numpy_array_pose_is_accepted_by_both`) failing identically on this base; whole-tree preflight 3051 passed / 5 failed / 4 errors with a failure set **byte-identical** to this base (absent `qpsolvers` metadata, a stale local `lerobot` and `websockets` below the declared floors).

## LOC

| file | executable statements |
|---|---|
| `simulation/base.py` | 853 -> 855 (**+2**) |
| `simulation/mujoco/simulation.py` | 1732 -> 1732 (+0) |
| `simulation/isaac/simulation.py` | 1976 -> 1976 (+0) |
| `hardware_robot.py` | 736 -> 736 (+0) |
| net source | **+2** |

The whole fix is one `if` and its `return`; the rest of the `+52/-4` in `base.py` is the docstring that now states the rule, and the four surfaces cost one argument each. Test side is +210 for the new file, +42/-6 across the four callers whose claims needed narrowing.