### PR TITLE
fix(inference): advertised metadata is held to the domain the local policy is

### DIFF
--- a/changelog.d/3207-remote-metadata-domain.md
+++ b/changelog.d/3207-remote-metadata-domain.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- `RemotePolicy` now holds the metadata a `PolicyServer` advertises in its
+  `ready` handshake to the same domain a locally-loaded policy is held to. The
+  two chunk counts arrived through a bare `int()` and the two capability flags
+  through a bare `bool()`, which was silent rather than lenient: an advertised
+  `execution_horizon` of `0` landed behind `Policy.execution_horizon`'s
+  `max(1, ...)` floor, so a peer declaring a 16-action chunk was mirrored as
+  single-step, `is_chunk_emitting()` answered `False` and `resolve_chunk_length`
+  consumed 8 of the 16 actions the peer said it emits, all reported as success;
+  `bool("no")` is `True`, so a peer answering `"no"` turned a capability on; and
+  a `null` raised `TypeError: int() argument must be a string...` out of the
+  middle of a connect, naming neither the field nor the peer.
+  `execution_horizon` and `actions_per_step` now share `chunk_count_error`'s
+  domain with the constructor parameters they mirror, `requires_images` and
+  `supports_rtc` must be JSON booleans, and `provider_name` a string. Every
+  field is checked before any is applied, so a refusal leaves the mirror
+  untouched, and a connection whose metadata was rejected is discarded on the
+  `reset` path as well as on the handshake. A field the handshake omits is still
+  not refused, so a peer advertising a subset of the metadata stays usable.

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -152,6 +152,22 @@ policy inside it - and the client declares the same set. A mimic tracker such as
 [ProtoMotions](../policies/protomotions.md) therefore reads its anchor link over
 the wire exactly as it does in-process.
 
+Advertised metadata is held to the same domain the local property is, in the same
+direction the forwarded parameters below are: a peer's numbers become this
+policy's introspection answers, so the handshake is where a locally-loaded
+checkpoint's constructor sits in the remote arrangement. `execution_horizon` and
+`actions_per_step` are slice bounds over the action chunk, so they share
+`chunk_count_error`'s domain with the constructor parameters they mirror - a
+positive `int`, nothing else - and `requires_images` / `supports_rtc` must be JSON
+booleans. Coercing instead is silent rather than lenient: an advertised `0` lands
+behind `execution_horizon`'s `max(1, ...)` floor, so a peer declaring a 16-action
+chunk is mirrored as single-step, `is_chunk_emitting()` answers `False`, and the
+rollout leaves the async-RTC path with nothing said; `bool("no")` is `True`, so a
+peer answering `"no"` turns a capability on. A field the handshake omits is not
+refused - the client keeps its own default, so a server advertising a subset stays
+usable - and a value it cannot mirror raises a `ConnectionError` naming the field,
+the value and the peer, without the connection being cached.
+
 ## Real-Time Chunking across the wire
 
 The RTC contract is preserved end to end. The runner counts how many control

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -32,10 +32,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.inference import protocol
-from strands_robots.policies.base import Policy
+from strands_robots.policies.base import Policy, chunk_count_error
 from strands_robots.utils import name_list_error, positive_finite_number_error, tcp_port_error
 
 if TYPE_CHECKING:
@@ -47,6 +48,63 @@ logger = logging.getLogger(__name__)
 #: this is generous; override via the ``request_timeout`` kwarg.
 DEFAULT_REQUEST_TIMEOUT = 60.0
 DEFAULT_CONNECT_TIMEOUT = 10.0
