### PR TITLE
fix(validation): an allowlist anchors at the absolute end of the string

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2158,6 +2158,17 @@ Corrections from code review that apply to all future contributions:
 - **Reject shell metacharacters in paths** - `;`, `|`, `$`, backticks, `>`, `<`,
   `\n`, `\r`, `\x00`. Also reject `..` path traversal components. Apply even when
   using argv-style subprocess.
+- **Anchor an allowlist with `\Z`, not `$`** - `$` matches at the end of the string
+  *or immediately before a single trailing newline*, so `re.match(r"^[a-z]+$", "abc\n")`
+  succeeds and the bullet above is not enforced by the pattern that claims to enforce
+  it. Spell the anchor `\Z`, or consult the pattern with `re.fullmatch`, which anchors
+  both ends itself. The difference is invisible in the pattern's rendered text and in
+  any test whose fixtures carry no line break, which is how the patterns in this
+  package came to disagree with the two that had been audited for it. Held for the
+  whole package by
+  `tests/test_allowlist_patterns_anchor_at_the_end_of_the_string.py`, whose population
+  is derived from the source rather than listed, so an allowlist added later is graded
+  on arrival.
 - **Bind to `127.0.0.1` by default**, not `0.0.0.0`. Users explicitly opt into
   network exposure.
 

--- a/changelog.d/3174-allowlist-anchors-at-end-of-string.md
+++ b/changelog.d/3174-allowlist-anchors-at-end-of-string.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- Every identifier allowlist in the package anchors at the absolute end of the
+  string (`\Z`) rather than with `$`, which in non-MULTILINE mode also matches
+  immediately before a single trailing newline. An otherwise-valid value carrying
+  one no longer passes: `dds_type_name('std_msgs/msg/String\n')` used to return
+  `'std_msgs::msg::dds_::String\n_'`, putting one DDS identifier on the graph
+  across two lines, and `harness_memory`'s `save_trace` used to write a trace file
+  whose name carried the line break. The two mesh validators that already
+  anchored this way (`peer_id`, `thing_name`) are unchanged; the ten patterns
+  already consulted with `re.fullmatch` change spelling but not behaviour.
+- `SagemakerTrainer.validate` enforces the documented 1-32 character bound on
+  `base_job_name` for a 33rd character that is a newline. The bound is spent in a
+  lookahead, so the end-of-string anchor decided the length as well as the
+  character set.

--- a/strands_robots/assets/download.py
+++ b/strands_robots/assets/download.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 MENAGERIE_REPO = "https://github.com/google-deepmind/mujoco_menagerie.git"
 
 # Only HTTPS GitHub URLs are allowed for cloning.
-_ALLOWED_CLONE_URL_RE = re.compile(r"^https://github\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+\.git$")
+_ALLOWED_CLONE_URL_RE = re.compile(r"^https://github\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+\.git\Z")
 
 
 # robot_descriptions integration
@@ -87,7 +87,7 @@ def _resolve_robot_descriptions_module(name: str, info: dict) -> str | None:
     for candidate in candidates:
         # Allow '+' so robot_descriptions modules like 'tiago++_mj_description'
         # are accepted (still no '/', '.', or whitespace -> no import traversal).
-        if not re.match(r"^[a-z0-9_+]+$", candidate):
+        if not re.match(r"^[a-z0-9_+]+\Z", candidate):
             continue
         try:
             importlib.import_module(f"robot_descriptions.{candidate}")
@@ -361,7 +361,7 @@ def _download_via_robot_descriptions(robots: dict[str, dict], dest_dir: Path) ->
             continue
         # Allow '+' so modules like 'tiago++_mj_description' pass (the upstream
         # robot_descriptions package legitimately uses '++' in some names).
-        if not re.match(r"^[a-z0-9_+]+$", module_name):
+        if not re.match(r"^[a-z0-9_+]+\Z", module_name):
             results[name] = f"skipped: invalid module name: {module_name}"
             continue
 
@@ -453,7 +453,7 @@ def _download_from_github(name: str, info: dict, dest_dir: Path) -> str:
     """Download a robot from a custom GitHub repo (``asset.source``)."""
     source = info["asset"]["source"]
     repo = source["repo"]
