### PR TITLE
feat(dashboard): a Lockout value type states what a dashboard may say about an e-stop

### DIFF
--- a/changelog.d/3185-dashboard-safety-state-lockout.md
+++ b/changelog.d/3185-dashboard-safety-state-lockout.md
@@ -1,0 +1,11 @@
+### Added: a `Lockout` value type states what a dashboard may say about an e-stop
+
+`strands_robots.dashboard.safety_state` is a pure value module for what the
+operator dashboard is entitled to claim about a fleet-wide e-stop lockout. A
+frozen `Lockout` carries the `state` (`locked` / `clear` / `unknown`), `since`,
+`by` and a human `reason`, and renders to wire fields through `as_fields()`.
+The transitions that fold mesh events into it (`apply_event`,
+`note_command_accepted`) are pure functions with no mesh or transport
+dependency, so the vocabulary the UI badge draws from is testable on its own and
+the same `Lockout` can back both the REST snapshot and the websocket snapshot
+without the two disagreeing.

--- a/strands_robots/dashboard/safety_state.py
+++ b/strands_robots/dashboard/safety_state.py
@@ -1,0 +1,105 @@
+"""What the dashboard is entitled to say about an e-stop lockout."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Lockout:
+    """The fleet-wide lockout as this dashboard understands it."""
+
+    state: str = "unknown"  # locked | clear | unknown
+    since: float | None = None
+    by: str | None = None
+    reason: str = "no e-stop or resume seen since this dashboard started"
+
+    def as_fields(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"state": self.state, "reason": self.reason}
+        if self.since is not None:
+            out["since"] = self.since
+        if self.by:
+            out["by"] = self.by
+        return out
+
+
+def _source_of(data: dict[str, Any]) -> str | None:
+    for key in ("source", "coordinator", "peer_id", "source_peer_id", "by", "sender"):
+        v = data.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def apply_event(current: Lockout, *, kind: str, data: dict[str, Any], now: float) -> Lockout:
+    """Fold one `strands/safety/**` event into the verdict."""
+    t_val = data.get("t")
+    when = t_val if isinstance(t_val, (int, float)) else now
+    who = _source_of(data)
+    if kind == "estop":
+        return Lockout(
+            state="locked",
+            since=float(when),
+            by=who,
+            reason=(f"an e-stop from {who} locked the fleet" if who else "an e-stop locked the fleet"),
+        )
+    if kind == "resume":
+        # NOT clear: every peer re-verifies the override code on its own and may refuse.
+        return Lockout(
+            state="unknown",
+            since=float(when),
+            by=who,
+            reason=(
+                "a resume was broadcast, but each peer verifies the override code itself - "
+                "not proof that any of them cleared"
+            ),
+        )
+    return current
+
+
+def note_command_accepted(current: Lockout, *, now: float) -> Lockout:
+    """A peer accepted a command a lockout would have refused: that is proof."""
+    if current.state == "clear":
+        return current
+    return Lockout(
+        state="clear",
+        since=now,
+        by=None,
+        reason="a command this peer accepted proves its lockout is not engaged",
+    )
+
+
+#: Actions a locked-out peer still answers, so accepting one proves nothing.
+LOCKOUT_EXEMPT_ACTIONS = frozenset({"status", "resume"})
+
+
+def proves_clear(action: str) -> bool:
+    """Would a locked-out peer have refused this action?"""
+    return bool(action) and action not in LOCKOUT_EXEMPT_ACTIONS
+
+
+def peer_lockout(fleet: Lockout, *, first_seen: float | None) -> Lockout:
+    """The verdict for ONE peer, given when the dashboard first saw it.
+
+    A peer that appeared after the e-stop is a process that never received it.
+    """
+    if fleet.state == "locked" and first_seen is not None and fleet.since is not None:
+        if first_seen > fleet.since:
+            return replace(
+                fleet,
+                state="unknown",
+                reason=(
+                    "this peer appeared after the fleet e-stop, so it may never have "
+                    "received it - drive it only if you know it is safe"
+                ),
+            )
+    return fleet
+
+
+def resolve_peer(fleet: Lockout, *, first_seen: float | None = None, proof_at: float | None = None) -> Lockout:
+    """The verdict shown on one peer's card."""
+    verdict = peer_lockout(fleet, first_seen=first_seen)
+    if proof_at is not None and (fleet.since is None or proof_at > fleet.since):
+        return note_command_accepted(verdict, now=proof_at)
+    return verdict

