### PR TITLE
feat(dashboard): mesh_bridge slice of #2848 — the signed rail honours the kill switch and an e-stop reports what the peers said (#2977)

### DIFF
--- a/changelog.d/2848-signed-estop-reports-what-the-peers-said.md
+++ b/changelog.d/2848-signed-estop-reports-what-the-peers-said.md
@@ -1,0 +1,33 @@
+### Fixed: the dashboard's signed e-stop reports what the peers said, not only that the rail latched
+
+`Mesh.emergency_stop` engages the issuer's lockout unconditionally, before it
+broadcasts anything, so `lockout_engaged` is true whatever the fleet does.
+`MeshBridge.signed_estop` returned that and nothing else, and the sheet rendered
+it as `peers refuse all commands until resumed` - a claim about the room made
+from a fact about this process:
+
+```python
+{k: v for k, v in signed_estop().items() if k != "responses"}
+# every peer acknowledged        -> {"signed": True, "issuer": "dash-safety", "lockout_engaged": True}
+# NOBODY answered at all         -> {"signed": True, "issuer": "dash-safety", "lockout_engaged": True}
+# two answered, NEITHER stopped  -> {"signed": True, "issuer": "dash-safety", "lockout_engaged": True}
+```
+
+One payload for three fleets, on the one screen an operator reads to decide
+whether to reach for the hardware cutoff.
+
+`lockout_engaged` keeps its value, because it is true and because the resume
+control is gated on it - reporting `False` on an unacknowledged stop would hide
+the only way to clear a lockout that really is engaged. The peer half is now
+carried alongside it, from the accounting `emergency_stop` already computes for
+its `strands/safety/estop` envelope: `responses_received` (replies received, not
+stops confirmed, keeping the meaning #1680 gave it) and `peers_not_stopped`
+(responders that affirmatively reported they did not stop). The grading stays in
+`mesh.core`, since a second copy of that rule on the safety path is how the sim
+dispatch branch once answered `ok=True` over a refusal it had in hand.
+
+The sheet's sentence derives from those two fields rather than from the latch -
+a lockout refuses the NEXT command and does not halt motion already underway,
+which is the distinction that decides whether an operator walks to the power
+supply. That half lives in the dashboard frontend and lands with the server
+slice of the #2848 decomposition (#2977).

--- a/changelog.d/2848-signed-rail-honours-the-mesh-kill-switch.md
+++ b/changelog.d/2848-signed-rail-honours-the-mesh-kill-switch.md
@@ -1,0 +1,31 @@
+### Fixed: the dashboard's signed safety rail honours the mesh kill switch
+
+`STRANDS_MESH=false` is documented as a hard kill switch, and
+`mesh_disabled_by_env()` is the one predicate every path which can open a
+session asks - #2515 added the check after `robot_mesh`'s gateway joined the
+fleet without it. `MeshBridge.start()` asks it. `MeshBridge._safety_mesh()`,
+the dashboard's second `Mesh` construction site, did not:
+
+```python
+os.environ["STRANDS_MESH"] = "false"
+MeshBridge(peer_id="dash").signed_estop()
+# before: a live "dash-safety" gateway peer joins the fleet
+# after:  {"signed": False, "error": "signed safety rail disabled by STRANDS_MESH=false"}
+```
+
+So an operator who asked for no mesh still got one, created by the first
+e-stop - the ghost-peer case the switch was added to close, arriving on the path
+where the peer list is least likely to be watched and by way of the action least
+likely to be debugged afterwards. The switch is now read before the constructor,
+because constructing a `Mesh` is what joins.
+
+The refusal names the variable rather than reporting "safety mesh unavailable",
+since an operator who set the switch would otherwise go hunting a fault instead
+of looking at the switch they set; a rail that is genuinely broken still reports
+"unavailable", so the two answers stay distinguishable. The per-peer broadcast
+stop is unaffected and still fans out.
+
+The new site is graded from the source rather than only by behaviour, so a third
+construction site added without the predicate fails on arrival - a missing case
+for an untested site is how this one stayed ungated while its neighbour was
+gated.

--- a/changelog.d/2977-dashboard-mesh-bridge.md
+++ b/changelog.d/2977-dashboard-mesh-bridge.md
@@ -1,0 +1,24 @@
+### Added: the `strands_robots.dashboard` mesh bridge
+
+`mesh_bridge` is the dashboard's mesh peer: it joins the fleet through
+`mesh.session`, mirrors presence/state/camera/sensor topics into a fleet
+snapshot, fans events out to async consumers with per-type coalescing, runs
+point-to-point commands with the same responder scoping `Mesh.send` enforces,
+and carries the signed safety rail (`signed_estop` / `signed_resume`) over a
+robot-less gateway `Mesh`.
+
+Extracted from draft #2848 as a slice of the #2977 decomposition, with the two
+mesh-safety findings from that draft's review fixed on arrival (the signed
+e-stop reports what the peers said, and the signed rail honours the mesh kill
+switch - each has its own fragment). Both of the bridge's session-opening paths
+ask `mesh_disabled_by_env()`, the predicate every construction site answers,
+and the e-stop grading is imported from `mesh.core` rather than copied.
+
+The module imports nothing the `[dashboard]` extra does not already supply -
+its mesh-side imports are lazy, matching the "documented no-zenoh path" the
+mesh package keeps - and it sits behind the package gate in
+`strands_robots/dashboard/__init__.py` all the same, so a caller without the
+extra gets one refusal naming it. The HTTP/WebSocket surface that serves this
+bridge (`dashboard.server`) is a later slice; until it lands the
+`peer_annotations` / `protected_peer_ids` / `managed_children` hooks simply
+stay unset, which the bridge is built to tolerate.

--- a/changelog.d/3205-dashboard-mesh-env-floats.md
+++ b/changelog.d/3205-dashboard-mesh-env-floats.md
@@ -1,0 +1,29 @@
+### Fixed: the dashboard reports the camera rate the mesh publishes at, not a second reading of the same variable
+
+`STRANDS_MESH_CAMERA_HZ` is the mesh's knob: `Mesh._resolve_camera_hz` reads it
+through `mesh.session.hz_from_env` and disables the camera loop when it is unset,
+non-positive, or a value no loop can pace itself with. The dashboard is the
+surface that *writes* that variable - the settings panel holds `camera_hz` and
+`settings.apply_mesh_env` pushes it into the environment the peers read - and its
+mesh posture payload read it back through a bare `float()`. Six of nine spellings
+an operator can type disagreed between the two: `-5`, `nan`, `inf` and `1e999`
+were echoed to the panel as live rates while the peer published nothing, and
+`nan`/`inf` are not JSON, so `/api/mesh/config` emitted a body no conformant
+client can parse. A typo or whitespace raised `ValueError` out of the handler
+instead, taking the endpoint that would have shown the posture with it.
+
+The bridge's own `STRANDS_DASHBOARD_*` rate and TTL knobs are resolved at import,
+where a bare `float()` costs more: a typo raised `ValueError` while the module
+body executed, so the mesh bridge did not lose one knob but failed to import,
+from a frame naming `float` rather than the variable. A non-finite value was
+accepted instead and reached each consumer as one side of a comparison it removes
+rather than widens - `age > ttl` is `False` for every age against both `nan` and
+`inf`, so a robot that left the fleet was never aged out of the snapshot.
+
+Both now ask the owner of the question: the camera rate through
+`mesh.session.hz_from_env` with the publisher's documented fallback, and the
+dashboard's own knobs through the shared `utils.finite_number_error` domain, with
+every rejection reported so a substituted default is not silent. Each knob's
+floor is left to its consumer, as before: `prune_peers` reads a non-positive TTL
+as "never prune" and the event coalescer reads a non-positive rate as "no
+ceiling".

--- a/changelog.d/3205-env-float-sweep-covers-module-scope.md
+++ b/changelog.d/3205-env-float-sweep-covers-module-scope.md
@@ -1,0 +1,12 @@
+### Fixed: the package-wide env-float sweep classifies the position an unusable value costs the most
+
+`tests/test_env_float_knobs_resolve_to_a_finite_value.py` states a package-wide
+rule and derived its population from every *function* that reads the environment
+and coerces with `float()`. A knob resolved by a module-level statement was not a
+function that failed that scan - it was invisible to it, so the sweep read as a
+clean tree, which is the same blind spot its own docstring records for a
+per-package root. That position is where an unusable value is worst, because the
+coercion runs during import. Module-level statements are now classified too, keyed
+`module::<module>`, and a guard is credited only to the scope that applies it: a
+walk that descended into an enclosed `def` read a block as bounded by an
+`isfinite` it never called.

--- a/changelog.d/3205-signed-resume-honours-the-kill-switch.md
+++ b/changelog.d/3205-signed-resume-honours-the-kill-switch.md
@@ -1,0 +1,18 @@
+### Fixed: the resume half of the signed safety rail reports a switched-off rail as a fault
+
+`MeshBridge.signed_estop` distinguishes "you switched this off" from "this is
+broken", because an operator acts on the two differently: one is the switch they
+set, the other is a fault to chase. `MeshBridge.signed_resume` is the same rail
+and the same operator and did not - with `STRANDS_MESH` set to any kill spelling
+it answered `safety mesh unavailable`, which is the wording the rail's own suite
+pins as meaning a fault. The troubleshooting sheet documents exactly two causes
+for a refused resume, both about `override_code`, so an operator who set the
+switch was sent to a code that is fine rather than to the switch they set.
+
+Both verbs now answer through one owner, so the two wordings have a single
+spelling and a second copy cannot disagree with the first. The rail's guard is
+widened with it: keying on `Mesh(...)` construction grades "did we open a
+session" and is structurally blind to a verb that constructs nothing, which is
+how the resume half drifted. Every answer that reports the rail unavailable is
+now graded for asking the kill switch, whether or not it opens a session, and
+`signed_resume` gains the behavioural cells it had none of.

--- a/docs/dashboard/troubleshooting.md
+++ b/docs/dashboard/troubleshooting.md
@@ -40,6 +40,25 @@ cameras={"wrist": {"index_or_path": 1}, "top": {"index_or_path": 0}}
 An unknown key is refused rather than dropped, deliberately: a silently
 discarded option would report success while the camera streamed at the default.
 
+**The settings panel reports `camera_hz` as 0 after I set a rate**
+
+That is the rate the mesh camera loop resolved, not the string in the settings
+store, and the two are now the same reading. `STRANDS_MESH_CAMERA_HZ` disables
+camera publishing when it is unset, non-positive, or a value no loop can pace
+itself with - `nan`, `inf`, or a typo - because frames are large and falling back
+to a rate you did not ask for is worse than not publishing. A `0` on the panel
+after you typed something else means the peer refused the value, and the server
+log names the variable and what it held. Retype it as a positive number.
+
+**A `STRANDS_DASHBOARD_*_HZ` or `_TTL_S` knob I set has no effect**
+
+Check the log for `is not a number` or `must be a finite number` naming that
+variable: an unusable value falls back to the documented default rather than
+being carried into a comparison it would silently remove. `nan` and `inf` are the
+ones to watch, because both read as "no bound" to every consumer - a `nan`
+`STRANDS_DASHBOARD_PEER_TTL_S` would keep departed peers on the fleet view
+forever rather than ageing them out.
+
 **A tile says `camera busy - another app is holding this device`**
 
 Exactly what it says. On macOS, Photo Booth, QuickTime, Zoom, Chrome's camera
@@ -77,7 +96,7 @@ kill it at 10 seconds and conclude the mesh is broken.
 **A peer's card is greyed as `stale`, then vanishes**
 
 Stale after 15s of silence; aged out after `STRANDS_DASHBOARD_PEER_TTL_S`
-(default 300). A peer with a live managed process is never dropped, so a running
+(default 300, which is also what an unusable value falls back to). A peer with a live managed process is never dropped, so a running
 robot cannot be erased by a state-stream hiccup - if a card disappeared, that
 process really is gone.
 

--- a/docs/dashboard/troubleshooting.md
+++ b/docs/dashboard/troubleshooting.md
@@ -183,6 +183,13 @@ brute-force throttled; the code itself never crosses the wire. Every peer must
 share the same `STRANDS_MESH_OVERRIDE_CODE`, or each one stays locked until its
 process restarts.
 
+If the answer names `STRANDS_MESH=false` rather than the code, the override is
+not the problem: the kill switch is set, so there is no signed rail to resume
+over and none was opened. Clear the switch to use the signed rail, or clear the
+lockout on each peer directly. Both signed verbs report the switch by name
+rather than as a fault, so "safety mesh unavailable" from either one means the
+rail was allowed and would not start.
+
 ## Tests
 
 **`ModuleNotFoundError: No module named 'psutil'` / `'msgpack'` during pytest

--- a/strands_robots/dashboard/mesh_bridge.py
+++ b/strands_robots/dashboard/mesh_bridge.py
@@ -1010,24 +1010,35 @@ class MeshBridge:
                 logger.warning("signed safety rail unavailable: %s", exc)
                 return None
 
+    def _rail_unavailable(self) -> dict[str, Any]:
+        """The one answer for "there is no signed rail", switch-aware.
+
+        "Switched off" and "broken" are different answers and an operator acts
+        on them differently: one is the switch they set, the other is a fault to
+        chase. Every rail verb answers through here so the two wordings have a
+        single owner. A second copy is exactly how the resume half came to
+        report a switched-off rail as a fault while the e-stop half reported it
+        correctly, 38 lines apart in this file -- and the operator reading
+        "unavailable" is sent to the two ``override_code`` causes the
+        troubleshooting sheet lists for a refused resume, neither of which is
+        the switch they set.
+        """
+        from strands_robots.mesh.core import mesh_disabled_by_env
+
+        return {
+            "signed": False,
+            "error": (
+                "signed safety rail disabled by STRANDS_MESH=false"
+                if mesh_disabled_by_env()
+                else "safety mesh unavailable"
+            ),
+        }
+
     def signed_estop(self) -> dict[str, Any]:
         """Fleet e-stop over the SIGNED rail."""
         m = self._safety_mesh()
         if m is None:
-            # "Switched off" and "broken" are different answers, and the sheet
-            # shows this string: an operator who set STRANDS_MESH=false chose
-            # to have no signed rail, and reading "unavailable" would send them
-            # hunting a fault instead of looking at the switch they set.
-            from strands_robots.mesh.core import mesh_disabled_by_env
-
-            return {
-                "signed": False,
-                "error": (
-                    "signed safety rail disabled by STRANDS_MESH=false"
-                    if mesh_disabled_by_env()
-                    else "safety mesh unavailable"
-                ),
-            }
+            return self._rail_unavailable()
         responses = m.emergency_stop()
         # Carried through rather than recomputed: _peers_that_did_not_stop
         # grades the four response shapes that report a stop which did NOT
