### PR TITLE
fix(transforms): a source column's names are read as lerobot writes them

### DIFF
--- a/changelog.d/3159-transform-source-column-names.md
+++ b/changelog.d/3159-transform-source-column-names.md
@@ -1,0 +1,37 @@
+### Fixed: a dataset transform reads a source column's `names` as LeRobot writes them
+
+`_SourceDataset` builds the output dataset's schema from the source's
+`observation.state` / `action` names, and the pass-through fills those columns by
+pairing each name with the source row -- so the name list decides how wide the
+output trajectory is. It was read as `list(feature.get("names") or [])`.
+
+LeRobot also writes that field as a mapping, and its own shipped teleoperators
+do: `teleop_keyboard.action_features` declares `{"motors": list(self.arm.motors)}`
+and `teleop_gamepad` declares `{"delta_x": 0, ...}`. On a mapping that call
+yields the keys -- one name per group rather than per column -- so a six-motor arm
+declared `{"motors": [...]}` transformed to a one-column action holding its
+shoulder-pan value alone, and a bimanual `{"left": [...], "right": [...]}` went
+from 12 columns to 2. Both returned `status="success"`, counted the episode in
+`episodes_written`, and wrote provenance claiming it is its source episode, while
+`docs/data/transforms.md` contract item 1 promises a generated episode is the
+same trajectory rendered differently.
+
+The two mapping spellings are read differently rather than flattened alike,
+because they do not mean the same thing: a list value holds the components (its
+key is a group label, not a column name), and an integer value is the
+component's index (the keys are the column names, ordered by that index rather
+than by insertion order). LeRobot's own `_flatten_feature_names` renders the
+second shape's indices as the names, which would name a six-motor arm `0..5`.
+
+A count that still disagrees with the column's declared width cannot be repaired
+by reading it differently, so `_SourceDataset.open` refuses it -- the fourth
+refusal there, beside the three it already makes for the same reason, that the
+output could not be the source rendered differently. Names short of the width
+would drop the trailing components; names past it would declare a column no
+frame supplies, which `add_frame` writes as `0.0`, itself a travel-to-zero
+command for an absolute-position actuator. The state and action pairings in
+`_write_episode` are `strict` now, so a path that reached them with disagreeing
+counts raises rather than quietly truncating a trajectory.
+
+Sources declaring a flat list -- every recording this package writes -- are
+unaffected.

--- a/docs/data/transforms.md
+++ b/docs/data/transforms.md
@@ -32,6 +32,20 @@ record (strands-robots)  ->  transform (this page)  ->  train (create_trainer)
    which way it went would depend only on the order the features were declared
    in. Such a source is refused, naming each camera and the dtype it declared;
    re-record or convert it so every camera stream shares one dtype.
+
+   The same promise decides how the state and action columns are read. Their
+   width in the output is the number of names the source declares for them, so
+   those names have to describe the vector they annotate. LeRobot writes them
+   either as a flat list (`["shoulder_pan", ...]`) or as a mapping that groups
+   the components (`{"motors": [...]}` from `teleop_keyboard`, `{"left": [...],
+   "right": [...]}` for a bimanual arm, `{"delta_x": 0, ...}` from
+   `teleop_gamepad`); all of those are read, so a dataset recorded through any
+   LeRobot teleoperator passes through whole. A declaration whose count still
+   disagrees with the column's width is refused rather than applied, naming both
+   counts: names short of the width would drop the trailing components, and
+   names past it would declare a column no frame supplies - written as `0.0`,
+   which is itself a travel-to-zero command for an absolute-position actuator.
+   Both are silent, and neither output would be the source rendered differently.
 2. **Provenance is mandatory.** Every generated episode is recorded in the
    output dataset's `meta/provenance.json` with `synthetic=true`, the source
    episode index, and the transform's name and version. Training filters and

--- a/strands_robots/transforms/base.py
+++ b/strands_robots/transforms/base.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 import logging
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -710,6 +710,72 @@ def _image_to_hwc_uint8(value: Any) -> np.ndarray:
     return arr
 
 
