### PR TITLE
test: the sys.modules orphan guard reads `from package import module` bindings

### DIFF
--- a/changelog.d/3168-sys-modules-orphan-guard-reads-from-imports.md
+++ b/changelog.d/3168-sys-modules-orphan-guard-reads-from-imports.md
@@ -1,0 +1,50 @@
+### Fixed: the `sys.modules` orphan guard reads `from package import module` bindings
+
+`tests/test_sys_modules_removal_leaves_no_orphan.py` grades a rule its own
+docstring states: a test may not leave `sys.modules` missing a module a sibling
+patches, because removing an entry does not undo an import, it *orphans* every
+reference already bound to that module -- the sibling's double is installed on
+an object nothing will look at again.
+
+Its binding collector walked only `ast.Import`. A module bound by
+`from a import b` was invisible, which is the spelling this tree uses for
+nearly every submodule, because a submodule is what a test wants to patch
+attributes on. The protected set read 43 modules where the rule describes 95,
+and the 52 it could not see included two unrestored removals, each with a
+symptom that appears only in a composed run:
+
+* `tests/tools/g1/test_motion_switcher_decoder.py` dropped
+  `strands_robots.tools.g1._motion_switcher`, orphaning the reference
+  `tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock.py`
+  patches `_load_motion_switcher_client` on. The Go2 driver's lazy import then
+  resolved the real loader, the open returned `None`, and the cells that grade
+  whether an RPC client's DDS endpoints are constructed under the shared
+  `_DDS_INIT_LOCK` reported "the open returned None instead of the recorder, so
+  this cell graded nothing". That lock exists because concurrent endpoint
+  construction segfaults the CycloneDDS bindings, which no `except` boundary
+  can turn into an error envelope.
+* `tests/simulation/test_policy_runner.py` dropped
+  `strands_robots.simulation.policy_runner`, and four cells in
+  `tests/simulation/test_recording_frame_loss_is_not_tolerated.py` then failed
+  with `KeyError` on that entry.
+
+Both files pass in isolation, so neither removal is visible except in a run
+that composes the pair.
+
+The collector now reads `ast.ImportFrom` as well, and both removals go through
+`monkeypatch.delitem`, the restoring idiom the guard's docstring already
+recommends. Recording a `from` import that names something other than a module
+costs nothing: the rule only intersects protected names with the literal keys a
+test removes from `sys.modules`, and a class is not registered there under that
+spelling, so the collector stays a static read with no import side effects.
+
+`test_policy_runner_import_does_not_pull_in_mujoco` also never performed the
+import it measures. It cleared every `mujoco` entry and then read `sys.modules`,
+so it asserted only that the entries it had just deleted were gone -- true
+whatever the runner's top level does. A module-level `import mujoco` planted in
+`policy_runner.py` passed it. The cell imports the module now and fails on that
+plant.
+
+The docstring described the `policy_runner` removal as a purge nothing patches,
+and a cell asserted the runner was unprotected. Both are corrected: two sibling
+modules patch it through a `from` import.

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -13,6 +13,7 @@ pure-Python ``FakeSim`` stub, plus the real-backend behaviours:
 from __future__ import annotations
 
 import base64
+import importlib
 import inspect
 import io
 import os
@@ -135,16 +136,31 @@ def test_policy_runner_only_touches_public_api():
         assert call[0] in allowed, f"PolicyRunner touched private API: {call}. Only {allowed} are allowed."
 
 
-def test_policy_runner_import_does_not_pull_in_mujoco():
-    """Importing policy_runner must not drag in mujoco."""
+def test_policy_runner_import_does_not_pull_in_mujoco(monkeypatch):
+    """Importing policy_runner must not drag in mujoco.
 
-    # Wipe any existing mujoco imports
+    The import is what is measured, so the cell has to perform it: clearing
+    ``mujoco`` and then reading ``sys.modules`` without importing the runner
+    asserts only that the entries just deleted are gone, which is true whatever
+    the runner's top level does.
+
+    Both removals go through ``monkeypatch`` so the entries are put back.
+    Leaving the runner out of ``sys.modules`` does not undo its import, it
+    orphans the references siblings already hold -
+    ``test_rollout_video_realtime_fps`` and
+    ``test_rollout_durations_survive_a_clock_step`` bind the module and patch
+    attributes on it, and ``test_recording_frame_loss_is_not_tolerated`` reads
+    its entry directly.
+    """
+    runner = "strands_robots.simulation.policy_runner"
+
+    # Wipe any existing mujoco imports, so an import below is attributable.
     for mod in [m for m in list(sys.modules) if m.startswith("mujoco")]:
-        del sys.modules[mod]
+        monkeypatch.delitem(sys.modules, mod)
 
-    # Force a fresh import of the runner module
-    if "strands_robots.simulation.policy_runner" in sys.modules:
-        del sys.modules["strands_robots.simulation.policy_runner"]
+    # Force a fresh import of the runner module, and perform it.
+    monkeypatch.delitem(sys.modules, runner, raising=False)
+    importlib.import_module(runner)
 
     leaked = [m for m in sys.modules if m.startswith("mujoco")]
     assert not leaked, (

--- a/tests/test_sys_modules_removal_leaves_no_orphan.py
+++ b/tests/test_sys_modules_removal_leaves_no_orphan.py
@@ -23,12 +23,29 @@ on the line above already makes the function-scope ``import boto3`` raise
 
 The rule graded here is derived from the tree rather than listed:
 
-* **Protected** is every module a test file binds with a module-level ``import``
-  *and* then patches an attribute on (``monkeypatch.setattr(<binding>, ...)``).
-  Those are exactly the references a removal can orphan - a file that only
-  *reads* ``mod.attr`` is unaffected by getting a fresh copy.
+* **Protected** is every module a test file binds with a module-level import -
+  ``import a.b`` *or* ``from a import b`` - *and* then patches an attribute on
+  (``monkeypatch.setattr(<binding>, ...)``). Those are exactly the references a
+  removal can orphan; a file that only *reads* ``mod.attr`` is unaffected by
+  getting a fresh copy.
 * **Reported** is a removal of a protected module with no restoration in the
   same function.
+
+Both import statements have to be read, because ``from a import b`` is how this
+tree binds nearly every submodule - a submodule is what a test wants to patch
+attributes on. Reading ``import`` alone left the protected set at 43 modules of
+95, and the 52 it could not see included two removals with live symptoms:
+``tests/tools/g1/test_motion_switcher_decoder.py`` dropped
+``strands_robots.tools.g1._motion_switcher``, orphaning the reference
+``tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock.py``
+patches ``_load_motion_switcher_client`` on, so the driver's lazy import reached
+the real loader and the open returned ``None`` - that file's cells grade whether
+an RPC client is constructed under the shared DDS lock, and they reported "the
+open returned None instead of the recorder, so this cell graded nothing";
+``tests/simulation/test_policy_runner.py`` dropped
+``strands_robots.simulation.policy_runner``, and four cells in
+``tests/simulation/test_recording_frame_loss_is_not_tolerated.py`` then failed
+with ``KeyError`` on that entry. Both pass in isolation.
 
 It is deliberately one-directional and under-reports rather than over-reports:
 
@@ -42,9 +59,10 @@ It is deliberately one-directional and under-reports rather than over-reports:
   same key.
 * Purging a module **no test patches** stays legal. That is a deliberate
   cache-invalidation idiom here - ``tests/policies/lerobot_local/
-  test_resolution.py`` drops ``lerobot.*`` to force re-registration, and
-  ``tests/simulation/test_policy_runner.py`` drops the runner to measure its
-  import graph - and neither can orphan a patched reference.
+  test_resolution.py`` drops ``lerobot.*`` to force re-registration, and it
+  cannot orphan a patched reference. ``tests/simulation/test_policy_runner.py``
+  used to be described as the same idiom; it is not, because two sibling
+  modules patch the runner through a ``from`` import, so it is graded.
 
 ``monkeypatch.setitem(sys.modules, name, None)`` is the idiom for "make
 ``import name`` raise ``ImportError``": it has the same effect and it restores.
@@ -70,12 +88,36 @@ _MINIMUM_PROTECTED = 10
 
 
 def _module_level_bindings(tree: ast.Module) -> dict[str, str]:
-    """Map each name bound by a module-level ``import X`` to its dotted path."""
+    """Map each name a module-level import binds to the dotted path it names.
+
+    Both import statements bind a module object a removal can orphan:
+
+    * ``import a.b`` binds ``a`` to ``a``, and ``import a.b as c`` binds ``c``
+      to ``a.b``.
+    * ``from a import b`` binds ``b`` to ``a.b`` - the spelling this tree uses
+      for almost every submodule, because a submodule is what a test wants to
+      patch attributes on (``from strands_robots.simulation import
+      policy_runner``).
+
+    A ``from`` import can also name something that is not a module
+    (``from a import SomeClass`` records ``a.SomeClass``). Recording it is
+    harmless rather than a source of false reports: the rule only ever
+    intersects these names with the literal keys a test removes from
+    ``sys.modules``, and a class is not registered there under that spelling,
+    so an entry that is not a module can never be matched by a removal.
+
+    Star imports bind no inspectable name and relative imports cannot be
+    resolved to a dotted path from the file alone, so neither is claimed.
+    """
     bindings: dict[str, str] = {}
     for node in tree.body:
         if isinstance(node, ast.Import):
             for alias in node.names:
                 bindings[alias.asname or alias.name.split(".")[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
+            for alias in node.names:
+                if alias.name != "*":
+                    bindings[alias.asname or alias.name] = f"{node.module}.{alias.name}"
     return bindings
 
 
@@ -236,14 +278,29 @@ class TestNoRemovalOrphansAPatchedModule:
     def test_purging_a_module_no_test_patches_stays_legal(self) -> None:
         """The cache-invalidation idiom is not reported - it cannot orphan a patch."""
         protected = protected_modules()
-        purges = [
-            "lerobot.policies.vla_jepa.processor_vla_jepa",
-            "strands_robots.simulation.policy_runner",
-        ]
+        purges = ["lerobot.policies.vla_jepa.processor_vla_jepa"]
         assert [key for key in purges if key in protected] == [], (
             "these are deliberately dropped to force a re-import; if a test starts "
             "patching one through a module-level binding the rule reaches it, but "
             f"today it must not: {sorted(protected)}"
+        )
+
+    def test_a_module_patched_through_a_from_import_is_protected(self) -> None:
+        """The binding this tree uses for a submodule is the one to reach.
+
+        Both of these are bound with ``from <package> import <module>`` and
+        attribute-patched, so a removal of either orphans a double. They are
+        named rather than derived because a rule that lost this statement would
+        empty the population it grades and still report a clean tree.
+        """
+        protected = protected_modules()
+        expected = {
+            "strands_robots.simulation.policy_runner",
+            "strands_robots.tools.g1._motion_switcher",
+        }
+        assert expected <= set(protected), (
+            "a module bound by `from package import module` and then attribute-"
+            f"patched must be protected; missing {sorted(expected - set(protected))}"
         )
 
 
@@ -308,6 +365,60 @@ class TestTheScanIsSpecific:
             ]
         )
         assert unrestored_removals(ast.parse(source)) == []
+
+    def test_a_from_import_binding_is_followed(self) -> None:
+        """``from a import b`` binds the module ``a.b``, under either spelling."""
+        plain = "\n".join(
+            [
+                "from pkg import mod",
+                "def test_x(monkeypatch):",
+                "    monkeypatch.setattr(mod, 'attr', None)",
+            ]
+        )
+        aliased = "\n".join(
+            [
+                "from pkg import mod as aliased",
+                "def test_x(monkeypatch):",
+                "    monkeypatch.setattr(aliased, 'attr', None)",
+            ]
+        )
+        assert _patched_module_level_imports(ast.parse(plain)) == {"pkg.mod"}
+        assert _patched_module_level_imports(ast.parse(aliased)) == {"pkg.mod"}
+
+    def test_a_star_or_relative_from_import_is_not_claimed(self) -> None:
+        """Neither resolves to a dotted path from the file alone."""
+        star = "\n".join(
+            ["from pkg import *", "def test_x(monkeypatch):", "    monkeypatch.setattr(mod, 'attr', None)"]
+        )
+        relative = "\n".join(
+            ["from . import mod", "def test_x(monkeypatch):", "    monkeypatch.setattr(mod, 'attr', None)"]
+        )
+        assert _patched_module_level_imports(ast.parse(star)) == set()
+        assert _patched_module_level_imports(ast.parse(relative)) == set()
+
+    def test_a_from_imported_non_module_is_recorded_but_matches_no_removal(self) -> None:
+        """Why recording ``pkg.SomeClass`` costs nothing.
+
+        The rule intersects the protected names with the literal keys a test
+        removes from ``sys.modules``. A class is not registered there under that
+        spelling, so the entry can never be matched - which is what lets the
+        binding collector stay a static read with no import side effects.
+        """
+        source = "\n".join(
+            [
+                "import sys",
+                "from pkg import SomeClass",
+                "def test_x(monkeypatch):",
+                "    monkeypatch.setattr(SomeClass, 'attr', None)",
+                "def test_y():",
+                "    sys.modules.pop('pkg', None)",
+            ]
+        )
+        tree = ast.parse(source)
+        assert _patched_module_level_imports(tree) == {"pkg.SomeClass"}
+        removed = {key for _, _, key in unrestored_removals(tree)}
+        assert removed == {"pkg"}, removed
+        assert removed & _patched_module_level_imports(tree) == set()
 
     def test_a_module_only_read_is_not_protected(self) -> None:
         """Reading ``mod.attr`` survives a fresh import; patching it does not."""

--- a/tests/tools/g1/test_motion_switcher_decoder.py
+++ b/tests/tools/g1/test_motion_switcher_decoder.py
@@ -356,7 +356,7 @@ class TestModuleImportsWithoutTheSDK:
     is safe without the SDK by re-importing the module in isolation.
     """
 
-    def test_module_can_be_imported_without_the_sdk(self) -> None:
+    def test_module_can_be_imported_without_the_sdk(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Importing :mod:`._motion_switcher` never touches the SDK.
 
         If the module imported the SDK at load, this test would either
@@ -365,6 +365,14 @@ class TestModuleImportsWithoutTheSDK:
         which are louder failure modes than the check here. The cell
         re-imports the module through :mod:`importlib` and asserts no
         ``unitree_sdk2py`` submodule was pulled in as a side effect.
+
+        The registry entry is dropped through ``monkeypatch`` so it is put
+        back afterwards. Removing it and leaving it removed does not undo an
+        import, it orphans every reference already bound to this module -
+        ``tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock``
+        binds it at module level and patches
+        :func:`_load_motion_switcher_client` on it, and against an orphan that
+        patch is invisible to the driver's own lazy import.
         """
         import importlib
         import sys
@@ -373,7 +381,7 @@ class TestModuleImportsWithoutTheSDK:
         before = {k for k in sys.modules if k.startswith("unitree_sdk2py")}
 
         # Force a fresh import so the module's top-level runs again.
-        sys.modules.pop("strands_robots.tools.g1._motion_switcher", None)
+        monkeypatch.delitem(sys.modules, "strands_robots.tools.g1._motion_switcher", raising=False)
         importlib.import_module("strands_robots.tools.g1._motion_switcher")
 
         after = {k for k in sys.modules if k.startswith("unitree_sdk2py")}


### PR DESCRIPTION
## What

`tests/test_sys_modules_removal_leaves_no_orphan.py` grades a rule its own docstring states: a test may not leave `sys.modules` missing a module a sibling patches. Removing an entry does not undo an import -- it **orphans** every reference already bound to that module, so the sibling's double is installed on an object nothing will look at again.

Its binding collector walked only `ast.Import`. `from a import b` was invisible, and that is the spelling this tree uses for nearly every submodule -- because a submodule is what a test wants to patch attributes on.

| | before | after |
|---|---|---|
| `protected_modules()` | **43** | **95** |
| `orphaning_removals()` | `[]` | 2 reports, then 0 once both are fixed |

Neither of the two it could not see is hypothetical.

## The two removals, and what each cost

**1. `tests/tools/g1/test_motion_switcher_decoder.py:376`** dropped `strands_robots.tools.g1._motion_switcher`, orphaning the reference `tests/drivers/test_motion_switcher_open_is_under_the_shared_dds_lock.py` binds (`from strands_robots.tools.g1 import _motion_switcher`) and patches `_load_motion_switcher_client` on. The Go2 driver's call-time import then resolved the *real* loader, `unitree_sdk2py` is absent, and the open returned `None`:

```
go2-over-the-sdk: the open returned None instead of the recorder, so this cell graded nothing
```

Those cells grade whether an RPC client's DDS endpoints are constructed under the shared `_DDS_INIT_LOCK`. That lock exists because concurrent endpoint construction segfaults the CycloneDDS bindings -- a failure no `except` boundary can turn into an error envelope, as the driver's own docstring says: *"the process dies, possibly while the robot stands under its own controller."*

**2. `tests/simulation/test_policy_runner.py:143,147`** dropped `mujoco*` and `strands_robots.simulation.policy_runner`. Four cells in `tests/simulation/test_recording_frame_loss_is_not_tolerated.py` then failed with `KeyError` on that entry.

| composed pair | base | this branch | each file alone (base) |
|---|---|---|---|
| `..._motion_switcher_decoder` -> `..._open_is_under_the_shared_dds_lock` | **1 failed**, 39 passed, 1 skipped | 40 passed, 1 skipped | 8 passed |
| `test_policy_runner` -> `test_recording_frame_loss_is_not_tolerated` | **4 failed**, 49 passed | 53 passed | 13 passed |

## Why the full suite did not catch it, and why that is worse

The same 20,183-test selection (`tests/simulation tests/drivers tests/tools`) is `1 failed, 20183 passed` on **both** trees -- the standing `newton/test_multi_camera.py::test_bad_position_shape_rejected`. The `KeyError` is absent there because an intervening module re-imports the runner and repopulates the entry. Measured:

```
after del, present: False
after an intervening import of a module that imports it, present: True
and it is a DIFFERENT object than the one held before: True
```

So the ordering that hides the loud `KeyError` produces the silent orphan instead -- exactly the state the guard exists to report. The loud symptom is the lucky one.

## A third finding: the cell was vacuous

`test_policy_runner_import_does_not_pull_in_mujoco` never performed the import it measures. It cleared every `mujoco` entry, then read `sys.modules` -- so it asserted only that the entries it had just deleted were gone, which is true whatever the runner's top level does. With a module-level `import mujoco` planted in `policy_runner.py`:

| | planted leak | clean |
|---|---|---|
| before | **passed** (graded nothing) | passed |
| after | **failed**, naming 15 leaked `mujoco.*` modules | passed |

This one is unconditional -- no ordering hides or reveals it.

## Change

* `_module_level_bindings` reads `ast.ImportFrom` too. Star and relative imports are still not claimed: neither resolves to a dotted path from the file alone.
* A `from` import naming something other than a module (`pkg.SomeClass`) is recorded, and that costs nothing -- the rule only ever intersects protected names with the literal keys a test removes from `sys.modules`, and a class is not registered there under that spelling. That is what lets the collector stay a static read with no import side effects. Pinned as its own cell.
* Both removals now go through `monkeypatch.delitem`, the restoring idiom the guard's docstring already recommends.
* `test_policy_runner_import_does_not_pull_in_mujoco` performs the import.
* The docstring described the `policy_runner` removal as a purge nothing patches, and `test_purging_a_module_no_test_patches_stays_legal` asserted the runner was unprotected. Both are corrected -- two sibling modules patch it through a `from` import. The `lerobot` cache-invalidation purge is genuinely unpatched and stays exempt.

## Tests

Reverting only the collector's one `elif` (keeping the new cells and both removal fixes):

```
3 failed, 13 passed   ->   16 passed
```

The three are the new cells, each naming the defect:

* `test_a_module_patched_through_a_from_import_is_protected` -- *missing ['strands_robots.simulation.policy_runner', 'strands_robots.tools.g1._motion_switcher']*
* `test_a_from_import_binding_is_followed` -- `assert set() == {'pkg.mod'}`
* `test_a_from_imported_non_module_is_recorded_but_matches_no_removal` -- `assert set() == {'pkg.SomeClass'}`

`test_a_star_or_relative_from_import_is_not_claimed` passes on both trees: it is the over-reach control.

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` (`strands_robots tests tests_integ`) | clean, 1848 files |
| `mypy strands_robots tests tests_integ` | 0 attributable (19 pre-existing `examples/isaac_gs`, identical list on both trees) |
| `scripts/check_whole_tree_graders.py` | 7 failed, **4216** passed (base: 7 failed, **4212** passed -- +4 is exactly the new cells; the 7 are environmental: `rclpy` resolvable from a system ROS install, installed `websockets` 16.0 under the declared `>=17.0`) |
| `tests/simulation tests/drivers tests/tools` | 1 failed, 20183 passed -- identical to base (same failing node id) |
| changelog graders | 91 passed |

Size: +206 / -21 across 4 files, of which the changelog fragment is 50 lines and the collector change is four statements (guard file 112 -> 133 executable statements by AST count). No production code changes.
