### PR TITLE
fix(simulation): a reset closes the open dataset episode on every backend

### DIFF
--- a/changelog.d/3198-reset-episode-boundary-parity.md
+++ b/changelog.d/3198-reset-episode-boundary-parity.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- `reset()` now closes the open dataset episode on **every** simulation backend, not
+  only MuJoCo. `DatasetRecordingMixin.save_episode` documents the boundary as a fact
+  about the class all three engines inherit, and `docs/recording.md` repeats it with a
+  worked `run_policy` + `reset` loop promising 20 episodes; on Newton and Isaac that
+  loop produced **one** episode whose frames spanned every reset teleport in between.
+  Nothing reported it - the recorder and the parquet both counted one episode, so
+  `stop_recording`'s author-versus-parquet gate had nothing to compare, and
+  `verify_dataset_episodes` counts episodes rather than comparing them to the rollouts
+  that were run. The rule now has a single owner that all three resets ask, so a
+  fourth backend inherits it. A *partial* Isaac reset (`reset(env_ids=[...])`)
+  deliberately cuts no boundary, because whether the recorded robot's rollout ended is
+  not knowable from `env_ids`.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -349,6 +349,14 @@ single `episode_index=0` (1200 steps in one episode). To DISCARD a partial
 rollout instead of flushing it on the next `reset()`, call
 `clear_episode_buffer()` first.
 
+Every backend cuts the boundary: `reset()` asks one shared rule, so the loop
+above yields 20 episodes on MuJoCo, Newton and Isaac alike. The one exception is
+a *partial* Isaac reset - `reset(env_ids=[...])` re-initializes only the named
+environments, and whether the recorded robot's rollout ended is not knowable
+from `env_ids`, so no boundary is cut and the buffer stays open. Call
+`save_episode()` yourself if a partial reset does end the episode you are
+recording.
+
 ## Verifying episode count
 
 An LLM agent narrating "20 episodes recorded" is not proof: a single

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -1368,6 +1368,20 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             if not self._world_created:
                 return {"status": "error", "content": [{"text": "No world created."}]}
 
+        # A full reset re-initializes the scene, so an open recording's buffered
+        # frames are the rollout that just ended - flush them as their own
+        # episode before the teleport. Ahead of the main-thread marshal because
+        # the flush is a dataset write and does not touch the kit runtime. A
+        # PARTIAL reset is deliberately not a boundary: it re-initializes some
+        # envs and this stream records one robot, so whether its rollout ended
+        # is not knowable from ``env_ids`` alone, and cutting an episode there
+        # would split a trajectory that never stopped.
+        flush_note = ""
+        if env_ids is None and (flush := self._flush_open_episode_before_reset()) is not None:
+            if flush.get("status") != "success":
+                return flush
+            flush_note = flush["content"][0]["text"] + " "
+
         def _reset_impl() -> dict[str, Any]:
             with self._lock:
                 # Re-checked under the lock: a pump-marshalled call may race a
@@ -1391,7 +1405,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 self._step_count = 0
 
                 if env_ids is None:
-                    msg = "Full reset complete."
+                    msg = f"{flush_note}Full reset complete."
                 else:
                     msg = f"Partial reset complete for {len(env_ids)} envs."
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4401,30 +4401,19 @@ class MuJoCoSimEngine(
             return err
 
         # A reset re-initializes the world, which is the start of a new
-        # rollout. If a recording is active with buffered (unsaved) frames,
-        # flush them as their own episode BEFORE the teleport mixes the next
-        # rollout into the same buffer. Without this, a run_policy + reset
-        # collection loop silently merges every rollout into a single
-        # episode_index=0 (total_episodes stuck at 1) - a data-integrity bug
-        # for downstream training/eval that slices by episode. This mirrors
-        # stop_recording, which already auto-flushes the trailing episode.
-        # save_episode() is a no-op on an empty buffer, so resets that are not
-        # preceded by recorded frames (e.g. eval_policy's internal per-episode
-        # resets, which do not feed the recorder) are unaffected. To DISCARD a
+        # rollout, so the frames buffered so far are that rollout's episode.
+        # ``_flush_open_episode_before_reset`` owns the rule for every backend -
+        # see it for what a merged episode costs downstream. To DISCARD a
         # partial rollout instead of flushing it, call clear_episode_buffer()
         # before reset().
         flush_note = ""
-        if self._world._backend_state.get("recording", False):
-            recorder = self._world._backend_state.get("dataset_recorder")
-            pending = getattr(recorder, "episode_frame_count", 0) if recorder is not None else 0
-            if pending > 0:
-                save_result = self.save_episode()
-                if save_result.get("status") != "success":
-                    # save_episode failed -> the recorder poisoned itself and
-                    # the facade already cleared the recording flag. Surface
-                    # the failure rather than resetting into an undefined state.
-                    return save_result
-                flush_note = save_result["content"][0]["text"] + " "
+        if (flush := self._flush_open_episode_before_reset()) is not None:
+            if flush.get("status") != "success":
+                # save_episode failed -> the recorder poisoned itself and
+                # the facade already cleared the recording flag. Surface the
+                # failure rather than resetting into an undefined state.
+                return flush
+            flush_note = flush["content"][0]["text"] + " "
 
         mj = self._mj
         with self._lock:

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -417,15 +417,32 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         return {"status": "success", "content": [{"text": "Newton world destroyed."}]}
 
     def reset(self) -> dict[str, Any]:
-        """Reset the world to its initial joint configuration."""
+        """Reset the world to its initial joint configuration.
+
+        While a dataset recording is open this is also an episode boundary: the
+        frames buffered since the last one are flushed as their own episode
+        before the world is rebuilt, which is the rule :meth:`save_episode`
+        documents. A reset with nothing buffered is unaffected.
+
+        Returns:
+            A ``{status, content}`` tool result. ``status`` is ``"error"`` when
+            no world exists, or when the episode flush this reset owes failed -
+            in that case the world is left untouched rather than rebuilt over a
+            recorder whose buffer is in an undefined state.
+        """
         if self._world is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        flush_note = ""
+        if (flush := self._flush_open_episode_before_reset()) is not None:
+            if flush.get("status") != "success":
+                return flush
+            flush_note = flush["content"][0]["text"] + " "
         with self._lock:
             self._targets = {}
             self._world.sim_time = 0.0
             self._world.step_count = 0
             self._rebuild()
-        return {"status": "success", "content": [{"text": "Newton world reset."}]}
+        return {"status": "success", "content": [{"text": f"{flush_note}Newton world reset."}]}
 
     def step(self, n_steps: int = 1) -> dict[str, Any]:
         """Advance the simulation by ``n_steps`` control steps.

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -1333,6 +1333,50 @@ class DatasetRecordingMixin:
             ],
         }
 
+    def _flush_open_episode_before_reset(self) -> dict[str, Any] | None:
+        """Close the open dataset episode before a reset re-initializes the world.
+
+        A reset is the start of a new rollout, so the frames buffered since the
+        last episode boundary belong to the rollout that just ended. Flushing
+        them here is what makes :meth:`save_episode`'s "``reset()`` is itself an
+        episode boundary while recording" true, and ``docs/recording.md`` states
+        the same rule without naming a backend. Without it a
+        ``run_policy`` + ``reset`` collection loop appends every rollout to the
+        same buffer, and ``stop_recording`` flushes the lot as a single
+        ``episode_index=0`` whose frames span every teleport in between -
+        ``total_episodes`` stuck at 1 for a dataset downstream training and eval
+        slice by episode. Nothing reports it: the episode count the recorder and
+        the parquet agree on is 1, so ``stop_recording``'s own
+        author-versus-parquet gate passes, and ``verify_dataset_episodes``
+        counts episodes rather than comparing them to the rollouts that were
+        run.
+
+        Owned here rather than per backend because all three concrete engines
+        reset the same recording session through the same
+        :meth:`_recording_state` accessor: a copy per backend is what left two
+        of them without the boundary while the shared docstring promised it.
+
+        Returns:
+            ``None`` when there is nothing to flush - no recording is open, or
+            no frame has been captured since the last boundary - so a reset that
+            is not preceded by recorded frames is unaffected. Otherwise the
+            :meth:`save_episode` result: a success envelope whose text names the
+            episode just written, for the caller to quote, or an error envelope
+            the caller must return instead of resetting, because a failed flush
+            leaves the recorder closed and its buffer in an undefined state.
+        """
+        state = self._recording_state()
+        if state is None or not state.get("recording", False):
+            return None
+        recorder = state.get("dataset_recorder", None)
+        # ``save_episode`` reports an empty buffer as a success ("no frames to
+        # flush"), which would add a note to every reset in a session. Ask the
+        # recorder first so a reset with nothing buffered reads exactly as it
+        # did before there was a boundary to cut.
+        if getattr(recorder, "episode_frame_count", 0) <= 0:
+            return None
+        return self.save_episode()
+
     def stream_dataset(self, repo_id: str, **kwargs: Any) -> "StreamingDatasetReader":
         """Open a streaming reader for a LeRobotDataset - read frames straight
         from the Hub (or a local root) with no full materialization.

--- a/tests/simulation/test_reset_is_an_episode_boundary_on_every_backend.py
+++ b/tests/simulation/test_reset_is_an_episode_boundary_on_every_backend.py
@@ -1,0 +1,277 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: ``reset`` closes the open dataset episode on every backend.
+
+:meth:`~strands_robots.simulation.recording.DatasetRecordingMixin.save_episode`
+states it as a fact about the class every engine inherits -- "``reset()`` is
+itself an episode boundary while recording: it flushes buffered frames before
+teleporting" -- and ``docs/recording.md`` repeats it without naming a backend.
+Until this fix only MuJoCo did it. Measured on MuJoCo 3.10.0 with the flush
+removed, one ``start_recording`` then two ten-step ``run_policy`` rollouts with
+a ``reset()`` between them:
+
+* ``reset()`` answered ``Reset to initial state.`` -- no episode written;
+* ``stop_recording`` answered ``status="success"``, ``frame_count=20``,
+  ``episode_count=1``, ``parquet_episode_count=1``,
+  ``episode_count_mismatch=False``;
+* ``meta/info.json`` held ``total_episodes=1``, ``total_frames=20``.
+
+So both rollouts landed in ``episode_index=0`` as one 20-frame trajectory with
+the reset teleport in the middle of it, and every reporting surface agreed: the
+recorder and the parquet both counted one episode, so ``stop_recording``'s
+author-versus-parquet gate had nothing to compare, and
+``verify_dataset_episodes`` counts episodes rather than comparing them to the
+rollouts that were run. The same script with the flush in place wrote
+``total_episodes=2``, ``total_frames=20``, ten frames per episode.
+
+The fix states the rule once, in
+``DatasetRecordingMixin._flush_open_episode_before_reset``, and all three
+``reset`` implementations ask it -- a copy per backend is what left two of them
+without the boundary while the shared docstring promised it.
+
+These tests need no GPU and neither ``newton``/``warp`` nor ``isaacsim``: the
+flush runs before either backend touches a solver or the kit runtime, so the
+unbound-instance stand-in pattern
+(``tests/simulation/test_reserved_camera_name_at_creation.py``) reaches it. The
+MuJoCo half drives a real engine and a real ``create_world``.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.recording import DatasetRecordingMixin
+
+#: The concrete engines that inherit the rule. Literal rather than derived from
+#: the package, so a backend dropped from the list fails
+#: ``TestTheRuleHasOneOwner`` instead of quietly leaving the population.
+BACKENDS = ("mujoco", "newton", "isaac")
+
+
+class _FakeRecorder:
+    """Stand-in for the LeRobot writer, shaped like the real one at the seam.
+
+    ``save_episode`` is the only call the flush makes, and the real recorder
+    answers it with the episode/frame counts the reset text quotes -- or an
+    error, after which it has closed itself.
+    """
+
+    def __init__(self, pending: int = 0, *, fail: bool = False) -> None:
+        self.episode_frame_count = pending
+        self.frame_count = pending
+        self.episode_count = 0
+        self.save_calls = 0
+        self._fail = fail
+
+    def save_episode(self) -> dict[str, Any]:
+        self.save_calls += 1
+        if self._fail:
+            return {"status": "error", "message": "parquet write refused"}
+        self.episode_count += 1
+        written = self.episode_frame_count
+        self.episode_frame_count = 0
+        return {
+            "status": "success",
+            "episode": self.episode_count,
+            "episode_frames": written,
+            "total_frames": self.frame_count,
+        }
+
+
+def _newton_engine() -> tuple[Any, dict[str, Any], list[bool]]:
+    """A Newton engine whose reset reaches the flush without a solver."""
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    # Typed ``Any``: the engine is built without ``__init__``, so every attribute
+    # below is injected rather than declared, and the reset under test reads them
+    # through the same names the real constructor sets.
+    engine: Any = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._lock = threading.RLock()
+    engine._targets = {("robot", "joint"): 1.0}
+    state: dict[str, Any] = {}
+    engine._world = SimpleNamespace(sim_time=5.0, step_count=99, _backend_state=state)
+    rebuilt: list[bool] = []
+
+    def _rebuild() -> None:
+        rebuilt.append(True)
+
+    engine._rebuild = _rebuild
+    return engine, state, rebuilt
+
+
+def _isaac_engine() -> tuple[Any, dict[str, Any], list[bool]]:
+    """An Isaac engine whose reset reaches the flush without the kit runtime."""
+    from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+    engine: Any = IsaacSimulation.__new__(IsaacSimulation)
+    engine._lock = threading.RLock()
+    engine._world_created = True
+    engine._world = None
+    state: dict[str, Any] = {}
+    engine._recording_state_dict = state
+    engine._sim_time = 5.0
+    engine._step_count = 99
+    engine._main_tid = threading.get_ident()
+    rebuilt: list[bool] = []
+
+    def _marshal(_method_name: str, fn: Any) -> Any:
+        """Run the reset body here: the marshal targets the kit runtime, not it."""
+        rebuilt.append(True)
+        return fn()
+
+    engine._marshal_main_thread_affine = _marshal
+    return engine, state, rebuilt
+
+
+def _mujoco_engine() -> tuple[Any, dict[str, Any], list[bool]]:
+    """A real MuJoCo engine with a compiled world."""
+    from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+    engine: Any = MuJoCoSimEngine()
+    assert engine.create_world()["status"] == "success"
+    engine.step(2)
+    return engine, engine._world._backend_state, []
+
+
+ENGINES = {"mujoco": _mujoco_engine, "newton": _newton_engine, "isaac": _isaac_engine}
+
+
+def _recording(state: dict[str, Any], recorder: _FakeRecorder) -> None:
+    """Open a recording session in the engine's own state seam."""
+    state["recording"] = True
+    state["dataset_recorder"] = recorder
+    state["trajectory"] = [object()]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+class TestEveryBackendCutsTheBoundary:
+    """The rule the shared docstring states, graded on each engine that inherits it."""
+
+    def test_buffered_frames_are_flushed_as_their_own_episode(self, backend: str) -> None:
+        """The frames of the rollout that just ended become one episode."""
+        engine, state, _ = ENGINES[backend]()
+        recorder = _FakeRecorder(pending=10)
+        _recording(state, recorder)
+
+        result = engine.reset()
+
+        assert result["status"] == "success", result
+        assert recorder.save_calls == 1, (
+            f"{backend}: reset did not flush the open episode, so the next rollout appends "
+            "to the same buffer and both land in episode_index=0"
+        )
+        assert recorder.episode_count == 1
+        assert recorder.episode_frame_count == 0
+
+    def test_the_reset_names_the_episode_it_wrote(self, backend: str) -> None:
+        """An operator reading the reset sees the boundary it cut."""
+        engine, state, _ = ENGINES[backend]()
+        _recording(state, _FakeRecorder(pending=10))
+
+        text = engine.reset()["content"][0]["text"]
+
+        assert "Episode 1 saved -- 10 frames" in text, (backend, text)
+
+    def test_a_failed_flush_is_reported_and_the_world_is_not_reset(self, backend: str) -> None:
+        """A poisoned recorder stops the reset instead of being reset over."""
+        engine, state, rebuilt = ENGINES[backend]()
+        _recording(state, _FakeRecorder(pending=10, fail=True))
+        # MuJoCo drives a real world, so the clock itself says whether the reset
+        # happened; the two stand-ins record the rebuild they were asked for.
+        before = engine._world._data.time if backend == "mujoco" else None
+
+        result = engine.reset()
+
+        assert result["status"] == "error", result
+        assert "save_episode failed" in result["content"][0]["text"]
+        assert rebuilt == [], f"{backend}: the world was re-initialized over a poisoned recorder"
+        if before is not None:
+            assert engine._world._data.time == before > 0.0
+
+    def test_nothing_buffered_leaves_the_reset_as_it_was(self, backend: str) -> None:
+        """Control: a reset not preceded by recorded frames is untouched."""
+        engine, state, _ = ENGINES[backend]()
+        recorder = _FakeRecorder(pending=0)
+        _recording(state, recorder)
+
+        result = engine.reset()
+
+        assert result["status"] == "success", result
+        assert recorder.save_calls == 0
+        assert "Episode" not in result["content"][0]["text"]
+
+    def test_a_reset_outside_a_recording_never_asks_the_recorder(self, backend: str) -> None:
+        """Control: the boundary belongs to a recording, not to every reset."""
+        engine, state, _ = ENGINES[backend]()
+        recorder = _FakeRecorder(pending=10)
+        state["recording"] = False
+        state["dataset_recorder"] = recorder
+
+        result = engine.reset()
+
+        assert result["status"] == "success", result
+        assert recorder.save_calls == 0
+
+
+class TestTheRuleHasOneOwner:
+    """One definition, asked by every reset - a copy per backend is the defect."""
+
+    OWNER = "_flush_open_episode_before_reset"
+
+    @staticmethod
+    def _reset_source(backend: str) -> str:
+        module = __import__(f"strands_robots.simulation.{backend}.simulation", fromlist=["x"])
+        engine = next(
+            cls
+            for name, cls in vars(module).items()
+            if isinstance(cls, type) and cls.__module__ == module.__name__ and "reset" in vars(cls)
+        )
+        return inspect.getsource(vars(engine)["reset"])
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_the_reset_asks_the_owner(self, backend: str) -> None:
+        """Grade the call, not the text: a mention in prose is not a call."""
+        tree = ast.parse(textwrap.dedent(self._reset_source(backend)))
+        called = {
+            node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert self.OWNER in called, (
+            f"{backend}.reset does not ask {self.OWNER}, so its recording keeps buffering across the teleport"
+        )
+
+    def test_the_owner_exists_and_is_the_only_definition(self) -> None:
+        """Non-vacuity: the cells above pass trivially if the name is gone."""
+        assert hasattr(DatasetRecordingMixin, self.OWNER)
+        root = Path(inspect.getfile(DatasetRecordingMixin)).parent
+        defining = [path for path in root.rglob("*.py") if f"def {self.OWNER}" in path.read_text()]
+        assert len(defining) == 1, f"the rule has {len(defining)} definitions: {defining}"
+
+    def test_the_documented_claim_is_what_this_pins(self) -> None:
+        """The premise: the shared docstring promises the boundary for every engine."""
+        doc = inspect.getdoc(DatasetRecordingMixin.save_episode) or ""
+        assert "is itself an episode boundary while recording" in doc
+
+
+class TestAPartialIsaacResetIsNotABoundary:
+    """A partial reset re-initializes some envs; one stream's rollout may not have ended."""
+
+    def test_env_ids_leaves_the_buffer_open(self) -> None:
+        engine, state, _ = _isaac_engine()
+        recorder = _FakeRecorder(pending=10)
+        _recording(state, recorder)
+
+        result = engine.reset(env_ids=[0])
+
+        assert result["status"] == "success", result
+        assert recorder.save_calls == 0
+        assert recorder.episode_frame_count == 10


### PR DESCRIPTION
## The claim, and where it holds

`DatasetRecordingMixin.save_episode` states this as a fact about the class **every** engine inherits:

> (`reset()` is itself an episode boundary while recording: it flushes buffered frames before teleporting, so the explicit `save_episode` above is what makes the boundary unconditional rather than what creates it - see `docs/recording.md`.)

`docs/recording.md` repeats it without naming a backend, with a worked loop whose comment promises `-> 20 episodes`. Only MuJoCo did it. `reset()` on Newton and Isaac never looked at the open recording.

| backend | `reset()` consults the recorder | `run_policy` + `reset` x2 |
|---|---|---|
| MuJoCo | yes | 2 episodes |
| Newton | **no** | **1 episode** |
| Isaac | **no** | **1 episode** |

## Measured

Real MuJoCo 3.10.0, real `LeRobotDataset`: one `start_recording`, two ten-step `run_policy` rollouts, one `reset()` between them. The same script, run twice - once with the flush in place, once with that one block removed so `reset()` behaves as Newton's and Isaac's do.

| | `reset()` answered | `stop_recording` | `meta/info.json` | frames per `episode_index` |
|---|---|---|---|---|
| boundary cut | `Episode 1 saved -- 10 frames ...` | `success`, `frame_count=20`, `episode_count=2`, `parquet_episode_count=2` | `total_episodes=2`, `total_frames=20` | `{0: 10, 1: 10}` |
| boundary absent | `Reset to initial state.` | `success`, `frame_count=20`, `episode_count=1`, `parquet_episode_count=1` | `total_episodes=1`, `total_frames=20` | `{0: 20}` |

Both are `status="success"` with `episode_count_mismatch: false`. **Nothing reports it.** The recorder and the parquet both counted one episode, so `stop_recording`'s author-versus-parquet gate had nothing to compare, and `verify_dataset_episodes` counts episodes rather than comparing them to the rollouts that were run.

What lands in that single episode is not one trajectory. The reset teleport is a **0.5207 rad** step in one frame on `shoulder_lift` - **6.1x** the largest step any action commanded in the whole recording (0.1702 rad) - and it sits at frame 9 -> 10 *inside* `episode_index=0`:

![reset as an episode boundary](https://raw.githubusercontent.com/cagataycali/robots/7066fe5abd63bdf730058af23634780a0507c808/.artifacts/reset_episode_boundary.png)

Both panels plot the *same* recorded frames; only the episode boundaries differ. A loader that slices by episode reads the top panel as one continuous 20-frame demonstration.

## The change

The rule gets one owner, `DatasetRecordingMixin._flush_open_episode_before_reset`, and all three `reset()` implementations ask it. Copying MuJoCo's block twice more is what produced this in the first place: three copies of one rule, two of which were never written.

```
reset()  ->  _flush_open_episode_before_reset()  ->  save_episode()   (mixin, already shared)
              |
              +-- None when no recording is open, or nothing buffered  -> reset unchanged
              +-- error envelope  -> returned; the world is NOT re-initialized
```

MuJoCo's behaviour is unchanged - it now delegates, which is **4 executable statements fewer** than the block it replaces. A reset with nothing buffered still reads exactly as before (the owner asks the recorder first, so `save_episode`'s "no frames to flush" success never becomes a note on every reset).

A **partial** Isaac reset deliberately cuts no boundary: `reset(env_ids=[...])` re-initializes only the named environments, and whether the recorded robot's rollout ended is not knowable from `env_ids`, so cutting an episode there would split a trajectory that never stopped. Pinned, so a later "make it uniform" change has to re-decide it rather than drift into it.

## Tests

`tests/simulation/test_reset_is_an_episode_boundary_on_every_backend.py`, table-driven over the three backends, driving each real `reset()`. On `main` the split is itself the parity report:

| cell | mujoco | newton | isaac |
|---|---|---|---|
| buffered frames flushed as their own episode | pass | **fail** | **fail** |
| the reset names the episode it wrote | pass | **fail** | **fail** |
| a failed flush is reported, world not reset | pass | **fail** | **fail** |
| control: nothing buffered -> reset unchanged | pass | pass | pass |
| control: not recording -> recorder never asked | pass | pass | pass |

Plus a structural cell per backend (the AST of each `reset` must *call* the owner, so a mention in prose does not count), a non-vacuity cell (the owner exists and has exactly one definition), a premise cell (the shared docstring still makes the claim this pins), and the partial-Isaac-reset boundary. **Pre-fix 10 failed / 11 passed; post-fix 21 passed.** The partial-reset cell passes both ways by construction - it is the over-reach control, and a fix that flushed on partial resets too would fail it.

No GPU, no `newton`/`warp`, no `isaacsim`: the flush runs before either backend touches a solver or the kit runtime, so the unbound-instance stand-in pattern already used by `tests/simulation/test_reserved_camera_name_at_creation.py` reaches it. The MuJoCo half drives a real engine and a real `create_world`.

## Gate

`ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy strands_robots tests tests_integ` -> **0 errors** (1864 files).

`tests/simulation`: **1 failed / 14280 passed / 13 skipped** in 16:29. The one failure is `newton/test_multi_camera.py::TestNamedCameraRegistration::test_bad_position_shape_rejected` (`assert '3 elements' in "... must be a 3-element vector, got 2"`), reproduced byte-identically on a pristine `main` worktree at `b318a026a` - a pre-existing message-wording assertion, unrelated to this change. The count checks out: `main` collects 14259 here, plus the 21 new cells.

`scripts/check_whole_tree_graders.py`: **7 failed / 4323 passed / 50 skipped**, all seven environmental on this host - five assert `rclpy` is absent where it resolves, and two read an installed `websockets` 16.0 against the `>=17.0` floor the `cosmos3-service` extra declares (`websockets.asyncio.server.Server` has no `shutdown` at that version at all).

## Size

`7 files changed, +387/-24`. Production is `+88/-24` across four files and **+14 executable statements** by AST count (`recording.py` +8, `newton` +5, `isaac` +5, `mujoco` **-4**); the rest is the docstring stating the rule once. Tests +277, docs +8, changelog fragment +14.