### PR TITLE
fix(policies/vera): the IK bridge a rollout solves on is a bridge for the model that is bound

### DIFF
--- a/changelog.d/3220-vera-ik-bridge-follows-the-bound-model.md
+++ b/changelog.d/3220-vera-ik-bridge-follows-the-bound-model.md
@@ -1,0 +1,20 @@
+### Fixed: the VERA IK bridge a rollout solves on is a bridge for the model that is bound
+
+`VeraPolicy._ensure_ik_bridge` cached the `MinkIKBridge` in a single slot keyed
+on nothing, while the bridge holds a `mink.Configuration` and both tasks built
+from ONE compiled `MjModel`. The simulation rebinds a policy on every rollout
+(`bind_policy_sim_context` -> `set_sim_context`) and hands it the model compiled
+*now*, which is a new object after any scene change; `autoconfigure_ik` returns
+early once an ee-frame is configured, so the rebind never re-entered
+`set_ik_target` and nothing invalidated the bridge.
+
+Both outcomes were silent at the boundary. When the DOF count changed, the stale
+bridge refused the seed built from the bound model - `solve: 'q_init' must be a
+9-element vector, got 16` - naming the caller's seed and the superseded model's
+`nq`. When it did not change (a robot re-placed, a scene rebuilt), the solve
+returned clean-looking joint targets for geometry that is no longer there.
+
+The cache is now keyed on every input the build reads: the model by identity,
+the end-effector frame name, and the frame type - the same shape the adjacent
+`_joint_qpos_addr` cache already uses for the same reason. An unchanged model and
+frame are still served from the cache.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -84,6 +84,11 @@ robot is drivable iff (its `action_space` matches a served embodiment) **and**
 **IK bridge** that maps the 6-DoF end-effector deltas to joint targets and
 auto-discovers the end-effector frame from the compiled MuJoCo model — so any
 kinematically-compatible 6/7-DoF arm can be driven once a matching IDM exists.
+The bridge solves against one compiled model, and the simulation rebinds the
+policy on every rollout, so it is rebuilt whenever the model or the frame
+changes: one policy object reused across rollouts of a scene that was rebuilt
+(a robot re-placed, an object added) solves in the world it is currently bound
+to, not the one it first saw.
 
 ## Checkpoints
 

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -282,6 +282,10 @@ class VeraPolicy(Policy):
         self._ik_prev_q: dict[str, float] = {}
         self._translation_scale: float = 1.0
         self._ik_bridge: Any = None  # lazily built MinkIKBridge
+        # What that bridge was built from: (mj_model, ee_frame_name, ee_frame_type).
+        # The bridge is only reusable while all three still hold - see
+        # :meth:`_ensure_ik_bridge`.
+        self._ik_bridge_binding: tuple[Any, str, str] | None = None
         self._sim_namespace: str | None = None  # robot namespace for ee-frame scoping
         self._warned_unbound: bool = False
 
@@ -388,6 +392,7 @@ class VeraPolicy(Policy):
         if translation_scale is not None:
             self._translation_scale = float(translation_scale)
         self._ik_bridge = None  # force rebuild
+        self._ik_bridge_binding = None
 
     def autoconfigure_ik(self, mj_model: Any, namespace: str | None = None, *, force: bool = False) -> bool:
         """Zero-config IK setup: discover the ee-frame from the MjModel.
@@ -772,11 +777,54 @@ class VeraPolicy(Policy):
         return addr
 
     def _ensure_ik_bridge(self, mj_model: Any, ee_frame: str):
-        """Lazily build (and cache) the MinkIKBridge."""
-        if self._ik_bridge is None:
-            from .sim_ik import MinkIKBridge
+        """Return the IK bridge for this model and frame, building it on a miss.
 
