### PR TITLE
fix(policies): the gait clock integrates at the rate the runtime states

### DIFF
--- a/changelog.d/3151-gait-clock-loop-rate.md
+++ b/changelog.d/3151-gait-clock-loop-rate.md
@@ -1,0 +1,18 @@
+### Fixed: the WBC gait clock integrates at the rate the runtime states
+
+`GaitClock` advances the bipedal phase by `dt * freq` per tick, and
+`WBCGaitPolicy.get_actions` called it without a `dt` -- so the phase always
+advanced by the upstream reference period (0.02 s) however fast the executing
+loop queried the policy. A commanded `gait_frequency` was therefore only in
+steps per second at 50 Hz; at any other control rate the realised cadence came
+out scaled by `control_frequency / 50` (6.0 steps/s for a commanded 1.5 at
+200 Hz, 0.5 at 12.5 Hz), and the warm-up window `0.5 / freq` was mistimed by
+the same factor.
+
+The rate was already available. `PolicyRunner` calls
+`Policy.set_control_frequency` before the rollout loop, and the
+`Policy.control_frequency` contract says a provider that needs the rate must
+warn loudly and fall back rather than silently assume one. `get_actions` now
+integrates at `1 / control_frequency`; an unstated rate warns once per policy
+and falls back to the upstream period, so a caller driving `get_actions`
+directly is unaffected.

--- a/docs/policies/wbc_gait.md
+++ b/docs/policies/wbc_gait.md
@@ -14,7 +14,12 @@ NVIDIA's reference repo ships **two** MuJoCo G1 controllers. The non-gait pair
   Frequency precedence is per-call kwarg > constructor default > `config.freq_cmd`,
   and every source in that chain must be a finite number `> 0`: the gait clock
   advances the phase by `dt * freq` and warms up over `0.5 / freq`, so a
-  non-positive step frequency cannot be honored. That is stricter than the
+  non-positive step frequency cannot be honored. `dt` is the period the
+  executing loop queries the policy at - taken from the `control_frequency` the
+  runtime states via `Policy.set_control_frequency`, which `PolicyRunner` calls
+  before the rollout - so `gait_frequency` is steps per second at any control
+  rate. Driving `get_actions` yourself without stating a rate warns and falls
+  back to the upstream 50 Hz reference period. That is stricter than the
   `finite`-only domain `WBCConfig` applies to `freq_cmd`, which the non-gait
   7-wide command block ignores entirely.
 - A 2-dim **bipedal phase clock** (`[clock_FL, clock_FR]`) appended to each

--- a/examples/wbc/wbc_g1_gait.py
+++ b/examples/wbc/wbc_g1_gait.py
@@ -55,7 +55,7 @@ def plot_clock(out_path: str, freq: float = 1.0, duration_s: float = 6.0) -> Non
         # static for the first and last third, walk forward in the middle.
         vx = 0.5 if (n // 3) <= i < (2 * n // 3) else 0.0
         scaled = np.array([vx, 0.0, 0.0]) * cmd_scale
-        c = clk.update(scaled, freq=freq)
+        c = clk.update(scaled, freq=freq, dt=dt)
         fl.append(c[0])
         fr.append(c[1])
         walking.append(clk.walking_mask)

--- a/strands_robots/policies/wbc/gait.py
+++ b/strands_robots/policies/wbc/gait.py
@@ -65,9 +65,12 @@ logger = logging.getLogger(__name__)
 GAIT_SINGLE_OBS_DIM = 95
 GAIT_COMMAND_DIM = 8
 
-# Control period used by the upstream gait runner: simulation_dt (0.005) x
+# Control period of the upstream gait runner: simulation_dt (0.005) x
 # control_decimation (4) = 0.02 s. The clock advances by ``dt * freq`` each
-# control tick and ``just_started`` accumulates by ``dt``.
+# control tick and ``just_started`` accumulates by ``dt``, so this is the
+# reference period only - a rollout integrates at the rate the runtime states
+# (:meth:`WBCGaitPolicy._control_dt`), because a period that is not the loop's
+# own scales the realised step frequency by ``control_frequency / 50``.
 _GAIT_CONTROL_DT = 0.02
 
 
@@ -336,6 +339,9 @@ class WBCGaitPolicy(WBCPolicy):
         **kwargs: Any,
     ) -> None:
         self._gait_clock = GaitClock()
