### PR TITLE
fix(dashboard): the auth store cache serves a hit only while the file still holds its bytes

### DIFF
--- a/changelog.d/3141-auth-store-cache-serves-the-bytes-on-disk.md
+++ b/changelog.d/3141-auth-store-cache-serves-the-bytes-on-disk.md
@@ -1,0 +1,20 @@
+### Fixed: the dashboard auth store cache serves a hit only while the file still holds its bytes
+
+`auth._load` cached the credential store under `(path, st_mtime_ns, st_size)`.
+That tuple names a file, not a version of it. The kernel stamps `st_mtime_ns`
+from a coarse clock, so two writes inside one tick are stamped alike, and a
+rewrite that keeps the byte count keeps `st_size` -- eight successive same-size
+rewrites of a store on ext4 produce one distinct `st_mtime_ns` between them.
+
+Under a stat-only hit the first such edit was the last one seen, and not
+transiently: the identity never changes again, so the stale store was served for
+the life of the process. An operator retiring a passkey record, or rotating a
+`jwt_secret` for one of the same length, is making exactly that same-size edit
+-- on the file that decides whether the dashboard is sealed.
+
+The cached entry now carries the bytes it was parsed from, and a hit is served
+only while the file still holds them. No stat field can substitute:
+`st_ctime_ns` comes from the same tick, and `st_ino` is unchanged by an in-place
+rewrite. The read stays and the parse is what the cache saves, which is what the
+read licenses skipping. The identity remains the key, the cache remains at one
+entry, and the atomic writer re-keys under the payload it just wrote.

--- a/strands_robots/dashboard/auth.py
+++ b/strands_robots/dashboard/auth.py
@@ -34,7 +34,7 @@ import threading
 import time
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 import jwt  # PyJWT
 from fastapi import HTTPException
@@ -120,15 +120,38 @@ def _forced_origin() -> str:
 
 _lock = threading.Lock()
 
-# The store, cached under the identity of the file it was read from. A value
-# global beside a parallel key global is an invariant maintained by hand at every
-# write - and the two can disagree, at which point a stale hit is
-# indistinguishable from a fresh one. Keyed this way they cannot: the key is the
-# dict's key, so a value is only reachable through the identity it was read
-# under. ``mesh/_acl_config.py`` keys its ACL cache on a file identity tuple for
-# the same reason. Holds at most one entry - there is one store path per process
-# - so an operator (or an attacker) rewriting the store cannot grow it.
-_cache: dict[tuple, dict[str, Any]] = {}
+# The store, cached under the identity of the file it was read from, together
+# with the bytes it was parsed from. A value global beside a parallel key global
+# is an invariant maintained by hand at every write - and the two can disagree,
+# at which point a stale hit is indistinguishable from a fresh one. Keyed this
+# way they cannot: the key is the dict's key, so a value is only reachable
+# through the identity it was read under. ``mesh/_acl_config.py`` keys its ACL
+# cache on a file identity tuple for the same reason. Holds at most one entry -
+# there is one store path per process - so an operator (or an attacker)
+# rewriting the store cannot grow it.
+#
+# The identity is the key; the bytes are the authority. A stat tuple names a
+# file, not a version of it: the kernel stamps ``st_mtime_ns`` from a coarse
+# clock, so two writes inside one tick carry the same mtime, and a rewrite that
+# keeps the byte count keeps ``st_size`` too. Eight successive same-size
+# rewrites of a store on ext4 can therefore share one identity tuple. Under a
+# stat-only hit that is a permanent stale read - the identity never changes
+# again, so the revocation that rewrote the file is never applied, on the file
+# that decides whether this dashboard is sealed. A hit is served only when the
+# file still holds the bytes the cached store was parsed from.
+_cache: dict[tuple, _CachedStore] = {}
+
+
+class _CachedStore(NamedTuple):
+    """A parsed store beside the exact bytes it was parsed from.
+
+    ``raw`` is what makes a hit checkable. Keeping it costs one copy of a file
+    that holds a JWT secret and a handful of passkey records, and buys the only
+    question a stat tuple cannot answer: are these still the file's contents?
+    """
+
+    raw: str
+    store: dict[str, Any]
 
 
 def _default_store() -> dict[str, Any]:
@@ -174,6 +197,12 @@ def _store_identity(path: Path) -> tuple | None:
     direction to fail in for the file that decides whether this dashboard is
     sealed: serving memory under a key that describes nothing is how a store
     replaced underneath the process goes unnoticed.
+
+    The tuple names a file, not a version of it. Two different contents can
+    share one: ``st_mtime_ns`` comes from a coarse kernel clock, so writes
+    inside one tick are stamped alike, and a rewrite of the same byte count
+    leaves ``st_size`` alone. That is why :func:`_load` checks the bytes a hit
+    was parsed from rather than trusting this tuple to have changed.
     """
     try:
         stat = path.stat()
@@ -182,32 +211,48 @@ def _store_identity(path: Path) -> tuple | None:
     return (str(path), stat.st_mtime_ns, stat.st_size)
 
 
-def _remember_locked(identity: tuple | None, store: dict[str, Any]) -> None:
+def _remember_locked(identity: tuple | None, raw: str, store: dict[str, Any]) -> None:
     """Make ``store`` the single cached entry, reachable only under ``identity``.
 
     Caller must hold :data:`_lock`. A None identity caches nothing, so the next
     :func:`_load` reads the file again instead of trusting memory.
+
+    Args:
+        identity: The stat tuple from :func:`_store_identity`, or None.
+        raw: The file contents ``store`` was parsed from - what :func:`_load`
+            compares against to decide a hit is still the file. Required
+            rather than defaulted, so a caller that cannot say what bytes it
+            holds fails here instead of caching an unverifiable entry.
+        store: The parsed store.
     """
     _cache.clear()
     if identity is not None:
-        _cache[identity] = store
+        _cache[identity] = _CachedStore(raw, store)
 
 
 def _load() -> dict[str, Any]:
-    """Read the store, re-reading the file whenever it changes on disk."""
+    """Read the store, serving memory only while the file still holds its bytes.
+
+    The cache spares a login the JSON parse, not the read: the read is what
+    establishes that the parse can be skipped. A stat tuple cannot establish it
+    - see :func:`_store_identity` for the two ways two contents come to share
+    one - and the store is the record that decides whether this dashboard is
+    sealed, so a hit is checked against the file rather than assumed.
+    """
     path = _store_path()
     with _lock:
         identity = _store_identity(path)
         if identity is not None:
-            cached = _cache.get(identity)
-            if cached is not None:
-                return cached
             try:
-                store: dict[str, Any] = json.loads(path.read_text())
+                raw = path.read_text()
+                cached = _cache.get(identity)
+                if cached is not None and cached.raw == raw:
+                    return cached.store
+                store: dict[str, Any] = json.loads(raw)
             except (OSError, ValueError) as exc:
                 _preserve_corrupt(path, exc)
             else:
-                _remember_locked(identity, store)
+                _remember_locked(identity, raw, store)
                 return store
         store = _default_store()
         _save_locked(store)
@@ -247,10 +292,11 @@ def _save_locked(store: dict[str, Any]) -> None:
     """
     path = _store_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(store, indent=2)
     fd, tmp = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=path.parent)
     try:
         with os.fdopen(fd, "w") as handle:
-            handle.write(json.dumps(store, indent=2))
+            handle.write(payload)
         os.replace(tmp, path)
     except BaseException:
         # Leave no debris behind a failed save: the store on disk is still
@@ -259,10 +305,12 @@ def _save_locked(store: dict[str, Any]) -> None:
         with contextlib.suppress(OSError):
             os.unlink(tmp)
         raise
-    # Re-key on the file just written. A store that vanished between the replace
-    # and this stat has no identity, so nothing is cached and the next _load
-    # re-reads - see _store_identity.
-    _remember_locked(_store_identity(path), store)
+    # Re-key on the file just written, under the payload that is now its
+    # contents. A store that vanished between the replace and this stat has no
+    # identity, so nothing is cached and the next _load re-reads - see
+    # _store_identity. A store somebody else rewrote in that window has other
+    # contents, so the next _load finds the bytes disagree and re-reads too.
+    _remember_locked(_store_identity(path), payload, store)
 
 
 def _save(store: dict[str, Any]) -> None:

