### PR TITLE
fix(drivers): an agent verb a driver does not declare is refused, not run as the halt

### DIFF
--- a/changelog.d/3213-undeclared-driver-verb-is-refused.md
+++ b/changelog.d/3213-undeclared-driver-verb-is-refused.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- Native drivers no longer run their halt verb for an agent `action` their own
+  `tool_spec` does not declare. Eleven of the twelve shipped drivers dispatched
+  with a bare `else`, so a typo (`"sensor"`), a verb borrowed from a sibling
+  (`"sensors"` on a `URDriver`, whose read verb is spelled `state`; `"stop"` on a
+  `CrazyflieDriver`, whose halt is spelled `land`) or a non-string all halted the
+  robot and answered as though the caller's own verb had been dispatched. Each
+  dispatcher now names its halt verb and refuses an undeclared one, naming every
+  declared verb so an agent can correct itself in the same turn.
+- `strands_robots.drivers.base` gains `declared_verbs` and
+  `undeclared_verb_error` as the single owner of that verb list and that
+  refusal, read back off the schema an agent planned against rather than
+  restated per driver. `FeetechDriver` - which already refused - drops its own
+  copy of both.

--- a/strands_robots/drivers/base.py
+++ b/strands_robots/drivers/base.py
@@ -270,3 +270,59 @@ def halt_failure_detail(envelope: dict[str, Any]) -> str | None:
             for payload in payloads
         )
     return "no detail reported"
+
+
+def declared_verbs(tool_spec: ToolSpec | dict[str, Any]) -> list[str]:
+    """The ``action`` verbs a driver's own tool spec declares, in schema order.
+
+    Read back out of the spec rather than restated, so the verb list a refusal
+    hands an agent is the one the schema really carries. A hand-copied list
+    drifts the moment a verb is added or narrowed, and the agent then corrects
+    itself towards a verb that is not there.
+
+    Args:
+        tool_spec: The driver's :attr:`HardwareDriver.tool_spec`.
+
+    Returns:
+        The declared verbs, in the order the schema lists them.
+    """
+    return [str(verb) for verb in tool_spec["inputSchema"]["json"]["properties"]["action"]["enum"]]
+
+
+def undeclared_verb_error(driver: Any, action: Any) -> dict[str, Any]:
+    """Refuse an ``action`` the driver's own tool spec does not declare.
+
+    The ``enum`` a ``tool_spec`` carries *describes* the verbs an agent may
+    send; nothing between the model and :meth:`HardwareDriver.stream` enforces
+    it. A dispatcher whose last branch is a bare ``else`` therefore runs its
+    final verb for every value the enum does not cover, and on these drivers
+    the final verb is the write one - so a typo, a stale verb from an earlier
+    schema, or a verb borrowed from a sibling driver halted the robot and
+    answered ``status="success"``, leaving the caller unable to tell that its
+    own verb had not been dispatched.
+
+    One owner rather than one per driver, because the list the refusal quotes
+    has to come off the same schema the agent planned against
+    (:func:`declared_verbs`).
+
+    Args:
+        driver: The driver that was invoked; named in the refusal, and read for
+            its :attr:`HardwareDriver.tool_spec`.
+        action: Whatever arrived in the tool input, quoted back verbatim - it is
+            not necessarily a string, and a caller cannot correct a value the
+            refusal does not show.
+
+    Returns:
+        A ``status="error"`` envelope naming the action and every declared verb.
+    """
+    return {
+        "status": "error",
+        "content": [
+            {
+                "text": (
+                    f"{type(driver).__name__}: unknown action {action!r}; "
+                    f"declared verbs are {declared_verbs(driver.tool_spec)}"
+                )
+            }
+        ],
+    }

--- a/strands_robots/drivers/booster.py
+++ b/strands_robots/drivers/booster.py
@@ -53,7 +53,7 @@ import threading
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
-from strands_robots.drivers.base import halt_failure_detail
+from strands_robots.drivers.base import halt_failure_detail, undeclared_verb_error
 from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.utils import boolean_flag_error, dds_domain_id_error, finite_number_error
 
@@ -508,8 +508,10 @@ class BoosterDriver:
             envelope = {"status": "success", "content": [{"json": self.read_state()}]}
         elif action == "status":
             envelope = await self.get_status()