-            self._ik_bridge = MinkIKBridge(mj_model, ee_frame, self._ee_frame_type)
+        Keyed on every input the bridge is built from - the compiled model, the
+        end-effector frame name, and the frame type - for the same reason
+        :meth:`_joint_qpos_addr` is keyed on the model. A bridge holds a
+        ``mink.Configuration`` and the tasks built from ONE ``MjModel``, so a
+        bridge built from a superseded model solves against the previous world's
+        kinematics.
+
+        That is reachable through the ordinary rollout path, not just an explicit
+        retarget. The simulation rebinds a policy on every rollout
+        (``bind_policy_sim_context`` -> :meth:`set_sim_context`) and hands it the
+        model compiled *now*, which is a new object after any scene change;
+        :meth:`autoconfigure_ik` returns early once an ee-frame is configured, so
+        the rebind does not re-enter :meth:`set_ik_target` and nothing else
+        invalidated the bridge. Both outcomes were silent at the boundary:
+
+        * the DOF count changed - the stale bridge refuses the seed built from
+          the bound model, naming ``q_init`` and the *superseded* model's ``nq``,
+          which reads as a caller bug;
+        * the DOF count did not change (a robot re-placed, a scene rebuilt) - the
+          solve returns joint targets for geometry that is no longer there, under
+          an action dict shaped exactly like a good one.
+
+        The model is held by identity rather than by ``id()``: an int key keeps
+        nothing alive, so a freed model's address can be reused by the model that
+        replaces it and collide. Holding it pins nothing new - ``self._mj_model``
+        already holds the same object for as long as it is the active model - and
+        this single-slot cache drops a superseded bridge on the next miss.
+
+        Args:
+            mj_model: The compiled ``mujoco.MjModel`` the solve runs against.
+            ee_frame: Name of the end-effector frame the IK tracks.
+
+        Returns:
+            The cached bridge when it was built from this model and frame, else a
+            freshly built one.
+        """
+        binding = (mj_model, ee_frame, self._ee_frame_type)
+        cached = self._ik_bridge
+        held = self._ik_bridge_binding
+        if cached is not None and held is not None and held[0] is mj_model and held[1:] == binding[1:]:
+            return cached
+
+        from .sim_ik import MinkIKBridge
+
+        self._ik_bridge = MinkIKBridge(mj_model, ee_frame, self._ee_frame_type)
+        self._ik_bridge_binding = binding
         return self._ik_bridge
 
     def _ik_chunk_to_action_dicts(

--- a/tests/policies/vera/test_vera_action_ik.py
+++ b/tests/policies/vera/test_vera_action_ik.py
@@ -146,6 +146,9 @@ def test_provider_ik_path_emits_joint_keys():
     p._mj_model = FakeBridge.model
     p._ee_frame_name = "hand"
     p._ik_bridge = FakeBridge()
+    # The cached bridge is served only while it is a bridge for THIS model and
+    # frame, so the injected one has to say which it stands for.
+    p._ik_bridge_binding = (FakeBridge.model, "hand", "body")
     obs = {"image": np.zeros((8, 8, 3), np.uint8), **{j: 0.0 for j in joints}}
     out = asyncio.run(p.get_actions(obs, "pick"))
     d = out[0]
@@ -223,6 +226,8 @@ def test_ik_smoothing_ema_damps_targets():
         p._mj_model = FakeBridge.model
         p._ee_frame_name = "hand"
         p._ik_bridge = FakeBridge()
+        # As above: the injected bridge states the model and frame it is for.
+        p._ik_bridge_binding = (FakeBridge.model, "hand", "body")
         obs = {"image": np.zeros((8, 8, 3), np.uint8), **{j: 0.0 for j in joints}}
         # one get_actions returns the first action; drain the queue for the chunk
         seq = []

--- a/tests/policies/vera/test_vera_ik_bridge_follows_the_bound_model.py
+++ b/tests/policies/vera/test_vera_ik_bridge_follows_the_bound_model.py
@@ -1,0 +1,262 @@
+"""The IK bridge a rollout solves on is a bridge for the model that is bound.
+
+``VeraPolicy`` turns an end-effector-delta chunk into joint targets through a
+:class:`~strands_robots.policies.vera.sim_ik.MinkIKBridge`, which holds a
+``mink.Configuration`` and the two tasks built from ONE compiled ``MjModel``.
+The simulation rebinds a policy on every rollout
+(``bind_policy_sim_context`` -> ``set_sim_context``) and hands it the model
+compiled *now* - a new object after any scene change - so which model a cached
+bridge was built from is part of whether that bridge is still usable.
+
+The sibling contracts pin the cache without ever varying that input:
+:mod:`tests.policies.vera.test_vera_ik_bridge_lazy_build` pins "builds once; a
+later inference reuses it" and the rebuild after an explicit
+``set_ik_target``, both against a single model; the adjacent qpos-address cache
+in :mod:`tests.policies.vera.test_vera_ik_qpos_addressing` is keyed on the model
+*and* the state keys and says so. A bridge served for a superseded model is
+silent at the boundary in both directions - it refuses the seed built from the
+bound model by naming the previous model's ``nq``, or it solves in the previous
+world's geometry and returns an action dict shaped exactly like a good one.
+
+The bridge is stood in for so these run without the optional ``mink`` stack, but
+the models are really compiled and the rebind is really the engine's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots import Simulation  # noqa: E402
+from strands_robots.policies.vera import sim_ik as sim_ik_mod  # noqa: E402
+from strands_robots.policies.vera.provider import VeraPolicy  # noqa: E402
+from strands_robots.simulation.ik import pose_vector_error  # noqa: E402
+
+#: One step of eef-delta: a 2 cm descent with the gripper column open.
+_CHUNK = np.zeros((1, 8), np.float32)
+_CHUNK[:, 2] = -0.02
+_CHUNK[:, 7] = 1.0
+
+#: A second compiled model, distinct from the scene's, carrying the two frames
+#: the keying table names. Only its identity matters to the table.
+_OTHER_XML = """
+<mujoco><worldbody>
+  <body name="panda/link7"><geom type="sphere" size="0.05"/>
+    <body name="panda/hand" pos="0.1 0 0"><geom type="sphere" size="0.05"/></body>
+  </body>
+</worldbody></mujoco>
+"""
+
+
+class _Client:
+    """A VERA client that serves one eef-delta chunk, so no server is needed."""
+
+    def get_server_metadata(self) -> dict[str, Any]:
+        return {
+            "action_space": "eef_delta",
+            "context_frames": 1,
+            "gripper_dim_index": 7,
+            "gripper_is_raw": True,
+            "view_keys": ["image"],
+        }
+
+    def configure(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def reset(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def close(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def infer(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"action": _CHUNK}
+
+
+class _FkBridge:
+    """A bridge stand-in that is honestly bound to ONE model.
+
+    Forward kinematics is real MuJoCo forward kinematics on the model it was
+    constructed with, and both configuration-reading methods hold their input to
+    that model's ``nq`` through the same :func:`pose_vector_error` the shipped
+    :class:`~strands_robots.simulation.ik.MinkIKBridge` uses. Both are what make
+    a bridge built from a superseded model observable at all.
+    """
+
+    #: Every bridge constructed during a test, in order.
+    built: list[_FkBridge] = []
+
+    def __init__(self, model: Any, ee_frame_name: str, ee_frame_type: str = "body", **_: Any) -> None:
+        self.model = model
+        self.ee_frame_name = ee_frame_name
+        self.ee_frame_type = ee_frame_type
+        self._data = mujoco.MjData(model)
+        _FkBridge.built.append(self)
+
+    def ee_pose(self, qpos: Any) -> np.ndarray:
+        q = np.asarray(qpos, np.float64)
+        if text := pose_vector_error("ee_pose", "qpos", q, self.model.nq):
+            raise ValueError(text)
+        self._data.qpos[:] = q
+        mujoco.mj_forward(self.model, self._data)
+        body = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, self.ee_frame_name)
+        pose = np.eye(4)
+        pose[:3, 3] = self._data.xpos[body]
+        return pose
+
+    def solve(self, target_pose: Any, q_init: Any) -> np.ndarray:
+        q = np.asarray(q_init, np.float64)
+        if text := pose_vector_error("solve", "q_init", q, self.model.nq):
+            raise ValueError(text)
+        return q
+
+
+@pytest.fixture
+def bridges(monkeypatch: pytest.MonkeyPatch) -> list[_FkBridge]:
+    """Route every build through :class:`_FkBridge` and record them."""
+    _FkBridge.built = []
+    monkeypatch.setattr(sim_ik_mod, "MinkIKBridge", _FkBridge)
+    return _FkBridge.built
+
+
+def _policy() -> VeraPolicy:
+    client: Any = _Client()
+    policy = VeraPolicy(client=client, auto_launch_server=False)
+    policy._runner = None
+    return policy
+
+
+def _rollout(policy: VeraPolicy, sim: Simulation) -> list[dict[str, Any]]:
+    """Bind the policy the way the engine does, then infer once."""
+    joints = sim.robot_joint_names("panda")
+    policy.set_robot_state_keys(joints)
+    sim.bind_policy_sim_context(policy, "panda")
+    policy.reset()
+    observation: dict[str, Any] = {"image": np.zeros((8, 8, 3), np.uint8), **dict.fromkeys(joints, 0.0)}
+    return asyncio.run(policy.get_actions(observation, "descend"))
+
+
+def _bound_model(sim: Simulation) -> Any:
+    """The compiled model the engine hands a policy for this scene."""
+    world = sim._world
+    assert world is not None, "the fixture must have created a world"
+    return world._model
+
+
+def _panda_world(**add_robot: Any) -> Simulation:
+    sim = Simulation(backend="mujoco", mesh=False)
+    sim.create_world()
+    sim.add_robot(name="panda", **add_robot)
+    return sim
+
+
+class TestEveryInputTheBridgeIsBuiltFromIsKeyed:
+    """A differing-value table over the three inputs the build reads."""
+
+    @pytest.mark.parametrize(
+        ("frame", "frame_type", "new_model", "rebuilt"),
+        [
+            pytest.param("panda/hand", "body", False, False, id="nothing-differs-is-served-from-the-cache"),
+            pytest.param("panda/hand", "body", True, True, id="the-model-differs"),
+            pytest.param("panda/link7", "body", False, True, id="the-frame-name-differs"),
+            pytest.param("panda/hand", "site", False, True, id="the-frame-type-differs"),
+        ],
+    )
+    def test_a_differing_input_re_derives_the_bridge(
+        self, bridges: list[_FkBridge], frame: str, frame_type: str, new_model: bool, rebuilt: bool
+    ) -> None:
+        sim = _panda_world()
+        try:
+            first_model = _bound_model(sim)
+            second_model = mujoco.MjModel.from_xml_string(_OTHER_XML)
+            policy = _policy()
+            policy.set_robot_state_keys(sim.robot_joint_names("panda"))
+            policy.set_ik_target(first_model, "panda/hand", "body")
+
+            first = policy._ensure_ik_bridge(first_model, "panda/hand")
+            policy._ee_frame_type = frame_type
+            second = policy._ensure_ik_bridge(second_model if new_model else first_model, frame)
+
+            assert (second is not first) is rebuilt
+            assert len(bridges) == (2 if rebuilt else 1)
+        finally:
+            sim.cleanup()
+
+
+class TestARolloutAfterASceneChangeSolvesInTheBoundWorld:
+    """The rebind the engine performs, driven end to end through ``get_actions``."""
+
+    def test_a_seed_from_the_bound_model_is_not_refused_against_the_previous_dof_count(
+        self, bridges: list[_FkBridge]
+    ) -> None:
+        """Adding an object recompiles the model, and the seed grows with it.
+
+        The seed is ``model.nq`` long for whichever model is bound, so a bridge
+        built from the previous one refuses it - naming ``q_init`` and the
+        superseded model's width, which reads as a caller bug for a value the
+        caller never chose.
+        """
+        sim = _panda_world()
+        try:
+            policy = _policy()
+            assert _rollout(policy, sim), "the first rollout must emit actions"
+            before = _bound_model(sim).nq
+
+            sim.add_object(name="cube", position=[0.4, 0.0, 0.1], size=[0.03, 0.03, 0.03])
+            assert _bound_model(sim).nq > before, "the free-floating object must add DOFs"
+
+            actions = _rollout(policy, sim)
+
+            assert actions, "the rollout after the scene change must still emit actions"
+            assert bridges[-1].model is _bound_model(sim)
+            assert len(bridges) == 2, "the recompiled model must be built against"
+        finally:
+            sim.cleanup()
+
+    def test_the_targets_are_solved_in_the_world_the_robot_is_in(self, bridges: list[_FkBridge]) -> None:
+        """Same DOF count, different geometry: the silent half.
+
+        Rebuilding the scene with the arm somewhere else leaves ``nq`` untouched,
+        so nothing refuses anything; the previous world's bridge simply reads and
+        writes end-effector poses half a metre from where the arm now is.
+        """
+        offset = 0.5
+        policy = _policy()
+        for position in ([0.0, 0.0, 0.0], [offset, 0.0, 0.0]):
+            sim = _panda_world(position=position)
+            try:
+                assert _rollout(policy, sim), "each rollout must emit actions"
+                bound = _bound_model(sim)
+            finally:
+                sim.cleanup()
+
+        assert len(bridges) == 2, "the second world must get its own bridge"
+        assert bridges[-1].model is bound
+        rest = np.zeros(bound.nq)
+        moved = float(np.linalg.norm(bridges[-1].ee_pose(rest)[:3, 3] - bridges[0].ee_pose(rest)[:3, 3]))
+        assert moved == pytest.approx(offset, abs=1e-6), (
+            "the two worlds must disagree by the offset, or this test pins nothing"
+        )
+
+    def test_an_unchanged_scene_is_still_served_the_built_bridge(self, bridges: list[_FkBridge]) -> None:
+        """The control: a second rollout in the same world must not rebuild.
+
+        The bridge resolves a QP backend and constructs a configuration plus two
+        tasks, so reuse is what the cache is for.
+        """
+        sim = _panda_world()
+        try:
+            policy = _policy()
+            assert _rollout(policy, sim), "the first rollout must emit actions"
+            assert _rollout(policy, sim), "the second rollout must emit actions"
+
+            assert len(bridges) == 1, "an unchanged model and frame must be served from the cache"
+        finally:
+            sim.cleanup()

--- a/tests/policies/vera/test_vera_ik_numeric_domains.py
+++ b/tests/policies/vera/test_vera_ik_numeric_domains.py
@@ -441,6 +441,9 @@ class TestTheGuardsSurviveARealRollout:
         policy._mj_model = _Bridge.model
         policy._ee_frame_name = "hand"
         policy._ik_bridge = _Bridge()
+        # The cache serves a bridge only for the model and frame it was built
+        # from, so the injected one states which those are.
+        policy._ik_bridge_binding = (_Bridge.model, "hand", "body")
         observation = {"image": np.zeros((8, 8, 3), np.uint8), **dict.fromkeys(joints, 0.0)}
         actions = asyncio.run(policy.get_actions(observation, "pick"))
         assert actions, "a usable pair must still produce actions"


### PR DESCRIPTION
![VeraPolicy IK bridge vs the bound model](https://raw.githubusercontent.com/cagataycali/robots/def5fdbb7cfe08aff077cce7f1b469b898244ab8/.artifacts/vera_ik_bridge_bound_model.png)

`VeraPolicy._ensure_ik_bridge` cached the `MinkIKBridge` in a single slot keyed on nothing:

```python
if self._ik_bridge is None:
    self._ik_bridge = MinkIKBridge(mj_model, ee_frame, self._ee_frame_type)
return self._ik_bridge
```

A bridge holds a `mink.Configuration` and both tasks built from **one** compiled `MjModel`. The simulation rebinds a policy on **every** rollout (`bind_policy_sim_context` -> `set_sim_context`) and hands it the model compiled *now*, which is a new object after any scene change. `autoconfigure_ik` returns early once an ee-frame is configured, so that rebind never re-entered `set_ik_target` and nothing invalidated the bridge.

The adjacent cache in the same class already keys on the model, and its docstring says why. `_joint_qpos_addr` follows the bound model; the bridge did not - so the two halves of one action disagreed.

## Measured

Driven through `Simulation` + `bind_policy_sim_context` + `get_actions`, with the bridge stood in for so no `mink` is needed. `bind_policy_sim_context` was confirmed to hand a distinct `MjModel` on each bind after a scene change (`nq` 9 -> 16 -> 22 for panda, +cube, +so101).

| rollout 2 scenario | bridges built (before) | outcome (before) | outcome (after) |
| --- | --- | --- | --- |
| after `add_object` (`nq` 9 -> 16) | 1, built from `nq=9` | `ValueError: solve: 'q_init' must be a 9-element vector, got 16` | 2 bridges; rollout completes |
| scene rebuilt, robot re-placed (`nq` 9 -> 9) | 1, built from world 1 | clean action dict, targets **0.500 m** out | 2 bridges; targets in the bound world |
| same, unchanged scene | 1 | served from the cache | served from the cache |

The refusal names `q_init` and the *superseded* model's width, so it reads as a caller bug for a value the caller never chose. The second row is the worse one: nothing refuses anything, and the emitted action dict is shaped exactly like a good one.

## Change

Key the cache on every input the build reads - the model **by identity**, the frame name, the frame type - the same single-slot shape `_joint_qpos_addr` uses. Identity rather than `id()`: an int key keeps nothing alive, so a freed model's address can be reused by its replacement and collide. `MinkIKBridge` is still constructed in exactly one place.

## Tests

New `tests/policies/vera/test_vera_ik_bridge_follows_the_bound_model.py`, 7 cells: a differing-value table over the three inputs the build reads (plus the vary-nothing control), and the three rollout scenarios above end to end. The stand-in bridge does real MuJoCo forward kinematics on the model it was constructed with and holds both configuration-reading methods to that model's `nq` through the same `pose_vector_error` the shipped bridge uses - which is what makes a superseded model observable at all.

On `main` + this file: **5 failed / 2 passed**, and the 2 passing are exactly the two controls. After: 7 passed.

The sibling contracts pinned the cache without ever varying the model - `test_vera_ik_bridge_lazy_build` pins "builds once; a later inference reuses it" and the rebuild after an explicit `set_ik_target`, both against a single model. Three tests inject a bridge to skip the build; they now also state which model and frame that injected bridge stands for.

## Gate

| check | result |
| --- | --- |
| `ruff check` + `ruff format --check` (`strands_robots tests tests_integ`) | clean, 1877 files |
| `mypy strands_robots tests tests_integ` | 20 errors on `main` and on this branch, error sets identical |
| `tests/policies tests/simulation/mujoco` | `main` 13F/**9545P**/74S -> branch 13F/**9552P**/74S (+7 = the new cells), failing node-id sets identical |

The 13 standing failures are absent optional deps and one long-standing parity baseline; unchanged by this PR.

## Size

| | files | + | - |
| --- | --- | --- | --- |
| total | 6 | 347 | 4 |

`strands_robots/policies/vera/provider.py` +52/-4 (46 of the additions are the docstring), `tests/.../test_vera_ik_bridge_follows_the_bound_model.py` +262, three widened doubles +8, `docs/policies/vera.md` +5, changelog fragment +20.

Renders are MuJoCo headless (EGL) of the two compiled worlds; the trace is real forward kinematics on each model for one identical joint trajectory.