### PR TITLE
fix(groot): an action chunk's horizon is one every value can answer for

### DIFF
--- a/changelog.d/3162-groot-action-chunk-shared-horizon.md
+++ b/changelog.d/3162-groot-action-chunk-shared-horizon.md
@@ -1,0 +1,25 @@
+### Fixed: a GR00T action chunk's horizon is one every value can answer for
+
+`_action_chunk_horizon` checked that **every** value in a GR00T action chunk
+carries a leading time axis, then read the horizon from whichever value the
+producer happened to serialize first. Both unpack paths iterate
+`range(horizon)` and index every value at each step, so a chunk whose values
+cover different horizons had two different outcomes for the same data,
+selected by the producer's key order: with the longest value first the loop
+indexed past the end of every shorter one and raised `IndexError: index 8 is
+out of bounds for axis 0 with size 8` from inside the loop, naming no key --
+precisely the opaque failure the sibling 0-D check exists to prevent. With the
+shortest value first it returned a success carrying 8 of the arm's 16
+commanded steps, the trailing steps dropped without a log line, and the
+consumer re-queried as though the whole chunk had run.
+
+The property that is returned is now checked, the same way the 0-D property
+was already checked across every value. A disagreeing chunk is refused with a
+`ValueError` naming every key, its horizon and its shape, so an operator can
+tell which head is short without re-running inference. It is refused rather
+than truncated to the shortest value: the steps a longer value carries are
+commands the model produced, so trimming them would execute part of a
+trajectory and re-query as if the whole chunk had completed. The refusal is
+identical whichever key the producer serialized first.
+
+`docs/policies/groot.md` gains a chunk-shape table documenting both refusals.

--- a/docs/policies/groot.md
+++ b/docs/policies/groot.md
@@ -66,6 +66,24 @@ is parsed and honoured in **either** mode. What service mode cannot do is
 cross-check it: a mapping naming a key the server does not have surfaces as a
 server-side error rather than a constructor refusal.
 
+## Action chunk shape
+
+Both unpack paths turn the model's / server's `{action.<key>: array}` chunk into
+one dict per timestep, reading every value at the same index. Two properties are
+therefore required of the chunk and refused with a `ValueError` naming the
+offending keys and their shapes:
+
+| Chunk | Result |
+|-------|--------|
+| every value `(horizon,)` or `(horizon, action_dim)`, same `horizon` | unpacked into `horizon` per-step dicts |
+| a 0-D / scalar value (no time axis) | refused - `scalar (0-D) action value(s)` |
+| values whose leading axes disagree (e.g. `(16, 7)` and `(8, 1)`) | refused - `time axes disagree` |
+
+A disagreeing chunk is refused rather than truncated to the shortest value: the
+steps a longer value carries are commands the model produced, so dropping them
+would execute part of a trajectory and re-query as if the whole chunk had run.
+The refusal is the same whichever key the producer serialized first.
+
 ## Versions
 
 | Version | Transport | Notes |

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -468,11 +468,22 @@ def _action_chunk_horizon(chunk: dict[str, np.ndarray]) -> int:
     """Return the shared time-axis length of a normalized action chunk.
 
     Both unpack paths reduce each action value to ``(horizon,)`` or
-    ``(horizon, action_dim)`` and then iterate ``range(horizon)``. Every value
-    must therefore carry a leading time axis. A 0-D / scalar value has no time
-    axis, so a server or model that emits one is malformed; surface it as an
-    actionable error instead of the opaque ``IndexError: tuple index out of
-    range`` that a ``.shape[0]`` read on a 0-D array would otherwise raise.
+    ``(horizon, action_dim)`` and then iterate ``range(horizon)``, indexing
+    EVERY value at each step. Two properties must therefore hold across the
+    whole chunk, and both are checked here so the horizon returned is one every
+    value can actually answer for:
+
+    * **Every value carries a leading time axis.** A 0-D / scalar value has
+      none, so a server or model that emits one is malformed; surface it as an
+      actionable error instead of the opaque ``IndexError: tuple index out of
+      range`` that a ``.shape[0]`` read on a 0-D array would otherwise raise.
+    * **Every value covers the same horizon.** Reading the length from one
+      value alone makes the outcome depend on which key the producer happened
+      to serialize first: with the longest value first the loop indexes past
+      the end of every shorter one (an opaque ``IndexError`` naming no key),
+      and with the shortest first the trailing steps of every longer value are
+      dropped and the truncated chunk is returned as a success. A chunk whose
+      values disagree cannot be unpacked either way, so refuse it here.
 
     Args:
         chunk: Normalized ``{bare_key: np.ndarray}`` action mapping (non-empty).
@@ -481,7 +492,8 @@ def _action_chunk_horizon(chunk: dict[str, np.ndarray]) -> int:
         The leading-axis length shared by the chunk's values.
 
     Raises:
-        ValueError: If any value is 0-D (has no leading time axis).
+        ValueError: If any value is 0-D (has no leading time axis), or if the
+            values do not all share one leading-axis length.
     """
     scalar_keys = [k for k, v in chunk.items() if v.ndim == 0]
     if scalar_keys:
@@ -491,7 +503,16 @@ def _action_chunk_horizon(chunk: dict[str, np.ndarray]) -> int:
             f"(shapes {shapes}); expected a leading time axis of shape (horizon,) "
             "or (horizon, action_dim). The action chunk is malformed."
         )
-    return next(iter(chunk.values())).shape[0]
+    horizons = {k: int(v.shape[0]) for k, v in chunk.items()}
+    if len(set(horizons.values())) > 1:
+        shapes = {k: tuple(v.shape) for k, v in chunk.items()}
+        raise ValueError(
+            f"GR00T returned action values whose time axes disagree: horizons "
+            f"{horizons} (shapes {shapes}). Every value in one chunk must cover "
+            "the same horizon, because each unpacked step reads every value at "
+            "the same index. The action chunk is malformed."
+        )
+    return next(iter(horizons.values()))
 
 
 # Gr00tPolicy

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -1491,11 +1491,15 @@ class TestServiceUnpackWithMapping:
 class TestUnpackMalformedActionChunk:
     """Both unpack paths must survive degenerate server/model action chunks.
 
-    A well-formed chunk carries a leading time axis on every value, so the
-    unpackers read ``.shape[0]`` for the horizon. An empty chunk yields no
-    actions; a scalar (0-D) value has no time axis and must raise an actionable
-    ``ValueError`` rather than the opaque ``IndexError: tuple index out of
-    range`` that ``.shape[0]`` on a 0-D array would otherwise surface.
+    A well-formed chunk carries a leading time axis on every value AND the same
+    horizon on every value, because each unpacked step indexes every value at
+    the same position. An empty chunk yields no actions; a scalar (0-D) value
+    has no time axis and must raise an actionable ``ValueError`` rather than the
+    opaque ``IndexError: tuple index out of range`` that ``.shape[0]`` on a 0-D
+    array would otherwise surface; and values whose horizons disagree must be
+    refused the same way in either key order, since reading the horizon from one
+    value alone lets the producer's serialization order decide between an opaque
+    ``IndexError`` and a silently truncated chunk returned as a success.
     """
 
     def test_service_empty_chunk_returns_no_actions(self):
@@ -1532,6 +1536,61 @@ class TestUnpackMalformedActionChunk:
         p._action_mapping = None
         result = p._unpack_service_actions({"action.single_arm": np.ones(3)})
         assert result == [{"single_arm": 1.0}, {"single_arm": 1.0}, {"single_arm": 1.0}]
+
+    # A chunk whose values cover different horizons cannot be unpacked: every
+    # step reads every value at the same index. Reading the horizon from one
+    # value leaves the outcome to the order the producer serialized its keys.
+    _MISMATCHED_CHUNKS = [
+        pytest.param(
+            {"action.single_arm": np.ones((1, 16, 7)), "action.gripper": np.ones((1, 8, 1))},
+            {"single_arm": 16, "gripper": 8},
+            id="longest-value-first",
+        ),
+        pytest.param(
+            {"action.gripper": np.ones((1, 8, 1)), "action.single_arm": np.ones((1, 16, 7))},
+            {"gripper": 8, "single_arm": 16},
+            id="shortest-value-first",
+        ),
+        pytest.param(
+            {"action.single_arm": np.ones((1, 16, 7)), "action.gripper": np.ones((1, 1, 16))},
+            {"single_arm": 16, "gripper": 1},
+            id="extra-leading-axis-leaves-a-horizon-of-one",
+        ),
+    ]
+
+    @pytest.mark.parametrize("unpack", ["_unpack_actions", "_unpack_service_actions"])
+    @pytest.mark.parametrize(("chunk", "horizons"), _MISMATCHED_CHUNKS)
+    def test_disagreeing_horizons_are_refused_in_either_key_order(self, unpack, chunk, horizons):
+        """Values covering different horizons are refused, whatever their order.
+
+        Both outcomes of reading the horizon from a single value are wrong, and
+        which one occurs is decided by the producer: listing the longest value
+        first indexes past the end of every shorter one, and listing the
+        shortest first drops the trailing steps of every longer one and returns
+        the truncated chunk as a success.
+        """
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._action_mapping = ActionMapping(actions={"single_arm": "arm", "gripper": "grip"})
+        with pytest.raises(ValueError, match="time axes disagree") as excinfo:
+            getattr(p, unpack)(chunk)
+        # The report must name every key and the horizon it actually carries, so
+        # an operator can tell which head is short without re-running inference.
+        message = str(excinfo.value)
+        for key, horizon in horizons.items():
+            assert key in message
+            assert str(horizon) in message
+
+    @pytest.mark.parametrize("unpack", ["_unpack_actions", "_unpack_service_actions"])
+    @pytest.mark.parametrize("reverse", [False, True], ids=["declared-order", "reversed-order"])
+    def test_agreeing_horizons_unpack_the_whole_chunk(self, unpack, reverse):
+        """The well-formed case is unchanged: key order does not affect the result."""
+        items = [("action.single_arm", np.ones((1, 16, 7))), ("action.gripper", np.ones((1, 16, 1)))]
+        chunk = dict(reversed(items) if reverse else items)
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._action_mapping = ActionMapping(actions={"single_arm": "arm", "gripper": "grip"})
+        actions = getattr(p, unpack)(chunk)
+        assert len(actions) == 16
+        assert actions[0] == {"arm": [1.0] * 7, "grip": [1.0]}
 
 
 # (section)


