### PR TITLE
docs(agents): a mergePullRequest permissions refusal names the object the ID resolved to, not your permission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -796,6 +796,7 @@ hatch run format            # ruff check --fix, ruff format
      | `R_kgDOD1WOFw` | `[0, 257265175]` | the #1916 stray |
      | `PR_kwDOD1WOF87DdSjQ` | `[0, 257265175, 3279235280]` | **the same stray** |
      | `PR_kwDORUMiZs7Kw3fA` | `[0, 1162027622, 3401807808]` | **`uutils/coreutils#11342`** |
+     | `PR_kwDORUMiZs7DHqZ3` | `[0, 1162027622, 3273565815]` | **`gip-inclusion/autometa#8`** |
 
      The third row is why #1916's three guessed IDs all failed the same way: one
      stale value contaminated every mutation, and the two that failed did so only
@@ -814,6 +815,25 @@ hatch run format            # ruff check --fix, ruff format
      for the same repository is the same unsound test done less precisely. See
      #2007.
 
+     **The fifth row is why the refusal that stops such a merge is not a verdict
+     on your own permission.** Aimed at that ID while merging #3175,
+     `mergePullRequest` returned `cagataycali does not have the correct
+     permissions to execute MergePullRequest`. The same account, the same
+     mutation and the same token four minutes later - on the ID resolved from
+     `repository(owner:, name:) { pullRequest(number: 3175) { id } }` - squashed
+     that pull request as `c418f74`. So the permission reported on was a
+     stranger's, and every permission the merge needed was held. Nothing in the
+     response separates the two cases, because permission is evaluated before
+     state: even a target that is *already merged*, which
+     `gip-inclusion/autometa#8` is, is refused for permissions rather than for
+     mergeability. Read at face value that sentence says "merging is a maintainer
+     action" - self-consistent, terminal, and leaving an approved `CLEAN` pull
+     request open with every required context `SUCCESS`. That is a third recorded
+     cause of the presentation #1905 and #1917 name, and the first on the write
+     side, so a sweep that has learned to re-read the gate with `PAT_TOKEN` still
+     lands in it. Treat a permissions refusal as being about the ID until a query
+     has ruled the ID out.
+
      So the decode has exactly one sound use: a middle field naming another
      repository is proof of a wrong ID, and a middle field naming this one proves
      nothing at all. **The rule is the one with no decode in it** - resolve every
@@ -829,12 +849,14 @@ hatch run format            # ruff check --fix, ruff format
 
      **Weight it by reversibility rather than by correctness**, because the two
      directions are not symmetric. A refused `mergePullRequest` leaves nothing
-     behind; a `createIssue` against a wrong ID succeeds and cannot be undone by
-     the account that made it, since `deleteIssue` needs admin on the target and a
-     stray write by definition lands where you have none. It has now happened
-     twice: the second was `Ali111q/todo#1` at 16:23 UTC on 2026-08-07, twenty
-     minutes after #2007 was filed, from a `repositoryId` whose repository field
-     reads `1060491130` and not this repository's `1162027622` - the one
+     behind in the repository, though the fifth row is why that is not the same
+     as costing nothing; a `createIssue` against a wrong ID succeeds and cannot
+     be undone by the account that made it, since `deleteIssue` needs admin on
+     the target and a stray write by definition lands where you have none. It has
+     now happened twice: the second was `Ali111q/todo#1` at 16:23 UTC on
+     2026-08-07, twenty minutes after #2007 was filed, from a `repositoryId`
+     whose repository field reads `1060491130` and not this repository's
+     `1162027622` - the one
      direction a decode does catch. So `createIssue`,
      `addComment` and `updateIssue` earn the read-back more than the merge that
      prompted the rule, not less. If one has already landed, the remedy is not

