### PR TITLE
test(training): the lerobot split pin drives lerobot's own DatasetConfig

### DIFF
--- a/changelog.d/3157-lerobot-split-pin-drives-lerobots-config.md
+++ b/changelog.d/3157-lerobot-split-pin-drives-lerobots-config.md
@@ -1,0 +1,32 @@
+### Fixed: the lerobot split pin drives lerobot's own `DatasetConfig`
+
+`LerobotTrainer.validate` refuses `streaming` together with `val_episodes`
+because lerobot holds out a validation split only on a **map-style** dataset:
+`make_train_eval_datasets` rebuilds both halves as `LeRobotDataset` objects,
+which is what makes the split addressable by episode. The cell that establishes
+that property drove `make_train_eval_datasets` with a hand-built
+`SimpleNamespace` for `cfg.dataset`, which has to mirror every field lerobot's
+factory reads and skips `DatasetConfig.__post_init__`.
+
+Both cost something inside the declared `lerobot>=0.6.1,<0.7.0` range. lerobot
+0.6.2 has the split path read `repo_type` and `depth_output_unit` (7 fields ->
+9), so the stand-in raises `AttributeError` from inside lerobot and two cells
+fail; and 0.6.2's `DatasetConfig` now refuses the pair when it is constructed
+(`eval_split requires map-style datasets and is not supported with
+dataset.streaming=true.`), which a namespace stand-in cannot see. So the
+consequence the refusal quoted -- that the whole dataset is materialized and the
+stream silently dropped -- is the pre-0.6.2 outcome only; on 0.6.2 a launched
+run fails at config construction instead.
+
+The pin now builds lerobot's own `DatasetConfig`, defaults intact, overriding
+only what the cell drives: the field set tracks lerobot by construction and the
+invariants run. It grades the constraint in whichever form the installed lerobot
+expresses it, and still fails with "lerobot may now honor the stream and the
+preflight refusal should be lifted" if neither holds -- the reason the original
+cell existed. The `make_dataset` double honours `dataset.streaming` the way
+lerobot's own does, so the recorded build order reflects the kind the factory
+chose rather than the kind the double happens to be.
+
+The refusal text and the training guide state the constraint lerobot itself
+states and name both outcomes rather than only the older one. The refusal and
+its two remedies are unchanged.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -425,11 +425,16 @@ local copy of the dataset, or pass lerobot's own knobs directly with
 `extra={"dataset.eval_split": 0.1, "eval_steps": 1000}`.
 
 `streaming` and `val_episodes` cannot both be honored, so `validate()` refuses
-the pair. A non-zero `eval_split` routes lerobot into `make_train_eval_datasets`,
-which rebuilds BOTH splits as map-style `LeRobotDataset` objects without
-consulting `dataset.streaming` - the streaming dataset it opened first is
-discarded. The run therefore materializes the whole dataset, which is exactly
-what `streaming` exists to avoid, and nothing reports it: an annulled stream is
+the pair. lerobot holds out a validation split only on a **map-style** dataset:
+`make_train_eval_datasets` rebuilds both halves as `LeRobotDataset` objects,
+which is what makes the split addressable by episode index. A streamed dataset
+is not one, and lerobot answers that contradiction differently across the
+supported range - from lerobot 0.6.2 `DatasetConfig` refuses the combination
+outright (`eval_split requires map-style datasets`), and before that it
+constructed and the factory discarded the streaming dataset it had opened first.
+Either way the pair delivers at most one of the two fields: it fails inside a
+launched run, or it materializes the whole dataset - exactly what `streaming`
+exists to avoid - while reporting nothing, because an annulled stream is
 indistinguishable from `streaming=False`. Set `streaming=False` to keep the
 validation split, or `val_episodes=None` to keep the stream.
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -634,13 +634,18 @@ class LerobotTrainer(Trainer):
 
         Each field is honored on its own, and neither survives the pair.
         :meth:`_val_eval_split` turns ``val_episodes`` into lerobot's