+        # Latch for the missing-rate warning below, so an unset control frequency
+        # is reported once per policy rather than on every tick of the rollout.
+        self._warned_missing_control_frequency = False
         # Before ``super().__init__`` - which loads the ONNX session(s) - so a
         # frequency the gait clock cannot honor is reported here rather than on
         # the first ``get_actions`` tick of a started rollout. Mirrors the
@@ -471,6 +477,45 @@ class WBCGaitPolicy(WBCPolicy):
 
         return command, raw_velocity
 
+    def _control_dt(self) -> float:
+        """Control period the gait phase is integrated over, in seconds.
+
+        The clock advances by ``dt * freq`` per tick, so ``dt`` has to be the
+        period the executing loop actually queries this policy at - otherwise
+        the commanded ``gait_frequency`` is not in steps per second. The runtime
+        states that rate via
+        :meth:`~strands_robots.policies.base.Policy.set_control_frequency`
+        before the rollout loop starts, and this reads it there.
+
+        Returns:
+            ``1 / control_frequency`` when the runtime has stated a rate,
+            otherwise the upstream reference period
+            (:data:`_GAIT_CONTROL_DT`), which is what a caller driving
+            ``get_actions`` directly gets.
+
+        Notes:
+            An unstated rate warns rather than assuming one silently, per the
+            :attr:`~strands_robots.policies.base.Policy.control_frequency`
+            contract: a wrong assumed period scales the realised step frequency
+            by ``control_frequency / 50`` at every rate except the assumed one,
+            which is a robot walking at a cadence nobody commanded. Warned once
+            per policy - the condition cannot change mid-rollout, and a per-tick
+            line at control rate is a flood.
+        """
+        if self.control_frequency is None:
+            if not self._warned_missing_control_frequency:
+                self._warned_missing_control_frequency = True
+                logger.warning(
+                    "WBCGaitPolicy: no control frequency stated, integrating the gait phase at the "
+                    "upstream reference period (%.3f s / %.1f Hz). Call set_control_frequency(hz) - "
+                    "PolicyRunner does - or the commanded gait_frequency is only in steps/s at %.1f Hz.",
+                    _GAIT_CONTROL_DT,
+                    1.0 / _GAIT_CONTROL_DT,
+                    1.0 / _GAIT_CONTROL_DT,
+                )
+            return _GAIT_CONTROL_DT
+        return 1.0 / self.control_frequency
+
     @staticmethod
     def _validate_gait_frequency(freq: Any) -> float:
         """Validate a step-frequency command (the ``freq_cmd`` override).
@@ -512,7 +557,10 @@ class WBCGaitPolicy(WBCPolicy):
 
         Reads the locomotion command from the well-known kwargs
         (``target_velocity``, ``gait_frequency``, optional ``target_orientation``
-        / ``height``); ``instruction`` is ignored. Advances the :class:`GaitClock`,
+        / ``height``); ``instruction`` is ignored. Advances the :class:`GaitClock`
+        by the period the executing loop queries this policy at
+        (:meth:`_control_dt`), so ``gait_frequency`` is steps per second at any
+        control rate rather than only at the upstream reference 50 Hz,
         builds the 95-dim stacked observation, runs the single ONNX policy, and
         returns one per-step action dict keyed by leg+waist actuator name.
         """
@@ -521,7 +569,7 @@ class WBCGaitPolicy(WBCPolicy):
         qj, dqj, base_ang_vel, quat = self._extract_state(observation_dict)
         proj_grav = projected_gravity(quat)
 
