### PR TITLE
fix(registry): a cached registry is served only while its files hold the bytes it was parsed from

### DIFF
--- a/changelog.d/3145-registry-cache-keyed-on-contents.md
+++ b/changelog.d/3145-registry-cache-keyed-on-contents.md
@@ -1,0 +1,25 @@
+### Fixed: the registry hot-reload cache is keyed on file contents, not a timestamp
+
+The `robots` registry is the package `robots.json` merged with the user overlay
+`user_robots.json`, and the loader cached that merge keyed on both files'
+`st_mtime`. The kernel stamps mtime from a coarse clock (4 ms on ext4), so two
+writes inside one tick carry the same timestamp - and it never changes again,
+so the first write's contents were served for the life of the process. There
+was no size in the signature either, so an edit that changed the file's length
+was invisible too: 58 of 60 rounds of "write the overlay, read, write it again"
+never observed the second edit. `register_robot` from a second process is that
+sequence.
+
+The signature is now the bytes of both files, and the overlay is parsed from
+the bytes the signature was taken from rather than re-read, so the cached merge
+and its key always describe the same overlay. The cache still skips the parse,
+the merge and the uniqueness validation for an unchanged registry - two reads
+add about 11 us per lookup and avoid about 164 us of work.
+
+`registry.user_registry_mtime()` is replaced by `registry.user_registry_source()`
+(the file's bytes) plus `registry.parse_user_robots(source)` (the parse), so one
+read feeds both the cache key and the cached value.
+
+A corrupt overlay whose bytes are not valid UTF-8 no longer raises
+`UnicodeDecodeError` out of `get_robot()`; undecodable bytes are ignored like
+truncated JSON already was.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,6 +31,7 @@ from strands_robots.registry import (
     list_robots, resolve_name, get_robot, has_sim, has_hardware, get_hardware_type,
     list_robots_by_category, list_aliases, format_robot_table,
     register_robot, unregister_robot, list_user_robots,
+    user_registry_source, parse_user_robots,
     list_policy_providers, resolve_policy, import_policy_class, build_policy_kwargs,
 )
 ```
@@ -48,6 +49,8 @@ from strands_robots.registry import (
 | `register_robot(name, entry)` | Add user-defined robot at runtime. |
 | `unregister_robot(name)` | Remove a runtime-registered robot. |
 | `list_user_robots()` | Names from `register_robot`. |
+| `user_registry_source()` | Raw bytes of `user_robots.json`, or `None` when absent. What the loader keys its hot-reload cache on, so an edit by another writer is seen even when it lands inside one filesystem timestamp tick. |
+| `parse_user_robots(source)` | Robot definitions held in those bytes; empty when absent or malformed. Parsing the bytes the cache was keyed on is what keeps the cached merge and the key describing the same overlay. |
 | `list_policy_providers()` | Providers from `policies.json`, canonical names only. |
 | `list_policy_aliases()` | Alias/shorthand -> canonical provider, from `policies.json`. Peer of `list_aliases()` for robots. |
 | `resolve_policy(uri)` | URI → provider name. |

--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -63,9 +63,10 @@ from .robots import (
 )
 from .user_registry import (
     list_user_robots,
+    parse_user_robots,
     register_robot,
     unregister_robot,
-    user_registry_mtime,
+    user_registry_source,
 )
 
 __all__ = [
@@ -97,7 +98,8 @@ __all__ = [
     "register_robot",
     "unregister_robot",
     "list_user_robots",
-    "user_registry_mtime",
+    "user_registry_source",
+    "parse_user_robots",
     # Utilities
     "reload",
     "invalidate_cache",

--- a/strands_robots/registry/loader.py
+++ b/strands_robots/registry/loader.py
@@ -1,4 +1,4 @@
-"""JSON registry loader with mtime-based hot-reload and validation.
+"""JSON registry loader with content-keyed hot-reload and validation.
 
 Loads robots.json and policies.json from the registry directory,
 re-reading only when the on-disk source changes.  Validates uniqueness of
@@ -7,11 +7,19 @@ aliases, shorthands, and URL patterns on every reload.
 The ``robots`` registry is not a single file: its effective contents are the
 package ``robots.json`` merged with the user-local overlay
 (``$STRANDS_BASE_DIR/user_robots.json`` - see :func:`_merge_user_robots`).  The
-hot-reload signature therefore tracks the mtimes of *both* files, so an edit to
-the user overlay made outside this process (a second process, a manual edit, or
-any writer that does not call :func:`invalidate_cache`) is picked up on the next
+hot-reload signature therefore covers *both* files, so an edit to the user
+overlay made outside this process (a second process, a manual edit, or any
+writer that does not call :func:`invalidate_cache`) is picked up on the next
 read - honoring the "re-read when the source changes" contract for the overlay
 just as for the package file.
+
+The signature is the file *contents*, not a stat.  A timestamp cannot express
+"the source changed": the kernel stamps ``st_mtime`` from a coarse clock, so
+two writes inside one tick share a timestamp and the second one is invisible -
+permanently, because that timestamp never changes again.  The bytes are the
+only field that always differs when the contents differ, so a cached value is
+served only while the file still holds the bytes it was parsed from.  The read
+is what licenses the hit; the parse and validation are the work it saves.
 """
 
 import json
@@ -22,36 +30,36 @@ logger = logging.getLogger(__name__)
 
 _REGISTRY_DIR = Path(__file__).parent
 _cache: dict[str, dict] = {}
-# Cache-validity signature per registry (a tuple of mtimes).  For ``robots``
-# the signature is (package_mtime, user_overlay_mtime_or_None); for every other
-# registry it is (package_mtime,).
-_mtimes: dict[str, tuple] = {}
+# Cache-validity signature per registry: the bytes the cached value was parsed
+# from.  For ``robots`` the signature is (package_source, overlay_source_or_None);
+# for every other registry it is (package_source,).
+_sources: dict[str, tuple] = {}
 
 
-def _user_registry_mtime() -> float | None:
-    """Modification time of the user-local robot overlay, or None if absent.
+def _user_registry_source() -> bytes | None:
+    """Contents of the user-local robot overlay, or None if absent.
 
     Kept in :mod:`user_registry` so the overlay path has a single source of
     truth; imported lazily to avoid an import cycle (``user_registry`` imports
     :func:`invalidate_cache` from this module).
     """
     try:
-        from .user_registry import user_registry_mtime
+        from .user_registry import user_registry_source
     except ImportError:
         return None
-    return user_registry_mtime()
+    return user_registry_source()
 
 
-def _registry_signature(name: str, pkg_mtime: float) -> tuple:
-    """Cache-validity signature for a registry.
+def _registry_signature(name: str, package_source: bytes) -> tuple:
+    """Cache-validity signature for a registry: the bytes it is parsed from.
 
     The ``robots`` registry merges the user overlay on top of the package JSON,
-    so its signature includes the overlay's mtime - otherwise an external edit
-    to ``user_robots.json`` would never invalidate the cached merge.
+    so its signature includes the overlay's contents - otherwise an external
+    edit to ``user_robots.json`` would never invalidate the cached merge.
     """
     if name != "robots":
-        return (pkg_mtime,)
-    return (pkg_mtime, _user_registry_mtime())
+        return (package_source,)
+    return (package_source, _user_registry_source())
 
 
 def _load(name: str) -> dict:
@@ -65,39 +73,47 @@ def _load(name: str) -> dict:
     """
     path = _REGISTRY_DIR / f"{name}.json"
     try:
-        pkg_mtime = path.stat().st_mtime
+        package_source = path.read_bytes()
     except FileNotFoundError:
         logger.error("Registry file not found: %s", path)
         return {}
 
-    signature = _registry_signature(name, pkg_mtime)
-    if name not in _cache or _mtimes.get(name) != signature:
-        with open(path, encoding="utf-8") as f:
-            data = json.load(f)
+    signature = _registry_signature(name, package_source)
+    if name not in _cache or _sources.get(name) != signature:
+        data = json.loads(package_source)
 
-        # Merge user-local robot registry (overlay on top of package JSON)
+        # Merge user-local robot registry (overlay on top of package JSON).
+        # Parsed from the bytes the signature was taken from, so the cached
+        # merge and the signature can never describe different overlay states.
         if name == "robots":
-            data = _merge_user_robots(data)
+            _, overlay_source = signature
+            data = _merge_user_robots(data, overlay_source)
 
         _validate(name, data)
         _cache[name] = data
-        _mtimes[name] = signature
-        logger.debug("Loaded registry: %s (%d bytes)", path, path.stat().st_size)
+        _sources[name] = signature
+        logger.debug("Loaded registry: %s (%d bytes)", path, len(package_source))
 
     return _cache[name]
 
 
-def _merge_user_robots(data: dict) -> dict:
+def _merge_user_robots(data: dict, overlay_source: bytes | None) -> dict:
     """Merge user-local robot registry on top of package robots.json.
 
     User entries override package entries on name collision.
+
+    Args:
+        data: Parsed package ``robots.json``.
+        overlay_source: Contents of ``user_robots.json``, or None when the
+            overlay is absent.  Taken from the caller rather than re-read so
+            the merged value and the cache signature describe the same bytes.
     """
     try:
-        from .user_registry import get_user_robots
+        from .user_registry import parse_user_robots
     except ImportError:
         return data
 
-    user_robots = get_user_robots()
+    user_robots = parse_user_robots(overlay_source)
     if not user_robots:
         return data
 
@@ -130,7 +146,7 @@ def _validate_robots(data: dict) -> None:
             robot name, or a ``hardware.driver`` outside
             :data:`~strands_robots.drivers.base.DRIVER_CHOICES`.
     """
-    # Imported lazily for the same reason as :func:`_user_registry_mtime` above:
+    # Imported lazily for the same reason as :func:`_user_registry_source` above:
     # the driver seam reads the registry, so importing it at module scope would
     # close an import cycle. A driver name is validated here rather than where it
     # is read, because every reader - the factory, a tool, a driver package -
@@ -204,9 +220,9 @@ def _validate_policies(data: dict) -> None:
 
 
 def reload() -> None:
-    """Force-reload all registry files (clears mtime cache)."""
+    """Force-reload all registry files (clears the cached sources)."""
     _cache.clear()
-    _mtimes.clear()
+    _sources.clear()
 
 
 def invalidate_cache(name: str | None = None) -> None:
@@ -217,7 +233,7 @@ def invalidate_cache(name: str | None = None) -> None:
     """
     if name is None:
         _cache.clear()
-        _mtimes.clear()
+        _sources.clear()
     else:
         _cache.pop(name, None)
-        _mtimes.pop(name, None)
+        _sources.pop(name, None)

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -57,19 +57,44 @@ def _get_user_registry_path() -> Path:
     return get_base_dir() / "user_robots.json"
 
 
-def user_registry_mtime() -> float | None:
-    """Modification time of the user-local robot registry file.
+def user_registry_source() -> bytes | None:
+    """Contents of the user-local robot registry file.
 
     Returns:
-        The file's ``st_mtime``, or ``None`` when the overlay file does not
-        exist yet. Used by the loader's mtime hot-reload so an external edit to
-        ``user_robots.json`` (a second process or a manual edit) invalidates the
-        merged ``robots`` cache without requiring a manual ``invalidate_cache``.
+        The file's bytes, or ``None`` when the overlay does not exist yet or
+        cannot be read. This is what the loader keys its hot-reload cache on, so
+        an external edit to ``user_robots.json`` (a second process or a manual
+        edit) invalidates the merged ``robots`` cache without requiring a manual
+        ``invalidate_cache`` - including an edit that lands inside one
+        filesystem timestamp tick, which a stat cannot distinguish.
     """
     try:
-        return _get_user_registry_path().stat().st_mtime
+        return _get_user_registry_path().read_bytes()
     except OSError:
         return None
+
+
+def parse_user_robots(source: bytes | None) -> dict[str, Any]:
+    """Robot definitions held in raw user-overlay bytes.
+
+    Args:
+        source: Contents of ``user_robots.json``, or None when the overlay is
+            absent. Taken as bytes so a caller that keys a cache on the file's
+            contents parses exactly what it keyed on.
+
+    Returns:
+        Dict mapping robot names to their definitions; empty when the overlay
+        is absent, unreadable, or does not declare ``"robots"``.
+    """
+    if source is None:
+        return {}
+    try:
+        data = json.loads(source)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("Failed to load user registry %s: %s", _get_user_registry_path(), exc)
+        return {}
+    robots = data.get("robots") if isinstance(data, dict) else None
+    return robots if isinstance(robots, dict) else {}
 
 
 def _load_user_registry() -> dict[str, Any]:
@@ -78,18 +103,7 @@ def _load_user_registry() -> dict[str, Any]:
     Returns:
         Dict with ``"robots"`` key mapping names to robot definitions.
     """
-    path = _get_user_registry_path()
-    if not path.exists():
-        return {"robots": {}}
-    try:
-        with open(path, encoding="utf-8") as f:
-            data = json.load(f)
-        if "robots" not in data:
-            data = {"robots": {}}
-        return data
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Failed to load user registry %s: %s", path, exc)
-        return {"robots": {}}
+    return {"robots": parse_user_robots(user_registry_source())}
 
 
 def _save_user_registry(data: dict[str, Any]) -> None:
@@ -108,7 +122,7 @@ def get_user_robots() -> dict[str, Any]:
     Returns:
         Dict mapping robot names to their definitions.
     """
-    return _load_user_registry().get("robots", {})
+    return parse_user_robots(user_registry_source())
 
 
 def register_robot(

--- a/tests/registry/test_public_member_docstrings.py
+++ b/tests/registry/test_public_member_docstrings.py
@@ -73,10 +73,11 @@ _EXPECTED_FUNCTIONS = {
     "robots.py::list_robots_by_category",
     "robots.py::resolve_name",
     "user_registry.py::get_user_robots",
+    "user_registry.py::parse_user_robots",
     "user_registry.py::list_user_robots",
     "user_registry.py::register_robot",
     "user_registry.py::unregister_robot",
-    "user_registry.py::user_registry_mtime",
+    "user_registry.py::user_registry_source",
 }
 
 

--- a/tests/registry/test_user_overlay_hot_reload.py
+++ b/tests/registry/test_user_overlay_hot_reload.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 import os
 
-from strands_robots.registry import get_robot, list_robots
+from strands_robots.registry import get_robot, list_robots, loader
 from strands_robots.utils import get_base_dir
 
 
@@ -84,3 +84,87 @@ def test_external_overlay_deletion_is_picked_up():
     assert get_robot("ext_deleted") is None, "external overlay deletion was not picked up (stale cache)"
     # Package robots are unaffected by the overlay churn.
     assert any(r["name"] == "so101" for r in list_robots())
+
+
+class TestAnOverlayEditInsideOneTimestampTickIsSeen:
+    """The tests above step the clock; a real writer does not.
+
+    ``test_external_overlay_modification_is_picked_up`` advances the overlay's
+    mtime by ten seconds "so the change is unambiguous regardless of filesystem
+    timestamp granularity" - which grades the reload while stepping around the
+    only case where a timestamp cannot express it.  The kernel stamps mtime from
+    a coarse clock (4 ms on ext4 here), so two writes inside one tick carry the
+    same timestamp, and that timestamp never changes again: a signature that
+    cannot see the second write serves the first one for the life of the
+    process.  Two processes registering robots a millisecond apart is exactly
+    that shape.
+
+    The tick is pinned with ``os.utime`` rather than raced for, so the cells are
+    deterministic on any filesystem: a real writer produces this state whenever
+    its two writes land in one tick, which is the common case, not the corner.
+    """
+
+    @staticmethod
+    def _rewrite_without_advancing_the_clock(robots: dict) -> None:
+        """Rewrite the overlay and restore the timestamp it had beforehand."""
+        path = _overlay_path()
+        before = path.stat()
+        _write_overlay(robots)
+        os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+        after = path.stat()
+        assert after.st_mtime_ns == before.st_mtime_ns, "the timestamp must be unchanged"
+
+    def test_a_same_size_rewrite_in_one_tick_is_picked_up(self):
+        """The overlay is re-read even when neither timestamp nor size moved.
+
+        Rotating one entry's value for another of equal length is what a
+        rename or a re-registration looks like on disk, and it leaves every
+        stat field identical.
+        """
+        _write_overlay({"tick_same": _entry("aaaa")})
+        assert get_robot("tick_same")["description"] == "aaaa"  # warm the cache
+
+        before = _overlay_path().stat()
+        self._rewrite_without_advancing_the_clock({"tick_same": _entry("bbbb")})
+        assert _overlay_path().stat().st_size == before.st_size, "the size must be unchanged too"
+
+        assert get_robot("tick_same")["description"] == "bbbb", (
+            "a same-tick overlay edit was not picked up (stale cache)"
+        )
+
+    def test_a_new_entry_added_in_one_tick_is_picked_up(self):
+        """A longer overlay is re-read too, so size is no substitute for it."""
+        _write_overlay({"tick_first": _entry("first")})
+        assert get_robot("tick_first") is not None  # warm the cache
+
+        self._rewrite_without_advancing_the_clock(
+            {"tick_first": _entry("first"), "tick_second": _entry("added in the same tick")}
+        )
+
+        got = get_robot("tick_second")
+        assert got is not None, "a robot registered in the same tick was not picked up (stale cache)"
+        assert got["description"] == "added in the same tick"
+
+    def test_an_unchanged_overlay_is_neither_reparsed_nor_revalidated(self, monkeypatch):
+        """Reading the source is what licenses the hit; the parse is what it saves.
+
+        Keying on contents costs one read per lookup and must still skip the
+        JSON parse, the overlay merge and the uniqueness validation - otherwise
+        the fix would have traded a stale cache for no cache.
+        """
+        _write_overlay({"tick_cached": _entry("once")})
+        assert get_robot("tick_cached") is not None  # warm the cache
+
+        validated: list[str] = []
+        real_validate = loader._validate
+
+        def counting_validate(name: str, data: dict) -> None:
+            validated.append(name)
+            real_validate(name, data)
+
+        monkeypatch.setattr(loader, "_validate", counting_validate)
+
+        for _ in range(5):
+            assert get_robot("tick_cached")["description"] == "once"
+
+        assert validated == [], "an unchanged registry must be served from cache, not reparsed"

--- a/tests/registry/test_user_registry.py
+++ b/tests/registry/test_user_registry.py
@@ -291,6 +291,18 @@ class TestPersistence:
         path.write_text("NOT JSON!!!")
         assert _load_user_registry() == {"robots": {}}
 
+    def test_bytes_that_are_not_utf8_return_empty(self):
+        """A corrupt overlay is ignored however it is corrupt.
+
+        Truncated JSON and undecodable bytes are the same failure to a reader -
+        the file does not hold robot definitions - so an overlay written by a
+        crashed writer must not raise out of ``get_robot()``.
+        """
+        path = _get_user_registry_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b'{"robots": {"\xff\xfe": {}}}')
+        assert _load_user_registry() == {"robots": {}}
+
     def test_valid_json_without_robots_key_returns_empty(self):
         path = _get_user_registry_path()
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -311,7 +323,7 @@ class TestLoaderMerge:
 
         data = {"robots": {"fake": {"description": "test"}}}
         with mock.patch.dict("sys.modules", {"strands_robots.registry.user_registry": None}):
-            result = _merge_user_robots(data)
+            result = _merge_user_robots(data, None)
         assert "fake" in result["robots"]
 
 

--- a/tests/test_driver_seam.py
+++ b/tests/test_driver_seam.py
@@ -556,7 +556,7 @@ class TestARegistryDeclarationIsValidated:
         from strands_robots.registry import loader as loader_mod
 
         source = inspect.getsource(loader_mod._load)
-        merge_at = source.index("_merge_user_robots(data)")
+        merge_at = source.index("_merge_user_robots(data")
         validate_at = source.index("_validate(name, data)")
         assert merge_at < validate_at, (
             "the user overlay must be merged before validation, or a driver typo in user_robots.json is never graded"

--- a/tests/test_user_registry.py
+++ b/tests/test_user_registry.py
@@ -339,7 +339,7 @@ class TestLoaderMerge:
 
         data = {"robots": {"fake": {"description": "test"}}}
         with mock.patch.dict("sys.modules", {"strands_robots.registry.user_registry": None}):
-            result = _merge_user_robots(data)
+            result = _merge_user_robots(data, None)
         assert "fake" in result["robots"]
 
 


### PR DESCRIPTION
The `robots` registry the read API serves is the package `robots.json` merged with the user overlay `$STRANDS_BASE_DIR/user_robots.json`. The loader cached that merge and keyed the cache on `(st_mtime, overlay_st_mtime)`.

A timestamp cannot express "the source changed". The kernel stamps mtime from a coarse clock, so two writes inside one tick carry the same one - and that timestamp never changes again, so the first write's contents are served for the life of the process. There is no size in the signature either, so an edit that changes the file's *length* is invisible too.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/registry-content-keyed-cache/registry-content-keyed-cache.png)

## Measured

On ext4 here the tick is 4 ms. Eight rewrites of differing length in a tight loop produced **1** distinct `st_mtime` and **8** distinct `(st_mtime, st_size)` pairs.

Driving the real read API, 60 unpinned rounds of *write overlay, `get_robot()`, write overlay again*:

| | second edit never observed |
|---|---:|
| before | **58 / 60** |
| after | 0 / 60 |

No clock manipulation - `register_robot` from a second process writes the whole file per call, so two registrations a millisecond apart is this sequence exactly. Three of the five edit shapes in the figure were already correct before; the two that move are the ones inside one tick, and one of them changes the file's length.

## Change

The signature is the bytes, for both files. A cached value is served only while the files still hold what it was parsed from.

```python
def _registry_signature(name: str, package_source: bytes) -> tuple:
    if name != "robots":
        return (package_source,)
    return (package_source, _user_registry_source())
```

The overlay is then parsed *from the bytes the signature was taken from* rather than re-read, so the cached merge and its key can never describe different overlay states - verifying with a second read would reopen that window rather than close it.

No stat field substitutes. `st_ctime_ns` comes from the same tick; `st_ino` is unchanged by an in-place rewrite, which is how the writer writes. Adding `st_size` would have closed the two rows above but not the general case: a same-length rewrite leaves every stat field identical.

The cache is verified, not abandoned. Per `_load('robots')`:

| | before | after |
|---|---:|---:|
| cache hit | 19 us | 30 us |
| cold reload (parse + merge + validate) | 186 us | 164 us |

The two reads add ~11 us and still avoid ~164 us of parse, merge and uniqueness validation. A test pins that an unchanged registry is neither reparsed nor revalidated.

## Surface

`user_registry_mtime()` (added for this signature) is replaced by `user_registry_source()` returning the bytes, plus `parse_user_robots(source)` for the parse - one helper out, the read/parse split in, so one read feeds both the key and the value. `_merge_user_robots` takes the overlay bytes as a **required** argument: a caller that forgets them now fails rather than silently merging an empty overlay.

Also fixed on the same read path: a corrupt overlay whose bytes are not UTF-8 raised `UnicodeDecodeError` out of `get_robot()`. The handler caught `JSONDecodeError` and `OSError`, and `UnicodeDecodeError` is neither, so a file from a crashed writer took down every registry lookup. Truncated JSON and undecodable bytes are the same failure to a reader and are now treated alike.

## Tests

`tests/registry/test_user_overlay_hot_reload.py` already claimed to pin create / modify / delete of the overlay - but its modify cell advances mtime by ten seconds "so the change is unambiguous regardless of filesystem timestamp granularity", stepping around the only case a timestamp cannot express. That cell is kept as the coarse control; three cells are added beside it, with the tick pinned via `os.utime` so they are deterministic on any filesystem.

On pristine `main`: **2 failed / 4 passed** in that file - the two same-tick cells red, the reparse bound and the three original cells green as controls. The UTF-8 cell is a third pre-fix failure (`UnicodeDecodeError`) in `tests/registry/test_user_registry.py`. All green after.

`tests/test_driver_seam.py` reads the merge call out of the loader source to grade merge-before-validate ordering; its literal is widened to `_merge_user_robots(data` so it stays spelling-stable.

## Gate

| | base | branch |
|---|---|---|
| full `tests/` | 64 failed, 45882 passed, 427 skipped, 37 errors | 64 failed, **45886** passed, 427 skipped, 37 errors |

101 failure node ids, **set-identical** on both trees (absent `awsiot`, installed-lerobot drift - all pre-existing in this environment). The +4 are exactly the new cells. `tests/registry` + `test_user_registry` + `test_driver_seam` scoped: 920 -> 924. `ruff check` / `ruff format` clean; `mypy` unchanged at its existing 20 errors in 6 files, none in the touched files.

## LOC

Source `+89 -57`, tests `+102 -5`, docs `+3`, plus a 25-line changelog fragment. The source diff is mostly prose: AST executable statements across the three changed modules go **194 -> 193 (-1)**.

`docs/api-reference.md` gains the two new registry symbols.

## Round 1 - no code change

A `py/cyclic-import` thread opened on `loader.py:112` and is resolved with no edit, because it is not this branch's cycle. Alert **76** has carried the byte-identical message on `refs/heads/main` since **2026-05-21** at `loader.py:96` - the same import, in the same function, 16 lines higher. Renaming `get_user_robots` -> `parse_user_robots` moved the line, and baseline matching is positional, so it was reported as new in changed code.

The edge set is unchanged: two function-local `from .user_registry import` sites in `loader.py` on both trees (`main` 39/96, here 47/112). The flagged import is the mitigation - the cycle is closed by the module-scope `user_registry.py:50`, separately open as alert 79 - so hoisting it to module scope to satisfy the query is the one edit that would make the cycle load-bearing at import time.

The underlying class is now tracked as **#3146** (23 open alerts, 4 in this package) rather than fixed here, per the rule that a pre-existing alert is its own change against `main` and not an unplanned round on whichever pull request shifted its line.