### PR TITLE
fix(training): a streaming run's validation-split conflict is decided without the episode count

### DIFF
--- a/changelog.d/3182-streaming-split-conflict-without-the-count.md
+++ b/changelog.d/3182-streaming-split-conflict-without-the-count.md
@@ -1,0 +1,29 @@
+### Fixed
+
+- A streamed training run that also asks for a validation split is refused on
+  the source `streaming` exists for. `LerobotTrainer.validate` asked whether
+  `streaming` and `val_episodes` can both be delivered from inside the branch
+  that had already read the dataset's `total_episodes`. That count is only
+  readable from a local `meta/info.json`, and streaming a Hub dataset is the
+  case with no local copy -- the download `streaming` exists to avoid -- so on
+  that source the pair was never refused. What was reported instead was the
+  unreadable-count refusal, whose remedy is
+  `extra={'dataset.eval_split': <fraction>, 'eval_steps': <steps>}`: applying it
+  with `streaming` still set left `validate()` reporting no problems at all and
+  emitted `--dataset.streaming=true` beside `--dataset.eval_split=0.1`, where
+  lerobot's split path rebuilds both halves map-style and materializes the whole
+  dataset with the stream annulled and nothing reporting it. Whether the two
+  fields can both be honored is a property of the two fields, so it is now
+  decided from them alone, ahead of every count-derived check; a local root with
+  an unreadable `meta/info.json` was the second source with the same gap and is
+  covered by the same change. Where the count is unreadable `streaming=False`
+  alone still cannot deliver the split, so the refusal names the local copy that
+  configuration also needs and both remedies it offers are honored. The refusal
+  also attributed the construction-time failure to "lerobot 0.6.2", which is not
+  a release -- 0.6.1 is the latest, and its same-worded guard
+  (`eval_split requires map-style datasets`) is keyed on `repo_type='bucket'`,
+  which this backend never sets, so on 0.6.1 the pair constructs and the silent
+  materialization is what happens. `lerobot.__version__` is
+  `importlib.metadata.version("lerobot")`, so it reports the installed
+  distribution rather than a release the claim could be checked against; the
+  refusal now names the predicate instead.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -428,15 +428,22 @@ local copy of the dataset, or pass lerobot's own knobs directly with
 the pair. lerobot holds out a validation split only on a **map-style** dataset:
 `make_train_eval_datasets` rebuilds both halves as `LeRobotDataset` objects,
 which is what makes the split addressable by episode index. A streamed dataset
-is not one, and lerobot answers that contradiction differently across the
-supported range - from lerobot 0.6.2 `DatasetConfig` refuses the combination
-outright (`eval_split requires map-style datasets`), and before that it
-constructed and the factory discarded the streaming dataset it had opened first.
-Either way the pair delivers at most one of the two fields: it fails inside a
-launched run, or it materializes the whole dataset - exactly what `streaming`
-exists to avoid - while reporting nothing, because an annulled stream is
-indistinguishable from `streaming=False`. Set `streaming=False` to keep the
-validation split, or `val_episodes=None` to keep the stream.
+is not one, and which way the pair fails depends on the installed lerobot: a
+`DatasetConfig` that guards `eval_split` against `streaming` refuses the
+combination when the run starts, and without that guard it constructs and the
+factory discards the streaming dataset it had opened first. Either way the pair
+delivers at most one of the two fields: it fails inside a launched run, or it
+materializes the whole dataset - exactly what `streaming` exists to avoid -
+while reporting nothing, because an annulled stream is indistinguishable from
+`streaming=False`. Set `streaming=False` to keep the validation split, or
+`val_episodes=None` to keep the stream.
+
+The refusal is decided from the two fields alone, so it does not depend on the
+dataset's episode count. That matters because the count is only readable from a
+local `meta/info.json`, and streaming a Hub dataset is the case with no local
+copy - the download `streaming` exists to avoid. On that source `streaming=False`
+alone is not enough to deliver the split either, so the refusal names the local
+copy that configuration also needs.
 
 ### GR00T (`groot`)
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -664,7 +664,7 @@ class LerobotTrainer(Trainer):
             "directly with extra={'dataset.eval_split': <fraction>, 'eval_steps': <steps>}."
         )
 