+def _column_names(feature: Any) -> list[str]:
+    """Return every component name a state/action feature declares, in order.
+
+    LeRobot writes a vector column's ``names`` either as a flat list
+    (``["shoulder_pan", ...]``) or as a mapping that groups the components -
+    ``{"motors": [...]}`` from ``teleop_keyboard``, ``{"left": [...], "right":
+    [...]}`` for a bimanual arm, ``{"delta_x": 0, ...}`` from
+    ``teleop_gamepad``. All three describe the same thing: one name per column,
+    in column order.
+
+    The two mapping spellings mean different things and are read differently:
+    values that are lists are the components (the key is a group label, not a
+    column name), and values that are integers are the components' indices (the
+    KEYS are the column names, ordered by that index rather than by insertion
+    order). LeRobot's own flattening helper renders the second shape's indices
+    as the names, which is why that distinction is drawn here.
+
+    Reading a mapping as a plain list yields its keys, which is one name per
+    GROUP - ``["motors"]`` for a six-motor arm. That is a narrower vector than
+    the one the dataset holds, and the output schema is derived from these
+    names, so the columns past the first of each group would be dropped from the
+    output without any error. A declaration that still cannot describe the
+    vector is refused by :meth:`_SourceDataset.open`.
+
+    Args:
+        feature: The column's ``meta/info.json`` entry, or anything else when
+            the dataset declares no such column.
+
+    Returns:
+        The declared component names, or an empty list when the column declares
+        none (``names: null``, which the pass-through leaves alone).
+    """
+    raw = feature.get("names") if isinstance(feature, dict) else None
+    if isinstance(raw, Mapping):
+        values = list(raw.values())
+        # ``{"motors": [...]}`` / ``{"left": [...], "right": [...]}``: a GROUP
+        # name mapped to its members, so the members are the column names and
+        # the group name is not one.
+        if values and all(isinstance(value, (list, tuple)) for value in values):
+            return [str(item) for value in values for item in value]
+        # ``{"delta_x": 0, "delta_y": 1, ...}``: a COLUMN name mapped to its
+        # index, so the keys are the names and the values order them. Sorting on
+        # the index rather than trusting insertion order is what makes a
+        # declaration written out of order still name the right column.
+        if values and all(isinstance(value, int) and not isinstance(value, bool) for value in values):
+            return [str(key) for key, _ in sorted(raw.items(), key=lambda item: int(item[1]))]
+        return [str(key) for key in raw]
+    if isinstance(raw, (list, tuple)):
+        return [str(item) for item in raw]
+    return []
+
+
+def _column_width(feature: Any) -> int | None:
+    """Return the number of columns a vector feature declares, or ``None``.
+
+    Args:
+        feature: The column's ``meta/info.json`` entry.
+
+    Returns:
+        The single dimension of a 1-D ``shape``. ``None`` for an absent or
+        multi-dimensional shape, which this reader does not name per component.
+    """
+    shape = tuple(feature.get("shape", ())) if isinstance(feature, dict) else ()
+    return int(shape[0]) if len(shape) == 1 else None
+
+
 class _SourceDataset:
     """Read side of the orchestration: one opened source LeRobotDataset.
 
@@ -745,8 +811,11 @@ class _SourceDataset:
         self.use_videos = all(dtype == "video" for dtype in self.camera_dtypes.values())
         state_feat = features.get("observation.state", {})
         action_feat = features.get("action", {})
-        self.state_names: list[str] = list(state_feat.get("names") or [])
-        self.action_names: list[str] = list(action_feat.get("names") or [])
+        # One name per column, whichever of LeRobot's two ``names`` spellings the
+        # source used - the output schema is built from these, so a grouped
+        # declaration read as its keys would narrow the output silently.
+        self.state_names: list[str] = _column_names(state_feat)
+        self.action_names: list[str] = _column_names(action_feat)
         self.fps = int(ds.meta.fps)
         self.robot_type = str(getattr(ds.meta, "robot_type", None) or "unknown")
         self.total_episodes = int(ds.meta.total_episodes)
@@ -758,10 +827,12 @@ class _SourceDataset:
 
         A string return keeps :meth:`DatasetTransform.transform`'s error
         channel uniform (a ``TransformResult`` with ``status="error"``) for
-        every source-side refusal. Three sources are refused, all for the same
+        every source-side refusal. Four sources are refused, all for the same
         reason - the output could not be the source rendered differently: one
         declaring a feature the pass-through cannot preserve, one declaring no
-        camera stream at all, and one whose cameras disagree about their dtype.
+        camera stream at all, one whose cameras disagree about their dtype, and
+        one whose ``observation.state`` / ``action`` names do not describe the
+        vector they annotate.
         """
         from lerobot.datasets.lerobot_dataset import LeRobotDataset
 
