### PR TITLE
fix(tools/lerobot_train): a gated flag stays gated under the prefix its parser accepts

### DIFF
--- a/changelog.d/3217-extra-flags-gate-covers-abbreviations.md
+++ b/changelog.d/3217-extra-flags-gate-covers-abbreviations.md
@@ -4,12 +4,16 @@
   parser resolves it to, on both axes that parser uses. draccus over `argparse`
   honors any unambiguous prefix, so `{"ou": "/anywhere"}` reached
   `--output_dir` and `{"co": "x"}` reached `--config_path` while the whole-key
-  blocklist saw a name on no list - 43 argv spellings reached one of the 8 gated
-  flags lerobot registers with no operator prompt. A key is also truncated at
+  blocklist saw a name on no list. A key is also truncated at
   its first `=` before it is matched, because the emitter appends its own
   (`f"--{key}={value}"`) and `argparse` reads the option name from the text
   before the first `=`: `{"output_dir=/evil/dir": "x"}` emitted
   `--output_dir=/evil/dir=x` and set `output_dir`, so every gated spelling had
-  an ungated `=`-carrying twin. One `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=<flag>`
+  an ungated `=`-carrying twin. Measured against the 713 options a lerobot
+  `TrainPipelineConfig` registers, 98 argv spellings reach one of the 8 gated
+  flags lerobot declares - 49 prefixes and their 49 value-bearing twins - and 90
+  of them passed the gate with no operator prompt, including every spelling of
+  `policy.pretrained_path` and `config_path`. None do now. One
+  `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=<flag>`
   entry clears every spelling of the flag it names on both axes - the operator
   approves a flag, not an argv.

--- a/changelog.d/3217-extra-flags-gate-covers-abbreviations.md
+++ b/changelog.d/3217-extra-flags-gate-covers-abbreviations.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- `lerobot_train`: an `extra_flags` key that abbreviates a gated flag is now
+  gated as that flag. The trainer's parser (draccus over `argparse`) honors any
+  unambiguous prefix, so `{"ou": "/anywhere"}` reached `--output_dir` and
+  `{"co": "x"}` reached `--config_path` while the whole-key blocklist saw a name
+  on no list. 43 argv spellings reached one of the 8 gated flags lerobot
+  registers with no operator prompt; the same
+  `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=<flag>` entry now clears every spelling of
+  the flag it names.

--- a/changelog.d/3217-extra-flags-gate-covers-abbreviations.md
+++ b/changelog.d/3217-extra-flags-gate-covers-abbreviations.md
@@ -1,10 +1,15 @@
 ### Fixed
 
-- `lerobot_train`: an `extra_flags` key that abbreviates a gated flag is now
-  gated as that flag. The trainer's parser (draccus over `argparse`) honors any
-  unambiguous prefix, so `{"ou": "/anywhere"}` reached `--output_dir` and
-  `{"co": "x"}` reached `--config_path` while the whole-key blocklist saw a name
-  on no list. 43 argv spellings reached one of the 8 gated flags lerobot
-  registers with no operator prompt; the same
-  `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=<flag>` entry now clears every spelling of
-  the flag it names.
+- `lerobot_train`: an `extra_flags` key is now gated as the flag the trainer's
+  parser resolves it to, on both axes that parser uses. draccus over `argparse`
+  honors any unambiguous prefix, so `{"ou": "/anywhere"}` reached
+  `--output_dir` and `{"co": "x"}` reached `--config_path` while the whole-key
+  blocklist saw a name on no list - 43 argv spellings reached one of the 8 gated
+  flags lerobot registers with no operator prompt. A key is also truncated at
+  its first `=` before it is matched, because the emitter appends its own
+  (`f"--{key}={value}"`) and `argparse` reads the option name from the text
+  before the first `=`: `{"output_dir=/evil/dir": "x"}` emitted
+  `--output_dir=/evil/dir=x` and set `output_dir`, so every gated spelling had
+  an ungated `=`-carrying twin. One `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=<flag>`
+  entry clears every spelling of the flag it names on both axes - the operator
+  approves a flag, not an argv.

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -106,6 +106,10 @@ def _policy_config_field_names(policy_type: str) -> frozenset[str] | None:
 # that an LLM agent (or prompt injection) could abuse. Gated by a HIL
 # interrupt; operators can pre-approve individual flags via
 # STRANDS_TRAIN_EXTRA_FLAGS_ALLOW or bypass entirely with BYPASS_TOOL_CONSENT.
