### PR TITLE
fix(rendering): a composited frame is the size its own camera parameters describe

### DIFF
--- a/changelog.d/3140-composite-layer-size-matches-the-camera.md
+++ b/changelog.d/3140-composite-layer-size-matches-the-camera.md
@@ -1,0 +1,23 @@
+### Fixed: a composited frame is the size its own camera parameters describe
+
+`HybridCompositor.render` aligned its layers by truncating to the shortest one
+(`h = min(fg_rgb.shape[0], bg_rgb.shape[0])`) while the returned
+`CompositeFrame` still carried the `CameraParams` the call resolved. A layer
+shorter than that camera therefore produced a frame the camera cannot
+describe: on a real MuJoCo scene requested at 320x240, a background capped at
+64 px returned a 64x64 composite reporting a 320x240 camera whose principal
+point (160, 120) lies outside the returned image -- wrong for any 3D-to-2D
+use, at a size nobody asked for, with nothing saying so.
+
+A short layer is reachable from either side, and both are extension points.
+`BackgroundRenderer` is a public `Protocol` accepted by
+`HybridCompositor(background=...)` and `set_background()`, so any third-party
+rasterizer that caps its output supplies one; and `IsaacSimEngine.get_frame`
+already decided this exact question the other way for the foreground, raising
+on a size it cannot render "rather than silently dropping the requested size".
+
+Every layer -- both `get_frame` buffers and both `BackgroundRenderer` buffers
+-- is now held to the size the resolved camera declares and refused with a
+`RuntimeError` naming the side, the buffer, both sizes and the remedy, for the
+reason the no-depth refusal beside it already states: silent wrong output is
+forbidden. A conforming render is unchanged, byte for byte.

--- a/strands_robots/rendering/backgrounds.py
+++ b/strands_robots/rendering/backgrounds.py
@@ -63,9 +63,14 @@ class BackgroundRenderer(Protocol):
 
         Returns:
             ``rgb`` as ``(H, W, 3) uint8`` and ``depth`` as ``(H, W) float32``
-            in meters. Pixels at "infinity" should report ``depth = np.inf``
-            (or any value larger than ``cam.zfar``) so the compositor's depth
-            test always picks the foreground.
+            in meters, where ``(H, W)`` is exactly
+            ``(cam.height, cam.width)`` - the composited frame reports ``cam``,
+            so a layer at any other size is refused by
+            :meth:`~strands_robots.rendering.HybridCompositor.render` rather
+            than truncated into a frame ``cam.K`` does not describe. Pixels at
+            "infinity" should report ``depth = np.inf`` (or any value larger
+            than ``cam.zfar``) so the compositor's depth test always picks the
+            foreground.
         """
 
 

--- a/strands_robots/rendering/compositor.py
+++ b/strands_robots/rendering/compositor.py
@@ -263,7 +263,11 @@ class CompositeFrame:
         depth: ``(H, W) float32`` foreground depth in meters (the simulation
             depth, since the foreground is what the user usually cares about
             measuring).
-        camera: :class:`CameraParams` used to render this frame.
+        camera: :class:`CameraParams` used to render this frame. Every array
+            above is ``(camera.height, camera.width)``, so ``camera.K``
+            describes them - :meth:`HybridCompositor.render` refuses a layer
+            at any other size rather than returning a frame its own camera
+            cannot describe.
     """
 
     rgb: np.ndarray
@@ -432,6 +436,11 @@ class HybridCompositor:
                 compositing without depth would silently paint the background
                 over/under the wrong pixels, and silent wrong output is
                 forbidden. Use a depth-capable backend (MuJoCo, Isaac).
