### PR TITLE
docs(readme): remove archived Robots Sim link from header nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
     ◆ <a href="https://github.com/google-deepmind/mujoco">MuJoCo</a>
     ◆ <a href="https://github.com/NVIDIA/Isaac-GR00T">NVIDIA GR00T</a>
     ◆ <a href="https://github.com/huggingface/lerobot">LeRobot</a>
-    ◆ <a href="https://github.com/strands-labs/robots-sim">Robots Sim</a>
     ◆ <a href="https://github.com/orgs/strands-labs/projects/2">Project Board</a>
   </p>
 </div>

--- a/changelog.d/3192-readme-drops-archived-robots-sim-link.md
+++ b/changelog.d/3192-readme-drops-archived-robots-sim-link.md
@@ -1,0 +1,10 @@
+### Docs: the README header nav no longer links to the archived robots-sim repository
+
+`strands-labs/robots-sim` was archived on 2026-08-06 and is read-only, but the
+README's header nav still listed it as `Robots Sim` beside the live external
+references, steering newcomers to a dead sibling project. The maintained
+simulation stack lives in this repository (`strands_robots/simulation/`, MuJoCo
+and Isaac backends). The entry and its diamond separator are removed; the
+surrounding entries (Strands Docs, MuJoCo, NVIDIA GR00T, LeRobot, Project
+Board) are unchanged, and no other `robots-sim` reference existed in the
+README.


### PR DESCRIPTION
## What changed

Removes the `Robots Sim` entry (and its diamond separator) from the README
header nav. `strands-labs/robots-sim` was archived on 2026-08-06 and is
read-only, so the main README should not steer newcomers to it as if it were a
live sibling project - the maintained simulation stack lives in this repository
(`strands_robots/simulation/`, MuJoCo + Isaac backends).

The removed entry sat mid-list (between LeRobot and Project Board), so no
dangling separator remains: each surviving entry carries its own leading
diamond and the first entry (Strands Docs) has none, exactly as before.

Also adds the changelog fragment
`changelog.d/3192-readme-drops-archived-robots-sim-link.md` per the news
fragment convention (issue number known at intake, so the fragment ships in
the first push).

Closes #3192

## Acceptance criteria (from the issue)

- [x] `grep -c "strands-labs/robots-sim" README.md` returns 0.
- [x] Header nav renders cleanly with no dangling diamond separator (the removed
      entry was mid-list; first-entry and mid-list edge cases both hold).
- [x] No other files changed beyond the README nav line + the changelog
      fragment; docs hygiene checks pass.

## Test surface

- `hatch run lint` - clean (ruff check, ruff format, mypy: no issues in 1861
  source files).
- `hatch run test` under `MUJOCO_GL=egl` - 46650 passed, 312 skipped, 95.60%
  coverage. The one failure in the first full run was this branch's own
  changelog fragment carrying the non-ASCII diamond glyph
  (`test_no_emoji_in_changelog_fragments`); the fragment now spells it
  "diamond separator" and the test passes.
- `hatch run whole-tree-check` - 4318 passed, 50 skipped.
- `python scripts/assemble_changelog.py --check` - fragments OK.

## Out of scope

Purging `robots-sim` mentions elsewhere in the repo (docs history, changelogs,
AGENTS.md) - per the issue, only the README nav link.

## Project board

If #3192 is tracked on the Strands Labs - Robots board, please move it to
"In review" (or it will auto-move to Done on merge via the closing reference).
