### PR TITLE
fix(policies/vera): a camera selection that names no view is refused, not served every view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2052,6 +2052,18 @@ which side the enum is on.
   the remedy names the `robots=` that caller passed rather than the `names=` it never
   did. Pinned by `tests/test_asset_download_selection_domain.py`, whose controls pin the
   three tolerated spellings so the narrowing stays deliberate rather than incidental.
+- **A provider keyword is the same surface, and the erasure can happen before the read.**
+  `VeraPolicy(image_keys=...)` selects which of the observation's own image keys are
+  width-concatenated into the one frame the video planner acts on, and `[]` was stored as
+  `None` - so the selection was gone before the resolver ran, and a caller who excluded
+  every camera drove the arm from all of them, in a *wider* frame, under a success result.
+  Four sites spell one parameter there (shape guard, store, resolver, and the docstring
+  that documented `None` alone), and the guard being gated on a truthy value is what let
+  `""` widen too - it never reached the bare-string refusal it was already owed. Fix the
+  store and the resolver together: one alone leaves the other free to widen. Pinned by
+  `tests/policies/vera/test_vera_image_keys_selection_domain.py`, whose controls pin the
+  documented spellings under both handshake cases and the `action_mapping` carve-out one
+  line below, which is a rename map rather than a subset and is correct as it stands.
 - Pinned by `tests/test_teleop_device_selection_domain.py`, whose controls assert that the
   documented spellings (`names=None`, a real subset, `detach_teleop(None)`) are unchanged,
   and by the render path's `cameras` resolution, which has read the same kind of selector

--- a/changelog.d/3202-vera-image-keys-empty-selection.md
+++ b/changelog.d/3202-vera-image-keys-empty-selection.md
@@ -1,0 +1,28 @@
+### Fixed: a VERA camera selection that names no view is refused, not served every view
+
+`VeraPolicy.image_keys` names a SUBSET of the observation's own image keys - the
+cameras to width-concat into the single `(H, W, 3)` frame the video planner acts
+on - and `None` is documented as "the server's `view_keys`, or every image key in
+the observation". It was read by truthiness at both the site that stored it and
+the site that resolved it, so an **empty** selection took that same branch: a
+caller who excluded every camera drove the arm from all of them, with no error
+and no log line.
+
+Measured against a two-camera observation, `image_keys=[]` and `image_keys=""`
+were byte-identical to `image_keys=None` at both surfaces - stored as `None`,
+resolved to both cameras - under a server that advertised `view_keys` and under
+one that did not. The one refusal that could have caught it, `_extract_frame`'s
+"requires at least one camera frame", was unreachable for an empty selection
+because the selection had already been widened.
+
+`image_keys` is now read `is not None`, and an empty selection is refused in the
+constructor - before any server or config work, so a refused selection leaves
+nothing to undo. The list shape stays with the shared `name_list_error` domain,
+which is where `""` is answered as the bare string it is; only the emptiness
+verdict is local, which is what that domain reserves for the caller.
+
+`action_mapping` on the next line reads the same way and is unchanged: it is a
+rename mapping rather than a subset of a collection the call owns, so `{}` and
+`None` both honestly mean "no rename, columns keep their server names".
+
+Pinned by `tests/policies/vera/test_vera_image_keys_selection_domain.py`.

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -167,11 +167,13 @@ class VeraPolicy(Policy):
         tracker_backend: IDM point-tracker backend override.
         motion_plan_scale: IDM motion-plan scale (applied live via ``configure``).
         host: Server hostname.
-        image_keys: Explicit ordered camera keys to width-concat. When ``None``
-            the server's ``view_keys`` (from the connect handshake) are used,
-            matched against the observation's image keys. Must be a list of
-            distinct non-blank names; a single key passed as a bare string is
-            refused rather than read one key per character.
+        image_keys: Explicit ordered camera keys to width-concat - a SUBSET of
+            the observation's own image keys. When ``None`` the server's
+            ``view_keys`` (from the connect handshake) are used, matched against
+            the observation's image keys. Must be a list of distinct non-blank
+            names; a single key passed as a bare string is refused rather than
+            read one key per character, and an EMPTY selection is refused rather
+            than widened to that ``None`` default, because it asks for no view.
         action_mapping: ``{action_column_name: robot_actuator_name}`` rename of
             the server's action columns to robot actuator names. When ``None``
             columns keep their server names (``action_0``, ``action_1``, …).
@@ -215,8 +217,28 @@ class VeraPolicy(Policy):
         # keys read out of the observation, and a bare string is iterable per
         # character, so an unchecked one raises KeyError mid-rollout - after the
         # policy server has been launched and the model loaded.
