### PR TITLE
fix(dashboard): a setting that is not a boolean cannot open the remote-code gate

### DIFF
--- a/changelog.d/3163-settings-boolean-cannot-open-the-remote-code-gate.md
+++ b/changelog.d/3163-settings-boolean-cannot-open-the-remote-code-gate.md
@@ -1,0 +1,32 @@
+### Fixed: a dashboard setting that is not a boolean can no longer open the remote-code gate
+
+`runtime.trust_remote_code` is published to `STRANDS_TRUST_REMOTE_CODE` by
+`dashboard.settings.apply_mesh_env`, which publishes a key by *truthiness*. The
+lenient coercion path (the settings file, the environment, the CLI) returned the
+value that had failed to be a boolean, so a non-boolean sat in a boolean slot
+and was published as the literal `"1"` - the exact spelling
+`policies.factory._check_trust_remote_code` accepts. A `settings.json` holding
+`"maybe"`, `"yes-please"` or `{"a": 1}` therefore opened the
+arbitrary-code-execution gate, while the same spelling handed to that gate
+directly is refused and `update_strict` refuses it by name. The file path was
+more permissive than the UI/API path for the one setting where that matters.
+
+The module already stated the rule this broke: a lenient degrade must land on
+the key's own SHAPE, "a list key that fell back to a scalar poisons every
+comma-split consumer, which is worse than the empty default". That rule covered
+the list keys and the four numeric keys and omitted the one boolean key.
+`_BOOL_KEYS` now owns that family for both the strict and the lenient path - the
+strict check spelled its own inline copy, so the two could disagree about which
+keys are booleans - and the degrade is fail-closed: a gate that cannot read its
+own setting stays shut. The spellings that do mean something (`true`, `1`,
+`false`, `off`, `""`, `0`) are unchanged in both directions.
+
+`docs/security.md` documented the environment-variable opt-in and never
+mentioned that the dashboard setting writes that same variable, which is how
+this was reachable without contradicting any documented behaviour; it now names
+the setting and its fail-closed reading.
+
+`tests/test_dashboard_settings_value_domain.py` pins both paths' answers across
+the whole value domain as one table, so a schema key added without a domain is
+visible. That domain was untested, which is why this reached `main`:
+`dashboard/settings.py` statement coverage rises from 63% to 95%.

--- a/docs/security.md
+++ b/docs/security.md
@@ -187,6 +187,7 @@ Because this is code execution, not just data loading, Strands Robots forces an 
 - The providers `lerobot_local` (`LerobotLocalPolicy`) and `kimodo` (`KimodoPolicy`) are on the remote-code list. Any provider that loads models with `trust_remote_code=True` must be listed in `_HF_REMOTE_CODE_PROVIDERS` so the opt-in is enforced.
 - Loading is blocked by default. Attempting to create a gated provider without opting in raises `UntrustedRemoteCodeError` with an explanation, rather than silently executing remote code.
 - To opt in, set `STRANDS_TRUST_REMOTE_CODE=1` (`1` / `true` / `yes` are accepted). The example CLI enforces the same gate before it will run `--policy lerobot_local`.
+- The dashboard writes that variable too. `runtime.trust_remote_code` in `settings.json` is published to `STRANDS_TRUST_REMOTE_CODE` by `dashboard.settings.apply_mesh_env`, so a value in that file is an opt-in for the dashboard process just as the environment variable is. A value that is not a boolean is read as `false` rather than as the value that failed to be one - the gate cannot be opened by a setting it could not read.
 
 Operator guidance:
 

--- a/strands_robots/dashboard/settings.py
+++ b/strands_robots/dashboard/settings.py
@@ -64,6 +64,14 @@ _LIST_KEYS = {
     ("security", "cors_origins"),
 }
 
+#: Keys whose value is a boolean. One owner, because the strict path and the
+#: lenient degrade below both have to agree about which keys these are: a key
+#: the strict path validates as a boolean and the lenient path degrades as a
+#: string is the disagreement this set exists to make impossible.
+_BOOL_KEYS: set[tuple[str, str]] = {
+    ("runtime", "trust_remote_code"),
+}
+
 _lock = threading.RLock()
 # The resolved tree, cached under the path it was resolved from. A `dict | None`
 # rebound through `global` -- and at two of the four write sites through
@@ -136,6 +144,16 @@ def _coerce(section: str, key: str, value: Any, strict: bool = False) -> Any:
         # default.
         if (section, key) in _LIST_KEYS:
             return []
