### PR TITLE
test(g1): the admission burst refuses against a live rollout, not a finished one

### DIFF
--- a/tests/drivers/test_g1_control_loop.py
+++ b/tests/drivers/test_g1_control_loop.py
@@ -659,33 +659,73 @@ class TestCleanupJoinsLoopBeforeClosingPubs:
 # ---------------------------------------------------------------------------
 
 
+def _admission_driver() -> Any:
+    """Return a real ``G1Driver`` whose cached FSM reading is fresh.
+
+    :class:`TestRunPolicyAdmissionLock` grades ``run_policy``'s own admission,
+    so it needs the real driver rather than :func:`_fake_driver`.  It still
+    needs ``_fake_driver``'s healthy-wire shape, and one attribute of it is
+    load-bearing here: the loop's per-step re-gate refuses on ``age is None``
+    (:meth:`G1Driver._check_motion_gates`, ``refresh=False``), while the
+    entry-point path tolerates it.  So a driver that assigns ``_fsm_id``
+    without stamping ``_fsm_read_at`` is admitted by ``run_policy`` and then
+    exits its rollout at step 0 with ``exit_reason="gate"``.  ``g1.py`` names
+    that asymmetry and names this fixture shape as what keeps the branch
+    reachable.
+
+    A rollout that is already over cannot refuse a second admission, so
+    without the stamp these two tests observe a *sequence* of admissions and
+    report it as a concurrent one.  Measured before the stamp on two CPUs:
+    the burst below reported 2 or 3 successes on three of five 50-thread
+    attempts, and failed one whole-directory run in six - while the greatest
+    number of loop threads alive at any one instant was 1 on every attempt.
+    So the message it printed named the one thing that had not happened.
+    """
+    from strands_robots.drivers.g1 import G1Driver
+
+    driver = G1Driver(port="127.0.0.1", network_interface="lo")
+    driver._pubs = _RecordingPublisher()  # type: ignore[assignment]
+    driver._connected = True
+    driver._mode_machine = 9
+    driver._fsm_id = 500
+    driver._battery = {"pct": 80.0}
+    driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+    # Mirrors _fake_driver: a live stamp plus a refresher that keeps stamping
+    # is the healthy wire, which is the case an admission test is about.
+    driver._refresh_fsm_id = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda: setattr(driver, "_fsm_read_at", time.monotonic())
+    )
+    driver._fsm_read_at = time.monotonic()
+    return driver
+
+
+def _reports_running(driver: Any) -> bool:
+    """Whether ``get_task_status`` reports a live rollout on this driver."""
+    return bool(driver.get_task_status()["content"][0]["json"]["running"])
+
+
 class TestRunPolicyAdmissionLock:
     """Two concurrent ``run_policy`` calls never both start."""
 
     def test_second_run_policy_refuses_when_first_is_running(self) -> None:
-        from strands_robots.drivers.g1 import G1Driver
-
-        driver = G1Driver(port="127.0.0.1", network_interface="lo")
-        driver._pubs = _RecordingPublisher()  # type: ignore[assignment]
-        driver._connected = True
-        driver._mode_machine = 9
-        driver._fsm_id = 500
-        driver._battery = {"pct": 80.0}
-        driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+        driver = _admission_driver()
 
         def policy(_obs: Any) -> dict[str, float]:
             return {"left_knee": 0.0}
 
-        first = driver.run_policy(policy, duration=60.0)
-        assert first["status"] == "success"
+        try:
+            first = driver.run_policy(policy, duration=60.0)
+            assert first["status"] == "success"
+            # The refusal below is about admission only if the first rollout is
+            # still running when the second call asks for one.
+            assert _reports_running(driver), "the first rollout ended before the second call was made"
 
-        second = driver.run_policy(policy, duration=60.0)
-        assert second["status"] == "error"
-        text = second["content"][0]["text"]
-        assert "already running" in text
-
-        # Clean up.
-        driver.cleanup()
+            second = driver.run_policy(policy, duration=60.0)
+            assert second["status"] == "error"
+            text = second["content"][0]["text"]
+            assert "already running" in text
+        finally:
+            driver.cleanup()
 
     def test_concurrent_run_policy_only_one_wins(self) -> None:
         """Fifty threads calling ``run_policy`` at once produce one loop.
@@ -696,42 +736,64 @@ class TestRunPolicyAdmissionLock:
         """
         import threading as _threading
 
