### PR TITLE
fix(inference): a served policy's required_bodies reach the host that supplies them

### DIFF
--- a/changelog.d/3189-required-bodies-cross-the-wire.md
+++ b/changelog.d/3189-required-bodies-cross-the-wire.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **Remote inference: a served policy's `required_bodies` now reach the host that
+  supplies them.** `Policy.required_bodies` is the "policy declares, runtime
+  supplies" contract, and both of its halves run on the machine driving the
+  rollout: the runtime resolves the names once up front, refuses one the scene
+  does not contain, and merges each body's world pose into every observation. The
+  `ready` handshake did not advertise the declaration and `RemotePolicy` did not
+  override it, so a policy behind a WebSocket declared nothing and both halves
+  were skipped - no pose was ever merged, and a body name the scene lacked was
+  never reported, leaving a rollout that reported success. `PolicyServer` now
+  advertises the declaration of the whole tree it serves (so a wrapper does not
+  hide the policy inside it) and `RemotePolicy` mirrors it, alongside the
+  `requires_images`, `execution_horizon`, `actions_per_step` and `supports_rtc`
+  it already mirrored. The walk and its type refusals moved to
+  `strands_robots.policies.base.collect_required_bodies`, read by both the
+  runtime and the handshake, so the two surfaces cannot report a different set
+  for one tree. A malformed declaration is refused when the server is built
+  rather than on every client handshake.

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -140,6 +140,17 @@ running the policy in-process:
 | `execution_horizon`  | size action chunks / re-query interval correctly           |
 | `actions_per_step`   | the remote policy's trained chunk length                   |
 | `supports_rtc`       | whether Real-Time Chunking blending runs server-side       |
+| `required_bodies`    | which named bodies' world pose to merge into every observation, and which names to check against the scene before the rollout |
+
+`required_bodies` is the one entry whose work happens entirely on the robot
+host: the runtime resolves the names once before the rollout, refuses one the
+scene does not contain (naming the bodies it does hold), and merges
+`body.<name>.pos` / `.quat` / `.lin_vel` / `.ang_vel` into every observation it
+sends. The policy that consumes them is on the inference host, so the server
+advertises its whole served tree's declaration - a wrapper does not hide the
+policy inside it - and the client declares the same set. A mimic tracker such as
+[ProtoMotions](../policies/protomotions.md) therefore reads its anchor link over
+the wire exactly as it does in-process.
 
 ## Real-Time Chunking across the wire
 

--- a/docs/policies/remote.md
+++ b/docs/policies/remote.md
@@ -22,9 +22,11 @@ policy = create_policy("ws://gpu-box:8765")
 | `request_timeout` | `60.0`        | Seconds to wait for each inference reply         |
 
 The client mirrors the server policy's `requires_images`, `execution_horizon`,
-`actions_per_step` and `supports_rtc`, and forwards the Real-Time Chunking
-observed-delay count on every request, so a remote rollout behaves like a local
-one. Install with `pip install 'strands-robots[inference]'`.
+`actions_per_step`, `supports_rtc` and `required_bodies`, and forwards the
+Real-Time Chunking observed-delay count on every request, so a remote rollout
+behaves like a local one. Mirroring `required_bodies` is what lets the robot
+host supply a body pose the remote policy needs - and refuse a body name its
+scene does not contain - since both of those happen locally. Install with `pip install 'strands-robots[inference]'`.
 
 See **[Remote Policy Inference](../inference/remote.md)** for the full
 two-machine setup, the server CLI, and the wire protocol.

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -163,6 +163,7 @@ class RemotePolicy(Policy):
         self._execution_horizon: int = 1
         self.actions_per_step: int = 1
         self.supports_rtc: bool = False
+        self._required_bodies: tuple[str, ...] = ()
 
     # -- connection lifecycle -------------------------------------------------
 
@@ -261,6 +262,14 @@ class RemotePolicy(Policy):
         self.actions_per_step = int(metadata.get("actions_per_step", self.actions_per_step))
         self.supports_rtc = bool(metadata.get("supports_rtc", self.supports_rtc))
         self._execution_horizon = int(metadata.get("execution_horizon", self._execution_horizon))