-    def _streaming_validation_split_problem(self, spec: TrainSpec) -> str:
+    def _streaming_validation_split_problem(self, spec: TrainSpec, count_readable: bool) -> str:
         """Refusal text for ``streaming`` and ``val_episodes`` asked for together.
 
         Each field is honored on its own, and neither survives the pair.
@@ -672,15 +672,25 @@ class LerobotTrainer(Trainer):
         ``dataset.eval_split``, and lerobot holds out a split only on a
         MAP-STYLE dataset - ``make_train_eval_datasets`` rebuilds both halves as
         ``LeRobotDataset`` objects, which is what makes the split addressable by
-        episode at all. A streamed dataset is not one, and lerobot answers the
-        contradiction differently across the range this backend supports:
-        ``DatasetConfig`` refuses the pair outright from lerobot 0.6.2
-        ("eval_split requires map-style datasets"), while before that it
-        constructed and the factory silently discarded the
-        ``StreamingLeRobotDataset`` it had built first. So the pair either fails
-        inside a launched run or materializes the whole dataset without
-        reporting it - an annulled stream is indistinguishable from
-        ``streaming=False``.
+        episode at all. A streamed dataset is not one, and which way the pair
+        fails depends on the installed lerobot rather than on anything the
+        caller can see: a ``DatasetConfig`` that guards ``eval_split`` against
+        ``streaming`` refuses the pair when the run starts, and without that
+        guard the factory rebuilds both halves map-style, so the
+        ``StreamingLeRobotDataset`` it opened first is discarded and the whole
+        dataset is materialized while nothing reports it - an annulled stream is
+        indistinguishable from ``streaming=False``.
+
+        The guard is keyed on ``streaming`` only in recent lerobot; 0.6.1 ships a
+        same-worded guard ("eval_split requires map-style datasets") keyed on
+        ``repo_type='bucket'``, which this backend never sets, so on 0.6.1 the
+        pair constructs and the silent materialization is what happens. That is
+        why the refusal names the predicate rather than a release: the quoted
+        sentence is present in a lerobot that does not raise it here, and
+        ``lerobot.__version__`` is ``importlib.metadata.version("lerobot")``, so
+        it reports the installed distribution's number - which for a source
+        install is a development version, not a release the claim could be
+        checked against.
 
         Refusing here mirrors :meth:`_unreadable_episode_count_problem`, which
         refuses rather than let a requested validation split be silently
@@ -688,15 +698,34 @@ class LerobotTrainer(Trainer):
         either field delivers the other one whole, and the raw ``extra``
         passthrough still reaches lerobot's own knobs for a caller who wants the
         combination anyway.
+
+        Args:
+            spec: The spec being validated; read for ``val_episodes``.
+            count_readable: Whether the dataset's episode count is readable from
+                a local ``meta/info.json``. ``streaming=False`` alone delivers
+                the split only when it is, so when it is not the remedy names
+                the local copy that configuration also needs - rather than
+                promising a split the next ``validate()`` would refuse for a
+                different reason. Streaming a Hub dataset is the case where it
+                is unreadable, which is exactly where this refusal fires.
         """
+        keep_the_split = (
+            "set streaming=False to keep the validation split"
+            if count_readable
+            else (
+                "set streaming=False and point dataset_root at a local copy of the dataset to keep "
+                "the validation split - the split is a FRACTION of the episode count, which is only "
+                "readable from a local meta/info.json"
+            )
+        )
         return (
             f"{self.provider_name}: streaming=True cannot be combined with "
             f"val_episodes={spec.val_episodes}. lerobot holds out a validation split only on a "
-            "map-style dataset, and a streamed dataset is not one: lerobot 0.6.2 refuses the "
-            "pair outright, and before it the stream is dropped for a map-style rebuild while "
-            "nothing reports that the whole dataset was materialized. Either set "
-            "streaming=False to keep the validation split, or val_episodes=None to keep the "
-            "stream."
+            "map-style dataset, and a streamed dataset is not one: a lerobot whose DatasetConfig "
+            "guards eval_split against streaming refuses the pair when the run starts, and without "
+            "that guard the stream is dropped for a map-style rebuild while nothing reports that "
+            f"the whole dataset was materialized. Either {keep_the_split}, or val_episodes=None to "
+            "keep the stream."
         )
 
     def _dataset_total_tasks(self, dataset_root: str) -> int:
