### PR TITLE
fix(training): the newest lerobot checkpoint is the highest step, not the last name

### DIFF
--- a/changelog.d/3165-lerobot-checkpoint-order-is-the-step.md
+++ b/changelog.d/3165-lerobot-checkpoint-order-is-the-step.md
@@ -1,0 +1,26 @@
+### Fixed: the newest lerobot checkpoint is the highest step, not the last name
+
+lerobot names a checkpoint directory
+`f"{step:0{max(6, len(str(total_steps)))}d}"` (`get_step_identifier`), so the
+zero-padding width is a property of the run that wrote the name rather than of
+the checkpoints tree. Continuing a run with a larger `steps` budget widens it,
+and `LerobotTrainer._resume_config_path` ordered those names as text, where
+`"100000"` sorts above `"0900000"`. Once a 100k-step run was continued to 1M,
+the step directories reported the step-100,000 checkpoint as the newest one on
+disk, and both consumers acted on it: resume restarted from the older
+checkpoint and re-ran the 800,000 steps in between, and `latest_checkpoint`
+handed `export`/`create_policy` the older model. Both reported success. Text
+order also ranked an unnumbered sibling directory above every real checkpoint,
+which needed no change of width at all. The wrong answer was intermittent: at
+the moment a continued run reached its budget exactly, text order agreed
+again, so a finished tree did not carry the symptom.
+
+The step directories are read when the `last` link lerobot maintains carries
+no config -- an absent link, or one left dangling by pruning the checkpoint it
+pointed at, which is routine when each checkpoint is gigabytes.
+
+The fallback now orders on the step parsed out of the name, which is what the
+GR00T trainer already does for its own `checkpoint-<step>` directories. A name
+lerobot did not number sorts below every numbered one, and the name breaks
+ties, so the ordering is total and an unnumbered directory is still the answer
+when it is the only one on disk.

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -389,6 +389,32 @@ def _dataset_codebase_version(dataset_root: str) -> str | None:
     return declared if isinstance(declared, str) else None
 
 
+def _checkpoint_step(name: str) -> tuple[int, str]:
+    """Order a lerobot checkpoint directory by its step number, not by its text.
+
+    lerobot names a checkpoint directory
+    ``f"{step:0{max(6, len(str(total_steps)))}d}"``
+    (lerobot's ``get_step_identifier``), so the zero-padding
+    width is a property of the run that wrote the directory rather than of the
+    checkpoints tree. A run resumed with a larger ``steps`` widens it -- and text
+    order then reads the narrower name as the later one, because ``"100000"``
+    sorts above ``"0900000"``. Reading the step keeps the newest checkpoint
+    newest whatever budget each run was given.
+
+    Args:
+        name: A checkpoints/ entry name, e.g. ``"0900000"``.
+
+    Returns:
+        ``(step, name)``. A name lerobot did not number carries a step of ``-1``,
+        so it sorts below every numbered checkpoint, and the name breaks ties so
+        the ordering is total.
+    """
+    try:
+        return (int(name, 10), name)
+    except ValueError:
+        return (-1, name)
+
+
 def _reward_registry() -> dict[str, type] | None:
     """Live ``RewardModelConfig`` ChoiceRegistry, or ``None`` when unavailable.
 
@@ -535,6 +561,12 @@ class LerobotTrainer(Trainer):
         derives policy_dir/checkpoint_path from it). This is the resume-wiring
         counterpart of the public :meth:`latest_checkpoint` (which returns the
         loadable DIRECTORY for ``export``/``create_policy``).
+
+        The ``last`` link lerobot maintains answers when it carries a config.
+        When it does not -- an absent link, or one left dangling by pruning the
+        checkpoint it pointed at -- the step directories are read instead, and
+        the newest is the highest step per :func:`_checkpoint_step`, not the last
+        name in text order.
         """
         ckpts = os.path.join(output_dir, "checkpoints")
         if not os.path.isdir(ckpts):
@@ -542,12 +574,15 @@ class LerobotTrainer(Trainer):
         last = os.path.join(ckpts, "last", "pretrained_model", "train_config.json")
         if os.path.isfile(last):
             return last