+
+
+#: Metadata fields the ``ready`` handshake advertises as a per-inference chunk
+#: count. Both are consumed as slice bounds over the action chunk, so they share
+#: :func:`~strands_robots.policies.base.chunk_count_error`'s domain with the
+#: constructor parameters a locally-loaded checkpoint is held to.
+_MIRRORED_CHUNK_COUNTS = ("execution_horizon", "actions_per_step")
+
+#: Metadata fields advertised as a capability flag. JSON spells a boolean
+#: ``true``/``false``, so anything else is a peer that does not speak this
+#: protocol - and a non-empty string is TRUTHY, which is how a peer answering
+#: ``"no"`` used to turn a capability ON.
+_MIRRORED_FLAGS = ("requires_images", "supports_rtc")
+
+
+def _metadata_refusal(metadata: Mapping[str, Any]) -> str | None:
+    """Report why advertised policy metadata cannot be mirrored.
+
+    The handshake is the one place a peer's own numbers become this policy's
+    introspection answers, so it is where they have to be checked. Reading them
+    unchecked is not merely lenient, it is silent: the chunk counts land behind
+    :attr:`Policy.execution_horizon`'s ``max(1, int(...))``, which is documented
+    on :func:`~strands_robots.policies.base.chunk_count_error` as "silently
+    destructive" for exactly this reason - a count no consumer can execute
+    becomes ``1``, so an advertised ``0`` turns a chunk-emitting remote policy
+    into a single-step one and :meth:`Policy.is_chunk_emitting` reports
+    ``False``, which takes the rollout off the async-RTC path with nothing said.
+
+    Holding the wire to ``chunk_count_error``'s domain is what that function
+    asks for: it exists so "the same chunk count cannot be refused by a local
+    checkpoint and accepted by the server serving it", and this handshake is the
+    place the server does the accepting.
+
+    A field the handshake omits is not refused - the client keeps its own
+    default for it, which is what makes a peer advertising a subset of the
+    metadata (an older server, a third-party implementation) still usable.
+
+    Args:
+        metadata: The ``metadata`` payload of a ``ready`` or ``reset`` reply.
+
+    Returns:
+        Refusal text naming the field and the value, or ``None`` when every
+        advertised field is one this client can mirror.
+    """
+    for param in _MIRRORED_CHUNK_COUNTS:
+        if param in metadata and (error := chunk_count_error(metadata[param], param, "the served policy")):
+            return error
+    for param in _MIRRORED_FLAGS:
+        value = metadata.get(param, False)
+        if param in metadata and not isinstance(value, bool):
+            return (
+                f"the served policy advertised {param}={value!r} ({type(value).__name__}), which is not a JSON boolean."
+            )
+    if "provider_name" in metadata and not isinstance(metadata["provider_name"], str):
+        name = metadata["provider_name"]
+        return f"the served policy advertised provider_name={name!r} ({type(name).__name__}), which is not a string."
+    return None
 
 
 class RemotePolicy(Policy):
@@ -254,14 +312,37 @@ class RemotePolicy(Policy):
                 self._connect()
 
     def _apply_metadata(self, metadata: dict[str, Any]) -> None:
-        """Mirror the server policy's introspection metadata locally."""
+        """Mirror the server policy's introspection metadata locally.
+
+        Every advertised field is checked before ANY is applied, so a refusal
+        leaves the mirror exactly as it was rather than half-updated with the
+        fields that happened to be read before the offending one.
+
+        The coercions this used to apply are gone with the check that replaces
+        them: ``int()`` truncated an advertised ``8.9`` to ``8`` and parsed a
+        ``"16"`` that no local checkpoint would be allowed to pass, and
+        ``bool()`` turned the truthy string ``"no"`` into ``True``.
+
+        Args:
+            metadata: The ``metadata`` payload of a ``ready`` handshake or of a
+                ``reset`` reply, which re-advertises it once the server policy
+                has firmed up.
+
+        Raises:
+            ConnectionError: If a field the peer advertised is not one this
+                client can mirror, per :func:`_metadata_refusal`.
+        """
         if not metadata:
             return