-        if image_keys and (err := name_list_error(image_keys, "image_keys", "VeraPolicy")):
-            raise ValueError(err)
+        #
+        # Read ``is not None``: image_keys selects a SUBSET of the observation's
+        # own image keys, so it takes the membership read that ``teleoperate``'s
+        # ``names``, ``download_robots``' ``names`` and the render path's
+        # ``cameras`` take - where an empty selection resolves to no camera
+        # rather than to every one. ``None`` is the documented "the server's
+        # view_keys, or every image key in the observation"; an empty selection
+        # is the opposite answer, not a spelling of it. Gated on truthiness the
+        # shape check was skipped for ``[]`` and ``""`` and both were erased to
+        # ``None`` below, so a caller who excluded every camera drove the arm
+        # from all of them - width-concatenated into one frame, with no error
+        # and no log line. The emptiness verdict is local because the shared
+        # name-list domain deliberately leaves it to the caller.
+        if image_keys is not None:
+            if err := name_list_error(image_keys, "image_keys", "VeraPolicy"):
+                raise ValueError(err)
+            if not image_keys:
+                raise ValueError(
+                    "VeraPolicy: image_keys=[] selects no camera view, so there is no frame to "
+                    "build. Pass image_keys=None to use the server's view_keys (or every image "
+                    "key in the observation), or name the views to width-concat."
+                )
         # Same reason, same place: the smoothing coefficient blends every
         # commanded joint target with the previous one inside get_actions, so
         # a value outside [0, 1) freezes or diverges the arm mid-rollout
@@ -239,7 +261,7 @@ class VeraPolicy(Policy):
             docker_image=docker_image or "strands-vera-server:latest",
             docker_gpus=docker_gpus or "all",
         )
-        self.image_keys = list(image_keys) if image_keys else None
+        self.image_keys = list(image_keys) if image_keys is not None else None
         self.action_mapping = dict(action_mapping) if action_mapping else None
         self.prompt = prompt
         self._robot_state_keys: list[str] = []
@@ -481,8 +503,17 @@ class VeraPolicy(Policy):
         self._started = True
 
     def _resolve_view_keys(self, observation_dict: dict[str, Any], meta: dict[str, Any]) -> list[str]:
-        """Ordered camera keys to width-concat: explicit > server views > discovered."""
-        if self.image_keys:
+        """Ordered camera keys to width-concat: explicit > server views > discovered.
+
+        The explicit selection is read ``is not None`` for the reason the
+        constructor refuses an empty one: an empty subset of the observation's
+        image keys asks for no view, and this is the site that would otherwise
+        answer it with every view. The constructor keeps ``[]`` from arriving
+        here, so this read is what holds for an attribute assigned after
+        construction - ``_extract_frame`` then refuses the frame rather than
+        building one from cameras that were excluded.
+        """
+        if self.image_keys is not None:
             return self.image_keys
         obs_image_keys = [k for k, v in observation_dict.items() if _is_image_value(v)]
         server_views = [str(v) for v in meta.get("view_keys", [])]

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1556,11 +1556,17 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
     through :func:`_read_name_list`, and a read that cannot finish is answered
     with a message rather than raising out of the guard.
 
-    Callers gate this check on a truthy value, because in both consumers a falsy
-    ``image_keys`` (``None``, or an empty list) already means "not supplied" and
-    the list is derived instead. So an empty sequence is not rejected here, and
-    ``None`` is the caller's to skip rather than this function's to accept - a
-    surface where an absent value IS an error keeps that verdict its own.
+    An empty sequence is not rejected here, and ``None`` is the caller's to skip
+    rather than this function's to accept - a surface where an absent value IS an
+    error keeps that verdict its own. Which verdict that is depends on what the
+    parameter names, and the two ``image_keys`` differ on exactly this. The
+    LeRobot one DECLARES the model's visual features, and absence derives them
+    from the embodiment instead, so a falsy value there genuinely means "not
+    supplied" and that caller gates this check on truthiness. The VERA one
+    SELECTS a subset of the observation it was handed, so an empty selection asks
+    for no view and is the opposite of the documented "every view" default;
+    ``VeraPolicy`` reads it ``is not None`` and supplies the refusal beside this
+    check.
 
     Args:
         value: The caller-supplied value.

--- a/tests/policies/test_image_keys_shape.py
+++ b/tests/policies/test_image_keys_shape.py
@@ -27,8 +27,18 @@ doubles the width of the frame the model sees.
 
 These tests pin the shared domain
 (:func:`strands_robots.utils.name_list_error`), that all four surfaces that
