### PR TITLE
fix(training): an RL evaluation's episode count is held to the shared count domain

### DIFF
--- a/changelog.d/3199-evaluate-episode-count-domain.md
+++ b/changelog.d/3199-evaluate-episode-count-domain.md
@@ -1,0 +1,28 @@
+### Fixed: an RL evaluation's episode count is held to the shared count domain
+
+`BaseRLAlgo.evaluate` reads `num_episodes` three times - as the `range()` bound
+of the episode loop, as the denominator of the reported `success_rate`, and
+verbatim as the `num_episodes` field of the returned metrics dict - and guarded
+it with a bare `num_episodes <= 0` test, which screens none of those.
+
+`True` ran one episode and came back as `{"num_episodes": True}` from a field
+documented `int`, with the success rate divided by a flag, while `False` was
+refused. `2.5` / `3.0` / `nan` / `inf` passed the comparison and raised
+`TypeError` out of `range()` - after the env, the networks and the optimizers had
+been built and a checkpoint loaded - from a method documenting
+`Raises: ValueError`.
+
+That raise also escaped the eval-mode window before it was closed. `evaluate`
+flips the actor-critic and the observation normalizer into `eval()` mode, and
+`EmpiricalNormalization` freezes its running statistics there. `collect_rollout`
+re-enters `actor_critic.train()` itself, but `evaluate` is the only place in the
+package that puts the normalizer back, so observation normalization silently
+stopped learning for the rest of the run - measured on a MuJoCo SO-101 PPO
+trainer, 3 of 7 episode counts left it frozen.
+
+`num_episodes` now consults `positive_count_error`, the same domain this
+package's other `range()`-bound counts (`total_timesteps` / `rollout_steps` /
+`num_envs`) already use, and the mode restore moved into `finally` so the stated
+side-effect-free contract holds on every exit rather than only the happy path - a
+caller-supplied reward term or `success_fn` raising on a live engine froze
+normalization the same way.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -183,6 +183,24 @@ the RL lifecycle hooks `setup`, `collect_rollout`, `update`, and
 those hooks; an off-policy algorithm overrides `train()` with a replay-buffer
 loop while keeping the same hooks and checkpoint format.
 
+`evaluate(spec=None, checkpoint_dir=None, num_episodes=10)` is the eval peer of
+`train()`: it rolls out the deterministic (mean) action with gradients disabled
+and observation normalization frozen, so its numbers are what a deployed
+`policy.pt` would produce. It returns `num_episodes`, `mean_return`,
+`std_return`, `min_return`, `max_return`, `mean_length`, `success_rate` (the
+fraction of episodes that ended on a genuine terminal via the env's
+`success_fn`, not a time-out) and the per-episode `returns`.
+
+`num_episodes` must be a positive integer, checked against the same shared count
+domain as `total_timesteps` / `rollout_steps` / `num_envs`: it is the `range()`
+bound of the episode loop, the denominator of the reported `success_rate`, and is
+echoed back as the `num_episodes` field, so a value that is not a count cannot be
+honored by any of the three. `evaluate()` is side-effect-free with respect to
+train/eval mode on **every** exit, including a raising one - the actor-critic and
+the observation normalizer are returned to the mode they were in before the call,
+so a `train -> evaluate -> train` continuation resumes with the running
+statistics still learning.
+
 ## RLTrainSpec
 
 `RLTrainSpec` extends `TrainSpec`. RL ignores the dataset fields

--- a/strands_robots/training/rl/base_algo.py
+++ b/strands_robots/training/rl/base_algo.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+from strands_robots.utils import positive_count_error
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from collections.abc import Callable
@@ -249,7 +250,13 @@ class BaseRLAlgo(Trainer):
                 evaluating. ``None`` keeps the in-memory weights (or the
                 latest checkpoint under ``spec.output_dir`` for a fresh
                 instance).
