### PR TITLE
fix(policies/wbc): the substep count one action is held for is the count the caller named

### DIFF
--- a/changelog.d/3218-wbc-substep-count-domain.md
+++ b/changelog.d/3218-wbc-substep-count-domain.md
@@ -1,0 +1,38 @@
+### Fixed: `WBCTorqueController`'s substep count is the count the caller named
+
+`WBCTorqueController` declares `owns_stepping`, so
+`physics_substeps_per_control` is not a hint -- it is the number of `mj_step`
+calls one `apply()` makes, and therefore the control period itself. At the SONIC
+0.005 s timestep the upstream `g1_gear_wbc.yaml` cadence of `4` is one inference
+per 20 ms (50 Hz).
+
+It arrived through `max(1, int(physics_substeps_per_control))`, which cannot
+report an unusable count -- it substitutes a usable one. Measured on the shipped
+`unitree_g1` scene, `0`, `-5` and `True` each became `1`, so one action advanced
+5 ms instead of 20 ms and the gait ran at 200 Hz where 50 Hz was asked for;
+`4.9` was truncated to `4` and `"4"` coerced to it. Every one of those rollouts
+completed with nothing naming the count that had been replaced, and
+`float("nan")` raised `ValueError: cannot convert float NaN to integer` from the
+`int()` itself, naming neither the parameter nor the class.
+
+The count is now held to `positive_whole_number_error`, the shared domain whose
+docstring already names "the physics steps one applied action is held for" as
+one of its two families, and which every backend's `send_action(n_substeps=)`
+uses for the same quantity. `PolicyRunner._control_substeps` had already been
+converted away from this exact clamp -- its docstring records that `0`/`-5`
+"silently collapsed to a single physics step" -- so this controller was the
+un-converted copy of a rule the rest of the tree already applies. An integral
+float and a NumPy integer stay first-class, as they are everywhere else in that
+domain; `int()` is applied after the guard rather than before it.
+
+Why a substituted count is not merely a slower rollout: the gait phase advances
+by the control period the loop actually runs at, so a commanded
+`gait_frequency` under a replaced count means something other than steps per
+second, and the robot walks at a rhythm nobody commanded while every reported
+number still looks right.
+
+The existing pin derived its expected physics advance from the attribute the
+controller stored, so it read as correct for any count that had been
+substituted; it now derives it from the nominal decimation. The constructor,
+previously undocumented, gained an `Args:` block -- the parameter that refuses
+is the one a caller most needs documented.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -226,7 +226,14 @@ installs the torque shim (the `WBCTorqueController` PD->torque loop) for the
 duration of the call, then hands the world back afterwards: the controller is
 deregistered from the action-controller seam **and** the actuators are restored,
 so a second `run_policy` on the same sim installs a fresh shim and behaves
-exactly like the first. With the real
+exactly like the first. Constructing the shim directly takes
+`physics_substeps_per_control` - the `mj_step` calls one action is held for,
+which at the SONIC 0.005 s timestep makes the upstream `control_decimation=4`
+one inference per 20 ms (50 Hz). It is the same quantity as `control_substeps`
+and `send_action(n_substeps=)`, held to the same domain: a non-positive or
+non-integral count is refused rather than clamped, because the gait clock
+integrates at the declared control period, so a count other than the one asked
+for would run the gait at a rhythm nobody commanded. With the real
 `GR00T-WholeBodyControl-{Balance,Walk}.onnx` weights and `target_velocity =
 [0.5, 0, 0]` the base advances ~1.9 m over 5 s while holding pelvis height
 ~0.75 m and staying upright. Pass `wbc_install_torque_control=False` to opt out

--- a/strands_robots/policies/wbc/sim_control.py
+++ b/strands_robots/policies/wbc/sim_control.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS, WBCPolicy
+from strands_robots.utils import positive_whole_number_error
 
 if TYPE_CHECKING:
     from strands_robots.simulation.base import SimEngine
@@ -94,6 +95,55 @@ class WBCTorqueController:
         physics_substeps_per_control: int = _CONTROL_DECIMATION,
         world: Any = None,
     ) -> None:
+        """Bind a resolved actuator set to the PD->torque control loop.
+
+        Normally reached through :meth:`from_sim` / :func:`install_wbc_torque_control`,
+        which resolve every id and address below from the compiled model. A direct
+        caller supplies them itself.
+
+        Args:
+            policy: The :class:`~strands_robots.policies.wbc.policy.WBCPolicy`
+                whose ``compute_torques`` PD law converts this step's position
+                targets to joint torques.
+            leg_waist_actuator_ids: Actuator ids of the WBC-driven leg + waist
+                joints, in :data:`WBC_G1_ALL_JOINTS` order.
+            arm_actuator_ids: Actuator ids of the held arm joints - the ones WBC
+                does not drive - in the same order.
+            leg_waist_qpos_addrs, leg_waist_dof_addrs, arm_qpos_addrs, arm_dof_addrs:
+                ``data.qpos`` / ``data.qvel`` addresses of those two joint sets,
+                positionally aligned with the actuator id lists above, so the PD
+                law reads each joint's own position and velocity.
+            saved_actuator_gains: Original ``(gaintype, biastype, gainprm,
+                biasprm, ctrlrange)`` per actuator id, as captured before the
+                flip to torque mode; :meth:`uninstall` restores them.
+            model: The compiled ``mujoco.MjModel`` these ids index.
+            physics_substeps_per_control: ``mj_step`` calls one applied action is
+                held for, as a positive whole number. This is the control period
+                in physics steps - with the SONIC 0.005 s timestep the upstream
+                ``g1_gear_wbc.yaml`` cadence of ``4`` is one inference per 20 ms
+                (50 Hz), which is the rate the policy's gait clock integrates at.
+                It is the same quantity as
+                :meth:`~strands_robots.simulation.policy_runner.PolicyRunner._control_substeps`'
+                ``control_substeps`` and every backend's ``send_action(n_substeps=)``,
+                and it is held to the same shared domain.
+            world: The world whose ``_backend_state`` registered this controller,
+                so :meth:`uninstall` can release that registration too. ``None``
+                when constructed directly: nothing registered it, so there is
+                nothing to release.
+
+        Raises:
+            ValueError: ``physics_substeps_per_control`` is not a positive whole
+                number. It used to be clamped with ``max(1, int(...))``, so ``0``
+                and a negative collapsed to a single physics step - a quarter of
+                the nominal control period, silently running the gait at 200 Hz
+                where 50 Hz was asked for - a non-integral count was truncated,
+                ``True`` acted as ``1``, and a non-finite one raised
+                ``ValueError: cannot convert float NaN to integer`` naming
+                neither the parameter nor this class. The gait clock integrates
+                at the declared control period, so a substep count that is not
+                the one the caller named makes the commanded gait frequency mean
+                something else while every reported number still looks right.
+        """
         self.policy = policy
         self.leg_waist_actuator_ids = list(leg_waist_actuator_ids)
         self.arm_actuator_ids = list(arm_actuator_ids)
@@ -108,7 +158,14 @@ class WBCTorqueController:
         # constructor directly: nothing registered it, so there is nothing to
         # release.
         self._world = world
-        self.physics_substeps_per_control = max(1, int(physics_substeps_per_control))
+        if text := positive_whole_number_error(
+            physics_substeps_per_control, "physics_substeps_per_control", "WBCTorqueController"
+        ):
+            raise ValueError(text)
+        # ``int()`` after the guard, never before: the shared rule has already
+        # compared the coercion back against the value it was given, so an
+        # integral float lands as the count it names instead of a truncation.
+        self.physics_substeps_per_control = int(physics_substeps_per_control)
         # The default-angle hold target, used until the policy returns its first
         # action (a stable first step: PD against the init pose -> ~0 torque).
         # Use the policy's RESOLVED default_angles (config or G1 SONIC fallback),

--- a/tests/policies/wbc/test_sim_control.py
+++ b/tests/policies/wbc/test_sim_control.py
@@ -36,6 +36,7 @@ from strands_robots.policies.wbc.policy import (
     _G1_SONIC_KDS,
     _G1_SONIC_KPS,
 )
+from strands_robots.policies.wbc.sim_control import _CONTROL_DECIMATION
 from strands_robots.simulation.base import SimEngine
 
 
@@ -187,7 +188,11 @@ class TestWBCTorqueController:
         ctrl.apply(action, model, data, "unitree_g1")
 
         # owns_stepping: apply advanced physics by decimation substeps of dt.
