### PR TITLE
fix(simulation): a policy's required_bodies survive being wrapped

### DIFF
--- a/changelog.d/3187-required-bodies-survive-a-wrapper.md
+++ b/changelog.d/3187-required-bodies-survive-a-wrapper.md
@@ -1,0 +1,27 @@
+### Fixed
+
+- A policy's declared `required_bodies` survive being wrapped.
+  `PolicyRunner._resolve_required_bodies` read the declaration off the object it
+  was handed, and a wrapper is a different object than the policy inside it, so
+  a child's declaration was reported as absent. Both halves of the contract went
+  with it: the per-tick merge that puts `body.<name>.{pos,quat,lin_vel,ang_vel}`
+  into every observation, and the up-front check that a declared body resolves in
+  the scene. On a real rollout a tracker declaring one body received 0 of its 4
+  pose keys through `PersistentPolicy` and through `CompositePolicy`, and a body
+  the scene does not contain -- refused before the first step when the policy is
+  driven bare -- ran to completion reporting `status="success"` instead, which is
+  the "300 steps of a silently absent key read as a zero pose" the up-front check
+  exists to prevent. That reaches the one shipped declarer: `ProtoMotionsPolicy`
+  declares its anchor link because the observation carries the floating base only
+  and `base_quat` is the pelvis, which the waist joints separate from
+  `torso_link`; and both wrappers hand their child the observation this method
+  decides the shape of, `PersistentPolicy` verbatim and `CompositePolicy`
+  filtered. The declaration is now collected over the whole policy tree through
+  the shipped `iter_policy_tree` walk, which is what `Policy.children` exists to
+  answer -- "so one probe walks to the policy that answers, instead of every
+  probe having to learn the name of every wrapper" -- so a wrapper is honored
+  without having to re-declare anything, including a wrapper around a wrapper.
+  Every refusal now names the policy that declared the body rather than the
+  wrapper it was reached through, so it points at the class to change. A policy
+  that declares nothing still sees the backend observation untouched, wrapped or
+  not, and a body named twice in one tree still yields one key set.

--- a/docs/policies/custom-policies.md
+++ b/docs/policies/custom-policies.md
@@ -149,6 +149,11 @@ Notes:
   every observation and being read as a zero pose.
 - Declaring nothing (the default) leaves the observation exactly as the backend
   produced it, so policies that do not need a link pay no extra read.
+- The declaration is collected across the whole policy tree (`children`), so it
+  survives being wrapped: a tracker inside a `CompositePolicy` or a
+  `PersistentPolicy` still receives its links, and a wrapper does not have to
+  re-declare them. A refusal names the policy that declared the body, not the
+  wrapper it was reached through.
 - In a multi-robot scene MuJoCo body names carry the robot's namespace prefix
   (`alice/Lower_Arm`), the same spelling `get_body_state` resolves.
 - Requires a backend that implements `get_body_state` (MuJoCo, Isaac).

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -357,6 +357,11 @@ class Policy(ABC):
         start of the rollout with the available body names, rather than reading
         a missing key as a zero pose on every tick.
 
+        The runtime collects this over the whole policy tree
+        (:func:`iter_policy_tree`), so a policy that declares a body is honoured
+        when it is wrapped: a wrapper which does not override this property does
+        not hide its child's declaration.
+
         Returns:
             Ordered, de-duplicated body names. Empty (the default) means the
             observation is left exactly as the backend produced it.

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -47,7 +47,7 @@ import numpy as np
 
 from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.dataset_recorder import RecordingFrameError
-from strands_robots.policies.base import resolve_chunk_length
+from strands_robots.policies.base import iter_policy_tree, resolve_chunk_length
 from strands_robots.utils import (
     non_negative_whole_number_error,
     positive_count_error,
@@ -924,53 +924,82 @@ class PolicyRunner:
     )
 
     def _resolve_required_bodies(self, policy: Policy | None) -> tuple[str, ...]:
-        """Validate a policy's declared ``required_bodies`` once, before the rollout.
+        """Validate the declared ``required_bodies`` of a policy TREE, before the rollout.
 
         Resolving up front is the whole point: a mimic tracker reads its anchor
         link on EVERY tick, so a name the scene does not contain has to fail
         here - with the available body names - rather than 300 steps of a
         silently absent key that the policy reads as a zero pose.
 