+                Also if any layer (either ``get_frame`` buffer, or either
+                buffer from the :class:`BackgroundRenderer`) is not the size
+                the resolved camera declares: the returned frame reports that
+                camera, so a layer at another size cannot be composited into
+                the image its ``K`` describes.
         """
         for label, size in (("width", width), ("height", height)):
             if size is not None and (text := positive_whole_number_error(size, label, "HybridCompositor.render")):
@@ -460,12 +469,44 @@ class HybridCompositor:
 
         bg_rgb, bg_depth = self._background_for(cam, camera_name)
 
-        # Align shapes defensively (foreground and background should both
-        # match the camera resolution, but guard against off-by-one).
-        h = min(fg_rgb.shape[0], bg_rgb.shape[0])
-        w = min(fg_rgb.shape[1], bg_rgb.shape[1])
-        fg_rgb, fg_depth = fg_rgb[:h, :w], fg_depth[:h, :w]
-        bg_rgb, bg_depth = bg_rgb[:h, :w], bg_depth[:h, :w]
+        # Every layer must be the size ``cam`` declares, because ``cam`` is
+        # what the returned frame reports: its ``K`` places the principal
+        # point at (cam.width / 2, cam.height / 2), and consumers project into
+        # an image of that size. Truncating to the shortest layer instead
+        # (``h = min(fg.shape[0], bg.shape[0])``) returned a composite ``cam``
+        # cannot describe - a 64x64 frame whose reported principal point
+        # (160, 120) lies outside it - at a size the caller never asked for
+        # and with nothing saying so. Refused for the reason the no-depth
+        # refusal above states: silent wrong output is forbidden. It is also
+        # the disposition the foreground's own producer already applies, since
+        # ``IsaacSimEngine.get_frame`` raises on a size it cannot render
+        # "rather than silently dropping the requested size".
+        for label, remedy, *layers in (
+            (
+                "foreground",
+                f"{type(self.sim).__name__}.get_frame must return arrays of the size it is asked for",
+                ("rgb", fg_rgb),
+                ("depth", fg_depth),
+            ),
+            (
+                "background",
+                f"{self.background.name!r} (a BackgroundRenderer) must return "
+                "(cam.height, cam.width) arrays for the CameraParams it is given",
+                ("rgb", bg_rgb),
+                ("depth", bg_depth),
+            ),
+        ):
+            for buffer_name, layer in layers:
+                got_h, got_w = layer.shape[0], layer.shape[1]
+                if (got_h, got_w) != (cam.height, cam.width):
+                    raise RuntimeError(
+                        f"HybridCompositor.render: the {label} {buffer_name} for camera "
+                        f"{camera_name!r} is {got_w}x{got_h}, not the {cam.width}x{cam.height} "
+                        f"the camera declares. The composited frame is described by its "
+                        f"camera parameters, whose principal point is "
+                        f"({cam.K[0, 2]:.1f}, {cam.K[1, 2]:.1f}) - a layer at another size "
+                        f"cannot be composited into that image. {remedy}."
+                    )
 
         # Foreground pixels are valid where the sim saw real geometry:
         # finite depth above epsilon (Isaac reports no-hit as 0 / inf) and
@@ -479,7 +520,7 @@ class HybridCompositor:
             # catcher plane the scene renders. They never win the composite --
             # the photoreal backdrop owns that surface -- but the shading the
             # simulator rendered onto them carries the robot's cast shadow.
-            plane_d = plane_depth(cam, self.shadow_plane_z)[:h, :w]
+            plane_d = plane_depth(cam, self.shadow_plane_z)
             catcher = valid_fg & np.isfinite(plane_d) & (np.abs(fg_depth - plane_d) <= self.shadow_plane_tolerance)
             valid_fg = valid_fg & ~catcher
 

--- a/tests/rendering/test_composite_layer_size_matches_the_camera.py
+++ b/tests/rendering/test_composite_layer_size_matches_the_camera.py
@@ -1,0 +1,173 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A composited frame is the size its own camera parameters describe.
+
+``HybridCompositor.render`` returns a ``CompositeFrame`` carrying the
+``CameraParams`` it resolved, and every consumer reads the image through them:
+``camera.K`` places the principal point at ``(width / 2, height / 2)``, and
+``camera.width`` / ``camera.height`` are what a video writer or a 3D->2D
+projection is sized from.
+
+The compositor used to align its layers by truncating to the shortest one
+(``h = min(fg.shape[0], bg.shape[0])``), so a layer shorter than the camera
+returned a composite at that shorter size while still reporting the camera the
+caller asked for -- a 64x64 frame whose reported principal point (160, 120) lies
+outside it, at a size nobody requested and with nothing saying so.
+
+A short layer is reachable from either side, and both are extension points:
+
+* ``BackgroundRenderer`` is a public :class:`typing.Protocol` that
+  ``HybridCompositor(background=...)`` and :meth:`set_background` accept, so any
+  third-party rasterizer that caps its output (a device/texture limit) supplies
+  one.
+* ``get_frame`` belongs to the engine. Its Isaac implementation already decided
+  this exact question the other way for the foreground -- it raises on a size it
+  cannot render "rather than silently dropping the requested size" -- naming the
+  compositor as the consumer that decision protects.
+
+So a layer at any other size is refused, naming the side, the buffer, the size
+it returned and the size the camera declares.
+"""
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import CameraParams, HybridCompositor
+
+W, H = 16, 12
+ZFAR = 100.0
+
+
+def _extent(cap: "int | None", capped: bool, height: int, width: int) -> tuple[int, int]:
+    """The ``(rows, cols)`` a capped rasterizer can actually draw."""
+    if cap is None or not capped:
+        return height, width
+    return min(cap, height), min(cap, width)
+
+
+class SizedBackground:
+    """Background whose rasterizer caps the frame it can draw.
+
+    Honours ``cam.K`` -- its pixel ``(i, j)`` is the same world ray as the
+    foreground's -- but cannot draw past ``cap`` pixels on an axis, the shape a
+    real device or texture limit produces. ``cap=None`` conforms.
+    """
+
+    name = "sized-bg"
+
+    def __init__(self, cap: "int | None" = None, buffers: tuple[str, ...] = ("rgb", "depth")) -> None:
+        self.cap = cap
+        self.buffers = buffers
+
+    def render(self, cam: CameraParams) -> tuple[np.ndarray, np.ndarray]:
+        rgb_h, rgb_w = _extent(self.cap, "rgb" in self.buffers, cam.height, cam.width)
+        d_h, d_w = _extent(self.cap, "depth" in self.buffers, cam.height, cam.width)
+        return (
+            np.zeros((rgb_h, rgb_w, 3), dtype=np.uint8),
+            np.full((d_h, d_w), cam.zfar, dtype=np.float32),
+        )
+
+
+class SizedSim:
+    """Frame source whose ``get_frame`` can under-deliver, like a capped RTX sensor."""
+
+    def __init__(self, cap: "int | None" = None, buffers: tuple[str, ...] = ("rgb", "depth")) -> None:
+        self.cap = cap
+        self.buffers = buffers
+
+    def get_camera_params(self, camera_name="default", width=None, height=None) -> CameraParams:
+        w, h = int(width or W), int(height or H)
+        fy = 0.5 * h / np.tan(np.deg2rad(45.0) / 2.0)
+        K = np.array([[fy, 0.0, w / 2.0], [0.0, fy, h / 2.0], [0.0, 0.0, 1.0]])
+        return CameraParams(K=K, T_world_cam=np.eye(4), width=w, height=h, znear=0.01, zfar=ZFAR)
+
+    def get_frame(self, camera_name="default", width=None, height=None) -> tuple[np.ndarray, np.ndarray]:
+        w, h = int(width or W), int(height or H)
+        rgb_h, rgb_w = _extent(self.cap, "rgb" in self.buffers, h, w)
+        d_h, d_w = _extent(self.cap, "depth" in self.buffers, h, w)
+        rgb = np.full((rgb_h, rgb_w, 3), 255, dtype=np.uint8)
+        depth = np.full((d_h, d_w), ZFAR, dtype=np.float32)
+        depth[d_h // 3 : 2 * d_h // 3, d_w // 3 : 2 * d_w // 3] = 1.0  # foreground geometry
+        return rgb, depth
+
+
+class TestALayerAtAnotherSizeIsRefused:
+    """The composite cannot be smaller than the camera it reports."""
+
+    @pytest.mark.parametrize("buffers", [("rgb", "depth"), ("rgb",), ("depth",)])
+    def test_a_short_background_is_refused(self, buffers: tuple[str, ...]) -> None:
+        comp = HybridCompositor(SizedSim(), background=SizedBackground(cap=4, buffers=buffers))
+        with pytest.raises(RuntimeError, match="background") as excinfo:
+            comp.render("cam")
+        text = str(excinfo.value)
+        assert "4x4" in text, text
+        assert f"{W}x{H}" in text, text
+        assert "sized-bg" in text, text
+
+    @pytest.mark.parametrize("buffers", [("rgb", "depth"), ("rgb",), ("depth",)])
+    def test_a_short_foreground_is_refused(self, buffers: tuple[str, ...]) -> None:
+        comp = HybridCompositor(SizedSim(cap=4, buffers=buffers), background=SizedBackground())
+        with pytest.raises(RuntimeError, match="foreground") as excinfo:
+            comp.render("cam")
+        text = str(excinfo.value)
+        assert "4x4" in text, text
+        assert f"{W}x{H}" in text, text
+        assert "get_frame" in text, text
+
+    def test_the_refusal_names_the_principal_point_the_layer_cannot_serve(self) -> None:
+        """The reason is geometric, so the message carries the point that moves."""
+        comp = HybridCompositor(SizedSim(), background=SizedBackground(cap=4))
+        with pytest.raises(RuntimeError, match=r"principal point is \(8\.0, 6\.0\)"):
+            comp.render("cam")
+
+    def test_a_taller_layer_is_still_a_disagreement(self) -> None:
+        """The refusal is equality, not a floor: an over-sized layer is a bug too."""
+
+        class OversizedBackground(SizedBackground):
+            def render(self, cam: CameraParams) -> tuple[np.ndarray, np.ndarray]:
+                return (
+                    np.zeros((cam.height + 2, cam.width + 2, 3), dtype=np.uint8),
+                    np.full((cam.height + 2, cam.width + 2), cam.zfar, dtype=np.float32),
+                )
+
+        comp = HybridCompositor(SizedSim(), background=OversizedBackground())
+        with pytest.raises(RuntimeError, match="background rgb"):
+            comp.render("cam")
+
+    def test_the_shadow_catcher_pass_refuses_it_too(self) -> None:
+        """The catcher path reads the layers as well, so it must not slip through."""
+        comp = HybridCompositor(SizedSim(), background=SizedBackground(cap=4), shadow_plane_z=0.0, feather_pixels=0)
+        with pytest.raises(RuntimeError, match="background"):
+            comp.render("cam")
+
+
+class TestAConformingCompositeIsUnchanged:
+    """Controls: nothing that already agreed with the camera is refused."""
+
+    def test_a_conforming_render_reports_the_size_it_wrote(self) -> None:
+        comp = HybridCompositor(SizedSim(), background=SizedBackground(), feather_pixels=0)
+        frame = comp.render("cam")
+        assert frame.rgb.shape == (H, W, 3)
+        assert frame.depth.shape == (H, W)
+        assert frame.foreground_mask.shape == (H, W)
+        assert (frame.camera.width, frame.camera.height) == (W, H)
+
+    def test_an_explicit_size_is_honoured_end_to_end(self) -> None:
+        """A per-call size resolves the camera, and every layer follows it."""
+        comp = HybridCompositor(SizedSim(), background=SizedBackground(), feather_pixels=0)
+        frame = comp.render("cam", width=24, height=20)
+        assert frame.rgb.shape == (20, 24, 3)
+        assert (frame.camera.width, frame.camera.height) == (24, 20)
+        assert frame.camera.K[0, 2] == pytest.approx(12.0)
+
+    def test_a_missing_depth_buffer_still_reports_its_own_reason(self) -> None:
+        """The size check must not shadow the pre-existing no-depth refusal."""
+
+        class DepthlessSim(SizedSim):
+            def get_frame(self, camera_name="default", width=None, height=None):
+                rgb, _ = super().get_frame(camera_name, width, height)
+                return rgb, None
+
+        comp = HybridCompositor(DepthlessSim(), background=SizedBackground())
+        with pytest.raises(RuntimeError, match="no depth buffer"):
+            comp.render("cam")

--- a/tests/rendering/test_compositor.py
+++ b/tests/rendering/test_compositor.py
@@ -46,8 +46,26 @@ class FakeSim:
         return CameraParams(K=K, T_world_cam=np.eye(4), width=w, height=h, znear=0.01, zfar=ZFAR)
 
     def get_frame(self, camera_name="default", width=None, height=None):
-        rgb = np.full((H, W, 3), 255, dtype=np.uint8)  # white robot pixels
-        return rgb, self._depth
+        """Return buffers at exactly the size asked for, as a real engine does.
+
+        The MuJoCo backend renders at the requested dimensions and the Isaac
+        one raises rather than return another size, so a double that ignored
+        the request could only be consumed by a compositor that truncated its
+        layers -- which
+        ``tests/rendering/test_composite_layer_size_matches_the_camera.py``
+        now refuses. At the default size this is the frame it always returned.
+        """
+        w, h = int(width or W), int(height or H)
+        rgb = np.full((h, w, 3), 255, dtype=np.uint8)  # white robot pixels
+        depth = self._depth
+        if depth is None or depth.shape == (h, w):
+            return rgb, depth
+        # Re-window the caller's depth pattern into the requested frame; sky
+        # (zfar) fills whatever the pattern does not cover.
+        sized = np.full((h, w), ZFAR, dtype=np.float32)
+        rows, cols = min(h, depth.shape[0]), min(w, depth.shape[1])
+        sized[:rows, :cols] = depth[:rows, :cols]
+        return rgb, sized
 
 
 def _square_depth() -> np.ndarray:


### PR DESCRIPTION
![composite layer size](https://raw.githubusercontent.com/cagataycali/robots/artifacts/composite-layer-size/composite_layer_size.png)

## The defect

`HybridCompositor.render` aligned its layers by truncating to the shortest one:

```python
h = min(fg_rgb.shape[0], bg_rgb.shape[0])
w = min(fg_rgb.shape[1], bg_rgb.shape[1])
```

The returned `CompositeFrame` still carried the `CameraParams` the call resolved, so a layer shorter than that camera produced a frame the camera cannot describe. Measured on a real MuJoCo SO-101 scene, camera `front` requested at 320x240, `PanoramaBackground` behind a size cap:

| background | `frame.rgb` | `frame.camera` | principal point | before | after |
| --- | --- | --- | --- | --- | --- |
| honours the camera | 320x240 | 320x240 | (160, 120) | agrees | agrees, byte-identical |
| capped at 200 px | 200x200 | 320x240 | (160, 120) | 52.1% of the frame it claims, returned as a frame | `RuntimeError` |
| capped at 64 px | 64x64 | 320x240 | (160, 120) | 5.3%, principal point outside the image | `RuntimeError` |

`camera.K` is what a consumer projects through and `camera.width` / `camera.height` are what a video writer is sized from, so a 64x64 frame reporting a principal point at (160, 120) is wrong for any 3D-to-2D use, at a size nobody asked for, with nothing saying so.

## Why a short layer is reachable

Both inputs are extension points.

- `BackgroundRenderer` is a public `Protocol` accepted by `HybridCompositor(background=...)` and `set_background()`, so any third-party rasterizer that caps its output supplies one. Its docstring asked for `(H, W, 3)` "for `cam`" without saying the size was required rather than advisory.
- `get_frame` belongs to the engine, and `IsaacSimEngine.get_frame` already decided this exact question the other way for the foreground: a requested size it cannot render "raises rather than silently dropping the requested size", naming `HybridCompositor` as the consumer that decision protects.

The two directions failed differently and only one was loud. An rgb mismatch returned a wrong-sized frame under a wrong camera (silent); a depth mismatch surfaced as a bare `ValueError: operands could not be broadcast together with shapes (12,16) (4,4)`, naming no camera, no layer and no remedy.

## The change

Every layer -- both `get_frame` buffers and both `BackgroundRenderer` buffers -- is held to the size the resolved camera declares and refused with a `RuntimeError` naming the side, the buffer, both sizes and the remedy. Same disposition and the same stated reason as the no-depth refusal immediately beside it ("silent wrong output is forbidden"), so the alignment block and its now-dead `h, w` are gone.

The docstrings are this API's reference (there is no `docs/` page for it), so: `CompositeFrame.camera` states that every array is `(camera.height, camera.width)`, `render`'s `Raises:` covers the refusal, and `BackgroundRenderer.render` states the size is required.

## Tests

`tests/rendering/test_composite_layer_size_matches_the_camera.py` -- **9 failed / 3 passed** on `main`, 12 pass here. It pins both sides against each buffer (rgb only, depth only, both), the geometric message, the shadow-catcher path, and an over-sized layer (the rule is equality, not a floor). The 3 that pass on `main` are the controls: a conforming render, an explicit per-call size resolved end to end, and the pre-existing no-depth refusal, which must keep reporting its own reason rather than being shadowed by the new one.

`FakeSim.get_frame` in `tests/rendering/test_compositor.py` ignored the size it was asked for and always returned a fixed 16x12 frame, so two existing cells (`test_requested_size_reaches_the_frame_source_and_defaults_when_absent`, `test_integral_options_are_normalized_to_plain_python_numbers`) were passing only because the compositor truncated. The double now honours the request, as both real engines do; at the default size it returns exactly the frame it always returned.

## Gate

- `ruff check` and `ruff format --check` clean (1788 files).
- `mypy strands_robots tests tests_integ`: 19 errors, all pre-existing in `examples/isaac_gs/`, error set identical to `main`.
- `tests/rendering/` plus `test_get_frame_camera_params`, `test_examples_gs_imports`, `test_docstring_xref_roles_resolve`: 899 passed, 1 skipped.
- `scripts/check_whole_tree_graders.py`: 7 failed / 4212 passed on this branch and on a pristine `main` worktree, the same seven node ids both times (local `rclpy` and `websockets` versions).
- The conforming composite is md5-identical on both trees (`a4e0530af505df58f998b9c064b2e2e3`), so nothing that already agreed with its camera changed.

Diff is +273/-13 over 5 files (173 of the additions are the new test, 23 the changelog fragment); production is **+1 executable statement** (`compositor.py` 178 -> 179 by AST count, `backgrounds.py` unchanged). The rest is the removed alignment block, the refusal's reasoning comment, and docstrings.