-        ``dataset.eval_split``, and a non-zero ``eval_split`` sends lerobot down
-        ``make_train_eval_datasets``, which rebuilds BOTH splits as map-style
-        ``LeRobotDataset`` objects without consulting ``dataset.streaming`` - the
-        ``StreamingLeRobotDataset`` it built first is discarded. So the run
-        materializes the whole dataset, which is the outcome ``streaming``
-        exists to avoid, and it does so while reporting nothing: an annulled
-        stream is indistinguishable from ``streaming=False``.
+        ``dataset.eval_split``, and lerobot holds out a split only on a
+        MAP-STYLE dataset - ``make_train_eval_datasets`` rebuilds both halves as
+        ``LeRobotDataset`` objects, which is what makes the split addressable by
+        episode at all. A streamed dataset is not one, and lerobot answers the
+        contradiction differently across the range this backend supports:
+        ``DatasetConfig`` refuses the pair outright from lerobot 0.6.2
+        ("eval_split requires map-style datasets"), while before that it
+        constructed and the factory silently discarded the
+        ``StreamingLeRobotDataset`` it had built first. So the pair either fails
+        inside a launched run or materializes the whole dataset without
+        reporting it - an annulled stream is indistinguishable from
+        ``streaming=False``.
 
         Refusing here mirrors :meth:`_unreadable_episode_count_problem`, which
         refuses rather than let a requested validation split be silently
@@ -651,9 +656,10 @@ class LerobotTrainer(Trainer):
         """
         return (
             f"{self.provider_name}: streaming=True cannot be combined with "
-            f"val_episodes={spec.val_episodes}. A held-out split makes lerobot rebuild both "
-            "splits as map-style datasets, so the whole dataset is materialized and the stream "
-            "is dropped - the disk/RAM blowup streaming exists to avoid. Either set "
+            f"val_episodes={spec.val_episodes}. lerobot holds out a validation split only on a "
+            "map-style dataset, and a streamed dataset is not one: lerobot 0.6.2 refuses the "
+            "pair outright, and before it the stream is dropped for a map-style rebuild while "
+            "nothing reports that the whole dataset was materialized. Either set "
             "streaming=False to keep the validation split, or val_episodes=None to keep the "
             "stream."
         )

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -5,9 +5,9 @@ end-to-end sim->train->load is exercised separately.
 """
 
 import ast
+import dataclasses
 import inspect
 import json
-import pathlib
 import sys
 from types import SimpleNamespace
 
@@ -1809,14 +1809,16 @@ class TestInProcessTrainerCorrectness:
 class TestStreamingAndValidationSplitAreMutuallyExclusive:
     """``streaming`` and ``val_episodes`` cannot both be honored by lerobot.
 
-    ``val_episodes`` becomes lerobot's ``dataset.eval_split``, and any non-zero
-    ``eval_split`` routes lerobot into ``make_train_eval_datasets``, which
-    rebuilds both splits as map-style ``LeRobotDataset`` objects without
-    consulting ``dataset.streaming``. The whole dataset is materialized - the
-    outcome ``streaming`` exists to avoid - and nothing reports it, because an
-    annulled stream looks exactly like ``streaming=False``. Preflight refuses
-    the pair instead, the same way an unreadable episode count is refused rather
-    than allowed to drop a requested split.
+    ``val_episodes`` becomes lerobot's ``dataset.eval_split``, and lerobot holds
+    out a split only on a MAP-STYLE dataset: ``make_train_eval_datasets``
+    rebuilds both halves as ``LeRobotDataset`` objects, which is what makes the
+    split addressable by episode. A streamed dataset is not one, and lerobot
+    answers that contradiction differently across the version range this backend
+    supports - ``DatasetConfig`` refuses the pair from lerobot 0.6.2, and before
+    that it constructed and the factory discarded the stream it had built first,
+    materializing the whole dataset while reporting nothing. Preflight refuses
+    the pair either way, the same way an unreadable episode count is refused
+    rather than allowed to drop a requested split.
     """
 
     def _spec(self, dataset_root, tmp_path, **kw):
@@ -1835,12 +1837,14 @@ class TestStreamingAndValidationSplitAreMutuallyExclusive:
         assert problems, "streaming + val_episodes delivers neither field, so it is not launchable"
         assert any("streaming=True cannot be combined with val_episodes=2" in p for p in problems)
 
-    def test_the_refusal_names_the_cost_of_the_silent_outcome(self, dataset_root, tmp_path):
+    def test_the_refusal_names_why_lerobot_cannot_deliver_both(self, dataset_root, tmp_path):
         spec = self._spec(dataset_root, tmp_path, streaming=True, val_episodes=2)
         (message,) = [p for p in LerobotTrainer().validate(spec) if "streaming=True" in p]
         # A caller who reads only the message must learn WHY the pair is refused:
-        # not a policy choice, but that the stream is dropped and the dataset lands
-        # on disk/in RAM in full.
+        # not a policy choice, but that a held-out split needs a map-style dataset,
+        # so the pair either fails in the launched run or lands the whole dataset
+        # on disk/in RAM with the stream annulled.
+        assert "map-style" in message
         assert "materialized" in message
         assert "stream is dropped" in message
 
@@ -1888,18 +1892,36 @@ class TestStreamingAndValidationSplitAreMutuallyExclusive:
         assert any("episode count is unavailable" in p for p in problems)
         assert not any("cannot be combined with" in p for p in problems)
 
-    def test_lerobot_split_path_still_drops_the_stream(self, monkeypatch):
-        """The measured constraint the refusal stands on, pinned against lerobot.
+    # ------------------------------------------------------------------ #
+    # The constraint the refusal stands on, pinned against lerobot itself.
+    #
+    # These drive lerobot through its OWN ``DatasetConfig`` rather than a
+    # hand-built namespace. A stand-in has to mirror every field the factory
+    # reads, so it goes stale the moment lerobot's factory reads one more
+    # (``depth_output_unit`` arrived with depth maps, ``repo_type`` with HF
+    # Storage Buckets) and the split assertion appears to break; worse, it
+    # bypasses ``DatasetConfig.__post_init__``, so a constraint lerobot starts
+    # DECLARING there is invisible here. lerobot's own config carries the fields
+    # and runs the invariants.
+    # ------------------------------------------------------------------ #
 
-        Asserts the property that makes the pair unsatisfiable: lerobot's
-        eval-split path constructs a map-style dataset even when
-        ``dataset.streaming`` is set. If lerobot starts honoring the stream
-        there, this fails and the refusal above should be lifted rather than
-        left to reject a combination that has become supportable.
+    @staticmethod
+    def _dataset_config(**overrides):
+        """lerobot's own ``DatasetConfig``, defaults intact but for overrides."""
+        default = pytest.importorskip("lerobot.configs.default")
+        return default.DatasetConfig(repo_id="local", use_imagenet_stats=False, **overrides)
+
+    @staticmethod
+    def _split_path_build_order(monkeypatch, dataset_cfg):
+        """Dataset kinds ``make_train_eval_datasets`` builds for one config.
+
+        Returns ``(built, train_type, eval_type)`` where ``built`` names each
+        dataset class the factory constructed, in order. The doubles honor
+        ``dataset.streaming`` the way lerobot's own ``make_dataset`` does, so the
+        order records which kind the factory chose rather than which kind the
+        double happens to be.
         """
-        pytest.importorskip("lerobot")
-        import lerobot.datasets.factory as factory
-
+        factory = pytest.importorskip("lerobot.datasets.factory")
         built: list[str] = []
 
         class _StubDataset:
@@ -1922,51 +1944,80 @@ class TestStreamingAndValidationSplitAreMutuallyExclusive:
 
         monkeypatch.setattr(factory, "LeRobotDataset", _StubMapStyle)
         monkeypatch.setattr(factory, "StreamingLeRobotDataset", _StubStreaming)
-        monkeypatch.setattr(factory, "make_dataset", lambda cfg: _StubStreaming())
+        monkeypatch.setattr(
+            factory,
+            "make_dataset",
+            lambda cfg: _StubStreaming() if cfg.dataset.streaming else _StubMapStyle(),
+        )
         monkeypatch.setattr(factory, "resolve_delta_timestamps", lambda *a, **k: None)
 
         cfg = SimpleNamespace(
-            dataset=SimpleNamespace(
-                repo_id="local",
-                root=None,
-                revision=None,
-                streaming=True,
-                eval_split=0.25,
-                video_backend=None,
-                # lerobot's factory reads this on all three of its dataset
-                # constructions (stream, train split, eval split). Mirror its
-                # own default so the stand-in config carries the surface the
-                # real DatasetConfig does.
-                depth_output_unit="mm",
-                image_transforms=SimpleNamespace(enable=False),
-                use_imagenet_stats=False,
-            ),
+            dataset=dataset_cfg,
             trainable_config=None,
             rename_map=None,
             tolerance_s=1e-4,
             num_workers=1,
         )
         train_dataset, eval_dataset = factory.make_train_eval_datasets(cfg)