+        # A JSON array of names. Coerced to the shape the robot host's runtime
+        # validates rather than trusted verbatim, so a peer sending something
+        # else cannot make the local resolver report the proxy as the declaring
+        # class; a server built on this release refuses a malformed declaration
+        # before it advertises one.
+        advertised = metadata.get("required_bodies")
+        if isinstance(advertised, list | tuple):
+            self._required_bodies = tuple(name for name in advertised if isinstance(name, str) and name.strip())
 
     def close(self) -> None:
         """Close the WebSocket connection. Safe to call more than once."""
@@ -363,6 +372,25 @@ class RemotePolicy(Policy):
         """Mirror the server policy's re-query interval so RTC/chunking stays correct."""
         self._ensure_connected()
         return max(1, self._execution_horizon)
+
+    @property
+    def required_bodies(self) -> tuple[str, ...]:
+        """Mirror the served tree's declared bodies so the robot host supplies them.
+
+        ``required_bodies`` is read on the machine driving the rollout, not on
+        the inference host: the simulation runtime resolves the names once
+        before the rollout, refuses one the scene does not contain, and merges
+        each body's pose into every observation it sends. The policy that needs
+        them is behind the wire, so unless this half declares them too both
+        halves of that contract are skipped - the rollout reports success having
+        never supplied the key, and a name the scene lacks is never reported.
+
+        Empty until the ``ready`` handshake has been read, so this connects
+        first, exactly as :attr:`requires_images` and :attr:`execution_horizon`
+        do.
+        """
+        self._ensure_connected()
+        return self._required_bodies
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
         """Store the robot state keys and forward them to the server policy.

--- a/strands_robots/inference/protocol.py
+++ b/strands_robots/inference/protocol.py
@@ -21,7 +21,10 @@ Message types (each message is one JSON object with a ``type`` field):
 * ``ready`` (server -> client, once on connect): advertises the wrapped
   policy's introspection metadata so the client can mirror it. Payload key
   ``metadata`` -> ``provider_name``, ``requires_images``, ``actions_per_step``,
-  ``supports_rtc``, ``execution_horizon``.
+  ``supports_rtc``, ``execution_horizon``, ``required_bodies``. The last is the
+  served tree's declaration of the named bodies whose world pose it needs; it is
+  read on the machine driving the rollout, so it has to cross the wire for that
+  runtime to supply the poses and to check the names against its scene.
 * ``set_state_keys`` (client -> server): forwards
   :meth:`Policy.set_robot_state_keys`. Payload key ``keys``.
 * ``set_control_frequency`` (client -> server): forwards

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -33,7 +33,7 @@ import traceback
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.inference import protocol
-from strands_robots.policies.base import Policy
+from strands_robots.policies.base import Policy, collect_required_bodies
 from strands_robots.utils import tcp_port_error
 
 if TYPE_CHECKING:
@@ -93,6 +93,10 @@ class PolicyServer:
     Raises:
         ValueError: If neither or both of ``policy`` / ``policy_provider`` are
             given, or if ``port`` cannot be bound.
+        TypeError: If the served policy tree declares
+            :attr:`~strands_robots.policies.base.Policy.required_bodies` that is
+            not a sequence of non-empty body names. Refused here rather than per
+            connection, since the declaration cannot be advertised.
     """
 
     def __init__(
@@ -124,6 +128,14 @@ class PolicyServer:
             policy = create_policy(policy_provider, **(policy_config or {}))
 
         self.policy: Policy = policy
+        # The bodies the served TREE declares, read once here for the same
+        # reason ``port`` is checked above rather than at ``serve()``: a
+        # declaration is a property of the policy classes, so a malformed one is
+        # refused at the point the caller named the policy instead of leaving
+        # every client's handshake to fail. Advertised in ``_metadata`` so the
+        # client half declares the same bodies and the robot host's runtime
+        # supplies them - see ``collect_required_bodies``.
+        self._required_bodies: tuple[str, ...] = tuple(collect_required_bodies(policy))
         self.host = host
         self.port = port
         self._server: Server | None = None
@@ -189,6 +201,7 @@ class PolicyServer:
             "actions_per_step": int(getattr(self.policy, "actions_per_step", 1)),
             "supports_rtc": bool(getattr(self.policy, "supports_rtc", False)),
             "execution_horizon": int(self.policy.execution_horizon),
+            "required_bodies": list(self._required_bodies),
         }
 
     def _handle(self, websocket: ServerConnection) -> None:

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -690,3 +690,59 @@ def iter_policy_tree(policy: Policy) -> Iterator[Policy]:
         seen.add(id(current))
         yield current
         stack.extend(reversed(tuple(getattr(current, "children", ()))))