-            num_episodes: Number of full episodes to roll out. Must be > 0.
+            num_episodes: Number of full episodes to roll out. Must be a
+                positive integer: it is consumed directly as a ``range()`` bound
+                and is the denominator of the reported ``success_rate``, so it is
+                held to the shared
+                :func:`~strands_robots.utils.positive_count_error` domain - the
+                same one this package's other ``range()``-bound counts
+                (``total_timesteps`` / ``rollout_steps`` / ``num_envs``) use.
 
         Returns:
             Metrics dict::
@@ -271,13 +278,24 @@ class BaseRLAlgo(Trainer):
             and ``success_rate`` is ``0.0``.
 
         Raises:
-            ValueError: ``num_episodes <= 0``, or the trainer is not set up and
-                no ``spec`` was provided to build it.
+            ValueError: ``num_episodes`` is not a positive integer, or the
+                trainer is not set up and no ``spec`` was provided to build it.
         """
         import torch
 
-        if num_episodes <= 0:
-            raise ValueError(f"num_episodes must be > 0, got {num_episodes}")
+        # ``num_episodes`` is read three times: as the ``range()`` bound of the
+        # episode loop, as the denominator of the reported ``success_rate``, and
+        # verbatim as the ``num_episodes`` field of the returned metrics. A bare
+        # ``<= 0`` test screens none of those: it read ``2.5`` / ``nan`` / ``inf``
+        # as usable and they raised ``TypeError`` out of ``range()`` - after the
+        # env, the networks and the optimizers had been built and a checkpoint
+        # loaded - and ``True`` landed as a silent count of one, reported back as
+        # ``{"num_episodes": True}`` from a field documented ``int``, with the
+        # success rate divided by a flag. Only a positive integer can be honored,
+        # so the count is held to the same shared domain as the other
+        # ``range()``-bound counts of an RL run.
+        if (error := positive_count_error(num_episodes, "num_episodes", "evaluate")) is not None:
+            raise ValueError(error)
 
         # Bring the trainer to a live state if it was not already set up.
         if getattr(self, "actor_critic", None) is None or getattr(self, "env", None) is None:
@@ -316,35 +334,45 @@ class BaseRLAlgo(Trainer):
         # first sub-env, which is a plain SimEnv with the (1,)-shaped contract.
         from strands_robots.training.rl.vec_env import VecSimEnv
 
-        eval_env = self.env.envs[0] if isinstance(self.env, VecSimEnv) else self.env
-
         returns: list[float] = []
         lengths: list[int] = []
         successes = 0
-        for _ in range(num_episodes):
-            obs = eval_env.reset()
-            ep_return = 0.0
-            ep_len = 0
-            terminated = False
-            while True:
-                actor_obs = _norm(obs["actor_obs"])
-                with torch.no_grad():
-                    action = self._deterministic_action(actor_obs)
-                obs, reward, done, info = eval_env.step(action)
-                ep_return += float(reward.item())
-                ep_len += 1
-                if bool(done.item()):
-                    terminated = bool(info.get("terminated", False))
-                    break
-            returns.append(ep_return)
-            lengths.append(ep_len)
-            if terminated:
-                successes += 1
-
-        # Restore the pre-eval mode (side-effect-free evaluate()).
-        self.actor_critic.train(_ac_was_training)
-        if actor_norm is not None:
-            actor_norm.train(_norm_was_training)
+        # The eval-mode window is closed in ``finally``, not after the loop: the
+        # modes flipped above are trainer state that outlives a raise, and this
+        # method documents itself as side-effect-free. ``actor_norm`` is the half
+        # that does not recover on its own - ``EmpiricalNormalization`` freezes
+        # its running statistics in eval mode and ``evaluate`` is the only place
+        # in the package that puts it back, whereas ``collect_rollout`` re-enters
+        # ``actor_critic.train()`` itself. An exception escaping the rollout (a
+        # caller-supplied reward term or ``success_fn`` raising on a live engine)
+        # would therefore stop observation normalization from learning for the
+        # rest of the run, with nothing reporting that it had stopped.
+        try:
+            eval_env = self.env.envs[0] if isinstance(self.env, VecSimEnv) else self.env
+            for _ in range(num_episodes):
+                obs = eval_env.reset()
+                ep_return = 0.0
+                ep_len = 0
+                terminated = False
+                while True:
+                    actor_obs = _norm(obs["actor_obs"])
+                    with torch.no_grad():
+                        action = self._deterministic_action(actor_obs)
+                    obs, reward, done, info = eval_env.step(action)
+                    ep_return += float(reward.item())
+                    ep_len += 1
+                    if bool(done.item()):
+                        terminated = bool(info.get("terminated", False))
+                        break
+                returns.append(ep_return)
+                lengths.append(ep_len)
+                if terminated:
+                    successes += 1
+        finally:
+            # Restore the pre-eval mode (side-effect-free evaluate()).
+            self.actor_critic.train(_ac_was_training)
+            if actor_norm is not None:
+                actor_norm.train(_norm_was_training)
 
         returns_t = torch.tensor(returns, dtype=torch.float32)
         return {

--- a/tests/training/test_rl_evaluate.py
+++ b/tests/training/test_rl_evaluate.py
@@ -3,6 +3,8 @@
 CPU-only: a tiny fake ``SimEngine`` drives a deterministic 1-DOF env so the test
 needs neither mujoco nor model downloads. Pins the eval contract: deterministic
 rollout, frozen normalizer, schema, success_rate, and the not-setup guard.
+The ``num_episodes`` domain is pinned as a table in
+``test_rl_evaluate_episode_count_domain.py``.
 """
 
 from __future__ import annotations
