### PR TITLE
fix(ci): how much of the suite ran is counted once, by the session that ran it

### DIFF
--- a/changelog.d/3172-truncation-extent-has-one-owner.md
+++ b/changelog.d/3172-truncation-extent-has-one-owner.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The job-summary report of how much of the required suite ran reads the extent
+  the session itself counted (`tests/session_truncation.py`) instead of
+  re-deriving it from the log's text, and falls back to the arithmetic only for a
+  log carrying no such section. The fallback now applies pytest's own rules --
+  the number selected is `collected - deselected`, and the collection line's
+  trailing tokens are read in any order -- so a run that reached every item it
+  selected is no longer reported as truncated, and the number of items executed
+  can no longer exceed the number collected.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,6 +38,13 @@ which states the size of the gap:
 A session that ran every test it collected prints nothing extra, so the section
 appears only where it changes what the counts below it mean.
 
+That section is where the extent is counted -- `len(session.items)` after
+deselection, against one tick per test entered. `scripts/report_truncated_test_run.py`
+puts the same statement on the job summary, where a reviewer reads it without
+downloading the log, and it reports the numbers that line already states rather
+than re-deriving them; reconstructing them from the log's text is its fallback
+for a run that was killed before the terminal summary.
+
 Coverage is collected through PEP 669 (`sys.monitoring`) rather than the default
 C trace function - `core = "sysmon"` in `[tool.coverage.run]`. It reports the
 same line coverage at roughly a tenth of the cost (measured +8.2% against

--- a/scripts/report_truncated_test_run.py
+++ b/scripts/report_truncated_test_run.py
@@ -62,6 +62,39 @@ what costs a round, because each hidden failure costs ~21 minutes of runner time
 plus one review approval, approval being this repository's scarcest resource
 (#1905).
 
+The session states its own extent, and this reading is the fallback
+------------------------------------------------------------------
+
+``tests/session_truncation.py`` states the same subtraction in the terminal
+summary, counted in process -- ``collected`` is ``len(session.items)`` after
+deselection and ``started`` is counted per test entered::
+
+    ===== session truncated: 34547 of 46583 collected tests ran =====
+    12036 collected tests never started, so the counts below are a floor, not a total.
+
+That is the owner of the extent, so this module reads that line when it is
+present and reports its numbers unchanged. Re-deriving them from the text is the
+fallback for a log that does not carry the section -- a run killed before the
+terminal summary, or a log kept from before it existed.
+
+Deriving it has to be pytest's own derivation
+---------------------------------------------
+
+The fallback reads the collection line, whose trailing tokens pytest writes in a
+fixed order and prints only when nonzero, so their positions relative to each
+other are not fixed::
+
+    collected 10 items / 1 error / 4 deselected / 1 skipped / 6 selected
+
+Two rules follow, and both are pytest's rather than this module's. The number
+selected is ``collected - deselected`` (``report_collect`` computes exactly
+that, and prints the token only when it differs from ``collected``), so it is
+read from ``deselected`` rather than from the presence of a ``selected`` token
+that another token can sit in front of. And a module skipped or failing at
+*import* is counted on both lines while being none of the collected items, so
+the counts line's totals exceed the item count by whatever the collection line
+already accounted for.
+
 A run killed mid-suite reports differently again
 -----------------------------------------------
 A job killed while pytest is still running writes no summary line at all, which
@@ -106,12 +139,19 @@ from dataclasses import dataclass, field
 # pytest's collection line. Matched with ``search`` rather than anchored,
 # because the same text is read both from the raw file this script is pointed at
 # and, when a reader pastes one, from a job log whose lines carry a timestamp
-# prefix added by the Actions log service.
-_COLLECTED = re.compile(
-    r"collected (?P<collected>\d+) items?"
-    r"(?: / (?P<deselected>\d+) deselected)?"
-    r"(?: / (?P<selected>\d+) selected)?"
-)
+# prefix added by the Actions log service. The trailing tokens are read as a run
+# of ``/ N label`` pairs rather than as an ordered alternation: pytest emits
+# ``errors``, ``deselected``, ``skipped`` and ``selected`` in that order and only
+# when each is nonzero, so an alternation naming two of them requires them to be
+# adjacent and a third token between them hides both.
+_COLLECTED = re.compile(r"collected (?P<collected>\d+) items?(?P<tokens>(?: / \d+ [a-z]+)*)")
+_COLLECT_TOKEN = re.compile(r"/ (?P<count>\d+) (?P<label>[a-z]+)")
+
+# The section tests/session_truncation.py writes above the counts line. The
+# session counted its own extent, so that is where the subtraction belongs and
+# this module delegates to it rather than keeping a second reading that can
+# report differently.
+_STATED_EXTENT = re.compile(r"session truncated: (?P<executed>\d+) of (?P<selected>\d+) collected tests ran")
 
 # The banner ``-x`` / ``--maxfail`` prints when it ends the session early.
 _STOPPING = re.compile(r"!+\s*stopping after (?P<failures>\d+) failures?\s*!+")
@@ -138,6 +178,17 @@ _LOG_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z ")
 # attempt at an item already counted under its final outcome.
 _EXECUTED_LABELS = frozenset({"failed", "passed", "skipped", "xfailed", "xpassed", "error", "errors"})
 
+# Outcomes the collection line has already accounted for, which are therefore not
+# among the items. A module skipped or failing at import is counted once there and
+# once on the counts line, so leaving it in the executed total makes the number of
+# items executed exceed the number collected.
+_NON_ITEM_COLLECT_LABELS = frozenset({"skipped", "error", "errors"})
+
+#: Who the reported extent came from, named in the report so a reader knows
+#: whether it was counted or reconstructed.
+_STATED_BY_SESSION = "the session's own count"
+_DERIVED_FROM_LOG = "derived from the log's counts"
+
 _COMPLETE = "complete"
 _TRUNCATED = "truncated"
 _NO_SUMMARY = "incomplete-no-summary"
@@ -155,6 +206,7 @@ class RunReport:
     never_ran: int | None = None
     stopped_after: int | None = None
     counts: dict[str, int] = field(default_factory=dict)
+    extent_source: str = ""
     detail: str = ""
 
     @property
@@ -200,8 +252,10 @@ def parse_run(text: str) -> RunReport:
     """
     collected: int | None = None
     selected: int | None = None
+    non_items = 0
     stopped_after: int | None = None
     summary: str | None = None
+    stated: tuple[int, int] | None = None
 
     for raw in text.splitlines():
         line = _LOG_TIMESTAMP.sub("", raw)
@@ -209,8 +263,17 @@ def parse_run(text: str) -> RunReport:
             found = _COLLECTED.search(line)
             if found:
                 collected = int(found.group("collected"))
-                explicit = found.group("selected")
-                selected = int(explicit) if explicit else collected
+                tokens = {
+                    token.group("label"): int(token.group("count"))
+                    for token in _COLLECT_TOKEN.finditer(found.group("tokens"))
+                }
+                # pytest's own derivation, so a token between ``deselected`` and
+                # ``selected`` cannot change the answer.
+                selected = collected - tokens.get("deselected", 0)
+                non_items = sum(count for label, count in tokens.items() if label in _NON_ITEM_COLLECT_LABELS)
+        told = _STATED_EXTENT.search(line)
+        if told:
+            stated = (int(told.group("executed")), int(told.group("selected")))
         stopping = _STOPPING.search(line)
         if stopping:
             stopped_after = int(stopping.group("failures"))
@@ -239,8 +302,13 @@ def parse_run(text: str) -> RunReport:
         for match in _COUNT.finditer(summary)
         if match.group("label") in _EXECUTED_LABELS
     }
-    executed = sum(counts.values())
     assert selected is not None
+    if stated is None:
+        extent_source = _DERIVED_FROM_LOG
+        executed = max(sum(counts.values()) - non_items, 0)
+    else:
+        extent_source = _STATED_BY_SESSION
+        executed, selected = stated
     never_ran = max(selected - executed, 0)
     truncated = stopped_after is not None or never_ran > 0
 
@@ -252,6 +320,7 @@ def parse_run(text: str) -> RunReport:
         never_ran=never_ran,
         stopped_after=stopped_after,
         counts=counts,
+        extent_source=extent_source,
     )
 
 
@@ -273,6 +342,8 @@ def render(report: RunReport) -> str:
         lines.append(f"| items that never ran | {report.never_ran} |")
     if report.stopped_after is not None:
         lines.append(f"| stopped after | {report.stopped_after} failure(s) |")
+    if report.extent_source:
+        lines.append(f"| extent | {report.extent_source} |")
     for label in sorted(report.counts):
         lines.append(f"| {label} | {report.counts[label]} |")
 

--- a/tests/test_truncated_test_run_is_reported.py
+++ b/tests/test_truncated_test_run_is_reported.py
@@ -28,6 +28,9 @@ bound.
 from __future__ import annotations
 
 import importlib.util
+import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -282,3 +285,183 @@ class TestTheReportIsWiredIntoTheRequiredCheck:
         # mismatch would be silent.
         assert "${RUNNER_TEMP}/pytest.log" in producer
         assert "${RUNNER_TEMP}/pytest.log" in consumer
+
+
+# One deselecting run of each shape pytest can print, with the collection line
+# exactly as pytest 9.0.3 writes it. The token order is pytest's -- ``errors``,
+# ``deselected``, ``skipped``, ``selected``, each printed only when nonzero -- so
+# which tokens sit between ``deselected`` and ``selected`` is a property of the
+# run, not of the format. TestTheseAreTheLinesPytestWrites grounds them.
+DESELECTING_RUNS = {
+    "deselected alone": (
+        "collected 900 items / 400 deselected / 500 selected\n===== 500 passed, 400 deselected in 12.00s =====\n",
+        500,
+        500,
+    ),
+    "a collection skip between deselected and selected": (
+        "collected 10 items / 4 deselected / 1 skipped / 6 selected\n"
+        "===== 6 passed, 1 skipped, 4 deselected in 0.01s =====\n",
+        6,
+        6,
+    ),
+    "a collection error before deselected": (
+        "collected 10 items / 1 error / 4 deselected / 1 skipped / 6 selected\n"
+        "===== 6 passed, 1 skipped, 4 deselected, 1 error in 0.02s =====\n",
+        6,
+        6,
+    ),
+    "every item deselected": (
+        "collected 10 items / 10 deselected / 1 skipped / 0 selected\n===== 1 skipped, 10 deselected in 0.01s =====\n",
+        0,
+        0,
+    ),
+    "a collection skip and no deselection": (
+        "collected 10 items / 1 skipped\n===== 10 passed, 1 skipped in 0.01s =====\n",
+        10,
+        10,
+    ),
+}
+
+
+class TestADeselectingRunIsNotReportedAsTruncated:
+    """Every one of these ran each item it selected, so none is a truncated run.
+
+    A false truncation is the one direction that costs something: it puts a
+    warning annotation on a green pull request telling the author most of the
+    suite never ran, and there is nothing in the log to contradict it.
+    """
+
+    @pytest.mark.parametrize(("log", "selected", "executed"), DESELECTING_RUNS.values(), ids=DESELECTING_RUNS)
+    def test_a_run_that_reached_every_selected_item_reports_complete(
+        self, log: str, selected: int, executed: int
+    ) -> None:
+        report = parse_run(log)
+
+        assert report.outcome == "complete"
+        assert report.selected == selected
+        assert report.executed == executed
+        assert report.never_ran == 0
+
+    @pytest.mark.parametrize("log", [run[0] for run in DESELECTING_RUNS.values()], ids=DESELECTING_RUNS)
+    def test_more_items_cannot_execute_than_were_collected(self, log: str) -> None:
+        # A module skipped or failing at import is counted on the counts line and
+        # is not one of the items, so leaving it in the total states an extent the
+        # run cannot have had -- "11 of 10 items executed" reads as a typo and is
+        # in fact the number the share of the suite is computed from.
+        report = parse_run(log)
+
+        assert report.executed is not None
+        assert report.collected is not None
+        assert report.executed <= report.collected
+
+
+class TestTheSessionsOwnCountOwnsTheExtent:
+    """The session counted its extent, so this module reports it rather than a second reading.
+
+    tests/session_truncation.py states ``started`` and ``collected`` from
+    ``pytest_runtest_logfinish`` and ``len(session.items)``. Re-deriving the same
+    two numbers from the text gives a second answer with nothing to say which is
+    right, so the derivation is the fallback for a log that carries no section.
+    """
+
+    STATED = (
+        "collected 13 items / 5 deselected / 1 skipped / 8 selected\n"
+        "==== session truncated: 4 of 8 collected tests ran ====\n"
+        "4 collected tests never started, so the counts below are a floor, not a total.\n"
+        "!!!! stopping after 1 failures !!!!\n"
+        "==== 1 failed, 3 passed, 1 skipped, 5 deselected in 22.14s ====\n"
+    )
+
+    def test_the_stated_extent_is_the_reported_extent(self) -> None:
+        report = parse_run(self.STATED)
+
+        assert report.outcome == "truncated"
+        assert report.executed == 4
+        assert report.selected == 8
+        assert report.never_ran == 4
+        assert report.extent_source == "the session's own count"
+
+    def test_the_report_names_which_reading_it_used(self) -> None:
+        # The two readings are not interchangeable -- one was counted and one
+        # reconstructed -- so a reader comparing this table against the terminal
+        # can see which spoke without diffing the numbers.
+        assert "| extent | the session's own count |" in render(parse_run(self.STATED))
+        assert "| extent | derived from the log's counts |" in render(parse_run(TRUNCATED_LOG))
+
+    def test_a_log_carrying_no_section_is_still_read(self) -> None:
+        # The section is written at terminal summary time, so a run killed before
+        # then carries none, as does any log kept from before it existed.
+        report = parse_run(TRUNCATED_LOG)
+
+        assert report.outcome == "truncated"
+        assert report.never_ran == 12036
+        assert report.extent_source == "derived from the log's counts"
+
+    def test_the_section_is_not_mistaken_for_the_collection_or_counts_line(self) -> None:
+        # It carries the words "collected" and "tests ran" and sits between the two
+        # lines this module reads, so a pattern matching it as either would report
+        # the section's own numbers as the whole run's.
+        report = parse_run(self.STATED)
+
+        assert report.collected == 13
+        assert report.counts == {"failed": 1, "passed": 3, "skipped": 1}
+
+
+class TestTheseAreTheLinesPytestWrites:
+    """Grade the fixtures above against pytest itself rather than against this module.
+
+    Every fixture here is a hand-written line, so the pins are only as good as the
+    claim that pytest writes lines of that shape. One nested run settles it, and
+    the same run is the oracle for the extent: the reporter counts it in process,
+    so the derivation has to reproduce the number the session states.
+    """
+
+    @staticmethod
+    def _run(tmp_path: Path, *args: str) -> str:
+        (tmp_path / "test_many.py").write_text(
+            "import pytest\n\n"
+            '@pytest.mark.parametrize("i", range(8))\n'
+            "def test_alpha(i):\n    assert i < 3\n\n"
+            '@pytest.mark.parametrize("i", range(5))\n'
+            "def test_beta(i):\n    assert True\n"
+        )
+        (tmp_path / "test_skipped_module.py").write_text(
+            'import pytest\n\npytest.importorskip("a_module_that_is_not_installed")\n\ndef test_never(): ...\n'
+        )
+        env = {**os.environ, "PYTHONPATH": str(_REPO_ROOT)}
+        env.pop("PYTEST_ADDOPTS", None)
+        # cwd is the tmp tree so the nested run inherits none of this
+        # repository's configuration, and no ``-q``: quiet suppresses the
+        # collection line, which is the line under test.
+        finished = subprocess.run(
+            [sys.executable, "-m", "pytest", ".", "-p", "no:cacheprovider", "-p", "no:randomly", *args],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=env,
+            timeout=300,
+        )
+        return finished.stdout
+
+    def test_a_token_really_does_sit_between_deselected_and_selected(self, tmp_path: Path) -> None:
+        out = self._run(tmp_path, "-k", "alpha")
+
+        assert "collected 13 items / 5 deselected / 1 skipped / 8 selected" in out
+        # And that run reached all 8 of the items it selected.
+        assert parse_run(out).outcome == "complete"
+
+    def test_the_derived_extent_is_the_extent_the_session_counted(self, tmp_path: Path) -> None:
+        out = self._run(tmp_path, "-k", "alpha", "-x", "-p", "tests.session_truncation")
+
+        stated = re.search(r"session truncated: (\d+) of (\d+) collected tests ran", out)
+        assert stated, "the reporter did not state an extent for a truncated run"
+        counted = (int(stated.group(1)), int(stated.group(2)))
+
+        # With the section present the numbers are the session's; with it removed
+        # they are this module's arithmetic. Both must be what the session counted.
+        without = "\n".join(
+            line for line in out.splitlines() if "truncated" not in line and "never started" not in line
+        )
+        for report in (parse_run(out), parse_run(without)):
+            assert report.outcome == "truncated"
+            assert (report.executed, report.selected) == counted


### PR DESCRIPTION
![before and after](https://raw.githubusercontent.com/cagataycali/robots/02ddd8d53749f4510c7339e56075600b8e1bc850/.artifacts/truncation-extent-one-owner.png)

## The subtraction had two owners and they disagreed

`tests/session_truncation.py` counts a truncated session's extent **in process** -- `len(session.items)` after deselection, against one tick per `pytest_runtest_logfinish`. `scripts/report_truncated_test_run.py` re-derived the same two numbers from the log's text. On one real truncated run, the two surfaces of one job said this eight lines apart:

| surface | what it said |
|---|---|
| terminal | `session truncated: 4 of 8 collected tests ran` / `4 collected tests never started` |
| job summary | `the run was truncated: 5 of 13 items executed, 8 never ran (61.5% of the suite)` |

The session's number is the counted one. The report now reads the line the session already states and reports it unchanged; reconstructing it from the text is the fallback for a log that carries no section (a run killed before the terminal summary, or a log kept from before it existed). Which reading spoke is named in the table, so the two are not silently interchangeable:

```
| extent | the session's own count |
| extent | derived from the log's counts |
```

## The fallback was reading pytest's line by a rule that is not pytest's

`report_collect` prints `errors`, `deselected`, `skipped`, `selected` in that order and **only when each is nonzero**, so their positions relative to each other are not fixed:

```
collected 10 items / 1 error / 4 deselected / 1 skipped / 6 selected
```

The pattern required `selected` to follow `deselected` immediately, so a token in between hid it and the number selected fell back to the number collected. Two corrections, both of them pytest's own rules rather than new ones:

- the number selected is `collected - deselected` (`report_collect` computes exactly that, and prints the token only when it differs from `collected`), so it is read from `deselected` rather than from a token another token can sit in front of;
- a module skipped or failing at *import* is counted on the collection line **and** on the counts line while being none of the collected items, so the counts line exceeds the item count by whatever the collection line already accounted for.

## What it cost, measured over the shapes pytest can print

A run that reached every item it selected was reported as truncated -- a warning annotation on a green pull request telling the author most of the suite never ran, with nothing in the log to contradict it.

| the run | pytest counted | before | after |
|---|---|---|---|
| `/ 400 deselected / 500 selected` | 500 of 500 | complete, 500 of 500 | complete, 500 of 500 |
| `/ 4 deselected / 1 skipped / 6 selected` | 6 of 6 | **truncated, 7 of 10, 3 never ran** | complete, 6 of 6 |
| `/ 1 error / 4 deselected / 1 skipped / 6 selected` | 6 of 6 | **truncated, 8 of 10, 2 never ran** | complete, 6 of 6 |
| `/ 10 deselected / 1 skipped / 0 selected` | 0 of 0 | **truncated, 1 of 10, 9 never ran** | complete, 0 of 0 |
| `/ 1 skipped` (no deselection) | 10 of 10 | complete, **11 of 10 items executed** | complete, 10 of 10 |
| truncated + deselection, no section | 4 of 8 | **truncated, 5 of 13, 8 never ran** | truncated, 4 of 8, 4 never ran |
| truncated + deselection, section present | 4 of 8 | **truncated, 5 of 13, 8 never ran** | truncated, 4 of 8, 4 never ran |

**1 of 7 read correctly before, 7 of 7 after.** Row 1 is the control: it is the one arrangement in which the wrong rule coincides with the right one, and it is what the existing pin `test_deselected_items_are_not_reported_as_never_run` poses -- so the guard for exactly this consequence was written against the only case that could not show it. Row 5 keeps the right verdict and states an extent the run cannot have had; that number is what the share of the suite is computed from.

## Tests

`tests/test_truncated_test_run_is_reported.py`, +16 cells. On the pre-fix script with only the test file applied: **10 failed, 29 passed**, and the coinciding row above passes on both trees.

Every hand-written collection line is graded against pytest itself rather than against this module -- one nested run asserts that `collected 13 items / 5 deselected / 1 skipped / 8 selected` is a line pytest writes, and the same run is the oracle for the extent: with the section present and with it stripped, both readings must reproduce the number the reporter counted.

## Gate

| | result |
|---|---|
| `ruff check` / `ruff format --check` (`strands_robots tests tests_integ`) | clean |
| `mypy strands_robots tests tests_integ` | 20 errors in 6 files, identical on base and branch |
| `tests/test_truncated_test_run_is_reported.py` + `tests/test_session_truncation_is_reported.py` | 52 passed |
| `scripts/check_whole_tree_graders.py` | 13 failed, 4200 passed, 56 skipped, 4 errors -- all pre-existing (absent `awsiot` / `qpsolvers`, installed `lerobot` and `websockets` versions) |

Size: +280 / -9 -- 183 lines of tests, 10 the changelog fragment, 7 the docs note, and +80 / -9 in the script, most of that the two paragraphs recording pytest's rules.

Refs #3169, #3164.