### PR TITLE
fix(simulation): stop_recording accepts no destination it will not write

### DIFF
--- a/changelog.d/3148-stop-recording-takes-no-destination.md
+++ b/changelog.d/3148-stop-recording-takes-no-destination.md
@@ -1,0 +1,30 @@
+### Fixed: `stop_recording` accepts no destination it will not write
+
+`Simulation.stop_recording` took an `output_path` in its first positional slot
+and discarded it, documented as an unused legacy argument. The dataset root is
+chosen once, at `start_recording(root=...)`, and the recorder has been writing
+there for the whole episode, so by the time this call runs there is nothing left
+to redirect: a destination here can only be dropped.
+
+It was reachable from an agent. `output_path` is a published field of the
+simulation tool schema, and the dispatcher's unknown-parameter refusal reads the
+method signature -- so the field bound here, the dataset was finalized at the
+recorder's own root, and the call reported `status="success"` about a path that
+stayed empty. A positional python call was swallowed the same way, answering
+"Was not recording." to `stop_recording(some_path)`.
+
+Nothing else in the tree wanted the parameter: `describe()` already advertised
+the method as `(push_to_hub=..., bucket=..., run_id=...)`, and the schema field's
+own list of sinks names `render`, `export_xml` and the rollout drivers rather
+than this one. It is removed, so both entry points now refuse a destination --
+the dispatcher by name (`Unknown parameter 'output_path' for action
+'stop_recording'. Valid: ['bucket', 'push_to_hub', 'run_id']`), python with a
+`TypeError` -- and the refusal precedes dispatch, leaving an open recording
+intact rather than finalized elsewhere under a success. The API table in
+`docs/simulation/overview.md`, which advertised `output_path` as the method's
+only parameter, is corrected to the three keyword arguments it does take.
+
+Honouring the path instead of removing it would have been new behaviour rather
+than a fix: the parquet and per-camera MP4s are already on disk under the
+recorder's root, so a destination given at stop time could only mean a copy or a
+move.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -301,7 +301,7 @@ returns the spec dicts to copy/fork as a starting point for your own task.
 |--------|-------|
 | `start_recording(repo_id, task="", fps=30, ...)` | LeRobot v3 (parquet+MP4); requires `[lerobot]` extra |
 | `save_episode()` | Flush the current rollout as one episode; call once per `run_policy` to record N episodes instead of one merged episode |
