### PR TITLE
perf(ci): collect coverage on the PEP 669 core, not the C trace function

### DIFF
--- a/changelog.d/3149-coverage-runs-on-the-sysmon-core.md
+++ b/changelog.d/3149-coverage-runs-on-the-sysmon-core.md
@@ -1,0 +1,27 @@
+### Changed: coverage is collected on the PEP 669 core, not the C trace function
+
+`[tool.pytest.ini_options].addopts` carries `--cov=strands_robots`, so every run
+of the suite is an instrumented one and the tracer's cost is part of the job's
+wall clock. That cost had never been measured. Over 17,102 tests
+(`tests/{drivers,mesh,policies,training,rendering}`), same selection, same
+reports, one machine, only the core varying: 321.19 s uninstrumented, 567.36 s
+on the default `ctrace` core (+76.6%), 347.47 s on `sysmon` (+8.2%). The default
+core was spending more time than the tests it measured.
+
+`[tool.coverage.run] core = "sysmon"` now selects coverage.py's
+`sys.monitoring` core. The two report the same measurement, compared per file
+rather than by the summary percentage: the same 303 files, the same 51,904
+statements, the same 605 exclusions, 56% either way, and the same verdict
+(4 failed, 17102 passed, 36 skipped). Exactly one line differed, and it differs
+between two runs of the *same* core as well -- `strands_robots/drivers/g1.py`'s
+FSM-refresher join-timeout branch, whose execution depends on thread
+scheduling -- so it is a race in the code under test, not a disagreement
+between tracers.
+
+Nothing else changes: no dependency, no coverage lost, and
+`--cov-fail-under=80` is untouched. `branch` is deliberately absent from the new
+section, because the equivalence was measured for statements, which is what
+that gate grades; `tests/test_coverage_runs_on_the_sysmon_core.py` pins the
+selection behaviourally (coverage.py registers either as a `sys.monitoring`
+tool or as a trace function) and reports if `branch` or `concurrency` ever
+appears without the equivalence being re-measured.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,6 +25,13 @@ mkdocs build --strict                # CI gate
 
 CI runs `hatch run test -x --strict-markers`.
 
