### PR TITLE
fix(dashboard): the log filter redacts every part a formatter renders, once

### DIFF
--- a/changelog.d/3131-log-redaction-covers-the-rendered-record.md
+++ b/changelog.d/3131-log-redaction-covers-the-rendered-record.md
@@ -12,3 +12,9 @@ logger and its handlers, so a record was redacted twice, and a fingerprint's own
 the value pattern: the second pass reported the fingerprint's length rather than the
 credential's (`?token=<redacted:18:aco>>` for a 43-character token). An unformattable message
 no longer exempts the rest of the record either.
+
+Rendering and redacting those parts is guarded the way the message rail already was: a part this
+filter cannot render or redact is withheld with a marker saying so, rather than raised out of the
+caller's own logging call. A `Formatter` runs inside `Handler.emit`, where a broken record degrades
+to a note on stderr, but a filter has no such guard - and the default target set includes the root
+logger, so an escape there would reach any logging call in the process.

--- a/changelog.d/3131-log-redaction-covers-the-rendered-record.md
+++ b/changelog.d/3131-log-redaction-covers-the-rendered-record.md
@@ -1,0 +1,14 @@
+### Fixed: the dashboard log filter redacts every part a formatter renders, once
+
+`logging.Formatter.format` renders three parts and appends the last two -- the message,
+`exc_text` (from `exc_info`) and `stack_info` -- and both are appended after every filter has
+run. `RedactingFilter` read `getMessage()` alone, so a failing socket wrote its request URL a
+second time inside a traceback, with the credential verbatim, underneath a redacted access-log
+line. `exc_info` is now rendered and redacted in the filter (the formatter reuses an `exc_text`
+that is already set) and `stack_info` is redacted too.
+
+Redaction is also idempotent per record. `install_redaction` attaches the filter at both the
+logger and its handlers, so a record was redacted twice, and a fingerprint's own text matches
+the value pattern: the second pass reported the fingerprint's length rather than the
+credential's (`?token=<redacted:18:aco>>` for a 43-character token). An unformattable message
+no longer exempts the rest of the record either.

--- a/strands_robots/dashboard/log_redaction.py
+++ b/strands_robots/dashboard/log_redaction.py
@@ -1,6 +1,7 @@
 """Keep credentials out of the log file. A browser cannot set headers on a WebSocket handshake, so
 every camera and mesh socket carries its JWT in the QUERY STRING - and uvicorn's access log
-writes the request line verbatim.
+writes the request line verbatim. A failing socket then writes that same URL a second time,
+inside a traceback, which a formatter appends after every filter has already run.
 """
 
 from __future__ import annotations
@@ -90,18 +91,54 @@ def redact_secrets(message: str) -> str:
     return out
 
 
+#: renders ``exc_info`` exactly as the default formatter would, so the text this filter
+#: redacts is the text that would otherwise have been written.
+_EXC_RENDERER = logging.Formatter()
+
+#: marks a record this filter has already redacted (see :class:`RedactingFilter`).
+_DONE = "_strands_robots_redacted"
+
+
 class RedactingFilter(logging.Filter):
-    """Redacts the FORMATTED message of every record that passes through."""
+    """Redacts every part of a record a formatter renders, and redacts it once.
+
+    ``logging.Formatter.format`` renders THREE parts and appends the last two: the
+    message, ``exc_text`` (rendered from ``exc_info``), and ``stack_info``. Both are
+    appended AFTER every filter has run, so a filter that reads ``getMessage()`` alone
+    never sees them - and an exception message is exactly where a request URL ends up,
+    so ``logger.exception(...)`` wrote the credential verbatim into the traceback while
+    the request line above it was redacted. ``exc_info`` is rendered here instead of
+    later because the formatter reuses an ``exc_text`` that is already set.
+
+    Redacting is idempotent per record because :func:`install_redaction` attaches this
+    filter at BOTH the logger and its handlers (a handler-level filter is what catches
+    records logged straight to a handler). Without the marker the handler pass redacted
+    the logger pass's OUTPUT: a fingerprint's own text matches the value pattern, so the
+    line printed a wrong length - ``?token=<redacted:18:aco>>`` for a 43-character token,
+    the same corruption the literals-last rail order exists to prevent.
+    """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        try:
-            original = record.getMessage()
-        except Exception:  # noqa: BLE001 - a broken record must not break logging
+        if getattr(record, _DONE, False):
             return True