+        if refusal := _metadata_refusal(metadata):
+            raise ConnectionError(
+                f"PolicyServer at {self.uri} advertised metadata this client cannot mirror: {refusal}"
+            )
         self._remote_provider_name = metadata.get("provider_name", self._remote_provider_name)
-        self._requires_images = bool(metadata.get("requires_images", self._requires_images))
-        self.actions_per_step = int(metadata.get("actions_per_step", self.actions_per_step))
-        self.supports_rtc = bool(metadata.get("supports_rtc", self.supports_rtc))
-        self._execution_horizon = int(metadata.get("execution_horizon", self._execution_horizon))
+        self._requires_images = metadata.get("requires_images", self._requires_images)
+        self.actions_per_step = metadata.get("actions_per_step", self.actions_per_step)
+        self.supports_rtc = metadata.get("supports_rtc", self.supports_rtc)
+        self._execution_horizon = metadata.get("execution_horizon", self._execution_horizon)
         # A JSON array of names. Coerced to the shape the robot host's runtime
         # validates rather than trusted verbatim, so a peer sending something
         # else cannot make the local resolver report the proxy as the declaring
@@ -447,7 +528,14 @@ class RemotePolicy(Policy):
                 self._reset_seed = seed
                 return
             reply = self._request({"type": protocol.MSG_RESET, "seed": seed})