+        The declaration is collected over the whole policy tree
+        (:func:`~strands_robots.policies.base.iter_policy_tree`), not off the
+        object this runner was handed. A wrapper is a different object than the
+        policy inside it, so reading the attribute off the wrapper reports a
+        child's declaration as absent - which is the case
+        :attr:`~strands_robots.policies.base.Policy.children` exists to answer,
+        "so one probe walks to the policy that answers, instead of every probe
+        having to learn the name of every wrapper". Both shipped wrappers hand
+        their child the observation this method decides the shape of:
+        :class:`~strands_robots.policies.persistent.PersistentPolicy` forwards it
+        verbatim and
+        :class:`~strands_robots.policies.composite.CompositePolicy` forwards a
+        filtered view, so a declaration lost here is lost for the policy that
+        made it - and both halves of this method go with it, the merge and the
+        scene check, leaving a rollout that reports success having never supplied
+        the key.
+
+        Every message names the DECLARING policy rather than the object handed
+        in, so a refusal through a wrapper points at the class to fix.
+
         Args:
-            policy: The policy about to be rolled out. ``None`` (replay) and a
-                policy that declares nothing both resolve to ``()``.
+            policy: Root of the policy tree about to be rolled out. ``None``
+                (replay) and a tree that declares nothing both resolve to ``()``.
 
         Returns:
             Ordered, de-duplicated body names to merge into each observation.
+            Order follows the tree walk (outermost policy first), so the merge
+            order is stable for a given tree.
 
         Raises:
-            TypeError: If ``required_bodies`` is not a sequence of non-empty
-                strings. A bare ``str`` is refused explicitly rather than
-                iterated into one entry per character.
+            TypeError: If any policy in the tree declares ``required_bodies``
+                that is not a sequence of non-empty strings. A bare ``str`` is
+                refused explicitly rather than iterated into one entry per
+                character.
             RuntimeError: If the backend exposes no ``get_body_state``, or a
                 declared body does not resolve in the current scene. Raised
                 rather than returned for the reason this layer raises
                 everywhere else: ``PolicyRunner`` is drivable directly and a
                 direct caller has no envelope to read a refusal from.
         """
-        declared = getattr(policy, "required_bodies", ()) or ()
-        if not declared:
-            return ()
-        if isinstance(declared, str):
-            raise TypeError(
-                f"{type(policy).__name__}.required_bodies must be a sequence of body names, "
-                f"not a bare str ({declared!r}) - a str iterates into one entry per character. "
-                f"Use a tuple: ('{declared}',)."
-            )
+        # name -> the policy that declared it first, so a refusal names the class
+        # that has to change rather than whichever wrapper is on the outside.
+        owner: dict[str, str] = {}
         bodies: list[str] = []
-        for name in declared:
-            if not isinstance(name, str) or not name.strip():
+        for member in () if policy is None else iter_policy_tree(policy):
+            declared = getattr(member, "required_bodies", ()) or ()
+            if not declared:
+                continue
+            who = type(member).__name__
+            if isinstance(declared, str):
                 raise TypeError(
-                    f"{type(policy).__name__}.required_bodies entries must be non-empty "
-                    f"body-name strings, got {name!r}."
+                    f"{who}.required_bodies must be a sequence of body names, "
+                    f"not a bare str ({declared!r}) - a str iterates into one entry per character. "
+                    f"Use a tuple: ('{declared}',)."
                 )
-            if name not in bodies:
-                bodies.append(name)
+            for name in declared:
+                if not isinstance(name, str) or not name.strip():
+                    raise TypeError(f"{who}.required_bodies entries must be non-empty body-name strings, got {name!r}.")
+                if name not in owner:
+                    owner[name] = who
+                    bodies.append(name)
+        if not bodies:
+            return ()
 
         probe = getattr(self.sim, "get_body_state", None)
         if not callable(probe):
+            declarers = " + ".join(dict.fromkeys(owner.values()))
             raise RuntimeError(
-                f"{type(policy).__name__} declares required_bodies={tuple(bodies)}, but backend "
+                f"{declarers} declares required_bodies={tuple(bodies)}, but backend "
                 f"{type(self.sim).__name__} exposes no get_body_state() to read a named body's "
                 f"pose from. Run this policy on a backend that implements it (MuJoCo, Isaac)."
             )
@@ -983,7 +1012,7 @@ class PolicyRunner:
                         str(block.get("text", "")) for block in result.get("content", []) if isinstance(block, dict)
                     ).strip()
                 raise RuntimeError(
-                    f"{type(policy).__name__} declares required_bodies entry {name!r}, which does "
+                    f"{owner[name]} declares required_bodies entry {name!r}, which does "
                     f"not resolve to a body in the current scene. {detail}".rstrip()
                 )
         return tuple(bodies)

--- a/tests/simulation/test_policy_required_bodies_observation.py
+++ b/tests/simulation/test_policy_required_bodies_observation.py
@@ -14,7 +14,9 @@ import pytest
 
 pytest.importorskip("mujoco")
 
+from strands_robots.policies.composite import CompositePolicy
 from strands_robots.policies.mock import MockPolicy
+from strands_robots.policies.persistent import PersistentPolicy
 from strands_robots.simulation.mujoco.simulation import Simulation
 from strands_robots.simulation.policy_runner import PolicyRunner
 
@@ -160,3 +162,93 @@ class TestEvalPathHonoursTheContract:
         assert result["status"] == "success"
         assert policy.seen
         assert f"body.{ARM_BODY}.quat" in policy.seen[0]
+
+
+class TestAWrapperDoesNotHideItsChildsDeclaration:
+    """A policy's declaration survives being wrapped.
+
+    ``PersistentPolicy`` and ``CompositePolicy`` both hand their child the
+    observation the runner assembles - the first verbatim, the second filtered -
+    so a declaration read off the WRAPPER instead of the tree is lost for the
+    policy that made it. Both halves of the contract go with it: the per-tick
+    merge and the up-front scene check, leaving a rollout that reports success
+    having never supplied the key. ``Policy.children`` exists so one probe walks
+    to the policy that answers, and these pin that this probe does.
+    """
+
+    @staticmethod
+    def _wrap(kind, sim, declared):
+        """Build ``(driven, declaring_child)`` for a wrapper ``kind``."""
+        joints = sim.robot_joint_names("alice")
+        child = _BodyReadingPolicy(declared)
+        if kind == "persistent":
+            return PersistentPolicy("mock", policy_object=child), child
+        composite = CompositePolicy(
+            lower=MockPolicy(),
+            upper=child,
+            lower_joints=set(joints[:3]),
+            upper_joints=set(joints[3:]),
+        )
+        if kind == "composite":
+            return composite, child
+        # Depth 2: a wrapper around a wrapper, so a fix that walks only one
+        # level down still fails.
+        return PersistentPolicy("mock", policy_object=composite), child
+
+    WRAPPERS = ("persistent", "composite", "nested")
+
+    @pytest.mark.parametrize("kind", WRAPPERS)
+    def test_the_childs_declared_body_still_reaches_the_child(self, sim_with_robot, kind):
+        """The four pose keys arrive in the observation the child is given."""
+        driven, child = self._wrap(kind, sim_with_robot, (ARM_BODY,))
+        result = _run(sim_with_robot, driven)
+
+        assert result["status"] == "success"
+        assert child.seen, "the declaring child should have been queried"
+        for obs in child.seen:
+            assert [len(obs[f"body.{ARM_BODY}.{s}"]) for s in ("pos", "quat", "lin_vel", "ang_vel")] == [3, 4, 3, 3]
+
+    @pytest.mark.parametrize("kind", WRAPPERS)
+    def test_a_body_the_scene_lacks_is_still_refused_up_front(self, sim_with_robot, kind):
+        """The scene check is the half that fails silently: it must still fire.
+
+        Without it the rollout runs to completion and reports success while the
+        key the child declared never reaches it.
+        """
+        driven, child = self._wrap(kind, sim_with_robot, ("no_such_link",))
+
+        with pytest.raises(RuntimeError, match="no_such_link"):
+            _run(sim_with_robot, driven)
+        assert child.seen == [], "rollout must not start with an unresolvable body"
+
+    def test_the_refusal_names_the_declaring_policy_not_the_wrapper(self, sim_with_robot):
+        """A refusal has to point at the class that has to change."""
+        driven, _child = self._wrap("persistent", sim_with_robot, ("no_such_link",))
+
+        with pytest.raises(RuntimeError) as excinfo:
+            _run(sim_with_robot, driven)
+        assert "_BodyReadingPolicy declares" in str(excinfo.value)
+
+    def test_a_declaration_made_twice_in_one_tree_collapses(self, sim_with_robot):
+        """Two policies naming one body yield one key set, not a duplicate merge."""
+        child = _BodyReadingPolicy((ARM_BODY,))
+        outer = CompositePolicy(
+            lower=_BodyReadingPolicy((ARM_BODY,)),
+            upper=child,
+            lower_joints=set(sim_with_robot.robot_joint_names("alice")[:3]),
+            upper_joints=set(sim_with_robot.robot_joint_names("alice")[3:]),
+        )
+        runner = PolicyRunner(sim_with_robot)
+
+        assert runner._resolve_required_bodies(outer) == (ARM_BODY,)
+
+    @pytest.mark.parametrize("kind", WRAPPERS)
+    def test_a_wrapper_whose_child_declares_nothing_stays_free(self, sim_with_robot, kind):
+        """Control: wrapping does not invent body keys for a policy that asked for none."""
+        driven, child = self._wrap(kind, sim_with_robot, ())
+        result = _run(sim_with_robot, driven)
+
+        assert result["status"] == "success"
+        assert child.seen
+        for obs in child.seen:
+            assert [k for k in obs if k.startswith("body.")] == []


### PR DESCRIPTION
## Problem

`Policy.required_bodies` is the "policy declares, runtime supplies" seam that carries a named link's world pose into the observation. `PolicyRunner._resolve_required_bodies` read it off the object it was handed:

```python
declared = getattr(policy, "required_bodies", ()) or ()
```

A wrapper is a different object than the policy inside it, so a child's declaration read as absent — and **both halves of the method went with it**: the per-tick merge of `body.<name>.{pos,quat,lin_vel,ang_vel}`, and the up-front check that a declared body resolves in the scene.

Measured on a real MuJoCo rollout (so100 arm, tracker declaring one body):

![required_bodies through a wrapper](https://raw.githubusercontent.com/cagataycali/robots/d50713f64b1d8ddabd30f5f48f8a6ae382734733/.artifacts/required_bodies_wrapper.png)

| object handed to `run_policy` | pose keys the policy got | body absent from the scene |
|---|---|---|
| bare policy (control) | 4 of 4 | refused up front, names the declarer |
| `PersistentPolicy(policy_object=tracker)` | **0 of 4** | **ran, reports `status="success"`** |
| `CompositePolicy(upper=tracker)` | **0 of 4** | **ran, reports `status="success"`** |
| `PersistentPolicy(CompositePolicy(tracker))` | **0 of 4** | **ran, reports `status="success"`** |

The right-hand column is the shape the up-front check exists to prevent — its own docstring: *"a name the scene does not contain has to fail here - with the available body names - rather than 300 steps of a silently absent key that the policy reads as a zero pose."*

This reaches the one shipped declarer. `ProtoMotionsPolicy.required_bodies` declares its anchor link precisely because the observation carries the floating base only and `base_quat` is the **pelvis**, which the three waist joints separate from `torso_link`. And both wrappers hand their child the observation this method decides the shape of: `PersistentPolicy` forwards it verbatim, `CompositePolicy` forwards a filtered view. `PersistentPolicy`'s own docstring says it is *"transparent … so the runtime drives it exactly as it would the bare policy"*, and both it and `CompositePolicy` already forward the other two members of the same stated contract — `requires_images` (as an `or`) and `execution_horizon` (as a `min`). This one was the omission.

## Change

Collect the declaration over the policy tree using the already-shipped `iter_policy_tree` walk, rather than adding a `required_bodies` override to each wrapper. That is what `Policy.children` exists to answer, in its own words:

> Declaring the children lets one probe walk to the policy that answers, instead of every probe having to learn the name of every wrapper.

One owner, so a future wrapper is honoured with no edit, and the walk is already cycle-safe, de-duplicating and duck-typed-tolerant. Every refusal now names the **declaring** policy instead of the wrapper it was reached through, so it points at the class to change.

`+7` executable statements in production (AST count, `policy_runner.py` 990 → 997); the rest of that file's diff is the docstring.

## Tests

`tests/simulation/test_policy_required_bodies_observation.py` (the file that owns this contract) gains 11 cells, table-driven over the two shipped wrappers plus a wrapper-around-a-wrapper. Pre-fix **8 failed / 13 passed** → **21 passed**; the 3 controls (a wrapped policy that declares nothing stays free) pass on both trees.

Reverting each part of the fix separately, against the new cells:

| mutation | cells that fire |
|---|---|
| control (unmodified) | 0 of 21 |
| read off the handed object only (pre-fix behaviour) | 8 — all four cell families |
| walk only one level down | 2 — exactly the wrapper-around-a-wrapper rows |
| refusal names the root, not the declarer | 1 |
| no de-duplication across the tree | 1 |

## Gate

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean (1855 files).
- `mypy 1.20.2 strands_robots tests tests_integ`: `Success: no issues found in 1852 source files`.
- `tests/simulation tests/policies`: 6 failed / 30677 passed — **0 attributable**; all 6 reproduce identically on a pristine `2f37927` worktree (absent `docker`, an `rclpy` that resolves from a system ROS install, and the standing `newton/test_multi_camera` assertion).
- `scripts/check_whole_tree_graders.py`: 7 failed / 4227 passed, the same environmental set (5 assert `rclpy` is absent where it resolves; 2 read `websockets` 16.0 against a declared `>=17.0` floor).
- All `tests/test_docs*.py` + changelog graders: 244 and 91 passed.

Docs: `docs/policies/custom-policies.md` gains the wrapper note beside the existing `required_bodies` notes; `Policy.required_bodies` states that the runtime collects it across the tree.

Figure numbers are asserted from the capture JSON inside the plot script (both captures taken from separate worktrees, and the script refuses if they came from one tree).
