### PR TITLE
fix(device_connect): the state RPC reads the device that owns the bus, wrapper or driver

### DIFF
--- a/changelog.d/3211-dc-state-rpc-resolves-the-device.md
+++ b/changelog.d/3211-dc-state-rpc-resolves-the-device.md
@@ -1,3 +1,5 @@
+### Fixed: the Device Connect state RPC reads the device that owns the bus, wrapper or driver
+
 `RobotDeviceDriver.getState` reported no `joints` key at all for a robot whose
 motors it could already read. A robot reaches its motors one of two ways -- a
 lerobot robot is a wrapper holding the device that owns the bus under `robot`, a

--- a/changelog.d/3211-dc-state-rpc-resolves-the-device.md
+++ b/changelog.d/3211-dc-state-rpc-resolves-the-device.md
@@ -1,0 +1,21 @@
+`RobotDeviceDriver.getState` reported no `joints` key at all for a robot whose
+motors it could already read. A robot reaches its motors one of two ways -- a
+lerobot robot is a wrapper holding the device that owns the bus under `robot`, a
+native driver owns its bus directly and so *is* the device -- and this RPC
+resolved only the first shape, `getattr(self._robot, "robot", None)` behind a
+`hasattr(inner, "get_observation")` gate. That is the same resolution that left a
+native driver publishing no joint telemetry on the mesh state topic (#2749); when
+the read here was converted to `bus_access.read_joints` (#2666) the resolution
+beside it was left as it was, so a native driver answered under the same
+successful status a readable arm gets. The gate also demanded the capability
+`read_joints` treats as its *fallback* while refusing a device carrying only the
+`bus.sync_read` it prefers.
+
+15 of the 25 registered native drivers carry a joint-read route and none of them
+could answer this RPC. The five `FeetechDriver` robots (`so100`, `so101`,
+`lekiwi`, `hope_jr`, `open_duck_mini`) hit both halves.
+
+The device is now resolved by `bus_access.joint_read_source`, the one owner of
+that question. An inner device is still preferred whenever one is present, the
+read still takes the shared motor-bus lock, and a robot that can answer no joint
+read is still reported without a `joints` key rather than as an error.

--- a/docs/device-connect.md
+++ b/docs/device-connect.md
@@ -50,7 +50,7 @@ Each robot is wrapped as a Device Connect device by a `DeviceDriver` adapter:
 | Driver | Wraps | Exposes |
 |--------|-------|---------|
 | `SimulationDeviceDriver` | a MuJoCo `Simulation` | `execute`, `getFeatures`, `getStatus`, `reset`, `step`, `stop` |
-| `RobotDeviceDriver` | a hardware `Robot` | the same RPC surface, driving real servos |
+| `RobotDeviceDriver` | a hardware `Robot` **or a native driver** | the same RPC surface, driving real servos |
 | `ReachyMiniDriver` | a Pollen Reachy Mini | device-native RPCs (`look`, `nod`, …) over Zenoh / WebSocket |
 
 `stop` reports what it halted rather than asserting that it did. On a simulation
@@ -62,6 +62,17 @@ rollout are different answers and either can be checked against
 `status="success"` with an empty `stopped` list — never an error, because a peer
 reported as "did not stop" when it had nothing to stop is the false alarm that
 teaches an operator to ignore the warning.
+
+`getState` reports joint positions for either kind of robot. A lerobot robot is a
+*wrapper* holding the device that owns the motor bus, while a native driver
+([`driver="strands"`](getting-started/robot-factory.md)) owns its bus directly and
+so *is* that device — `Robot(mode="real")` attaches Device Connect to both, and the
+RPC resolves which one to read through the same resolution the mesh state topic
+uses. The read goes through the shared motor-bus lock, so it waits its turn behind
+an in-flight rollout, teleop write or mesh probe rather than colliding with it, and
+it reads the motors directly: a robot whose camera is failing still reports where
+its joints are. A robot that can answer no joint read at all is reported without a
+`joints` key rather than as an error.
 
 ### Published state events
 

--- a/strands_robots/device_connect/robot_driver.py
+++ b/strands_robots/device_connect/robot_driver.py
@@ -18,7 +18,7 @@ from device_connect_edge.drivers import (
 )
 from device_connect_edge.types import DeviceIdentity, DeviceStatus
 
-from strands_robots.bus_access import read_joints
+from strands_robots.bus_access import joint_read_source, read_joints
 from strands_robots.device_connect._authz import authz_error, is_authorized_caller
 from strands_robots.mesh.security import is_safe_policy_provider
 
@@ -199,6 +199,11 @@ class RobotDeviceDriver(DeviceDriver):
         waits its turn behind an in-flight rollout, teleop write or mesh probe
         instead of colliding with it, and reports the joints even when a
         camera on the same driver is failing.
+
+        The device those joints are read from is resolved by
+        :func:`~strands_robots.bus_access.joint_read_source`, so a native driver
+        that owns its bus directly answers this RPC as well as a lerobot wrapper
+        does.
         """
         result = {}
         task = getattr(self._robot, "_task_state", None)
@@ -218,8 +223,20 @@ class RobotDeviceDriver(DeviceDriver):
         # away the joint positions already in hand. The frame filter below still
         # matters: a driver exposing no readable motor bus falls back to the full
         # observation, frames included.
-        inner = getattr(self._robot, "robot", None)
-        if inner and hasattr(inner, "get_observation"):
+        # Resolve the device through :func:`joint_read_source` rather than
+        # reading ``self._robot.robot`` here. A robot reaches its motors one of
+        # two ways: a lerobot robot is a WRAPPER holding the device under
+        # ``robot``, while a native driver owns its bus directly and so IS the
+        # device. Resolving only the wrapper shape is what left a native driver
+        # publishing no joint telemetry on the mesh state topic (#2749), and
+        # ``Robot(mode="real")`` attaches Device Connect to both kinds -- so this
+        # RPC answered a native driver with no ``joints`` key at all, under the
+        # same successful status a readable arm gets. Its admission rule is
+        # derived from ``read_joints``' own branch, so demanding
+        # ``get_observation`` here also refused a device whose bus the reader
+        # below prefers and could already read.
+        inner = joint_read_source(self._robot)
+        if inner is not None:
             try:
                 obs = await asyncio.to_thread(read_joints, inner)
                 # Filter out camera frames (numpy arrays) - only include scalars

--- a/tests/test_device_connect_all_robots.py
+++ b/tests/test_device_connect_all_robots.py
@@ -521,9 +521,19 @@ class TestEdgeCases:
         assert "joints" not in result
 
     def test_no_inner_robot(self):
-        """robot.robot is None → getState skips observation."""
+        """A host with no inner device and no joint read of its own → no joints.
+
+        The two ``del``s are what make the mock able to state that. A device is
+        resolved through ``bus_access.joint_read_source``, which falls back to
+        the host itself when it holds no inner device -- and a ``MagicMock``
+        answers every attribute, so it auto-creates both a ``bus.sync_read`` and
+        a ``get_observation`` and reads as a perfectly good joint source. Only a
+        host that refuses both routes poses the case named here.
+        """
         robot = _make_mock_robot("so100", _REGISTRY["so100"], task_status="running")
         robot.robot = None
+        del robot.bus
+        del robot.get_observation
         driver = RobotDeviceDriver(robot)
         result = asyncio.run(driver.getState())
         assert result["task_status"] == "running"

--- a/tests/test_device_connect_state_rpc_reads_a_driver_that_owns_its_bus.py
+++ b/tests/test_device_connect_state_rpc_reads_a_driver_that_owns_its_bus.py
@@ -1,0 +1,191 @@
+"""The Device Connect state RPC answers a driver that owns its motor bus.
+
+A robot reaches its motors one of two ways. A lerobot robot is a *wrapper*:
+:class:`strands_robots.hardware_robot.Robot` holds the device that owns the bus
+under ``robot``, and the wrapper answers no read itself. A native driver
+(:mod:`strands_robots.drivers`) owns the bus directly, so it *is* the device.
+:func:`~strands_robots.bus_access.joint_read_source` is the one place that
+resolves both, and ``Robot(mode="real")`` attaches Device Connect to both kinds
+-- "both drivers are robots on the fleet, so both get the same two attachments".
+
+:meth:`~strands_robots.device_connect.robot_driver.RobotDeviceDriver.getState`
+resolved only the wrapper shape, ``getattr(self._robot, "robot", None)``, which
+is the same resolution that left a native driver publishing no joint telemetry on
+the mesh state topic (#2749) -- pinned there by
+``tests/mesh/test_read_state_joints_from_a_driver_that_owns_its_bus.py``. The
+reader was converted to :func:`~strands_robots.bus_access.read_joints` for the
+bus-lock and dead-camera incidents (#2666) and the resolution beside it was left
+as it was, so on this surface a native driver answered the RPC with no ``joints``
+key at all, under the same successful status a readable arm gets.
+
+The old gate demanded ``get_observation``, which is the capability
+:func:`read_joints` treats as its *fallback*, while refusing a device carrying
+only the ``bus.sync_read`` it prefers. That is the disagreement
+``_answers_a_joint_read`` exists to prevent -- its docstring says keeping the
+admission rule and the reader in one module is what stops a caller "refusing one
+it could have read" -- so both halves of the resolution are graded here.
+
+What this file does not assert: that ``getState`` gates on ``is_connected`` the
+way the mesh snapshot does. That is a published-broadcast decision about a robot
+nobody asked about; this RPC answers a caller who did, and a device that reports
+positions is reported. Nor does it assert a wrapper may be read in place of the
+device it wraps -- an inner device is still preferred whenever one is present.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+from typing import Any
+
+import pytest
+
+pytest.importorskip("device_connect_edge")
+
+from strands_robots.bus_access import joint_read_source, read_joints  # noqa: E402
+from strands_robots.device_connect import robot_driver  # noqa: E402
+from strands_robots.device_connect.robot_driver import RobotDeviceDriver  # noqa: E402
+
+from .test_bus_read_joints import POSITIONS, _Arm, _Bus  # noqa: E402
+
+#: The reading as ``read_joints`` shapes it, with lerobot's own ``.pos`` suffix.
+_EXPECTED = {f"{motor}.pos": value for motor, value in POSITIONS.items()}
+
+
+class _NativeDriver(_Arm):
+    """A native driver: owns its bus, has no ``robot``, and its camera is dead.
+
+    ``_Arm`` is the eleven-hour-incident arm from ``test_bus_read_joints`` -- its
+    ``get_observation`` raises the camera error -- so a joints answer here can
+    only have come through the bus, which is the path that takes the lock.
+    """
+
+    #: Narrowed from ``_Arm``'s optional bus: this shape always has one.
+    bus: _Bus
+
+    def __init__(self) -> None:
+        super().__init__(_Bus(POSITIONS))
+        self._task_state = None
+        self.tool_name_str = "unitree_g1"
+
+
+class _BusOnlyDevice:
+    """A device whose telemetry IS its motor bus: no ``get_observation`` at all.
+
+    The shape of an SO-100/SO-101 class arm, where joint position, velocity and
+    current are the whole of the telemetry.
+    """
+
+    def __init__(self) -> None:
+        self.bus = _Bus(POSITIONS)
+        self.config = None
+        self.is_connected = True
+
+
+class _Wrapper:
+    """A ``hardware_robot.Robot``-shaped host holding one device under ``robot``."""
+
+    def __init__(self, device: Any) -> None:
+        self.robot = device
+        self._task_state = None
+        self.tool_name_str = "so101"
+
+
+class _NoJointSource:
+    """A host with neither an inner device nor any way to answer a joint read."""
+
+    def __init__(self) -> None:
+        self._task_state = None
+
+
+def _get_state(host: Any) -> dict[str, Any]:
+    return asyncio.run(RobotDeviceDriver(host).getState())
+
+
+class TestADriverThatOwnsItsBusAnswersTheStateRpc:
+    """The shape #2749 fixed on the mesh, now answered on this surface too."""
+
+    def test_the_joints_key_is_present(self) -> None:
+        assert "joints" in _get_state(_NativeDriver())
+
+    def test_the_joints_are_the_positions_the_bus_reported(self) -> None:
+        assert _get_state(_NativeDriver())["joints"] == pytest.approx(_EXPECTED)
+
+    def test_the_read_went_through_the_bus_and_not_the_failing_camera(self) -> None:
+        driver = _NativeDriver()
+        _get_state(driver)
+        assert driver.bus.calls == [{"register": "Present_Position", "num_retry": 3}]
+        assert driver.observation_calls == 0
+
+
+class TestADeviceCarryingOnlyABusIsNotRefused:
+    """The admission rule tracks the reader rather than demanding its fallback."""
+
+    def test_a_bus_only_device_reports_its_joints(self) -> None:
+        assert _get_state(_Wrapper(_BusOnlyDevice()))["joints"] == pytest.approx(_EXPECTED)
+
+    def test_the_reader_could_already_read_it(self) -> None:
+        device = _BusOnlyDevice()
+        assert not hasattr(device, "get_observation")
+        assert read_joints(device) == pytest.approx(_EXPECTED)
+
+
+class TestTheWrapperPathIsUnchanged:
+    def test_a_lerobot_wrapper_still_reports_its_joints(self) -> None:
+        assert _get_state(_Wrapper(_NativeDriver()))["joints"] == pytest.approx(_EXPECTED)
+
+    def test_the_inner_device_is_the_resolved_source(self) -> None:
+        device = _NativeDriver()
+        assert joint_read_source(_Wrapper(device)) is device
+
+    def test_a_host_that_answers_no_joint_read_reports_no_joints(self) -> None:
+        # Absent rather than empty, and not an error: nothing to read is not a
+        # failure, and this is what the RPC has always answered for such a host.
+        assert "joints" not in _get_state(_NoJointSource())
+
+
+class TestBothSurfacesResolveOneDevice:
+    """The RPC and the mesh snapshot answer for the same device, per shape."""
+
+    @pytest.mark.parametrize(
+        "host_factory",
+        [_NativeDriver, lambda: _Wrapper(_NativeDriver()), lambda: _Wrapper(_BusOnlyDevice())],
+        ids=["native-driver", "lerobot-wrapper", "wrapper-over-bus-only-device"],
+    )
+    def test_the_rpc_reports_what_the_shared_resolution_can_read(self, host_factory) -> None:
+        source = joint_read_source(host_factory())
+        assert source is not None, "the shared resolution found no device to read"
+        assert set(_get_state(host_factory())["joints"]) == set(read_joints(source))
+
+
+class TestTheResolutionHasOneOwner:
+    """A source-level pin, because the last conversion moved the reader alone.
+
+    #2666 replaced this handler's ``get_observation`` call with
+    :func:`read_joints` and left ``getattr(self._robot, "robot", None)`` beside
+    it, so the surface kept the resolution the reader's own module had already
+    replaced. Deriving the population from the module rather than naming lines
+    means a third reader added here is held to the rule on arrival.
+    """
+
+    def test_the_module_resolves_no_device_itself(self) -> None:
+        tree = ast.parse(inspect.getsource(robot_driver))
+        own_reads = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and node.args
+            and ast.unparse(node.args[0]) == "self._robot"
+            and len(node.args) > 1
+            and getattr(node.args[1], "value", None) == "robot"
+        ]
+        assert own_reads == [], (
+            "the device a joint read is answered from is resolved by "
+            f"bus_access.joint_read_source, not read here: line(s) {[n.lineno for n in own_reads]}"
+        )
+
+    def test_the_owner_is_the_one_imported(self) -> None:
+        assert robot_driver.joint_read_source is joint_read_source


### PR DESCRIPTION
`RobotDeviceDriver.getState` is the "what is this arm doing" RPC. It answered with **no `joints` key at all** for a robot whose motors it could already read — under the same successful status a readable arm gets.

## Measured, same fixtures both trees

| host shape | joints `read_joints` can read | reported before | reported after |
|---|---:|---:|---:|
| native driver (owns its bus, no `robot`) | 6 | **0, no key** | 6 |
| wrapper over a device carrying only a bus | 6 | **0, no key** | 6 |
| lerobot wrapper *(control)* | 6 | 6 | 6 |
| host answering no joint read *(control)* | 0 | 0, no key | 0, no key |

## Why

A robot reaches its motors one of two ways, and `bus_access.joint_read_source` is the one place that resolves both:

```mermaid
flowchart LR
  H[robot handed to the driver] --> Q{holds an inner device<br/>under `robot`?}
  Q -- yes --> D[that device owns the bus]
  Q -- no --> S[the robot IS the device<br/>native driver]
  D --> R[read_joints]
  S --> R
```

`getState` resolved only the left branch — `getattr(self._robot, "robot", None)` behind a `hasattr(inner, "get_observation")` gate. That is the same resolution that left a native driver publishing no joint telemetry on the mesh state topic (#2749). When the read here was converted to `read_joints` for the bus-lock and dead-camera incidents (#2666), the resolution *beside* it was left as it was, so this surface kept the shape the reader's own module had already replaced. `Robot(mode="real")` attaches Device Connect to both kinds — "both drivers are robots on the fleet, so both get the same two attachments".

The gate is the second half. It demanded `get_observation`, which is the capability `read_joints` treats as its **fallback**, while refusing a device carrying only the `bus.sync_read` it *prefers*. `_answers_a_joint_read`'s docstring names exactly this: keeping the admission rule and the reader in one module is what stops a caller "refusing one it could have read".

## Population

**15 of the 25** registered native drivers carry a joint-read route, and none could answer this RPC. Five of them hit *both* halves — `FeetechDriver` has a `bus.sync_read("Present_Position")` and no `get_observation` at all:

| driver class | robots | route | unreachable via `robot` | refused by the gate |
|---|---|---|:-:|:-:|
| `FeetechDriver` | `so100`, `so101`, `lekiwi`, `hope_jr`, `open_duck_mini` | `bus.sync_read` | yes | **yes** |
| `FrankaDriver` | `panda`, `fr3`, `fr3_v2` | `get_observation` | yes | no |
| `URDriver` | `ur5e`, `ur10e` | `get_observation` | yes | no |
| `RobotiqDriver` | `robotiq_2f85`, `robotiq_2f85_v4` | `get_observation` | yes | no |
| `BoosterDriver` / `EarthRoverDriver` / `MicroduckDriver` | `booster_t1`, `earthrover`, `microduck` | `get_observation` | yes | no |

## Change

One resolution, routed to its owner:

```diff
-        inner = getattr(self._robot, "robot", None)
-        if inner and hasattr(inner, "get_observation"):
+        inner = joint_read_source(self._robot)
+        if inner is not None:
```

Nothing else moves: an inner device is still preferred whenever one is present, the read still takes the shared motor-bus lock, and a robot that answers no joint read is still reported *without* a `joints` key rather than as an error. `getState` does **not** adopt the mesh snapshot's `is_connected` gate — that is a published-broadcast decision about a robot nobody asked about, while this RPC answers a caller who did.

## Tests

`tests/test_device_connect_state_rpc_reads_a_driver_that_owns_its_bus.py`, the Device Connect sibling of the mesh pin for the same shape. Pre-fix on this branch's tests against unchanged source: **8 failed / 5 passed**, every failure naming the real symptom (`KeyError: 'joints'`) and all five controls green.

The native-driver double subclasses `_Arm` from `test_bus_read_joints` — the eleven-hour-incident arm, whose `get_observation` raises the camera error — so a joints answer can only have come through the bus, which is the path that takes the lock. One cell asserts exactly that (`bus.calls == [Present_Position]`, `observation_calls == 0`).

One existing cell is **retargeted, not relaxed**. `test_no_inner_robot` sets `robot.robot = None` on a `MagicMock` and asserts no `joints`; a `MagicMock` auto-creates both a `bus.sync_read` and a `get_observation`, so it reads as a perfectly good joint source and could not express the case its own name states. It now deletes both routes, which is what poses that case — the same trap the sibling test file already documents ("deliberately not a `MagicMock`: on a mock, `inner.bus` auto-creates a child that HAS `sync_read`").

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` (`strands_robots tests tests_integ`) | clean, 1872 files |
| `mypy strands_robots tests tests_integ` | **25 errors in 10 files, identical to base** |
| new file | 13 passed |
| `tests/test_device_connect_*` + `tests/device_connect/` + `tests/test_bus_read_joints.py` + the mesh pin | 1211 passed, 7 skipped, 2 failed — both failing on unmodified `main` too (absent optional dep) |
| docs graders (`env_reference`, `docstring_xref_roles`, `no_unicode_dashes`) | 37 passed |

No rendered frame applies: nothing in sim, rendering, recording or any policy changes. The artifact for a reporting fix is the reporting, measured on both trees above.

## Size

| | lines |
|---|---:|
| `strands_robots/device_connect/robot_driver.py` | +20 / -3 (net +17; the resolution itself is 2 lines for 2, the rest is the comment and docstring recording why) |
| `tests/…reads_a_driver_that_owns_its_bus.py` (new) | +187 |
| `tests/test_device_connect_all_robots.py` | +11 / -1 |
| `docs/device-connect.md` | +12 / -1 |
| `changelog.d/3211-*.md` | +23 |
| **total** | **+255 / -5** |

Net-positive, and the additions are the pin plus the reasoning. Executable statements in the changed handler are unchanged at 2 for 2.

Refs #2749, #2666.

---

## Round 1

**Concern:** two red checks, `Changelog Fragment Check` and the required
`call-test-lint / Test and Lint`. Both were the same single authoring mistake.

`changelog.d/3211-dc-state-rpc-resolves-the-device.md` was written as prose with
no `### <Category>: <summary>` first line, so `validate_fragment` refused it.
That fragment was the *only* failure in the entire suite run:

```
FAILED tests/test_changelog_fragments.py::test_repository_fragments_are_valid
  - assert ["3211-dc-sta...robot whose'"] == []
```

Heading added, body unchanged. `python3 scripts/assemble_changelog.py --check`
-> `changelog fragments OK`. No source or test file is touched.
