### PR TITLE
fix(simulation): a refused start_recording keeps the dataset it was replacing

### DIFF
--- a/changelog.d/3196-refused-recording-keeps-the-dataset.md
+++ b/changelog.d/3196-refused-recording-keeps-the-dataset.md
@@ -1,0 +1,54 @@
+### Fixed: a refused `start_recording` keeps the dataset it was replacing
+
+`overwrite=True` is the one posture that deletes a real LeRobotDataset without
+asking (`DatasetRecordingMixin._prepare_dataset_target`), and it is what the
+`run_policy` agent tool records with. Every camera-shaped refusal
+`start_recording` makes was already ahead of that deletion -- the `cameras=`
+name-list domain, the boolean postures, the fps domain, and the scene-level key
+collision, whose guard is documented as running "before any dataset is created,
+resumed or wiped".
+
+One was not. A single unknown name in `cameras=` was refused from inside the
+schema-declaration block, roughly a hundred lines after the deletion, so the
+call reported an error having already removed the dataset it was replacing.
+Measured against a real single-episode recording:
+
+| | `total_episodes` | `total_frames` | MP4s |
+|---|---|---|---|
+| after recording | 1 | 20 | 1 |
+| after `cameras=["camera1", "camrea2"], overwrite=True` | -- | -- | -- |
+
+The directory was gone. The refusal itself is right, and its remedy is what
+makes the ordering costly: "Add them with `add_camera(...)` before recording, or
+omit `cameras=` to record all of them" asks for a retry against the data the
+same call destroyed. All three backends that declare a dataset schema carried
+it, and `run_policy` cannot pre-flight the name on the caller's behalf -- the
+available cameras are known only to the engine, which is why the tool forwards
+`dataset_cameras` verbatim to a call that hardcodes `overwrite=True`.
+
+The hazard was already written down for the sibling failure mode:
+`camera_schema_key_collision_error`'s docstring notes that a colliding pair
+surfaces "as the FIRST `add_frame` being rejected, after `overwrite=True` has
+already wiped the dataset being replaced", and that guard was placed ahead of
+the deletion for exactly that reason. This is the same ordering, applied to the
+last refusal that still followed it.
+
+Nothing between resolving the target and building the recorder reads or writes
+the dataset directory -- the schema is read from the scene -- so the deletion is
+deferred to the last statement before the recorder is built. That is a move, not
+a rewrite: the executable statement count of all three backends is unchanged
+(136 / 176 / 194 before and after), and the four documented outcomes still
+happen, just later. `overwrite=True` still replaces an existing dataset rather
+than appending to it, `overwrite=False` still resumes, a pre-existing empty root
+is still cleared, and a non-empty non-dataset directory is still reported rather
+than clobbered.
+
+The regression is graded two ways, because the guard was correct and only
+reached too late. A behavioural cell records a real episode, drives the refused
+call, and reopens the dataset through `LeRobotDataset` to assert its frames,
+metadata and per-camera video survived; a structural cell derived from the tree
+asserts no backend refuses between the deletion and the recorder, so a backend
+or a refusal added later is graded on arrival. `overwrite=False` is a passing
+control that locates the damage in the destructive posture specifically, and
+deleting the deletion outright fails the "still replaces" cell -- the two ways
+this could be over-corrected.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -121,7 +121,9 @@ sim.start_recording(
 The dataset schema then declares only those three image features. Names may be
 given in raw MuJoCo form (`arm0/wrist_cam`) or schema-safe form
 (`arm0__wrist_cam`); an unknown name fails loudly and lists the available
-cameras rather than silently recording the wrong set. Omit `cameras=` to keep
+cameras rather than silently recording the wrong set. The names are checked
+before any dataset is created, resumed or wiped, so a typo costs nothing even
+under `overwrite=True`. Omit `cameras=` to keep
 the legacy behavior of recording every camera - in that case a one-time
 warning is logged when the implicit `default` overview camera is swept in
 alongside your real sensor cameras, so the stray view is never recorded
@@ -193,6 +195,12 @@ When `root` already contains a LeRobotDataset (a `meta/` directory),
 `overwrite=True`, which wipes and recreates it. A `root` that exists, is not a
 LeRobotDataset, and is **not empty** is left untouched and reported as an error
 rather than clobbered - pass `overwrite=True` or choose a new/empty `root`.
+
+Because `overwrite=True` is the one posture that deletes a dataset without
+asking, it is applied as the last step before the recorder is built: every
+refusal `start_recording` can make - the fps and camera domains, the boolean
+postures, an unknown camera name, a scene whose camera names collide - happens
+first, so a refused call leaves the dataset that was already there untouched.
 
 `overwrite` and `push_to_hub` select a **posture**, so both must be booleans and
 are checked before anything is created, resumed, wiped or published. Neither is

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -214,7 +214,9 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 behaves identically across engines. Names may be given in
                 either the raw camera name or the schema-safe form (``/``
                 collapsed to ``__``); an unknown name fails loudly, listing
-                the available cameras. Two scene cameras whose
+                the available cameras, and is refused before any dataset is
+                created, resumed or wiped, so a typo costs nothing even under
+                ``overwrite=True``. Two scene cameras whose
                 names collapse onto one dataset column (``arm0/wrist`` and
                 ``arm0__wrist``) are refused before any dataset is created,
                 because the column would be named after whichever of them lost
@@ -338,11 +340,6 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
             state["last_dataset_root"] = str(dataset_dir)
 
             try:
-                # Create-vs-resume semantics shared with MuJoCo/Newton: resume
-                # an existing dataset, clear a pre-existing EMPTY root, wipe on
-                # overwrite. See DatasetRecordingMixin._prepare_dataset_target.
-                resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
-
                 (
                     joint_names,
                     action_names,
@@ -393,6 +390,23 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                     recording_cameras = [tpl for tpl in recording_cameras if tpl[0] in selected_raw]
 
                 state["recording_cameras"] = recording_cameras
+
+                # Create-vs-resume, and the wipe it can perform, are deferred to here
+                # rather than opened with. ``overwrite=True`` deletes the dataset being
+                # replaced, so every refusal this method can still make is made above it:
+                # the camera scoping just above used to sit behind this line, and a single
+                # unknown name in ``cameras=`` refused the call after the existing dataset
+                # had already been removed - the refusal's own remedy ("Add them with
+                # add_camera(...) ... or omit cameras=") asks for a retry against the data
+                # that same call destroyed. Nothing between the target resolution above and
+                # this line reads or writes the dataset directory (the schema is read from
+                # the scene), so the success path is unchanged. Resume an existing dataset,
+                # clear a pre-existing EMPTY root (e.g. tempfile.mkdtemp()) so create() does
+                # not dead-end on FileExistsError, and wipe on overwrite - the four outcomes
+                # of DatasetRecordingMixin._prepare_dataset_target. This is the ordering
+                # camera_schema_key_collision_error already establishes for the scene-level
+                # collision, applied to the last refusal that still followed the wipe.
+                resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
 
                 if resume_existing:
                     logger.info("Resuming existing dataset for append: %s", dataset_dir)

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -162,7 +162,9 @@ class RecordingMixin(DatasetRecordingMixin):
                 ``cameras=["camera1", "camera2", "camera3"]`` for a 3-camera
                 SmolVLA dataset) and keep the stray ``default`` view out of the
                 schema. Names may be raw (``arm0/wrist_cam``) or schema-safe
-                (``arm0__wrist_cam``); an unknown name fails loudly. Two scene cameras whose
+                (``arm0__wrist_cam``); an unknown name fails loudly, and is refused
+                before any dataset is created, resumed or wiped, so a typo costs
+                nothing even under ``overwrite=True``. Two scene cameras whose
                 names collapse onto one dataset column (``arm0/wrist`` and
                 ``arm0__wrist``) are refused before any dataset is created,
                 because the column would be named after whichever of them lost
@@ -278,17 +280,7 @@ class RecordingMixin(DatasetRecordingMixin):
         # after stop_recording has finalized the dataset and dropped the recorder.
         self._world._backend_state["last_dataset_root"] = str(dataset_dir)
 
-        # Multi-episode append: when NOT overwriting and a dataset already
-        # exists on disk, resume it (append new episodes) instead of calling
-        # create() - which hard-fails with FileExistsError. resume() is the
-        # only correct append path in LeRobot 0.5.2+ (the plain constructor is
-        # read-only). A pre-existing EMPTY root (e.g. tempfile.mkdtemp()) is
-        # cleared so create() does not dead-end on its own existence guard;
-        # overwrite=True wipes and recreates from scratch. See
-        # DatasetRecordingMixin._prepare_dataset_target.
         try:
-            resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
-
             # Collect joint names from every robot. When the scene contains
             # more than one robot (e.g. multi-agent dual-task recording), prefix
             # each joint with the robot's instance name (``alice__shoulder_pan``)
@@ -455,6 +447,23 @@ class RecordingMixin(DatasetRecordingMixin):
                     sensor_cams,
                     sensor_cams,
                 )
