### PR TITLE
fix(drivers/ur): every RTDE read is held to the axis count the command path enforces

### DIFF
--- a/changelog.d/3210-ur-axis-count-on-every-read.md
+++ b/changelog.d/3210-ur-axis-count-on-every-read.md
@@ -1,0 +1,25 @@
+### Fixed: `URDriver` holds every RTDE read to the axis count its command path enforces
+
+`URDriver` names each vector the controller answers by zipping it against
+`JOINT_NAMES`, and `_read_joints` owns the rule that makes that legal: a width
+other than six is refused by name, because this driver serves six-axis e-Series
+arms only. `send_action` was held to it. `state()` was not - it re-read
+`getActualQ` itself and zipped with `strict=False`, so the same controller
+`send_action` refused was reported as `status="success"`.
+
+A five-axis answer lost its last joints. A seven-axis answer had its extra
+element truncated away, producing six named joints that are shaped exactly like
+a genuine six-axis read, so nothing downstream could tell the two apart. Since
+`state()` also writes the cache `get_observation` serves - and `connect_eagerly`
+primes it through `_absorb_state` - that pose is what reached the mesh joint
+read. `joint_velocities` carried the same truncating zip, and a velocity vector
+that disagreed with the position vector was reported as far as it went.
+
+The width rule now has one module-level owner, `_axis_count_refusal`, read by
+`_read_joints` and by `state()`, so the read and command surfaces cannot come to
+disagree about which controllers this driver serves. `state()` asks
+`_read_joints` for the joint vector and refuses with its reason, holds the
+velocity vector to the same rule, and both zips are `strict=True` once the width
+is established. `connect_eagerly` still succeeds and still ignores a refused
+priming read; the difference is that it no longer seeds the mesh with a pose the
+driver cannot name.

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -130,6 +130,13 @@ command the way a servo bus does - it accepts the register and performs nothing:
   proximal joints are held to 120 deg/s - so the same policy cadence can be admitted on
   one arm and refused on the other.
 
+Reads are held to one further rule, and it applies to every surface rather than only to a
+write: each RTDE vector is named by its position against the arm's six joints, so a
+controller answering a different width is refused by name - `state()` and the mesh joint
+read included - instead of being reported as far as it goes. A seven-axis answer is the
+case that makes it load-bearing: naming its first six elements produces a pose that reads
+exactly like a genuine six-axis one. This driver serves six-axis e-Series arms only.
+
 Stopping a rollout is reported rather than asserted. `stop_task()` signals the loop,
 waits up to two seconds for its thread and decelerates the arm with `servoStop`; a
 policy blocking on a remote inference call outlasts that budget, and the envelope then

--- a/strands_robots/drivers/ur.py
+++ b/strands_robots/drivers/ur.py
@@ -209,6 +209,34 @@ def _refuse(reason: str) -> dict[str, Any]:
     return {"status": "error", "content": [{"text": reason}]}
 
 
+def _axis_count_refusal(values: list[float], quantity: str) -> str | None:
+    """Refuse a controller vector that does not hold one value per joint.
+
+    Every quantity this driver reads off the RTDE registers is positional: it
+    is named by zipping it against :data:`JOINT_NAMES`. So a vector of a
+    different width is not a partial answer to be reported as far as it goes -
+    it is an answer this driver cannot name. A shorter one drops the joints it
+    has no values for, and a longer one has its extra element truncated away,
+    which is the case that cannot be told apart from a genuine six-axis read
+    afterwards.
+
+    Args:
+        values: The vector the controller answered with.
+        quantity: What it holds, named as the refusal should read it -
+            ``"joint positions"``, ``"joint velocities"``.
+
+    Returns:
+        ``None`` when the width is right, otherwise the reason, which the
+        caller prefixes with its own verb name.
+    """
+    if len(values) == len(JOINT_NAMES):
+        return None
+    return (
+        f"the controller reported {len(values)} {quantity}, expected {len(JOINT_NAMES)}. "
+        "This driver serves six-axis e-Series arms only."
+    )
+
+
 def _resolve_rtde() -> tuple[Any, Any] | str:
     """Import ``ur_rtde``'s two interfaces, or report why they are unavailable.
 
@@ -851,14 +879,19 @@ class URDriver:
             ``joint_velocities``, ``tcp_pose`` (x, y, z in metres then an
             axis-angle rotation vector), ``tcp_speed``, ``wrench`` (three forces
             in newtons then three torques in newton-metres) and the two
-            controller modes; or a refusal when the arm is not connected.
+            controller modes; or a refusal when the arm is not connected, or
+            when the controller answers a vector that is not one value per
+            joint - the same axis-count rule :meth:`send_action` is held to,
+            since ``joints`` and ``joint_velocities`` are named by position.
         """
         with self._lock:
             receive = self._receive
         if receive is None:
             return _refuse("state: not connected - call connect_eagerly() first")
