### PR TITLE
fix(simulation/isaac): a robot's prim prune is bounded at the USD path separator

### DIFF
--- a/changelog.d/3214-isaac-prim-prune-at-the-path-boundary.md
+++ b/changelog.d/3214-isaac-prim-prune-at-the-path-boundary.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Isaac `remove_robot` no longer drops another robot's prim from the teardown
+  registry.** The prune is documented as removing "any prims rooted at the
+  robot's prim path", and tested that with a bare `startswith` on the path
+  string. A prim path is interpolated from the robot's name
+  (`{stage_path}/Robots/{name}`), so a robot whose name merely *extends* the
+  removed one's counted as a prim beneath it: with `arm` and `arm_left` both
+  live, `remove_robot("arm")` dropped `/World/Robots/arm_left` while `arm_left`
+  stayed registered, leaving a live robot with no prim for `destroy` to release
+  and a `prims_released` count one short. The prune is now bounded at `/`, USD's
+  path separator, so it keeps the subtree it promises and stops at a sibling.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -3318,6 +3318,12 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         prim deletion is delegated to :meth:`destroy` / world teardown in
         Phase 1; only the in-Python registry is updated here.
 
+        "Rooted at" is judged at the USD path boundary, so a robot whose name
+        merely *extends* this one keeps its prim. Prim paths are interpolated
+        from the name (``{stage_path}/Robots/{name}``), so with ``arm`` and
+        ``arm_left`` both live the two paths share a prefix without one
+        containing the other.
+
         Parameters
         ----------
         name : str
@@ -3336,7 +3342,21 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                     "content": [{"text": f"Robot '{name}' not found."}],
                 }
             prim_path = self._robots[name].prim_path
-            self._prim_registry = [p for p in self._prim_registry if not p.startswith(prim_path)]
+            # ``/`` is USD's path separator, so it is what separates a
+            # descendant prim from a sibling that merely shares a prefix. A bare
+            # ``startswith`` test made every robot whose NAME extends this one a
+            # descendant: with ``arm`` and ``arm_left`` both live,
+            # ``remove_robot("arm")`` dropped ``/World/Robots/arm_left`` from the
+            # teardown registry too, leaving a robot that is still registered in
+            # ``_robots`` with zero tracked prims for :meth:`destroy` to release
+            # -- the same corruption an empty name used to cause, reachable from
+            # two ordinary names. The other two removal verbs
+            # (:meth:`remove_object`, :meth:`remove_camera`) ask for their exact
+            # path, which cannot over-match; this one keeps the subtree prune its
+            # docstring promises and bounds it at the separator.
+            self._prim_registry = [
+                p for p in self._prim_registry if p != prim_path and not p.startswith(f"{prim_path}/")
+            ]
             del self._robots[name]
             # A controller closed over this robot's articulation is stale
             # the moment the robot is gone; drop it with the robot.