-receive the value agree on it, that each refusal precedes the expensive work it
-guards, and that a falsy value keeps its "not supplied" meaning.
+receive the value agree on the SHAPE, and that each refusal precedes the
+expensive work it guards.
+
+The emptiness verdict is deliberately not part of that agreement, because the
+two providers do not name the same kind of thing with this parameter. The
+LeRobot side DECLARES the model's visual features, and absence derives them from
+the embodiment, so an empty list there keeps its "not supplied" meaning. The
+VERA side SELECTS a subset of the observation it was handed, so an empty
+selection asks for no view and cannot be a spelling of "every view" - it is
+refused, which is the verdict the shared domain reserves for the caller.
+:class:`TestTheEmptinessVerdictIsPerSurface` states that divergence rather than
+leaving it to be read out of a parity table.
 """
 
 from __future__ import annotations
@@ -64,9 +74,15 @@ GOOD_SHAPES: list[tuple[str, Any]] = [
     ("a tuple", ("observation.images.image",)),
 ]
 
-# Falsy values mean "not supplied" in both providers, which derive the list
-# instead. The guards are gated on a truthy value so that meaning is preserved.
-ABSENT_VALUES: list[tuple[str, Any]] = [("None", None), ("an empty list", [])]
+# ``None`` means "not supplied" on every surface, which derives the list instead.
+ABSENT_VALUES: list[tuple[str, Any]] = [("None", None)]
+
+# An empty list is a usable SHAPE whose meaning is the receiving surface's to
+# decide, so it is tabled separately from ``None``: it is "not supplied" to the
+# LeRobot declaration and an empty SELECTION - refused - to VERA. It used to sit
+# in ``ABSENT_VALUES``, which is what let the VERA cell below assert that a
+# selection naming no camera view falls back to every one of them.
+EMPTY_SELECTION: list[tuple[str, Any]] = [("an empty list", [])]
 
 
 class _FakeVeraClient:
@@ -154,8 +170,15 @@ class TestLerobotFeatureKeys:
         keys = ["observation.images.image", "observation.images.wrist_image"]
         assert molmoact2.derive_image_keys(keys, None) == keys
 
-    @pytest.mark.parametrize(("label", "value"), ABSENT_VALUES, ids=[c[0] for c in ABSENT_VALUES])
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        ABSENT_VALUES + EMPTY_SELECTION,
+        ids=[c[0] for c in ABSENT_VALUES + EMPTY_SELECTION],
+    )
     def test_an_absent_value_still_derives_the_default_list(self, label: str, value: Any) -> None:
+        """Both spellings are "not supplied" here: this parameter declares the
+        model's features rather than selecting a subset of a collection the call
+        owns, so absence derives them and an empty list is that same absence."""
         assert molmoact2.derive_image_keys(value, None) == list(molmoact2.DEFAULT_IMAGE_KEYS)
 
     def test_the_refusal_precedes_the_weight_load(self) -> None:
@@ -233,6 +256,20 @@ class TestVeraViewKeys:
         assert policy.image_keys is None
         assert policy._resolve_view_keys(_observation(), {"view_keys": ["front"]}) == ["front"]
 
+    @pytest.mark.parametrize(("label", "value"), EMPTY_SELECTION, ids=[c[0] for c in EMPTY_SELECTION])
+    def test_an_empty_selection_is_refused_rather_than_falling_back(self, label: str, value: Any) -> None:
+        """This row used to be one of the ``ABSENT_VALUES`` above.
+
+        It is retargeted rather than dropped, because the assertion it made was
+        the defect: ``image_keys`` selects a subset of the observation's cameras,
+        so an empty selection asks for no view, and falling back served every one
+        of them - the opposite answer, under a success result. The full domain,
+        with the frame it produces, is pinned by
+        ``tests/policies/vera/test_vera_image_keys_selection_domain.py``.
+        """
+        with pytest.raises(ValueError, match="selects no camera view"):
+            _vera(value)
+
 
 # --------------------------------------------------------------------------- #
 # The surfaces must not diverge
@@ -252,6 +289,9 @@ class TestCrossProviderParity:
     feature keys against observation camera keys - but a value either is a list
     of distinct names or is not, so a shape refused by one surface cannot be
     accepted by another.
+
+    The empty list is not a shape question and is therefore not in this table;
+    :class:`TestTheEmptinessVerdictIsPerSurface` covers it.
     """
 
     @pytest.mark.parametrize(
@@ -273,3 +313,28 @@ class TestCrossProviderParity:
                 "VeraPolicy": _verdict(lambda: _vera(fresh())),
             }
         assert len(set(verdicts.values())) == 1, f"surfaces disagree for {label}: {verdicts}"
