### PR TITLE
fix(hardware): an operator's step-telemetry opt-out publishes nothing

### DIFF
--- a/changelog.d/3176-stream-hz-off-switch-holds-on-hardware.md
+++ b/changelog.d/3176-stream-hz-off-switch-holds-on-hardware.md
@@ -1,0 +1,17 @@
+### Fixed: `STRANDS_MESH_STREAM_HZ=0` publishes no step telemetry from the hardware control loop
+
+The variable's documented contract is that a non-positive or unusable value
+switches step publishing off rather than changing the rate, and
+`stream_min_period_from_env` spells that off as an infinite period on the
+reasoning that no elapsed time reaches one. `Robot._execute_task_async` starts
+its throttle base at `-inf`, so that a rollout's first step is due wherever the
+platform's monotonic epoch sits rather than depending on it being far from zero
+- and `monotonic() - (-inf) >= inf` is `inf >= inf`, which is true. One
+`publish_step`, carrying a whole observation, action and instruction, therefore
+escaped onto the mesh per rollout despite the operator's opt-out; the publish
+then wrote a finite base, which is why it was one and not many.
+
+The period is now tested for finiteness once, when the constructor resolves it,
+and the publish is gated on the result, so an infinite period is honored rather
+than inferred from the subtraction. A configured rate is unaffected, and the
+`-inf` base still owes an enabled stream its first publish immediately.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -21,6 +21,7 @@ import difflib
 import functools
 import importlib
 import logging
+import math
 import pkgutil
 import shutil
 import threading
@@ -574,6 +575,13 @@ class Robot(TeleopMixin, AgentTool):
         # loop can honor. Never a bare division: this runs in __init__, so a
         # ZeroDivisionError here fails the whole Robot(mode="real") bring-up.
         self._stream_min_period: float = stream_min_period_from_env()
+        # An infinite period is the operator's opt-out, and no finite elapsed
+        # time reaches it -- but ``_last_stream_pub`` starts below every
+        # reading, so the subtraction alone reads ``inf >= inf`` and lets
+        # exactly one publish (a whole observation, action and instruction)
+        # past the opt-out per rollout. The period is therefore tested
+        # directly, once here rather than on every tick of the control loop.
+        self._stream_enabled: bool = math.isfinite(self._stream_min_period)
         # Annotated with the base class rather than the concrete pool: the two
         # uses below are ``submit`` and ``shutdown``, so a caller substituting a
         # different Executor is honouring the contract, not evading it.
@@ -1769,7 +1777,7 @@ class Robot(TeleopMixin, AgentTool):
                     # (robot_mesh watch, dashboards) but no producers. Rate-
                     # limited; failures never touch the control loop.
                     _mesh = getattr(self, "mesh", None)
-                    if _mesh is not None:
+                    if _mesh is not None and self._stream_enabled:
                         _now_stream = time.monotonic()
                         if _now_stream - self._last_stream_pub >= self._stream_min_period:
                             self._last_stream_pub = _now_stream

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -303,9 +303,19 @@ def stream_min_period_from_env() -> float:
     bring-up.
 
     A period rather than a rate is returned because that is what both callers
-    hold, and it lets "off" be expressed as ``inf``: no elapsed time ever
-    reaches an infinite period, so the throttle simply never fires and neither
-    caller needs a second flag to test.
+    hold, and it lets "off" be expressed as ``inf``: no *finite* elapsed time
+    reaches an infinite period, so the throttle refuses every step it is asked
+    about.
+
+    That is a property of the elapsed time as much as of the period, so it does
+    not survive every base. A caller starting its throttle base at ``-inf`` --
+    which is what a monotonic base wants to be, a reading being meaningful only
+    relative to another one, so that a rollout's first step is due wherever the
+    platform's epoch sits -- computes an infinite elapsed time on that first
+    step, and ``inf >= inf`` is true. The subtraction alone then lets exactly
+    one publish past the opt-out. Such a caller tests this value for finiteness
+    once, where it resolves it, and gates the publish on that: the returned
+    period alone is not the whole opt-out.
 
     The fallback for an unusable value follows :meth:`Mesh._resolve_camera_hz`,
     the other opt-out publishing loop: warn naming the variable and the