-        assert built.count("_StubStreaming") == 1, "the stream is built once, to read metadata"
-        assert type(train_dataset) is _StubMapStyle, "lerobot rebuilds the TRAIN split map-style, discarding the stream"
-        assert type(eval_dataset) is _StubMapStyle
+        return built, type(train_dataset), type(eval_dataset)
+
+    def test_lerobot_does_not_deliver_a_held_out_split_on_a_stream(self, monkeypatch):
+        """The measured constraint the refusal stands on, pinned against lerobot.
+
+        Asserts the property that makes the pair unsatisfiable, in whichever form
+        this lerobot expresses it. From lerobot 0.6.2 ``DatasetConfig`` refuses
+        the combination when it is constructed; before that it constructed and
+        the eval-split path rebuilt the TRAIN half map-style, discarding the
+        stream. If lerobot starts honoring the stream there, neither arm holds
+        and the refusal above should be lifted rather than left to reject a
+        combination that has become supportable.
+        """
+        try:
+            streamed_with_split = self._dataset_config(streaming=True, eval_split=0.25)
+        except ValueError as refusal:
+            assert "map-style" in str(refusal), (
+                "lerobot refuses streaming with a held-out split, but not on the map-style "
+                f"grounds this backend's refusal quotes: {refusal}"
+            )
+            return
+        _, train_type, _ = self._split_path_build_order(monkeypatch, streamed_with_split)
+        assert train_type.__name__ == "_StubMapStyle", (
+            "lerobot neither refuses streaming with a held-out split nor rebuilds the split "
+            "map-style, so it may now honor the stream and the preflight refusal above should "
+            "be lifted"
+        )
+
+    def test_a_held_out_split_alone_rebuilds_both_halves_map_style(self, monkeypatch):
+        """Why a split needs a map-style dataset, on a config lerobot accepts.
+
+        This is the half of the mechanism that holds in every supported lerobot
+        version and is what the refusal's wording rests on: the split is carved
+        by episode index, so both halves come back as ``LeRobotDataset``.
+        """
+        built, train_type, eval_type = self._split_path_build_order(monkeypatch, self._dataset_config(eval_split=0.25))
+        assert train_type.__name__ == "_StubMapStyle"
+        assert eval_type.__name__ == "_StubMapStyle"
+        assert built.count("_StubStreaming") == 0, "nothing is streamed for a map-style request"
+
+    def test_the_split_path_is_a_no_op_without_a_split(self, monkeypatch):
+        """The control: eval_split=0.0 leaves the requested dataset alone."""
+        built, train_type, eval_type = self._split_path_build_order(monkeypatch, self._dataset_config(streaming=True))
+        assert built == ["_StubStreaming"], "a stream with no split is built once and kept"
+        assert train_type.__name__ == "_StubStreaming"
+        assert eval_type is type(None), "no held-out half is asked for, so none is built"
 
 
-class TestTheStandInConfigTracksLerobotsOwnFactory:
-    """A field lerobot's factory starts reading fails here, not inside lerobot.
+class TestTheConfigTheSplitPinDrivesIsLerobotsOwn:
+    """The split pin above cannot go stale on a field lerobot's factory adds.
 
     ``make_train_eval_datasets`` reads ``cfg.dataset.<field>`` straight off the
-    config it is handed, so a stand-in missing one raises ``AttributeError``
-    from inside lerobot rather than failing an assertion in this suite. lerobot
-    is tracked from source, so that field set grows: ``depth_output_unit``
-    arrived with its depth-map support and the stand-in did not carry it, which
-    surfaced as this file's own split assertion appearing to break.
-
-    The expectation is derived from the function the split test actually calls,
-    not from the module. ``make_dataset`` also reads ``episodes``,
-    ``exclude_episodes`` and ``repo_type`` on paths the split test never
-    reaches, so a module-wide rule would demand three fields the stand-in has
-    no reason to carry.
+    config it is handed, so a hand-built stand-in raises ``AttributeError`` from
+    inside lerobot rather than failing an assertion in this suite - and lerobot
+    is tracked from source, so that field set grows (``depth_output_unit``
+    arrived with depth-map support, ``repo_type`` with HF Storage Buckets).
+    Driving lerobot's own ``DatasetConfig`` removes the mirroring entirely; these
+    cells pin that it really is lerobot's config being driven, and that the
+    config covers what the factory reads.
     """
 
     @staticmethod
@@ -1990,42 +2041,43 @@ class TestTheStandInConfigTracksLerobotsOwnFactory:
         }
 
     @staticmethod
-    def _stand_in_dataset_fields() -> set[str]:
-        """The keys this file's own stand-in ``cfg.dataset`` namespace carries."""
-        tree = ast.parse(pathlib.Path(__file__).read_text(encoding="utf-8"))
-        namespaces = [
-            node
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "SimpleNamespace"
-            and any(keyword.arg == "repo_id" for keyword in node.keywords)
-        ]
-        assert len(namespaces) == 1, f"expected one stand-in dataset namespace, found {len(namespaces)}"
-        return {keyword.arg for keyword in namespaces[0].keywords if keyword.arg}
+    def _dataset_config_fields() -> set[str]:
+        """The field names lerobot's own ``DatasetConfig`` declares."""
+        default = pytest.importorskip("lerobot.configs.default")
+        return {field.name for field in dataclasses.fields(default.DatasetConfig)}
 
