### PR TITLE
fix(tools): a session store and a detached log are read on a decode policy that cannot raise

### DIFF
--- a/changelog.d/3158-session-reads-decode-without-raising.md
+++ b/changelog.d/3158-session-reads-decode-without-raising.md
@@ -1,0 +1,43 @@
+### Fixed: the lerobot session tools read a store and a detached log on a decode policy that cannot raise
+
+`lerobot_train` and `lerobot_teleoperate` each read back two files whose
+bytes they do not control, and both reads were strict UTF-8.
+
+The detached child's log is opened as the subprocess's `stdout`/`stderr`
+sink, so its contents are whatever the child wrote to the fd it
+inherited - a native library printing latin-1, a progress renderer, or a
+multi-byte character torn in half when the run was killed all produce a
+byte that is not UTF-8. Tailing that file in `status` raised
+`UnicodeDecodeError`, which is a `ValueError` and therefore passed
+`lerobot_train`'s `except OSError` - the handler written to keep the rest
+of the report - and reached the action's outer guard. The whole report
+was replaced by `Tool execution failed: 'utf-8' codec can't decode byte
+...`, discarding the pid, the uptime and the running verdict, all of
+which were computed before the log was opened. `lerobot_teleoperate`
+catches broadly and kept its report, but printed the codec message where
+the tail should have been.
+
+The session store was read the same way, under
+`except (OSError, json.JSONDecodeError)`. That handler answers the two
+failures the store was expected to have - it is gone, or it is not JSON -
+and an undecodable byte is neither, so the degradation both modules
+document ("a store that cannot be read degrades to empty rather than
+raising") did not happen. Every action that consults the store failed
+instead, `stop` included, and both modules record that this store is the
+only place a detached process's pid is written down.
+
+Both files are now read with `errors="replace"`, and the writes name the
+same encoding as the reads. Damage stays in the field that carries it: a
+pid is ASCII either way, so a record damaged in a session name still
+names its process and `stop` still signals it, and a log tail is shown
+with U+FFFD marking where the child's output stopped being text.
+Substitution rather than omission is asserted, because a byte dropped
+silently changes the text an operator is reading without saying so.
+
+The existing pin for this store wrote `"{not json"` - valid UTF-8, and
+the one corruption shape the handler could already take. The undecodable
+shape is pinned beside it in each store's own test file, and
+`tests/tools/test_status_reports_a_log_it_did_not_encode.py` drives the
+log tail through both tools' `status` action. The clean-log and
+not-JSON-store cells pass on both trees, so they read as controls rather
+than as casualties of the change.

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -301,7 +301,12 @@ class SessionManager:
             return {}
 
         try:
-            with open(self.sessions_file) as f:
+            # Read with a decode policy that cannot raise, for the reason the
+            # training store carries: the handler below answers "gone" and "not
+            # JSON", and an undecodable byte is a ``ValueError`` that is neither,
+            # so it would abort the action instead of degrading. U+FFFD keeps a
+            # damaged record's ASCII pid readable, and a pid is what stops it.
+            with open(self.sessions_file, encoding="utf-8", errors="replace") as f:
                 sessions = json.load(f)
 
             # Check if processes are still running and clean up dead sessions
@@ -339,9 +344,9 @@ class SessionManager:
             return {}
 
     def _save_sessions(self, sessions: dict[str, Any]):
-        """Save sessions to disk."""
+        """Save sessions to disk, in the encoding the load path reads."""
         try:
-            with open(self.sessions_file, "w") as f:
+            with open(self.sessions_file, "w", encoding="utf-8") as f:
                 json.dump(sessions, f, indent=2)
         except OSError as e:
             logger.error(f"Error saving sessions: {e}")
@@ -1290,7 +1295,12 @@ def lerobot_teleoperate(
                 content_lines.append(f"Log file: `{log_file_path}`")
 
                 try:
-                    with open(str(log_file_path)) as f:
+                    # The log is the detached child's byte stream, not this
+                    # process's text, so a byte that is not UTF-8 is expected.
+                    # The handler below keeps the report either way; reading
+                    # with substitution keeps the tail itself, which is the part
+                    # an operator asked for.
+                    with open(str(log_file_path), encoding="utf-8", errors="replace") as f:
                         lines = f.readlines()
                         if lines:
                             tail_lines = lines[-10:]  # Last 10 lines

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -261,12 +261,21 @@ class SessionManager:
 
         Returns:
             Every stored session record, keyed by session name. A store that
-            cannot be read degrades to empty rather than raising.
+            cannot be read degrades to empty rather than raising - including one
+            carrying bytes this store's encoding does not describe, which is
+            read as U+FFFD so a record damaged outside its pid still stops.
         """
         if not self.sessions_file.exists():
             return {}
         try:
-            with open(self.sessions_file) as f:
+            # Read with a decode policy that cannot raise. The handler below
+            # names the two failures this store was expected to have - it is
+            # gone, or it is not JSON - and an undecodable byte is neither:
+            # ``UnicodeDecodeError`` is a ``ValueError``, so it passes both
+            # clauses and aborts the tool action that asked. Substituting
+            # U+FFFD keeps the damage local to the field that carries it, and
+            # a pid is ASCII, so the record still names the process it named.
+            with open(self.sessions_file, encoding="utf-8", errors="replace") as f:
                 sessions: dict[str, Any] = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             logger.error(f"Error loading sessions: {e}")
@@ -317,7 +326,9 @@ class SessionManager:
 
     def _save_sessions(self, sessions: dict[str, Any]) -> None:
         try:
-            with open(self.sessions_file, "w") as f:
+            # Name the encoding the reader names, so the store's spelling is a
+            # property of the file rather than of the locale that wrote it.
+            with open(self.sessions_file, "w", encoding="utf-8") as f:
                 json.dump(sessions, f, indent=2)
         except OSError as e:
             logger.error(f"Error saving sessions: {e}")
@@ -1126,7 +1137,13 @@ def lerobot_train(
             if log_file_path and Path(str(log_file_path)).exists():
                 lines.append(f"Log file: `{log_file_path}`")
                 try:
-                    with open(str(log_file_path)) as f:
+                    # The log holds whatever the detached child wrote to the fd
+                    # it inherited, so its bytes are not this process's text and
+                    # need not be UTF-8. Reading it strictly makes one such byte
+                    # raise past the handler below - which exists to keep the
+                    # rest of this report - and lose the pid, uptime and
+                    # running verdict already computed above.
+                    with open(str(log_file_path), encoding="utf-8", errors="replace") as f:
                         tail = f.readlines()[-15:]
                     if tail:
                         lines.extend(["", "**Recent Log Output:**", "```", "".join(tail).strip(), "```"])

--- a/tests/tools/test_status_reports_a_log_it_did_not_encode.py
+++ b/tests/tools/test_status_reports_a_log_it_did_not_encode.py
@@ -1,0 +1,133 @@
+"""``status`` reports on a detached run whose log is not valid UTF-8.
+
+Both session tools launch their subprocess detached with the log file opened as
+the child's ``stdout``/``stderr`` sink::
+
+    with open(log_file, "w") as f:
+        proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, ...)
+
+What lands in that file is whatever the child wrote to the fd it inherited, so
+its bytes are the child's and need not be UTF-8: a native library printing
+latin-1, a progress renderer, or a multi-byte character torn in half when the
+run was killed all produce one. The parent then reads the file back to show the
+tail, and reading it strictly turns the child's byte into this process's
+exception.
+
+That exception is not the failure either tail handler was written for. In
+``lerobot_train`` the handler names ``OSError``, so a ``UnicodeDecodeError`` -
+which is a ``ValueError`` - passes it and reaches the action's outer guard: the
+whole ``status`` report is replaced by ``Tool execution failed: 'utf-8' codec
+can't decode byte ...``, discarding the pid, the uptime and the running verdict
+that were already computed before the log was opened. ``lerobot_teleoperate``
+catches broadly and so keeps its report, but loses the tail and prints the codec
+message in its place.
+
+Both are read with substitution instead. The undecodable byte becomes U+FFFD,
+which is asserted here rather than merely tolerated: a dropped byte would change
+the text an operator is reading without saying so, while a replacement
+character shows exactly where the log stopped being text.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import pytest
+
+import strands_robots.tools.lerobot_teleoperate as tele_mod
+import strands_robots.tools.lerobot_train as train_mod
+
+
+class Tool(NamedTuple):
+    """One session tool, reduced to what this contract drives."""
+
+    name: str
+    module: Any
+    status: Callable[[str], dict[str, Any]]
+    record: dict[str, Any]
+
+    def __repr__(self) -> str:  # pragma: no cover - test ids only
+        return self.name
+
+
+TOOLS = [
+    Tool(
+        "lerobot_train",
+        train_mod,
+        lambda session: train_mod.lerobot_train(dataset_root="/unused", action="status", session_name=session),
+        {"action": "train", "policy_type": "act", "output_dir": "/out"},
+    ),
+    Tool(
+        "lerobot_teleoperate",
+        tele_mod,
+        lambda session: tele_mod.lerobot_teleoperate(action="status", session_name=session),
+        {"action": "teleoperate", "robot_type": "so101_follower"},
+    ),
+]
+
+#: A line the child wrote as latin-1. Valid text to the child, undecodable here.
+UNDECODABLE_LOG = b"INFO step:1.2K loss:0.123\nWARN saving to caf\xe9/checkpoint\n"
+
+
+def _seed(tool: Tool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, log: bytes) -> tuple[str, int]:
+    """One live session whose log file holds ``log``. Returns (name, pid)."""
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(tool.module, "SESSION_DIR", session_dir)
+
+    pid = os.getpid()
+    assert tool.module.psutil.pid_exists(pid), "premise: the test process must exist"
+    log_file = session_dir / "run.log"
+    log_file.write_bytes(log)
+    record = {"pid": pid, "start_time": 0.0, "log_file": str(log_file), **tool.record}
+    (session_dir / "active_sessions.json").write_text(json.dumps({"run": record}, indent=2))
+    return "run", pid
+
+
+def _text(result: dict[str, Any]) -> str:
+    return next(block["text"] for block in result["content"] if "text" in block)
+
+
+@pytest.mark.parametrize("tool", TOOLS, ids=lambda t: t.name)
+def test_status_still_reports_the_session_it_was_asked_about(
+    tool: Tool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pid and the running verdict do not depend on the log being decodable."""
+    name, pid = _seed(tool, tmp_path, monkeypatch, UNDECODABLE_LOG)
+
+    result = tool.status(name)
+
+    assert result["status"] == "success", f"{tool.name} status failed on a log it did not encode: {result}"
+    text = _text(result)
+    assert f"PID: {pid}" in text, f"the report must still name the pid it was about: {text}"
+    assert "Status: Running" in text, f"the running verdict is taken before the log is read: {text}"
+
+
+@pytest.mark.parametrize("tool", TOOLS, ids=lambda t: t.name)
+def test_the_tail_survives_with_the_damage_shown_where_it_is(
+    tool: Tool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Substitution, not omission: the decodable log stays and U+FFFD marks the rest."""
+    name, _ = _seed(tool, tmp_path, monkeypatch, UNDECODABLE_LOG)
+
+    text = _text(tool.status(name))
+
+    assert "step:1.2K loss:0.123" in text, f"the decodable lines are what the tail is for: {text}"
+    assert "\ufffd" in text, (
+        f"a byte dropped silently would misreport the child's output; it must read as U+FFFD: {text}"
+    )
+
+
+@pytest.mark.parametrize("tool", TOOLS, ids=lambda t: t.name)
+def test_a_decodable_log_is_reported_unchanged(tool: Tool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Control: the ordinary case must read exactly as before, U+FFFD-free."""
+    name, _ = _seed(tool, tmp_path, monkeypatch, b"INFO step:1.2K loss:0.123\n")
+
+    text = _text(tool.status(name))
+
+    assert "step:1.2K loss:0.123" in text, f"a clean log must still be tailed: {text}"
+    assert "\ufffd" not in text, f"nothing was damaged, so nothing may be marked as damaged: {text}"

--- a/tests/tools/test_teleop_session_store_keeps_a_live_pid.py
+++ b/tests/tools/test_teleop_session_store_keeps_a_live_pid.py
@@ -87,6 +87,30 @@ def _stored(mgr: Any) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# A record damaged outside its PID keeps its PID.
+# ---------------------------------------------------------------------------
+def test_a_store_byte_that_is_not_utf8_still_yields_the_pid_it_names() -> None:
+    """A strict read makes an undecodable byte cost the whole store.
+
+    ``UnicodeDecodeError`` is a ``ValueError``, so it is neither of the failures
+    ``except (OSError, json.JSONDecodeError)`` answers, and the prune below it
+    never runs: the action that asked fails instead, and by this module's own
+    reasoning the PID it would have reported is the only handle on a process
+    still driving the arm. The 0xE9 sits in the session *name*; the PID is ASCII.
+    """
+    mgr = SessionManager()
+    pid = _live_pid()
+    raw = json.dumps({"arm-cafe": {"pid": pid, "action": "teleoperate", "start_time": 0.0}}, indent=2)
+    mgr.sessions_file.write_bytes(raw.encode("utf-8").replace(b"cafe", b"caf\xe9"))
+
+    loaded = mgr.list_sessions()
+
+    assert [info["pid"] for info in loaded.values()] == [pid], (
+        f"a byte outside the PID's field must not cost the PID: {loaded}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # A process that exists but cannot be inspected keeps its record.
 # ---------------------------------------------------------------------------
 def test_an_uninspectable_live_session_survives_on_disk(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_train_session_store_keeps_a_live_pid.py
+++ b/tests/tools/test_train_session_store_keeps_a_live_pid.py
@@ -284,3 +284,61 @@ def test_a_corrupt_store_still_degrades_to_empty() -> None:
     mgr.sessions_file.write_text("{not json")
 
     assert mgr.list_sessions() == {}
+
+
+def _store_one_record_with_an_undecodable_byte(mgr: Any, pid: int) -> None:
+    """Write a store whose JSON is well-formed but whose bytes are not UTF-8.
+
+    The 0xE9 sits inside a session *name*, which is the field a hand-edit or a
+    latin-1 writer touches; every other field, the pid included, stays ASCII.
+    """
+    mgr.sessions_file.parent.mkdir(parents=True, exist_ok=True)
+    raw = json.dumps({"run-cafe": {"pid": pid, "action": "train", "start_time": 0.0}}, indent=2)
+    mgr.sessions_file.write_bytes(raw.encode("utf-8").replace(b"cafe", b"caf\xe9"))
+
+
+def test_a_store_byte_that_is_not_utf8_still_yields_the_pid_it_names() -> None:
+    """The one damage shape the handler cannot answer, so the read must not raise.
+
+    ``UnicodeDecodeError`` is a ``ValueError``, so it is neither of the two
+    failures ``except (OSError, JSONDecodeError)`` above was written for - the
+    store is gone, or it is not JSON. A strict read therefore aborts whichever
+    action consulted the store, and by the module docstring that includes
+    ``stop``, which is the only supported way to end a detached run. Damage
+    stays in the field that carries it instead: a pid is ASCII either way.
+    """
+    mgr = SessionManager()
+    pid = _live_pid()
+    _store_one_record_with_an_undecodable_byte(mgr, pid)
+
+    loaded = mgr.list_sessions()
+
+    assert [info["pid"] for info in loaded.values()] == [pid], (
+        f"a byte outside the pid's field must not cost the pid: {loaded}"
+    )
+
+
+def test_stop_reaches_a_session_whose_record_carries_an_undecodable_byte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator-visible point, driven through the tool rather than the store.
+
+    The name to pass is the one ``list`` reports, since that is the only
+    spelling of it the operator can see; what is pinned is that the signals
+    still reach the recorded pid.
+    """
+    mgr = SessionManager()
+    pid = _live_pid()
+    _store_one_record_with_an_undecodable_byte(mgr, pid)
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(train_mod.os, "kill", lambda p, sig: signalled.append((p, sig)))
+
+    listed = lerobot_train(dataset_root=UNUSED_DATASET, action="list")
+    assert listed["status"] == "success", f"list must report the store it can read: {listed}"
+    name = next(iter(next(block["json"] for block in listed["content"] if "json" in block)["sessions"]))
+
+    lerobot_train(dataset_root=UNUSED_DATASET, action="stop", session_name=name)
+
+    # psutil.pid_exists probes with signal 0, so only a real signal counts as a stop.
+    sent = [entry for entry in signalled if entry[1] != 0]
+    assert sent and sent[0] == (pid, signal.SIGTERM), f"stop must signal the recorded pid, sent {sent}"


### PR DESCRIPTION
Both `lerobot_train` and `lerobot_teleoperate` read back two files whose bytes they do not control, and read them as strict UTF-8.

![before and after, measured](https://raw.githubusercontent.com/cagataycali/robots/artifacts/tool-decode-matrix/artifacts/decode_matrix.png)

## The two files

**The detached child's log.** Both tools launch their subprocess with the log file opened as its sink, so what lands in it is whatever the child wrote to the fd it inherited:

```python
with open(log_file, "w") as f:
    proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, ...)
```

Those bytes need not be UTF-8 - a native library printing latin-1, a progress renderer, a multi-byte character torn in half when the run was killed. `status` then tails the file strictly, and `UnicodeDecodeError` is a `ValueError`, so it passes `lerobot_train`'s `except OSError` (the handler that exists to keep the rest of the report) and reaches the action's outer guard:

```
status -> {"status": "error", "content": [{"text":
  "Tool execution failed: 'utf-8' codec can't decode byte 0xe9 in position 44: invalid continuation byte"}]}
```

The pid, the uptime and the running verdict were all computed *before* the log was opened, and all of them are discarded. `lerobot_teleoperate` catches broadly and keeps its report, but prints the codec message where the tail should be.

**The session store.** Read under `except (OSError, json.JSONDecodeError)`, which answers the two failures the store was expected to have - it is gone, or it is not JSON. An undecodable byte is neither, so the degradation both modules document does not happen:

> A store that cannot be read degrades to empty rather than raising.

Instead every action that consults the store fails, `stop` included - and both modules state that this store is the only place a detached process's pid is written down, so that is the supported way to end the run.

## The change

Read both with `errors="replace"`, and name the same encoding on the writes as on the reads. Damage then stays in the field that carries it, and a pid is ASCII either way:

| | before | after |
|---|---|---|
| store with a 0xE9 in a session name | `error` - no session, no pid | `success` - 1 session, pid reported, `stop` still signals it |
| store that is not JSON *(control)* | `success` - 0 sessions | unchanged |
| child's log with a 0xE9 | train: `error`, report lost / teleop: tail lost | `success` - pid + tail, U+FFFD where the bytes stop being text |
| clean log *(control)* | `success` - pid + tail | unchanged |

`errors="replace"` rather than `"ignore"` deliberately: a dropped byte changes the text an operator is reading without saying so, while U+FFFD shows where the log stopped being text. This is the same rule the mesh audit walker reads on (#3154), applied to the two files these tools read back.

## Tests

The existing pin `test_a_corrupt_store_still_degrades_to_empty` writes `"{not json"` - valid UTF-8, and the one corruption shape the handler *can* take. The undecodable shape is added beside it in each store's own test file, plus a table-driven pin over both tools for the log tail.

```
before: 6 failed, 23 passed
after:  29 passed
```

Green on both trees, so they are controls rather than casualties: the clean-log cells, the not-JSON store cells, and `test_status_still_reports_the_session_it_was_asked_about[lerobot_teleoperate]` (its broad handler already kept the report - only the tail was missing).

`tests/tools` full suite: 8 failed / 3787 passed on main, 8 failed / 3796 passed here, the failing node-id sets identical (installed-lerobot drift on `should_save_checkpoint`); +9 is exactly the new cells. Whole-tree graders unchanged at 13 failed / 4196 passed / 4 errors. ruff and mypy clean.

## Size

Source +35 / -8, tests +215 / -0 (133 of it the new table-driven file), plus a 43-line changelog fragment. The AST executable-statement count of both modules is unchanged - 355 and 350 before and after - because the fix is two keyword arguments per read and the comments explaining why.