### PR TITLE
fix(ci): the truncation report measures both its numbers on selected items

### DIFF
--- a/changelog.d/3170-truncation-extent-is-measured-on-selected-items.md
+++ b/changelog.d/3170-truncation-extent-is-measured-on-selected-items.md
@@ -1,0 +1,39 @@
+### Fixed: the truncation report measures both its numbers on selected items
+
+`scripts/report_truncated_test_run.py` decides whether a pull request carries a
+"the failure count is a lower bound, not a total" warning, from
+`never_ran = selected - executed`. The two halves were read off different
+populations, so the difference between them was not the number of items that
+never ran.
+
+`selected` came from a pattern that expected `deselected` and `selected` to be
+adjacent on pytest's collection line. pytest appends those tokens conditionally
+and in a fixed order (`TerminalReporter.report_collect`):
+
+```
+collected N items[ / E errors][ / D deselected][ / S skipped][ / X selected]
+```
+
+A collection error or a module-level skip lands between them, the `selected`
+group reads as absent, and the count falls back to the pre-deselection total.
+`executed` summed the outcome labels on the summary line, which include the ones
+*collection* produced -- a module that fails to import is an `error`, one that
+skips itself for an absent optional dependency is a `skipped` -- and neither was
+ever a selected item.
+
+The two errors point opposite ways and partly cancel, which is why a run whose
+tokens happened to be adjacent read correctly and the existing pin, whose
+fixture poses exactly that arrangement, passed.
+
+Measured on five real pytest sessions, one per arrangement of those tokens,
+against the counts pytest's own session held. A run that selected 2 items with
+`-k` and ran both, in a tree where one module skipped itself, was reported
+`truncated` with 2 of 5 items never run -- **40% of a session that finished
+everything it selected**. Four of the five arrangements misreported the extent.
+
+Both numbers now come from the collection line that already reports the
+deselected and collection-phase counts, and `tests/session_truncation.py` --
+which holds `len(session.items)` and counts the items it saw entered -- settles
+the extent whenever its section is in the log, so one derivation of the
+subtraction owns it and the text arithmetic is the fallback. The report says
+which of the two produced the numbers.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,6 +38,17 @@ which states the size of the gap:
 A session that ran every test it collected prints nothing extra, so the section
 appears only where it changes what the counts below it mean.
 