--- a/tests/test_dashboard_auth_store_cache_is_keyed_on_the_file.py
+++ b/tests/test_dashboard_auth_store_cache_is_keyed_on_the_file.py
@@ -19,6 +19,11 @@ per process, so the bound is one entry -- and these cells grade both halves of
 that: the entry is replaced rather than accumulated, and two different store
 paths never answer for each other.
 
+What the identity cannot decide is graded here too: it names a file, not a
+version of it. `st_mtime_ns` comes from a coarse kernel clock and a rewrite of
+the same byte count keeps `st_size`, so two contents share one tuple -- which is
+why a hit is checked against the bytes the cached store was parsed from.
+
 The re-read-on-change and read-from-memory-on-hit behaviours are graded by
 `test_dashboard_auth_module.py::test_store_hot_reloads_on_file_change` and
 `test_dashboard_auth_store_write_is_atomic.py::TestWhatTheAtomicWriteDoesNotChange`
@@ -26,6 +31,7 @@ and are deliberately not repeated here.
 """
 
 import json
+import os
 
 import pytest
 
@@ -71,6 +77,37 @@ class TestTheCacheIsBounded:
             assert auth._load()["note"] == f"outside-{i}", "an outside change is re-read"
 
         assert len(auth._cache) == 1, f"8 outside changes left {len(auth._cache)} cached entries, want 1"
+
+
+class TestAHitIsTheBytesOnDisk:
+    """The tuple says which file; only the bytes say what is in it."""
+
+    def test_a_same_size_rewrite_under_an_unchanged_stat_tuple_is_re_read(self, tmp_path):
+        """Two contents can share one identity tuple, so the tuple cannot license a hit.
+
+        ``os.utime`` only makes the collision deterministic on every filesystem; it
+        arrives on its own, because the kernel stamps ``st_mtime_ns`` from a coarse
+        clock and a rewrite of the same byte count leaves ``st_size`` alone -- eight
+        successive same-size rewrites of a store on ext4 share one tuple.
+
+        What rides on it is a revocation. The operator rewrites the store to retire a
+        passkey record, and under a stat-only hit the process goes on honouring the
+        retired one -- not until the next write, but for good, because the identity it
+        is cached under never changes again.
+        """
+        path = tmp_path / "auth.json"
+        auth._save({"credentials": [{"id": "keyAAAA"}], "jwt_secret": "s"})
+        assert auth._load()["credentials"] == [{"id": "keyAAAA"}]
+        before = path.stat()
+
+        # Same length by construction, so st_size cannot betray the rewrite either.
+        path.write_text(path.read_text().replace("keyAAAA", "keyBBBB"))
+        os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+        assert path.stat().st_size == before.st_size, "the rewrite kept the byte count"
+        assert path.stat().st_mtime_ns == before.st_mtime_ns, "and the mtime"
+
+        assert auth._load()["credentials"] == [{"id": "keyBBBB"}], "the file on disk is what is served"
+        assert len(auth._cache) == 1, "the entry is replaced, not given up on"
 
 
 class TestOneStoreNeverAnswersForAnother:

--- a/tests/test_dashboard_auth_store_write_is_atomic.py
+++ b/tests/test_dashboard_auth_store_write_is_atomic.py
@@ -204,16 +204,20 @@ class TestWhatTheAtomicWriteDoesNotChange:
         auth._save({"credentials": [], "jwt_secret": "s"})
         assert json.loads(nested.read_text())["jwt_secret"] == "s"
 
-    def test_the_cache_is_updated_so_the_next_read_needs_no_disk(self, tmp_path, monkeypatch):
-        """A save leaves the store readable without touching the file's contents again.
+    def test_the_cache_is_updated_so_the_next_read_needs_no_parse(self, tmp_path, monkeypatch):
+        """A save leaves the store readable without parsing the file again.
 
-        Asserted by making a body read fail: the store is still stat-ed, because that is what
-        detects a file somebody else changed, but on a hit its contents come from memory.
+        Asserted by making the parse fail: on a hit the store comes from memory. The body
+        is still read, and that read is what licenses skipping the parse - a stat tuple
+        cannot, because it names the file rather than a version of it (two writes inside
+        one coarse-clock mtime tick that keep the byte count share one). This cell asked
+        for no read at all while the tuple was trusted to have changed; what it grades
+        now is the work the cache actually saves.
         """
         auth._save({"credentials": [], "jwt_secret": "cached"})
 