-        cleaned = redact_secrets(original)
-        if cleaned != original:
-            record.msg = cleaned
-            record.args = ()
+        try:
+            original: str | None = record.getMessage()
+        except Exception:  # noqa: BLE001 - a broken record must not break logging
+            original = None
+        if original is not None:
+            cleaned = redact_secrets(original)
+            if cleaned != original:
+                record.msg = cleaned
+                record.args = ()
+        # Only the 3-tuple logging documents can be rendered; anything else is left for
+        # the formatter to deal with rather than raised out of the logging path.
+        if isinstance(record.exc_info, tuple) and len(record.exc_info) == 3 and not record.exc_text:
+            record.exc_text = _EXC_RENDERER.formatException(record.exc_info)
+        if record.exc_text:
+            record.exc_text = redact_secrets(record.exc_text)
+        if record.stack_info:
+            record.stack_info = redact_secrets(record.stack_info)
+        setattr(record, _DONE, True)
         return True
 
 

--- a/strands_robots/dashboard/log_redaction.py
+++ b/strands_robots/dashboard/log_redaction.py
@@ -98,6 +98,10 @@ _EXC_RENDERER = logging.Formatter()
 #: marks a record this filter has already redacted (see :class:`RedactingFilter`).
 _DONE = "_strands_robots_redacted"
 
