### PR TITLE
fix(policies/cosmos3): action_mapping is a rename, so two columns cannot become one

### DIFF
--- a/changelog.d/3216-cosmos3-action-mapping-is-a-rename.md
+++ b/changelog.d/3216-cosmos3-action-mapping-is-a-rename.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **policies/cosmos3**: `action_mapping` is now required to be a rename. Two
+  action columns arriving at one actuator name used to collapse into a single
+  entry of the per-step action dict, dropping the losing column's command with
+  `status="success"` - reachable from a single mapping entry aimed at another
+  column's own name (`{"joint_0": "joint_1"}` on the DROID
+  `[joint_0..joint_6, gripper]` layout), and worse in reverse
+  (`{"gripper": "joint_6"}` commanded `joint_6` with the gripper's value and left
+  the gripper uncommanded). Construction already validated the mapping's keys;
+  it now validates the targets too, refusing before any request reaches the
+  server and naming the colliding columns and the target they arrive at.

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -69,6 +69,15 @@ keys must be columns of the active space. Mapping the gripper is therefore
 `{"grasp": ...}` under `midtrain` and `{"gripper": ...}` under `joint_pos`; a key
 that names no column is refused, listing the ones that are valid.
 
+It has to be a rename, so two columns may not arrive at one actuator name. A
+step dict holds one entry per column, so a merge would collapse two columns into
+one entry and drop a command - the actuator that lost would hold position while
+the model asked it to move. Both spellings are refused at construction, naming
+the columns and the target they collide on: two entries sharing a target, and a
+single entry aimed at another column's own name (`{"joint_0": "joint_1"}` on
+`joint_pos` names only real columns and still costs a joint). Renaming *every*
+column is a bijection and is accepted.
+
 `joint_pos` needs seven joint values plus a gripper, and it reads them in the
 order you declare with `set_robot_state_keys()`. Declaring that order is what
 every example here does, and it is what binds the request to the joints you mean.

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -133,8 +133,12 @@ class Cosmos3Policy(Policy):
             request reaches the server.
         action_mapping: ``{action_column_name: robot_actuator_name}``. Renames
             the embodiment's action-layout columns to robot actuator names.
-            Keys are validated against the active layout at construction.
-            When ``None``, columns keep their layout names.
+            Validated against the active layout at construction, before any
+            request reaches the server: keys must name real columns, and the
+            rename must be injective. Two columns arriving at one actuator name
+            are refused rather than collapsed, since a per-step action dict
+            holds one entry per column and the losing column's command would be
+            dropped. When ``None``, columns keep their layout names.
         robot: Convenience - name of a known robot (``"panda"``/``"franka"``)
             whose built-in DROID-layout action mapping is applied when
             ``action_mapping`` is not given. Explicit ``action_mapping`` wins.
@@ -272,12 +276,38 @@ class Cosmos3Policy(Policy):
         # RoboLab server's post-processed ``action_space`` layout (joint_pos /
         # midtrain); ``diffusers`` returns the model's raw unified action named
         # by ``raw_action_layout``. Validate against whichever is active.
-        layout_cols = set(self._active_action_layout())
+        layout = self._active_action_layout()
+        layout_cols = set(layout)
         bad = [k for k in self._action_mapping if k not in layout_cols]
         if bad:
             raise ValueError(
                 f"action_mapping keys {bad} are not in the {self.embodiment.name!r} "
                 f"{backend!r}-backend action layout. Valid columns: {sorted(layout_cols)}"
+            )
+        # The rename must also be injective, which is the other half of the same
+        # caller mistake. ``_unpack_actions`` emits one dict entry per action
+        # column, so two columns arriving at one actuator name collapse into a
+        # single entry: the column written last wins and every other column's
+        # command is DROPPED. Nothing downstream can notice - the chunk still
+        # unpacks, the step dict is still well-formed, and the actuator whose
+        # column was swallowed simply holds position while the model asked it to
+        # move. Two shapes get past the key check above, and neither is a typo
+        # that check can see: two entries sharing one target, and a single entry
+        # whose target is another column's own unmapped name (on the DROID
+        # ``[joint_0..joint_6, gripper]`` layout, ``{"joint_0": "joint_1"}`` names
+        # only real columns and still costs a joint).
+        arrivals: dict[str, list[str]] = {}
+        for column in layout:
+            arrivals.setdefault(self._action_mapping.get(column, column), []).append(column)
+        collisions = {name: cols for name, cols in arrivals.items() if len(cols) > 1}
+        if collisions:
+            detail = "; ".join(f"{cols} -> {name!r}" for name, cols in sorted(collisions.items()))
+            raise ValueError(
+                f"action_mapping is not a rename: {detail}. Every column of the "
+                f"{self.embodiment.name!r} {backend!r}-backend action layout needs its own "
+                "actuator name, because a per-step action dict holds one entry per column - "
+                "columns arriving at one name collapse into a single entry and only the "
+                f"last column's value survives. Active layout: {layout}"
             )
         # ``mode`` (policy / forward_dynamics / inverse_dynamics) is a diffusers-
         # only physics surface (CosmosActionCondition.mode). The service RoboLab

