### PR TITLE
fix(hardware_rtps_bridge): each robot's joint_states reach that robot's own topic

### DIFF
--- a/changelog.d/3209-rtps-per-robot-joint-writers.md
+++ b/changelog.d/3209-rtps-per-robot-joint-writers.md
@@ -1,0 +1,13 @@
+### Fixed: `HardwareRtpsBridge` publishes each robot's `joint_states` on that robot's own topic
+
+`publish_joint_states` takes `robot` per call and derives
+`/<robot>/joint_states` from it, but the pure-RTPS bridge cached a single
+DataWriter for the whole bridge. The first robot to publish owned the only
+writer, so every later robot's `JointState` went to that robot's topic: a
+subscriber to the second robot's `joint_states` found no writer at all, while
+the first robot's topic carried both arms interleaved - and the sample's own
+`frame_id` still named the robot it came from, so nothing reported the
+mismatch. The joint writers are now cached per robot, matching the
+`_image_writers` cache in the same class and the rclpy transport's per-robot
+publisher cache, which is what makes the two transports advertise the same
+topics for the same calls. `shutdown()` drops every robot's writer.

--- a/strands_robots/hardware_rtps_bridge.py
+++ b/strands_robots/hardware_rtps_bridge.py
@@ -242,7 +242,11 @@ class HardwareRtpsBridge(RosTelemetryBase):
             self._participant = DomainParticipant(self._domain_id)
 
         self._robot_name = self._safe(self._resolve_robot_name(robot) if robot is not None else "robot")
-        self._joint_writer: Any = None
+        # One writer per robot, as in ``_image_writers`` below and in the rclpy
+        # transport's ``_joint_pubs``: ``robot`` is a per-call argument that
+        # selects the topic, so caching a single writer would publish every
+        # later robot's state on the first one's topic.
+        self._joint_writers: dict[str, Any] = {}
         self._image_writers: dict[str, Any] = {}
 
         # Cache the resolved IDL classes once (KeyError here = the bundle is
@@ -304,10 +308,14 @@ class HardwareRtpsBridge(RosTelemetryBase):
         """Publish one ``JointState`` for ``robot`` on ``/<robot>/joint_states``.
 
         Signature matches ``RosTelemetryBridge.publish_joint_states`` so the
-        hardware ``Robot`` telemetry path is transport-agnostic.
+        hardware ``Robot`` telemetry path is transport-agnostic - including the
+        writer being resolved per ``robot``. The writers are lazy, so a bridge
+        only ever advertises the robots it was actually asked to publish.
         """
-        if self._joint_writer is None:
-            self._joint_writer = self._make_writer(self.joint_states_topic(robot), self._JointState)
+        writer = self._joint_writers.get(robot)
+        if writer is None:
+            writer = self._make_writer(self.joint_states_topic(robot), self._JointState)
+            self._joint_writers[robot] = writer
         msg = self._JointState(
             header=self._header(self._safe(robot)),
             name=list(names),
@@ -315,7 +323,7 @@ class HardwareRtpsBridge(RosTelemetryBase):
             velocity=[],
             effort=[],
         )
-        self._joint_writer.write(msg)
+        writer.write(msg)
 
     def publish_image(self, robot: str, camera: str, image: np.ndarray) -> None:
         """Publish one RGB ``Image`` on ``/<robot>/<camera>/image_raw``."""
@@ -414,7 +422,7 @@ class HardwareRtpsBridge(RosTelemetryBase):
         # Dropping references lets cyclonedds reclaim the readers/writers and
         # the participant; there is no explicit close() in the python binding.
         self._command_reader = None
-        self._joint_writer = None
+        self._joint_writers = {}
         self._image_writers = {}
         self._participant = None
 

--- a/tests/test_hardware_rtps_bridge.py
+++ b/tests/test_hardware_rtps_bridge.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import sys
 from types import ModuleType
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -436,3 +436,112 @@ def test_start_poll_is_idempotent(fake_cyclonedds: dict[str, Any]) -> None:
 
     b.shutdown()
     assert b._poll_thread is None
