### PR TITLE
fix(tools/lerobot_camera): every span the tool reports is measured on the clock that cannot step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1910,6 +1910,19 @@ which side the enum is on.
   the tree sat in `dashboard/auth.py`, where a WebAuthn challenge's TTL was measured on the
   wall clock. Same predicate, wider root, found it at once: a walk root narrower than the
   shape being graded reports a clean tree, not an ungraded one.
+- **A predicate that grades a decision does not grade a report.** That scan reports a
+  wall-clock read inside the test of a wait, which is the shape that truncates one, and
+  `lerobot_camera` was clean by it while four of its five handlers measured every span
+  they *report* on the wall clock - `capture`'s connect and read times, `capture_batch`'s
+  per-camera time and its total, `record`'s achieved duration, and `test`'s connect plus
+  two ten-frame windows. Nothing there decides on a clock (the recording is bounded by a
+  frame count, the windows by `range(10)`), and `preview`, whose deadline does decide, had
+  already moved. A reported span is a duration all the same, and the `test` action turns
+  each one into a verdict about the *camera*: a -30 s correction inside a ten-frame window
+  reports `Est. FPS: -0.3` and calls the camera `Good`, because a negative average is
+  below the 100 ms threshold. Pinned on behaviour by
+  `tests/tools/test_camera_durations_survive_a_clock_step.py`, which asserts what the tool
+  reports across a step rather than which clock the source names.
 - Pinned by `tests/test_expiry_gates_survive_a_clock_step.py` (a scan over the whole
   package, no exemption list), by `tests/tools/test_tool_wait_budgets_survive_a_clock_step.py`
   for the real `spin_for` behaviour, by

--- a/changelog.d/3200-camera-spans-on-a-monotonic-clock.md
+++ b/changelog.d/3200-camera-spans-on-a-monotonic-clock.md
@@ -1,0 +1,39 @@
+### Fixed: a camera tool's reported span is the work's, not the size of a clock correction
+
+Four of `lerobot_camera`'s five span-reporting handlers measured those spans on
+`time.time()` -- `capture`'s connect and read times, `capture_batch`'s per-camera
+time and its batch total, `record`'s achieved duration, and `test`'s connect plus
+its two ten-frame read windows. `preview` already measured its bases on
+`time.monotonic()`, so the module held both answers at once.
+
+`time.time()` is the current opinion about the date, so an NTP correction, a
+`date -s` or a resume from suspend landing inside one of those windows is
+subtracted from the span, and nothing raises. On a camera reading in 20 ms, with
+one correction placed inside the ten sync reads of `action="test"`:
+
+```
++30 s   Average: 3.020s    Est. FPS: 0.3     Sync capture: Slow
+-30 s   Average: -2.980s   Est. FPS: -0.3    Sync capture: Good
+```
+
+The second line is the worse one. `test` does not merely report the span: it
+turns it into a claim about the camera -- `Est. FPS` is `1 / avg_sync_time`,
+`Sync capture` is `Good` below 100 ms, `Connection` is `Fast` below one second --
+and a negative average is below every one of those thresholds. So a corrected
+clock reported a physically impossible frame rate and called the device good,
+while an average of exactly zero divided by zero. `capture` reported
+`Connect time: -29.980s` on the same step, and `capture_batch` reported
+`Total time: 30.041s` for a batch of one 20 ms read.
+
+Every duration base now reads `time.monotonic()` and carries that clock in its
+name, and `capture_batch` no longer spells its base and its duration as one
+variable. The absolute stamps this tool writes -- a filename's date, a report's
+`Timestamp` line -- come from `datetime.now()` and are unchanged; the module
+states that boundary once, in its docstring, and now reads no wall clock at all.
+
+The package-wide scan in `tests/test_expiry_gates_survive_a_clock_step.py` was
+silent on all of this and was right to be: it grades a wall-clock read that
+decides whether to keep *waiting*, and none of these does -- the recording is
+bounded by a frame count and the windows by `range(10)`. The new cells in
+`tests/tools/test_camera_durations_survive_a_clock_step.py` grade what the tool
+*reports* across a step instead.

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -2,6 +2,18 @@
 """
 LeRobot-based camera tool for Strands agents.
 Leverages LeRobot's OpenCV and RealSense camera classes for professional camera management.
+
+Every span this tool measures - a connect time, a per-frame capture time, a
+recording's achieved duration - is a duration, so it is measured on
+``time.monotonic()`` and its base carries that clock in its name
+(``..._started_mono``). ``time.time()`` is not a clock but the current opinion
+about the date, and an NTP correction, a ``date -s`` or a resume from suspend
+landing inside one of these windows subtracts the step from the span. The
+performance test then reads that span as a verdict about the camera (``Est.
+FPS``, ``Fast``/``Slow``, ``Good``/``Slow``), so a corrected clock is reported
+as a device measurement. The absolute stamps this tool writes - a filename's
+date, a report's ``Timestamp`` line - are the other half of that boundary and
+stay on ``datetime.now()``.
 """
 
 import json