### PR DESCRIPTION
`_action_chunk_horizon` checks that **every** value in a GR00T action chunk carries a leading time axis, then reads the horizon from whichever value the producer happened to serialize first. Both unpack paths iterate `range(horizon)` and index **every** value at each step, so a chunk whose values cover different horizons had two different outcomes for the same data — decided by the producer's key order.

![action chunk before/after](https://raw.githubusercontent.com/cagataycali/robots/4e2e4ed843db6148b1e0facf09bbffc1186b4629/.artifacts/groot-chunk-horizon.png)

| chunk | before | after |
|---|---|---|
| `(16,7)` + `(16,1)` — well formed | 16 steps | 16 steps (unchanged) |
| `(16,7)` then `(8,1)` — longest first | `IndexError: index 8 is out of bounds for axis 0 with size 8` | refused |
| `(8,1)` then `(16,7)` — shortest first | **success with 8 of 16 steps** | refused |
| `(16,7)` + `(1,16)` — extra leading axis | `IndexError: index 1 is out of bounds for axis 0 with size 1` | refused |

Measured on both paths (`_unpack_actions`, `_unpack_service_actions`); they behave identically.

Both outcomes are wrong, and the silent one is worse: the arm's trailing 8 steps are commands the model produced, dropped with no log line, and the consumer re-queries as if the whole chunk had run. The `IndexError` is raised from inside the loop and names no key — precisely the opaque failure the sibling 0-D check exists to prevent. The function's own docstring already promised "the leading-axis length **shared** by the chunk's values".

## Change

Check the property that is returned, the same way the 0-D property is already checked across every value, and refuse a disagreeing chunk naming every key, its horizon and its shape:

```
ValueError: GR00T returned action values whose time axes disagree: horizons
{'single_arm': 16, 'gripper': 8} (shapes {'single_arm': (16, 7), 'gripper': (8, 1)}).
Every value in one chunk must cover the same horizon, because each unpacked step
reads every value at the same index. The action chunk is malformed.
```

Refused rather than truncated to the shortest value: trimming would execute part of a trajectory and re-query as though the whole chunk had run. The refusal is now identical in either key order.

## Tests

Added to `TestUnpackMalformedActionChunk`, whose docstring enumerated the damage shapes but whose multi-key fixtures all used the same horizon (16/16, 4/4, 2/2/2) — a mismatch was the shape never posed. Table-driven over 3 chunk shapes × both unpack paths, plus a control that the well-formed case is unchanged in either key order.

On pristine `main` with only the test file applied: **6 failed / 10 passed** — the failures name both mechanisms (`IndexError` for longest-first, `DID NOT RAISE` for shortest-first) and the 4 control cells pass. `tests/policies/groot` 334 → 344 passed; `tests/policies` 12F/5454P → 12F/**5464**P with the failing node-id sets identical (pre-existing optional-dep drift). `ruff check` / `ruff format` clean on `strands_robots tests tests_integ`, and `mypy strands_robots tests tests_integ` unchanged at 20 errors in 6 files on both trees.

## Size

Source `+28/−7`, tests `+64/−5`, docs `+18`, plus a 25-line changelog fragment — `+135/−12` in total. AST executable statements in `policy.py` 502 → 506. Docs: a chunk-shape table in `docs/policies/groot.md` documenting both refusals.