+
+
+# --- per-robot topics (both transports) --------------------------------------
+
+
+def test_each_robot_published_through_one_bridge_reaches_its_own_joint_states_topic(
+    fake_cyclonedds: dict[str, Any],
+) -> None:
+    """``robot`` is a per-call argument, so it has to select the writer too.
+
+    A bridge in telemetry-only mode is a pure publisher, and ``robot`` is the
+    topic namespace the caller supplies per call - the shape
+    ``SimEngine._publish_ros_telemetry`` drives when it loops over
+    ``list_robots()``. Caching one writer for the whole bridge publishes every
+    later robot's state on whichever robot happened to publish first, and the
+    sample is not even wrong about itself: its ``frame_id`` names the robot it
+    came from while the topic names another, so a subscriber to the second
+    robot's ``joint_states`` sees no writer at all and the first robot's topic
+    carries two arms interleaved. Nothing reports it - a write to a matched
+    writer succeeds either way.
+    """
+    b = _bridge(enable_commands=False)
+    for robot, positions in (("arm_a", [0.1]), ("arm_b", [7.7]), ("arm_a", [0.2])):
+        b.publish_joint_states(robot, ["j0"], positions)
+
+    by_topic: dict[str, list[Any]] = {}
+    for writer in fake_cyclonedds["writers"]:
+        by_topic.setdefault(writer.topic, []).extend(writer.samples)
+
+    assert sorted(by_topic) == ["rt/arm_a/joint_states", "rt/arm_b/joint_states"]
+    assert [s.position for s in by_topic["rt/arm_a/joint_states"]] == [[0.1], [0.2]]
+    assert [s.position for s in by_topic["rt/arm_b/joint_states"]] == [[7.7]]
+    # Two robots, three publishes: the writers are cached per robot, not per call.
+    assert len(fake_cyclonedds["writers"]) == 2
+    # Every sample's own frame_id agrees with the topic it was written to.
+    for topic, samples in by_topic.items():
+        for sample in samples:
+            assert f"rt/{sample.header.frame_id}/joint_states" == topic
+
+
+def test_the_rtps_and_rclpy_transports_advertise_the_same_per_robot_topics(
+    fake_cyclonedds: dict[str, Any],
+) -> None:
+    """The two transports are byte-identical on the graph only if both key on ``robot``.
+
+    ``RosTelemetryBase`` exists so the topic names live in one place, but each
+    subclass owns its own publisher cache - so the cache is where the two can
+    still disagree about how many topics one call sequence advertises. This
+    drives the same sequence through both and compares what each would put on
+    the graph. The rclpy side is read from its real ``_joint_publisher`` /
+    ``_image_publisher``, bound to a stub, so no sourced ROS 2 distro is needed.
+    """
+    from types import SimpleNamespace
+
+    from strands_robots.ros_telemetry import RosTelemetryBridge
+    from strands_robots.rtps.mangling import dds_topic_name
+
+    calls = (("arm_a", "wrist"), ("arm_b", "wrist"))
+    frame = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    bridge = _bridge(enable_commands=False)
+    for robot, camera in calls:
+        bridge.publish_joint_states(robot, ["j0"], [0.0])
+        bridge.publish_image(robot, camera, frame)
+    rtps_topics = sorted(w.topic for w in fake_cyclonedds["writers"])
+
+    created: list[str] = []
+
+    class _Node:
+        def create_publisher(self, _msg_type: Any, topic: str, _depth: int) -> object:
+            created.append(topic)
+            return object()
+
+    stub = SimpleNamespace(
+        _joint_pubs={},
+        _image_pubs={},
+        _node=_Node(),
+        _JointState=object(),
+        _Image=object(),
+        _qos_depth=10,
+        joint_states_topic=RosTelemetryBridge.joint_states_topic,
+        image_topic=RosTelemetryBridge.image_topic,
+    )
+    # The two cache methods read only the attributes above, so binding them to
+    # the stub grades the real rclpy codepath without a rclpy install.
+    as_bridge = cast(RosTelemetryBridge, stub)
+    for robot, camera in calls:
+        RosTelemetryBridge._joint_publisher(as_bridge, robot)
+        RosTelemetryBridge._image_publisher(as_bridge, robot, camera)
+
+    assert created, "premise: the rclpy transport advertised nothing"
+    assert rtps_topics == sorted(dds_topic_name(topic) for topic in created)
+
+
+def test_shutdown_drops_every_robots_joint_writer(fake_cyclonedds: dict[str, Any]) -> None:
+    """Shutdown releases the DDS entities for all robots, not just one.
+
+    The python binding has no explicit ``close()``, so dropping the references
+    is what lets cyclonedds reclaim the writers; a writer left behind keeps this
+    participant advertising a robot the bridge no longer publishes.
+    """
+    b = _bridge(enable_commands=False)
+    b.publish_joint_states("arm_a", ["j0"], [0.1])
+    b.publish_joint_states("arm_b", ["j0"], [0.2])
+    assert len(fake_cyclonedds["writers"]) == 2
+
+    b.shutdown()
+    assert b._joint_writers == {}
+    assert b._image_writers == {}