@@ -1063,7 +1074,7 @@ class MeshBridge:
         """Clear the fleet lockout with the operator override code."""
         m = self._safety_mesh()
         if m is None:
-            return {"signed": False, "error": "safety mesh unavailable"}
+            return self._rail_unavailable()
         res = m._resume_lockout(override_code)
         return {"signed": True, "issuer": m.peer_id, **(res or {})}
 

--- a/strands_robots/dashboard/mesh_bridge.py
+++ b/strands_robots/dashboard/mesh_bridge.py
@@ -18,13 +18,117 @@ from typing import Any, cast
 
 from strands_robots.dashboard import safety_state
 from strands_robots.mesh._zenoh_config import cmd_bytes_cap as _cmd_bytes_cap
+from strands_robots.utils import finite_number_error
 
 logger = logging.getLogger(__name__)
+
+
+def _env_float(name: str, default: str) -> float:
+    """Read an operator-tunable float out of the environment.
+
+    Every knob below is resolved once, at import, from a string an operator
+    typed, and ``float()`` accepts far more than a knob can honor: it raises on
+    a typo, and it returns ``nan`` for ``"nan"`` and ``inf`` for both ``"inf"``
+    and an overflowing ``"1e999"``. A bare coercion therefore has two failure
+    modes, and neither is reported. A typo raises ``ValueError`` while the
+    module body is executing, so the dashboard's mesh bridge does not fail to
+    read one knob - it fails to import, with a traceback that names ``float``
+    rather than the variable. A non-finite value is worse for being accepted:
+    it reaches a comparison as one side of a bound and removes the bound
+    instead of widening it. ``PEER_TTL_S`` is compared as ``age > ttl``, which
+    is ``False`` for every age against ``nan`` and against ``inf``, so a robot
+    that left the fleet is never aged out of the snapshot; each
+    :data:`COALESCE_HZ` rate becomes a period through ``1.0 / hz``, and no
+    elapsed span is under ``nan`` or under the ``0.0`` an ``inf`` rate yields,
+    so the repeat ceiling that rate names never applies.
+
+    Finiteness is decided by the shared numeric domain
+    (:func:`~strands_robots.utils.finite_number_error`) rather than left to a
+    comparison, which cannot express it: ``inf > 0`` is ``True``, so a
+    positivity floor admits ``inf``, ``Infinity`` and ``1e999`` as resolved
+    knobs and refuses ``nan`` only incidentally, because ``nan > 0`` is
+    ``False``. This is the rule
+    :func:`~strands_robots.simulation.isaac.simulation._env_float` and
+    :func:`~strands_robots.mesh.core._parse_positive_float_env` already state
+    and apply for the same kind of operator input, and every rejection is
+    reported for the reason those two report theirs: substituting the default
+    in silence leaves the operator's model of the knob wrong with nothing to
+    correct it against.
+
+    No floor is applied, deliberately, and for the reason
+    :func:`~strands_robots.mesh.core._parse_positive_float_env` gives: what a
+    zero means differs per knob, so it belongs to the consumer rather than to
+    this domain. Both consumers here already decide it - ``prune_peers`` treats
+    a non-positive ``ttl`` as "never prune" and
+    :meth:`EventCoalescer.allow` treats a non-positive rate as "no ceiling".
+
+    Args:
+        name: Environment variable to read. Unset, blank or unusable falls back.
+        default: Value applied when the variable names no usable number, held as
+            the string it would have been read from so the log names what the
+            fallback was.
+
+    Returns:
+        The override when it is a usable finite number, else ``default``.
+    """
+    raw = os.getenv(name, default)
+    if raw.strip() == "":
+        return float(default)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("%s=%r is not a number; using %r", name, raw, default)
+        return float(default)
+    reason = finite_number_error(value, name, "dashboard mesh bridge")
+    if reason is not None:
+        logger.warning("%s; using %r", reason, default)
+        return float(default)
+    return value
+
+
+def _resolve_mesh_camera_hz() -> float:
+    """Resolve the camera publish rate ``STRANDS_MESH_CAMERA_HZ`` names.
+
+    This is not the dashboard's knob. ``STRANDS_MESH_CAMERA_HZ`` is the mesh's,
+    read by :meth:`~strands_robots.mesh.core.Mesh._resolve_camera_hz` to
+    decide whether the camera loop runs at all, and the dashboard is the surface
+    that *writes* it: the settings panel holds ``camera_hz``, and
+    :func:`~strands_robots.dashboard.settings.apply_mesh_env` pushes it into the
+    environment the mesh peers then read. Reporting it back through a second,
+    looser reading closed that loop onto a value nothing publishes at - an
+    operator typing a rate the mesh refuses saw it echoed as the live one, on
+    the same panel they had typed it into.
+
+    So the question is asked of the mesh's own owner,
+    :func:`~strands_robots.mesh.session.hz_from_env`, and the fallback mirrors
+    the publisher's documented one: unset takes the
+    :data:`~strands_robots.mesh.session.CAMERA_HZ` default, and non-positive or
+    unusable is ``0.0``, camera publishing off. Frames are large, so an
+    unusable override disables the loop rather than substituting a rate the
+    operator did not ask for, and this surface has to say the same. The two
+    answers are held equal across every spelling an operator can type, which is
+    the invariant to keep: whatever this returns has to be what the camera loop
+    resolves, so it is asked of the loop's own resolver rather than re-derived.
+
+    Returns:
+        The rate the mesh camera loop resolves for this host, in Hz, with
+        ``0.0`` meaning camera publishing is off.
+    """
+    from strands_robots.mesh.session import CAMERA_HZ, hz_from_env
+
+    hz, reason = hz_from_env("STRANDS_MESH_CAMERA_HZ")
+    if reason is not None:
+        logger.warning("%s; camera publishing off", reason)
+        return 0.0
+    if hz is None:
+        hz = CAMERA_HZ
+    return hz if hz > 0 else 0.0
+
 
 PEER_STALE_S = 15.0  # presence heartbeat timeout before a card greys out
 
 # : How long a peer may stay quiet before it is dropped from the fleet snapshot : entirely.
