### PR TITLE
test(ci): a session that stops early states how much of the suite never ran

### DIFF
--- a/changelog.d/3167-session-truncation-is-reported.md
+++ b/changelog.d/3167-session-truncation-is-reported.md
@@ -1,0 +1,24 @@
+### Changed: a truncated test session states how much of the suite never ran
+
+CI runs the suite under `-x`, so a red required check stops at the first failure
+with the rest of the suite unexecuted. The counts line pytest then prints is
+shaped exactly like a complete run's -- `1 failed, 34268 passed, 278 skipped`
+reads as a total whether 34547 tests ran or 46583 did. pytest names the abort
+(`!!! stopping after 1 failures !!!`) but does not size it, so how much of the
+suite never started was recoverable only from the trailing progress token of the
+last verbose line, one token at the end of a multi-megabyte log.
+
+`tests/session_truncation.py` registers a terminal-summary section that states
+the size:
+
+```
+============= session truncated: 1926 of 4878 collected tests ran ==============
+2952 collected tests never started, so the counts below are a floor, not a total.
+```
+
+It reads the item count collection settled on (after deselection) and counts the
+tests that were entered, so it is independent of why a session stopped -- a
+`--maxfail` budget, an interrupt or a test that takes the process down all
+truncate the report the same way. It is silent when the session ran everything it
+collected, so the section appears only where it changes what the counts below it
+mean, and it changes no flag, bound or workflow file.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,6 +25,19 @@ mkdocs build --strict                # CI gate
 
 CI runs `hatch run test -x --strict-markers`.
 
