### PR TITLE
ci(test-lint): a red required check says how much of the suite it never reached

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -167,7 +167,24 @@ jobs:
           # mock in tests/conftest.py and break torch-dependent tests.
           UV_TORCH_BACKEND: cpu
         run: |
+          # `tee` below keeps a copy of the suite's output for the truncation
+          # report in the next step, which needs the `collected N items` line and
+          # the summary line together -- they sit ~35k lines apart in a 6.4 MB
+          # job log, so nobody subtracts them by hand (#3164).
+          #
+          # pipefail is load-bearing, not tidiness. The default shell for `run:`
+          # is `bash -e`, which does NOT set it, so a pipeline exits with the
+          # status of its LAST command -- `tee`, which always succeeds. Without
+          # this line a failing suite would report SUCCESS on the one required
+          # check, and nothing else in this repository would notice.
+          set -o pipefail
           # Diagnose the torch the hatch test env actually resolved BEFORE
           # running the suite, so a mock fallback is obvious in the log.
           hatch run python -c "import torch, sys; print('TORCH_DIAG file=%s version=%s mock=%s' % (getattr(torch,'__file__','?'), getattr(torch,'__version__','MOCK-NO-VERSION'), not hasattr(torch,'__version__')), file=sys.stderr)" || true
-          hatch run test -x --strict-markers
+          hatch run test -x --strict-markers | tee "${RUNNER_TEMP}/pytest.log"
+
+      # Runs on failure too: a truncated run is the case this exists for, and
+      # the reporter never fails the job (see its module docstring).
+      - name: Report whether the suite ran to completion
+        if: always()
+        run: python3 scripts/report_truncated_test_run.py "${RUNNER_TEMP}/pytest.log"