-        candidates = []
-        for name in sorted(os.listdir(ckpts)):
-            cfg = os.path.join(ckpts, name, "pretrained_model", "train_config.json")
-            if os.path.isfile(cfg):
-                candidates.append(cfg)
-        return candidates[-1] if candidates else None
+        numbered = [
+            name
+            for name in os.listdir(ckpts)
+            if os.path.isfile(os.path.join(ckpts, name, "pretrained_model", "train_config.json"))
+        ]
+        if not numbered:
+            return None
+        newest = max(numbered, key=_checkpoint_step)
+        return os.path.join(ckpts, newest, "pretrained_model", "train_config.json")
 
     def latest_checkpoint(self, output_dir: str) -> str | None:
         """Return the newest loadable ``pretrained_model`` directory, or None.

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -6,6 +6,7 @@ end-to-end sim->train->load is exercised separately.
 
 import ast
 import dataclasses
+import importlib
 import inspect
 import json
 import sys
@@ -414,15 +415,88 @@ class TestCheckpointResolution:
         # latest_checkpoint returns the loadable DIRECTORY (parent of the file)
         assert LerobotTrainer().latest_checkpoint(str(out)) == str(last)
 
-    def test_falls_back_to_highest_numbered_step(self, tmp_path):
-        out = tmp_path / "out"
-        for step in ("000100", "000200"):
-            pm = out / "checkpoints" / step / "pretrained_model"
+    @staticmethod
+    def _tree(out, names):
+        """Write a checkpoints/ tree holding one config per given step name."""
+        for name in names:
+            pm = out / "checkpoints" / name / "pretrained_model"
             pm.mkdir(parents=True)
             (pm / "train_config.json").write_text("{}")
-        # No "last" dir -> newest by sorted name wins (000200).
-        cfg_file = LerobotTrainer()._resume_config_path(str(out))
-        assert cfg_file.endswith("000200/pretrained_model/train_config.json")
+
+    # lerobot names a checkpoint directory f"{step:0{max(6, len(str(steps)))}d}",
+    # so the padding width belongs to the RUN that wrote the name, not to the
+    # tree: resuming with a larger steps budget widens it, and from then on text
+    # order reads the narrower name as the later one. The newest checkpoint is
+    # the highest step, whatever budget each run was given.
+    @pytest.mark.parametrize(
+        ("case", "names", "newest"),
+        [
+            ("one run, 100k budget", ["020000", "100000"], "100000"),
+            ("one run, 1M budget", ["0200000", "0900000"], "0900000"),
+            ("100k run continued to 1M", ["100000", "0900000"], "0900000"),
+            ("100k run continued to 10M", ["100000", "09000000"], "09000000"),
+            # The same tree once the continued run reaches its budget: text order
+            # agrees again, so the wrong answer is intermittent rather than final.
+            ("...once it reaches 1M", ["100000", "1000000"], "1000000"),
+        ],
+    )
+    def test_falls_back_to_highest_numbered_step(self, tmp_path, case, names, newest):
+        out = tmp_path / "out"
+        self._tree(out, names)
+        assert LerobotTrainer()._resume_config_path(str(out)) == str(
+            out / "checkpoints" / newest / "pretrained_model" / "train_config.json"
+        ), case
+
+    def test_export_reads_the_highest_step_across_two_budgets(self, tmp_path):
+        """latest_checkpoint feeds export/create_policy, so it answers the same."""
+        out = tmp_path / "out"
+        self._tree(out, ["100000", "0900000"])
+        assert LerobotTrainer().latest_checkpoint(str(out)) == str(out / "checkpoints" / "0900000" / "pretrained_model")
+
+    def test_a_dangling_last_link_falls_back_to_the_highest_step(self, tmp_path):
+        """The route by which the fallback answers at all: `last` carries no config.
+
+        lerobot keeps a `last` symlink and it is preferred, so the step
+        directories are read when it is absent or its target has been pruned -
+        which is when the ordering has to be right.
+        """
+        out = tmp_path / "out"
+        self._tree(out, ["100000", "0900000"])
+        (out / "checkpoints" / "last").symlink_to("0950000")  # target pruned
+        assert not (out / "checkpoints" / "last").exists()
+        assert LerobotTrainer()._resume_config_path(str(out)) == str(
+            out / "checkpoints" / "0900000" / "pretrained_model" / "train_config.json"
+        )
+
+    def test_an_unnumbered_directory_does_not_outrank_a_checkpoint(self, tmp_path):
+        """A name lerobot did not number is ordered, not preferred or fatal."""
+        out = tmp_path / "out"
+        self._tree(out, ["000100", "handpicked"])
+        assert LerobotTrainer()._resume_config_path(str(out)) == str(
+            out / "checkpoints" / "000100" / "pretrained_model" / "train_config.json"
+        )
+        # ...and it is still the answer when it is the only one on disk.
+        only = tmp_path / "only"
+        self._tree(only, ["handpicked"])
+        assert LerobotTrainer()._resume_config_path(str(only)) == str(
+            only / "checkpoints" / "handpicked" / "pretrained_model" / "train_config.json"
+        )
+
+    def test_the_widths_are_lerobots_own(self):
+        """The fixture names above are what lerobot writes for those budgets."""
+        pytest.importorskip("lerobot")
+        get_step_identifier = None
+        for mod in ("lerobot.utils.train_utils", "lerobot.common.train_utils"):
+            try:  # the module moved between lerobot 0.5 and 0.6
+                get_step_identifier = importlib.import_module(mod).get_step_identifier
+                break
+            except ModuleNotFoundError:
+                continue
+        if get_step_identifier is None:
+            pytest.skip("lerobot exposes no get_step_identifier")
+        assert get_step_identifier(100_000, 100_000) == "100000"
+        assert get_step_identifier(900_000, 1_000_000) == "0900000"
+        assert get_step_identifier(9_000_000, 10_000_000) == "09000000"
 
     def test_checkpoints_dir_without_configs_returns_none(self, tmp_path):
         out = tmp_path / "out"


### PR DESCRIPTION
lerobot names a checkpoint directory `f"{step:0{max(6, len(str(total_steps)))}d}"` (`get_step_identifier`), so the zero-padding **width is a property of the run that wrote the name**, not of the checkpoints tree. Continuing a run with a larger `steps` budget widens it, and `_resume_config_path` ordered those names as text — `"100000"` sorts above `"0900000"`.

![which checkpoint is called newest, and what the wrong answer costs](https://raw.githubusercontent.com/cagataycali/robots/2d548a89ec6603cc1385b6a462032bda3f6a53dc/.artifacts/checkpoint-order.png)

| `checkpoints/` on disk | before | after |
|---|---|---|
| `020000` `100000` — one run, 100k budget | `100000` | `100000` (unchanged) |
| `0200000` `0900000` — one run, 1M budget | `0900000` | `0900000` (unchanged) |
| `100000` `0900000` — 100k run continued to 1M | **`100000`** | `0900000` |
| `100000` `09000000` — continued to 10M | **`100000`** | `09000000` |
| `100000` `1000000` — once it reaches 1M | `1000000` | `1000000` (unchanged) |
| `000100` `handpicked` — an unnumbered sibling | **`handpicked`** | `000100` |

Both consumers act on the answer. `_resume_config_path` becomes `--config_path`, so resume restarts from the older checkpoint and re-runs every step in between (800,000 in the figure); `latest_checkpoint` hands `export` / `create_policy` the older model. Both report success. The last row needs no width change at all — under text order any name starting with a letter outranks every real checkpoint.

Row 5 is why this is easy to miss: once the continued run reaches its budget exactly, text order agrees again, so the wrong answer is intermittent and absent from the finished tree.

## Reachability

The `last` link lerobot maintains is checked first and preferred, so the step directories are read when it carries no config — an absent link, or one left dangling by pruning the checkpoint it pointed at, which is routine when each checkpoint is gigabytes. That route is pinned end to end. The widths come from lerobot itself: `get_step_identifier(100_000, 100_000) == "100000"` and `get_step_identifier(900_000, 1_000_000) == "0900000"`, and `--steps` is passed on every launch, alongside `--config_path` on resume, so the second run's budget is what names its checkpoints.

## Change

Order on the step parsed out of the name, which is what `Gr00tTrainer.latest_checkpoint` in this package already does for its own `checkpoint-<step>` directories. A name lerobot did not number sorts below every numbered one and the name breaks ties, so the ordering is total and an unnumbered directory is still the answer when it is the only one on disk.

## Tests

`TestCheckpointResolution::test_falls_back_to_highest_numbered_step` claimed step order in its name but posed only two names of the **same width** (`000100`, `000200`) — the one case where text order and step order coincide — and its comment recorded the mechanism it was accepting ("newest by sorted name wins"). It is now table-driven over the six shapes above, joined by the public `latest_checkpoint`, the dangling-`last` route, an unnumbered-directory control, and a cell that grades the fixture widths against lerobot's own namer.

On pristine `main` with only the test file applied: **5 failed / 7 passed** — the three same-width rows, the lerobot-width cell and the three pre-existing cells all pass, so the controls hold on unfixed code. `tests/training` 7F/3683P/9E → 7F/**3691**P/9E with the failing node-id sets identical (pre-existing lerobot-version drift); `tests/test_docstring_xref_roles_resolve.py` + `tests/training/test_tool.py` + `tests/tools/test_train_policy.py` 68 passed; `scripts/check_whole_tree_graders.py` 13F/4196P/4E, unchanged. `ruff check` / `ruff format` clean, `mypy strands_robots tests tests_integ` 20 errors in 6 files on both trees.

## Size

`+148/-13` in total: source `+41/-6` (14 code lines, the rest the docstring explaining why the width is not the tree's), tests `+81/-7`, and a 26-line changelog fragment. AST executable statements in `training/lerobot.py` 544 → 547. No documentation stated the old rule, so nothing is left stale; the selection rule is documented on the two methods that implement it.