@@ -134,20 +136,6 @@ def test_evaluate_requires_spec_when_not_setup() -> None:
     trainer = PpoTrainer()
     with pytest.raises(ValueError, match="setup"):
         trainer.evaluate(num_episodes=2)
-
-
-def test_evaluate_rejects_bad_episode_count(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    trainer = PpoTrainer()
-    spec = RLTrainSpec(
-        env_factory=_make_env,
-        output_dir=str(tmp_path),
-        rollout_steps=4,
-        num_mini_batches=2,
-        hidden_dims=(8,),
-    )
-    trainer.setup(spec)
-    with pytest.raises(ValueError, match="num_episodes"):
-        trainer.evaluate(num_episodes=0)
 
 
 def test_evaluate_loads_checkpoint_fresh_instance(tmp_path) -> None:  # type: ignore[no-untyped-def]

--- a/tests/training/test_rl_evaluate_episode_count_domain.py
+++ b/tests/training/test_rl_evaluate_episode_count_domain.py
@@ -1,0 +1,260 @@
+"""``BaseRLAlgo.evaluate`` holds its episode count to the shared count domain.
+
+``num_episodes`` is read three times inside ``evaluate``: as the ``range()``
+bound of the episode loop, as the denominator of the reported ``success_rate``,
+and verbatim as the ``num_episodes`` field of the returned metrics dict. A bare
+``num_episodes <= 0`` test screened none of those, and the shared domain's own
+docstring names the two ways it fails: an integral or non-finite float "raises
+``TypeError`` ... rather than being coerced", and ``bool`` "is an ``int``
+subclass, so a bare ``value < 1`` test lets ``True`` through as a silent count
+of 1 while rejecting ``False``".
+
+Both consequences were reachable through the public method:
+
+* ``evaluate(num_episodes=True)`` ran one episode and reported
+  ``{"num_episodes": True, "success_rate": <successes>/True}`` - a ``bool`` in a
+  field documented ``int``, with a success rate divided by a flag.
+* ``2.5`` / ``nan`` / ``inf`` passed the comparison and raised ``TypeError`` out
+  of ``range()`` - after the env, networks and optimizers had been built and a
+  checkpoint loaded - from a method documenting ``Raises: ValueError``. That
+  raise escaped the eval-mode window before it was closed, and
+  :class:`~strands_robots.training.rl.normalization.EmpiricalNormalization`
+  freezes its running statistics in eval mode, so observation normalization
+  silently stopped learning for the rest of the run.
+
+The three sibling ``range()``-bound counts of an RL run (``total_timesteps`` /
+``rollout_steps`` / ``num_envs``) already consult
+:func:`~strands_robots.utils.positive_count_error`; this pins that the episode
+count does too, and that a count it cannot honor leaves nothing frozen.
+
+Same CPU-only shape as ``test_rl_evaluate.py``: a tiny stand-in engine drives a
+deterministic 1-DOF env, so the normalizer, the actor-critic and the eval loop
+are the real ones while the physics is not needed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from strands_robots.simulation.base import SimEngine  # noqa: E402
+from strands_robots.training.rl import PpoTrainer, RLTrainSpec, SimEnv  # noqa: E402
+from strands_robots.training.rl.normalization import EmpiricalNormalization  # noqa: E402
+from strands_robots.utils import positive_count_error  # noqa: E402
+
+# Every value the method cannot honor as an episode count. ``0`` and ``-1`` are
+# the two the replaced ``<= 0`` test already refused, kept as the rows that hold
+# both before and after the fix; the rest are the ones it let through.
+REFUSED: list[Any] = [0, -1, False, True, 2.5, 3.0, float("nan"), float("inf"), "2", None]
+ACCEPTED: list[int] = [1, 3]
+
+
+class _StandInEngine:
+    """One joint ``J`` integrated by the action - no physics backend needed."""
+
+    def __init__(self) -> None:
+        self._j = 0.0
+        self._vel = 0.0
+
+    def list_robots(self) -> list[str]:
+        return ["arm"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return ["J"]
+
+    def robot_action_keys(self, robot_name: str) -> list[str]:
+        return ["J"]
+
+    def reset(self) -> dict[str, Any]:
+        self._j = 0.0
+        self._vel = 0.0
+        return {"status": "success"}
+
+    def get_observation(self, robot_name: Any = None, *, skip_images: bool = False) -> dict[str, float]:
+        return {"J": self._j, "J.vel": self._vel}
+
+    def send_action(self, action: Any, robot_name: Any = None, n_substeps: int = 1) -> dict[str, Any]:
+        self._vel = 0.1 * (float(action[0]) if len(action) else 0.0)
+        self._j += self._vel
+        return {"status": "success"}
+
+
+def _env_factory(reward: Any = None) -> Any:
+    """Build a zero-arg factory for a deterministic 1-DOF env."""
+
+    def factory() -> SimEnv:
+        # ``SimEngine`` is a nominal ABC and ``SimEnv`` touches only the handful of
+        # methods above, so the cast is safe here - the same idiom
+        # ``test_rl_sim_env.py`` uses for its own stand-ins.
+        return SimEnv(
+            cast(SimEngine, _StandInEngine()),
+            actor_obs_keys=["J", "J.vel"],
+            reward_terms=[reward or (lambda e: 1.0)],
+            action_dim=1,
+            max_episode_steps=3,
+        )
+
+    return factory
+
+
+def _live_trainer(tmp_path: Any, reward: Any = None) -> PpoTrainer:
+    """A trainer that has been ``setup`` and has an observation normalizer."""
+    trainer = PpoTrainer()
+    trainer.setup(
+        RLTrainSpec(
+            env_factory=_env_factory(reward),
+            output_dir=str(tmp_path),
+            rollout_steps=4,
+            num_mini_batches=2,
+            hidden_dims=(8,),
+            normalize_obs=True,
+            seed=0,
+        )
+    )
+    _normalizer(trainer)  # fail here, not mid-cell, if the spec built none
+    return trainer
+
+
+def _normalizer(trainer: PpoTrainer) -> EmpiricalNormalization:
+    """The trainer's live observation normalizer.
+
+    Asserted rather than skipped: every cell below is about what happens to the
+    running statistics, so a trainer built without one would pass vacuously.
+    """
+    norm = trainer.actor_norm
+    assert norm is not None, "this pin needs a live observation normalizer (normalize_obs=True)"
+    return norm
+
+
+def _normalizer_samples(trainer: PpoTrainer) -> int:
+    """Samples the observation normalizer has folded into its running stats."""
+    return int(_normalizer(trainer).count.item())
+
+
+class TestTheEpisodeCountIsHeldToTheSharedDomain:
+    """Only a positive integer can be honored, so only one is accepted."""
+
+    @pytest.mark.parametrize("value", REFUSED, ids=repr)
+    def test_a_value_that_is_not_a_positive_integer_is_refused(self, tmp_path: Any, value: Any) -> None:
+        trainer = _live_trainer(tmp_path)
+        with pytest.raises(ValueError) as excinfo:
+            trainer.evaluate(num_episodes=value)
+        assert "num_episodes" in str(excinfo.value), (
+            f"evaluate({value!r}) was refused without naming the parameter: {excinfo.value}"
+        )
+
+    def test_the_refusal_is_the_shared_domains_own_wording(self, tmp_path: Any) -> None:
+        """Graded through the answer, not the source: a hand-rolled copy would drift.
+
+        The method must not re-implement the rule - it must ask the domain the
+        three sibling counts ask, so the same count cannot be refused by one
+        surface of an RL run and accepted by another.
+        """
+        trainer = _live_trainer(tmp_path)
+        for value in REFUSED:
+            expected = positive_count_error(value, "num_episodes", "evaluate")
+            assert expected is not None, "the shared domain does not refuse this value - fix the table"
+            with pytest.raises(ValueError) as excinfo:
+                trainer.evaluate(num_episodes=value)
+            assert str(excinfo.value) == expected, (
+                f"evaluate({value!r}) answered {str(excinfo.value)!r}, not the shared domain's {expected!r}"
+            )
+
+    @pytest.mark.parametrize("value", ACCEPTED)
+    def test_a_positive_integer_is_still_honored(self, tmp_path: Any, value: int) -> None:
+        """Over-reach control: the accepted domain is unchanged."""
+        out = _live_trainer(tmp_path).evaluate(num_episodes=value)
+        assert out["num_episodes"] == value
+        assert len(out["returns"]) == value
+        assert 0.0 <= out["success_rate"] <= 1.0
+
+    def test_a_bool_is_not_reported_as_the_episode_count(self, tmp_path: Any) -> None:
+        """``True`` used to run one episode and be echoed into the metrics dict.
+
+        ``success_rate`` is ``successes / num_episodes``, so a flag reaching the
+        field made it the denominator of a reported rate as well as the loop
+        bound - and ``False`` was refused while ``True`` was not.
+        """
+        trainer = _live_trainer(tmp_path)
+        with pytest.raises(ValueError, match="num_episodes"):
+            trainer.evaluate(num_episodes=True)
+
+
+class TestACountItCannotHonorLeavesNothingFrozen:
+    """The severity of the old guard: a refused count froze normalization.
+
+    ``evaluate`` flips the actor-critic and the observation normalizer into
+    ``eval()`` mode. ``collect_rollout`` re-enters ``actor_critic.train()``
+    itself, but ``evaluate`` is the only place in the package that puts the
+    normalizer back - so a raise that skipped the restore stopped the running
+    statistics from ever updating again, with nothing reporting that.
+    """
+
+    @pytest.mark.parametrize("value", [2.5, float("nan"), float("inf")], ids=repr)
+    def test_the_normalizer_still_learns_after_a_refused_count(self, tmp_path: Any, value: Any) -> None:
+        trainer = _live_trainer(tmp_path)
+        trainer.collect_rollout()
+        before = _normalizer_samples(trainer)
+        assert before > 0, "the normalizer folded nothing, so this cell would pass vacuously"
+
+        with pytest.raises(ValueError, match="num_episodes"):
+            trainer.evaluate(num_episodes=value)
+
+        assert _normalizer(trainer).training is True, f"evaluate({value!r}) left the normalizer in eval() mode"
+        trainer.collect_rollout()
+        assert _normalizer_samples(trainer) > before, (
+            f"observation normalization stopped learning after evaluate({value!r}): "
+            f"the running stats are still at {before} samples"
+        )
+
+
+class TestTheEvalModeWindowIsClosedOnEveryExit:
+    """A reward term raising on a live engine must not freeze the trainer either.
+
+    The count guard removes the trigger this module is named for; the window is
+    closed in ``finally`` so the stated "side-effect-free" contract does not
+    depend on which exception was possible.
+    """
+
+    @staticmethod
+    def _reward_that_fails_after(n: int) -> Any:
+        calls = {"n": 0}
+
+        def reward(engine: Any) -> float:
+            calls["n"] += 1
+            if calls["n"] > n:
+                raise RuntimeError("reward term failed on a live engine")
+            return 1.0
+
+        reward.calls = calls  # type: ignore[attr-defined]
+        return reward
+
+    def test_an_exception_from_the_rollout_restores_the_modes(self, tmp_path: Any) -> None:
+        reward = self._reward_that_fails_after(6)
+        trainer = _live_trainer(tmp_path, reward=reward)
+        trainer.collect_rollout()
+        before = _normalizer_samples(trainer)
+
+        with pytest.raises(RuntimeError, match="reward term failed"):
+            trainer.evaluate(num_episodes=3)
+
+        assert trainer.actor_critic.training is True, "actor_critic left in eval() after a raising rollout"
+        assert _normalizer(trainer).training is True, "actor_norm left in eval() after a raising rollout"
+
+        reward.calls["n"] = -(10**6)  # let the reward work again
+        trainer.collect_rollout()
+        assert _normalizer_samples(trainer) > before, "observation normalization stopped learning after a raise"
+
+    def test_the_exception_is_not_swallowed(self, tmp_path: Any) -> None:
+        """Control: the restore is a ``finally``, never a ``return``/``except``.
+
+        Holds both before and after the fix - it is what stops the remedy from
+        turning a failed evaluation into a reported one.
+        """
+        trainer = _live_trainer(tmp_path, reward=self._reward_that_fails_after(6))
+        trainer.collect_rollout()
+        with pytest.raises(RuntimeError, match="reward term failed"):
+            trainer.evaluate(num_episodes=3)


### PR DESCRIPTION
`BaseRLAlgo.evaluate` reads `num_episodes` three times, and guarded it with a bare `num_episodes <= 0` test that screens none of them:

| read | line |
| --- | --- |
| the `range()` bound of the episode loop | `for _ in range(num_episodes)` |
| the denominator of the reported success rate | `"success_rate": float(successes / num_episodes)` |
| the `num_episodes` field of the returned metrics | `"num_episodes": num_episodes` |

The shared count domain's own docstring names both ways that test fails: an integral or non-finite float "raises `TypeError` ... rather than being coerced", and `bool` "is an `int` subclass, so a bare `value < 1` test lets `True` through as a silent count of 1 while rejecting `False`". The three sibling `range()`-bound counts of an RL run (`total_timesteps` / `rollout_steps` / `num_envs`) already consult it; the episode count did not.

## Measured

One PPO trainer per row over a MuJoCo SO-101: `setup` -> `collect_rollout` -> `evaluate(value)` -> `collect_rollout`.

![evaluate() episode count, before and after](https://raw.githubusercontent.com/cagataycali/robots/07918e8423aab2bcbefe39ee150c32396bf7703d/.artifacts/evaluate_episode_count.png)

| `num_episodes` | before | after |
| --- | --- | --- |
| `2` | returned, `num_episodes=2`, 2 episodes | unchanged |
| `0` | `ValueError` | `ValueError` |
| `True` | **returned, `num_episodes=True`, 1 episode** | `ValueError` |
| `2.5` | `TypeError`, **normalization frozen** | `ValueError` |
| `nan` | `TypeError`, **normalization frozen** | `ValueError` |
| `inf` | `TypeError`, **normalization frozen** | `ValueError` |
| `'2'` | `TypeError` | `ValueError` |

`0` and `2` are the rows the replaced test already got right, and they are unchanged.

## Why a frozen normalizer is the cost

`evaluate` flips the actor-critic **and** the observation normalizer into `eval()` mode, and `EmpiricalNormalization` freezes its running statistics in eval mode ("the learned statistics are frozen at BOTH entry points"). The restore sat after the episode loop, so a raise out of `range(num_episodes)` skipped it. `collect_rollout` re-enters `actor_critic.train()` itself, but `evaluate` is the **only** place in the package that puts the normalizer back:

```
evaluate(num_episodes=2.5)  ->  TypeError
normalizer samples: 4  ->  collect_rollout()  ->  4      # never updates again
```

against every healthy row's `4 -> 8`. Nothing reports that it stopped: `mean_return` and `success_rate` keep being produced.

That window is reachable without a bad count at all - a caller-supplied reward term or `success_fn` raising on a live engine froze normalization identically (measured: `RuntimeError` propagates, `4 -> 4`). So the restore moved into `finally`, which is what makes the stated "side-effect-free evaluate()" contract hold on every exit instead of only the happy path.

## Change

* `num_episodes` consults `positive_count_error(num_episodes, "num_episodes", "evaluate")`, so the refusal is the shared domain's own wording and the documented `Raises: ValueError` is what a caller actually gets.
* The eval-mode window is closed in `finally`. The exception is re-raised, not swallowed - no `return`/`break` in the `finally`.
* `Args:` and `Raises:` corrected; `docs/training/rl.md` gained the `evaluate` contract, which was the one `BaseRLAlgo` lifecycle method the page did not document.

Production change is **+2 executable statements** (113 -> 115 by AST); the rest of the source diff is the comment explaining the three reads.

## Tests

`tests/training/test_rl_evaluate_episode_count_domain.py` (new, CPU-only, same stand-in-engine shape as `test_rl_evaluate.py`, so the normalizer, actor-critic and eval loop are the real ones):

* a 10-value table of counts that cannot be honored, plus a cell asserting each refusal is **byte-identical to `positive_count_error`'s own answer** - graded through the answer, not the source, so a hand-rolled copy cannot drift back in;
* the normalizer still learns after a refused count (`2.5` / `nan` / `inf`), with a non-vacuity assert that it had folded samples first;
* an exception from the rollout restores both modes and leaves normalization learning.

Pre-fix (source reverted, tests kept): **13 failed / 12 passed** - each failure naming the defect (`DID NOT RAISE ValueError`, `'float' object cannot be interpreted as an integer`, `actor_critic left in eval() after a raising rollout`). Post-fix: **25 passed**. The rows that hold both ways are the controls: `0` / `-1` / `False` refused, `1` / `3` accepted, and the exception not swallowed.

`test_evaluate_rejects_bad_episode_count` is removed: it drove only `num_episodes=0`, which is row 1 of the new table (-14 lines, no coverage lost).

## Gate

| check | result |
| --- | --- |
| `ruff check` / `ruff format --check` (`strands_robots tests tests_integ`) | clean, 1868 files |
| `mypy strands_robots tests tests_integ` (1.20.2) | `Success: no issues found in 1865 source files`, 0 suppressions |
| `pytest tests/training` | 3782 passed, 4 skipped, 0 failed |
| `pytest tests/test_docs*.py tests/test_markdown_links_resolve.py` | 245 passed |
| changelog graders | 91 passed |
| `scripts/check_whole_tree_graders.py` | 4323 passed, 7 failed - all environmental on this host (`rclpy` resolvable where 5 cells assert it is absent; installed `websockets` 16.0 has no `Server.shutdown` at all, which 2 cells read against the declared `>=17.0`) |

`tests/training` collected 3768 -> 3786: +19 new cells, -1 folded.

Size: +367 / -45 across 5 files, of which the new test file is +260 and the changelog fragment +28.