--- a/changelog.d/3164-a-red-check-says-how-much-it-never-reached.md
+++ b/changelog.d/3164-a-red-check-says-how-much-it-never-reached.md
@@ -1,0 +1,49 @@
+### Fixed: a red required check says how much of the suite it never reached
+
+The one required check runs the suite under `-x`, so it stops at the first
+failure. That is deliberate, but it means **a red `call-test-lint` is not a
+count**: it names one failing cell, and the number of failing cells stays
+unknown until the run is repeated on a tree where that one passes.
+
+Measured on run 33690980247, the `Test and Lint` job of #3161 at `48881ea`:
+`collected 46583 items`, then `1 failed, 34268 passed, 278 skipped`. So 34547
+items executed and **12036 -- 25.8% of the suite -- never ran**. The failure
+that was hidden was neither hypothetical nor distant: the next one was four
+lines below the first, in the same class, with the same cause, so the
+truncation turned a one-round fix into two. `--cov-fail-under=80` is no
+backstop either -- that same truncated run reported
+`Total coverage: 81.54%` and the gate read as a pass.
+
+pytest does print a `stopping after 1 failures` banner, so this was not an
+unrecorded event. What was missing was the subtraction: the banner does not say
+how much was skipped, the `collected` line it needs sits **34,927 lines
+earlier** in a 6.4 MB log, and neither number reaches a surface short of
+downloading that log.
+
+`scripts/report_truncated_test_run.py` now pairs those two numbers and writes
+the result to the job summary and to a check annotation, so a reviewer reads
+"12036 never ran, the failure count is a lower bound" without opening the log.
+It reports three outcomes -- `complete`, `truncated`, and
+`incomplete-no-summary` for a run killed before pytest finished reporting --
+and returns 0 for every input including an unreadable one, because it runs
+inside the required check's own job where a nonzero exit would either duplicate
+the suite's own red or, on a parsing bug, invent one on a green tree.
+
+**`-x` itself stays, and that is a measurement rather than a preference.**
+Dropping it would make a red run cost what a green one costs, and a green one
+is already close to the bound: over the last 40 `main` pushes the `Test and
+Lint` job took 32.6 to 57.5 minutes on the 37 runs that completed, median 46.9,
+against `timeout-minutes: 60` -- with run 33631903156 already reaped at 60.12.
+The comment on that bound records that a further raise cannot be spent there
+(#2457, #2239), so letting a red run continue would put it in reach of the
+reap. Describing the truncation is the change that costs no runner time at all.
+
+Capturing the output needs a pipe, and the pipe brings its own hazard worth
+naming: the default shell for `run:` is `bash -e`, which does **not** set
+`pipefail`, so a pipeline exits with the status of its last command -- `tee`,
+which always succeeds. Without `set -o pipefail` a failing suite would report
+SUCCESS on the one required check, and nothing else in this repository reads
+the suite's verdict independently. That invariant is pinned rather than left to
+review.
+
+Closes #3164.

--- a/scripts/report_truncated_test_run.py
+++ b/scripts/report_truncated_test_run.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Report whether the required test suite ran to completion, and name what it skipped.
+
+Why this exists
+---------------
+``.github/workflows/test-lint.yml`` runs the one required check as::
+
+    hatch run test -x --strict-markers
+
+``-x`` stops the session at the first failure. The check is not wrong -- it is
+red when the tree is red -- but **the report is not a count**. A red
+``call-test-lint`` names one failing cell, and the number of failing cells is
+unknown until the run is repeated on a tree where that one passes.
+
+Measured on run 33690980247, the ``Test and Lint`` job of #3161 at ``48881ea``::
+
+    line  2207:  collecting ... collected 46583 items
+    line 37134:  !!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!
+    line 37135:  ==== 1 failed, 34268 passed, 278 skipped, 57 warnings in 1259.55s ====
+
+34268 + 278 + 1 = 34547 of 46583 items executed, so **12036 items -- 25.8% of
+the suite -- never ran**. The failure that was hidden was neither hypothetical
+nor distant: reproduced on the same commit, the next failure was four lines
+below the first, in the same class, with the same cause. Both would have been in
+one report from an un-truncated run.
+
+Why the numbers above are not already legible
+---------------------------------------------
+pytest *does* emit the ``stopping after N failures`` banner, so the truncation is
+not literally unrecorded. Three things stop that from being an answer:
+
+- The banner does not say how much was skipped. The count needs the
+  ``collected`` line as well, and the two sit **34,927 lines apart** in a 6.4 MB
+  log -- nobody subtracts them by hand.
+- The banner sits one line above the summary, which is the line every reader is
+  already looking at, so it reads as part of the failure rather than as a
+  statement about the run's extent.
+- Neither number reaches a surface short of downloading that log. A check's
+  annotations and the job summary are what a reviewer sees, and the truncation
+  appears in neither.
+
+``--cov-fail-under=80`` is not a backstop either: on that truncated run coverage
+reported ``Total coverage: 81.54%`` and the gate read as a pass, so it adds no
+signal that the run was short.
+
+Why the flag stays
+------------------
+Removing ``-x`` would make a red run cost what a green one costs, and that is
+already close to the bound. Measured over the last 40 ``main`` pushes of
+``pr-and-push.yml`` (2026-09-01T23:51Z -> 2026-09-03T02:11Z), the ``Test and
+Lint`` job on the 37 runs that completed took **32.6 to 57.5 minutes, median
+46.9**, against the job's ``timeout-minutes: 60`` -- and run 33631903156 was
+already reaped at **60.12 minutes** with every step reporting success. The
+bound cannot absorb the difference, and raising it is explicitly spent: the
+comment on that ``timeout-minutes`` line records that "the next raise cannot be
+spent here" (#2457, #2239).
+
+So the early exit is load-bearing and this module does not touch it. What it
+removes is the *ambiguity*: an aborted run and a complete run with one failure
+are indistinguishable in the summary line, and that -- not the early exit -- is
+what costs a round, because each hidden failure costs ~21 minutes of runner time
+plus one review approval, approval being this repository's scarcest resource
+(#1905).
+
+A run killed mid-suite reports differently again
+-----------------------------------------------
+A job killed while pytest is still running writes no summary line at all, which
+is the other way a run can be incomplete. It is reported as
+``incomplete-no-summary`` rather than folded into either of the two above, so a
+run that never finished reporting is not read as a run with one failure.
+
+That branch is defensive rather than observed, and the distinction is worth
+keeping straight. The one reaped job in the measured window, run 33631903156 at
+60.12 minutes, turns out **not** to be an instance: its suite completed
+(46449 of 46449 items, ``46152 passed, 297 skipped``) at 54.5 minutes and the
+job was killed in a later step. So the reap in #3143 did not truncate that
+suite, and this module reports it as ``complete``, which is the honest answer.
+
+Why this never fails the job
+----------------------------
+It is wired into the required check's own job, so a nonzero exit here would be
+indistinguishable from the suite failing -- and on a *green* run a parsing bug
+would turn the one required check red for every open pull request. The verdict
+this module produces is a description of a run whose outcome is already decided
+by pytest, so it is reported and never gated: ``main`` returns 0 for every
+input, including a log it cannot read. That is deliberate and is pinned by
+tests/test_truncated_test_run_is_reported.py.
+
+Usage
+-----
+::
+
+    python3 scripts/report_truncated_test_run.py "$RUNNER_TEMP/pytest.log"
+
+See issue #3164, #3143 for the bound, and the "PR Workflow" section of
+AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from dataclasses import dataclass, field
+
+# pytest's collection line. Matched with ``search`` rather than anchored,
+# because the same text is read both from the raw file this script is pointed at
+# and, when a reader pastes one, from a job log whose lines carry a timestamp
+# prefix added by the Actions log service.
+_COLLECTED = re.compile(
+    r"collected (?P<collected>\d+) items?"
+    r"(?: / (?P<deselected>\d+) deselected)?"
+    r"(?: / (?P<selected>\d+) selected)?"
+)
+
+# The banner ``-x`` / ``--maxfail`` prints when it ends the session early.
+_STOPPING = re.compile(r"!+\s*stopping after (?P<failures>\d+) failures?\s*!+")
+
+# The final ``= 1 failed, 34268 passed, ... in 1259.55s =`` line. Only the
+# surrounding rule and the trailing duration are fixed; the counts in between
+# vary, so they are read by scanning rather than by one exhaustive alternation.
+_SUMMARY_LINE = re.compile(r"^=+ .*\bin \d+(?:\.\d+)?s.*=+$")
+_COUNT = re.compile(r"(?P<count>\d+) (?P<label>[a-z]+)")
+
+# The Actions log service prefixes every line it stores with an RFC3339 stamp.
+# The file this script is pointed at in CI is the raw `tee` copy and carries
+# none, but a maintainer diagnosing a past run downloads the stored log, and the
+# summary line is the one pattern anchored to the start of a line -- so without
+# this the script would silently report ``incomplete-no-summary`` on exactly the
+# input a human reaches for. Stripped rather than tolerated in each pattern so
+# there is one place that knows about the prefix.
+_LOG_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z ")
+
+# Outcome labels that mean a test item was actually executed. ``warnings`` and
+# ``deselected`` are deliberately absent: a warning is not an item, and a
+# deselected item was never going to run, so counting either would understate
+# what the abort skipped. ``rerun`` is absent because a rerun is a second
+# attempt at an item already counted under its final outcome.
+_EXECUTED_LABELS = frozenset({"failed", "passed", "skipped", "xfailed", "xpassed", "error", "errors"})
+
+_COMPLETE = "complete"
+_TRUNCATED = "truncated"
+_NO_SUMMARY = "incomplete-no-summary"
+_UNREADABLE = "unreadable"
+
+
+@dataclass
+class RunReport:
+    """What one pytest log says about its own extent."""
+
+    outcome: str
+    collected: int | None = None
+    selected: int | None = None
+    executed: int | None = None
+    never_ran: int | None = None
+    stopped_after: int | None = None
+    counts: dict[str, int] = field(default_factory=dict)
+    detail: str = ""
+
+    @property
+    def share_skipped(self) -> float | None:
+        """Fraction of the selected items that never ran, or None if unknown."""
+        if self.selected in (None, 0) or self.never_ran is None:
+            return None
+        assert self.selected is not None
+        return self.never_ran / self.selected
+
+    @property
+    def summary(self) -> str:
+        """One line naming the run's extent, suitable for an annotation."""
+        if self.outcome == _COMPLETE:
+            return f"the suite ran to completion: {self.executed} of {self.selected} items executed"
+        if self.outcome == _TRUNCATED:
+            share = self.share_skipped
+            share_text = f" ({share:.1%} of the suite)" if share is not None else ""
+            return (
+                f"the run was truncated: {self.executed} of {self.selected} items executed, "
+                f"{self.never_ran} never ran{share_text}. The failure count is a lower "
+                f"bound, not a total."
+            )
+        if self.outcome == _NO_SUMMARY:
+            return (
+                "the run produced no summary line, so it did not finish reporting and "
+                "neither its failure count nor its extent is known."
+            )
+        return f"the run's extent could not be read: {self.detail}"
+
+
+def parse_run(text: str) -> RunReport:
+    """Read a pytest log and report whether the session covered every selected item.
+
+    Args:
+        text: The captured stdout of one pytest session.
+
+    Returns:
+        A RunReport. ``outcome`` is ``complete`` when every selected item was
+        accounted for, ``truncated`` when the session ended early, and
+        ``incomplete-no-summary`` when no summary line was written at all --
+        which is what a job killed at its timeout bound leaves behind.
+    """
+    collected: int | None = None
+    selected: int | None = None
+    stopped_after: int | None = None
+    summary: str | None = None
+
+    for raw in text.splitlines():
+        line = _LOG_TIMESTAMP.sub("", raw)
+        if collected is None:
+            found = _COLLECTED.search(line)
+            if found:
+                collected = int(found.group("collected"))
+                explicit = found.group("selected")
+                selected = int(explicit) if explicit else collected
+        stopping = _STOPPING.search(line)
+        if stopping:
+            stopped_after = int(stopping.group("failures"))
+        stripped = line.strip()
+        if _SUMMARY_LINE.match(stripped):
+            summary = stripped
+
+    if collected is None:
+        return RunReport(
+            outcome=_UNREADABLE,
+            stopped_after=stopped_after,
+            detail="no 'collected N items' line was found",
+        )
+
+    if summary is None:
+        return RunReport(
+            outcome=_NO_SUMMARY,
+            collected=collected,
+            selected=selected,
+            stopped_after=stopped_after,
+            detail="no pytest summary line was found",
+        )
+
+    counts = {
+        match.group("label"): int(match.group("count"))
+        for match in _COUNT.finditer(summary)
+        if match.group("label") in _EXECUTED_LABELS
+    }
+    executed = sum(counts.values())
+    assert selected is not None
+    never_ran = max(selected - executed, 0)
+    truncated = stopped_after is not None or never_ran > 0
+
+    return RunReport(
+        outcome=_TRUNCATED if truncated else _COMPLETE,
+        collected=collected,
+        selected=selected,
+        executed=executed,
+        never_ran=never_ran,
+        stopped_after=stopped_after,
+        counts=counts,
+    )
+
+
+def render(report: RunReport) -> str:
+    """Render a report as the markdown written to the job summary."""
+    lines = ["## Did the required suite run to completion?", ""]
+    lines.append(report.summary)
+    lines.append("")
+    lines.append("| field | value |")
+    lines.append("|---|---|")
+    lines.append(f"| outcome | `{report.outcome}` |")
+    if report.collected is not None:
+        lines.append(f"| items collected | {report.collected} |")
+    if report.selected is not None and report.selected != report.collected:
+        lines.append(f"| items selected | {report.selected} |")
+    if report.executed is not None:
+        lines.append(f"| items executed | {report.executed} |")
+    if report.never_ran is not None:
+        lines.append(f"| items that never ran | {report.never_ran} |")
+    if report.stopped_after is not None:
+        lines.append(f"| stopped after | {report.stopped_after} failure(s) |")
+    for label in sorted(report.counts):
+        lines.append(f"| {label} | {report.counts[label]} |")
+
+    if report.outcome == _TRUNCATED:
+        lines.extend(
+            [
+                "",
+                "The suite runs under `-x`, so it stops at the first failure and the",
+                "remaining items are not evidence of anything. Fix the failure named",
+                "above and expect the next run to reach further -- possibly onto another",
+                "failure that this run could not reach. The flag is deliberate: a full",
+                "run of this suite measures 32.6 to 57.5 min against a 60 min bound, so",
+                "letting a red run continue would put it in reach of the reap (#3143).",
+            ]
+        )
+    elif report.outcome == _NO_SUMMARY:
+        lines.extend(
+            [
+                "",
+                "No summary line means pytest did not finish reporting, so neither the",
+                "failure count nor the extent of this run is known. A job killed while",
+                "the suite was still running looks like this; a reap at the",
+                "`timeout-minutes` bound renders as CANCELLED and so reads as a",
+                "concurrency cancel rather than a timeout (#3143). Check the job's",
+                "duration before re-running it.",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Report a run's extent to the job summary and as an annotation.
+
+    Always returns 0. See this module's docstring: the verdict describes a run
+    whose pass/fail outcome pytest has already decided, and this runs inside the
+    one required check's job, so failing here would either duplicate the suite's
+    own red or -- on a parsing bug -- invent one on a green tree.
+    """
+    parser = argparse.ArgumentParser(description="Report whether a pytest run was truncated.")
+    parser.add_argument("log", help="Path to the captured pytest output.")
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.log, encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
+    except OSError as exc:
+        report = RunReport(outcome=_UNREADABLE, detail=f"{args.log} could not be read ({exc.strerror})")
+    else:
+        report = parse_run(text)
+
+    document = render(report)
+    print(document)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as handle:
+                handle.write(document)
+        except OSError as exc:
+            print(f"note: could not write the job summary ({exc.strerror})")
+
+    if report.outcome == _TRUNCATED:
+        print(f"::warning title=The test run was truncated::{report.summary}")
+    elif report.outcome == _NO_SUMMARY:
+        print(f"::warning title=The test run did not finish reporting::{report.summary}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_truncated_test_run_is_reported.py
+++ b/tests/test_truncated_test_run_is_reported.py
@@ -1,0 +1,284 @@
+"""Contract pins for the report of whether the required suite ran to completion.
+
+The one required check runs the suite under ``-x``, so it stops at the first
+failure and **the report is not a count**. Measured on run 33690980247, the
+``Test and Lint`` job of #3161 at ``48881ea``::
+
+    line  2207:  collecting ... collected 46583 items
+    line 37134:  !!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!
+    line 37135:  ==== 1 failed, 34268 passed, 278 skipped, 57 warnings in 1259.55s ====
+
+12036 items -- 25.8% of the suite -- never ran, and the next failure was four
+lines below the first in the same class, so the truncation turned a one-round fix
+into two. pytest does print the ``stopping after`` banner, so this is not an
+unrecorded event; what is missing is the subtraction, because the two numbers it
+needs sit 34,927 lines apart in a 6.4 MB log and neither reaches a surface a
+reviewer reads.
+
+``-x`` itself stays, and that is a measurement rather than a preference. Over the
+last 40 ``main`` pushes the ``Test and Lint`` job took 32.6 to 57.5 minutes on
+the 37 runs that completed, median 46.9, against ``timeout-minutes: 60`` -- so
+letting a red run continue would put it in reach of the reap, and the comment on
+that bound records that a further raise cannot be spent there (#2457, #2239).
+
+See scripts/report_truncated_test_run.py, issue #3164, and issue #3143 for the
+bound.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="pyyaml is an optional dev dependency")
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "scripts" / "report_truncated_test_run.py"
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "test-lint.yml"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("report_truncated_test_run", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+# Reached through the importlib load above, so these are module attributes at
+# runtime rather than names mypy can resolve. ``hatch run lint`` covers only the
+# package and its tests, so the script is checked separately.
+parse_run: Any = mod.parse_run
+render: Any = mod.render
+main: Any = mod.main
+
+
+# The tail of run 33690980247's log, verbatim apart from the elision, so the
+# arithmetic below is the arithmetic that run actually produced.
+TRUNCATED_LOG = """\
+collecting ... collected 46583 items
+
+tests/test_a.py::test_one PASSED                                         [  0%]
+tests/test_hardware_robot_lifecycle.py::TestExecuteTaskSync::test_sync_runner_no_running_loop_completes FAILED [ 74%]
+
+=========================== short test summary info ============================
+FAILED tests/test_hardware_robot_lifecycle.py::TestExecuteTaskSync::test_sync_runner_no_running_loop_completes
+!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
+==== 1 failed, 34268 passed, 278 skipped, 57 warnings in 1259.55s (0:20:59) ====
+"""
+
+# Run 33702826136 at ``0a04d2b``, a complete green run on ``main``.
+COMPLETE_LOG = """\
+collecting ... collected 46575 items
+
+tests/test_a.py::test_one PASSED                                         [  0%]
+
+Required test coverage of 80% reached. Total coverage: 81.62%
+============ 46278 passed, 297 skipped, 61 warnings in 2101.31s (0:35:01) ======
+"""
+
+
+class TestATruncatedRunNamesWhatItSkipped:
+    """The extent of an aborted run is reported as a number, not left implicit."""
+
+    def test_the_measured_truncation_is_reported_with_its_own_numbers(self) -> None:
+        report = parse_run(TRUNCATED_LOG)
+
+        assert report.outcome == "truncated"
+        assert report.collected == 46583
+        # 1 failed + 34268 passed + 278 skipped, which is what that run executed.
+        assert report.executed == 34547
+        assert report.never_ran == 12036
+        assert report.stopped_after == 1
+
+    def test_the_skipped_share_is_the_figure_the_issue_computed_by_hand(self) -> None:
+        report = parse_run(TRUNCATED_LOG)
+
+        share = report.share_skipped
+        assert share is not None
+        assert round(share * 100, 1) == 25.8
+
+    def test_the_summary_says_the_failure_count_is_a_lower_bound(self) -> None:
+        # The whole cost this addresses is that a reader takes "1 failed" for a
+        # total, so the report has to contradict that reading in words.
+        summary = parse_run(TRUNCATED_LOG).summary
+
+        assert "12036 never ran" in summary
+        assert "lower bound" in summary
+
+    def test_warnings_are_not_counted_as_executed_items(self) -> None:
+        # 57 warnings appear in that summary line and are not test items. Counting
+        # them would understate what the abort skipped, which is the one direction
+        # this report must not err in.
+        report = parse_run(TRUNCATED_LOG)
+
+        assert "warnings" not in report.counts
+        assert report.never_ran == 12036
+
+
+class TestACompleteRunIsNotReportedAsTruncated:
+    """The negative control: a green run must add no warning to any pull request."""
+
+    def test_a_complete_run_reports_complete(self) -> None:
+        report = parse_run(COMPLETE_LOG)
+
+        assert report.outcome == "complete"
+        assert report.collected == 46575
+        assert report.executed == 46575
+        assert report.never_ran == 0
+
+    def test_a_complete_run_raises_no_annotation(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert render(parse_run(COMPLETE_LOG)).count("::warning") == 0
+        capsys.readouterr()
+
+    def test_deselected_items_are_not_reported_as_never_run(self) -> None:
+        # ``-m 'not slow'`` selects a subset. Those items were never going to run,
+        # so counting them as skipped-by-the-abort would warn on every such run.
+        log = "collected 900 items / 400 deselected / 500 selected\n===== 500 passed, 400 deselected in 12.00s =====\n"
+        report = parse_run(log)
+
+        assert report.outcome == "complete"
+        assert report.selected == 500
+        assert report.never_ran == 0
+
+
+class TestARunThatNeverReportedIsNamedApart:
+    """A run killed mid-suite is not readable as a run with one failure."""
+
+    def test_a_log_with_no_summary_line_is_not_called_complete(self) -> None:
+        report = parse_run("collecting ... collected 46583 items\ntests/a.py::t PASSED [ 10%]\n")
+
+        assert report.outcome == "incomplete-no-summary"
+        assert report.executed is None
+
+    def test_a_log_with_no_collection_line_is_unreadable_rather_than_complete(self) -> None:
+        report = parse_run("Killed\n")
+
+        assert report.outcome == "unreadable"
+
+
+class TestTheReportNeverDecidesTheJob:
+    """It runs inside the required check's own job, so it must not be able to fail it."""
+
+    @pytest.mark.parametrize(
+        "log_text",
+        [TRUNCATED_LOG, COMPLETE_LOG, "collected 5 items\n", "", "Killed\n"],
+        ids=["truncated", "complete", "no-summary", "empty", "unreadable"],
+    )
+    def test_every_input_exits_zero(self, tmp_path: Path, capsys: pytest.CaptureFixture[str], log_text: str) -> None:
+        log = tmp_path / "pytest.log"
+        log.write_text(log_text, encoding="utf-8")
+
+        assert main([str(log)]) == 0
+        capsys.readouterr()
+
+    def test_an_absent_log_exits_zero_rather_than_raising(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ``if: always()`` means this step also runs when an earlier step failed
+        # before the suite produced a log at all.
+        assert main([str(tmp_path / "absent.log")]) == 0
+        capsys.readouterr()
+
+    def test_a_truncated_run_is_reported_as_an_annotation(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        log = tmp_path / "pytest.log"
+        log.write_text(TRUNCATED_LOG, encoding="utf-8")
+
+        assert main([str(log)]) == 0
+        out = capsys.readouterr().out
+        assert "::warning title=The test run was truncated::" in out
+
+
+class TestTheStoredLogFormIsReadableToo:
+    """A maintainer diagnosing a past run downloads the timestamped log."""
+
+    def test_the_actions_timestamp_prefix_does_not_hide_the_summary_line(self) -> None:
+        stamped = "".join(f"2026-09-03T00:07:28.1897683Z {line}\n" for line in TRUNCATED_LOG.splitlines())
+
+        report = parse_run(stamped)
+
+        # Without the prefix being stripped, the anchored summary pattern misses
+        # and this reports ``incomplete-no-summary`` on exactly the input a human
+        # reaches for -- a wrong answer shaped like a different finding.
+        assert report.outcome == "truncated"
+        assert report.never_ran == 12036
+
+
+def _run_tests_step() -> dict[str, Any]:
+    document = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    steps = [step for job in document["jobs"].values() for step in job["steps"]]
+    piped = [step for step in steps if "hatch run test" in str(step.get("run", ""))]
+    assert len(piped) == 1, [step.get("name") for step in piped]
+    return piped[0]
+
+
+class TestCapturingTheSuiteCannotHideItsVerdict:
+    """The pipe that captures the log must not become the pipeline's exit status."""
+
+    def test_a_piped_suite_sets_pipefail(self) -> None:
+        step = _run_tests_step()
+        body = str(step["run"])
+
+        if "|" not in body.split("hatch run test", 1)[1].splitlines()[0]:
+            pytest.skip("the suite's output is not piped, so pipefail is not required")
+
+        # The default shell for ``run:`` is ``bash -e``, which does NOT set
+        # pipefail, so the pipeline would exit with ``tee``'s status. A failing
+        # suite would then report SUCCESS on the one required check, and nothing
+        # else in this repository reads the suite's verdict independently.
+        assert "set -o pipefail" in body, body
+
+    def test_pipefail_is_set_before_the_suite_runs(self) -> None:
+        body = str(_run_tests_step()["run"])
+        if "set -o pipefail" not in body:
+            pytest.skip("the suite's output is not piped")
+
+        assert body.index("set -o pipefail") < body.index("hatch run test -x")
+
+    def test_the_early_exit_flag_is_still_in_place(self) -> None:
+        # Removing ``-x`` would make a red run cost what a green one costs, which
+        # is 32.6-57.5 min against a 60 min bound. This module's whole premise is
+        # that the flag stays and the truncation is described instead.
+        assert "-x" in str(_run_tests_step()["run"])
+
+
+class TestTheReportIsWiredIntoTheRequiredCheck:
+    """A reporter nothing calls is the failure mode #1905 records for its own cause."""
+
+    def test_a_step_runs_the_reporter(self) -> None:
+        document = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+        steps = [step for job in document["jobs"].values() for step in job["steps"]]
+        callers = [step for step in steps if "report_truncated_test_run.py" in str(step.get("run", ""))]
+
+        assert len(callers) == 1, [step.get("name") for step in callers]
+
+    def test_the_reporter_runs_even_when_the_suite_failed(self) -> None:
+        document = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+        steps = [step for job in document["jobs"].values() for step in job["steps"]]
+        caller = next(step for step in steps if "report_truncated_test_run.py" in str(step.get("run", "")))
+
+        # A truncated run is by definition a failed run, so a step that only runs
+        # on success would describe every case except the one it exists for.
+        assert str(caller.get("if", "")).strip() == "always()"
+
+    def test_the_reporter_reads_the_file_the_suite_wrote(self) -> None:
+        document = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+        steps = [step for job in document["jobs"].values() for step in job["steps"]]
+        bodies = [str(step.get("run", "")) for step in steps]
+        producer = next(body for body in bodies if "hatch run test" in body)
+        consumer = next(body for body in bodies if "report_truncated_test_run.py" in body)
+
+        # One path, spelled the same on both sides: a reporter pointed at a file
+        # nothing writes reports ``unreadable`` forever and exits 0, so the
+        # mismatch would be silent.
+        assert "${RUNNER_TEMP}/pytest.log" in producer
+        assert "${RUNNER_TEMP}/pytest.log" in consumer


### PR DESCRIPTION
## What

The one required check runs the suite under `-x`, so it stops at the first failure. That is deliberate and stays. What this changes is that **a red `call-test-lint` now says how much of the suite it never reached**, instead of leaving the failure count readable as a total when it is a lower bound.

Closes #3164.

## Why

Measured on run [33690980247](https://github.com/strands-labs/robots/actions/runs/33690980247), the `Test and Lint` job of #3161 at `48881ea`:

```
line  2207:  collecting ... collected 46583 items
line 37134:  !!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!
line 37135:  ==== 1 failed, 34268 passed, 278 skipped, 57 warnings in 1259.55s ====
```

34547 of 46583 items executed, so **12036 -- 25.8% of the suite -- never ran**. The hidden failure was neither hypothetical nor distant: the next one was four lines below the first, in the same class, with the same cause, so the truncation turned a one-round fix into two. `--cov-fail-under=80` is no backstop -- that same truncated run reported `Total coverage: 81.54%` and the gate read as a pass.

### What was actually missing

Worth correcting something #3164 asserts: pytest **does** print the `stopping after 1 failures` banner, so the truncation is not an unrecorded event, and the `[ 74%]` token is not its only trace. What is missing is the *subtraction*:

- the banner does not say how much was skipped;
- the `collected` line the count needs sits **34,927 lines earlier** in a 6.4 MB log;
- neither number reaches a surface short of downloading that log -- a check's annotations and the job summary are what a reviewer reads, and the truncation appeared in neither.

## Why `-x` stays

#3164's decision table estimated a full run at "~28 min of pytest inside a ~33 min job... under the bound". That estimate is wrong, and the correction settles the decision. Measured over the last 40 `main` pushes of `pr-and-push.yml`, the `Test and Lint` job on the 37 runs that completed took **32.6 to 57.5 minutes, median 46.9**, against `timeout-minutes: 60` -- and run 33631903156 was already reaped at **60.12 minutes**.

So dropping `-x` would make a red run cost what a green one costs, which is already in reach of the reap, and raising the bound is explicitly spent: the comment on that `timeout-minutes` line records that "the next raise cannot be spent here" (#2457, #2239). That leaves the option #3164 calls orthogonal and cheap -- describe the truncation -- which costs no runner time at all.

One datum worth recording against #3143 while here: that reaped run **did not** have its suite truncated. Its pytest completed (46449 of 46449 items, `46152 passed, 297 skipped`) at 54.5 min and the job was killed in a later step, so the reporter calls it `complete`, which is the honest answer.

## How

- **`scripts/report_truncated_test_run.py`** pairs the `collected` line with the summary line and reports `complete`, `truncated`, or `incomplete-no-summary` (a run killed before pytest finished reporting) to the job summary and as a `::warning` annotation. `warnings`, `deselected` and `rerun` are deliberately excluded from the executed count -- counting any of them would *understate* what the abort skipped, the one direction this must not err in.
- **It never fails the job.** It runs inside the required check's own job, so a nonzero exit would either duplicate the suite's own red or, on a parsing bug, turn the one required check red on a green tree for every open pull request. `main` returns 0 for every input, including a log it cannot read, and that is pinned.
- **`.github/workflows/test-lint.yml`** tees the suite's output so the report has something to read, and sets `set -o pipefail` before it.

### The pipefail line is load-bearing

The default shell for `run:` is `bash -e`, which does **not** set `pipefail`, so a pipeline exits with the status of its last command -- `tee`, which always succeeds. Without that line a failing suite would report SUCCESS on the one required check, and nothing else in this repository reads the suite's verdict independently. It is pinned rather than left to review: the pin skips when the command is not piped, so it is a guard against the shape rather than an assertion about today's text.

## Verification

Run against the **real logs**, not fixtures:

| log | run | reported |
|---|---|---|
| truncated | 33690980247 | `truncated`, 34547 of 46583 executed, **12036 never ran (25.8%)** |
| complete | 33702826136 | `complete`, 46575 of 46575 (`46278 passed, 297 skipped`) |
| complete | 33697089523 | `complete`, 46565 of 46565 (`46268 passed, 297 skipped`) |
| reaped | 33631903156 | `complete` -- suite finished, job killed later |

The truncated row reproduces the figure #3164 computed by hand. The two green rows are the negative control that matters: a false `truncated` would put a warning on every pull request.

Both pins were confirmed to fail on pre-fix code rather than merely pass on post-fix code:

- against `main`'s workflow, the three wiring pins fail (`3 failed, 1 passed, 2 skipped`) and the pipefail pins correctly skip, there being no pipe;
- against a mutant that adds the pipe and omits `set -o pipefail` -- the catastrophic case -- `test_a_piped_suite_sets_pipefail` fails.

Also run: `23 passed` on the new module; `236 passed` across the whole-tree graders that grade any new file (`test_no_host_paths`, `test_log_strings_are_ascii`, `test_test_case_names_describe_behaviour`, `test_raises_docstring_completeness`, `test_except_tuples_state_their_real_scope`, `test_workflow_action_refs_pin_a_sha`, `test_workflow_jobs_are_bounded`, both concurrency-group pins); `ruff check`, `ruff format --check` and `mypy` clean.

The full suite is not run locally -- it is the 47-minute job this PR is about -- so `call-test-lint` on this branch is the first complete run of it, and its own truncation report is the first thing to read if it goes red.

## Note for review

This edits `.github/workflows/**`, so `mergeStateStatus` will read `BLOCKED` under the Actions `GITHUB_TOKEN` regardless of the real state; read it with a PAT (AGENTS.md PR Workflow step 8, #1917).

## Changelog

`changelog.d/3164-a-red-check-says-how-much-it-never-reached.md`, numbered from the issue rather than the PR so it ships in the first push and cannot race an approval (AGENTS.md step 3).

<!-- rounds -->
### Round log

- **Round 1** -- initial submission.