-    def test_the_stand_in_carries_every_field_the_split_path_reads(self) -> None:
+    def test_lerobots_config_carries_every_field_its_split_path_reads(self) -> None:
         needed = self._factory_dataset_fields("make_train_eval_datasets")
-        carried = self._stand_in_dataset_fields()
+        carried = self._dataset_config_fields()
         missing = sorted(needed - carried)
         assert not missing, (
-            f"lerobot's make_train_eval_datasets reads cfg.dataset.{missing} and the stand-in "
-            "config does not carry it, so the split test raises AttributeError from inside "
-            "lerobot instead of grading the split. Add the field to the stand-in, mirroring "
-            "lerobot's own default for it."
+            f"lerobot's make_train_eval_datasets reads cfg.dataset.{missing}, which its own "
+            "DatasetConfig does not declare, so the split pin above raises AttributeError from "
+            "inside lerobot however the config is built"
         )
 
     def test_both_derived_sets_are_populated(self) -> None:
         needed = self._factory_dataset_fields("make_train_eval_datasets")
-        carried = self._stand_in_dataset_fields()
+        carried = self._dataset_config_fields()
         assert len(needed) >= 5, f"only {len(needed)} fields derived - the scan is looking in the wrong place"
-        assert len(carried) >= 5, f"only {len(carried)} stand-in keys derived - the scan is looking in the wrong place"
+        assert len(carried) >= 5, f"only {len(carried)} config fields derived - the scan is looking in the wrong place"
 
