### PR TITLE
fix(mesh): the reported e-stop lockout duration is measured on the monotonic clock

### DIFF
--- a/changelog.d/3155-mesh-lockout-elapsed-monotonic.md
+++ b/changelog.d/3155-mesh-lockout-elapsed-monotonic.md
@@ -1,0 +1,6 @@
+The e-stop resume path measures `lockout_elapsed_s` on the monotonic clock
+instead of reconstructing it from two wall-clock reads, so a clock adjustment
+while the fleet was held (an RTC-less robot's first NTP sync, a VM resumed from
+suspend, an operator correcting the clock) can no longer distort -- or make
+negative -- the field the safety audit trail keeps to answer how long the fleet
+was halted. The envelope's `t` remains a wall-clock instant.

--- a/changelog.d/3155-mesh-lockout-elapsed-monotonic.md
+++ b/changelog.d/3155-mesh-lockout-elapsed-monotonic.md
@@ -1,6 +1,7 @@
-The e-stop resume path measures `lockout_elapsed_s` on the monotonic clock
-instead of reconstructing it from two wall-clock reads, so a clock adjustment
-while the fleet was held (an RTC-less robot's first NTP sync, a VM resumed from
-suspend, an operator correcting the clock) can no longer distort -- or make
-negative -- the field the safety audit trail keeps to answer how long the fleet
-was halted. The envelope's `t` remains a wall-clock instant.
+### Fixed: the e-stop resume path measures `lockout_elapsed_s` on the monotonic clock
+
+The duration is no longer reconstructed from two wall-clock reads, so a clock
+adjustment while the fleet was held (an RTC-less robot's first NTP sync, a VM
+resumed from suspend, an operator correcting the clock) can no longer distort --
+or make negative -- the field the safety audit trail keeps to answer how long the
+fleet was halted. The envelope's `t` remains a wall-clock instant.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -3755,6 +3755,10 @@ class Mesh(SensorLoopsMixin):
 
         Structured detail is preserved in the local
         ``publish_safety_event`` audit record where forensics can use it.
