### PR TITLE
fix(rendering): a cached backdrop belongs to the camera it was rendered for

### DIFF
--- a/changelog.d/3173-background-cache-key-covers-the-camera.md
+++ b/changelog.d/3173-background-cache-key-covers-the-camera.md
@@ -1,0 +1,24 @@
+### Fixed: a cached photoreal backdrop is no longer served to a camera whose clip planes moved
+
+`HybridCompositor` caches each `BackgroundRenderer.render(cam)` result and
+reuses it while only the robot moves. The key covered four of `CameraParams`'
+six fields - name, image size, pose and intrinsics - and omitted `znear` and
+`zfar`, which the backdrops consume: `PanoramaBackground` fills its entire
+depth buffer with `cam.zfar`, and `GsplatBackground` hands both planes to the
+rasterizer as its clip planes.
+
+MuJoCo derives both planes from `model.stat.extent`, which the compiler
+recomputes from the scene bounds, so any scene change (`add_object`,
+`attach_bodies`, `load_scene`) moves them while a fixed named camera keeps the
+pose, intrinsics and size the key did read - the entry then stood for a camera
+the engine no longer described, and the depth test judged the scene against a
+far plane it did not have. Geometry beyond the stale plane was composited away:
+measured on a MuJoCo tabletop that gained a distant landmark, 5810 pixels
+(the whole landmark, at 186 m, against a backdrop parked at 50 m) were replaced
+by backdrop, and the same code produced a different frame depending only on
+whether the cache was warm.
+
+The key is now derived from every `CameraParams` field, so a field added later
+participates on arrival. Callers do not have to invalidate anything after a
+scene change; `clear_caches()` remains for releasing memory or for forcing a
+re-render after mutating a background renderer in place.

--- a/strands_robots/rendering/compositor.py
+++ b/strands_robots/rendering/compositor.py
@@ -34,6 +34,21 @@ full-frame photoreal backdrops usually want ``create_world(ground_plane=False)``
 (or an example-side floor-hiding shim) so the sim floor doesn't fight the
 background's own floor.
 
+Background caching: the backdrop is rendered once per camera and reused while
+only the robot moves, since ``BackgroundRenderer.render(cam)`` depends on
+nothing but the camera. "Per camera" means per distinct
+:class:`~strands_robots.rendering.camera.CameraParams` -- pose, intrinsics,
+image size **and both clip planes** -- because the backdrop is built from all
+of them: the panorama parks its whole depth buffer at ``cam.zfar`` and the
+gsplat backdrop hands ``cam.znear`` / ``cam.zfar`` to the rasterizer. That
+matters because a backend can move the clip planes on its own: MuJoCo derives
+both from ``model.stat.extent``, which the compiler recomputes from the scene
+bounds, so any scene change (``add_object``, ``attach_bodies``,
+``load_scene``) moves them while a fixed named camera keeps its pose and its
+intrinsics. Callers therefore do not have to invalidate anything after a scene
+change; :meth:`HybridCompositor.clear_caches` remains available to drop the
+entries outright.
+
 Concurrency contract: :meth:`HybridCompositor.render` calls straight into the
 engine's ``get_frame`` on the calling thread -- thread-affinity is the
 *backend's* contract (MuJoCo caches GL renderers per-thread; Isaac renders
@@ -47,7 +62,7 @@ from __future__ import annotations
 import logging
 import math
 import numbers
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any, Protocol
 
 import numpy as np
@@ -230,6 +245,53 @@ def plane_depth(cam: CameraParams, plane_z: float) -> np.ndarray:
     return depth.astype(np.float32)
 
 
