### PR TITLE
fix(ci): the last-push rule names the "Update branch" button, not just a git push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -772,7 +772,9 @@ hatch run format            # ruff check --fix, ruff format
      **contributor's** branch - that is the `require_last_push_approval` identity
      problem below, which is independent of dismissal and does not care that the
      merge was clean. Ask the contributor to absorb `main` so they stay the last
-     pusher; #1827 was left alone for that reason.
+     pusher; #1827 was left alone for that reason. The **"Update branch" button**
+     is covered too -- it is the same push, and #2907 spent its sole approval on
+     it twice.
    - *And that the mutation named the object you meant.* A mutation
      names its subject by node ID and by nothing else - `createIssue` takes a
      `repositoryId`, not an owner and a name - so a well-formed ID that is wrong
@@ -1604,8 +1606,8 @@ hatch run format            # ruff check --fix, ruff format
    | #1035 at `8d6a4c42` | the maintainer | the maintainer | the maintainer | `REVIEW_REQUIRED` |
    | #1722 | `strands-robots` | the maintainer | the maintainer | `REVIEW_REQUIRED` |
 
-   So **pushing a fix to a contributor's branch consumes the approval of
-   whoever owns the token you push with**, turning a PR one maintainer could
+   So **putting a commit on a contributor's head consumes the approval of
+   whoever that head is attributed to**, turning a PR one maintainer could
    merge into one that needs a second. It compounds with
    `dismiss_stale_reviews_on_push`, which drops the existing approval in the
    same motion that disqualifies that account from re-supplying it. Prefer
@@ -1613,6 +1615,17 @@ hatch run format            # ruff check --fix, ruff format
    pusher; when the agent must push, that PR now requires a second approver,
    and saying so is the difference between a one-line request and a branch that
    never merges.
+
+   **Every spelling counts, including the one that is not a `git` command.** The
+   **"Update branch" button** on the pull request page is this same push. It sits
+   beside the merge button, presents itself as branch maintenance, prompts
+   nothing, needs no local checkout and handles no token the operator holds --
+   and it makes whoever clicked it the last pusher exactly as `git push` does. It
+   is not an exception because it is one click. Measured on #2907, a branch whose
+   author is `logesh4v`: the button produced its head twice, four days apart, and
+   each press spent the pull request's sole approval -- the second time after the
+   mechanism had already been written up in a comment on that same pull request.
+   A base refresh on a contributor's branch is theirs to make.
 
    **#1035 later crossed into the second row, which makes it the whole rule
    observed twice on one pull request.** CI triage on it correctly diagnosed a
@@ -1643,11 +1656,24 @@ hatch run format            # ruff check --fix, ruff format
    state now, and needs an approver who is not the account that pushed
    `8d6a4c42`.
 
-   Do not try to settle this from the commit metadata, which misleads in both
-   directions. #1722's author and committer are `strands-robots`, an identity
-   distinct from the approver, which reads as the rule being satisfied when it is
-   not; #1035's head names the maintainer outright. Same `REVIEW_REQUIRED`,
-   opposite metadata. Only `triggering_actor` is load-bearing.
+   Do not try to settle this from the commit metadata, which misleads in three
+   different directions. All three heads below read `REVIEW_REQUIRED`; only
+   `triggering_actor` is load-bearing.
+
+   | head | git author / committer | metadata reads as |
+   |---|---|---|
+   | #1722 `d938686` | both `strands-robots`, an identity distinct from the approver | rule satisfied |
+   | #1035 `8d6a4c42` | both the maintainer outright | rule unsatisfied |
+   | #2907 `1c66c8f3` | author the maintainer, committer **`web-flow`** | nobody pushed this at all |
+
+   The third row is the most reassuring of the three and so the least likely to
+   prompt a check: a commit whose committer is a GitHub service account reads as
+   GitHub having performed the merge rather than a person. It is what the
+   **"Update branch" button** leaves behind, and the clicker survives only in the
+   git *author* field and in `triggering_actor` -- both `cagataycali` on that
+   head, across all 12 of its workflow runs, on a branch authored by `logesh4v`.
+   A table that stopped two of the three shapes is why this one was read twice as
+   harmless.
 
    All of the above was documented here and enforced by nothing, which is the
    same shape as the changelog rule in step 3 before #1784. It is now surfaced by