+        ``lockout_elapsed_s`` is measured in the monotonic domain (from
+        ``_last_estop_mono``, stamped with ``_last_estop_ts`` at engage time),
+        so a wall-clock adjustment while the fleet was held cannot distort the
+        one field that answers how long it was held.
         Local callers (e.g. operator tooling that wants to show "already
         unlocked" UI) can still distinguish via the local audit log.
             {"status": "error", "error": "<reason>"}  # rejected
@@ -3907,7 +3911,21 @@ class Mesh(SensorLoopsMixin):
             _emit_resume_denied("bad override code", "warning")
             return _generic_error
 
-        elapsed = time.time() - self._last_estop_ts
+        # ``lockout_elapsed_s`` is a DURATION, so it is measured in the
+        # monotonic domain every other piece of local safety bookkeeping
+        # uses -- the pair ``_last_estop_ts``/``_last_estop_mono`` is
+        # stamped together at engage time precisely so a duration never has
+        # to be reconstructed from two wall-clock reads. A wall-clock
+        # adjustment between the engage and this resume (chrony stepping an
+        # RTC-less robot at its first NTP sync, a VM resumed from suspend, an
+        # operator correcting the clock) moves ``time.time()`` without any
+        # time being held, so the wall-clock difference reports a lockout
+        # that did not happen -- inflated by a forward step, and NEGATIVE by
+        # a backward one, in the one field the audit trail keeps to answer
+        # how long the fleet was halted. ``_last_estop_ts`` stays the source
+        # of the envelope's ``t``: that is an absolute instant, and the wall
+        # clock is the only domain a remote peer can interpret.
+        elapsed = time.monotonic() - self._last_estop_mono
         self._estop_lockout.clear()
         # M-1: a correct code clears the brute-force counter + any cooldown.
         with self._resume_bruteforce_lock:

--- a/tests/mesh/test_estop_recovery_prerequisites.py
+++ b/tests/mesh/test_estop_recovery_prerequisites.py
@@ -66,6 +66,7 @@ def _mint_resume(*, issuer_clock_offset_s: float = 0.0) -> dict[str, Any]:
     operator._publish_safety_envelope = lambda key, env: captured.update(env)
     operator._estop_lockout.set()
     operator._last_estop_ts = time.time() - 3.0
+    operator._last_estop_mono = time.monotonic() - 3.0
     real_time = time.time
     with patch.object(core.time, "time", lambda: real_time() + issuer_clock_offset_s):
         result = operator._resume_lockout(_CODE)

--- a/tests/mesh/test_mesh_safety_hardening.py
+++ b/tests/mesh/test_mesh_safety_hardening.py
@@ -160,6 +160,7 @@ class TestM1ResumeBruteForce:
         m.peer_id = "p"
         m._estop_lockout = threading.Event()
         m._last_estop_ts = 0.0
+        m._last_estop_mono = 0.0
         m.publish_safety_event = lambda **kw: None
         return m
 

--- a/tests/mesh/test_resume_lockout_elapsed_clock_domain.py
+++ b/tests/mesh/test_resume_lockout_elapsed_clock_domain.py
@@ -1,0 +1,212 @@
+"""``lockout_elapsed_s`` is a duration, so it rides the monotonic clock.
+
+``Mesh`` stamps two timestamps together whenever the e-stop lockout engages:
+``_last_estop_ts`` (wall) and ``_last_estop_mono`` (monotonic). The split
+exists because the two answer different questions. ``_last_estop_ts`` is an
+absolute instant, published as the envelope's ``t`` where the wall clock is the
+only domain a remote peer can interpret. ``_last_estop_mono`` is what durations
+are measured from, because the wall clock can be adjusted underneath a running
+process.
+
+``test_corroboration_clock_domain`` already pins that rule for the 0.2s
+corroboration window. The resume path reports a second duration --
+``lockout_elapsed_s``, the field the audit trail keeps to answer how long the
+fleet was halted, echoed into the resume envelope and the operator log line --
+and it was reconstructed from two wall-clock reads. A clock adjustment during
+the lockout (chrony stepping an RTC-less robot at its first NTP sync, a VM
+resumed from suspend, an operator correcting the clock) therefore moved the
+reported duration without any time being held: inflated by a forward step,
+negative by a backward one.
+
+The pins below drive the real ``_resume_lockout`` and read the three places the
+duration surfaces, plus the two controls that keep the fix honest -- an
+undisturbed clock still reports the time actually held, and ``t`` stays on the
+wall clock.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh import core
+
+_CODE = "operator-secret"
+_WALL_AT_ENGAGE = 1_800_000_000.0
+_MONO_AT_ENGAGE = 500_000.0
+
+
+class _Clock:
+    """A wall clock that can be stepped beside a monotonic clock that cannot."""
+
+    def __init__(self) -> None:
+        self.wall = _WALL_AT_ENGAGE
+        self.mono = _MONO_AT_ENGAGE
+
+    def hold(self, seconds: float, *, wall_step: float = 0.0) -> None:
+        """Hold the lockout for *seconds*, with the wall clock also stepped."""
+        self.mono += seconds
+        self.wall += seconds + wall_step
+
+    def time(self) -> float:
+        return self.wall
+
+    def monotonic(self) -> float:
+        return self.mono
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> _Clock:
+    clk = _Clock()
+    monkeypatch.setattr(core.time, "time", clk.time)
+    monkeypatch.setattr(core.time, "monotonic", clk.monotonic)
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", _CODE)
+    return clk
+
+
+def _engaged_operator(monkeypatch: pytest.MonkeyPatch) -> tuple[core.Mesh, dict[str, Any], list[dict]]:
+    """An operator peer holding an engaged lockout, with its sinks captured.
+
+    The lockout is stamped exactly as ``emergency_stop`` stamps it -- both
+    timestamps, from the clock under test -- so the pins read production state
+    rather than a half-wired approximation of it.
+    """
+    mesh = core.Mesh(robot=object(), peer_id="operator-1")
+    mesh._running = True
+    audited: list[dict] = []
+    mesh.publish_safety_event = lambda **kw: audited.append(kw)  # type: ignore[method-assign]
+    monkeypatch.setattr(mesh, "_local_session_zid", lambda: None)
+    monkeypatch.setattr(mesh, "_safety_wire_zid", lambda key: None)
+    published: dict[str, Any] = {}
+    monkeypatch.setattr(core, "put", lambda key, payload: published.update(payload))
+
+    mesh._estop_lockout.set()
+    mesh._last_estop_ts = core.time.time()
+    mesh._last_estop_mono = core.time.monotonic()
+    return mesh, published, audited
+
+
+def _resume(mesh: core.Mesh) -> None:
+    assert mesh._resume_lockout(_CODE) == {"status": "ok"}
+
+
+class TestTheReportedLockoutIsTheTimeTheFleetWasHeld:
+    """The duration cannot be moved by an adjustment of the wall clock."""
+
+    def test_an_undisturbed_clock_reports_the_time_the_fleet_was_held(
+        self, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Control: with no clock adjustment both domains agree, so this
+        passes with or without the fix -- it is what gives the two pins below
+        their meaning."""
+        mesh, published, _ = _engaged_operator(monkeypatch)
+        clock.hold(12.5)
+        _resume(mesh)
+        assert published["lockout_elapsed_s"] == pytest.approx(12.5)
+
+    @pytest.mark.parametrize(
+        ("adjustment", "wall_step"),
+        [
+            ("chrony steps the clock forward one hour", 3600.0),
+            ("an operator corrects the clock back two hours", -7200.0),
+            ("an RTC-less robot syncs to NTP for the first time", -100_000_000.0),
+        ],
+    )
+    def test_a_wall_clock_adjustment_does_not_move_the_reported_lockout(
+        self, clock: _Clock, monkeypatch: pytest.MonkeyPatch, adjustment: str, wall_step: float
+    ) -> None:
+        """The fleet is held for 12.5s in every row; only the wall clock moves."""
+        mesh, published, _ = _engaged_operator(monkeypatch)
+        clock.hold(12.5, wall_step=wall_step)
+        _resume(mesh)
+        assert published["lockout_elapsed_s"] == pytest.approx(12.5), adjustment
+
+    def test_a_backward_correction_cannot_report_a_negative_lockout(
+        self, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A duration read off a monotonic clock cannot be negative, so the
+        audit trail can never claim the fleet resumed before it stopped."""
+        mesh, published, audited = _engaged_operator(monkeypatch)
+        clock.hold(12.5, wall_step=-7200.0)
+        _resume(mesh)
+        assert published["lockout_elapsed_s"] >= 0.0
+        resume_ok = [e for e in audited if e["event_type"] == "resume_ok"]
+        assert [e["payload"]["lockout_elapsed_s"] for e in resume_ok] == [pytest.approx(12.5)]
+
+    def test_every_sink_reports_the_same_duration(
+        self, clock: _Clock, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The audit record, the resume envelope and the operator log line are
+        three views of one measurement, so a forward step must not leave them
+        describing different lockouts."""
+        mesh, published, audited = _engaged_operator(monkeypatch)
+        clock.hold(30.0, wall_step=3600.0)
+        with caplog.at_level(logging.WARNING, logger=core.logger.name):
+            _resume(mesh)
+
+        audited_elapsed = [e["payload"]["lockout_elapsed_s"] for e in audited if e["event_type"] == "resume_ok"]
+        assert audited_elapsed == [pytest.approx(30.0)]
+        assert published["lockout_elapsed_s"] == pytest.approx(30.0)
+        assert "resume after 30.0s lockout" in caplog.text
+
+
+class TestTheEnvelopeInstantStaysOnTheWallClock:
+    """The complement of the rule: ``t`` is an instant, not a duration."""
+
+    def test_the_envelope_timestamp_is_a_wall_clock_instant(
+        self, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A receiver compares ``t`` against its own wall clock for freshness,
+        so moving it into the monotonic domain would make every resume look
+        decades stale. This fails if the two timestamps are conflated."""
+        mesh, published, _ = _engaged_operator(monkeypatch)
+        clock.hold(12.5)
+        _resume(mesh)
+        assert published["t"] == pytest.approx(clock.wall)
+
+    def test_the_proof_binds_the_duration_the_envelope_carries(
+        self, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The override proof is recomputed by every receiver over the body it
+        actually sees, so the duration the issuer measured is the duration
+        bound into the MAC."""
+        mesh, published, _ = _engaged_operator(monkeypatch)
+        clock.hold(12.5, wall_step=3600.0)
+        _resume(mesh)
+        expected = core.hmac.new(
+            _CODE.encode(),
+            json.dumps(
+                {
+                    "peer_id": "operator-1",
+                    "t": published["t"],
+                    "lockout_elapsed_s": published["lockout_elapsed_s"],
+                    "proof_nonce": published["proof_nonce"],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode(),
+            "sha256",
+        ).hexdigest()
+        assert published["override_proof"] == expected
+
+
+class TestAResumeIsStillAcceptedEndToEnd:
+    """A receiver clears its lockout from the envelope the issuer minted."""
+
+    def test_a_receiver_recovers_from_the_minted_envelope(self, clock: _Clock, monkeypatch: pytest.MonkeyPatch) -> None:
+        mesh, published, _ = _engaged_operator(monkeypatch)
+        clock.hold(12.5, wall_step=-7200.0)
+        _resume(mesh)
+
+        receiver = core.Mesh(robot=object(), peer_id="robot-1")
+        receiver.publish_safety_event = MagicMock()  # type: ignore[method-assign]
+        receiver._estop_lockout.set()
+        sample = MagicMock()
+        sample.payload.to_bytes.return_value = json.dumps(published).encode()
+        receiver._on_safety_resume(sample)
+
+        assert receiver._estop_lockout.is_set() is False, "the fleet would stay e-stopped"

--- a/tests/mesh/test_resume_proof_fallback_path.py
+++ b/tests/mesh/test_resume_proof_fallback_path.py
@@ -52,6 +52,7 @@ def test_resume_proof_verifies_when_published_on_fallback_path(monkeypatch):
     # Engage the local lockout, then resume with the correct override code.
     issuer._estop_lockout.set()
     issuer._last_estop_ts = core.time.time()
+    issuer._last_estop_mono = core.time.monotonic()
     result = issuer._resume_lockout("operator-secret")
     assert result == {"status": "ok"}
 

--- a/tests/mesh/test_safety_envelope_zenoh_absent.py
+++ b/tests/mesh/test_safety_envelope_zenoh_absent.py
@@ -181,6 +181,7 @@ class TestRemoteResumeStillVerifiesWhenZenohIsAbsent:
 
         issuer._estop_lockout.set()
         issuer._last_estop_ts = core.time.time()
+        issuer._last_estop_mono = core.time.monotonic()
         assert issuer._resume_lockout("operator-secret") == {"status": "ok"}
 
         assert published["key"] == RESUME_KEY
@@ -215,6 +216,7 @@ class TestRemoteResumeStillVerifiesWhenZenohIsAbsent:
 
         issuer._estop_lockout.set()
         issuer._last_estop_ts = core.time.time()
+        issuer._last_estop_mono = core.time.monotonic()
         issuer._resume_lockout("operator-secret")
 
         envelope = published["payload"]

--- a/tests/mesh/test_safety_timing_and_replay_defenses.py
+++ b/tests/mesh/test_safety_timing_and_replay_defenses.py
@@ -49,6 +49,7 @@ class TestResumeLockoutTimingOracleClosed:
         m.peer_id = "test-peer"
         m._estop_lockout = threading.Event()
         m._last_estop_ts = 0.0
+        m._last_estop_mono = 0.0
         m.publish_safety_event = lambda **kw: None
         return m
 


### PR DESCRIPTION
`Mesh` stamps two timestamps together whenever the e-stop lockout engages, because they answer different questions:

| field | domain | what it is | published as |
|---|---|---|---|
| `_last_estop_ts` | wall | an absolute instant | envelope `t` -- the only domain a remote peer can interpret |
| `_last_estop_mono` | monotonic | what durations are measured from | corroboration window, and now `lockout_elapsed_s` |

`_resume_lockout` reconstructed `lockout_elapsed_s` from two wall-clock reads. A clock adjustment between the engage and the resume therefore moved the reported duration without any time being held -- and that field is the one the audit trail keeps to answer how long the fleet was halted, echoed into the resume envelope and the operator log line.

![lockout_elapsed_s before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/lockout-clock-domain/lockout_clock_domain.png)

The fleet is held for **12.5 s** in every row; only the wall clock moves.

| wall-clock event during the lockout | before | after |
|---|---|---|
| none | 12.5 s | 12.5 s |
| chrony steps forward 1 h | **3612.5 s** | 12.5 s |
| operator corrects the clock back 2 h | **-7187.5 s** | 12.5 s |
| RTC-less robot's first NTP sync | **-99999987.5 s** | 12.5 s |

The backward rows are the sharp ones: the audit record claims the fleet resumed before it stopped, and `logger.warning("resume after %.1fs lockout")` prints it.

## The rule was already in the tree

`tests/mesh/test_corroboration_clock_domain.py` exists for exactly this, for the 0.2 s corroboration window:

> This MUST use `time.monotonic()` (the same domain as every other local bookkeeping timestamp in the safety subsystem), NOT `time.time()` (wall-clock).

`_last_estop_mono` was introduced by that fix. Its structural pin is scoped to the `< 0.2` comparison and explicitly exempts the audit payload -- "`_last_estop_ts` is still used for audit payloads and logging" -- but `lockout_elapsed_s` is a duration, not a timestamp, so it belongs on the same side of the rule as the window.

## Change

`elapsed = time.monotonic() - self._last_estop_mono`. `_last_estop_ts` still sources the envelope's `t`: that is an absolute instant, and a receiver compares it against its own wall clock for freshness.

Scoped out deliberately: `mesh/input.py` ages an input frame with `time.time() - data["t"]`, where `t` came from a *different host*. There the wall clock is the only shared domain, and that path already tolerates skew explicitly (`_resume_forward_skew_s`).

## Tests

New `tests/mesh/test_resume_lockout_elapsed_clock_domain.py` drives the real `_resume_lockout` against a steppable wall clock beside a monotonic one that cannot step. Pre-fix **5 failed / 4 passed**; after, 9 passed. The four that pass on both are the controls that give the pins meaning:

- an undisturbed clock still reports the time actually held;
- `t` stays a wall-clock instant (this fails if someone "fixes" it by conflating the two);
- the override proof still binds the duration the envelope carries;
- a receiver still clears its lockout from the minted envelope end to end.

The pins read all three sinks -- the `resume_ok` audit payload, the published envelope, and the operator log line -- because they are three views of one measurement.

Six hand-wired `Mesh` doubles set `_last_estop_ts` without its monotonic sibling, a state `__init__` never produces (and which `test_last_estop_mono_initialized_at_init` already pins). Two of them raised `AttributeError` on the fixed code; all six now stamp the pair the way `emergency_stop` does.

## Local gate

`tests/mesh`: base **21 failed / 4807 passed / 24 errors**, branch **21 failed / 4816 passed / 24 errors** -- failing node-id sets identical (`awsiot` absent), +9 = exactly the new cells. ruff check + format clean; mypy unchanged at the repository's standing 20 errors in 6 files, none in the touched paths.

Source and tests are **+237 / -1**, plus a 7-line changelog fragment. 19 of the added source lines are the comment explaining the domain split; the executable change is one line.

## Round 2

One concern, one commit: `4ef12eb`.

**`Refuse a changelog entry that breaks the fragment convention` was red.** The
fragment opened with body prose, and the check said so precisely:

```
3155-mesh-lockout-elapsed-monotonic.md: first line must be a level-3 entry
heading ('### <Category>: <summary>'), got 'The e-stop resume path measures
`lockout_elapsed_s` on the monotonic clock'
```

This is a real contract, not a formality: `assemble_changelog.py` folds a
fragment into `CHANGELOG.md` *by* its `### ` line (`FRAGMENT_HEADING =
re.compile(r"^### \S")`), so a fragment without one has nothing to be folded
under and would have gone missing from the released log.

Added the heading the rest of `changelog.d` uses, and removed the opening
sentence the heading now carries so the entry does not state its own subject
twice. Verified against the checker's own two rules before pushing -- first
non-blank line matches `^### \S`, and exactly one `### ` line in the file -- plus
pure-ASCII and a trailing newline.

No source, test, or behaviour change: the diff is 7 insertions / 6 deletions in
the fragment alone.