@@ -806,6 +877,27 @@ class _SourceDataset:
                 "promoted to video - which the schema-parity half of the pass-through contract forbids. "
                 "Re-record or convert the source so every observation.images.* stream shares one dtype."
             )
+        for key, names in (("observation.state", reader.state_names), ("action", reader.action_names)):
+            # Same reason as the three refusals above. The output schema declares
+            # exactly these names, and the pass-through fills them by pairing them
+            # with the source row, so a count that disagrees with the column width
+            # writes a DIFFERENT trajectory: names short of the width drop the
+            # trailing components, and names past it fabricate a command for a
+            # column no frame supplies (recorded as 0.0, which is itself a
+            # travel-to-zero command for an absolute-position actuator). Both are
+            # silent, so the source is refused instead.
+            width = _column_width(features.get(key))
+            if names and width is not None and len(names) != width:
+                return (
+                    f"source dataset declares {len(names)} name(s) for its {width}-column {key} "
+                    f"vector: {names}. The output dataset declares the source's names, and the "
+                    "pass-through pairs them with the source row, so a count that disagrees would "
+                    f"silently write a {min(len(names), width)}-column {key} - dropping the "
+                    "components past the shorter of the two, or fabricating a value for a column no "
+                    "frame supplies. Correct the source's names to one entry per column (LeRobot "
+                    "writes them either as a flat list or as a mapping grouping them, and both are "
+                    "read here) so the output can be the source rendered differently."
+                )
         return reader
 
     def selected_episodes(self, episodes: list[int] | None) -> list[int] | str:
@@ -894,20 +986,27 @@ class _SourceDataset:
 
 
 def _write_episode(recorder: Any, reader: _SourceDataset, episode: dict[str, Any]) -> None:
-    """Write one generated episode through the recorder, columns pass-through."""
+    """Write one generated episode through the recorder, columns pass-through.
+
+    The state and action pairings are ``strict``: every declared name takes a
+    value from the row and every value in the row has a name.
+    :meth:`_SourceDataset.open` has already refused a source where those counts
+    disagree, so this is the assertion that the refusal covered every path to
+    here rather than a second, quieter place to truncate a trajectory.
+    """
     tasks: list[str] = episode["task"]
     frame_count = len(tasks)
     for t in range(frame_count):
         observation: dict[str, Any] = {}
         if reader.state_names and "observation.state" in episode:
             state_row = episode["observation.state"][t]
-            observation.update(zip(reader.state_names, (float(v) for v in state_row)))
+            observation.update(zip(reader.state_names, (float(v) for v in state_row), strict=True))
         for cam in reader.camera_keys:
             observation[cam] = episode[f"{_IMAGE_PREFIX}{cam}"][t]
         action: dict[str, Any] = {}
         if reader.action_names and "action" in episode:
             action_row = episode["action"][t]