--- a/tests/simulation/isaac/test_removing_a_robot_prunes_at_the_prim_path_boundary.py
+++ b/tests/simulation/isaac/test_removing_a_robot_prunes_at_the_prim_path_boundary.py
@@ -1,0 +1,184 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: removing one robot leaves a prefix-sharing sibling's prim tracked.
+
+``IsaacSimulation.remove_robot`` documents that it "prunes any prims rooted at
+the robot's prim path from ``self._prim_registry``". A prim path is interpolated
+from the robot's name (``{stage_path}/Robots/{name}``), and the prune tested that
+relation with a bare ``p.startswith(prim_path)`` -- which is a test on the
+*string*, not on the USD path. So every robot whose NAME extends the removed
+one's was treated as a prim rooted under it:
+
+* two robots ``arm`` and ``arm_left``, ``remove_robot("arm")`` ->
+  ``/World/Robots/arm_left`` dropped from the teardown registry while ``arm_left``
+  stayed registered in ``_robots``. The registry is what :meth:`destroy` releases
+  and counts (``num_prims_released = len(self._prim_registry)``), so a live robot
+  was left with zero tracked prims and destroy under-reported by one.
+* ``arm``/``arm2`` and ``panda``/``panda_gripper`` behave identically -- the
+  arrangement needs no unusual name, only a name that is a prefix of another.
+
+This is the same corruption the empty name used to cause, which
+``tests/simulation/test_entity_name_domain_at_creation.py`` closed at the
+creation site: ``add_robot("")`` reserved the *container* path
+``/World/Robots/``, so ``remove_robot("")`` pruned every robot. Refusing the
+empty name stopped that one arrangement from arising; it left the prune rule
+itself unchanged, and the rule over-matches for any two ordinary names in that
+relation.
+
+The two sibling removal verbs never had this: :meth:`remove_object` and
+:meth:`remove_camera` ask for their exact path (``if prim_path in
+self._prim_registry``), which cannot over-match. ``remove_robot`` is the one that
+prunes a subtree, so the fix bounds the subtree at ``/`` -- USD's path separator,
+and therefore what separates a descendant prim from a sibling that merely shares
+a prefix -- rather than narrowing it to an exact match, which would drop the
+subtree prune the docstring promises.
+
+None of this needs Isaac Sim or a GPU: the procedural ``add_robot`` branch and
+all three removal verbs touch no stage, so the unbound methods run against the
+small ``types.SimpleNamespace`` stand-in for ``self`` that the neighbouring Isaac
+name-domain tests already use.
+"""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import (
+    IsaacSimulation,
+    _CameraState,
+    _ObjectState,
+)
+
+#: ``(removed, survivor)`` name pairs. The first row is the arrangement where the
+#: string test and the path test AGREE -- neither name is a prefix of the other --
+#: so it is the control that held before the fix and must still hold. The rest are
+#: the relation the string test cannot see: ``removed`` is a prefix of
+#: ``survivor``, one character short of the ``/`` that would make it a parent.
+_PAIRS = (
+    ("arm", "helper"),
+    ("arm", "arm_left"),
+    ("arm", "arm2"),
+    ("panda", "panda_gripper"),
+    ("so101", "so101_leader"),
+)
+
+
+def _stub() -> types.SimpleNamespace:
+    """A stand-in for ``self`` carrying only what add/remove read."""
+    return types.SimpleNamespace(
+        _lock=threading.RLock(),
+        _world_created=True,
+        _world=None,
+        _config=IsaacConfig(),
+        _robots={},
+        _objects={},
+        _cameras={},
+        _action_controllers={},
+        _replicated=False,
+        _prim_registry=[],
+    )
+
+
+def _with_robots(*names: str) -> types.SimpleNamespace:
+    """Register ``names`` procedurally and assert each one took."""
+    stub = _stub()
+    for name in names:
+        result = IsaacSimulation.add_robot(stub, name, data_config="panda")  # type: ignore[arg-type]
+        assert result["status"] == "success", (name, result)
+    assert stub._prim_registry == [f"/World/Robots/{n}" for n in names]
+    return stub
+
+
+class TestAPruneIsBoundedAtThePathSeparator:
+    """A removal drops the removed robot's prims and only those."""
+
+    @pytest.mark.parametrize(("removed", "survivor"), _PAIRS)
+    def test_the_surviving_robot_keeps_its_prim(self, removed, survivor):
+        stub = _with_robots(removed, survivor)
+
+        assert IsaacSimulation.remove_robot(stub, removed)["status"] == "success"  # type: ignore[arg-type]
+
+        assert f"/World/Robots/{survivor}" in stub._prim_registry
+        assert f"/World/Robots/{removed}" not in stub._prim_registry
+
+    @pytest.mark.parametrize(("removed", "survivor"), _PAIRS)
+    def test_every_robot_still_registered_has_a_tracked_prim(self, removed, survivor):
+        """The teardown invariant, stated as the count :meth:`destroy` reports.
+
+        ``destroy`` releases ``_prim_registry`` and reports its length as
+        ``prims_released``, so a robot present in ``_robots`` with no entry there
+        is a prim nothing will release and nothing will count.
+        """
+        stub = _with_robots(removed, survivor)
+
+        IsaacSimulation.remove_robot(stub, removed)  # type: ignore[arg-type]
+
+        assert sorted(stub._robots) == [survivor]
+        assert len(stub._prim_registry) == len(stub._robots)
+
+    def test_a_descendant_prim_is_still_pruned(self):
+        """The prune is bounded, not narrowed to an exact match.
+
+        ``remove_robot`` is documented as pruning "any prims rooted at the
+        robot's prim path", so a child prim registered beneath it goes with the
+        robot. An exact-membership prune -- what the two sibling removal verbs
+        use -- would leave it behind.
+        """
+        stub = _with_robots("arm", "arm_left")
+        stub._prim_registry.append("/World/Robots/arm/gripper")
+
+        IsaacSimulation.remove_robot(stub, "arm")  # type: ignore[arg-type]
+
+        assert stub._prim_registry == ["/World/Robots/arm_left"]
+
+    def test_a_refused_removal_prunes_nothing(self):
+        """An unknown name is an error, and an error changes no bookkeeping."""
+        stub = _with_robots("arm", "arm_left")
+
+        assert IsaacSimulation.remove_robot(stub, "arm_")["status"] == "error"  # type: ignore[arg-type]
+
+        assert stub._prim_registry == ["/World/Robots/arm", "/World/Robots/arm_left"]
+        assert sorted(stub._robots) == ["arm", "arm_left"]
+
+
+class TestEveryRemovalVerbScopesItsPrune:
+    """All three removal verbs leave a prefix-sharing sibling's prim tracked.
+
+    ``remove_object`` and ``remove_camera`` already did, by asking for their
+    exact path. Graded together so the three cannot drift back apart: the prim
+    path of every entity is interpolated from its name, so the relation exists on
+    all three surfaces.
+    """
+
+    def test_remove_object(self):
+        stub = _stub()
+        for name in ("crate", "crate_lid"):
+            path = f"/World/Objects/{name}"
+            stub._objects[name] = _ObjectState(name=name, prim_path=path, shape="box", is_static=True)
+            stub._prim_registry.append(path)
+
+        assert IsaacSimulation.remove_object(stub, "crate")["status"] == "success"  # type: ignore[arg-type]
+
+        assert stub._prim_registry == ["/World/Objects/crate_lid"]
+
+    def test_remove_camera(self):
+        stub = _stub()
+        for name in ("wrist", "wrist_left"):
+            path = f"/World/Cameras/{name}"
+            stub._cameras[name] = _CameraState(name=name, prim_path=path, width=64, height=64)
+            stub._prim_registry.append(path)
+
+        assert IsaacSimulation.remove_camera(stub, "wrist")["status"] == "success"  # type: ignore[arg-type]
+
+        assert stub._prim_registry == ["/World/Cameras/wrist_left"]
+
+    def test_remove_robot(self):
+        stub = _with_robots("arm", "arm_left")
+
+        assert IsaacSimulation.remove_robot(stub, "arm")["status"] == "success"  # type: ignore[arg-type]
+
+        assert stub._prim_registry == ["/World/Robots/arm_left"]