+        joints, reason = self._read_joints(receive)
+        if reason is not None:
+            return _refuse(f"state: {reason}")
         try:
-            joints = [float(value) for value in receive.getActualQ()]
             velocities = [float(value) for value in receive.getActualQd()]
             tcp_pose = [float(value) for value in receive.getActualTCPPose()]
             tcp_speed = [float(value) for value in receive.getActualTCPSpeed()]
@@ -867,8 +900,10 @@ class URDriver:
             safety_mode = int(receive.getSafetyMode())
         except (OSError, RuntimeError, TypeError, ValueError) as exc:
             return _refuse(f"state: the controller's RTDE read failed: {exc}")
+        if (reason := _axis_count_refusal(velocities, "joint velocities")) is not None:
+            return _refuse(f"state: {reason}")
 
-        named = dict(zip(JOINT_NAMES, joints, strict=False))
+        named = dict(zip(JOINT_NAMES, joints, strict=True))
         with self._lock:
             self._joints = dict(named)
             self._pose = {"tcp_pose": tcp_pose, "frame": "base"}
@@ -880,7 +915,7 @@ class URDriver:
                         "robot": self._tool_name,
                         "model": self._model,
                         "joints": named,
-                        "joint_velocities": dict(zip(JOINT_NAMES, velocities, strict=False)),
+                        "joint_velocities": dict(zip(JOINT_NAMES, velocities, strict=True)),
                         "tcp_pose": tcp_pose,
                         "tcp_speed": tcp_speed,
                         "wrench": wrench,
@@ -968,11 +1003,8 @@ class URDriver:
             joints = [float(value) for value in receive.getActualQ()]
         except (OSError, RuntimeError, TypeError, ValueError) as exc:
             return [], f"the controller's joint read failed: {exc}"
-        if len(joints) != len(JOINT_NAMES):
-            return [], (
-                f"the controller reported {len(joints)} joint positions, expected {len(JOINT_NAMES)}. "
-                "This driver serves six-axis e-Series arms only."
-            )
+        if (reason := _axis_count_refusal(joints, "joint positions")) is not None:
+            return [], reason
         return joints, None
 
     def _absorb_state(self) -> None:

--- a/tests/drivers/ur/test_ur_driver_over_a_fake_controller.py
+++ b/tests/drivers/ur/test_ur_driver_over_a_fake_controller.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import sys
 import time
 from typing import Any
 
@@ -542,3 +543,84 @@ def _wait_for_exit(driver: URDriver, timeout: float = 5.0) -> None:
             return
         time.sleep(0.01)
     raise AssertionError("the rollout did not finish within its budget")