@@ -903,7 +932,18 @@ class LerobotTrainer(Trainer):
 
         if not val_problems and spec.val_episodes is not None:
             total = self._dataset_total_episodes(spec.dataset_root) if spec.dataset_root else None
-            if total is None:
+            if spec.streaming:
+                # Decided from the two fields alone, ahead of every count-derived
+                # check below, because the pair delivers neither field whatever
+                # the episode count is. That count is only readable from a local
+                # copy, and streaming a Hub dataset is the case with no local
+                # copy - so asking this inside the branch that HAS a count left
+                # the pair unrefused on exactly the configuration `streaming`
+                # exists for, and answered it with the unreadable-count remedy
+                # instead, whose `extra` passthrough puts the pair back on the
+                # command line with nothing left to refuse it.
+                problems.append(self._streaming_validation_split_problem(spec, count_readable=total is not None))
+            elif total is None:
                 # The split is a FRACTION derived from the episode count, so with
                 # no count to divide by there is nothing to emit - and a missing
                 # eval_split is indistinguishable from "no validation asked for".
@@ -921,12 +961,6 @@ class LerobotTrainer(Trainer):
                 )
                 if split_err:
                     problems.append(split_err)
-                if spec.streaming and self._val_eval_split(spec) is not None:
-                    # Both fields were honored in isolation and neither survives
-                    # the pair: lerobot's split path rebuilds the dataset
-                    # map-style, so the stream is dropped. Refuse rather than
-                    # emit a config that silently delivers one of the two.
-                    problems.append(self._streaming_validation_split_problem(spec))
 
         # Shared by BOTH run types: policy and reward-model training load the
         # same dataset, so an unreadable format version refuses either one.

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -7,8 +7,10 @@ end-to-end sim->train->load is exercised separately.
 import ast
 import dataclasses
 import importlib
+import importlib.metadata
 import inspect
 import json
+import re
 import sys
 from types import SimpleNamespace
 
@@ -1886,13 +1888,17 @@ class TestStreamingAndValidationSplitAreMutuallyExclusive:
     ``val_episodes`` becomes lerobot's ``dataset.eval_split``, and lerobot holds
     out a split only on a MAP-STYLE dataset: ``make_train_eval_datasets``
     rebuilds both halves as ``LeRobotDataset`` objects, which is what makes the
