### PR TITLE
fix(hardware_robot): the provider a robot's tool schema advertises is one the registry holds

### DIFF
--- a/changelog.d/3183-advertised-provider-is-one-the-registry-holds.md
+++ b/changelog.d/3183-advertised-provider-is-one-the-registry-holds.md
@@ -1,0 +1,43 @@
+### Fixed: the provider a robot's tool schema advertises is one the registry holds
+
+`Robot.tool_spec` described its `policy_provider` parameter as `"Policy
+provider (groot, openai, etc.)"`. `openai` is not a registered provider - it is
+in none of the 31 spellings the JSON and runtime registries hold - and that
+schema is the only thing the model driving the tool reads, so it is a name the
+model will pass.
+
+Neither resolver names the schema that supplied it. `create_policy("openai")`
+raises `Unknown policy provider`, and on this path that happens inside
+`Robot._get_policy` on the executor thread, after `start_task` has already
+answered `Task started` and the arm has connected. `resolve_policy("openai")`
+returns `("lerobot_local", {"pretrained_name_or_path": "openai"})`, so on the
+surfaces that reach it the name resolves - to the wrong provider, pointed at a
+checkpoint repository that does not exist.
+
+The refusal that arrives first is not about the provider either. `_get_policy`
+reads the registry's `requires` field to decide whether a port is owed and
+falls back to demanding one when the provider is unknown, so
+`start_task(..., policy_provider="openai")` with no port is refused with
+`policy_port is required to build a policy` - byte-identical to the same call
+naming the real `groot`. Nothing on that path says the provider does not exist.
+
+The description now names registered providers and points at `list_providers()`
+for the enumeration, which is the form the MuJoCo tool spec already uses.
+
+`tests/registry/test_advertised_providers_are_registered.py` exists for this
+class and its docstring names both failure modes, but its population was one
+file - `simulation/mujoco/tool_spec.json`, the surface that prompted it.
+Measured over the package there are two `policy_provider` schema entries; that
+one advertises five names and all five are registered, and the other is the one
+above. The sweep now walks the package and grades every schema entry it finds -
+the `e.g.` examples and the `default` - so a third surface is graded on arrival
+rather than needing the guard to be widened again. The walk is rooted at an
+imported symbol, so `scripts/check_whole_tree_graders.py` rosters the module
+with no second edit.
+
+The same sweep grades the 30 `policy_provider=` signature defaults in the
+package, which is the half #3075 asks for: those are reached by exactly the
+calls that pass the fewest arguments, so a provider rename or removal leaves
+them naming nothing and the loss stays invisible until a caller omits the
+argument. All 30 pass today, and `None` is skipped as the not-supplied
+sentinel.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -2654,7 +2654,9 @@ class Robot(TeleopMixin, AgentTool):
                         },
                         "policy_provider": {
                             "type": "string",
-                            "description": "Policy provider (groot, openai, etc.)",
+                            "description": (
+                                "Policy provider name (e.g. groot, lerobot_local, mock). See list_providers()."
+                            ),
                             "default": "groot",
                         },
                         "duration": {

--- a/tests/registry/test_advertised_providers_are_registered.py
+++ b/tests/registry/test_advertised_providers_are_registered.py
@@ -1,32 +1,82 @@
 """Guard against phantom policy providers advertised to agents and users.
 
-The MuJoCo ``run_policy`` tool spec (``tool_spec.json``) and the
-``strands_robots.registry.policies`` docstrings enumerate example policy
-provider names to guide LLM agents and library callers. If any advertised
-name is not actually registered, the caller gets an ``Unknown policy
-provider`` error late in a rollout (after world init / camera setup) or is
-silently redirected to the ``lerobot_local`` fallback -- a wasteful, confusing
-failure mode.
+An agent-facing tool schema enumerates example policy provider names to guide
+the model driving the tool, and carries a ``default`` for the parameter. The
+model reads that schema and nothing else, so a name it advertises which is not
+actually registered is not a documentation nit -- it is a provider the model
+will pass. What happens then depends on which resolver the surface reaches, and
+neither outcome names the schema that supplied the name:
 
-These tests pin the invariant that every provider name advertised in the tool
-spec and in the resolver docstrings resolves to a registered provider, so
-documentation cannot drift ahead of the implementation again.
+* ``create_policy`` raises ``Unknown policy provider``, and on the hardware
+  path that happens inside ``Robot._get_policy`` on the executor thread, after
+  ``start_task`` has already answered ``Task started`` and the arm has
+  connected.
+* ``resolve_policy`` redirects any unrecognised string to ``lerobot_local``
+  with the string as ``pretrained_name_or_path``, so the name resolves -- to
+  the wrong provider, pointed at a checkpoint repository that does not exist.
+
+The refusal for an unregistered provider is also not distinguishable from the
+refusal for a registered one. ``Robot._get_policy`` reads the registry's
+``requires`` field to decide whether a port is owed and falls back to demanding
+one when the provider is unknown, so a schema-advertised phantom name passed
+without a port is refused for the *port* -- byte-identical to the same call
+naming a real port-dialing provider. Nothing on that path says the provider
+does not exist.
+
+**The population is derived from the tree, not listed here.** These tests used
+to read one file, ``simulation/mujoco/tool_spec.json``, which is the surface
+that prompted them. Measured over the package there are two ``policy_provider``
+schema entries, and the second one -- ``Robot.tool_spec``, the schema every
+hardware robot presents -- advertised ``openai``, which resolves to
+``lerobot_local`` rather than to itself. A guard for this class that names its
+own subject cannot see a second surface arrive, so the sweep walks the package
+and grades whatever it finds: a schema entry added later is graded on arrival.
+
+Two spellings of the same literal are graded, because a provider name reaches a
+caller by two routes:
+
+* a ``policy_provider`` entry in a tool ``inputSchema`` -- its ``e.g.``
+  examples and its ``default`` -- which is what an agent reads;
+* a ``policy_provider=`` default in a function signature, which is what a
+  Python caller gets when the argument is omitted.
+
+The second is the gap #3075 names: nothing links a registry entry to the
+defaults that name it, so a provider rename or removal leaves those defaults
+naming nothing and the loss is invisible until a caller omits the argument.
+``None`` is skipped there -- it is the not-supplied sentinel, not a provider.
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
 import json
+import pathlib
 import re
-from pathlib import Path
+from typing import Any
 
-from strands_robots.registry.policies import list_policy_providers, resolve_policy
+import pytest
 
-ROOT = Path(__file__).resolve().parents[2]
-TOOL_SPEC = ROOT / "strands_robots" / "simulation" / "mujoco" / "tool_spec.json"
+from strands_robots.policies import list_aliases, list_providers
+from strands_robots.registry.policies import resolve_policy
+
+# Derived from the defining module of an imported symbol rather than from a
+# path literal, which is what lets scripts/check_whole_tree_graders.py resolve
+# the walk below and roster this module without a second edit.
+_PACKAGE_ROOT = pathlib.Path(inspect.getfile(resolve_policy)).parents[1]
+
+# The two surfaces the sweep is known to reach. Asserted rather than iterated:
+# a resolver or layout change that leaves the walk finding nothing would
+# otherwise pass every cell below vacuously.
+_KNOWN_SCHEMA_FILES = {
+    "hardware_robot.py",
+    "tool_spec.json",
+}
 
 
-def _registered() -> set[str]:
-    return set(list_policy_providers())
+def _registered_spellings() -> set[str]:
+    """Every provider spelling either registry holds, canonical or alias."""
+    return set(list_providers()) | set(list_aliases())
 
 
 def _eg_names(text: str) -> list[str]:
@@ -37,35 +87,185 @@ def _eg_names(text: str) -> list[str]:
     return [tok.strip() for tok in re.split(r"[,/]", match.group(1)) if tok.strip()]
 
 
-def _tool_spec_provider_examples() -> list[str]:
-    spec = json.loads(TOOL_SPEC.read_text())
-    desc = spec["properties"]["policy_provider"]["description"]
-    return _eg_names(desc)
+def _is_schema_entry(value: Any) -> bool:
+    """Is ``value`` a JSON-schema property rather than a config mapping?
 
-
-def test_tool_spec_advertises_provider_examples() -> None:
-    """The tool spec description must list concrete example providers."""
-    assert _tool_spec_provider_examples(), "no 'e.g. ...' provider examples found in tool_spec description"
-
-
-def test_tool_spec_provider_examples_are_registered() -> None:
-    """Every provider named in the MuJoCo tool spec must be registered."""
-    registered = _registered()
-    unknown = [name for name in _tool_spec_provider_examples() if name not in registered]
-    assert not unknown, f"tool_spec advertises unregistered providers {unknown}; registered={sorted(registered)}"
-
-
-def test_tool_spec_provider_examples_resolve_to_themselves() -> None:
-    """Advertised names must resolve to their own provider, not the fallback.
-
-    ``resolve_policy`` redirects any unrecognised string to ``lerobot_local``.
-    A phantom name (e.g. ``lerobot_async``) therefore "resolves" but to the
-    wrong provider, silently misdirecting the caller. Asserting the resolved
-    provider equals the advertised name catches that.
+    A property declares a ``type``. Keying on that keeps a ``policy_provider``
+    key that merely holds a configured value out of the population, which is
+    what would otherwise make the sweep grade a caller's argument as though it
+    were an advertisement.
     """
-    for name in _tool_spec_provider_examples():
-        provider, _ = resolve_policy(name)
-        assert provider == name, f"advertised provider {name!r} resolves to {provider!r} (phantom/misdirecting)"
+    return isinstance(value, dict) and "type" in value
+
+
+def _py_schema_entries(path: pathlib.Path) -> list[tuple[str, dict[str, Any]]]:
+    """Every ``{"policy_provider": {...}}`` schema literal in a Python file."""
+    found: list[tuple[str, dict[str, Any]]] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values):
+            if not (isinstance(key, ast.Constant) and key.value == "policy_provider"):
+                continue
+            if not isinstance(value, ast.Dict):
+                continue
+            entry: dict[str, Any] = {}
+            for inner_key, inner_value in zip(value.keys, value.values):
+                if not (isinstance(inner_key, ast.Constant) and isinstance(inner_key.value, str)):
+                    continue
+                if isinstance(inner_value, ast.Constant):
+                    entry[inner_key.value] = inner_value.value
+            if _is_schema_entry(entry):
+                found.append((f"{path.name}:{value.lineno}", entry))
+    return found
+
+
+def _json_schema_entries(path: pathlib.Path) -> list[tuple[str, dict[str, Any]]]:
+    """Every ``"policy_provider"`` schema property in a JSON file."""
+    found: list[tuple[str, dict[str, Any]]] = []
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return found
+    pending: list[Any] = [doc]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, dict):
+            for key, value in current.items():
+                if key == "policy_provider" and _is_schema_entry(value):
+                    found.append((path.name, value))
+                pending.append(value)
+        elif isinstance(current, list):
+            pending.extend(current)
+    return found
+
+
+def _provider_schema_entries() -> list[tuple[str, dict[str, Any]]]:
+    """Every agent-facing ``policy_provider`` schema entry in the package."""
+    found: list[tuple[str, dict[str, Any]]] = []
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        found.extend(_py_schema_entries(path))
+    for path in sorted(_PACKAGE_ROOT.rglob("*.json")):
+        found.extend(_json_schema_entries(path))
+    return found
+
+
+def _signature_defaults() -> list[tuple[str, str]]:
+    """Every ``policy_provider=`` default in the package, as (site, name).
+
+    ``None`` defaults are skipped: that is the not-supplied sentinel the
+    port-requiring entry points use, not a provider name.
+    """
+    found: list[tuple[str, str]] = []
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            args = node.args
+            positional = args.posonlyargs + args.args
+            padding: list[ast.expr | None] = [None] * (len(positional) - len(args.defaults))
+            pairs = list(zip(positional, padding + list(args.defaults)))
+            pairs += list(zip(args.kwonlyargs, args.kw_defaults))
+            for arg, default in pairs:
+                if arg.arg != "policy_provider" or default is None:
+                    continue
+                if isinstance(default, ast.Constant) and isinstance(default.value, str):
+                    found.append((f"{path.name}:{node.lineno} {node.name}", default.value))
+    return found
+
+
+_SCHEMA_ENTRIES = _provider_schema_entries()
+_SIGNATURE_DEFAULTS = _signature_defaults()
+
+_ADVERTISED = [(site, name) for site, entry in _SCHEMA_ENTRIES for name in _eg_names(str(entry.get("description", "")))]
+_SCHEMA_DEFAULTS = [
+    (site, entry["default"]) for site, entry in _SCHEMA_ENTRIES if isinstance(entry.get("default"), str)
+]
+
+
+def test_the_sweep_reaches_every_known_provider_schema() -> None:
+    """The walk must find both known surfaces, so nothing below passes vacuously."""
+    files = {site.split(":")[0] for site, _ in _SCHEMA_ENTRIES}
+    assert _KNOWN_SCHEMA_FILES <= files, (
+        f"the policy_provider schema sweep found {sorted(files)}; "
+        f"expected at least {sorted(_KNOWN_SCHEMA_FILES)}. A surface moved or the walk broke - "
+        "re-read the discovery helpers rather than trimming this expectation."
+    )
+
+
+def test_every_provider_schema_advertises_examples_in_a_readable_form() -> None:
+    """Each schema must list its examples as ``e.g. a, b, c``.
+
+    The form is what makes the examples gradable at all. ``Robot.tool_spec``
+    advertised ``"Policy provider (groot, openai, etc.)"``, which names two
+    providers and matches no ``e.g.`` clause, so the phantom one was invisible
+    to a guard that reads the clause.
+    """
+    silent = [site for site, entry in _SCHEMA_ENTRIES if not _eg_names(str(entry.get("description", "")))]
+    assert not silent, (
+        f"policy_provider schemas at {silent} state no 'e.g. ...' provider examples, "
+        "so the names they advertise cannot be graded against the registry"
+    )
+
+
+@pytest.mark.parametrize(("site", "name"), _ADVERTISED)
+def test_every_advertised_provider_example_is_registered(site: str, name: str) -> None:
+    """Every provider a schema names as an example must be registered."""
+    registered = _registered_spellings()
+    assert name in registered, f"{site} advertises unregistered provider {name!r}; registered={sorted(registered)}"
+
+
+@pytest.mark.parametrize(("site", "name"), _ADVERTISED)
+def test_every_advertised_provider_example_resolves_to_itself(site: str, name: str) -> None:
+    """An advertised name must resolve to its own provider, not the fallback.
+
+    ``resolve_policy`` redirects an unrecognised string to ``lerobot_local``,
+    so a phantom name "resolves" and misdirects rather than refusing. Asserting
+    the resolved provider equals the advertised name is what separates the two.
+    """
+    provider, _ = resolve_policy(name)
+    assert provider == name, f"{site} advertises {name!r}, which resolves to {provider!r} (phantom/misdirecting)"
+
+
+@pytest.mark.parametrize(("site", "name"), _SCHEMA_DEFAULTS)
+def test_every_provider_schema_default_resolves_to_itself(site: str, name: str) -> None:
+    """A schema ``default`` is what the model sends when it says nothing.
+
+    It is written by hand beside the signature default it mirrors rather than
+    derived from it, so the two go stale independently: a Python caller reads
+    the signature and an agent reads the schema.
+    """
+    registered = _registered_spellings()
+    assert name in registered, f"{site} defaults to unregistered provider {name!r}; registered={sorted(registered)}"
+    provider, _ = resolve_policy(name)
+    assert provider == name, f"{site} defaults to {name!r}, which resolves to {provider!r}"
+
+
+@pytest.mark.parametrize(("site", "name"), _SIGNATURE_DEFAULTS)
+def test_every_policy_provider_signature_default_resolves_to_itself(site: str, name: str) -> None:
+    """A ``policy_provider=`` default must name a registered provider.
+
+    This is the half #3075 names: the defaults are reached by exactly the calls
+    that pass the fewest arguments, so a provider rename or removal leaves them
+    naming nothing and the loss stays invisible until a caller omits the
+    argument. Deriving the population means a provider-dialing entry point
+    added later is held to the rule on arrival.
+    """
+    registered = _registered_spellings()
+    assert name in registered, f"{site} defaults to unregistered provider {name!r}; registered={sorted(registered)}"
+    provider, _ = resolve_policy(name)
+    assert provider == name, f"{site} defaults to {name!r}, which resolves to {provider!r}"
+
+
+def test_the_signature_default_sweep_reaches_the_entry_points() -> None:
+    """The signature sweep must find defaults, so the cells above are not empty."""
+    assert len(_SIGNATURE_DEFAULTS) >= 20, (
+        f"the policy_provider signature sweep found {len(_SIGNATURE_DEFAULTS)} defaults; "
+        "the entry points that carry one are the driver start_task family and the simulation "
+        "rollout helpers, so a count this low means the walk broke"
+    )
 
 
 def test_resolve_policy_docstring_examples_reference_registered_providers() -> None:
@@ -73,6 +273,6 @@ def test_resolve_policy_docstring_examples_reference_registered_providers() -> N
     doc = resolve_policy.__doc__ or ""
     names = re.findall(r'#\s*\u2192\s*\("([^"]+)"', doc)
     assert names, "no docstring resolution examples found in resolve_policy"
-    registered = _registered()
+    registered = _registered_spellings()
     unknown = [name for name in names if name not in registered]
     assert not unknown, f"resolve_policy docstring references unregistered providers {unknown}"


### PR DESCRIPTION
## The defect

`Robot.tool_spec` described its `policy_provider` parameter as `"Policy provider (groot, openai, etc.)"`. `openai` is not a registered provider — it is in none of the 31 spellings the JSON and runtime registries hold — and that schema is the only thing the model driving the tool reads. So it is not a documentation nit: it is a provider name the model will pass.

## What a caller who trusts the schema gets, measured

Neither resolver names the schema that supplied the name, and the two disagree about what the name even means:

| resolver | `"groot"` (the schema's default) | `"openai"` (the schema's other example) |
|---|---|---|
| `create_policy` | builds, or `ImportError` naming the `groot-service` extra | `ValueError: Unknown policy provider: 'openai'` |
| `resolve_policy` | `('groot', {})` | `('lerobot_local', {'pretrained_name_or_path': 'openai'})` |