-        else:  # "stop"
+        elif action == "stop":
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/crazyflie.py
+++ b/strands_robots/drivers/crazyflie.py
@@ -98,7 +98,7 @@ import threading
 from collections.abc import AsyncGenerator, Mapping
 from typing import TYPE_CHECKING, Any, cast
 
-from strands_robots.drivers.base import halt_failure_detail
+from strands_robots.drivers.base import halt_failure_detail, undeclared_verb_error
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.utils import (
     finite_number_error,
@@ -663,12 +663,14 @@ class CrazyflieDriver:
             )
         elif action == "status":
             envelope = await self.get_status()
-        else:  # "land"
+        elif action == "land":
             # The sibling's envelope verbatim. Building one here could only
             # restate the intent ("asked it to land"), while the descent itself
             # can be refused - a disconnected link, an unusable duration - and
             # the agent needs that verdict rather than an acknowledgement.
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/dynamixel/driver.py
+++ b/strands_robots/drivers/dynamixel/driver.py
@@ -47,6 +47,8 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
+from strands_robots.drivers.base import undeclared_verb_error
+
 if TYPE_CHECKING:
     from strands.types.tools import ToolSpec, ToolUse
 
@@ -192,12 +194,14 @@ class DynamixelDriver:
                 "status": "success",
                 "content": [{"json": {"joint_state": None, "reason": _NOT_WIRED}}],
             }
-        else:  # "stop"
+        elif action == "stop":
             await self.stop()
             envelope = {
                 "status": "success",
                 "content": [{"text": f"stop: {_NOT_WIRED}"}],
             }
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/earthrover.py
+++ b/strands_robots/drivers/earthrover.py
@@ -38,7 +38,7 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Any, cast
 
-from strands_robots.drivers.base import halt_failure_detail
+from strands_robots.drivers.base import halt_failure_detail, undeclared_verb_error
 from strands_robots.utils import finite_number_error, positive_finite_number_error
 
 if TYPE_CHECKING:
@@ -256,8 +256,10 @@ class EarthRoverDriver:
             envelope = {"status": "success", "content": [{"json": self.read_state()}]}
         elif action == "status":
             envelope = await self.get_status()
-        else:  # "stop"
+        elif action == "stop":
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/feetech/driver.py
+++ b/strands_robots/drivers/feetech/driver.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from strands_robots.policies import Policy
 
 from strands_robots.bus_access import bus_lock
+from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.drivers.feetech.bus import SO_ARM_MOTORS, FeetechBus
 from strands_robots.utils import boolean_flag_error
 
@@ -212,19 +213,6 @@ class FeetechDriver:
             },
         }
 
-    @property
-    def declared_verbs(self) -> list[str]:
-        """The action verbs this driver's schema declares, in schema order.
-
-        Read back out of :attr:`tool_spec` rather than restated, so the verb
-        list an agent is handed when it fires an unknown action is the one the
-        schema really carries. A hand-copied list drifts the moment a verb is
-        added or narrowed, and the agent then corrects itself towards a verb
-        that does not exist.
-        """
-        action_schema = self.tool_spec["inputSchema"]["json"]["properties"]["action"]
-        return [str(verb) for verb in action_schema["enum"]]
-
     async def stream(
         self,
         tool_use: ToolUse,
@@ -275,9 +263,7 @@ class FeetechDriver:
         elif action == "stop":
             envelope = self._set_torque_envelope(False)
         else:
-            envelope = _refuse(
-                f"FeetechDriver: unknown action {action!r}; declared verbs are {self.declared_verbs}",
-            )
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/franka/driver.py
+++ b/strands_robots/drivers/franka/driver.py
@@ -74,6 +74,7 @@ import threading
 from collections.abc import AsyncGenerator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.registry import resolve_name
 from strands_robots.utils import finite_number_error, positive_finite_number_error
 
@@ -547,8 +548,10 @@ class FrankaDriver:
                 }
         elif action == "status":
             envelope = {"status": "success", "content": [{"json": await self.get_status()}]}
-        else:  # "stop"
+        elif action == "stop":
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -49,6 +49,7 @@ import time
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.tools.g1 import HANDSHAKE_FSMS, WALK_FSMS, decode_code
 from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
