### PR TITLE
fix(doctor): a written version bound is not below the floor pyproject declares

### DIFF
--- a/changelog.d/3188-written-bound-not-below-the-declared-floor.md
+++ b/changelog.d/3188-written-bound-not-below-the-declared-floor.md
@@ -1,0 +1,37 @@
+### Fixed: a written version bound never names a floor below the one the manifest declares
+
+Two sites told a reader that an older `strands-agents` was enough. The
+doctor's remedy for "strands-agents not importable" named `>=1.0`, and the
+`so101_curobo` example's agent + UI install line named `>=0.1` - from before
+the 1.x line existed. The declared floor is `>=1.7.0,<2.0.0`.
+
+A bound below the real floor does not make a stale install *unsatisfying*, so
+the command reports success and upgrades nothing. Against a virtualenv holding
+1.5.0, a release the manifest refuses:
+
+```
+$ pip install "strands-agents>=1.0"
+Requirement already satisfied: strands-agents>=1.0 ... (1.5.0)
+$ pip install "strands-agents>=1.7.0,<2.0.0"
+Successfully installed strands-agents-1.54.0
+```
+
+Both lines now name the declared requirement. Where `strands-agents` is absent
+every spelling resolves the newest release, so what the stale bound cost was the
+already-installed case - and, for the doctor, a remedy that could report success
+without reaching the floor the package requires.
+
+The rule is now graded rather than left to the next reader: a written bound on a
+distribution `[project.dependencies]` declares must not sit below the declared
+floor. It joins the audit that already sweeps written install hints for
+undeclared extras, over the same scan roots, and reads the manifest rather than
+restating a number - so raising a floor reports the hints that no longer match
+instead of leaving them to drift silently, which is how both of these got here.
+
+The rule is "not below" and not "equal" on purpose. Of the 16 bounds swept, 14
+are `numpy` above the declared `>=1.21.0`: the VERA websocket client requires
+`numpy>=1.24` and the Cosmos 3 wire path `numpy>=2`. Those are correct local
+requirements, and an equality rule would have reported every one of them.
+`[project.optional-dependencies]` is outside the reader, because one
+distribution can be declared by several extras at several floors and "the
+floor" is then not a single number.

--- a/examples/so101_curobo/README.md
+++ b/examples/so101_curobo/README.md
@@ -38,7 +38,7 @@ an actionable message — the app still loads and the loop is still demonstrable
 # Real SO-101 in MuJoCo + the LeRobot dataset writer used by the collector.
 pip install "strands-robots[sim-mujoco,lerobot]"
 # The natural-language agent + interactive UI (app.py) additionally need:
-pip install "strands-agents>=0.1" "gradio>=4,<7" numpy
+pip install "strands-agents>=1.7.0,<2.0.0" "gradio>=4,<7" numpy
 # cuRobo and Isaac Sim are optional, out-of-band installs (see "Flipping to
 # Isaac + cuRobo" below).
 

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -685,7 +685,14 @@ def check_strands_agents() -> str:
     try:
         import strands  # noqa: F401
     except ImportError:
-        return _fail("strands-agents not importable", fix='uv pip install "strands-agents>=1.0"')
+        return _fail(
+            "strands-agents not importable",
+            # The bound is the one pyproject declares. A remedy that names a
+            # lower floor is satisfied by a release this package refuses, so
+            # pip reports "Requirement already satisfied" against a stale
+            # environment and the diagnosis this line answers survives it.
+            fix='uv pip install "strands-agents>=1.7.0,<2.0.0"',
+        )
     return _pass(f"strands-agents {_resolve_version('strands', 'strands-agents')}")
 
 

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -664,6 +664,159 @@ def test_written_install_hints_name_only_declared_extras() -> None:
     )
 
 