+
+
+# --------------------------------------------------------------------------- #
+# The one value whose verdict is the surface's own
+# --------------------------------------------------------------------------- #
+class TestTheEmptinessVerdictIsPerSurface:
+    """An empty list is a usable shape, so the shared domain returns nothing.
+
+    ``name_list_error([])`` is ``None`` on purpose - "a surface where an absent
+    value IS an error keeps that verdict its own" - and the two surfaces reach
+    opposite verdicts because they name different contracts with the one option
+    name. Asserted here so the divergence is deliberate and stays visible: a
+    later sweep that made either side match the other would have to delete this.
+    """
+
+    def test_the_shared_domain_returns_no_verdict(self) -> None:
+        assert name_list_error([], "image_keys", "Surface") is None
+
+    def test_the_declaration_reads_it_as_not_supplied(self) -> None:
+        assert molmoact2.derive_image_keys([], None) == list(molmoact2.DEFAULT_IMAGE_KEYS)
+        LerobotLocalPolicy.preflight({"front"}, image_keys=[])
+
+    def test_the_selection_refuses_it(self) -> None:
+        with pytest.raises(ValueError, match="selects no camera view"):
+            _vera([])

--- a/tests/policies/test_state_key_name_list_contract.py
+++ b/tests/policies/test_state_key_name_list_contract.py
@@ -90,8 +90,11 @@ The by-name section below is now a table derived from ``_TOTAL_BY_MEMBERSHIP``,
 the guard the owning half already had, so a provider cannot be classified as
 already-total without being driven.
 
-``None`` and an empty list keep their existing "auto-detect" meaning: like every
-other consumer of the shared domain, the check is gated on a truthy value.
+``None`` and an empty list keep their existing "auto-detect" meaning: like the
+other consumers of the shared domain whose absent value DERIVES the list, this
+check is gated on a truthy value. (The VERA ``image_keys`` is the one consumer
+where it is not, because it selects a subset of the observation it was handed, so
+an empty selection there is refused rather than derived.)
 
 The AST classifier below proves that each of the nine owning surfaces CALLS
 the shared domain. It cannot prove that any of them RAISES: a body keeping the