+
+            # Create-vs-resume, and the wipe it can perform, are deferred to here
+            # rather than opened with. ``overwrite=True`` deletes the dataset being
+            # replaced, so every refusal this method can still make is made above it:
+            # the camera scoping just above used to sit behind this line, and a single
+            # unknown name in ``cameras=`` refused the call after the existing dataset
+            # had already been removed - the refusal's own remedy ("Add them with
+            # add_camera(...) ... or omit cameras=") asks for a retry against the data
+            # that same call destroyed. Nothing between the target resolution above and
+            # this line reads or writes the dataset directory (the schema is read from
+            # the scene), so the success path is unchanged. Resume an existing dataset,
+            # clear a pre-existing EMPTY root (e.g. tempfile.mkdtemp()) so create() does
+            # not dead-end on FileExistsError, and wipe on overwrite - the four outcomes
+            # of DatasetRecordingMixin._prepare_dataset_target. This is the ordering
+            # camera_schema_key_collision_error already establishes for the scene-level
+            # collision, applied to the last refusal that still followed the wipe.
+            resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
 
             assert _DatasetRecorder is not None  # checked above
             if resume_existing:

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -152,7 +152,9 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 ``run_policy(dataset_cameras=...)`` behaves identically on both
                 engines. Names may be given in either the raw camera name or the
                 schema-safe form (``/`` collapsed to ``__``); an unknown name