-| `stop_recording(output_path=None)` | Finalise dataset (flushes any trailing rollout) |
+| `stop_recording(push_to_hub=False, bucket=None, run_id=None)` | Finalise dataset (flushes any trailing rollout) |
 | `get_recording_status` | Episode, frame count, output dir |
 | `start_cameras_recording(...)` | Plain MP4 via imageio-ffmpeg; `[sim-mujoco]` only, no lerobot |
 | `stop_cameras_recording` / `get_cameras_recording_status` | - |

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -879,7 +879,6 @@ class DatasetRecordingMixin:
 
     def stop_recording(
         self,
-        output_path: str | None = None,
         *,
         push_to_hub: bool = False,
         bucket: str | None = None,
@@ -904,8 +903,15 @@ class DatasetRecordingMixin:
         ``replay_episode`` and bare ``step`` loops do not, so recording around
         those produces zero frames and is reported as an error.
 
+        Takes no destination. The dataset root is chosen once, at
+        ``start_recording(root=...)``, and the recorder has been writing there
+        for the whole episode, so nothing is left here to redirect - an
+        ``output_path`` could only be discarded. Both entry points refuse one:
+        the agent dispatcher by name (``output_path`` is a published schema
+        field, so it used to bind here and be dropped), python with a
+        ``TypeError``.
+
         Args:
-            output_path: Unused legacy arg (kept for back-compat).
             push_to_hub: Publish to a versioned HF *dataset* repo (the finished
                 artifact). Overrides the ``push_to_hub`` set at start_recording.
                 Requires an open recording session; on the idle path this

--- a/tests/simulation/mujoco/test_stop_recording_finalize.py
+++ b/tests/simulation/mujoco/test_stop_recording_finalize.py
@@ -524,3 +524,56 @@ class TestStopRecordingParquetTruthGate:
         assert payload["episode_count"] == 0
         assert payload["episode_count_mismatch"] is True
         assert "parquet has 0" in result["content"][0]["text"]
+
+
+class TestStopRecordingNamesNoDestination:
+    """``stop_recording`` accepts no destination, because it writes to none.
+
+    The dataset root is chosen once, at ``start_recording(root=...)``, and the
+    recorder has been writing there for the whole episode - by the time this
+    call runs there is nothing left to redirect. An ``output_path`` was accepted
+    anyway, in the first positional slot, and discarded. That mattered on the
+    agent path: ``output_path`` is a PUBLISHED field of the simulation tool
+    schema, so ``_dispatch_action`` bound it by name (its unknown-parameter
+    refusal reads the method signature) and the call finalized the dataset at
+    the recorder's own root while reporting ``status="success"`` about a path
+    that stayed empty. Nothing else in the tree wanted the parameter:
+    ``describe()`` already advertised ``stop_recording`` as
+    ``(push_to_hub=..., bucket=..., run_id=...)``, and the schema field's own
+    list of sinks names ``render`` / ``export_xml`` / the rollout drivers and
+    not this one.
+    """
+
+    def test_the_agent_dispatcher_refuses_a_destination_by_name(self, recording_sim, tmp_path):
+        rec = _FakeRecorder()
+        _arm(recording_sim, rec)
+        asked = tmp_path / "somewhere" / "dataset"
+
+        result = recording_sim(action="stop_recording", output_path=str(asked))
+
+        assert result["status"] == "error"
+        assert "output_path" in result["content"][0]["text"]
+        assert not asked.exists()
+        # The refusal precedes dispatch, so the open recording is untouched -
+        # rather than finalized at another root under a success the caller reads
+        # as "written where I asked".
+        assert rec.calls == []
+        assert recording_sim._world._backend_state["recording"] is True
+
+    def test_the_python_path_names_no_positional_parameter(self, recording_sim):
+        # The first positional slot was the dead one, so any positional call -
+        # `stop_recording(repo_id)` mirroring start_recording, say - was
+        # swallowed and answered "Was not recording."
+        with pytest.raises(TypeError):
+            recording_sim.stop_recording("/tmp/a-destination-nothing-writes-to")
+
+    def test_the_advertised_bookkeeping_kwargs_still_reach_the_recorder(self, recording_sim):
+        # Control: the three surviving keyword arguments are unaffected, so the
+        # refusals above are about a destination and not about the call shape.
+        rec = _FakeRecorder(sync_result={"status": "success", "bucket_uri": "hf://org/buck/run1"})
+        _arm(recording_sim, rec)
+
+        result = recording_sim(action="stop_recording", bucket="org/buck", run_id="run1")
+
+        assert result["status"] == "success"
+        assert rec.sync_args == ("org/buck", "run1")


### PR DESCRIPTION
![what the caller asked for vs what happened](https://raw.githubusercontent.com/cagataycali/robots/artifacts/stop-recording-destination/stop_recording_destination.png)

`stop_recording` took an `output_path` in its first positional slot and discarded it - `Unused legacy arg (kept for back-compat)`. The dataset root is chosen once, at `start_recording(root=...)`, and the recorder has been writing there for the whole episode, so by the time this call runs there is nothing left to redirect: an `output_path` here can only be dropped.

It was reachable from an agent. `output_path` is a **published field of the simulation tool schema**, and `_dispatch_action`'s unknown-parameter refusal reads the method signature - so the field bound here, the dataset was finalized at the recorder's own root, and the call answered `status="success"` about a path that stayed empty.

## Measured, with a live recording open (20 frames, `root=/tmp/art-agent-*`)

| call | before | after |
|---|---|---|
| `sim(action="stop_recording", output_path=P)` | `success`, `P` does not exist | `error` - `Unknown parameter 'output_path' for action 'stop_recording'. Valid: ['bucket', 'push_to_hub', 'run_id']` |
| `sim.stop_recording(P)` | `success`, `"Was not recording."` | `TypeError: stop_recording() takes 1 positional argument but 2 were given` |
| `sim(action="stop_recording")` (control) | `success` | `success` |

On the agent path the refusal now precedes dispatch, so the open recording is left intact rather than finalized elsewhere under a success the caller reads as "written where I asked".

## Nothing in the tree wanted the parameter

- `describe()` already advertised `stop_recording` as `(push_to_hub=False, bucket=None, run_id=None) -> dict` - without it.
- The `output_path` schema field's own description enumerates its sinks: `render` (PNG), `export_xml` (MJCF), `run_policy` / `start_policy` / `eval_policy` / `evaluate_benchmark` (rollout MP4). Not this one.
- No caller in `strands_robots/`, `tests/`, `tests_integ/`, `examples/` or `docs/` passed it.

Only the signature and the docs API table disagreed; the table advertised `stop_recording(output_path=None)` as the method's *only* parameter and is corrected here.

Not honoured instead of removed because honouring it would be new behaviour, not a fix: the parquet and per-camera MP4s are already on disk under the recorder's root, so a destination given at stop time could only mean a copy or a move.

## The recording lifecycle is untouched

Full round trip on this branch - `start_recording(root=)` -> `run_policy(video=)` -> `save_episode()` -> `stop_recording()` -> reopen with `LeRobotDataset`: 90 frames, 1 episode, fps 30, `payload` and reopened dataset agreeing, plus a 252,671-byte MP4 (rollout in MuJoCo, headless EGL):

![rollout](https://raw.githubusercontent.com/cagataycali/robots/artifacts/stop-recording-destination/rollout.gif)

## Tests

Three cells in `tests/simulation/mujoco/test_stop_recording_finalize.py`, on the existing fake-recorder fixture (no `lerobot` extra needed):

- `test_the_agent_dispatcher_refuses_a_destination_by_name` - refused, names the field, asked-for path absent, `rec.calls == []`, recording still open. Pre-fix: `assert 'success' == 'error'`.
- `test_the_python_path_names_no_positional_parameter` - pre-fix: `DID NOT RAISE <class 'TypeError'>`.
- `test_the_advertised_bookkeeping_kwargs_still_reach_the_recorder` - the control; passes on both trees, so the two refusals above are about a destination and not about the call shape.

On pristine `main` the file is 2 failed / 30 passed; on this branch 32 passed.

## Size

`strands_robots/simulation/recording.py` +8/-2 (one signature line removed, a docstring paragraph replacing the `Unused legacy arg` line), `docs/simulation/overview.md` +1/-1, tests +53, plus a 30-line changelog fragment. Executable statements in the touched module: **325 -> 325** - the source change is a signature and its documentation, nothing else.