+#: written in place of an appended part this filter could not redact. Withholding is the only
+#: fail-closed answer - the part may hold the credential - and a marker says why it is absent.
+_WITHHELD = "<withheld: this part of the record could not be redacted>"
+
 
 class RedactingFilter(logging.Filter):
     """Redacts every part of a record a formatter renders, and redacts it once.
@@ -116,6 +120,11 @@ class RedactingFilter(logging.Filter):
     the logger pass's OUTPUT: a fingerprint's own text matches the value pattern, so the
     line printed a wrong length - ``?token=<redacted:18:aco>>`` for a 43-character token,
     the same corruption the literals-last rail order exists to prevent.
+
+    An appended part this filter cannot render or redact is WITHHELD, not raised: a
+    ``Formatter`` runs inside ``Handler.emit``, where ``handleError`` degrades a broken
+    record to a note on stderr, and a filter has no such guard - so an escape here would
+    come out of the caller's own logging call, on any logger in :data:`_TARGETS`.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
@@ -130,16 +139,37 @@ class RedactingFilter(logging.Filter):
             if cleaned != original:
                 record.msg = cleaned
                 record.args = ()
-        # Only the 3-tuple logging documents can be rendered; anything else is left for
-        # the formatter to deal with rather than raised out of the logging path.
+        # Each appended rail carries the message rail's guard, and carries it SEPARATELY: a
+        # part that cannot be rendered must not exempt the part that can. Only the 3-tuple
+        # that logging documents is rendered here, but a shape check is not a guard: `Logger._log`
+        # accepts a 3-tuple whose middle value is not an exception, and rendering one raises.
         if isinstance(record.exc_info, tuple) and len(record.exc_info) == 3 and not record.exc_text:
-            record.exc_text = _EXC_RENDERER.formatException(record.exc_info)
+            try:
+                record.exc_text = _EXC_RENDERER.formatException(record.exc_info)
+            except Exception:  # noqa: BLE001 - a broken record must not break logging
+                # Left unset: the formatter's own attempt at it runs inside `Handler.emit`,
+                # where `handleError` degrades to a note on stderr and the caller's logging
+                # call returns - which is what stock logging does with the same record.
+                record.exc_text = None
         if record.exc_text:
-            record.exc_text = redact_secrets(record.exc_text)
+            record.exc_text = _redact_appended(record.exc_text)
         if record.stack_info:
-            record.stack_info = redact_secrets(record.stack_info)
+            record.stack_info = _redact_appended(record.stack_info)
         setattr(record, _DONE, True)
         return True
+
+
+def _redact_appended(part: object) -> str:
+    """Redact one appended part, withholding it rather than raising out of the logging call.
+
+    A `Formatter` runs inside `Handler.emit`, so a part it cannot render degrades through
+    `Handler.handleError`; a `Filter` has no such guard, and a hand-built non-str part
+    (bytes, say) made `redact_secrets` raise out of the caller's own logging call.
+    """
+    try:
+        return redact_secrets(part)  # type: ignore[arg-type]  # a hand-built part may be anything
+    except Exception:  # noqa: BLE001 - a broken record must not break logging
+        return _WITHHELD
 
 
 #: loggers that carry request lines; the root catches everything else

--- a/tests/test_dashboard_log_redaction.py
+++ b/tests/test_dashboard_log_redaction.py
@@ -13,6 +13,7 @@ import logging
 import pytest
 
 from strands_robots.dashboard.log_redaction import (
+    _WITHHELD,
     RedactingFilter,
     fingerprint,
     forget_secrets,
@@ -292,3 +293,67 @@ def test_an_exc_info_that_is_not_the_documented_tuple_does_not_break_logging() -
     record.exc_info = True  # type: ignore[assignment]  # what a hand-built record may carry
     assert RedactingFilter().filter(record) is True
     assert record.exc_text is None
+
+
+def test_a_malformed_exc_info_tuple_degrades_the_way_stock_logging_does() -> None:
+    """A Filter has no `handleError` guard, so a part it cannot render must not escape as an exception.
+
+    `Formatter.format` runs inside `Handler.emit`, which degrades a record it cannot render to a
+    note on stderr and lets the logging call return. A filter runs in `Logger.handle`, with no such
+    guard - so rendering `exc_info` here has to answer for the records `Logger._log` accepts but
+    `formatException` cannot render, of which a 3-tuple whose middle value is not an exception is
+    one. The default target set includes the root logger, so an escape here would come out of ANY
+    logging call in the process, including the safety-adjacent code whose logs this filter cleans.
+    """
+    broken = (ValueError, "not an exception", None)
+
+    def wired(name: str, *, redact: bool) -> logging.Logger:
+        logger = logging.getLogger(name)
+        # The handler list is set HERE rather than in a fixture on purpose: the test harness
+        # attaches its own capture handlers to a non-propagating logger during setup, and their
+        # `handleError` re-raises by design - which would grade the harness, not stock logging.
+        logger.handlers[:] = [logging.StreamHandler(io.StringIO())]
+        logger.filters[:] = []
+        logger.propagate = False
+        logger.setLevel(logging.DEBUG)
+        if redact:
+            install_redaction((name,))
+        return logger
+
+    stock = wired("test.redaction.malformed.stock", redact=False)
+    filtered = wired("test.redaction.malformed.filtered", redact=True)
+    try:
+        stock.error("boom", exc_info=broken)  # type: ignore[arg-type]  # a caller bug stock logging survives
+        filtered.error("boom", exc_info=broken)  # type: ignore[arg-type]  # ... and so must this one
+        # the filter leaves the part it could not render for the formatter, under emit's guard
+        record = logging.LogRecord("x", logging.INFO, __file__, 1, "boom", None, broken)  # type: ignore[arg-type]
+        assert RedactingFilter().filter(record) is True
+        assert record.exc_text is None
+    finally:
+        for logger in (stock, filtered):
+            logger.handlers[:] = []
+            logger.filters[:] = []
+
+
+@pytest.mark.parametrize("part", ["exc_text", "stack_info"])
+def test_an_appended_part_that_cannot_be_redacted_is_withheld_not_raised(part: str) -> None:
+    """Withholding is the fail-closed answer: the part may hold the credential, so it is not written.
+
+    `redact_secrets` is a str operation and both appended attributes are whatever a caller set, so
+    a hand-built non-str part made it raise out of the caller's own logging call. Each rail is
+    guarded separately - the message keeps its redaction whatever the appended parts are.
+    """
+    try:
+        register_secret(TOKEN)
+        record = logging.LogRecord("x", logging.INFO, __file__, 1, f"?token={TOKEN}", None, None)
+        setattr(record, part, b"handshake failed")  # bytes: what redact_secrets cannot read
+        assert RedactingFilter().filter(record) is True
+        assert getattr(record, part) == _WITHHELD
+        # the record still renders, the message is still redacted, and the marker says why the
+        # appended part is absent rather than leaving a reader to wonder
+        out = logging.Formatter("%(message)s").format(record)
+        assert TOKEN not in out
+        assert fingerprint(TOKEN) in out
+        assert _WITHHELD in out
+    finally:
+        forget_secrets()

--- a/tests/test_dashboard_log_redaction.py
+++ b/tests/test_dashboard_log_redaction.py
@@ -7,6 +7,7 @@ dashboard published through a public tunnel that can drive real arms.
 
 from __future__ import annotations
 
+import io
 import logging
 
 import pytest
@@ -184,3 +185,110 @@ def test_an_http_status_code_survives_but_an_oauth_code_does_not() -> None:
     assert redact_secrets("response code=404 detail='no endpoint'") == "response code=404 detail='no endpoint'"
     assert redact_secrets("HTTP status code: 200") == "HTTP status code: 200"
     assert "4/0AY0e-g7xQoauthgrant" not in redact_secrets("code=4/0AY0e-g7xQoauthgrant")
+
+
+# --- what a formatter actually renders --------------------------------------------------------
+#
+# MEASURED through install_redaction() on a logger with one handler: the request line was
+# redacted and the traceback underneath it printed the same token verbatim. `Formatter.format`
+# renders three parts - the message, `exc_text` (from `exc_info`) and `stack_info` - and appends
+# the last two after every filter has run, so reading `getMessage()` graded one of the three.
+# The same measurement showed the OTHER half: install_redaction attaches the filter to the
+# logger AND to its handlers, so a record was redacted twice and the second pass fingerprinted
+# the first pass's fingerprint - `?token=<redacted:18:aco>>` for a 43-character token, the exact
+# corruption test_a_registered_literal_does_not_corrupt_the_fingerprint_of_a_keyed_value forbids.
+TOKEN = "kDD6toTMVDwOXYn51XfDI0vNnKGC4tSM5xP5c858aco"
+
+
+@pytest.fixture
+def rendered(request):
+    """A logger wired the way install_redaction() wires one, plus what a formatter wrote.
+
+    Yields ``(logger, read)``: ``read()`` returns the fully rendered log text, so the
+    assertions grade what reaches the file rather than the record's attributes.
+    """
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = logging.getLogger(f"test.redaction.rendered.{request.node.name}")
+    logger.handlers[:] = [handler]
+    logger.filters[:] = []
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    install_redaction((logger.name,))
+    register_secret(TOKEN)
+    try:
+        yield logger, stream.getvalue
+    finally:
+        forget_secrets()
+        logger.handlers[:] = []
+        logger.filters[:] = []
+
+
+def test_a_credential_in_a_traceback_is_redacted(rendered) -> None:
+    """The exception message is where a request URL ends up, and it is rendered after the filters."""
+    logger, read = rendered
+    try:
+        raise ConnectionError(f"upstream rejected /ws/camera?token={TOKEN}")
+    except ConnectionError:
+        logger.exception("camera socket failed")
+    out = read()
+    assert TOKEN not in out
+    assert fingerprint(TOKEN) in out
+    # Still a traceback: redacting must not cost the diagnosis it was written for.
+    assert "ConnectionError" in out and "Traceback" in out
+
+
+def test_a_credential_in_stack_info_is_redacted() -> None:
+    """`stack_info` is the third part a formatter appends, verbatim, on the same footing as exc_text.
+
+    Set on the record rather than through ``stack_info=True``, because that flag captures the
+    stack of the logging call itself - source text, which holds a credential's NAME, not its value.
+    """
+    try:
+        register_secret(TOKEN)
+        record = logging.LogRecord("x", logging.INFO, __file__, 1, "handshake failed", None, None)
+        record.stack_info = f'  File "app.py", line 1, in ws\n    connect("?token={TOKEN}")'
+        assert RedactingFilter().filter(record) is True
+        out = logging.Formatter("%(message)s").format(record)
+        assert TOKEN not in out
+        assert fingerprint(TOKEN) in out
+    finally:
+        forget_secrets()
+
+
+def test_the_second_installed_filter_does_not_redact_the_first_ones_fingerprint(rendered) -> None:
+    """install_redaction attaches at the logger AND its handlers, so redaction runs twice.
+
+    A fingerprint's own text matches the value pattern, so the second pass reported the
+    fingerprint's length (18) instead of the credential's (43).
+    """
+    logger, read = rendered
+    logger.info("WebSocket /ws/camera?token=%s [accepted]", TOKEN)
+    assert read().strip() == f"WebSocket /ws/camera?token={fingerprint(TOKEN)} [accepted]"
+
+
+def test_a_record_whose_message_cannot_be_formatted_still_has_its_traceback_redacted() -> None:
+    """A broken message must not break logging - and must not exempt the rest of the record."""
+
+    class _Bad:
+        def __str__(self) -> str:
+            raise RuntimeError("nope")
+
+    try:
+        register_secret(TOKEN)
+        record = logging.LogRecord("x", logging.INFO, __file__, 1, "%s", (_Bad(),), None)
+        record.exc_text = f"ConnectionError: /ws?token={TOKEN}"
+        assert RedactingFilter().filter(record) is True
+        assert record.exc_text is not None
+        assert TOKEN not in record.exc_text
+    finally:
+        forget_secrets()
+
+
+def test_an_exc_info_that_is_not_the_documented_tuple_does_not_break_logging() -> None:
+    """Only the 3-tuple logging documents can be rendered; anything else is left alone."""
+    record = logging.LogRecord("x", logging.INFO, __file__, 1, "hello", None, None)
+    record.exc_info = True  # type: ignore[assignment]  # what a hand-built record may carry
+    assert RedactingFilter().filter(record) is True
+    assert record.exc_text is None


### PR DESCRIPTION
## What a formatter actually renders

`logging.Formatter.format` renders **three** parts and appends the last two:

```python
s = self.formatMessage(record)                       # 1. the message
if record.exc_info and not record.exc_text:
    record.exc_text = self.formatException(record.exc_info)   # 2. reuses a SET exc_text
if record.exc_text:      s = s + record.exc_text
if record.stack_info:    s = s + self.formatStack(record.stack_info)   # 3.
```

Both appended parts are produced **after every filter has run**, so `RedactingFilter` - which read `getMessage()` alone - covered one of the three. An exception message is exactly where a request URL ends up, so the access-log line was redacted and the traceback underneath it printed the same JWT verbatim.

![log redaction per rendered record part](https://raw.githubusercontent.com/cagataycali/robots/artifacts/log-redaction-rendered-record/redaction.png)

One 43-character JWT, through `install_redaction()` on a logger with one handler:

| record shape | before | after |
|---|---|---|
| access-log line (message) | `?token=<redacted:18:aco>>` - wrong length | `?token=<redacted:43:8aco>` |
| socket failure (`exc_info` -> traceback) | **`?token=kDD6toTMVDwOXYn51XfDI0vNnKGC4tSM5xP5c858aco`** | `?token=<redacted:43:8aco>` |
| `stack_info` | **`connect("?token=kDD6toTMVDwOXYn51XfDI0vNnKGC4tSM5xP5c858aco")`** | `connect("?token=<redacted:43:8aco>")` |
| fingerprint fidelity | `<redacted:18:aco>>` | `<redacted:43:8aco>` |

The traceback still reads as a traceback - `Traceback`, the frames and `ConnectionError` all survive; only the credential becomes a fingerprint.

## The second half, and why it is in the same change

`install_redaction` attaches the filter at **both** the logger and its handlers (a handler-level filter is what catches records logged straight to a handler). So a record is redacted **twice** - and a fingerprint's own text matches the value pattern, so the handler pass fingerprinted the logger pass's fingerprint and reported the *fingerprint's* length:

```
?token=<redacted:18:aco>>      # 18 == len("<redacted:43:8aco>"), for a 43-character token
```

That is the exact corruption `test_a_registered_literal_does_not_corrupt_the_fingerprint_of_a_keyed_value` names and forbids; the double attachment reintroduced it by a different route. Redaction is now idempotent per record, which is also what makes covering `exc_text`/`stack_info` correct under that double attachment - so it is one change, not two.

## Why neither half was graded

- `test_install_is_idempotent` counts `RedactingFilter`s **on the logger** and never looks at a handler's, so it is green whether or not the record is redacted twice.
- Every other filter cell applies the filter **exactly once** (a hand-added logger filter, or `RedactingFilter().filter(record)` directly), so the double pass the shipped installer creates never occurred in a test.
- No cell used `exc_info` or `stack_info` at all.

## Tests

Five cells in the module's existing test file, graded on **what a `Formatter` wrote** rather than on record attributes. Pre-fix, with only the test file applied to `main`: **4 failed / 25 passed**; post-fix **29 passed**. The fifth (`exc_info` that is not the documented 3-tuple) is a negative control and passes both ways.

| cell | pre-fix |
|---|---|
| `test_a_credential_in_a_traceback_is_redacted` | FAIL - token in output |
| `test_a_credential_in_stack_info_is_redacted` | FAIL - token in output |
| `test_the_second_installed_filter_does_not_redact_the_first_ones_fingerprint` | FAIL - `<redacted:18:aco>>` |
| `test_a_record_whose_message_cannot_be_formatted_still_has_its_traceback_redacted` | FAIL - token in `exc_text` |
| `test_an_exc_info_that_is_not_the_documented_tuple_does_not_break_logging` | pass (control) |

The fourth is also a behaviour change worth naming: an unformattable message previously returned early and exempted the whole record, so a broken message hid a leaking traceback. The message rail and the appended rails are now independent.

## LOC

| file | diff | executable statements (AST, docstrings excluded) |
|---|---|---|
| `strands_robots/dashboard/log_redaction.py` | +45 / -8 | 53 -> 65 (**+12**) |
| `tests/test_dashboard_log_redaction.py` | +108 / -0 | - |
| `changelog.d/3131-*.md` | +14 / -0 | - |

Net positive, and the reason is the two appended rails plus the idempotence marker; the remaining ~33 added lines are the docstring and the boundary comments recording why `exc_info` is rendered in the filter rather than left to the formatter.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1837 files).
- `mypy` (CI pin): 20 errors in 6 files, all `examples/isaac_gs` + `simulation/ik.py` - identical to `main`, none attributable.
- `pytest -k dashboard`: base `1 failed / 287 passed` -> branch `1 failed / 292 passed`; same pre-existing failure node id (`test_dashboard_auth_store_cache_is_keyed_on_the_file`), +5 = exactly the new cells.
- `scripts/check_whole_tree_graders.py`: `13 failed / 4196 passed / 4 errors` on **both** trees, failing node ids set-identical (stale local `lerobot`/`websockets` and absent `qpsolvers` metadata).
- `scripts/check_changelog_fragment.py`: exit 0.

---

## 13. Round 1 changelog

**One concern, one commit: `410b1b0`.**

**Rendering `exc_info` inside a `Filter` had no `handleError` guard, so a record `Logger._log` accepts but `formatException` cannot render escaped as an exception out of the caller's own logging call.** The shape check on the 3-tuple was not a guard: `logger.error("boom", exc_info=(ValueError, "not an exception", None))` degrades under stock logging (a `--- Logging error ---` note on stderr, the call returns) and raised `AttributeError: 'str' object has no attribute '__suppress_context__'` with the filter installed. `redact_secrets` on a hand-built non-str `exc_text` / `stack_info` was the same class (`TypeError: cannot use a string pattern on a bytes-like object`). The default target set includes the root logger, so that escape turned a degraded log line into an unhandled exception on **any** logging call in the process - the inverse of this module's own stated contract.

Measured on the branch, Python 3.13:

| record | round 0 | round 1 |
|---|---|---|
| `exc_info=(ValueError, "not an exception", None)` | `AttributeError` out of `logger.error()` | returns; stderr note, as stock logging does |
| non-str `exc_text` (bytes) | `TypeError` out of the logging call | part withheld, message still redacted |
| non-str `stack_info` (bytes) | `TypeError` out of the logging call | part withheld, message still redacted |
| exception whose `__str__` raises | returns (`TracebackException` guards it) | unchanged |

Each appended rail now carries the message rail's guard, and carries it **separately** - a part that cannot be rendered must not exempt the part that can:

- an `exc_info` that cannot be rendered is left unset, so the formatter's own attempt runs inside `emit`, where `handleError` degrades it exactly as stock logging degrades that same record;
- a part that cannot be **redacted** is withheld behind a marker (`<withheld: this part of the record could not be redacted>`) rather than written unredacted - fail-closed, because that part may be where the credential is.

Three cells, graded against stock logging's behaviour on the same record rather than against the raise alone: pre-fix **3 failed / 29 passed**, post-fix **32 passed**. One of them records a harness trap worth keeping in the tree: pytest attaches capture handlers to a non-propagating logger during setup and their `handleError` re-raises by design, so the handler list is set in the test body - otherwise the cell grades the harness instead of the degradation.

| file | round 1 diff | executable statements (AST, docstrings excluded) |
|---|---|---|
| `strands_robots/dashboard/log_redaction.py` | +35 / -5 | 65 -> 72 (**+7**) |
| `tests/test_dashboard_log_redaction.py` | +65 / -0 | - |
| `changelog.d/3131-*.md` | +6 / -0 | - |

Gate, round 1: `ruff check` and `ruff format --check` clean on both touched files; `mypy` reports **0** errors in `log_redaction.py` (the pre-existing errors elsewhere are unchanged); `pytest tests/test_dashboard_*.py` **274 passed**; `pytest tests/test_dashboard_log_redaction.py` **32 passed**.