### PR TITLE
fix(assets): a mesh scan is memoised for one pass, not for the process

### DIFF
--- a/changelog.d/3147-mesh-scan-memo.md
+++ b/changelog.d/3147-mesh-scan-memo.md
@@ -1,0 +1,20 @@
+### Fixed: a mesh scan is memoised for one resolution pass, not for the process
+
+`_has_meshes` cached its answer on `(directory, st_mtime)` while answering for
+the whole subtree. A directory's own `st_mtime` does not move when a file
+appears inside one of its subdirectories, so that key cannot observe the thing
+it caches, and no later `stat` can tell the two states apart.
+
+`resolve_model_path` is the caller that re-checks after `auto_download_robot`,
+and downloads land meshes in the subdirectory the MJCF declares through
+`<compiler meshdir=...>`. The re-check recomputed an identical key, was served
+the pre-download answer, and fell through to its "no meshes available"
+fallback - discarding a successful download and preferring a mesh-less
+candidate whose XML will fail to load in MuJoCo.
+
+The memo now belongs to the caller and spans a single pass over candidate
+locations, with a fresh one for the pass after a download. Caching is opt-in
+per scan, so it cannot outlive a change the resolver itself made. This keeps
+the saving the cache was justified by - candidates sharing a directory are
+walked once - and removes both the process-lifetime staleness and the
+unbounded growth that keying on a float mtime produced.

--- a/strands_robots/assets/manager.py
+++ b/strands_robots/assets/manager.py
@@ -86,28 +86,29 @@ def _auto_download_robot(name: str, info: dict) -> bool:
 
 _MESH_EXTS = frozenset({".stl", ".obj", ".msh", ".ply"})
 
-# Cache of (directory, mtime) -> has_meshes result. Avoids re-walking the tree
-# when ``resolve_model_path`` checks multiple candidate locations for the same
-# robot and when it re-checks after auto-download.
-_MESH_CACHE: dict[tuple[str, float], bool] = {}
 
-
-def _has_meshes(directory: Path) -> bool:
-    """Check if a directory tree contains mesh files (cached, early-exit).
+def _has_meshes(directory: Path, memo: dict[str, bool] | None = None) -> bool:
+    """Check whether a directory tree contains mesh files (early-exit).
 
     Uses ``os.scandir`` with an early break on the first mesh found rather