-        def no_reads(self, *a, **k):
-            raise AssertionError(f"read the store body on a cache hit: {self}")
+        def no_parse(*a, **k):
+            raise AssertionError("parsed the store body on a cache hit")
 
-        monkeypatch.setattr(auth.Path, "read_text", no_reads)
+        monkeypatch.setattr(auth.json, "loads", no_parse)
         assert auth._load()["jwt_secret"] == "cached"


### PR DESCRIPTION
![before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/auth-store-bytes/auth-store-bytes.png)

## The tuple names a file, not a version of it

`auth._load` caches the credential store under `(path, st_mtime_ns, st_size)`. Two different contents share that tuple routinely:

- the kernel stamps `st_mtime_ns` from a **coarse clock**, so writes inside one tick are stamped alike;
- a rewrite that keeps the byte count keeps `st_size`.

Measured on ext4: eight successive `write_text` calls of the same length produce **one distinct `st_mtime_ns`** between them. Under a stat-only hit the first edit is the last one seen -- and not transiently. The identity never changes again, so the stale entry is served for the life of the process, on the file that decides whether the dashboard is sealed. The right panel above is that loop: the operator's eight edits land on disk, the process keeps answering with the pre-edit store.

What rides on it is a revocation. An operator rewriting the store to retire a passkey record, or rotating `jwt_secret` for one of the same length, is making a same-size edit -- exactly the shape the tuple cannot see.

`tests/test_dashboard_auth_store_cache_is_keyed_on_the_file.py::TestTheCacheIsBounded::test_a_re_read_after_an_outside_change_does_not_accumulate_entries` already asserted "an outside change is re-read" and was **failing on `main`** on any filesystem where that loop collides.

## The change

The cached entry carries the bytes it was parsed from (`_CachedStore(raw, store)`), and a hit is served only while the file still holds them. Nothing else moves: the identity stays the key, the cache stays at one entry, the atomic writer re-keys under the payload it just wrote.

The read stays; the parse is what the cache saves, and the read is what licenses skipping it. No stat field can substitute -- `st_ctime_ns` comes from the same tick and `st_ino` is unchanged by an in-place rewrite -- so the bytes are the only available authority.

| | before | after |
|---|---|---|
| no rewrite (a hit) | serves the file | serves the file |
| rewrite, size differs | serves the file | serves the file |
| same size, later mtime tick | serves the file | serves the file |
| same size, same mtime tick | **serves the retired record** | serves the file |
| same size, stat tuple identical | **serves the retired record** | serves the file |

## Tests

`TestAHitIsTheBytesOnDisk::test_a_same_size_rewrite_under_an_unchanged_stat_tuple_is_re_read` pins it deterministically: a same-length rewrite plus `os.utime` back to the recorded `st_mtime_ns`, so the collision reproduces on every filesystem rather than only where the tick happens to land. It also asserts the cache still holds one entry -- the fix is verification, not giving up on caching.

Pre-fix, new cells against `main`: **2 failed, 15 passed** (the new pin, and the cell that was already red). Post-fix: **17 passed**. Dashboard suite: `1 failed / 287 passed` -> **`0 failed / 289 passed`**.

One existing cell changed, because its stated premise is the defect. `test_the_cache_is_updated_so_the_next_read_needs_no_disk` asserted that a hit reads nothing, on the reasoning that "the store is still stat-ed, because that is what detects a file somebody else changed". The stat does not detect it. The cell is kept and now grades the work the cache really saves -- a hit performs no parse -- so a future change that stops caching after a save still fails here. It passes on both trees.

Source and tests are `+120 / -31`, plus a 20-line changelog fragment. `strands_robots/dashboard/auth.py` is `+71 / -23`, of which the executable delta is **+5 statements** (395 -> 400) -- the rest is the comment block and docstrings recording why a stat tuple cannot license a hit.

Whole-tree grader preflight: `13 failed / 4196 passed / 4 errors`, the 17 failing node ids **set-identical** on this branch and on `main`. `ruff check`, `ruff format --check` clean; `mypy` unchanged at its 20 pre-existing errors in 6 files, none in these paths.