### PR TITLE
fix(simulation): the policy preflight builds the observation only when it is read

### DIFF
--- a/changelog.d/3136-preflight-observation-only-when-read.md
+++ b/changelog.d/3136-preflight-observation-only-when-read.md
@@ -1,0 +1,24 @@
+### Fixed: the policy preflight builds the runtime observation only for a provider that reads it
+
+`SimEngine._preflight_policy_config` ran a provider's class-level `Policy.preflight` hook
+against the keys the runtime observation will carry, and built that observation before asking
+whether the hook exists. `preflight_policy` is a no-op for any provider that does not override
+the hook - every shipped provider except `lerobot_local` - so on that path a full
+`get_observation` rendered every model camera plus every python camera in the scene and the
+frames were discarded. In a lekiwi + unitree_go2 + so101 scene with one added camera that
+observation renders 6 image keys in 1.283s on a software rasterizer, against 0.00026s for the
+joint state alone.
+
+The cost is not only wasted work: the preflight runs before the rollout loop, so it also
+delays the loop's cooperative-stop check. Fleet-wide, three `mock` rollouts stopped
+immediately after `start_policy` went quiet 2.430s after the stop was acknowledged, and
+`examples/fleet/04_emergency_evacuation.py` exceeded its 10s abort deadline and exited 1 on a
+software-GL host.
+
+The keys are now passed to `preflight_policy` as a supplier, so the one place that decides
+whether the hook consumes them is the place that invokes it. `mock` renders nothing;
+`lerobot_local`, whose hook validates camera routing, still receives the full observation with
+its camera keys. The same seam serves `run_policy`, `eval_policy` and `start_policy`. Time to
+fleet quiet falls to 0.050s and the example passes (abort 1.50s). A supplier returning `None`
+reports an observation that is not available yet, preserving the existing disposition that
+such a run is not blocked by the check.

--- a/docs/policies/custom-policies.md
+++ b/docs/policies/custom-policies.md
@@ -66,8 +66,23 @@ Aliases and shorthands are validated on load: each must be unique across provide
 | `provider_name` (property) | yes | - |
 | `requires_images` (property) | no | `True` |
 | `required_bodies` (property) | no | `()` |
+| `preflight(observation_keys, **config)` (classmethod) | no | no-op |
 | `reset(seed=None)` | no | no-op |
 | `get_actions_sync(...)` | no | sync wrapper |
+
+`preflight` is the fail-fast seam: the simulation calls it on your **class**,
+before `create_policy` constructs anything and therefore before any weight
+download, with the keys the runtime observation will carry (joint names plus
+camera names). Raise `ValueError` from it to reject a configuration your policy
+cannot consume - a declared image input that no sim camera can be routed to is
+the motivating case - instead of surfacing it deep inside the first inference.
+Implementations must be cheap: local metadata and the given keys, no network,
+no instantiation.
+
+Overriding it is not free for the *caller*: collecting those keys makes the
+simulation build a full observation, which renders every camera in the scene.
+A provider that does not override the hook is never asked for them, so leaving
+`preflight` at its default costs nothing.
 
 ## Declaring body poses your policy needs
 

--- a/strands_robots/policies/factory.py
+++ b/strands_robots/policies/factory.py
@@ -295,7 +295,11 @@ def create_policy(provider: str, **kwargs) -> Policy:
     return PolicyClass(**resolved_kwargs)
 
 