+
+
+def collect_required_bodies(policy: Policy | None) -> dict[str, str]:
+    """Body names a policy TREE declares, mapped to the class that declared each.
+
+    Single owner of "what bodies does this tree need, and is the declaration
+    well-formed". Two surfaces ask it and must not disagree: the simulation
+    runtime, which merges each body's pose into every observation and refuses a
+    name the scene does not contain, and
+    :class:`~strands_robots.inference.server.PolicyServer`, which advertises the
+    served tree's declaration in its handshake so a
+    :class:`~strands_robots.inference.client.RemotePolicy` driving the rollout
+    on another host declares the same bodies the policy behind it does. A
+    second copy of the walk on either side could report a different set for one
+    tree, which is the failure both halves of the contract rest on not having.
+
+    The declaration is collected over the tree rather than off the object
+    handed in (:func:`iter_policy_tree`), so a wrapper that does not override
+    :attr:`Policy.required_bodies` does not hide its child's declaration.
+    Insertion order is the walk order - outermost policy first - so the caller's
+    merge order is stable for a given tree.
+
+    Args:
+        policy: Root of the tree. ``None`` (a replay, which drives no policy)
+            and a tree that declares nothing both resolve to an empty mapping.
+
+    Returns:
+        Ordered, de-duplicated body name -> name of the class in this tree that
+        declared it first. The value exists so a caller's refusal names a
+        declaring class rather than whichever wrapper happened to be on the
+        outside. A proxy that mirrors a declaration made on another host - a
+        :class:`~strands_robots.inference.client.RemotePolicy` - is itself the
+        declaring class here, which is what it is from this tree's side.
+
+    Raises:
+        TypeError: If any policy in the tree declares ``required_bodies`` that
+            is not a sequence of non-empty strings. A bare ``str`` is refused
+            explicitly rather than iterated into one entry per character.
+    """
+    owner: dict[str, str] = {}
+    for member in () if policy is None else iter_policy_tree(policy):
+        declared = getattr(member, "required_bodies", ()) or ()
+        if not declared:
+            continue
+        who = type(member).__name__
+        if isinstance(declared, str):
+            raise TypeError(
+                f"{who}.required_bodies must be a sequence of body names, "
+                f"not a bare str ({declared!r}) - a str iterates into one entry per character. "
+                f"Use a tuple: ('{declared}',)."
+            )
+        for name in declared:
+            if not isinstance(name, str) or not name.strip():
+                raise TypeError(f"{who}.required_bodies entries must be non-empty body-name strings, got {name!r}.")
+            owner.setdefault(name, who)
+    return owner

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -357,10 +357,12 @@ class Policy(ABC):
         start of the rollout with the available body names, rather than reading
         a missing key as a zero pose on every tick.
 
-        The runtime collects this over the whole policy tree
-        (:func:`iter_policy_tree`), so a policy that declares a body is honoured
-        when it is wrapped: a wrapper which does not override this property does
-        not hide its child's declaration.
+        Every surface that reads this collects it over the whole policy tree
+        through :func:`collect_required_bodies`, so a policy that declares a
+        body is honoured when it is wrapped: a wrapper which does not override
+        this property does not hide its child's declaration. That one owner is
+        shared with the remote-inference handshake, so a policy served over the
+        wire declares the same bodies it does in-process.
 
         Returns:
             Ordered, de-duplicated body names. Empty (the default) means the

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -931,9 +931,12 @@ class PolicyRunner:
         here - with the available body names - rather than 300 steps of a
         silently absent key that the policy reads as a zero pose.
 
