### PR TITLE
fix(tools): lerobot_camera refuses a capture span its rate records no frame in

### DIFF
--- a/changelog.d/3134-camera-record-span-product.md
+++ b/changelog.d/3134-camera-record-span-product.md
@@ -1,0 +1,23 @@
+### Fixed: `lerobot_camera` refuses a capture span its rate records no frame in
+
+The `record` action's loop bound is a product, `int(fps * capture_duration)`, but
+`capture_duration` was validated by `positive_finite_number_error`, which reads
+that factor alone. Every span below one frame period -- anything under `0.0333`
+at the default `fps=30` -- is therefore positive, finite, and makes that bound
+zero: the loop body never runs, and the tool returns `status="success"` with
+`Frames: 0` while its `Saved:` line names a 258-byte MP4 that no decoder will
+open. Measured over 27 recordings at `fps` 10/30/60, 12 reported a complete
+recording whose file decodes to zero frames.
+
+Which side of the line a span falls on is not a property of the span, so
+`_numeric_option_error` now reads the two factors together once each has passed
+its own domain, and the refusal quotes both of them along with the shortest span
+that would work. Refused rather than floored to one frame, for the reason the
+horizon guard in `Simulation._validate_duration` gives for the same product: a
+recording that cannot be honored as asked is a caller error, not a value to
+silently substitute. The shortest span each rate can honor still records.
+
+`preview_duration` is deliberately not paired with `fps` this way. The preview
+loop is bounded by a `time.monotonic()` deadline whose first iteration always
+runs, so a short preview displays a frame rather than none; pairing it would
+refuse a preview that works.

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -147,6 +147,20 @@ def _numeric_option_error(
     ``timeout_ms`` is only effective under ``async_mode``: the synchronous read
     takes no timeout, so a value it never consumes is not refused.
 
+    **The frame count is a product, so one factor's sign does not decide whether a
+    frame can be captured.** ``positive_finite_number_error`` reads
+    ``capture_duration`` alone, and at the default ``fps=30`` every span below
+    ``0.0333`` is positive, finite, and makes the recording loop's bound
+    ``int(fps * capture_duration) == 0`` - the loop body never runs, and the tool
+    reports ``status="success"`` with ``Frames: 0`` while its ``Saved:`` line names
+    the same 258-byte MP4 that no decoder will open. Which side of the line a span
+    falls on is not a property of the span, so the rate is read with it. Refused
+    rather than floored to one frame: a recording that cannot be honored as asked
+    is a caller error, not a value to silently substitute. ``preview_duration`` is
+    deliberately not paired with ``fps`` this way - the preview is bounded by a
+    ``time.monotonic()`` deadline whose first iteration always runs, so a short
+    preview displays a frame rather than none.
+
     Args:
         action: The requested action; decides which options are effective.
         width: Frame width in pixels, as supplied.
@@ -176,6 +190,21 @@ def _numeric_option_error(
             error = check(value, param, action)
             if error:
                 return error
+    # Reaching here means every option this action consumes is individually
+    # usable, which is what lets the pair be judged together. Keyed on the two
+    # names being consumed rather than on ``action == "record"``, so an action
+    # that later gains a capture span is covered without a second edit.
+    # Compared as floats rather than through the consumer's ``int(...)``: both
+    # factors are bounded only by the float64 range, so their product can be
+    # ``inf``, and ``int(inf)`` raises out of the guard that exists so a frame
+    # count never raises. For a non-negative product the tests are equivalent -
+    # ``int(p) < 1`` iff ``p < 1``.
+    if {"fps", "capture_duration"} <= consumed and float(fps) * float(capture_duration) < 1.0:
+        return (
+            f"{action}: capture_duration={float(capture_duration):g} at fps={int(fps)} records 0 frames, "
+            f"so the file would contain no video. Raise capture_duration to at least "
+            f"{1.0 / float(fps):g}, or lower fps."
+        )
     return None
 
 

--- a/tests/tools/test_lerobot_camera_numeric_options.py
+++ b/tests/tools/test_lerobot_camera_numeric_options.py
@@ -14,6 +14,10 @@ was checked. The consequences differed per option and none of them was reportabl
   still left that stub file behind.
 * ``capture_duration=True`` silently recorded one second, since ``True`` is an
   ``int`` worth 1.
+* A ``capture_duration`` that is positive and finite but shorter than one frame
+  period - every span below ``0.0333`` at the default ``fps=30`` - made that same
+  bound zero, so refusing only the non-positive spans left the reported-complete
+  empty recording reachable through the other factor.
 * ``width=640.0`` reached ``cv2.VideoWriter`` and died in a raw OpenCV overload
   resolution dump, even though the sibling plain-MP4 recorders honor an integral
   float for exactly this parameter.
@@ -107,8 +111,23 @@ def _call(**kwargs: Any) -> dict[str, Any]:
     return cam_mod.lerobot_camera(**kwargs)
 
 
+#: ``(fps, capture_duration)`` pairs where each value is individually usable but
+#: ``int(fps * capture_duration)`` is zero, so the loop body never runs.
+EMPTY_RECORDINGS = ((30, 0.02), (30, 1.0 / 60), (10, 0.09), (60, 0.016), (1, 0.9))
+
+#: The same product at its boundary: the shortest span each rate can honor, which
+#: must still record. These are what keep the pairing from over-refusing.
+ONE_FRAME_RECORDINGS = ((10, 0.1), (2, 0.5), (30, 1.0 / 30), (1, 1.0))
+
+
 class TestARecordingThatCannotHappenIsRefused:
-    """The headline: a non-positive span reported a complete recording."""
+    """The headline: a span that captures no frame reported a complete recording.
+
+    The span's own sign is only half of it. The loop bound is the product
+    ``int(fps * capture_duration)``, so which side of the line a span falls on is
+    not a property of the span - a positive, finite span below one frame period
+    produces the identical empty recording, and the pair has to be judged together.
+    """
 
     @pytest.mark.parametrize("duration", BAD_SPANS)
     def test_a_capture_duration_that_records_no_frame_is_refused(
@@ -148,6 +167,69 @@ class TestARecordingThatCannotHappenIsRefused:
 
         assert result["status"] == "success"
         assert "Frames: 1" in _text(result)
+
+    @pytest.mark.parametrize(("fps", "duration"), EMPTY_RECORDINGS)
+    def test_a_span_shorter_than_one_frame_period_is_refused(
+        self, recorder: _Recorder, tmp_path: Any, fps: int, duration: float
+    ) -> None:
+        """Each value is in its own domain, so only the product can refuse this."""
+        assert positive_whole_number_error(fps, "fps", "record") is None
+        assert positive_finite_number_error(duration, "capture_duration", "record") is None
+
+        result = _call(action="record", camera_id=0, save_path=str(tmp_path), fps=fps, capture_duration=duration)
+
+        assert result["status"] == "error"
+        # The refusal precedes the device, so - the point of the fix - no MP4 stub
+        # is left for the summary to call "Saved".
+        assert recorder.opened == []
+        assert list(tmp_path.iterdir()) == []
+
+    @pytest.mark.parametrize(("fps", "duration"), ONE_FRAME_RECORDINGS)
+    def test_the_shortest_span_a_rate_can_honor_still_records(
+        self, recorder: _Recorder, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, fps: int, duration: float
+    ) -> None:
+        """A frame count of exactly one is honored, not rounded away."""
+        writer = type("_W", (), {"write": lambda self, f: None, "release": lambda self: None})()
+        monkeypatch.setattr(cam_mod.cv2, "VideoWriter", lambda *a, **k: writer)
+        monkeypatch.setattr(cam_mod.cv2, "VideoWriter_fourcc", lambda *a, **k: 0, raising=False)
+        monkeypatch.setattr(cam_mod.os.path, "getsize", lambda p: 1234)
+
+        result = _call(action="record", camera_id=0, save_path=str(tmp_path), fps=fps, capture_duration=duration)
+
+        assert result["status"] == "success"
+        assert "Frames: 1" in _text(result)
+
+    def test_the_refusal_names_both_factors_and_the_span_that_would_work(
+        self, recorder: _Recorder, tmp_path: Any
+    ) -> None:
+        text = _text(_call(action="record", camera_id=0, save_path=str(tmp_path), fps=30, capture_duration=0.02))
+
+        assert text.startswith("record:")
+        assert "capture_duration=0.02" in text
+        assert "fps=30" in text
+        # A refusal an agent can act on has to quote the span that would work.
+        assert "0.0333333" in text
+        assert all(ord(c) < 128 for c in text), text
+
+    def test_a_preview_shorter_than_one_frame_period_is_not_refused(
+        self, recorder: _Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``preview_duration`` is a deadline, not a factor of a frame count.
+
+        The preview loop is bounded by ``time.monotonic() - start < duration``, so
+        its first iteration always runs and a short preview displays a frame rather
+        than none. Pairing it with ``fps`` the way ``capture_duration`` is paired
+        would refuse a preview that works, so the scoping is pinned here.
+        """
+        monkeypatch.setattr(cam_mod.cv2, "cvtColor", lambda frame, code: frame, raising=False)
+        for name in ("putText", "imshow", "destroyAllWindows"):
+            monkeypatch.setattr(cam_mod.cv2, name, lambda *a, **k: None, raising=False)
+        monkeypatch.setattr(cam_mod.cv2, "waitKey", lambda delay: 0, raising=False)
+
+        result = _call(action="preview", camera_id=0, fps=30, preview_duration=0.001)
+
+        assert result["status"] == "success", _text(result)
+        assert recorder.opened == [(640, 480, 30)]
 
 
 class TestGeometryIsValidatedOnEveryCameraAction:
@@ -266,6 +348,28 @@ class TestTheDomainCannotDriftFromTheSharedHelpers:
         )
 
         assert tool_refuses == (positive_finite_number_error(value, "capture_duration", "record") is not None)
+
+    def test_the_span_parity_is_over_the_value_domain_alone(self) -> None:
+        """The row above is a claim about one value, not about the whole request.
+
+        Membership in the shared span domain is necessary but not sufficient: the
+        loop bound is a product, so a span in the domain is still refused when the
+        rate makes it capture no frame. Every value the parity row probes is many
+        frames at its ``fps=10``, which is what keeps the two claims compatible -
+        pinned here so a later widening of that row cannot quietly assert that the
+        shared domain is the whole guard.
+        """
+        assert all(10 * float(value) >= 1.0 for value in (0.5, 2.5, 30, np.float32(1.5)))
+        assert cam_mod._numeric_option_error(
+            "record",
+            width=640,
+            height=480,
+            fps=10,
+            capture_duration=0.05,
+            preview_duration=10.0,
+            timeout_ms=1000,
+            async_mode=False,
+        )
 
     def test_every_camera_opening_handler_has_a_table_row(self) -> None:
         """A new action configured with the caller's geometry must be validated too."""

--- a/tests/tools/test_output_path_is_confined_to_its_directory.py
+++ b/tests/tools/test_output_path_is_confined_to_its_directory.py
@@ -197,7 +197,10 @@ class TestTheCameraToolRefusesAnEscapingName:
             camera_id=0,
             save_path=str(tmp_path / "captures"),
             filename=filename,
-            capture_duration=0.01,
+            # A span the rate can honor, so the refusal under test is the name and
+            # not the frame count: ``0.01`` at the default ``fps=30`` records no
+            # frame and is refused before the path is ever composed.
+            capture_duration=0.5,
         )
         assert result["status"] == "error", result
         assert "outside the directory it must be written into" in _text(result)


### PR DESCRIPTION
The `record` loop's bound is a product, `int(fps * capture_duration)`, but `capture_duration` was validated by `positive_finite_number_error`, which reads that factor alone. Every span below one frame period is therefore positive, finite, and makes the bound zero: the loop body never runs, and the tool returns `status="success"` with `Frames: 0` while its `Saved:` line names a 258-byte MP4 that no decoder will open.

![capture span sweep](https://raw.githubusercontent.com/cagataycali/robots/artifacts/camera-span-product/camera_span_product.png)

27 real recordings through the tool at `fps` 10/30/60, x normalised to the other factor's units so all three rates collapse onto one curve. y is the frames a decoder actually yields from the file the tool said it saved (`cv2.VideoCapture`, not the tool's own count).

| | before | after |
|---|---|---|
| reported success, 0 decodable frames | **12 / 27** | 0 / 27 |
| refused | 0 | 12 |
| accepted rows whose file decodes to the reported count | 15 / 15 | 15 / 15 |

The shaded band is `capture_duration * fps < 1`. At the default `fps=30` that is every span below `0.0333`.

```
 fps  periods   status  frames  bytes  decodable      <- before
  30      0.5  success       0    258          0
  30      0.9  success       0    258          0
  30      1.0  success       1    911          1
```

## Change

`_numeric_option_error` reads the two factors together once each has passed its own domain. Which side of the line a span falls on is not a property of the span, so the rate has to be read with it — the same argument, and the same refuse-don't-floor decision, as `Simulation._validate_duration` on the sim side. The refusal quotes both factors and the shortest span that would work:

```
record: capture_duration=0.02 at fps=30 records 0 frames, so the file would
contain no video. Raise capture_duration to at least 0.0333333, or lower fps.
```

It is keyed on the two option names being consumed rather than on `action == "record"`, so an action that later gains a capture span is covered without a second edit. The product is compared as floats rather than through the consumer's `int(...)`: both factors are bounded only by the float64 range, so their product can be `inf`, and `int(inf)` raises out of the guard whose job is that a frame count never raises. For a non-negative product the two tests are equivalent.

**`preview_duration` is deliberately not paired this way.** The preview loop is bounded by a `time.monotonic()` deadline whose first iteration always runs, so a short preview displays a frame rather than none. Pairing it with `fps` would refuse a preview that works; that scoping is pinned by its own cell.

## Tests

`tests/tools/test_lerobot_camera_numeric_options.py` already carried this defect's other half — its module docstring describes `capture_duration <= 0` producing "a 258-byte MP4 that no decoder will open", and the class is named `TestARecordingThatCannotHappenIsRefused`. Only the non-positive spans were refused, so the identical empty recording stayed reachable through the other factor. The new cells go in that class:

- 5 `(fps, span)` pairs where each value passes its own domain (asserted in the test) but the product is zero — refused, no camera opened, no file left behind. **Red pre-fix.**
- 4 boundary pairs at exactly one frame — still record `Frames: 1`. Green pre-fix, as controls must be; these are what keep the pairing from over-refusing.
- the refusal names both factors and the span that would work. **Red pre-fix.**
- a `preview_duration` of `0.001` at `fps=30` is *not* refused — the scoping control.

`test_the_tool_agrees_with_the_shared_domain_for_a_span` asserted the tool refuses a span exactly when the shared helper does, which pins the guard as nothing more than that helper. It still passes (every value it probes is many frames at its `fps=10`), but the claim is now only true of one value rather than of a whole request, so a sibling cell states what the parity is over and asserts the joint refusal the row cannot see.

One call site updated: a path-confinement test passed `capture_duration=0.01` at the default `fps=30` — a span that records nothing — incidentally, to reach a filename assertion. It now passes a span the rate can honor, so the refusal under test is the name and not the frame count.

Pre-fix: 7 cells red. Post-fix `pytest tests/tools/` failure set is node-id-identical to `main` on the same interpreter. `ruff check`, `ruff format --check` clean; `mypy` identical to `main`.

## LOC

| file | lines | executable statements |
|---|---|---|
| `strands_robots/tools/lerobot_camera.py` | +29 / -0 | 422 -> 424 (**+2**) |
| `tests/.../test_lerobot_camera_numeric_options.py` | +105 / -1 | 106 -> 141 (+35) |
| `tests/.../test_output_path_is_confined_to_its_directory.py` | +4 / -1 | 128 -> 128 (+0) |

The guard is one `if` and one `return`; the rest of the product-code diff is the reasoning paragraph and the comments explaining the float comparison.