+`-x` means a red run stops at the first failure with the rest of the suite
+unexecuted, and its counts line is shaped exactly like a complete run's. So
+`tests/conftest.py` registers the reporter in `tests/session_truncation.py`,
+which states the size of the gap:
+
+```
+============= session truncated: 1926 of 4878 collected tests ran ==============
+2952 collected tests never started, so the counts below are a floor, not a total.
+```
+
+A session that ran every test it collected prints nothing extra, so the section
+appears only where it changes what the counts below it mean.
+
 Coverage is collected through PEP 669 (`sys.monitoring`) rather than the default
 C trace function - `core = "sysmon"` in `[tool.coverage.run]`. It reports the
 same line coverage at roughly a tenth of the cost (measured +8.2% against

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,19 @@ Also disables the Zenoh mesh by default during the test suite so the
 sessions and background heartbeat threads when ``eclipse-zenoh`` is
 installed in the test environment.  Mesh-specific tests opt back in
 explicitly via ``monkeypatch.delenv`` or by patching ``init_mesh``.
+
+Finally, registers the session-truncation reporter from
+:mod:`tests.session_truncation`, so a run that stops before every collected test
+has started says so instead of reporting counts that read as a total.
 """
 
 import os
+
+import pytest
+
+# Neither import below touches strands_robots, so both are safe above the
+# environment defaults that the strands_robots imports further down depend on.
+from tests.session_truncation import register_truncation_reporter
 
 # Disable mesh BEFORE any strands_robots import below pulls in robot.py.
 # Use setdefault so tests that explicitly enable the mesh (e.g. integ tests)
@@ -29,3 +39,11 @@ from tests.mocks.torch_mock import install_torch_mock
 
 # Must run before any test imports policy modules
 install_torch_mock()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Report the size of a session that stops before every test has started.
+
+    See :mod:`tests.session_truncation` for why the counts alone do not say it.
+    """
+    register_truncation_reporter(config)

--- a/tests/session_truncation.py
+++ b/tests/session_truncation.py
@@ -1,0 +1,96 @@
+"""State the size of a pytest session that stopped before every test ran.
+
+A session that aborts early reports the same counts line as one that ran to
+completion: ``1 failed, 34268 passed, 278 skipped`` reads as a total whether
+34547 tests ran or 46583 did. pytest names the abort - ``!!! stopping after 1
+failures !!!`` - but not its size, so how much of the suite never started is
+recoverable only from the trailing progress percentage of the last verbose line,
+one token at the end of a multi-megabyte log.
+
+The distinction matters because the two reports mean different things. A
+complete run's counts are a total, so a red check is a list of everything to
+fix. A truncated run's counts are a floor, and the number of failures is
+unknown until the suite is run again on a tree where the named one passes -
+which costs another full run of the suite, and (because a push dismisses
+approval) another review.
+
+This plugin states the size and nothing else: how many collected tests ran, how
+many never started, and that the counts are therefore a floor. It is silent on a
+complete session, so the statement appears only where it changes what the counts
+below it mean, and it is independent of *why* the session stopped - a
+``--maxfail`` budget, an interrupt, or a test that took the process down all
+truncate the report the same way.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from _pytest.terminal import TerminalReporter
+
+#: Name the reporter is registered under, so a second registration is a no-op
+#: rather than a duplicate section.
+PLUGIN_NAME = "session_truncation_reporter"
+
+
+def truncation_summary(*, collected: int | None, started: int) -> tuple[str, str] | None:
+    """Describe a session that ran fewer tests than it collected.
+
+    Args:
+        collected: Number of tests collection settled on, after deselection, or
+            ``None`` when collection never finished (nothing can be said then).
+        started: Number of those tests that were entered.
+
+    Returns:
+        A ``(heading, detail)`` pair for the terminal summary, or ``None`` when
+        the session ran every test it collected and there is nothing to say.
+    """
+    if collected is None or started >= collected:
+        return None
+    missed = collected - started
+    heading = f"session truncated: {started} of {collected} collected tests ran"
+    detail = f"{missed} collected tests never started, so the counts below are a floor, not a total."
+    return heading, detail
+
+
+class SessionTruncationReporter:
+    """Report the size of a truncated session in the terminal summary."""
+
+    def __init__(self) -> None:
+        self._collected: int | None = None
+        self._started = 0
+
+    def pytest_collection_finish(self, session: pytest.Session) -> None:
+        """Record the item count collection settled on, after deselection."""
+        self._collected = len(session.items)
+
+    def pytest_runtest_logfinish(self, nodeid: str) -> None:
+        """Count a test that was entered, whatever its outcome."""
+        self._started += 1
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_terminal_summary(self, terminalreporter: TerminalReporter, config: pytest.Config) -> None:
+        """Write the truncation section, last, so it sits beside the counts."""
+        if config.getoption("collectonly", default=False):
+            return  # Collecting without running is not a truncated run.
+        summary = truncation_summary(collected=self._collected, started=self._started)
+        if summary is None:
+            return
+        heading, detail = summary
+        terminalreporter.write_sep("=", heading, red=True)
+        terminalreporter.write_line(detail)
+
+
+def register_truncation_reporter(config: pytest.Config) -> None:
+    """Register :class:`SessionTruncationReporter` once for this session."""
+    if config.pluginmanager.get_plugin(PLUGIN_NAME) is not None:
+        return
+    config.pluginmanager.register(SessionTruncationReporter(), PLUGIN_NAME)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the reporter when this module is loaded as a plugin (``-p``)."""
+    register_truncation_reporter(config)

--- a/tests/test_session_truncation_is_reported.py
+++ b/tests/test_session_truncation_is_reported.py
@@ -1,0 +1,148 @@
+"""A session that stops before every collected test ran says how much never ran.
+
+``.github/workflows/test-lint.yml`` runs the required check under ``-x``, so the
+suite can abort at the first failure with a quarter of its items unexecuted. The
+counts line pytest then prints (``1 failed, 34268 passed, 278 skipped``) is
+shaped exactly like a complete run's, and the abort banner names the stop
+without sizing it - so a reader cannot tell a total from a floor. These cells
+pin the statement that distinguishes them, and pin that it stays absent when the
+session did run everything it collected.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_FIVE_TESTS = """\
+def test_one(): pass
+def test_two(): assert False
+def test_three(): assert False
+def test_four(): pass
+def test_five(): pass
+"""
+
+
+def _run_pytest(target: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a nested pytest over ``target`` with the reporter loaded as a plugin.
+
+    The nested run deliberately does not sit under this repository's rootdir, so
+    it inherits none of its ``addopts`` and the only plugin under test is the one
+    named on the command line.
+    """
+    env = {**os.environ, "PYTHONPATH": str(_REPO_ROOT)}
+    env.pop("PYTEST_ADDOPTS", None)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(target),
+            "-p",
+            "tests.session_truncation",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=target.parent,
+        env=env,
+        timeout=120,
+    )
+
+
+class TestTheSummaryStatesTheSizeOfWhatDidNotRun:
+    """The message is derived from the two counts and says nothing else."""
+
+    @staticmethod
+    def _summary(collected: int | None, started: int) -> tuple[str, str] | None:
+        from tests.session_truncation import truncation_summary
+
+        return truncation_summary(collected=collected, started=started)
+
+    @pytest.mark.parametrize(
+        ("collected", "started", "expected_numbers"),
+        [
+            pytest.param(46583, 34547, ("34547", "46583", "12036"), id="the-measured-ci-run"),
+            pytest.param(5, 2, ("2", "5", "3"), id="stopped-at-the-second-of-five"),
+            pytest.param(2, 1, ("1", "2", "1"), id="one-test-short"),
+        ],
+    )
+    def test_a_short_session_is_sized(self, collected: int, started: int, expected_numbers: tuple[str, ...]) -> None:
+        summary = self._summary(collected, started)
+        assert summary is not None, "a session that ran fewer tests than it collected has something to say"
+        heading, detail = summary
+        assert (heading, detail) == (
+            f"session truncated: {started} of {collected} collected tests ran",
+            f"{collected - started} collected tests never started, so the counts below are a floor, not a total.",
+        )
+        for number in expected_numbers:
+            assert number in heading + detail
+
+    @pytest.mark.parametrize(
+        ("collected", "started"),
+        [
+            pytest.param(46583, 46583, id="every-collected-test-ran"),
+            pytest.param(0, 0, id="nothing-was-collected"),
+            pytest.param(None, 3, id="collection-never-finished"),
+            pytest.param(5, 7, id="more-runs-than-items-stepwise-or-rerun"),
+        ],
+    )
+    def test_a_session_with_nothing_to_report_is_silent(self, collected: int | None, started: int) -> None:
+        assert self._summary(collected, started) is None
+
+
+class TestTheSuiteReportsItsOwnTruncation:
+    """The reporter is wired into this suite, not only importable by it."""
+
+    def test_the_reporter_is_registered_for_this_session(self, pytestconfig: pytest.Config) -> None:
+        from tests.session_truncation import PLUGIN_NAME, SessionTruncationReporter
+
+        plugin = pytestconfig.pluginmanager.get_plugin(PLUGIN_NAME)
+        assert isinstance(plugin, SessionTruncationReporter), (
+            "tests/conftest.py must register the reporter, or a truncated run of this suite says nothing"
+        )
+
+    def test_registering_twice_leaves_one_reporter(self, pytestconfig: pytest.Config) -> None:
+        from tests.session_truncation import PLUGIN_NAME, register_truncation_reporter
+
+        before = pytestconfig.pluginmanager.get_plugin(PLUGIN_NAME)
+        register_truncation_reporter(pytestconfig)
+        assert pytestconfig.pluginmanager.get_plugin(PLUGIN_NAME) is before
+
+
+class TestARunThatStopsEarlyReportsHowMuchNeverRan:
+    """Driven end to end through a nested pytest, on its terminal output."""
+
+    def test_maxfail_one_names_the_three_tests_that_never_started(self, tmp_path: Path) -> None:
+        (tmp_path / "test_five.py").write_text(_FIVE_TESTS)
+        result = _run_pytest(tmp_path, "-x")
+        assert "1 failed, 1 passed" in result.stdout, result.stdout
+        assert "session truncated: 2 of 5 collected tests ran" in result.stdout, result.stdout
+        assert "3 collected tests never started, so the counts below are a floor, not a total." in result.stdout
+
+    def test_a_complete_run_says_nothing(self, tmp_path: Path) -> None:
+        (tmp_path / "test_five.py").write_text(_FIVE_TESTS)
+        result = _run_pytest(tmp_path)
+        assert "2 failed, 3 passed" in result.stdout, result.stdout
+        assert "session truncated" not in result.stdout, result.stdout
+
+    def test_a_deselecting_run_that_finishes_says_nothing(self, tmp_path: Path) -> None:
+        (tmp_path / "test_five.py").write_text(_FIVE_TESTS)
+        result = _run_pytest(tmp_path, "-k", "test_one or test_four")
+        assert "2 passed, 3 deselected" in result.stdout, result.stdout
+        assert "session truncated" not in result.stdout, result.stdout
+
+    def test_collecting_without_running_is_not_a_truncated_session(self, tmp_path: Path) -> None:
+        (tmp_path / "test_five.py").write_text(_FIVE_TESTS)
+        result = _run_pytest(tmp_path, "--collect-only")
+        assert "5 tests collected" in result.stdout, result.stdout
+        assert "session truncated" not in result.stdout, result.stdout


