### PR TITLE
fix(assets): mesh presence is answered by the owner of that question

### DIFF
--- a/changelog.d/3203-asset-mesh-presence-one-owner.md
+++ b/changelog.d/3203-asset-mesh-presence-one-owner.md
@@ -1,0 +1,51 @@
+### Fixed: mesh presence is answered by the owner of that question
+
+"Are this model's meshes on disk?" has one owner,
+`strands_robots.assets.download._mjcf_missing_meshes`, which resolves each
+`file=` reference against the model's `<compiler meshdir>` the way MuJoCo does,
+read once across every `<include>`d fragment. Two readers ask it: the download
+decision, and the check that gates `add_robot`.
+
+`resolve_model_path` is the third reader and documents the same question as its
+own second download trigger -- "XML is found but mesh files are missing,
+downloads the asset". It answered that by walking the model directory for files
+with a mesh extension, a different reading, and the two disagree in both
+directions:
+
+| layout | owner | directory walk | resolver fetched | MuJoCo |
+|---|---|---|---|---|
+| meshes beside the model | complete | complete | no | loads |
+| meshes one level down (`meshdir="assets"`) | complete | complete | no | loads |
+| **meshes one level up (`meshdir="../meshes/"`)** | **complete** | **none found** | **yes, every call** | **loads** |
+| **declares no meshes** | **nothing to fetch** | **none found** | **yes, every call** | **loads** |
+| **one of two declared absent** | **1 missing** | **complete** | **no** | **fails** |
+| the only declared one absent | 1 missing | none found | yes | fails |
+
+The upward `meshdir` is a shipped layout, not a hypothetical: `aliengo`,
+`unitree_a1`, `jvrc` and `asimov_v0` all ship as `<robot>/xml/<model>.xml`
+declaring `<compiler meshdir="../meshes/"/>`, with the meshes in
+`<robot>/meshes/`. All four load in MuJoCo (5, 5, 70 and 15 meshes). Every one
+of them drew a `robot_descriptions` fetch on *every* call to
+`resolve_model_path`, and the fetch could never satisfy the condition it was
+reaching for, because a download does not move meshes into the directory being
+walked. Over the 61 registry robots resolvable on a warm cache, the resolver and
+the download decision disagreed about exactly those four.
+
+The other direction is the documented trigger silently not firing: a model
+missing one of the meshes it declares still has its other meshes on disk, so the
+walk reported it as fine, no fetch was attempted, and the caller was handed a
+path MuJoCo refuses to load. `MuJoCoSimEngine.add_robot` re-asks the owner and
+recovers; `NewtonSimEngine`, whose only mesh reading is this resolver, does not.
+
+The resolver now asks the owner. The walker and its mesh-extension frozenset are
+removed rather than corrected: a second copy of the rule is what let the readings
+drift apart, and the correct predicate is the one MuJoCo itself applies. An
+unreadable model is read as "fetch", which is the reading the download decision
+already takes of the same failure. Cost is ~1 ms per candidate against the
+network fetch it removes.
+
+Three existing cells named the second trigger while their fixture wrote a model
+declaring *no* meshes -- the case the walk and the owner happen to agree about,
+and the exact conflation the defect lived in. They now declare a mesh that is
+absent, so their ids mean what they say. The suite that reasoned about a
+`<compiler meshdir>` never declared one either; it does now.

--- a/strands_robots/assets/manager.py
+++ b/strands_robots/assets/manager.py
@@ -8,7 +8,6 @@ Resolves robot model files (MJCF XML) from:
 """
 
 import logging
-import os
 from pathlib import Path
 
 from strands_robots.registry import (
@@ -84,50 +83,43 @@ def _auto_download_robot(name: str, info: dict) -> bool:
     return _auto_download_robot_impl(name, info)
 
 
-_MESH_EXTS = frozenset({".stl", ".obj", ".msh", ".ply"})
+def _model_meshes_resolve(model_path: Path) -> bool:
+    """Whether every mesh *model_path* declares is on disk where MuJoCo looks.
 
+    Asked through the single owner of that question,
+    :func:`strands_robots.assets.download._mjcf_missing_meshes`, rather than by
+    walking the model directory for files with a mesh extension. The two are not
+    the same reading and they disagree in both directions:
 
-def _has_meshes(directory: Path, memo: dict[str, bool] | None = None) -> bool:
-    """Check whether a directory tree contains mesh files (early-exit).
+    * ``<compiler meshdir="../meshes"/>`` places a model's meshes OUTSIDE its own
+      directory - a real shipped layout - so a downward walk reports a complete
+      asset as mesh-less. The resolver then reaches for a download that cannot
+      change the answer, on every call, for a model that already loads.
+    * a model missing one of the meshes it declares still has the rest of them on
+      disk, so a walk reports it as fine and the fetch that would repair it is
+      never attempted. The caller gets a path MuJoCo refuses to load.
 
-    Uses ``os.scandir`` with an early break on the first mesh found rather
-    than ``rglob("*")``, which stats every file.
+    One owner is what keeps this resolver, :func:`~strands_robots.assets.download._needs_download`
+    and :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine._ensure_meshes`
+    from judging the same model present and absent.
 
     Args:
-        directory: Root of the tree to search.
-        memo: Optional per-scan cache of ``str(directory) -> result``, shared by
-              the caller across one pass over candidate locations. It is the
-              caller's job to scope it: a memo must not outlive the scan it was
-              created for, because a mesh landing anywhere in the subtree makes
-              every answer in it stale. Omitting it always walks the tree.
+        model_path: Path to the model's MAIN file.
 
     Returns:
-        True when a mesh file exists anywhere under *directory*.
+        True when the model declares no meshes or every reference resolves - the
+        two cases a caller may treat alike, since neither has anything to fetch.
+        False when a declared reference is absent, and when the model cannot be
+        read: this resolver's own next step is a download, which is the reading
+        :func:`~strands_robots.assets.download._needs_download` takes of the same
+        failure, because a fetch is what replaces a file it cannot read.
     """