--- a/changelog.d/3191-last-push-rule-names-the-update-branch-button.md
+++ b/changelog.d/3191-last-push-rule-names-the-update-branch-button.md
@@ -1,0 +1,44 @@
+### Fixed: the last-push rule names the "Update branch" button, not just a `git push`
+
+`require_last_push_approval` keys on who the head commit is attributed to.
+Every spelling this repository's guidance named was a `git push`, so the
+**"Update branch" button** on the pull request page went unnamed -- and it is
+the same act: one click, no local checkout, no token the operator handles, and
+the same new last pusher.
+
+Measured on #2907, a branch authored by `logesh4v`. Its head `1c66c8f3` is a
+base refresh the button produced, and it carries a third commit-metadata shape
+the guidance did not list:
+
+| head | git author / committer | metadata reads as |
+|---|---|---|
+| #1722 `d938686` | both `strands-robots`, distinct from the approver | rule satisfied |
+| #1035 `8d6a4c42` | both the maintainer outright | rule unsatisfied |
+| #2907 `1c66c8f3` | author the maintainer, committer **`web-flow`** | nobody pushed this at all |
+
+The third is the most reassuring of the three and so the least likely to prompt
+a check, because a commit whose committer is a GitHub service account reads as
+GitHub having merged rather than a person having pushed. The clicker survives
+only in the git *author* field and in `triggering_actor` -- both `cagataycali`
+across all twelve workflow runs on that head. The sole approval therefore
+stopped counting, twice, four days apart.
+
+The classifier was right every time; what was silent was the remedy printed
+beside the finding. It read "pushing a fix onto a contributor's branch consumes
+the approval of whoever owns the token it is pushed with" -- neither what the
+operator did nor how they did it, so the warning read as being about somebody
+else. `check_last_push_approval.py` and `check_pr_head_is_current.py` now name
+both spellings, and the second already quoted `Head branch is out of date`, the
+button's own label, while telling the reader not to *push*. `AGENTS.md` gains
+the button beside `git push`, the `web-flow` row in the commit-metadata table
+that existed to stop this inference, and the standing consequence: a base
+refresh on a contributor's branch is theirs to make, and the button is not an
+exception because it is one click.
+
+Neither script changes an executable statement -- the guidance lives in
+existing string tuples. The new pin drives the real renderers and derives the
+population of that guidance from the tree, keyed on *stating the consequence*
+rather than on the constant's name, so a further check that copies it joins the
+requirement with no edit. `check_checkout_is_pr_head.py` defines the same
+constant and its remedy is about fetching the right commit, so it is exempt and
+is asserted to be.

--- a/scripts/check_last_push_approval.py
+++ b/scripts/check_last_push_approval.py
@@ -195,9 +195,13 @@ WHAT_CLEARS_THIS: tuple[str, ...] = (
     "   that account pushed defeats the control rather than working around a",
     "   technicality.",
     "",
-    "Avoiding it next time: pushing a fix onto a contributor's branch consumes",
-    "the approval of whoever owns the token it is pushed with. Prefer leaving",
-    "the change as review feedback for the author to push, or land it as a",
+    "Avoiding it next time: whatever puts the head commit there becomes the last",
+    "push, and consumes the approval of the account it is attributed to. That is",
+    '`git push`, and it is equally the **"Update branch" button** on the pull',
+    "request page: one click, no local checkout, no token the operator handles,",
+    "and the same new last pusher. The button is not an exception because it is",
+    "one click. A base refresh on a contributor's branch is theirs to make, so",
+    "prefer leaving the change as review feedback for the author, or land it as a",
     "separate pull request against the base branch.",
 )
 

--- a/scripts/check_pr_head_is_current.py
+++ b/scripts/check_pr_head_is_current.py
@@ -104,11 +104,13 @@ takes the default types, so ``reopened`` recomputes with no commit, therefore no
 push, therefore neither ``dismiss_stale_reviews_on_push`` nor a new last pusher.
 
 Do not push the branch, even though "out of date" reads like a request to