-def preflight_policy(provider: str, observation_keys: set[str], **kwargs) -> None:
+def preflight_policy(
+    provider: str,
+    observation_keys: set[str] | Callable[[], set[str] | None],
+    **kwargs,
+) -> None:
     """Run a provider's class-level :meth:`Policy.preflight` check, if any.
 
     Resolves ``provider`` to its policy class WITHOUT instantiating it (so no
@@ -315,7 +319,15 @@ def preflight_policy(provider: str, observation_keys: set[str], **kwargs) -> Non
         provider: Provider name, HF model ID, or server URL (as passed to
             ``create_policy``).
         observation_keys: Keys the runtime observation will contain (joint
-            names + camera names).
+            names + camera names), or a zero-argument callable returning them.
+            Collecting those keys can be expensive - a simulation builds them
+            from an observation that renders every scene camera - and only a
+            provider that OVERRIDES ``preflight`` reads them, which is decided
+            here and nowhere else. A callable is therefore invoked only once
+            the two early returns below are past, so a caller pays for the keys
+            exactly when the hook consumes them. A callable returning ``None``
+            reports that the runtime observation is not available yet; there is
+            then nothing to validate against and the hook is not run.
         **kwargs: Provider-specific parameters (the policy_config).
 
     Raises:
@@ -335,7 +347,12 @@ def preflight_policy(provider: str, observation_keys: set[str], **kwargs) -> Non
     if hook is None or getattr(hook, "__func__", hook) is base_hook:
         # Provider did not override the default no-op preflight.
         return
-    PolicyClass.preflight(set(observation_keys), **resolved_kwargs)
+    keys = observation_keys() if callable(observation_keys) else observation_keys
+    if keys is None:
+        # The caller cannot supply the runtime observation yet, so there is
+        # nothing for the hook to validate the configuration against.
+        return
+    PolicyClass.preflight(set(keys), **resolved_kwargs)
 
 
 def policy_provider_error(provider: str, **kwargs) -> str | None:

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1092,6 +1092,17 @@ class SimEngine(ABC):
         unresolvable name reach ``create_policy``, whose raise escapes the
         ``status=error`` envelope this method exists to produce.
 
+        The observation is passed as a supplier, not a value, because only a
+        provider that overrides ``preflight`` reads it. Building it eagerly
+        rendered every camera in the scene before every rollout on behalf of
+        the providers that do not - and ``mock``, the classical planners and
+        the whole-body controllers all inherit the no-op - so the frames were
+        rendered and discarded. On a software rasterizer that render is
+        seconds per call, and it runs before the rollout loop and its
+        cooperative-stop check can start, which delayed a fleet-wide abort
+        past its deadline. ``preflight_policy`` decides whether the hook
+        consumes the keys, so it is what invokes the supplier.
+
         Returns:
             A ``status=error`` dict (for the caller to return) when the
             provider cannot be resolved or its preflight rejects the
@@ -1104,11 +1115,14 @@ class SimEngine(ABC):
         if reason is not None:
             return {"status": "error", "content": [{"text": reason}]}
 
-        obs = self.get_observation(robot_name)
-        if not isinstance(obs, dict) or not obs:
-            return None
+        def observation_keys() -> set[str] | None:
+            obs = self.get_observation(robot_name)
+            if not isinstance(obs, dict) or not obs:
+                return None
+            return set(obs.keys())
+
         try:
-            preflight_policy(policy_provider, set(obs.keys()), **(policy_config or {}))
+            preflight_policy(policy_provider, observation_keys, **(policy_config or {}))
         except ValueError as e:
             return {"status": "error", "content": [{"text": str(e)}]}
         return None

--- a/tests/simulation/test_preflight_builds_the_observation_only_when_read.py
+++ b/tests/simulation/test_preflight_builds_the_observation_only_when_read.py
@@ -1,0 +1,163 @@
+"""The policy preflight builds the runtime observation only when it is read.
+
+``SimEngine._preflight_policy_config`` runs a provider's class-level
+:meth:`~strands_robots.policies.base.Policy.preflight` hook against the keys
+the runtime observation will carry. Collecting those keys in a simulation is
+expensive - ``get_observation`` renders every model camera plus every python
+camera in the scene - while
+:func:`~strands_robots.policies.preflight_policy` is a no-op for any provider
+that does not override the hook, which is every shipped provider except
+``lerobot_local``. Building the observation before that decision rendered
+every camera and discarded the frames on behalf of ``mock``, the classical
+planners (cuRobo, MoveIt2) and the whole-body controllers.
+
+That is not only wasted work. The preflight runs before the rollout loop, so
+on a software rasterizer (llvmpipe / ``MUJOCO_GL=osmesa``), where a
+whole-scene render is seconds rather than milliseconds, it also delays the
+loop's cooperative-stop check - which is what ``stop_policy`` needs to be
+observed - by that much per rollout.
+
+So the keys are passed as a supplier and ``preflight_policy`` - the one place
+that knows whether the hook consumes them - decides when to invoke it. Pinned
+on both sides of that seam: the factory must not ask for keys nobody reads,
+and the simulation must not build an observation the factory did not ask for.
+Rule 2 of ``test_policy_preflight_fail_fast`` (an unavailable observation
+skips the check) is the behaviour the supplier's ``None`` return preserves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.policies import factory as policy_factory
+from strands_robots.policies import preflight_policy, register_policy
+from strands_robots.policies.base import Policy
+from strands_robots.policies.mock import MockPolicy
+
+_ACCEPTING_PROVIDER = "preflight_accepting_supplier_probe"
+
+
+class _AcceptingPreflightPolicy(MockPolicy):
+    """Overrides ``preflight`` and records the keys each call was given."""
+
+    seen: list[set[str]] = []
+
+    @classmethod
+    def preflight(cls, observation_keys: set[str], **policy_config: object) -> None:
+        cls.seen.append(set(observation_keys))
+
+
+@pytest.fixture
+def accepting_provider():
+    """Register the overriding provider and remove it again after the test."""
+    _AcceptingPreflightPolicy.seen.clear()
+    register_policy(_ACCEPTING_PROVIDER, lambda: _AcceptingPreflightPolicy)
+    try:
+        yield _ACCEPTING_PROVIDER
+    finally:
+        policy_factory._runtime_registry.pop(_ACCEPTING_PROVIDER, None)
+        _AcceptingPreflightPolicy.seen.clear()
+
+
+class _Supplier:
+    """Records how often the deferred key supplier was invoked."""
+
+    def __init__(self, keys: set[str] | None) -> None:
+        self.keys = keys
+        self.calls = 0
+
+    def __call__(self) -> set[str] | None:
+        self.calls += 1
+        return self.keys
+
+
+class TestTheFactoryAsksForKeysOnlyWhenTheHookReadsThem:
+    """``preflight_policy`` owns the decision, so it owns the invocation."""
+
+    def test_a_provider_with_the_default_no_op_hook_is_never_asked(self):
+        """``mock`` inherits ``Policy.preflight``, so nothing reads the keys and
+        the cost of collecting them must not be paid."""
+        supplier = _Supplier({"joint_0", "camera_top"})
+        assert preflight_policy("mock", supplier) is None
+        assert supplier.calls == 0
+
+    def test_an_unresolvable_provider_is_never_asked(self):
+        """Resolution fails before the hook question can even be asked, so the
+        keys are not owed either (``create_policy`` raises the real error)."""
+        supplier = _Supplier({"joint_0"})
+        assert preflight_policy("nonexistent_provider_xyz_123", supplier) is None
+        assert supplier.calls == 0
+
+    def test_an_overriding_provider_is_asked_exactly_once(self, accepting_provider):
+        """The one provider family that reads the keys still gets them, whole,
+        and pays for exactly one collection."""
+        supplier = _Supplier({"joint_0", "camera_top"})
+        assert preflight_policy(accepting_provider, supplier) is None
+        assert supplier.calls == 1
+        assert _AcceptingPreflightPolicy.seen == [{"joint_0", "camera_top"}]
+
+    def test_a_supplier_reporting_no_observation_yet_does_not_run_the_hook(self, accepting_provider):
+        """``None`` means the runtime observation is not available, so there is
+        nothing to validate the configuration against - the same disposition an
+        empty observation has always had, not an empty key set."""
+        supplier = _Supplier(None)
+        assert preflight_policy(accepting_provider, supplier) is None
+        assert supplier.calls == 1
+        assert _AcceptingPreflightPolicy.seen == []
+
+    def test_a_plain_key_set_is_still_read(self, accepting_provider):
+        """The eager spelling is unchanged: a caller that already holds the keys
+        passes them directly."""
+        assert preflight_policy(accepting_provider, {"joint_0"}) is None
+        assert _AcceptingPreflightPolicy.seen == [{"joint_0"}]
+
+    def test_mock_declares_no_images_and_overrides_no_preflight(self):
+        """Premise of the whole rule, and the contract ``requires_images``
+        documents: the image-free provider is exactly one that reads no keys."""
+        assert MockPolicy(**{}).requires_images is False
+        # Compared the way ``preflight_policy`` compares it: accessing a
+        # classmethod builds a fresh bound object each time, so identity holds
+        # only on the underlying function.
+        assert MockPolicy.preflight.__func__ is Policy.preflight.__func__
+
+
+@pytest.mark.usefixtures("accepting_provider")
+class TestTheSimulationBuildsNoObservationTheFactoryDidNotAskFor:
+    """The expensive half: a scene with a camera, driven through the real seam."""
+
+    @pytest.fixture
+    def counted_sim(self, monkeypatch):
+        """A real MuJoCo scene with a camera, counting observation builds."""
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation(tool_name="preflight_supplier_probe", mesh=False)
+        assert sim.create_world()["status"] == "success"
+        assert sim.add_robot(name="alice", data_config="so100")["status"] == "success"
+        assert sim.add_camera("overhead", position=[0.0, -1.0, 1.0], target=[0.0, 0.0, 0.0])["status"] == "success"
+        real = sim.get_observation
+        calls: list[str] = []
+
+        def counting(*args, **kwargs):
+            calls.append("build")
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(sim, "get_observation", counting)
+        yield sim, calls
+        sim.cleanup()
+
+    def test_a_no_op_preflight_renders_nothing(self, counted_sim):
+        """``mock`` before every ``run_policy`` / ``eval_policy`` /
+        ``start_policy`` rollout: no observation, so no camera render."""
+        sim, calls = counted_sim
+        assert sim._preflight_policy_config("alice", "mock", None) is None
+        assert calls == []
+
+    def test_an_overriding_preflight_still_sees_the_camera_keys(self, counted_sim, accepting_provider):
+        """Control: the provider that validates camera routing must still get a
+        full observation, cameras included - the render is owed here."""
+        sim, calls = counted_sim
+        assert sim._preflight_policy_config("alice", accepting_provider, None) is None
+        assert len(calls) == 1
+        assert _AcceptingPreflightPolicy.seen
+        assert "overhead" in _AcceptingPreflightPolicy.seen[0]