--- a/changelog.d/3180-a-permissions-refusal-names-the-id.md
+++ b/changelog.d/3180-a-permissions-refusal-names-the-id.md
@@ -1,0 +1,32 @@
+### Docs: a `mergePullRequest` permissions refusal names the object the ID resolved to, not your permission
+
+`AGENTS.md` step 8 recorded that a mutation aimed at a well-formed but wrong node
+ID "was stopped by permissions rather than by the check". That reads as a safety
+net. It is also a false negative about the pull request you meant, and the
+wording invites exactly one wrong conclusion.
+
+Measured while merging #3175, which read `APPROVED` / `CLEAN` / `MERGEABLE` with
+every required context `SUCCESS`. A `pullRequestId` recalled from an earlier
+response rather than resolved in that run - `PR_kwDORUMiZs7DHqZ3`, whose middle
+field is this repository's databaseId, so the offline decode clears it - returned
+`cagataycali does not have the correct permissions to execute MergePullRequest`.
+It names `gip-inclusion/autometa#8`. Four minutes later the same account, token
+and mutation squashed #3175 as `c418f74` from the ID resolved by
+`repository(owner:, name:) { pullRequest(number: 3175) { id } }`. So the
+permission reported on was a stranger's, and every permission the merge needed
+was held.
+
+Nothing in the response separates the two cases: permission is evaluated before
+state, so even that already-merged target - a merge no permission could have
+completed - was refused for permissions rather than for mergeability. Read at
+face value the sentence says "merging is a maintainer action", which is
+self-consistent, terminal, and leaves an approved pull request open. That is a
+third recorded cause of the presentation #1905 and #1917 describe, and the first
+on the write side, so re-reading the merge gate with `PAT_TOKEN` does not reach
+it.
+
+Two corrections in step 8's node-ID bullet, pinned by
+`tests/test_graphql_node_id_targeting.py`: the refusal is not a verdict on your
+own permission, and "a refused `mergePullRequest` leaves nothing behind" is now
+scoped to the repository, since the belief it plants is what costs the run.
+Filed as #3180.

--- a/tests/test_graphql_node_id_targeting.py
+++ b/tests/test_graphql_node_id_targeting.py
@@ -29,6 +29,7 @@ node ID                    decodes to                       resolves to
 ``R_kgDOD1WOFw``           ``[0, 257265175]``               the #1916 stray
 ``PR_kwDOD1WOF87DdSjQ``    ``[0, 257265175, 3279235280]``   the same stray
 ``PR_kwDORUMiZs7Kw3fA``    ``[0, 1162027622, 3401807808]``  ``uutils/coreutils#11342``
+``PR_kwDORUMiZs7DHqZ3``    ``[0, 1162027622, 3273565815]``  ``gip-inclusion/autometa#8``
 =========================  ===============================  ==========================
 
 That third row is the finding the incident write-up did not have: all three
@@ -49,6 +50,24 @@ while merging #2006 was stopped by permissions rather than by any check. The two
 IDs also share 14 of their 19 characters, so comparing one by eye against a
 known-good ID for the same repository is the same unsound test done less
 precisely. See #2007.