--- a/tests/policies/vera/test_vera_image_keys_selection_domain.py
+++ b/tests/policies/vera/test_vera_image_keys_selection_domain.py
@@ -1,0 +1,193 @@
+"""``VeraPolicy.image_keys`` is a subset selector, so it is read by membership.
+
+``image_keys`` names a SUBSET of the observation's own image keys - the cameras
+to width-concat into the single ``(H, W, 3)`` frame the video planner acts on.
+``None`` is documented as "the server's ``view_keys`` (from the connect
+handshake), or every image key in the observation". Read by truthiness, every
+other falsy value took that same branch, and for a selector that is not a wider
+default but the *opposite* answer: a caller who selected no camera view was
+served every one of them.
+
+Four sites spelled the one parameter, and the two reads were independent
+mistakes - the shape guard was gated on a truthy value, so it never saw the
+empty selection; the store erased ``[]`` to ``None``, so the selection was gone
+before the resolver ran; and the resolver read the attribute by truthiness too.
+
+Measured before the fix, one ``VeraPolicy(embodiment="pusht",
+auto_launch_server=False, image_keys=X)`` per row against a two-camera
+observation, offline - no server, no ``vera`` package, no GPU:
+
+| ``image_keys=`` | stored | resolved views (no server ``view_keys``) |
+| --- | --- | --- |
+| ``None`` | ``None`` | ``['...images.top', '...images.wrist']`` |
+| ``[]``   | **``None``** | **``['...images.top', '...images.wrist']``** |
+| ``""``   | **``None``** | **``['...images.top', '...images.wrist']``** |
+| ``['...images.wrist']`` | ``['...images.wrist']`` | ``['...images.wrist']`` |
+
+``[]`` and ``""`` were byte-identical to ``None`` at both surfaces, under a
+server that advertised ``view_keys`` and under one that did not.
+
+The consequence is silent in the direction that cannot be noticed: the excluded
+cameras are concatenated into a *wider* frame and the rollout succeeds, so the
+mistake presents as a policy that does not solve. The one refusal that could
+have caught it - ``_extract_frame``'s "requires at least one camera frame" -
+was unreachable for an empty selection, because by then it had been widened.
+
+``image_keys`` reaches this from configuration: it is a ``VeraPolicy``
+constructor keyword, so it arrives through ``create_policy("vera", ...)`` and
+``policy_config``, and an empty list is what a filter that matched nothing
+produces.
+
+The list shape stays with the shared name-list domain (a bare string is
+iterable per character, a repeat concatenates one panel twice); only the
+emptiness verdict is local, which is what that domain's docstring reserves for
+the caller. ``""`` is refused by the shape half, as the bare string it is.
+
+Everything here is offline - no server, no socket, no ``vera`` package, no GPU.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.vera import VeraPolicy
+
+TOP = "observation.images.top"
+WRIST = "observation.images.wrist"
+
+
+def _two_camera_observation() -> dict[str, Any]:
+    """An observation carrying two distinguishable camera frames."""
+    return {
+        TOP: np.zeros((8, 8, 3), dtype=np.uint8),
+        WRIST: np.full((8, 8, 3), 255, dtype=np.uint8),
+        "observation.state": np.zeros((6,), dtype=np.float32),
+    }
+
+
+def _policy(**kwargs: Any) -> VeraPolicy:
+    """A provider built without launching or contacting a server."""
+    return VeraPolicy(embodiment="pusht", auto_launch_server=False, **kwargs)
+
+
+class TestAnEmptySelectionIsRefusedRatherThanWidened:
+    """``[]`` asks for no view, so it cannot resolve to every view."""
+
+    @pytest.mark.parametrize("empty", [[], ()], ids=["list", "tuple"])
+    def test_an_empty_selection_is_refused(self, empty: Any) -> None:
+        with pytest.raises(ValueError) as exc:
+            _policy(image_keys=empty)
+        assert "image_keys" in str(exc.value)
+
+    def test_the_refusal_names_the_spelling_that_means_every_view(self) -> None:
+        """The remedy has to name ``None``, which is the branch it stopped taking."""
+        with pytest.raises(ValueError) as exc:
+            _policy(image_keys=[])
+        message = str(exc.value)
+        assert "image_keys=None" in message
+        assert "no camera view" in message
+
+    def test_the_refusal_precedes_the_server_runner(self) -> None:
+        """A refused selection leaves no runner to stop and no server to reap."""
+        started: list[str] = []
+
+        class _SpyRunner:
+            def start(self) -> None:
+                started.append("start")
+
+            def stop(self) -> None:
+                started.append("stop")
+
+        with pytest.raises(ValueError):
+            VeraPolicy(embodiment="pusht", image_keys=[], server_runner=_SpyRunner())  # type: ignore[arg-type]
+        assert started == []
+
+
+class TestAnEmptySelectionIsNeverServedAnUnselectedCamera:
+    """The behaviour the refusal exists for, asserted on the frame itself."""
+
+    def test_a_one_camera_selection_builds_a_one_camera_frame(self) -> None:
+        policy = _policy(image_keys=[WRIST])
+        frame = policy._extract_frame(_two_camera_observation(), {})
+        both = _policy()._extract_frame(_two_camera_observation(), {})
+        assert frame.shape[1] * 2 == both.shape[1]
+        # The selected camera is the one in the frame, not the excluded one.
+        assert int(frame.min()) == 255
+
+    def test_an_empty_attribute_resolves_to_no_camera_and_the_frame_is_refused(self) -> None:
+        """The resolver's own read, reached by assigning the attribute directly.
+
+        The constructor keeps ``[]`` from arriving here, so this pins the second
+        of the two independent truthiness reads: an empty selection resolves to
+        no camera and ``_extract_frame`` refuses, rather than the resolver
+        answering it with every camera in the observation.
+        """
+        policy = _policy()
+        policy.image_keys = []
+        assert policy._resolve_view_keys(_two_camera_observation(), {}) == []
+        with pytest.raises(ValueError):
+            policy._extract_frame(_two_camera_observation(), {})
+
+
+class TestTheDocumentedSpellingsAreUnchanged:
+    """Controls: the narrowing is confined to the empty selection."""
+
+    def test_none_resolves_to_every_image_key_when_the_server_names_no_view(self) -> None:
+        policy = _policy(image_keys=None)
+        assert policy.image_keys is None
+        assert policy._resolve_view_keys(_two_camera_observation(), {}) == [TOP, WRIST]
+
+    def test_none_resolves_to_the_server_views_when_the_handshake_names_them(self) -> None:
+        policy = _policy(image_keys=None)
+        resolved = policy._resolve_view_keys(_two_camera_observation(), {"view_keys": [TOP]})
+        assert resolved == [TOP]
+
+    def test_a_real_subset_is_stored_and_resolved_as_written(self) -> None:
+        policy = _policy(image_keys=[WRIST])
+        assert policy.image_keys == [WRIST]
+        assert policy._resolve_view_keys(_two_camera_observation(), {}) == [WRIST]
+        # An explicit selection outranks the server's advertised views.
+        assert policy._resolve_view_keys(_two_camera_observation(), {"view_keys": [TOP]}) == [WRIST]
+
+    def test_the_selection_is_copied_so_a_later_mutation_cannot_reach_the_policy(self) -> None:
+        selection = [WRIST]
+        policy = _policy(image_keys=selection)
+        selection.append(TOP)
+        assert policy.image_keys == [WRIST]
+
+
+class TestTheShapeVerdictStaysWithTheSharedDomain:
+    """Controls: the spellings the name-list domain already refused still are."""
+
+    def test_a_bare_string_is_refused_as_one_name_per_character(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            _policy(image_keys=WRIST)  # type: ignore[arg-type]
+        assert "must be a list of names, not a single string" in str(exc.value)
+
+    def test_an_empty_string_is_refused_by_the_same_half(self) -> None:
+        """``""`` was widened exactly like ``[]``; it is a bare string, so it takes that verdict."""
+        with pytest.raises(ValueError) as exc:
+            _policy(image_keys="")  # type: ignore[arg-type]
+        assert "must be a list of names, not a single string" in str(exc.value)
+
+    def test_a_repeated_name_is_still_refused(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            _policy(image_keys=[WRIST, WRIST])
+        assert "repeat" in str(exc.value)
+
+
+class TestTheRuleDoesNotReachActionMapping:
+    """Recorded so the narrowing is not re-proposed one line further down.
+
+    ``action_mapping`` reads the same way (``dict(action_mapping) if
+    action_mapping else None``) and is correct: it is a rename mapping rather
+    than a subset of a collection the call owns, so ``{}`` and ``None`` both
+    honestly mean "no rename, columns keep their server names".
+    """
+
+    def test_an_empty_action_mapping_is_accepted_and_means_no_rename(self) -> None:
+        assert _policy(action_mapping={}).action_mapping is None
+        assert _policy(action_mapping=None).action_mapping is None

--- a/tests/policies/vera/test_vera_image_keys_selection_domain.py
+++ b/tests/policies/vera/test_vera_image_keys_selection_domain.py
@@ -48,6 +48,9 @@ Everything here is offline - no server, no socket, no ``vera`` package, no GPU.
 
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
 from typing import Any
 
 import numpy as np
@@ -191,3 +194,81 @@ class TestTheRuleDoesNotReachActionMapping:
     def test_an_empty_action_mapping_is_accepted_and_means_no_rename(self) -> None:
         assert _policy(action_mapping={}).action_mapping is None
         assert _policy(action_mapping=None).action_mapping is None
+
+
+def _reads_image_keys_bare(test: ast.expr) -> bool:
+    """``image_keys`` used as a condition on its own, i.e. read by truthiness."""
+    return (isinstance(test, ast.Name) and test.id == "image_keys") or (
+        isinstance(test, ast.Attribute) and test.attr == "image_keys"
+    )
+
+
+def _image_keys_reads(func: Any) -> tuple[list[ast.expr], list[ast.Compare]]:
+    """Every conditional read of ``image_keys`` in ``func``, split by how it reads."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    bare = [
+        node.test
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.If, ast.IfExp)) and _reads_image_keys_bare(node.test)
+    ]
+    membership = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Compare)
+        and any(isinstance(op, (ast.Is, ast.IsNot)) for op in node.ops)
+        and _reads_image_keys_bare(node.left)
+    ]
+    return bare, membership
+
+
+class TestEveryReadOfTheSelectionUsesMembership:
+    """The third read, which no value can reach any more, graded structurally.
+
+    The three reads this module names are pinned by behaviour above except one.
+    The shape guard is pinned by the refusal; the resolver is pinned by an
+    attribute assigned after construction. The store runs only at construction,
+    *below* a guard that now refuses every empty value, so no value can reach it
+    to tell the two spellings apart - yet it is the line that erased ``[]`` to
+    ``None`` and it is the reason the resolver never saw a selection to widen.
+
+    Its spelling is a ternary rather than an ``if``, so both conditional forms
+    are scanned: a check written for statement conditionals alone leaves the
+    store free to return to truthiness, and a later change that relaxed or moved
+    the refusal would then restore the widening with nothing failing.
+    """
+
+    @pytest.mark.parametrize(
+        "func",
+        [VeraPolicy.__init__, VeraPolicy._resolve_view_keys],
+        ids=["__init__", "_resolve_view_keys"],
+    )
+    def test_no_conditional_reads_the_selection_by_truthiness(self, func: Any) -> None:
+        bare, _ = _image_keys_reads(func)
+        assert not bare, (
+            f"{func.__qualname__} reads image_keys by truthiness at line(s) "
+            f"{[node.lineno for node in bare]}, which reads an empty selection as absent "
+            "and widens it to every view"
+        )
+
+    @pytest.mark.parametrize(
+        "func",
+        [VeraPolicy.__init__, VeraPolicy._resolve_view_keys],
+        ids=["__init__", "_resolve_view_keys"],
+    )
+    def test_the_scan_is_looking_at_a_membership_read(self, func: Any) -> None:
+        """Non-vacuity: deleting the reads would satisfy the rule above."""
+        _, membership = _image_keys_reads(func)
+        assert membership, f"{func.__qualname__} does not read image_keys against None at all"
+
+    def test_the_constructor_holds_both_conditional_forms(self) -> None:
+        """The gate is an ``if`` and the store is a ternary, so both are in scope.
+
+        Recorded because the two forms are what a partial scan splits: the counts
+        below are the reason :meth:`test_no_conditional_reads_the_selection_by_truthiness`
+        cannot be written against ``ast.If`` alone.
+        """
+        tree = ast.parse(textwrap.dedent(inspect.getsource(VeraPolicy.__init__)))
+        statements = [n for n in ast.walk(tree) if isinstance(n, ast.If)]
+        ternaries = [n for n in ast.walk(tree) if isinstance(n, ast.IfExp)]
+        assert statements, "the constructor no longer guards with an if statement"
+        assert ternaries, "the constructor no longer stores the selection through a ternary"


