### PR TITLE
fix(simulation): a render-dimension refusal names the method that was called

### DIFF
--- a/changelog.d/3201-render-dims-refusal-names-the-caller.md
+++ b/changelog.d/3201-render-dims-refusal-names-the-caller.md
@@ -1,0 +1,48 @@
+### Fixed: a render-dimension refusal names the method that was called
+
+Both the MuJoCo and the Newton backend funnel the width/height domain of every
+render surface through one helper -- `_validate_render_dims` on MuJoCo,
+`_resolve_camera_view` on Newton -- and each helper spelled the subject of its
+own refusals as the literal `render`. Each serves more than `render`, so five of
+the eleven entry points across the three backends reported a method the caller
+had not called. Measured with `width=0` against a live world on each backend:
+
+| backend | called | before | after |
+|---|---|---|---|
+| mujoco | `render` | `render: ...` | unchanged |
+| mujoco | `render_depth` | **`render: ...`** | `render_depth: ...` |
+| mujoco | `get_frame` | **`render: ...`** | `get_frame: ...` |
+| mujoco | `get_camera_params` | **`render: ...`** | `get_camera_params: ...` |
+| mujoco | `add_camera` | `add_camera: ...` | unchanged |
+| newton | `render` | `render: ...` | unchanged |
+| newton | `get_frame` | **`render: ...`** | `get_frame: ...` |
+| newton | `get_camera_params` | **`render: ...`** | `get_camera_params: ...` |
+| isaac | `get_frame` / `get_camera_params` | names itself | unchanged |
+
+The reader is usually an agent -- `render` and `add_camera` are tool-callable and
+return the text in an error envelope, while `get_frame` and `get_camera_params`
+raise it -- so the repair the message suggests is a call the caller never made.
+`render` also has a different signature and return type from the two raising
+methods, so following it means editing an unrelated call site.
+
+That the misattribution mattered was already established in the tree twice over.
+MuJoCo's `add_camera` repaired it after the fact with
+`text.replace("render:", "add_camera:", 1)`, a coupling to the literal prefix of
+all four messages the guard can return which a rewording would silently break;
+and Isaac never had the defect, passing its own name to `positive_count_error` at
+each call site. The ~20 domain helpers in `strands_robots.utils` all take their
+caller's name for the same reason -- these two guards were the exception.
+
+Both now take a required `context`, so each entry point names itself and the
+string patch is gone. Required rather than defaulted to `"render"`, because a
+default is the shape that produced the defect. Isaac is unchanged: it is the
+control.
+
+Two existing parity suites asserted the two texts were byte-identical, which is
+a stronger claim than the drift they exist to catch -- byte-identity also
+*required* `render_depth` and `get_camera_params` to report `render`, so the
+misattribution was the pinned behaviour. Both now compare the reason with each
+subject stripped, keeping the anti-drift guarantee while making a wrong subject a
+failure. The new suite derives the expected subject from each call's own
+enclosing method, so a sixth entry point cannot join either funnel without naming
+itself -- the failure mode that produced this.

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -265,9 +265,27 @@ class RenderingMixin:
         def _apply_kinematic_attachments(self) -> None:
             """Provided by ``ManipulationMixin``; declared here for type-checkers."""
 
-    def _validate_render_dims(self, width: int, height: int) -> dict[str, Any] | None:
+    def _validate_render_dims(self, width: int, height: int, context: str) -> dict[str, Any] | None:
         """reject non-positive render dims; convert MuJoCo's framebuffer
         overflow to a plain-English message that tells the LLM the actual cap.
+
+        Args:
+            width: Requested image width in pixels.
+            height: Requested image height in pixels.
+            context: The public method being called, quoted as the subject of
+                every refusal below. Required rather than defaulted to
+                ``"render"``, the way the ~20 domain helpers in
+                :mod:`strands_robots.utils` all take their caller's name: this
+                guard serves five public entry points, and a default is the
+                shape that let four of them report ``render`` to a caller who
+                had not called it. ``add_camera`` used to repair that after the
+                fact with ``text.replace("render:", "add_camera:", 1)`` - a
+                coupling to the literal prefix of every message here, which a
+                rewording would silently break.
+
+        Returns:
+            An agent-tool error envelope naming ``context``, or ``None`` when
+            the dimensions are usable.
         """
         # bool is an int subclass, so `isinstance(True, int)` passes: True would
         # be taken as a 1-pixel dimension and reach MuJoCo, which rejects it
