### PR TITLE
docs(policies): the ABC contract table lists every public member of Policy

### DIFF
--- a/changelog.d/3138-policy-abc-contract-table.md
+++ b/changelog.d/3138-policy-abc-contract-table.md
@@ -1,0 +1,18 @@
+### Fixed: the documented Policy ABC contract lists every public member of the class
+
+`docs/policies/custom-policies.md` is the page a subclass author reads before writing a
+provider, and its "ABC contract" table named 7 of the 15 public members of `Policy`. The eight
+missing ones were `preflight`, `children`, `execution_horizon`, `is_chunk_emitting`,
+`control_frequency`, `set_control_frequency`, `rtc_observed_delay_steps` and
+`set_rtc_observed_delay` - so the fail-fast validation hook, the re-query interval that is the
+single source of truth for chunk consumption, the wrapper-delegation surface and the whole
+Real-Time Chunking handshake were invisible on the page whose job is to enumerate the
+contract. `control_frequency` and `rtc_observed_delay_steps` carry no docstring either, so
+they were undiscoverable from the source as well.
+
+The table now lists all fifteen with their default, and the members the runtime supplies to a
+policy rather than the reverse are called out as such. The expectation is derived from the
+class in `tests/policies/test_documented_abc_contract_matches_the_policy_class.py`, as a
+biconditional in both directions plus an abstract-column check, so a member added to `Policy`
+joins the requirement without an edit to the test and a row naming a member the class no
+longer has is refused too.

--- a/docs/policies/custom-policies.md
+++ b/docs/policies/custom-policies.md
@@ -59,6 +59,11 @@ Aliases and shorthands are validated on load: each must be unique across provide
 
 ## ABC contract
 
+Every public member of `Policy`, so a subclass author can see the whole surface
+in one place. Three are abstract; the rest have a working default, and the last
+four are supplied *to* the policy by the runtime that drives it rather than
+implemented by it.
+
 | Method / property | Abstract | Default |
 |---|---|---|
 | `async get_actions(obs, instruction, **kw) -> list[dict]` | yes | - |
@@ -66,8 +71,38 @@ Aliases and shorthands are validated on load: each must be unique across provide
 | `provider_name` (property) | yes | - |
 | `requires_images` (property) | no | `True` |
 | `required_bodies` (property) | no | `()` |
+| `children` (property) | no | `()` |
+| `execution_horizon` (property) | no | `1` |
+| `is_chunk_emitting()` | no | `execution_horizon > 1` |
+| `preflight(observation_keys, **config)` (classmethod) | no | no-op |
 | `reset(seed=None)` | no | no-op |
 | `get_actions_sync(...)` | no | sync wrapper |
+| `set_control_frequency(hz)` | no | records the rate |
+| `control_frequency` (attribute) | no | `None` |
+| `set_rtc_observed_delay(steps)` | no | records the delay |
+| `rtc_observed_delay_steps` (attribute) | no | `None` |
+
+`preflight` is the fail-fast seam: the simulation calls it on your **class**,
+before `create_policy` constructs anything and therefore before any weight
+download, with the keys the runtime observation will carry (joint names plus
+camera names). Raise `ValueError` from it to reject a configuration your policy
+cannot consume - a declared image input that no sim camera can be routed to is
+the motivating case - instead of surfacing that deep inside the first inference.
+Implementations must be cheap: local metadata and the given keys, no network, no
+instantiation.
+
+`execution_horizon` is the single source of truth for the re-query interval: how
+many actions a consumer takes from one `get_actions` chunk before asking again.
+Leave it at `1` for a policy that returns one action per inference;
+`is_chunk_emitting()` is derived from it, so a chunk-emitting policy only needs
+to declare the horizon. `children` is what a *wrapper* returns so a capability
+probe reaches the policy inside it.
+
+The runtime calls `set_control_frequency` once before the rollout loop and
+`set_rtc_observed_delay` before each `get_actions`, so a provider that estimates
+an inference budget or does Real-Time Chunking can read the rate and the
+observed delay off itself. Both default to `None` - meaning not yet told - so
+read them defensively.
 
 ## Declaring body poses your policy needs
 