-        The declaration is collected over the whole policy tree
-        (:func:`~strands_robots.policies.base.iter_policy_tree`), not off the
-        object this runner was handed. A wrapper is a different object than the
+        The declaration is collected over the whole policy tree by
+        :func:`~strands_robots.policies.base.collect_required_bodies`, not off
+        the object this runner was handed. That function owns the walk and the
+        ``TypeError`` refusals documented below, and the remote-inference
+        handshake reads the same owner, so what a tree declares cannot depend on
+        which surface asked. A wrapper is a different object than the
         policy inside it, so reading the attribute off the wrapper reports a
         child's declaration as absent - which is the case
         :attr:`~strands_robots.policies.base.Policy.children` exists to answer,

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -47,7 +47,7 @@ import numpy as np
 
 from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.dataset_recorder import RecordingFrameError
-from strands_robots.policies.base import iter_policy_tree, resolve_chunk_length
+from strands_robots.policies.base import collect_required_bodies, resolve_chunk_length
 from strands_robots.utils import (
     non_negative_whole_number_error,
     positive_count_error,
@@ -971,27 +971,12 @@ class PolicyRunner:
                 everywhere else: ``PolicyRunner`` is drivable directly and a
                 direct caller has no envelope to read a refusal from.
         """
-        # name -> the policy that declared it first, so a refusal names the class
-        # that has to change rather than whichever wrapper is on the outside.
-        owner: dict[str, str] = {}
-        bodies: list[str] = []
-        for member in () if policy is None else iter_policy_tree(policy):
-            declared = getattr(member, "required_bodies", ()) or ()
-            if not declared:
-                continue
-            who = type(member).__name__
-            if isinstance(declared, str):
-                raise TypeError(
-                    f"{who}.required_bodies must be a sequence of body names, "
-                    f"not a bare str ({declared!r}) - a str iterates into one entry per character. "
-                    f"Use a tuple: ('{declared}',)."
-                )
-            for name in declared:
-                if not isinstance(name, str) or not name.strip():
-                    raise TypeError(f"{who}.required_bodies entries must be non-empty body-name strings, got {name!r}.")
-                if name not in owner:
-                    owner[name] = who
-                    bodies.append(name)
+        # The walk and its type refusals live in one place shared with the
+        # remote-inference handshake, so what a tree declares cannot depend on
+        # which surface asked. The mapping's value is the declaring class, so a
+        # refusal below names the class to fix rather than an outer wrapper.
+        owner = collect_required_bodies(policy)
+        bodies = list(owner)
         if not bodies:
             return ()
 

--- a/tests/inference/test_required_bodies_survive_the_wire.py
+++ b/tests/inference/test_required_bodies_survive_the_wire.py
@@ -1,0 +1,228 @@
+"""A remotely-served policy's declared bodies reach the host that supplies them.
+
+``Policy.required_bodies`` is the "policy declares, runtime supplies" contract:
+the simulation runtime resolves the names once before a rollout, refuses one the
+scene does not contain, and merges each body's world pose into every observation
+it hands to ``get_actions``. Both halves run on the machine driving the rollout,
+so when the policy is behind a WebSocket the declaration has to cross the wire -
+otherwise the proxy declares nothing, no pose is ever merged, no name is ever
+checked, and the rollout reports success having supplied none of it.
+
+The end-to-end cells drive a real MuJoCo rollout twice over one table - the
+policy in-process, and the same policy behind a real ``PolicyServer`` - and
+assert the two agree. The declaration-mirroring cell is derived from ``Policy``
+itself, so a fifth declaration property added later joins the requirement
+without an edit here.
+"""
+
+import pytest
+
+from strands_robots.inference import PolicyServer
+from strands_robots.inference.client import RemotePolicy
+from strands_robots.policies.base import Policy
+from strands_robots.policies.persistent import PersistentPolicy
+
+pytest.importorskip("mujoco", reason="sim rollout requires mujoco - pip install 'strands-robots[sim-mujoco]'")
+
+import strands_robots as sr  # noqa: E402
+
+ANCHOR = "cube"  # a body the scene below contains
+GHOST = "no_such_anchor_link"  # a body it does not
+
+
+class AnchorPolicy(Policy):
+    """A policy that consumes a named body's world pose, as a mimic tracker does."""
+
+    def __init__(self, *bodies: str, horizon: int = 1) -> None:
+        self._bodies = bodies
+        self._horizon = horizon
+        self._keys: list[str] = []
+        #: Per tick: did ``body.<name>.quat`` arrive for every declared body?
+        self.pose_arrived: list[bool] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "anchor"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    @property
+    def required_bodies(self) -> tuple[str, ...]:
+        return self._bodies
+
+    @property
+    def execution_horizon(self) -> int:
+        return self._horizon
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self._keys = list(robot_state_keys)
+
+    async def get_actions(self, observation, instruction=""):  # noqa: ANN001, ANN201, ARG002
+        self.pose_arrived.append(all(f"body.{name}.quat" in observation for name in self._bodies))
+        return [{key: 0.0 for key in self._keys} for _ in range(self._horizon)]
+
+
+class BareStrPolicy(AnchorPolicy):
+    """Declares a bare ``str`` - the shape that iterates into one entry per character."""
+
+    @property
+    def required_bodies(self):  # type: ignore[override]  # deliberately the wrong shape
+        return "torso_link"
+
+
+def _scene():
+    """A real so101 world holding one extra body named ``cube``."""
+    sim = sr.Robot("so101", mode="sim", mesh=False)
+    sim.add_object(name=ANCHOR, shape="box", size=[0.04] * 3, position=[0.2, 0.0, 0.05])
+    return sim
+
+
+def _drive(policy: Policy, *, remote: bool, steps: int = 5):
+    """Roll ``policy`` out in MuJoCo, in-process or behind a real PolicyServer.
+
+    Returns the rollout's status dict, or the message of a pre-rollout refusal
+    prefixed with ``"raised: "`` so a caller can compare the two paths' verdicts.
+    """
+    sim = _scene()
+    server = PolicyServer(policy=policy, host="127.0.0.1", port=0).start() if remote else None
+    try:
+        driven = RemotePolicy(host="127.0.0.1", port=server.port) if server is not None else policy
+        try:
+            return sim.run_policy(
+                robot_name="so101",
+                policy_object=driven,
+                n_steps=steps,
+                control_frequency=30.0,
+                fast_mode=True,
+            )
+        except (RuntimeError, TypeError) as refusal:
+            return f"raised: {refusal}"
+    finally:
+        if server is not None:
+            server.stop()
+        sim.cleanup()
+
+
+@pytest.mark.parametrize("remote", [False, True], ids=["in_process", "over_the_wire"])
+class TestTheDeclarationReachesTheRuntimeEitherWay:
+    """Every guarantee the local path gives holds when the policy is remote."""
+
+    def test_the_declared_body_pose_is_merged_into_every_observation(self, remote):
+        policy = AnchorPolicy(ANCHOR)
+        result = _drive(policy, remote=remote)
+        assert not isinstance(result, str), result
+        assert result["status"] == "success", result
+        assert policy.pose_arrived, "the policy was never asked for an action, so nothing was measured"
+        assert all(policy.pose_arrived), (
+            f"body.{ANCHOR}.quat reached {sum(policy.pose_arrived)} of "
+            f"{len(policy.pose_arrived)} observations (remote={remote})"
+        )
+
+    def test_a_body_the_scene_lacks_is_refused_before_the_rollout(self, remote):
+        policy = AnchorPolicy(GHOST)
+        result = _drive(policy, remote=remote)
+        assert isinstance(result, str), f"the rollout ran instead of refusing (remote={remote}): {result}"
+        assert GHOST in result and "does not resolve to a body" in result, result
+        # The refusal is worth having because it names what the scene does hold.
+        assert ANCHOR in result, result
+        assert not policy.pose_arrived, "the policy was stepped despite an unresolvable declaration"
+
+    def test_a_policy_declaring_nothing_is_unaffected(self, remote):
+        """Control: the ungated path is identical either way, and stays that way."""
+        policy = AnchorPolicy()
+        result = _drive(policy, remote=remote)
+        assert not isinstance(result, str), result
+        assert result["status"] == "success", result
+        assert policy.pose_arrived and all(policy.pose_arrived), "vacuously true only if never stepped"
+
+
+class TestTheHandshakeCarriesTheDeclaration:
+    """The wire payload is what makes the client half able to declare anything."""
+
+    def test_the_served_tree_declaration_is_advertised(self):
+        server = PolicyServer(policy=AnchorPolicy("torso_link", "pelvis"), host="127.0.0.1", port=0)
+        assert server._metadata()["required_bodies"] == ["torso_link", "pelvis"]
+
+    def test_a_wrapper_does_not_hide_the_policy_it_serves(self):
+        """The advertised set is collected over the served TREE, not off its root."""
+        wrapped = PersistentPolicy("mock", policy_object=AnchorPolicy("torso_link"))
+        assert wrapped.required_bodies == (), "PersistentPolicy is expected not to override the property"
+        server = PolicyServer(policy=wrapped, host="127.0.0.1", port=0)
+        assert server._metadata()["required_bodies"] == ["torso_link"]
+
+    def test_a_malformed_declaration_is_refused_when_the_server_is_built(self):
+        """A bare str would advertise one body per character, so it is refused."""
+        with pytest.raises(TypeError, match="not a bare str"):
+            PolicyServer(policy=BareStrPolicy(), host="127.0.0.1", port=0)
+
+    @pytest.mark.parametrize(
+        "advertised",
+        ["torso_link", 7, {"torso_link": 1}, ["", "  ", 3, None]],
+        ids=["bare_str", "int", "mapping", "unusable_entries"],
+    )
+    def test_a_peer_advertising_something_unusable_is_ignored(self, advertised):
+        """A value the runtime could not validate never becomes this half's declaration."""
+        client = RemotePolicy(host="127.0.0.1", port=1)
+        client._apply_metadata({"required_bodies": advertised})
+        assert client._required_bodies == ()
+
+
+class TestEveryDeclarationPropertyTracksTheServedPolicy:
+    """Derived: a declaration property the proxy does not mirror is a dropped contract.
+
+    Enumerated from ``Policy`` rather than listed, so a property added later is
+    graded here on arrival. Four are exempt, each because the proxy answers for
+    itself rather than for its peer, and each exemption is checked to name a
+    real ``Policy`` member so a rename cannot silently widen the carve-out.
+    """
+
+    #: property -> why the proxy's answer is deliberately its own.
+    NOT_MIRRORED = {
+        "provider_name": "identifies the client half; read remote_provider_name for the peer's",
+        "children": "the proxy is a leaf on this host - the served tree is walked on the server",
+        "control_frequency": "set by the local runner and forwarded, not declared by the peer",
+        "rtc_observed_delay_steps": "counted by the local runner and forwarded on each request",
+    }
+
+    @staticmethod
+    def _declaration_properties() -> set[str]:
+        return {
+            name
+            for name in dir(Policy)
+            if not name.startswith("_")
+            and isinstance(getattr(Policy, name, None), property)
+            and name not in TestEveryDeclarationPropertyTracksTheServedPolicy.NOT_MIRRORED
+        }
+
+    def test_the_enumeration_finds_the_contract(self):
+        found = self._declaration_properties()
+        assert {"requires_images", "required_bodies", "execution_horizon"} <= found, found
+        assert not (set(self.NOT_MIRRORED) - set(dir(Policy))), "an exemption names no Policy member"
+        # ``is_chunk_emitting`` answers a declaration too but is a method, so it
+        # is outside this enumeration and graded by name in the cell below.
+        assert callable(Policy.__dict__["is_chunk_emitting"])
+
+    def test_each_one_reports_the_served_policy_value(self):
+        # Every value below differs from the Policy default, so a property that
+        # is not mirrored reports the default and fails rather than coinciding.
+        served = AnchorPolicy(ANCHOR, horizon=6)
+        assert served.requires_images is False
+        assert served.execution_horizon == 6
+        assert served.is_chunk_emitting() is True
+
+        server = PolicyServer(policy=served, host="127.0.0.1", port=0).start()
+        try:
+            client = RemotePolicy(host="127.0.0.1", port=server.port)
+            drifted = {
+                name: (getattr(client, name), getattr(served, name))
+                for name in sorted(self._declaration_properties())
+                if getattr(client, name) != getattr(served, name)
+            }
+            assert not drifted, f"the proxy does not report the served policy's declaration: {drifted}"
+            # Derived from ``execution_horizon``, so mirroring that property is
+            # what makes the proxy answer this correctly. Graded, not assumed.
+            assert client.is_chunk_emitting() == served.is_chunk_emitting() is True
+        finally:
+            server.stop()


### PR DESCRIPTION
`Policy.required_bodies` is the "policy declares, runtime supplies" contract, and **both of its halves run on the machine driving the rollout**: `PolicyRunner` resolves the names once up front, refuses one the scene does not contain, and merges each body's world pose into every observation it hands to `get_actions`.

The `ready` handshake advertised five introspection values and not this one, and `RemotePolicy` did not override it. So a policy served over the wire declared nothing, and both halves went with it.

![required_bodies across the remote-inference wire](https://raw.githubusercontent.com/cagataycali/robots/43fc475c7b4cad7e0757d7ff7d79cde03043081a/.artifacts/contract_across_the_wire.png)

## What was measured

One policy declaring one body, one real so101 MuJoCo scene holding a body named `cube`, driven twice: in-process, and behind a real `PolicyServer` on a real WebSocket.

| rollout | before | after |
|---|---|---|
| local / body in scene | pose supplied 5/5 ticks | unchanged |
| remote / body in scene | `status: success`, pose supplied **0/5** | pose supplied 5/5 ticks |
| local / body not in scene | refused before the rollout, naming all 8 bodies the scene holds | unchanged |
| remote / body not in scene | **`status: success`** | refused before the rollout |

The last row is the one that costs most, and it is the same shape as the wrapper case: the missing **validation**, not the missing data. The up-front refusal — the one whose whole purpose is to fail "rather than 300 steps of a silently absent key that the policy reads as a zero pose" — became a rollout reporting success.

`_resolve_required_bodies` already describes this outcome in its own docstring, for the wrapper case: *"a declaration lost here is lost for the policy that made it - and both halves of this method go with it, the merge and the scene check, leaving a rollout that reports success having never supplied the key."* The wire loses it the same way.

**Reachability.** `remote` is a registered provider, so `run_policy(policy_provider="ws://gpu-box:8765")` is the documented path. ProtoMotions is the shipped policy that declares this: its anchor link is not derivable from the observation's floating-base signals (`base_quat` is the pelvis, and the torso differs from it by the three waist joints), which is exactly why it declares. Splitting a mimic tracker across an edge robot and a remote GPU is the setup `docs/inference/remote.md` exists for, and that page claims the mirrored metadata makes "the runtime behave identically to running the policy in-process".

## The change

The walk and its type refusals move to `collect_required_bodies` in `policies/base.py`, beside `iter_policy_tree`, and **both surfaces read it** — the runtime, and the server when it advertises. A second copy could report a different set for one tree, which is what both halves of the contract rest on not having. Because the owner walks the tree, a wrapper does not hide the policy inside it, so this composes with the wrapper fix rather than duplicating it (graded: a `PersistentPolicy` around a declaring policy still advertises `['torso_link']`).

Two smaller decisions, both with in-file precedent:

- The server reads the declaration **when it is built**, where `port` is already checked "rather than at `serve()`". A malformed declaration is refused at the point the caller named the policy instead of failing every client's handshake.
- The client **coerces** the advertised array to the shape the runtime validates. A peer sending something else cannot make the local resolver report the proxy as the declaring class.

`is_chunk_emitting` needed nothing — it derives from `execution_horizon`, which the handshake already carried. That is graded by name rather than assumed, and the mirroring requirement is derived from `Policy` itself, so a declaration property added later is graded on arrival instead of joining the same blind spot. Four properties are exempt with a stated reason each (`provider_name`, `children`, `control_frequency`, `rtc_observed_delay_steps` — the proxy answers those for itself), and each exemption is checked to name a real `Policy` member.

## Tests

`tests/inference/test_required_bodies_survive_the_wire.py`, 15 cells. The end-to-end cells drive a real MuJoCo rollout over one table parametrized `[in_process, over_the_wire]` and assert the two agree.

Reverting only the production files, keeping the test: **10 failed / 5 passed** → **15 passed**. Each failure names the defect (`body.cube.quat reached 0 of 5 observations`; `the rollout ran instead of refusing`; `the proxy does not report the served policy's declaration: {'required_bodies': ((), ('cube',))}`).

The 5 that pass on both trees are the controls: the two in-process rows (already correct), and the no-declaration case (identical either way by construction) — plus the structural enumeration cell.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1860 files).
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1857 source files`.
- `tests/inference tests/policies tests/simulation`: 6 failed / 19,948 passed. The **same 6 node ids fail on `upstream/main`** in this environment — 3 need `websockets>=17.0` (16.0 installed, so `shutdown(close_connections=)` is absent), 2 need `docker`, 1 is the newton camera-message wording. 0 attributable.
- `scripts/check_whole_tree_graders.py`: 2 failed / 2,900 passed — both the same `websockets` floor.
- Changelog graders: 91 passed.

## Size

384 insertions / 34 deletions across 9 files: 228 the new test, 19 the changelog fragment, 16 docs. Production is **+121 / −31**, and by AST statement count the runtime *shrinks* — `policy_runner.py` **858 → 846 (−12)** as the extraction removes its copy of the walk (and its last use of `iter_policy_tree`), against `base.py` +12, `client.py` +5, `server.py` +1. Net **+6** executable statements for the fix; the rest is docstring stating why each surface reads one owner.

An earlier revision of this section reported production as +102 / −24. Re-measured against `main`, the figure at that head was +109 / −24 — understated by seven lines. Corrected above, together with the docstring commit below.

## Changelog

**`c8fe455` — the `required_bodies` cross-references name the collector, not the walk below it.** Self-review while the PR is still unreviewed; nothing was asked for.

`_resolve_required_bodies` documents a `TypeError` in its `Raises:` section, but this branch moved the walk *and* those refusals into `collect_required_bodies`. Both docstring cross-references still pointed at `iter_policy_tree` — one layer below the new owner, and a function that raises nothing — so a reader following the link to find the raising code would not have found it. The reference was correct on `main`, where the method really did call the walk; it is stale only on this branch, so the drift is this branch's own. `Policy.required_bodies` carried the same stale reference and now also names the remote-inference handshake as the second surface reading that one owner, which is the whole reason the collector is single-owner.

Docstring-only, measured rather than asserted:

| check | result |
|---|---|
| AST of both files, docstrings stripped | identical to `2e9f679` |
| statement count | unchanged — `base.py` 115, `policy_runner.py` 1015 |
| `ruff check` / `ruff format --check` | clean |
| 29 cross-reference graders | pass — both new roles resolve |
| `required_bodies` behaviour cells, incl. the 15 wire cells | 65 passed / 2 skipped |
| the suite's 65 docstring-reading graders | failing node ids byte-identical to `2e9f679` — 0 attributable |