-    def test_the_module_wide_set_is_wider_than_the_path_the_split_test_drives(self) -> None:
-        """Why the expectation is function-scoped and not module-scoped."""
-        split_path = self._factory_dataset_fields("make_train_eval_datasets")
-        other_path = self._factory_dataset_fields("make_dataset")
-        assert other_path - split_path, (
-            "make_dataset no longer reads any field make_train_eval_datasets does not, so the "
-            "function scoping above no longer buys anything and could be widened to the module"
+    def test_the_split_pin_drives_lerobots_own_config(self) -> None:
+        """It is lerobot's ``DatasetConfig``, not a namespace shaped like one.
+
+        A stand-in has to be told each field, so it lags by exactly the field
+        lerobot's factory read most recently - and it silently skips
+        ``__post_init__``, so a constraint lerobot starts DECLARING there is
+        invisible. Both are pinned here: the object is lerobot's config, and its
+        validation runs.
+        """
+        default = pytest.importorskip("lerobot.configs.default")
+        driven = TestStreamingAndValidationSplitAreMutuallyExclusive._dataset_config(eval_split=0.25)
+        assert isinstance(driven, default.DatasetConfig), (
+            "the split pin drives a stand-in cfg.dataset; build lerobot's own DatasetConfig so "
+            "the field set and its invariants come from lerobot"
         )
+        with pytest.raises(ValueError):
+            # A value lerobot's own __post_init__ refuses. A namespace stand-in
+            # accepts it, which is why a declared constraint can go unnoticed.
+            TestStreamingAndValidationSplitAreMutuallyExclusive._dataset_config(eval_split=1.5)


### PR DESCRIPTION
`LerobotTrainer.validate` refuses `streaming` together with `val_episodes`, and that refusal stands on a measured property of lerobot: a held-out split makes lerobot rebuild both halves **map-style**, so a streamed dataset cannot carry one. The cell that establishes it drove `make_train_eval_datasets` with a hand-built `SimpleNamespace` for `cfg.dataset` — which has to mirror every field lerobot's factory reads, and skips `DatasetConfig.__post_init__` entirely.

Both cost something inside the declared `lerobot>=0.6.1,<0.7.0` range.

![lerobot split-path drift](https://raw.githubusercontent.com/cagataycali/robots/artifacts/lerobot-split-config/lerobot-split-drift.png)

## What changed under us

Measured by running the same probe against both lerobot source trees (`v0.6.1` = what `uv.lock` resolves, `0.6.2` = latest):

| request | lerobot v0.6.1 | lerobot 0.6.2 |
| --- | --- | --- |
| `streaming=True` + `eval_split=0.25` | config **constructs** it; the split path builds the stream, then rebuilds both halves map-style and discards it | `DatasetConfig` **refuses** it: `eval_split requires map-style datasets and is not supported with dataset.streaming=true.` |
| `eval_split=0.25` alone | both halves map-style | both halves map-style |
| `streaming=True` alone | stream built once, kept | stream built once, kept |

And `make_train_eval_datasets` grew its read set from 7 fields to 9 (`repo_type`, `depth_output_unit`).

So two things follow. The stand-in no longer carries what lerobot reads, and it never saw the new refusal — which means the message this backend prints ("the whole dataset is materialized and the stream is dropped") describes the v0.6.1 outcome only. On 0.6.2 the run fails at config construction instead.

## Failing before, passing after

`tests/training/test_lerobot.py`, the split + config cells (22 selected):

| suite | lerobot v0.6.1 | lerobot 0.6.2 |
| --- | --- | --- |
| `main` | 20 passed, 0 failed | **2 failed**, 18 passed |
| this branch | 22 passed, 0 failed | 22 passed, 0 failed |

The two failures on `main` are `test_lerobot_split_path_still_drops_the_stream` (`AttributeError: 'types.SimpleNamespace' object has no attribute 'repo_type'`) and the derived guard that names the missing field. That guard did its job — it pointed at `repo_type` and quoted the remedy. Adding the field would buy one release; this removes the mirroring instead.

## Change

- The split pin builds lerobot's own `DatasetConfig` (defaults intact, overriding only what the cell drives). The field set tracks lerobot by construction, and `__post_init__` runs.
- The pin grades the constraint in whichever form this lerobot expresses it — config refusal, or a map-style rebuild — and still fails with *"lerobot may now honor the stream and the preflight refusal should be lifted"* if neither holds. That was the whole point of the original cell and it is preserved.
- The `make_dataset` double now honours `dataset.streaming` the way lerobot's own does, so the recorded build order reflects the kind the factory **chose** rather than the kind the double happens to be. A control cell covers `eval_split=0.0`.
- The refusal text and `docs/training/overview.md` state the constraint lerobot itself states (a held-out split needs a map-style dataset) and name both outcomes rather than only the older one. The refusal itself is unchanged, as are the two remedies it offers.
- The field-parity guard is retargeted: lerobot's `DatasetConfig` must declare everything its own split path reads, and the pin must really be driving that config (asserted, plus a value `__post_init__` refuses — the check a namespace stand-in silently skips).

## Break table

On this branch, over the 22 selected cells:

| mutation | cells firing |
| --- | --- |
| control — unchanged | 0 |
| hand-mirrored `SimpleNamespace` `cfg.dataset` reinstated | 2 |
| the `make_dataset` double ignores `dataset.streaming` | 1 |
| the refusal drops every mention of map-style | 1 |
| lerobot lifts the constraint and honors the stream | 2 |
| lerobot's factory reads one more field its own config declares | 0 — **2 on `main`** |

The last row is the point: a field arriving in lerobot's factory breaks `main`'s suite and not this one. lerobot's source was restored md5-identical after each row.

## Gate

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` → `Success: no issues found in 1842 source files`. `tests/training/` → 3748 passed, 4 skipped, 0 failed (`main` on the same interpreter: 2 failed, 3744 passed). Whole-tree graders → 4212 passed with 7 pre-existing environment failures (5 assert `rclpy` is absent where it resolves, 2 read an installed `websockets` below the declared floor), unchanged from `main`.

Diff: `strands_robots/training/lerobot.py` +16/-10 (message and docstring only — executable statement count unchanged at 544 by AST), `tests/training/test_lerobot.py` +136/-84, `docs/training/overview.md` +10/-5, plus a 32-line changelog fragment.