The hardware path reaches `create_policy`, via `Robot._get_policy`. So the phantom name is finally judged on the **executor thread**, after `start_task` has already answered `Task started` and the arm has connected:

```
_get_policy(policy_port=5555, policy_provider='groot')  -> ImportError: 'zmq' is required for GR00T service inference
_get_policy(policy_port=5555, policy_provider='openai') -> ValueError: Unknown policy provider: 'openai'
```

On the surfaces that reach `resolve_policy` instead, the name does not fail at all — it resolves to `lerobot_local` pointed at a checkpoint repository named `openai`. That second outcome is the one the guard's own docstring already called out as the expensive one.

**And the refusal that arrives first is not about the provider.** `_get_policy` reads the registry's `requires` field to decide whether a port is owed and falls back to demanding one when the provider is unknown, so the schema's own name, passed without a port, is refused for the *port*:

```
start_task('pick up the cube', policy_provider='openai') -> error: start_task: policy_port is required to build a policy
start_task('pick up the cube', policy_provider='groot')  -> error: start_task: policy_port is required to build a policy
```

Byte-identical. Nothing on that path says the provider does not exist.

## Why nothing caught it

`tests/registry/test_advertised_providers_are_registered.py` exists for exactly this class — its docstring names both failure modes, including the silent `lerobot_local` redirect. Its population was **one file**: `simulation/mujoco/tool_spec.json`, the surface that prompted it.