### PR DESCRIPTION
Closes #3132.

![preflight](https://raw.githubusercontent.com/cagataycali/robots/artifacts/preflight-observation/preflight_figure.png)

## The defect

`SimEngine._preflight_policy_config` runs a provider's class-level `Policy.preflight` hook against the keys the runtime observation will carry, and built that observation **before** asking whether the hook exists:

```python
obs = self.get_observation(robot_name)          # renders every camera in the scene
...
preflight_policy(policy_provider, set(obs.keys()), **(policy_config or {}))
```

`preflight_policy` is a documented no-op for a provider that does not override the hook - and exactly one shipped policy class overrides it:

```
$ grep -rn "def preflight" strands_robots/
strands_robots/policies/base.py:285              # the no-op default
strands_robots/policies/lerobot_local/policy.py:1452
```

So for `mock`, the classical planners (cuRobo, MoveIt2), the whole-body controllers and every other provider, `get_observation` rendered every model camera plus every python camera and the frames were discarded. In a lekiwi + unitree_go2 + so101 scene with one added camera that is **6 image keys in 1.283 s** against **0.00026 s** for the joint state alone.

The wasted work is the smaller half. The preflight runs before the rollout loop, so it also delays the loop's cooperative-stop check - the thing `stop_policy` needs to be observed. Three `mock` rollouts stopped immediately after `start_policy` went quiet **2.430 s** after the stop was acknowledged, and on a software-GL host the documented command fails outright:

```
$ MUJOCO_GL=osmesa STRANDS_MESH_HITL_ACTIONS=none python examples/fleet/04_emergency_evacuation.py
RuntimeError: abort missed its 10s deadline; still running: ['lekiwi-1', 'go2-1', 'arm-1']
exit 1
```

## The change

The keys are passed to `preflight_policy` as a supplier, so the one place that decides whether the hook consumes them is the place that invokes it. Nothing else moves.

| | before | after |
|---|---|---|
| `get_observation` calls in a `mock` preflight | 1 (6 cameras rendered, discarded) | 0 |
| `get_observation` calls in a `lerobot_local` preflight | 1 (camera keys present) | 1 (unchanged) |
| 3-robot fleet: stop ack -> quiet | 2.430 s | 0.050 s |
| `examples/fleet/04` on software GL | exit 1, deadline missed | exit 0, abort 1.50 s, benchmark PASS |

`requires_images` is the wrong predicate here even though it names the same providers: it is an instance property, read off a constructed policy (`policy_runner.py:1570`), and the preflight exists to run *before* construction. "Does this class override `preflight`" is answerable on the class, and it is strictly more precise - it is the condition under which the keys are read at all.

A supplier returning `None` reports an observation that is not available yet. That preserves rule 2 of `test_policy_preflight_fail_fast` - such a run is not blocked by the check - rather than calling the hook with an empty key set, which would reject configurations that are fine.

The eager spelling still works: a caller holding the keys passes them directly, and the existing `preflight_policy` tests do.

## Tests

`tests/simulation/test_preflight_builds_the_observation_only_when_read.py`, 8 cells. Against pristine `bbcbd668f`: **3 failed, 5 passed**; after: **8 passed**. The decisive one drives a real MuJoCo scene with a camera through the real seam:

```
test_a_no_op_preflight_renders_nothing - AssertionError: assert ['build'] == []
```

The other two pin the deferred-supplier contract. The remaining five are controls that hold both ways by construction - the factory was already lazy-safe for `mock`, so the bug was only ever the eager build on the caller's side, and the plain-set path and the `requires_images` / no-override premise are unchanged.

Its control cell asserts the provider that *does* read the keys still gets the full observation with `"overhead"` in it, so the camera-routing validation `lerobot_local` performs is untouched.

## Gate

- `ruff check` + `ruff format --check` clean (1788 files).
- `mypy strands_robots tests tests_integ`: 19 errors on both this branch and `bbcbd668f`, identical lists, **0 attributable** (all `examples/isaac_gs`, outside the lint scope).
- `tests/policies` + `tests/simulation`: 3 failed / 19688 passed here vs 5 failed / 19678 passed on `bbcbd668f`; **no failing id is attributable** (branch-only set empty). The pass delta of 10 is the 8 new cells plus two wall-clock pacer cells that are flaky under load.
- `scripts/check_whole_tree_graders.py`: 7 failed / 4212 passed on **both** trees, failing ids set-identical (absent `rclpy`, installed `websockets` 16.0 below the declared floor).
- Figure panel 5 is a control run on the fixed tree: a real 45-frame rollout recording an MP4 (81,696 B, 45 frames, 0 black, 0 frozen) and a LeRobotDataset that reopens with `observation.images.camera1` + `observation.images.default` at `[3, 256, 256]` and `action (6,)`.

## Docs

`docs/policies/custom-policies.md` omitted `preflight` from the ABC-contract table, so the hook was undiscoverable on the page a policy author reads. Added, with the cost model the change makes real: overriding it makes the simulation build a full observation for you, leaving it at the default costs nothing.