+# Decimal places each ``CameraParams`` matrix is rounded to before it enters a
+# background cache key, so float jitter in a pose the caller did not move does
+# not bust the cache. Scalars are keyed exactly: they arrive from the backend as
+# a single multiply and reproduce bit-for-bit, and a spurious *miss* only costs
+# one background pass while a spurious *hit* returns a frame rendered for
+# another camera.
+_CACHE_KEY_MATRIX_DECIMALS = {"T_world_cam": 4, "K": 3}
+_CACHE_KEY_DEFAULT_DECIMALS = 6
+
+
+def _background_cache_key(camera_name: str, background_name: str, cam: CameraParams) -> tuple[Any, ...]:
+    """Identify a cached ``BackgroundRenderer.render`` result.
+
+    ``render(cam)`` reads nothing but ``cam``, so the key covers **every**
+    :class:`CameraParams` field rather than a hand-listed subset: the
+    equirectangular backdrop fills its whole depth buffer with ``cam.zfar``
+    and the gsplat backdrop hands ``cam.znear`` / ``cam.zfar`` to the
+    rasterizer as its clip planes, so a camera whose clip planes moved is a
+    different render even when its pose, intrinsics and image size are
+    untouched. Deriving the key from the dataclass rather than listing fields
+    means a field added to :class:`CameraParams` later participates on
+    arrival instead of silently widening what one entry stands for.
+
+    Args:
+        camera_name: the camera as named to the engine. Two cameras can share
+            a pose (a duplicated MJCF camera), so the name is part of the key.
+        background_name: :attr:`BackgroundRenderer.name` of the renderer that
+            produced the entry, so a hot-swapped backdrop cannot be served
+            from the previous one's entry.
+        cam: the parameters ``render`` was, or would be, called with.
+
+    Returns:
+        A hashable key. Matrix fields are rounded (see
+        ``_CACHE_KEY_MATRIX_DECIMALS``) and keyed by bytes; scalar fields are
+        keyed exactly.
+    """
+    parts: list[Any] = [camera_name, background_name]
+    for field in fields(cam):
+        value = getattr(cam, field.name)
+        if isinstance(value, np.ndarray):
+            decimals = _CACHE_KEY_MATRIX_DECIMALS.get(field.name, _CACHE_KEY_DEFAULT_DECIMALS)
+            parts.append(np.round(value, decimals).tobytes())
+        else:
+            parts.append(value)
+    return tuple(parts)
+
+
 class FrameSource(Protocol):
     """The slice of ``SimEngine`` the compositor needs (structural typing)."""
 
@@ -401,11 +463,12 @@ class HybridCompositor:
         self.shadow_plane_tolerance = float(shadow_plane_tolerance)
         self.shadow_min_factor = float(shadow_min_factor)
         self.blend_in_linear = bool(blend_in_linear)
-        # Cache of background renders keyed by (camera_name, W, H, background
-        # name) + a rounded hash of the camera pose/intrinsics. The background
-        # only changes when the *camera* moves, not when the robot does -- so
-        # during a live motion we recompute only the cheap sim foreground, not
-        # the expensive panorama/gsplat pass.
+        # Cache of background renders keyed by the camera name, the background
+        # name and every ``CameraParams`` field (see
+        # :func:`_background_cache_key`). The background only changes when the
+        # *camera* does, not when the robot moves -- so during a live motion we
+        # recompute only the cheap sim foreground, not the expensive
+        # panorama/gsplat pass.
         self._bg_cache: dict[tuple[Any, ...], tuple[np.ndarray, np.ndarray]] = {}
 
     # ----- main API ----- #
@@ -570,17 +633,9 @@ class HybridCompositor:
         )
 
     def _background_for(self, cam: CameraParams, camera_name: str) -> tuple[np.ndarray, np.ndarray]:
-        """Return ``(bg_rgb, bg_depth)`` for ``cam``, cached by camera pose."""
-        pose_key = (
-            camera_name,
-            cam.width,
-            cam.height,
-            self.background.name,
-            # Round the pose so tiny float jitter doesn't bust the cache.
-            np.round(cam.T_world_cam, 4).tobytes(),
-            np.round(cam.K, 3).tobytes(),
-        )
-        cached = self._bg_cache.get(pose_key)
+        """Return ``(bg_rgb, bg_depth)`` for ``cam``, cached by camera."""
+        key = _background_cache_key(camera_name, self.background.name, cam)
+        cached = self._bg_cache.get(key)
         if cached is None:
             bg_rgb, bg_depth = self.background.render(cam)
             bg_rgb = np.asarray(bg_rgb)
@@ -590,7 +645,7 @@ class HybridCompositor:
             # Keep the cache tiny -- only a handful of cameras are ever live.
             if len(self._bg_cache) > 16:
                 self._bg_cache.clear()
-            self._bg_cache[pose_key] = cached
+            self._bg_cache[key] = cached
         return cached
 
     # ----- convenience ----- #
@@ -602,7 +657,16 @@ class HybridCompositor:
         self._bg_cache.clear()
 
     def clear_caches(self) -> None:
-        """Drop cached background renders (call after a scene rebuild)."""
+        """Drop every cached background render.
+
+        Not needed to track the camera: entries are keyed by the full
+        :class:`CameraParams` -- pose, intrinsics, image size and both clip
+        planes -- so a camera that moved, including one whose clip planes a
+        scene recompile moved, is a miss rather than a stale hit. Use this to
+        release the memory, or to force a re-render after mutating a background
+        renderer in place (a swapped renderer is already handled by
+        :meth:`set_background`).
+        """
         self._bg_cache.clear()
 
 

--- a/tests/rendering/test_background_cache_key_covers_the_camera.py
+++ b/tests/rendering/test_background_cache_key_covers_the_camera.py
@@ -1,0 +1,166 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A cached background render belongs to the camera it was rendered for.
+
+:meth:`HybridCompositor.render` renders the photoreal backdrop once per camera
+and reuses it while only the robot moves, so the cache key has to identify the
+camera completely: ``BackgroundRenderer.render(cam)`` reads nothing but ``cam``,
+and every :class:`CameraParams` field is an input to it. The clip planes are the
+easy ones to overlook and the ones a backend moves without touching anything
+else -- MuJoCo derives both from ``model.stat.extent``, which the compiler
+recomputes from the scene bounds, so any scene change (``add_object``,
+``attach_bodies``, ``load_scene``) moves ``znear``/``zfar`` while a fixed named
+camera keeps its pose, its intrinsics and its image size. The panorama backdrop
+fills its whole depth buffer with ``cam.zfar`` and the gsplat one hands both
+planes to the rasterizer, so serving the previous entry composites the scene
+against a far plane the camera no longer has.
+
+The field table below is asserted to cover the dataclass, so a field added to
+:class:`CameraParams` later is graded here on arrival rather than silently
+widening what one cache entry stands for.
+"""
+
+from dataclasses import fields, replace
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import CameraParams, HybridCompositor
+
+W, H = 16, 12
+# The measured MuJoCo pair: a tabletop world (``stat.extent`` 1.0) gaining one
+# object 6 m away recompiles to ``extent`` 6.673205, and the clip planes are
+# ``extent * model.vis.map.{znear,zfar}``. The camera's pose, K and size do not
+# move with it.
+NEAR_BEFORE, FAR_BEFORE = 0.01, 50.0
+NEAR_AFTER, FAR_AFTER = 0.066732, 333.6603
+# Foreground geometry outside the first far plane and inside the second, i.e.
+# the depths whose composite verdict the two cameras disagree about.
+FAR_GEOMETRY_M = 120.0
+NEAR_GEOMETRY_M = 1.0
+
+
+def _camera(**overrides) -> CameraParams:
+    """A pinhole camera at ``W x H``, with ``overrides`` applied."""
+    fy = 0.5 * H / np.tan(np.deg2rad(45.0) / 2.0)
+    base = CameraParams(
+        K=np.array([[fy, 0.0, W / 2.0], [0.0, fy, H / 2.0], [0.0, 0.0, 1.0]]),
+        T_world_cam=np.eye(4),
+        width=W,
+        height=H,
+        znear=NEAR_BEFORE,
+        zfar=FAR_BEFORE,
+    )
+    return replace(base, **overrides) if overrides else base
+
+
+def _moved_pose() -> np.ndarray:
+    moved = np.eye(4)
+    moved[0, 3] = 0.5  # half a metre along +x
+    return moved
+
+
+def _widened_intrinsics() -> np.ndarray:
+    K = _camera().K.copy()
+    K[0, 0] *= 1.5  # a different horizontal focal length
+    return K
+
+
+# One differing value per CameraParams field. Two cameras differing only in the
+# named field are different cameras, so they cannot share a background entry.
+DIFFERING_VALUE = {
+    "K": _widened_intrinsics(),
+    "T_world_cam": _moved_pose(),
+    "width": W + 4,
+    "height": H + 2,
+    "znear": NEAR_AFTER,
+    "zfar": FAR_AFTER,
+}
+
+
+class CountingBackground:
+    """Backdrop at the camera's far plane, counting renders (as the panorama does)."""
+
+    name = "counting-bg"
+
+    def __init__(self) -> None:
+        self.render_calls = 0
+
+    def render(self, cam: CameraParams) -> tuple[np.ndarray, np.ndarray]:
+        self.render_calls += 1
+        rgb = np.zeros((cam.height, cam.width, 3), dtype=np.uint8)
+        rgb[..., 2] = 255  # blue backdrop
+        return rgb, np.full((cam.height, cam.width), cam.zfar, dtype=np.float32)
+
+
+class ProgrammableSim:
+    """Frame source whose camera the test replaces, as a recompile would."""
+
+    def __init__(self, cam: CameraParams) -> None:
+        self.cam = cam
+
+    def get_camera_params(self, camera_name="default", width=None, height=None) -> CameraParams:
+        return self.cam
+
+    def get_frame(self, camera_name="default", width=None, height=None):
+        """White geometry: a near patch, plus a patch beyond the first far plane."""
+        cam = self.cam
+        rgb = np.full((cam.height, cam.width, 3), 255, dtype=np.uint8)
+        depth = np.full((cam.height, cam.width), cam.zfar, dtype=np.float32)
+        depth[1:3, 1:4] = NEAR_GEOMETRY_M
+        depth[6:9, 6:10] = FAR_GEOMETRY_M
+        return rgb, depth
+
+
+def _compositor(cam: CameraParams) -> tuple[HybridCompositor, CountingBackground, ProgrammableSim]:
+    bg = CountingBackground()
+    sim = ProgrammableSim(cam)
+    return HybridCompositor(sim, background=bg, feather_pixels=0), bg, sim
+
+
+def test_the_differing_value_table_covers_every_camera_field() -> None:
+    """A field added to CameraParams has to be given a differing value here."""
+    assert {field.name for field in fields(CameraParams)} == set(DIFFERING_VALUE)
+
+
+@pytest.mark.parametrize("field_name", sorted(DIFFERING_VALUE))
+def test_a_camera_differing_in_one_field_is_not_served_the_other_camera_s_background(field_name: str) -> None:
+    comp, bg, sim = _compositor(_camera())
+    comp.render("cam")
+    sim.cam = _camera(**{field_name: DIFFERING_VALUE[field_name]})
+    comp.render("cam")
+    assert bg.render_calls == 2, (
+        f"the background rendered for a camera with {field_name}="
+        f"{getattr(_camera(), field_name)!r} was served for one with "
+        f"{field_name}={DIFFERING_VALUE[field_name]!r}"
+    )
+
+
+def test_geometry_inside_the_new_far_plane_is_not_composited_away_by_the_old_one() -> None:
+    """The scene-change case end to end: the far patch is the disagreement."""
+    comp, bg, sim = _compositor(_camera())
+    before = comp.render("cam")
+    # Outside the first camera's frustum, so the backdrop legitimately owns it.
+    assert not before.foreground_mask[7, 7]
+    assert before.foreground_mask[2, 2]
+
+    # The recompile: both clip planes move, nothing else does.
+    sim.cam = _camera(znear=NEAR_AFTER, zfar=FAR_AFTER)
+    after = comp.render("cam")
+
+    assert bg.render_calls == 2, "the backdrop was served from the pre-recompile camera's entry"
+    assert after.foreground_mask[7, 7], (
+        f"geometry at {FAR_GEOMETRY_M} m is inside the camera's far plane "
+        f"({FAR_AFTER} m) but lost the depth test to a backdrop parked at the "
+        f"previous far plane ({FAR_BEFORE} m)"
+    )
+    assert tuple(after.rgb[7, 7]) == (255, 255, 255)
+    assert after.foreground_mask[2, 2], "the near patch is unaffected by either far plane"
+
+
+def test_an_unchanged_camera_is_still_served_from_the_cache() -> None:
+    """The caching this key exists for: a still camera renders the backdrop once."""
+    comp, bg, _sim = _compositor(_camera())
+    for _ in range(3):
+        comp.render("cam")
+    assert bg.render_calls == 1