Measured over the package, there are exactly two `policy_provider` schema entries:

| site | advertises | registered? | graded before |
|---|---|---|---|
| `simulation/mujoco/tool_spec.json` | `groot, lerobot_local, lerobot_async, cosmos3, mock` | 5 of 5 | yes |
| `hardware_robot.py:2655` (`Robot.tool_spec`) | `groot, openai` | **1 of 2** | no |

A guard for this class that names its own subject cannot see a second surface arrive. That is the whole mechanism.

## The change

**1. The description names registered providers** and points at `list_providers()` for the enumeration, which is the form the MuJoCo tool spec already uses — an example list is a thing that goes stale, an enumerating call is not.

**2. The sweep's population is derived from the tree.** It walks the package (`.py` via AST, `.json` via a recursive walk) for every `policy_provider` mapping that declares a `type`, and grades both the `e.g.` examples and the `default`. A third surface is graded on arrival rather than needing this guard widened again. The walk is rooted at an imported symbol rather than a path literal, so `scripts/check_whole_tree_graders.py` rosters the module with no second edit — verified, the roster names it and comes to 99.

Requiring the `e.g.` form is load-bearing rather than cosmetic: the pre-fix description spelled its examples as a bare parenthetical, which matches no `e.g.` clause, so the phantom name was invisible to a grader that reads the clause. That is the cell that fires on the unfixed tree.