-    split addressable by episode. A streamed dataset is not one, and lerobot
-    answers that contradiction differently across the version range this backend
-    supports - ``DatasetConfig`` refuses the pair from lerobot 0.6.2, and before
-    that it constructed and the factory discarded the stream it had built first,
-    materializing the whole dataset while reporting nothing. Preflight refuses
-    the pair either way, the same way an unreadable episode count is refused
-    rather than allowed to drop a requested split.
+    split addressable by episode. A streamed dataset is not one, and which way
+    the pair fails depends on the installed lerobot: a ``DatasetConfig`` that
+    guards ``eval_split`` against ``streaming`` refuses it when the run starts,
+    and without that guard the factory discards the stream it had built first,
+    materializing the whole dataset while reporting nothing. 0.6.1 carries the
+    same-worded guard keyed on ``repo_type='bucket'``, which this backend never
+    sets, so the silent form is what a 0.6.1 caller gets. Preflight refuses the
+    pair either way - decided from the two fields alone, so the refusal does not
+    depend on a local episode count that a streamed Hub dataset does not have -
+    the same way an unreadable episode count is refused rather than allowed to
+    drop a requested split.
     """
 
     def _spec(self, dataset_root, tmp_path, **kw):
@@ -1949,22 +1955,170 @@ class TestStreamingAndValidationSplitAreMutuallyExclusive:
         spec = self._spec(dataset_root, tmp_path, val_episodes=2)
         assert LerobotTrainer().validate(spec) == []
 
-    def test_a_hub_source_with_no_readable_count_keeps_its_own_refusal(self, tmp_path):
-        # With no local meta/info.json no split is emitted at all, so the pair is
-        # not what is wrong here - the episode count is. Reporting both would name
-        # a conflict that this spec does not have.
-        spec = TrainSpec(
-            dataset_root="",
-            dataset_repo_id="lerobot/aloha_sim_transfer_cube_human",
-            base_model="",
-            output_dir=str(tmp_path / "out"),
-            streaming=True,
-            val_episodes=2,
-            extra={"policy_type": "act"},
+    @staticmethod
+    def _pair_refusal(problems):
+        """The pair refusal out of ``problems``, named rather than unpacked."""
+        found = [p for p in problems if "cannot be combined with val_episodes" in p]
+        assert len(found) == 1, f"expected exactly one refusal naming the pair, got {problems}"
+        return found[0]
+
+    @staticmethod
+    def _hub_stream_spec(tmp_path, **kw):
+        """A Hub source streamed with no local copy - what ``streaming`` is for."""
+        fields = {
+            "dataset_root": "",
+            "dataset_repo_id": "lerobot/aloha_sim_transfer_cube_human",
+            "base_model": "",
+            "output_dir": str(tmp_path / "out"),
+            "streaming": True,
+            "val_episodes": 2,
+            "extra": {"policy_type": "act"},
+        }
+        fields.update(kw)
+        return TrainSpec(**fields)
+
+    def test_a_hub_stream_with_no_readable_count_is_refused_for_the_pair(self, tmp_path):
+        """The pair is what is wrong, on the source ``streaming`` exists for.
+
+        This spec emits no ``eval_split``, which is why the count refusal used to
+        be reported here on the grounds that "no split is emitted at all, so the
+        pair is not what is wrong". That reasoning describes the spec as written
+        and stops holding as soon as the caller acts on it: the count refusal's
+        remedy is ``extra={'dataset.eval_split': ...}``, and applying it while
+        ``streaming`` is still set is the combination the sibling refusal exists
+        to prevent - see
+        :meth:`test_the_count_remedy_is_not_offered_to_a_streaming_caller`.
+        The conflict is a property of the two fields on this spec, both of which
+        are set, so it is decidable here and is what a caller needs told.
+        """
+        problems = LerobotTrainer().validate(self._hub_stream_spec(tmp_path))
+        assert any("streaming=True cannot be combined with val_episodes=2" in p for p in problems), (
+            f"the pair is set on this spec and delivers neither field, so it must be refused: {problems}"
         )
-        problems = LerobotTrainer().validate(spec)
-        assert any("episode count is unavailable" in p for p in problems)
-        assert not any("cannot be combined with" in p for p in problems)
+
+    def test_the_count_remedy_is_not_offered_to_a_streaming_caller(self, tmp_path):
+        """The refusal must not prescribe the passthrough that reinstates the pair.
+
+        ``extra`` is a documented raw passthrough and is deliberately not
+        policed - see :meth:`test_the_passthrough_still_reaches_lerobots_own_knobs`.
+        What must not happen is this backend NAMING it as the remedy to a caller
+        who still has ``streaming`` set, because that hands them the silent
+        whole-dataset materialization as the way forward.
+        """
+        problems = LerobotTrainer().validate(self._hub_stream_spec(tmp_path))
+        assert not any("dataset.eval_split" in p for p in problems), (
+            f"a streaming caller must not be told to pass the split through extra: {problems}"
+        )
+        assert not any("episode count is unavailable" in p for p in problems), (
+            "the count is moot once the pair is refused: no split will be emitted for it to size"
+        )
+
+    def test_the_passthrough_still_reaches_lerobots_own_knobs(self, tmp_path):
+        """Premise, not a fix pin: ``extra`` is raw and stays raw.
+
+        Holds both before and after the refusal is made reachable, and is
+        recorded because it is what gives the misdirected remedy its
+        consequence - the pair really does reach the command line unrefused when
+        it arrives through ``extra``, which is the documented contract for that
+        field and the reason the fix is to stop prescribing it rather than to
+        start policing it.
+        """
+        spec = self._hub_stream_spec(
+            tmp_path,
+            val_episodes=None,
+            extra={"policy_type": "act", "dataset.eval_split": 0.1, "eval_steps": 1000},
+        )
+        trainer = LerobotTrainer()
+        assert trainer.validate(spec) == []
+        emitted = trainer.build_command(spec)
+        assert "--dataset.streaming=true" in emitted
+        assert "--dataset.eval_split=0.1" in emitted
+
+    @pytest.mark.parametrize(
+        "source",
+        ["a local root with a readable count", "a Hub id with no local copy", "a local root with no readable meta"],
+    )
+    def test_the_pair_is_refused_whether_or_not_the_count_can_be_read(self, source, dataset_root, tmp_path):
+        """The conflict is decided from the two fields, not from the dataset.
+
+        Whether ``streaming`` and ``val_episodes`` can both be delivered does not
+        depend on the episode count - it is a property of the two fields. Asking
+        it inside the branch that HAS a count made the refusal unreachable on the
+        two sources where the count is unreadable, and streaming a Hub dataset is
+        one of them: the count comes from a local ``meta/info.json``, which is the
+        download ``streaming`` exists to avoid. The readable-count row is the
+        control that held before and must keep holding.
+        """
+        empty = tmp_path / "no-meta"
+        empty.mkdir()
+        roots = {
+            "a local root with a readable count": {"dataset_root": dataset_root},
+            "a Hub id with no local copy": {"dataset_root": "", "dataset_repo_id": "org/big"},
+            "a local root with no readable meta": {"dataset_root": str(empty)},
+        }
+        fields = {
+            "base_model": "",
+            "output_dir": str(tmp_path / "out"),
+            "streaming": True,
+            "val_episodes": 2,
+            "extra": {"policy_type": "act"},
+        }
+        fields.update(roots[source])
+        problems = LerobotTrainer().validate(TrainSpec(**fields))
+        assert any("cannot be combined with val_episodes=2" in p for p in problems), (
+            f"{source}: the pair delivers neither field here either, so it must be refused: {problems}"
+        )
+
+    def test_the_remedy_names_the_local_copy_when_the_count_is_unreadable(self, tmp_path):
+        """Both remedies the refusal offers must be honored where it fires.
+
+        ``streaming=False`` alone delivers the split only when the episode count
+        is readable. On a Hub source with no local copy it is not, so naming that
+        remedy unqualified would promise a split the next ``validate()`` refuses
+        for a different reason - which is what the second assertion measures.
+        """
+        trainer = LerobotTrainer()
+        message = self._pair_refusal(trainer.validate(self._hub_stream_spec(tmp_path)))
+        assert "point dataset_root at a local copy" in message, (
+            f"streaming=False alone cannot deliver the split for this source, so the remedy must say so: {message}"
+        )
+        # The measurement that makes the qualification necessary rather than wordy.
+        dropped_streaming = trainer.validate(self._hub_stream_spec(tmp_path, streaming=False))
+        assert dropped_streaming, "streaming=False alone does not make this source launchable"
+        # And the other remedy is unconditional: dropping the split keeps the stream whole.
+        assert trainer.validate(self._hub_stream_spec(tmp_path, val_episodes=None)) == []
+
+    def test_the_refusal_does_not_key_its_explanation_on_a_lerobot_release(self, dataset_root, tmp_path):
+        """A release number in this refusal is not checkable by the caller.
+
+        ``lerobot.__version__`` is ``importlib.metadata.version("lerobot")``, so
+        it reports the installed DISTRIBUTION's number - a development version
+        for a source install, which is not a release the claim could be checked
+        against. The quoted grounds make it worse: 0.6.1 carries the same
+        sentence keyed on ``repo_type='bucket'``, which this backend never sets,
+        so the sentence is present in a lerobot that does not raise it here. The
+        refusal therefore names the predicate, which is verifiable, and the
+        second assertion keeps this from being read as "delete the digits".
+
+        Driven from a local root, where this refusal fires either way, so it
+        grades the wording rather than the reachability the cells above own.
+        """
+        spec = self._spec(dataset_root, tmp_path, streaming=True, val_episodes=2)
+        message = self._pair_refusal(LerobotTrainer().validate(spec))
+        assert not re.search(r"lerobot\s+\d+\.\d+", message), (
+            f"the refusal attributes behavior to a lerobot release the caller cannot check: {message}"
+        )
+        assert "guards eval_split against streaming" in message, "the predicate is what replaces the release number"
+
+    def test_the_installed_lerobot_reports_its_version_from_distribution_metadata(self):
+        """The premise the rule above stands on, executed against lerobot."""
+        lerobot = pytest.importorskip("lerobot")
+        source = inspect.getsource(importlib.import_module("lerobot.__version__"))
+        assert 'version("lerobot")' in source, (
+            "lerobot no longer derives __version__ from installed metadata; the reason a release "
+            "number in a refusal is uncheckable may no longer hold"
+        )
+        assert lerobot.__version__ == importlib.metadata.version("lerobot")
 
     # ------------------------------------------------------------------ #
     # The constraint the refusal stands on, pinned against lerobot itself.
@@ -2039,12 +2193,14 @@ class TestStreamingAndValidationSplitAreMutuallyExclusive:
         """The measured constraint the refusal stands on, pinned against lerobot.
 
         Asserts the property that makes the pair unsatisfiable, in whichever form