-        clock = self._gait_clock.update(command[:3], float(command[4]))
+        clock = self._gait_clock.update(command[:3], float(command[4]), dt=self._control_dt())
 
         frame = build_gait_frame(
             self._config,

--- a/tests/policies/wbc/test_gait_clock_integrates_at_the_loop_rate.py
+++ b/tests/policies/wbc/test_gait_clock_integrates_at_the_loop_rate.py
@@ -1,0 +1,121 @@
+"""The gait phase advances by the period the executing loop actually runs at.
+
+``GaitClock`` advances by ``dt * freq`` per tick, so a ``dt`` that is not the
+control period the policy is queried at makes the commanded ``gait_frequency``
+mean something other than steps per second: the realised cadence comes out
+scaled by ``control_frequency / 50``, and the robot walks at a rhythm nobody
+commanded while every reported number looks right. The runtime states its rate
+via ``Policy.set_control_frequency`` before the loop starts, which is what these
+pin the clock to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc import GaitClock, WBCGaitPolicy
+from strands_robots.policies.wbc.gait import _GAIT_CONTROL_DT
+from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS
+
+_COMMANDED_STEPS_PER_S = 1.5
+_WALL_SECONDS = 4.0
+
+
+class _StubInput:
+    name = "obs"
+
+
+class _StubSession:
+    """Minimal onnxruntime.InferenceSession stand-in returning a fixed action."""
+
+    def get_inputs(self) -> list[_StubInput]:
+        return [_StubInput()]
+
+    def run(self, output_names, feed):  # type: ignore[no-untyped-def]
+        return [np.full((1, 15), 0.03, dtype=np.float32)]
+
+
+def _observation() -> dict[str, object]:
+    keys = list(WBC_G1_ALL_JOINTS)
+    obs: dict[str, object] = {k: 0.0 for k in keys}
+    obs.update({f"{k}.vel": 0.0 for k in keys})
+    obs["base_ang_vel"] = [0.0, 0.0, 0.0]
+    obs["base_quat"] = [1.0, 0.0, 0.0, 0.0]
+    return obs
+
+
+def _walk(control_frequency: float | None, wall_seconds: float = _WALL_SECONDS) -> list[float]:
+    """Drive a gait policy for a wall-clock span; return the gait-phase trace."""
+    policy = WBCGaitPolicy(allow_missing_models=True)
+    policy.policy_session = _StubSession()
+    policy.set_robot_state_keys(list(WBC_G1_ALL_JOINTS))
+    if control_frequency is not None:
+        policy.set_control_frequency(control_frequency)
+    rate = control_frequency if control_frequency is not None else 1.0 / _GAIT_CONTROL_DT
+    obs = _observation()
+    phases: list[float] = []
+    for _ in range(int(wall_seconds * rate)):
+        asyncio.run(policy.get_actions(obs, "", target_velocity=[0.5, 0.0, 0.0], gait_frequency=_COMMANDED_STEPS_PER_S))
+        phases.append(policy._gait_clock.gait_indices)
+    return phases
+
+
+def _reference_phases(wall_seconds: float = _WALL_SECONDS) -> list[float]:
+    """Phase trace of a clock stepped explicitly at the upstream reference period."""
+    clock = GaitClock()
+    phases: list[float] = []
+    for _ in range(int(wall_seconds / _GAIT_CONTROL_DT)):
+        clock.update(np.array([1.0, 0.0, 0.0]), freq=_COMMANDED_STEPS_PER_S, dt=_GAIT_CONTROL_DT)
+        phases.append(clock.gait_indices)
+    return phases
+
+
+def _cycles(phases: list[float]) -> int:
+    """Completed gait cycles in a phase trace (the phase wraps at 1.0)."""
+    return sum(1 for before, after in zip(phases, phases[1:], strict=False) if after < before)
+
+
+@pytest.mark.parametrize("control_frequency", [12.5, 25.0, 50.0, 100.0, 200.0])
+def test_the_commanded_step_frequency_is_realised_at_every_control_rate(control_frequency):
+    """A cadence command is steps per second, whatever rate the loop runs at.
+
+    Pre-fix the phase advanced by a hardcoded 0.02 s per tick however fast the
+    loop queried the policy, so this walk realised
+    ``1.5 * control_frequency / 50`` steps/s - 4x too fast at 200 Hz and 3x too
+    slow at 12.5 Hz.
+    """
+    realised = _cycles(_walk(control_frequency)) / _WALL_SECONDS
+    assert realised == pytest.approx(_COMMANDED_STEPS_PER_S, abs=0.25), (
+        f"at {control_frequency} Hz the gait realised {realised} steps/s for a commanded {_COMMANDED_STEPS_PER_S}"
+    )
+
+
+def test_the_upstream_reference_rate_is_unchanged():
+    """50 Hz is the period the upstream runner uses, and it still integrates the same.
+
+    The control: reading the loop rate must not move the one rate that was
+    already right, so the 50 Hz trace matches a clock stepped explicitly at the
+    upstream reference period.
+    """
+    assert _walk(1.0 / _GAIT_CONTROL_DT) == pytest.approx(_reference_phases())
+
+
+def test_an_unstated_control_rate_warns_once_and_uses_the_reference_period(caplog):
+    """No rate stated is reported, not silently assumed.
+
+    ``Policy.control_frequency`` documents the contract: a provider that needs
+    the rate warns loudly and falls back rather than assuming one. The warning
+    is latched per policy - at control rate a per-tick line is a flood.
+    """
+    with caplog.at_level(logging.WARNING, logger="strands_robots.policies.wbc.gait"):
+        phases = _walk(None, wall_seconds=0.5)
+
+    warnings = [r for r in caplog.records if "control frequency" in r.message]
+    assert len(warnings) == 1, f"expected one latched warning, got {len(warnings)}"
+    assert "set_control_frequency" in warnings[0].getMessage()
+    # Fallback is the upstream reference period, so a direct caller is unaffected.
+    assert phases == pytest.approx(_reference_phases(wall_seconds=0.5))


### PR DESCRIPTION
`GaitClock` advances the bipedal phase by `dt * freq` per tick. `WBCGaitPolicy.get_actions` called it **without a `dt`**, so the phase always advanced by the upstream reference period (0.02 s) however fast the executing loop queried the policy. The commanded `gait_frequency` was therefore only in steps per second at 50 Hz - everywhere else the realised cadence came out scaled by `control_frequency / 50`, and the warm-up window `0.5 / freq` was mistimed by the same factor.

![gait clock at five control rates, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gait-clock-loop-rate/gait_clock_loop_rate.png)

Left: `clock_FR`, the phase channel the network reads, over **wall-clock** seconds. Before, one commanded cadence produces five different rhythms. Right: realised cadence for a commanded `gait_frequency = 1.5` steps/s, driven through `get_actions` with `set_control_frequency(hz)` called exactly as `PolicyRunner` calls it, 4 s per rate.

| control_frequency | 12.5 Hz | 25 Hz | 50 Hz | 100 Hz | 200 Hz |
|---|---|---|---|---|---|
| realised, before | 0.5 | 0.75 | **1.5** | 3.0 | 6.0 |
| realised, after | 1.5 | 1.5 | **1.5** | 1.5 | 1.5 |

## The rate was already there

`PolicyRunner` calls `Policy.set_control_frequency(control_frequency)` before the rollout loop, and the `Policy.control_frequency` docstring already states the contract for a provider that needs it:

> `None` means the runtime has not told the policy its clock yet - providers that need it MUST warn loudly and fall back rather than silently assuming a rate (a wrong assumed rate corrupts RTC blending at every control frequency except the assumed one).

The gait clock did neither: it assumed 50 Hz even when it had been told 200. `MicroduckPolicyBundle._tick_episodic` is the in-tree precedent for reading it (`dt = 1.0 / self.control_frequency`, refusing when unstated).

`get_actions` now integrates at `1 / control_frequency` via a new `_control_dt()`. An unstated rate warns **once per policy** (a per-tick line at control rate is a flood) and falls back to the upstream reference period, so a caller driving `get_actions` directly keeps today's behaviour. `GaitClock.update(dt=...)` is unchanged - the knob already existed and had no production caller.

## Tests

`tests/policies/wbc/test_gait_clock_integrates_at_the_loop_rate.py`, on pre-fix code: **5 failed, 2 passed**.

- the realised cadence equals the commanded one at 12.5 / 25 / 50 / 100 / 200 Hz - pre-fix 4 of the 5 fail, naming the number (`at 200.0 Hz the gait realised 6.0 steps/s for a commanded 1.5`); the 50 Hz cell passes on both trees because that is the rate that was already right;
- the 50 Hz trace still matches a clock stepped explicitly at the upstream period - the control that shows reading the loop rate does not move the reference case (passes on both trees);
- an unstated rate warns once and falls back to the reference period - pre-fix no warning is emitted at all.

`tests/policies` + `tests/simulation`: 13 failed / 19389 passed on `main`, 13 failed / **19396** passed on this branch, failing node-id sets identical (+7 = exactly the new cells). `ruff check` / `ruff format` clean; mypy unchanged at the 20 pre-existing errors in 6 files.

## Size

| | + | - |
|---|---|---|
| `policies/wbc/gait.py` | 52 | 4 |
| `tests/.../test_gait_clock_integrates_at_the_loop_rate.py` | 121 | 0 |
| `changelog.d/3151-gait-clock-loop-rate.md` | 18 | 0 |
| `docs/policies/wbc_gait.md` | 6 | 1 |
| `examples/wbc/wbc_g1_gait.py` | 1 | 1 |

Net positive, and the source half is mostly prose: `gait.py` grows **8 executable statements** (174 -> 182, AST-counted). The example change is a one-liner in the same subject - its clock plot builds a `dt = 0.02` time axis and then called `update()` without passing it, so the figure's x-axis was correct only because the default happened to agree.

Docs: `docs/policies/wbc_gait.md` states where `dt` comes from beside the frequency-precedence rule it belongs to.