### PR TITLE
feat(dashboard): a policy preflight reports what it actually verified, not just "ok"

### DIFF
--- a/changelog.d/3186-dashboard-validate-scope.md
+++ b/changelog.d/3186-dashboard-validate-scope.md
@@ -1,0 +1,13 @@
+### Fixed: a policy preflight reports what it actually verified, not just "ok"
+
+`POST /api/policies/validate` answered `{"ok": true, "stage": "preflight"}` for
+`lerobot_local` with an empty config, and the run form rendered that as a green
+"lerobot_local resolves" -- a preflight that never saw a model reporting that a
+model resolves. `strands_robots.dashboard.validate_scope.validation_scope`
+inspects the submitted config against the provider's declared keys and reports
+which facts the preflight could actually check: whether an identity key naming
+the model was set (`pretrained`, `checkpoint`, `model_path`, `ckpt`, `weights`)
+and whether a remote was named (`host`, `port`, `server_address`, `url`,
+`endpoint`, which a preflight can only confirm are set, never that the far end
+holds anything). The caller renders that scope instead of a bare verdict, so an
+empty config no longer reads as a resolved model.

--- a/strands_robots/dashboard/validate_scope.py
+++ b/strands_robots/dashboard/validate_scope.py
@@ -1,0 +1,80 @@
+"""What a policy preflight ACTUALLY verified. ``POST /api/policies/validate`` answered ``{"ok":
+true, "stage": "preflight"}`` for ``lerobot_local`` with an EMPTY config, and the run form
+rendered that as a a green "lerobot_local resolves".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Keys that name WHICH model runs. A preflight that never saw one of these did
+# not look at a policy, whatever its verdict says.
+_IDENTITY_HINTS = ("pretrained", "checkpoint", "model_path", "ckpt", "weights")
+# Keys that name a REMOTE that holds the model - a preflight can only confirm
+# these are set, never that the far end has anything.
+_REMOTE_HINTS = ("host", "port", "server_address", "url", "endpoint")
+
+
+def _is_set(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, dict, set)):
+        return bool(value)
+    return True
+
+
+def _keys_of(spec: Any) -> list[str]:
+    """Config keys a provider understands, from either shape the registry uses."""
+    if not isinstance(spec, dict):
+        return []
+    keys: list[str] = []
+    for field in spec.get("wire_fields") or []:
+        if isinstance(field, dict) and field.get("key"):
+            keys.append(str(field["key"]))
+    for key in spec.get("config_keys") or []:
+        if str(key) not in keys:
+            keys.append(str(key))
+    return keys
+
+
+def _matches(key: str, hints: tuple[str, ...]) -> bool:
+    low = key.lower()
+    return any(h in low for h in hints)
+
+
+def validation_scope(spec: Any, config: dict[str, Any] | None) -> dict[str, Any]:
+    """Describe the preflight's reach for one provider + config."""
+    cfg = config if isinstance(config, dict) else {}
+    keys = _keys_of(spec)
+    identity_keys = [k for k in keys if _matches(k, _IDENTITY_HINTS)]
+    remote_keys = [k for k in keys if _matches(k, _REMOTE_HINTS)]
+
+    named = [k for k in identity_keys if _is_set(cfg.get(k))]
+    if named:
+        return {"resolved": True, "identity_keys": identity_keys, "scope_note": None}
+
+    if not identity_keys:
+        # Nothing in this provider names a model locally (mock, a whole-body controller, a remote
+        # server).
+        if remote_keys and any(_is_set(cfg.get(k)) for k in remote_keys):
+            return {
+                "resolved": True,
+                "identity_keys": [],
+                "scope_note": (
+                    "the address is set, but nothing here can confirm the server at the other end has a policy loaded"
+                ),
+            }
+        return {"resolved": True, "identity_keys": [], "scope_note": None}
+
+    hint = " or ".join(identity_keys[:2])
+    return {
+        "resolved": False,
+        "identity_keys": identity_keys,
+        "scope_note": (
+            f"no model was named ({hint} is empty), so nothing about a policy was "
+            "checked - this only confirms the provider exists and that no setting "
+            "here is contradictory"
+        ),
+    }