### PR DESCRIPTION
![composited frames](https://raw.githubusercontent.com/cagataycali/robots/aff62c9d5ff31bd1c45632ff34af99fcb8c02254/.artifacts/background_cache_key.png)

Panels 2 and 3 are the **same code rendering the same scene**, differing only in whether the background cache happened to be warm.

## What the key stood for

`HybridCompositor` renders the photoreal backdrop once per camera and reuses it while only the robot moves. `BackgroundRenderer.render(cam)` reads nothing but `cam`, so the entry is only reusable for a camera that `cam` still describes - and the key read four of `CameraParams`' six fields:

| `CameraParams` field | in the key | read by `render(cam)` |
|---|---|---|
| `T_world_cam` | yes (rounded bytes) | ray directions |
| `K` | yes (rounded bytes) | ray directions |
| `width` / `height` | yes | buffer shape |
| **`znear`** | **no** | gsplat `near_plane`; `depth <= znear` promoted |
| **`zfar`** | **no** | panorama fills its **whole** depth buffer with `cam.zfar`; gsplat `far_plane` |

`PanoramaBackground.render` ends `depth = np.full((H, W), cam.zfar)` - the far plane is not a detail of that render, it *is* its entire depth channel.

## Why the omitted two move on their own

MuJoCo derives both planes from `model.stat.extent` (`rendering.py`: `znear = extent * model.vis.map.znear`, `zfar = extent * model.vis.map.zfar`), and the compiler recomputes `extent` from the scene bounds. So any scene change recompiles new clip planes, while a fixed named camera keeps the pose (`data.cam_xpos`), the intrinsics (`cam_fovy`) and the size that the key does read. Measured on a tabletop world, headless EGL, one `add_object` 6 m away:

| | before | after |
|---|---:|---:|
| `model.stat.extent` | 1.000000 | 6.673205 |
| `cam.znear` | 0.010000 | 0.066732 |
| `cam.zfar` | 50.0000 | 333.6603 |
| pose / `K` / size | | **byte-identical** |
| cache key | | **identical** |

## The consequence, and its boundary

The backdrop is served at the old far plane, so `foreground_depth < background_depth` judges the scene against a plane the camera does not have. Geometry beyond the stale plane loses and is painted over with backdrop. Measured on the frames above (tabletop, then one `add_object` 200 m out, so `extent` 1.0 -> 228.3 and `zfar` 50 -> 11416.04):

| composite of the identical scene | foreground pixels |
|---|---:|
| warm cache, before this change | **21760** |
| cache dropped, same code (`clear_caches()`) | 27570 |
| warm cache, after this change | 27570 |

5810 pixels - the whole landmark, every one of them at depth 185.6-186.6 m - were deleted from the composite by a backdrop parked at 50 m. After the change the warm-cache mask is byte-identical to the cache-dropped one.

Stated plainly, since it is what bounds the visible symptom: pixels are only lost where real geometry sits past the stale far plane, i.e. once the scene's bounds grow by more than `model.vis.map.zfar` (50 by default). The 6.67x tabletop case above changes which camera the entry stands for but not that frame's pixels. It is unbounded for a gsplat backdrop, where both planes are rasterizer culling parameters and any move changes the backdrop's own content.

## The change

Key on every `CameraParams` field, derived from the dataclass rather than listed, so a field added later participates on arrival instead of silently widening what one entry stands for. Matrices keep their existing rounding (float jitter in a pose nobody moved should not bust the cache); scalars are keyed exactly, because a spurious *miss* costs one background pass while a spurious *hit* returns a frame rendered for another camera.

Callers no longer have to invalidate anything after a scene change. `clear_caches()` stays, with its docstring corrected - it is for releasing memory or forcing a re-render after mutating a renderer in place, not for tracking the camera.

## Tests

`tests/rendering/test_background_cache_key_covers_the_camera.py`, graded through the public `render()` only. Pre-fix, with just the test file added to `main`: **3 failed, 6 passed**.

| cell | on `main` |
|---|---|
| one differing field: `znear` | **fail** (1 render, not 2) |
| one differing field: `zfar` | **fail** (1 render, not 2) |
| geometry inside the new far plane survives the composite | **fail** |
| one differing field: `K`, `T_world_cam`, `width`, `height` | pass - already keyed |
| the differing-value table covers every `CameraParams` field | pass |
| an unchanged camera is still served from the cache | pass |

The four passing field rows and the still-cached control are the point: the fields that were already right stay right, and the cache this exists for is not disabled. The table-coverage cell is asserted against `dataclasses.fields(CameraParams)`, so a new field fails here until it is given a value to differ by.

## Gate

| | `main` | this branch |
|---|---|---|
| `tests/rendering` | 850 passed, 5 skipped | **859 passed**, 5 skipped (+9 = the new cells) |
| whole-tree graders | 13 failed, 4200 passed, 56 skipped, 4 errors | identical, and the 17 failing node ids are **set-identical** |
| `ruff check` / `format --check` (`strands_robots tests tests_integ`) | clean | clean |
| `mypy strands_robots tests tests_integ` | 25 errors in 10 files | 25 errors in 10 files, none in the touched files |

## Size

+273 / -19: source `compositor.py` +83 / -19, tests +166 (new file), changelog fragment +24. The source net (+64) is mostly prose - the module-docstring caching contract and the key builder's docstring; executable statements in `compositor.py` go 196 -> 208.