### PR TITLE
fix(simulation): a camera-recording flush that encodes nothing keeps its buffer

### DIFF
--- a/changelog.d/3152-camera-flush-keeps-an-unencoded-buffer.md
+++ b/changelog.d/3152-camera-flush-keeps-an-unencoded-buffer.md
@@ -1,0 +1,25 @@
+### Fixed: a camera-recording flush that encodes nothing keeps its buffer
+
+`stop_cameras_recording` and the synchronous `finalize` cleared the recording's
+registration immediately after flushing it, whatever the flush reported.
+`_flush_cameras_recording_state` is best-effort and folds a per-camera encode
+failure into its success envelope, so it has exactly one hard failure - no
+`imageio` - and it returns before opening any writer. Nothing is encoded and
+every buffer is intact, which is the state the expired-join refusal beside it
+calls recoverable; deregistering there discarded those frames permanently.
+
+The failure is reachable through a published extra: `imageio` comes with
+`[sim-mujoco]`, but `[sim-newton]` and `[cosmos3-sim]` declare `mujoco` without
+it, and neither start verb probes the encoder, so the flush is the first call
+that needs one. Measured on a scene with 13 frames captured, the stop reported
+an error, `get_cameras_recording_status` then answered `[idle]`, and installing
+the encoder and calling again - the remedy the error message names - answered
+"Was not recording cameras." with all 13 frames gone and no MP4 written.
+
+Both flush paths now deregister only when the flush encoded, so a stop that
+could not encode leaves the recording in the `unflushed` phase and a later call
+writes the frames. The refusal carries the per-camera buffered counts and names
+the verb that encodes them, matching the expired-join refusal, and the
+synchronous `finalize` keys its no-op on the registration rather than the
+`running` flag it clears itself. The verdict of a stop that cannot flush is
+unchanged; only what survives it is.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -455,19 +455,30 @@ then only a lower bound, reported in the `unreadable_files` diagnostics.
 | `save_episode` | `[lerobot]` | Close current rollout as one episode (call once per `run_policy` for N episodes) |
 | `start_cameras_recording` / `stop_cameras_recording` | `[sim-mujoco]` alone | Plain MP4, no parquet |
 
-`stop_cameras_recording` returns a verdict, not just a report. The daemon
-recorder runs in its own thread, so the stop asks that loop to exit and waits
-5 s for it; if the loop is still inside `render` when the budget expires -- a
-wedged GL context, an EGL device that stopped answering -- the call is a
-structured **error** carrying `stopped: False` and the per-camera buffered frame
-counts, and no MP4 is written:
+`stop_cameras_recording` returns a verdict, not just a report. Two things stop
+it finishing, and both answer the same way: a structured **error** carrying
+`stopped: False` and the per-camera buffered frame counts, no MP4 written, and
+the recording left registered so a later call can still encode it.
+
+The first is a join that expires. The daemon recorder runs in its own thread, so
+the stop asks that loop to exit and waits 5 s for it; if the loop is still inside
+`render` when the budget runs out -- a wedged GL context, an EGL device that
+stopped answering -- reading a buffer it may still append to is refused rather
+than encoded.
+
+The second is a flush with no encoder to call. `imageio` comes with
+`[sim-mujoco]`, but `[sim-newton]` and `[cosmos3-sim]` bring `mujoco` without
+it, and neither start verb probes the encoder, so the flush is the first call
+that needs one. It reports before opening any writer, so every buffer is intact
+and installing the encoder and calling again writes them.
 
 ```python
 result = sim.stop_cameras_recording()
 if result["status"] == "error":
-    # The loop is still capturing. Nothing was encoded (an MP4 read from a
-    # buffer that is still growing would not describe either frame list), and
-    # the recording is still registered -- call stop again to re-join it.
+    # Nothing was encoded -- either the loop is still capturing (an MP4 read
+    # from a buffer that is still growing would not describe either frame list)
+    # or there is no encoder installed. Either way the frames are still there
+    # and the recording is still registered, so calling again flushes them.
     result = sim.stop_cameras_recording()
 ```
 

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -2448,6 +2448,11 @@ class RenderingMixin:
         on a wedged GL context is the ordinary case. That outcome decides all
         three of what happens next:
 