-            self._apply_metadata(reply.get("metadata", {}))
+            try:
+                self._apply_metadata(reply.get("metadata", {}))
+            except ConnectionError:
+                # Same rule the handshake follows: a connection whose metadata
+                # this client rejected must not be handed to the next request,
+                # or the refusal is raised once and then served on silently.
+                self._discard_connection()
+                raise
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/tests/inference/test_advertised_metadata_is_held_to_the_local_domain.py
+++ b/tests/inference/test_advertised_metadata_is_held_to_the_local_domain.py
@@ -1,0 +1,199 @@
+"""The ``ready`` handshake's metadata is held to the domain a local policy is.
+
+:class:`~strands_robots.inference.client.RemotePolicy` answers every
+introspection probe with a number the peer sent it, so the handshake is where a
+locally-loaded checkpoint's constructor sits in the remote arrangement -- and
+:func:`~strands_robots.policies.base.chunk_count_error` exists precisely so
+"the same chunk count cannot be refused by a local checkpoint and accepted by
+the server serving it".
+
+The two chunk counts used to arrive through a bare ``int()`` and the two
+capability flags through a bare ``bool()``, which is silent rather than lenient:
+
+* an advertised ``0`` landed behind :attr:`Policy.execution_horizon`'s
+  ``max(1, int(...))`` floor, so a peer declaring a 16-action chunk was mirrored
+  as single-step and :meth:`Policy.is_chunk_emitting` answered ``False`` -- the
+  outcome ``chunk_count_error`` documents that floor as "silently destructive"
+  for;
+* an advertised ``8.9`` was truncated to ``8`` and a ``"16"`` parsed, neither of
+  which a local checkpoint may pass;
+* ``bool("no")`` is ``True``, so a peer answering ``"no"`` turned a capability
+  ON;
+* and ``null`` reached CPython, raising ``TypeError: int() argument must be a
+  string...`` out of the middle of a connect, naming neither the field nor the
+  peer.
+
+The sibling module ``test_remote_policy_handshake_contract.py`` pins the loud
+seams of a misbehaving peer; these pin the quiet ones.
+"""
+
+from typing import Any
+
+import pytest
+
+from strands_robots.inference import RemotePolicy, protocol
+from strands_robots.policies.base import chunk_count_error
+
+#: Every mirrored field, with the value a compliant peer sends.
+_COMPLIANT: dict[str, Any] = {
+    "provider_name": "lerobot_local",
+    "requires_images": True,
+    "actions_per_step": 16,
+    "supports_rtc": False,
+    "execution_horizon": 16,
+}
+
+#: ``(field, advertised value, what reading it unchecked produced)``. The last
+#: column is measured on the pre-fix client and is what the refusal replaces.
+_UNMIRRORABLE: list[tuple[str, Any, str]] = [
+    ("execution_horizon", 0, "floored to 1: a 16-action chunk mirrored as single-step"),
+    ("execution_horizon", -5, "floored to 1"),
+    ("execution_horizon", 8.9, "truncated to 8"),
+    ("execution_horizon", "16", "parsed: a str no local checkpoint may pass"),
+    ("execution_horizon", True, "a bool counted as 1"),
+    ("execution_horizon", None, "TypeError from int(), naming no field"),
+    ("actions_per_step", 0, "mirrored as 0"),
+    ("actions_per_step", None, "TypeError from int(), naming no field"),
+    ("actions_per_step", "many", "ValueError from int(), naming no field"),
+    ("requires_images", "false", 'bool("false") is True: frames rendered anyway'),
+    ("supports_rtc", "no", 'bool("no") is True: RTC turned on'),
+    ("provider_name", 12345, "reported as the remote provider's name"),
+]
+
+
+class _FakeConnection:
+    """Minimal stand-in for a ``websockets.sync`` connection over seeded frames."""
+
+    def __init__(self, frames: list[str]) -> None:
+        self._frames = list(frames)
+        self.sent: list[str] = []
+        self.closed = False
+
+    def recv(self, timeout: float | None = None) -> str:  # noqa: ARG002 - parity with the real API
+        if not self._frames:
+            raise AssertionError("client called recv() more times than the test seeded frames")
+        return self._frames.pop(0)
+
+    def send(self, text: str) -> None:
+        self.sent.append(text)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _ready(metadata: dict[str, Any]) -> str:
+    """A well-formed ``ready`` handshake advertising *metadata*."""
+    return protocol.dumps(
+        {"type": protocol.MSG_READY, "protocol_version": protocol.PROTOCOL_VERSION, "metadata": metadata}
+    )
+
+
+def _client(monkeypatch: pytest.MonkeyPatch, frames: list[str]) -> tuple[RemotePolicy, _FakeConnection]:
+    """A client whose next connect yields *frames*, plus the connection it gets."""
+    fake = _FakeConnection(frames)
+    monkeypatch.setattr("websockets.sync.client.connect", lambda *a, **k: fake)
+    return RemotePolicy(endpoint="ws://127.0.0.1:65535"), fake
+
+
+def _advertising(monkeypatch: pytest.MonkeyPatch, field: str, value: Any) -> tuple[RemotePolicy, _FakeConnection]:
+    """A client handed compliant metadata with one field replaced by *value*."""
+    return _client(monkeypatch, [_ready({**_COMPLIANT, field: value})])
+
+
+@pytest.mark.parametrize(("field", "value", "unchecked"), _UNMIRRORABLE, ids=lambda v: str(v)[:24])
+def test_a_field_this_client_cannot_mirror_is_refused_by_name(
+    monkeypatch: pytest.MonkeyPatch, field: str, value: Any, unchecked: str
+) -> None:
+    """A value outside the local domain is a named refusal, not a quiet mirror."""
+    client, _ = _advertising(monkeypatch, field, value)
+
+    with pytest.raises(ConnectionError, match=field) as raised:
+        _ = client.execution_horizon
+
+    assert repr(value) in str(raised.value), f"the refusal does not quote the value ({unchecked})"
+
+
+def test_compliant_metadata_is_still_mirrored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The values a ``PolicyServer`` actually sends pass through unchanged."""
+    client, _ = _client(monkeypatch, [_ready(_COMPLIANT)])
+
+    assert client.execution_horizon == 16
+    assert client.actions_per_step == 16
+    assert client.requires_images is True
+    assert client.supports_rtc is False
+    assert client.remote_provider_name == "lerobot_local"
+    assert client.is_chunk_emitting() is True
+
+
+def test_metadata_omitting_a_field_keeps_this_client_s_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A peer advertising a subset is usable: an absent field is not a refusal."""
+    client, _ = _client(monkeypatch, [_ready({"provider_name": "recording", "requires_images": False})])
+
+    assert client.requires_images is False
+    assert client.execution_horizon == 1
+    assert client.actions_per_step == 1
+
+
+def test_a_refused_handshake_leaves_the_mirror_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nothing is applied when one field is refused, so no half-mirrored state is served."""
+    # ``provider_name`` and ``requires_images`` are read before the offending
+    # count in the pre-fix order, so they are what a partial apply would leak.
+    client, _ = _advertising(monkeypatch, "execution_horizon", 0)
+
+    with pytest.raises(ConnectionError):
+        _ = client.execution_horizon
+
+    assert client.remote_provider_name == "unknown"
+    assert client.actions_per_step == 1
+
+
+def test_a_refused_handshake_does_not_leave_the_connection_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rejected connection is closed and dropped, not served on afterwards."""
+    client, fake = _advertising(monkeypatch, "supports_rtc", "no")
+
+    with pytest.raises(ConnectionError):
+        _ = client.execution_horizon
+
+    assert fake.closed is True
+    assert client._ws is None
+
+
+def test_a_refused_reset_re_advertisement_does_not_leave_the_connection_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server re-advertising an unmirrorable count on ``reset`` is refused the same way."""
+    client, fake = _client(
+        monkeypatch,
+        [
+            _ready(_COMPLIANT),
+            protocol.dumps({"type": protocol.MSG_OK, "metadata": {**_COMPLIANT, "execution_horizon": 0}}),
+        ],
+    )
+    assert client.execution_horizon == 16  # connected on compliant metadata
+
+    with pytest.raises(ConnectionError, match="execution_horizon"):
+        client.reset(seed=0)
+
+    assert fake.closed is True
+    assert client._ws is None
+
+
+@pytest.mark.parametrize("value", [16, 1, 0, -5, 8.9, "16", True, None, [16]], ids=repr)
+def test_the_wire_and_the_constructor_agree_about_a_chunk_count(monkeypatch: pytest.MonkeyPatch, value: Any) -> None:
+    """One value, one verdict: what a checkpoint's constructor refuses, the wire refuses.
+
+    Grounded in ``chunk_count_error`` itself -- the domain
+    :class:`~strands_robots.policies.lerobot_local.policy.LerobotLocalPolicy`
+    and ``LerobotAsyncPolicy`` hold their ``actions_per_step`` to -- rather than
+    in a list of values this test picked, so the two cannot drift apart.
+    """
+    constructor_refuses = chunk_count_error(value, "actions_per_step", "lerobot_local") is not None
+    client, _ = _advertising(monkeypatch, "actions_per_step", value)
+
+    try:
+        _ = client.execution_horizon
+        wire_refuses = False
+    except ConnectionError:
+        wire_refuses = True
+
+    assert wire_refuses is constructor_refuses


### PR DESCRIPTION
`RemotePolicy` answers every introspection probe with a number the peer sent it, so the `ready` handshake is where a locally-loaded checkpoint's constructor sits in the remote arrangement. The two chunk counts arrived through a bare `int()` and the two capability flags through a bare `bool()`.

![advertised-metadata domain matrix](https://raw.githubusercontent.com/cagataycali/robots/b14e7369b7270b8803985a25e3e3efb79d3169af/.artifacts/remote-metadata-domain.png)

## The headline row

One `ready` handshake declaring `actions_per_step: 16` and `execution_horizon: 0`. Measured through `resolve_chunk_length(policy, action_horizon=8)`, the helper every consumer reads:

| | compliant peer | `execution_horizon: 0`, before | after |
|---|---:|---:|---|
| mirrored `execution_horizon` | 16 | **1** (the `max(1, ...)` floor) | refused |
| `is_chunk_emitting()` | `True` | **`False`** | refused |
| actions consumed per inference | 16 of 16 | **8 of 16** | refused |
| reported | success | **success** | `ConnectionError` naming the field, the value and the peer |

Half the chunk the peer says it emits is dropped every inference and the rollout leaves the async-RTC path, with nothing said. `chunk_count_error` already documents that floor as "silently destructive" for exactly this reason.

## Why the handshake is where it has to be checked

`chunk_count_error` exists so "the same chunk count cannot be refused by a local checkpoint and accepted by the server serving it" — and this handshake is where the server does the accepting. `LerobotLocalPolicy` and `LerobotAsyncPolicy` hold their `actions_per_step` to that domain at the constructor; the mirror of the same count took `0`, `-5`, `8.9`, `"16"` and `true`.

The rule is also already written down for the opposite direction, in `docs/inference/remote.md` on the parameters the client *forwards*: "The server passes them through verbatim rather than coercing them — JSON carries `NaN`, `Infinity` and `true`, and coercing a `true` to `1.0` would install a 1 Hz clock no local caller could have set." The return direction did the coercing.

## Change

* `execution_horizon` and `actions_per_step` go through `chunk_count_error` — a positive `int`, nothing else.
* `requires_images` and `supports_rtc` must be JSON booleans. `bool("no")` is `True`, which is how a peer answering `"no"` turned a capability on.
* `provider_name` must be a string.
* Every advertised field is checked **before any is applied**, so a refusal leaves the mirror untouched instead of half-updated with whatever was read before the offending field.
* A refused re-advertisement on the `reset` reply discards the connection too, per the rule the handshake already follows: a connection this client rejected must not be handed to the next request.

Unchanged: a field the handshake omits is not refused, so a peer advertising a subset (an older server, a third-party implementation of the JSON protocol) stays usable. `required_bodies` keeps its own coercion, which already declines to trust the peer verbatim.

## Tests

`tests/inference/test_advertised_metadata_is_held_to_the_local_domain.py`, 26 cells. Pre-fix on this branch's tests against `main`'s source: **22 failed / 4 passed**, the 4 being the controls (compliant metadata still mirrored; a handshake omitting fields still keeps the client defaults; the agreement rows for `16` and `1`).

The last cell is table-driven off `chunk_count_error` itself rather than off a list of values the test picked, so the wire and the constructor cannot drift apart:

```python
constructor_refuses = chunk_count_error(value, "actions_per_step", "lerobot_local") is not None
...
assert wire_refuses is constructor_refuses
```

The sibling `test_remote_policy_handshake_contract.py` pins the loud seams of a misbehaving peer; these pin the quiet ones.

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` | clean (1872 files) |
| `mypy strands_robots tests tests_integ` (1.20.2) | 20 errors in 6 files, **identical on `main`**, none in the changed files |
| `pytest tests/inference` | 3 failed / 207 passed; the 3 are `test_a_stopped_server_stops_serving_its_clients.py`, **set-identical to `main`** (3 failed / 181 passed there) — +26 is exactly the new cells |
| `pytest tests/policies` | 12 failed / 5470 passed, unchanged baseline (installed-lerobot drift) |
| `scripts/check_whole_tree_graders.py` | 13 failed / 4307 passed / 4 errors, the standing baseline — every one an absent optional dep or installed-`lerobot`/`websockets` version drift, none in `tests/inference` |
| `tests/test_docstring_xref_roles_resolve.py`, `tests/inference/test_public_member_docstrings.py` | 28 passed |

## Size

| | + | - |
|---|---:|---:|
| `strands_robots/inference/client.py` | 95 | 7 |
| `tests/inference/...local_domain.py` | 199 | 0 |
| `docs/inference/remote.md` | 16 | 0 |
| `changelog.d/3207-*.md` | 20 | 0 |

Net additive at +330/-7: the check and its refusal text are new surface, most of it the one-behaviour-per-pin test table.