### PR DESCRIPTION
Fixes #3202

## The selector and the two reads

`VeraPolicy.image_keys` names a SUBSET of the observation's own image keys - the cameras `_extract_frame` width-concatenates into the single `(H, W, 3)` frame the video planner acts on. `None` is documented as "the server's `view_keys` (from the connect handshake), or every image key in the observation".

It was read by truthiness at **both** the site that stores it and the site that resolves it, and the shape guard was gated on a truthy value too, so the empty selection never reached any of the three:

```
provider.py:218   if image_keys and (err := name_list_error(...)):   # skipped entirely for [] and ""
provider.py:242   self.image_keys = list(image_keys) if image_keys else None   # [] erased to None
provider.py:485   if self.image_keys:                                # second, independent spelling
```

For a selector that is not a wider default but the **opposite answer**: a caller who excluded every camera drove the arm from all of them.

## Measured

One `VeraPolicy(embodiment="pusht", auto_launch_server=False, image_keys=X)` per row against a two-camera observation. Offline - no server, no socket, no `vera` package, no GPU.

| `image_keys=` | stored | resolved (no server `view_keys`) | resolved (`view_keys=['...top']`) | frame |
|---|---|---|---|---|
| `None` | `None` | `['...top', '...wrist']` | `['...top']` | `(252, 504, 3)` |
| **`[]`** | **`None`** | **`['...top', '...wrist']`** | **`['...top']`** | **`(252, 504, 3)`** |
| **`""`** | **`None`** | **`['...top', '...wrist']`** | **`['...top']`** | **`(252, 504, 3)`** |
| `['...wrist']` | `['...wrist']` | `['...wrist']` | `['...wrist']` | `(252, 252, 3)` |