-        expected_dt = ctrl.physics_substeps_per_control * float(model.opt.timestep)
+        # Derived from the nominal SONIC decimation, not from the attribute the
+        # controller stored: reading back what was stored made this pass for any
+        # count the constructor substituted (see
+        # ``test_substep_count_domain.py``).
+        expected_dt = _CONTROL_DECIMATION * float(model.opt.timestep)
         assert abs((float(data.time) - t0) - expected_dt) < 1e-6
 
         # At least one driven actuator received a finite torque command.

--- a/tests/policies/wbc/test_substep_count_domain.py
+++ b/tests/policies/wbc/test_substep_count_domain.py
@@ -1,0 +1,269 @@
+"""The substep count one action is held for is the count the caller named.
+
+:class:`WBCTorqueController` declares ``owns_stepping``, so
+``physics_substeps_per_control`` is not a hint - it is the number of ``mj_step``
+calls :meth:`WBCTorqueController.apply` makes, and therefore the control period
+itself: at the SONIC 0.005 s timestep the upstream ``g1_gear_wbc.yaml`` cadence
+of ``4`` is one inference per 20 ms (50 Hz).
+
+It arrived through ``max(1, int(physics_substeps_per_control))``, which cannot
+report an unusable count - it substitutes a usable one. Measured on the real
+``unitree_g1`` scene, one control action then advanced physics by:
+
+=====================  ========  =============  =================  =============
+requested              stored    ``mj_step``s   physics s/action   realised rate
+=====================  ========  =============  =================  =============
+``4`` (SONIC nominal)  ``4``     4              0.0200             50 Hz
+``0``                  ``1``     1              0.0050             200 Hz
+``-5``                 ``1``     1              0.0050             200 Hz
+``True``               ``1``     1              0.0050             200 Hz
+``4.9``                ``4``     4              0.0200             50 Hz
+``"4"``                ``4``     4              0.0200             50 Hz
+=====================  ========  =============  =================  =============
+
+Every row is ``status``-free: the controller constructs, the rollout runs, and
+nothing names the count that was replaced. The three ``1`` rows are the damaging
+ones - a quarter of the control period the caller asked for - and they are the
+same failure ``PolicyRunner._control_substeps`` documents having already been
+converted away from for the identical quantity ("It used to be clamped with
+``max(1, int(override))``, so ``0``/``-5`` silently collapsed to a single
+physics step"). ``float("nan")`` did raise, but as
+``ValueError: cannot convert float NaN to integer`` from ``int()`` - naming
+neither the parameter nor this class.
+
+Why a wrong count is not merely a slower rollout:
+``tests/policies/wbc/test_gait_clock_integrates_at_the_loop_rate.py`` pins that
+the gait phase advances by the control period the loop actually runs at, so a
+commanded ``gait_frequency`` under a substituted count "means something other
+than steps per second ... and the robot walks at a rhythm nobody commanded while
+every reported number looks right".
+
+The count is therefore held to the shared domain its siblings already use -
+:func:`~strands_robots.utils.positive_whole_number_error`, whose own docstring
+names "the physics steps one applied action is held for" as one of its two
+families and explains why ``0`` is refused there rather than honoured. The
+grounding class below asserts the constructor's verdict IS that function's, so
+the two cannot drift, and the first-class table pins the values a caller may
+still legitimately ask for.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc import WBCConfig, WBCPolicy, WBCTorqueController
+from strands_robots.policies.wbc.sim_control import _CONTROL_DECIMATION, _SIM_DT
+from strands_robots.utils import positive_whole_number_error
+
+#: Counts no rollout can be held for, and what the clamp turned each into.
+_UNUSABLE = [
+    pytest.param(0, id="zero-advances-no-physics"),
+    pytest.param(-1, id="negative"),
+    pytest.param(-5, id="negative-large"),
+    pytest.param(True, id="bool-true-acted-as-one"),
+    pytest.param(False, id="bool-false-acted-as-one"),
+    pytest.param(4.9, id="fractional-was-truncated"),
+    pytest.param(0.5, id="fractional-below-one"),
+    pytest.param("4", id="string-was-coerced"),
+    pytest.param(None, id="none"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+]
+
+#: Counts that stay first-class, so the guard cannot creep into refusing a
+#: cadence a caller may legitimately ask for. ``4.0`` and ``np.int64(4)`` are in
+#: the shared domain by documented policy (an integral float computed from a
+#: config, a NumPy integer read off a model).
+_FIRST_CLASS = [
+    pytest.param(_CONTROL_DECIMATION, 4, id="sonic-nominal-four"),
+    pytest.param(1, 1, id="one-physics-step-per-action"),
+    pytest.param(25, 25, id="high-decimation"),
+    pytest.param(4.0, 4, id="integral-float"),
+    pytest.param(np.int64(4), 4, id="numpy-integer"),
+]
+
+
+class _StubSession:
+    """Minimal onnxruntime session stand-in - no SONIC weights needed."""
+
+    class _In:
+        name = "obs"
+
+    def get_inputs(self) -> list[Any]:
+        return [self._In()]
+
+    def run(self, output_names: Any, feed: Any) -> list[np.ndarray]:
+        return [np.zeros((1, 15), dtype=np.float32)]
+
+
+def _g1_policy() -> WBCPolicy:
+    policy = WBCPolicy(config=WBCConfig(policy_path="x.onnx"), walk=False, allow_missing_models=True)
+    policy.policy_session = _StubSession()
+    return policy
+
+
+def _controller(substeps: Any, **overrides: Any) -> WBCTorqueController:
+    """Construct the controller with an empty actuator set.
+
+    The count is graded on arrival, before any id or address is read, so the
+    refusal rows need no compiled model - which is what keeps them running
+    wherever the package is installed rather than only where the G1 assets are.
+    """
+    kwargs: dict[str, Any] = {
+        "leg_waist_actuator_ids": [],
+        "arm_actuator_ids": [],
+        "leg_waist_qpos_addrs": [],
+        "leg_waist_dof_addrs": [],
+        "arm_qpos_addrs": [],
+        "arm_dof_addrs": [],
+        "saved_actuator_gains": {},
+        "model": None,
+        "physics_substeps_per_control": substeps,
+    }
+    kwargs.update(overrides)
+    return WBCTorqueController(_g1_policy(), **kwargs)
+
+
+class TestACountNoRolloutCanBeHeldForIsRefused:
+    """Regression: the clamp substituted a usable count for an unusable one."""
+
+    @pytest.mark.parametrize("substeps", _UNUSABLE)
+    def test_construction_raises(self, substeps: Any) -> None:
+        with pytest.raises(ValueError):
+            _controller(substeps)
+
+    @pytest.mark.parametrize("substeps", _UNUSABLE)
+    def test_the_refusal_names_the_parameter_and_the_class(self, substeps: Any) -> None:
+        """A dead-end ``int()`` failure named neither, so both are asserted."""
+        with pytest.raises(ValueError) as excinfo:
+            _controller(substeps)
+        message = str(excinfo.value)
+        assert "physics_substeps_per_control" in message, message
+        assert "WBCTorqueController" in message, message
+
+
+class TestACadenceACallerMayAskForStaysFirstClass:
+    """Over-reach control: the guard narrows to the unusable counts only."""
+
+    @pytest.mark.parametrize(("substeps", "expected"), _FIRST_CLASS)
+    def test_the_count_is_stored_as_the_whole_number_it_names(self, substeps: Any, expected: int) -> None:
+        controller = _controller(substeps)
+        assert controller.physics_substeps_per_control == expected
+        # ``range()`` in ``apply`` takes a true int; an integral float would
+        # raise there rather than here.
+        assert type(controller.physics_substeps_per_control) is int
+
+    def test_the_default_is_the_upstream_sonic_decimation(self) -> None:
+        """Omitting the count keeps the 50 Hz cadence at the 0.005 s timestep."""
+        controller = WBCTorqueController(
+            _g1_policy(),
+            leg_waist_actuator_ids=[],
+            arm_actuator_ids=[],
+            leg_waist_qpos_addrs=[],
+            leg_waist_dof_addrs=[],
+            arm_qpos_addrs=[],
+            arm_dof_addrs=[],
+            saved_actuator_gains={},
+            model=None,
+        )
+        assert controller.physics_substeps_per_control == _CONTROL_DECIMATION
+        assert _CONTROL_DECIMATION * _SIM_DT == pytest.approx(0.020)
+
+
+class TestTheVerdictIsTheSharedDomains:
+    """Derived, so the constructor and its siblings cannot drift apart.
+
+    The same quantity reaches ``send_action(n_substeps=)`` on all three
+    simulation backends through this function. A row added to either table above
+    is graded against it rather than against a restated copy of its rule.
+    """
+
+    @pytest.mark.parametrize("substeps", _UNUSABLE + [p.values[0] for p in _FIRST_CLASS])
+    def test_the_constructor_refuses_exactly_what_the_domain_refuses(self, substeps: Any) -> None:
+        domain_refuses = (
+            positive_whole_number_error(substeps, "physics_substeps_per_control", "WBCTorqueController") is not None
+        )
+        try:
+            _controller(substeps)
+            constructor_refuses = False
+        except ValueError:
+            constructor_refuses = True
+        assert constructor_refuses is domain_refuses
+
+
+mujoco = pytest.importorskip("mujoco", reason="mujoco not installed")
+
+
+class TestTheAcceptedCountIsThePhysicsActuallyAdvanced:
+    """The consequence cell: the count is the control period, on a real scene.
+
+    Asserted against the literal the caller passed rather than against the
+    stored attribute - deriving the expectation from what was stored is what let
+    a substituted count read as correct.
+    """
+
+    @pytest.fixture
+    def g1(self) -> tuple[Any, Any, str]:
+        from strands_robots.simulation.model_registry import resolve_model
+
+        xml = resolve_model("unitree_g1")
+        if not xml:
+            pytest.skip("unitree_g1 model assets not available")
+        model = mujoco.MjModel.from_xml_path(xml)
+        data = mujoco.MjData(model)
+        namespace = (
+            "unitree_g1/"
+            if (mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, 1) or "").startswith("unitree_g1/")
+            else ""
+        )
+        return model, data, namespace
+
+    @pytest.mark.parametrize("requested", [1, 2, 4, 7])
+    def test_one_action_advances_the_requested_number_of_physics_steps(
+        self, g1: tuple[Any, Any, str], requested: int
+    ) -> None:
+        from strands_robots.policies.wbc import WBC_G1_LEG_WAIST_JOINTS, install_wbc_torque_control
+        from strands_robots.simulation.base import SimEngine
+
+        model, data, namespace = g1
+
+        class _Robot:
+            def __init__(self) -> None:
+                self.namespace = namespace
+
+        class _World:
+            def __init__(self) -> None:
+                self._model, self._data = model, data
+                self.robots = {"unitree_g1": _Robot()}
+                self._backend_state: dict[str, Any] = {}
+
+        class _Sim:
+            def __init__(self) -> None:
+                self._world = _World()
+
+        resolved = install_wbc_torque_control(cast(SimEngine, _Sim()), _g1_policy(), "unitree_g1")
+        policy = resolved.policy
+        controller = WBCTorqueController(
+            policy,
+            leg_waist_actuator_ids=resolved.leg_waist_actuator_ids,
+            arm_actuator_ids=resolved.arm_actuator_ids,
+            leg_waist_qpos_addrs=resolved.leg_waist_qpos_addrs,
+            leg_waist_dof_addrs=resolved.leg_waist_dof_addrs,
+            arm_qpos_addrs=resolved.arm_qpos_addrs,
+            arm_dof_addrs=resolved.arm_dof_addrs,
+            saved_actuator_gains={},
+            model=model,
+            physics_substeps_per_control=requested,
+        )
+        action = {name: float(policy.default_angles[i]) for i, name in enumerate(WBC_G1_LEG_WAIST_JOINTS)}
+        before = float(data.time)
+        controller.apply(action, model, data, "unitree_g1")
+
+        advanced = float(data.time) - before
+        assert advanced == pytest.approx(requested * float(model.opt.timestep))
+        # The whole point of the count: the control period the gait clock is
+        # integrated at is this many physics steps of the SONIC timestep.
+        assert advanced == pytest.approx(requested * _SIM_DT)


### PR DESCRIPTION
`WBCTorqueController` declares `owns_stepping`, so `physics_substeps_per_control` is not a hint — it is the number of `mj_step` calls one `apply()` makes, and therefore the control period itself. It arrived through `max(1, int(...))`, which cannot report an unusable count: it substitutes a usable one.

![measured on the unitree_g1 scene](https://raw.githubusercontent.com/cagataycali/robots/5c28b7a8df5b1c8ebba3be905b4c056193d55895/.artifacts/wbc_substeps.png)

## Measured on the shipped `unitree_g1` scene (dt = 0.005 s)

| requested | stored | `mj_step`s | physics s / action | realised rate | before | after |
|---|---|---|---|---|---|---|
| `4` (SONIC nominal) | `4` | 4 | 0.0200 | 50 Hz | ok | `4` accepted |
| `0` | `1` | 1 | 0.0050 | **200 Hz** | silently wrong | refused |
| `-5` | `1` | 1 | 0.0050 | **200 Hz** | silently wrong | refused |
| `True` | `1` | 1 | 0.0050 | **200 Hz** | silently wrong | refused |
| `4.9` | `4` | 4 | 0.0200 | 50 Hz | silently truncated | refused |
| `"4"` | `4` | 4 | 0.0200 | 50 Hz | silently coerced | refused |
| `float("nan")` | — | — | — | — | `ValueError: cannot convert float NaN to integer` | refused, parameter named |

Every row above completed a rollout. Nothing named the count that had been replaced. Physics advanced per action is exactly `requested * 0.005` for 1..8, which is what makes this parameter the control period rather than a performance knob — and the same 250-action rollout covered **5.00 s at the requested `4`, 1.25 s once the count was replaced by `1`**.

## The rule already exists three times over

- `PolicyRunner._control_substeps` was **already converted away from this exact clamp** for the identical quantity. Its docstring records the conversion: *"It used to be clamped with `max(1, int(override))`, so `0`/`-5` silently collapsed to a single physics step — reinstating the exact under-integration this helper exists to prevent — and a float was truncated."*
- `positive_whole_number_error` names *"the physics steps one applied action is held for — the `n_substeps` of every backend's `send_action`"* as one of its two families, and explains why `0` is refused there rather than honoured as "write but do not advance". All three simulation backends already route `n_substeps` through it.
- `tests/policies/wbc/test_gait_clock_integrates_at_the_loop_rate.py` pins that the gait phase advances by the control period the loop actually runs at, so a commanded `gait_frequency` under a replaced count *"means something other than steps per second ... and the robot walks at a rhythm nobody commanded while every reported number looks right."*

This controller was the un-converted copy. It now calls the same shared domain, with `int()` applied **after** the guard so an integral float lands as the count it names instead of a truncation. An integral float and a NumPy integer stay first-class, as they are everywhere else in that domain.

## Tests

New `tests/policies/wbc/test_substep_count_domain.py` (48 cells):

| class | what it pins | pre-fix |
|---|---|---|
| `TestACountNoRolloutCanBeHeldForIsRefused` | 11 unusable counts raise, and the message names both the parameter and the class | **22 fail** |
| `TestTheVerdictIsTheSharedDomains` | the constructor's verdict **is** `positive_whole_number_error`'s, derived rather than restated | **9 fail** |
| `TestACadenceACallerMayAskForStaysFirstClass` | `1`, `4`, `25`, `4.0`, `np.int64(4)` still accepted and stored as a true `int`; the default is still the upstream decimation | green both trees |
| `TestTheAcceptedCountIsThePhysicsActuallyAdvanced` | on the real scene, one action advances exactly `requested * dt` for 1/2/4/7 | green both trees |

Pre-fix split on `bb85062`: **31 failed / 37 passed**, with all 30 control cells green — the guard narrows to the unusable counts only.

The existing pin `test_apply_writes_torques_and_owns_stepping` derived its expected advance from `ctrl.physics_substeps_per_control` — the attribute the controller *stored* — so it read as correct for any count that had been substituted. Retargeted to derive it from the nominal decimation rather than deleted.

## Gate

| check | base `bb85062` | this branch |
|---|---|---|
| `tests/policies` + `tests/simulation/mujoco` | 13 failed / **9534** passed / 74 skipped | 13 failed / **9582** passed / 74 skipped |
| failing node ids | — | **set-identical** (pre-existing: absent optional deps + installed-lerobot drift) |
| `mypy strands_robots tests tests_integ` (1.20.2) | 20 errors in 6 files | 20 errors in 6 files |
| `ruff check` / `ruff format --check` | clean | clean |

Passed delta is **+48**, exactly the new cells.

## Size

`5 files changed, 379 insertions(+), 3 deletions(-)` — 57 in `sim_control.py` (guard + the previously-undocumented constructor's `Args:`/`Raises:` block, which the `Args:` completeness guard's own thesis calls for once a parameter refuses), 275 in tests, 8 in `docs/policies/wbc.md`, 39 changelog.

Renders and traces are a headless MuJoCo rollout of the shipped `unitree_g1` scene. A zero-action stub stands in for the SONIC weights, so both robots descend — what the cadence changes is the physics integrated for one rollout, not the gait quality.