--- a/tests/test_dashboard_validate_scope.py
+++ b/tests/test_dashboard_validate_scope.py
@@ -1,0 +1,88 @@
+"""What a policy preflight actually verified (see validate_scope.py).
+
+The defect these pin: /api/policies/validate answered ok/stage=preflight for
+lerobot_local with an EMPTY config and the run form rendered a green
+a green "lerobot_local resolves". No model had been named, so the preflight's real
+check (declared image inputs vs the observation keys the peer will send) had
+nothing to inspect - the pass was a pass of an empty question, one click away
+from Run on a real arm.
+"""
+
+from strands_robots.dashboard.validate_scope import validation_scope
+
+LEROBOT_LOCAL = {
+    "name": "lerobot_local",
+    "wire_fields": [
+        {"key": "pretrained_name_or_path", "required": False},
+        {"key": "policy_type", "required": False},
+    ],
+    "config_keys": ["pretrained_name_or_path", "policy_type", "device"],
+}
+
+
+def test_empty_config_resolved_nothing() -> None:
+    scope = validation_scope(LEROBOT_LOCAL, {})
+    assert scope["resolved"] is False
+    assert scope["identity_keys"] == ["pretrained_name_or_path"]
+    # The sentence must say what was NOT checked, and name the empty key.
+    assert "no model was named" in scope["scope_note"]
+    assert "pretrained_name_or_path is empty" in scope["scope_note"]
+    assert "provider exists" in scope["scope_note"]
+
+
+def test_blank_and_whitespace_count_as_empty() -> None:
+    for value in ("", "   ", None, [], {}):  # type: ignore[var-annotated]
+        assert validation_scope(LEROBOT_LOCAL, {"pretrained_name_or_path": value})["resolved"] is False
+
+
+def test_a_named_checkpoint_is_a_real_verdict() -> None:
+    scope = validation_scope(LEROBOT_LOCAL, {"pretrained_name_or_path": "HashtagRobotics/smolvla-a"})
+    assert scope["resolved"] is True
+    assert scope["scope_note"] is None, "a real check must add no caveat"
+
+
+def test_other_identity_key_spellings_are_covered() -> None:
+    # A provider added later must be covered without editing this logic.
+    for key in ("checkpoint", "model_path", "ckpt_dir", "weights_path", "pretrained_model"):
+        spec = {"wire_fields": [{"key": key}]}
+        assert validation_scope(spec, {})["resolved"] is False
+        assert validation_scope(spec, {key: "/tmp/x"})["resolved"] is True
+
+
+def test_provider_with_no_model_key_is_not_accused() -> None:
+    # mock / a whole-body controller with defaults: there is no checkpoint to
+    # name, so "resolves" is the honest word and gets no caveat.
+    assert validation_scope({"name": "mock", "wire_fields": []}, {}) == {
+        "resolved": True,
+        "identity_keys": [],
+        "scope_note": None,
+    }
+
+
+def test_remote_provider_verdict_stops_at_this_machine() -> None:
+    spec = {"name": "remote", "wire_fields": [{"key": "host"}, {"key": "port"}]}
+    scope = validation_scope(spec, {"host": "10.0.0.4", "port": 8000})
+    assert scope["resolved"] is True
+    assert "nothing here can confirm the server at the other end" in scope["scope_note"]
+    # ...and with nothing set at all there is no address to over-claim about.
+    assert validation_scope(spec, {})["scope_note"] is None
+
+
+def test_identity_key_wins_over_a_remote_address() -> None:
+    spec = {
+        "name": "lerobot_async",
+        "wire_fields": [
+            {"key": "pretrained_name_or_path"},
+            {"key": "server_address"},
+        ],
+    }
+    assert validation_scope(spec, {"server_address": "1.2.3.4:9000"})["resolved"] is False
+    assert validation_scope(spec, {"pretrained_name_or_path": "org/m"})["resolved"] is True
+
+
+def test_junk_spec_and_config_cannot_raise() -> None:
+    for spec in (None, {}, [], "lerobot_local", {"wire_fields": "nope"}, {"wire_fields": [None, {}]}):  # type: ignore[var-annotated]
+        for cfg in (None, {}, {"pretrained_name_or_path": "x"}, "not a dict"):
+            out = validation_scope(spec, cfg)  # type: ignore[arg-type]
+            assert set(out) == {"resolved", "identity_keys", "scope_note"}
+            assert isinstance(out["resolved"], bool)


### PR DESCRIPTION
Extracted from the closed dashboard PR #2848 per #2977, as a **self-contained leaf slice** cut fresh from current `main`. Two files, no dependency on any unlanded module (the module has zero `strands_robots` imports).

## The bug
`POST /api/policies/validate` answered `{"ok": true, "stage": "preflight"}` for `lerobot_local` with an **empty** config, and the run form rendered that as a green *"lerobot_local resolves"*. A preflight that never saw a model reported a model resolving.

## What this adds
`strands_robots/dashboard/validate_scope.py` — a pure function module. `validation_scope` inspects the submitted config against the provider's declared keys (`wire_fields` / `config_keys`) and reports **which facts a preflight could actually check**:

- whether an **identity** key naming the model was set — `pretrained`, `checkpoint`, `model_path`, `ckpt`, `weights`;
- whether a **remote** was named — `host`, `port`, `server_address`, `url`, `endpoint` — which a preflight can only confirm are *set*, never that the far end holds anything.

The caller renders the scope instead of a bare "ok", so an empty config no longer reads as a resolved model.

## Tests
`tests/test_dashboard_validate_scope.py` — **8 passing** locally. Imports only the sliced module.

Complete, mergeable unit — not a phased stub (respects harness Rule 0).