`[]` and `""` were byte-identical to `None` at every surface, under both handshake cases. The last column is the consequence: the excluded cameras are concatenated into a frame **twice as wide** as the one the selection asked for, and the rollout *succeeds* - so the mistake presents as a policy that does not solve rather than as an error. The one refusal that could have caught it, `_extract_frame`'s `if not view_keys: raise`, was unreachable for an empty selection, because by then it had been widened.

Nothing had to write `[]` to get here: `image_keys` is a `VeraPolicy` constructor keyword, so it arrives through `create_policy("vera", ...)` / `policy_config` as caller-supplied configuration, and an empty list is what a filter that matched nothing produces.

## The change

| site | before | after |
|---|---|---|
| shape guard | gated on `image_keys and ...` | `if image_keys is not None:` - the shape check, then the local emptiness refusal |
| store | `list(image_keys) if image_keys else None` | `... if image_keys is not None else None` |
| resolver | `if self.image_keys:` | `if self.image_keys is not None:` |
| `Args:` entry | documented `None` alone | names the subset, and that an empty selection is refused |

Both reads move together on purpose: fixing one alone leaves the other free to widen. The refusal is in the constructor, ahead of any config or server work, so a refused selection leaves nothing half-configured to undo - the same placement the two ports and `ik_smoothing` on this class already take.