**3. The same sweep grades the 30 `policy_provider=` signature defaults**, which is the half #3075 asks for and which presupposes none of its three options. Those defaults are reached by exactly the calls that pass the fewest arguments, so a provider rename or removal leaves them naming nothing with nothing to report it. `None` is skipped — it is the not-supplied sentinel, not a provider.

One correction to how #3075 sizes that surface: it counts 17 `policy_provider=` sites plus the schema literal. Measured on `2f37927` there are **30** signature defaults — 18 `groot` (the issue's list omits `drivers/earthrover.py:470`), 10 `mock` on the simulation and device-connect rollout helpers, and 2 `None` — plus the one schema literal. All 31 name a registered provider today.

## Grading

Every cell was driven against a planted defect, so none of them is a test that cannot fail. Each names the offending site:

| planted | cell that fires |
|---|---|
| the tree as it is (`(groot, openai, etc.)`) | `..._advertises_examples_in_a_readable_form` — `['hardware_robot.py:2655'] state no 'e.g. ...' provider examples` |
| `e.g. groot, openai, mock` | `..._example_is_registered[hardware_robot.py:2655-openai]` **and** `..._example_resolves_to_itself[...]` |
| `"default": "openai"` | `..._schema_default_resolves_to_itself[hardware_robot.py:2655-openai]` |
| `drivers/g1.py` default renamed to `groot_service` | `..._signature_default_resolves_to_itself[g1.py:1085 start_task-groot_service]` |