+        A flush that cannot encode at all - no encoder installed - keeps the
+        registration for the same reason, so both of this method's failure paths
+        leave a buffer that a later call can still write. See
+        :meth:`_flush_and_deregister_cameras_recording`.
+
         * ``status="error"`` with ``stopped=False``, so a caller cannot read
           "success" while frames are still being captured.
         * **Nothing is encoded.** The flush walks each buffer twice (once to
@@ -2500,7 +2505,31 @@ class RenderingMixin:
                 ],
             }
 
+        return self._flush_and_deregister_cameras_recording(state)
+
+    def _flush_and_deregister_cameras_recording(self, state: dict) -> dict:
+        """Flush ``state``, and deregister it only if the flush encoded.
+
+        The one place the "only a successful flush deregisters" rule lives, for
+        the same reason :meth:`_refuse_replacing_cams_recording` is the one
+        place the start verbs ask their question: both flush paths - the daemon
+        :meth:`stop_cameras_recording` and the synchronous ``finalize`` - had
+        the same hole, so both ask through here.
+
+        :meth:`_flush_cameras_recording_state` is best-effort and folds a
+        per-camera encode failure into its success envelope, so its
+        ``status="error"`` is the one case where no camera was written at all:
+        the encoder is missing, and it reports that before opening a writer.
+        Every buffer is therefore intact, and the remedy its message names -
+        install the encoder, call again - is only followable while the
+        recording is still registered. Deregistering there discarded exactly
+        the frames that message promised were still available, and left
+        :meth:`get_cameras_recording_status` answering ``[idle]`` about them,
+        which is the one reading that verb documents it must never give.
+        """
         result = self._flush_cameras_recording_state(state)
+        if result.get("status") == "error":
+            return result
         self._cams_rec_state = None
         return result
 
@@ -2564,9 +2593,34 @@ class RenderingMixin:
                     encode_clip(to_encode, path, fps=state["fps"])
                     frames_written = len(to_encode)
                 except ImportError:
+                    # Fires on the first camera holding frames, before any
+                    # writer is opened, so nothing is encoded and no buffer is
+                    # touched. Report it the way the expired-join refusal
+                    # reports its own recoverable state - counts included, and
+                    # naming the verb that encodes them - because the caller
+                    # here can follow that advice for the same reason: the
+                    # recording is left registered. See
+                    # :meth:`_flush_and_deregister_cameras_recording`.
+                    buffered = {_c: len(state["buffers"][_c]) for _c in state["cameras"]}
                     return {
                         "status": "error",
-                        "content": [{"text": "imageio not installed. pip install imageio imageio-ffmpeg"}],
+                        "content": [
+                            {
+                                "text": (
+                                    "imageio not installed. pip install imageio imageio-ffmpeg\n"
+                                    f"Nothing was encoded and nothing was dropped: camera recording "
+                                    f"{state['name']!r} is left registered holding {buffered}. Install "
+                                    f"the encoder and call stop_cameras_recording() again to flush it."
+                                )
+                            },
+                            {
+                                "json": {
+                                    "stopped": False,
+                                    "recording": state["name"],
+                                    "buffered_frames": buffered,
+                                }
+                            },
+                        ],
                     }
                 except Exception as e:  # noqa: BLE001 - best-effort flush must never raise
                     flush_error = f"{type(e).__name__}: {e}"
@@ -2842,17 +2896,24 @@ class RenderingMixin:
 
             Returns the same standard result dict as
             :meth:`stop_cameras_recording` so callers can log artifacts
-            uniformly. Calling ``finalize()`` after the first call is a
+            uniformly. Calling ``finalize()`` after a call that *encoded* is a
             no-op success ("Was not recording cameras.") - matching the