-        from strands_robots.drivers.g1 import G1Driver
-
-        driver = G1Driver(port="127.0.0.1", network_interface="lo")
-        driver._pubs = _RecordingPublisher()  # type: ignore[assignment]
-        driver._connected = True
-        driver._mode_machine = 9
-        driver._fsm_id = 500
-        driver._battery = {"pct": 80.0}
-        driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+        driver = _admission_driver()
 
         def policy(_obs: Any) -> dict[str, float]:
             return {"left_knee": 0.0}
 
         started = _threading.Barrier(50)
         results: list[dict[str, Any]] = []
-        results_lock = _threading.Lock()
+        admitted: list[Any] = []
+        overlaps: list[str] = []
+        bookkeeping = _threading.Lock()
 
         def caller() -> None:
             started.wait()
             r = driver.run_policy(policy, duration=60.0)
-            with results_lock:
+            with bookkeeping:
                 results.append(r)
+                if r["status"] != "success":
+                    return
+                loop = driver._loop
+                # Recorded by the admitting thread itself, because it is the
+                # only place the question can be asked: an earlier rollout
+                # still alive at this instant is two loops publishing on
+                # ``rt/lowcmd`` at once, which is the state the lock exists to
+                # prevent.  Counting successes cannot tell that apart from a
+                # rollout that ended and a later admission (see
+                # _admission_driver).
+                overlaps.extend(
+                    f"{id(earlier):x} was alive when {id(loop):x} was admitted"
+                    for earlier in admitted
+                    if earlier is not None and earlier is not loop and earlier.is_running
+                )
+                admitted.append(loop)
 
         threads = [_threading.Thread(target=caller) for _ in range(50)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        try:
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
 
-        # Exactly one succeeded; the rest carried the refusal.
-        successes = [r for r in results if r["status"] == "success"]
-        errors = [r for r in results if r["status"] == "error"]
-        assert len(successes) == 1, f"admission lock leaked: {len(successes)} rollouts started concurrently"
-        assert len(errors) == 49
+            # The safety property, asserted from the observation above rather
+            # than inferred from the count.
+            assert overlaps == [], f"two rollouts were alive at once: {overlaps}"
 
-        driver.cleanup()
+            # And with a healthy wire the burst admits exactly one: the
+            # winner holds its rollout for the whole ``duration``, so every
+            # other thread meets a running loop.  Stated separately from the
+            # overlap check because a second *sequential* admission is a
+            # fixture that let the first rollout die, not a leaked lock.
+            assert _reports_running(driver), "the winning rollout ended before the burst was counted"
+            successes = [r for r in results if r["status"] == "success"]
+            errors = [r for r in results if r["status"] == "error"]
+            assert len(successes) == 1, f"the burst admitted {len(successes)} rollouts, not one"
+            assert len(errors) == 49
+        finally:
+            # In a ``finally`` so a failed assertion cannot leave a 500 Hz
+            # daemon thread spinning for the rest of the session.
+            driver.cleanup()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

`tests/drivers/test_g1_control_loop.py::TestRunPolicyAdmissionLock` is flaky, and when it fails it accuses the wrong component. This PR fixes the fixture that makes it flaky and re-states its safety claim as an observation. **No line of `strands_robots/` is touched** - the production code is correct, and its own comment predicted this fixture.

## The mechanism

Both tests built a real `G1Driver` and assigned `_mode_machine`, `_fsm_id`, `_battery` and `_imu` - but never stamped `_fsm_read_at`. `_check_motion_gates` treats a missing stamp asymmetrically, on purpose:

| path | `refresh` | `age is None` |
| --- | --- | --- |
| entry point (`run_policy`) | `True` | tolerated |
| loop's per-step re-gate | `False` | refused |

So `run_policy` admitted the rollout and the loop then exited **at step 0** with `exit_reason="gate"`. `g1.py` already names this exact fixture shape as what keeps that branch reachable:

> `age is None` ... remains reachable for the cache-only path (`refresh=False`) exercised by fixtures that assign `_fsm_id` directly without going through admission; the loop backstops that by refusing too on `age is None` there.

A rollout that is already over cannot refuse a second admission. So in the 50-thread burst a later thread was admitted **legitimately**, and the test read a *sequence* of admissions as a *concurrent* one.

## Measured

Instrumenting `_ControlLoop.start` to count how many loop threads were alive at the same instant, 50 threads on two CPUs, five attempts:

| attempt | successes | loops created | **max alive simultaneously** | every loop's exit |
| --- | ---: | ---: | ---: | --- |
| 1 | 3 | 3 | **1** | `gate`, step 0 |
| 2 | 1 | 1 | **1** | `gate`, step 0 |
| 3 | 1 | 1 | **1** | `gate`, step 0 |
| 4 | 2 | 2 | **1** | `gate`, step 0 |
| 5 | 2 | 2 | **1** | `gate`, step 0 |

```
exit_detail='FSM 500 last confirmed never, over the 1.000s staleness bound (10 missed reads at 10 Hz)'
```

The assertion printed `admission lock leaked: 2 rollouts started concurrently` on attempts 1, 4 and 5. Two rollouts were never alive at once on any attempt. **The lock was never involved** - and the test also never exercised a running rollout, so even its passing runs passed by timing accident.

## The fix

Stamp `_fsm_read_at` and keep it fresh with a refresher double, mirroring `_fake_driver`'s documented healthy-wire shape ("a no-op `MagicMock` plus a live timestamp is the healthy-wire case, which is what every test in this file is about"). The winner's rollout then survives its whole `duration`, so the other 49 threads deterministically meet a running loop. Both tests move onto one `_admission_driver()` helper that states the reason once.

No unit test can hold a rollout alive by wall clock alone by accident, which is worth recording: `unitree_sdk2py` is not a dependency of this package, so without the module-level autouse SDK stub the first frame build refuses and the loop exits with `exit_reason="policy"` in well under a millisecond. The stub is what makes a live rollout available here at all.

## The claim is now an observation, not an inference

The word "concurrently" in the old message was inferred from a count. It is now measured where the question can actually be asked - by each admitting thread, at the instant it is admitted:

```python
overlaps.extend(
    f"{id(earlier):x} was alive when {id(loop):x} was admitted"
    for earlier in admitted
    if earlier is not None and earlier is not loop and earlier.is_running
)
```

The count survives as its own cell, worded to say what it saw (`the burst admitted N rollouts, not one`). The two are kept apart deliberately: a second *sequential* admission is a fixture that let the first rollout die, not a leaked lock - which is the whole content of this PR.

I first tried a cheaper pin - sampling `get_task_status()["running"]` after the burst - and **dropped it as unsound**: on the pre-fix fixture it passed on the very run where the bug manifested, because it observes the *current* loop rather than whether an earlier one overlapped. It is kept only where it is sound (asserting the winner is live), and the overlap ledger carries the safety claim.

Both tests also gained a `finally` around cleanup, so a failed assertion cannot leave a 500 Hz daemon thread spinning for the remainder of the session.

## Gate

Same harness in every row: `taskset -c 0,1` (matching the 2-vCPU runner), coverage on, whole `tests/drivers`.

| | before | after |
| --- | ---: | ---: |
| admission-lock failures | **1 / 6 runs** | **0 / 10 runs** |
| pre-existing absent-extra failures | 47 | 47 (unchanged) |
| passed / skipped | 2080 / 59 | 2080 / 59 |

- `tests/drivers/test_g1_control_loop.py`: **35 passed**, 1.2s.
- Removing only the stamp and keeping the new assertions reproduces the original failure at directory scope - so the fix is pinned by its own removal.
- In isolation the class passes 8/8 both before and after; the flake needs the directory's contention, which is why the comparison above is made at that scope.
- `ruff check` / `ruff format --check`: clean. `mypy tests/drivers/test_g1_control_loop.py`: `Success: no issues found in 1 source file`.
- Meta-graders `test_whole_tree_graders_roster_is_complete`, `test_workflow_jobs_are_bounded`, `test_dependency_audit`: 175 passed, 1 skipped, 1 failed - `test_declared_qp_backends_are_real_qpsolvers_extras`, absent `qpsolvers` metadata on this box (only `.[dev]` installed, not `.[all]`), not attributable. The whole-tree grader script needs `.[all]` too and stops in `tests/tools/conftest.py` on absent `serial` for the same reason.

## No changelog fragment, deliberately

Stated so a round is not spent asking. `changelog.d/README.md` scopes fragments to what would have gone into `CHANGELOG.md`, and `changelog-fragment.yml` refuses exactly two things: an `### ` entry added to `[Unreleased]` that no fragment accounts for, and a malformed fragment the branch adds. This diff is one test file, adds no entry and no fragment, and changes nothing a user of the package can observe - so there is nothing for a release to render.

## Boundary

Six other files assign `_fsm_id` on a real `G1Driver` and call `run_policy` / `start_task` without stamping `_fsm_read_at`. None of them are touched here: they assert refusals or envelope shapes that do not require a live rollout, and the only other place that asserts the real "already running" refusal against a real driver is the sibling test in this class, which this PR fixes as well. Whether that fixture shape should be refused rather than merely avoided is a question about `_check_motion_gates`, not about this diff.

The flake was recorded as out of scope in #3149's boundary section; this is that follow-up. The related `g1.py:2050` coverage race noted there is a different thread-scheduling question and is not addressed here.