Two cells assert the sweep reached something (`_KNOWN_SCHEMA_FILES <= files`, and a floor on the signature-default count), so a resolver or layout change that left the walk finding nothing fails loudly instead of passing every cell above vacuously.

## Verification

| | result |
|---|---|
| `tests/registry/` + the grader-roster pin | **927 passed, 14 skipped** |
| the module, pre-fix / post-fix | **1 failed, 42 passed** → **49 passed** |
| `ruff format`, `ruff check`, `mypy` on both files | clean |
| `hatch run whole-tree-check` (§2) | **16 failed, 4189 passed, 128 skipped** |

The 16 are environmental and pre-existing: the same 16 node ids fail on `2f37927` with this branch stashed, so the delta in both directions is empty. They are the `tests/mesh/` IoT and ACL cells (no `awscrt`/`awsiot` in this env), `test_lerobot_import_surface`, `test_docs_vera_pusht_experimental` and one mesh loop-rate timing cell.

No behaviour changes. The only non-test edit is the schema description string; the `default` stays `groot`.

Refs #3075 — this takes the guard that issue asks for and the live instance it turned out to have, and leaves the provider-removal decision (its options 1–3) untouched.

## §13 changelog

- **round 0** — initial: schema description corrected; the phantom-provider guard's population derived from the tree instead of naming one file; the `policy_provider=` signature defaults brought under it.