+# A written requirement bound: a distribution name followed directly by a lower
+# bound operator, in any file type the extras sweep already reads. The negative
+# lookbehind keeps a longer name from matching on its tail, so ``msgpack-numpy``
+# is not read as a bound on ``numpy``. A ``v`` prefix is tolerated because prose
+# writes one.
+_WRITTEN_BOUND_RE = re.compile(r"(?<![\w.-])([A-Za-z][A-Za-z0-9._-]*)\s*(?:>=|~=|==)\s*v?([0-9][0-9A-Za-z.*]*)")
+
+_WRITTEN_BOUND_ALLOWED = {
+    # The declaration itself. Comparing it against itself grades nothing.
+    "pyproject.toml",
+    # This test states the rule, so it quotes the below-floor spellings the rule
+    # forbids.
+    "tests/test_dependency_audit.py",
+}
+
+
+def _declared_dependency_floors() -> dict[str, str]:
+    """Lower bound each ``[project.dependencies]`` entry declares, by distribution.
+
+    Returns:
+        Mapping of normalized distribution name to the highest lower bound the
+        entry states, as the raw version string the manifest writes.
+
+    Only the unconditional ``[project.dependencies]`` are read.
+    ``[project.optional-dependencies]`` is deliberately outside this: one
+    distribution can be declared by several extras at several floors, so "the
+    floor" is not a single number there, and the surfaces that hand a reader an
+    extra's bound already have owners (``lerobot`` in
+    ``tests/test_lerobot_install_hints_pypi.py``).
+    """
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    floors: dict[str, str] = {}
+    for spec in data["project"]["dependencies"]:
+        name = re.match(r"[A-Za-z0-9._-]+", spec)
+        bounds = re.findall(r">=\s*([0-9][0-9A-Za-z.*]*)", spec)
+        if name and bounds:
+            # _normalize_extra applies the same substitution PEP 503 requires
+            # for a distribution name, which is what makes ``Pillow`` and
+            # ``pillow`` one key.
+            floors[_normalize_extra(name.group())] = max(bounds, key=_version_key)
+    return floors
+
+
+def _version_key(raw: str) -> tuple[int, ...]:
+    """Order a release string by its numeric components.
+
+    ``numpy>=2`` and ``numpy>=1.21.0`` are both written in the tree, so the
+    comparison pads rather than requiring equal arity: ``2`` sorts above
+    ``1.21.0``. A non-numeric component ends the read (``2.*``, ``1.0rc1``),
+    which keeps a pre-release from sorting above the release it precedes.
+    """
+    parts: list[int] = []
+    for component in raw.split("."):
+        digits = re.match(r"[0-9]+", component)
+        if digits is None:
+            break
+        parts.append(int(digits.group()))
+    return tuple(parts)
+
+
+def _below_floor_bounds(text: str, floors: dict[str, str]) -> list[tuple[str, str, str]]:
+    """Return ``(distribution, written bound, declared floor)`` for each stale bound.
+
+    Args:
+        text: One line, or a whole file.
+        floors: Declared floors, keyed as ``_declared_dependency_floors`` returns.
+
+    Returns:
+        One entry per written bound sitting below the declared floor. A bound at
+        or above the floor is not reported: several sites state a stricter
+        requirement of their own on purpose (the VERA websocket client needs
+        ``numpy>=1.24``, the Cosmos 3 wire path ``numpy>=2``), and those are
+        correct rather than drifted.
+    """
+    stale: list[tuple[str, str, str]] = []
+    for name, written in _WRITTEN_BOUND_RE.findall(text):
+        floor = floors.get(_normalize_extra(name))
+        if floor is None:
+            continue
+        if _version_key(written) < _version_key(floor):
+            stale.append((name, written, floor))
+    return stale
+
+
+def test_written_version_bounds_are_not_below_the_declared_floor() -> None:
+    """No written bound on a declared dependency may name a floor below it.
+
+    A bound below the real floor does not make a stale install unsatisfying, so
+    the command a reader runs reports success and upgrades nothing - the failure
+    mode #1507 fixed for the notebook install lines. Measured against an
+    environment holding ``strands-agents`` 1.5.0, with the manifest declaring
+    ``>=1.7.0``::
+
+        $ pip install "strands-agents>=1.0"
+        Requirement already satisfied: strands-agents>=1.0 ... (1.5.0)
+        $ pip install "strands-agents>=1.7.0,<2.0.0"
+        Successfully installed strands-agents-1.54.0
+
+    So the number is load-bearing, and nothing was keeping it in step with the
+    manifest: the two sites this cell first reported both named a pre-1.7 floor,
+    one of them (``>=0.1``) from before the 1.x line existed.
+    """
+    floors = _declared_dependency_floors()
+    assert floors, "no lower bound read from [project.dependencies]; the manifest reader has drifted"
+
+    offenders: list[str] = []
+    swept = 0
+    for path in _iter_scanned_files():
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        if rel in _WRITTEN_BOUND_ALLOWED:
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8", errors="ignore").splitlines(), 1):
+            swept += sum(1 for name, _ in _WRITTEN_BOUND_RE.findall(line) if _normalize_extra(name) in floors)
+            for name, stale, floor in _below_floor_bounds(line, floors):
+                offenders.append(
+                    f"{rel}:{lineno} writes {name}>={stale}, declared floor {floor} -- {line.strip()[:90]}"
+                )
+
+    # The sweep is only meaningful if it is actually reading the tree.
+    assert swept >= 12, f"the bound sweep matched only {swept} mentions; the scan roots have drifted"
+    assert not offenders, (
+        "these sites name a version floor below the one pyproject declares, so the install they "
+        "describe leaves an environment this package refuses and still exits 0. Declared floors: "
+        f"{floors}\n" + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        # Below the floor: reported, with the floor it undercuts.
+        ('pip install "strands-agents>=1.0"', [("strands-agents", "1.0", "1.7.0")]),
+        ('pip install "strands-agents>=0.1"', [("strands-agents", "0.1", "1.7.0")]),
+        # At the floor, and above it: a stricter local requirement is correct.
+        ('pip install "strands-agents>=1.7.0,<2.0.0"', []),
+        ("pip install 'numpy>=1.24'", []),
+        ("composes with numpy>=2", []),
+        # A distribution the manifest does not declare sets no floor to be below.
+        ('pip install "gradio>=4,<7"', []),
+        # A longer name is not read as a bound on its tail.
+        ("pip install msgpack-numpy>=0.4", []),
+    ],
+)
+def test_the_written_bound_rule_can_both_accept_and_reject(line: str, expected: list[tuple[str, str, str]]) -> None:
+    """The comparison must fire on a stale bound and stay silent on a stricter one.
+
+    Both halves are graded here because the sweep above is green on a correct
+    tree, so on its own it cannot show that it would report anything at all.
+    """
+    floors = {"strands-agents": "1.7.0", "numpy": "1.21.0"}
+    assert _below_floor_bounds(line, floors) == expected
+
+
 # Headers that mean "the extra you install". A column merely containing the word
 # is not one: ``Extra outputs`` in the Cosmos 3 page lists result keys, and a
 # header whose prose mentions an extra in passing is prose.