+The same statement is read back in CI. `scripts/report_truncated_test_run.py`
+runs after the suite and writes the extent to the job summary and a check
+annotation, so a reviewer sees it without downloading the log. The reporter above
+is the owner of the number: it holds the session's own item list, so when its
+section is in the log the script reads it rather than re-deriving a second answer
+from the counts line. The arithmetic remains as the fallback for a log that
+carries no such section, and it is measured on items rather than on outcome
+labels - a module that fails to import, or one that skips itself for an absent
+optional dependency, is an outcome on the summary line but was never a selected
+item.
+
 Coverage is collected through PEP 669 (`sys.monitoring`) rather than the default
 C trace function - `core = "sysmon"` in `[tool.coverage.run]`. It reports the
 same line coverage at roughly a tenth of the cost (measured +8.2% against

--- a/scripts/report_truncated_test_run.py
+++ b/scripts/report_truncated_test_run.py
@@ -86,6 +86,23 @@ by pytest, so it is reported and never gated: ``main`` returns 0 for every
 input, including a log it cannot read. That is deliberate and is pinned by
 tests/test_truncated_test_run_is_reported.py.
 
+One owner for the subtraction
+-----------------------------
+``tests/session_truncation.py`` states the same extent in process, from
+``len(session.items)`` and a count of the items it saw entered, and writes it
+into the log this module reads. Two derivations of one number can disagree, so
+when that section is present it settles the extent and the text arithmetic here
+is only the fallback -- for a log written before the reporter was wired, or one
+whose reporter never got to speak.
+
+The fallback is measured on items, not on outcome labels. The summary line counts
+every outcome the session produced, including the ones *collection* produced: a
+module that fails to import is an ``error`` and one that skips itself for an
+absent optional dependency is a ``skipped``, and neither was ever one of the
+selected items. Both are already reported on the collection line, which is also
+where the post-deselection ``selected`` count comes from, so both numbers in the
+subtraction are read off that one line.
+
 Usage
 -----
 ::
@@ -107,14 +124,33 @@ from dataclasses import dataclass, field
 # because the same text is read both from the raw file this script is pointed at
 # and, when a reader pastes one, from a job log whose lines carry a timestamp
 # prefix added by the Actions log service.
-_COLLECTED = re.compile(
-    r"collected (?P<collected>\d+) items?"
-    r"(?: / (?P<deselected>\d+) deselected)?"
-    r"(?: / (?P<selected>\d+) selected)?"
-)
+#
+# Only the item count is read positionally. Everything after it is a sequence of
+# ``/ <n> <label>`` tokens that pytest appends conditionally, in this order
+# (``TerminalReporter.report_collect``)::
+#
+#     collected N items[ / E errors][ / D deselected][ / S skipped][ / X selected]
+#
+# so the tokens are scanned by label rather than matched in a fixed sequence. A
+# pattern that expected ``deselected`` and ``selected`` adjacently reads
+# ``selected`` as absent the moment either of the other two lands between them -
+# which happens on any run that hits a collection error or a module-level skip -
+# and then falls back to the pre-deselection total, inflating "never ran" by the
+# deselected count on a run that ran everything it selected.
+_COLLECTED = re.compile(r"collected (?P<collected>\d+) items?(?P<tokens>[^\r\n]*)")
+_COLLECT_TOKEN = re.compile(r"/ (?P<count>\d+) (?P<label>deselected|selected|skipped|errors?)")
 
 # The banner ``-x`` / ``--maxfail`` prints when it ends the session early.
 _STOPPING = re.compile(r"!+\s*stopping after (?P<failures>\d+) failures?\s*!+")
+
+# The same subtraction, already computed in process and written into this very
+# log by ``tests/session_truncation.py``. That reporter holds
+# ``len(session.items)`` and a count of the items it saw entered, so when its
+# section is present it is the authoritative answer and this module reads it
+# instead of deriving a second one from text. Anchored on the heading rather
+# than on the surrounding rule so the section is found whatever width the
+# terminal chose for it.
+_SESSION_STATEMENT = re.compile(r"session truncated: (?P<started>\d+) of (?P<collected>\d+) collected tests ran")
 
 # The final ``= 1 failed, 34268 passed, ... in 1259.55s =`` line. Only the
 # surrounding rule and the trailing duration are fixed; the counts in between
@@ -156,6 +192,10 @@ class RunReport:
     stopped_after: int | None = None
     counts: dict[str, int] = field(default_factory=dict)
     detail: str = ""
+    #: Whether the extent was read from the session reporter's own statement
+    #: rather than re-derived from the counts line. Reported so a maintainer
+    #: reading the summary can tell which owner produced the numbers.
+    stated_by_session: bool = False
 
     @property
     def share_skipped(self) -> float | None:
@@ -186,6 +226,32 @@ class RunReport:
         return f"the run's extent could not be read: {self.detail}"
 
 
+def _collection_tokens(tail: str) -> dict[str, int]:
+    """Read the ``/ <n> <label>`` tokens pytest appends to its collection line.
+
+    Args:
+        tail: Whatever followed the item count on that line.
+
+    Returns:
+        One entry per token, keyed by label. ``errors`` is normalised to
+        ``error`` so that one key means one thing whatever the count was.
+    """
+    tokens: dict[str, int] = {}
+    for match in _COLLECT_TOKEN.finditer(tail):
+        label = match.group("label")
+        tokens["error" if label.startswith("error") else label] = int(match.group("count"))
+    return tokens
+
+
+def _outcome_count(counts: dict[str, int], label: str) -> int:
+    """Read one summary count under either its singular or plural spelling.
+
+    pytest writes ``1 error`` and ``2 errors``, so a label read off the summary
+    line is not a stable key on its own.
+    """
+    return counts.get(label, 0) + counts.get(label + "s", 0)
+
+
 def parse_run(text: str) -> RunReport:
     """Read a pytest log and report whether the session covered every selected item.
 
@@ -202,6 +268,8 @@ def parse_run(text: str) -> RunReport:
     selected: int | None = None
     stopped_after: int | None = None
     summary: str | None = None
+    stated: tuple[int, int] | None = None
+    collect_tokens: dict[str, int] = {}
 
     for raw in text.splitlines():
         line = _LOG_TIMESTAMP.sub("", raw)
@@ -209,11 +277,24 @@ def parse_run(text: str) -> RunReport:
             found = _COLLECTED.search(line)
             if found:
                 collected = int(found.group("collected"))
-                explicit = found.group("selected")
-                selected = int(explicit) if explicit else collected
+                collect_tokens = _collection_tokens(found.group("tokens"))
+                if "selected" in collect_tokens:
+                    selected = collect_tokens["selected"]
+                elif "deselected" in collect_tokens:
+                    # pytest prints ``selected`` whenever it differs from the
+                    # item count, so this branch is unreached today. It is the
+                    # subtraction rather than a second fallback to ``collected``
+                    # so that a release which stopped printing the token would
+                    # narrow the report, not silently widen it.
+                    selected = collected - collect_tokens["deselected"]
+                else:
+                    selected = collected
         stopping = _STOPPING.search(line)
         if stopping:
             stopped_after = int(stopping.group("failures"))
+        said = _SESSION_STATEMENT.search(line)
+        if said:
+            stated = (int(said.group("started")), int(said.group("collected")))
         stripped = line.strip()
         if _SUMMARY_LINE.match(stripped):
             summary = stripped
@@ -240,8 +321,30 @@ def parse_run(text: str) -> RunReport:
         if match.group("label") in _EXECUTED_LABELS
     }
     executed = sum(counts.values())
+    # The summary line labels every outcome the session produced, including the
+    # ones *collection* produced: a module that failed to import is an ``error``
+    # and one that skipped itself is a ``skipped``, and neither was ever one of
+    # the selected items. Counting them as executed items compares a count of
+    # outcomes against a count of items, and the difference between those two is
+    # not "never ran" - it understates it by exactly the collection-phase
+    # outcomes. The collection line already reported them, so they are
+    # subtracted here from the same line that supplied ``selected``.
+    for label in ("error", "skipped"):
+        at_collection = collect_tokens.get(label, 0)
+        if at_collection:
+            executed -= min(at_collection, _outcome_count(counts, label))
+    executed = max(executed, 0)
     assert selected is not None
     never_ran = max(selected - executed, 0)
+    if stated is not None:
+        # One owner for the subtraction. The reporter held the session's own
+        # item list, so its pair settles the extent and the arithmetic above
+        # stays as the fallback for a log that carries no such section - a run
+        # from before it was wired, or one whose reporter never got to speak.
+        started, session_collected = stated
+        selected = session_collected
+        executed = started
+        never_ran = max(session_collected - started, 0)
     truncated = stopped_after is not None or never_ran > 0
 
     return RunReport(
@@ -252,6 +355,7 @@ def parse_run(text: str) -> RunReport:
         never_ran=never_ran,
         stopped_after=stopped_after,
         counts=counts,
+        stated_by_session=stated is not None,
     )
 
 
@@ -273,6 +377,8 @@ def render(report: RunReport) -> str:
         lines.append(f"| items that never ran | {report.never_ran} |")
     if report.stopped_after is not None:
         lines.append(f"| stopped after | {report.stopped_after} failure(s) |")
+    if report.stated_by_session:
+        lines.append("| extent stated by | the session reporter, in process |")
     for label in sorted(report.counts):
         lines.append(f"| {label} | {report.counts[label]} |")
 

--- a/tests/test_truncated_test_run_is_reported.py
+++ b/tests/test_truncated_test_run_is_reported.py
@@ -28,6 +28,9 @@ bound.
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -147,6 +150,232 @@ class TestACompleteRunIsNotReportedAsTruncated:
         assert report.outcome == "complete"
         assert report.selected == 500
         assert report.never_ran == 0
+
+
+# Collection lines produced by running pytest itself, one per way the tokens
+# after the item count can be arranged. pytest appends them conditionally and in
+# a fixed order (``TerminalReporter.report_collect``)::
+#
+#     collected N items[ / E errors][ / D deselected][ / S skipped][ / X selected]
+#
+# so ``deselected`` and ``selected`` are adjacent only when neither of the other
+# two fired. Each row carries the summary line the same run printed, and the
+# extent pytest's own item list had: ``selected`` is ``len(session.items)`` and
+# ``ran`` is how many of those were entered.
+_COLLECTION_SHAPES = [
+    pytest.param(
+        "collected 5 items / 3 deselected / 2 selected",
+        "===== 2 passed, 3 deselected in 0.01s =====",
+        2,
+        2,
+        id="deselected-and-selected-adjacent",
+    ),
+    pytest.param(
+        "collected 5 items / 3 deselected / 1 skipped / 2 selected",
+        "===== 2 passed, 1 skipped, 3 deselected in 0.01s =====",
+        2,
+        2,
+        id="a-module-skipped-itself-between-them",
+    ),
+    pytest.param(
+        "collected 5 items / 1 error / 3 deselected / 2 selected",
+        "===== 3 deselected, 1 error in 0.13s =====",
+        2,
+        0,
+        id="a-module-failed-to-import-before-them",
+    ),
+    pytest.param(
+        "collected 5 items / 1 error / 3 deselected / 1 skipped / 2 selected",
+        "===== 1 skipped, 3 deselected, 1 error in 0.13s =====",
+        2,
+        0,
+        id="both-tokens-between-them",
+    ),
+    pytest.param(
+        "collected 5 items / 1 error",
+        "===== 1 error in 0.13s =====",
+        5,
+        0,
+        id="a-failed-import-with-nothing-deselected",
+    ),
+]
+
+
+class TestTheExtentIsMeasuredOnOnePopulation:
+    """``never_ran`` subtracts executed items from selected items - one population.
+
+    Both halves used to be read off a different one. ``selected`` fell back to the
+    pre-deselection item count whenever an ``error`` or ``skipped`` token landed
+    between ``deselected`` and ``selected``, and ``executed`` summed outcome
+    labels that include the ones *collection* produced - a module that failed to
+    import, or one that skipped itself - neither of which was ever a selected
+    item. The two errors point opposite ways and partly cancel, which is why a
+    run whose tokens happened to be adjacent read correctly.
+    """
+
+    @pytest.mark.parametrize(("collect_line", "summary_line", "selected", "ran"), _COLLECTION_SHAPES)
+    def test_every_collection_line_shape_reports_the_extent_pytest_had(
+        self, collect_line: str, summary_line: str, selected: int, ran: int
+    ) -> None:
+        report = parse_run(f"{collect_line}\n{summary_line}\n")
+
+        assert report.selected == selected
+        assert report.executed == ran
+        assert report.never_ran == selected - ran
+        assert report.outcome == ("complete" if ran == selected else "truncated")
+
+    def test_a_scoped_run_that_finished_is_not_warned_about(self) -> None:
+        # The everyday case: a subset selected with -k, in a suite where some
+        # module skips itself for an absent optional dependency. Every selected
+        # item ran, so a pull request must carry no truncation warning.
+        log = (
+            "collected 5 items / 3 deselected / 1 skipped / 2 selected\n"
+            "===== 2 passed, 1 skipped, 3 deselected in 0.01s =====\n"
+        )
+        report = parse_run(log)
+
+        assert report.outcome == "complete"
+        assert render(report).count("::warning") == 0
+
+
+class TestTheSubtractionHasOneOwner:
+    """The session reporter computes this in process; this module reads it.
+
+    ``tests/session_truncation.py`` holds the session's own item list, so when
+    its section is in the log the extent is already settled and re-deriving it
+    from text would give a second answer with nothing to say which is right.
+    """
+
+    _STATED = "session truncated: 30 of 100 collected tests ran\n===== 1 failed, 28 passed, 1 skipped in 9.00s =====\n"
+
+    def test_the_reporters_statement_is_preferred_over_the_counts_line(self) -> None:
+        # The collection line would put ``selected`` at 900; the reporter, which
+        # held the items, says 100. Only one of those can be reported.
+        log = "collected 900 items / 800 deselected / 100 selected\n" + self._STATED
+        report = parse_run(log)
+
+        assert report.stated_by_session is True
+        assert report.selected == 100
+        assert report.executed == 30
+        assert report.never_ran == 70
+        assert report.outcome == "truncated"
+
+    def test_the_provenance_of_the_numbers_is_reported(self) -> None:
+        log = "collected 100 items\n" + self._STATED
+        assert "extent stated by | the session reporter" in render(parse_run(log))
+
+    def test_a_log_without_the_section_still_gets_the_arithmetic(self) -> None:
+        # The fallback: a log from before the reporter was wired, or one whose
+        # reporter never got to speak, is still described.
+        report = parse_run(TRUNCATED_LOG)
+
+        assert report.stated_by_session is False
+        assert report.outcome == "truncated"
+        assert report.never_ran == 12036
+
+    def test_the_reporters_heading_is_not_read_as_a_collection_or_summary_line(self) -> None:
+        # It says "collected tests", not "collected N items", and carries no
+        # trailing duration - so neither of the other two patterns claims it.
+        # Without that the section would be parsed as the run's own extent.
+        heading = "===== session truncated: 30 of 100 collected tests ran ====="
+        report = parse_run(f"{heading}\n")
+
+        assert report.outcome == "unreadable"
+
+
+# A conftest that records what pytest's own session held, so the assertion below
+# is grounded in pytest rather than in a count written out by hand: ``selected``
+# is ``len(session.items)`` after deselection, and ``started`` counts the items
+# that were entered. This is the same pair ``tests/session_truncation.py`` keeps.
+_TRUTH_CONFTEST = """
+import json, os
+_state = {"selected": None, "started": 0}
+
+
+def pytest_collection_finish(session):
+    _state["selected"] = len(session.items)
+
+
+def pytest_runtest_logfinish(nodeid):
+    _state["started"] += 1
+
+
+def pytest_sessionfinish(session, exitstatus):
+    with open(os.environ["TRUTH_OUT"], "w") as handle:
+        json.dump(_state, handle)
+"""
+
+_KEEP_AND_DROP = """
+def test_keep_one(): pass
+def test_keep_two(): pass
+def test_drop_one(): pass
+def test_drop_two(): pass
+def test_drop_three(): pass
+"""
+
+# A module that skips itself for an absent optional dependency - the idiom used
+# by several hundred files in this suite - and one that fails to import. Either
+# puts a token between ``deselected`` and ``selected`` on the collection line.
+_SKIPS_ITSELF = 'import pytest\npytest.importorskip("a_dependency_this_suite_does_not_have")\ndef test_never(): pass\n'
+_FAILS_TO_IMPORT = 'raise RuntimeError("this module cannot be imported")\n'
+
+
+class TestTheReportAgreesWithPytestsOwnCounts:
+    """The end-to-end pin: real sessions, and the extent pytest itself recorded.
+
+    The rows in :data:`_COLLECTION_SHAPES` are transcriptions. This runs the
+    sessions that produce them, so the expected numbers come from pytest's own
+    item list rather than from this file.
+    """
+
+    @pytest.mark.parametrize(
+        ("modules", "select"),
+        [
+            pytest.param({"test_a.py": _KEEP_AND_DROP}, "keep", id="deselecting-only"),
+            pytest.param(
+                {"test_a.py": _KEEP_AND_DROP, "test_skips.py": _SKIPS_ITSELF},
+                "keep",
+                id="deselecting-with-a-self-skipping-module",
+            ),
+            pytest.param(
+                {"test_a.py": _KEEP_AND_DROP, "test_broken.py": _FAILS_TO_IMPORT},
+                "keep",
+                id="deselecting-with-an-unimportable-module",
+            ),
+            pytest.param(
+                {
+                    "test_a.py": _KEEP_AND_DROP,
+                    "test_broken.py": _FAILS_TO_IMPORT,
+                    "test_skips.py": _SKIPS_ITSELF,
+                },
+                "keep",
+                id="deselecting-with-both",
+            ),
+            pytest.param({"test_a.py": _KEEP_AND_DROP}, None, id="selecting-everything"),
+        ],
+    )
+    def test_the_reported_extent_is_the_extent_the_session_had(
+        self, tmp_path: Path, modules: dict[str, str], select: str | None
+    ) -> None:
+        (tmp_path / "conftest.py").write_text(_TRUTH_CONFTEST)
+        for name, body in modules.items():
+            (tmp_path / name).write_text(body)
+        truth_file = tmp_path / "truth.json"
+
+        environment = {**os.environ, "TRUTH_OUT": str(truth_file), "PYTEST_ADDOPTS": ""}
+        command = [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", *modules]
+        if select is not None:
+            command += ["-k", select]
+        completed = subprocess.run(command, cwd=tmp_path, env=environment, capture_output=True, text=True)
+
+        truth = json.loads(truth_file.read_text())
+        assert truth["selected"] is not None, "the session never finished collecting, so it poses no case"
+        report = parse_run(completed.stdout)
+
+        assert report.selected == truth["selected"]
+        assert report.executed == truth["started"]
+        assert report.never_ran == truth["selected"] - truth["started"]
+        assert report.outcome == ("complete" if report.never_ran == 0 else "truncated")
 
 
 class TestARunThatNeverReportedIsNamedApart:


### PR DESCRIPTION
`scripts/report_truncated_test_run.py` decides whether a pull request carries a "the failure count is a lower bound, not a total" warning, from `never_ran = selected - executed`. Both halves were read off a different population, so the difference between them was not the number of items that never ran.

![extent measured on five real pytest sessions](https://raw.githubusercontent.com/cagataycali/robots/0dc4c16d3782a8fbb9ff884c23ad4301c24eb624/.artifacts/truncation-extent.png)

## The two halves

**`selected`** came from a pattern expecting `deselected` and `selected` adjacent on pytest's collection line. pytest appends those tokens conditionally, in a fixed order (`TerminalReporter.report_collect`):

```
collected N items[ / E errors][ / D deselected][ / S skipped][ / X selected]
```

A collection error or a module-level skip lands between them, the `selected` group reads as absent, and the count falls back to the pre-deselection total.

**`executed`** summed the outcome labels on the summary line. Those include the labels *collection* produced: a module that fails to import is an `error`, one that skips itself for an absent optional dependency is a `skipped`. Neither was ever a selected item.

The two errors point opposite ways and partly cancel. That is why a run whose tokens happen to be adjacent reads correctly, and why `test_deselected_items_are_not_reported_as_never_run` passed: its fixture poses `collected 900 items / 400 deselected / 500 selected`, the one arrangement where the wrong rule coincides with the right one.

## Measured

Five real pytest sessions, one per arrangement, graded against the counts pytest's own session held (`len(session.items)`, and the items it saw entered).

| collection line the session printed | pytest had | before | after |
|---|---|---|---|
| `collected 5 items / 3 deselected / 2 selected` | 2 ran, 0 never | complete, 0 never ran | complete, 0 never ran |
| `... / 3 deselected / 1 skipped / 2 selected` | 2 ran, 0 never | **truncated, 2 never ran** | complete, 0 never ran |
| `... / 1 error / 3 deselected / 2 selected` | 0 ran, 2 never | truncated, **4** never ran | truncated, 2 never ran |
| `... / 1 error / 3 deselected / 1 skipped / 2 selected` | 0 ran, 2 never | truncated, **3** never ran | truncated, 2 never ran |
| `collected 5 items / 1 error` | 0 ran, 5 never | truncated, **4** never ran | truncated, 5 never ran |

Row 2 is the one that matters most: a run that selected 2 items with `-k` and ran both, in a tree where one module skipped itself, was reported as truncated with 40% of the suite never run. That is the false warning the `TestACompleteRunIsNotReportedAsTruncated` control exists to prevent. Four of the five arrangements misreported the extent; the fifth is the one already pinned. After the change all five agree with pytest exactly.

`-k` and `-m` are the everyday way to scope a run, and several hundred files in this suite guard themselves with a module-level `importorskip`, so row 2 is the ordinary case rather than a contrived one. The required check itself deselects nothing today, so it is not currently exposed - it would become exposed by any change that selects a subset, which is one of the options under discussion in #3143.

## One owner for the subtraction

`tests/session_truncation.py` already computes this in process, from the session's own item list, and writes it into the log this script reads. Two derivations of one number can disagree, so when that section is present it now settles the extent and the text arithmetic is the fallback - for a log written before the reporter was wired, or one whose reporter never got to speak. The report states which of the two produced the numbers.

The fallback itself now takes both numbers off the collection line, which already reports the deselected count and the collection-phase outcomes.

## Tests

`tests/test_truncated_test_run_is_reported.py`, +15 cells. On `main`'s source with only this file applied: **11 failed, 27 passed**; after: **51 passed** with `tests/test_session_truncation_is_reported.py`.

Four of the new cells pass on both trees and are the controls: the adjacent arrangement, both real sessions that deselect nothing, and the pin that the reporter's own heading is not mistaken for a collection or summary line.

`TestTheReportAgreesWithPytestsOwnCounts` runs the five sessions as subprocesses and takes the expected numbers from a conftest that records `len(session.items)` and counts `pytest_runtest_logfinish`, so the parametrized rows above are graded against pytest rather than against literals in the test file.

Both figures the existing suite pins are unchanged: the 12036 / 25.8% measured on run 33690980247, and the complete-run control.

## Size

`+392 / -7` over 4 files: `+113/-7` script, `+229` tests, `+11` docs, `+39` changelog fragment. Production delta is `+29` executable statements by AST count (91 -> 120), most of it the collection-token reader and the delegation branch.

Refs #3169.