@@ -519,7 +520,7 @@ class G1Driver:
                 "status": "success",
                 "content": [{"json": await self.get_status()}],
             }
-        else:  # "stop"
+        elif action == "stop":
             # Report the halt outcome rather than assert one.  ``stop()`` is
             # the protocol's shutdown hook and returns ``None``, so an
             # envelope built beside it can only restate the intent: a policy
@@ -530,6 +531,8 @@ class G1Driver:
             # timeout reason), so the verb returns that envelope rather than
             # re-deriving it from the loop handle.
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/go2.py
+++ b/strands_robots/drivers/go2.py
@@ -73,6 +73,7 @@ import time
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
 from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
@@ -607,12 +608,14 @@ class Go2Driver:
             envelope: dict[str, Any] = {"status": "success", "content": [{"json": self.state}]}
         elif action == "status":
             envelope = {"status": "success", "content": [{"json": await self.get_status()}]}
-        else:  # "stop"
+        elif action == "stop":
             # ``stop_task`` already decides the verdict, including the join
             # timeout, so the verb returns that envelope rather than
             # re-deriving one that could read "success" over a loop still
             # holding the wire.
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/microduck.py
+++ b/strands_robots/drivers/microduck.py
@@ -46,6 +46,7 @@ import threading
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.policies.microduck import MICRODUCK_JOINT_NAMES
 from strands_robots.utils import (
     boolean_flag_error,
@@ -625,7 +626,7 @@ class MicroduckDriver:
             }
         elif action == "status":
             envelope = {"status": "success", "content": [{"json": await self.get_status()}]}
-        else:  # "stop"
+        elif action == "stop":
             # Report the halt outcome rather than assert one.  ``stop`` is the
             # protocol's shutdown hook and returns ``None``: it returns early
             # for a client that is gone and swallows an ``OSError`` from
@@ -635,6 +636,8 @@ class MicroduckDriver:
             # decides the verdict, so the verb returns that envelope rather
             # than re-deriving one.
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -64,6 +64,7 @@ import time
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.tools.reachy import envelope_error
 from strands_robots.utils import finite_number_error, tcp_port_error
 
@@ -342,7 +343,7 @@ class ReachyDriver:
             }
         elif action == "status":
             envelope = {"status": "success", "content": [{"json": await self.get_status()}]}
-        else:  # "stop"
+        elif action == "stop":
             # Report the halt outcome rather than assert one.  ``stop`` is the
             # protocol's shutdown hook and returns ``None``: a daemon that
             # refuses the stop is logged and swallowed, so an envelope built