-            action.update(zip(reader.action_names, (float(v) for v in action_row)))
+            action.update(zip(reader.action_names, (float(v) for v in action_row), strict=True))
         recorder.add_frame(
             observation,
             action,

--- a/tests/transforms/test_source_column_names_describe_the_vector.py
+++ b/tests/transforms/test_source_column_names_describe_the_vector.py
@@ -1,0 +1,257 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A source column's ``names`` are read as LeRobot writes them, or refused.
+
+``_SourceDataset`` derives the output dataset's schema from the source's
+``observation.state`` / ``action`` names -- ``create_output_recorder`` documents
+itself as "the SOURCE schema (parity by construction)" -- and ``_write_episode``
+fills those columns by pairing each name with the source row. So the name list
+decides how wide the output trajectory is, and reading it wrongly writes a
+different trajectory than the one recorded.
+
+LeRobot writes a vector column's ``names`` in two spellings. Most datasets use a
+flat list. But its own shipped teleoperators use a mapping:
+``teleop_keyboard.action_features`` declares ``{"motors": list(self.arm.motors)}``
+and ``teleop_gamepad`` declares ``{"delta_x": 0, "delta_y": 1, ...}``. The reader
+did ``list(feature.get("names") or [])``, which on a mapping yields its KEYS --
+one name per GROUP, not per column:
+
+=====================================================  ==========  ==============
+source ``action.names``                                6-col ->    outcome
+=====================================================  ==========  ==============
+``["shoulder_pan", ..., "gripper"]``                   6 -> 6      unaffected
+``{"motors": [6 motors]}`` (``teleop_keyboard``)       6 -> **1**  5 dropped
+``{"left": [6], "right": [6]}`` (bimanual)             12 -> **2** 10 dropped
+``{"delta_x": 0, ...}`` (``teleop_gamepad``)           6 -> 6      unaffected
+=====================================================  ==========  ==============
+
+Every one of those transformed with ``status="success"``, wrote provenance
+claiming the episode is its source, and reported it in ``episodes_written``.
+``docs/data/transforms.md`` contract item 1 promises a generated episode is "the
+*same trajectory* rendered differently"; a six-motor arm recorded as its
+shoulder-pan column alone is not that.
+
+The two mapping spellings do not mean the same thing, which is why they are read
+differently rather than flattened alike: a list value holds the components (its
+key is a group label), an integer value is the component's index (the key is the
+column name). LeRobot's own ``_flatten_feature_names`` renders the second shape's
+indices as the names, so following it would name a six-motor arm ``0..5``.
+
+A count that still disagrees with the declared column width cannot be repaired by
+reading it differently, so it is refused -- the fourth refusal in
+:meth:`~strands_robots.transforms.base._SourceDataset.open`, beside the three it
+already makes for the same reason (the output could not be the source rendered
+differently). Both directions are silent otherwise: names short of the width drop
+the trailing components, and names past it declare a column no frame supplies,
+which ``DatasetRecorder.add_frame`` writes as ``0.0`` -- itself a travel-to-zero
+command for an absolute-position actuator, per
+:func:`~strands_robots.dataset_recorder.unrecordable_action_columns_error`.
+``verify_dataset._declared_column_blocks`` already declined to use a ``names``
+whose length differs from the vector's width ("a ``names`` list of a different
+length does not describe this vector"); this holds the transform reader to the
+same rule.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+lerobot = pytest.importorskip("lerobot")
+
+from strands_robots.transforms import TransformSpec, create_transform  # noqa: E402
+
+_ARM = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+_BIMANUAL = [f"left_{joint}" for joint in _ARM] + [f"right_{joint}" for joint in _ARM]
+
+
+@pytest.fixture
+def source_declaring(tmp_path):
+    """Record a real source dataset, then rewrite its declared column ``names``.
+
+    Returns a callable ``(joints, names) -> root``. ``names`` is written verbatim
+    into ``meta/info.json`` for both ``observation.state`` and ``action``, which
+    is how a dataset recorded by a LeRobot teleoperator arrives: the column data
+    is well-formed and only the declaration's spelling differs.
+    """
+    from strands_robots.dataset_recorder import DatasetRecorder
+
+    def _record(joints: list[str], names: object) -> str:
+        root = tmp_path / f"source-{len(joints)}-{abs(hash(repr(names))) % 10000}"
+        recorder = DatasetRecorder.create(
+            "local/source",
+            fps=10,
+            camera_keys=["cam"],
+            camera_dims={"cam": (64, 64)},
+            joint_names=list(joints),
+            action_names=list(joints),
+            root=str(root),
+        )
+        for step in range(4):
+            observation: dict[str, object] = {joint: 0.1 * (index + 1) + step for index, joint in enumerate(joints)}
+            observation["cam"] = np.full((64, 64, 3), 40 + step, dtype=np.uint8)
+            action = {joint: 1.0 * (index + 1) + step for index, joint in enumerate(joints)}
+            recorder.add_frame(observation, action, task="pick")
+        recorder.save_episode()
+        recorder.finalize()
+
+        info_path = root / "meta" / "info.json"
+        info = json.loads(info_path.read_text(encoding="utf-8"))
+        for key in ("observation.state", "action"):
+            info["features"][key]["names"] = names
+        info_path.write_text(json.dumps(info, indent=2), encoding="utf-8")
+        return str(root)
+
+    return _record
+
+
+def _transform(source_root: str, tmp_path: Path):
+    """Run the mock transform over one source and return (result, output_root)."""
+    output_root = str(tmp_path / f"out-{Path(source_root).name}")
+    result = create_transform("mock").transform(
+        TransformSpec(source_root=source_root, output_root=output_root, variants_per_episode=1, seed=7)
+    )
+    return result, output_root
+
+
+def _column(root: str, repo_id: str, key: str) -> np.ndarray:
+    """Stack one column of episode 0 from a dataset on disk."""
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    dataset = LeRobotDataset(repo_id=repo_id, root=root)
+    info = dataset.meta.episodes[0]
+    start, stop = int(info["dataset_from_index"]), int(info["dataset_to_index"])
+    return np.stack([np.asarray(dataset[index][key]).ravel() for index in range(start, stop)])
+
+
+class TestTheDeclarationSpellingsAreReadAsWritten:
+    """``_column_names`` yields one name per column for every spelling LeRobot writes.
+
+    Imported per-cell rather than at module scope: a module-level import of the
+    reader would abort collection of the whole file on a tree without it, so the
+    behavioural classes below would never be graded at all.
+    """
+
+    @staticmethod
+    def _readers():
+        from strands_robots.transforms.base import _column_names, _column_width
+
+        return _column_names, _column_width
+
+    @pytest.mark.parametrize(
+        ("label", "declared", "expected"),
+        [
+            ("flat list", list(_ARM), list(_ARM)),
+            ("group mapping (teleop_keyboard)", {"motors": list(_ARM)}, list(_ARM)),
+            (
+                "group mapping, two groups (bimanual)",
+                {"left": _BIMANUAL[:6], "right": _BIMANUAL[6:]},
+                list(_BIMANUAL),
+            ),
+            ("index mapping (teleop_gamepad)", {joint: i for i, joint in enumerate(_ARM)}, list(_ARM)),
+            # The index is what orders the columns, so a declaration written out
+            # of insertion order still names the right column.
+            ("index mapping, written out of order", {"gripper": 1, "shoulder_pan": 0}, ["shoulder_pan", "gripper"]),
+            ("no declaration", None, []),
+        ],
+    )
+    def test_every_component_is_named_in_column_order(self, label, declared, expected):
+        column_names, _ = self._readers()
+        assert column_names({"shape": [len(expected)], "names": declared}) == expected, label
+
+    def test_a_group_label_is_not_itself_a_column_name(self):
+        """The regression in one line: the mapping's key is a group, not a column."""
+        column_names, _ = self._readers()
+        names = column_names({"shape": [6], "names": {"motors": list(_ARM)}})
+        assert "motors" not in names
+        assert len(names) == 6
+
+    def test_the_width_comes_from_a_one_dimensional_shape_only(self):
+        _, column_width = self._readers()
+        assert column_width({"shape": [6]}) == 6
+        # An image feature is not named per component, so it has no width here.
+        assert column_width({"shape": [3, 64, 64]}) is None
+        assert column_width({}) is None
+
+
+class TestAGroupedDeclarationRoundTripsTheWholeVector:
+    """The pass-through carries every component of a mapping-declared column."""
+
+    @pytest.mark.parametrize(
+        ("label", "joints", "declared"),
+        [
+            ("teleop_keyboard", _ARM, {"motors": list(_ARM)}),
+            ("bimanual", _BIMANUAL, {"left": _BIMANUAL[:6], "right": _BIMANUAL[6:]}),
+        ],
+    )
+    def test_the_output_trajectory_is_the_source_trajectory(self, label, joints, declared, source_declaring, tmp_path):
+        source_root = source_declaring(joints, declared)
+        result, output_root = _transform(source_root, tmp_path)
+        assert result.status == "success", result.message
+
+        for key in ("action", "observation.state"):
+            source_column = _column(source_root, "local/source", key)
+            output_column = _column(output_root, "local/augmented", key)
+            assert output_column.shape == source_column.shape, (
+                f"{label}: {key} lost columns - source {source_column.shape} -> output {output_column.shape}"
+            )
+            assert np.array_equal(output_column, source_column), f"{label}: {key} is not the source trajectory"
+            assert source_column.shape[1] == len(joints), f"{label}: the fixture did not record {len(joints)} columns"
+
+    def test_the_output_names_the_components_not_the_groups(self, source_declaring, tmp_path):
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        source_root = source_declaring(_ARM, {"motors": list(_ARM)})
+        result, output_root = _transform(source_root, tmp_path)
+        assert result.status == "success", result.message
+        output = LeRobotDataset(repo_id="local/augmented", root=output_root)
+        assert dict(output.meta.features)["action"]["names"] == list(_ARM)
+
+
+class TestAFlatDeclarationIsUnaffected:
+    """Over-reach control: the spelling every shipped recording uses is untouched."""
+
+    def test_a_flat_list_source_still_round_trips(self, source_declaring, tmp_path):
+        source_root = source_declaring(_ARM, list(_ARM))
+        result, output_root = _transform(source_root, tmp_path)
+        assert result.status == "success", result.message
+        for key in ("action", "observation.state"):
+            assert np.array_equal(
+                _column(output_root, "local/augmented", key), _column(source_root, "local/source", key)
+            ), key
+
+
+class TestADeclarationThatCannotDescribeTheVectorIsRefused:
+    """A name count that disagrees with the column width is refused, not narrowed."""
+
+    @pytest.mark.parametrize(
+        ("label", "declared", "declared_count"),
+        [
+            # Short: the trailing components would be dropped from the output.
+            ("names short of the width", list(_ARM)[:5], 5),
+            # Long: the extra column is one no frame supplies, so the recorder
+            # would write 0.0 - a travel-to-zero command on a position actuator.
+            ("names past the width", [*_ARM, "phantom_joint"], 7),
+        ],
+    )
+    def test_the_refusal_names_both_counts_and_writes_nothing(
+        self, label, declared, declared_count, source_declaring, tmp_path
+    ):
+        source_root = source_declaring(_ARM, declared)
+        result, output_root = _transform(source_root, tmp_path)
+
+        assert result.status == "error", f"{label}: a source whose names cannot describe its vector was accepted"
+        assert f"{declared_count} name(s)" in result.message, result.message
+        assert f"{len(_ARM)}-column" in result.message, result.message
+        # Refused at open(), so no partial dataset is left behind to be trained on.
+        assert not Path(output_root).exists(), f"{label}: a refused source still wrote an output dataset"
+
+    def test_a_mapping_whose_components_do_not_cover_the_vector_is_refused(self, source_declaring, tmp_path):
+        """The mapping spelling gets the same rule, not an exemption for being nested."""
+        source_root = source_declaring(_ARM, {"motors": list(_ARM)[:4]})
+        result, _ = _transform(source_root, tmp_path)
+        assert result.status == "error", result.message
+        assert "4 name(s)" in result.message and "6-column" in result.message, result.message