+
+The fifth row is the same failure again, and it is here for what the *refusal*
+turned out to mean. That ID was recalled rather than queried while merging #3175,
+and ``mergePullRequest`` answered ``cagataycali does not have the correct
+permissions to execute MergePullRequest`` - a sentence about the account. Four
+minutes later the same account, token and mutation squashed that same pull
+request as ``c418f74``, using the ID from
+``repository(owner:, name:) { pullRequest(number: 3175) { id } }``. So the
+permission being reported on was a stranger's, and the wording is the one an
+agent has no reason to doubt: taken at face value it says merging is a
+maintainer's job, which is self-consistent, terminal, and leaves an approved
+``CLEAN`` pull request open with every required context ``SUCCESS`` - a third
+cause of the presentation ``tests/test_merge_gate_viewer_scope.py`` was written
+for (#1917, #1905), and the first on the write side, so re-reading the gate with
+``PAT_TOKEN`` does not reach it. Nothing in the response distinguishes the two
+cases either, because permission is evaluated before state: the stray target was
+already ``MERGED``, and a merge that could not have succeeded for anyone was
+still refused for permissions rather than for mergeability.
 
 The exposure is also not symmetric, and that is what the reject direction is
 worth keeping for. A refused ``mergePullRequest`` leaves nothing behind; a
@@ -77,6 +96,13 @@ the object it names belongs to another repository, so a matching middle field
 cannot establish the target. The reject direction is asserted alongside it, so
 the fix is not satisfiable by deleting the decode.
 
+``TestARefusalIsNotAVerdictOnThePermission`` *executes* the fifth row. It holds
+the two IDs against the outcomes they earned, and asserts that the reading the
+refusal invites - this account cannot merge here - contradicts the merge the same
+account performed minutes later, while a reading keyed on the ID does not. The
+recorded ``MERGED`` state of the stray target carries the before-state ordering,
+which is why the response cannot be triaged by its wording.
+
 ``TestTheGuidanceNamesTheDecodableEnvelope`` pins the prose, because the prose
 is the deliverable: an agent reads ``AGENTS.md``, not this module. What is
 asserted is *adjacency* rather than vocabulary - the fail-open property, the
@@ -88,11 +114,11 @@ the same structural reason ``tests/test_merge_gate_viewer_scope.py`` and
 ``tests/test_codeql_query_filters.py`` exist, and these text assertions follow
 the shape those modules established.
 
-Negative control: with ``origin/main``'s ``AGENTS.md`` restored, the five
-qualifiers the correction introduces fail while the four the #1916 write-up
-already carried keep passing, and both executable classes pass unchanged. The
-envelope and the routing field are properties of GitHub's IDs rather than of this
-change; only the guidance is new.
+Negative control: with ``origin/main``'s ``AGENTS.md`` restored, the qualifiers
+each correction introduces fail while the ones the write-up before it already
+carried keep passing, and the executable classes pass unchanged. The envelope,
+the routing field and the recorded outcomes are properties of GitHub's IDs and of
+what already happened rather than of any change here; only the guidance is new.
 """
 
 from __future__ import annotations
@@ -100,6 +126,7 @@ from __future__ import annotations
 import base64
 import struct
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -142,6 +169,34 @@ _CROSS_REPOSITORY_ACTUAL_DATABASE_ID = 11847500
 _SECOND_STRAY_REPOSITORY_NODE_ID = "R_kgDOPzXPeg"
 _SECOND_STRAY_REPOSITORY_DATABASE_ID = 1060491130
 _SECOND_STRAY_RESOLVES_TO = "Ali111q/todo#1"
+
+# The ID a `mergePullRequest` was aimed at while merging #3175 - recalled from an
+# earlier response rather than resolved in that run. Like the row above it carries
+# this repository's databaseId, so the decode clears it; it names a merged pull
+# request in a third repository. Every value read back from one `node(id:)` query
+# and one `repository(owner: "gip-inclusion", name: "autometa")` query. See #3180.
+_RECALLED_NODE_ID = "PR_kwDORUMiZs7DHqZ3"
+_RECALLED_OWN_DATABASE_ID = 3273565815
+_RECALLED_RESOLVES_TO = "gip-inclusion/autometa#8"
+_RECALLED_ACTUAL_DATABASE_ID = 1127363528
+
+#: The state that target was already in. It matters because it rules out the
+#: hope that an impossible merge announces itself as one: permission is evaluated
+#: first, so this pull request was refused for permissions and not for
+#: mergeability.
+_RECALLED_TARGET_STATE = "MERGED"
+
+#: What the mutation answered, verbatim. Pinned as a string because the reading it
+#: invites - an account without the permission - is the whole defect.
+_REFUSAL = "does not have the correct permissions to execute MergePullRequest"
+
+# The ID that mutation should have carried, resolved from
+# `repository(owner: "strands-labs", name: "robots") { pullRequest(number: 3175) }`
+# four minutes later, and the squash the same account, token and mutation then
+# performed - which is what proves the refusal above was not about its permission.
+_QUERIED_NODE_ID = "PR_kwDORUMiZs8AAAABCBKOHA"
+_QUERIED_OWN_DATABASE_ID = 4430401052
+_QUERIED_MERGE_COMMIT = "c418f74"
 
 #: The ID that mutation should have carried, from
 #: ``repository(owner:, name:) { pullRequest(number: 2006) { id } }``. Kept to
@@ -380,6 +435,137 @@ class TestTheDecodeIsARejectAndNeverAPass:
         assert _decode_node_id(_CROSS_REPOSITORY_NODE_ID)[1][2] != _decode_node_id(_INTENDED_PULL_REQUEST_NODE_ID)[1][2]
 
 
+class _Call(NamedTuple):
+    """One recorded ``mergePullRequest`` call, as issued and as answered.
+
+    Every field except ``node_id`` is identical across the two recorded calls, so
+    the pair isolates the ID as the only input that differed. ``refusal`` and
+    ``merge_commit`` are mutually exclusive by construction: a call either was
+    answered with an error or landed a squash.
+    """
+
+    node_id: str
+    obtained_by: str
+    account: str
+    mutation: str
+    intended_target: int
+    resolves_to: str
+    refusal: str | None
+    merge_commit: str | None
+
+
+#: The pair measured while merging #3175, in the order they were issued. See #3180.
+_RECORDED_CALLS = (
+    _Call(
+        node_id=_RECALLED_NODE_ID,
+        obtained_by="recalled from an earlier response",
+        account="cagataycali",
+        mutation="mergePullRequest",
+        intended_target=3175,
+        resolves_to=_RECALLED_RESOLVES_TO,
+        refusal=f"cagataycali {_REFUSAL}",
+        merge_commit=None,
+    ),
+    _Call(
+        node_id=_QUERIED_NODE_ID,
+        obtained_by="repository(owner:, name:) { pullRequest(number: 3175) { id } }",
+        account="cagataycali",
+        mutation="mergePullRequest",
+        intended_target=3175,
+        resolves_to="strands-labs/robots#3175",
+        refusal=None,
+        merge_commit=_QUERIED_MERGE_COMMIT,
+    ),
+)
+
+
+def _viewer_lacks_the_permission(call: _Call) -> bool:
+    """The verdict the refusal's wording invites: read it as about the account."""
+    return call.refusal is not None
+
+
+def _the_id_named_something_else(call: _Call) -> bool:
+    """The verdict that survives the pair: read it as about the ID."""
+    return call.resolves_to != f"strands-labs/robots#{call.intended_target}"
+
+
+class TestARefusalIsNotAVerdictOnThePermission:
+    """A permissions error reports on the object the ID resolved to."""
+
+    def test_the_recalled_id_clears_the_decode(self) -> None:
+        # The reject direction cannot fire here either: the middle field is this
+        # repository's, exactly as in the `uutils/coreutils` row above.
+        _, values = _decode_node_id(_RECALLED_NODE_ID)
+        assert values == [0, _REPOSITORY_DATABASE_ID, _RECALLED_OWN_DATABASE_ID], (
+            f"{_RECALLED_NODE_ID!r} should decode to [0, this repository, its own "
+            "databaseId]. If it does not, re-read the constants from a node(id:) query "
+            "rather than relaxing this - the decode clearing a wrong ID is the premise "
+            "of the whole class. See #3180."
+        )
+        assert _encoded_repository(_RECALLED_NODE_ID) == _REPOSITORY_DATABASE_ID
+
+    def test_the_object_it_named_belongs_to_another_repository(self) -> None:
+        assert _RECALLED_ACTUAL_DATABASE_ID != _REPOSITORY_DATABASE_ID, (
+            f"{_RECALLED_RESOLVES_TO} must be in a different repository from this one "
+            "for the measurement to mean anything. If these databaseIds ever agree the "
+            "constants have drifted; re-read them from a node(id:) query. See #3180."
+        )
+        assert _encoded_repository(_RECALLED_NODE_ID) != _RECALLED_ACTUAL_DATABASE_ID
+
+    def test_the_two_ids_differ_in_the_routing_field_alone(self) -> None:
+        # Why nothing offline separated them: both name this repository, and the
+        # field GitHub actually routes on is the only one that disagrees.
+        recalled = _decode_node_id(_RECALLED_NODE_ID)[1]
+        queried = _decode_node_id(_QUERIED_NODE_ID)[1]
+        assert recalled[:2] == queried[:2] == [0, _REPOSITORY_DATABASE_ID]
+        assert recalled[2] != queried[2], (
+            "the recalled and the queried ID must differ in their own-databaseId field. "
+            "That third element is what GitHub routes on, and it is the only difference "
+            "between a refusal and a merge here. See #3180."
+        )
+
+    def test_the_verdict_the_refusal_invites_is_false_of_the_account(self) -> None:
+        # The arithmetic behind the guidance: one verdict keyed on the response,
+        # one keyed on the ID, over the same two observations.
+        refused = [call for call in _RECORDED_CALLS if _viewer_lacks_the_permission(call)]
+        merged = [call for call in _RECORDED_CALLS if call.merge_commit is not None]
+        assert refused and merged, (
+            "the recorded pair must hold one refused call and one that landed a squash; "
+            "without both there is nothing to contradict. See #3180."
+        )
+        assert refused[0].refusal is not None and _REFUSAL in refused[0].refusal
+        assert {call.account for call in _RECORDED_CALLS} == {"cagataycali"}
+        assert {call.mutation for call in _RECORDED_CALLS} == {"mergePullRequest"}
+        assert {call.intended_target for call in _RECORDED_CALLS} == {3175}
+        assert merged[0].merge_commit == _QUERIED_MERGE_COMMIT, (
+            "the second call must record the squash it produced. It is the only thing "
+            "that proves the account held every permission the merge needed, and so "
+            "that the refusal was not about that permission. See #3180."
+        )
+
+    def test_the_verdict_keyed_on_the_id_holds_on_both_rows(self) -> None:
+        # And the reading that survives: it separates the rows the refusal cannot.
+        assert [_the_id_named_something_else(call) for call in _RECORDED_CALLS] == [
+            True,
+            False,
+        ], (
+            "asking which object the ID resolved to must separate the refused call from "
+            "the one that merged. That is the substitute for a verdict the response "
+            "cannot support, and it is what AGENTS.md now tells the reader to reach for."
+        )
+
+    def test_permission_is_evaluated_before_the_pull_requests_state(self) -> None:
+        # Why the response cannot be triaged by its wording: the stray target was
+        # already merged, so no permission on earth could have merged it again -
+        # and the error still spoke of permissions rather than of mergeability.
+        assert _RECALLED_TARGET_STATE == "MERGED"
+        assert "mergeable" not in _REFUSAL.lower(), (
+            "the recorded refusal must not mention mergeability. An already-merged "
+            "target being refused for permissions is what shows the check order, and "
+            "therefore that an impossible merge does not announce itself. See #3180."
+        )
+
+
 def _agents_text() -> str:
     return _AGENTS_PATH.read_text(encoding="utf-8")
 
@@ -533,4 +719,52 @@ class TestTheGuidanceLimitsTheDecodeToAReject:
             "AGENTS.md must name the remedy for a stray write that succeeded, because "
             "the instinct - delete it - is the one thing that does not work: deleteIssue "
             "needs admin on the target. See #2007."
+        )
+
+
+class TestTheGuidanceStatesWhatARefusalDecides:
+    """The correction is only actionable with its four qualifiers beside it."""
+
+    def test_the_guidance_says_a_refusal_is_not_a_verdict_on_the_permission(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "not a verdict on your own permission" in bullet, (
+            "AGENTS.md must say the refusal is not a verdict on the viewer's own "
+            "permission. Recorded only as 'was stopped by permissions' it reads as a "
+            "safety net, which is the half that is true and the half that costs "
+            "nothing. See #3180."
+        )
+
+    def test_the_guidance_carries_the_pair_that_measures_it(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None
+        assert _RECALLED_RESOLVES_TO in bullet and _QUERIED_MERGE_COMMIT in bullet, (
+            f"AGENTS.md must keep both halves of the measurement - {_RECALLED_RESOLVES_TO} "
+            f"and the squash {_QUERIED_MERGE_COMMIT} the same account performed minutes "
+            "later. Either alone is an anecdote; together they are what rules out the "
+            "account genuinely lacking the permission. See #3180."
+        )
+
+    def test_the_guidance_states_that_permission_is_evaluated_before_state(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "evaluated before" in bullet, (
+            "AGENTS.md must say permission is evaluated before state. Without it a "
+            "reader is left with the hope that an impossible merge would have announced "
+            "itself as unmergeable, and it does not. See #3180."
+        )
+
+    def test_the_guidance_names_the_misreading_it_prevents(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "merging is a maintainer" in bullet, (
+            "AGENTS.md must name the conclusion the refusal invites. The failure is not "
+            "confusion but a confident wrong belief that ends the work with an approved "
+            "pull request left open, which is the presentation #1905 and #1917 record "
+            "for their own causes. See #3180."
+        )
+
+    def test_the_reversibility_clause_no_longer_says_a_refusal_costs_nothing(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "behind in the repository" in bullet, (
+            "AGENTS.md's reversibility weighting must scope 'leaves nothing behind' to "
+            "the repository. Unqualified it is the sentence that invites skipping the "
+            "read-back on exactly the mutation measured here. See #3180."
         )

--- a/tests/test_graphql_node_id_targeting.py
+++ b/tests/test_graphql_node_id_targeting.py
@@ -517,6 +517,13 @@ class TestARefusalIsNotAVerdictOnThePermission:
         # field GitHub actually routes on is the only one that disagrees.
         recalled = _decode_node_id(_RECALLED_NODE_ID)[1]
         queried = _decode_node_id(_QUERIED_NODE_ID)[1]
+        assert queried == [0, _REPOSITORY_DATABASE_ID, _QUERIED_OWN_DATABASE_ID], (
+            f"{_QUERIED_NODE_ID!r} should decode to [0, this repository, pull request "
+            "3175's own databaseId]. Pinned to the recorded value rather than compared "
+            "field-by-field for the same reason as the two rows above: the inequality "
+            "below would still hold if this ID had drifted to name a third object, and "
+            "then the row it stands for would no longer be the one that merged. See #3180."
+        )
         assert recalled[:2] == queried[:2] == [0, _REPOSITORY_DATABASE_ID]
         assert recalled[2] != queried[2], (
             "the recalled and the queried ID must differ in their own-databaseId field. "


### PR DESCRIPTION
`AGENTS.md` step 8 records that a `mergePullRequest` aimed at a well-formed but wrong node ID *"was stopped by permissions rather than by the check"*. That is the half that reads as a safety net. The other half is that the refusal is worded about **your account** while reporting on **a stranger's pull request**, and this cycle it was the half that mattered: it is what made an approved, green, `CLEAN` pull request look like it was waiting on a maintainer.

## Measured

Two `mergePullRequest` calls while merging #3175, which read `APPROVED` / `CLEAN` / `MERGEABLE` with every required context `SUCCESS`. Same account, same token, same mutation, same intended target, four minutes apart -- the `pullRequestId` is the only input that differed:

| `pullRequestId` | how it was obtained | decodes to | resolves to | answer |
|---|---|---|---|---|
| `PR_kwDORUMiZs7DHqZ3` | recalled from an earlier response | `[0, 1162027622, 3273565815]` | `gip-inclusion/autometa#8`, already `MERGED` (that repository's own databaseId is `1127363528`) | `cagataycali does not have the correct permissions to execute MergePullRequest` |
| `PR_kwDORUMiZs8AAAABCBKOHA` | `repository(owner:, name:) { pullRequest(number: 3175) { id } }` | `[0, 1162027622, 4430401052]` | `strands-labs/robots#3175` | merged, `c418f74`, 12:11:02Z |

So every permission the merge needed was held, and the permission the first call reported on was somebody else's.

Three properties make this unrecoverable from the response alone:

- **The decode clears the ID.** Its middle field is this repository's databaseId, so the one sound offline direction -- `TestTheDecodeIsARejectAndNeverAPass` -- does not fire. This is the second recorded instance of that exact shape after `uutils/coreutils#11342` (#2007).
- **Permission is evaluated before state.** The stray target was already `MERGED`, so no permission could have merged it -- and it was still refused *for permissions*, not for mergeability. An impossible merge does not announce itself as one.
- **The wording invites one conclusion, and it is wrong.** "does not have the correct permissions" reads as a fact about the account. Acting on it means declining to merge and reporting the pull request as waiting on a reviewer.

That last presentation is the one `tests/test_merge_gate_viewer_scope.py` was written for -- "an agent polling the gate exactly as documented reads `BLOCKED`, correctly declines to merge, and reports a ready pull request as waiting on a reviewer" (#1917, and #1905 for its own cause). Both known causes are read-side. This one is write-side, so a sweep that has learned to re-read the gate with `PAT_TOKEN` still lands in it.

## Change

Prose only, in step 8's node-ID bullet -- no production code:

- A fifth row in the decode table, `PR_kwDORUMiZs7DHqZ3` -> `gip-inclusion/autometa#8`, continuing the existing "the third row is why... the fourth row is why..." structure.
- **The fifth row is why the refusal that stops such a merge is not a verdict on your own permission**: the pair above, the before-state check order, the misreading it produces, and the instruction -- treat a permissions refusal as being about the ID until a query has ruled the ID out.
- The reversibility weighting is corrected. "A refused `mergePullRequest` leaves nothing behind" is true of the repository and false of the run, so it is now scoped: *"leaves nothing behind in the repository, though the fifth row is why that is not the same as costing nothing"*. Unqualified, it is the sentence that licenses skipping the read-back on exactly this mutation.

The sound rule is unchanged and was already written down -- resolve every mutation's ID from a query in the same run that names the object by `owner`/`name`/`number`. What was missing is what the refusal means when you did not.

## Tests

Extends `tests/test_graphql_node_id_targeting.py`, which already owns the wrong-ID class, its recorded IDs and its decoder -- so no new module and no grader-roster change.

`TestARefusalIsNotAVerdictOnThePermission` (6 cells) executes the row rather than restating it: the recalled ID decodes to this repository and resolves elsewhere; the two IDs agree on every field but the one GitHub routes on; and two verdicts run over the recorded pair -- one keyed on the response ("the account lacks the permission") which the second row falsifies, one keyed on the ID which separates them. A cell pins the already-`MERGED` state of the stray target beside a refusal that never mentions mergeability, which is the check-order evidence.

`TestTheGuidanceStatesWhatARefusalDecides` (5 cells) pins the prose by *adjacency*, in the shape the three sibling step-8 modules established: each qualifier must stay inside the same bullet as the instruction it qualifies, since "was stopped by permissions" reads perfectly well alone and is exactly what a later tidy-up would leave behind.

**Negative control**, with `main`'s `AGENTS.md` restored and the tests in place: `5 failed, 36 passed` -- the five prose pins fail and name what is missing, while all 6 new executable cells and the 30 pre-existing ones pass unchanged. The executable half records what GitHub did, not what the guidance says, so it cannot fail pre-fix; that is deliberate and is what makes the prose pins the fix pins.

## Gate

| check | result |
|---|---|
| `tests/test_graphql_node_id_targeting.py` | 41 passed (30 before) |
| the three sibling step-8 modules + roster + changelog gate | 185 passed |
| `ruff check` / `ruff format --check` on the changed file | clean |
| non-ASCII in added AGENTS.md lines / the fragment | 0 / 0 |
| whole-tree graders (97 of 99; 2 need `lerobot`, unrelated to this diff) | **identical failing-id sets on this branch and on a clean `c418f74` worktree** -- 144 each, 0 attributable |

The 144 are environmental in the minimal venv this ran in (`mujoco`, `rclpy` and friends absent), which is why the claim made here is the equivalence rather than a green count. None of them names an AGENTS.md, node-ID, GraphQL or changelog grader.

## Size

3 files, +299/-11 against `c418f74`: `AGENTS.md` +23/-3 of prose (the rest of the delta is one reflowed paragraph), tests +244/-8, changelog fragment +32. No production file touched.

Closes #3180

---

## Round 1 changes

One concern, one commit: `261ce6a`.

**Code scanning flagged `_QUERIED_OWN_DATABASE_ID` as an unused global** (`tests/test_graphql_node_id_targeting.py:198`). It was an omission rather than a leftover, so it is consumed rather than deleted.

That constant is the third field of the decode of the **second row of the table above** -- the ID that actually merged #3175. Both sibling constants of its kind in this module are already consumed by a full-payload equality (`_CROSS_REPOSITORY_OWN_DATABASE_ID`, `_RECALLED_OWN_DATABASE_ID`); this one was the only one recorded in prose and asserted nowhere. `test_the_two_ids_differ_in_the_routing_field_alone` now opens with the same shape:

```python
assert queried == [0, _REPOSITORY_DATABASE_ID, _QUERIED_OWN_DATABASE_ID]
```

Deleting it would have cleared the alert too, but it would have left `recalled[2] != queried[2]` as the only statement about that ID -- and that inequality would still hold if the ID drifted to name a third object, at which point the row would no longer be the one that merged. The inequality is kept, since it is what states why nothing offline separated the two IDs; it is just not sufficient alone.

| check | result |
|---|---|
| `tests/test_graphql_node_id_targeting.py` | 41 passed -- unchanged count, no new cell |
| mutation check: `_QUERIED_OWN_DATABASE_ID` off by one | 1 failed, and only this cell -- the pin is not vacuous |
| module + merge gate + grader roster + the three changelog gates | 195 passed |
| `ruff check` / `ruff format --check` | clean |
| non-ASCII in the added lines | 0 |

Net effect on the diff: +7 lines in one test file. No production file, `AGENTS.md` or changelog fragment touched this round.