### PR TITLE
fix(policies): a cached qpos-address map belongs to the robot it was built for

### DIFF
--- a/changelog.d/3177-qpos-addr-cache-covers-the-robot.md
+++ b/changelog.d/3177-qpos-addr-cache-covers-the-robot.md
@@ -1,0 +1,16 @@
+### Fixed: a cached qpos-address map is no longer served to a different robot
+
+`VeraPolicy._joint_qpos_addr` caches the `{state_key: qpos_index}` mapping that
+the IK seed and the decoded IK targets both address through, and it was keyed on
+`id(mj_model)` alone. A simulation binds one compiled world model to whichever
+robot it is starting a rollout for, immediately after setting that robot's
+`robot_state_keys`, so a second robot in the same scene arrives with new keys and
+the identical model - and was served the previous robot's addresses.
+
+Neither consumer could report it, because both skip a key the mapping does not
+carry: the IK seed silently kept the model rest pose instead of the observed
+joint configuration, and the decoded action dicts silently omitted every arm
+joint. The mapping is now keyed on both inputs it is derived from. The model is
+also held and compared by identity rather than by `id()`, which is unique only
+while its object is alive, so a freed model's address can no longer be matched
+by the model that replaces it.

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -690,11 +690,32 @@ class VeraPolicy(Policy):
         Robot joints are namespaced in the compiled model (``<ns>/<joint>``);
         ``robot_state_keys`` are unqualified. Match by suffix so the IK seed and
         output read/write the correct qpos slots regardless of other DOFs (free
-        bodies, multiple robots) present in the scene. Cached per model id.
+        bodies, multiple robots) present in the scene.
+
+        Cached against both inputs the mapping is derived from - the model and
+        ``robot_state_keys`` - because they move independently and the model is
+        not the one that moves on a rebind. ``SimEngine`` hands the single
+        compiled world model to whichever robot it binds
+        (``bind_policy_sim_context``), immediately after setting that robot's
+        keys, so a second robot in the same scene arrives with new keys and the
+        *identical* model. A model-only key served it the previous robot's
+        addresses, and neither consumer can report that: both skip a key the
+        mapping does not carry, so the IK seed silently keeps the rest pose
+        (:meth:`_resolve_ik_inputs`) and the decoded targets silently omit every
+        arm joint (:meth:`_ik_chunk_to_action_dicts`). The keys are the whole
+        domain of this mapping, so a stale one is not a near miss.
+
+        The model is held and compared by identity, not by ``id()``: an ``id()``
+        is unique only while its object is alive and an int key keeps nothing
+        alive, so a freed model's address can be reused by the model that
+        replaces it and collide. Holding it pins nothing new - ``self._mj_model``
+        already holds the same object for as long as it is the active model, and
+        this single-slot cache drops a superseded one on the next miss.
         """
+        keys = tuple(self._robot_state_keys)
         cache = getattr(self, "_qpos_addr_cache", None)
-        if cache is not None and cache[0] == id(mj_model):
-            return cache[1]
+        if cache is not None and cache[0] is mj_model and cache[1] == keys:
+            return cache[2]
 
         addr: dict[str, int] = {}
         # Real MjModel: map robot_state_keys -> qpos addresses by (namespaced)
@@ -709,14 +730,14 @@ class VeraPolicy(Policy):
                     continue
                 short = name.split("/")[-1]
                 qadr = int(mj_model.jnt_qposadr[j])
-                for k in self._robot_state_keys:
+                for k in keys:
                     if k in (short, name):
                         addr[k] = qadr
         except (AttributeError, ImportError, TypeError):
             addr = {}
         if not addr:
-            addr = {k: i for i, k in enumerate(self._robot_state_keys)}
-        self._qpos_addr_cache = (id(mj_model), addr)
+            addr = {k: i for i, k in enumerate(keys)}
+        self._qpos_addr_cache = (mj_model, keys, addr)
         return addr
 
     def _ensure_ik_bridge(self, mj_model: Any, ee_frame: str):

--- a/tests/policies/vera/test_vera_ik_qpos_addressing.py
+++ b/tests/policies/vera/test_vera_ik_qpos_addressing.py
@@ -7,8 +7,10 @@ server, GPU, or the optional ``mink`` IK solver:
 * ``VeraPolicy._joint_qpos_addr`` -- maps unqualified ``robot_state_keys`` to
   their qpos addresses in a compiled MuJoCo model by namespaced-joint suffix,
   so the IK seed and output read/write the correct slots even when unrelated
-  DOFs (free bodies, other robots) shift the addresses. Plus the per-model
-  cache and the positional-identity fallback for introspection-less stubs.
+  DOFs (free bodies, other robots) shift the addresses. Plus the cache - keyed
+  on the model *and* the state keys, since one scene binds one model to several
+  robots in turn - and the positional-identity fallback for introspection-less
+  stubs.
 * ``VeraPolicy._resolve_ik_inputs`` -- gathers ``(mj_model, ee_frame, q_init)``
   for an IK solve, returning ``None`` for each "not enough wiring" guard
   (no model/ee-frame, no state keys, missing observation key) and seeding
@@ -38,6 +40,37 @@ _MODEL_XML = """
       <geom type="box" size="0.1 0.1 0.1"/>
       <body name="b2" pos="0.2 0 0">
         <joint name="myarm/elbow" type="hinge" axis="0 1 0"/>