-    if not re.match(r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$", repo):
+    if not re.match(r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+\Z", repo):
         return f"failed: invalid repo format: {repo}"
 
     subdir = source.get("subdir", "")

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -128,8 +128,8 @@ def _codec_create_kwargs(sig_params: Any, vcodec: str, *, context: str = "create
 # "org/name"; `run_id` is a single path segment. Neither may contain shell
 # metacharacters, path-traversal (".."), or separators beyond the one allowed
 # bucket "org/name" slash.
-_BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$")
-_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?\Z")
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 
 
 def sync_dataset_to_bucket(

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 # Security hardening: recorded-move names are interpolated into a REST URL
 # path, so restrict them to a safe charset to prevent path traversal and
 # query/parameter injection into the daemon API.
-_MOVE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+_MOVE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}\Z")
 
 
 def _key_prefix_error(value: Any, param: str, cls_name: str) -> str | None:

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -91,7 +91,7 @@ _PATH_MOVE_LIST = "/api/move/recorded-move-datasets/list/{dataset}"
 #: A recorded move's name goes into a URL path, so the admitted alphabet is the
 #: same one :mod:`strands_robots.device_connect.reachy_mini_driver` enforces -
 #: anything else is refused before a request is built from it.
-_MOVE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+_MOVE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}\Z")
 
 #: The two recorded-move libraries the daemon serves, mapped to their
 #: HuggingFace dataset ids. A dict rather than string surgery so a refusal can

--- a/strands_robots/mesh/_mobile_base.py
+++ b/strands_robots/mesh/_mobile_base.py
@@ -280,9 +280,9 @@ class MobileBaseRobot:
     """
 
     #: Pattern a ``node_name`` must match. Overridable per platform.
-    _NAME_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9_/~]+$")
+    _NAME_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9_/~]+\Z")
     #: Pattern a topic/service name must match. Overridable per platform.
-    _TOPIC_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9_/~]+$")
+    _TOPIC_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9_/~]+\Z")
     #: Appended to ``node_name`` validation errors to say what a good value
     #: looks like. Overridable per platform alongside :attr:`_NAME_RE`, which
     #: it must describe.

--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -100,7 +100,7 @@ _CA_ROTATION_RUNBOOK = 'README > "CA Pin Rotation Runbook"'
 
 # Regex: 64 hex chars, lowercase. Matches what hashlib.sha256(...).hexdigest()
 # emits and rejects anything else (operator typos surface immediately).
-_PIN_RE = re.compile(r"^[0-9a-f]{64}$")
+_PIN_RE = re.compile(r"^[0-9a-f]{64}\Z")
 
 # Cap the CA download response to a generous multiple of the real ~1.4 KiB
 # certificate. Defeats body-size DoS attacks (a captive portal returning a
@@ -386,7 +386,7 @@ _OPERATOR_POLICY_DOC: dict[str, Any] = {
 # Operators who use ``:`` in pre-existing AWS IoT Thing names need to
 # rename the Thing or maintain a mapping; we choose the safer subset
 # here over compatibility with every legal AWS Thing name.
-_THING_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+_THING_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}\Z")
 
 
 #: Thing attribute the provisioners inject to route fleet safety. The e-stop
@@ -431,7 +431,7 @@ def _validate_thing_name(thing_name: str) -> None:
     """Raise :class:`ValueError` when *thing_name* is unsafe for use as a
     filesystem component AND as an AWS IoT Thing name.
 
-    The accepted pattern is ``^[a-zA-Z0-9_-]{1,128}$``: alphanumerics,
+    The accepted pattern is ``^[a-zA-Z0-9_-]{1,128}\\Z``: alphanumerics,
     dash and underscore, length 1-128.  This is a **strict subset** of
     AWS IoT's accepted Thing-name charset (AWS allows ``:`` server-side;
     we reject it because of NTFS / classic Mac filesystem semantics).
@@ -463,7 +463,7 @@ def provision_robot(
 ) -> ProvisionedThing:
     """Provision a robot Thing and write its credentials to disk.
 
-    Validates *thing_name* against ``^[a-zA-Z0-9_-]{1,128}$`` before any
+    Validates *thing_name* against ``^[a-zA-Z0-9_-]{1,128}\\Z`` before any
     AWS call. The pattern is a **strict subset** of AWS IoT's accepted
     Thing-name charset (AWS server-side accepts ``:`` as well; we reject
     it for filesystem-path safety on NTFS / classic Mac where ``:`` is a

--- a/strands_robots/mesh/ros_bridge.py
+++ b/strands_robots/mesh/ros_bridge.py
@@ -84,7 +84,7 @@ _NAV_ACTION_TYPE = "nav2_msgs/action/NavigateToPose"
 # ROS 2 graph names: leading slash plus alnum / _ / ~ segments. Reject anything
 # else early so a malformed topic fails at construction with a clear message
 # rather than deep inside a forwarded ``use_ros`` call.
-_ROS2_GRAPH_NAME_RE = re.compile(r"^[A-Za-z0-9_/~]+$")
+_ROS2_GRAPH_NAME_RE = re.compile(r"^[A-Za-z0-9_/~]+\Z")
 
 
 def _check_topic(label: str, value: str) -> str:

--- a/strands_robots/mesh/rtps_robot.py
+++ b/strands_robots/mesh/rtps_robot.py
@@ -48,8 +48,8 @@ _TWIST_TYPE = "geometry_msgs/msg/Twist"
 # ``use_rtps`` writes to a DDS topic directly, so a topic must be absolute -
 # a stricter grammar than the ROS 2 bridge's, which also accepts relative and
 # private (``~``) names for rclpy to resolve.
-_RTPS_TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]$")
-_RTPS_NAME_RE = re.compile(r"^[A-Za-z0-9_/~]+$")
+_RTPS_TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]\Z")
+_RTPS_NAME_RE = re.compile(r"^[A-Za-z0-9_/~]+\Z")
 
 
 class _UseRtpsTransport:

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -84,7 +84,7 @@ MAX_SERVER_ADDRESS_LEN: int = 256
 #: Allowed characters for HF repo ids and local model paths. We reject
 #: ``..`` traversal, shell metacharacters, NUL bytes, whitespace, and any
 #: byte outside the printable ASCII subset below.
-_MODEL_PATH_RE = re.compile(r"^[A-Za-z0-9_./\-]+$")
+_MODEL_PATH_RE = re.compile(r"^[A-Za-z0-9_./\-]+\Z")
 
 #: Maximum length of a mesh ``peer_id`` as carried on wire-side ``cmd``
 #: payloads (e.g. ``teleop_receive.source_peer_id``). The local
@@ -99,7 +99,7 @@ MAX_PEER_ID_LEN: int = 128
 #: shell metacharacters, no whitespace, no NULs, no unicode controls)
 #: but additionally forbids ``/`` because peer_ids are not paths and any
 #: ``/`` in one is a wire-side red flag.
-_PEER_ID_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
+_PEER_ID_RE = re.compile(r"^[A-Za-z0-9_.\-]+\Z")
 
 #: Charset gate for wire-routing passthrough fields (``turn_id``,
 #: ``sender_id``, ``override_code``) and host/address strings stored in
@@ -108,7 +108,7 @@ _PEER_ID_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
 #: type-check + length-bound so a malicious payload with embedded control
 #: bytes is rejected cleanly rather than passing through to audit logs or
 #: downstream string ops.
-_SAFE_PASSTHROUGH_RE = re.compile(r"^[\x20-\x7E]+$")
+_SAFE_PASSTHROUGH_RE = re.compile(r"^[\x20-\x7E]+\Z")
 
 #: Control characters refused in a natural-language payload
 #: (``instruction``): C0 (0x00-0x1F, which includes NUL, CR and LF), DEL
@@ -323,7 +323,7 @@ def _resolve_input_value_abs(key: str, value_abs_by_key: Mapping[str, float] | N
 #: Charset for teleop input-frame keys (motor/joint names like
 #: ``"motor.pos"``, ``"shoulder_pan"``, ``"j0"``). Printable, no
 #: whitespace, no shell metacharacters, no path separators.
-_INPUT_KEY_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
+_INPUT_KEY_RE = re.compile(r"^[A-Za-z0-9_.\-]+\Z")
 
 #: Maximum length of a single input-frame key name.
 MAX_INPUT_KEY_LEN: int = 64
@@ -359,12 +359,12 @@ MAX_WORLD_UPDATE_BYTES: int = 65536
 #: Symmetric with :data:`_POLICY_HOST_ENTRY_RE` so this module presents a
 #: uniform fail-loud-on-misconfig posture across every
 #: operator-extensible env-var allowlist.
-_HF_REPO_ENTRY_RE = re.compile(r"^[A-Za-z0-9_./\-]+$")
+_HF_REPO_ENTRY_RE = re.compile(r"^[A-Za-z0-9_./\-]+\Z")
 
 #: Charset for entries in ``STRANDS_MESH_POLICY_TYPE_ALLOW``. Lowercase
 #: identifier shape -- matches the spirit of the built-in
 #: :data:`_DEFAULT_POLICY_TYPES` set.
-_POLICY_TYPE_ENTRY_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_POLICY_TYPE_ENTRY_RE = re.compile(r"^[a-z][a-z0-9_]*\Z")
 
 #: LeRobot policy *families* accepted as ``policy_type``. This half of the
 #: allowlist names an external vocabulary (LeRobot's own policy registry), not
@@ -487,7 +487,7 @@ ALLOWED_ACTIONS: frozenset[str] = frozenset(
 #: apply to a device's own advertised function surface. We still bound the
 #: name to a conservative identifier charset so a function name cannot carry
 #: control bytes / shell metacharacters into the device runtime or audit log.
-_DC_RPC_FUNC_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DC_RPC_FUNC_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\Z")
 
 #: Max length of a Device Connect RPC function name.
 MAX_DC_RPC_FUNC_LEN: int = 64
@@ -557,7 +557,7 @@ class LockoutError(SecurityError):
 #: ``STRANDS_MESH_POLICY_HOST_ALLOW``. Rejects shell metacharacters,
 #: whitespace, NUL bytes, and any byte outside the printable ASCII
 #: subset typical of DNS labels and CIDR ranges.
-_POLICY_HOST_ENTRY_RE = re.compile(r"^[A-Za-z0-9.:/_\-]+$")
+_POLICY_HOST_ENTRY_RE = re.compile(r"^[A-Za-z0-9.:/_\-]+\Z")
 
 
 def _validate_env_allowlist_entries(env_var: str, raw: str, regex: re.Pattern[str]) -> list[str]:

--- a/strands_robots/policies/curobo/policy.py
+++ b/strands_robots/policies/curobo/policy.py
@@ -81,7 +81,7 @@ logger = logging.getLogger(__name__)
 # ``mesh.security.validate_command`` and :class:`MoveIt2Policy` for
 # ``target_joints`` keys, so a value the mesh accepts can flow
 # end-to-end without a second allowlist mismatch.
-_JOINT_NAME_PATTERN = r"^[A-Za-z][A-Za-z0-9_-]*$"
+_JOINT_NAME_PATTERN = r"^[A-Za-z][A-Za-z0-9_-]*\Z"
 
 # Cap on how big a trajectory we will keep cached. cuRobo's interpolated
 # plans are typically O(100s) of waypoints; this bound exists to fail

--- a/strands_robots/policies/moveit2/policy.py
+++ b/strands_robots/policies/moveit2/policy.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # ``mesh.security.validate_command`` for ``target_joints`` keys, so a
 # value the mesh accepts can flow end-to-end without a second
 # allowlist mismatch.
-_JOINT_NAME_PATTERN = r"^[A-Za-z][A-Za-z0-9_-]*$"
+_JOINT_NAME_PATTERN = r"^[A-Za-z][A-Za-z0-9_-]*\Z"
 
 
 class MoveIt2Policy(Policy):
@@ -417,10 +417,10 @@ class MoveIt2Policy(Policy):
             raise ValueError(f"planning_group must be a str, got {type(planning_group).__name__}")
         # Same charset as joint names - matches the MoveIt2 group naming
         # conventions documented at https://moveit.picknik.ai/.
-        if not re.match(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$", planning_group):
+        if not re.match(r"^[A-Za-z][A-Za-z0-9_-]{0,63}\Z", planning_group):
             raise ValueError(
                 f"planning_group {planning_group!r} must match "
-                "'^[A-Za-z][A-Za-z0-9_-]{0,63}$' (letters, digits, "
+                "'^[A-Za-z][A-Za-z0-9_-]{0,63}\\Z' (letters, digits, "
                 "underscore, hyphen; max 64 chars)"
             )
 

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -157,7 +157,7 @@ _WALK_VELOCITY_THRESHOLD = 0.05
 # HuggingFace repo id: "<org>/<repo>", each segment letters/digits/._- only.
 # Used to decide whether a non-existent checkpoint string is an HF id worth
 # downloading vs. a local path that should surface a clean not-found error.
-_HF_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+_HF_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 
 
 def _looks_like_hf_repo_id(value: str) -> bool:

--- a/strands_robots/registry/discovery.py
+++ b/strands_robots/registry/discovery.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 # Robot names are interpolated into ``importlib`` module paths, so restrict them
 # to a conservative allowlist before any lookup - no dots, slashes, or
 # whitespace can reach the import machinery.
-_NAME_RE = re.compile(r"^[a-z0-9_]+$")
+_NAME_RE = re.compile(r"^[a-z0-9_]+\Z")
 
 # ``robot_descriptions`` names every MuJoCo (MJCF) description module with this
 # suffix, e.g. ``go2_mj_description`` -> canonical robot name ``go2``.

--- a/strands_robots/rtps/mangling.py
+++ b/strands_robots/rtps/mangling.py
@@ -46,15 +46,15 @@ import re
 
 # ROS 2 graph names: leading slash plus alnum/_ segments (tilde/braces are
 # substitution syntax that must already be resolved before mangling).
-_ROS_TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]$")
+_ROS_TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]\Z")
 
 # Message interfaces only - see the module docstring for why ``srv``/``action``
 # cannot appear here.
-_ROS_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/msg/[A-Za-z0-9_]+$")
+_ROS_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/msg/[A-Za-z0-9_]+\Z")
 
 # A well-formed service or action interface. Matched separately so it is refused
 # with the mapping explained instead of being reported as a malformed name.
-_ROS_SERVICE_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/(srv|action)/[A-Za-z0-9_]+$")
+_ROS_SERVICE_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/(srv|action)/[A-Za-z0-9_]+\Z")
 
 # DDS topic prefixes per the ROS 2 mapping. Only ``rt`` (topics) is used in v1.
 _TOPIC_PREFIX = "rt"

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -146,7 +146,7 @@ def _image_allowlist() -> tuple[str, ...]:
 # Anything outside that (whitespace, ``;$()`` `\`` etc.) is rejected before
 # the value reaches argv, defence in depth even though the container is
 # started with subprocess in argv-mode (no shell).
-_IMAGE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@-]*$")
+_IMAGE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@-]*\Z")
 
 
 def _is_allowed_image(image_name: str) -> bool:
@@ -204,7 +204,7 @@ def _is_allowed_repo_url(repo_url: str) -> bool:
 # git refs may legitimately contain letters, digits, and ``._/-``; anything
 # else (whitespace, shell metacharacters, a leading ``-`` that git would read
 # as an option) is rejected before the value reaches ``git --branch``/checkout.
-_REPO_TAG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+_REPO_TAG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*\Z")
 
 
 def _is_allowed_repo_tag(repo_tag: str) -> bool:
@@ -468,7 +468,7 @@ def _numeric_option_error(
     return None
 
 
-_ENUMERABLE_OPTION_RE = re.compile(r"^[a-z][a-z0-9_]+$")
+_ENUMERABLE_OPTION_RE = re.compile(r"^[a-z][a-z0-9_]+\Z")
 
 #: Per-action set of enumerable string options the action's command line reads.
 #: The keys mirror :data:`_ACTION_NUMERIC_OPTIONS` -- these five options are

--- a/strands_robots/tools/harness_memory.py
+++ b/strands_robots/tools/harness_memory.py
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)
 
 # Task names become file names: strict allowlist, no path separators, no
 # metacharacters. LLM-provided strings are untrusted (see AGENTS.md, PR #92).
-_TASK_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_TASK_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+\Z")
 _MAX_TASK_NAME_LEN = 128
 
 # Global-memory rule kinds map to fixed file names (never user-derived).
@@ -167,7 +167,7 @@ def _validate_task_name(task: str | None) -> str:
     if len(task) > _MAX_TASK_NAME_LEN:
         raise ValueError(f"task name too long ({len(task)} > {_MAX_TASK_NAME_LEN} chars)")
     if not _TASK_NAME_RE.match(task):
-        raise ValueError(f"invalid task name {task!r}: must match ^[a-zA-Z0-9_-]+$ (no paths, no metacharacters)")
+        raise ValueError(f"invalid task name {task!r}: must match ^[a-zA-Z0-9_-]+\\Z (no paths, no metacharacters)")
     return task
 
 
@@ -538,7 +538,7 @@ def harness_memory(
     Args:
         action: Action to perform.
         task: Task key, matched exactly on later runs. Must match
-            ^[a-zA-Z0-9_-]+$ (max 128 chars; no dots, so use "task_v2"
+            ^[a-zA-Z0-9_-]+\\Z (max 128 chars; no dots, so use "task_v2"
             rather than "task.v2").
         trace: Solution skeleton: list of primitive-invocation dicts, one per
             step, e.g. {"action": "run_policy", "instruction": "grasp the

--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -91,7 +91,7 @@ class LeRobotCalibrationManager:
     def get_calibration_path(self, device_type: str, device_model: str, device_id: str) -> Path:
         """Get the full path to a calibration file."""
         # Security hardening: restrict path components to prevent traversal.
-        _SAFE_COMPONENT = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+        _SAFE_COMPONENT = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*\Z")
         _VALID_DEVICE_TYPES = {"teleoperators", "robots"}
         if device_type not in _VALID_DEVICE_TYPES:
             raise ValueError(f"device_type must be one of {_VALID_DEVICE_TYPES}, got {device_type!r}")

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -59,7 +59,7 @@ from strands_robots.utils import finite_number_error, positive_count_error, posi
 # extended ``STRANDS_MESH_SUBSCRIBE_ALLOW`` with a wildcard pattern such as
 # ``strands/*/stream``. Allowed: alphanumerics, ``.``, ``_``, ``-``; first
 # char must be alphanumeric; max 64 chars (Zenoh peer-id practical limit).
-_PEER_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_PEER_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
 
 logger = logging.getLogger(__name__)
 

--- a/strands_robots/tools/use_ros.py
+++ b/strands_robots/tools/use_ros.py
@@ -77,8 +77,8 @@ logger = logging.getLogger(__name__)
 # substitution braces); interface types are pkg/(msg|srv)/Name. Rejecting
 # everything else keeps untrusted, agent-supplied strings from carrying
 # unexpected characters into the rclpy graph API or type-resolution layer.
-_NAME_RE = re.compile(r"^[A-Za-z0-9_/~{}]+$")
-_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/[A-Za-z0-9_]+/[A-Za-z0-9_]+$")
+_NAME_RE = re.compile(r"^[A-Za-z0-9_/~{}]+\Z")
+_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/[A-Za-z0-9_]+/[A-Za-z0-9_]+\Z")
 
 
 def _gate_command(kind: str, name: str, tool_context: ToolContext | None) -> dict[str, Any] | None:

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -58,9 +58,9 @@ from strands_robots.utils import tcp_port_error
 logger = logging.getLogger(__name__)
 
 # Graph names: same allowlist posture as use_ros. Types are ROS1 two-segment.
-_NAME_RE = re.compile(r"^[A-Za-z0-9_/~]+$")
-_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/[A-Za-z0-9_]+$")
-_HOST_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_NAME_RE = re.compile(r"^[A-Za-z0-9_/~]+\Z")
+_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/[A-Za-z0-9_]+\Z")
+_HOST_RE = re.compile(r"^[A-Za-z0-9._-]+\Z")
 
 # The top of the 16-bit port space is a legal TCP port that this transport cannot
 # address. autobahn builds the WebSocket URL behind roslibpy with

--- a/strands_robots/tools/use_rtps.py
+++ b/strands_robots/tools/use_rtps.py
@@ -59,8 +59,8 @@ logger = logging.getLogger(__name__)
 
 # ROS 2 graph names: absolute, alnum/_ segments. Validate before mangling so a
 # malformed agent-supplied name fails with a clear message.
-_TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]$")
-_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/(msg|srv|action)/[A-Za-z0-9_]+$")
+_TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]\Z")
+_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/(msg|srv|action)/[A-Za-z0-9_]+\Z")
 
 # Which numeric options each action actually consumes. ``status``, ``types``,
 # ``advertise`` and ``subscribe`` read none of them, so the guard below is driven

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -147,7 +147,7 @@ if TYPE_CHECKING:
 # no ``=``, no whitespace or shell metacharacters. We deliberately do NOT try to
 # enumerate every valid backend flag - that allowlist is impossible to keep
 # current and would break the documented ``extra`` escape hatch.
-_EXTRA_KEY_RE = re.compile(r"^[a-z][a-z0-9_.]*$")
+_EXTRA_KEY_RE = re.compile(r"^[a-z][a-z0-9_.]*\Z")
 
 # Scalars that are interpolated as the value of a single argv flag
 # (e.g. ``--dataset.root={dataset_root}``). A leading ``-`` is the injection

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -472,7 +472,7 @@ def _reward_friendly_fields(rtype: str) -> set[str]:
 # Hugging Face Hub dataset id: ``org/name`` (each segment alnum plus ._-). Used
 # to gate the agent-supplied ``dataset_repo_id`` before it becomes lerobot's
 # ``DatasetConfig.repo_id`` (which load_dataset/HfApi feed to a Hub URL).
-_HUB_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+_HUB_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 
 
 class LerobotTrainer(Trainer):

--- a/strands_robots/training/sagemaker.py
+++ b/strands_robots/training/sagemaker.py
@@ -69,20 +69,20 @@ _PURPOSE = "submitting SageMaker training jobs (strands_robots.training.sagemake
 # The lookahead carries the length half. The base job name keeps 32 chars so
 # the appended UTC stamp + entropy suffix ("-YYYYmmdd-HHMMSS-<8 hex>",
 # 25 chars) always fits under 63.
-_BASE_JOB_NAME_RE = re.compile(r"^(?=.{1,32}$)[a-zA-Z0-9](-*[a-zA-Z0-9]){0,31}$")
+_BASE_JOB_NAME_RE = re.compile(r"^(?=.{1,32}\Z)[a-zA-Z0-9](-*[a-zA-Z0-9]){0,31}\Z")
 
 # SageMaker training instance types are "ml.<family>.<size>", e.g.
 # "ml.g5.12xlarge" / "ml.p4d.24xlarge". Format allowlist only - the live
 # catalog changes too often to enumerate, and a wrong-but-well-formed type is
 # refused by CreateTrainingJob itself.
-_INSTANCE_TYPE_RE = re.compile(r"^ml\.[a-z0-9-]+\.[a-z0-9]+$")
+_INSTANCE_TYPE_RE = re.compile(r"^ml\.[a-z0-9-]+\.[a-z0-9]+\Z")
 
-_ROLE_ARN_RE = re.compile(r"^arn:aws[a-zA-Z-]*:iam::\d{12}:role/.+$")
+_ROLE_ARN_RE = re.compile(r"^arn:aws[a-zA-Z-]*:iam::\d{12}:role/.+\Z")
 
 # An input channel / output path is an S3 URI: bucket (S3 naming rules,
 # loosely) plus optional key prefix. A local path cannot be mounted into a
 # managed job, so it is refused here rather than failing at job start.
-_S3_URI_RE = re.compile(r"^s3://[a-z0-9][a-z0-9.\-]*[a-z0-9](/.*)?$")
+_S3_URI_RE = re.compile(r"^s3://[a-z0-9][a-z0-9.\-]*[a-z0-9](/.*)?\Z")
 
 # CreateTrainingJob limits: at most 100 hyperparameters, each key at most 256
 # characters and each value at most 2500. Checked in validate() so an

--- a/tests/test_allowlist_patterns_anchor_at_the_end_of_the_string.py
+++ b/tests/test_allowlist_patterns_anchor_at_the_end_of_the_string.py
@@ -1,0 +1,312 @@
+"""Every allowlist in this package anchors at the absolute end of the string.
+
+Python's ``$`` matches at the end of the string *or immediately before a single
+trailing newline*, so ``re.match(r"^[a-z]+$", "abc\\n")`` succeeds. An allowlist
+spelled that way therefore admits a value whose characters it says it forbids.
+
+Two modules already knew, and each wrote the reason down:
+
+* ``strands_robots.mesh.core`` anchors its ``peer_id`` and wire-ZID allowlists
+  with ``\\Z``, pinned by
+  ``tests/mesh/test_mesh_identifier_trailing_newline_rejected.py``;
+* ``strands_robots.mesh.iot.provision`` reaches the same end by calling
+  ``fullmatch``, pinned by ``tests/mesh/test_iot_provision.py`` whose
+  ``TestValidateThingNameFullmatch`` docstring states the mechanism verbatim --
+  "``re.match(r'^[a-zA-Z0-9_-]{1,128}$', s)`` accepts ``'robot\\n'`` because in
+  non-MULTILINE mode ``$`` matches just before a trailing newline".
+
+That is a property of ``$``, not of the mesh, and nothing held the rest of the
+package to it. These tests do, in two halves: a derived source-level cell over
+every regex the package compiles, so an allowlist added later is graded on
+arrival rather than when someone thinks to audit it, and behavioural cells that
+drive the surfaces where the admitted value reached a wire name, a file name or
+a managed-job name.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+import strands_robots
+
+_PKG_ROOT = Path(strands_robots.__file__).resolve().parent
+
+#: ``re`` functions whose first positional argument is a pattern.
+_RE_FUNCTIONS = frozenset({"compile", "match", "search", "fullmatch", "sub", "subn", "split", "findall", "finditer"})
+
+#: Names that hold a pattern; the assignment is graded even when the call that
+#: consults it lives in another module (a class attribute, or a pattern passed
+#: to a shared validator).
+_PATTERN_NAME_SUFFIXES = ("_RE", "_REGEX", "_PATTERN", "_PAT")
+
+
+def _has_end_of_line_anchor(pattern: str) -> bool:
+    """Whether *pattern* contains a ``$`` acting as an anchor.
+
+    A ``$`` that is escaped (``\\$``) or inside a character class matches a
+    literal dollar sign and is not an anchor, so neither is reported.
+    """
+    index = 0
+    in_class = False
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "\\":
+            index += 2
+            continue
+        if in_class:
+            if char == "]":
+                in_class = False
+        elif char == "[":
+            in_class = True
+        elif char == "$":
+            return True
+        index += 1
+    return False
+
+
+def _regex_literals() -> list[tuple[Path, int, str]]:
+    """Every regex pattern the package spells as a literal.
+
+    Returns:
+        ``(file, line, pattern)`` for each string literal that is either the
+        first positional argument of an ``re`` function or the value assigned
+        to a name suffixed like a pattern constant.
+    """
+    found: list[tuple[Path, int, str]] = []
+    for path in sorted(_PKG_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in _RE_FUNCTIONS
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "re"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                found.append((path, node.args[0].lineno, node.args[0].value))
+            targets: list[ast.expr] = []
+            value: ast.expr | None = None
+            if isinstance(node, ast.Assign):
+                targets, value = list(node.targets), node.value
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                targets, value = [node.target], node.value
+            if value is None or not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+                continue
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id.endswith(_PATTERN_NAME_SUFFIXES):
+                    found.append((path, value.lineno, value.value))
+    return found
+
+
+def test_no_regex_in_the_package_anchors_with_the_end_of_line_marker() -> None:
+    """No pattern this package compiles uses ``$``; the anchor is ``\\Z``.
+
+    ``$`` and ``\\Z`` differ on exactly one input -- a value carrying a single
+    trailing newline -- and no pattern here is compiled with ``re.MULTILINE``,
+    so ``$``'s extra reach is never the intent. Grading the spelling rather
+    than each validator's behaviour is what makes this hold for an allowlist
+    added after this test was written.
+    """
+    literals = _regex_literals()
+    assert literals, "the sweep resolved no regex literals; its population is wrong, not the package"
+    offenders = [
+        f"{path.relative_to(_PKG_ROOT.parent)}:{line}: {pattern!r}"
+        for path, line, pattern in literals
+        if _has_end_of_line_anchor(pattern)
+    ]
+    assert not offenders, (
+        f"{len(offenders)} regex literal(s) anchor with '$', which also matches immediately "
+        "before a trailing newline; anchor with '\\\\Z' (or consult the pattern with "
+        "fullmatch):\n  " + "\n  ".join(offenders)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_memory_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the ``harness_memory`` surface out of the developer's real store.
+
+    The task name under test becomes a file name, so the cell has to be allowed
+    to write one; ``STRANDS_MEMORY_DIR`` relocates the whole store.
+    """
+    monkeypatch.setenv("STRANDS_MEMORY_DIR", str(tmp_path / "memory"))
+
+
+def _refuses_value_error(function: Callable[[str], object]) -> Callable[[str], bool]:
+    """Adapt a function that raises ``ValueError`` on refusal to a verdict."""
+
+    def refuses(value: str) -> bool:
+        try:
+            function(value)
+        except ValueError:
+            return True
+        return False
+
+    return refuses
+
+
+def _refuses_task_name(value: str) -> bool:
+    """Whether the ``harness_memory`` tool refuses *value* as a task name.
+
+    The task name becomes the store's file name, so the tool's own allowlist is
+    the only thing standing between an agent-supplied string and a path.
+    """
+    from strands_robots.tools.harness_memory import harness_memory
+
+    result = harness_memory(
+        action="save_trace",
+        task=value,
+        trace=[{"action": "get_state"}],
+        summary={"task": "pick the cube", "success": True},
+    )
+    text = "\n".join(item.get("text", "") for item in result.get("content", []))
+    return result["status"] == "error" and "task name" in text
+
+
+def _refuses_base_job_name(value: str) -> bool:
+    """Whether ``SagemakerTrainer.validate`` refuses *value* as a job-name prefix."""
+    from strands_robots.training import TrainSpec
+    from strands_robots.training.sagemaker import SagemakerTrainer
+
+    trainer = SagemakerTrainer(
+        image_uri="123456789012.dkr.ecr.us-east-1.amazonaws.com/trainer:1",
+        role_arn="arn:aws:iam::123456789012:role/SageMakerRole",
+        base_job_name=value,
+    )
+    spec = TrainSpec(dataset_root="s3://bucket/data", output_dir="s3://bucket/out")
+    return any("base_job_name" in problem for problem in trainer.validate(spec))
+
+
+@dataclasses.dataclass(frozen=True)
+class _Surface:
+    """One allowlist reached through a public entry point.
+
+    Attributes:
+        name: Test id.
+        clean: A value the allowlist accepts, so a refusal cannot be vacuous.
+        refuses: Verdict for one candidate value.
+        sink: What the accepted value goes on to become, quoted in the failure.
+    """
+
+    name: str
+    clean: str
+    refuses: Callable[[str], bool]
+    sink: str
+
+
+def _surfaces() -> list[_Surface]:
+    """The public entry points graded below.
+
+    ``rtps.mangling`` is imported here rather than at module scope so a failure
+    to import is attributed to the surface that needs it.
+    """
+    from strands_robots.mesh.iot import provision
+    from strands_robots.rtps import mangling
+
+    return [
+        _Surface(
+            "rtps.dds_topic_name",
+            "/turtle1/cmd_vel",
+            _refuses_value_error(mangling.dds_topic_name),
+            "a DDS topic name published on the graph",
+        ),
+        _Surface(
+            "rtps.dds_type_name",
+            "std_msgs/msg/String",
+            _refuses_value_error(mangling.dds_type_name),
+            "a DDS type name whose trailing '_' would land after the line break",
+        ),
+        _Surface(
+            "rtps.ros_topic_name",
+            "rt/turtle1/cmd_vel",
+            _refuses_value_error(mangling.ros_topic_name),
+            "a ROS 2 topic name handed back as recovered from the graph",
+        ),
+        _Surface(
+            "harness_memory.task",
+            "pick_cube",
+            _refuses_task_name,
+            "the trace store's file name",
+        ),
+        _Surface(
+            "sagemaker.base_job_name",
+            "strands-train",
+            _refuses_base_job_name,
+            "the TrainingJobName sent to SageMaker",
+        ),
+        _Surface(
+            "mesh.iot.thing_name",
+            "robot-01",
+            _refuses_value_error(provision._validate_thing_name),
+            "an AWS Thing name and the cert paths derived from it",
+        ),
+    ]
+
+
+@pytest.mark.parametrize("surface", _surfaces(), ids=lambda s: s.name)
+def test_an_otherwise_valid_value_with_a_trailing_newline_is_refused(surface: _Surface) -> None:
+    """A trailing newline does not smuggle a value past an allowlist.
+
+    ``mesh.iot.thing_name`` is the control: it already refused, because it
+    consults its pattern with ``fullmatch``. The others differed from it only
+    in the spelling of the anchor.
+    """
+    assert not surface.refuses(surface.clean), (
+        f"{surface.name}: the clean value {surface.clean!r} must be accepted, "
+        "otherwise the refusal below proves nothing"
+    )
+    assert surface.refuses(surface.clean + "\n"), (
+        f"{surface.name}: {surface.clean + chr(10)!r} was accepted and became {surface.sink}"
+    )
+
+
+def test_the_base_job_name_length_bound_holds_for_a_trailing_newline() -> None:
+    """The documented 1-32 bound counts a newline as a character.
+
+    ``_BASE_JOB_NAME_RE`` spends its length bound in a lookahead
+    (``(?=.{1,32}\\Z)``), so the anchor decides the bound as well as the
+    character set: with ``$`` a 33-character value was refused unless its 33rd
+    character was a newline, which the refusal's own text ("1-32 ...
+    characters") does not allow for.
+    """
+    assert not _refuses_base_job_name("a" * 32), "32 characters is inside the documented bound"
+    assert _refuses_base_job_name("a" * 33), "33 characters is outside it"
+    assert _refuses_base_job_name("a" * 32 + "\n"), "a 33rd character that is a newline is still a 33rd character"
+
+
+def test_a_dollar_that_is_not_an_anchor_is_not_reported() -> None:
+    """The sweep reads regex syntax, not the character.
+
+    A ``$`` inside a character class or escaped is a literal dollar sign, so
+    reporting it would make the rule above unsatisfiable for a pattern that
+    legitimately matches one.
+    """
+    assert _has_end_of_line_anchor(r"^[a-z]+$")
+    assert _has_end_of_line_anchor(r"^(?=.{1,32}$)[a-z]+\Z")
+    assert not _has_end_of_line_anchor(r"^[a-z$]+\Z")
+    assert not _has_end_of_line_anchor(r"^\$[0-9]+\Z")
+    assert not _has_end_of_line_anchor(r"^[a-z]+\Z")
+
+
+def test_every_graded_surface_names_a_distinct_module() -> None:
+    """The table is a census of modules, not several views of one validator."""
+    names: list[str] = [surface.name for surface in _surfaces()]
+    assert len(names) == len(set(names))
+    modules: set[str] = {name.split(".")[0] for name in names}
+    assert len(modules) >= 4, f"only {sorted(modules)} are represented; widen the table"
+
+
+def test_the_sweep_reads_the_whole_package() -> None:
+    """The derived population covers every module, not a listed subset."""
+    literals = _regex_literals()
+    files = {path for path, _, _ in literals}
+    assert len(files) > 20, f"only {len(files)} files contributed a pattern; the sweep is too narrow"


### PR DESCRIPTION
![before and after](https://raw.githubusercontent.com/cagataycali/robots/71b3748f9b27b051c34541ac89d9f55a094e947d/.artifacts/allowlist-anchor-before-after.png)

Python's `$` matches at the end of the string **or immediately before a single trailing newline**, so `re.match(r"^[a-z]+$", "abc\n")` succeeds. An allowlist spelled that way admits a value carrying a character it says it forbids.

Two modules already knew, and each wrote the reason down:

| module | remedy | pinned by |
|---|---|---|
| `mesh/core.py` (`peer_id`, wire ZID) | `\Z` | `tests/mesh/test_mesh_identifier_trailing_newline_rejected.py` |
| `mesh/iot/provision.py` (`thing_name`) | `fullmatch` | `tests/mesh/test_iot_provision.py::TestValidateThingNameFullmatch` |

That second docstring states the mechanism verbatim - "`re.match(r'^[a-zA-Z0-9_-]{1,128}$', s)` accepts `'robot\n'` because in non-MULTILINE mode `$` matches just before a trailing newline" - and names the consequence: "a bypass surface exists wherever `thing_name` is interpolated into a filesystem path or an AWS API call".

It is a property of `$`, not of the mesh. The other **50** regex literals in `strands_robots` spelled `$`, and **30** of them are consulted with `.match()`, so each accepted the value those two refuse.

## Measured, through public entry points

| entry point | value | before | after |
|---|---|---|---|
| `rtps.mangling.dds_topic_name` | `'/turtle1/cmd_vel\n'` | `'rt/turtle1/cmd_vel\n'` | refused |
| `rtps.mangling.dds_type_name` | `'std_msgs/msg/String\n'` | `'std_msgs::msg::dds_::String\n_'` | refused |
| `rtps.mangling.ros_topic_name` | `'rt/turtle1/cmd_vel\n'` | `'/turtle1/cmd_vel\n'` | refused |
| `harness_memory` `save_trace` | `task='pick_cube\n'` | wrote `'pick_cube\n.trace.jsonl'` | refused |
| `SagemakerTrainer.validate` | `base_job_name='strands-train\n'` | no problem reported | refused |
| `SagemakerTrainer.validate` | `base_job_name` = 32 `a` + `'\n'` | no problem reported | refused |
| `mesh/iot` `_validate_thing_name` **(control)** | `'robot-01\n'` | refused | refused |

The DDS type-name row is the sharpest. `dds_type_name` splits on `/` and appends the suffix the DDS convention requires, so the newline lands *inside* the identifier and the trailing `_` ends up on a second line - one name, two lines, put on the graph. `_require_ros_topic`'s own docstring promises the opposite: "Both directions apply this one rule, so a name `dds_topic_name` would refuse is never a name `ros_topic_name` hands back either."

The `base_job_name` rows are a second consequence that is not about newlines being unwanted characters. `_BASE_JOB_NAME_RE` spends its length bound inside a lookahead (`(?=.{1,32}$)`), so the anchor decided the bound as well as the character set: a 33-character value was refused **unless** its 33rd character was a newline. The refusal's own text says "1-32 ... characters".

One more disagreement worth naming: `robot_mesh`'s `_PEER_ID_RE` is a second copy of the same `peer_id` allowlist that `mesh/core.py` anchors with `\Z`. On `'robot-1\n'` the library refused and the agent-facing tool accepted.

## Change

Every regex literal in `strands_robots` now anchors with `\Z`. No pattern in the package is compiled with `re.MULTILINE`, so `$`'s extra reach was never the intent. The 10 patterns already consulted with `fullmatch` change spelling but not behaviour - that uniformity is what lets one derived rule cover all of them instead of a per-call-site judgement about which verb was used. Four prose sites that quoted a pattern verbatim were updated to match the code; `sagemaker.py:65` was left alone because it quotes AWS's documented `TrainingJobName` pattern, not this module's.

## Tests

`tests/test_allowlist_patterns_anchor_at_the_end_of_the_string.py`, two halves:

- one source-level cell over **every** regex the package compiles - population derived from the AST (first argument of an `re` function, or a value assigned to a `_RE`/`_PATTERN`-suffixed name), not listed - so an allowlist added later is graded on arrival rather than when someone thinks to audit it. Its `$`-detection reads regex syntax, so a `$` inside a character class or escaped is not reported, and that is pinned separately;
- behavioural cells driving the five surfaces in the table, table-driven over one `_Surface` row each, with `mesh/iot`'s already-correct `thing_name` as the control and every clean value asserted accepted first so a refusal cannot be vacuous.

| | before | after |
|---|---|---|
| the new file | **7 failed, 4 passed** (all 4 controls green; the source cell reports 50 offenders) | **11 passed** |
| `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` | clean | clean |
| `mypy strands_robots tests tests_integ` (CI pin) | 20 errors in 6 files | 20 errors in 6 files (identical) |

Full `pytest tests` was run on both trees; the FAILED/ERROR node-id sets are compared in a follow-up comment.

## Size

+378 / -55 over 26 files. 50 of the source lines are the one-token anchor change; the rest is the new test file (312 lines) and one `AGENTS.md` bullet recording the trap next to the existing "reject `\n`, `\r`" rule that the `$` spelling silently failed to enforce.