@@ -277,13 +295,15 @@ class RenderingMixin:
             return {
                 "status": "error",
                 "content": [
-                    {"text": f"render: width/height must be int, got {type(width).__name__}/{type(height).__name__}."}
+                    {
+                        "text": f"{context}: width/height must be int, got {type(width).__name__}/{type(height).__name__}."
+                    }
                 ],
             }
         if width <= 0 or height <= 0:
             return {
                 "status": "error",
-                "content": [{"text": f"render: width and height must be > 0, got {width}x{height}."}],
+                "content": [{"text": f"{context}: width and height must be > 0, got {width}x{height}."}],
             }
         # Hard absolute ceiling regardless of model config (OOM protection).
         _ABS_MAX = 4096
@@ -292,7 +312,7 @@ class RenderingMixin:
                 "status": "error",
                 "content": [
                     {
-                        "text": f"render: {width}x{height} exceeds absolute maximum offscreen framebuffer cap ({_ABS_MAX}x{_ABS_MAX}). Lower width/height or set offwidth/offheight in the model."
+                        "text": f"{context}: {width}x{height} exceeds absolute maximum offscreen framebuffer cap ({_ABS_MAX}x{_ABS_MAX}). Lower width/height or set offwidth/offheight in the model."
                     }
                 ],
             }