+        # A boolean key degrades to False, not to the value that failed to be
+        # one. Returning the raw value left a non-boolean in a boolean slot, and
+        # `apply_mesh_env` publishes such a key by TRUTHINESS - so an
+        # unparseable spelling was published as the literal "1", the exact
+        # spelling `policies.factory._check_trust_remote_code` accepts, while
+        # the same spelling reaching that gate directly is refused. A gate that
+        # cannot read its own setting must stay shut, so the degrade is
+        # fail-closed rather than a passthrough.
+        if (section, key) in _BOOL_KEYS:
+            return False
         return None if key in ("temperature", "camera_hz", "max_tokens", "port") else value
 
 
@@ -149,7 +167,7 @@ def _coerce_strict(section: str, key: str, value: Any) -> Any:
         if value is not None and not isinstance(value, (str, list, tuple)):
             raise CoercionError(f"{key}: expected a list or comma-separated string, got {type(value).__name__}")
         return _as_list(value)
-    if key in ("trust_remote_code",):
+    if (section, key) in _BOOL_KEYS:
         if not isinstance(value, bool):
             spelled = str(value).strip().lower()
             if spelled not in _TRUTHY and spelled not in _FALSY:

--- a/tests/test_dashboard_settings_value_domain.py
+++ b/tests/test_dashboard_settings_value_domain.py
@@ -1,0 +1,189 @@
+"""A settings value that is not usable is refused or degraded, never published.
+
+``settings`` coerces on two paths. The strict one (UI / API writes, via
+:func:`~strands_robots.dashboard.settings.update_strict`) REPORTS an unusable
+value. The lenient one (the settings file, the environment, the CLI, via
+:func:`~strands_robots.dashboard.settings.update` and
+:func:`~strands_robots.dashboard.settings.load`) cannot report to anyone, so it
+degrades - and the module states the rule that makes degrading safe: it must
+degrade to *the key's own shape*, because "a list key that fell back to a scalar
+poisons every comma-split consumer, which is worse than the empty default".
+
+That rule was applied to the list keys and to the four numeric keys and omitted
+for the one boolean key, ``runtime.trust_remote_code`` - whose consumer is the
+remote-code execution gate. The lenient path returned the value that had failed
+to be a boolean, so a non-boolean sat in a boolean slot, and
+:func:`~strands_robots.dashboard.settings.apply_mesh_env` publishes that key by
+TRUTHINESS. A spelling like ``"maybe"`` was therefore published as the literal
+``"1"`` - which is exactly what
+``policies.factory._check_trust_remote_code`` accepts, since its allowlist is
+``("1", "true", "yes")``. The same spelling reaching that gate directly is
+refused. So the settings layer converted a value the gate rejects into the one
+it accepts, off a typo in ``settings.json``, while the API path refused the very
+same value by name.
+
+``test_an_unreadable_spelling_does_not_open_the_remote_code_gate`` is the cell
+that discriminates: it drives the real gate and fails against the passthrough.
+The rest pin the two paths' answers across the whole value domain as one table,
+so a key added to the schema without a domain is visible, and the spellings that
+legitimately mean true or false are pinned as controls - they pass either way,
+which is what keeps the fix from reading as "refuse more things".
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from strands_robots.dashboard import settings
+
+# (section, key, value, substring the strict path must report, lenient result).
+# One row per unusable value; the lenient column is the key's own shape.
+_UNUSABLE = [
+    ("agent", "temperature", "abc", "is not a number", None),
+    ("agent", "temperature", 5.0, "outside 0..2", None),
+    ("agent", "temperature", float("inf"), "is not a finite number", None),
+    ("agent", "max_tokens", "x", "is not an integer", None),
+    ("agent", "max_tokens", 0, "must be at least 1", None),
+    ("mesh", "port", 70000, "outside 1..65535", None),
+    ("mesh", "camera_hz", 0.0, "outside (0, 240]", None),
+    ("mesh", "camera_hz", 500.0, "outside (0, 240]", None),
+    ("mesh", "connect", 5, "expected a list or comma-separated string", []),
+    ("security", "cors_origins", {"a": 1}, "expected a list", []),
+    ("runtime", "trust_remote_code", "maybe", "is not a boolean", False),
+    ("runtime", "trust_remote_code", {"a": 1}, "is not a boolean", False),
+]
+
+# Spellings that DO mean something. Controls: green on both trees.
+_USABLE_BOOL = [("1", True), ("true", True), (1, True), ("false", False), ("off", False), ("", False), (0, False)]
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    """Point the module at a scratch settings file, resolved from built-in defaults.
+
+    Every environment variable the schema reads is dropped, so a value under test
+    comes from the file and nothing else. ``apply_mesh_env`` writes to
+    ``os.environ`` by design, and a leftover ``ZENOH_CONNECT`` would otherwise
+    reach the next test as that key's default.
+    """
+    path = tmp_path / "settings.json"
+    path.write_text("{}")
+    monkeypatch.setattr(settings, "SETTINGS_FILE", path)
+    for keys in settings._SCHEMA.values():
+        for env_name, _default in keys.values():
+            if env_name:
+                monkeypatch.delenv(env_name, raising=False)
+    settings.clear_overrides()
+    settings.load(refresh=True)
+    yield path
+    settings.clear_overrides()
+    settings.load(refresh=True)
+
+
+def _from_file(path, section: str, key: str, value):
+    """Write one raw value to the file and return what ``load()`` resolves."""
+    path.write_text(json.dumps({section: {key: value}}))
+    settings.clear_overrides()
+    return settings.load(refresh=True)[section][key]
+
+
+class TestTheRemoteCodeGateIsNotOpenedByAValueItWouldRefuse:
+    def test_an_unreadable_spelling_does_not_open_the_remote_code_gate(self, store, monkeypatch):
+        """The end-to-end consequence, driven through the real gate."""
+        from strands_robots.policies.factory import UntrustedRemoteCodeError, _check_trust_remote_code
+
+        gated = "kimodo"
+        # Premise: with nothing set, the gate refuses. If this ever stops being
+        # true the rest of the cell proves nothing.
+        with pytest.raises(UntrustedRemoteCodeError):
+            _check_trust_remote_code(gated)
+
+        store.write_text(json.dumps({"runtime": {"trust_remote_code": "maybe"}}))
+        settings.clear_overrides()
+        settings.load(refresh=True)
+        settings.apply_mesh_env()
+
+        # Pre-fix this published "1" - the gate's own opt-in spelling - so the
+        # gate opened off a value it refuses when handed it directly.
+        with pytest.raises(UntrustedRemoteCodeError):
+            _check_trust_remote_code(gated)
+
+    def test_the_spelling_is_not_republished_as_the_gates_opt_in_token(self, store, monkeypatch):
+        monkeypatch.setenv("STRANDS_TRUST_REMOTE_CODE", "maybe")
+        settings.clear_overrides()
+        settings.load(refresh=True)
+
+        applied = settings.apply_mesh_env()
+
+        assert "STRANDS_TRUST_REMOTE_CODE" not in applied, (
+            f"an unreadable spelling was republished as {applied.get('STRANDS_TRUST_REMOTE_CODE')!r}"
+        )
+
+    @pytest.mark.parametrize(("spelled", "expected"), _USABLE_BOOL)
+    def test_a_spelling_that_does_mean_something_still_means_it(self, store, spelled, expected):
+        """Control: the readable spellings are unchanged in both directions."""
+        assert _from_file(store, "runtime", "trust_remote_code", spelled) is expected
+
+    def test_an_opted_in_setting_still_reaches_the_environment(self, store):
+        _from_file(store, "runtime", "trust_remote_code", "true")
+        assert settings.apply_mesh_env().get("STRANDS_TRUST_REMOTE_CODE") == "1"
+
+
+class TestAnUnusableValueIsReportedOrDegradedToTheKeysShape:
+    @pytest.mark.parametrize(("section", "key", "value", "reported", "_degraded"), _UNUSABLE)
+    def test_the_strict_path_reports_it_and_stores_nothing(self, store, section, key, value, reported, _degraded):
+        changed, errors = settings.update_strict({section: {key: value}})
+
+        assert changed == []
+        assert len(errors) == 1, errors
+        assert errors[0].startswith(f"{section}.{key}:")
+        assert reported in errors[0]
+        assert json.loads(store.read_text()) == {}, "a value that was reported was also stored"
+
+    @pytest.mark.parametrize(("section", "key", "value", "_reported", "degraded"), _UNUSABLE)
+    def test_the_lenient_path_degrades_to_the_keys_own_shape(self, store, section, key, value, _reported, degraded):
+        got = _from_file(store, section, key, value)
+
+        assert got == degraded
+        assert type(got) is type(degraded), f"{section}.{key} degraded to a {type(got).__name__}"
+
+
+class TestTheStoreStillAnswersTheRestOfItsSurface:
+    def test_a_value_the_file_cannot_hold_heals_to_the_default(self, store):
+        """A non-finite literal is not JSON, so the file counts as corrupt."""
+        store.write_text('{"agent": {"temperature": NaN}}')
+        settings.clear_overrides()
+
+        assert settings.load(refresh=True)["agent"]["temperature"] is None
+
+    def test_unknown_keys_names_what_the_schema_does_not_know(self, store):
+        assert settings.unknown_keys({"agent": {"model_id": "m", "nope": 1}, "bogus": {"x": 1}}) == [
+            "agent.nope",
+            "bogus.*",
+        ]
+
+    def test_get_answers_a_section_a_key_and_a_default(self, store):
+        _from_file(store, "voice", "voice_name", "alloy")
+
+        assert settings.get("voice", "voice_name") == "alloy"
+        assert settings.get("voice")["voice_name"] == "alloy"
+        assert settings.get("voice", "provider") == "openai"
+        assert settings.get("nosuchsection", "k", "fallback") == "fallback"
+        # An unset key is the default, not an empty string.
+        assert settings.get("agent", "model_id", "fallback") == "fallback"
+
+    def test_a_list_setting_reaches_the_environment_comma_joined(self, store):
+        _from_file(store, "mesh", "connect", ["tcp/a:7447", "tcp/b:7447"])
+
+        assert settings.apply_mesh_env()["ZENOH_CONNECT"] == "tcp/a:7447,tcp/b:7447"
+
+    def test_a_section_the_file_spells_as_a_scalar_is_ignored(self, store):
+        store.write_text(json.dumps({"mesh": "not-a-section", "voice": {"provider": "kept"}}))
+        settings.clear_overrides()
+
+        tree = settings.load(refresh=True)
+
+        assert tree["voice"]["provider"] == "kept"
+        assert tree["mesh"]["connect"] == []

--- a/tests/test_dashboard_settings_value_domain.py
+++ b/tests/test_dashboard_settings_value_domain.py
@@ -40,7 +40,10 @@ from strands_robots.dashboard import settings
 
 # (section, key, value, substring the strict path must report, lenient result).
 # One row per unusable value; the lenient column is the key's own shape.
-_UNUSABLE = [
+# Annotated because the shapes differ per row: the value column spans str / float
+# / dict and the lenient column spans None / [] / False, so the bare ``[]`` leaves
+# mypy with a partial type it cannot close.
+_UNUSABLE: list[tuple[str, str, object, str, object]] = [
     ("agent", "temperature", "abc", "is not a number", None),
     ("agent", "temperature", 5.0, "outside 0..2", None),
     ("agent", "temperature", float("inf"), "is not a finite number", None),


### PR DESCRIPTION
`runtime.trust_remote_code` is published to `STRANDS_TRUST_REMOTE_CODE` by `dashboard.settings.apply_mesh_env`, which publishes a key **by truthiness**. The lenient coercion path (the settings file, the environment, the CLI) returned the value that had *failed* to be a boolean, so a non-boolean sat in a boolean slot and was published as the literal `"1"` - the exact spelling `policies.factory._check_trust_remote_code` accepts, since its allowlist is `("1", "true", "yes")`.

So a typo in `settings.json` opened the arbitrary-code-execution gate. The same spelling handed to that gate directly is refused, and `update_strict` (the UI / API path) refuses it *by name* - the file path was more permissive than the API path for the one setting where that matters.

![value-domain matrix and coverage delta](https://raw.githubusercontent.com/cagataycali/robots/artifacts/settings-boolean-gate/trust_gate_matrix.png)

## Measured

Driving the real store and the real gate on each tree:

| `settings.json` value | API path (`update_strict`) | before: resolved | published | gate | after: resolved | published | gate |
|---|---|---|---|---|---|---|---|
| `'maybe'` | refused | `'maybe'` (str) | `"1"` | **OPEN** | `False` (bool) | unset | shut |
| `'yes-please'` | refused | `'yes-please'` (str) | `"1"` | **OPEN** | `False` (bool) | unset | shut |
| `{'a': 1}` | refused | `{'a': 1}` (dict) | `"1"` | **OPEN** | `False` (bool) | unset | shut |
| `'true'` / `'1'` | accepted | `True` | `"1"` | OPEN | `True` | `"1"` | OPEN |
| `'false'` / `'off'` | accepted | `False` | unset | shut | `False` | unset | shut |

The last two rows are controls and are identical in both columns: the readable spellings keep meaning what they meant, so this is not "refuse more things".

The `{'a': 1}` row is the tell that this was a shape leak rather than a value decision - an empty list is falsy and happened to be safe, while a non-empty dict is truthy and was not. The outcome was decided by the Python truthiness of whatever JSON happened to be in the file.

## Change

The module already states the rule this broke, beside the code that breaks it: a lenient degrade must land on *the key's own SHAPE*, because "a list key that fell back to a scalar poisons every comma-split consumer, which is worse than the empty default". That rule was applied to the list keys and to the four numeric keys, and omitted for the one boolean key - whose consumer is the remote-code gate.

`_BOOL_KEYS` now owns that family for **both** paths (the strict check read `key in ("trust_remote_code",)` inline, so the two could disagree about which keys are booleans), and the degrade is fail-closed: a gate that cannot read its own setting stays shut.

## Tests

`tests/test_dashboard_settings_value_domain.py`. `test_an_unreadable_spelling_does_not_open_the_remote_code_gate` is the discriminating cell - it drives the real `_check_trust_remote_code` end to end and fails against the passthrough. Pre-fix, with only the test file added to a pristine tree: **4 failed / 35 passed**; post-fix **39 passed**.

The rest pin both paths' answers across the whole value domain as one table (temperature, `max_tokens`, `port`, `camera_hz`, the list keys, the boolean key), so a key added to the schema without a domain is visible.

That domain was untested, which is why this reached `main`: `dashboard/settings.py` statement coverage **63% -> 95%**, uncovered statements **83 -> 11** of 227.

| check | result |
|---|---|
| `ruff check` / `ruff format` on the changed files | clean |
| `mypy strands_robots` | 5 errors in 4 files, unchanged from `main` |
| every test touching `dashboard` or `trust_remote_code` (43 files) | base 8F/1023P -> branch 8F/**1062P**, +39 = exactly the new cells, failing node-id sets identical (installed-lerobot drift) |
| `scripts/check_whole_tree_graders.py` | 13F/4196P/56s/4E - unchanged from `main` |

## Size

`+241 / -1` total: source `+19 / -1`, tests `+189`, docs `+1`, changelog fragment `+32`. `docs/security.md` documented the env-var opt-in and never mentioned that the dashboard setting writes that same variable - the omission that let this be reachable without contradicting any documented behaviour.

---

## Round 2

**Concern: the required check was red, and the description's own gate table is why I did not see it coming.**

The table above reports `mypy strands_robots` - 5 errors in 4 files, unchanged from `main`. The lint script runs **`mypy strands_robots tests tests_integ`** (`pyproject.toml:773`). I validated a narrower scope than the gate, so the one error this PR introduced was in the segment I never checked:

```
tests/test_dashboard_settings_value_domain.py:43: error: Need type annotation for "_UNUSABLE"  [var-annotated]
Found 1 error in 1 file (checked 1846 source files)
```

mypy runs before pytest inside `lint`, so **no test executed at all** - the job ended at exit 1 on that single line. None of the 39 new cells this PR is about had a chance to report.

**Cause:** `_UNUSABLE` is a `parametrize` table whose rows are deliberately heterogeneous - the value column spans `str` / `float` / `dict` and the lenient column spans `None` / `[]` / `False`. The bare `[]` leaves mypy an open item type it cannot close, so it asks for the annotation.

**Fix (`5eabbc4f`): annotation only.** `_UNUSABLE: list[tuple[str, str, object, str, object]]`, which is exactly the tuple the two `parametrize` decorators destructure at lines 135 and 145. No row, value, or assertion changed; 12 rows before and after by AST count. Module-level variable annotations are not evaluated at runtime, so there is no runtime effect.

### Measured

Same file, repo's own mypy config, before and after:

| tree | mypy on the file |
|---|---|
| `bc7c1025` | `error: Need type annotation for "_UNUSABLE"  [var-annotated]` |
| `5eabbc4f` | clean |

`ruff check` and `ruff format --check` on the changed file: clean, already formatted. (The one residual `import-not-found` for `pytest` in the local run is this sandbox lacking pytest; CI installs it.)