-refresh it. On a contributor's branch a push consumes the approval of whoever
-owns the pushing token under ``require_last_push_approval``, converting a pull
-request one maintainer could merge into one that needs a second approver -- the
-state #1035 has been in since 2026-08-01. On #2508 the branch also needed
-nothing: the author had already merged the base cleanly.
+refresh it -- and the ``Update branch`` button beside that label is that push,
+not an alternative to it. On a contributor's branch either spelling consumes the
+approval of the account the new head is attributed to under
+``require_last_push_approval``, converting a pull request one maintainer could
+merge into one that needs a second approver -- the state #1035 has been in since
+2026-08-01. On #2508 the branch also needed nothing: the author had already
+merged the base cleanly.
 
 Read the close/reopen history first, per AGENTS.md step 8, counting ``nodes``
 rather than ``totalCount``. #2508 had zero, so a single flip was safe. An
@@ -179,14 +181,15 @@ WHAT_CLEARS_THIS: tuple[str, ...] = (
     "An alternating run means something is undoing you and a further flip only",
     "lengthens it.",
     "",
-    "Do **not** push the branch to refresh it, however much `Head branch is out",
-    "of date` reads like a request to. There is no staleness gate on this",
-    "repository to satisfy -- the `default` ruleset sets",
+    "Do **not** refresh the branch, however much `Head branch is out of date`",
+    'reads like a request to -- and that includes the **"Update branch" button**',
+    "the label belongs to, which is that push made in one click. There is no",
+    "staleness gate on this repository to satisfy -- the `default` ruleset sets",
     "`strict_required_status_checks_policy: false` and `main` has no classic",
-    "protection -- and on a contributor's branch a push consumes the approval of",
-    "whoever owns the pushing token under `require_last_push_approval`, which",
-    "turns a pull request one maintainer could merge into one needing a second",
-    "approver.",
+    "protection -- and on a contributor's branch either spelling consumes the",
+    "approval of the account the new head is attributed to under",
+    "`require_last_push_approval`, which turns a pull request one maintainer",
+    "could merge into one needing a second approver.",
     "",
     "Expect `reviewDecision` to move to `REVIEW_REQUIRED` once the record",
     "catches up, and read that as bookkeeping rather than lost review: the",

--- a/tests/test_last_push_rule_names_the_update_branch_button.py
+++ b/tests/test_last_push_rule_names_the_update_branch_button.py
@@ -1,0 +1,173 @@
+"""The last-push rule names the "Update branch" button, not just ``git push``.
+
+``require_last_push_approval`` keys on who the head commit is attributed to, and
+every spelling this repository's guidance named was a ``git push``. The **"Update
+branch" button** on the pull request page is the same act -- one click, no local
+checkout, no token the operator handles -- and it makes the clicker the last
+pusher exactly as a push does.
+
+That silence has a measured cost. #2907's head ``1c66c8f3`` is a base refresh the
+button produced: its git *author* is the maintainer, its **committer is
+``web-flow``**, all twelve workflow runs on it report
+``triggering_actor: cagataycali``, and the branch author is ``logesh4v``. So the
+sole approval stopped counting. It happened twice, four days apart, the second
+time after the mechanism had been written up in a comment on that same pull
+request -- because the remedy the checks print at the moment the finding fires
+described "pushing a fix" with "the token it is pushed with", which is neither
+what the operator did nor how they did it.
+
+Two tiers, because the rule lives in two kinds of place:
+
+* The text the checks **emit** on a finding, driven through the real renderers.
+  This is what an operator reads when it has already happened.
+* The population of that guidance, derived from the tree rather than listed, so a
+  fourth tool that copies it joins the requirement without an edit here. The
+  population is keyed on *stating the consequence*, not on the constant's name:
+  ``check_checkout_is_pr_head.py`` also defines ``WHAT_CLEARS_THIS`` and its
+  remedy is about fetching the right commit, so it is exempt and is asserted to
+  be -- a rule keyed on the name would have demanded the button of a check that
+  never mentions approvals.
+
+See scripts/check_last_push_approval.py, scripts/check_pr_head_is_current.py,
+issue #3190, and the "PR Workflow" section of AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = _ROOT / "scripts"
+
+# The one-click spelling. Required verbatim: an operator searching the guidance
+# for what they just pressed is searching for the button's own label.
+BUTTON = "Update branch"
+
+# The phrase by which a remedy declares it is talking about this rule. Derived
+# population, not a list of filenames.
+STATES_THE_CONSEQUENCE = "consumes the approval"
+
+
+def _load(stem: str) -> Any:
+    """Import a ``scripts/`` check by path; they are standalone stdlib modules."""
+    spec = importlib.util.spec_from_file_location(stem, _SCRIPTS / f"{stem}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _flat(text: str) -> str:
+    """Collapse whitespace, so a phrase wrapped across lines still reads as one.
+
+    Load-bearing rather than tidiness: every one of these texts is a tuple of
+    hand-wrapped lines, and ``Update branch`` split over a line break is the
+    same silence this file exists to close.
+    """
+    return " ".join(text.split())
+
+
+def _remedy_modules() -> dict[str, Any]:
+    """Every ``scripts/`` check whose ``WHAT_CLEARS_THIS`` states this rule."""
+    found: dict[str, Any] = {}
+    for path in sorted(_SCRIPTS.glob("check_*.py")):
+        module = _load(path.stem)
+        remedy = getattr(module, "WHAT_CLEARS_THIS", None)
+        if remedy and STATES_THE_CONSEQUENCE in _flat("\n".join(remedy)):
+            found[path.stem] = module
+    return found
+
+
+class TestTheEmittedRemedyNamesTheButton:
+    """What a check prints when the finding fires, through the real renderer."""
+
+    def test_the_last_push_finding_report_names_it(self) -> None:
+        mod = _load("check_last_push_approval")
+        verdict = mod.classify("cagataycali", [mod.Review("cagataycali", "APPROVED")])
+        assert verdict.outcome == mod.PUSHER_ONLY_APPROVAL, "fixture must pose the finding"
+        report = mod.render(verdict, "strands-labs/robots", 2907, "1c66c8f3")
+        assert BUTTON in _flat(report), (
+            "the remedy printed on a pusher-only-approval finding does not name the "
+            "one-click spelling that produced #2907's head"
+        )
+
+    def test_the_last_push_sweep_names_it_too(self) -> None:
+        """Both reports, since the sweep is what a scheduled scan reads."""
+        mod = _load("check_last_push_approval")
+        verdict = mod.classify("cagataycali", [mod.Review("cagataycali", "APPROVED")])
+        swept = mod.render_sweep([mod.SweepRow(2907, "1c66c8f3", verdict)], [], "strands-labs/robots")
+        assert BUTTON in _flat(swept)
+
+    def test_the_stale_head_finding_names_it(self) -> None:
+        """The check that prescribes a refresh is the one that must name it.
+
+        Its remedy already quotes ``Head branch is out of date`` -- the button's
+        own label -- while telling the reader not to *push*. Quoting the label
+        and naming only the other spelling is the gap at its sharpest.
+        """
+        mod = _load("check_pr_head_is_current")
+        verdict = mod.classify("aaaaaaa", "bbbbbbb")
+        assert verdict.outcome == mod.STALE_HEAD_RECORD, "fixture must pose the finding"
+        row = mod.Row(2907, verdict, "logesh4v/robots", "feat/x", "MERGEABLE", "BLOCKED", "REVIEW_REQUIRED")
+        assert BUTTON in _flat(mod.render_one("strands-labs/robots", row))
+        assert BUTTON in _flat(mod.render_sweep("strands-labs/robots", [row], []))
+
+
+class TestEveryPlaceThatStatesTheRuleNamesTheButton:
+    """Derived, so a fourth copy of the guidance joins without an edit here."""
+
+    def test_the_population_is_not_empty(self) -> None:
+        """A derived population that resolved to nothing would pass vacuously."""
+        found = _remedy_modules()
+        assert len(found) >= 2, f"expected the guidance in at least two checks, found {sorted(found)}"
+
+    @pytest.mark.parametrize("stem", sorted(_remedy_modules()))
+    def test_each_states_both_spellings(self, stem: str) -> None:
+        remedy = _flat("\n".join(_remedy_modules()[stem].WHAT_CLEARS_THIS))
+        assert BUTTON in remedy, f"{stem} states the rule but names only a git push"
+        assert "git push" in remedy or "push" in remedy, f"{stem} should still name the push spelling"
+
+    def test_a_remedy_that_does_not_state_the_rule_is_exempt(self) -> None:
+        """The rule is keyed on the consequence, not on the constant's name.
+
+        ``check_checkout_is_pr_head.py`` defines ``WHAT_CLEARS_THIS`` too and its
+        remedy is about fetching the branch by name; requiring the button of it
+        would be requiring an approval rule of a check that has no opinion on
+        approvals. This holds on either side of the fix, which is the point.
+        """
+        module = _load("check_checkout_is_pr_head")
+        remedy = _flat("\n".join(module.WHAT_CLEARS_THIS))
+        assert STATES_THE_CONSEQUENCE not in remedy
+        assert "check_checkout_is_pr_head" not in _remedy_modules()
+
+
+class TestTheWrittenRuleCoversTheButtonAndItsMetadata:
+    """AGENTS.md is where the rule is reasoned about rather than reported."""
+
+    @staticmethod
+    def _agents() -> str:
+        return _flat((_ROOT / "AGENTS.md").read_text(encoding="utf-8"))
+
+    def test_the_rule_names_the_button(self) -> None:
+        assert BUTTON in self._agents(), (
+            'AGENTS.md documents require_last_push_approval without naming the "Update '
+            'branch" button, so the rule as written does not reach the spelling that '
+            "spent #2907's approval twice"
+        )
+
+    def test_the_commit_metadata_guidance_covers_the_web_flow_shape(self) -> None:
+        """The table exists to stop this inference; it stopped two of three shapes.
+
+        A committer of ``web-flow`` is the most reassuring of the three and the
+        least likely to prompt a check, because it reads as GitHub having merged
+        rather than a person having pushed.
+        """
+        agents = self._agents()
+        assert "web-flow" in agents, "the commit-metadata guidance does not name the button's own shape"
+        assert "triggering_actor" in agents


### PR DESCRIPTION
Closes #3190.

`require_last_push_approval` keys on **who the head commit is attributed to**. Every spelling the guidance named was a `git push`. The **"Update branch" button** on the pull request page is the same act -- one click, no local checkout, no token the operator handles -- and it makes the clicker the last pusher exactly as a push does.

## The remedy printed beside the finding described neither act

The classifier was right every time. What was silent is the text an operator reads at the moment it has already happened. Run against #2907 today:

```
$ python3 scripts/check_last_push_approval.py --repo strands-labs/robots --pr 2907
Outcome: **pusher-only-approval**
...
Avoiding it next time: pushing a fix onto a contributor's branch consumes
the approval of whoever owns the token it is pushed with. Prefer leaving
the change as review feedback for the author to push, ...
```

The operator pushed no fix and handled no token, so the warning reads as being about somebody else. After:

```
Avoiding it next time: whatever puts the head commit there becomes the last
push, and consumes the approval of the account it is attributed to. That is
`git push`, and it is equally the **"Update branch" button** on the pull
request page: one click, no local checkout, no token the operator handles,
and the same new last pusher. The button is not an exception because it is
one click. A base refresh on a contributor's branch is theirs to make, ...
```

`check_pr_head_is_current.py` is the sharper case: its remedy already **quoted the button's own label**, `Head branch is out of date`, and then told the reader not to *push*. Quoting the label while naming only the other spelling is the gap at its narrowest.

## Measured

#2907 is a branch authored by `logesh4v`; its head `1c66c8f3` is a base refresh the button produced.

| field | value |
|---|---|
| git author | `./c² <cagataycali@icloud.com>` -> `cagataycali` |
| git committer | `GitHub <noreply@github.com>` -> **`web-flow`** |
| workflow runs on the head | 12, every one `event=pull_request`, `triggering_actor=cagataycali` |
| branch author | `logesh4v` |
| current approvals | `cagataycali` only |
| verdict | `pusher-only-approval`, exit 1 |

So the sole approval stopped counting. Twice, four days apart -- the second time after the mechanism had already been written up in a comment on that same pull request.

That third metadata shape is why. `AGENTS.md` already said "do not settle this from the commit metadata, which misleads in both directions" and listed two shapes; the button produces a third, and it is the most reassuring of them:

| head | git author / committer | metadata reads as |
|---|---|---|
| #1722 `d938686` | both `strands-robots`, distinct from the approver | rule satisfied |
| #1035 `8d6a4c42` | both the maintainer outright | rule unsatisfied |
| #2907 `1c66c8f3` | author the maintainer, committer **`web-flow`** | nobody pushed this at all |

A commit whose committer is a GitHub service account reads as GitHub having merged rather than a person having pushed, so it is the least likely of the three to prompt a check. A table that stopped two of three shapes is why this one was read twice as harmless.

## Change

- Both emitted remedies name the button beside `git push`.
- `AGENTS.md`: the button in the rule itself, in the dismissal section's cross-reference, and the `web-flow` row added to the commit-metadata table; plus the standing consequence -- a base refresh on a contributor's branch is theirs to make, and the button is not an exception because it is one click.
- The rule is broadened from "pushing a fix" to "putting a commit on the head", which is what the ruleset actually keys on.

**Neither script changes an executable statement** (AST: 204 -> 204 and 197 -> 197). The guidance lives inside existing string tuples.

## Test

Two tiers, because the rule lives in two kinds of place. The behavioural cells drive the **real renderers** (`render`, `render_sweep`, `render_one`) and assert the emitted text. The derived cells take the population of that guidance **from the tree** -- every `scripts/check_*.py` whose `WHAT_CLEARS_THIS` states the consequence -- so a further check that copies it joins the requirement with no edit here.

The population is keyed on *stating the consequence*, not on the constant's name. `check_checkout_is_pr_head.py` defines `WHAT_CLEARS_THIS` too and its remedy is about fetching the branch by name; requiring the button of it would be requiring an approval rule of a check that has no opinion on approvals. It is exempt, and asserted to be.

Pre-fix (source at `main`, new test file only): **7 failed / 2 passed**. The 2 passing are the controls -- the non-vacuity floor and the exempt sibling -- which hold on either side by construction. Post-fix: **9 passed**.

| mutation | fires | which |
|---|---|---|
| control, no change | 0 | 9 passed |
| button dropped from `check_last_push_approval` remedy | 3 | its report, its sweep, its derived cell |
| button dropped from `check_pr_head_is_current` remedy | 2 | its report, its derived cell |
| button dropped from `AGENTS.md` (all 3 mentions) | 1 | the written-rule cell |
| `web-flow` row dropped from the table | 1 | the metadata cell |
| population keyed on the constant *name* | 2 | the exempt control, plus the third check wrongly enrolled |
| phrase wrapped across a line break | 0 | whitespace normalisation holds |

Six mutations, six distinct firing sets, control 0. The last two rows are why the design is what it is: the key is load-bearing, and a phrase hand-wrapped across a line break is the same silence this closes, so the readers normalise whitespace.

## Gate

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean, 1863 files. Also clean on both changed scripts.
- `mypy strands_robots tests tests_integ` (1.20.2, the pinned version): `Success: no issues found in 1860 source files`.
- `scripts/check_whole_tree_graders.py`: **2 failed / 4316 passed / 50 skipped**. Both failures are the installed `websockets` 16.0 against the `>=17.0` floor `cosmos3-service` declares, reproduced byte-identically on a pristine `main` worktree (`2 failed, 15 passed`). 0 attributable.
- The suites owning the edited subjects -- `test_last_push_approval`, `test_pr_head_is_current`, `test_checkout_is_pr_head`, `test_documented_guard_names_resolve`, `test_merge_gate_viewer_scope` -- plus the new file: **125 passed**.
- Grader roster: 100 derived on `main` -> 101 here. The new file is picked up by the tree scan with no roster edit.

## Size

`+273 / -23` over 5 files: `AGENTS.md` +34/-8, the two scripts +22/-15 (no executable statements), the test +173, the changelog fragment +44.

## Note on scope

#3190 proposed this as documentation only, on the reading that `check_last_push_approval.py` "already reports the state correctly" -- which it does; the verdict was never wrong. But the same silence is in the remedy both checks *emit*, which is the text an operator actually reads when the finding fires, so the change is there too rather than in prose alone.

#2907 is `CONFLICTING` and needs its base absorbed again. Per the rule as now written, that absorption is the author's to make -- by either spelling.