The list shape stays with the shared `name_list_error` domain (a bare string is one name per character; a repeat concatenates one panel twice). Only the emptiness verdict is local, which is exactly what that domain reserves for the caller: "a surface where an absent value IS an error keeps that verdict its own". `""` needs no new rule - once the guard is no longer gated on truthiness it is answered as the bare string it is.

```
VeraPolicy: image_keys=[] selects no camera view, so there is no frame to build.
Pass image_keys=None to use the server's view_keys (or every image key in the
observation), or name the views to width-concat.
```

## Deliberately unchanged

* **`action_mapping`, one line below**, reads the same way (`dict(action_mapping) if action_mapping else None`) and is **correct**: a rename mapping is not a subset of a collection the call owns, so `{}` and `None` both honestly mean "no rename, columns keep their server names". Pinned as a control so the narrowing is not re-proposed one line further down.
* **The LeRobot `image_keys`** shares the parameter name and not the contract: it *declares* the model's visual features, and absence derives them from the embodiment's `obs_rename` targets (`derive_image_keys` priority 2/3), so a falsy value there does mean "not supplied". That caller keeps its truthiness gate. What did drift is the shared domain's own docstring, which said *both* consumers gate on truthiness - it now states which verdict each surface owns.

## Tests

`tests/policies/vera/test_vera_image_keys_selection_domain.py`, 14 cells. Against the **pre-fix** provider: **6 failed / 8 passed**; post-fix **14 passed**.

The 8 that pass pre-fix are the controls, which is the point of including them: `None` under both handshake cases, a real subset outranking the advertised views, the defensive copy, the bare-string and repeated-name refusals, and the `action_mapping` carve-out. The 6 failures are the defect - the constructor refusal (list and tuple), the remedy naming `None`, the refusal preceding the injected server runner, the resolver's own read, and `""`.

One cell asserts the consequence rather than the flag: a one-camera selection builds a frame half the width of the unselected one, and its pixels are the selected camera's.

## Size

| file | lines |
|---|---|
| `strands_robots/policies/vera/provider.py` | +41 / -10 |
| `strands_robots/utils.py` | docstring only (+11 / -5) |
| `tests/policies/vera/test_vera_image_keys_selection_domain.py` | +196 (new, 14 cells) |
| `tests/policies/test_image_keys_shape.py` | +72 / -6 (round 1) |
| `tests/policies/test_state_key_name_list_contract.py` | docstring only (round 1) |
| `AGENTS.md` | +12 (the rule's site list + pin) |
| `changelog.d/3202-vera-image-keys-empty-selection.md` | +26 |

The executable change is four lines at three sites; the rest is the pin and the reasons.

## §13 round changelog

* **round 0** - initial submission.
* **round 1** (`930118e`) - CI named one failure, and it was the tree's own statement of the defect: `test_image_keys_shape.py` tabled `[]` alongside `None` in `ABSENT_VALUES`, so `TestVeraViewKeys::test_an_absent_value_still_falls_back_to_the_server_views[an empty list]` asserted that a selection naming no camera view falls back to every one of them. **Retargeted, not deleted** - its id said "an absent value", and an empty selection is not absent. `[]` now has its own `EMPTY_SELECTION` table, because its verdict belongs to the receiving surface: the LeRobot cells keep it (that parameter declares, and absence derives), the VERA cell asserts the refusal. `TestCrossProviderParity` is a *shape* table, so the empty list leaves it, and the divergence it would otherwise have hidden is stated outright by a new `TestTheEmptinessVerdictIsPerSurface` - shared domain returns no verdict, declaration reads it as not supplied, selection refuses it. Also drops a stale clause in `test_state_key_name_list_contract.py` that said every consumer of the shared domain gates the check on truthiness. No production code changed in this round.

## Gate

`ruff check` + `ruff format --check` clean on every changed file. Round 0 CI reached 10776 items with 1 failure under `-x` (the retargeted cell above); the rest of the suite was never reached, so round 1's run is the first full measurement. This runner has no `torch` / `mujoco` / `gymnasium`, so `tests/policies/test_image_keys_shape.py` cannot be executed here (it imports `LerobotLocalPolicy`) - the two behaviours its new cells assert are each already asserted elsewhere in that file or in the new VERA suite, and CI is the measurement.