-            ``stop_cameras_recording`` idempotency contract.
+            ``stop_cameras_recording`` idempotency contract. After one that
+            could not encode anything it retries the flush instead, because
+            that state still holds the frames.
             """
             current = getattr(self, "_cams_rec_state", None)
-            if current is not state or not state.get("running"):
+            # Registration, not ``running``: this method clears the flag before
+            # it flushes, so reading the flag would answer "was not recording"
+            # about the state a failed flush leaves behind - registered, frames
+            # unencoded - which is the false idle report the whole registration
+            # rule exists to prevent. A flush that encoded deregisters, so the
+            # identity check alone still makes a second call the no-op its
+            # contract promises.
+            if current is not state:
                 return {"status": "success", "content": [{"text": "Was not recording cameras."}]}
             state["running"] = False
-            result = self._flush_cameras_recording_state(state)
-            self._cams_rec_state = None
-            return result
+            return self._flush_and_deregister_cameras_recording(state)
 
         msg = (
             f"Recording {len(names)} camera(s) @ {fps} FPS -> {out_dir} (synchronous mode)\n"

--- a/tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py
+++ b/tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py
@@ -22,6 +22,15 @@ defect: the state decays -- the slow ``render`` returns, the loop exits -- into
 one that no liveness read can see but that still holds those frames, so a guard
 keyed on liveness would let a `start` drop them under ``status="success"``.
 
+A stop has a second way to not finish, and it reaches the same three answers:
+the flush itself cannot encode. ``_flush_cameras_recording_state`` folds a
+per-camera encode failure into its success envelope, so it has exactly one hard
+failure - no ``imageio`` - and reports it before opening any writer, with every
+buffer intact. ``sim-newton`` and ``cosmos3-sim`` both declare ``mujoco``
+without ``imageio`` and neither start verb probes the encoder, so that flush is
+the first call which needs one. Its message asks the caller to install the
+encoder and call again, which only a still-registered recording can honour.
+
 Each cell drives a real daemon thread and wedges it inside ``render``, mirroring
 ``test_daemon_camera_recording.py``'s fake-render harness so no GL context is
 needed. The join budget is monkeypatched down so a cell costs a fraction of a
@@ -31,8 +40,10 @@ second rather than the production wait.
 from __future__ import annotations
 
 import io
+import sys
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +53,7 @@ import pytest
 mujoco = pytest.importorskip("mujoco", reason="mujoco not installed - pip install strands-robots[sim-mujoco]")
 imageio = pytest.importorskip("imageio", reason="imageio not installed - pip install imageio imageio-ffmpeg")
 
+from strands_robots import utils  # noqa: E402
 from strands_robots.simulation import Simulation  # noqa: E402
 from strands_robots.simulation.mujoco import rendering  # noqa: E402
 
@@ -102,12 +114,21 @@ class _WedgeableRecorder:
         state = self.sim._cams_rec_state
         return 0 if state is None else len(state["buffers"][camera])
 
+    def buffer_a_few(self, n: int = 3) -> int:
+        """Wait until the capture loop has appended real frames.
+
+        The flush skips a camera whose buffer is empty, so "some frames landed"
+        is the premise of every cell about what a flush does with them.
+        """
+        deadline = time.monotonic() + 30.0
+        while self.buffered() < n and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert self.buffered() >= n, "premise: the recorder buffers frames"
+        return self.buffered()
+
     def wedge(self) -> threading.Thread:
         """Buffer a few real frames, then park the loop inside ``render``."""
-        deadline = time.monotonic() + 30.0
-        while self.buffered() < 3 and time.monotonic() < deadline:
-            time.sleep(0.02)
-        assert self.buffered() >= 3, "premise: the recorder buffers frames before it is wedged"
+        self.buffer_a_few()
         thread = self.sim._cams_rec_state["thread"]
         self._armed.set()
         assert self.wedged.wait(timeout=30), "premise: the recorder thread reaches the blocking render"
@@ -149,6 +170,32 @@ def recorder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         thread = (rec.sim._cams_rec_state or {}).get("thread")
         if thread is not None:
             thread.join(timeout=10)
+
+
+@contextmanager
+def _blocked_encoder():
+    """An install that has ``mujoco`` but not ``imageio``, for one block.
+
+    Two steps, because :func:`~strands_robots.utils.require_optional` memoises a
+    module it has already imported: the ``sys.modules`` entry is what makes the
+    import fail, and dropping the cache entry is what stops an earlier import in
+    the same session from answering instead.
+    """
+    cached = utils._lazy_modules.pop("imageio", None)
+    sys.modules["imageio"] = None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        del sys.modules["imageio"]
+        if cached is not None:
+            utils._lazy_modules["imageio"] = cached
+
+
+@pytest.fixture
+def no_encoder():
+    """:func:`_blocked_encoder` for a whole cell."""
+    with _blocked_encoder():
+        yield
 
 
 def _json_block(envelope: dict) -> dict:
@@ -324,6 +371,124 @@ class TestASettledRecordingIsNotDroppable:
         with imageio.v2.get_reader(str(artifact["path"])) as reader:
             assert sum(1 for _ in reader) == buffered
         assert recorder.sim._cams_rec_state is None
+
+
+class TestAStopWhoseFlushCannotEncode:
+    """The other way a stop cannot finish, and the same three answers.
+
+    Nothing is encoded, so the buffers are exactly as the capture loop left
+    them - which makes them recoverable in the sense the expired-join refusal
+    already uses, and makes the registration the only route back to them.
+    """
+
+    def test_the_stop_refuses_and_says_what_it_kept(self, recorder, no_encoder) -> None:
+        """The verdict, and the counts that make the advice followable."""
+        buffered = recorder.buffer_a_few()
+
+        result = recorder.sim.stop_cameras_recording()
+
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "pip install imageio" in text, text
+        assert "stop_cameras_recording()" in text, text
+        payload = _json_block(result)
+        assert payload["stopped"] is False
+        assert payload["recording"] == "wedge"
+        assert payload["buffered_frames"]["cam_a"] >= buffered
+
+    def test_the_recording_stays_registered_so_a_later_call_encodes_it(self, recorder, tmp_path) -> None:
+        """Following the message's own advice recovers every frame."""
+        with _blocked_encoder():
+            buffered = recorder.buffer_a_few()
+            first = recorder.sim.stop_cameras_recording()
+            assert first["status"] == "error", first
+            assert list(tmp_path.glob("*.mp4")) == [], "nothing is encoded without an encoder"
+            assert recorder.sim._cams_rec_state is not None, "the registration is the only route back"
+
+        second = recorder.sim.stop_cameras_recording()
+
+        assert second["status"] == "success", second
+        artifacts = _json_block(second)["artifacts"]
+        assert artifacts[0]["frames"] >= buffered, artifacts
+        assert list(tmp_path.glob("*.mp4")) != []
+
+    def test_the_status_verb_does_not_call_the_unencoded_buffer_idle(self, recorder, no_encoder) -> None:
+        """``[idle]`` promises there is no buffer left to encode."""
+        recorder.buffer_a_few()
+        recorder.sim.stop_cameras_recording()
+
+        status = recorder.sim.get_cameras_recording_status()
+
+        text = status["content"][0]["text"]
+        assert "[idle]" not in text, text
+        assert "[unflushed]" in text, text
+        assert _json_block(status)["phase"] == "unflushed"
+
+    def test_a_start_cannot_discard_the_frames_the_refusal_promised(self, recorder, tmp_path, no_encoder) -> None:
+        """A start reads the registration, so it refuses instead of replacing."""
+        buffered = recorder.buffer_a_few()
+        recorder.sim.stop_cameras_recording()
+
+        again = recorder.sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="second")
+
+        assert again["status"] == "error", again
+        assert "stop_cameras_recording() first" in again["content"][0]["text"]
+        assert recorder.sim._cams_rec_state["name"] == "wedge"
+        assert recorder.buffered() >= buffered
+
+    def test_the_synchronous_finalize_keeps_them_too(self, tmp_path) -> None:
+        """``finalize`` shares the rule: it retries rather than reporting idle."""
+        rec = _WedgeableRecorder()
+        started = rec.sim.start_cameras_recording_synchronous(
+            cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="sync"
+        )
+        assert started["status"] == "success", started
+        block = _json_block(started)
+        on_frame, finalize = block["on_frame"], block["finalize"]
+        for step in range(3):
+            on_frame(step, {}, {})
+        assert rec.buffered() == 3, "premise: the synchronous recorder buffered frames"
+
+        with _blocked_encoder():
+            first = finalize()
+            assert first["status"] == "error", first
+            assert rec.sim._cams_rec_state is not None
+
+        second = finalize()
+
+        assert second["status"] == "success", second
+        assert _json_block(second)["artifacts"][0]["frames"] == 3
+        assert list(tmp_path.glob("*.mp4")) != []
+
+
+class TestAFlushThatEncodesStillDeregisters:
+    """The over-reach control: keeping a buffer is about a flush that failed."""
+
+    def test_a_stop_that_encodes_deregisters_and_the_next_call_is_the_no_op(self, recorder) -> None:
+        recorder.buffer_a_few()
+
+        first = recorder.sim.stop_cameras_recording()
+
+        assert first["status"] == "success", first
+        assert recorder.sim._cams_rec_state is None
+        again = recorder.sim.stop_cameras_recording()
+        assert again["status"] == "success"
+        assert "Was not recording cameras." in again["content"][0]["text"]
+
+    def test_a_synchronous_finalize_that_encodes_is_the_no_op_on_the_second_call(self, tmp_path) -> None:
+        rec = _WedgeableRecorder()
+        started = rec.sim.start_cameras_recording_synchronous(
+            cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="sync_ok"
+        )
+        block = _json_block(started)
+        block["on_frame"](0, {}, {})
+
+        first = block["finalize"]()
+
+        assert first["status"] == "success", first
+        assert rec.sim._cams_rec_state is None
+        again = block["finalize"]()
+        assert "Was not recording cameras." in again["content"][0]["text"]
 
 
 class TestARecorderThatExitsIsUnaffected:


### PR DESCRIPTION
`stop_cameras_recording` and the synchronous `finalize` both cleared `_cams_rec_state` immediately after the flush, whatever the flush reported.

`_flush_cameras_recording_state` is best-effort and folds a per-camera encode failure into its success envelope, so it has exactly one hard failure -- no `imageio` -- and it returns **before opening any writer**. Nothing is encoded and every buffer is intact, which is the state the expired-join refusal beside it calls recoverable. Deregistering there discarded those frames permanently and left `get_cameras_recording_status` answering `[idle]` about them.

![camera flush keeps its unencoded buffer](https://raw.githubusercontent.com/cagataycali/robots/artifacts/camera-flush-keeps-buffer/camera-flush-keeps-buffer.png)

## Measured

One SO-101 scene, one camera, real EGL renders, 13 frames buffered by the real capture loop, `imageio` absent. Same script on both trees:

| | before | after |
|---|---|---|
| `start_cameras_recording()` | success | success |
| frames buffered | 13 | 13 |
| `stop_cameras_recording()` | error | error |
| ...registration | **dropped** | kept |
| `get_cameras_recording_status()` | `[idle]` | `[unflushed]` |
| install the encoder, call again | success, `"Was not recording cameras."` | success, encoded |
| frames in the resulting MP4 | **0 of 13** | 13 of 13 |

The verdict of the first stop is unchanged, so this is not a change to what is refused -- only to what survives it. The refusal's own message asks the caller to install the encoder and call again, which only a still-registered recording can honour.

## Reachable through a published extra

`imageio` comes with `[sim-mujoco]`, but `[sim-newton]` and `[cosmos3-sim]` both declare `mujoco` **without** it, and neither start verb probes the encoder -- the flush is the first call that needs one.

## Why nothing caught it

The invariant is already written down four times, and the code held it on one of the two failure paths:

- `stop_cameras_recording`: "A successful flush is what clears the registration"
- `_cams_recording_phase`: "`_cams_rec_state` is set by the two start verbs and cleared only by a successful flush"
- `get_cameras_recording_status`: "only a flush deregisters a recording, so `[idle]` promises there is no buffer left to encode, and answering it about a settled-but-registered state would report captured frames as if they had never existed"
- `docs/recording.md`: "Only a flush deregisters a recording"

The expired-join path implements it; the flush path did not. `tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py` pinned the join half only.

## Change

Both flush paths now route through `_flush_and_deregister_cameras_recording`, which deregisters only when the flush encoded -- one place for the rule, mirroring how `_refuse_replacing_cams_recording` is the one place the start verbs ask their question. Two follow-ons:

- The flush's refusal now carries the buffered counts and names the verb that encodes them, matching the expired-join refusal it sits beside.
- The synchronous `finalize` keys its no-op on the registration rather than the `running` flag it clears itself; reading that flag would answer "was not recording" about the state a failed flush leaves behind.

## Tests

Five cells in `TestAStopWhoseFlushCannotEncode`, beside the join class they mirror: the refusal reports what it kept, the recording stays registered so a later call encodes it, the status verb does not call the buffer `[idle]`, a start cannot discard it, and the synchronous `finalize` behaves the same. Two cells in `TestAFlushThatEncodesStillDeregisters` are the over-reach control.

Pre-fix (base source, these tests): **5 failed / 15 passed** -- the five naming the defect (`[idle] No active camera recording.`, `the registration is the only route back`, and a start answering `status="success"`), with both controls and all 13 pre-existing cells green. After: 20 passed.

Gate: `ruff check`/`format` clean, mypy 1.20.2 with 0 attributable errors, `tests/simulation/mujoco` + `tests/rendering` 4940 passed / 8 skipped, whole-tree graders unchanged against base.

## Size

`rendering.py` +68/-7 raw but **+3 executable statements** (953 -> 956 by AST count) -- the rest is the docstring and the comment stating the rule. Tests +169/-4 (the 4 are a wait loop lifted into a shared `buffer_a_few` premise), `docs/recording.md` +20/-9, plus a 25-line changelog fragment. Whole diff: +282/-20 across 4 files.