-        this lerobot expresses it. From lerobot 0.6.2 ``DatasetConfig`` refuses
-        the combination when it is constructed; before that it constructed and
-        the eval-split path rebuilt the TRAIN half map-style, discarding the
-        stream. If lerobot starts honoring the stream there, neither arm holds
-        and the refusal above should be lifted rather than left to reject a
-        combination that has become supportable.
+        this lerobot expresses it. A ``DatasetConfig`` that guards ``eval_split``
+        against ``streaming`` refuses the combination when it is constructed;
+        without that guard it constructs and the eval-split path rebuilds the
+        TRAIN half map-style, discarding the stream. Both arms are live in the
+        supported range, so neither is keyed on a release number here. If lerobot
+        starts honoring the stream there, neither arm holds and the refusal above
+        should be lifted rather than left to reject a combination that has become
+        supportable.
         """
         try:
             streamed_with_split = self._dataset_config(streaming=True, eval_split=0.25)


### PR DESCRIPTION
`LerobotTrainer.validate` asked whether `streaming` and `val_episodes` can both be delivered from **inside the branch that had already read the dataset's `total_episodes`**. That count is only readable from a local `meta/info.json`, and streaming a Hub dataset is the case with no local copy -- the download `streaming` exists to avoid. So on the one source `streaming` is for, the pair was never refused.

![refusal matrix](https://raw.githubusercontent.com/cagataycali/robots/8e4070f8132c5bbea796e61a5d3803213bcde8b1/.artifacts/streaming-split-refusal-matrix.png)

## Measured

`validate()` on `streaming=True, val_episodes=2`, one row per dataset source, captured from a clean `c418f74` worktree and from this branch:

| source | before | after |
|---|---|---|
| Hub id, no local copy (**what `streaming` is for**) | pair not refused; remedy prescribed: `extra={'dataset.eval_split': ...}` | pair refused |
| local root, no readable `meta/info.json` | pair not refused; same remedy prescribed | pair refused |
| local root, readable count *(control)* | pair refused | pair refused |
| Hub id, no local copy, `val_episodes=None` *(control)* | launchable | launchable |

The refusal that fired instead is the unreadable-count one, and its remedy is the bypass. Following it while `streaming` is still set:

```
spec = TrainSpec(dataset_repo_id="org/big-50gb", dataset_root=None, streaming=True,
                 extra={"policy_type": "act", "dataset.eval_split": 0.1, "eval_steps": 1000})
validate()      -> []
build_command() -> ... --dataset.streaming=true --dataset.eval_split=0.1 --eval_steps=1000
```

No problem reported, and both flags on one command line -- where lerobot's split path rebuilds both halves map-style, so the `StreamingLeRobotDataset` it opened first is discarded and the whole dataset is materialized with nothing reporting it. That is exactly the outcome `_streaming_validation_split_problem` exists to prevent.

`extra` is a documented raw passthrough and is deliberately **not** policed by this change; what stops is this backend *naming* it as the way forward to a caller who still has `streaming` set.

## Change

Whether the two fields can both be honored is a property of the two fields, so it is decided from them alone, ahead of every count-derived check. `+1` executable statement in `lerobot.py` (547 -> 548 by AST count); the rest of the `+56/-22` there is comment and docstring.

Once the refusal fires on a source with no local copy, `streaming=False` alone no longer delivers the split either -- the count is still unreadable -- so the remedy names the local copy that configuration also needs, keeping the class's existing "both remedies are honored" property true where it now fires.

## The version claim in the same message

The refusal said *"lerobot 0.6.2 refuses the pair outright"*. 0.6.2 is not a release. `DatasetConfig(streaming=True, eval_split=0.1)`, measured directly:

| lerobot | outcome |
|---|---|
| `v0.6.1` -- PyPI's latest, and what `lerobot>=0.6.1,<0.7.0` resolves | **constructs** |
| `main` (guard moved onto `streaming` on 2026-09-01, unreleased) | `ValueError: eval_split requires map-style datasets and is not supported with dataset.streaming=true.` |

So the behaviour attributed to "0.6.2" happens on no release, and the silent materialization it called historical is what a caller gets today. Two things made the claim easy to reach and hard to check: 0.6.1 carries the **same-worded** guard (`eval_split requires map-style datasets`) keyed on `repo_type='bucket'`, which this backend never sets -- so the quoted sentence is present in a lerobot that does not raise it here -- and `lerobot.__version__` is `importlib.metadata.version("lerobot")`, which reports the installed *distribution* (`0.6.2` for a source install), not a release the claim could be checked against. The message now names the predicate, which is verifiable.

## Tests

`tests/training/test_lerobot.py`, in the class that already owns this refusal -- no new module, no roster change. +8 cells (3756 -> 3764 in `tests/training`).

`test_a_hub_source_with_no_readable_count_keeps_its_own_refusal` **pinned the defect** and is retargeted rather than deleted: it asserted the count refusal was correct here because *"no split is emitted at all, so the pair is not what is wrong"*. That describes the spec as written and stops holding the moment the caller acts on it, since the remedy is what puts the split back. Its replacement pins the same question with the opposite answer and says why.

The count-independence table drives three sources; the readable-count row is the built-in control that held before and still holds. `test_the_passthrough_still_reaches_lerobots_own_knobs` is a **premise, not a fix pin** -- it holds both ways, and is recorded because it is what gives the misdirected remedy its consequence. The wording pin runs from a local root, where the refusal fires either way, so it grades the wording rather than the reachability the other cells own.

**Pre-fix split**, production reverted to `c418f74` with the tests in place: `6 failed, 12 passed`, each failure naming the defect --

```
test_a_hub_stream_with_no_readable_count_is_refused_for_the_pair
  -> the pair is set on this spec and delivers neither field, so it must be refused
test_the_count_remedy_is_not_offered_to_a_streaming_caller
  -> a streaming caller must not be told to pass the split through extra
test_the_pair_is_refused_whether_or_not_the_count_can_be_read[a Hub id with no local copy]
test_the_pair_is_refused_whether_or_not_the_count_can_be_read[a local root with no readable meta]
test_the_remedy_names_the_local_copy_when_the_count_is_unreadable
test_the_refusal_does_not_key_its_explanation_on_a_lerobot_release
  -> the refusal attributes behavior to a lerobot release the caller cannot check
```

## Gate

| check | result |
|---|---|
| `tests/training` + both `lerobot_train` tool suites + every `tests/test_docs*.py` | **4064 passed, 4 skipped, 0 failed** |
| `tests/training` alone | 3764 passed (3756 before; +8 = exactly the new cells) |
| changelog fragment graders | 91 passed |
| `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` | clean (1855 files) |
| `mypy strands_robots tests tests_integ` | `Success: no issues found in 1852 source files` |
| `scripts/check_whole_tree_graders.py` | 4227 passed, 50 skipped, 7 failed |

The 7 are environmental in the venv this ran in and none of them names a training, lerobot, docs or changelog grader: five assert `rclpy` is absent where it resolves from `/opt/ros/jazzy`, and two read the installed `websockets` 16.0 against the `>=17.0` floor `cosmos3-service` declares. The graders roster does not select `tests/training/test_lerobot.py`, so this diff cannot move that population.

The figure's every caption is asserted from the captured JSON inside the plot script, including that the two trees differ and that exactly the two bracketed rows flip.

## Size

4 files, +285/-59: production +56/-22 (`+1` executable statement), tests +184/-28, docs +16/-9, changelog fragment +29.