### PR DESCRIPTION
The required check runs the suite under `-x`, so a red run stops at the first failure with the rest of the suite unexecuted. The counts line it prints is shaped exactly like a complete run's, so a reader cannot tell a total from a floor - and the number of failures stays unknown until the suite is run again on a tree where the named one passes, which costs another full run and (because a push dismisses approval) another review.

![session truncation before/after](https://raw.githubusercontent.com/cagataycali/robots/478371a36f3ce0d8fb50abe32216499f44ef0fce/.artifacts/session-truncation.png)

| run | collected | ran | never started | what the counts line said |
|---|---:|---:|---:|---|
| CI, run 33690980247 | 46583 | 34547 | **12036 (25.8%)** | `1 failed, 34268 passed, 278 skipped` |
| `pytest tests/mesh -x -v`, rendered above | 4878 | 1926 | **2952 (60.5%)** | `1916 passed, 9 skipped, 1 error` |

One correction to the measurement in #3164 while reproducing it: pytest does emit `!!! stopping after 1 failures !!!` and it is present in that job's log (line 37134 of 6.4 MB), so `[ 74%]` is not the only trace of the abort. The banner names the stop; it does not size it, and the size is what decides whether the counts are a list of everything to fix or a floor.

## Change

`tests/session_truncation.py` registers a terminal-summary section that states the size:

```
============= session truncated: 1926 of 4878 collected tests ran ==============
2952 collected tests never started, so the counts below are a floor, not a total.
```

It reads the item count collection settled on (after deselection) and counts the tests that were entered, so it is independent of *why* the session stopped - a `--maxfail` budget, an interrupt, or a test that takes the process down all truncate the report the same way. It writes `trylast` so the section lands beside the counts rather than above the coverage table, and it is silent when the session ran everything it collected, so the statement appears only where it changes what the counts below it mean.

That makes it decision-independent with respect to the `-x` / `--maxfail=N` / drop-the-flag question in #3164, which is untouched here: no flag, bound or workflow file is changed, and the section is correct under any of them.

## Tests

`tests/test_session_truncation_is_reported.py` - 13 cells: the message table-driven over 3 truncated and 4 complete shapes, the wiring (`tests/conftest.py` registers it, and registering twice leaves one reporter), and 4 end-to-end cells driving a nested `pytest` and grading its terminal output.

On pristine `main` with only the test file applied: **13 failed**. Both silence controls are graded by planted regression rather than by assertion alone - relaxing `started >= collected` to `>` fails 4 cells (a complete run reported as `2 of 2 collected tests ran`), and removing the `--collect-only` guard fails 1.

Full suite on both trees: base **63 failed / 45999 passed / 427 skipped / 37 errors** in 28:57, branch **63 / 46012 / 427 / 37** in 29:13 - the 100 `FAILED`+`ERROR` node ids are set-identical (pre-existing optional-dep drift), and +13 passed is exactly the new cells. The whole-tree graders are unchanged at 13 failed / 4196 passed / 56 skipped / 4 errors. `ruff check` and `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy strands_robots tests tests_integ` byte-identical at 25 errors in 10 files on both trees.

## Size

`+299/-0`: reporter 96, tests 148, `tests/conftest.py` 18, `docs/contributing.md` 13, changelog fragment 24. No production code changes - `strands_robots/` is untouched.

Refs #3164