+Coverage is collected through PEP 669 (`sys.monitoring`) rather than the default
+C trace function - `core = "sysmon"` in `[tool.coverage.run]`. It reports the
+same line coverage at roughly a tenth of the cost (measured +8.2% against
++76.6% over 17,102 tests), so `--no-cov` above is a smaller win than it used to
+be. The setting is for line coverage only; enabling `branch` means re-measuring
+that equivalence first.
+
 ## Rules
 
 **Lazy imports** - heavy modules (`mujoco`, `lerobot`, `torch`, `zenoh`) must not load at top-level. Use PEP 562 `__getattr__`. Enforced by `tests/test_init.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -945,3 +945,31 @@ markers = [
     "molmoact2: requires lerobot >= 0.5.2 (from source) + the [molmoact2] extra (transformers, peft, scipy). Run with: pytest -m molmoact2",
     "rtps: requires cyclonedds ([ros2] extra) + a live ROS 2 peer (e.g. turtlesim) on the DDS domain. Run with: RTPS_LIVE=1 pytest -m rtps",
 ]
+
+[tool.coverage.run]
+# Collect line coverage through PEP 669 (`sys.monitoring`) instead of the
+# default C trace function. The two report the same measurement; what differs is
+# what it costs. Measured over 17,102 tests
+# (tests/{drivers,mesh,policies,training,rendering}), same selection, same
+# reports, one machine, only the core varying:
+#
+#     core                  wall clock   cost of measuring
+#     none (no --cov)          321.19 s   -
+#     ctrace (the default)     567.36 s   +76.6%
+#     sysmon                   347.47 s    +8.2%
+#
+# So the tracer, not the tests, was the larger half of the growth in an
+# instrumented run: sysmon returns 219.89 s of the 246.17 s the default core
+# spends. All three runs agreed on the verdict (4 failed, 17102 passed, 36
+# skipped) and the two instrumented runs agreed on the measurement - the same
+# 303 files, the same 51,904 statements, the same 605 exclusions, 56% either
+# way. Exactly one line differed, and it is one that also differs between two
+# runs of the *same* core: the FSM-refresher join-timeout branch in
+# `strands_robots/drivers/g1.py`, whose execution depends on thread scheduling.
+#
+# `branch` is deliberately absent. The equivalence above was measured for
+# statements, which is what `--cov-fail-under` in `[tool.pytest.ini_options]`
+# grades; turning branch coverage on means re-measuring before trusting this
+# core for it. `tests/test_coverage_runs_on_the_sysmon_core.py` pins both the
+# setting and that boundary.
+core = "sysmon"

--- a/tests/test_coverage_runs_on_the_sysmon_core.py
+++ b/tests/test_coverage_runs_on_the_sysmon_core.py
@@ -1,0 +1,146 @@
+"""The suite measures coverage with PEP 669, not with a C trace function.
+
+``[tool.pytest.ini_options].addopts`` carries ``--cov=strands_robots``, so every
+run of this suite is an instrumented one and the cost of *measuring* is part of
+the suite's wall clock. Measured over 17,102 tests
+(``tests/{drivers,mesh,policies,training,rendering}``), same selection, same
+reports, one machine, only the core varying:
+
+===================== ============ ==================
+core                  wall clock   cost of measuring
+===================== ============ ==================
+none (no ``--cov``)      321.19 s   -
+``ctrace`` (default)     567.36 s   +76.6%
+``sysmon``               347.47 s    +8.2%
+===================== ============ ==================
+
+The default core was therefore spending more time than the tests it measured.
+All three runs agreed on the verdict (4 failed, 17102 passed, 36 skipped) and
+the two instrumented runs agreed on the measurement: the same 303 files, the
+same 51,904 statements, the same 605 exclusions, 56% either way.
+
+What is pinned here is the *selection*, behaviourally rather than as a string in
+a file: coverage.py installs itself either as a ``sys.monitoring`` tool or as a
+trace function, and which one it chose is readable from the standard library.
+The control below derives its config from this repository's own by deleting the
+one setting, so a config that stops asking for the core is reported as the
+trace-function run it would become rather than passing on the literal's absence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+#: Start coverage under the given config and report how it installed itself.
+#: Run out of process: this suite is itself under coverage, and a second
+#: in-process ``Coverage`` would contend for the same monitoring tool id.
+_PROBE = """
+import json, sys, coverage
+cov = coverage.Coverage(config_file=sys.argv[1])
+cov.start()
+installed = {
+    "monitoring_tool": sys.monitoring.get_tool(sys.monitoring.COVERAGE_ID),
+    "has_trace_function": sys.gettrace() is not None,
+}
+cov.stop()
+print(json.dumps(installed))
+"""
+
+
+def _coverage_config() -> dict[str, object]:
+    """This repository's ``[tool.coverage.run]`` table."""
+    tool = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["tool"]
+    return dict(tool.get("coverage", {}).get("run", {}))
+
+
+def _how_coverage_installed_itself(config_file: Path) -> dict[str, object]:
+    """Whether coverage.py became a monitoring tool or a trace function."""
+    # The environment variable outranks the config file, so drop it: the
+    # question is what the *file* selects.
+    env = {k: v for k, v in os.environ.items() if k != "COVERAGE_CORE"}
+    done = subprocess.run(
+        [sys.executable, "-c", _PROBE, str(config_file)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return dict(json.loads(done.stdout))
+
+
+def _config_without_the_core(tmp_path: Path) -> Path:
+    """This repository's config with the one setting under test removed."""
+    lines = _PYPROJECT.read_text(encoding="utf-8").splitlines()
+    kept = [line for line in lines if line.strip() != 'core = "sysmon"']
+    # Compare counts, not the joined text: a trailing-newline difference would
+    # make a text comparison true even when nothing was removed.
+    assert len(kept) < len(lines), (
+        'the config no longer declares core = "sysmon", so the control removed '
+        "nothing and would pass against the very default it exists to catch"
+    )
+    # coverage.py reads a ``[tool.coverage.*]`` table only from a file named
+    # pyproject.toml, so the control has to keep the name.
+    target = tmp_path / "pyproject.toml"
+    target.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    return target
+
+
+class TestTheCoreIsSelected:
+    """The declared core is the one coverage.py installs."""
+
+    def test_the_repo_config_installs_coverage_as_a_monitoring_tool(self) -> None:
+        installed = _how_coverage_installed_itself(_PYPROJECT)
+        assert installed["monitoring_tool"] == "coverage.py", (
+            f"coverage did not register as a sys.monitoring tool: {installed}; "
+            'expected [tool.coverage.run] core = "sysmon" to select the PEP 669 core'
+        )
+        assert installed["has_trace_function"] is False, (
+            f"a trace function is still installed: {installed}; the PEP 669 core "
+            "replaces it, so both being present means the core was not selected"
+        )
+
+    def test_dropping_the_setting_falls_back_to_a_trace_function(self, tmp_path: Path) -> None:
+        """The control: without the setting this is the slow run measured above."""
+        installed = _how_coverage_installed_itself(_config_without_the_core(tmp_path))
+        assert installed["monitoring_tool"] is None, (
+            f"a config with no core still registered a monitoring tool: {installed}; "
+            "then the setting is not what selects the core and this pin proves nothing"
+        )
+        assert installed["has_trace_function"] is True, (
+            f"a config with no core installed no trace function either: {installed}"
+        )
+
+
+class TestThePremisesTheSettingRestsOn:
+    """The two facts that make the measurement above the suite's own cost."""
+
+    def test_coverage_is_on_the_suites_own_hot_path(self) -> None:
+        """``--cov`` is in ``addopts``, so every run pays the core's cost."""
+        addopts = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["tool"]["pytest"]["ini_options"]["addopts"]
+        assert "--cov=strands_robots" in addopts, (
+            f"addopts no longer collects coverage ({addopts!r}); the core is then a "
+            "setting for ad-hoc runs rather than for this suite's wall clock"
+        )
+
+    @pytest.mark.parametrize("setting", ["branch", "concurrency"])
+    def test_the_equivalence_was_measured_without_it(self, setting: str) -> None:
+        """The measured agreement covers statements collected single-threadedly.
+
+        Both settings change what the core has to track, and neither was part of
+        the run that established the two cores report the same numbers. Turning
+        either on is a reason to re-measure, not a reason to keep this pin.
+        """
+        assert setting not in _coverage_config(), (
+            f"[tool.coverage.run] now declares {setting!r}, which the sysmon/ctrace "
+            "equivalence was not measured with; re-measure before widening this pin"
+        )


### PR DESCRIPTION
![coverage core measurement](https://raw.githubusercontent.com/cagataycali/robots/artifacts/coverage-sysmon-core/coverage_core.png)

## What changed

One setting. `[tool.coverage.run] core = "sysmon"` selects coverage.py's PEP 669 (`sys.monitoring`) core instead of the default C trace function.

`[tool.pytest.ini_options].addopts` carries `--cov=strands_robots`, so **every** run of this suite is an instrumented one and the tracer's cost is part of the job's wall clock. It had never been measured.

## Measured

17,102 tests (`tests/{drivers,mesh,policies,training,rendering}`), same selection, same reports, one machine, only the core varying:

| core | wall clock | cost of measuring |
| --- | --- | --- |
| none (no `--cov`) | 321.19 s | - |
| `ctrace` (the default) | 567.36 s | **+76.6%** |
| `sysmon` | 347.47 s | **+8.2%** |

The default core was spending more time than the tests it measured. An instrumented run now costs 61.2% of what it did: sysmon returns 219.89 s of the 246.17 s the default core spends.

## The two cores report the same measurement

Compared per file, not by the summary percentage:

| | `ctrace` | `sysmon` |
| --- | --- | --- |
| files | 303 | 303 |
| statements | 51,904 | 51,904 |
| excluded lines | 605 | 605 |
| reported coverage | 56% | 56% |
| differing lines | | **1** |

All three runs also agreed on the verdict: `4 failed, 17102 passed, 36 skipped, 6 warnings, 2 errors`.

The one differing line is `strands_robots/drivers/g1.py:2050` - the `logger.debug` reached only when the FSM refresher misses its join timeout, so whether it executes depends on thread scheduling. Running the whole of `tests/drivers` three times per core:

```
ctrace   line 2050 covered:  no    yes   yes
sysmon   line 2050 covered:  yes   yes   no
```

It differs between two runs of the *same* core, so it is a race in the code under test rather than a disagreement between tracers.

## What this means for the suite's bound

#3143 measures `call-test-lint / Test and Lint` at a p50 of 53.42 min against a 60-minute bound, growing +0.92 min/day, and names coverage instrumentation as the one candidate that was never measured - the one that could explain per-test cost rising 58.6% while test count rose 36.8%. It can: the tracer's share grows with the statements each test executes, not with the number of tests.

The transferable quantity is the ratio, not the seconds - the runner here is not a 2-vCPU hosted one. Applying the measured ratios to that issue's own p50 of 49.03 min for `Run tests` projects ~27.8 min uninstrumented and ~30.0 min on this core, i.e. about 19 min back, without giving up any coverage.

That matters for how the rest of #3143 gets decided: its remaining options each cost something (a third bound raise, a new dev dependency and a relock, or N times the runner minutes plus a change to the required-check contract). This one costs nothing measurable - no dependency, no matrix change, no coverage lost, no change to `--cov-fail-under=80`. It does not decide the bound question, it buys room to decide it.

## Test surface

`tests/test_coverage_runs_on_the_sysmon_core.py` pins the selection **behaviourally**, through the standard library rather than as a string in a file: coverage.py installs itself either as a `sys.monitoring` tool or as a trace function, and `sys.monitoring.get_tool(sys.monitoring.COVERAGE_ID)` / `sys.gettrace()` say which. The probe runs out of process, since this suite is itself under coverage and a second in-process `Coverage` would contend for the same tool id.

Five cells, and the control derives its config from this repository's own by deleting the one line - so a config that stops asking for the core is reported as the trace-function run it would become, rather than passing on the literal's absence. The two premise cells (`--cov` is in `addopts`; neither `branch` nor `concurrency` is declared) hold either way by construction.

- Pre-change: **2 failed, 3 passed** - the selection pin naming the actual state (`{'monitoring_tool': None, 'has_trace_function': True}`), and the control naming that it removed nothing.
- Post-change: **5 passed**.
- `ruff check` / `ruff format --check` clean over 1,840 files; `mypy strands_robots tests tests_integ` - `Success: no issues found in 1837 source files`.
- `tests/test_whole_tree_graders_roster_is_complete.py`, `tests/test_workflow_jobs_are_bounded.py`, `tests/test_dependency_audit.py`: 176 passed, 1 skipped.
- End to end through the real `addopts` with no overrides: coverage still collected (`TOTAL` row present, `--cov-fail-under` still evaluated), 1,234 passed, and no trace function installed - which only this core can do.

## Boundary

`branch` is deliberately absent from the new section. The equivalence above was measured for statements, which is what `--cov-fail-under=80` grades; turning branch coverage on is a reason to re-measure, and the parametrized premise cell says so if either `branch` or `concurrency` ever appears.

Separately, the race behind that one line is worth its own look: `g1.py:2050` is reached when the FSM refresher misses its join, and `tests/drivers/test_g1_control_loop.py::TestRunPolicyAdmissionLock::test_concurrent_run_policy_only_one_wins` is flaky for a related reason (1/15 without coverage, 3/15 with). Out of scope here - this PR changes no `strands_robots` code.

LOC: `+35` of config and docs (28 of them the comment recording the measurement), `+146` for the new test file, `+27` for the changelog fragment. No line of `strands_robots/` is touched.