-    than ``rglob("*")``, which stats every file. Result is cached per
-    (directory, mtime) so repeated calls are free.
+    than ``rglob("*")``, which stats every file.
+
+    Args:
+        directory: Root of the tree to search.
+        memo: Optional per-scan cache of ``str(directory) -> result``, shared by
+              the caller across one pass over candidate locations. It is the
+              caller's job to scope it: a memo must not outlive the scan it was
+              created for, because a mesh landing anywhere in the subtree makes
+              every answer in it stale. Omitting it always walks the tree.
+
+    Returns:
+        True when a mesh file exists anywhere under *directory*.
     """
     if not directory.exists():
         return False
-    try:
-        cache_key = (str(directory), directory.stat().st_mtime)
-    except OSError:
-        cache_key = (str(directory), 0.0)
-    cached = _MESH_CACHE.get(cache_key)
-    if cached is not None:
-        return cached
+    key = str(directory)
+    if memo is not None and key in memo:
+        return memo[key]
 
     def _walk(path: str) -> bool:
         try:
@@ -123,8 +124,9 @@ def _has_meshes(directory: Path) -> bool:
             return False
         return False
 
-    result = _walk(str(directory))
-    _MESH_CACHE[cache_key] = result
+    result = _walk(key)
+    if memo is not None:
+        memo[key] = result
     return result
 
 
@@ -287,9 +289,12 @@ def resolve_model_path(
         return None
 
     # Prefer the candidate whose directory contains mesh files,
-    # because an XML without meshes will fail to load in MuJoCo.
+    # because an XML without meshes will fail to load in MuJoCo. The memo spans
+    # this pass alone, so two candidates that share a directory are walked once
+    # and the download below cannot be answered from a pre-download reading.
+    scan: dict[str, bool] = {}
     for path in candidates:
-        if _has_meshes(path.parent):
+        if _has_meshes(path.parent, scan):
             logger.debug("Resolved %s -> %s (has meshes)", name, path)
             return Path(path)
 
@@ -299,10 +304,13 @@ def resolve_model_path(
     if allow_download:
         logger.info("XML found for %s but no meshes, attempting auto-download...", name)
         if _auto_download_robot(name, info):
-            # Re-scan after download (new symlinks may have appeared)
+            # Re-scan after download (new symlinks may have appeared). A new
+            # memo, because the download is exactly the change the pass above
+            # could not have observed.
             refreshed = _resolve_candidates(asset_dir_name, xml_file, name)
+            rescan: dict[str, bool] = {}
             for path in refreshed:
-                if _has_meshes(path.parent):
+                if _has_meshes(path.parent, rescan):
                     logger.debug("Resolved %s -> %s (auto-downloaded)", name, path)
                     return Path(path)
 

--- a/tests/registry/test_discovery.py
+++ b/tests/registry/test_discovery.py
@@ -194,7 +194,6 @@ def test_resolve_model_path_uses_discovery_for_uncurated_robot(monkeypatch, tmp_
     (disc_dir / "discbot.xml").write_text(_MINIMAL_MJCF)
     monkeypatch.setenv("STRANDS_BASE_DIR", str(tmp_path))
     monkeypatch.setenv("STRANDS_ASSETS_DIR", str(assets_dir))
-    manager._MESH_CACHE.clear()
 
     synth = {
         "description": "discbot (discovered)",

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -9,7 +9,7 @@ a robot name to its MJCF model XML, directory, and availability status:
     - get_robot_info: enriched metadata with resolved path
     - list_available_robots: presence-filtered listing
     - path-traversal protection on registry-sourced path components
-    - _has_meshes: mesh detection with per-(dir, mtime) caching
+    - _has_meshes: mesh detection, with an optional per-scan memo
 
 These exercise observable behavior (returned paths, booleans, None) against a
 temp asset tree wired through STRANDS_ASSETS_DIR + the user registry, with no
@@ -43,10 +43,8 @@ def _isolate_assets(tmp_path, monkeypatch):
     monkeypatch.setenv("STRANDS_BASE_DIR", str(tmp_path))
     monkeypatch.setenv("STRANDS_ASSETS_DIR", str(assets_dir))
     _invalidate_cache()
-    manager._MESH_CACHE.clear()
     yield
     _invalidate_cache()
-    manager._MESH_CACHE.clear()
 
 
 def _register_bot(
@@ -213,27 +211,45 @@ class TestHasMeshes:
         (d / "meshes" / "link.obj").write_bytes(b"o")
         assert manager._has_meshes(d) is True
 
-    def test_result_is_cached_per_directory(self, tmp_path):
+    def test_a_memo_answers_a_repeat_of_the_same_directory(self, tmp_path):
+        """Within one scan the tree is walked once per directory.
+
+        This is the saving the memo exists for: ``resolve_model_path`` ranks
+        several candidate XMLs that can share a directory, and a mesh-less tree
+        is the case the walk cannot early-exit out of.
+        """
+        d = tmp_path / "cachedir"
+        d.mkdir()
+        memo: dict[str, bool] = {}
+        assert manager._has_meshes(d, memo) is False
+        assert memo == {str(d): False}
+        # A mesh arriving mid-scan is not re-walked: the memo is the answer.
+        (d / "late.stl").write_bytes(b"m")
+        assert manager._has_meshes(d, memo) is False
+
+    def test_a_scan_that_brings_no_memo_reads_the_tree(self, tmp_path):
+        """A mesh that appeared is observed even when no timestamp moved.
+
+        A directory's own ``st_mtime`` is held stable here, which is what a
+        write into one of its subdirectories does anyway. Mesh detection answers
+        from the tree, so nothing outside a caller-owned memo can go stale.
+        """
         d = tmp_path / "cachedir"
         d.mkdir()
         assert manager._has_meshes(d) is False
-        key = (str(d), d.stat().st_mtime)
-        assert manager._MESH_CACHE.get(key) is False
-        # Adding a mesh without busting the cache still returns the cached value
+        before = d.stat()
         (d / "late.stl").write_bytes(b"m")
-        os.utime(d, (d.stat().st_atime, key[1]))  # keep mtime stable
-        assert manager._has_meshes(d) is False
+        os.utime(d, ns=(before.st_atime_ns, before.st_mtime_ns))
+        assert d.stat().st_mtime_ns == before.st_mtime_ns
+        assert manager._has_meshes(d) is True
 
-    def test_stat_oserror_falls_back_to_stable_cache_key(self, tmp_path, monkeypatch):
+    def test_an_unstattable_directory_is_still_searched(self, tmp_path, monkeypatch):
         """A ``stat()`` failure after ``exists()`` must not crash mesh discovery.
 