--- a/tests/test_dashboard_safety_state.py
+++ b/tests/test_dashboard_safety_state.py
@@ -1,0 +1,106 @@
+"""A locked-out arm must never render as a healthy one (Q43).
+
+Measured 2026-08-20: both SO-101 arms had been e-stop locked for ten hours while
+/api/fleet showed so101-arm-2 with six live joints, stale=false and no safety field of
+any kind. The only representation of a lockout in the product was a five-second flash,
+so a page reload erased it.
+"""
+
+from __future__ import annotations
+
+from strands_robots.dashboard.safety_state import (
+    Lockout,
+    apply_event,
+    note_command_accepted,
+    proves_clear,
+    resolve_peer,
+)
+
+
+class TestSeenEvents:
+    def test_before_anything_is_seen_the_answer_is_unknown_not_clear(self) -> None:
+        # The mesh does not advertise lockout state, so silence is not safety.
+        assert Lockout().state == "unknown"
+        assert "since this dashboard started" in Lockout().reason
+
+    def test_an_estop_locks_and_names_who_sent_it(self) -> None:
+        # the real incident: COORDINATOR_ID of examples/fleet/04_emergency_evacuation.py
+        lock = apply_event(Lockout(), kind="estop", data={"source": "evac-coordinator", "t": 100.0}, now=200.0)
+        assert lock.state == "locked"
+        assert lock.by == "evac-coordinator"
+        assert lock.since == 100.0
+        assert "evac-coordinator" in lock.reason
+
+    def test_an_estop_without_a_named_source_still_locks(self) -> None:
+        lock = apply_event(Lockout(), kind="estop", data={}, now=50.0)
+        assert lock.state == "locked" and lock.since == 50.0 and lock.by is None
+
+    def test_a_resume_is_a_broadcast_not_a_receipt(self) -> None:
+        # Each peer re-verifies the override code and MAY REFUSE. Painting the fleet
+        # green here would be a claim about hardware that nobody checked.
+        locked = apply_event(Lockout(), kind="estop", data={"source": "x"}, now=10.0)
+        after = apply_event(locked, kind="resume", data={"source": "operator"}, now=20.0)
+        assert after.state == "unknown", "a published resume is not proof any peer cleared"
+        assert "verifies the override code itself" in after.reason
+
+    def test_an_unrelated_event_kind_changes_nothing(self) -> None:
+        locked = apply_event(Lockout(), kind="estop", data={}, now=1.0)
+        assert apply_event(locked, kind="weather", data={}, now=2.0) == locked
+
+
+class TestProof:
+    def test_only_an_action_a_lockout_would_refuse_proves_anything(self) -> None:
+        assert proves_clear("task") is True
+        assert proves_clear("teleop_publish") is True
+        assert proves_clear("status") is False, "a locked peer answers status - it proves nothing"
+        assert proves_clear("resume") is False
+        assert proves_clear("") is False
+
+    def test_an_accepted_command_clears_the_verdict(self) -> None:
+        locked = apply_event(Lockout(), kind="estop", data={}, now=10.0)
+        proved = note_command_accepted(locked, now=30.0)
+        assert proved.state == "clear"
+        assert "accepted" in proved.reason
+
+    def test_proof_older_than_the_estop_is_ignored(self) -> None:
+        locked = apply_event(Lockout(), kind="estop", data={}, now=100.0)
+        # a command accepted an hour before the e-stop says nothing about now
+        assert resolve_peer(locked, first_seen=1.0, proof_at=50.0).state == "locked"
+
+    def test_proof_after_the_estop_wins(self) -> None:
+        locked = apply_event(Lockout(), kind="estop", data={}, now=100.0)
+        assert resolve_peer(locked, first_seen=1.0, proof_at=150.0).state == "clear"
+
+    def test_proof_after_a_resume_is_how_a_fleet_goes_green_again(self) -> None:
+        locked = apply_event(Lockout(), kind="estop", data={}, now=10.0)
+        resumed = apply_event(locked, kind="resume", data={}, now=20.0)
+        assert resolve_peer(resumed, first_seen=1.0, proof_at=25.0).state == "clear"
+
+
+class TestPerPeer:
+    def test_a_peer_that_appeared_after_the_estop_is_unknown_not_locked(self) -> None:
+        # A freshly spawned child has its own unset lockout flag; inheriting the fleet's
+        # verdict would mark it red on no evidence.
+        locked = apply_event(Lockout(), kind="estop", data={}, now=100.0)
+        v = resolve_peer(locked, first_seen=150.0)
+        assert v.state == "unknown"
+        assert "appeared after the fleet e-stop" in v.reason
+
+    def test_a_peer_present_before_the_estop_is_locked(self) -> None:
+        locked = apply_event(Lockout(), kind="estop", data={}, now=100.0)
+        assert resolve_peer(locked, first_seen=10.0).state == "locked"
+
+    def test_an_unknown_first_seen_does_not_soften_a_lockout(self) -> None:
+        locked = apply_event(Lockout(), kind="estop", data={}, now=100.0)
+        assert resolve_peer(locked, first_seen=None).state == "locked"
+
+    def test_the_verdict_always_carries_a_reason(self) -> None:
+        for v in (
+            Lockout(),
+            apply_event(Lockout(), kind="estop", data={}, now=1.0),
+            resolve_peer(apply_event(Lockout(), kind="estop", data={}, now=1.0), first_seen=2.0),
+            note_command_accepted(Lockout(), now=1.0),
+        ):
+            fields = v.as_fields()
+            assert fields["reason"], "a badge with no explanation sends the operator hunting"
+            assert fields["state"] in {"locked", "clear", "unknown"}


### PR DESCRIPTION
Extracted from the closed dashboard PR #2848 per #2977, as a **self-contained leaf slice** cut fresh from current `main`. Two files, no dependency on unlanded modules.

## What this adds
`strands_robots/dashboard/safety_state.py` — a pure value module for **what the operator dashboard is entitled to say about a fleet-wide e-stop lockout**:

- `Lockout` — a frozen dataclass (`state` ∈ `locked|clear|unknown`, `since`, `by`, `reason`) with `as_fields()` for the wire.
- The pure transitions that fold mesh events into it (`apply_event`, `note_command_accepted`), kept free of any mesh/transport code so the vocabulary is testable on its own.

## Why a separate module
Keeping the "what may we claim about the lockout" vocabulary as a leaf value type lets the mesh bridge (a later slice) fold events through it without the badge logic depending on the transport. This module is also a prerequisite for the `mesh_bridge` findings-7/8 slice, which is why it lands first.

## Tests
`tests/test_dashboard_safety_state.py` — **14 passing** locally. The two bridge-snapshot integration tests that couple `safety_state` to `dashboard.mesh_bridge` travel with the (not-yet-landed) `mesh_bridge` slice, so this PR pins only the value type and its transitions.

Not a phased stub — this is a complete, mergeable unit (respects harness Rule 0).