### PR DESCRIPTION
Two written bounds on `strands-agents` named a floor below the one `pyproject.toml` declares (`>=1.7.0`), and nothing in the tree was keeping them in step with it.

| site | written | declared floor |
|---|---|---|
| `strands_robots/doctor.py:688` (the remedy for "strands-agents not importable") | `>=1.0` | `>=1.7.0` |
| `examples/so101_curobo/README.md:41` (the agent + UI install line) | `>=0.1` | `>=1.7.0` |

`>=0.1` predates the 1.x line entirely.

## Why the number is load-bearing

A bound below the real floor does not make a stale install **unsatisfying**, so the command a reader runs reports success and upgrades nothing. This is the failure mode #1507 already fixed for the notebook install lines, which recorded the remedy in prose: *"A version floor on the requirement works equally well, since it makes the installed release genuinely unsatisfying."* Measured, not asserted -- a venv holding `strands-agents` 1.5.0, which the manifest refuses:

```
$ pip install "strands-agents>=1.0"
Requirement already satisfied: strands-agents>=1.0 in ./lib/python3.13/site-packages (1.5.0)
$ pip install "strands-agents>=0.1"
Requirement already satisfied: strands-agents>=0.1 in ./lib/python3.13/site-packages (1.5.0)
$ pip install "strands-agents>=1.7.0,<2.0.0"
Successfully installed strands-agents-1.54.0
```

Both stale bounds leave the environment at 1.5.0 and exit 0. The declared bound is what moves it.

Scoped honestly: where `strands-agents` is **absent**, all three commands resolve the latest release and the reader is fine. What the stale bound costs is the already-installed case -- and, in the doctor's line, a remedy that can report success without reaching the floor the package requires.

## The rule, and where it lives