--- a/tests/test_control_loop_budgets_survive_a_clock_step.py
+++ b/tests/test_control_loop_budgets_survive_a_clock_step.py
@@ -47,6 +47,13 @@ settled the same boundary three times (``tests/mesh/test_replay_cache_monotonic.
 bookkeeping and belongs on a monotonic clock, while an absolute stamp a reader
 correlates with other logs stays on the wall clock.
 
+The telemetry throttle's *off* switch is pinned here for the same reason: it
+is decided by the same subtraction against the same base, and the base is the
+one this file installs. ``STRANDS_MESH_STREAM_HZ=0`` resolves to an infinite
+period, which no finite elapsed time reaches -- but a ``-inf`` base makes the
+first step's elapsed time infinite too, so the opt-out has to be tested for
+rather than inferred from the arithmetic.
+
 No serial/USB hardware is touched: the driver and the leader are in-memory
 fakes and the policy is a structural stub.
 """
@@ -54,6 +61,7 @@ fakes and the policy is a structural stub.
 from __future__ import annotations
 
 import importlib
+import math
 import threading
 import time as real_time
 from concurrent.futures import ThreadPoolExecutor
@@ -65,6 +73,7 @@ from strands_robots import hardware_robot as hardware_robot_module
 from strands_robots import teleop_mixin as teleop_mixin_module
 from strands_robots.hardware_robot import Robot as HardwareRobot
 from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from strands_robots.mesh.session import stream_min_period_from_env
 from tests.test_hardware_control_loop_rate_guard import _FakeArm
 from tests.test_teleop import FakeHost, FakeTeleop
 
@@ -195,6 +204,11 @@ def _hardware_robot(mesh: Any = None, stream_min_period: float = 0.05) -> Hardwa
     robot.robot = _RecordingArm()
     robot._last_stream_pub = float("-inf")
     robot._stream_min_period = stream_min_period
+    # Derived here the way ``Robot.__init__`` derives it, because this harness
+    # builds the robot through ``__new__``. That the constructor really does
+    # derive it from the environment is pinned separately, against a real
+    # ``HardwareRobot``, in ``TestAnOperatorsOptOutPublishesNothing``.
+    robot._stream_enabled = math.isfinite(stream_min_period)
 
     async def _connected() -> tuple[bool, str]:
         return (True, "")
@@ -424,3 +438,95 @@ class TestTheThrottleStartsDue:
 
     def test_a_fresh_task_state_has_no_start_reading(self):
         assert RobotTaskState().start_mono == 0.0
+
+
+class TestAnOperatorsOptOutPublishesNothing:
+    """``STRANDS_MESH_STREAM_HZ=0`` means no step telemetry, including the first.
+
+    The variable's documented contract is that a non-positive or unusable value
+    "switches step publishing off rather than changing the rate" (README), and
+    ``stream_min_period_from_env`` spells that off as ``math.inf`` on the
+    reasoning that no elapsed time reaches an infinite period.
+
+    That reasoning holds for a finite base. ``_last_stream_pub`` is not finite:
+    it starts at ``-inf`` so the first step of a rollout is due wherever the
+    platform's monotonic epoch sits, and ``monotonic() - (-inf) >= inf`` is
+    ``inf >= inf``, which is ``True``. So one ``publish_step`` -- a whole
+    observation, action and instruction -- escaped onto the mesh per rollout
+    despite the opt-out, and the publish then wrote a finite base, which is why
+    it was one and not many. Measured on the loop below, before the gate::
+
+        STRANDS_MESH_STREAM_HZ    period  commands  publish_step  reported
+        unset (default)              0.1        74             4   success
+        0                            inf        75             1   success
+        nonsense                     inf        75             1   success
+
+    The two controls are the point alongside the zeroes: an operator who asked
+    for a rate still gets one, and an enabled stream's first step is still due
+    immediately. Together they refuse the two wrong fixes -- gating on
+    something that also silences a configured stream, and moving the base to
+    ``0.0``, which would make the first publish depend on the host's uptime.
+    """
+
+    #: Every spelling of "off" the variable accepts: non-positive, and the
+    #: unusable values the warn-and-leave-off fallback covers.
+    OFF_VALUES = ["0", "0.0", "-1", "nonsense", "inf", "nan"]
+
+    @pytest.mark.parametrize("raw", OFF_VALUES)
+    def test_an_off_value_publishes_no_step_at_all(self, monkeypatch: pytest.MonkeyPatch, raw: str):
+        """A rollout under the opt-out must put nothing on the mesh."""
+        monkeypatch.setenv("STRANDS_MESH_STREAM_HZ", raw)
+        period = stream_min_period_from_env()
+        assert period == math.inf, f"{raw!r} no longer resolves to the off sentinel"
+
+        mesh = _RecordingMesh()
+        run = _run_rollout(monkeypatch, 0.0, mesh=mesh, stream_min_period=period)
+
+        assert run["commands"] > 1, "the rollout did not run, so publishing nothing proves nothing"
+        assert mesh.publish_times == [], (
+            f"STRANDS_MESH_STREAM_HZ={raw!r} still let {len(mesh.publish_times)} publish(es) onto the mesh"
+        )
+
+    def test_a_rate_the_operator_asked_for_is_still_published(self, monkeypatch: pytest.MonkeyPatch):
+        """Control: the gate must not silence a configured stream."""
+        monkeypatch.setenv("STRANDS_MESH_STREAM_HZ", "100")
+        period = stream_min_period_from_env()
+        assert math.isfinite(period)
+
+        mesh = _RecordingMesh()
+        _run_rollout(monkeypatch, 0.0, mesh=mesh, stream_min_period=period)
+
+        assert len(mesh.publish_times) >= 2, "a configured stream published at most once"
+
+    def test_an_enabled_streams_first_step_is_still_due_immediately(self, monkeypatch: pytest.MonkeyPatch):
+        """Control: the ``-inf`` base still owes the first publish.
+
+        Asked for a period far longer than the rollout, an enabled stream
+        publishes exactly once and does it at the start. Moving the base to
+        ``0.0`` to dodge the sentinel would make this depend on the host's
+        monotonic epoch being past the period.
+        """
+        mesh = _RecordingMesh()
+        started = real_time.monotonic()
+        _run_rollout(monkeypatch, 0.0, mesh=mesh, stream_min_period=3600.0)
+
+        assert len(mesh.publish_times) == 1, "an hour-long period published more than the first step"
+        assert mesh.publish_times[0] - started < BUDGET / 2, "the first publish was not due at the start"
+
+    @pytest.mark.parametrize(("raw", "enabled"), [("0", False), ("nonsense", False), ("50", True)])
+    def test_the_constructor_resolves_the_gate_from_the_environment(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str, enabled: bool
+    ):
+        """The flag the loop reads is decided once, in ``__init__``, from the env.
+
+        The harness above builds its robot through ``__new__``, so this is the
+        cell that grades the real constructor.
+        """
+        monkeypatch.setenv("STRANDS_MESH_STREAM_HZ", raw)
+        monkeypatch.setattr(HardwareRobot, "_initialize_robot", lambda self, robot, cameras, **kw: _FakeArm())
+        monkeypatch.setattr(HardwareRobot, "_migrate_legacy_calibration", lambda self: None)
+        robot = HardwareRobot(tool_name="test_arm", robot="fake_arm")
+        try:
+            assert robot._stream_enabled is enabled
+        finally:
+            robot.cleanup()


### PR DESCRIPTION
Fixes #3176.

`STRANDS_MESH_STREAM_HZ` advertises one operator-facing guarantee: a non-positive or unusable value *"switches step publishing off rather than changing the rate"* (README:1205). On the hardware control loop that guarantee was off by exactly one publish per rollout.

`stream_min_period_from_env` spells "off" as `math.inf`, on the stated reasoning that *"no elapsed time ever reaches an infinite period, so the throttle simply never fires and neither caller needs a second flag to test"*. That reasoning holds for a finite base. The control loop's base is not finite:

| | |
|---|---|
| `hardware_robot.py:567` | `self._last_stream_pub: float = float("-inf")` |
| `hardware_robot.py:1774` | `if _now_stream - self._last_stream_pub >= self._stream_min_period:` |

`monotonic() - (-inf)` is `inf`, and `inf >= inf` is `True`. So one `publish_step` -- a whole observation, action and instruction -- escaped onto the mesh despite the explicit opt-out. The publish then wrote a finite base, which is why it was one and not many.

The `-inf` sentinel is not the defect and is deliberately kept: a monotonic reading is meaningful only relative to another one, so a rollout's first step should be due wherever the platform's epoch sits rather than depend on it being far from zero (`TestTheThrottleStartsDue` pins that). The defect is inferring the opt-out from the subtraction instead of testing for it.

## Measured

Driving the real loop through the existing harness in `tests/test_control_loop_budgets_survive_a_clock_step.py`, on a clean `main` worktree, with the period each env value actually resolves to:

| `STRANDS_MESH_STREAM_HZ` | period | commands applied | `publish_step` calls | reported |
|---|---|---|---|---|
| unset (default) | `0.1` | 74 | 4 | `success` |
| `0` (the opt-out) | `inf` | 75 | **1** | `success` |
| `nonsense` (warn-and-off) | `inf` | 75 | **1** | `success` |

No error, no log line, no failing test -- the shape Key Convention 6 ("No silent defaults on error") exists to refuse.

## The change

+3 executable lines. The period is tested once where `__init__` already resolves it, and the publish is gated on the result:

```python
self._stream_enabled: bool = math.isfinite(self._stream_min_period)
...
if _mesh is not None and self._stream_enabled:
```

Resolved once at construction rather than per tick, so the control loop pays nothing. The alternative -- moving the base to `0.0` -- would dodge the sentinel by making a rollout's first publish depend on the host's uptime, and is refused by a control cell below.

### Doc drift this change causes, fixed in the same diff

`stream_min_period_from_env`'s docstring is the contract both throttles read, and its "neither caller needs a second flag to test" clause is exactly the claim this fix falsifies. It is corrected to state the property truthfully: an infinite period is unreachable *for a finite base*, a `-inf` base computes an infinite elapsed time on the first step, and a caller with such a base tests the value for finiteness where it resolves it. Phrased as a property rather than as a headcount of what the current call sites do, so it stays true regardless of what any other site does later.

## Tests

11 cells added to the file that already owns this loop's time-based pins, which is where #3176 asked for them (the throttle is decided by the same subtraction against the same base this file installs).

| cell | on `main` |
|---|---|
| 6x `an_off_value_publishes_no_step_at_all` (`0`, `0.0`, `-1`, `nonsense`, `inf`, `nan`) | **fail** -- 1 publish each |
| 3x `the_constructor_resolves_the_gate_from_the_environment` (`0`, `nonsense`, `50`) | **fail** -- `AttributeError` |
| *control:* `a_rate_the_operator_asked_for_is_still_published` | pass |
| *control:* `an_enabled_streams_first_step_is_still_due_immediately` | pass |

**Pre-fix, with only the test change applied to `main`: 9 failed, 23 passed.**

The two controls are the point alongside the failures, and they pass on both trees by design: they refuse the two wrong fixes. One asserts a configured rate still publishes (a gate that silenced everything would fail it); the other asserts an hour-long period still publishes exactly once, at the start (moving the base to `0.0` would fail it). The off-values are driven through `stream_min_period_from_env` rather than a hardcoded `inf`, so the cells pin the operator-facing config and not an internal float.

The env-driven cells grade the real constructor, because the harness builds its robot through `__new__` and so derives the flag itself -- without those cells a fix living only in the harness would pass.

## Gate

| | `main` | this branch |
|---|---|---|
| `tests/test_control_loop_budgets_survive_a_clock_step.py` | 21 passed | **32 passed** (+11 = the new cells) |
| blast radius: 51 files naming `hardware_robot`/`publish_step`/the period, + `tests/mesh` | 233 failed, 5969 passed, 169 skipped, 114 errors | 233 failed, **5980 passed**, 169 skipped, 114 errors |
| ... failing/erroring node ids | 347 | 347, **set-identical** (`diff` empty) |
| `ruff check` / `format --check` (`strands_robots tests`) | clean | clean |
| `mypy strands_robots tests` | 23 errors in 20 files | 23 errors in 20 files, none in the touched files |
| `scripts/assemble_changelog.py --check` | OK | OK |

Stated plainly rather than left to read as a full run: the 347 failures/errors are absent-optional-dependency artifacts (`lerobot`, `torch`, `awsiot`) on this box, and 4 further modules in the blast radius cannot be collected at all for the same reason, so they are excluded from both sides equally. Both trees were measured in the same directory against the same editable install -- an earlier attempt using a second worktree reported a different baseline purely because the shared install rooted module resolution at the other path, which is why the comparison is reported as a node-id set rather than a pass count alone. The required `call-test-lint` job is the authority on the full suite.

## Scope

The sim `run_policy` hook is the other consumer of the same period. On `main` its base is finite, so the subtraction alone honors the opt-out there and this defect does not reach it; #3175 moves that site to a monotonic clock and carries its own gate for the same reason. Nothing in this diff asserts what that site does, so the two can merge in either order.

## Size

+145 / -4. Source +26 / -4, of which **3 added lines are executable** (`import math`, the flag, the gate condition); the rest is the comment stating why the subtraction is not the whole opt-out, and the docstring correction. Tests +106, changelog fragment +17.

---

### 13. Round changelog

**Round 1** -- initial submission. Nothing to restate yet.