### PR DESCRIPTION
`_SourceDataset` builds the output dataset's schema from the source's `observation.state` / `action` names, and `_write_episode` fills those columns by pairing each name with the source row. **So the name list decides how wide the output trajectory is.**

It was read as `list(feature.get("names") or [])`. LeRobot also writes that field as a mapping, and its own shipped teleoperators do — so on those sources the call yielded the *keys*, one name per group rather than per column.

![before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/transform-column-names/column_names.png)

## Measured, one episode through the `mock` transform

| source `action.names` | before | after |
|---|---|---|
| `["shoulder_pan", ..., "gripper"]` | 6 -> 6 cols | 6 -> 6 cols |
| `{"motors": [6 motors]}` — `teleop_keyboard` | **6 -> 1 col**, 5 commands dropped | 6 -> 6 cols |
| `{"left": [6], "right": [6]}` — bimanual | **12 -> 2 cols**, 10 dropped | 12 -> 12 cols |
| `{"delta_x": 0, ...}` — `teleop_gamepad` | 6 -> 6 cols | 6 -> 6 cols |
| 5 names for a 6-column vector | **6 -> 5 cols**, 1 dropped | refused |

Every red row returned `status="success"`, counted the episode in `episodes_written`, and wrote provenance claiming it is its source episode. `docs/data/transforms.md` contract item 1 promises a generated episode is "the *same trajectory* rendered differently"; a six-motor arm recorded as its shoulder-pan column alone is not that, and nothing reported it.