@@ -647,16 +659,16 @@ def _capture_single_image(
         camera = _create_camera(camera_type, camera_id, width, height, fps, color_mode, rotation)
 
         # Connect and capture
-        start_time = time.time()
+        connect_started_mono = time.monotonic()
         camera.connect(warmup=warmup)
-        connect_time = time.time() - start_time
+        connect_time = time.monotonic() - connect_started_mono
 
-        start_time = time.time()
+        capture_started_mono = time.monotonic()
         if async_mode:
             frame = camera.async_read(timeout_ms=timeout_ms)
         else:
             frame = camera.read()
-        capture_time = time.time() - start_time
+        capture_time = time.monotonic() - capture_started_mono
 
         # Save image
         success = cv2.imwrite(file_path, cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
@@ -723,7 +735,7 @@ def _capture_batch_images(
 
         results = []
         successful_captures = 0
-        total_time = time.time()
+        batch_started_mono = time.monotonic()
 
         def capture_single_camera(cam_id):
             try:
@@ -739,7 +751,7 @@ def _capture_batch_images(
                 # Create and use camera
                 camera = _create_camera(camera_type, cam_id, width, height, fps, color_mode, rotation)
 
-                start_time = time.time()
+                capture_started_mono = time.monotonic()
                 camera.connect(warmup=warmup)
 
                 if async_mode:
@@ -747,7 +759,7 @@ def _capture_batch_images(
                 else:
                     frame = camera.read()
 
-                capture_time = time.time() - start_time
+                capture_time = time.monotonic() - capture_started_mono
 
                 # Save image
                 success = cv2.imwrite(file_path, cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
@@ -784,7 +796,7 @@ def _capture_batch_images(
                 if result["status"] == "success":
                     successful_captures += 1
 
-        total_time = time.time() - total_time
+        total_time = time.monotonic() - batch_started_mono
 
         # Format results and prepare content list
         result_info = [" **Batch Camera Capture Results:**", ""]
@@ -866,7 +878,7 @@ def _record_video_sequence(
         video_writer = cv2.VideoWriter(video_path, fourcc, fps, (width, height))
 
         frames_captured = 0
-        start_time = time.time()
+        started_mono = time.monotonic()
         target_frames = int(fps * capture_duration)
 
         try:
@@ -883,7 +895,7 @@ def _record_video_sequence(
 
                 # Progress update every second
                 if frames_captured % fps == 0:
-                    elapsed = time.time() - start_time
+                    elapsed = time.monotonic() - started_mono
                     remaining = capture_duration - elapsed
                     print(f"Recording... {elapsed:.1f}s / {capture_duration:.1f}s ({remaining:.1f}s remaining)")
 
@@ -891,7 +903,7 @@ def _record_video_sequence(
             video_writer.release()
             camera.disconnect()
 
-        actual_duration = time.time() - start_time
+        actual_duration = time.monotonic() - started_mono
         file_size = os.path.getsize(video_path)
 
         result_info = [
@@ -1036,19 +1048,19 @@ def _test_camera_performance(
         test_results.append(" **Camera Performance Test**\n")
 
         # Connection test
-        start_time = time.time()
+        connect_started_mono = time.monotonic()
         camera = _create_camera(camera_type, camera_id, width, height, fps, color_mode, rotation)
         camera.connect(warmup=warmup)
-        connect_time = time.time() - start_time
+        connect_time = time.monotonic() - connect_started_mono
 
         test_results.append(f"**Connection Test**: {connect_time:.3f}s")
 
         # Frame capture test (sync)
         capture_times = []
         for i in range(10):
-            start_time = time.time()
+            read_started_mono = time.monotonic()
             frame = camera.read()
-            capture_time = time.time() - start_time
+            capture_time = time.monotonic() - read_started_mono
             capture_times.append(capture_time)
 
         avg_sync_time = np.mean(capture_times)
@@ -1065,9 +1077,9 @@ def _test_camera_performance(
         if async_mode:
             async_times = []
             for i in range(10):
-                start_time = time.time()
+                read_started_mono = time.monotonic()
                 frame = camera.async_read(timeout_ms=timeout_ms)
-                async_time = time.time() - start_time
+                async_time = time.monotonic() - read_started_mono
                 async_times.append(async_time)
 
             avg_async_time = np.mean(async_times)

--- a/tests/tools/test_camera_durations_survive_a_clock_step.py
+++ b/tests/tools/test_camera_durations_survive_a_clock_step.py
@@ -1,0 +1,292 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Every span ``lerobot_camera`` reports is measured on the clock that cannot step.
+
+``lerobot_camera`` reports a span from four of its actions: ``capture`` reports a
+connect time and a capture time, ``capture_batch`` a per-camera capture time and
+a batch total, ``record`` the recording's achieved duration, and ``test`` a
+connect time plus two ten-frame read windows. Those windows are durations, so the
+tree's clock boundary puts them on ``time.monotonic()`` -- and ``preview``, the
+fifth, already had them there, with the reason written above its bases. The other
+four measured on ``time.time()``, which is not a clock but the current opinion
+about the date: an NTP correction, a ``date -s`` or a resume from suspend lands
+inside the window and the step is subtracted from the span, with nothing raised.
+
+``test`` is why this is not only a cosmetic mis-report. It turns each span into a
+verdict about the *camera*: ``Est. FPS: {1 / avg_sync_time}``, ``Connection:
+Fast`` below one second, ``Sync capture: Good`` below 100 ms, ``Frame rate:
+Stable`` within a 50 ms spread. A +30 s correction landing in the ten sync reads
+makes one sample 30 s, so a camera reading in 20 ms is reported as ``Slow`` at
+``0.3`` FPS; a -30 s correction makes the sample negative, and the tool then
+reports a negative frame rate as a measurement, calls the camera ``Good`` because
+a negative average is below the threshold, and can divide by a zero average.
+
+These cells drive the real handlers with a wall clock that takes one step
+mid-window and assert on what the tool *reports*, which is stronger than the
+source shape: a span measured on the wall clock cannot pass them whatever it is
+named. The step is a property of the clock double rather than of a read the
+implementation performs, so it lands whether or not the code under test consults
+that clock -- which a correct implementation does not. That is the same shape as
+``tests/tools/test_tool_wait_budgets_survive_a_clock_step.py``, which pins the
+budgets ``spin_for`` and the preview *decide* on; this file pins the spans this
+tool *reports*, and the last cell pins that no wall-clock read is left in the
+module for a later span to be built from.
+
+The package-wide source scan cannot see any of this and is right not to:
+``tests/test_expiry_gates_survive_a_clock_step.py`` grades a wall-clock read that
+decides whether to keep waiting, and none of these four does. The recording is
+bounded by a frame count and the ten-frame loops by ``range(10)``, so the tree
+was clean by that predicate while four handlers reported spans off the wall
+clock.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+import time
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.lerobot_camera as cam_mod
+
+#: Real seconds each modelled device operation takes. Wide enough that a clock
+#: step can be armed to land inside a specific window, and small enough to keep
+#: the whole file under a second of real time.
+_READ_SECONDS = 0.02
+
+
+class _SlowCamera:
+    """A camera stand-in whose every operation takes a measurable span.
+
+    ``tests/tools/test_lerobot_camera_async_read_budget.py`` has a sibling double
+    for the read *budget*; this one exists for the read *span*, so its reads are
+    slow enough (``_READ_SECONDS``) for a clock step to be placed inside one and
+    fast enough that a real camera's verdicts still hold: 20 ms per frame is
+    ``Good`` (under 100 ms) at an estimated 50 FPS.
+    """
+
+    def __init__(self) -> None:
+        self.width = 8
+        self.height = 6
+        self.fps = 30
+        self.color_mode = type("_M", (), {"value": "RGB"})()
+        self.rotation: Any = None
+
+    def connect(self, warmup: bool = True) -> None:
+        time.sleep(_READ_SECONDS)
+
+    def disconnect(self) -> None:
+        return None
+
+    def _frame(self) -> np.ndarray:
+        time.sleep(_READ_SECONDS)
+        return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+    def read(self) -> np.ndarray:
+        return self._frame()
+
+    def async_read(self, timeout_ms: float = 1000) -> np.ndarray:
+        return self._frame()
+
+
+class _SteppingWallClock:
+    """A wall clock that takes a single step, the way an NTP correction does.
+
+    Elapsed real time comes from ``time.monotonic()``, so the double advances
+    exactly as the true wall clock would, plus one discontinuity of ``step_by``
+    seconds once ``step_after`` seconds of real time have passed. The trigger is
+    real time rather than a read count, so the step lands whether or not the code
+    under test reads this clock -- which is what lets the premise be asserted
+    independently of the behaviour.
+    """
+
+    def __init__(self, step_after: float, step_by: float) -> None:
+        self._epoch = 1_700_000_000.0
+        self._origin = time.monotonic()
+        self._step_after = step_after
+        self._step_by = step_by
+        self._stepped = False
+
+    def __call__(self) -> float:
+        elapsed = time.monotonic() - self._origin
+        if not self._stepped and elapsed >= self._step_after:
+            self._stepped = True
+            self._epoch += self._step_by
+        return self._epoch + elapsed
+
+
+@pytest.fixture
+def camera(monkeypatch: pytest.MonkeyPatch) -> _SlowCamera:
+    """Substitute the camera factory and neutralise every sink a handler writes to."""
+    cam = _SlowCamera()
+
+    monkeypatch.setattr(cam_mod, "_create_camera", lambda *a, **k: cam)
+    writer = type("_W", (), {"write": lambda self, f: None, "release": lambda self: None})()
+    monkeypatch.setattr(cam_mod.cv2, "VideoWriter", lambda *a, **k: writer)
+    monkeypatch.setattr(cam_mod.cv2, "VideoWriter_fourcc", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr(cam_mod.cv2, "imwrite", lambda *a, **k: True)
+    monkeypatch.setattr(cam_mod.os.path, "getsize", lambda p: 1234)
+    return cam
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, clock: _SteppingWallClock) -> None:
+    """Make ``clock`` the process wall clock for the duration of one cell."""
+    monkeypatch.setattr(cam_mod.time, "time", clock)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+def _reported(text: str, label: str) -> float:
+    """The number the report states for ``label``, as the caller reads it."""
+    match = re.search(rf"{re.escape(label)}[^-\d]*(-?\d+\.?\d*)", text)
+    assert match is not None, f"the report states no {label!r}: {text}"
+    return float(match.group(1))
+
+
+def test_the_stepping_wall_clock_double_takes_the_step_it_advertises() -> None:
+    """Pin the double: with no real discontinuity the cells below prove nothing."""
+    clock = _SteppingWallClock(step_after=0.01, step_by=+30.0)
+    before = clock()
+    time.sleep(0.05)
+    after = clock()
+
+    assert after - before > 29.0, f"the double advanced {after - before:.3f}s, so it never stepped"
+
+
+class TestASpanIsNotTheSizeOfAClockCorrection:
+    """A reported span is the work's, so a step cannot appear in it."""
+
+    def test_a_capture_reports_the_connect_and_read_spans_it_measured(
+        self, camera: _SlowCamera, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A -30 s step inside the connect makes a wall-clock span negative."""
+        _install(monkeypatch, _SteppingWallClock(step_after=_READ_SECONDS / 2, step_by=-30.0))
+
+        result = cam_mod.lerobot_camera(
+            action="capture", camera_type="opencv", camera_id=0, save_path=str(tmp_path), width=8, height=6
+        )
+
+        assert result["status"] == "success"
+        text = _text(result)
+        assert 0.0 <= _reported(text, "Connect time:") < 5.0, text
+        assert 0.0 <= _reported(text, "Capture time:") < 5.0, text
+
+    def test_a_batch_reports_a_total_that_is_the_work_rather_than_the_step(
+        self, camera: _SlowCamera, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The batch total shared one variable with its own base, so it is graded too."""
+        _install(monkeypatch, _SteppingWallClock(step_after=_READ_SECONDS / 2, step_by=+30.0))
+
+        result = cam_mod.lerobot_camera(
+            action="capture_batch", camera_type="opencv", camera_ids=[0], save_path=str(tmp_path), width=8, height=6
+        )
+
+        assert result["status"] == "success"
+        assert 0.0 <= _reported(_text(result), "Total time:") < 5.0, _text(result)
+
+    @pytest.mark.parametrize("step_by", (+30.0, -30.0))
+    def test_a_recording_reports_the_duration_it_actually_took(
+        self, camera: _SlowCamera, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, step_by: float
+    ) -> None:
+        """The recording is frame-bounded, so only its reported duration can be wrong.
+
+        The step is armed for ``_READ_SECONDS * 2``, which is inside the four-frame
+        loop rather than inside the connect that precedes it: a step landing
+        *before* the duration base is taken moves the base and the end together
+        and is invisible, so a window this cell can only grade from inside.
+        """
+        _install(monkeypatch, _SteppingWallClock(step_after=_READ_SECONDS * 2, step_by=step_by))
+
+        result = cam_mod.lerobot_camera(
+            action="record",
+            camera_type="opencv",
+            camera_id=0,
+            save_path=str(tmp_path),
+            width=8,
+            height=6,
+            fps=2,
+            capture_duration=2.0,
+        )
+
+        assert result["status"] == "success"
+        assert 0.0 <= _reported(_text(result), "Duration:") < 5.0, _text(result)
+
+
+class TestAPerformanceVerdictIsAboutTheCameraNotTheClock:
+    """``test`` turns each span into a verdict, so a step becomes a device claim."""
+
+    def test_a_forward_step_does_not_report_a_fast_camera_as_slow(
+        self, camera: _SlowCamera, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One +30 s sample among ten 20 ms reads averages 3 s: ``Slow`` at 0.3 FPS."""
+        _install(monkeypatch, _SteppingWallClock(step_after=_READ_SECONDS * 3, step_by=+30.0))
+
+        result = cam_mod.lerobot_camera(
+            action="test", camera_type="opencv", camera_id=0, save_path=str(tmp_path), width=8, height=6
+        )
+
+        assert result["status"] == "success"
+        text = _text(result)
+        assert "Sync capture: Good" in text, text
+        assert "Connection: Fast" in text, text
+        assert _reported(text, "Est. FPS:") > 5.0, text
+
+    def test_a_backward_step_does_not_report_a_negative_frame_rate(
+        self, camera: _SlowCamera, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A negative average is also below every threshold, so the verdict flatters."""
+        _install(monkeypatch, _SteppingWallClock(step_after=_READ_SECONDS * 3, step_by=-30.0))
+
+        result = cam_mod.lerobot_camera(
+            action="test", camera_type="opencv", camera_id=0, save_path=str(tmp_path), width=8, height=6
+        )
+
+        assert result["status"] == "success"
+        text = _text(result)
+        assert _reported(text, "Est. FPS:") > 5.0, text
+        assert _reported(text, "Average:") >= 0.0, text
+        assert _reported(text, "Min:") >= 0.0, text
+
+
+def test_no_span_in_the_module_can_be_built_from_the_wall_clock_again() -> None:
+    """The module reads no wall clock at all, so a new span cannot pick one up.
+
+    Every clock read here is a duration; the absolute stamps this tool writes -- a
+    filename's date, a report's ``Timestamp`` line -- come from ``datetime.now()``
+    rather than from ``time.time()``, which is why the count that holds is zero
+    rather than "the stamps only". The premise below states that the stamps are
+    still written, so this is not read as a module that stopped stamping.
+    """
+    source = pathlib.Path(cam_mod.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    wall_reads = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in ("time", "time_ns")
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "time"
+    ]
+    stamps = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "now"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "datetime"
+    ]
+
+    assert stamps, "premise: this module stamps its reports, so a stamp call must be present"
+    assert not wall_reads, (
+        f"these lines read the wall clock: {wall_reads}. Every span this tool reports is a "
+        "duration and belongs on time.monotonic(); an absolute stamp here is written with "
+        "datetime.now()"
+    )


### PR DESCRIPTION
## What is wrong

Four of `lerobot_camera`'s five span-reporting handlers measured those spans on `time.time()`:

| handler | span it reports | measured on |
|---|---|---|
| `capture` | `Connect time`, `Capture time` | `time.time()` |
| `capture_batch` | per-camera time, `Total time` | `time.time()` |
| `record` | `Duration` (achieved) | `time.time()` |
| `test` | `Connection Test`, two ten-frame windows | `time.time()` |
| `preview` | `Duration`, `Average FPS` | **`time.monotonic()`** already |

So the module held both answers at once, and the one it already had carried the reason above its bases ("Durations, so they are measured on `time.monotonic()`").

`time.time()` is not a clock but the current opinion about the date: an NTP correction, a `date -s` or a resume from suspend lands inside the window and the step is subtracted from the span, with nothing raised.

## Measured

A camera reading in 20 ms, with a single +/-30 s wall-clock correction placed inside the window, read off the text the tool returns:

| step | `test` reports | verdict it derives |
|---|---|---|
| +30 s in the ten sync reads | `Average: 3.020s`, `Est. FPS: 0.3` | `Sync capture: Slow` |
| -30 s in the ten sync reads | `Average: -2.980s`, `Est. FPS: -0.3` | `Sync capture: Good` |

The second row is the worse one. `test` is not merely reporting a number: it turns each span into a claim about the *camera* - `Est. FPS: {1 / avg_sync_time}`, `Connection: Fast` under one second, `Sync capture: Good` under 100 ms, `Frame rate: Stable` within a 50 ms spread - and a negative average is below every one of those thresholds. So a corrected clock reports a physically impossible frame rate and calls the device good, and an average of exactly zero divides by zero.

The other two handlers on the same step:

```
capture        Connect time: -29.980s     (a span that cannot be negative)
capture_batch  Total time: 30.041s        (on a batch of one 20 ms read)
```

`capture_batch` also spelled its duration base and the duration itself as one variable (`total_time = time.time()` ... `total_time = time.time() - total_time`), which is the arrangement the tree's clock boundary says to split.

## What changed

- Every duration base in the module reads `time.monotonic()` and carries that clock in its name (`connect_started_mono`, `capture_started_mono`, `batch_started_mono`, `started_mono`, `read_started_mono`), so a later reader cannot subtract a wall-clock stamp from one. `capture_batch`'s base and duration are now two names.
- The boundary is stated once, in the module docstring, rather than repeated at each site: the spans are durations, and the absolute stamps this tool writes - a filename's date, a report's `Timestamp` line - come from `datetime.now()` and are untouched.
- No wall-clock read is left in the module at all, so a new span cannot pick one up.
- `tests/tools/test_camera_durations_survive_a_clock_step.py` (new, 8 cells) drives the real handlers with a wall clock that takes one step mid-window and asserts on **what the tool reports**, which is stronger than a source shape. The step is a property of the clock double rather than of a read the implementation performs, so it lands whether or not the code consults that clock - which a correct implementation does not. One cell is an AST scan pinning the zero remaining wall-clock reads, with a premise assertion that the stamps are still written.
- `AGENTS.md`: one bullet in the clock section recording why the existing package-wide scan was silent here.

No behaviour changes with an unstepped clock: the recording is still bounded by its frame count, the windows still by `range(10)`, and the reported values are the same spans.

## Why the package-wide scan did not catch it, and why it was right not to

`tests/test_expiry_gates_survive_a_clock_step.py` reports a wall-clock read *inside the test of a wait* - the shape that truncates one. None of these four does that: the recording is bounded by a frame count, the ten-frame loops by `range(10)`, and each connect is a single blocking call. The tree was clean by that predicate while four handlers reported spans off the wall clock. A predicate that grades a decision does not grade a report - the sibling of the walk-root lesson already recorded in that file's own docstring, which is why the new cells are behavioural and subsystem-scoped rather than a widening of the scan.

## Grading

| check | result |
|---|---|
| new cells on this head | **8 passed** |
| new cells on the parent commit `31d7ed5` | **7 failed, 1 passed** - the one that passes is the clock double's own premise, which is a property of the double |
| `tests/tools/test_lerobot_camera*.py` + both clock-step families | 309 passed, 5 failed - all five are this sandbox's `lerobot` stub (`OpenCVCamera has no attribute 'find_cameras'`, `lerobot.cameras.realsense` absent), none touch the changed lines |
| `tests/test_expiry_gates_survive_a_clock_step.py` | passed (unchanged) |
| doc / changelog / xref graders (`markdown_links_resolve`, `changelog_fragments`, `changelog_format`, `docstring_module_xrefs`, `agent_tool_parameter_descriptions`) | 130 passed |
| `ruff check` / `ruff format --check` | clean |
| `mypy` on both changed Python files | `Success: no issues found in 2 source files` |

This sandbox has no `lerobot` and no `torch`, so the five failures above are environmental and CI grades the rest.

## Risk

Contained to one tool module. The spans reported are the same values on an unstepped clock; the change is which clock they come from, plus their names. No parameter, action, schema or return shape moves.