-PEER_TTL_S = float(os.getenv("STRANDS_DASHBOARD_PEER_TTL_S", "300"))
+PEER_TTL_S = _env_float("STRANDS_DASHBOARD_PEER_TTL_S", "300")
 
 
 def prune_peers(
@@ -52,7 +156,7 @@ def prune_peers(
 # larger is dropped pre-deserialise and the sender only ever sees a : timeout, so we check
 # before publishing and return a real error instead.
 # One parser, the SDK's: this was a hand copy of the default (16*1024) that
-# would silently diverge the day _zenoh_config changes DEFAULT_MAX_CMD_BYTES —
+# would silently diverge the day _zenoh_config changes DEFAULT_MAX_CMD_BYTES -
 # the pre-publish check here MUST agree with the transport's drop filter or a
 # command passes the check and vanishes into the documented timeout anyway.
 # cmd_bytes_cap() also refuses a garbage env value with an actionable message.
@@ -273,20 +377,20 @@ def stop_outcome(response: dict[str, Any] | None) -> dict[str, Any]:
 
 # : Per-type ceiling on UNCHANGED repeats, in Hz.
 COALESCE_HZ: dict[str, float] = {
-    "presence": float(os.getenv("STRANDS_DASHBOARD_PRESENCE_HZ", "1.0")),
-    "camera_meta": float(os.getenv("STRANDS_DASHBOARD_CAMERA_META_HZ", "2.0")),
+    "presence": _env_float("STRANDS_DASHBOARD_PRESENCE_HZ", "1.0"),
+    "camera_meta": _env_float("STRANDS_DASHBOARD_CAMERA_META_HZ", "2.0"),
     # The SensorLoops rates these mirror are pose/imu/odom 10 Hz each and lidar
     # summary 5 Hz, so one rover publishing all of them is ~36 events/s -- the
     # order of the 34.7 Hz for a single arm this coalescer was built for. A
     # CHANGED reading is never delayed, so a moving robot still streams; the
     # rate is the floor for a repeat that says nothing new.
-    "pose": float(os.getenv("STRANDS_DASHBOARD_POSE_HZ", "1.0")),
-    "imu": float(os.getenv("STRANDS_DASHBOARD_IMU_HZ", "1.0")),
-    "odom": float(os.getenv("STRANDS_DASHBOARD_ODOM_HZ", "1.0")),
-    "lidar": float(os.getenv("STRANDS_DASHBOARD_LIDAR_HZ", "1.0")),
+    "pose": _env_float("STRANDS_DASHBOARD_POSE_HZ", "1.0"),
+    "imu": _env_float("STRANDS_DASHBOARD_IMU_HZ", "1.0"),
+    "odom": _env_float("STRANDS_DASHBOARD_ODOM_HZ", "1.0"),
+    "lidar": _env_float("STRANDS_DASHBOARD_LIDAR_HZ", "1.0"),
     # Health already publishes at 0.5 Hz upstream; the floor matches it rather
     # than inventing a slower one.
-    "health": float(os.getenv("STRANDS_DASHBOARD_HEALTH_HZ", "0.5")),
+    "health": _env_float("STRANDS_DASHBOARD_HEALTH_HZ", "0.5"),
 }
 
 #: Fields that tick on their own and therefore say nothing about whether the
@@ -346,6 +450,19 @@ class EventCoalescer:
         return (event.get("type"), event.get("peer_id"), event.get("cam"), event.get("kind"))
 
     def allow(self, event: dict, now: float) -> bool:
+        """Has enough time passed to forward an UNCHANGED repeat of *event*?
+
+        Args:
+            event: The event to decide about.
+            now: Reading of a MONOTONIC clock. What is compared is ``now`` minus
+                the previous reading against ``1.0 / hz``, an elapsed span, so a
+                clock that can be stepped moves the decision by the size of the
+                step rather than by the time that passed.
+
+        Returns:
+            ``True`` when the event is new, changed, or carries no rate, and when
+            its rate is non-positive - which every consumer reads as "no ceiling".
+        """
         hz = self.rates.get(event.get("type") or "")
         if not hz or hz <= 0:
             self.forwarded += 1
@@ -538,7 +655,6 @@ class MeshBridge:
         from strands_robots.dashboard import settings
 
         local_dev = os.getenv("STRANDS_MESH_LOCAL_DEV", "") not in ("", "0", "false")
-        camera_hz = os.getenv("STRANDS_MESH_CAMERA_HZ")
         info = {
             **self._endpoints,
             "online": self._running,
@@ -550,7 +666,7 @@ class MeshBridge:
             # _build_config logs "WIRE SECURITY DISABLED". Surface it so a lab
             # posture can't be mistaken for a secured one.
             "wire_security": "DISABLED (local dev)" if local_dev else self._endpoints.get("auth_mode"),
-            "camera_hz": float(camera_hz) if camera_hz else 0.0,
+            "camera_hz": _resolve_mesh_camera_hz(),
             "settings": settings.load()["mesh"],
             "multicast": os.getenv("STRANDS_MESH_MULTICAST", ""),
             "max_cmd_bytes": MAX_CMD_BYTES,
@@ -622,9 +738,12 @@ class MeshBridge:
         if loop is None or loop.is_closed():
             return
         # Coalesce BEFORE fan-out: one decision serves every client, and the
-        # serialization it avoids is per-client.
+        # serialization it avoids is per-client. On the monotonic clock, because
+        # what the coalescer compares is an elapsed span against a period: an NTP
+        # step moves a wall-clock span by the size of the step, which either
+        # suppresses a reading that was due or forwards one the rate had capped.
         with self._coalesce_lock:
-            if not self._coalescer.allow(event, time.time()):
+            if not self._coalescer.allow(event, time.monotonic()):
                 return
         with self._queues_lock:
             queues = list(self._queues)
@@ -835,7 +954,7 @@ class MeshBridge:
             # Without it, any ACL-authorised peer observing a turn_id could
             # answer someone else's pending turn and have its result taken
             # for the target's. Legacy peers that omit responder_id are
-            # rejected the same way — an absent identity is not a match.
+            # rejected the same way - an absent identity is not a match.
             expected = self._expected_responders.get(turn)
             if expected is not None and responder != expected:
                 logger.warning(
@@ -963,7 +1082,7 @@ class MeshBridge:
             return {"error": "mesh offline", "ok": False}
         # Mesh.send parity, missing from this clone until now (§2.1):
         # target sanity + client-side validate_command. Receiver-side
-        # _exec_cmd still validates — this turns "the peer refused it" (a
+        # _exec_cmd still validates - this turns "the peer refused it" (a
         # timeout or opaque error narrated as a robot fault) into a
         # structured local error naming the actual defect.
         if not isinstance(target, str) or not target:

--- a/strands_robots/dashboard/mesh_bridge.py
+++ b/strands_robots/dashboard/mesh_bridge.py
@@ -1,0 +1,1149 @@
+"""Zenoh mesh <-> asyncio bridge for the dashboard."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import json
+import logging
+import os
+import socket
+import threading
+import time
+import uuid
+from collections import deque
+from collections.abc import Iterable, Mapping
+from typing import Any, cast
+
+from strands_robots.dashboard import safety_state
+from strands_robots.mesh._zenoh_config import cmd_bytes_cap as _cmd_bytes_cap
+
+logger = logging.getLogger(__name__)
+
+PEER_STALE_S = 15.0  # presence heartbeat timeout before a card greys out
+
+# : How long a peer may stay quiet before it is dropped from the fleet snapshot : entirely.
+PEER_TTL_S = float(os.getenv("STRANDS_DASHBOARD_PEER_TTL_S", "300"))
+
+
+def prune_peers(
+    peers: dict[str, dict[str, Any]],
+    now: float,
+    ttl: float = PEER_TTL_S,
+    protected_ids: set[str] | frozenset[str] | None = None,
+    stale_after: float = PEER_STALE_S,
+) -> dict[str, dict[str, Any]]:
+    """Flag quiet peers stale and drop the ones that aged past ``ttl``."""
+    protected = protected_ids or frozenset()
+    out: dict[str, dict[str, Any]] = {}
+    for pid, entry in peers.items():
+        age = now - entry.get("last_seen", 0)
+        # Child sim peers are named "<parent>__<robot>"; they live and die with
+        # the parent's process, so the parent's protection covers them.
+        parent = pid.partition("__")[0]
+        if ttl > 0 and age > ttl and pid not in protected and parent not in protected:
+            continue
+        out[pid] = {**entry, "stale": age > stale_after}
+    return out
+
+
+# : Transport low-pass filter on ``**/cmd`` (_zenoh_config.DEFAULT_MAX_CMD_BYTES). : Anything
+# larger is dropped pre-deserialise and the sender only ever sees a : timeout, so we check
+# before publishing and return a real error instead.
+# One parser, the SDK's: this was a hand copy of the default (16*1024) that
+# would silently diverge the day _zenoh_config changes DEFAULT_MAX_CMD_BYTES —
+# the pre-publish check here MUST agree with the transport's drop filter or a
+# command passes the check and vanishes into the documented timeout anyway.
+# cmd_bytes_cap() also refuses a garbage env value with an actionable message.
+MAX_CMD_BYTES = _cmd_bytes_cap()
+
+#: How many fleet actions to keep for the activity panel.
+ACTIVITY_CAP = 300
+
+
+def peer_is_known(
+    peer_id: str,
+    peers: Mapping[str, Any] | Iterable[str],
+    managed_ids: Iterable[str] = (),
+) -> bool:
+    """Is this peer id something the fleet could plausibly answer for?"""
+    if not peer_id:
+        return False
+    haystack = set(peers) | set(managed_ids)
+    if peer_id in haystack:
+        return True
+    # Both halves must be non-empty, matching route_task_target's own condition exactly: "arm-1__"
+    # does NOT get rerouted there, so calling it known here would hand it straight back to the
+    # timeout this guard exists to avoid.
+    parent, _, child = peer_id.partition("__")
+    return bool(parent and child) and parent in haystack
+
+
+def managed_without_presence(
+    peers: Mapping[str, Mapping[str, Any]],
+    managed_ids: Iterable[str] = (),
+    *,
+    spawn_times: Mapping[str, float] | None = None,
+    now: float | None = None,
+    grace_s: float = 20.0,
+) -> list[str]:
+    present = set(peers)
+    stamps = spawn_times or {}
+    clock = time.time() if now is None else now
+    out: list[str] = []
+    for pid in managed_ids:
+        if not pid or pid in present:
+            continue
+        if any(p.partition("__")[0] == pid for p in present if "__" in p):
+            continue
+        parent, _, child = pid.partition("__")
+        if parent and child and parent in present:
+            continue
+        started = stamps.get(pid)
+        if started is not None and clock - started < grace_s:
+            continue
+        out.append(pid)
+    return sorted(out)
+
+
+def silent_arms(peers: Mapping[str, Mapping[str, Any]]) -> dict[str, Any] | None:
+    ids = list(peers)
+    streaming: list[str] = []
+    silent: list[str] = []
+    hosts = 0
+    stale = 0
+    for pid in ids:
+        rec = peers.get(pid) or {}
+        state = rec.get("state") or {}
+        joints = state.get("joints") or {}
+        if joints:
+            streaming.append(pid)
+            continue
+        if rec.get("stale"):
+            stale += 1
+            continue
+        if any(other != pid and other.startswith(f"{pid}__") for other in ids):
+            hosts += 1  # a host process, not an arm: silence is its normal state
+            continue
+        silent.append(pid)
+    if not silent:
+        return None
+    return {
+        "streaming": len(streaming),
+        "silent": sorted(silent),
+        **({"host_processes": hosts} if hosts else {}),
+        **({"stale": stale} if stale else {}),
+    }
+
+
+def peer_origins(
+    peer_ids: Mapping[str, Any] | Iterable[str],
+    managed_ids: Iterable[str] = (),
+) -> dict[str, str]:
+    """Label each peer ``"managed"`` (this dashboard spawned it) or ``"external"``."""
+    managed = set(managed_ids)
+
+    def origin(pid: str) -> str:
+        if pid in managed:
+            return "managed"
+        parent, _, child = pid.partition("__")
+        if parent and child and parent in managed:
+            return "managed"
+        return "external"
+
+    return {pid: origin(pid) for pid in peer_ids}
+
+
+def absent_children(
+    peers: Mapping[str, Any] | Iterable[str],
+    children: Iterable[Mapping[str, Any]] = (),
+) -> list[dict[str, Any]]:
+    present = set(peers)
+    families = {pid.split("__", 1)[0] for pid in present if "__" in pid}
+    out: list[dict[str, Any]] = []
+    for child in children or ():
+        if not isinstance(child, Mapping):
+            continue
+        peer_id = str(child.get("peer_id") or "")
+        if not peer_id or child.get("alive"):
+            continue
+        if peer_id in present or peer_id in families:
+            continue
+        out.append(
+            {
+                "peer_id": peer_id,
+                "robot_name": child.get("robot_name"),
+                "mode": child.get("mode"),
+                "returncode": child.get("returncode"),
+                "started_at": child.get("started_at"),
+            }
+        )
+    out.sort(key=lambda c: c["peer_id"])
+    return out
+
+
+def route_task_target(target: str, cmd: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Route commands aimed at a child sim peer to its parent Simulation peer."""
+    if "__" in target and not cmd.get("robot_name"):
+        parent, _, robot_name = target.partition("__")
+        if parent and robot_name:
+            cmd = {**cmd, "robot_name": robot_name}
+            target = parent
+    return target, cmd
+
+
+def command_succeeded(response: dict[str, Any] | None) -> bool:
+    """Did a peer actually carry the command out?"""
+    if not isinstance(response, dict):
+        return False
+    if response.get("error") or response.get("type") == "error":
+        return False
+    if response.get("ok") is False:
+        return False
+    result = response.get("result")
+    if isinstance(result, dict):
+        if result.get("ok") is False:
+            return False
+        if str(result.get("status", "")).lower() in ("error", "failed"):
+            return False
+        # An ``error`` INSIDE the payload is the peer's own refusal, and it arrives with no ``ok`` key
+        # and no ``status`` at all -- a plain ``{"error": "gripper jammed"}`` from a tool.
+        if result.get("error"):
+            return False
+        # A peer that wraps a tool result nests it once more. Both depths are real -- the dashboard's
+        # own reader has always looked at ``result.error ?? result.result.error``.
+        inner = result.get("result")
+        if isinstance(inner, dict) and inner.get("error"):
+            return False
+    return True
+
+
+def _raw_to_jpeg(raw: bytes, shape: Any) -> tuple[bytes | None, str | None]:
+    """Transcode raw pixel bytes to JPEG. Returns ``(jpeg, error)``. Only called for frames whose
+    ``encoding`` is not JPEG.
+    """
+    if not (isinstance(shape, (list, tuple)) and len(shape) in (2, 3)):
+        return None, f"encoding is not jpeg and shape {shape!r} is unusable"
+    try:
+        import numpy as np
+        from PIL import Image
+    except ImportError:
+        return None, "raw frame received but numpy/Pillow are not installed to transcode it"
+    try:
+        dims = tuple(int(d) for d in shape)
+        expected = 1
+        for d in dims:
+            expected *= d
+        if len(raw) != expected:
+            return None, f"raw frame is {len(raw)} B but shape {dims} needs {expected} B"
+        array = np.frombuffer(raw, dtype=np.uint8).reshape(dims)
+        if array.ndim == 3 and array.shape[2] == 4:
+            image = Image.fromarray(array, "RGBA").convert("RGB")
+        elif array.ndim == 3 and array.shape[2] == 3:
+            image = Image.fromarray(array, "RGB")
+        elif array.ndim == 2:
+            image = Image.fromarray(array, "L")
+        else:
+            return None, f"unsupported raw frame shape {dims}"
+        buffer = io.BytesIO()
+        image.save(buffer, format="JPEG", quality=80)
+        return buffer.getvalue(), None
+    except Exception as exc:  # noqa: BLE001 - a bad frame must not kill the sub
+        return None, f"raw frame transcode failed: {type(exc).__name__}: {exc}"
+
+
+def stop_outcome(response: dict[str, Any] | None) -> dict[str, Any]:
+    """Classify one peer's answer to a stop into the three honest states. ``stopped`` / ``not_stopped``
+    (the peer answered but could not stop) / ``no_answer`` (timeout).
+    """
+    if not isinstance(response, dict):
+        return {"state": "no_answer", "detail": "no response"}
+    error = response.get("error")
+    if error and "timeout" in str(error).lower():
+        return {"state": "no_answer", "detail": str(error)}
+    if command_succeeded(response):
+        return {"state": "stopped", "detail": ""}
+    result = response.get("result")
+    detail = ""
+    if isinstance(result, dict):
+        detail = str(result.get("error") or result.get("status") or "")
+    return {"state": "not_stopped", "detail": detail or str(error or "refused")}
+
+
+# : Per-type ceiling on UNCHANGED repeats, in Hz.
+COALESCE_HZ: dict[str, float] = {
+    "presence": float(os.getenv("STRANDS_DASHBOARD_PRESENCE_HZ", "1.0")),
+    "camera_meta": float(os.getenv("STRANDS_DASHBOARD_CAMERA_META_HZ", "2.0")),
+    # The SensorLoops rates these mirror are pose/imu/odom 10 Hz each and lidar
+    # summary 5 Hz, so one rover publishing all of them is ~36 events/s -- the
+    # order of the 34.7 Hz for a single arm this coalescer was built for. A
+    # CHANGED reading is never delayed, so a moving robot still streams; the
+    # rate is the floor for a repeat that says nothing new.
+    "pose": float(os.getenv("STRANDS_DASHBOARD_POSE_HZ", "1.0")),
+    "imu": float(os.getenv("STRANDS_DASHBOARD_IMU_HZ", "1.0")),
+    "odom": float(os.getenv("STRANDS_DASHBOARD_ODOM_HZ", "1.0")),
+    "lidar": float(os.getenv("STRANDS_DASHBOARD_LIDAR_HZ", "1.0")),
+    # Health already publishes at 0.5 Hz upstream; the floor matches it rather
+    # than inventing a slower one.
+    "health": float(os.getenv("STRANDS_DASHBOARD_HEALTH_HZ", "0.5")),
+}
+
+#: Fields that tick on their own and therefore say nothing about whether the
+#: PAYLOAD changed. Compared-out so a per-frame timestamp cannot defeat coalescing.
+_VOLATILE_FIELDS = frozenset(
+    {
+        "t",
+        "ts",
+        "time",
+        "timestamp",
+        "last_seen",
+        "seq",
+        "frame",
+        "frames",
+        "frame_id",
+        "count",
+        "uptime",
+        "uptime_s",
+        "elapsed",
+        "fps",
+    }
+)
+
+
+def _stable_content(data: Any) -> str:
+    """A comparable rendering of an event payload, minus self-ticking fields."""
+
+    def strip(v: Any) -> Any:
+        if isinstance(v, dict):
+            return {k: strip(x) for k, x in sorted(v.items()) if k not in _VOLATILE_FIELDS}
+        if isinstance(v, (list, tuple)):
+            return [strip(x) for x in v]
+        return v
+
+    try:
+        return json.dumps(strip(data), sort_keys=True, default=str)
+    except Exception:  # noqa: BLE001 - never let bookkeeping drop an event
+        return repr(data)[:2000]
+
+
+class EventCoalescer:
+    """Decides whether an event is worth another JSON serialization."""
+
+    def __init__(self, rates: dict | None = None) -> None:
+        self.rates = dict(COALESCE_HZ if rates is None else rates)
+        self._last: dict[tuple, tuple] = {}
+        self.suppressed = 0
+        self.forwarded = 0
+
+    def key(self, event: dict) -> tuple:
+        # `kind` separates two streams that share a type: lidar publishes both a
+        # summary and a state document, and without it their alternating
+        # payloads read as a change every tick and coalesce to nothing. A strict
+        # no-op for the types that predate it -- `allow` returns before ever
+        # calling this when a type carries no rate, and neither rated type
+        # (presence, camera_meta) sets `kind`.
+        return (event.get("type"), event.get("peer_id"), event.get("cam"), event.get("kind"))
+
+    def allow(self, event: dict, now: float) -> bool:
+        hz = self.rates.get(event.get("type") or "")
+        if not hz or hz <= 0:
+            self.forwarded += 1
+            return True
+        k = self.key(event)
+        content = _stable_content(event.get("data"))
+        prev = self._last.get(k)
+        if prev is not None and prev[0] == content and (now - prev[1]) < (1.0 / hz):
+            self.suppressed += 1
+            return False
+        self._last[k] = (content, now)
+        self.forwarded += 1
+        return True
+
+    def forget(self, peer_id: str) -> None:
+        """Drop bookkeeping for a peer that left, so a respawn starts clean."""
+        for k in [k for k in self._last if k[1] == peer_id]:
+            self._last.pop(k, None)
+
+    def stats(self) -> dict:
+        total = self.forwarded + self.suppressed
+        return {
+            "forwarded": self.forwarded,
+            "suppressed": self.suppressed,
+            "suppressed_pct": round(100 * self.suppressed / total, 1) if total else 0.0,
+            "rates_hz": dict(self.rates),
+        }
+
+
+class MeshBridge:
+    """Dashboard-side mesh peer. One instance per server process."""
+
+    def __init__(self, peer_id: str | None = None) -> None:
+        self.peer_id = peer_id or f"dashboard-{socket.gethostname().split('.')[0]}-{uuid.uuid4().hex[:4]}"
+        self._session: Any | None = None
+        self._subs: list[Any] = []
+        self._running = False
+
+        # Fleet snapshot: peer_id -> {presence, state, stream, last_seen, cameras:{name:{t,shape}}}
+        self.peers: dict[str, dict[str, Any]] = {}
+        self._peers_lock = threading.Lock()
+
+        # Latest camera frames: (peer_id, cam) -> {"t": float, "jpeg": bytes, "shape": [...]}
+        self.frames: dict[tuple[str, str], dict[str, Any]] = {}
+        self._frames_lock = threading.Lock()
+
+        # Async fan-out. Subscribers get JSON-able event dicts.
+        self._queues: set[asyncio.Queue] = set()
+        self._queues_lock = threading.Lock()
+        self._coalescer = EventCoalescer()
+        self._coalesce_lock = threading.Lock()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+        self._lockout = safety_state.Lockout()
+        self._lockout_proof: dict[str, float] = {}
+        # Signed safety rail (lazy - see _safety_mesh)
+        self._safety: Any | None = None
+        self._safety_lock = threading.Lock()
+
+        # RPC correlation (mirrors Mesh.send)
+        self._pending: dict[str, threading.Event] = {}
+        self._responses: dict[str, dict[str, Any]] = {}
+        # turn_id -> the ONE peer allowed to answer it (mirrors
+        # Mesh._expected_responders): without this, any ACL-authorised peer
+        # observing a turn_id could answer someone else's pending turn.
+        self._expected_responders: dict[str, str] = {}
+        self._rpc_lock = threading.Lock()
+
+        # Fleet activity: every command this dashboard issued + safety
+        # envelopes seen on the wire. Cheap forensics for "who moved that arm?"
+        self.activity: deque[dict[str, Any]] = deque(maxlen=ACTIVITY_CAP)
+        self._activity_lock = threading.Lock()
+
+        # Resolved endpoints of the live session, for /api/mesh/config.
+        self._endpoints: dict[str, Any] = {}
+
+        # Set by the server to a callable returning peer ids that must never be
+        # aged out (LIVE managed local processes). Optional by design: the
+        # bridge stays usable standalone.
+        self.protected_peer_ids: Any | None = None
+
+        self.peer_annotations: Any | None = None
+        self.managed_children: Any | None = None
+
+    def _peer_annotations(self) -> dict[str, dict[str, Any]]:
+        if self.peer_annotations is None:
+            return {}
+        try:
+            data = self.peer_annotations()
+            return data if isinstance(data, dict) else {}
+        except Exception as exc:  # never let a bad hook break the snapshot
+            logger.warning("[mesh] peer annotation lookup failed (%r)", exc)
+            return {}
+
+    def _managed_children(self) -> list[Any]:
+        # getattr, not self.managed_children: snapshot() must keep working on a bridge that predates
+        # this hook.
+        hook = getattr(self, "managed_children", None)
+        if hook is None:
+            return []
+        try:
+            data = hook()
+            return list(data) if data else []
+        except Exception as exc:  # a memorial may never break the fleet snapshot
+            logger.warning("[mesh] managed children lookup failed (%r)", exc)
+            return []
+
+    def _protected_peer_ids(self) -> frozenset[str]:
+        if self.protected_peer_ids is None:
+            return frozenset()
+        try:
+            return frozenset(self.protected_peer_ids())
+        except Exception as exc:  # never let a bad hook break the snapshot
+            logger.warning("[mesh] protected peer lookup failed (%r)", exc)
+            return frozenset()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self, loop: asyncio.AbstractEventLoop) -> bool:
+        """Join the mesh. Returns False when zenoh is unavailable."""
+        from strands_robots.dashboard import settings
+        from strands_robots.mesh.session import get_session
+
+        # ZENOH_CONNECT / ZENOH_LISTEN / STRANDS_MESH_PORT are read *inside*
+        # get_session(), so remote-endpoint settings have to be in the
+        # environment before this call - not after.
+        settings.apply_mesh_env()
+
+        self._loop = loop
+        from strands_robots.mesh.core import mesh_disabled_by_env
+
+        if mesh_disabled_by_env():
+            logger.warning(
+                "STRANDS_MESH=false - not joining the mesh; the dashboard serves "
+                "settings, devices and cameras but shows no peers",
+            )
+            return False
+        session = get_session()
+        if session is None:
+            logger.warning("Mesh session unavailable (is eclipse-zenoh installed?) - dashboard runs offline")
+            return False
+        self._session = session
+        self._running = True
+
+        sub = session.declare_subscriber
+        self._subs = [
+            sub("strands/*/presence", self._on_presence),
+            sub("strands/*/state", self._on_state),
+            sub("strands/*/stream", self._on_stream),
+            sub("strands/*/camera/**", self._on_camera),
+            # SensorLoops publishes these and nothing here consumed them, so a
+            # rover or a humanoid rendered as a name and a camera. Same
+            # raw-zenoh shape as state: one subscriber per topic, the payload
+            # forwarded as the SDK wrote it.
+            sub("strands/*/pose", self._on_pose),
+            sub("strands/*/health", self._on_health),
+            sub("strands/*/imu", self._on_imu),
+            sub("strands/*/odom", self._on_odom),
+            sub("strands/*/lidar/**", self._on_lidar),
+            sub("strands/safety/estop", self._on_safety),
+            sub("strands/safety/resume", self._on_safety),
+            sub(f"strands/{self.peer_id}/response/**", self._on_response),
+        ]
+        self._endpoints = self._read_endpoints()
+        logger.info("MeshBridge online as %s", self.peer_id)
+        return True
+
+    def _read_endpoints(self) -> dict[str, Any]:
+        """What the live session is actually talking to."""
+        from strands_robots.dashboard import settings
+
+        info: dict[str, Any] = {
+            "connect": settings.as_list(os.getenv("ZENOH_CONNECT")),
+            "listen": settings.as_list(os.getenv("ZENOH_LISTEN")),
+            "port": os.getenv("STRANDS_MESH_PORT", "7447"),
+            "backend": os.getenv("STRANDS_MESH_BACKEND", "zenoh"),
+        }
+        try:
+            from strands_robots.mesh._zenoh_config import resolve_auth_mode
+
+            info["auth_mode"] = resolve_auth_mode()
+        except Exception:  # noqa: BLE001 - introspection only
+            info["auth_mode"] = "unknown"
+        return info
+
+    def mesh_info(self) -> dict[str, Any]:
+        """Mesh posture for /api/mesh/config and the settings panel."""
+        from strands_robots.dashboard import settings
+
+        local_dev = os.getenv("STRANDS_MESH_LOCAL_DEV", "") not in ("", "0", "false")
+        camera_hz = os.getenv("STRANDS_MESH_CAMERA_HZ")
+        info = {
+            **self._endpoints,
+            "online": self._running,
+            "peer_id": self.peer_id,
+            "peers": len(self.peers),
+            "live_peers": len(self.live_peers()),
+            "local_dev": local_dev,
+            # STRANDS_MESH_LOCAL_DEV=1 runs the entire mesh with auth "none";
+            # _build_config logs "WIRE SECURITY DISABLED". Surface it so a lab
+            # posture can't be mistaken for a secured one.
+            "wire_security": "DISABLED (local dev)" if local_dev else self._endpoints.get("auth_mode"),
+            "camera_hz": float(camera_hz) if camera_hz else 0.0,
+            "settings": settings.load()["mesh"],
+            "multicast": os.getenv("STRANDS_MESH_MULTICAST", ""),
+            "max_cmd_bytes": MAX_CMD_BYTES,
+        }
+        try:
+            from strands_robots.mesh.security import _policy_type_allowlist
+
+            info["policy_allow"] = sorted(_policy_type_allowlist())
+        except Exception:  # noqa: BLE001
+            info["policy_allow"] = []
+        return info
+
+    def restart(self) -> bool:
+        """Re-open the mesh session against the current settings."""
+        loop = self._loop
+        if loop is None:
+            return False
+        self.stop()
+        with self._peers_lock:
+            self.peers.clear()
+        with self._frames_lock:
+            self.frames.clear()
+        ok = self.start(loop)
+        self.record_activity("mesh", "restart", detail=self._endpoints, ok=ok)
+        self._emit({"type": "mesh_reconfigured", "ok": ok, "mesh": self.mesh_info()})
+        return ok
+
+    def stop(self) -> None:
+        self._running = False
+        if self._safety is not None:
+            try:
+                self._safety.stop()
+            except Exception:  # noqa: BLE001 - teardown is best-effort
+                pass
+            self._safety = None
+        for s in self._subs:
+            with contextlib.suppress(Exception):
+                s.undeclare()
+        self._subs.clear()
+        if self._session is not None:
+            from strands_robots.mesh.session import release_session
+
+            with contextlib.suppress(Exception):
+                release_session()
+            self._session = None
+
+    # ------------------------------------------------------------------
+    # Fan-out
+    # ------------------------------------------------------------------
+
+    def attach_queue(self) -> asyncio.Queue:
+        q: asyncio.Queue = asyncio.Queue(maxsize=500)
+        with self._queues_lock:
+            self._queues.add(q)
+        return q
+
+    def detach_queue(self, q: asyncio.Queue) -> None:
+        with self._queues_lock:
+            self._queues.discard(q)
+
+    def coalesce_stats(self) -> dict[str, Any]:
+        """Forwarded vs suppressed /ws/mesh events since process start."""
+        with self._coalesce_lock:
+            return self._coalescer.stats()
+
+    def _emit(self, event: dict[str, Any]) -> None:
+        """Push an event to all consumer queues (thread -> loop safe)."""
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        # Coalesce BEFORE fan-out: one decision serves every client, and the
+        # serialization it avoids is per-client.
+        with self._coalesce_lock:
+            if not self._coalescer.allow(event, time.time()):
+                return
+        with self._queues_lock:
+            queues = list(self._queues)
+        for q in queues:
+
+            def _put(q: Any = q) -> None:
+                if q.full():
+                    with contextlib.suppress(asyncio.QueueEmpty):
+                        q.get_nowait()  # drop oldest - dashboards want latest
+                with contextlib.suppress(asyncio.QueueFull):
+                    q.put_nowait(event)
+
+            loop.call_soon_threadsafe(_put)
+
+    # ------------------------------------------------------------------
+    # Zenoh callbacks (zenoh worker threads)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode(sample: Any) -> dict[str, Any] | None:
+        try:
+            data = json.loads(sample.payload.to_bytes().decode())
+        except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _touch_peer(self, peer_id: str) -> dict[str, Any]:
+        with self._peers_lock:
+            entry = self.peers.setdefault(peer_id, {"peer_id": peer_id})
+            now = time.time()
+            # When this dashboard first saw the peer: a peer that appeared AFTER an
+            # e-stop is a process that never received it (safety_state.peer_lockout).
+            entry.setdefault("first_seen", now)
+            entry["last_seen"] = now
+            return entry
+
+    def _on_presence(self, sample: Any) -> None:
+        data = self._decode(sample)
+        if not data:
+            return
+        peer_id = data.get("robot_id")
+        if not isinstance(peer_id, str) or peer_id == self.peer_id:
+            return
+        entry = self._touch_peer(peer_id)
+        entry["presence"] = data
+        self._emit({"type": "presence", "peer_id": peer_id, "data": data})
+
+    def _on_state(self, sample: Any) -> None:
+        data = self._decode(sample)
+        if not data:
+            return
+        peer_id = data.get("peer_id")
+        if not isinstance(peer_id, str):
+            return
+        entry = self._touch_peer(peer_id)
+        entry["state"] = data
+        self._emit({"type": "state", "peer_id": peer_id, "data": data})
+
+    def _on_stream(self, sample: Any) -> None:
+        data = self._decode(sample)
+        if not data:
+            return
+        peer_id = data.get("peer_id")
+        if not isinstance(peer_id, str):
+            return
+        entry = self._touch_peer(peer_id)
+        entry["stream"] = data
+        self._emit({"type": "stream", "peer_id": peer_id, "data": data})
+
+    def _on_camera(self, sample: Any) -> None:
+        data = self._decode(sample)
+        if not data:
+            return
+        peer_id = data.get("peer_id")
+        cam = data.get("cam")
+        encoded = data.get("data")
+        if not (isinstance(peer_id, str) and isinstance(cam, str) and isinstance(encoded, str)):
+            return
+        import base64
+
+        try:
+            raw: bytes | None = base64.b64decode(encoded)
+        except Exception:
+            return
+        meta: dict[str, Any] = {
+            "t": data.get("t"),
+            "shape": data.get("shape"),
+            "encoding": data.get("encoding"),
+        }
+        # A peer may publish raw pixel bytes instead of JPEG.
+        if str(meta["encoding"] or "jpeg").lower() not in ("jpeg", "jpg"):
+            raw, error = _raw_to_jpeg(cast(bytes, raw), meta.get("shape"))
+            meta["converted"] = error is None
+            if error:
+                meta["error"] = error
+        meta["displayable"] = raw is not None
+        with self._frames_lock:
+            self.frames[(peer_id, cam)] = {"jpeg": raw, **meta}
+        entry = self._touch_peer(peer_id)
+        cams = entry.setdefault("cameras", {})
+        cams[cam] = meta
+        # Lightweight notification (no pixels) so the UI knows a frame arrived.
+        self._emit({"type": "camera_meta", "peer_id": peer_id, "cam": cam, "data": meta})
+
+    def _sensor_sample(self, sample: Any, slot: str) -> tuple[str | None, dict[str, Any]]:
+        """Decode a sensor topic and file its payload under ``slot`` on the peer.
+
+        The four scalar sensor topics differ only in which key they land on, so
+        the decode/attribute/store steps live here once. The frame itself is
+        built at each call site with a literal type, because the guard asking
+        for a frontend reader for every emitted frame type reads those literals
+        out of the AST: a type assembled from a variable would leave that guard
+        passing while covering nothing.
+
+        Args:
+            sample: The raw zenoh sample.
+            slot: Key on the peer entry to store the payload under.
+
+        Returns:
+            ``(peer_id, data)``, or ``(None, {})`` when the sample carries no
+            usable payload or names no peer to attribute it to.
+        """
+        data = self._decode(sample)
+        if not data:
+            return None, {}
+        peer_id = data.get("peer_id")
+        if not isinstance(peer_id, str):
+            return None, {}
+        entry = self._touch_peer(peer_id)
+        entry[slot] = data
+        return peer_id, data
+
+    def _on_pose(self, sample: Any) -> None:
+        peer_id, data = self._sensor_sample(sample, "pose")
+        if peer_id is None:
+            return
+        self._emit({"type": "pose", "peer_id": peer_id, "data": data})
+
+    def _on_health(self, sample: Any) -> None:
+        peer_id, data = self._sensor_sample(sample, "health")
+        if peer_id is None:
+            return
+        self._emit({"type": "health", "peer_id": peer_id, "data": data})
+
+    def _on_imu(self, sample: Any) -> None:
+        peer_id, data = self._sensor_sample(sample, "imu")
+        if peer_id is None:
+            return
+        self._emit({"type": "imu", "peer_id": peer_id, "data": data})
+
+    def _on_odom(self, sample: Any) -> None:
+        peer_id, data = self._sensor_sample(sample, "odom")
+        if peer_id is None:
+            return
+        self._emit({"type": "odom", "peer_id": peer_id, "data": data})
+
+    def _on_lidar(self, sample: Any) -> None:
+        """One type, two documents: ``lidar/summary`` and ``lidar/state``.
+
+        They are kept apart under ``lidar`` rather than filed on one key,
+        because a summary landing on top of a state (or the reverse) would show
+        an operator a field the other document never carried.
+        """
+        data = self._decode(sample)
+        if not data:
+            return
+        peer_id = data.get("peer_id")
+        if not isinstance(peer_id, str):
+            return
+        key = str(getattr(sample, "key_expr", ""))
+        kind = "state" if key.endswith("/state") else "summary"
+        entry = self._touch_peer(peer_id)
+        with self._peers_lock:
+            lidar = dict(entry.get("lidar") or {})
+            lidar[kind] = data
+            entry["lidar"] = lidar
+        self._emit({"type": "lidar", "kind": kind, "peer_id": peer_id, "data": data})
+
+    def _on_safety(self, sample: Any) -> None:
+        data = self._decode(sample)
+        if not data:
+            return
+        key = str(getattr(sample, "key_expr", ""))
+        kind = "estop" if key.endswith("estop") else "resume"
+        # A five-second flash in the header was the ONLY representation of a lockout in
+        # this product, so a reload erased it while two arms stayed locked for ten hours.
+        with self._peers_lock:
+            self._lockout = safety_state.apply_event(self._lockout, kind=kind, data=data, now=time.time())
+            if kind == "estop":
+                self._lockout_proof.clear()
+        self.record_activity("safety", kind, detail=data, ok=True)
+        self._emit({"type": "safety", "kind": kind, "data": data})
+
+    def _on_response(self, sample: Any) -> None:
+        data = self._decode(sample)
+        if not data:
+            return
+        turn = data.get("turn_id")
+        if not isinstance(turn, str):
+            return
+        responder = data.get("responder_id")
+        with self._rpc_lock:
+            evt = self._pending.get(turn)
+            if evt is None:
+                return
+            # Point-to-point scope check (mirrors Mesh._on_response): a
+            # response is accepted only from the peer send_cmd addressed.
+            # Without it, any ACL-authorised peer observing a turn_id could
+            # answer someone else's pending turn and have its result taken
+            # for the target's. Legacy peers that omit responder_id are
+            # rejected the same way — an absent identity is not a match.
+            expected = self._expected_responders.get(turn)
+            if expected is not None and responder != expected:
+                logger.warning(
+                    "[mesh_bridge] response for turn %s rejected: responder %r != expected %r",
+                    turn,
+                    responder,
+                    expected,
+                )
+                return
+            self._responses[turn] = data
+            evt.set()
+
+    # ------------------------------------------------------------------ Commands (dashboard ->
+    # robot).
+
+    # ------------------------------------------------------------------ Signed safety rail (A6).
+
+    def _safety_mesh(self) -> Any | None:
+        """Lazily start the robot-less Mesh used for signed safety envelopes."""
+        with self._safety_lock:
+            if self._safety is not None and getattr(self._safety, "alive", False):
+                return self._safety
+            try:
+                from strands_robots.mesh.core import Mesh, mesh_disabled_by_env
+
+                # STRANDS_MESH=false is asked HERE and not only in start().
+                # This is the second site in this process that can OPEN a
+                # session, and mesh_disabled_by_env()'s own docstring states
+                # the rule: an operator who set the switch asked for no Zenoh
+                # session and no presence on the fleet, "so every path that
+                # can open one answers this". #2515 closed the same gap for
+                # the robot-less gateway in tools/robot_mesh after a direct
+                # Mesh(...) construction put a live gateway-* peer on the
+                # fleet past the inline check. Reaching it from the e-stop is
+                # the worst case of that: a new peer appears on the fleet at
+                # the moment the operator is trying to halt it, and it is the
+                # action they are least likely to want to debug afterwards.
+                if mesh_disabled_by_env():
+                    logger.warning(
+                        "STRANDS_MESH=false - signed safety rail not started; the "
+                        "per-peer broadcast stop is unaffected and still fanned out",
+                    )
+                    return None
+
+                m = Mesh(None, peer_id=f"{self.peer_id}-safety", peer_type="gateway")
+                m.start()
+                if not m.alive:
+                    return None
+                self._safety = m
+                logger.info("signed safety rail online as %s", m.peer_id)
+                return m
+            except Exception as exc:  # noqa: BLE001 - rail is enrichment over broadcast-stop
+                logger.warning("signed safety rail unavailable: %s", exc)
+                return None
+
+    def signed_estop(self) -> dict[str, Any]:
+        """Fleet e-stop over the SIGNED rail."""
+        m = self._safety_mesh()
+        if m is None:
+            # "Switched off" and "broken" are different answers, and the sheet
+            # shows this string: an operator who set STRANDS_MESH=false chose
+            # to have no signed rail, and reading "unavailable" would send them
+            # hunting a fault instead of looking at the switch they set.
+            from strands_robots.mesh.core import mesh_disabled_by_env
+
+            return {
+                "signed": False,
+                "error": (
+                    "signed safety rail disabled by STRANDS_MESH=false"
+                    if mesh_disabled_by_env()
+                    else "safety mesh unavailable"
+                ),
+            }
+        responses = m.emergency_stop()
+        # Carried through rather than recomputed: _peers_that_did_not_stop
+        # grades the four response shapes that report a stop which did NOT
+        # happen, and Mesh.emergency_stop() already puts its verdict in the
+        # strands/safety/estop envelope and the audit record. A second copy of
+        # that grading on the safety path would be a second thing to keep
+        # right. (Its name is private and this is its second caller; promoting
+        # it is the follow-up if a third appears.)
+        from strands_robots.mesh.core import _peers_that_did_not_stop
+
+        return {
+            "signed": True,
+            "issuer": m.peer_id,
+            "responses": responses,
+            # The ISSUER's own latch. emergency_stop() sets it unconditionally
+            # before it broadcasts, so True here is a true statement about THIS
+            # rail -- "a resume is required to clear it" -- and not about the
+            # fleet. The fleet half is the two fields below, and conflating them
+            # is what let one value describe a stop that reached everybody and
+            # one that reached nobody. It must also stay true whenever a resume
+            # is genuinely needed: the operator's resume control is gated on it.
+            "lockout_engaged": True,
+            # What the peers actually said. responses_received keeps its
+            # meaning from Mesh.emergency_stop (replies received, not stops
+            # confirmed), so the two numbers can be compared rather than one
+            # absorbing the other; peers that never answered are the gap
+            # between this and the peer count.
+            "responses_received": len(responses),
+            "peers_not_stopped": sorted(_peers_that_did_not_stop(responses)),
+        }
+
+    def signed_resume(self, override_code: str) -> dict[str, Any]:
+        """Clear the fleet lockout with the operator override code."""
+        m = self._safety_mesh()
+        if m is None:
+            return {"signed": False, "error": "safety mesh unavailable"}
+        res = m._resume_lockout(override_code)
+        return {"signed": True, "issuer": m.peer_id, **(res or {})}
+
+    def send_cmd(
+        self,
+        target: str,
+        cmd: dict[str, Any],
+        timeout: float = 30.0,
+        *,
+        source: str = "api",
+    ) -> dict[str, Any]:
+        """Send a command to a peer and wait for its response (blocking)."""
+        from strands_robots.mesh.session import put
+
+        if not self._running:
+            return {"error": "mesh offline", "ok": False}
+        # Mesh.send parity, missing from this clone until now (§2.1):
+        # target sanity + client-side validate_command. Receiver-side
+        # _exec_cmd still validates — this turns "the peer refused it" (a
+        # timeout or opaque error narrated as a robot fault) into a
+        # structured local error naming the actual defect.
+        if not isinstance(target, str) or not target:
+            return {"error": "send_cmd: target must be a non-empty string", "ok": False}
+        if "\x00" in target:
+            return {"error": "send_cmd: target may not contain NUL", "ok": False}
+        from strands_robots.mesh import security as _security
+
+        try:
+            cmd = _security.validate_command(cmd)
+        except _security.ValidationError as exc:
+            result = {"ok": False, "error": f"validation: {exc}"}
+            self.record_activity(source, cmd.get("action", "?"), target=target, detail=result, ok=False)
+            return result
+        turn = uuid.uuid4().hex
+        envelope = {
+            "sender_id": self.peer_id,
+            "turn_id": turn,
+            "command": cmd,
+            "timestamp": time.time(),
+        }
+        # The transport silently drops cmd messages over the low-pass cap, so
+        # the caller would otherwise see a bare timeout with nothing to act on.
+        size = len(json.dumps(envelope, default=str).encode())
+        if size > MAX_CMD_BYTES:
+            result = {
+                "ok": False,
+                "error": f"command too large: {size} B > transport cap {MAX_CMD_BYTES} B "
+                "(raise STRANDS_MESH_MAX_CMD_BYTES on every peer, or shrink the payload)",
+            }
+            self.record_activity(source, cmd.get("action", "?"), target=target, detail=result, ok=False)
+            return result
+
+        evt = threading.Event()
+        with self._rpc_lock:
+            self._pending[turn] = evt
+            self._expected_responders[turn] = target
+        started = time.time()
+        try:
+            put(f"strands/{target}/cmd", envelope)
+            if not evt.wait(timeout):
+                result = {"error": f"timeout after {timeout:g}s", "turn_id": turn, "ok": False}
+            else:
+                with self._rpc_lock:
+                    result = self._responses.pop(turn, {"error": "response lost", "ok": False})
+            if not result.get("error") and safety_state.proves_clear(str(cmd.get("action", ""))):
+                with self._peers_lock:
+                    self._lockout_proof[target] = time.time()
+            self.record_activity(
+                source,
+                cmd.get("action", "?"),
+                target=target,
+                detail={"instruction": cmd.get("instruction"), "provider": cmd.get("policy_provider")},
+                ok=command_succeeded(result),
+                result=result,
+                elapsed=time.time() - started,
+            )
+            return result
+        finally:
+            with self._rpc_lock:
+                self._pending.pop(turn, None)
+                self._responses.pop(turn, None)
+                self._expected_responders.pop(turn, None)
+
+    async def send_cmd_async(
+        self,
+        target: str,
+        cmd: dict[str, Any],
+        timeout: float = 30.0,
+        *,
+        source: str = "api",
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(self.send_cmd, target, cmd, timeout, source=source)
+
+    # ------------------------------------------------------------------
+    # Activity log
+    # ------------------------------------------------------------------
+
+    def record_activity(
+        self,
+        source: str,
+        action: str,
+        *,
+        target: str = "",
+        detail: Any = None,
+        ok: bool | None = None,
+        result: Any = None,
+        elapsed: float | None = None,
+    ) -> None:
+        entry = {
+            "t": time.time(),
+            "source": source,
+            "action": action,
+            "target": target,
+            "ok": ok,
+            "detail": detail,
+            "elapsed": round(elapsed, 3) if elapsed is not None else None,
+        }
+        if result is not None:
+            entry["result"] = json.dumps(result, default=str)[:400]
+        with self._activity_lock:
+            self.activity.append(entry)
+        self._emit({"type": "activity", "data": entry})
+
+    def activity_log(self, limit: int = 100) -> list[dict[str, Any]]:
+        with self._activity_lock:
+            items = list(self.activity)
+        return items[-limit:][::-1]
+
+    # ------------------------------------------------------------------
+    # Snapshot for initial page load
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> dict[str, Any]:
+        now = time.time()
+        protected = self._protected_peer_ids()
+        with self._peers_lock:
+            peers = prune_peers(self.peers, now, PEER_TTL_S, protected)
+            # Forget the aged-out peers for good: keeping them in self.peers
+            # only feeds the same ghosts back on every later snapshot.
+            for pid in set(self.peers) - set(peers):
+                self.peers.pop(pid, None)
+                # Drop coalescing bookkeeping too, so a peer that comes BACK with the same content as when it
+                # left is forwarded at once instead of waiting out a rate window against a memory of its
+                # former self.
+                with self._coalesce_lock:
+                    self._coalescer.forget(pid)
+        stamps: dict[str, float] = {}
+        for m in self._managed_children():
+            mid = getattr(m, "peer_id", None)
+            if mid:
+                stamps[str(mid)] = float(getattr(m, "started_at", 0.0) or 0.0)
+        quiet = managed_without_presence(peers, protected, spawn_times=stamps, now=now)
+        for pid, origin in peer_origins(peers, protected).items():
+            peer = peers.get(pid)
+            if isinstance(peer, dict):
+                peers[pid] = {**peer, "origin": origin}
+        try:
+            with self._peers_lock:
+                fleet_lockout = getattr(self, "_lockout", None) or safety_state.Lockout()
+                proofs = dict(getattr(self, "_lockout_proof", None) or {})
+            for pid, peer in list(peers.items()):
+                if not isinstance(peer, dict):
+                    continue
+                verdict = safety_state.resolve_peer(
+                    fleet_lockout,
+                    first_seen=peer.get("first_seen"),
+                    proof_at=proofs.get(pid),
+                )
+                peers[pid] = {**peer, "lockout": verdict.as_fields()}
+        except Exception as exc:  # pragma: no cover - an annotation must never break the fleet view
+            logger.debug("lockout annotation skipped: %s", exc)
+        for pid, fields in self._peer_annotations().items():
+            peer = peers.get(pid)
+            if isinstance(peer, dict) and isinstance(fields, dict):
+                # A plain overlay, deliberately: ``joint_silence.merge`` grades a
+                # ``joint_problem`` annotation against the peer's live joints
+                # before applying it, but that module arrives with the server
+                # slice of the #2848 decomposition (#2977) -- the same slice
+                # that supplies the only ``peer_annotations`` hook, so until it
+                # lands this loop has no input to grade. The server slice
+                # upgrades this line to ``joint_silence.merge(peer, fields)``
+                # when it brings both halves.
+                peers[pid] = {**peer, **fields}
+        return {
+            "type": "snapshot",
+            "managed_no_presence": quiet,
+            "dashboard_peer_id": self.peer_id,
+            "peers": peers,
+            "mesh": self.mesh_info(),
+            "absent_children": absent_children(peers, self._managed_children()),
+            "t": now,
+        }
+
+    def live_peers(self) -> list[str]:
+        """Peer ids with a fresh presence heartbeat."""
+        now = time.time()
+        with self._peers_lock:
+            return [pid for pid, entry in self.peers.items() if (now - entry.get("last_seen", 0)) <= PEER_STALE_S]
+
+    def latest_frame(self, peer_id: str, cam: str) -> dict[str, Any] | None:
+        with self._frames_lock:
+            return self.frames.get((peer_id, cam))

--- a/tests/test_dashboard_mesh_knobs_resolve_through_their_owner.py
+++ b/tests/test_dashboard_mesh_knobs_resolve_through_their_owner.py
@@ -1,0 +1,223 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Every operator float the dashboard's mesh bridge reads is resolved by its owner.
+
+The bridge reads floats out of the environment in two kinds of place, and each
+kind has an owner it has to ask.
+
+``STRANDS_MESH_CAMERA_HZ`` is not the dashboard's knob at all. It is the mesh's,
+resolved by :meth:`~strands_robots.mesh.core.Mesh._resolve_camera_hz` to decide
+whether the camera loop runs, and the dashboard is the surface that *writes* it:
+the settings panel holds ``camera_hz`` and
+:func:`~strands_robots.dashboard.settings.apply_mesh_env` pushes it into the
+environment the peers read. Reading it back through a second, looser coercion
+closed that loop onto a rate nothing publishes at, on the one panel where an
+operator both sets the value and learns what took effect. So the two answers are
+held equal here across every spelling an operator can type, rather than being
+described as equal in a comment: parity is the property, and a comment is not a
+grader. The oracle is the publisher's own method, called unbound because it reads
+no instance state - a second copy of its rule in this file would be the defect
+under test.
+
+The dashboard's own ``STRANDS_DASHBOARD_*`` knobs are resolved at import, where
+``float()`` has a failure mode a per-call resolver does not: a typo raises
+``ValueError`` while the module body is executing, so the bridge does not lose
+one knob but fails to import, from a frame naming ``float`` rather than the
+variable. A non-finite value is accepted instead, and reaches each consumer as
+one side of a comparison that it removes rather than widens - ``age > ttl`` is
+``False`` for every age against both ``nan`` and ``inf``, so a robot that left
+the fleet is never aged out.
+
+Both are one missing question - "is this string a number a consumer can honor?" -
+which the package answers in
+:func:`~strands_robots.utils.finite_number_error` and in
+:func:`~strands_robots.mesh.session.hz_from_env`. What is *not* pinned here is
+each knob's floor: ``prune_peers`` reads a non-positive ttl as "never prune" and
+:meth:`~strands_robots.dashboard.mesh_bridge.EventCoalescer.allow` reads a
+non-positive rate as "no ceiling", and those are the consumers' decisions rather
+than this domain's.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from strands_robots.dashboard import mesh_bridge
+from strands_robots.mesh.core import Mesh
+
+#: Every spelling of the rate an operator can leave in the environment, from the
+#: unset case through the three ``float()`` accepts and no loop can pace itself
+#: with. ``"  "`` is here because whitespace is truthy: the reading this replaced
+#: tested the raw string and so coerced it.
+RATE_SPELLINGS = ("5", "0.5", "0", "-5", "nan", "inf", "Infinity", "1e999", "not-a-number", "  ", "")
+
+#: Values no knob can be resolved to, and which a bare ``float()`` either returns
+#: or raises on. Split from the spellings above because these are asserted
+#: against a *default*, not against a second surface's answer.
+UNUSABLE = ("nan", "inf", "-inf", "Infinity", "1e999", "not-a-number", "1,5", "")
+
+#: The dashboard's own knobs and the default each documents, read from the module
+#: rather than restated: the point is that these resolve, not what they default
+#: to, and a knob renamed here without being renamed there fails
+#: :meth:`TestEveryDashboardKnobResolvesToAUsableNumber.test_the_knobs_scanned_are_the_knobs_the_module_reads`.
+DASHBOARD_KNOBS = (
+    ("STRANDS_DASHBOARD_PEER_TTL_S", 300.0),
+    ("STRANDS_DASHBOARD_PRESENCE_HZ", 1.0),
+    ("STRANDS_DASHBOARD_CAMERA_META_HZ", 2.0),
+    ("STRANDS_DASHBOARD_POSE_HZ", 1.0),
+    ("STRANDS_DASHBOARD_IMU_HZ", 1.0),
+    ("STRANDS_DASHBOARD_ODOM_HZ", 1.0),
+    ("STRANDS_DASHBOARD_LIDAR_HZ", 1.0),
+    ("STRANDS_DASHBOARD_HEALTH_HZ", 0.5),
+)
+
+
+def _set_rate(monkeypatch: pytest.MonkeyPatch, spelling: str) -> None:
+    """Put *spelling* in the environment, or take the variable out entirely."""
+    if spelling == "":
+        monkeypatch.delenv("STRANDS_MESH_CAMERA_HZ", raising=False)
+    else:
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_HZ", spelling)
+
+
+def _published_rate() -> float:
+    """What the mesh camera loop resolves, from the publisher's own method.
+
+    Called unbound: :meth:`Mesh._resolve_camera_hz` reads the environment and two
+    module constants and no instance state, so this is the shipped rule rather
+    than a copy of it - which is the whole point, since a copy is what this file
+    exists to refuse.
+    """
+    return Mesh._resolve_camera_hz(None)  # type: ignore[arg-type]
+
+
+class TestTheReportedCameraRateIsThePublishedOne:
+    """One knob, two surfaces, and the panel that writes it must not disagree."""
+
+    @pytest.mark.parametrize("spelling", RATE_SPELLINGS)
+    def test_the_dashboard_reports_the_rate_the_camera_loop_resolves(
+        self, monkeypatch: pytest.MonkeyPatch, spelling: str
+    ) -> None:
+        _set_rate(monkeypatch, spelling)
+        reported = mesh_bridge.MeshBridge(peer_id="parity").mesh_info()["camera_hz"]
+        assert reported == _published_rate(), (
+            f"STRANDS_MESH_CAMERA_HZ={spelling!r}: the settings panel reports {reported!r} while the "
+            f"camera loop resolves {_published_rate()!r}, so an operator reads a rate nothing publishes at"
+        )
+
+    @pytest.mark.parametrize("spelling", RATE_SPELLINGS)
+    def test_the_posture_payload_is_json_a_client_can_parse(
+        self, monkeypatch: pytest.MonkeyPatch, spelling: str
+    ) -> None:
+        """``NaN`` and ``Infinity`` are not JSON, so ``/api/mesh/config`` must not emit them."""
+        _set_rate(monkeypatch, spelling)
+        rate = mesh_bridge.MeshBridge(peer_id="json").mesh_info()["camera_hz"]
+        assert math.isfinite(rate), f"STRANDS_MESH_CAMERA_HZ={spelling!r} reported {rate!r}"
+        json.dumps({"camera_hz": rate}, allow_nan=False)
+
+    @pytest.mark.parametrize(("spelling", "expected"), [("5", 5.0), ("0.5", 0.5), ("30", 30.0)])
+    def test_a_usable_rate_is_still_reported_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch, spelling: str, expected: float
+    ) -> None:
+        """The over-reach control: routing the read must not swallow a good value."""
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_HZ", spelling)
+        assert mesh_bridge.MeshBridge(peer_id="ok").mesh_info()["camera_hz"] == expected
+
+    def test_an_unusable_rate_is_reported_to_the_operator(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Substituting the default in silence leaves the operator's model wrong."""
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_HZ", "nan")
+        with caplog.at_level("WARNING", logger=mesh_bridge.logger.name):
+            mesh_bridge.MeshBridge(peer_id="warns").mesh_info()
+        said = [r.getMessage() for r in caplog.records if r.name == mesh_bridge.logger.name]
+        assert any("STRANDS_MESH_CAMERA_HZ" in message and "nan" in message for message in said), said
+
+
+class TestEveryDashboardKnobResolvesToAUsableNumber:
+    """The bridge's own knobs are read at import, where a typo costs the module."""
+
+    @pytest.mark.parametrize(("name", "default"), DASHBOARD_KNOBS)
+    @pytest.mark.parametrize("spelling", UNUSABLE)
+    def test_an_unusable_value_falls_back_to_the_documented_default(
+        self, monkeypatch: pytest.MonkeyPatch, name: str, default: float, spelling: str
+    ) -> None:
+        if spelling == "":
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, spelling)
+        resolved = mesh_bridge._env_float(name, str(default))
+        assert resolved == default, f"{name}={spelling!r} resolved to {resolved!r}"
+        assert math.isfinite(resolved)
+
+    @pytest.mark.parametrize(("spelling", "expected"), [("42", 42.0), ("0", 0.0), ("-1", -1.0), ("0.25", 0.25)])
+    def test_a_usable_value_is_honoured_including_the_floors_its_consumer_owns(
+        self, monkeypatch: pytest.MonkeyPatch, spelling: str, expected: float
+    ) -> None:
+        """The over-reach control: this domain decides finiteness, not the floor.
+
+        ``0`` and a negative are usable numbers here on purpose - ``prune_peers``
+        reads a non-positive ttl as "never prune" and
+        :meth:`~strands_robots.dashboard.mesh_bridge.EventCoalescer.allow` reads a
+        non-positive rate as "no ceiling", so refusing them here would take a
+        decision away from the consumer that documents it.
+        """
+        monkeypatch.setenv("STRANDS_DASHBOARD_PEER_TTL_S", spelling)
+        assert mesh_bridge._env_float("STRANDS_DASHBOARD_PEER_TTL_S", "300") == expected
+
+    @pytest.mark.parametrize("spelling", ["not-a-number", "nan", "inf", "1e999"])
+    def test_the_module_still_imports_when_a_knob_is_unusable(self, spelling: str) -> None:
+        """The failure this position has and a per-call resolver does not.
+
+        Run out of process because the import is what is under test: the module is
+        already in ``sys.modules`` here, so re-reading the knob in-process would
+        grade a different thing.
+        """
+        probe = textwrap.dedent(
+            """
+            from strands_robots.dashboard import mesh_bridge
+            import math
+            assert math.isfinite(mesh_bridge.PEER_TTL_S), mesh_bridge.PEER_TTL_S
+            assert all(math.isfinite(hz) for hz in mesh_bridge.COALESCE_HZ.values()), mesh_bridge.COALESCE_HZ
+            print(mesh_bridge.PEER_TTL_S)
+            """
+        )
+        done = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            # Inherit the environment and override only the knobs: a pristine env
+            # would also drop whatever puts the package on this interpreter's path,
+            # so the probe would fail to import for a reason unrelated to the knob.
+            env={**os.environ, "STRANDS_DASHBOARD_PEER_TTL_S": spelling, "STRANDS_DASHBOARD_POSE_HZ": spelling},
+        )
+        assert done.returncode == 0, f"STRANDS_DASHBOARD_PEER_TTL_S={spelling!r} broke the import: {done.stderr}"
+        assert done.stdout.strip() == "300.0", done.stdout
+
+    def test_the_knobs_scanned_are_the_knobs_the_module_reads(self) -> None:
+        """Derived non-vacuity: a knob added or renamed cannot skip the table above."""
+        import ast
+        import inspect
+
+        source = ast.parse(inspect.getsource(mesh_bridge))
+        read: set[str] = set()
+        for node in ast.walk(source):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "_env_float"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                read.add(node.args[0].value)
+        assert read == {name for name, _ in DASHBOARD_KNOBS}, (
+            f"the module resolves {sorted(read)} but this file grades {sorted(name for name, _ in DASHBOARD_KNOBS)}"
+        )

--- a/tests/test_dashboard_signed_estop_reports_what_the_peers_said.py
+++ b/tests/test_dashboard_signed_estop_reports_what_the_peers_said.py
@@ -1,0 +1,141 @@
+"""``signed_estop`` reports what the peers said, not only that the rail latched.
+
+``Mesh.emergency_stop`` sets the issuer's lockout unconditionally, before it
+broadcasts anything. ``MeshBridge.signed_estop`` returned that fact as
+``lockout_engaged: True`` and nothing else, so one value described a stop that
+reached every peer and a stop that reached nobody identically -- and the sheet
+rendered it as "peers refuse all commands until resumed", which is a claim about
+the room made from a fact about this process.
+
+``lockout_engaged`` stays ``True``, because it is true and because the operator's
+resume control is gated on it: making it ``False`` on an unacknowledged stop
+would hide the only way to clear a lockout that really is engaged. What was
+missing is the peer half, which ``Mesh.emergency_stop`` already computes for its
+own ``strands/safety/estop`` envelope and audit record:
+
+* ``responses_received`` -- REPLIES received, not stops confirmed, keeping the
+  meaning #1680 gave it so the two numbers can be compared;
+* ``peers_not_stopped`` -- responders that AFFIRMATIVELY reported they did not
+  stop, graded by ``mesh.core._peers_that_did_not_stop`` rather than by a second
+  copy of that rule here.
+
+These pin that the three fleets read differently and that the grading is not
+re-implemented. The route that forwards both fields to the operator (and the
+sheet sentence derived from them) lives in ``dashboard.server`` and the
+frontend, which land with the server slice of the #2848 decomposition (#2977);
+the route-level pin travels with that slice.
+
+Run with --no-cov.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from strands_robots.dashboard.mesh_bridge import MeshBridge
+
+# The response shapes _reports_failure_to_stop grades, per its docstring: the
+# stop verbs disagree about their envelope, so both spellings must be graded.
+ACK = {"responder_id": "arm-1", "result": {"ok": True, "status": "stopped"}}
+ACK_2 = {"responder_id": "arm-4", "result": {"ok": True, "status": "stopped"}}
+NO_STOP_TASK = {"responder_id": "arm-2", "result": {"ok": False, "error": "peer exposes no stop_task"}}
+SIM_REFUSED = {"responder_id": "sim-1", "result": {"status": "error", "error": "stop_policy refused"}}
+SIM_PARTIAL = {"responder_id": "sim-2", "result": {"ok": False, "not_stopped": ["r1"]}}
+ANONYMOUS_FAILURE = {"result": {"ok": False}}  # no responder_id
+UNRECOGNISED = {"responder_id": "arm-3", "result": {"pending": True}}
+
+
+class FakeMesh:
+    """Stands in for the safety Mesh: emergency_stop returns scripted replies."""
+
+    peer_id = "dash-safety"
+    alive = True
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = responses
+
+    def emergency_stop(self) -> list[dict[str, Any]]:
+        return list(self._responses)
+
+
+def signed_estop_over(responses: list[dict[str, Any]]) -> dict[str, Any]:
+    bridge = MeshBridge(peer_id="dash")
+    with mock.patch.object(MeshBridge, "_safety_mesh", return_value=FakeMesh(responses)):
+        return bridge.signed_estop()
+
+
+def operator_visible(payload: dict[str, Any]) -> str:
+    """What the route forwards: everything except the raw responses."""
+    return json.dumps({k: v for k, v in payload.items() if k != "responses"}, sort_keys=True)
+
+
+# --------------------------------------------------------------- the defect
+def test_three_different_fleets_no_longer_read_identically():
+    """The defect in one assertion: these three produced ONE payload."""
+    everybody = signed_estop_over([ACK, ACK_2])
+    nobody = signed_estop_over([])
+    refused = signed_estop_over([NO_STOP_TASK, SIM_REFUSED])
+
+    rendered = {operator_visible(p) for p in (everybody, nobody, refused)}
+    assert len(rendered) == 3, f"these fleets are indistinguishable to an operator: {rendered}"
+
+
+def test_a_stop_nobody_answered_reports_no_acknowledgement():
+    out = signed_estop_over([])
+
+    assert out["responses_received"] == 0
+    assert out["peers_not_stopped"] == []
+    # Still latched: a resume IS required, and the resume box is gated on this.
+    assert out["lockout_engaged"] is True
+
+
+def test_peers_that_reported_not_stopping_are_named_not_counted():
+    out = signed_estop_over([ACK, NO_STOP_TASK, SIM_REFUSED])
+
+    assert out["peers_not_stopped"] == ["arm-2", "sim-1"], "name them; a count is not actionable"
+    # Replies received, not stops confirmed - the two numbers stay comparable.
+    assert out["responses_received"] == 3
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (NO_STOP_TASK, ["arm-2"]),
+        (SIM_REFUSED, ["sim-1"]),
+        (SIM_PARTIAL, ["sim-2"]),
+        (UNRECOGNISED, []),  # conservative: an unknown shape is not a failure report
+        (ACK, []),
+    ],
+)
+def test_each_graded_shape_reaches_the_operator(response, expected):
+    assert signed_estop_over([response])["peers_not_stopped"] == expected
+
+
+def test_an_unidentified_failure_still_counts():
+    """A response with no responder_id must not vanish from the accounting."""
+    out = signed_estop_over([ANONYMOUS_FAILURE])
+
+    assert out["responses_received"] == 1
+    assert len(out["peers_not_stopped"]) == 1
+    assert "unidentified" in out["peers_not_stopped"][0]
+
+
+def test_the_grading_has_one_owner_and_is_not_reimplemented():
+    """The bridge's verdict must equal mesh.core's for the same replies.
+
+    A second copy of this rule on the safety path is how the sim dispatch branch
+    once reported ok=True over a refusal it already had in hand.
+    """
+    from strands_robots.mesh.core import _peers_that_did_not_stop
+
+    replies = [ACK, NO_STOP_TASK, SIM_REFUSED, SIM_PARTIAL, UNRECOGNISED, ANONYMOUS_FAILURE]
+    assert signed_estop_over(replies)["peers_not_stopped"] == sorted(_peers_that_did_not_stop(replies))
+
+
+def test_the_latch_is_reported_on_every_fleet_because_resume_needs_it():
+    for responses in ([], [ACK], [NO_STOP_TASK], [ACK, SIM_REFUSED]):
+        assert signed_estop_over(responses)["lockout_engaged"] is True

--- a/tests/test_dashboard_signed_rail_honours_the_mesh_kill_switch.py
+++ b/tests/test_dashboard_signed_rail_honours_the_mesh_kill_switch.py
@@ -16,16 +16,33 @@ arriving on the one path where an operator is least likely to be watching the
 peer list, by way of the action they are least likely to want to debug
 afterwards.
 
-These pin, for the bridge's construction sites:
+The switch has two consequences and they need separate pins. One is about the
+SESSION: no Zenoh peer may be opened. The other is about the ANSWER: a verb that
+reports "there is no rail" must say which of the two reasons applies, because an
+operator acts on them differently -- one is the switch they set, the other is a
+fault to chase.
+
+``signed_estop`` got both. ``signed_resume`` -- the same rail, the same
+operator, 38 lines down the same file -- got only the first, and answered
+``"safety mesh unavailable"`` in the one state this file spends 30 lines proving
+is not a fault. ``docs/dashboard/troubleshooting.md`` lists exactly two causes
+for a refused resume, both about ``override_code``, so "unavailable" sends the
+operator to a code that is fine rather than to the switch they set.
+
+These pin, for both consequences:
 
 * the switch is asked BEFORE a Mesh is constructed -- not after, because
   constructing one is what joins the fleet;
-* ``signed_estop`` says the rail was switched OFF rather than "unavailable", so
+* BOTH rail verbs say the rail was switched OFF rather than "unavailable", so
   the operator is pointed at the switch they set and not at a fault;
-* with the switch clear, the rail still starts -- the guard refuses a session,
-  it does not disable the feature;
+* with the switch clear, both verbs still reach the rail -- the guard refuses a
+  session, it does not disable the feature;
 * a future third construction site is graded from the source, since a new site
-  added without the predicate is exactly how this defect arrived.
+  added without the predicate is exactly how this defect arrived;
+* and so is a future third *answer*: the construction-site guard keys on
+  ``Mesh(...)`` and is structurally blind to a verb that constructs nothing,
+  which is why the resume half could drift. The wording has one owner and that
+  owner is what gets graded.
 
 Parametrized over ``_mesh_switch.NEGATIVE`` directly, per that module's own
 note: the vocabulary has one owner and a test that restates it would pass while
@@ -51,6 +68,11 @@ KILLED = (*NEGATIVE, *(v.upper() for v in NEGATIVE), *(f"  {v}  " for v in NEGAT
 #: Values that leave the switch clear: an opt-in, and "said nothing".
 ALLOWED = ("true", "1", "")
 
+#: The wording that means *a fault*, pinned by
+#: ``test_a_broken_rail_still_reports_unavailable_not_switched_off`` below. The
+#: source-derived guard reads it from here so the two cannot drift apart.
+FAULT_WORDING = "safety mesh unavailable"
+
 
 class RecordingMesh:
     """Stands in for Mesh and records that it was constructed/started at all.
@@ -73,6 +95,10 @@ class RecordingMesh:
     def emergency_stop(self) -> list[dict[str, Any]]:
         RecordingMesh.events.append(("emergency_stop", self.peer_id))
         return []
+
+    def _resume_lockout(self, override_code: str) -> dict[str, Any]:
+        RecordingMesh.events.append(("resume_lockout", self.peer_id))
+        return {"resumed": True}
 
 
 @pytest.fixture
@@ -130,6 +156,90 @@ def test_the_guard_refuses_a_session_it_does_not_disable_the_rail(value, recorde
 
     assert m is not None
     assert recorder.events == [("constructed", "dash-safety"), ("started", "dash-safety")]
+
+
+@pytest.mark.parametrize("value", KILLED)
+def test_a_resume_under_the_kill_switch_reports_the_switch_not_a_fault(value, recorder, monkeypatch):
+    """The regression: the resume half named a fault for a switch that was set.
+
+    Same rail, same operator and the same two answers as the e-stop half, which
+    has pointed at the switch since it was written. Reading "unavailable" here
+    sends the operator to the two ``override_code`` causes the troubleshooting
+    sheet documents for a refused resume -- and to a code that is fine.
+    """
+    monkeypatch.setenv("STRANDS_MESH", value)
+    bridge = MeshBridge(peer_id="dash")
+
+    out = bridge.signed_resume("operator-code")
+
+    assert out["signed"] is False
+    assert recorder.events == [], f"resume opened a session under STRANDS_MESH={value!r}"
+    assert "STRANDS_MESH" in out["error"], out["error"]
+    assert "unavailable" not in out["error"], out["error"]
+
+
+def test_a_broken_rail_still_reports_unavailable_on_the_resume_path(recorder, monkeypatch):
+    """The other half of the distinction, so the fix is not one string for both.
+
+    With the switch clear a rail that will not start IS a fault, and the resume
+    half must keep saying so -- otherwise "point at the switch" would have been
+    bought by describing every failure as the switch.
+    """
+    monkeypatch.setenv("STRANDS_MESH", "true")
+    bridge = MeshBridge(peer_id="dash")
+
+    with mock.patch.object(MeshBridge, "_safety_mesh", return_value=None):
+        out = bridge.signed_resume("operator-code")
+
+    assert out == {"signed": False, "error": FAULT_WORDING}
+
+
+@pytest.mark.parametrize("value", ALLOWED)
+def test_with_the_switch_clear_a_resume_reaches_the_rail(value, recorder, monkeypatch):
+    """A gate, not a mute: the resume verb still does its work when allowed."""
+    monkeypatch.setenv("STRANDS_MESH", value)
+    bridge = MeshBridge(peer_id="dash")
+
+    out = bridge.signed_resume("operator-code")
+
+    assert out["signed"] is True
+    assert ("resume_lockout", "dash-safety") in recorder.events, recorder.events
+
+
+def test_every_rail_unavailable_answer_asks_the_kill_switch():
+    """The invariant that actually failed, graded from the source.
+
+    The construction-site guard below keys on ``Mesh(...)``. That is the right
+    key for "did we open a session" and it is structurally blind to this defect:
+    ``signed_resume`` constructs nothing, so it was never in that guard's
+    population, and it still answered on the rail's behalf. The rule that broke
+    is about the ANSWER, so this grades every function that can emit the fault
+    wording -- which after the fix is the single owner both verbs call.
+
+    A second copy of the wording anywhere that does not ask the predicate fails
+    here, whether or not it opens a session.
+    """
+    import ast
+    import inspect
+
+    import strands_robots.dashboard.mesh_bridge as bridge_mod
+
+    tree = ast.parse(inspect.getsource(bridge_mod))
+    emitters: dict[str, bool] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        strings = {n.value for n in ast.walk(node) if isinstance(n, ast.Constant) and isinstance(n.value, str)}
+        if any(FAULT_WORDING in s for s in strings):
+            called = {n.func.id for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)}
+            emitters[node.name] = "mesh_disabled_by_env" in called
+
+    assert emitters, f"nothing emits {FAULT_WORDING!r} any more - has the wording moved?"
+    ungated = sorted(name for name, gated in emitters.items() if not gated)
+    assert not ungated, (
+        f"these answer that the rail is unavailable without asking mesh_disabled_by_env(): {ungated}. "
+        "A switched-off rail is not a fault, and the operator acts on the difference."
+    )
 
 
 def test_every_mesh_construction_site_in_the_bridge_asks_the_predicate():

--- a/tests/test_dashboard_signed_rail_honours_the_mesh_kill_switch.py
+++ b/tests/test_dashboard_signed_rail_honours_the_mesh_kill_switch.py
@@ -1,0 +1,161 @@
+"""The signed safety rail asks the mesh kill switch before it opens a session.
+
+``STRANDS_MESH=false`` is a hard kill switch, and
+:func:`strands_robots.mesh.core.mesh_disabled_by_env` states the rule in its own
+docstring: an operator who sets the switch asked for no Zenoh session and no
+presence on the fleet, so EVERY path which can open a session asks the same
+question -- #2515 closed the same gap for the robot-less gateway in
+``tools/robot_mesh`` after a direct ``Mesh(...)`` construction bypassed the
+inline test and put a live ``gateway-*`` peer on the fleet.
+
+``MeshBridge.start()`` honours it. ``MeshBridge._safety_mesh()`` is the second
+site in the same file that constructs and starts a ``Mesh``, and it did not:
+with the switch set, the first e-stop still put a ``<peer>-safety`` gateway peer
+on the live fleet. That is the ghost-peer case the switch was added to close,
+arriving on the one path where an operator is least likely to be watching the
+peer list, by way of the action they are least likely to want to debug
+afterwards.
+
+These pin, for the bridge's construction sites:
+
+* the switch is asked BEFORE a Mesh is constructed -- not after, because
+  constructing one is what joins the fleet;
+* ``signed_estop`` says the rail was switched OFF rather than "unavailable", so
+  the operator is pointed at the switch they set and not at a fault;
+* with the switch clear, the rail still starts -- the guard refuses a session,
+  it does not disable the feature;
+* a future third construction site is graded from the source, since a new site
+  added without the predicate is exactly how this defect arrived.
+
+Parametrized over ``_mesh_switch.NEGATIVE`` directly, per that module's own
+note: the vocabulary has one owner and a test that restates it would pass while
+the product and the switch disagreed.
+
+Run with --no-cov.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from strands_robots._mesh_switch import NEGATIVE
+from strands_robots.dashboard.mesh_bridge import MeshBridge
+
+#: Every kill spelling, plus the normalisation ``mesh_env_request`` documents
+#: (case and surrounding whitespace), derived from the owner rather than typed.
+KILLED = (*NEGATIVE, *(v.upper() for v in NEGATIVE), *(f"  {v}  " for v in NEGATIVE))
+
+#: Values that leave the switch clear: an opt-in, and "said nothing".
+ALLOWED = ("true", "1", "")
+
+
+class RecordingMesh:
+    """Stands in for Mesh and records that it was constructed/started at all.
+
+    Construction is recorded separately from ``start()`` because constructing a
+    Mesh is already asking for one: a guard placed after the constructor must
+    not pass this.
+    """
+
+    events: list[tuple[str, str | None]] = []
+    alive = True
+
+    def __init__(self, robot: Any, peer_id: str | None = None, peer_type: str = "robot") -> None:
+        self.peer_id = peer_id
+        RecordingMesh.events.append(("constructed", peer_id))
+
+    def start(self) -> None:
+        RecordingMesh.events.append(("started", self.peer_id))
+
+    def emergency_stop(self) -> list[dict[str, Any]]:
+        RecordingMesh.events.append(("emergency_stop", self.peer_id))
+        return []
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> type[RecordingMesh]:
+    """Patch the Mesh class the bridge imports, and reset the event log."""
+    import strands_robots.mesh.core as core
+
+    RecordingMesh.events = []
+    monkeypatch.setattr(core, "Mesh", RecordingMesh)
+    return RecordingMesh
+
+
+@pytest.mark.parametrize("value", KILLED)
+def test_the_kill_switch_refuses_the_safety_rail_a_session(value, recorder, monkeypatch):
+    monkeypatch.setenv("STRANDS_MESH", value)
+    bridge = MeshBridge(peer_id="dash")
+
+    assert bridge._safety_mesh() is None
+    assert recorder.events == [], f"STRANDS_MESH={value!r} still opened a session: {recorder.events}"
+
+
+@pytest.mark.parametrize("value", KILLED)
+def test_an_estop_under_the_kill_switch_creates_no_ghost_peer(value, recorder, monkeypatch):
+    """The regression: the FIRST e-stop was what put the ghost peer on the fleet."""
+    monkeypatch.setenv("STRANDS_MESH", value)
+    bridge = MeshBridge(peer_id="dash")
+
+    out = bridge.signed_estop()
+
+    assert out["signed"] is False
+    assert recorder.events == [], f"e-stop opened a session under STRANDS_MESH={value!r}"
+    # Switched off, not broken - the operator is pointed at the switch.
+    assert "STRANDS_MESH" in out["error"], out["error"]
+    assert "unavailable" not in out["error"], out["error"]
+
+
+def test_a_broken_rail_still_reports_unavailable_not_switched_off(recorder, monkeypatch):
+    """The two answers stay distinguishable: this one really is a fault."""
+    monkeypatch.setenv("STRANDS_MESH", "true")
+    bridge = MeshBridge(peer_id="dash")
+
+    with mock.patch.object(MeshBridge, "_safety_mesh", return_value=None):
+        out = bridge.signed_estop()
+
+    assert out == {"signed": False, "error": "safety mesh unavailable"}
+
+
+@pytest.mark.parametrize("value", ALLOWED)
+def test_the_guard_refuses_a_session_it_does_not_disable_the_rail(value, recorder, monkeypatch):
+    """With the switch clear the rail starts, so the guard is a gate not a mute."""
+    monkeypatch.setenv("STRANDS_MESH", value)
+    bridge = MeshBridge(peer_id="dash")
+
+    m = bridge._safety_mesh()
+
+    assert m is not None
+    assert recorder.events == [("constructed", "dash-safety"), ("started", "dash-safety")]
+
+
+def test_every_mesh_construction_site_in_the_bridge_asks_the_predicate():
+    """Derived from the source, so a NEW site cannot skip the gate silently.
+
+    Grading behaviour alone would leave a third construction site untested
+    until someone wrote a case for it, and the absence of that case is how
+    ``_safety_mesh`` stayed ungated while ``start`` was gated.
+    """
+    import ast
+    import inspect
+
+    import strands_robots.dashboard.mesh_bridge as bridge_mod
+
+    tree = ast.parse(inspect.getsource(bridge_mod))
+    opens_session: dict[str, bool] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        called = {n.func.id for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)}
+        if "Mesh" in called:  # constructing one is what joins the fleet
+            opens_session[node.name] = "mesh_disabled_by_env" in called
+
+    assert opens_session, "no Mesh construction site found - has the class been renamed?"
+    ungated = sorted(name for name, gated in opens_session.items() if not gated)
+    assert not ungated, (
+        f"these open a mesh session without asking mesh_disabled_by_env(): {ungated}. "
+        "STRANDS_MESH=false must be honoured at every construction site."
+    )

--- a/tests/test_env_float_knobs_resolve_to_a_finite_value.py
+++ b/tests/test_env_float_knobs_resolve_to_a_finite_value.py
@@ -22,8 +22,19 @@ admitted ``inf`` for the Isaac idle live-preview period. This sweep replaces the
 mesh-rooted one and walks the whole package, so its root is the scope of the rule
 it enforces.
 
-The population is derived, never listed: a function that both reads the
-environment and coerces with ``float()``. Only the exemptions are named, each
+A resolver's *position* is the same kind of blind spot as its root. The
+population was every such **function**, and a knob resolved by a module-level
+statement is not a function that failed the scan - it is invisible to it, so the
+sweep read as a clean tree again. That position is the one where an unusable
+value costs the most: the coercion runs while the module body executes, so a
+typo does not degrade one knob but raises ``ValueError`` out of the import, from
+a frame that names ``float`` rather than the variable. Module-level statements
+are therefore classified too, keyed ``module::<module>``, and a knob resolved
+through a resolver leaves that population by construction - it no longer
+coerces in the statement at all.
+
+The population is derived, never listed: a function - or a module-level
+statement - that both reads the environment and coerces with ``float()``. Only the exemptions are named, each
 with the reason it is not a resolver-level domain, and
 :meth:`TestEveryEnvFloatResolverIsFinitenessBounded.test_every_exemption_is_still_discovered`
 fails when one stops matching, so an exemption cannot outlive the code it
@@ -73,8 +84,15 @@ LANDMARK_RESOLVERS = (
 )
 
 #: Non-vacuity floor, well below the count measured on this tree, so a resolver
-#: added or removed does not send a contributor to edit a number.
+#: added or removed does not send a contributor to edit a number. Counted over
+#: the function population alone: a module-level knob resolved correctly leaves
+#: the population entirely, so a floor over the whole classification would be a
+#: floor on how many modules still coerce at import.
 MINIMUM_RESOLVERS = 6
+
+#: Stands in for the function name in a module-level entry's key. Not a legal
+#: Python identifier, so it cannot collide with a function called this.
+MODULE_SCOPE = "<module>"
 
 
 #: The scanned tree, derived from the imported package rather than from a path
@@ -85,9 +103,27 @@ MINIMUM_RESOLVERS = 6
 PACKAGE_ROOT = pathlib.Path(inspect.getfile(strands_robots)).parent
 
 
+#: Node types whose bodies belong to a different member of the population. A
+#: module-level statement must not be credited with a guard - nor charged with a
+#: coercion - that lives inside a function it merely encloses, and a class body
+#: is only ever a container for methods the function scan already classifies.
+_OWN_SCOPE = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+
+
+def _within_one_scope(node: ast.AST) -> list[ast.AST]:
+    """*node* and its descendants, stopping at anything that owns its own scope."""
+    seen: list[ast.AST] = []
+    stack: list[ast.AST] = [node]
+    while stack:
+        current = stack.pop()
+        seen.append(current)
+        stack.extend(child for child in ast.iter_child_nodes(current) if not isinstance(child, _OWN_SCOPE))
+    return seen
+
+
 def _reads_the_environment(fn: ast.AST) -> bool:
     """True when *fn* really reads ``os.environ`` / ``os.getenv``."""
-    for node in ast.walk(fn):
+    for node in _within_one_scope(fn):
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
             value = node.func.value
             if node.func.attr == "getenv" and isinstance(value, ast.Name) and value.id == "os":
@@ -101,7 +137,7 @@ def _reads_the_environment(fn: ast.AST) -> bool:
 
 def _calls_any(fn: ast.AST, names: frozenset[str] | set[str]) -> bool:
     """True when *fn* calls any function in *names*, bare or as an attribute."""
-    for node in ast.walk(fn):
+    for node in _within_one_scope(fn):
         if isinstance(node, ast.Call):
             func = node.func
             if isinstance(func, ast.Name) and func.id in names:
@@ -112,15 +148,29 @@ def _calls_any(fn: ast.AST, names: frozenset[str] | set[str]) -> bool:
 
 
 def _classify(paths: list[pathlib.Path], root: pathlib.Path) -> dict[str, bool]:
-    """Map ``module::function`` to whether it tests finiteness."""
+    """Map ``module::function`` - and ``module::<module>`` - to whether it tests finiteness.
+
+    A module contributes at most one ``<module>`` entry however many statements
+    resolve knobs there, and it is bounded only when every one of them is: the
+    import either survives an operator's typo or it does not, so one unguarded
+    statement is the whole module's answer.
+    """
     found: dict[str, bool] = {}
     for path in paths:
         tree = ast.parse(path.read_text(encoding="utf-8"))
+        name = path.relative_to(root).as_posix()
         for node in ast.walk(tree):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             if _calls_any(node, {"float"}) and _reads_the_environment(node):
-                found[f"{path.relative_to(root).as_posix()}::{node.name}"] = _calls_any(node, FINITENESS_GUARDS)
+                found[f"{name}::{node.name}"] = _calls_any(node, FINITENESS_GUARDS)
+        for statement in tree.body:
+            if isinstance(statement, _OWN_SCOPE):
+                continue
+            if _calls_any(statement, {"float"}) and _reads_the_environment(statement):
+                bounded = _calls_any(statement, FINITENESS_GUARDS)
+                key = f"{name}::{MODULE_SCOPE}"
+                found[key] = found.get(key, True) and bounded
     return found
 
 
@@ -190,6 +240,65 @@ class TestTheDetectorAnswersOnPlantedSource:
             encoding="utf-8",
         )
         assert _scan(tmp_path) == {"planted.py::_resolve": True}, label
+
+    def test_a_module_level_resolution_is_reported(self, tmp_path: pathlib.Path) -> None:
+        """The position an unusable value raises out of the import from."""
+        (tmp_path / "planted.py").write_text(
+            'import os\n\nTTL = float(os.getenv("TTL", "300"))\n',
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {"planted.py::<module>": False}
+
+    def test_a_module_level_knob_read_through_a_resolver_is_not_in_the_population(self, tmp_path: pathlib.Path) -> None:
+        """Routing the knob is the remedy, and it leaves nothing to grade."""
+        (tmp_path / "planted.py").write_text(
+            "import math\nimport os\n\n\n"
+            "def _env_float(name: str, default: float) -> float:\n"
+            "    value = float(os.getenv(name, str(default)))\n"
+            "    return value if math.isfinite(value) else default\n\n\n"
+            'TTL = _env_float("TTL", 300.0)\n',
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {"planted.py::_env_float": True}
+
+    def test_one_unguarded_statement_answers_for_the_whole_module(self, tmp_path: pathlib.Path) -> None:
+        """A guarded sibling does not vouch for the statement beside it."""
+        (tmp_path / "planted.py").write_text(
+            "import math\nimport os\n\n"
+            'A = float(os.getenv("A", "1")) if math.isfinite(float(os.getenv("A", "1"))) else 1.0\n'
+            'B = float(os.getenv("B", "2"))\n',
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {"planted.py::<module>": False}
+
+    def test_a_statement_is_not_credited_with_a_guard_from_a_scope_it_encloses(self, tmp_path: pathlib.Path) -> None:
+        """A guard inside an enclosed ``def`` belongs to that ``def``, not to its host.
+
+        The coercion here runs at import and is unguarded; the ``isfinite`` sits in
+        a function the block merely contains, and is never applied to it. A walk
+        that descends into the nested scope reads the block as bounded.
+        """
+        (tmp_path / "planted.py").write_text(
+            "import math\nimport os\n\n"
+            "if True:\n"
+            '    TTL = float(os.getenv("TTL", "300"))\n\n'
+            "    def _unrelated(value: float) -> bool:\n"
+            "        return math.isfinite(value)\n",
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {"planted.py::<module>": False}
+
+    def test_a_resolver_is_not_credited_with_a_guard_from_its_own_closure(self, tmp_path: pathlib.Path) -> None:
+        """The same rule one scope down: a helper defined but not applied is not a bound."""
+        (tmp_path / "planted.py").write_text(
+            "import math\nimport os\n\n\n"
+            "def _resolve(name: str) -> float:\n"
+            "    def _ok(value: float) -> bool:\n"
+            "        return math.isfinite(value)\n\n"
+            '    return float(os.getenv(name, "1"))\n',
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {"planted.py::_resolve": False}
 
     def test_a_comment_mentioning_getenv_is_not_a_resolver(self, tmp_path: pathlib.Path) -> None:
         """The detector must not re-acquire the text scan's false positive."""


### PR DESCRIPTION
## What

The first decomposition slice of draft #2848, per #2977's own seam table: `strands_robots/dashboard/mesh_bridge.py` — the dashboard's mesh peer (fleet snapshot, event coalescing, responder-scoped RPC, signed safety rail) — extracted whole from the draft and landed with the two must-fix findings that belong to this slice resolved. The module is @logesh4v's work from #2848 (including their own fixes for both findings on the PR branch, commits 59fc905d / 0173d5db); this PR is extraction + adaptation to current `main`, filed so the slice can be reviewed to a conclusion at reviewable size (+1,539 across 6 files vs the draft's 476).

## Finding 7 — an e-stop that reached nobody must not report like one that reached everyone

`lockout_engaged` deliberately stays `True` — `Mesh.emergency_stop` sets the local lockout unconditionally *before* broadcasting, so "let it say False" would be a second false statement and would hide the resume control the UI gates on. Instead the payload now carries the peer half alongside: `responses_received` (replies, the #1680 meaning, so numbers stay comparable) and `peers_not_stopped`, graded by importing `mesh.core._peers_that_did_not_stop` — the single owner of that rule — so only affirmative failure reports flag a peer. A test pins that the bridge's verdict equals mesh.core's for the same replies, and that all-acked / nobody-answered / answered-but-refused fleets render three distinct payloads.

## Finding 8 — `STRANDS_MESH=false` must keep the safety rail off the fleet

`_safety_mesh()` now asks `mesh_disabled_by_env()` — main's sole kill-switch predicate, resolving through `_mesh_switch`'s single-owner vocabulary, no env re-parse — *before* constructing `Mesh`, since constructing is what joins the fleet. The refusal names the switch ("signed safety rail disabled by STRANDS_MESH=false") while a genuinely broken rail still reads "unavailable". An AST guard test fails any future `Mesh` construction site in this file that skips the predicate; the kill-switch test parametrizes over `_mesh_switch.NEGATIVE` directly.

## Adaptations from the draft

- The draft's `mesh_kill_switch_engaged` predicate does not exist on main — all three call sites route through `mesh_disabled_by_env` with comments citing that predicate's "every path that can open one answers this" doctrine and #2515.
- `joint_silence.merge` → plain overlay with a documented why (that module and its only feeder land with the server slice).
- Stays behind the dashboard `__init__.py` `require_optionals` gate, matching fragment 3051's documented decision.

## Out of scope (next slices, per #2977's own decomposition)

The frontend half of finding 7 (EstopSheet.tsx / estopReach.ts) and the `/api/safety/estop` route pin (need `dashboard.server`); finding 4 (`degraded_report` in mesh/core.py); findings 1–3, 5–6.

## Tests

34/34 slice tests; 156/156 including main's kill-switch, vocabulary-single-owner, session-acquire, e-stop-grading and safety-state suites; 128/128 repo guard tests (changelog fragments, no-host-paths, docstring xrefs). `ruff check`, `ruff format --check`, `mypy` clean on touched files. Three `changelog.d/` fragments; `CHANGELOG.md` untouched.

Closes nothing on its own — advances #2977 (slice 1 of the plan), addresses findings 7+8 of #2848.

## Round changelog

**Round 5** (head `d1be3a3a`) — the required check was red on two `main` graders that landed after this branch's merge base, not on anything the review asked for.

- `5074b5d7` merges `origin/main` (359 commits behind; `git merge-tree` reported zero conflicts, `git show --cc` is 0 lines, so the PR's own diff is byte-identical). This is what the `Detect an untested overlap with the base branch` check was asking for.
- `2f836914` documents the eight `STRANDS_DASHBOARD_*` knobs `mesh_bridge.py` reads in `docs/reference/configuration.md`, which `tests/test_env_vars_the_package_reads_are_documented.py` (now on `main`) refuses to leave unnamed. That was the one failing test in `call-test-lint` at `f9da7fea` (`1 failed, 36829 passed`).
- `d1be3a3a` routes `_raw_to_jpeg`'s refused `shape` through `refusal_repr`, the shared renderer `tests/test_refusal_messages_never_raise.py` requires of every guard in the package. Message text is unchanged for any shape `repr` could already render.

Verification: the five slice/grader suites pass (274 tests), and the whole-tree roster was run on this composition and on bare `main` in the same environment; the only delta was the two `test_refusal_messages_never_raise` cases that `d1be3a3a` clears. The remaining failures are identical on both and are environment-bound (no `mujoco`, `lerobot`, `torch` on this host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmv1uhoHXZxuP3GKhfJuq2