-        There is a window between the ``directory.exists()`` guard and the
-        ``directory.stat().st_mtime`` cache-key read where the directory can
-        become un-stattable (a TOCTOU removal, or its permissions stripped).
-        Mesh detection degrades gracefully: it falls back to a stable
-        ``(path, 0.0)`` cache key and still walks the tree, rather than letting
-        the ``OSError`` escape and abort robot-asset resolution. Removing the
-        fallback would let the ``stat()`` raise propagate and break this.
+        A directory can become un-stattable between the ``exists()`` guard and
+        any later read of it (a TOCTOU removal, or its permissions stripped).
+        Mesh detection asks the tree and never the clock, so there is no
+        timestamp read left on this path for such a failure to escape from.
         """
         d = tmp_path / "withmesh"
         (d / "meshes").mkdir(parents=True)
@@ -248,9 +264,6 @@ class TestHasMeshes:
         monkeypatch.setattr(Path, "stat", _raise_stat)
 
         assert manager._has_meshes(d) is True
-        # The fallback key (mtime pinned to 0.0) was used, so the walk result
-        # is memoised there and served from cache on the next call.
-        assert manager._MESH_CACHE.get((str(d), 0.0)) is True
 
 
 class TestAutoDownloadFallback:
@@ -347,7 +360,6 @@ class TestDownloadCanBeDeclined:
 
         monkeypatch.setattr(manager, "_auto_download_robot", lambda _n, _i: False)
         failed_download = manager.resolve_model_path("unitbot")
-        manager._MESH_CACHE.clear()
 
         attempts: list[str] = []
         monkeypatch.setattr(manager, "_auto_download_robot", self._recording_downloader(attempts))
@@ -653,13 +665,46 @@ class TestResolveModelPathEdges:
 
         def fake_download(_name, _info):
             (robot_dir / "link.stl").write_bytes(b"meshbytes")
-            # A real download writes new files; invalidate the stale mtime-keyed
-            # mesh cache so the post-download re-scan observes them.
-            manager._MESH_CACHE.clear()
             return True
 
         monkeypatch.setattr(manager, "_auto_download_robot", fake_download)
         assert manager.resolve_model_path("unitbot") == xml
+
+
+class TestDownloadIntoTheDeclaredMeshdir:
+    """A download that lands meshes below the model directory is not discarded.
+
+    ``<compiler meshdir="assets"/>`` puts meshes one level down, and
+    :func:`strands_robots.assets.download._mjcf_mesh_subdir` exists to place
+    them there. A POSIX directory's own ``st_mtime`` does not move when a file
+    appears inside one of its subdirectories, so a reading of the model
+    directory taken before the download cannot describe the tree after it.
+    """
+
+    def test_the_post_download_pass_prefers_the_dir_the_meshes_landed_in(self, tmp_path, monkeypatch):
+        # Two candidate locations for one robot. The mesh-less one is ranked
+        # first, so a stale mesh answer is visible in the resolved path rather
+        # than in a log line alone.
+        _register_bot(tmp_path / "assets")  # candidate 0, never gets meshes
+        proj = tmp_path / "proj"  # CWD/assets is the second search path
+        downloaded = proj / "assets" / "unitbot"
+        downloaded.mkdir(parents=True)
+        (downloaded / "unitbot.xml").write_text(_MINIMAL_MJCF)
+        (downloaded / "assets").mkdir()  # declared meshdir: pre-exists, empty
+        monkeypatch.chdir(proj)
+        before = downloaded.stat().st_mtime_ns
+
+        def fake_download(_name, _info):
+            (downloaded / "assets" / "pelvis.stl").write_bytes(b"meshbytes")
+            return True
+
+        monkeypatch.setattr(manager, "_auto_download_robot", fake_download)
+        resolved = manager.resolve_model_path("unitbot")
+
+        # The write was invisible to the model directory's own timestamp, which
+        # is what makes this deterministic rather than a clock race.
+        assert downloaded.stat().st_mtime_ns == before
+        assert resolved == downloaded / "unitbot.xml"
 
 
 class TestResolveModelDirEdges:


### PR DESCRIPTION
Closes #3144. Implements option 1 from that analysis (scope the memo to one resolution), which removes both defects it lists.

![before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-scan-memo/mesh-scan-memo.png)

## The defect

`_has_meshes` cached on `(str(directory), directory.stat().st_mtime)` but answers a question about the whole **subtree**. A POSIX directory's `st_mtime` moves only when its own entries change, so a mesh appearing inside an existing subdirectory is invisible to that key - and no later `stat` can distinguish the two states, so the pre-download answer is served for the life of the process.

That matters at the one call site that re-checks after writing: `resolve_model_path` reads `_has_meshes` over the candidates, calls `_auto_download_robot`, then re-reads. `robot_descriptions` lands meshes in the subdirectory the MJCF declares (`<compiler meshdir="assets"/>` - `download._mjcf_mesh_subdir` exists to resolve exactly that), so the re-check recomputes an identical key, is answered `False`, and falls through to

```python
logger.debug("Resolved %s -> %s (no meshes available)", name, candidates[0])
```

A successful download is discarded and the log states "no meshes available" about a tree that holds them.

## Measured

Two candidate locations for one robot, the mesh-less one ranked first, so a stale answer shows up in the resolved path and not only in a log line. 10 trials per row:

| download writes | model dir `st_mtime` | before | after |
|---|---|---|---|
| top level, later mtime tick | moved | resolved (0/10 discarded) | resolved |
| top level, same mtime tick | often unchanged | **discarded 6/10** | resolved |
| declared meshdir subdir, later tick | UNCHANGED | **discarded 10/10** | resolved |
| declared meshdir subdir, same tick | UNCHANGED | **discarded 10/10** | resolved |

The subdirectory rows are deterministic - the key cannot observe the write at all. The top-level row is the coarse-clock tie #3141/#3142 fixed elsewhere, and it flips run to run. The first row is the control that passes on both trees, which is what isolates the mechanism to the key rather than to the download.

## The change

The memo belongs to the caller and spans one pass over candidate locations:

```python
def _has_meshes(directory: Path, memo: dict[str, bool] | None = None) -> bool
```

`resolve_model_path` creates one for the ranking pass and a **new** one for the post-download pass, because the download is precisely the change the first pass could not have observed. Omitting the memo always walks the tree, so caching is opt-in per scan and cannot outlive the scan it was made for. The `st_mtime` read is gone, along with the `OSError` fallback that existed only to produce a cache key.

This keeps the only saving the old comment justified - candidates sharing a directory are walked once - and drops the process-lifetime staleness plus the unbounded growth that keying on a float mtime produced (an mtime in the key replaces nothing; it accumulates one entry per change).

Cost of no longer caching across calls, measured per scan: a mesh-bearing directory early-exits in **39.5 us** (91 entries), a mesh-less one walks fully in **459 us** (492 entries), against a **1.6 us** memo hit. Bounded, and negligible beside the MuJoCo model load that follows.

## Tests

3 new cells, 1 replaced. Pre-fix on this branch's tests against `main`: **3 failed, 74 passed**; after: **77 passed**.

- `TestDownloadIntoTheDeclaredMeshdir::test_the_post_download_pass_prefers_the_dir_the_meshes_landed_in` - end-to-end, and it asserts the model directory's `st_mtime_ns` is unchanged, so it pins the mechanism rather than racing a clock. Pre-fix it fails on the resolved path.
- `TestHasMeshes::test_a_scan_that_brings_no_memo_reads_the_tree` - a mesh that appeared is observed with the timestamp held stable.
- `TestHasMeshes::test_a_memo_answers_a_repeat_of_the_same_directory` - the saving is still pinned, now as a statement about the per-scan memo (this replaces `test_result_is_cached_per_directory`, which asserted the stale read was intended).
- `test_stat_oserror_falls_back_to_stable_cache_key` -> `test_an_unstattable_directory_is_still_searched`: same guarantee (a `stat()` failure cannot break mesh discovery), now structural, since no timestamp is read on this path.

Two call sites shed a workaround that was the tell: `test_auto_download_supplies_missing_meshes`'s fake download called `manager._MESH_CACHE.clear()` with the comment "invalidate the stale mtime-keyed mesh cache so the post-download re-scan observes them" - the test was doing for the resolver what the resolver could not do for itself. It passes on both trees without it.

## Gate

`ruff check` / `ruff format --check` clean on the touched files; `mypy strands_robots tests tests_integ` unchanged at its baseline (20 errors in 6 files, none here). Full `MUJOCO_GL=egl pytest tests/`: base **63 failed / 45928 passed / 37 errors**, this branch **63 failed / 45930 passed / 37 errors**, with the failing node-id sets **identical** (100 ids, all pre-existing environment gaps: absent `awsiot`, installed-lerobot drift). The +2 passes are the net new cells.

Size: `strands_robots/assets/manager.py` is +30/-22 raw and **151 -> 150 executable statements** (net -1); tests +69/-25 across two files, plus a 20-line changelog fragment.