### PR TITLE
test(g1): the SDK-load-hygiene pins measure the import, not the process

### DIFF
--- a/changelog.d/3160-sdk-load-hygiene-pins-measure-the-import.md
+++ b/changelog.d/3160-sdk-load-hygiene-pins-measure-the-import.md
@@ -1,0 +1,16 @@
+### Tests
+
+- The two g1 SDK-load-hygiene pins now measure the import in a clean
+  interpreter instead of reading process-wide `sys.modules`. A process-wide read
+  answers "has anything here imported `unitree_sdk2py`", and two sibling tests
+  import the real SDK for good reasons - one decides at module scope whether to
+  install a stub, the other grades the wire format against the real IDL - so on
+  a host that has the SDK installed the read was already non-empty when a pin
+  ran (101 modules in a `tests/drivers` run, 115 in `tests/tools/g1`) and both
+  pins failed naming the wrong module. A subprocess asks the question the names
+  ask, and with a guarded eager import planted in `g1_actions` the new pins fail
+  for it and pass for clean code in both contexts, where the old in-suite
+  verdict was the same either way. Production code is unchanged: a clean
+  interpreter importing `strands_robots.tools.g1.g1_actions`,
+  `strands_robots.tools.g1.use_unitree` or `strands_robots.drivers.g1` loads no
+  SDK module.

--- a/tests/drivers/test_g1_actions_write_the_driver_envelope.py
+++ b/tests/drivers/test_g1_actions_write_the_driver_envelope.py
@@ -12,7 +12,7 @@ refusal alike - the verbs do not reshape).
 
 from __future__ import annotations
 
-import importlib
+import subprocess
 import sys
 from typing import Any
 
@@ -119,10 +119,32 @@ def _text(envelope: dict[str, Any]) -> str:
 
 
 def test_the_import_pulls_no_sdk_module() -> None:
-    """SDK-load hygiene: importing the verbs must not import unitree_sdk2py."""
-    importlib.import_module("strands_robots.tools.g1.g1_actions")
-    pulled = [name for name in sys.modules if name.startswith("unitree_sdk2py")]
-    assert not pulled, f"strands_robots.tools.g1.g1_actions imports pulled SDK submodules: {pulled}"
+    """SDK-load hygiene: importing the verbs must not import unitree_sdk2py.
+
+    Measured in a clean interpreter, for the reason
+    ``test_g1_driver.test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time``
+    states: this session's ``sys.modules`` already holds whatever every other
+    collected module imported, so reading it here answers "has anything in this
+    process imported the SDK" - which is neither what this test claims nor
+    anything ``g1_actions`` controls. A neighbouring file decides at module scope
+    whether to install an SDK stub by importing the real one, and collection runs
+    that before the first test, so on a host that has the SDK installed the
+    process-wide read is non-empty from the start and reports it as an eager
+    import by this module.
+
+    A subprocess asks the question the name asks, and it is the only spelling
+    that can answer it: an eager import is observable only where the SDK is
+    installed, which is exactly the host the process-wide read cannot be used on.
+    """
+    probe = (
+        "import importlib, sys; importlib.import_module('strands_robots.tools.g1.g1_actions'); "
+        "print(sorted(n for n in sys.modules if n.startswith('unitree_sdk2py')))"
+    )
+    completed = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=False)
+    assert completed.returncode == 0, f"importing the verb module failed: {completed.stderr}"
+    assert completed.stdout.strip() == "[]", (
+        f"importing strands_robots.tools.g1.g1_actions pulled SDK submodules: {completed.stdout.strip()}"
+    )
 
 
 def test_every_verb_has_an_actions_table_row() -> None:

--- a/tests/tools/g1/test_use_unitree_meta_discovery_is_robot_free.py
+++ b/tests/tools/g1/test_use_unitree_meta_discovery_is_robot_free.py
@@ -13,14 +13,29 @@ Also pins the SDK-load-hygiene contract: importing the module pulls no
 
 from __future__ import annotations
 
-import importlib
+import subprocess
 import sys
 
 
 def test_importing_use_unitree_pulls_no_sdk_submodule() -> None:
-    importlib.import_module("strands_robots.tools.g1.use_unitree")
-    leaked = sorted(m for m in sys.modules if m.startswith("unitree_sdk2py"))
-    assert not leaked, f"strands_robots.tools.g1.use_unitree imports pulled SDK submodules: {leaked}"
+    """Measured in a clean interpreter, not against this session's ``sys.modules``.
+
+    A process-wide read answers "has anything here imported the SDK", and the
+    tests that grade the wire formats against the real IDL legitimately import
+    it, so the answer says nothing about this module. A subprocess measures the
+    import that is actually under test - and it is the only spelling that can,
+    because an eager import shows up only on a host where the SDK is installed,
+    which is the host a process-wide read is guaranteed to be wrong on.
+    """
+    probe = (
+        "import importlib, sys; importlib.import_module('strands_robots.tools.g1.use_unitree'); "
+        "print(sorted(n for n in sys.modules if n.startswith('unitree_sdk2py')))"
+    )
+    completed = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=False)
+    assert completed.returncode == 0, f"importing use_unitree failed: {completed.stderr}"
+    assert completed.stdout.strip() == "[]", (
+        f"strands_robots.tools.g1.use_unitree imports pulled SDK submodules: {completed.stdout.strip()}"
+    )
 
 
 def test_list_services_names_the_six_sdk_clients() -> None:


### PR DESCRIPTION
Two pins claim to check that importing a g1 tool module pulls no `unitree_sdk2py` submodule, and both read process-wide `sys.modules`:

```python
importlib.import_module("strands_robots.tools.g1.g1_actions")
pulled = [name for name in sys.modules if name.startswith("unitree_sdk2py")]
assert not pulled
```

That expression answers *has anything in this process imported the SDK* - not what the module under test imports, and not something it controls.

![verdict matrix](https://raw.githubusercontent.com/cagataycali/robots/artifacts/sdk-load-hygiene/sdk-load-hygiene-matrix.png)

Two sibling tests import the real SDK for good reasons: `test_g1_control_loop_terminal_observability.py` calls `importlib.import_module("unitree_sdk2py.idl.default")` at module scope to decide whether to install a stub, and `TestTheRealSdkBehavesTheWayTheDoubleDoes` grades the wire format against the real IDL. So on a host that has the SDK installed the read is already non-empty when a pin runs - **101** modules in a `tests/drivers` run (present before the first test, from collection) and **115** in a `tests/tools/g1` run - and both pins fail, naming the wrong module:

```
FAILED tests/drivers/test_g1_actions_write_the_driver_envelope.py::test_the_import_pulls_no_sdk_module
  AssertionError: strands_robots.tools.g1.g1_actions imports pulled SDK submodules: [... 101 names ...]
FAILED tests/tools/g1/test_use_unitree_meta_discovery_is_robot_free.py::test_importing_use_unitree_pulls_no_sdk_submodule
  AssertionError: strands_robots.tools.g1.use_unitree imports pulled SDK submodules: [... 115 names ...]
```

The same two files pass when run alone, so the verdict is a property of the session rather than of the module.

## Change

Both pins now measure the import in a clean interpreter - the spelling `test_g1_driver_module_does_not_import_unitree_sdk2py_at_load_time` already uses one directory over, whose docstring states the rule:

> A subprocess cannot rebind anything here, and it states the contract more strongly - no SDK module is loaded at all, rather than none beyond whatever an earlier test in this session already imported.

## What the pins now discriminate

With a guarded eager import planted at module scope in `g1_actions` (`try: import unitree_sdk2py.idl.default / except ImportError: pass` - the shape that would slip through a review as "warm the IDL"):

| host | production code | context | before | after |
| --- | --- | --- | --- | --- |
| SDK installed | clean | pin file alone | PASS | PASS |
| SDK installed | clean | in a suite run | **FAIL** (false alarm) | PASS |
| SDK installed | eager import planted | pin file alone | FAIL | FAIL |
| SDK installed | eager import planted | in a suite run | FAIL (same verdict as clean) | FAIL |
| SDK absent | clean | in a suite run | PASS | PASS |
| SDK absent | eager import planted | in a suite run | PASS (cannot see it) | PASS (cannot see it) |

Before, the in-suite verdict is FAIL whether the module is clean or not, so it carries no information there. After, the verdict tracks the production code.

The last two rows are the honest limit, unchanged by this PR: where `unitree_sdk2py` is not installed, no spelling can observe a *guarded* eager import, because nothing is loaded. What the subprocess adds is that the pin is now correct on the hosts that do have the SDK - the ones where import cost at tool-load time is paid.

Production code is not touched, and does not need to be: a clean interpreter importing `strands_robots.tools.g1.g1_actions`, `strands_robots.tools.g1.use_unitree` or `strands_robots.drivers.g1` loads **0** SDK modules.

## Tests

| suite | before | after |
| --- | --- | --- |
| `tests/drivers` | 1 failed, 2178 passed, 7 skipped | **2179 passed**, 7 skipped |
| `tests/tools/g1` | 1 failed, 208 passed | **209 passed** |

Whole-tree graders unchanged at 13 failed / 4196 passed / 56 skipped / 4 errors on both trees (unrelated: absent optional deps and installed-lerobot drift). `ruff check`, `ruff format` and `mypy` clean.

## Size

Tests only: +46/-9 across two files, plus a 16-line changelog fragment (+62/-9 total). AST executable statements 46 -> 47 and 30 -> 32. No production change.