No new grader file. `tests/test_dependency_audit.py` is already the owner of manifest-versus-tree dependency claims and already sweeps written install hints for undeclared extras (#1738), so the bound rule joins it and reuses that sweep's scan roots:

> A written bound on a distribution `[project.dependencies]` declares must not name a floor below the declared one.

**Not below**, rather than equal. That distinction is the whole reason the rule is safe to apply tree-wide: of the 16 bounds swept, 14 are `numpy` at or above the declared `>=1.21.0` -- the VERA websocket client needs `numpy>=1.24`, the Cosmos 3 wire path `numpy>=2` -- and those are correct local requirements, not drift. An equality rule would report all 14.

`[project.optional-dependencies]` is deliberately outside the reader: one distribution can be declared by several extras at several floors, so "the floor" is not a single number there, and those surfaces have owners already (`lerobot` in `tests/test_lerobot_install_hints_pypi.py`). Stated in the docstring so the omission is a decision rather than an oversight.

## Break table

| | mutation | result |
|---|---|---|
| b0 | control | 8 passed |
| b1 | restore both pre-fix bounds (the defect as it stands on `main`) | **2 offender rows**, each naming file:line, the written bound and the floor it undercuts |
| b2 | raise the manifest floor to `1.13.0`, leaving the fixed sites at `1.7.0` | **2 offender rows** -- the rule reads the manifest, it does not restate a number |
| b3 | lower one `numpy` control from `>=1.24` to `>=1.20` | fires on `docs/policies/vera.md:264` -- the sweep is not `strands-agents`-only, and docs are in scope |
| b4 | raise the sweep-size floor to 999 | fires -- the non-vacuity assertion has teeth |

b2 is worth calling out: it is the shape a floor raise takes, and it shows the grader turns a silent drift into a caught one-line change. A companion parametrized cell grades the comparison directly on 7 synthetic lines (below-floor reported, at-floor and above-floor silent, an undeclared distribution ignored, and `msgpack-numpy>=0.4` not read as a bound on `numpy`), because the sweep is green on a correct tree and so on its own cannot show it would report anything.

## Verification

Whole-tree grader roster (100 modules, derived) run before and after:

| | base `c8fb5a03` | head `4f0bab2` |
|---|---|---|
| failed | 57 | **57** |
| errors | 151 | **151** |
| passed | 3688 | **3696** |

**Regressions: none.** The +8 are exactly this branch's new cells. The shared 57/151 are this environment's absent optional dependencies (`lerobot`, `torch`, `mujoco`, `qpsolvers`, `zenoh`), identical in both runs.

`ruff check` and `ruff format --check` clean on both touched Python files. No non-ASCII on any added line.

## Note on an in-flight sibling (corrected)

#3184 raises this same floor to `>=1.13.0`. An earlier revision of this note said that whichever branch lands second, the grader reports the two hints and they move in one line -- "b2, and the intended behaviour rather than a conflict". **That was wrong about the timing, and the timing is the whole risk.** b2 describes what the grader does once both changes are in one tree; it does not follow that this happens *before* the second merge.

Measured rather than assumed:

- The branch ruleset's `required_status_checks` sets **`strict_required_status_checks_policy: false`**, so a branch is not required to be up to date and the required check is **not** re-run against the other change before merge.
- The two branches shared **zero files** at #3184's `c6bbb192`, so `git merge-tree` exited **0** -- no conflict, `mergeable: MERGEABLE` on both. The collision was invisible to `mergeable`, to `git merge-tree` and to `check_duplicate_claim.py --all-open`.
- Running this branch's grader on git's own merged tree of the two heads reproduced b2 exactly:

```
FAILED test_written_version_bounds_are_not_below_the_declared_floor
  strands_robots/doctor.py:694 writes strands-agents>=1.7.0, declared floor 1.13.0
  examples/so101_curobo/README.md:41 writes strands-agents>=1.7.0, declared floor 1.13.0
```

So the composition was red while **both** pull requests were green, with no mechanism to surface it before it reached `main`.

#3184 has since moved both hints to `>=1.13.0` at its head `bd47a1b5`, which makes the interaction a **textual** conflict on those two lines (`git merge-tree` now exits 1) -- a state GitHub blocks on, which is what `strict: false` leaves as the only reliable guard. Whichever lands second conflicts there; **resolve in favour of `>=1.13.0`**, which is measured green against this grader (8 passed).

This branch is unchanged by any of that: it still records the floor `main` declares today, still takes no position on the floor raise, and needs no edit for either merge order. The correction is to this note only.
