### PR TITLE
fix(assets): one owner decides whether a model's meshes are on disk

### DIFF
--- a/changelog.d/3156-asset-mesh-scan-one-owner.md
+++ b/changelog.d/3156-asset-mesh-scan-one-owner.md
@@ -1,0 +1,30 @@
+### Fixed: one owner decides whether a model's meshes are on disk
+
+`_needs_download` (should a robot's assets be fetched?) and
+`MuJoCoSimEngine._ensure_meshes` (may `add_robot` proceed?) ask the same
+question about the same model. `_ensure_meshes` reads the model the way MuJoCo
+does -- the main file plus every `<include>`d fragment, with the `<compiler>`
+mesh directory taken across fragments. `_needs_download` read the main file
+alone, so a model whose meshes only an included fragment declares had no mesh
+reference to check, which is indistinguishable from a model whose meshes are
+all present.
+
+Shipped Menagerie assets are built that way: `ability_hand`'s `scene.xml`
+declares none of its 13 meshes, and its included hand fragment declares all 13
+plus the `meshdir`. With those meshes absent MuJoCo refuses the model and
+`_ensure_meshes` correctly asks for a download -- and the download it asked for
+was a no-op, because the download path reported the assets present, leaving the
+caller with the mesh-not-found error that check exists to prevent. `force=True`
+could not reach such a model either: the early return for "no mesh references"
+was taken before `force` was consulted, so
+`download_robots(names=["ability_hand"], force=True)` answered "All 1 robots
+already have assets. Use force=True to re-download."
+
+The scan is now one function, `_mjcf_missing_meshes`, beside the resolution rule
+it applies; both callers use it and the private copy in `_ensure_meshes` is
+deleted, which also settles two smaller asymmetries between the copies (the mesh
+extension set, and which fragments count as the model). The two paths keep their
+opposite readings of an *unreadable* model, now stated in one place rather than
+emerging from two implementations: the download path fetches, because a fetch is
+what replaces a file it cannot read, while the sim path proceeds, because MuJoCo
+names the unreadable file itself on the load that follows.

--- a/strands_robots/assets/download.py
+++ b/strands_robots/assets/download.py
@@ -165,8 +165,83 @@ def _mjcf_mesh_candidates(mesh_ref: str, model_dir: str, mesh_subdir: str, inclu
     return candidates
 
 
+#: Mesh file extensions an MJCF ``file=`` reference may name. MuJoCo loads
+#: ``.stl``, ``.obj`` and ``.msh``; the case variants appear in shipped assets.
+_MESH_REF_RE = re.compile(r'file="([^"]+\.(?:stl|STL|obj|OBJ|msh))"')
+
+#: ``<include file="...">`` - the fragments that make up one model.
+_INCLUDE_RE = re.compile(r'<include\s+file="([^"]+)"')
+
+
+def _mjcf_missing_meshes(model_path: str | os.PathLike[str]) -> list[str]:
+    """Return the mesh references a model declares that are absent on disk.
+
+    This is the single owner of "are this model's meshes on disk?". Two callers
+    ask it - :func:`_needs_download` (should the assets be fetched?) and
+    :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine._ensure_meshes`
+    (may ``add_robot`` proceed?) - and one owner is what keeps them from judging
+    the same model present and absent.
+
+    A model is its main file plus every ``<include>``d fragment, because both
+    halves of the rule span fragments:
+
+    * ``<compiler meshdir|assetdir>`` is model-global (see
+      :func:`_mjcf_mesh_subdir`), so the fragment declaring the directory need
+      not be the one declaring the mesh;
+    * a fragment may declare meshes the main file never mentions - shipped
+      Menagerie assets do exactly this (``ability_hand``'s scene declares none
+      of its 13 meshes; its included hand fragment declares all of them plus
+      the ``meshdir``). Reading the main file alone reports such a model as
+      declaring no meshes at all, which is indistinguishable from a model whose
+      meshes are all present.
+
+    Each reference is resolved the way MuJoCo resolves it, via
+    :func:`_mjcf_mesh_candidates`.
+
+    Args:
+        model_path: Path to the model's MAIN file (the one the registry names).
+
+    Returns:
+        The absent references, as authored. Empty when the model declares no
+        meshes or every one of them resolves - the two cases callers may treat
+        alike, since neither has anything to fetch.
+
+    Raises:
+        OSError: The main file cannot be read.
+        UnicodeDecodeError: The main file is not decodable text. An unreadable
+            *fragment* is not an error: it declares no reference this scan can
+            check, and MuJoCo names it on the load that follows.
+    """
+    model_dir = os.path.dirname(os.path.abspath(os.fspath(model_path)))
+    main = Path(model_path).read_text()
+
+    # (fragment directory relative to model_dir, fragment text)
+    fragments: list[tuple[str, str]] = [("", main)]
+    for inc in _INCLUDE_RE.findall(main):
+        inc_path = os.path.join(model_dir, inc)
+        try:
+            text = Path(inc_path).read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        rel = os.path.relpath(os.path.dirname(os.path.abspath(inc_path)), model_dir)
+        fragments.append(("" if rel == os.curdir else rel, text))
+
+    mesh_subdir = _mjcf_mesh_subdir(*(text for _rel, text in fragments))
+    missing: list[str] = []
+    for rel_dir, text in fragments:
+        for ref in _MESH_REF_RE.findall(text):
+            if not any(os.path.exists(c) for c in _mjcf_mesh_candidates(ref, model_dir, mesh_subdir, rel_dir)):
+                missing.append(ref)
+    return missing
+
+
 def _needs_download(name: str, info: dict[str, Any] | None, force: bool = False) -> bool:
-    """Return *True* if a robot's mesh files are missing."""
+    """Return *True* if a robot's mesh files are missing.
+
+    ``force`` re-fetches a model whose meshes are all present. A model with
+    nothing missing is the only case ``force`` decides: a missing reference is
+    fetched either way.
+    """
     if info is None:
         return False
     asset = info.get("asset", {})
@@ -180,19 +255,15 @@ def _needs_download(name: str, info: dict[str, Any] | None, force: bool = False)
         if not model_path.exists():
             continue
         try:
-            content = model_path.read_text()
-            mesh_files = re.findall(r'file="([^"]+\.(?:stl|STL|obj|OBJ|msh))"', content)
-            if not mesh_files:
-                return False
-            meshdir = _mjcf_mesh_subdir(content)
-            for mesh in mesh_files:
-                # The model file declares these itself, so there is no
-                # include-relative candidate to consider.
-                if not any(os.path.exists(p) for p in _mjcf_mesh_candidates(mesh, str(model_path.parent), meshdir)):
-                    return True
-            return force
+            missing = _mjcf_missing_meshes(model_path)
         except Exception:
+            # An unreadable model tells us nothing about its meshes, so fetch
+            # the assets rather than declare them present.
             return True
+        if missing:
+            logger.debug("assets: %s declares %d mesh reference(s) not on disk: %s", name, len(missing), missing)
+            return True
+        return force
 
     return True
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -65,7 +65,6 @@ import json
 import logging
 import numbers
 import os
-import re
 import threading
 import time
 from collections.abc import AsyncGenerator, Callable, Mapping, Sequence

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1305,51 +1305,22 @@ class MuJoCoSimEngine(
         ``force=True`` re-download on every ``add_robot`` and refuses the robot
         outright when that download cannot run.
         """
-        # One owner for the resolution rule: the download path applies the same
-        # rule to decide whether a robot's assets need fetching, so a second
-        # copy here could disagree with it about the same model.
-        from strands_robots.assets.download import _mjcf_mesh_candidates, _mjcf_mesh_subdir
+        # One owner for the resolution rule AND for the scan that applies it:
+        # the download path decides the same question when it works out whether
+        # a robot's assets need fetching, so a second copy here could disagree
+        # with it about the same model.
+        from strands_robots.assets.download import _mjcf_missing_meshes
 
-        model_dir = os.path.dirname(os.path.abspath(model_path))
-
-        files_to_check = [model_path]
         try:
-            with open(model_path) as _f:
-                top_content = _f.read()
-            for inc in re.findall(r'<include\s+file="([^"]+)"', top_content):
-                inc_path = os.path.join(model_dir, inc)
-                if os.path.exists(inc_path):
-                    files_to_check.append(inc_path)
+            missing = bool(_mjcf_missing_meshes(model_path))
         except (OSError, UnicodeDecodeError):
-            # An unreadable top-level model contributes no includes to scan.
-            # MuJoCo names the unreadable file itself on the load that follows,
-            # which is a better report than anything this check could invent.
-            pass
-
-        # (fragment directory relative to model_dir, fragment text)
-        fragments: list[tuple[str, str]] = []
-        for xml_path in files_to_check:
-            try:
-                with open(xml_path) as _f:
-                    content = _f.read()
-            except (OSError, UnicodeDecodeError):
-                # Same reasoning: a fragment we cannot read declares no mesh
-                # references, and MuJoCo reports it on load.
-                continue
-            frag_dir = os.path.dirname(os.path.abspath(xml_path))
-            rel_dir = os.path.relpath(frag_dir, model_dir)
-            fragments.append(("" if rel_dir == os.curdir else rel_dir, content))
-
-        mesh_subdir = _mjcf_mesh_subdir(*(text for _rel, text in fragments))
-
-        missing = False
-        for rel_dir, content in fragments:
-            for mf in re.findall(r'file="([^"]+\.(?:stl|STL|obj))"', content):
-                if not any(os.path.exists(p) for p in _mjcf_mesh_candidates(mf, model_dir, mesh_subdir, rel_dir)):
-                    missing = True
-                    break
-            if missing:
-                break
+            # An unreadable model contributes no reference this check can
+            # resolve. MuJoCo names the unreadable file itself on the load that
+            # follows, which is a better report than anything invented here -
+            # so proceed rather than spend a download on a guess. The download
+            # path takes the opposite reading of the same failure, because a
+            # fetch is what replaces a file it cannot read.
+            missing = False
 
         if not missing:
             return None

--- a/tests/simulation/mujoco/test_ensure_meshes.py
+++ b/tests/simulation/mujoco/test_ensure_meshes.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import inspect
 import os
+import struct
 
 import pytest
 
@@ -28,6 +29,23 @@ pytest.importorskip("mujoco")
 from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine  # noqa: E402
 
 _ensure_meshes = MuJoCoSimEngine._ensure_meshes
+
+
+def _binary_stl(faces=((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))) -> bytes:
+    """A loadable binary STL (a unit tetrahedron by default).
+
+    MuJoCo compiles a mesh it can hull, so a fixture that claims its meshes are
+    present has to hand it real geometry - a stub file is refused for reasons
+    that have nothing to do with where the reference resolved.
+    """
+    vertices = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)]
+    out = b"\0" * 80 + struct.pack("<I", len(faces))
+    for face in faces:
+        out += struct.pack("<3f", 0.0, 0.0, 0.0)  # normal; MuJoCo recomputes it
+        for index in face:
+            out += struct.pack("<3f", *vertices[index])
+        out += b"\0\0"  # attribute byte count
+    return out
 
 
 def _write(path, content):
@@ -276,12 +294,81 @@ class TestAReferenceIsResolvedTheWayMuJoCoResolvesIt:
 class TestTheDownloadPathUsesTheSameRule:
     """``_needs_download`` decides the same question and must not disagree.
 
-    Both paths ask "are this model's meshes on disk?". They read the rule from
-    one place so a model cannot be judged present by one and absent by the
-    other.
+    Both paths ask "are this model's meshes on disk?". They read the rule - and
+    the scan that applies it - from one place, so a model cannot be judged
+    present by one and absent by the other.
+
+    The shape that separates two owners is a model whose meshes only an
+    ``<include>``d fragment declares. Shipped Menagerie assets are built this
+    way (``ability_hand``'s scene declares none of its 13 meshes; its included
+    hand fragment declares all of them plus the ``meshdir``), and a scan that
+    reads the main file alone finds no reference to check there at all - which
+    is indistinguishable from a model whose meshes are all present.
     """
 
-    def test_needs_download_honors_assetdir(self, tmp_path):
+    @staticmethod
+    def _include_shaped_model(tmp_path, *, meshes_present: bool):
+        """Write a model whose only mesh - and its ``meshdir`` - an include declares.
+
+        Returns the main model path and the registry entry naming it.
+        """
+        root = tmp_path / "robots"
+        (root / "parts").mkdir(parents=True)
+        (root / "assets").mkdir()
+        _write(
+            root / "parts" / "arm.xml",
+            '<mujoco><compiler meshdir="assets"/><asset><mesh file="arm.stl"/></asset>'
+            '<worldbody><body><geom type="mesh" mesh="arm"/></body></worldbody></mujoco>',
+        )
+        model = _write(root / "robot.xml", '<mujoco><include file="parts/arm.xml"/></mujoco>')
+        if meshes_present:
+            (root / "assets" / "arm.stl").write_bytes(_binary_stl())
+        return model, {"asset": {"model_xml": "robot.xml", "dir": "robots"}}
+
+    @pytest.mark.parametrize("meshes_present", [True, False])
+    def test_the_two_owners_agree_about_a_mesh_only_an_include_declares(self, tmp_path, monkeypatch, meshes_present):
+        """Both answers track MuJoCo's own verdict on the same tree.
+
+        MuJoCo is the tie-breaker: it is the reader whose opinion the two
+        owners exist to predict, so the case is not built on either one's
+        reading of the model.
+        """
+        import mujoco
+
+        import strands_robots.assets.download as dl_mod
+
+        model, info = self._include_shaped_model(tmp_path, meshes_present=meshes_present)
+        monkeypatch.setattr(dl_mod, "get_search_paths", lambda: [tmp_path])
+
+        try:
+            mujoco.MjModel.from_xml_path(model)
+            mujoco_loads = True
+        except ValueError:
+            mujoco_loads = False
+        assert mujoco_loads is meshes_present, "the fixture does not pose the case it claims"
+
+        fetches: list[list[str]] = []
+        monkeypatch.setattr("strands_robots.assets.resolve_robot_name", lambda n: n)
+        monkeypatch.setattr(dl_mod, "download_robots", lambda names, force: fetches.append(names))
+        _ensure_meshes(model, "robot")
+
+        assert bool(fetches) is (not meshes_present), "add_robot's check disagreed with MuJoCo"
+        assert dl_mod._needs_download("robot", info) is (not meshes_present), (
+            "the download path disagreed with MuJoCo, so the fetch add_robot asks for is a no-op"
+        )
+
+    def test_force_reaches_a_model_whose_meshes_an_include_declares(self, tmp_path, monkeypatch):
+        """``force`` decides the nothing-missing case, whichever fragment declares it."""
+        import strands_robots.assets.download as dl_mod
+
+        _model, info = self._include_shaped_model(tmp_path, meshes_present=True)
+        monkeypatch.setattr(dl_mod, "get_search_paths", lambda: [tmp_path])
+
+        assert dl_mod._needs_download("robot", info, force=False) is False
+        assert dl_mod._needs_download("robot", info, force=True) is True
+
+    def test_needs_download_honors_assetdir(self, tmp_path, monkeypatch):
+        import strands_robots.assets.download as dl_mod
         from strands_robots.assets.download import _needs_download
 
         (tmp_path / "robots" / "assets").mkdir(parents=True)
@@ -291,27 +378,26 @@ class TestTheDownloadPathUsesTheSameRule:
             encoding="utf-8",
         )
         info = {"asset": {"model_xml": "robot.xml", "dir": "robots"}}
-        import strands_robots.assets.download as dl_mod
+        monkeypatch.setattr(dl_mod, "get_search_paths", lambda: [tmp_path])
+        assert _needs_download("robot", info) is False
 
-        original = dl_mod.get_search_paths
-        try:
-            dl_mod.get_search_paths = lambda: [tmp_path]
-            assert _needs_download("robot", info) is False
-        finally:
-            dl_mod.get_search_paths = original
-
-    def test_both_paths_read_the_subdir_rule_from_one_place(self):
-        """The rule has a single owner, so the two callers cannot drift."""
+    def test_both_paths_read_the_scan_from_one_place(self):
+        """The scan has a single owner, so the two callers cannot drift."""
         import strands_robots.assets.download as dl_mod
         from strands_robots.simulation.mujoco import simulation as sim_mod
 
-        assert callable(dl_mod._mjcf_mesh_subdir)
-        assert callable(dl_mod._mjcf_mesh_candidates)
-        source = inspect.getsource(sim_mod.MuJoCoSimEngine._ensure_meshes)
-        assert "_mjcf_mesh_subdir" in source
-        assert "_mjcf_mesh_candidates" in source
-        # ...and no second copy of the regex it replaces.
-        assert 'meshdir="([^"]*)"' not in source
+        assert callable(dl_mod._mjcf_missing_meshes)
+        for source in (
+            inspect.getsource(sim_mod.MuJoCoSimEngine._ensure_meshes),
+            inspect.getsource(dl_mod._needs_download),
+        ):
+            assert "_mjcf_missing_meshes" in source
+            # ...and no second copy of the rules that owner applies: neither the
+            # subdir attributes, nor which fragments make up the model, nor
+            # which extensions name a mesh.
+            assert 'meshdir="([^"]*)"' not in source
+            assert "<include\\s+file=" not in source
+            assert "(?:stl|STL" not in source
 
 
 class TestTheSubdirRuleItself:


### PR DESCRIPTION
Two functions ask "are this model's meshes on disk?" about the same model: `_needs_download` (should a robot's assets be fetched?) and `MuJoCoSimEngine._ensure_meshes` (may `add_robot` proceed?). `_ensure_meshes` reads the model the way MuJoCo does - the main file **plus every `<include>`d fragment**, with the `<compiler>` mesh directory taken across fragments. `_needs_download` read the main file alone.

So a model whose meshes only an included fragment declares had no mesh reference to check at all, which is indistinguishable from a model whose meshes are all present. Shipped Menagerie assets are built exactly that way.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-scan-one-owner/artifact.png)

## Measured on `ability_hand` (a registry robot)

Its `scene.xml` declares **none** of its 13 meshes; the included `hands/abh_right_large.xml` declares all 13 plus `meshdir="./assets"`.

| meshes on disk | MuJoCo | `_ensure_meshes` asks for a fetch | `_needs_download` (force=False) | (force=True) |
|---|---|---|---|---|
| 17 | loads | no | no | **no** -> after: yes |
| 0 | refuses | **yes** | **no** -> after: yes | **no** -> after: yes |

Row 2 is the failure that ships: MuJoCo refuses the model, `_ensure_meshes` correctly asks for a download, and the download it asks for is a no-op because the download path reports the assets present. The user sees MuJoCo's mesh-not-found - the cryptic error `_ensure_meshes` exists to prevent.

`force=True` could not reach such a model either. The early return for "no mesh references" was taken before `force` was consulted:

```python
>>> download_robots(names=["ability_hand"], force=True)   # 0 meshes on disk
{'downloaded': 0, 'skipped': 1, 'failed': 0,
 'message': 'All 1 robots already have assets. Use force=True to re-download.'}
```

## Change

The scan becomes one function, `_mjcf_missing_meshes`, next to the resolution rule it applies; both callers use it and `_ensure_meshes`'s private copy is deleted. That also removes two smaller asymmetries between the copies: the extension set (`.OBJ`/`.msh` were only in one) and which fragments count as the model.

The two paths keep their opposite - and separately pinned - readings of an *unreadable* model, now stated in one place instead of emerging from two implementations: the download path fetches (a fetch is what replaces a file it cannot read), the sim path proceeds (MuJoCo names the file itself on the load that follows).

## Tests

The agreement is pinned against **MuJoCo's own verdict on the same tree**, so neither owner's reading of the model is the reference. Table-driven over meshes-present / meshes-absent, plus a `force` cell. The structural pin that checked one caller's source for the shared rule now checks both callers for the shared scan.

Pre-fix on this branch's tests: 3 failed / 20 passed - the meshes-present row passes on the unfixed tree, so the case is the include shape and not the fixture.

## Gate

`tests/simulation/mujoco`: 4028 passed on main, 4031 on this branch (+3 = the new cells), the one failure identical on both trees (a pre-existing `mink`/`qpsolvers` gap in `test_pose_vector_rule_parity`). `tests/test_asset_download*.py` + the isaac mesh-rule test: 117 passed. ruff and ruff format clean; mypy unchanged.

Source is +96/-54 (a net-negative `_ensure_meshes`: -46 lines of scan, +17 of delegation), tests +107/-21, plus a changelog fragment.

---

## Review rounds

### Round 1 - the lint gate refused the pushed head

`ruff check strands_robots tests tests_integ` failed with `F401 re imported but unused` at `strands_robots/simulation/mujoco/simulation.py:68`. Cause is this change and not the environment: `main` has exactly two `re.` uses in that file, both inside the `_ensure_meshes` scan this PR deletes, so moving the scan to `assets/download.py` orphaned the import.

The "ruff and ruff format clean" line under **Gate** above was measured before the scan was lifted into `_mjcf_missing_meshes` and did not hold for the pushed head. Leaving it stated rather than quietly editing it, because the re-measurement below is the claim that counts.

- `fix(simulation): drop the re import the mesh-scan move left behind` - one line deleted, `import re`. No other source or test change.
- Re-measured on the new head: `ruff check strands_robots tests tests_integ` clean on the full tree, `ruff format --check` clean on the touched file.
- Worth stating because it changes what the next green run proves: `hatch run lint` gates *before* pytest, so the suite had never executed on this branch in CI. The test numbers under **Gate** are local runs; this is the first head where CI confirms them.