+
+
+def _refused_for_the_axis_count(envelope: dict[str, Any]) -> bool:
+    """Whether this envelope is the axis-count refusal, rather than any error."""
+    return envelope["status"] == "error" and "six-axis" in text_of(envelope)
+
+
+def _reason_without_the_verb(envelope: dict[str, Any]) -> str:
+    """The refusal text with the leading ``<verb>: `` prefix dropped."""
+    return text_of(envelope).split(": ", 1)[1]
+
+
+class TestTheAxisCountRuleHoldsOnEverySurface:
+    """A controller whose vectors are not six wide is refused by every verb.
+
+    ``joints`` and ``joint_velocities`` are named by zipping the controller's
+    answer against :data:`JOINT_NAMES`, so a width that is not six cannot be
+    named: a shorter vector loses its last joints and a longer one has the
+    extra element truncated away. That second case is the one that cannot be
+    recognised afterwards - six named joints from a seven-axis read are
+    byte-identical in shape to a genuine six-axis read - which is why the read
+    surfaces have to answer it the same way the command path does.
+    """
+
+    @pytest.mark.parametrize("axes", [5, 6, 7])
+    def test_the_read_and_the_command_path_refuse_the_same_controllers(self, fake_rtde: FakeRTDE, axes: int) -> None:
+        """One controller, one verdict - whichever verb asks it."""
+        driver = _connected(fake_rtde)
+        fake_rtde.receive.q = [0.1 * (index + 1) for index in range(axes)]
+
+        by_state = _refused_for_the_axis_count(driver.state())
+        by_command = _refused_for_the_axis_count(driver.send_action({"elbow_joint": 0.1}))
+
+        assert by_state == by_command == (axes != 6)
+
+    def test_both_verbs_state_the_rule_in_the_same_words(self, fake_rtde: FakeRTDE) -> None:
+        """One rule, so one sentence - not two that can drift apart."""
+        driver = _connected(fake_rtde)
+        fake_rtde.receive.q = [0.0] * 7
+
+        assert _reason_without_the_verb(driver.state()) == _reason_without_the_verb(
+            driver.send_action({"elbow_joint": 0.1})
+        )
+
+    def test_a_truncated_read_is_not_published_as_the_arms_pose(self, fake_rtde: FakeRTDE) -> None:
+        """The mesh keeps the last pose it could name, not six of seven joints."""
+        driver = _connected(fake_rtde)
+        assert driver.get_observation() == dict(zip(JOINT_NAMES, MEASURED_Q, strict=True))
+        fake_rtde.receive.q = [9.0] * 7
+
+        assert driver.state()["status"] == "error"
+        assert driver.get_observation() == dict(zip(JOINT_NAMES, MEASURED_Q, strict=True))
+
+    def test_a_wrong_width_from_the_first_read_publishes_no_joints(
+        self, fake_rtde: FakeRTDE, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Priming on connect must not seed the mesh with an unnameable read."""
+        module = sys.modules["rtde_receive"]
+        build = module.RTDEReceiveInterface
+
+        def seven_axis(host: str, frequency: float | None = None) -> Any:
+            interface = build(host, frequency)
+            interface.q = [9.0] * 7
+            return interface
+
+        monkeypatch.setattr(module, "RTDEReceiveInterface", seven_axis)
+        driver = URDriver(tool_name="ur5e", port=HOST)
+        assert driver.connect_eagerly() is None
+
+        assert driver.get_observation() == {}
+
+    def test_the_velocity_register_is_held_to_the_same_rule(self, fake_rtde: FakeRTDE) -> None:
+        """A velocity vector disagreeing with the position one is not reported."""
+        driver = _connected(fake_rtde)
+        fake_rtde.receive.qd = [0.0] * 5
+
+        envelope = driver.state()
+
+        assert envelope["status"] == "error"
+        assert "5 joint velocities" in text_of(envelope)
+        assert "six-axis" in text_of(envelope)

--- a/tests/mocks/ur_rtde.py
+++ b/tests/mocks/ur_rtde.py
@@ -34,6 +34,11 @@ class FakeReceive:
         self.host = host
         self.frequency = frequency
         self.q = list(MEASURED_Q)
+        # The velocity register, read separately on a real controller. ``None``
+        # derives it from ``q``'s width, which is what a healthy arm reports;
+        # setting it poses a velocity vector that disagrees with the position
+        # one, which a double deriving the two from one list cannot express.
+        self.qd: list[float] | None = None
         self.robot_mode = 7  # RUNNING
         self.safety_mode = 1  # NORMAL
         self.disconnected = False
@@ -42,7 +47,7 @@ class FakeReceive:
         return list(self.q)
 
     def getActualQd(self) -> list[float]:  # noqa: N802
-        return [0.0] * len(self.q)
+        return [0.0] * len(self.q) if self.qd is None else list(self.qd)
 
     def getActualTCPPose(self) -> list[float]:  # noqa: N802
         return list(MEASURED_TCP_POSE)


### PR DESCRIPTION
`URDriver` names every vector the controller answers by zipping it against `JOINT_NAMES`. `_read_joints` owns that rule and refuses a width that is not six *by name*; `send_action` is held to it. `state()` re-read `getActualQ` itself and zipped with `strict=False`, so the controller `send_action` refused was reported as `status="success"` - and since `state()` writes the `_joints` cache `get_observation` serves (primed at `connect_eagerly` via `_absorb_state`), that unnameable pose is what reached the mesh joint read.

![axis-count verdict matrix](https://raw.githubusercontent.com/cagataycali/robots/cc9ba31867dbee14efa3e088d9eecab128ac28d1/.artifacts/ur_axis_count_matrix.png)

_Both columns produced by driving `URDriver` over the controller double, on this branch and on `main`._

## The seven-axis row is the one that cannot be recognised afterwards

| controller answers | `send_action` | `state()` before | mesh read before | after |
| --- | --- | --- | --- | --- |
| 5 joint positions | refused, `"5 ..., expected 6"` | success, **5 named joints** | 5 joints published | refused, same sentence |
| 6 (healthy arm) | passes the axis rule | success, 6 named joints | 6 joints published | unchanged |
| 7 joint positions | refused, `"7 ..., expected 6"` | success, **6 named joints** | **6 joints published** | refused, same sentence |
| 6 positions, 5 velocities | n/a | success, **5 named velocities** | n/a | refused, `"5 joint velocities, expected 6"` |

A shorter vector loses its last joints, which is at least visible. A longer one has its extra element truncated away, so six named joints from a seven-axis read are shaped exactly like a genuine six-axis read - nothing downstream can tell them apart, and `get_observation`'s docstring promise of "the six joint positions" is satisfied on the surface. The existing pin for this case, `test_a_controller_reporting_the_wrong_axis_count_is_refused`, drives `send_action` only; its docstring ("a seven-axis answer would mis-index every joint after the extra one") describes exactly what the read path was committing.

## Change

The width rule becomes one module-level owner, `_axis_count_refusal(values, quantity)`, read by `_read_joints` and by `state()` - so the two surfaces cannot come to disagree about which controllers this driver serves.

- `state()` asks `_read_joints` for the joint vector and refuses with its reason, prefixed with its own verb name.
- `joint_velocities` is held to the same rule (`"5 joint velocities, expected 6"`).
- Both zips become `strict=True`, now that the width is established before them.
- `connect_eagerly` still succeeds and `_absorb_state` still ignores a refused priming read, unchanged - the difference is that it no longer seeds the mesh with a pose it cannot name.

## Tests

New class `TestTheAxisCountRuleHoldsOnEverySurface`, 7 cells, table-driven over the widths:

- the read path and the command path reach the same verdict for 5 / 6 / 7 axes (the 6 row is the control, green on `main`);
- both verbs state the rule in the same words (one owner, so one sentence);
- a truncated read is not published as the arm's pose - the mesh keeps the last pose it could name;
- a wrong width on the *first* read publishes nothing at all;
- the velocity register is held to the same rule.

Pre-fix on this file: **6 failed, 87 passed**, with the 6-axis control green. Post-fix: **93 passed**. Whole directory: `tests/drivers` 2179 -> 2186 passed (+7, exactly the new cells), 7 skipped both.

The controller double derived its velocity register from the width of its position register, so a velocity vector disagreeing with the position one could not be expressed; `FakeReceive.qd` is now its own optional value, `None` keeping the previous behaviour.

## Gate

`ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`. `mypy strands_robots tests tests_integ` 20 errors in 6 files, unchanged from `main` (all in `examples/isaac_gs` plus `simulation/ik.py`). Whole-tree graders: 13 failed / 4307 passed / 56 skipped / 4 errors, identical failure set to `main` on this host (absent optional deps, and installed-lerobot drift).

## Size

`strands_robots/drivers/ur.py` +42/-8, `docs/robots/arms.md` +7, `tests/mocks/ur_rtde.py` +6/-1, the test file +82, plus a 25-line changelog fragment. Net-positive: a refusal path that did not exist, plus the pins for it.

Refs #2812 - same shape on a different bus: a bound stated in two places, where the copy that answers the caller had drifted from the one that validates.