### PR DESCRIPTION
![measured DDS graph, before and after](https://raw.githubusercontent.com/cagataycali/robots/e3a696a0ac4e549965eb37edbe86bcc7a90f09b1/.artifacts/rtps-per-robot-joint-states.png)

Two robots published through one telemetry-only `HardwareRtpsBridge`. Both panels are the measured writer set, dumped from the same call sequence on each tree.

## What the graph shows

`publish_joint_states` takes `robot` per call and derives `/<robot>/joint_states` from it, but the bridge cached a single `_joint_writer`. The first robot to publish owned the only writer, so every later robot's `JointState` was written to *that* robot's topic.

| Same call sequence | rclpy transport | RTPS before | RTPS after |
|---|---|---|---|
| `publish_joint_states("arm_a", ...)` | `/arm_a/joint_states` | `rt/arm_a/joint_states` | `rt/arm_a/joint_states` |
| `publish_joint_states("arm_b", ...)` | `/arm_b/joint_states` | **`rt/arm_a/joint_states`** | `rt/arm_b/joint_states` |
| `publish_image("arm_a", "wrist", ...)` | `/arm_a/wrist/image_raw` | `rt/arm_a/wrist/image_raw` | `rt/arm_a/wrist/image_raw` |
| `publish_image("arm_b", "wrist", ...)` | `/arm_b/wrist/image_raw` | `rt/arm_b/wrist/image_raw` | `rt/arm_b/wrist/image_raw` |
| **topics advertised** | 4 | **3** | 4 |

So a subscriber to `/arm_b/joint_states` found no writer at all, while `/arm_a/joint_states` carried both arms interleaved. The sample was not wrong about itself - its `frame_id` read `arm_b` while the topic read `arm_a` - so nothing surfaced the disagreement: a write to a matched writer succeeds either way. `joint_states` is also the topic a controller echoes back into `joint_command`, which the `joint_limits` docstring calls out as the intended loop.

## Why it is a defect and not a design choice

Two places in the tree already answer this question the other way:

- **The same class.** `_image_writers` is keyed per `(robot, camera)` ten lines below, so the image path already advertised all four topics - only the joint path did not.
- **The other transport.** `RosTelemetryBridge._joint_publisher` keys `_joint_pubs` per robot. `ros_telemetry`'s module docstring is explicit that this is the point: the rclpy machinery adds "node ownership, **per-robot publisher caching**, and message construction", and `RosTelemetryBase` exists so the two transports are "byte-identical on the ROS 2 graph by construction". `docs/ros2-integration.md` states the same contract as `/<robot>/joint_states` and "**identical topics**".

`RosTelemetryBase` deliberately "pulls in no transport library; each subclass owns its own machinery", so the cache is the subclass's - which is exactly why it is where the two could still drift. The fix mirrors the sibling rather than moving the cache into the base.

## Change

`_joint_writer: Any = None` becomes `_joint_writers: dict[str, Any]`, resolved per `robot` with the same get-or-create shape as `_image_writers`, and `shutdown()` drops all of them. Writers stay lazy, so a bridge only advertises the robots it was actually asked to publish.

## Tests

Three cells in `tests/test_hardware_rtps_bridge.py`. Against unfixed source they are **3 failed / 22 passed**, with all 22 pre-existing cells green as controls; after the fix, **25 passed**.

| Cell | Pre-fix failure |
|---|---|
| `..._reaches_its_own_joint_states_topic` | `['rt/arm_a/joint_states'] != [..., 'rt/arm_b/joint_states']` |
| `..._transports_advertise_the_same_per_robot_topics` | RTPS advertises 3 topics where rclpy advertises 4 |
| `test_shutdown_drops_every_robots_joint_writer` | `assert 1 == 2` writers |

The parity cell drives the *real* `_joint_publisher` / `_image_publisher` bound to a stub, so it grades the rclpy codepath with no sourced ROS 2 distro, and compares through `dds_topic_name` - a drift in either cache or in the mangling fails it. The first cell publishes `arm_a, arm_b, arm_a` so it also pins that the writers are cached per robot rather than per call, and asserts each sample's `frame_id` agrees with the topic it landed on.

## Gate

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean (1871 files).
- `mypy` 1.20.2: no new diagnostics in the changed files relative to base.
- ROS/RTPS + docs/docstring graders (`tests/test_hardware_*`, `tests/rtps`, `tests/tools/test_use_rtps.py`, `tests/simulation/test_ros_sim_bridge.py`, `tests/mesh/test_rtps_*`, every `tests/test_docs*` / `test_docstring*` / `test_public*`): base **467 passed / 1 failed**, branch **470 passed / 1 failed** - the same single pre-existing failure on both trees (the registry declares a lerobot type the installed lerobot does not register), and +3 is exactly the new cells.
- `scripts/check_whole_tree_graders.py` on the branch: 4307 passed / 13 failed / 56 skipped / 4 errors, all from absent optional deps (`awsiot`, `qpsolvers`) and installed-lerobot / `websockets` version drift.

## Size

+137 / -7 over 3 files: **+14 / -6 production**, +110 / -1 tests, +13 changelog. The production change is net +8 lines, most of it the comment explaining why the cache is keyed.