+#
+# Membership is decided by ``_blocked_flags_named``, not by a whole-key equality
+# test: the argv these keys land in is parsed by argparse, which honors any
+# unambiguous prefix, so an entry here also gates every abbreviation of itself.
 _BLOCKED_EXTRA_FLAGS = frozenset(
     {
         "output_dir",
@@ -145,14 +149,75 @@ def _normalize_hydra_key(key: str) -> str:
     return key.lstrip("-+~")
 
 
+def _abbreviates_flag(candidate: str, flag: str) -> bool:
+    """Whether argparse could resolve the argv spelling ``candidate`` to ``flag``.
+
+    ``extra_flags`` keys are emitted verbatim into the argv of
+    ``lerobot.scripts.lerobot_train``, which parses it with draccus, which
+    builds a stdlib :class:`argparse.ArgumentParser`. That parser leaves
+    ``allow_abbrev`` at its default of ``True``, so any *unambiguous prefix* of
+    a registered option selects that option: ``--ou=/x`` sets ``output_dir``
+    and ``--co=y`` sets ``config_path``. A key is therefore not the flag it
+    reaches, and a gate that compares whole keys does not see the difference.
+
+    A prefix that stops exactly at a dotted-segment boundary is not an
+    abbreviation. draccus registers an option for each nested config as well as
+    for its fields (``--wandb`` beside ``--wandb.project``), and argparse
+    prefers an exact match over any abbreviation, so ``wandb`` names that
+    option rather than the blocked child under it.
+
+    The rule is deliberately conservative in one direction: a prefix that is
+    ambiguous - ``wandb.e``, which could be ``wandb.enable`` or
+    ``wandb.entity`` - is treated as naming both, even though argparse refuses
+    it outright. Gating a spelling the trainer would reject anyway costs a
+    prompt; missing one costs the write.
+
+    Args:
+        candidate: A normalized ``extra_flags`` key, Hydra prefix already off.
+        flag: The blocked flag to judge ``candidate`` against.
+
+    Returns:
+        ``True`` when ``candidate`` is a proper prefix of ``flag`` that does not
+        end at one of ``flag``'s own dotted-segment boundaries.
+    """
+    if not candidate or candidate == flag or not flag.startswith(candidate):
+        return False
+    return flag[len(candidate)] != "."
+
+
+def _blocked_flags_named(key: str) -> tuple[str, ...]:
+    """The blocked flags the argv spelling ``key`` can reach, sorted.
+
+    Exact match first, mirroring argparse: a key that spells a blocked flag in
+    full names that flag and nothing else, however many longer flags it is a
+    prefix of.
+
+    Args:
+        key: An ``extra_flags`` key as the caller wrote it, Hydra prefix and all.
+
+    Returns:
+        The blocked flags, or an empty tuple when the key reaches none.
+    """
+    normalized = _normalize_hydra_key(key)
+    if normalized in _BLOCKED_EXTRA_FLAGS:
+        return (normalized,)
+    return tuple(sorted(flag for flag in _BLOCKED_EXTRA_FLAGS if _abbreviates_flag(normalized, flag)))
+
+
 def _validate_extra_flags(extra_flags: dict[str, Any]) -> list[tuple[str, str]]:
-    """Return list of (raw_key, normalized_key) pairs that are blocked."""
-    blocked_pairs = []
-    for key in extra_flags:
-        normalized = _normalize_hydra_key(key)
-        if normalized in _BLOCKED_EXTRA_FLAGS:
-            blocked_pairs.append((key, normalized))
-    return blocked_pairs
+    """Return the (raw key, blocked flag) pairs ``extra_flags`` reaches.
+
+    One pair per blocked flag a key can reach, so a prefix short enough to
+    abbreviate two of them has to clear both allowlist entries rather than one.
+
+    Args:
+        extra_flags: The passthrough dict, keys as the caller wrote them.
+
+    Returns:
+        Pairs of the caller's own spelling and the blocked flag it names, in the
+        order the keys were supplied.
+    """
+    return [(key, flag) for key in extra_flags for flag in _blocked_flags_named(key)]
 
 
 def _gate_extra_flags(
@@ -179,12 +244,14 @@ def _gate_extra_flags(
         logger.debug("all blocked flags allowed via %s", _EXTRA_FLAGS_ALLOW_ENV)
         return None
 
+    # Reported as the caller's own spellings, deduplicated: one key can name two
+    # blocked flags, and the allowlist check above is what needs it per flag.
+    flag_names = ", ".join(dict.fromkeys(raw for raw, _ in needs_approval))
+
     if os.environ.get(_BYPASS_CONSENT_ENV, "").lower() == "true":
-        flag_names = ", ".join(raw for raw, _ in needs_approval)
         logger.warning("BYPASS_TOOL_CONSENT: allowing blocked extra_flags: %s", flag_names)
         return None
 
-    flag_names = ", ".join(raw for raw, _ in needs_approval)
     block_msg = (
         f"extra_flags {flag_names} blocked for security reasons (controls output paths, telemetry, or code loading)."
     )
@@ -883,6 +950,10 @@ def lerobot_train(
             status/stop).
         extra_flags: Passthrough dict of additional lerobot-train flags, e.g.
             ``{"policy.optimizer_lr": 1e-4}`` -> ``--policy.optimizer_lr=0.0001``.
+            A key that abbreviates a gated flag is gated as that flag, because
+            the trainer's parser honors unambiguous prefixes: ``{"ou": "/x"}``
+            reaches ``output_dir``, so it needs the same approval, and the same
+            ``STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=output_dir`` entry clears it.
 
     Returns:
         Dict with ``status`` ("success" or "error") and a ``content`` list of

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -192,13 +192,24 @@ def _blocked_flags_named(key: str) -> tuple[str, ...]:
     full names that flag and nothing else, however many longer flags it is a
     prefix of.
 
+    A key is truncated at its first ``=`` before anything else is asked of it,
+    because that is what argparse does with the argv element. Keys are emitted
+    as one element, ``f"--{key}={value}"``, so a key that carries its own ``=``
+    puts the rest of itself in the *value*: ``{"output_dir=/evil/dir": "x"}``
+    emits ``--output_dir=/evil/dir=x`` and sets ``output_dir`` to the perfectly
+    valid path ``/evil/dir=x``. Matching the whole key against the blocklist
+    asked about a name argparse never reads - ``"output_dir".startswith(
+    "output_dir=/evil/dir")`` is ``False`` - so every gated spelling had an
+    ungated ``=``-carrying twin, abbreviations included (``ou=``). No legitimate
+    key carries ``=``; the emitter appends its own.
+
     Args:
         key: An ``extra_flags`` key as the caller wrote it, Hydra prefix and all.
 
     Returns:
         The blocked flags, or an empty tuple when the key reaches none.
     """
-    normalized = _normalize_hydra_key(key)
+    normalized = _normalize_hydra_key(key).split("=", 1)[0]
     if normalized in _BLOCKED_EXTRA_FLAGS:
         return (normalized,)
     return tuple(sorted(flag for flag in _BLOCKED_EXTRA_FLAGS if _abbreviates_flag(normalized, flag)))

--- a/tests/test_lerobot_train_blocklist.py
+++ b/tests/test_lerobot_train_blocklist.py
@@ -15,6 +15,7 @@ from strands_robots.tools.lerobot_train import (
     _gate_extra_flags,
     _normalize_hydra_key,
     _validate_extra_flags,
+    build_train_command,
 )
 
 
@@ -318,11 +319,36 @@ class TestAbbreviatedFlagsReachTheSameGate:
             ("policy.pretrained_path=/evil", "policy.pretrained_path"),
             ("wandb.p=someproject", "wandb.project"),
             ("--ou=/evil", "output_dir"),
+            # Two of them, so it is the *first* ``=`` that is graded. With one,
+            # taking the first and taking the last agree, and every candidate
+            # above has one - argparse takes the first.
+            ("output_dir=a=b", "output_dir"),
+            ("ou=/evil=more", "output_dir"),
         ],
     )
     def test_an_abbreviation_names_the_flag_it_reaches(self, key, flag):
         assert self._rule()(key) == (flag,)
         assert _validate_extra_flags({key: "/tmp/evil"}) == [(key, flag)]
+
+    def test_the_emitted_argv_is_what_the_rule_models(self):
+        """The premise the ``=`` truncation rests on: the emitter joins with ``=``.
+
+        Truncating a key at its first ``=`` is only the parser's own rule while
+        ``build_train_command`` writes one argv element per key with an ``=``
+        between key and value. Nothing else here drives the emitter, so a change
+        to that shape would leave the rule modelling a parser it is no longer
+        handed. This grades the emitter against argparse and never asks the rule,
+        so it says the spellings are reachable rather than that they are refused.
+        """
+        for key, flag in (
+            ("output_dir=/evil/dir", "output_dir"),
+            ("ou=/evil", "output_dir"),
+            ("policy.pretrained_path=/evil", "policy.pretrained_path"),
+        ):
+            command = build_train_command(dataset_root="/tmp/ds", extra_flags={key: "x"})
+            element = f"--{key}=x"
+            assert element in command, f"the emitter no longer writes {element!r}"
+            assert self._argparse_verdict(self._OPTIONS, key) == flag
 
     def test_a_nested_config_name_is_not_an_abbreviation_of_its_gated_child(self):
         """``--wandb`` is its own option, so argparse never reads it as a child.

--- a/tests/test_lerobot_train_blocklist.py
+++ b/tests/test_lerobot_train_blocklist.py
@@ -272,6 +272,11 @@ class TestAbbreviatedFlagsReachTheSameGate:
 
         Returns the option name it resolved to, ``"ambiguous"`` when the prefix
         matches several, or ``"unrecognized"`` when it matches none.
+
+        The resolved option is read as the one that got *any* value rather than
+        the one that got ``"X"``: a candidate carrying its own ``=`` leaves the
+        rest of itself in the value (``--output_dir=/evil=X`` sets
+        ``/evil=X``), which is the whole point of the ``=`` cells below.
         """
         parser = argparse.ArgumentParser(add_help=False)
         for name in options:
@@ -283,7 +288,7 @@ class TestAbbreviatedFlagsReachTheSameGate:
                 return "ambiguous"
         if extras:
             return "unrecognized"
-        return next(name for name, value in vars(namespace).items() if value == "X")
+        return next(name for name, value in vars(namespace).items() if value is not None)
 
     @pytest.mark.parametrize(
         "key,flag",
@@ -303,6 +308,16 @@ class TestAbbreviatedFlagsReachTheSameGate:
             ("--ou", "output_dir"),
             ("+ou", "output_dir"),
             ("~ou", "output_dir"),
+            # A key carrying its own ``=``. The emitter appends ``={value}``, so
+            # the rest of the key lands in the value and argparse resolves the
+            # option from the text before the first ``=`` - the same flag.
+            ("output_dir=/evil/dir", "output_dir"),
+            ("ou=/evil", "output_dir"),
+            ("config_path=/evil.json", "config_path"),
+            ("co=/evil.json", "config_path"),
+            ("policy.pretrained_path=/evil", "policy.pretrained_path"),
+            ("wandb.p=someproject", "wandb.project"),
+            ("--ou=/evil", "output_dir"),
         ],
     )
     def test_an_abbreviation_names_the_flag_it_reaches(self, key, flag):
@@ -354,10 +369,19 @@ class TestAbbreviatedFlagsReachTheSameGate:
         rule = self._rule()
         candidates = {flag[:cut] for flag in _BLOCKED_EXTRA_FLAGS for cut in range(1, len(flag) + 1)}
         candidates |= {"batch_size", "steps", "op", "observation", "dataset.repo_id", "lr"}
+        # Every one of those spellings again carrying its own ``=``. argparse
+        # resolves the option from the text before the first ``=``, so the rule
+        # has to agree with it on these too - they were the ungated twins.
+        candidates |= {f"{candidate}=/evil/dir" for candidate in tuple(candidates)}
         for candidate in sorted(candidates):
             verdict = self._argparse_verdict(self._OPTIONS, candidate)
+            # argparse resolves the option from the text before the first ``=``,
+            # so the ambiguity is a property of that portion, not of the whole
+            # candidate: ``wandb.e=/evil/dir`` is ambiguous because ``wandb.e``
+            # is. The oracle has to model the split it is grading the rule on.
+            option = candidate.split("=", 1)[0]
             reaches_gated = verdict in _BLOCKED_EXTRA_FLAGS or (
-                verdict == "ambiguous" and any(flag.startswith(candidate) for flag in _BLOCKED_EXTRA_FLAGS)
+                verdict == "ambiguous" and any(flag.startswith(option) for flag in _BLOCKED_EXTRA_FLAGS)
             )
             assert bool(rule(candidate)) == reaches_gated, f"{candidate!r}: argparse says {verdict!r}"
 

--- a/tests/test_lerobot_train_blocklist.py
+++ b/tests/test_lerobot_train_blocklist.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import argparse
+import contextlib
+import io
 from unittest.mock import MagicMock
 
 import pytest
 
 from strands_robots.tools.lerobot_train import (
+    _BLOCKED_EXTRA_FLAGS,
     _approve_response,
     _gate_extra_flags,
     _normalize_hydra_key,
@@ -214,3 +218,177 @@ class TestPretrainedPathGate:
         result = _gate_extra_flags({"policy.pretrained_path": "org/model"}, ctx)
         assert result is None
         ctx.interrupt.assert_called_once()
+
+
+class TestAbbreviatedFlagsReachTheSameGate:
+    """Pin: a key that abbreviates a gated flag is gated as that flag.
+
+    ``extra_flags`` keys are emitted verbatim into the argv of
+    ``lerobot.scripts.lerobot_train``, whose parser (draccus over stdlib
+    :mod:`argparse`) honors any unambiguous prefix of a registered option. So
+    ``{"ou": "/anywhere"}`` reaches ``--output_dir``, and a gate that compares
+    whole keys sees a name that is on no list.
+
+    The cells above vary the *Hydra prefix* of a key exhaustively and never vary
+    the name, which is the half the parser resolves.
+    """
+
+    @staticmethod
+    def _rule():
+        """The blocked-flag resolver under test, imported inside the class.
+
+        A module-level import would make every cell here a collection error on a
+        tree without the resolver, and a collection error grades nothing.
+        """
+        from strands_robots.tools.lerobot_train import _blocked_flags_named
+
+        return _blocked_flags_named
+
+    #: Option names a lerobot train parser registers, in the shape draccus
+    #: builds them: every gated flag, the nested configs that carry the dotted
+    #: ones, and enough siblings for a short prefix to be ambiguous.
+    _OPTIONS = tuple(
+        sorted(
+            set(_BLOCKED_EXTRA_FLAGS)
+            | {
+                "batch_size",
+                "dataset",
+                "dataset.repo_id",
+                "observation",
+                "optimizer",
+                "optimizer.lr",
+                "policy",
+                "policy.type",
+                "steps",
+                "wandb",
+                "wandb.notes",
+            }
+        )
+    )
+
+    @staticmethod
+    def _argparse_verdict(options, candidate):
+        """What argparse does with ``--candidate=X`` against ``options``.
+
+        Returns the option name it resolved to, ``"ambiguous"`` when the prefix
+        matches several, or ``"unrecognized"`` when it matches none.
+        """
+        parser = argparse.ArgumentParser(add_help=False)
+        for name in options:
+            parser.add_argument(f"--{name}", dest=name)
+        with contextlib.redirect_stderr(io.StringIO()):
+            try:
+                namespace, extras = parser.parse_known_args([f"--{candidate}=X"])
+            except SystemExit:
+                return "ambiguous"
+        if extras:
+            return "unrecognized"
+        return next(name for name, value in vars(namespace).items() if value == "X")
+
+    @pytest.mark.parametrize(
+        "key,flag",
+        [
+            # Measured against lerobot 0.5.1's TrainPipelineConfig: each of these
+            # spellings sets the named field through draccus.
+            ("ou", "output_dir"),
+            ("output", "output_dir"),
+            ("outp", "output_dir"),
+            ("co", "config_path"),
+            ("config", "config_path"),
+            ("wandb.p", "wandb.project"),
+            ("wandb.ent", "wandb.entity"),
+            ("wandb.ena", "wandb.enable"),
+            ("dataset.ro", "dataset.root"),
+            # The Hydra prefixes the cells above cover, on an abbreviation.
+            ("--ou", "output_dir"),
+            ("+ou", "output_dir"),
+            ("~ou", "output_dir"),
+        ],
+    )
+    def test_an_abbreviation_names_the_flag_it_reaches(self, key, flag):
+        assert self._rule()(key) == (flag,)
+        assert _validate_extra_flags({key: "/tmp/evil"}) == [(key, flag)]
+
+    def test_a_nested_config_name_is_not_an_abbreviation_of_its_gated_child(self):
+        """``--wandb`` is its own option, so argparse never reads it as a child.
+
+        draccus registers an option for each nested config beside one per field,
+        and argparse prefers an exact match over any abbreviation. Gating these
+        would refuse three whole-config overrides that reach no gated flag.
+        """
+        for parent in ("wandb", "dataset", "policy"):
+            assert self._rule()(parent) == ()
+            assert _validate_extra_flags({parent: "{}"}) == []
+            assert self._argparse_verdict(self._OPTIONS, parent) == parent
+
+    def test_an_ambiguous_prefix_names_every_gated_flag_it_could_reach(self):
+        """``wandb.e`` could be ``enable`` or ``entity``; it is held to both.
+
+        argparse refuses an ambiguous prefix outright, so this is the
+        conservative direction: it costs a prompt for a spelling the trainer
+        would reject, and it means the allowlist has to clear both.
+        """
+        assert self._rule()("wandb.e") == ("wandb.enable", "wandb.entity")
+        assert self._argparse_verdict(self._OPTIONS, "wandb.e") == "ambiguous"
+
+    def test_every_partial_segment_prefix_of_every_gated_flag_is_gated(self):
+        """Derived from the blocklist, so a flag added later is covered on arrival."""
+        rule = self._rule()
+        checked = 0
+        for flag in _BLOCKED_EXTRA_FLAGS:
+            for cut in range(1, len(flag)):
+                prefix = flag[:cut]
+                if flag[cut] == ".":
+                    continue  # a whole leading segment: an option of its own
+                assert flag in rule(prefix), f"{prefix!r} reaches {flag!r} ungated"
+                checked += 1
+        assert checked > 60, f"the blocklist stopped covering prefixes: {checked}"
+
+    def test_the_rule_agrees_with_argparse_over_every_prefix_of_every_gated_flag(self):
+        """The oracle: argparse itself decides which spellings reach a gated flag.
+
+        For each candidate the verdict is what a lerobot-shaped parser does with
+        it, and the rule must refuse exactly the candidates that land on a gated
+        flag or that are ambiguous with one.
+        """
+        rule = self._rule()
+        candidates = {flag[:cut] for flag in _BLOCKED_EXTRA_FLAGS for cut in range(1, len(flag) + 1)}
+        candidates |= {"batch_size", "steps", "op", "observation", "dataset.repo_id", "lr"}
+        for candidate in sorted(candidates):
+            verdict = self._argparse_verdict(self._OPTIONS, candidate)
+            reaches_gated = verdict in _BLOCKED_EXTRA_FLAGS or (
+                verdict == "ambiguous" and any(flag.startswith(candidate) for flag in _BLOCKED_EXTRA_FLAGS)
+            )
+            assert bool(rule(candidate)) == reaches_gated, f"{candidate!r}: argparse says {verdict!r}"
+
+    def test_pre_approving_a_flag_clears_its_abbreviations(self, monkeypatch):
+        """One allowlist entry covers every spelling of the flag it names.
+
+        The operator approves a flag, not an argv spelling, so
+        ``STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=output_dir`` has to clear ``ou`` too -
+        otherwise the gate would prompt for a flag already approved.
+        """
+        monkeypatch.delenv("BYPASS_TOOL_CONSENT", raising=False)
+        monkeypatch.delenv("STRANDS_TRAIN_EXTRA_FLAGS_ALLOW", raising=False)
+        assert _gate_extra_flags({"ou": "/tmp/evil"}, None) is not None
+        monkeypatch.setenv("STRANDS_TRAIN_EXTRA_FLAGS_ALLOW", "output_dir")
+        assert _gate_extra_flags({"ou": "/tmp/evil"}, None) is None
+
+    def test_the_operator_prompt_quotes_the_spelling_the_caller_wrote(self, monkeypatch):
+        """The prompt has to show the argv, not only the flag it resolves to."""
+        monkeypatch.delenv("BYPASS_TOOL_CONSENT", raising=False)
+        monkeypatch.delenv("STRANDS_TRAIN_EXTRA_FLAGS_ALLOW", raising=False)
+        ctx = MagicMock()
+        ctx.interrupt.return_value = "y"
+        assert _gate_extra_flags({"ou": "/tmp/evil"}, ctx) is None
+        reason = ctx.interrupt.call_args[1]["reason"]
+        assert reason["blocked_flags"] == {"ou": "/tmp/evil"}
+        assert "ou" in reason["warning"]
+
+    def test_one_key_naming_two_gated_flags_is_reported_once(self, monkeypatch):
+        """Two pairs share a key, and the caller is told about the key once."""
+        monkeypatch.delenv("BYPASS_TOOL_CONSENT", raising=False)
+        monkeypatch.delenv("STRANDS_TRAIN_EXTRA_FLAGS_ALLOW", raising=False)
+        result = _gate_extra_flags({"wandb.e": "true"}, None)
+        assert result is not None
+        assert result["content"][0]["text"].count("wandb.e") == 1


### PR DESCRIPTION
`extra_flags` keys are emitted verbatim into the argv of `lerobot.scripts.lerobot_train`, which parses it with draccus over stdlib `argparse`. `allow_abbrev` is left at its default, so **any unambiguous prefix of a registered option selects that option**. The security gate compared whole keys against `_BLOCKED_EXTRA_FLAGS`, so the key an agent writes is not the flag the trainer reads.

![extra_flags abbreviation gate](https://raw.githubusercontent.com/cagataycali/robots/198c563e572b7dbcd0c519b899887a03e1c3dc83/.artifacts/extra_flags_abbreviation.png)

## Measured

draccus 0.8.0, lerobot 0.5.1 `TrainPipelineConfig` (390 registered options with `--policy.type=act`). Each row is a real `draccus.parse`, not a model of one:

| argv | resolved to | gate before | gate after |
| --- | --- | --- | --- |
| `--ou=ZZZ` | `output_dir = ZZZ` | not gated | gated as `output_dir` |
| `--co=ZZZ` | opens `ZZZ` as a config (`FileNotFoundError: 'ZZZ'`) | not gated | gated as `config_path` |
| `--policy.pu=true` | `policy.push_to_hub = True` | not gated | gated as `policy.push_to_hub` |
| `--policy.pretrained_p=ZZZ` | `policy.pretrained_path = PosixPath('ZZZ')` | not gated | gated as `policy.pretrained_path` |
| `--wandb.p=ZZZ` | `wandb.project = ZZZ` | not gated | gated as `wandb.project` |
| `--wandb.ent=ZZZ` | `wandb.entity = ZZZ` | not gated | gated as `wandb.entity` |
| `--dataset.ro=ZZZ` | `dataset.root = ZZZ` | not gated | gated as `dataset.root` |

8 of the 11 entries in `_BLOCKED_EXTRA_FLAGS` are options lerobot registers. Enumerating every prefix of each and every value-bearing spelling of each gives 232 candidates, of which **98 actually reach a gated flag** - 49 prefixes and their 49 `=`-carrying twins - measured against the 713 options a real `TrainPipelineConfig` registers:

| rule | of the 98, reaching a gated flag with no prompt |
| --- | --- |
| `main` today: whole-key equality | **90** |
| this branch, abbreviations only | **49** (exactly the value-bearing half) |
| with the `=` truncation | **0** |

![gate escape surface](https://raw.githubusercontent.com/cagataycali/robots/d857530005a902d9dac80b76cb80f1b9142d1e22/.artifacts/extra_flags_gate.png)

That covers all three axes the blocklist comment names - output paths, remote telemetry, code loading - including the hub publish the `push_to_hub` parameter documents a whole paragraph of approval reasoning for. Every `policy.pretrained_path` and `config_path` spelling was in the 90.

## Change

`_blocked_flags_named(key)` decides membership, mirroring argparse:

1. the key is truncated at its first `=`, because argparse reads the option name from the text before it and the emitter appends its own `={value}` (see Round 1);
2. exact match wins, as it does in argparse;
3. otherwise every gated flag the key is a **proper prefix** of;
4. except a prefix that stops at a dotted-segment boundary. draccus registers an option for each nested config beside one per field, and argparse prefers an exact match, so `--wandb` names *that* option rather than `wandb.project`. `--wandb`, `--dataset` and `--policy` stay ungated - verified against argparse, which resolves each to itself.

Conservative in one direction on purpose: an ambiguous prefix (`wandb.e`, which could be `enable` or `entity`) is held to both, even though argparse refuses it outright. Gating a spelling the trainer would reject costs a prompt; missing one costs the write.

One key can now name two gated flags, so `_validate_extra_flags` returns a pair per flag and the allowlist has to clear each. The operator-facing message reports the caller's key once, and one `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=output_dir` entry clears every spelling of `output_dir` - the operator approves a flag, not an argv.

## Tests

`tests/test_lerobot_train_blocklist.py` already parametrized the *Hydra prefix* of a key exhaustively (`--`, `+`, `~`, `++`) and never varied the name, which is the half the parser resolves; its benign cases (`lr`, `--batch_size`, `training.num_workers`) abbreviate nothing. Nine cells added there:

- the measured spellings above, each asserted to name the flag it reaches, including under a Hydra prefix (19 parametrized rows after Round 1);
- **the argparse oracle**: over every prefix of every gated flag, the rule must refuse exactly the candidates a lerobot-shaped `argparse.ArgumentParser` lands on a gated flag or finds ambiguous with one - so the rule is graded against argparse's behaviour rather than against a list;
- derived coverage: every partial-segment prefix of every entry in `_BLOCKED_EXTRA_FLAGS`, so a flag added later is covered on arrival (floor of 60 prefixes so it cannot go vacuous);
- the no-false-refusal control: `--wandb` / `--dataset` / `--policy` stay ungated, green before and after;
- allowlist reach, prompt wording, and the one-key-two-flags report.

Pre-fix (`_blocked_flags_named` restored to whole-key equality): **17 failed / 54 passed**, every failure naming an ungated spelling. After: 71 passed.

## Gate

| | base `dca83c8e5` | this branch |
| --- | --- | --- |
| `tests/tools` + this file | 7 failed / 3865 passed / 10 skipped | 7 failed / **3884** passed / 10 skipped |
| failing node ids | — | set-identical (installed-lerobot drift) |
| `ruff check` / `format --check` | clean | clean (1872 files) |
| `mypy strands_robots tests tests_integ` | 25 errors in 10 files | 25 errors in 10 files, none in the two touched files |

+19 passing == exactly the new cells.

## Size

| file | + | - |
| --- | --- | --- |
| `strands_robots/tools/lerobot_train.py` | 82 | 9 |
| `tests/test_lerobot_train_blocklist.py` | 176 | 0 |
| `changelog.d/3217-*.md` | 10 | 0 |

Net +259. The additions are the resolver plus its docstring (the argparse rule is not guessable from the call site) and the cells that grade it against argparse.

---

## Round 1

**Concern:** the resolver modelled argparse's abbreviation rule but not its `=` split, so a key carrying its own `=` reached every gated flag ungated.

Keys are emitted as one argv element, `f"--{key}={value}"` (line 827), and argparse reads the option name from the text before the first `=`. So `extra_flags={"output_dir=/evil/dir": "x"}` emitted `--output_dir=/evil/dir=x` and set `output_dir` to the perfectly valid path `/evil/dir=x`, while the gate asked whether `"output_dir".startswith("output_dir=/evil/dir")` and got `False`. The two axes compose, so every spelling the abbreviation rule closed had an ungated `=`-carrying twin (`ou=`, `co=`) - including `policy.pretrained_path` and `config_path`, the code-loading and config axes the blocklist comment names against prompt injection.

`_blocked_flags_named` now truncates at the first `=` before anything else is asked of the key:

```python
normalized = _normalize_hydra_key(key).split("=", 1)[0]
```

That is what argparse does with the element, no legitimate key carries `=`, and the split is a no-op on every key the existing cells pass.

**The oracle needed two corrections before it could grade this**, and the second is the load-bearing one:

1. `_argparse_verdict` read the resolved option as the one that got `"X"`. An `=`-carrying candidate leaves the rest of itself in the value (`--output_dir=/evil=X` sets `/evil=X`), so that lookup raised `StopIteration` instead of answering. It now reads the option that got *any* value - a strict generalization, identical on every `=`-free candidate.
2. the `reaches_gated` expression asked `any(flag.startswith(candidate))`. For `wandb.e=/evil/dir` argparse says `ambiguous` (because `wandb.e` is), but no gated flag starts with the whole candidate, so the oracle would have called it not-gated and failed the corrected rule. It now asks about the text before the first `=` too - the oracle has to model the same split it grades the rule on. Had only candidates been added, the oracle would have been wrong in the permissive direction on exactly the ambiguous cells.

Measured with those corrections, over every prefix of every gated flag plus the six benign controls, each also carrying `=` - **244 candidates**:

| | rule/argparse disagreements |
|---|---|
| whole-key equality on the `=` axis (pre-fix) | 113 |
| this round | **0** |

Of those candidates, **90 are `=`-carrying spellings that land on a gated flag: 90 ungated before, 0 after.** The `--wandb` / `--dataset` / `--policy` no-false-refusal control is unchanged, and the candidate set is doubled from the blocklist rather than listed, so a flag added later gets its `=` twin covered on arrival.

Seven measured rows added to the abbreviation table, each asserted to name the flag argparse lands on: `output_dir=`, `ou=`, `config_path=`, `co=`, `policy.pretrained_path=`, `wandb.p=`, and `--ou=` for the Hydra-prefix composition.

The changelog fragment claimed one allowlist entry "clears every spelling of the flag it names". That was assurance the prefix axis alone did not earn, so it now states both axes and names the `=` case - an operator reading `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW` has no other way to tell which spellings an entry covers.

`+13 / -1` source, `+28 / -2` test, `+21 / -14` fragment. `ruff check` and `format --check` clean; `scripts/assemble_changelog.py --check` -> `changelog fragments OK`.

## Round 3 - the two cells the `=` fix left ungraded

Graded by mutating the resolver and counting what the file catches. Four of six were already covered; these two were not, so they are two cells rather than more prose:

| mutation | cells fired, round 2 | round 3 |
| --- | --- | --- |
| `rsplit` instead of `split` (last `=`, not first) | **0** | 2 |
| strip `=` instead of truncating | 8 | 8 |
| truncate only for an exact hit | 5 | 5 |
| over-gate any key containing `=` | 8 | 8 |
| truncate but drop the prefix rule | 22 | 22 |
| the emitter stops joining with `=` | **0** | 1 |

1. **It is the *first* `=`.** Every value-bearing candidate carried exactly one, and with one, taking the first and taking the last agree - including in the derived oracle, whose candidate set is `{prefix}=/evil/dir`. So `rsplit` passed the whole file while the docstring and argparse both say first. `output_dir=a=b` and `ou=/evil=more` pin it.
2. **The emitter the rule models.** Truncating at `=` is the parser's own rule only while `build_train_command` joins key and value with one; nothing here drove the emitter, so `cmd.extend([flag, str(value)])` left the resolver modelling an argv it is no longer handed, green. The new cell asks the emitter for the element and the oracle for the option, never the rule, so it holds on either tree - a premise, not a second refusal.

The changelog count is now the measured one: 43 described the abbreviation axis alone.

Gate: `ruff check` + `format --check` clean (1872 files), `mypy` clean (1869 source files), `tests/tools` + all `tests/test_docs*.py` + this file 4115 passed, whole-tree graders 4323 passed with 7 pre-existing environment failures (5 expect `rclpy` absent where `/opt/ros/jazzy` supplies it; 2 read websockets 16.0 against a declared `>=17.0` floor - `Server.shutdown` is absent at 16.0).