--- a/tests/policies/cosmos3/test_action_mapping_is_a_rename.py
+++ b/tests/policies/cosmos3/test_action_mapping_is_a_rename.py
@@ -1,0 +1,150 @@
+"""``action_mapping`` renames action columns; it cannot merge two of them.
+
+:class:`~strands_robots.policies.cosmos3.policy.Cosmos3Policy` unpacks a
+``[T, D]`` action chunk into one dict entry per column, keyed by the column's
+name after the caller's ``action_mapping`` rename. A dict holds one value per
+key, so two columns arriving at one actuator name collapse into a single entry:
+the column written last wins and the other column's command is dropped. The
+chunk still unpacks and the step dict is still well-formed, so the only visible
+trace is an actuator that holds position while the model asked it to move.
+
+The construction-time check on mapping *keys* exists for the neighbouring
+mistake ("a typo'd rename can't silently emit a key the robot never consumes").
+These cells hold the target side of the same dict to the same standard, and pin
+that a rename which does not collide still delivers every column unchanged.
+"""
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.cosmos3 import Cosmos3Policy
+from strands_robots.policies.cosmos3.embodiments import ROBOT_ACTION_MAPPINGS, get_embodiment
+
+# The released DROID joint_pos layout: 7 joints plus a gripper.
+DROID_JOINT_POS = ["joint_0", "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "gripper"]
+WIDTH = len(DROID_JOINT_POS)
+
+
+class RecordingClient:
+    """Records every ``infer`` call so a refusal can be shown to precede one."""
+
+    def __init__(self, action: np.ndarray) -> None:
+        self._action = action
+        self.infer_calls = 0
+
+    def infer(self, observation: dict) -> dict:
+        self.infer_calls += 1
+        return {"action": self._action, "server_timing": {}}
+
+    def reset(self) -> None:
+        pass
+
+    def get_server_metadata(self) -> dict:
+        return {}
+
+
+def _chunk() -> np.ndarray:
+    """A chunk whose value states its own column, so a swap is readable."""
+    return np.tile(np.arange(WIDTH, dtype=np.float32), (4, 1))
+
+
+def _observation() -> dict:
+    image = np.zeros((360, 640, 3), dtype=np.uint8)
+    obs: dict = {
+        key: image
+        for key in (
+            "observation/wrist_image_left",
+            "observation/exterior_image_1_left",
+            "observation/exterior_image_2_left",
+        )
+    }
+    for i in range(7):
+        obs[f"joint_{i}"] = float(i) * 0.1
+    obs["gripper"] = 0.5
+    return obs
+
+
+def _rollout(mapping: dict[str, str] | None) -> tuple[list[dict], RecordingClient]:
+    client = RecordingClient(_chunk())
+    policy = Cosmos3Policy(
+        embodiment="droid",
+        # A recording stand-in for the WebSocket client (dependency injection).
+        client=client,  # type: ignore[arg-type]
+        action_mapping=mapping,
+    )
+    policy.set_robot_state_keys([f"joint_{i}" for i in range(7)] + ["gripper"])
+    return asyncio.run(policy.get_actions(_observation(), "pick up the cube")), client
+
+
+# (mapping, the columns that would arrive together, the name they collide on)
+COLLIDING = {
+    "two entries share one target": ({"joint_0": "j6", "joint_1": "j6"}, ["joint_0", "joint_1"], "j6"),
+    "one entry onto a sibling column's own name": ({"joint_0": "joint_1"}, ["joint_0", "joint_1"], "joint_1"),
+    "one entry onto the gripper column's name": ({"joint_6": "gripper"}, ["joint_6", "gripper"], "gripper"),
+    # The reverse of the row above, and the sharper one: the surviving entry is
+    # keyed on a JOINT and carries the GRIPPER's value, so the joint is
+    # mis-commanded rather than merely uncommanded.
+    "the gripper column onto a joint's name": ({"gripper": "joint_6"}, ["joint_6", "gripper"], "joint_6"),
+    "a whole layout folded onto one actuator": (
+        dict.fromkeys(DROID_JOINT_POS, "everything"),
+        DROID_JOINT_POS,
+        "everything",
+    ),
+}
+
+NOT_COLLIDING = {
+    "no mapping at all": None,
+    "distinct fresh targets": {"joint_0": "shoulder_pan", "gripper": "grip"},
+    # A shift of *every* column is a bijection, so it is a legitimate rename
+    # even though each individual target is another column's source name.
+    "a shift of every column": {f"joint_{i}": f"joint_{i + 1}" for i in range(7)},
+}
+
+
+class TestACollidingRenameIsRefused:
+    """A mapping that would merge two columns is refused, naming both."""
+
+    @pytest.mark.parametrize(("mapping", "columns", "target"), COLLIDING.values(), ids=list(COLLIDING))
+    def test_construction_refuses_and_names_both_columns_and_the_target(self, mapping, columns, target):
+        with pytest.raises(ValueError, match="action_mapping is not a rename") as excinfo:
+            Cosmos3Policy(embodiment="droid", client=RecordingClient(_chunk()), action_mapping=mapping)
+        message = str(excinfo.value)
+        for column in columns:
+            assert column in message, f"the refusal does not name the colliding column {column!r}"
+        assert repr(target) in message, "the refusal does not name the target the columns collide on"
+
+    def test_the_refusal_precedes_any_inference(self):
+        """Refused client-side, before a request reaches the server."""
+        client = RecordingClient(_chunk())
+        with pytest.raises(ValueError, match="action_mapping is not a rename"):
+            Cosmos3Policy(embodiment="droid", client=client, action_mapping={"joint_6": "gripper"})
+        assert client.infer_calls == 0
+
+
+class TestARenameThatDoesNotCollideDeliversEveryColumn:
+    """The control: an injective rename is untouched by the refusal."""
+
+    @pytest.mark.parametrize("mapping", NOT_COLLIDING.values(), ids=list(NOT_COLLIDING))
+    def test_every_column_of_the_chunk_reaches_its_own_key(self, mapping):
+        steps, client = _rollout(mapping)
+        assert client.infer_calls == 1
+        for step in steps:
+            assert len(step) == WIDTH, f"a {WIDTH}-column chunk unpacked to {len(step)} keys: {sorted(step)}"
+            expected = {
+                (mapping or {}).get(column, column): float(index) for index, column in enumerate(DROID_JOINT_POS)
+            }
+            assert step == expected
+
+    def test_every_built_in_robot_mapping_is_injective(self):
+        """Derived floor: a built-in mapping added later is graded on arrival."""
+        assert ROBOT_ACTION_MAPPINGS, "no built-in mappings to grade"
+        for robot in ROBOT_ACTION_MAPPINGS:
+            steps, _ = _rollout(dict(ROBOT_ACTION_MAPPINGS[robot]))
+            assert len(steps[0]) == WIDTH, f"the built-in {robot!r} mapping merges columns: {sorted(steps[0])}"
+
+
+def test_the_droid_layout_this_module_reasons_about_is_the_shipped_one():
+    """Anchor the hand-written layout to the registry it stands in for."""
+    assert get_embodiment("droid").action_layouts["joint_pos"] == DROID_JOINT_POS

--- a/tests/policies/cosmos3/test_policy.py
+++ b/tests/policies/cosmos3/test_policy.py
@@ -106,6 +106,10 @@ def test_action_mapping_renames_columns():
     assert "shoulder_pan" in out[0]
     assert "grip" in out[0]
     assert "joint_0" not in out[0]
+    # A rename must be a rename: the step dict still carries one entry per
+    # action column. Membership alone would also hold for a mapping that
+    # merged two columns into one key and dropped a command.
+    assert len(out[0]) == 8
 
 
 def test_default_prompt_used_when_instruction_empty():


### PR DESCRIPTION
`Cosmos3Policy._unpack_actions` emits **one dict entry per action column**, keyed by the column's name after the caller's `action_mapping` rename. A dict holds one value per key, so two columns arriving at one actuator name collapsed into a single entry: the column written last won, the other column's command was dropped, and the chunk still unpacked with `status="success"`.

Construction already validated the mapping's **keys**, on its own stated reasoning - *"a typo'd rename can't silently emit a key the robot never consumes"* (`policy.py:269`). The **target** side of the same dict was unchecked. That is the other half of one caller mistake, and the key check cannot see either spelling of it, because both name only real columns.

![measured before/after](https://raw.githubusercontent.com/cagataycali/robots/efcff9bdbb7d227600fb67bae97648b084c5aa85/.artifacts/cosmos3_action_mapping_collision.png)

## Measured

DROID `joint_pos` layout `[joint_0..joint_6, gripper]`, an 8-column chunk whose every value states its own column index, driven through the public `get_actions` on both trees:

| `action_mapping` | before | after |
|---|---|---|
| `None` | 8 of 8 delivered | 8 of 8 delivered |
| `{joint_0: shoulder_pan, gripper: grip}` | 8 of 8 delivered | 8 of 8 delivered |
| `{joint_i: joint_i+1}` for all 7 | 8 of 8 delivered | 8 of 8 delivered |
| `{joint_0: j, joint_1: j}` | **7 keys**, `joint_0` uncommanded | refused |
| `{joint_0: joint_1}` | **7 keys**, `joint_0` uncommanded | refused |
| `{joint_6: gripper}` | **7 keys**, `joint_6` uncommanded | refused |
| `{gripper: joint_6}` | **7 keys**, `joint_6` <- col 7 | refused |

Three things the table is there to say:

1. **One entry is enough.** `{"joint_0": "joint_1"}` names only columns that exist, passes the key check, and costs a joint. No typo, no unknown name.
2. **The reverse is worse than a drop.** `{"gripper": "joint_6"}` delivered `joint_6 = 7.0` - *the gripper's* value - while the gripper was never commanded at all. A joint mis-actuated with a gripper command, reported as success.
3. **Which column survives is decided by layout order**, not by anything the caller wrote, since the last write into the dict wins.

Renaming *every* column is a bijection, so it is a legitimate rename and stays accepted - that row is the control that keeps the refusal from being "no target may be a column name".

## Change

One block beside the existing key check, over the same layout: group the columns by the name each arrives at, and refuse any name reached by more than one. Refused at construction, before any request reaches the server - the standard the neighbouring camera-mapping validation already sets (*"raises a client-side ValueError naming the missing keys, before any request reaches the server"*).

```
ValueError: action_mapping is not a rename: ['joint_6', 'gripper'] -> 'gripper'.
Every column of the 'droid' 'service'-backend action layout needs its own actuator
name, because a per-step action dict holds one entry per column - columns arriving
at one name collapse into a single entry and only the last column's value survives.
Active layout: ['joint_0', ..., 'joint_6', 'gripper']
```

Trimming is not an option here: the swallowed column is a value the model produced for an actuator, so silently not commanding it leaves the arm executing part of the predicted action.

## Tests

`tests/policies/cosmos3/test_action_mapping_is_a_rename.py`, table-driven and graded through public `get_actions` / construction - no new private symbol is imported.

| | |
|---|---|
| pre-fix (base source + this file) | **6 failed / 5 passed**, every failure `DID NOT RAISE` |
| post-fix | **11 passed** |
| controls (green on both trees) | the 3 non-colliding mappings, the built-in-mapping floor, the layout anchor |

- 5 collision shapes parametrized; each asserts the refusal names **both** colliding columns and the target.
- One cell pins that the refusal precedes any inference (the injected client records 0 `infer` calls).
- The non-colliding rows assert the whole step dict equals the expected per-column mapping, so a future change that reorders or renames a surviving column fails here too - not just `len(step) == 8`.
- A derived floor walks `ROBOT_ACTION_MAPPINGS`, so a built-in mapping added later is graded on arrival.
- `test_the_droid_layout_this_module_reasons_about_is_the_shipped_one` anchors the hand-written layout to the registry it stands in for.

Retargeted rather than deleted: `test_action_mapping_renames_columns` asserted membership only (`"shoulder_pan" in out[0]`), which also holds for a mapping that merged two columns and dropped a command. It now states the count.

## Gate

| | base | this branch |
|---|---|---|
| `pytest tests/policies` | 12 failed / 5491 passed | 12 failed / **5501** passed (+10 = exactly the new cells), failing node ids **set-identical** |
| `scripts/check_whole_tree_graders.py` | 13F / 4307P / 56s / 4E | **identical** |
| `ruff check` + `ruff format --check` (`strands_robots tests tests_integ`) | clean | clean, 1873 files |
| `mypy` (1.20.2, same scope) | 1 error (`simulation/ik.py:174`, pre-existing) | **identical** |

The 12 `tests/policies` failures and the graders' 13F/4E are pre-existing on `main` in this environment (a newer installed `lerobot` than the pin resolves).

## Size

`+208 / -3` over 5 files: 36 in `policy.py` (executable statements 186 -> 194, i.e. 8 - the rest is the comment stating why the check exists), 150 for the new test module, 4 retargeting the existing pin, 9 in `docs/policies/cosmos3.md`, 12 for the changelog fragment.

## Scope

The `vera` provider builds its per-step dict the same way (`provider.py:672`), but its column names come from runtime `action_dim` and `robot_state_keys` rather than a layout known at construction, so the same rule needs a different owner there. Not touched here.