-                fails loudly, listing the available cameras. Two scene cameras whose
+                fails loudly, listing the available cameras, and is refused before any dataset is
+                created, resumed or wiped, so a typo costs nothing even under
+                ``overwrite=True``. Two scene cameras whose
                 names collapse onto one dataset column (``arm0/wrist`` and
                 ``arm0__wrist``) are refused before any dataset is created,
                 because the column would be named after whichever of them lost
@@ -272,12 +274,6 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         world._backend_state["last_dataset_root"] = str(dataset_dir)
 
         try:
-            # Resolve create-vs-resume and make the target safe for create():
-            # resume an existing dataset, clear a pre-existing EMPTY root (e.g.
-            # tempfile.mkdtemp()) so create() does not dead-end on FileExistsError,
-            # and wipe on overwrite. See DatasetRecordingMixin._prepare_dataset_target.
-            resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
-
             (
                 joint_names,
                 action_names,
@@ -362,6 +358,23 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 recording_cameras = [tpl for tpl in recording_cameras if tpl[0] in selected_raw]
 
             world._backend_state["recording_cameras"] = recording_cameras
+
+            # Create-vs-resume, and the wipe it can perform, are deferred to here
+            # rather than opened with. ``overwrite=True`` deletes the dataset being
+            # replaced, so every refusal this method can still make is made above it:
+            # the camera scoping just above used to sit behind this line, and a single
+            # unknown name in ``cameras=`` refused the call after the existing dataset
+            # had already been removed - the refusal's own remedy ("Add them with
+            # add_camera(...) ... or omit cameras=") asks for a retry against the data
+            # that same call destroyed. Nothing between the target resolution above and
+            # this line reads or writes the dataset directory (the schema is read from
+            # the scene), so the success path is unchanged. Resume an existing dataset,
+            # clear a pre-existing EMPTY root (e.g. tempfile.mkdtemp()) so create() does
+            # not dead-end on FileExistsError, and wipe on overwrite - the four outcomes
+            # of DatasetRecordingMixin._prepare_dataset_target. This is the ordering
+            # camera_schema_key_collision_error already establishes for the scene-level
+            # collision, applied to the last refusal that still followed the wipe.
+            resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
 
             if resume_existing:
                 logger.info("Resuming existing dataset for append: %s", dataset_dir)

--- a/tests/simulation/test_refused_recording_keeps_the_existing_dataset.py
+++ b/tests/simulation/test_refused_recording_keeps_the_existing_dataset.py
@@ -1,0 +1,344 @@
+"""A refused ``start_recording`` leaves the caller's dataset where it was.
+
+``overwrite=True`` is the one posture that deletes a real LeRobotDataset without
+asking (:meth:`~strands_robots.simulation.recording.DatasetRecordingMixin._prepare_dataset_target`),
+and it is what the ``run_policy`` agent tool records with. Every camera-shaped
+refusal ``start_recording`` makes was already ahead of that deletion - the
+``cameras=`` name-list domain, the boolean postures, the fps domain, and the
+scene-level key collision, whose own guard is documented as running "before any
+dataset is created, resumed or wiped". One was not: a single unknown name in
+``cameras=`` was refused from inside the schema-declaration block, roughly a
+hundred lines after the wipe, so the call reported an error having already
+removed the dataset it was replacing - and the refusal's remedy ("Add them with
+``add_camera(...)`` ... or omit ``cameras=``") asks for a retry against the data
+that same call destroyed.
+
+Nothing between resolving the target and building the recorder reads or writes
+the dataset directory - the schema is read from the scene - so the deletion is
+deferred to the last statement before the recorder is built, which puts every
+refusal ahead of it.
+
+Covers:
+
+* an existing dataset survives a refused ``cameras=`` call, byte for byte, and
+  still reopens through ``LeRobotDataset`` with its frames and image column;
+* the refusal itself is unchanged - same status, same message, no session left
+  open (the invariant refusing earlier must not break);
+* no refusal sits between the deletion and the recorder in any backend that
+  ships a ``start_recording``, derived from the tree so a backend or a refusal
+  added later is graded on arrival;
+* ``overwrite=True`` still replaces an existing dataset and a non-dataset
+  directory is still not clobbered - the deletion is deferred, not dropped.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("lerobot")
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+_ROBOT_XML = """
+<mujoco model="test_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.05 0.05" rgba="0.3 0.3 0.8 1"/>
+      <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+      <camera name="wrist" pos="0.25 0 0.05" xyaxes="0 -1 0 0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan_act" joint="shoulder_pan" kp="50"/>
+  </actuator>
+</mujoco>
+"""
+
+_UNKNOWN = "wrsit"  # the transposition an operator actually types for "wrist"
+
+
+def _sim(tmp_path):
+    """A one-joint arm carrying a single ``arm/wrist`` camera."""
+    from strands_robots.simulation import Simulation
+
+    path = tmp_path / "test_arm.xml"
+    path.write_text(_ROBOT_XML)
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("arm", urdf_path=str(path))
+    return sim
+
+
+def _text(result) -> str:
+    return " ".join(block.get("text", "") for block in result["content"])
+
+
+def _marker_dataset(root: Path) -> str:
+    """Stand in for "a dataset already lives here", byte-addressably.
+
+    ``_prepare_dataset_target`` decides resume-vs-create on the presence of
+    ``meta/``, and the property under test is whether the bytes already on disk
+    are still there afterwards - so a marker file states it exactly, and the
+    round-trip cell below carries the same claim for a real recording.
+    """
+    (root / "meta").mkdir(parents=True)
+    payload = '{"pre": "existing"}'
+    (root / "meta" / "info.json").write_text(payload)
+    return payload
+
+
+def _record_one_episode(sim, root: Path, *, cameras: list[str] | None = None) -> None:
+    """Write a real single-episode LeRobotDataset at ``root``."""
+    started = sim.start_recording(
+        repo_id="local/refused_recording",
+        root=str(root),
+        task="pan the arm",
+        overwrite=True,
+        cameras=cameras,
+    )
+    assert started["status"] == "success", _text(started)
+    rollout = sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=6, control_frequency=30.0)
+    assert rollout["status"] == "success", _text(rollout)
+    stopped = sim.stop_recording()
+    assert stopped["status"] == "success", _text(stopped)
+
+
+def _episode_count(root: Path) -> int:
+    return int(json.loads((root / "meta" / "info.json").read_text())["total_episodes"])
+
+
+class TestThePremise:
+    """The name really is unknown, and naming it really is refused."""
+
+    def test_the_scene_does_not_carry_the_requested_camera(self, tmp_path):
+        import mujoco as mj
+
+        sim = _sim(tmp_path)
+        try:
+            model = sim._world._model
+            names = [mj.mj_id2name(model, mj.mjtObj.mjOBJ_CAMERA, i) for i in range(model.ncam)]
+            assert "arm/wrist" in names, names
+            assert _UNKNOWN not in names, names
+        finally:
+            sim.destroy()
+
+    def test_the_refusal_names_the_unknown_camera_and_what_exists(self, tmp_path):
+        # Holds either way: the refusal is right, and this pins that deferring
+        # the deletion did not change what the caller is told.
+        sim = _sim(tmp_path)
+        try:
+            result = sim.start_recording(
+                repo_id="local/refused_recording",
+                root=str(tmp_path / "ds"),
+                overwrite=True,
+                cameras=["arm/wrist", _UNKNOWN],
+            )
+            assert result["status"] == "error", result
+            text = _text(result)
+            assert _UNKNOWN in text, text
+            # The available list is the scene's RAW names, which is what a
+            # caller must pass to add_camera - not the collapsed column name.
+            assert "arm/wrist" in text, text
+        finally:
+            sim.destroy()
+
+
+class TestARefusedCallKeepsTheDataset:
+    """The refusal is not what was wrong - deleting first was."""
+
+    @pytest.mark.parametrize("overwrite", [True, False])
+    def test_the_bytes_already_on_disk_are_untouched(self, tmp_path, overwrite):
+        # ``overwrite=False`` resumes rather than deletes, so that row held
+        # before this change too: it is the control that locates the damage in
+        # the destructive posture specifically - the one ``run_policy`` uses.
+        root = tmp_path / "ds"
+        payload = _marker_dataset(root)
+        sim = _sim(tmp_path)
+        try:
+            result = sim.start_recording(
+                repo_id="local/refused_recording",
+                root=str(root),
+                overwrite=overwrite,
+                cameras=["arm/wrist", _UNKNOWN],
+            )
+            assert result["status"] == "error", result
+            assert (root / "meta" / "info.json").exists(), sorted(p.name for p in root.rglob("*"))
+            assert (root / "meta" / "info.json").read_text() == payload
+        finally:
+            sim.destroy()
+
+    def test_a_recorded_dataset_still_reopens_after_a_refused_call(self, tmp_path):
+        # The marker cell states the property exactly; this one states it about
+        # a dataset LeRobot itself wrote and can still read - parquet, metadata
+        # and the per-camera video - which is what the caller stood to lose.
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        root = tmp_path / "ds"
+        sim = _sim(tmp_path)
+        try:
+            _record_one_episode(sim, root, cameras=["arm/wrist"])
+            before = LeRobotDataset(repo_id="local/refused_recording", root=str(root))
+            frames, episodes = before.meta.total_frames, before.meta.total_episodes
+            assert frames > 0 and episodes == 1, (frames, episodes)
+
+            refused = sim.start_recording(
+                repo_id="local/refused_recording",
+                root=str(root),
+                overwrite=True,
+                cameras=["arm/wrist", _UNKNOWN],
+            )
+            assert refused["status"] == "error", _text(refused)
+        finally:
+            sim.destroy()
+
+        # Asserted before reopening: a deleted local dataset sends
+        # ``LeRobotDataset`` to the Hub for ``local/refused_recording``, and the
+        # 404 that comes back names neither the directory nor the refusal.
+        assert (root / "meta" / "info.json").exists(), f"the refused call removed the dataset at {root}"
+        after = LeRobotDataset(repo_id="local/refused_recording", root=str(root))
+        assert (after.meta.total_frames, after.meta.total_episodes) == (frames, episodes)
+        assert "observation.images.arm__wrist" in after.meta.features, sorted(after.meta.features)
+        videos = sorted(path for path in root.rglob("*.mp4"))
+        assert videos, sorted(p.name for p in root.rglob("*"))
+        assert all(path.stat().st_size > 0 for path in videos), videos
+
+    def test_no_session_is_left_open(self, tmp_path):
+        # Holds either way. The refusal already unwound the session flag; this
+        # pins that refusing before the deletion does not leave one behind.
+        root = tmp_path / "ds"
+        _marker_dataset(root)
+        sim = _sim(tmp_path)
+        try:
+            sim.start_recording(
+                repo_id="local/refused_recording",
+                root=str(root),
+                overwrite=True,
+                cameras=["arm/wrist", _UNKNOWN],
+            )
+            assert not sim._world._backend_state.get("recording")
+            assert sim._world._backend_state.get("dataset_recorder") is None
+        finally:
+            sim.destroy()
+
+
+class TestTheDeletionIsDeferredNotDropped:
+    """Controls: the four documented outcomes still happen, just later."""
+
+    def test_overwrite_still_replaces_an_existing_dataset(self, tmp_path):
+        # The failure mode of "stop deleting so early" is "stop deleting": a
+        # second overwrite=True rollout must replace the first episode, not
+        # append to it.
+        root = tmp_path / "ds"
+        sim = _sim(tmp_path)
+        try:
+            _record_one_episode(sim, root, cameras=["arm/wrist"])
+            assert _episode_count(root) == 1
+            _record_one_episode(sim, root, cameras=["arm/wrist"])
+            assert _episode_count(root) == 1, "overwrite=True appended instead of replacing"
+        finally:
+            sim.destroy()
+
+    def test_a_non_dataset_directory_is_still_not_clobbered(self, tmp_path):
+        root = tmp_path / "ds"
+        root.mkdir()
+        (root / "unrelated.txt").write_text("keep me")
+        sim = _sim(tmp_path)
+        try:
+            result = sim.start_recording(
+                repo_id="local/refused_recording",
+                root=str(root),
+                overwrite=False,
+                cameras=["arm/wrist"],
+            )
+            assert result["status"] == "error", result
+            assert (root / "unrelated.txt").read_text() == "keep me"
+        finally:
+            sim.destroy()
+
+
+class TestNoRefusalFollowsTheDeletion:
+    """Derived from the tree, so a later backend or refusal is graded on arrival.
+
+    The rule is positional because that is what the defect was: the guard was
+    written, correct, and reached too late. Only the span between the deletion
+    and the recorder is constrained - the two returns after the recorder is
+    built are its success envelope and its own failure handler, neither of which
+    could precede the object they report on.
+    """
+
+    @staticmethod
+    def _recording_modules() -> dict[str, str]:
+        import strands_robots.simulation as simulation
+
+        root = Path(inspect.getfile(simulation)).parent
+        return {
+            path.parent.name: path.read_text()
+            for path in sorted(root.glob("*/recording.py"))
+            if "def start_recording" in path.read_text()
+        }
+
+    @staticmethod
+    def _span(source: str) -> tuple[int, int, list[int]]:
+        """``(deletion lineno, recorder lineno, refusal linenos between them)``."""
+        start = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name == "start_recording"
+        )
+        deletion = next(
+            node.lineno
+            for node in ast.walk(start)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_prepare_dataset_target"
+        )
+        recorder = min(
+            node.lineno
+            for node in ast.walk(start)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"create", "resume"}
+            and isinstance(node.func.value, ast.Name)
+            and "DatasetRecorder" in node.func.value.id
+        )
+        between = [
+            node.lineno
+            for node in ast.walk(start)
+            if isinstance(node, ast.Return) and deletion < node.lineno < recorder
+        ]
+        return deletion, recorder, between
+
+    def test_more_than_one_backend_is_graded(self):
+        # Without this the rules below pass on an empty inventory.
+        assert len(self._recording_modules()) >= 2, sorted(self._recording_modules())
+
+    def test_every_backend_still_resolves_the_target_before_building_the_recorder(self):
+        for backend, source in self._recording_modules().items():
+            deletion, recorder, _ = self._span(source)
+            assert deletion < recorder, backend
+
+    def test_no_backend_refuses_after_the_deletion(self):
+        offenders = {
+            backend: between
+            for backend, source in self._recording_modules().items()
+            if (between := self._span(source)[2])
+        }
+        assert offenders == {}, offenders
+
+    def test_every_backend_still_carries_the_camera_scoping_refusal(self):
+        # Non-vacuity for the rule above, and it holds either way: deleting the
+        # guard would also satisfy "no refusal after the deletion", so the rule
+        # is only meaningful while the guard it moved is still there.
+        for backend, source in self._recording_modules().items():
+            assert "unknown camera(s)" in source, backend


### PR DESCRIPTION
## The problem

`overwrite=True` is the one posture that deletes a real LeRobotDataset without asking (`DatasetRecordingMixin._prepare_dataset_target`), and it is what the `run_policy` agent tool records with. Every camera-shaped refusal `start_recording` makes was already ahead of that deletion. One was not.

A single unknown name in `cameras=` was refused from inside the schema-declaration block, roughly a hundred lines after the deletion. Measured against a real single-episode MuJoCo recording:

| | `total_episodes` | `total_frames` | MP4s | reopens via `LeRobotDataset` |
|---|---|---|---|---|
| after recording | 1 | 20 | 1 | yes, `observation.images.camera1` |
| after `cameras=["camera1", "camrea2"], overwrite=True` | — | — | — | **directory gone** |

The refusal itself is right. Its remedy is what makes the ordering costly:

```
start_recording: unknown camera(s) ['camrea2'] in cameras=. Available scene
cameras: ['camera1', 'default']. Add them with add_camera(...) before
recording, or omit cameras= to record all of them.
```

It asks for a retry against the data the same call destroyed.

## Where the refusals sit

```mermaid
flowchart LR
  subgraph B["before"]
    direction TB
    b1["fps / boolean postures /<br/>cameras= name list /<br/>scene key collision"] --> b2["resolve target"]
    b2 --> b3["DELETE existing dataset"]
    b3 --> b4["declare schema from scene"]
    b4 --> b5{"unknown<br/>camera name?"}
    b5 -->|"yes"| b6["return error<br/>dataset already gone"]
    b5 -->|"no"| b7["build recorder"]
  end
  subgraph A["after"]
    direction TB
    a1["fps / boolean postures /<br/>cameras= name list /<br/>scene key collision"] --> a2["resolve target"]
    a2 --> a4["declare schema from scene"]
    a4 --> a5{"unknown<br/>camera name?"}
    a5 -->|"yes"| a6["return error<br/>dataset intact"]
    a5 -->|"no"| a3["DELETE existing dataset"]
    a3 --> a7["build recorder"]
  end
  style b3 fill:#ffdddd,stroke:#cc0000
  style b6 fill:#ffdddd,stroke:#cc0000
  style a3 fill:#ddffdd,stroke:#00aa00
  style a6 fill:#ddffdd,stroke:#00aa00
```

All three backends that declare a dataset schema carried it — `mujoco` refused at L418 with the deletion at L290, `newton` at L347 with L279, `isaac` at L378 with L344.

`run_policy` cannot pre-flight the name on the caller's behalf: the available cameras are known only to the engine, which is why the tool forwards `dataset_cameras` verbatim to a call that hardcodes `overwrite=True`. The tool's own pre-flight block already checks `control_frequency`, `action_horizon`, `dataset_fps`, `seed`, `video`, `policy_config`, `policy_kwargs` and `stop_when` for exactly this reason — that a knob refused later is refused "AFTER an existing dataset at `dataset_root` was removed and replaced with an empty one".

The hazard was already written down for the sibling failure mode. `camera_schema_key_collision_error`'s docstring notes that a colliding pair surfaces "as the FIRST `add_frame` being rejected, after `overwrite=True` has already wiped the dataset being replaced", and that guard was placed ahead of the deletion for that reason — `tests/simulation/test_camera_schema_key_collision.py` grades it with the comment "a guard called after either refuses a call that has already cost the caller their dataset". This is the same ordering, applied to the last refusal that still followed it.

## The change

Nothing between resolving the target and building the recorder reads or writes the dataset directory — the schema is read from the scene — so the deletion is deferred to the last statement before the recorder is built. That puts every refusal ahead of it, including any added later.

That is a move, not a rewrite. Executable statements (AST) per backend, before → after:

| backend | statements | Δ |
|---|---|---|
| mujoco | 136 → 136 | 0 |
| newton | 176 → 176 | 0 |
| isaac | 194 → 194 | 0 |

The rest of the production diff is the comment stating the ordering, moved with the call.

## The four documented outcomes still happen, just later

Driven for real on MuJoCo:

| outcome | result |
|---|---|
| `overwrite=True` on an existing dataset | replaced: `episodes=1 frames=6`, not appended |
| `overwrite=False` on an existing dataset | resumed: `episodes=2 frames=12` |
| pre-existing empty root, `overwrite=False` | cleared and recorded: `episodes=1 frames=6` |
| non-empty non-dataset root, `overwrite=False` | reported, and `unrelated.txt` still readable |

## Tests

`tests/simulation/test_refused_recording_keeps_the_existing_dataset.py`, 12 cells. Graded two ways, because the guard was correct and only reached too late: a behavioural cell records a real episode, drives the refused call, and reopens the dataset through `LeRobotDataset` to assert its frames, metadata and per-camera video survived; a structural cell derived from the tree asserts no backend refuses between the deletion and the recorder, so a backend or a refusal added later is graded on arrival.

Pre-fix: **3 failed / 9 passed**, each failure naming the defect —

```
FAILED ...::test_the_bytes_already_on_disk_are_untouched[True] - AssertionError: []
FAILED ...::test_a_recorded_dataset_still_reopens_after_a_refused_call
        - AssertionError: the refused call removed the dataset at /tmp/.../ds
FAILED ...::test_no_backend_refuses_after_the_deletion
        - AssertionError: {'isaac': [378], 'mujoco': [418], 'newton': [347]}
```

Post-fix: 12 passed. `overwrite=False` is a passing control that locates the damage in the destructive posture specifically. Mutations, `collected` stable at 12 on every row:

| mutation | fires | including |
|---|---|---|
| control | 0 | — |
| revert mujoco only | 3 | the structural cell names one backend |
| revert all three | 3 | the structural cell names all three |
| deferring becomes never deleting | 3 | `overwrite` still replaces |
| deferred past the recorder | 3 | target resolved before the recorder |
| refusal stops naming `unknown camera(s)` | 1 | the non-vacuity cell |
| refusal stops listing what exists | 1 | the premise cell |

The last two rows matter because deleting the guard would also satisfy "no refusal after the deletion", and the two middle rows are the ways this could be over-corrected.

The existing `test_unknown_camera_fails_loudly` passes either way: it records into `tmp_path / "bad"`, a root that does not exist, so there was never a dataset for the refusal to remove. It still grades the message, which is unchanged.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` clean (ruff 0.15.20, 1866 files).
- `mypy strands_robots tests tests_integ` — `Success: no issues found in 1863 source files` (mypy 1.20.2).
- `MUJOCO_GL=egl pytest tests/simulation` — **1 failed / 14259 passed / 13 skipped** in 16m39s. The one failure is `newton/test_multi_camera.py::TestNamedCameraRegistration::test_bad_position_shape_rejected`, reproduced on a pristine `upstream/main` worktree at `f4cf60c0c` in 13s; it asserts `'3 elements'` against `"must be a 3-element vector"` and touches nothing here.
- `scripts/check_whole_tree_graders.py` — 7 failed / 4323 passed / 50 skipped; all 7 are environmental on this host (5 assert `rclpy` is absent while it resolves from `/opt/ros/jazzy`, 2 read installed `websockets` 16.0 against the `cosmos3-service` `>=17.0` floor). None is in `recording`.
- Changelog and link graders: 124 passed.

## Size

+467 / −25 across 6 files: production +60 / −24 (all comment and docstring; 0 executable statements), tests +344, docs +9 / −1, changelog fragment +54.

## Docs

The `cameras:` docstring in all three backends said only that an unknown name "fails loudly", while the collision sentence beside it stated its ordering; both now state it. `docs/recording.md` says the same in the `cameras=` section, and its `root` / `overwrite` section now states the general rule — that `overwrite=True` is applied as the last step before the recorder is built, so a refused call leaves the dataset that was already there untouched.