-    if not directory.exists():
-        return False
-    key = str(directory)
-    if memo is not None and key in memo:
-        return memo[key]
+    from strands_robots.assets.download import _mjcf_missing_meshes
 
-    def _walk(path: str) -> bool:
-        try:
-            with os.scandir(path) as it:
-                for entry in it:
-                    if entry.is_file(follow_symlinks=False):
-                        ext = os.path.splitext(entry.name)[1].lower()
-                        if ext in _MESH_EXTS:
-                            return True
-                    elif entry.is_dir(follow_symlinks=False) and _walk(entry.path):
-                        return True
-        except OSError:
-            return False
+    try:
+        return not _mjcf_missing_meshes(model_path)
+    except (OSError, UnicodeDecodeError):
         return False
-
-    result = _walk(key)
-    if memo is not None:
-        memo[key] = result
-    return result
 
 
 def _resolve_candidates(asset_dir_name: str, xml_file: str, name: str) -> list[Path]:
@@ -200,16 +192,20 @@ def resolve_model_path(
     """Resolve a robot name to its MJCF model XML path.
 
     Looks up the robot in ``registry/robots.json``, then searches
-    the asset directories for the actual file.  If no XML is found, or XML is
-    found but mesh files are missing, downloads the asset via
-    ``robot_descriptions`` before returning - unless ``allow_download`` declines.
+    the asset directories for the actual file.  If no XML is found, or a mesh the
+    model DECLARES is absent, downloads the asset via ``robot_descriptions``
+    before returning - unless ``allow_download`` declines.
+
+    Mesh presence is read from the model's declarations, resolved against its
+    ``<compiler meshdir>`` the way MuJoCo resolves them, so a model whose meshes
+    live outside its own directory is not mistaken for one that has none.
 
     ``allow_download=False`` makes this a pure filesystem lookup: no network, no
     ``robot_descriptions`` import. Within the curated registry it is exactly
     equivalent to a download that declines, so it cannot change the answer for an
-    asset already on disk - an absent XML still returns ``None`` and a mesh-less
-    XML still returns its first candidate, the same two outcomes a failed download
-    produces today.
+    asset already on disk - an absent XML still returns ``None`` and an XML whose
+    declared mesh is absent still returns its first candidate, the same two
+    outcomes a failed download produces today.
 
     It declines the discovery fallback too, so a name only
     :mod:`strands_robots.registry.discovery` could synthesize an entry for reports
@@ -288,33 +284,31 @@ def resolve_model_path(
         logger.warning("Robot model not found: %s -> %s/%s", name, asset_dir_name, xml_file)
         return None
 
-    # Prefer the candidate whose directory contains mesh files,
-    # because an XML without meshes will fail to load in MuJoCo. The memo spans
-    # this pass alone, so two candidates that share a directory are walked once
-    # and the download below cannot be answered from a pre-download reading.
-    scan: dict[str, bool] = {}
+    # Prefer the candidate whose declared meshes all resolve, because an XML with
+    # a mesh reference MuJoCo cannot open will fail to load. Each candidate is
+    # read on its own, so the download below cannot be answered from a
+    # pre-download reading.
     for path in candidates:
-        if _has_meshes(path.parent, scan):
-            logger.debug("Resolved %s -> %s (has meshes)", name, path)
+        if _model_meshes_resolve(path):
+            logger.debug("Resolved %s -> %s (declared meshes resolve)", name, path)
             return Path(path)
 
     # XML found but no meshes - auto-download and re-check. Declining the
     # download leaves the first candidate to the fallback below, which is what a
     # download that fails already does.
     if allow_download:
-        logger.info("XML found for %s but no meshes, attempting auto-download...", name)
+        logger.info("XML found for %s but a declared mesh is absent, attempting auto-download...", name)
         if _auto_download_robot(name, info):
-            # Re-scan after download (new symlinks may have appeared). A new
-            # memo, because the download is exactly the change the pass above
-            # could not have observed.
+            # Re-read after download: the fetch is exactly the change the pass
+            # above could not have observed.
             refreshed = _resolve_candidates(asset_dir_name, xml_file, name)
-            rescan: dict[str, bool] = {}
             for path in refreshed:
-                if _has_meshes(path.parent, rescan):
+                if _model_meshes_resolve(path):
                     logger.debug("Resolved %s -> %s (auto-downloaded)", name, path)
                     return Path(path)
 
-    # Final fallback: return first candidate (some robots have no meshes)
+    # Final fallback: return the first candidate, which is what a download that
+    # cannot supply the absent reference leaves the caller with either way.
     logger.debug("Resolved %s -> %s (no meshes available)", name, candidates[0])
     return Path(candidates[0])
 

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -9,14 +9,12 @@ a robot name to its MJCF model XML, directory, and availability status:
     - get_robot_info: enriched metadata with resolved path
     - list_available_robots: presence-filtered listing
     - path-traversal protection on registry-sourced path components
-    - _has_meshes: mesh detection, with an optional per-scan memo
 
 These exercise observable behavior (returned paths, booleans, None) against a
 temp asset tree wired through STRANDS_ASSETS_DIR + the user registry, with no
 network and no auto-download dependency.
 """
 
-import os
 from pathlib import Path
 
 import pytest
@@ -47,6 +45,22 @@ def _isolate_assets(tmp_path, monkeypatch):
     _invalidate_cache()
 
 
+def _mjcf(*, meshdir: str | None = None, declares: tuple[str, ...] = ()) -> str:
+    """A minimal MJCF, optionally declaring meshes under a ``<compiler meshdir>``.
+
+    Mesh presence is a property of what a model DECLARES, not of what happens to
+    sit in its directory: ``<compiler meshdir>`` is where MuJoCo resolves a
+    ``file=`` reference, and it can name a directory outside the model's own.
+    A fixture that writes mesh files without declaring them cannot pose either
+    case, so a model with a missing mesh is spelled here and not by an unlinked
+    file alone.
+    """
+    compiler = f'<compiler meshdir="{meshdir}"/>' if meshdir else ""
+    refs = "".join(f'<mesh name="m{i}" file="{m}"/>' for i, m in enumerate(declares))
+    asset = f"<asset>{refs}</asset>" if refs else ""
+    return f'<mujoco>{compiler}{asset}<worldbody><body><geom size="0.1"/></body></worldbody></mujoco>'
+
+
 def _register_bot(
     assets_dir: Path,
     name: str = "unitbot",
@@ -54,14 +68,24 @@ def _register_bot(
     *,
     scene_xml: str | None = None,
     meshes: tuple[str, ...] = (),
+    declares: tuple[str, ...] = (),
+    meshdir: str | None = None,
 ) -> Path:
-    """Create a minimal MJCF asset dir and register it; return the dir path."""
+    """Create a minimal MJCF asset dir and register it; return the dir path.
+
+    ``declares`` names the mesh references the model asks MuJoCo for, resolved
+    against ``meshdir``; ``meshes`` names the files actually written. Passing a
+    reference in ``declares`` that is absent from ``meshes`` is how a model with
+    a missing mesh is posed.
+    """
     robot_dir = assets_dir / name
     robot_dir.mkdir(parents=True, exist_ok=True)
-    (robot_dir / xml_name).write_text(_MINIMAL_MJCF)
+    model = _mjcf(meshdir=meshdir, declares=declares)
+    (robot_dir / xml_name).write_text(model)
     if scene_xml:
-        (robot_dir / scene_xml).write_text(_MINIMAL_MJCF)
+        (robot_dir / scene_xml).write_text(model)
     for mesh in meshes:
+        (robot_dir / mesh).parent.mkdir(parents=True, exist_ok=True)
         (robot_dir / mesh).write_bytes(b"meshbytes")
     register_robot(
         name=name,
@@ -195,77 +219,6 @@ class TestPathTraversalProtection:
         assert manager.is_robot_asset_present("evil") is False
 
 
-class TestHasMeshes:
-    def test_false_for_missing_directory(self, tmp_path):
-        assert manager._has_meshes(tmp_path / "does_not_exist") is False
-
-    def test_false_when_no_mesh_files(self, tmp_path):
-        d = tmp_path / "bare"
-        d.mkdir()
-        (d / "model.xml").write_text(_MINIMAL_MJCF)
-        assert manager._has_meshes(d) is False
-
-    def test_true_for_nested_mesh(self, tmp_path):
-        d = tmp_path / "withmesh"
-        (d / "meshes").mkdir(parents=True)
-        (d / "meshes" / "link.obj").write_bytes(b"o")
-        assert manager._has_meshes(d) is True
-
-    def test_a_memo_answers_a_repeat_of_the_same_directory(self, tmp_path):
-        """Within one scan the tree is walked once per directory.
-
-        This is the saving the memo exists for: ``resolve_model_path`` ranks
-        several candidate XMLs that can share a directory, and a mesh-less tree
-        is the case the walk cannot early-exit out of.
-        """
-        d = tmp_path / "cachedir"
-        d.mkdir()
-        memo: dict[str, bool] = {}
-        assert manager._has_meshes(d, memo) is False
-        assert memo == {str(d): False}
-        # A mesh arriving mid-scan is not re-walked: the memo is the answer.
-        (d / "late.stl").write_bytes(b"m")
-        assert manager._has_meshes(d, memo) is False
-
-    def test_a_scan_that_brings_no_memo_reads_the_tree(self, tmp_path):
-        """A mesh that appeared is observed even when no timestamp moved.
-
-        A directory's own ``st_mtime`` is held stable here, which is what a
-        write into one of its subdirectories does anyway. Mesh detection answers
-        from the tree, so nothing outside a caller-owned memo can go stale.
-        """
-        d = tmp_path / "cachedir"
-        d.mkdir()
-        assert manager._has_meshes(d) is False
-        before = d.stat()
-        (d / "late.stl").write_bytes(b"m")
-        os.utime(d, ns=(before.st_atime_ns, before.st_mtime_ns))
-        assert d.stat().st_mtime_ns == before.st_mtime_ns
-        assert manager._has_meshes(d) is True
-
-    def test_an_unstattable_directory_is_still_searched(self, tmp_path, monkeypatch):
-        """A ``stat()`` failure after ``exists()`` must not crash mesh discovery.
-
-        A directory can become un-stattable between the ``exists()`` guard and
-        any later read of it (a TOCTOU removal, or its permissions stripped).
-        Mesh detection asks the tree and never the clock, so there is no
-        timestamp read left on this path for such a failure to escape from.
-        """
-        d = tmp_path / "withmesh"
-        (d / "meshes").mkdir(parents=True)
-        (d / "meshes" / "link.obj").write_bytes(b"o")
-
-        def _raise_stat(self, *args, **kwargs):
-            raise OSError("stat unavailable")
-
-        # exists() stays truthy (the dir is really there); only the cache-key
-        # stat() read fails, exactly as a mid-call permission strip would look.
-        monkeypatch.setattr(Path, "exists", lambda self, *a, **k: True)
-        monkeypatch.setattr(Path, "stat", _raise_stat)
-
-        assert manager._has_meshes(d) is True
-
-
 class TestAutoDownloadFallback:
     """When no XML is found on disk, resolution attempts an auto-download."""
 
@@ -329,7 +282,7 @@ class TestDownloadCanBeDeclined:
 
     def test_missing_meshes_return_the_xml_without_attempting(self, tmp_path, monkeypatch):
         """Second trigger: XML present, meshes absent. Declining keeps the XML."""
-        robot_dir = _register_bot(tmp_path / "assets")  # registered with no meshes
+        robot_dir = _register_bot(tmp_path / "assets", declares=("link.stl",))
         assert manager.is_robot_asset_present("unitbot") is True, "presence alone would not gate this"
         attempts: list[str] = []
         monkeypatch.setattr(manager, "_auto_download_robot", self._recording_downloader(attempts))
@@ -339,7 +292,9 @@ class TestDownloadCanBeDeclined:
 
     def test_the_downloading_default_is_unchanged(self, tmp_path, monkeypatch):
         """Over-reach control: adding the knob must not stop the default fetching."""
-        _register_bot(tmp_path / "assets")  # no meshes -> the default reaches for them
+        # A DECLARED mesh that is absent is what makes a fetch the helpful thing.
+        # A model declaring none has nothing to fetch, so it cannot show this.
+        _register_bot(tmp_path / "assets", declares=("link.stl",))
         attempts: list[str] = []
         monkeypatch.setattr(manager, "_auto_download_robot", self._recording_downloader(attempts))
 
@@ -353,7 +308,7 @@ class TestDownloadCanBeDeclined:
         This is what makes the knob safe to add to a resolver 46 call sites
         already use: it introduces no third outcome.
         """
-        robot_dir = _register_bot(tmp_path / "assets")
+        robot_dir = _register_bot(tmp_path / "assets", declares=("link.stl",))
         if delete_xml:
             (robot_dir / "unitbot.xml").unlink()
             _invalidate_cache()
@@ -591,17 +546,6 @@ class TestAutoDownloadUnavailable:
         assert calls == [("unitbot", {"k": 1})]
 
 
-class TestHasMeshesScandirError:
-    """A non-walkable path (not a directory / unreadable) degrades to False."""
-
-    def test_false_when_scandir_raises(self, tmp_path):
-        # A regular file passes ``Path.exists()`` and ``stat()`` but scandir
-        # raises NotADirectoryError (an OSError subclass) during the walk.
-        not_a_dir = tmp_path / "model.xml"
-        not_a_dir.write_text(_MINIMAL_MJCF)
-        assert manager._has_meshes(not_a_dir) is False
-
-
 class TestIsRobotAssetPresentEdges:
     """Standard-search-path resolution and user-path traversal fall-through."""
 
@@ -685,11 +629,14 @@ class TestDownloadIntoTheDeclaredMeshdir:
         # Two candidate locations for one robot. The mesh-less one is ranked
         # first, so a stale mesh answer is visible in the resolved path rather
         # than in a log line alone.
-        _register_bot(tmp_path / "assets")  # candidate 0, never gets meshes
+        # Both candidates DECLARE the mesh under meshdir="assets"; only the
+        # second ever receives the file. Declaring it is what makes the ranking
+        # depend on the meshdir the model names rather than on a stray file.
+        _register_bot(tmp_path / "assets", declares=("pelvis.stl",), meshdir="assets")
         proj = tmp_path / "proj"  # CWD/assets is the second search path
         downloaded = proj / "assets" / "unitbot"
         downloaded.mkdir(parents=True)
-        (downloaded / "unitbot.xml").write_text(_MINIMAL_MJCF)
+        (downloaded / "unitbot.xml").write_text(_mjcf(meshdir="assets", declares=("pelvis.stl",)))
         (downloaded / "assets").mkdir()  # declared meshdir: pre-exists, empty
         monkeypatch.chdir(proj)
         before = downloaded.stat().st_mtime_ns

--- a/tests/test_asset_mesh_presence_has_one_owner.py
+++ b/tests/test_asset_mesh_presence_has_one_owner.py
@@ -1,0 +1,328 @@
+"""Mesh presence is answered by one owner, so every reader agrees about a model.
+
+"Are this model's meshes on disk?" has a single owner,
+:func:`strands_robots.assets.download._mjcf_missing_meshes`, which resolves each
+``file=`` reference the way MuJoCo does: against the model's ``<compiler
+meshdir>``, read once across every ``<include>``d fragment. Two readers ask it -
+:func:`~strands_robots.assets.download._needs_download` (should the assets be
+fetched?) and
+:meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine._ensure_meshes`
+(may ``add_robot`` proceed?).
+
+:func:`~strands_robots.assets.manager.resolve_model_path` is the third reader,
+and it documents the same question as its own second download trigger: "XML is
+found but mesh files are missing, downloads the asset". Answering that by walking
+the model directory for files with a mesh extension is a different reading, and
+the two disagree in BOTH directions:
+
+* ``<compiler meshdir="../meshes/"/>`` puts the meshes outside the model's own
+  directory, so a downward walk reports a complete asset as mesh-less and the
+  resolver reaches for a fetch that cannot change its answer - on every call,
+  for a model that already loads.
+* a model missing one of the meshes it declares still has its other meshes on
+  disk, so a walk reports it as fine, the documented fetch never fires, and the
+  caller is handed a path MuJoCo refuses to load.
+
+The cells below pin both directions through the public resolver, plus the
+agreement with ``_needs_download`` that makes "one owner" observable.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+import strands_robots.assets.manager as manager
+from strands_robots.assets.download import _mjcf_missing_meshes, _needs_download
+from strands_robots.registry import get_robot, list_robots
+from strands_robots.registry.user_registry import _invalidate_cache, register_robot
+
+
+def _mjcf(*, meshdir: str | None = None, declares: tuple[str, ...] = ()) -> str:
+    """A minimal MJCF that declares *declares* resolved against *meshdir*."""
+    compiler = f'<compiler meshdir="{meshdir}"/>' if meshdir else ""
+    refs = "".join(f'<mesh name="m{i}" file="{m}"/>' for i, m in enumerate(declares))
+    asset = f"<asset>{refs}</asset>" if refs else ""
+    return f'<mujoco>{compiler}{asset}<worldbody><body><geom size="0.1"/></body></worldbody></mujoco>'
+
+
+@pytest.fixture(autouse=True)
+def _isolate_assets(tmp_path, monkeypatch):
+    """Point the asset search at a temp tree and clear the registry cache."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    monkeypatch.setenv("STRANDS_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(assets))
+    _invalidate_cache()
+    yield
+    _invalidate_cache()
+
+
+def _register(
+    assets: Path,
+    *,
+    model_xml: str = "unitbot.xml",
+    meshdir: str | None = None,
+    declares: tuple[str, ...] = (),
+    present: tuple[str, ...] = (),
+) -> Path:
+    """Write and register a model, then place *present* under its ``meshdir``.
+
+    *present* is relative to the resolved mesh directory, so a reference in
+    *declares* that is absent from *present* is a mesh the model asks for and
+    does not have.
+    """
+    model = assets / "unitbot" / model_xml
+    model.parent.mkdir(parents=True, exist_ok=True)
+    model.write_text(_mjcf(meshdir=meshdir, declares=declares))
+    mesh_root = (model.parent / meshdir) if meshdir else model.parent
+    for ref in present:
+        target = (mesh_root / ref).resolve()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"meshbytes")
+    register_robot(
+        name="unitbot",
+        model_xml=model_xml,
+        description="unit test robot",
+        category="arm",
+        joints=6,
+        overwrite=True,
+    )
+    _invalidate_cache()
+    return model
+
+
+def _record_attempts(monkeypatch) -> list[str]:
+    """Install a downloader that records the names it is asked for and declines.
+
+    Declining is what keeps this off the network: a failed fetch is a documented
+    outcome of both triggers, so the resolved path is the same one a real
+    download failure yields.
+    """
+    seen: list[str] = []
+
+    def _decline(name: str, _info: dict) -> bool:
+        seen.append(name)
+        return False
+
+    monkeypatch.setattr(manager, "_auto_download_robot", _decline)
+    return seen
+
+
+def _attempts(monkeypatch, **kwargs) -> tuple[list[str], Path | None]:
+    """Resolve ``unitbot``, recording every download attempt without running one."""
+    seen = _record_attempts(monkeypatch)
+    return seen, manager.resolve_model_path("unitbot", **kwargs)
+
+
+class TestAModelWhoseMeshesAreOutsideItsOwnDirectory:
+    """The shipped ``meshdir="../meshes/"`` layout is a complete asset.
+
+    ``aliengo``, ``unitree_a1``, ``jvrc`` and ``asimov_v0`` all ship as
+    ``<robot>/xml/<model>.xml`` declaring ``<compiler meshdir="../meshes/"/>``,
+    with the mesh files in ``<robot>/meshes/``. MuJoCo loads every one of them.
+    """
+
+    @staticmethod
+    def _shipped_layout(assets: Path) -> Path:
+        return _register(
+            assets,
+            model_xml="xml/unitbot.xml",
+            meshdir="../meshes/",
+            declares=("trunk.stl", "calf.stl"),
+            present=("trunk.stl", "calf.stl"),
+        )
+
+    def test_the_owner_reports_the_asset_complete(self, tmp_path):
+        """Premise: the references really do resolve, one level up."""
+        model = self._shipped_layout(tmp_path / "assets")
+        assert _mjcf_missing_meshes(model) == []
+        assert (model.parent.parent / "meshes" / "trunk.stl").exists()
+        assert not list(model.parent.glob("*.stl")), "the meshes are NOT beside the model"
+
+    def test_a_complete_asset_is_resolved_without_reaching_for_a_download(self, tmp_path, monkeypatch):
+        model = self._shipped_layout(tmp_path / "assets")
+        seen, resolved = _attempts(monkeypatch)
+        assert resolved == model
+        assert seen == [], f"fetched a model whose declared meshes are all on disk: {seen}"
+
+    def test_the_fetch_it_would_attempt_is_not_satisfiable(self, tmp_path, monkeypatch):
+        """A download cannot change a reading taken in the wrong directory.
+
+        This is what separates a slow first call from a permanent one: the
+        condition is false for a reason no fetch addresses, so it is false again
+        on the next call, and every call after that.
+        """
+        self._shipped_layout(tmp_path / "assets")
+        seen, _ = _attempts(monkeypatch)
+        first = list(seen)
+        seen.clear()
+        manager.resolve_model_path("unitbot")
+        assert (first, seen) == ([], []), "the fetch repeats on every call"
+
+
+class TestAModelMissingOneOfTheMeshesItDeclares:
+    """The documented second trigger: XML present, a declared mesh absent."""
+
+    @staticmethod
+    def _partial(assets: Path) -> Path:
+        return _register(
+            assets,
+            meshdir="assets",
+            declares=("base.stl", "gripper.stl"),
+            present=("base.stl",),  # gripper.stl is never written
+        )
+
+    def test_the_owner_names_the_absent_reference(self, tmp_path):
+        """Premise: one of two declared references is missing."""
+        model = self._partial(tmp_path / "assets")
+        assert _mjcf_missing_meshes(model) == ["gripper.stl"]
+
+    def test_the_download_the_resolver_documents_is_attempted(self, tmp_path, monkeypatch):
+        self._partial(tmp_path / "assets")
+        seen, resolved = _attempts(monkeypatch)
+        assert seen == ["unitbot"], "a declared mesh is absent and no fetch was attempted"
+        assert resolved is not None, "a failed fetch still yields the XML"
+
+    def test_the_meshes_that_are_present_do_not_hide_it(self, tmp_path, monkeypatch):
+        """The sibling mesh on disk is exactly what a directory walk finds first."""
+        model = self._partial(tmp_path / "assets")
+        assert list((model.parent / "assets").glob("*.stl")), "a mesh IS present beside the missing one"
+        seen, _ = _attempts(monkeypatch)
+        assert seen == ["unitbot"]
+
+
+#: ``(id, meshdir, declared, present, the asset is complete)`` - the layouts a
+#: model can ship in, including the two the readings disagree about.
+_LAYOUTS = [
+    ("meshes-beside-the-model", None, ("a.stl",), ("a.stl",), True),
+    ("meshes-one-level-down", "assets", ("a.stl",), ("a.stl",), True),
+    ("meshes-one-level-up", "../meshes", ("a.stl",), ("a.stl",), True),
+    ("declares-nothing", None, (), (), True),
+    ("one-of-two-absent", "assets", ("a.stl", "b.stl"), ("a.stl",), False),
+    ("the-only-one-absent", "assets", ("a.stl",), (), False),
+    ("absent-under-an-upward-meshdir", "../meshes", ("a.stl", "b.stl"), ("a.stl",), False),
+]
+
+
+class TestTheResolverAgreesWithTheDownloadDecision:
+    """One owner, observable: the two readers reach the same verdict.
+
+    ``_needs_download`` is the download module's own answer to "should these
+    assets be fetched?". The resolver documents the same question as its second
+    trigger, so a layout where one fetches and the other does not is a model the
+    package judges present and absent at once.
+    """
+
+    @pytest.mark.parametrize(
+        ("meshdir", "declared", "present", "complete"),
+        [pytest.param(*row[1:], id=row[0]) for row in _LAYOUTS],
+    )
+    def test_the_fetch_decision_matches(self, tmp_path, monkeypatch, meshdir, declared, present, complete):
+        model = _register(
+            tmp_path / "assets",
+            model_xml="xml/unitbot.xml" if meshdir and meshdir.startswith("..") else "unitbot.xml",
+            meshdir=meshdir,
+            declares=declared,
+            present=present,
+        )
+        assert (_mjcf_missing_meshes(model) == []) is complete, "fixture does not pose what it claims"
+
+        wants = _needs_download("unitbot", get_robot("unitbot"))
+        seen, resolved = _attempts(monkeypatch)
+
+        assert bool(seen) == wants, f"resolver fetched={bool(seen)} while _needs_download said {wants}"
+        assert wants is not complete, "a complete asset has nothing to fetch"
+        assert resolved == model
+
+
+class TestTheResolverKeepsItsOtherBehaviour:
+    """Controls: the trigger this change does not touch, and the declining knob."""
+
+    def test_an_absent_xml_still_reports_a_miss_after_attempting(self, tmp_path, monkeypatch):
+        """First trigger, unchanged: no XML anywhere."""
+        model = _register(tmp_path / "assets", declares=("a.stl",), present=("a.stl",))
+        model.unlink()
+        _invalidate_cache()
+        seen, resolved = _attempts(monkeypatch)
+        assert (seen, resolved) == (["unitbot"], None)
+
+    def test_declining_never_attempts_on_either_trigger(self, tmp_path, monkeypatch):
+        _register(tmp_path / "assets", meshdir="assets", declares=("a.stl",), present=())
+        seen, resolved = _attempts(monkeypatch, allow_download=False)
+        assert seen == []
+        assert resolved is not None, "declining keeps the XML it found"
+
+
+class TestOnlyOneReaderAnswersTheQuestion:
+    """Structural: the resolver holds no second reading of mesh presence.
+
+    A copy of the rule is what let the readings drift apart, so the absence of
+    one is the property worth pinning rather than the wording of the one that
+    remains.
+    """
+
+    @staticmethod
+    def _tree() -> ast.Module:
+        return ast.parse(Path(inspect.getfile(manager)).read_text())
+
+    def test_the_resolver_asks_the_owner(self):
+        calls = {
+            n.func.id
+            for n in ast.walk(ast.parse(inspect.getsource(manager._model_meshes_resolve)))
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        }
+        assert "_mjcf_missing_meshes" in calls, f"mesh presence is answered locally: {sorted(calls)}"
+
+    def test_no_mesh_extension_set_is_declared_here(self):
+        """A module-level set of mesh suffixes is the shape of a second reader."""
+        literals = [
+            ast.unparse(n)
+            for n in ast.walk(self._tree())
+            if isinstance(n, ast.Constant)
+            and isinstance(n.value, str)
+            and n.value.lower() in {".stl", ".obj", ".msh", ".ply"}
+        ]
+        assert literals == [], f"a mesh-extension reading lives beside the owner: {literals}"
+
+    def test_every_mesh_presence_read_routes_through_the_one_helper(self):
+        """Non-vacuity: the helper exists and the resolver is the only caller."""
+        names = [
+            n.func.id
+            for n in ast.walk(self._tree())
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "_model_meshes_resolve"
+        ]
+        assert len(names) == 2, f"expected the two ranking passes to ask, got {len(names)}"
+
+
+class TestTheShippedCorpusAgrees:
+    """The same agreement over whatever assets are actually installed.
+
+    Skipped where no asset is on disk. Where they are, this is the reading that
+    reports a shipped ``meshdir="../meshes/"`` model as needing a fetch it
+    cannot use.
+    """
+
+    def test_no_installed_robot_is_both_complete_and_fetched(self, monkeypatch):
+        monkeypatch.delenv("STRANDS_ASSETS_DIR", raising=False)
+        monkeypatch.delenv("STRANDS_BASE_DIR", raising=False)
+        _invalidate_cache()
+        seen = _record_attempts(monkeypatch)
+
+        disagree = []
+        checked = 0
+        for entry in list_robots(mode="sim"):
+            name = entry["name"]
+            if not manager.is_robot_asset_present(name):
+                continue
+            checked += 1
+            seen.clear()
+            manager.resolve_model_path(name)
+            wants = _needs_download(name, get_robot(name))
+            if bool(seen) != wants:
+                disagree.append((name, bool(seen), wants))
+
+        if checked == 0:
+            pytest.skip("no robot assets installed on this machine")
+        assert disagree == [], f"resolver and _needs_download disagree about {disagree}"


### PR DESCRIPTION
![Four shipped robots the resolver reported as having no meshes on disk](https://raw.githubusercontent.com/cagataycali/robots/dd3a5fa5031abc63d8f99187206811b76c474bec/.artifacts/resolver_fetches_complete_assets.png)

*Rendered in MuJoCo (headless). Each model declares an upward `<compiler meshdir>`, so its meshes sit outside its own directory. `resolve_model_path` attempted a `robot_descriptions` fetch for all four on every call.*

## The two readings

"Are this model's meshes on disk?" has one owner, `_mjcf_missing_meshes`, which resolves each `file=` reference against the model's `<compiler meshdir>` the way MuJoCo does. `_needs_download` and `MuJoCoSimEngine._ensure_meshes` both ask it, and its docstring says why: "one owner is what keeps them from judging the same model present and absent."

`resolve_model_path` is the third reader. It documents the same question as its own second download trigger -- "XML is found but mesh files are missing, downloads the asset" -- and answered it by walking the model directory for files with a mesh extension. That is a different reading, and the two disagree in **both** directions:

| layout | owner | directory walk | resolver fetched | MuJoCo |
|---|---|---|---|---|
| meshes beside the model | complete | complete | no | loads |
| meshes one level down (`meshdir="assets"`) | complete | complete | no | loads |
| **meshes one level up (`meshdir="../meshes/"`)** | **complete** | **none found** | **yes, every call** | **loads** |
| **declares no meshes** | **nothing to fetch** | **none found** | **yes, every call** | **loads** |
| **one of two declared absent** | **1 missing** | **complete** | **no** | **fails** |
| the only declared one absent | 1 missing | none found | yes | fails |

## Direction 1: a permanent fetch for a complete asset

The upward `meshdir` is a shipped layout. `aliengo`, `unitree_a1`, `jvrc` and `asimov_v0` ship as `<robot>/xml/<model>.xml` declaring `<compiler meshdir="../meshes/"/>`, with the meshes in `<robot>/meshes/` -- one level up from the model, so a downward walk finds nothing. Measured against the installed cache, with the downloader recording and declining:

| robot | meshes MuJoCo loaded | `_needs_download` | resolver fetch attempts (1st call / 2nd call) |
|---|---|---|---|
| `aliengo` | 5 | `False` | **1 / 1** |
| `unitree_a1` | 5 | `False` | **1 / 1** |
| `jvrc` | 70 | `False` | **1 / 1** |
| `asimov_v0` | 15 | `False` | **1 / 1** |
| `so101` | (meshes beside) | `False` | 0 / 0 |
| `panda` | (meshes beside) | `False` | 0 / 0 |

The second call attempting again is the point: **the fetch can never satisfy the condition it is reaching for**, because a download does not move meshes into the directory being walked. So it is not a slow first call, it is a `robot_descriptions` import and possible clone on every call, forever, for a model that already loads. Over the 61 registry robots resolvable on a warm cache the resolver and the download decision disagreed about exactly those four.

## Direction 2: the documented fetch silently not firing

A model missing one of the meshes it declares still has its other meshes on disk, so the walk reports it as fine. Real `so101` asset copied and one declared STL removed:

| | value |
|---|---|
| owner (`_mjcf_missing_meshes`) | `['base_motor_holder_so101_v1.stl']` |
| directory walk | `True` (the sibling meshes are there) |
| `_needs_download` | `True` |
| **resolver fetch attempts** | **0** |
| MuJoCo | `ValueError: Error opening file 'assets/base_motor_holder_so101_v1.stl'` |

`MuJoCoSimEngine.add_robot` re-asks the owner and recovers. `NewtonSimEngine`, whose only mesh reading is this resolver, does not.

## The change

The resolver asks the owner. The walker and its mesh-extension frozenset are **removed** rather than corrected -- a second copy of the rule is what let the readings drift apart, and the correct predicate is the one MuJoCo itself applies. An unreadable model reads as "fetch", which is the reading `_needs_download` already takes of the same failure. Cost is ~1 ms per candidate (vs 40-99 us for the walk) against the network fetch it removes.

**No resolved path changes.** All 64 registry entries resolved on both trees: **0 paths differ**, 61 non-None either way. The fix removes fetches without changing a single answer.

## Tests

Pre-fix (base `manager.py`, new suite): **11 failed / 8 passed**; post-fix **19 passed**. Every failure names the defect, including the corpus cell:

```
AssertionError: resolver and _needs_download disagree about
  [('aliengo', True, False), ('asimov_v0', True, False), ('jvrc', True, False), ('unitree_a1', True, False)]
```

The 8 that pass pre-fix are the two premises, the two controls, and **4 of the 7 parity rows -- exactly the layouts where the two readings coincide**, which is what a table posing only those rows would have looked like.

Three existing cells named the second trigger while their fixture wrote a model declaring *no* meshes -- the one case the walk and the owner agree about, and the exact conflation the defect lived in. `TestDownloadIntoTheDeclaredMeshdir` reasoned at length about `<compiler meshdir>` and never declared one. All four are retargeted, not deleted, so their ids mean what they say. The fixture can now write a model that declares meshes, which is what makes "a missing mesh" expressible at all.

## Gate

`ruff check` + `ruff format --check` clean (1871 files). `mypy strands_robots tests tests_integ`: `Success: no issues found in 1868 source files`. Asset + registry suites **1046 passed**; assets + every `test_docs_*` / docstring / xref grader **1083 passed**; whole-tree graders **4323 passed**, with 7 pre-existing environmental failures unrelated to this change (5 assert `rclpy` is absent where the host supplies it; 2 read `websockets` 16.0 against a declared `>=17.0`).

## Size

| file | lines | AST statements |
|---|---|---|
| `strands_robots/assets/manager.py` | +49 / -55 | **160 -> 139 (-21)** |
| `tests/test_asset_manager.py` | +39 / -92 | 459 -> 418 (-41) |
| `tests/test_asset_mesh_presence_has_one_owner.py` | +328 | new (19 cells) |
| `changelog.d/3203-...md` | +51 | - |

Existing code shrinks by 63 lines and the resolver loses 21 executable statements; the addition is the regression suite for a defect that was silent in both directions.