--- a/tests/simulation/test_entity_name_domain_at_creation.py
+++ b/tests/simulation/test_entity_name_domain_at_creation.py
@@ -490,14 +490,21 @@ class TestIsaacRefusesTheSameNames:
         assert list(stub._robots) == ["arm"]
         assert stub._prim_registry == ["/World/Robots/arm"]
 
-    def test_removing_one_robot_keeps_every_other_robots_prim(self):
+    def test_a_refused_empty_name_never_reaches_the_prune(self):
         """Regression for the corruption an empty name used to cause.
 
         ``/World/Robots/`` prefixes every robot's prim path, and
         ``remove_robot`` prunes the cleanup registry by prefix - so removing the
         empty-named robot used to drop EVERY robot's prim while leaving the
         robots themselves registered. With the name refused at creation the
-        empty name never enters the registry, so the prune stays scoped.
+        empty name never enters the registry, so the prune is never asked about
+        it.
+
+        That is all this cell grades. The two survivors are ``arm`` and
+        ``helper``, neither of which is a prefix of the other, so the prune's own
+        boundary is invisible here - it is graded in
+        ``tests/simulation/isaac/test_removing_a_robot_prunes_at_the_prim_path_boundary.py``,
+        where a name that DOES extend another exercises the same rule.
         """
         stub = _isaac_stub()
         for label in ("arm", "helper"):


### PR DESCRIPTION
`IsaacSimulation.remove_robot` documents that it "prunes any prims **rooted at** the robot's prim path from `self._prim_registry`". It tested that relation with `p.startswith(prim_path)` — a test on the *string*, not on the USD path. A prim path is interpolated from the robot's name (`{stage_path}/Robots/{name}`), so every robot whose **name** extends the removed one's was treated as a prim rooted under it.