The two green rows are controls and pass on both trees — the flat list every shipped recording uses, and the gamepad mapping, which came out right only because its keys happened to be in index order.

## The two mapping spellings mean different things

They are read differently rather than flattened alike:

- a **list** value holds the components, so its key is a group label and not a column name (`{"motors": [...]}`, `{"left": [...], "right": [...]}`);
- an **integer** value is the component's index, so the *keys* are the column names, ordered by that index rather than by insertion order.

LeRobot's own `_flatten_feature_names` renders the second shape's indices as the names, which would name a six-motor arm `0..5`, so following it was not an option.

## A count that still cannot describe the vector is refused

Reading the field differently cannot repair a name count that disagrees with the column's declared width, so `open()` refuses it — the **fourth** refusal there, beside the three it already makes for one reason, that the output could not be the source rendered differently. Both directions are otherwise silent:

- names **short** of the width drop the trailing components;
- names **past** it declare a column no frame supplies, which `add_frame` writes as `0.0` — itself a travel-to-zero command for an absolute-position actuator, as `unrecordable_action_columns_error` already documents.

`verify_dataset._declared_column_blocks` already declined to use a `names` whose length differs from the vector's width ("a `names` list of a different length does not describe this vector"); this holds the transform reader to the same rule. The two pairings in `_write_episode` are now `strict`, so a path reaching them with disagreeing counts raises rather than quietly truncating a trajectory.