@@ -351,6 +352,8 @@ class ReachyDriver:
             # ``/api/move/stop`` and already decides the verdict, so the verb
             # returns that envelope rather than re-deriving one.
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/robotiq/driver.py
+++ b/strands_robots/drivers/robotiq/driver.py
@@ -43,6 +43,7 @@ import time
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.drivers.robotiq.protocol import (
     DEFAULT_TCP_PORT,
     DEFAULT_UNIT_ID,
@@ -381,11 +382,13 @@ class RobotiqDriver:
             envelope = self.read_status()
         elif action == "status":
             envelope = await self.get_status()
-        else:  # "stop"
+        elif action == "stop":
             # Delegate rather than re-derive: stop_task decides whether the halt
             # reached the gripper, and an agent that read a restated success here
             # would be told the fingers stopped when the write failed.
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/strands_robots/drivers/ur.py
+++ b/strands_robots/drivers/ur.py
@@ -70,6 +70,7 @@ import time
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
+from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.registry import resolve_name
 from strands_robots.utils import (
@@ -539,12 +540,14 @@ class URDriver:
             envelope = self.state()
         elif action == "status":
             envelope = {"status": "success", "content": [{"json": await self.get_status()}]}
-        else:  # "stop"
+        elif action == "stop":
             # ``stop`` is the protocol's shutdown hook and returns ``None``, so
             # an envelope built beside it could only restate the intent.
             # ``stop_task`` performs the same halt and already decides the
             # verdict, so the verb reports that.
             envelope = self.stop_task()
+        else:
+            envelope = undeclared_verb_error(self, action)
         yield {"toolUseId": tool_use_id, **envelope}
 
     # ------------------------------------------------------------------ #

--- a/tests/drivers/test_agent_stop_verb_reports_the_halt_outcome.py
+++ b/tests/drivers/test_agent_stop_verb_reports_the_halt_outcome.py
@@ -179,15 +179,26 @@ def _stop_task_can_refuse(node: ast.AST) -> bool:
     return False
 
 
+#: How the shipped dispatchers spell the halt verb. ``land`` is the Crazyflie's
+#: spelling of the same decision - a drone stops by descending.
+_HALT_VERBS = ("stop", "land")
+
+
 def _stream_stop_branch(node: ast.AST) -> str:
-    """The source of the final ``else`` of a ``stream`` action dispatch."""
-    branch: list[ast.stmt] | None = None
+    """The source of the ``stream`` dispatch branch that performs the halt.
+
+    Found by the verb its test names rather than as "the final ``else``": the
+    terminal branch now refuses a verb the schema does not declare
+    (:func:`~strands_robots.drivers.base.undeclared_verb_error`), so the halt has
+    a branch of its own and reading the ``else`` would report on the refusal.
+    """
     for inner in ast.walk(node):
-        if isinstance(inner, ast.If) and inner.orelse and not any(isinstance(x, ast.If) for x in inner.orelse):
-            branch = inner.orelse
-    if branch is None:
-        return ""
-    return ast.unparse(ast.Module(body=branch, type_ignores=[]))
+        if not isinstance(inner, ast.If):
+            continue
+        test = ast.unparse(inner.test)
+        if any(f"action == {verb!r}" in test for verb in _HALT_VERBS):
+            return ast.unparse(ast.Module(body=inner.body, type_ignores=[]))
+    return ""
 
 
 def _reports_the_verdict(branch: str) -> bool:
@@ -417,8 +428,10 @@ class TestTheRuleIsNotVacuous:
                 envelope = {"status": "ok"}
             elif action == "status":
                 envelope = {"status": "ok"}
-            else:
+            elif action == "stop":
                 envelope = self.stop_task()
+            else:
+                envelope = undeclared_verb_error(self, action)
             yield envelope
     """
 
@@ -428,9 +441,11 @@ class TestTheRuleIsNotVacuous:
                 envelope = {"status": "ok"}
             elif action == "status":
                 envelope = {"status": "ok"}
-            else:
+            elif action == "stop":
                 await self.stop()
                 envelope = {"status": "success", "content": [{"text": "asked it to stop"}]}
+            else:
+                envelope = undeclared_verb_error(self, action)
             yield envelope
     """
 

--- a/tests/drivers/test_an_undeclared_verb_is_refused_not_dispatched.py
+++ b/tests/drivers/test_an_undeclared_verb_is_refused_not_dispatched.py
@@ -1,0 +1,233 @@
+"""An agent verb a driver's schema does not declare is refused, not dispatched.
+
+A driver's ``tool_spec`` carries an ``action`` ``enum``. That enum *describes*
+the verbs an agent may send; nothing between the model and
+:meth:`~strands_robots.drivers.base.HardwareDriver.stream` enforces it. So a
+dispatcher whose last branch is a bare ``else`` runs its final verb for every
+value the enum does not cover - and on every shipped native driver that final
+verb is the *write* one, the halt.
+
+``FeetechDriver`` already refuses, and
+``tests/drivers/test_feetech_driver.py::test_an_undeclared_verb_is_refused_not_run``
+states why in the past tense: "The fallthrough branch used to be ``stop``, so
+any verb outside the schema released torque on every motor and answered
+``success``. ``home`` is the one an agent reaches for first - this driver
+deliberately does not declare it - and a held payload dropped while the
+transcript read as a clean move." That reasoning was never applied to the other
+eleven drivers, so on those a typo (``"sensor"``), a verb borrowed from a sibling
+(``"sensors"`` on a ``URDriver``, whose read verb is spelled ``state``) or a
+non-string all halted the robot and reported ``status="success"``.
+
+The population here is **derived from the registry** rather than listed, so a
+driver added later is graded on arrival - the same relation shape
+``test_agent_stop_verb_reports_the_halt_outcome.py`` uses for its own fleet
+rule. Two things are graded, because the envelope alone is not the safety
+property: the refusal must *say* the verb is unknown, and the halt must not
+have *happened*.
+
+The vocabulary divergence the fleet already carries is left as it is and only
+made visible: ``CrazyflieDriver`` declares ``land`` where its siblings declare
+``stop``, and ``URDriver`` declares ``state`` where its siblings declare
+``sensors``. Refusing and naming the declared verbs lets an agent correct itself
+in the same turn; silently running the halt for both spellings is what this
+module refuses.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import textwrap
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers as drivers_pkg
+from strands_robots.drivers.base import declared_verbs, undeclared_verb_error
+from strands_robots.drivers.registry import get_native_driver_class
+
+#: Every driver class shipped today. A walk that silently found fewer than this
+#: would make every parametrized cell below vacuous.
+_MINIMUM_DRIVER_CLASSES = 12
+
+#: Verbs no shipped schema declares. ``None`` is included because the schema
+#: says ``"type": "string"`` and nothing enforces that either, and ``"sensor"``
+#: because a one-character typo is the case an agent actually produces.
+_UNDECLARED = ("home", "halt", "SENSORS", "sensor", "", None)
+
+#: Attributes a fallthrough could have reached. Named so the halt cell can
+#: refuse to pass on a driver whose halt it never managed to observe.
+_HALT_MEMBERS = ("stop_task", "stop")
+
+
+def _driver_classes() -> dict[str, type[Any]]:
+    """Every distinct native driver class the registry can build, by name."""
+    return {
+        cls.__name__: cls
+        for cls in (get_native_driver_class(robot) for robot in drivers_pkg.list_native_drivers())
+        if cls is not None
+    }
+
+
+def _first_robot_for(cls: type[Any]) -> str:
+    """A registry name that resolves to ``cls`` or to a base of it.
+
+    Read through the MRO so a subclass built inside a test - the widened-schema
+    driver below - inherits the name its base is registered under, rather than
+    needing a registry entry of its own.
+    """
+    for candidate in cls.__mro__:
+        for robot in drivers_pkg.list_native_drivers():
+            if get_native_driver_class(robot) is candidate:
+                return robot
+    raise AssertionError(f"{cls.__name__} is in the population but no robot names it")
+
+
+def _build(cls: type[Any]) -> Any:
+    """Build ``cls`` off hardware, through the factory's own contract."""
+    return cls(tool_name=_first_robot_for(cls), cameras=None, data_config=None)
+
+
+def _invoke(driver: Any, action: Any) -> dict[str, Any]:
+    """Drive one agent invocation and return its single envelope."""
+
+    async def _drive() -> dict[str, Any]:
+        results = [
+            event
+            async for event in driver.stream({"toolUseId": "call-1", "name": "t", "input": {"action": action}}, {})
+        ]
+        assert len(results) == 1, f"the verb must yield exactly one result, got {len(results)}"
+        return results[0]
+
+    return asyncio.run(_drive())
+
+
+def _text(envelope: dict[str, Any]) -> str:
+    """Join every text block, for substring assertions."""
+    return " ".join(str(block.get("text", "")) for block in envelope.get("content") or [] if isinstance(block, dict))
+
+
+_CLASSES = sorted(_driver_classes().items())
+
+
+def test_the_population_is_the_whole_fleet() -> None:
+    """Without this, a registry walk that found nothing would grade nothing."""
+    found = _driver_classes()
+    assert len(found) >= _MINIMUM_DRIVER_CLASSES, (
+        f"expected at least {_MINIMUM_DRIVER_CLASSES} native driver classes, found {sorted(found)}"
+    )
+
+
+@pytest.mark.parametrize(("name", "cls"), _CLASSES, ids=[n for n, _ in _CLASSES])
+@pytest.mark.parametrize("action", _UNDECLARED, ids=[repr(a) for a in _UNDECLARED])
+def test_an_undeclared_verb_is_refused_and_names_the_declared_ones(name: str, cls: type[Any], action: Any) -> None:
+    """The refusal has to be actionable: a caller cannot guess the vocabulary."""
+    driver = _build(cls)
+    verbs = declared_verbs(driver.tool_spec)
+    assert action not in verbs, f"premise: {action!r} must be outside {name}'s schema"
+
+    envelope = _invoke(driver, action)
+
+    assert envelope["status"] == "error", f"{name} ran undeclared verb {action!r} instead of refusing it"
+    text = _text(envelope)
+    for verb in verbs:
+        assert verb in text, f"{name}'s refusal must name declared verb {verb!r}: {text}"
+
+
+@pytest.mark.parametrize(("name", "cls"), _CLASSES, ids=[n for n, _ in _CLASSES])
+@pytest.mark.parametrize("action", _UNDECLARED, ids=[repr(a) for a in _UNDECLARED])
+def test_an_undeclared_verb_does_not_reach_the_halt(name: str, cls: type[Any], action: Any) -> None:
+    """The envelope is half of it; the robot must not have been halted.
+
+    A refusal that arrived *after* the halt ran would satisfy the cell above and
+    still be the defect - the fallthrough's whole cost is that a read request
+    stopped the robot.
+    """
+    driver = _build(cls)
+    called: list[str] = []
+    patched = [member for member in _HALT_MEMBERS if hasattr(driver, member)]
+    assert patched, f"{name} exposes none of {_HALT_MEMBERS}, so no halt could be observed"
+    for member in patched:
+        # The stand-in answers a success envelope rather than ``None``, and
+        # matches the sync/async shape of the member it replaces, so a
+        # dispatcher that reaches the halt fails on this cell's own assertion
+        # rather than on a ``TypeError`` from awaiting or unpacking the result.
+        def _record(*args: Any, _member: str = member, **kwargs: Any) -> dict[str, Any]:
+            called.append(_member)
+            return {"status": "success", "content": [{"text": f"{_member} stand-in"}]}
+
+        async def _record_async(*args: Any, _member: str = member, **kwargs: Any) -> dict[str, Any]:
+            return _record(_member=_member)
+
+        original = getattr(driver, member)
+        setattr(driver, member, _record_async if inspect.iscoroutinefunction(original) else _record)
+
+    _invoke(driver, action)
+
+    assert called == [], f"{name} halted the robot for undeclared verb {action!r} (called {called})"
+
+
+@pytest.mark.parametrize(("name", "cls"), _CLASSES, ids=[n for n, _ in _CLASSES])
+def test_every_declared_verb_is_dispatched(name: str, cls: type[Any]) -> None:
+    """The control, and the other half of the contract.
+
+    A verb in the schema must have a branch: a declared verb the driver refuses
+    as unknown is worse than one it never declared. Only the *unknown-verb*
+    refusal is refused here - a declared verb may still fail on "not connected",
+    which is the honest answer off hardware.
+    """
+    driver = _build(cls)
+    for verb in declared_verbs(driver.tool_spec):
+        text = _text(_invoke(driver, verb))
+        assert "unknown action" not in text, f"{name} declares {verb!r} but its dispatcher does not handle it: {text}"
+
+
+@pytest.mark.parametrize(("name", "cls"), _CLASSES, ids=[n for n, _ in _CLASSES])
+def test_the_refusal_reads_its_verb_list_off_the_schema(name: str, cls: type[Any]) -> None:
+    """A restated list drifts the first time a schema gains or loses a verb.
+
+    A driver that widens its own schema is the case that catches it: the extra
+    verb has to appear in the refusal without any edit to the refusal.
+    """
+
+    class _WiderSchema(cls):  # type: ignore[valid-type,misc]
+        """A driver whose schema declares one verb more than its base."""
+
+        @property
+        def tool_spec(self) -> Any:
+            spec = super().tool_spec
+            spec["inputSchema"]["json"]["properties"]["action"]["enum"].append("wiggle")
+            return spec
+
+    driver = _build(_WiderSchema)
+    assert "wiggle" in declared_verbs(driver.tool_spec)
+    text = _text(_invoke(driver, "home"))
+    assert "wiggle" in text, f"{name} restated a verb list instead of reading its schema: {text}"
+
+
+@pytest.mark.parametrize(("name", "cls"), _CLASSES, ids=[n for n, _ in _CLASSES])
+def test_no_dispatcher_ends_in_a_bare_else(name: str, cls: type[Any]) -> None:
+    """The structural half, so the next driver is held to this on arrival.
+
+    Read as source rather than behaviour because a driver may grow a verb whose
+    branch this module cannot drive off hardware, while the *shape* - a terminal
+    ``else`` that refuses rather than acts - is checkable either way.
+    """
+    function = ast.parse(textwrap.dedent(inspect.getsource(cls.stream))).body[0]
+    assert isinstance(function, ast.AsyncFunctionDef | ast.FunctionDef)
+    chains = [
+        node
+        for node in function.body
+        if isinstance(node, ast.If) and "action" in ast.unparse(node.test) and node.orelse
+    ]
+    assert len(chains) == 1, f"{name}.stream has {len(chains)} action dispatch chains, expected exactly 1"
+    # Follow the elif chain to its own tail; a nested if/else inside one branch
+    # is a different decision and is not what this grades.
+    node = chains[0]
+    while len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
+        node = node.orelse[0]
+    body = "".join(ast.unparse(statement) for statement in node.orelse)
+    assert undeclared_verb_error.__name__ in body, (
+        f"{name}.stream's terminal else runs a verb instead of refusing an undeclared one: {body}"
+    )

--- a/tests/drivers/test_feetech_driver.py
+++ b/tests/drivers/test_feetech_driver.py
@@ -36,6 +36,7 @@ from strands_robots.drivers import (
     list_native_drivers,
     missing_driver_members,
 )
+from strands_robots.drivers.base import declared_verbs
 from strands_robots.drivers.feetech import FeetechDriver
 from strands_robots.drivers.feetech.bus import SO_ARM_MOTORS
 from strands_robots.drivers.feetech.driver import _NO_POLICY_LOOP, SUPPORTED_ROBOTS
@@ -663,7 +664,7 @@ class TestStream:
         assert result["status"] == "error", f"undeclared verb {verb!r} must be refused, not run"
         assert _port(driver).writes == [], f"undeclared verb {verb!r} reached the wire"
         text = result["content"][0]["text"]
-        for declared in driver.declared_verbs:
+        for declared in declared_verbs(driver.tool_spec):
             assert declared in text, f"the refusal must name declared verb {declared!r}: {text}"
 
     def test_the_refusal_reads_its_verb_list_off_the_schema(self) -> None:
@@ -685,7 +686,7 @@ class TestStream:
                 return spec
 
         driver = _ExtraVerbDriver(tool_name="so101", port="/dev/fake")
-        assert "wiggle" in driver.declared_verbs
+        assert "wiggle" in declared_verbs(driver.tool_spec)
         result = _run_stream(driver, {"toolUseId": "tid-8", "name": "so101", "input": {"action": "home"}})
         assert result["status"] == "error"
         assert "wiggle" in result["content"][0]["text"], (


### PR DESCRIPTION
A driver's `tool_spec` carries an `action` `enum`. That enum **describes** the verbs an agent may send; nothing between the model and `stream` enforces it. Eleven of the twelve shipped native drivers dispatched with a bare `else`, so every value the enum did not cover ran that branch's verb — and on every one of them that verb is the **write** one, the halt.

`FeetechDriver` already refuses, and `tests/drivers/test_feetech_driver.py` states why in the past tense:

> The fallthrough branch used to be `stop`, so any verb outside the schema released torque on every motor and answered `success`. `home` is the one an agent reaches for first — this driver deliberately does not declare it — and a held payload dropped while the transcript read as a clean move.

That reasoning was never applied to the other eleven.

## The census, measured

`action="sensor"` (a one-character typo) on each driver built off hardware, with the halt members instrumented:

| driver | declared verbs | halt reached before | after |
|---|---|:--:|:--:|
| `BoosterDriver` (1.2 m biped) | `sensors, status, stop` | `stop_task` | refused |
| `CrazyflieDriver` (quadrotor) | `sensors, status, land` | `stop_task` | refused |
| `DynamixelDriver` | `status, sensors, stop` | `stop` | refused |
| `EarthRoverDriver` | `sensors, status, stop` | `stop_task` | refused |
| `FrankaDriver` | `sensors, status, stop` | `stop_task` | refused |
| `G1Driver` (humanoid) | `sensors, status, stop` | `stop_task` | refused |
| `Go2Driver` (quadruped) | `sensors, status, stop` | `stop_task` | refused |
| `MicroduckDriver` | `sensors, status, stop` | `stop_task` | refused |
| `ReachyDriver` | `sensors, status, stop` | `stop_task` | refused |
| `RobotiqDriver` | `open, close, sensors, status, stop` | `stop_task` | refused |
| `URDriver` (industrial arm) | `state, status, stop` | `stop_task` | refused |
| **`FeetechDriver`** | `status, sensors, move_to, set_torque, stop` | **already refused** | refused |

Two rows make the confusion likely rather than hypothetical, because the fleet's vocabulary is not uniform: `CrazyflieDriver` spells its halt `land` where its siblings spell it `stop`, and `URDriver` spells its read `state` where its siblings spell it `sensors`. So `stop` on a drone and `sensors` on a UR arm are both *undeclared*, and both reached the halt.

Verbatim, on `URDriver` at `main`, off hardware — a read request answered by a halt refusal:

```python
>>> stream({"action": "sensor"})
{'status': 'error', 'content': [{'text': 'stop_task: not connected'}]}
```

Connected, that same call returns `status="success"` with the arm halted, and nothing in the envelope names the verb the caller actually sent.

## Change

One owner in `strands_robots/drivers/base.py`:

- `declared_verbs(tool_spec)` — the verbs read back off the schema, in schema order.
- `undeclared_verb_error(driver, action)` — the refusal, naming the action verbatim (it is not necessarily a string) and every declared verb, so an agent can correct itself in the same turn.

Each dispatcher's terminal `else` becomes an explicit `elif action == "<halt verb>"` plus that refusal. `FeetechDriver`'s hand-rolled `declared_verbs` property and its restated refusal are **deleted** in favour of the shared pair, so the two cannot disagree about one schema.

The vocabulary divergence is left as it is and only made visible — renaming a halt verb is a separate decision, and refusing while naming the right verb is already actionable.

## Tests

New `tests/drivers/test_an_undeclared_verb_is_refused_not_dispatched.py`, a fleet relation whose population is **derived from the registry**, so a driver added later is graded on arrival. It pins both halves, because the envelope alone is not the safety property:

1. an undeclared verb is refused and the refusal names every declared verb;
2. **the halt did not happen** — a refusal that arrived *after* the halt ran would satisfy (1) and still be the defect;
3. control: every declared verb is dispatched (no verb is refused as unknown);
4. a driver that widens its own schema sees the extra verb in the refusal (so the list is read, not restated);
5. structural: no dispatcher's action chain ends in a branch that acts rather than refuses.

| | pre-fix | post-fix |
|---|---|---|
| new module | **155 failed / 26 passed** | **181 passed** |
| `tests/drivers` | 2179 passed / 7 skipped | **2360 passed / 7 skipped** (+181 = exactly the new cells) |

Pre-fix was measured with the `base.py` helpers present and the eleven dispatchers unchanged, so the graders run rather than error at import. The 26 that pass pre-fix are the controls: **all 12 `FeetechDriver` cells** (the driver the fix had already landed on is green on both trees) and **all 12 `test_every_declared_verb_is_dispatched` cells** (nothing that worked stopped working). Sample pre-fix message:

```
AssertionError: BoosterDriver halted the robot for undeclared verb 'SENSORS' (called ['stop_task'])
AssertionError: DynamixelDriver halted the robot for undeclared verb 'SENSORS' (called ['stop'])
```

`tests/drivers/test_agent_stop_verb_reports_the_halt_outcome.py` is retargeted in the same change: its `_stream_stop_branch` located the halt as "the final `else`", which is now the refusal. It finds the branch by the verb its test names instead, and its two non-vacuity fixtures move to the shipped shape. Its own rule is unchanged and still green for all ten drivers it grades.

## Gate

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1872 files). `mypy strands_robots tests tests_integ` — **20 errors in 6 files, against 23 in 7 on `main`**; no new error, and the removed `FeetechDriver` property accounts for the drop. `tests/test_changelog_*` green.

## Size

`strands_robots/`: **+103 / −30** across 13 files — 56 of those additions are the one shared owner and its docstring, every dispatcher is +2 net, and `FeetechDriver` is −14. Tests: +233 for the new module, +33 / −5 retargeting two existing ones, plus a 15-line `changelog.d` fragment.