![prim prune boundary](https://raw.githubusercontent.com/cagataycali/robots/68c561e9cd8321796b0bc33ce99a290f451badc3/.artifacts/isaac_prim_prune.png)

## Measured

Procedural `add_robot`, no Isaac Sim, both trees:

| A / B | relation | before | after |
|---|---|---|---|
| `arm` / `helper` | unrelated | kept — 1 prim / 1 robot | kept — 1 prim / 1 robot |
| `arm` / `arm_left` | `arm` is a prefix | **LOST** — 0 prims / 1 robot | kept — 1 prim / 1 robot |
| `arm` / `arm2` | `arm` is a prefix | **LOST** — 0 prims / 1 robot | kept — 1 prim / 1 robot |
| `panda` / `panda_gripper` | `panda` is a prefix | **LOST** — 0 prims / 1 robot | kept — 1 prim / 1 robot |
| `so101` / `so101_leader` | `so101` is a prefix | **LOST** — 0 prims / 1 robot | kept — 1 prim / 1 robot |

The first row is the arrangement where the string test and the path test agree, and it is why this was never noticed. The rest need no unusual name — only a name that is a prefix of another, one character short of the `/` that would make it a child.

`destroy` releases `_prim_registry` and reports its length as `prims_released`, so a **LOST** row is a robot still registered in `_robots` with no prim for teardown to release, and a count one short.

## Why bounded rather than exact

`/` is USD's path separator, so it is what separates a descendant prim from a sibling that merely shares a prefix:

| prim path | | `startswith(p)` | boundary at `/` |
|---|---|---|---|
| `/World/Robots/arm` | the robot being removed | pruned | pruned |
| `/World/Robots/arm/gripper` | a child prim of it | pruned | pruned |
| `/World/Robots/arm_left` | a different robot | **pruned** | kept |
| `/World/Robots/arm2` | a different robot | **pruned** | kept |
| `/World/Robots/helper` | a different robot | kept | kept |

`remove_object` and `remove_camera` ask for their **exact** path (`if prim_path in self._prim_registry`), which cannot over-match, and never had this. `remove_robot` is the one that prunes a subtree, so it keeps the subtree and bounds it at the separator instead of narrowing to exact membership — which would drop the child prim in row 2.

## Relation to the empty-name fix

This is the same corruption an empty name used to cause: `add_robot("")` reserved the *container* path `/World/Robots/`, so `remove_robot("")` pruned every robot. That was closed at the creation site by refusing the name. It stopped that one arrangement from arising; it left the prune rule unchanged.

The cell that guarded it, `tests/simulation/test_entity_name_domain_at_creation.py::test_removing_one_robot_keeps_every_other_robots_prim`, held `arm` and `helper` — the row above where both rules agree — so its name claimed more than it graded. Retargeted to `test_a_refused_empty_name_never_reaches_the_prune`, which is what it actually pins, with a pointer to where the boundary is graded. Kept, not deleted: it is the control for the creation-site refusal.

## Tests

New `tests/simulation/isaac/test_removing_a_robot_prunes_at_the_prim_path_boundary.py`, 15 cells. Pre-fix, against unmodified source: **10 failed / 5 passed**, and the 5 that pass are exactly the controls:

```
PASSED test_the_surviving_robot_keeps_its_prim[arm-helper]
PASSED test_every_robot_still_registered_has_a_tracked_prim[arm-helper]
PASSED test_a_refused_removal_prunes_nothing
PASSED TestEveryRemovalVerbScopesItsPrune::test_remove_object
PASSED TestEveryRemovalVerbScopesItsPrune::test_remove_camera

FAILED test_the_surviving_robot_keeps_its_prim[arm-arm_left]   assert '/World/Robots/arm_left' in []
FAILED test_every_robot_still_registered_has_a_tracked_prim[arm-arm_left]   assert 0 == 1
FAILED test_a_descendant_prim_is_still_pruned                  assert [] == ['/World/Robots/arm_left']
FAILED TestEveryRemovalVerbScopesItsPrune::test_remove_robot   assert [] == ['/World/Robots/arm_left']
```

After: 15 passed. `TestEveryRemovalVerbScopesItsPrune` grades all three removal verbs against the same relation so they cannot drift apart. Isaac Sim and a GPU are not needed — the procedural `add_robot` branch and all three removal verbs touch no stage, so the unbound methods run against the `types.SimpleNamespace` stand-in the neighbouring Isaac name-domain tests already use.

## Gate

| | dev | base |
|---|---|---|
| `ruff check` + `ruff format --check` (`strands_robots tests tests_integ`, 1872 files) | clean | clean |
| `mypy strands_robots tests tests_integ` (1.20.2) | 20 errors in 6 files | 20 errors in 6 files |
| `pytest tests/simulation` | 1 failed / 14159 passed / 248 skipped, 556s | same 1 failure, byte-identical |
| `tests/simulation/test_entity_name_domain_at_creation.py` + new file | 370 passed | — |

The one `tests/simulation` failure is `test_pose_vector_rule_parity.py::TestVerdictsMatchAcrossEntryPoints::test_a_numpy_array_pose_is_accepted_by_both`; it fails identically on unmodified `main` in a pristine worktree (local dependency drift), so it is standing baseline and untouched by this change.

## Size

| file | + | − |
|---|---|---|
| `strands_robots/simulation/isaac/simulation.py` | 21 | 1 |
| `tests/simulation/isaac/…prunes_at_the_prim_path_boundary.py` (new) | 184 | 0 |
| `tests/simulation/test_entity_name_domain_at_creation.py` | 9 | 2 |
| `changelog.d/3214-…md` (new) | 12 | 0 |
| **total** | **226** | **3** |

One executable line changes; the other 20 in `simulation.py` are the comment recording the arrangement and the docstring sentence naming where "rooted at" is judged. The 184 new test lines are the regression, table-driven over the five arrangements and the three removal verbs rather than one file per case.