## Tests

`tests/transforms/test_source_column_names_describe_the_vector.py`, 15 cells. On unmodified `main` with only this file added: **14 fail, 1 passes**, the behavioural ones on their own assertions —

```
teleop_keyboard: action lost columns - source (4, 6) -> output (4, 1)
bimanual:        action lost columns - source (4, 12) -> output (4, 2)
assert ['motors'] == ['shoulder_pan', ..., 'gripper']
a source whose names cannot describe its vector was accepted
```

The one that passes pre-fix is the over-reach control (`TestAFlatDeclarationIsUnaffected`), which is what makes the rest of the pins mean something rather than reading as a rewrite. Byte-equality is asserted on both `action` and `observation.state`, and the refusal cells also assert no partial output dataset is left on disk.

| gate | `main` | this branch |
|---|---|---|
| `tests/transforms` | 380 passed | **395 passed** (+15 = exactly the new cells) |
| `scripts/check_whole_tree_graders.py` | 13F / 4196P / 56s / 4E | **identical**, same node ids |
| `mypy strands_robots` | 1 error (`simulation/ik.py`) | **identical** |
| `ruff check` / `ruff format` | clean | clean |

## Size

Source `+107/-8`, docs `+14`, tests `+257`, plus a 37-line changelog fragment. AST executable statements in `transforms/base.py` 223 -> 240; the additions are the two readers and the refusal, and no call site outside the module changes.