+        <geom type="box" size="0.1 0.1 0.1"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# A SECOND robot in the SAME compiled world. This is what SimEngine binds: one
+# world model handed to whichever robot it is starting a rollout for, so the
+# model is the input that does NOT change between two robots' key sets.
+# ``otherarm`` joints sit at qpos 9/10, past ``myarm``'s 7/8.
+_TWO_ROBOT_XML = """
+<mujoco>
+  <worldbody>
+    <body name="free1">
+      <freejoint name="obj/free"/>
+      <geom type="sphere" size="0.05"/>
+    </body>
+    <body name="b1">
+      <joint name="myarm/shoulder" type="hinge" axis="0 0 1"/>
+      <geom type="box" size="0.1 0.1 0.1"/>
+      <body name="b2" pos="0.2 0 0">
+        <joint name="myarm/elbow" type="hinge" axis="0 1 0"/>
+        <geom type="box" size="0.1 0.1 0.1"/>
+      </body>
+    </body>
+    <body name="c1" pos="1 0 0">
+      <joint name="otherarm/hip" type="hinge" axis="0 0 1"/>
+      <geom type="box" size="0.1 0.1 0.1"/>
+      <body name="c2" pos="0.2 0 0">
+        <joint name="otherarm/knee" type="hinge" axis="0 1 0"/>
         <geom type="box" size="0.1 0.1 0.1"/>
       </body>
     </body>
@@ -76,6 +109,12 @@ def _build_model():
     import mujoco
 
     return mujoco.MjModel.from_xml_string(_MODEL_XML)
+
+
+def _build_two_robot_model():
+    import mujoco
+
+    return mujoco.MjModel.from_xml_string(_TWO_ROBOT_XML)
 
 
 class TestJointQposAddr:
@@ -150,3 +189,118 @@ class TestResolveIkInputs:
         assert list(q_full[3:7]) == [1.0, 0.0, 0.0, 0.0]
         assert q_full[7] == 0.3
         assert q_full[8] == -0.4
+
+
+class TestCacheKeyCoversTheStateKeys:
+    """The mapping is re-derived when either input it is built from changes.
+
+    ``SimEngine`` sets a robot's keys and then hands it the one compiled world
+    model (``base.py`` -> ``bind_policy_sim_context``), so binding a second
+    robot in the same scene changes the keys and *not* the model. The keys are
+    this mapping's whole domain, so serving the previous robot's map is not a
+    near miss - every lookup misses, and both consumers skip a missing key
+    silently rather than refusing.
+    """
+
+    def test_a_rebind_against_one_model_is_not_served_the_previous_map(self):
+        model = _build_two_robot_model()
+        p = _make_policy(["shoulder", "elbow"])
+
+        first = p._joint_qpos_addr(model)
+        assert first == {"shoulder": 7, "elbow": 8}
+
+        # Same model object - only the robot changed.
+        p.set_robot_state_keys(["hip", "knee"])
+        second = p._joint_qpos_addr(model)
+
+        assert second == {"hip": 9, "knee": 10}
+
+    def test_the_seed_carries_the_rebound_robots_joint_values(self):
+        # The consequence at _resolve_ik_inputs: a stale map carries none of the
+        # new keys, so every observed value is skipped and the seed degrades to
+        # the model rest pose with nothing reporting it.
+        model = _build_two_robot_model()
+        p = _make_policy(["shoulder", "elbow"])
+        p.set_ik_target(model, ee_frame_name="b2", ee_frame_type="body")
+        p._resolve_ik_inputs({"shoulder": 0.3, "elbow": -0.4})  # warms the cache
+
+        # A rebind does NOT re-enter set_ik_target: autoconfigure_ik returns
+        # early once an ee-frame is configured, so nothing else invalidates.
+        p.set_robot_state_keys(["hip", "knee"])
+        out = p._resolve_ik_inputs({"hip": 0.3, "knee": -0.4})
+
+        assert out is not None
+        q_full = out[2]
+        assert q_full[9] == 0.3
+        assert q_full[10] == -0.4
+        # Not the rest pose: the observed values reached the seed.
+        import numpy as np
+
+        assert not np.array_equal(q_full, np.asarray(model.qpos0, dtype=np.float64))
+
+    def test_the_decoded_targets_name_the_rebound_robots_joints(self):
+        # The consequence at the output consumer: reading each arm joint back
+        # from a stale map drops every key, emitting an action dict carrying no
+        # arm joint at all.
+        model = _build_two_robot_model()
+        p = _make_policy(["shoulder", "elbow"])
+        p._joint_qpos_addr(model)  # warms the cache for myarm
+
+        p.set_robot_state_keys(["hip", "knee"])
+        addr = p._joint_qpos_addr(model)
+
+        row_width = model.nq
+        emitted = {k: addr[k] for k in ["hip", "knee"] if k in addr and addr[k] < row_width}
+        assert emitted == {"hip": 9, "knee": 10}
+
+    def test_the_positional_fallback_is_rebuilt_for_new_keys(self):
+        # The introspection-less path builds a positional map, so its values
+        # depend on the key list alone - a stale one is wrong by construction.
+        p = _make_policy(["a", "b", "c"])
+        stub = object()
+        assert p._joint_qpos_addr(stub) == {"a": 0, "b": 1, "c": 2}
+
+        p.set_robot_state_keys(["x", "y"])
+        assert p._joint_qpos_addr(stub) == {"x": 0, "y": 1}
+
+    def test_every_input_the_mapping_reads_is_keyed(self):
+        # Differing-value table over the two inputs _joint_qpos_addr reads.
+        # Each row varies exactly one and must re-derive; the control varies
+        # neither and must still be served from the cache.
+        model = _build_two_robot_model()
+        other_model = _build_two_robot_model()
+        p = _make_policy(["shoulder", "elbow"])
+        baseline = p._joint_qpos_addr(model)
+
+        # Row 1: the model differs (equal contents, distinct object).
+        assert p._joint_qpos_addr(other_model) is not baseline
+
+        # Row 2: the state keys differ.
+        p2 = _make_policy(["shoulder", "elbow"])
+        base2 = p2._joint_qpos_addr(model)
+        p2.set_robot_state_keys(["hip", "knee"])
+        assert p2._joint_qpos_addr(model) is not base2
+
+        # Control: neither differs -> the cache this exists for is not disabled.
+        p3 = _make_policy(["shoulder", "elbow"])
+        base3 = p3._joint_qpos_addr(model)
+        assert p3._joint_qpos_addr(model) is base3
+
+    def test_the_key_cannot_alias_a_released_models_address(self):
+        # An id() is unique only while its object lives, and an int key keeps
+        # nothing alive - so a model-address key can be matched by whatever is
+        # allocated there next. Holding the model is what forecloses that, and
+        # it is observable: the entry keeps its model reachable.
+        import gc
+        import weakref
+
+        p = _make_policy(["shoulder", "elbow"])
+        model = _build_two_robot_model()
+        ref = weakref.ref(model)
+        # No set_ik_target here, so the cache entry is the only strong reference.
+        p._joint_qpos_addr(model)
+
+        del model
+        gc.collect()
+
+        assert ref() is not None


### PR DESCRIPTION
`VeraPolicy._joint_qpos_addr` caches the `{state_key: qpos_index}` mapping the IK seed and the IK output both address through. It was keyed on `id(mj_model)` alone.

The mapping is derived from **two** inputs, and the one that changes on a rebind is the one that was not in the key.

| input to the mapping | in the key | read by the builder |
|---|---|---|
| `mj_model` | yes (as `id()`) | `njnt`, `mj_id2name`, `jnt_qposadr` |
| **`self._robot_state_keys`** | **no** | the suffix match, and the whole domain of the result |

## Why the omitted input moves on its own - and the model does not

`SimEngine` binds a rollout in two adjacent statements (`simulation/base.py:4164` and `:4411`):

```python
policy.set_robot_state_keys(self.robot_action_keys(resolved_robot))
self.bind_policy_sim_context(policy, resolved_robot)
```

`bind_policy_sim_context` passes `self._world._model` - the **one compiled world model**, the identical object for every robot in the scene. So binding a second robot changes the keys and leaves `id(mj_model)` untouched. Nothing else invalidates: `autoconfigure_ik` returns early once an ee-frame is configured, so the rebind never re-enters `set_ik_target` (the one place that does clear state, `self._ik_bridge = None`).

Measured on one compiled world holding two arms, driving the real code path:

```
joint 0: obj/free        qposadr=0     (7 DoF)
joint 1: arma/shoulder   qposadr=7
joint 2: arma/elbow      qposadr=8
joint 3: armb/hip        qposadr=9
joint 4: armb/knee       qposadr=10    nq=11
```

| | rollout 1 (`arma`) | rollout 2 (`armb`), same model object |
|---|---|---|
| `addr` returned | `{shoulder: 7, elbow: 8}` | `{shoulder: 7, elbow: 8}` - **`arma`'s map**, `is` the same dict |
| observed values | `0.3, -0.4` | `0.3, -0.4` |
| seed at the robot's slots | `q_full[7:9] == [0.3, -0.4]` | **`q_full[9:11] == [0.0, 0.0]`** |
| seed vs. `model.qpos0` | differs | **byte-identical to the rest pose** |

## Why nothing reports it

Both consumers skip a key the mapping does not carry, so a stale map is not a near miss - `armb`'s keys are absent from `arma`'s map entirely, and every lookup misses:

- **The seed**, `_resolve_ik_inputs`: `if k in addr: q_full[addr[k]] = val`. Every observed joint value is dropped and `q_full` stays at `qpos0`, so IK solves from the rest pose instead of where the robot is.
- **The output**, `_ik_chunk_to_action_dicts`: `{k: float(row[addr[k]]) for k in arm_keys if k in addr and ...}`. The emitted action dict carries **no arm joint at all**.

No exception, no log line, no refusal - which is the shape Key Convention 6 forbids ("No silent defaults on error").

## Second half: an `id()` is unique only while its object is alive

The key was a bare `int` and the entry held no reference to the model, so nothing kept the keyed object alive:

```
cached key           = 140185096084592   (a bare int)
cache tuple contents = int + dict
cache referenced by the model?  False
```

A freed model's address can be reused by the model that replaces it, and the entry would match. That matters here specifically because a scene change *recompiles* the model, and a recompile moves `jnt_qposadr` - so an aliased hit would write joint values into the wrong slots rather than merely dropping them.

## The change

Key on both inputs, and hold the model by identity rather than by address:

```python
keys = tuple(self._robot_state_keys)
if cache is not None and cache[0] is mj_model and cache[1] == keys:
    return cache[2]
...
self._qpos_addr_cache = (mj_model, keys, addr)
```

Keying rather than invalidating at the three writers (`set_robot_state_keys`, `set_ik_target`, `set_sim_context`) keeps this derivable in one place instead of a rule three setters have to remember - the same resolution as #3173.

Holding the model pins nothing new: `self._mj_model` already holds the identical object for as long as it is the active model, and this single-slot cache drops a superseded one on the next miss. A `weakref` would also work (`MjModel` is weakref-able, verified) but buys nothing reachable here and adds a branch, so it is not used.

## Tests

Six cells added to `tests/policies/vera/test_vera_ik_qpos_addressing.py`, the existing owner of this contract, graded through the returned mapping and the returned seed. **Pre-fix, with only the test change applied to `main`: 6 failed, 7 passed.**

| cell | on `main` |
|---|---|
| a rebind against one model is not served the previous map | **fail** (returns `arma`'s map) |
| the seed carries the rebound robot's joint values | **fail** (seed is `qpos0`) |
| the decoded targets name the rebound robot's joints | **fail** (no arm joint emitted) |
| the positional fallback is rebuilt for new keys | **fail** (`{a,b,c}` for keys `{x,y}`) |
| every input the mapping reads is keyed (2-row table + control) | **fail** (keys row) |
| the key cannot alias a released model's address | **fail** (weakref dies) |
| *control:* unchanged model + unchanged keys still served from cache | pass, both ways |

The control is the point alongside the failures: the pre-existing `test_result_is_cached_per_model` asserts `second is first`, and it passes on both trees - the cache this exists for is not disabled. The table cell varies each input in turn and asserts a re-derivation, so an input added later has a row to fail in.

## Gate

| | `main` | this branch |
|---|---|---|
| `tests/policies/vera` | 827 passed, 3 skipped | **833 passed**, 3 skipped (+6 = the new cells) |
| whole-tree graders (93 of 98) | 67 failed, 3623 passed, 161 skipped | identical, and the 67 failing node ids are **set-identical** (`diff` empty) |
| `ruff check` / `format --check` (`strands_robots tests tests_integ`) | clean | clean |
| `mypy strands_robots tests tests_integ` | 27 errors in 23 files | 27 errors in 23 files, none in the touched files |

Stated plainly rather than left to read as a full run: 5 of the 98 graders cannot be **collected** on this box for absent optional dependencies (`lerobot`/`torch`), and the 67 failures are the same absent-dependency artifacts - both are identical on `main`, which is why the comparison is reported as a delta and a node-id set rather than as a pass count. The required `call-test-lint` job is the authority on the full suite.

## Size

+183 / -8. `provider.py` +27 / -6, of which **6 added lines are executable** (the `keys` local, the two-term cache read, the `return`, the loop source, the fallback comprehension, the cache write) and 21 are the caching contract in the docstring. Tests +156 / -2 (the -2 and 4 of the additions correct the module docstring, which described the cache as per-model).

---

### 13. Round changelog

**Round 1** - initial submission. Nothing to restate yet.
