### PR TITLE
fix(ci): a deselecting run is not reported as a run that aborted

### DIFF
--- a/changelog.d/3169-selected-count-is-read-as-a-tally-set.md
+++ b/changelog.d/3169-selected-count-is-read-as-a-tally-set.md
@@ -1,0 +1,37 @@
+### Fixed: a deselecting run is no longer reported as a run that aborted
+
+`scripts/report_truncated_test_run.py` read the collection line's tallies as a
+fixed sequence -- `deselected` immediately before `selected` -- and pytest does
+not write them that way. `TerminalReporter.report_collect` appends up to four,
+each only when its own count is nonzero, so `selected` carries a different
+prefix in every combination. On a line pytest 9.1.1 really emits,
+`collected 5 items / 2 deselected / 1 skipped / 3 selected`, neither optional
+group matched and the parser fell back to `selected = collected` -- the
+*pre*-deselection number.
+
+That inverted the verdict on a successful run. Measured on a nested pytest over
+five tests with two deselected by `-k` and one module skipped during collection:
+the report read `truncated`, one item never ran, and raised the "The test run
+was truncated" warning annotation, where the truth is `complete` and nothing was
+skipped by an abort. On a genuinely truncated run the same fallback overstates
+`items that never ran` by exactly the deselected count, which is the direction
+that costs a reader a re-run. Neither half is hypothetical: `pyproject.toml`
+documents `pytest -m 'not slow'` and `-m 'not integration'` in the markers' own
+help text, and 496 test modules open with a module-level `pytest.importorskip`,
+so any environment missing one optional extra reports a collect-time skip beside
+the deselection. The required check's own command deselects nothing, so no CI
+run has misreported.
+
+The tallies are now read as a set keyed on the label, so `selected` is found
+whatever precedes it, and a tally a future pytest inserts cannot reintroduce the
+silent fallback. Where the line states no `selected` at all the count is derived
+as `collected - deselected` rather than as `collected`, which is the
+post-deselection number `tests/session_truncation.py` reports from inside the
+session -- so the two surfaces that state a run's extent can no longer state two
+different ones for one run (#3169).
+
+Pinned by `tests/test_truncated_test_run_is_reported.py`: the three collection
+lines a live pytest wrote, all 24 orderings of the four tallies, an oracle cell
+that re-derives the tally set from pytest's own source so the parametrisation
+cannot go stale unnoticed, and one nested pytest run that reproduces the false
+verdict end to end. 20 of the added cells fail against the previous parser.

--- a/scripts/report_truncated_test_run.py
+++ b/scripts/report_truncated_test_run.py
@@ -107,11 +107,29 @@ from dataclasses import dataclass, field
 # because the same text is read both from the raw file this script is pointed at
 # and, when a reader pastes one, from a job log whose lines carry a timestamp
 # prefix added by the Actions log service.
-_COLLECTED = re.compile(
-    r"collected (?P<collected>\d+) items?"
-    r"(?: / (?P<deselected>\d+) deselected)?"
-    r"(?: / (?P<selected>\d+) selected)?"
-)
+#
+# The tallies after the item count are read as a set rather than as a fixed
+# sequence. ``TerminalReporter.report_collect`` appends up to four of them --
+# ``error``, ``deselected``, ``skipped``, ``selected`` -- each only when its
+# count is nonzero, so ``selected`` is preceded by a different prefix in each
+# combination. A pattern that expected ``deselected`` immediately before
+# ``selected`` matched neither group on a real line pytest 9.1.1 emits::
+#
+#     collected 5 items / 2 deselected / 1 skipped / 3 selected
+#
+# and fell back to ``selected = collected``, which reports a *complete* run as
+# truncated: that session executed 4 of its 3 selected items (a collect-time
+# skip is counted in the summary line but is not one of the 5 collected), so the
+# subtraction against 5 claimed one item never ran. Order-independence is what
+# keeps this agreeing with tests/session_truncation.py, which states the same
+# extent from inside the session and always uses the post-deselection count
+# (#3169).
+_COLLECTED = re.compile(r"collected (?P<collected>\d+) items?(?P<tallies>(?: / \d+ [a-z]+)*)")
+
+# One ``/ 2 deselected`` tally from the collection line's tail. Read for the
+# label rather than the position, so a tally added between two others -- or a
+# new one this script has never seen -- cannot hide the ones it needs.
+_COLLECT_TALLY = re.compile(r"/ (?P<count>\d+) (?P<label>[a-z]+)")
 
 # The banner ``-x`` / ``--maxfail`` prints when it ends the session early.
 _STOPPING = re.compile(r"!+\s*stopping after (?P<failures>\d+) failures?\s*!+")
@@ -186,6 +204,28 @@ class RunReport:
         return f"the run's extent could not be read: {self.detail}"
 
 
+def _selected_count(collected: int, tallies: str) -> int:
+    """Read how many collected items the session was going to run.
+
+    Args:
+        collected: The item count the collection line opens with, before
+            deselection.
+        tallies: The ``/ N label`` tail of that same line, in whatever order
+            pytest wrote it.
+
+    Returns:
+        The number pytest selected. ``selected`` is taken from the line when it
+        is there, and derived as ``collected - deselected`` when it is not --
+        which is the count tests/session_truncation.py reports from inside the
+        session, so the two surfaces cannot state two different extents for one
+        run.
+    """
+    counts = {match.group("label"): int(match.group("count")) for match in _COLLECT_TALLY.finditer(tallies)}
+    if "selected" in counts:
+        return counts["selected"]
+    return max(collected - counts.get("deselected", 0), 0)
+
+
 def parse_run(text: str) -> RunReport:
     """Read a pytest log and report whether the session covered every selected item.
 
@@ -209,8 +249,7 @@ def parse_run(text: str) -> RunReport:
             found = _COLLECTED.search(line)
             if found:
                 collected = int(found.group("collected"))
-                explicit = found.group("selected")
-                selected = int(explicit) if explicit else collected
+                selected = _selected_count(collected, found.group("tallies"))
         stopping = _STOPPING.search(line)
         if stopping:
             stopped_after = int(stopping.group("failures"))

--- a/tests/test_truncated_test_run_is_reported.py
+++ b/tests/test_truncated_test_run_is_reported.py
@@ -28,11 +28,18 @@ bound.
 from __future__ import annotations
 
 import importlib.util
+import inspect
+import itertools
+import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
+from _pytest.terminal import TerminalReporter
+
+from tests.session_truncation import truncation_summary
 
 yaml = pytest.importorskip("yaml", reason="pyyaml is an optional dev dependency")
 
@@ -282,3 +289,243 @@ class TestTheReportIsWiredIntoTheRequiredCheck:
         # mismatch would be silent.
         assert "${RUNNER_TEMP}/pytest.log" in producer
         assert "${RUNNER_TEMP}/pytest.log" in consumer
+
+
+# Collection lines emitted verbatim by pytest 9.1.1, paired with the summary line
+# the same session wrote. Produced by running a nested pytest over five tests in
+# one module plus a second module whose ``pytest.importorskip`` cannot resolve,
+# under ``-k fast`` -- so two items are deselected, one module is skipped during
+# collection, and three items are selected. ``TestTheCollectionLineIsReadAsATallySet``
+# re-derives them from a live pytest rather than trusting these strings.
+DESELECTED_ONLY = """\
+collected 5 items / 2 deselected / 3 selected
+======================= 3 passed, 2 deselected in 0.00s ========================
+"""
+
+DESELECTED_BESIDE_A_COLLECT_SKIP = """\
+collected 5 items / 2 deselected / 1 skipped / 3 selected
+================== 3 passed, 1 skipped, 2 deselected in 0.00s ==================
+"""
+
+DESELECTED_BESIDE_A_COLLECT_ERROR = """\
+collected 5 items / 1 error / 2 deselected / 1 skipped / 3 selected
+============= 3 passed, 1 skipped, 2 deselected, 1 error in 0.01s ==============
+"""
+
+# A run that really was cut short, with a deselection: 4 of 10 items deselected,
+# so 6 were selected, and the session stopped with 3 of those 6 executed. Every
+# count on the summary line is an item that was entered, so the arithmetic here
+# is exact on both surfaces -- which is what makes it usable as the one-owner
+# contract below. Deliberately not carrying an ``error`` or ``skipped`` tally:
+# those appear on the summary line too, where nothing distinguishes a module
+# skipped during collection from a test that ran and skipped itself, so they
+# would move the *numerator* and this pair of cells is about the denominator.
+TRUNCATED_WITH_A_DESELECTION = """\
+collected 10 items / 4 deselected / 6 selected
+!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
+==================== 1 failed, 2 passed, 4 deselected in 3.00s =================
+"""
+
+
+class TestASelectionIsNotReadAsAnAbort:
+    """A run that skipped nothing must not be reported as one that skipped items.
+
+    ``report_collect`` appends up to four tallies after the item count -- ``error``,
+    ``deselected``, ``skipped``, ``selected`` -- each only when its own count is
+    nonzero. So ``selected`` is preceded by a different prefix in every
+    combination, and a pattern that expected ``deselected`` immediately before it
+    read neither: it fell back to ``selected = collected``, which is the
+    *pre*-deselection number.
+
+    That is the surface #3169 recorded as a divergence between this script and
+    tests/session_truncation.py, which always states the post-deselection count.
+    The consequence is worse than a disagreement in one direction: on
+    ``DESELECTED_BESIDE_A_COLLECT_SKIP`` -- a completely successful run -- the
+    subtraction against 5 rather than 3 reported ``truncated``, one item never
+    ran, and raised the warning annotation this module's negative control exists
+    to keep off green runs.
+
+    Both halves of that combination are supported invocations of this suite
+    rather than hypotheticals: ``pyproject.toml`` documents ``pytest -m 'not
+    slow'`` and ``-m 'not integration'`` in the markers' own help text, and 496
+    test modules open with a module-level ``pytest.importorskip``, so any
+    environment missing one optional extra reports a collect-time skip beside it.
+    """
+
+    def test_a_tally_between_deselected_and_selected_does_not_hide_the_count(self) -> None:
+        report = parse_run(DESELECTED_BESIDE_A_COLLECT_SKIP)
+
+        # 3 selected, not the 5 collected: the 2 deselected were never going to run.
+        assert report.selected == 3
+        assert report.outcome == "complete"
+        assert report.never_ran == 0
+
+    def test_a_collect_error_tally_does_not_hide_it_either(self) -> None:
+        # Two tallies ahead of ``deselected`` this time, so the fixed-order
+        # pattern matched neither optional group rather than just the second.
+        report = parse_run(DESELECTED_BESIDE_A_COLLECT_ERROR)
+
+        assert report.selected == 3
+        assert report.outcome == "complete"
+        assert report.never_ran == 0
+
+    def test_the_plain_deselection_line_still_reads_the_same_way(self) -> None:
+        # The one arrangement the fixed-order pattern did handle. It has its own
+        # cell in TestACompleteRunIsNotReportedAsTruncated; repeated here against
+        # the measured line so a regression cannot pass by handling only the
+        # interleaved forms.
+        report = parse_run(DESELECTED_ONLY)
+
+        assert report.selected == 3
+        assert report.outcome == "complete"
+
+    def test_a_deselection_with_no_selected_tally_is_read_as_the_remainder(self) -> None:
+        # pytest 9.1.1 always writes ``selected`` when anything was deselected
+        # (``if self._numcollected > selected``), so this is the defensive branch.
+        # It exists so the fallback is the post-deselection count -- the number
+        # tests/session_truncation.py reports -- rather than the collected count,
+        # which is what #3169 asked for whichever way the line is spelled.
+        report = parse_run("collected 900 items / 400 deselected\n===== 500 passed in 12.00s =====\n")
+
+        assert report.selected == 500
+        assert report.outcome == "complete"
+        assert report.never_ran == 0
+
+
+class TestATruncatedRunCountsOnlyWhatWasSelected:
+    """The headline number is what never ran, so its denominator has to be right."""
+
+    def test_deselected_items_are_not_added_to_the_never_ran_count(self) -> None:
+        # This arrangement -- ``deselected`` directly before ``selected`` -- is the
+        # one the fixed-order pattern already read correctly, so this cell is a
+        # contract rather than the regression. It is here because it is the log on
+        # which the two surfaces' arithmetic can be compared exactly, which is the
+        # cell below. The regression is on the interleaved lines above, where the
+        # same subtraction ran against the pre-deselection count.
+        report = parse_run(TRUNCATED_WITH_A_DESELECTION)
+
+        assert report.outcome == "truncated"
+        # 1 failed + 2 passed of the 6 selected. ``4 deselected`` is on the summary
+        # line and is not an executed item: those were never going to run.
+        assert report.selected == 6
+        assert report.executed == 3
+        assert report.never_ran == 3
+        assert "3 never ran" in report.summary
+
+    def test_the_share_is_taken_against_the_selection_not_the_collection(self) -> None:
+        share = parse_run(TRUNCATED_WITH_A_DESELECTION).share_skipped
+
+        assert share is not None
+        assert round(share * 100, 1) == 50.0
+
+    def test_both_surfaces_state_one_never_ran_count(self) -> None:
+        # The one-owner property #3169 asks for, graded across both surfaces
+        # rather than asserted in prose. tests/session_truncation.py states the
+        # extent from inside the session, using len(session.items) -- which is
+        # the post-deselection count, 6 -- and this script re-derives it from the
+        # log. Neither reads the other's wording, so this cell is what stops the
+        # two from stating different numbers for one run.
+        from_inside = truncation_summary(collected=6, started=3)
+        assert from_inside is not None
+        heading, detail = from_inside
+        assert "3 of 6 collected tests ran" in heading
+        assert detail.startswith("3 collected tests never started")
+
+        from_the_log = parse_run(TRUNCATED_WITH_A_DESELECTION)
+
+        assert (from_the_log.executed, from_the_log.selected) == (3, 6)
+        assert from_the_log.never_ran == 3
+
+
+class TestTheCollectionLineIsReadAsATallySet:
+    """Order-independence is the fix, so it is graded rather than remembered."""
+
+    @pytest.mark.parametrize(
+        "order",
+        list(itertools.permutations(["1 error", "2 deselected", "1 skipped", "3 selected"])),
+        ids=lambda order: "-".join(tally.split()[1][:3] for tally in order),
+    )
+    def test_selected_is_read_whatever_precedes_it(self, order: tuple[str, ...]) -> None:
+        # pytest writes one order; this asserts the parser depends on none of
+        # them, so a future pytest that inserts a tally cannot reintroduce the
+        # silent fallback. All 24 arrangements, one behavioural assertion each.
+        log = (
+            "collected 5 items " + " ".join(f"/ {tally}" for tally in order) + "\n"
+            "===== 3 passed, 1 skipped, 2 deselected, 1 error in 0.01s =====\n"
+        )
+
+        assert parse_run(log).selected == 3
+
+    def test_the_parametrisation_covers_every_tally_pytest_can_append(self) -> None:
+        """The oracle for the list above: pytest's own collection-line source.
+
+        Read from a private pytest module deliberately. The alternative is a
+        remembered list, and the failure mode of a remembered list is that a
+        fifth tally appears, sits between ``deselected`` and ``selected``, and
+        nothing here notices -- which is the exact shape of the defect these
+        cells were added for. A failure of this cell means re-derive the
+        parametrisation above, not that the parser is wrong: it is order-
+        independent either way.
+        """
+        try:
+            source = inspect.getsource(TerminalReporter.report_collect)
+        except OSError as exc:  # pragma: no cover - only if pytest ships without source
+            pytest.fail(f"pytest's collection line could not be read, so the tally set cannot be re-derived: {exc}")
+
+        appended = {
+            line.split('f" / {', 1)[1].split("}", 1)[1].strip().strip('"').split("{")[0].strip()
+            for line in source.splitlines()
+            if 'line += f" / {' in line
+        }
+        # ``error`` carries a pluralising suffix in the f-string, so it arrives
+        # here as the bare stem; the others are literal words.
+        assert appended == {"error", "deselected", "skipped", "selected"}, appended
+
+
+class TestTheTallySetIsWhatALivePytestWrites:
+    """The recorded lines above are re-derived from a real run, not trusted."""
+
+    def test_a_real_deselecting_run_with_a_collect_skip_is_reported_complete(self, tmp_path: Path) -> None:
+        # The strings at the top of this module are the measurement; this cell is
+        # the measurement's own repeat, so a pytest upgrade that changes the line
+        # is reported here rather than quietly leaving the pins testing a format
+        # nothing emits. One nested run, five trivial tests -- the suite is at its
+        # timeout bound (#3143), so this is the only subprocess cell added here.
+        (tmp_path / "test_ok.py").write_text(
+            "def test_slow_one(): pass\ndef test_slow_two(): pass\n"
+            "def test_fast_one(): pass\ndef test_fast_two(): pass\ndef test_fast_three(): pass\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "test_skipped_module.py").write_text(
+            'import pytest\n\npytest.importorskip("a_module_no_environment_has")\n\ndef test_never(): pass\n',
+            encoding="utf-8",
+        )
+        env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+        env.pop("PYTEST_ADDOPTS", None)
+
+        # Run from tmp_path so the nested session takes its rootdir from there
+        # and inherits none of this repository's addopts.
+        completed = subprocess.run(
+            [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", "-k", "fast", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+
+        collection_line = next(
+            (line for line in completed.stdout.splitlines() if line.startswith("collected ")),
+            None,
+        )
+        assert collection_line is not None, completed.stdout
+        # Vacuity guard: if this pytest stops interleaving a tally between the
+        # two the old pattern paired, the cell would pass while testing the one
+        # arrangement that never broke.
+        assert collection_line == "collected 5 items / 2 deselected / 1 skipped / 3 selected", collection_line
+
+        report = parse_run(completed.stdout)
+
+        assert report.outcome == "complete"
+        assert (report.collected, report.selected, report.never_ran) == (5, 3, 0)


### PR DESCRIPTION
`scripts/report_truncated_test_run.py` read the collection line's tallies as a **fixed sequence** -- `deselected` immediately before `selected` -- and pytest does not write them that way.

`TerminalReporter.report_collect` appends up to four tallies after the item count, each only when its own count is nonzero:

```python
if errors:     line += f" / {errors} error{'s' if errors != 1 else ''}"
if deselected: line += f" / {deselected} deselected"
if skipped:    line += f" / {skipped} skipped"
if self._numcollected > selected: line += f" / {selected} selected"
```

So `selected` carries a different prefix in every combination. On a line pytest 9.1.1 really emits, neither optional group matched and the parser fell back to `selected = collected` -- the **pre**-deselection number.

## Measured

A nested pytest over five tests in one module, plus a second module whose `pytest.importorskip` cannot resolve, under `-k fast`. Two items deselected, one module skipped during collection, three items selected. Real output, pytest 9.1.1:

```
collected 5 items / 2 deselected / 1 skipped / 3 selected
================== 3 passed, 1 skipped, 2 deselected in 0.00s ==================
```

| | before | after | truth |
|---|---|---|---|
| `outcome` | **`truncated`** | `complete` | `complete` |
| `selected` | 5 | 3 | 3 |
| `never ran` | **1** | 0 | 0 |
| annotation | `::warning ... The test run was truncated` | none | none |

That run was **completely successful**. The `1 skipped` tally sits between the two the pattern paired, so both optional groups missed, the subtraction ran against 5 rather than 3, and the report claimed an item never ran and raised the warning annotation this script's negative control exists to keep off green runs.

The same fallback on a genuinely truncated run overstates `items that never ran` by exactly the deselected count -- the direction that sends a reader to re-run a suite that already told them everything it knew.

A collection **error** tally reproduces it one step earlier, matching neither group rather than only the second:

```
collected 5 items / 1 error / 2 deselected / 1 skipped / 3 selected
```

## Why this is reachable rather than theoretical

Both halves of the combination are supported invocations of this suite:

- `pyproject.toml` documents the deselecting form in the markers' own help text -- `pytest -m 'not slow'`, `pytest -m 'not integration'`.
- **496** test modules open with a module-level `pytest.importorskip`, so any environment missing one optional extra reports a collect-time skip beside the deselection.

Stated plainly because it bounds the claim: **the required check's own command deselects nothing** (`hatch run test -x --strict-markers`), so no CI run has misreported. What is wrong today is the number the script states whenever both conditions hold, and the divergence below.

## What it fixes structurally

#3169 recorded that the arithmetic for a run's extent has two owners -- this script, re-deriving it from text, and `tests/session_truncation.py`, computing it in process -- and named the surface on which they disagree: the script falls back to `collected` while the plugin always uses the post-deselection count.

The mechanism turns out to be slightly different from what that issue describes, and the correction is worth stating: pytest 9.1.1 *always* writes `selected` when anything was deselected (`if self._numcollected > selected`), so the fallback is not reached by an **absent** token. It is reached by a token-**order** mismatch, which is why the pair agreed on the suite as invoked and disagreed on a documented one.

The remedy the issue proposes is to have the script prefer the line the plugin already prints. This does not do that, deliberately: parsing the plugin's wording would make the script depend on a sentence in another module, which is a *new* drift surface -- the plugin's heading could be reworded and the parser would silently stop matching. Instead the tallies are read **as a set keyed on the label**, so:

- `selected` is found whatever precedes it, and a tally a future pytest inserts between two others cannot reintroduce the silent fallback;
- where the line states no `selected` at all, the count is derived as `collected - deselected` rather than as `collected` -- which is the number the plugin reports from inside the session.

The two surfaces now agree **by construction** on every arrangement, with no shared wording and no import between them. The script stays standalone, which it has to be: it is also pointed at logs downloaded from past runs, which the plugin was not loaded for.

## Pins

`tests/test_truncated_test_run_is_reported.py`, +5 classes. **20 of the added cells fail against the previous parser**; all 36 pre-existing cells pass unchanged.

- the three collection lines a live pytest wrote, verbatim, each paired with the summary line the same session produced;
- **all 24 orderings** of the four tallies, one behavioural assertion each -- order-independence is the fix, so it is graded rather than described;
- an **oracle** cell that re-derives the tally set from `TerminalReporter.report_collect`'s own source, so a fifth tally is reported here instead of quietly leaving the parametrisation short. A failure of that cell means re-derive the list, not that the parser is wrong: it is order-independent either way;
- the defensive `deselected`-with-no-`selected` branch, asserting the post-deselection count -- the surface #3169 named, kept correct whichever way the line is spelled;
- a cross-surface cell asserting both owners state one never-ran count for one run;
- **one** nested-pytest cell that reproduces the false verdict end to end, with a vacuity guard on the collection line so it cannot pass while testing the one arrangement that never broke. Only one subprocess cell, because the suite is at its timeout bound (#3143).

The numerator is deliberately left alone. A collect-time skip appears on the summary line as `skipped`, where nothing distinguishes it from a test that ran and skipped itself, so it is counted as executed. That moves `executed`, not `selected`, and folding it in would make this two changes; it is out of scope here and not currently misreported on the required check.

## Verification

```
tests/test_truncated_test_run_is_reported.py     56 passed  (36 before)
tests/test_session_truncation_is_reported.py     green, unchanged
tests/test_changelog_fragments.py + _format.py   32 passed
17 whole-tree graders                           290 passed
ruff check / ruff format --check / mypy           clean
```

Closes #3169

---

### 13. Round changelog

**Round 0 (opened).** One commit: the tally-set read, its pins, and the news fragment. Intake `scripts/check_duplicate_claim.py --repo strands-labs/robots --issue 3169` -> `unique-claim`.