@@ -305,7 +325,7 @@ class RenderingMixin:
                     "content": [
                         {
                             "text": (
-                                f"render: requested {width}x{height} exceeds the offscreen "
+                                f"{context}: requested {width}x{height} exceeds the offscreen "
                                 f"framebuffer cap ({max_w}x{max_h}). Lower width/height or "
                                 f"rebuild the model with a larger <global offwidth='...' offheight='...'/>."
                             )
@@ -1121,7 +1141,7 @@ class RenderingMixin:
         cam_cfg = registry_entry(self._world.cameras, camera_name) if camera_name not in FREE_CAMERA_TOKENS else None
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
-        if err := self._validate_render_dims(w, h):
+        if err := self._validate_render_dims(w, h, "render"):
             return err
 
         try:
@@ -1250,7 +1270,7 @@ class RenderingMixin:
         cam_cfg = registry_entry(self._world.cameras, camera_name) if camera_name not in FREE_CAMERA_TOKENS else None
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
-        if err := self._validate_render_dims(w, h):
+        if err := self._validate_render_dims(w, h, "render_depth"):
             return err
 
         try:
@@ -1456,7 +1476,7 @@ class RenderingMixin:
         cam_cfg = registry_entry(self._world.cameras, camera_name) if camera_name not in FREE_CAMERA_TOKENS else None
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
-        if err := self._validate_render_dims(w, h):
+        if err := self._validate_render_dims(w, h, "get_frame"):
             raise ValueError(err["content"][0]["text"])
 
         import numpy as _np
@@ -1573,7 +1593,7 @@ class RenderingMixin:
         # the offscreen framebuffer cap describes a frame render()/get_frame()
         # refuse to draw. Same guard, same message as those two call sites -
         # raised here because this API reports failure by exception.
-        if err := self._validate_render_dims(w, h):
+        if err := self._validate_render_dims(w, h, "get_camera_params"):
             raise ValueError(err["content"][0]["text"])
 
         with self._lock:

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4137,9 +4137,8 @@ class MuJoCoSimEngine(
         # ``render`` validates its dims, so a bad size fails at config time with
         # a clear message instead of deferring a cryptic GL/Renderer error (or a
         # silent non-positive dimension) to the first rollout that renders it.
-        if dim_err := self._validate_render_dims(width, height):
-            text = dim_err["content"][0]["text"].replace("render:", "add_camera:", 1)
-            return {"status": "error", "content": [{"text": text}]}
+        if dim_err := self._validate_render_dims(width, height, "add_camera"):
+            return dim_err
 
         # reject duplicate camera names.  Previously a second
         # add_camera(name=existing) silently overwrote the registry entry but

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1568,7 +1568,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         is_default = camera_name in FREE_CAMERA_TOKENS
         label = "default" if is_default else camera_name
         try:
-            eye, target, fov_deg, w, h = self._resolve_camera_view(camera_name, width, height)
+            eye, target, fov_deg, w, h = self._resolve_camera_view(camera_name, width, height, "render")
         except KeyError:
             return {
                 "status": "error",
@@ -1719,7 +1719,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """
         if self._world is None or self._model is None:
             raise RuntimeError("No world. Call create_world first.")
-        eye, target, fov_deg, w, h = self._resolve_camera_view(camera_name, width, height)
+        eye, target, fov_deg, w, h = self._resolve_camera_view(camera_name, width, height, "get_frame")
         rgb = self._render_rgb(w, h, eye=eye, target=target, fov_deg=fov_deg)
         return np.asarray(rgb, dtype=np.uint8), None
 
@@ -1754,7 +1754,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
         if self._world is None or self._model is None:
             raise RuntimeError("No world. Call create_world first.")
-        eye, target, fov_deg, w, h = self._resolve_camera_view(camera_name, width, height)
+        eye, target, fov_deg, w, h = self._resolve_camera_view(camera_name, width, height, "get_camera_params")
 
         fy = 0.5 * h / math.tan(math.radians(fov_deg) / 2.0)
         K = np.array([[fy, 0.0, 0.5 * w], [0.0, fy, 0.5 * h], [0.0, 0.0, 1.0]], dtype=np.float64)
@@ -1777,7 +1777,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         return _CameraParams(K=K, T_world_cam=T, width=w, height=h, znear=0.01, zfar=1_000_000.0)
 
     def _resolve_camera_view(
-        self, camera_name: str | None, width: int | None, height: int | None
+        self, camera_name: str | None, width: int | None, height: int | None, context: str
     ) -> tuple[tuple[float, ...], tuple[float, ...], float, int, int]:
         """Resolve ``(eye, target, fov_deg, width, height)`` for a camera name.
 
@@ -1788,10 +1788,20 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         A supplied ``width`` / ``height`` is validated on the same shared floor
         (:func:`~strands_robots.utils.positive_count_error`) that
         ``add_camera`` applies, so the config-time and call-time domains agree
-        and every render entry point reports the same refusal. ``None`` means
+        and every render entry point refuses the same values for the same
+        reason. ``context`` is the caller's own name, so each of the three
+        reports that refusal as its own: the funnel is shared, the subject of
+        the message is not. ``None`` means
         "take the camera's configured size"; membership decides that, not
         truthiness - reading ``0`` as omitted would render at the default
         resolution and report it as the requested one.
+
+        Args:
+            camera_name: Camera to resolve, or a free-camera token.
+            width: Requested width override, or ``None`` for the camera's own.
+            height: Requested height override, or ``None`` for the camera's own.
+            context: The public method being called, quoted as the subject of a
+                dimension refusal so a caller is pointed at the call it made.
 
         Raises:
             KeyError: unknown camera name.
@@ -1799,7 +1809,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 the camera's mount body is no longer in the model.
         """
         for param, value in (("width", width), ("height", height)):
-            if value is not None and (text := positive_count_error(value, param, "render")) is not None:
+            if value is not None and (text := positive_count_error(value, param, context)) is not None:
                 raise ValueError(text)
         if camera_name in FREE_CAMERA_TOKENS:
             return (

--- a/tests/simulation/mujoco/test_render_dimension_limits.py
+++ b/tests/simulation/mujoco/test_render_dimension_limits.py
@@ -13,7 +13,10 @@ on a headless host.
 sites, so each is pinned with its own suite plus a cross-call-site parity
 suite: a refactor that drops one of them (letting a 8000x8000 depth request
 reach the offscreen framebuffer, or building a pinhole ``K`` for a 0-pixel
-image) would slip past the RGB tests alone.
+image) would slip past the RGB tests alone. The guard takes its caller's name,
+so the parity those suites assert is of the domain and the reason - each entry
+point names itself as the subject; see
+``tests/simulation/test_render_dimension_refusal_names_the_caller.py``.
 
 ``get_camera_params`` reports failure by exception rather than by an
 agent-tool dict, and its dimensions are not merely a buffer size: ``fx``,
@@ -94,14 +97,27 @@ class TestRenderDepthDimensionCaps:
         assert "offscreen framebuffer cap" in res["content"][0]["text"]
 
     def test_depth_and_rgb_agree_on_bad_dimensions(self, sim_with_world):
-        """The two render paths reject identical bad dimensions identically -
-        the parity contract that keeps the shared guard from drifting."""
+        """The two render paths reject identical bad dimensions for the same
+        reason, each naming itself - the parity contract that keeps the shared
+        guard from drifting.
+
+        Byte-identity of the two texts is what this asserted before, and it is
+        a stronger claim than the drift it exists to catch: it also required
+        ``render_depth`` to report ``render``, so the caller of one method was
+        pointed at the other. Comparing the reason with each subject stripped
+        keeps the anti-drift guarantee and makes the misattribution a failure
+        rather than the pinned behaviour.
+        """
         for width, height in (("640", 480), (8000, 480), (0, 480), (640, -1)):
             rgb = sim_with_world.render(camera_name="default", width=width, height=height)
             depth = sim_with_world.render_depth(camera_name="default", width=width, height=height)
             assert rgb["status"] == "error"
             assert depth["status"] == "error"
-            assert rgb["content"][0]["text"] == depth["content"][0]["text"]
+            rgb_text = rgb["content"][0]["text"]
+            depth_text = depth["content"][0]["text"]
+            assert rgb_text.startswith("render: "), rgb_text
+            assert depth_text.startswith("render_depth: "), depth_text
+            assert rgb_text.removeprefix("render: ") == depth_text.removeprefix("render_depth: ")
 
 
 class TestRenderMaxBytesCap:
@@ -178,7 +194,9 @@ class TestRenderDimensionGuardParity:
     The three render-dimension call sites (``render``, ``get_frame`` /
     ``render_depth``, ``get_camera_params``) describe the same image. An
     accepted domain that diverges between them lets a caller hold intrinsics
-    for a frame no call can render.
+    for a frame no call can render. What must match is the verdict and the
+    reason - each entry point names itself as the subject, so a caller is
+    pointed at the call it made.
     """
 
     @pytest.mark.parametrize(
@@ -186,11 +204,21 @@ class TestRenderDimensionGuardParity:
         [(0, 240), (320, 0), (-64, 240), (320, -48), (2.7, 240), ("640", 240), (True, 240), (8000, 480)],
     )
     def test_render_and_camera_params_reject_identically(self, sim_with_world, width, height):
-        """Same rejection, same message text, through both call sites."""
+        """Same rejection, same reason, each naming the call it came through.
+
+        Byte-identity of the two texts is what this compared before, which also
+        required ``get_camera_params`` to report ``render`` - so the divergence
+        it guards against was pinned together with a subject naming the wrong
+        method. The reason is what has to agree; the subject is what has to
+        differ.
+        """
         rendered = sim_with_world.render(camera_name="default", width=width, height=height)
         assert rendered["status"] == "error"
-        expected = rendered["content"][0]["text"]
+        rendered_text = rendered["content"][0]["text"]
+        assert rendered_text.startswith("render: "), rendered_text
 
         with pytest.raises(ValueError) as excinfo:
             sim_with_world.get_camera_params(camera_name="default", width=width, height=height)
-        assert str(excinfo.value) == expected
+        params_text = str(excinfo.value)
+        assert params_text.startswith("get_camera_params: "), params_text
+        assert params_text.removeprefix("get_camera_params: ") == rendered_text.removeprefix("render: ")

--- a/tests/simulation/test_camera_pixel_count_domain.py
+++ b/tests/simulation/test_camera_pixel_count_domain.py
@@ -143,8 +143,20 @@ def _newton_add_camera(stub: types.SimpleNamespace, **kwargs: Any) -> dict[str, 
 
 
 def _newton_resolve(stub: types.SimpleNamespace, camera_name: str | None, **kwargs: Any) -> tuple:
-    """``_resolve_camera_view``, the funnel Newton's three render surfaces share."""
-    return NewtonSimEngine._resolve_camera_view(stub, camera_name, kwargs.get("width"), kwargs.get("height"))  # type: ignore[arg-type]
+    """``_resolve_camera_view``, the funnel Newton's three render surfaces share.
+
+    ``context`` defaults to ``"render"`` here because these cells grade the
+    shared domain rather than which caller a refusal names; the attribution
+    itself is graded in
+    ``tests/simulation/test_render_dimension_refusal_names_the_caller.py``.
+    """
+    return NewtonSimEngine._resolve_camera_view(
+        stub,  # type: ignore[arg-type]
+        camera_name,
+        kwargs.get("width"),
+        kwargs.get("height"),
+        kwargs.get("context", "render"),
+    )
 
 
 def _verdict(call: Callable[[], Any]) -> str:
@@ -248,16 +260,18 @@ class TestNewtonAddCamera:
 
 class TestNewtonRenderFamily:
     """``_resolve_camera_view`` is the funnel ``render`` / ``get_frame`` /
-    ``get_camera_params`` share, so one guard covers all three."""
+    ``get_camera_params`` share, so one guard covers all three - and each one
+    reports it under its own name, which is what ``context`` carries."""
 
     @pytest.mark.parametrize("bad", _BAD_DIMS)
     @pytest.mark.parametrize("param", ["width", "height"])
     @pytest.mark.parametrize("camera", ["default", "cam"])
-    def test_unusable_override_is_refused(self, camera, param, bad):
+    @pytest.mark.parametrize("context", ["render", "get_frame", "get_camera_params"])
+    def test_unusable_override_is_refused(self, context, camera, param, bad):
         stub = _newton_stub()
         assert _newton_add_camera(stub, name="cam", width=320, height=240)["status"] == "success"
-        with pytest.raises(ValueError, match=f"render: {param} must be a positive integer"):
-            _newton_resolve(stub, camera, **{param: bad})
+        with pytest.raises(ValueError, match=f"{context}: {param} must be a positive integer"):
+            _newton_resolve(stub, camera, context=context, **{param: bad})
 
     def test_zero_is_refused_rather_than_read_as_omitted(self):
         """Membership, not truthiness.

--- a/tests/simulation/test_render_dimension_refusal_names_the_caller.py
+++ b/tests/simulation/test_render_dimension_refusal_names_the_caller.py
@@ -1,0 +1,187 @@
+"""A render-dimension refusal names the method that was called.
+
+Both the MuJoCo and the Newton backend funnel the width/height domain of every
+render surface through one helper - ``_validate_render_dims`` on MuJoCo,
+``_resolve_camera_view`` on Newton - and each helper used to spell the subject
+of its own refusals as the literal ``render``. It serves more than ``render``,
+so a caller of another entry point was told about a method it had not called:
+
+* MuJoCo, five callers: ``render``, ``render_depth``, ``get_frame``,
+  ``get_camera_params``, ``add_camera``. Three of them reported ``render``.
+* Newton, three callers: ``render``, ``get_frame``, ``get_camera_params``. Two
+  of them reported ``render``.
+
+The reader is usually an agent - ``render`` and ``add_camera`` are tool-callable
+and return the text in an error envelope, while ``get_frame`` and
+``get_camera_params`` raise it - and the repair it suggests is a call the caller
+never made. ``render`` also has a *different signature and return type* from
+the two raising methods, so following the message means editing an unrelated
+call.
+
+That the misattribution mattered was already established in the tree: MuJoCo's
+``add_camera`` repaired it after the fact with
+``text.replace("render:", "add_camera:", 1)``, a coupling to the literal prefix
+of every message the guard can return, which a rewording would silently break.
+Isaac never had the defect - it passes ``"get_frame"`` / ``"get_camera_params"``
+to ``positive_count_error`` at each call site - and its two call sites are the
+control below: the target state is the one a sibling backend already ships, and
+the ~20 domain helpers in :mod:`strands_robots.utils` all take their caller's
+name for the same reason.
+
+The structural cell is the one that keeps this closed: it derives the expected
+subject from each call's own enclosing method, so a sixth entry point cannot
+join the funnel without naming itself.
+"""
+
+import ast
+import inspect
+import pathlib
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+_ROOT = pathlib.Path(inspect.getfile(NewtonSimEngine)).resolve().parents[3]
+
+# ``(module, shared guard, how many calls to it that module must still hold)``.
+# The floors are the populations measured when this was written - four render
+# surfaces in MuJoCo's rendering mixin, ``add_camera`` in its engine, and
+# Newton's three - and exist so a guard that stops being shared cannot make the
+# rule below vacuous.
+_FUNNELS = (
+    ("strands_robots/simulation/mujoco/rendering.py", "_validate_render_dims", 4),
+    ("strands_robots/simulation/mujoco/simulation.py", "_validate_render_dims", 1),
+    ("strands_robots/simulation/newton/simulation.py", "_resolve_camera_view", 3),
+)
+
+
+def _context_arguments(path: pathlib.Path, helper: str) -> list[tuple[str, str | None]]:
+    """Every call to ``helper``, as ``(enclosing method, context literal)``.
+
+    ``None`` for the context when the last argument is not a string literal,
+    which is itself a finding: a subject computed at the call site is not one a
+    reader can check against the method it names.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    calls: list[tuple[str, str | None]] = []
+    stack: list[str] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            func = node.func
+            # the definition itself is not a call, and neither is a docstring
+            if isinstance(func, ast.Attribute) and func.attr == helper and node.args:
+                last = node.args[-1]
+                literal = last.value if isinstance(last, ast.Constant) and isinstance(last.value, str) else None
+                calls.append((stack[-1] if stack else "<module>", literal))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return calls
+
+
+class TestEveryCallerNamesItself:
+    """Derived from the tree, so a new entry point joins the rule on arrival."""
+
+    @pytest.mark.parametrize(("module", "helper", "floor"), _FUNNELS)
+    def test_the_context_is_the_enclosing_method(self, module: str, helper: str, floor: int) -> None:
+        calls = _context_arguments(_ROOT / module, helper)
+        assert len(calls) >= floor, f"{module}: found {len(calls)} calls to {helper}, expected at least {floor}"
+        wrong = [(method, ctx) for method, ctx in calls if ctx != method]
+        assert not wrong, (
+            f"{module}: {len(wrong)} call(s) to {helper} name a method other than their own caller: {wrong}. "
+            "A refusal must name the entry point the caller invoked."
+        )
+
+    def test_isaac_already_passed_its_own_name(self) -> None:
+        """The control: Isaac needed no change, and holds either way.
+
+        Its render surfaces call the shared ``positive_count_error`` directly
+        with their own names, which is the arrangement the two funnels above
+        now reach. A fix that regressed Isaac to a hardcoded subject fails here.
+        """
+        source = (_ROOT / "strands_robots/simulation/isaac/simulation.py").read_text(encoding="utf-8")
+        for entry_point in ("get_frame", "get_camera_params"):
+            assert f'positive_count_error(arg, arg_name, "{entry_point}")' in source, entry_point
+
+
+class TestTheSubjectIsNotPatchedAfterTheFact:
+    def test_no_caller_rewrites_the_guards_subject(self) -> None:
+        """``add_camera`` used to do this, and it is why the parameter exists.
+
+        Rewriting the subject in the caller couples it to the literal prefix of
+        every message the guard can return - four of them here - so a reworded
+        message keeps the wrong subject and nothing reports it.
+        """
+        for module, _helper, _floor in _FUNNELS:
+            source = (_ROOT / module).read_text(encoding="utf-8")
+            for statement in ast.walk(ast.parse(source)):
+                if not isinstance(statement, ast.Call):
+                    continue
+                func = statement.func
+                if isinstance(func, ast.Attribute) and func.attr == "replace" and statement.args:
+                    first = statement.args[0]
+                    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                        assert not first.value.startswith("render:"), (
+                            f"{module}: a caller still rewrites the refusal subject via "
+                            f"str.replace({first.value!r}, ...) instead of passing its own name."
+                        )
+
+
+class TestMujocoEntryPointsNameThemselves:
+    """The dimension guard short-circuits before any GL context, so these run headless."""
+
+    @pytest.fixture
+    def sim(self) -> Any:
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        engine = Simulation()
+        engine.create_world()
+        yield engine
+        engine.destroy()
+
+    @pytest.mark.parametrize("entry_point", ["render", "render_depth"])
+    def test_envelope_surfaces(self, sim: Any, entry_point: str) -> None:
+        result = getattr(sim, entry_point)(camera_name="default", width=0, height=48)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith(f"{entry_point}: "), text
+
+    def test_add_camera(self, sim: Any) -> None:
+        result = sim.add_camera(name="cam", position=[0.5, 0.0, 0.3], target=[0.0, 0.0, 0.0], width=0, height=48)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith("add_camera: "), text
+
+    @pytest.mark.parametrize("entry_point", ["get_frame", "get_camera_params"])
+    def test_raising_surfaces(self, sim: Any, entry_point: str) -> None:
+        with pytest.raises(ValueError, match=rf"^{entry_point}: "):
+            getattr(sim, entry_point)(camera_name="default", width=0, height=48)
+
+
+class TestNewtonEntryPointsNameThemselves:
+    """Driven through the production resolver bound to a stub, as its sibling
+    suite does, so the attribution is graded without the Newton runtime."""
+
+    @staticmethod
+    def _stub() -> types.SimpleNamespace:
+        stub = types.SimpleNamespace(default_width=640, default_height=480, _world=None)
+        stub._resolve_camera_view = types.MethodType(NewtonSimEngine._resolve_camera_view, stub)
+        return stub
+
+    @pytest.mark.parametrize("entry_point", ["render", "get_frame", "get_camera_params"])
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_each_surface_reports_its_own_name(self, entry_point: str, param: str) -> None:
+        stub = self._stub()
+        dims: dict[str, int] = {"width": 320, "height": 240}
+        dims[param] = 0
+        with pytest.raises(ValueError, match=rf"^{entry_point}: {param} "):
+            stub._resolve_camera_view("default", dims["width"], dims["height"], entry_point)


### PR DESCRIPTION
Both the MuJoCo and the Newton backend funnel the width/height domain of every render surface through one helper -- `_validate_render_dims` on MuJoCo, `_resolve_camera_view` on Newton -- and each helper spelled the subject of its own refusals as the literal `render`. Each serves more than `render`, so a caller of another entry point was told about a method it had not called.

## Measured

`width=0` against a live world on each backend, captured on a pristine `main` (`31d7ed5ab`) and on this branch:

| backend | called | before | after |
|---|---|---|---|
| mujoco | `render` | `render: width and height must be > 0` | unchanged |
| mujoco | `render_depth` | **`render:`** ... | `render_depth:` ... |
| mujoco | `get_frame` | **`render:`** ... | `get_frame:` ... |
| mujoco | `get_camera_params` | **`render:`** ... | `get_camera_params:` ... |
| mujoco | `add_camera` | `add_camera:` ... | unchanged |
| newton | `render` | `render: width must be a positive integer` | unchanged |
| newton | `get_frame` | **`render:`** ... | `get_frame:` ... |
| newton | `get_camera_params` | **`render:`** ... | `get_camera_params:` ... |
| isaac | `get_frame` / `get_camera_params` | names itself | unchanged |

Five of the eleven entry points named the wrong method.

```text
# before, MuJoCo
>>> sim.get_frame(camera_name="default", width=0, height=48)
ValueError: render: width and height must be > 0, got 0x48.

# after
ValueError: get_frame: width and height must be > 0, got 0x48.
```

## Why it matters

The reader is usually an agent. `render` and `add_camera` are tool-callable and return the text in an error envelope; `get_frame` and `get_camera_params` raise it. Either way the repair the message suggests is a call the caller never made -- and `render` has a *different signature and return type* from the two raising methods (an envelope with PNG bytes, versus `(rgb, depth)` ndarrays and a `CameraParams`), so following the message means editing an unrelated call site.

## The tree already said this mattered, twice

1. MuJoCo's `add_camera` repaired it after the fact:

   ```python
   if dim_err := self._validate_render_dims(width, height):
       text = dim_err["content"][0]["text"].replace("render:", "add_camera:", 1)
   ```

   That is a coupling to the literal prefix of all four messages the guard can return; a reworded message keeps the wrong subject and nothing reports it. Its three sibling callers did not do this.

2. Isaac never had the defect -- it passes `"get_frame"` / `"get_camera_params"` to `positive_count_error` at each call site. So the target state is one a sibling backend already ships.

The ~20 domain helpers in `strands_robots.utils` (`positive_count_error`, `camera_fov_error`, `entity_name_error`, ...) *all* take their caller's name. These two guards were the exception.

## Change

Both guards take a required `context`, so every entry point names itself and the string patch is deleted. Required rather than defaulted to `"render"`, because a default is the shape that produced the defect. Isaac is untouched -- it is the control.

Production is **net -1 executable statement** (AST count: `add_camera` loses the workaround and the envelope rebuild; the two guard modules are +0). The rest of the source diff is docstring.

## Two existing suites pinned the defect

`test_depth_and_rgb_agree_on_bad_dimensions` and `test_render_and_camera_params_reject_identically` asserted the two texts were **byte-identical**. That is a stronger claim than the drift they exist to catch, and byte-identity also *required* `render_depth` and `get_camera_params` to report `render` -- so the misattribution was the pinned behaviour. Both now compare the reason with each subject stripped, which keeps the anti-drift guarantee and makes a wrong subject a failure. Retargeted, not removed.

## Tests

`tests/simulation/test_render_dimension_refusal_names_the_caller.py`. The structural cell derives the expected subject from each call's *own enclosing method*, so a sixth entry point cannot join either funnel without naming itself -- the failure mode that produced this -- with per-module floors so a guard that stops being shared cannot make the rule vacuous.

Pre-fix (subject reverted to the literal, signatures kept, so failures are readable assertions rather than `TypeError`): **9 failed / 7 passed**.

```
FAILED TestEveryCallerNamesItself::test_the_context_is_the_enclosing_method[mujoco/simulation.py]
FAILED TestMujocoEntryPointsNameThemselves::test_envelope_surfaces[render_depth]
FAILED TestMujocoEntryPointsNameThemselves::test_raising_surfaces[get_frame]
FAILED TestMujocoEntryPointsNameThemselves::test_raising_surfaces[get_camera_params]
FAILED TestNewtonEntryPointsNameThemselves::...[width-get_frame]  (+3 more)
FAILED TestTheSubjectIsNotPatchedAfterTheFact::test_no_caller_rewrites_the_guards_subject
```

The 7 that pass pre-fix are the controls, and they hold either way: `render` on both backends, `add_camera` (right already, via the workaround), Isaac's two call sites, and the two funnels whose call sites a behavioural revert does not touch.

Post-fix: 16 passed; the two retargeted suites 489 passed together with the new file.

## Gate

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean (ruff 0.15.20).
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1866 source files`.
- `MUJOCO_GL=egl pytest tests/simulation`: **14399 passed, 13 skipped, 2 failed** -- both pre-existing and attributed by running the same node ids on a pristine `31d7ed5ab` worktree: `newton/test_multi_camera.py::test_bad_position_shape_rejected` fails byte-identically on `main`, and `test_rendering_pacers_survive_a_clock_step[forward_30s]` is wall-clock-sensitive and passes on both trees unloaded.
- All 214 docs/docstring-xref graders pass.
- Newton is exercised both through the production resolver bound to a stub (as its sibling suite does, so CI grades it without the Newton runtime) and against a real Newton world.

The artifact here is the text itself, so it is quoted above rather than rendered.