--- a/tests/policies/test_documented_abc_contract_matches_the_policy_class.py
+++ b/tests/policies/test_documented_abc_contract_matches_the_policy_class.py
@@ -1,0 +1,94 @@
+"""The documented ABC contract names every public member of ``Policy``.
+
+``docs/policies/custom-policies.md`` carries an "ABC contract" table which is
+the surface a subclass author reads before writing a provider. A member absent
+from it is not merely undocumented - it is invisible on the page whose job is
+to enumerate the contract, so an author cannot know to override it. That had
+already happened to eight of the fifteen public members, ``preflight`` among
+them, which is the member deciding whether the simulation renders the whole
+scene before a rollout.
+
+The expectation is DERIVED from the class rather than pinned as a literal list,
+so a member added to ``Policy`` joins the requirement with no edit here. It is a
+biconditional: every public member appears in the table, and every name in the
+table is a public member (a row for something the class no longer has is
+equally misleading).
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+import re
+
+from strands_robots.policies.base import Policy
+
+_DOC = pathlib.Path(inspect.getfile(Policy)).parents[2] / "docs" / "policies" / "custom-policies.md"
+_HEADING = "## ABC contract"
+
+
+def _public_members() -> set[str]:
+    """Public members declared on ``Policy`` itself (not inherited from object)."""
+    return {name for name in vars(Policy) if not name.startswith("_")}
+
+
+def _documented_members() -> set[str]:
+    """First identifier of each row in the ABC-contract table."""
+    text = _DOC.read_text(encoding="utf-8")
+    start = text.index(_HEADING)
+    end = text.index("\n## ", start + len(_HEADING))
+    names = set()
+    for cell in re.findall(r"^\|\s*`([^`]+)`", text[start:end], re.M):
+        match = re.search(r"\b([a-z_][a-z0-9_]*)\b", cell.replace("async ", ""))
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+class TestTheTableAndTheClassAgree:
+    """One table, one class, and no member visible in only one of them."""
+
+    def test_the_scan_finds_both_populations(self):
+        """Non-vacuity control: an empty side would make either assertion below
+        pass for the wrong reason. Floors only - the counts themselves are not
+        the claim, so this holds whatever the table currently lists."""
+        assert len(_public_members()) >= 15, "the class scan found no members"
+        assert _documented_members(), "the table scan found no rows"
+
+    def test_every_public_member_is_documented(self):
+        """A member the page omits cannot be overridden by an author who only
+        reads the page."""
+        missing = sorted(_public_members() - _documented_members())
+        assert not missing, f"public Policy members absent from the ABC-contract table: {missing}"
+
+    def test_every_documented_row_is_a_public_member(self):
+        """The other direction: a row for a member the class does not have sends
+        an author to write something nothing calls."""
+        stale = sorted(_documented_members() - _public_members())
+        assert not stale, f"ABC-contract table rows naming no public Policy member: {stale}"
+
+    def test_the_abstract_column_matches_the_class(self):
+        """``yes`` in the table must mean ``abstractmethod`` on the class, so the
+        three members an implementation MUST supply stay the three that raise if
+        it does not."""
+        text = _DOC.read_text(encoding="utf-8")
+        start = text.index(_HEADING)
+        end = text.index("\n## ", start + len(_HEADING))
+        documented_abstract = set()
+        # The name cell may carry a kind suffix after the backticks, e.g.
+        # "`provider_name` (property)", so consume it before the column break.
+        for row in re.findall(r"^\|\s*`([^`]+)`[^|]*\|([^|]*)\|", text[start:end], re.M):
+            cell, abstract = row
+            match = re.search(r"\b([a-z_][a-z0-9_]*)\b", cell.replace("async ", ""))
+            if match and abstract.strip() == "yes":
+                documented_abstract.add(match.group(1))
+        actual_abstract = set()
+        for name, obj in vars(Policy).items():
+            if name.startswith("_"):
+                continue
+            target = getattr(obj, "fget", None) or getattr(obj, "__func__", None) or obj
+            if getattr(target, "__isabstractmethod__", False):
+                actual_abstract.add(name)
+        assert documented_abstract == actual_abstract, (
+            f"table says abstract={sorted(documented_abstract)}, class says {sorted(actual_abstract)}"
+        )


### PR DESCRIPTION
Follow-up to #3135, which made `Policy.preflight` the member that decides whether a rollout renders the whole scene. `preflight` is not in the ABC-contract table on the page a subclass author reads, and it turns out neither are seven others.

## The gap

`docs/policies/custom-policies.md` heads a table "ABC contract". Derived from the class, it names **7 of the 15** public members of `Policy`:

| absent | what an author cannot discover from the page |
|---|---|
| `preflight` (classmethod) | the fail-fast hook; after #3135 it also decides whether the simulation renders every camera before the rollout |
| `execution_horizon` (property) | its own docstring calls it "the SINGLE source of truth for the re-query interval" - how many actions a consumer takes from one chunk |
| `is_chunk_emitting()` | derived from that horizon; what marks a policy as chunk-emitting |
| `children` (property) | what a wrapper returns so a capability probe reaches the policy inside it |
| `set_control_frequency(hz)` / `control_frequency` | the runtime tells the policy the loop rate before the rollout |
| `set_rtc_observed_delay(steps)` / `rtc_observed_delay_steps` | the runtime tells it the inference delay before each `get_actions` - the whole Real-Time Chunking handshake |

`control_frequency` and `rtc_observed_delay_steps` are plain class attributes (`base.py:69` and `:113`) with **no docstring**, so they were not discoverable from the source either. `children` and `required_bodies` are described in `docs/architecture.md`; the page that claims to enumerate the contract listed only one of them.

## Change

The table lists all fifteen with their default, in the same three columns, plus short paragraphs for the ones that need one - and it says which members the runtime supplies *to* a policy rather than the reverse, since that distinction is the reason the RTC pair looks odd in an "implement this" table.

No source change. Defaults were read off the class, not transcribed: `execution_horizon` is `1`, `is_chunk_emitting()` is `execution_horizon > 1`, `children` and `required_bodies` are `()`, both runtime-set attributes are `None`.

## Test

`tests/policies/test_documented_abc_contract_matches_the_policy_class.py`, 4 cells, derived from `Policy` rather than pinned as a literal list - so a member added to the class joins the requirement with no edit here, which is the failure mode that produced this gap. It is a biconditional: every public member appears in the table, and every row names a public member (a row for a member the class no longer has sends an author to write something nothing calls). A fourth cell holds the `Abstract` column to `__isabstractmethod__`, so `yes` keeps meaning "raises if you do not supply it".

Against pristine `bbcbd668f`: **1 failed, 3 passed** -

```
FAILED ...::test_every_public_member_is_documented - AssertionError: public Policy members
absent from the ABC-contract table: ['children', 'control_frequency', 'execution_horizon',
'is_chunk_emitting', 'preflight', 'rtc_observed_delay_steps', 'set_control_frequency',
'set_rtc_observed_delay']
```

After: **4 passed**. The three that pass either way are controls - the non-vacuity floors, the no-stale-rows direction, and the abstract column, all of which were already correct.

## Gate

- `ruff check` + `ruff format --check` clean (1788 files); `mypy` on the new file: `Success: no issues found in 1 source file`.
- `tests/policies` + every `tests/test_docs*.py` + the three changelog graders: 5795 passed, 3 failed - two are `docker not found on PATH` (`tests/policies/vera/`, absent on this host and failing identically on `bbcbd668f`), the third was this branch's own changelog fragment before it was named for the PR.
