### PR TITLE
fix(registry): an alias is keyed by the fold every lookup applies to its query

### DIFF
--- a/changelog.d/3221-alias-lookup-key-fold.md
+++ b/changelog.d/3221-alias-lookup-key-fold.md
@@ -1,0 +1,28 @@
+### Fixed: a robot alias is keyed by the fold every lookup applies to its query
+
+`resolve_name` folds a caller's query before looking it up - lowercase, trim,
+dash as underscore - and canonical robot names are stored folded, so they match.
+Aliases were keyed as *declared*, and that asymmetry did not merely fail a
+lookup. An alias whose declared spelling was not already folded was unreachable
+in every spelling, including the one it was registered with, because the query is
+folded before it reaches the map; and the fold could carry it onto another
+robot's key, so `register_robot(name="probe_arm", aliases=["Franka-Panda"])` was
+accepted and `resolve_name("Franka-Panda")` then answered `panda`, with
+`get_robot` returning the Franka's entry - a name declared for one robot
+resolving to another.
+
+The uniqueness constraints in `_validate_robots` compared declared spellings
+too, so two aliases that are one key to every reader passed validation and the
+alias map kept whichever entry merged last (the user overlay). Both sides now
+compare under the fold, which is what lets the fail-closed check in
+`register_robot` refuse such an alias at registration instead of persisting a
+lookup that lands on someone else. An alias that folds to its OWNER's canonical
+name stays legal - the same carve-out `_validate_policies` already makes with
+`alias != provider_name` - which is what the shipped `reachy_mini` /
+`reachy-mini` pair needs.
+
+The fold had four hand-written copies across `discovery`, `robots` and
+`user_registry`. It now has one owner, `loader.normalize_robot_name`, exported
+from `strands_robots.registry` so a caller can predict which robot a name
+reaches, and documented in `docs/api-reference.md` and
+`docs/getting-started/robot-factory.md`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,7 +29,7 @@ import strands_robots
 ```python
 from strands_robots.registry import (
     list_robots, resolve_name, get_robot, has_sim, has_hardware, get_hardware_type,
-    list_robots_by_category, list_aliases, format_robot_table,
+    list_robots_by_category, list_aliases, normalize_robot_name, format_robot_table,
     register_robot, unregister_robot, list_user_robots,
     user_registry_source, parse_user_robots,
     list_policy_providers, resolve_policy, import_policy_class, build_policy_kwargs,
@@ -39,12 +39,13 @@ from strands_robots.registry import (
 | Symbol | What |
 |--------|------|
 | `list_robots(category)` | All robots in a category, or `"all"`. |
-| `resolve_name(name)` | Alias → canonical name. |
+| `resolve_name(name)` | Alias → canonical name. The query is folded by `normalize_robot_name` first, so any spelling of a name or alias reaches the same robot. |
 | `get_robot(name)` | Full registry entry dict. |
 | `has_sim(name)` / `has_hardware(name)` | Sim / real support flags. |
 | `get_hardware_type(name)` | LeRobot type string for `mode="real"`. |
 | `list_robots_by_category()` | `{category: [names]}`. |
-| `list_aliases()` | All 119 aliases, including every GR00T `data_config` spelling (so `data_config` names resolve as robot names). |
+| `list_aliases()` | All 121 aliases, keyed by `normalize_robot_name` (so every key is a spelling a folded query can produce), including every GR00T `data_config` spelling (so `data_config` names resolve as robot names). |
+| `normalize_robot_name(name)` | The fold every registry lookup applies: lowercase, trimmed, dashes as underscores. Canonical names, aliases and the uniqueness constraints over both are all keyed by it, so this is the rule that predicts which robot a name reaches. |
 | `format_robot_table()` | Pretty-printed robot table. |
 | `register_robot(name, entry)` | Add user-defined robot at runtime. |
 | `unregister_robot(name)` | Remove a runtime-registered robot. |

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -42,7 +42,14 @@ resolve_name("franka")    # 'panda'
 resolve_name("g1")        # 'unitree_g1'
 ```
 
-Case-insensitive, hyphens/underscores interchangeable. Full alias map in `registry/robots.json`.
+Case-insensitive, hyphens/underscores interchangeable. That fold is
+`registry.normalize_robot_name`, and it is the rule the registry is keyed by, not
+just the rule queries pass through: a canonical name is stored folded and an
+alias is keyed folded, so an alias declared `"My-Arm"` answers `my_arm`,
+`MY-ARM` and `My-Arm` alike. Two aliases that fold to one key are therefore one
+alias, and `register_robot` refuses an alias that folds onto another robot's name
+or alias rather than letting it resolve to that robot. Full alias map in
+`registry/robots.json`.
 
 ## Real hardware
 

--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -39,7 +39,7 @@ from .discovery import (
     is_discoverable,
     list_discoverable,
 )
-from .loader import invalidate_cache, reload
+from .loader import invalidate_cache, normalize_robot_name, reload
 from .policies import (
     build_policy_kwargs,
     get_policy_provider,
@@ -101,6 +101,7 @@ __all__ = [
     "user_registry_source",
     "parse_user_robots",
     # Utilities
+    "normalize_robot_name",
     "reload",
     "invalidate_cache",
 ]

--- a/strands_robots/registry/discovery.py
+++ b/strands_robots/registry/discovery.py
@@ -35,6 +35,8 @@ import re
 from functools import lru_cache
 from typing import Any
 
+from .loader import normalize_robot_name
+
 logger = logging.getLogger(__name__)
 
 # Robot names are interpolated into ``importlib`` module paths, so restrict them
@@ -59,11 +61,6 @@ _SCENE_CANDIDATES = ("scene.xml", "scene_mjx.xml")
 
 # Cache of synthesized entries (and negative results) keyed by normalized name.
 _DISCOVER_CACHE: dict[str, dict[str, Any] | None] = {}
-
-
-def _normalize(name: str) -> str:
-    """Lowercase, strip, and underscore-normalize a robot name."""
-    return name.lower().strip().replace("-", "_")
 
 
 @lru_cache(maxsize=1)
@@ -105,7 +102,7 @@ def descriptions_module(name: str) -> str | None:
         descriptions_module("go2")   # -> "go2_mj_description"
         descriptions_module("so100") # -> None (curated, not a description)
     """
-    norm = _normalize(name)
+    norm = normalize_robot_name(name)
     if not _NAME_RE.match(norm):
         return None
     return _mjcf_modules().get(norm)
@@ -143,7 +140,7 @@ def discover_robot(name: str) -> dict[str, Any] | None:
         or ``None`` if the robot is not an MJCF-capable ``robot_descriptions``
         robot.
     """
-    norm = _normalize(name)
+    norm = normalize_robot_name(name)
     if norm in _DISCOVER_CACHE:
         return _DISCOVER_CACHE[norm]
 
@@ -246,7 +243,7 @@ def urdf_descriptions_module(name: str) -> str | None:
         urdf_descriptions_module("atlas_v4") # -> "atlas_v4_description"
         urdf_descriptions_module("so100")    # -> None (curated, not a description)
     """
-    norm = _normalize(name)
+    norm = normalize_robot_name(name)
     if not _NAME_RE.match(norm):
         return None
     return _urdf_modules().get(norm)
@@ -283,7 +280,7 @@ def discover_urdf_path(name: str) -> str | None:
         URDF-capable ``robot_descriptions`` robot, the module cannot be
         imported, or it exposes no readable ``URDF_PATH``.
     """
-    norm = _normalize(name)
+    norm = normalize_robot_name(name)
     module_name = urdf_descriptions_module(norm)
     if module_name is None:
         return None

--- a/strands_robots/registry/loader.py
+++ b/strands_robots/registry/loader.py
@@ -36,6 +36,30 @@ _cache: dict[str, dict] = {}
 _sources: dict[str, tuple] = {}
 
 
+def normalize_robot_name(name: str) -> str:
+    """Fold a robot name or alias to the key every registry lookup uses.
+
+    One rule, spelled once: lowercase, trim surrounding whitespace, and read a
+    dash as an underscore. It is the rule
+    :func:`~strands_robots.registry.robots.resolve_name` applies to a caller's
+    query, so it is also the rule the things a query is matched against have to
+    be keyed by - a canonical robot name (normalized by
+    :func:`~strands_robots.registry.user_registry.register_robot`), an alias
+    (keyed by :func:`~strands_robots.registry.robots._build_alias_map`), and the
+    uniqueness constraints :func:`_validate_robots` enforces over both. A
+    consumer that folds while a producer or a validator does not is how
+    ``"Franka-Panda"`` becomes a lookup nobody can satisfy, or worse, one that
+    lands on a different robot.
+
+    Args:
+        name: A robot name or alias, in any spelling.
+
+    Returns:
+        The lookup key for ``name``.
+    """
+    return name.lower().strip().replace("-", "_")
+
+
 def _user_registry_source() -> bytes | None:
     """Contents of the user-local robot overlay, or None if absent.
 
@@ -154,7 +178,11 @@ def _validate_robots(data: dict) -> None:
     # typo as "no preference" and quietly builds the default driver.
     from strands_robots.drivers.base import DRIVER_CHOICES
 
-    seen_aliases: dict[str, str] = {}
+    # Keyed by the lookup key, not the declared spelling: two aliases that
+    # differ only in case or separator are ONE key to every reader, so raw
+    # comparison passes a pair that the alias map then silently collapses to
+    # whichever entry is merged last (the user overlay).
+    seen_aliases: dict[str, tuple[str, str]] = {}
     for robot_name, info in data.get("robots", {}).items():
         declared_driver = info.get("hardware", {}).get("driver")
         if declared_driver is not None and declared_driver not in DRIVER_CHOICES:
@@ -163,13 +191,25 @@ def _validate_robots(data: dict) -> None:
                 f"which is not a driver. Valid drivers: {', '.join(DRIVER_CHOICES)}."
             )
         for alias in info.get("aliases", []):
-            if alias in seen_aliases:
+            key = normalize_robot_name(alias)
+            if key in seen_aliases:
+                prior_alias, prior_robot = seen_aliases[key]
+                shared = "" if prior_alias == alias else f" ({prior_alias!r} and {alias!r} are one lookup key, '{key}')"
                 raise ValueError(
-                    f"Duplicate robot alias '{alias}': claimed by both '{seen_aliases[alias]}' and '{robot_name}'"
+                    f"Duplicate robot alias '{alias}': claimed by both '{prior_robot}' and '{robot_name}'{shared}"
                 )
-            if alias in data.get("robots", {}):
-                raise ValueError(f"Robot alias '{alias}' in '{robot_name}' collides with a canonical robot name")
-            seen_aliases[alias] = robot_name
+            # An alias that folds to its OWNER's canonical name is a second
+            # spelling of that name, which the fold already accepts - the same
+            # carve-out :func:`_validate_policies` makes with ``alias !=
+            # provider_name``. Only a fold onto a DIFFERENT robot is a collision,
+            # and it is refused because the canonical name wins the lookup, so
+            # the alias would resolve to the other robot.
+            if key != robot_name and key in data.get("robots", {}):
+                spelled = "" if key == alias else f" (as '{key}')"
+                raise ValueError(
+                    f"Robot alias '{alias}' in '{robot_name}' collides with a canonical robot name{spelled}"
+                )
+            seen_aliases[key] = (alias, robot_name)
 
 
 def _validate_policies(data: dict) -> None:

--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -33,8 +33,22 @@ def _build_alias_map() -> dict[str, str]:
     reg = _load("robots")
     alias_map: dict[str, str] = {}
     for name, info in reg.get("robots", {}).items():
+        canonical_key = normalize_robot_name(name)
         for alias in info.get("aliases", []):
-            alias_map[normalize_robot_name(alias)] = name
+            key = normalize_robot_name(alias)
+            # An alias that folds onto its OWNER's canonical name is a second
+            # spelling of that name, not a separate lookup: ``resolve_name``
+            # answers it from ``canonical_names`` whether or not it is here.
+            # Emitting it anyway would make this an identity entry, and
+            # ``list_aliases`` is the public read of this map - a caller asking
+            # "what does this alias mean" would be told it means itself. The
+            # shipped registry has exactly one (``reachy_mini`` aliases
+            # ``reachy-mini``), which only became an identity entry once alias
+            # keys were folded. Skipping it costs no resolution; it is the same
+            # carve-out ``_validate_robots`` makes when it allows the alias.
+            if key == canonical_key:
+                continue
+            alias_map[key] = name
     return alias_map
 
 

--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -8,7 +8,7 @@ or modify robots.
 import logging
 from typing import Any
 
-from .loader import _load
+from .loader import _load, normalize_robot_name
 
 logger = logging.getLogger(__name__)
 
@@ -24,12 +24,17 @@ def _build_alias_map() -> dict[str, str]:
 
     Each robot entry may have an "aliases" list.  This function
     inverts those into a flat lookup dict.
+
+    Keyed by :func:`~strands_robots.registry.loader.normalize_robot_name`, the
+    same fold :func:`resolve_name` applies to the query it looks up here: an
+    alias keyed as declared is unreachable in EVERY spelling once its declared
+    one is not already folded, because the query is folded before it arrives.
     """
     reg = _load("robots")
     alias_map: dict[str, str] = {}
     for name, info in reg.get("robots", {}).items():
         for alias in info.get("aliases", []):
-            alias_map[alias] = name
+            alias_map[normalize_robot_name(alias)] = name
     return alias_map
 
 
@@ -48,7 +53,7 @@ def resolve_name(name: str) -> str:
         resolve_name("SO100_follower") # → "so100"
         resolve_name("g1")            # → "unitree_g1"
     """
-    normalized = name.lower().strip().replace("-", "_")
+    normalized = normalize_robot_name(name)
     alias_map = _build_alias_map()
     # Canonical names come straight from the registry keys. Using
     # ``alias_map.values()`` here was wrong: it only contains robots that

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -47,7 +47,7 @@ from typing import Any
 
 from strands_robots.utils import get_base_dir, resolve_asset_path
 
-from .loader import invalidate_cache
+from .loader import invalidate_cache, normalize_robot_name
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +165,12 @@ def register_robot(
               (``STRANDS_ASSETS_DIR`` or ``~/.strands_robots/assets/``).
             - None: defaults to ``<assets_dir>/<name>/``.
         scene_xml: Scene XML (with ground/lights). Defaults to ``model_xml``.
-        aliases: Alternative names for this robot.
+        aliases: Alternative names for this robot. Folded to a lookup key the
+            same way ``name`` is (see
+            :func:`~strands_robots.registry.loader.normalize_robot_name`), so
+            ``"My-Arm"`` and ``"my_arm"`` are one alias, and an alias that folds
+            onto another robot's canonical name or alias is refused rather than
+            resolving to that robot.
         robot_descriptions_module: Optional ``robot_descriptions`` module name.
         hardware: Optional hardware config dict (``lerobot_type``, etc.).
         overwrite: If False (default), raises ValueError if robot already exists.
@@ -193,7 +198,7 @@ def register_robot(
         )
     """
     # Normalize name
-    name = name.lower().strip().replace("-", "_")
+    name = normalize_robot_name(name)
 
     # Load existing
     data = _load_user_registry()
@@ -291,7 +296,7 @@ def unregister_robot(name: str) -> bool:
     Returns:
         True if the robot was removed, False if it wasn't in the user registry.
     """
-    name = name.lower().strip().replace("-", "_")
+    name = normalize_robot_name(name)
     data = _load_user_registry()
 
     if name not in data.get("robots", {}):

--- a/tests/registry/test_alias_lookup_keys_follow_the_query_fold.py
+++ b/tests/registry/test_alias_lookup_keys_follow_the_query_fold.py
@@ -1,0 +1,211 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""An alias is keyed by the same fold the query it answers is keyed by.
+
+:func:`~strands_robots.registry.robots.resolve_name` folds a caller's query
+before looking it up - lowercase, trimmed, dashes as underscores
+(:func:`~strands_robots.registry.loader.normalize_robot_name`). Canonical robot
+names are stored folded, so they match. Aliases were keyed as DECLARED, and that
+asymmetry has two consequences, neither of them a failed lookup:
+
+* An alias whose declared spelling is not already folded is unreachable in
+  EVERY spelling, including the one it was registered with, because the query
+  is folded before it reaches the map.
+* The fold can carry it onto a DIFFERENT robot's key. ``aliases=["Franka-Panda"]``
+  folds to ``franka_panda``, which the shipped registry already gives to
+  ``panda``, so ``resolve_name("Franka-Panda")`` answered ``"panda"`` and
+  ``get_robot`` returned the Franka's entry - a name declared for one robot
+  resolving to another.
+
+The uniqueness constraints are the other half of the same rule: ``_validate_robots``
+compared declared spellings, so two aliases that are ONE key to every reader passed
+validation, and the alias map then silently kept whichever entry merged last (the
+user overlay). Both sides now compare under the fold, which is what lets the
+fail-closed check in ``register_robot`` refuse such an alias at registration
+instead of persisting a lookup that lands on someone else.
+
+The carve-out: an alias that folds to its OWNER's canonical name is a second
+spelling of that name, which the fold already accepts. The shipped registry
+declares one (``reachy_mini`` aliases ``reachy-mini``), and
+``_validate_policies`` already makes the same exception with ``alias !=
+provider_name``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from strands_robots.registry import (
+    get_robot,
+    list_aliases,
+    normalize_robot_name,
+    register_robot,
+    resolve_name,
+)
+from strands_robots.registry import loader as loader_mod
+
+_MINIMAL_MJCF = '<mujoco><worldbody><body><geom size="0.1"/></body></worldbody></mujoco>'
+
+#: A robot the shipped registry gives ``franka_panda`` to, as an alias.
+_SHIPPED_ALIAS_OWNER = ("franka_panda", "panda")
+
+
+@pytest.fixture
+def robot_dir(tmp_path: Path) -> Path:
+    """A minimal MJCF robot directory to register entries against."""
+    d = tmp_path / "assets" / "bot"
+    d.mkdir(parents=True)
+    (d / "bot.xml").write_text(_MINIMAL_MJCF)
+    return d
+
+
+def _register(robot_dir: Path, name: str, aliases: list[str]) -> dict:
+    """Register ``name`` with ``aliases`` against the temp asset dir."""
+    return register_robot(
+        name=name,
+        model_xml="bot.xml",
+        asset_dir=str(robot_dir),
+        description="probe",
+        category="arm",
+        joints=6,
+        aliases=aliases,
+    )
+
+
+class TestAnAliasIsReachableByItsDeclaredSpelling:
+    """A declared alias answers the query, whatever spelling it was declared in."""
+
+    @pytest.mark.parametrize(
+        "declared",
+        ["My-Arm-V2", "my-arm-v2", "MY_ARM_V2", "  my_arm_v2  ", "my_arm_v2"],
+        ids=["dashed-mixed-case", "dashed", "upper", "padded", "already-folded"],
+    )
+    @pytest.mark.parametrize(
+        "queried",
+        ["My-Arm-V2", "my-arm-v2", "MY_ARM_V2", "  my_arm_v2  ", "my_arm_v2"],
+        ids=["dashed-mixed-case", "dashed", "upper", "padded", "already-folded"],
+    )
+    def test_every_spelling_of_one_alias_reaches_the_robot_that_declared_it(
+        self, robot_dir: Path, declared: str, queried: str
+    ) -> None:
+        """Declared spelling and queried spelling are independent of each other.
+
+        Both go through the same fold, so the 25 pairs are one lookup. Only the
+        already-folded declaration used to answer, which is the arrangement the
+        pre-existing alias grader happened to pick.
+        """
+        _register(robot_dir, "probe_arm", [declared])
+
+        assert resolve_name(queried) == "probe_arm"
+        entry = get_robot(queried)
+        assert entry is not None, f"{queried!r} reached no robot"
+        assert entry["description"] == "probe", f"{queried!r} reached a different robot"
+
+    def test_the_alias_map_is_keyed_by_the_fold_so_every_key_is_answerable(self) -> None:
+        """No key of the shipped alias map is a spelling the query cannot produce.
+
+        A key that is not its own fold can never be matched: the query is folded
+        first, so nothing the caller types arrives in that form.
+        """
+        aliases = list_aliases()
+        assert len(aliases) >= 100, f"premise: the shipped registry declares few aliases ({len(aliases)})"
+        unreachable = {key: canonical for key, canonical in aliases.items() if key != normalize_robot_name(key)}
+        assert not unreachable, f"alias keys no folded query can match: {unreachable}"
+
+
+class TestAnAliasThatFoldsOntoAnotherRobotIsRefused:
+    """The uniqueness constraints compare the keys, not the declared spellings."""
+
+    def test_an_alias_folding_onto_a_shipped_alias_is_refused_not_silently_rerouted(self, robot_dir: Path) -> None:
+        """The registration is refused, and nothing is persisted for it.
+
+        Pre-fix this registration succeeded and ``resolve_name`` answered the
+        OTHER robot, so the refusal and the absence of the entry are one claim:
+        the alias never becomes a lookup that lands elsewhere.
+        """
+        shipped_alias, owner = _SHIPPED_ALIAS_OWNER
+        assert resolve_name(shipped_alias) == owner, f"premise: {shipped_alias!r} no longer belongs to {owner!r}"
+
+        declared = "Franka-Panda"
+        assert normalize_robot_name(declared) == shipped_alias
+
+        with pytest.raises(ValueError) as excinfo:
+            _register(robot_dir, "probe_arm", [declared])
+        message = str(excinfo.value)
+        assert declared in message and owner in message, message
+        assert shipped_alias in message, f"the shared key is not named: {message}"
+
+        assert get_robot("probe_arm") is None, "the refused registration was persisted anyway"
+        assert resolve_name(shipped_alias) == owner, "the shipped alias was rerouted"
+
+    def test_an_alias_folding_onto_another_robots_canonical_name_is_refused(self, robot_dir: Path) -> None:
+        """A canonical name wins the lookup, so such an alias could never answer."""
+        assert get_robot("so100") is not None, "premise: so100 is not a shipped robot"
+        assert normalize_robot_name("SO100") == "so100"
+
+        with pytest.raises(ValueError, match="canonical robot name"):
+            _register(robot_dir, "probe_arm", ["SO100"])
+
+        assert get_robot("probe_arm") is None, "the refused registration was persisted anyway"
+
+    def test_two_aliases_that_are_one_key_cannot_both_be_claimed(self, robot_dir: Path) -> None:
+        """The pair the raw comparison passed and the alias map then collapsed."""
+        _register(robot_dir, "first_arm", ["My-Shared-Alias"])
+        assert resolve_name("my_shared_alias") == "first_arm"
+
+        with pytest.raises(ValueError) as excinfo:
+            _register(robot_dir, "second_arm", ["MY_SHARED_ALIAS"])
+        assert "my_shared_alias" in str(excinfo.value), str(excinfo.value)
+
+        # The first claimant keeps the key rather than losing it to the merge order.
+        assert resolve_name("My-Shared-Alias") == "first_arm"
+
+
+class TestTheShippedRegistryKeepsLoading:
+    """Controls: the fold widens what validates, it does not narrow it."""
+
+    def test_an_alias_that_folds_to_its_own_canonical_name_is_allowed(self) -> None:
+        """The shipped self-alias, which a fold-blind collision check would refuse."""
+        registry = json.loads((Path(loader_mod.__file__).parent / "robots.json").read_text())["robots"]
+        self_aliased = {
+            name: alias
+            for name, info in registry.items()
+            for alias in info.get("aliases", [])
+            if normalize_robot_name(alias) == name and alias != name
+        }
+        assert self_aliased, "premise: no shipped alias is a second spelling of its own canonical name"
+
+        for name, alias in self_aliased.items():
+            assert resolve_name(alias) == name
+            assert get_robot(alias) is not None
+
+    def test_every_shipped_alias_still_resolves_to_the_robot_that_declares_it(self) -> None:
+        """Re-keying the map moved no alias off its owner."""
+        registry = json.loads((Path(loader_mod.__file__).parent / "robots.json").read_text())["robots"]
+        declared = [(name, alias) for name, info in registry.items() for alias in info.get("aliases", [])]
+        assert len(declared) >= 100, f"premise: few shipped aliases to check ({len(declared)})"
+
+        misrouted = [(alias, name, resolve_name(alias)) for name, alias in declared if resolve_name(alias) != name]
+        assert not misrouted, f"aliases that stopped resolving to their owner: {misrouted}"
+
+
+class TestTheFoldHasOneOwner:
+    """The rule is spelled once, so a reader and a validator cannot drift."""
+
+    def test_no_registry_module_respells_the_fold(self) -> None:
+        """Four modules folded names by hand; the fold now has a single owner."""
+        package = Path(loader_mod.__file__).parent
+        spelled = {
+            path.name: path.read_text().count('.lower().strip().replace("-", "_")') for path in package.glob("*.py")
+        }
+        assert spelled.get("loader.py") == 1, f"premise: loader.py does not define the fold ({spelled})"
+        respelled = {name: count for name, count in spelled.items() if count and name != "loader.py"}
+        assert not respelled, f"modules respelling the fold instead of importing it: {respelled}"
+
+    def test_the_fold_is_the_rule_its_callers_need(self) -> None:
+        """The exported rule answers the same key the lookups are keyed by."""
+        for spelling in ("My-Arm", "  MY-ARM  ", "my_arm"):
+            assert normalize_robot_name(spelling) == "my_arm"

--- a/tests/registry/test_alias_lookup_keys_follow_the_query_fold.py
+++ b/tests/registry/test_alias_lookup_keys_follow_the_query_fold.py
@@ -182,6 +182,40 @@ class TestTheShippedRegistryKeepsLoading:
             assert resolve_name(alias) == name
             assert get_robot(alias) is not None
 
+    def test_a_self_folding_alias_resolves_without_an_identity_map_entry(self) -> None:
+        """The carve-out is a canonical-name hit, not an alias entry meaning itself.
+
+        ``resolve_name`` answers a second spelling of a canonical name from
+        ``canonical_names``, so keying it into the alias map as well adds an
+        entry whose key equals its value. That is not free: ``list_aliases`` is
+        the public read of this map, and
+        ``tests/policies/test_provider_alias_discovery.py::test_the_policy_alias_mapping_has_the_shape_the_robot_one_does``
+        states the shape both registries answer in - no alias means itself. The
+        entry only became an identity once alias keys were folded, so the fold
+        is what makes skipping it necessary rather than merely tidy.
+        """
+        registry = json.loads((Path(loader_mod.__file__).parent / "robots.json").read_text())["robots"]
+        self_folding = {
+            name: alias
+            for name, info in registry.items()
+            for alias in info.get("aliases", [])
+            if normalize_robot_name(alias) == normalize_robot_name(name)
+        }
+        assert self_folding, "premise: no shipped alias folds onto its own canonical name"
+
+        alias_map = list_aliases()
+        identity = {key: value for key, value in alias_map.items() if key == value}
+        assert not identity, f"alias map reports entries that mean themselves: {identity}"
+
+        for name, alias in self_folding.items():
+            assert normalize_robot_name(alias) not in alias_map, (
+                f"'{alias}' is keyed in the alias map as well as being canonical '{name}'"
+            )
+            # Resolution is unchanged in every spelling, off the canonical map.
+            for spelling in (alias, alias.upper(), f"  {alias}  ", name):
+                assert resolve_name(spelling) == name
+                assert get_robot(spelling) is not None
+
     def test_every_shipped_alias_still_resolves_to_the_robot_that_declares_it(self) -> None:
         """Re-keying the map moved no alias off its owner."""
         registry = json.loads((Path(loader_mod.__file__).parent / "robots.json").read_text())["robots"]

--- a/tests/registry/test_integrity.py
+++ b/tests/registry/test_integrity.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+from strands_robots.registry import normalize_robot_name
+
 REGISTRY_PATH = Path(__file__).resolve().parents[2] / "strands_robots" / "registry" / "robots.json"
 
 
@@ -93,24 +95,23 @@ def _all_canonical_names(registry: dict) -> set[str]:
     return set(registry.keys())
 
 
-def _collect_aliases(registry: dict) -> dict[str, str]:
-    """Return mapping of alias → owning robot name."""
-    out: dict[str, str] = {}
-    for name, info in registry.items():
-        for alias in info.get("aliases", []) or []:
-            out.setdefault(alias, name)
-    return out
-
-
 def test_aliases_unique_across_registry(registry: dict) -> None:
-    """No two robots may declare the same alias - last-loaded would silently win."""
-    seen: dict[str, str] = {}
+    """No two robots may declare the same alias - last-loaded would silently win.
+
+    Compared as lookup keys (:func:`~strands_robots.registry.loader.normalize_robot_name`),
+    not as declared spellings: every reader folds a query before matching it, so
+    ``"My-Arm"`` and ``"my_arm"`` are one alias and comparing them raw passes the
+    very pair whose winner the merge order then decides.
+    """
+    seen: dict[str, tuple[str, str]] = {}
     collisions: list[str] = []
     for name, info in registry.items():
         for alias in info.get("aliases", []) or []:
-            if alias in seen and seen[alias] != name:
-                collisions.append(f"{alias!r} used by {seen[alias]} AND {name}")
-            seen[alias] = name
+            key = normalize_robot_name(alias)
+            if key in seen and seen[key][1] != name:
+                prior_alias, prior_name = seen[key]
+                collisions.append(f"{alias!r} used by {name} AND {prior_alias!r} by {prior_name} (one key: {key!r})")
+            seen[key] = (alias, name)
     assert not collisions, "Alias collisions:\n  " + "\n  ".join(collisions)
 
 
@@ -119,14 +120,17 @@ def test_no_alias_shadows_canonical_name(registry: dict) -> None:
 
     Shadowing causes resolution order to silently determine the winner, which
     is fragile - a future reorder of robots.json could flip which robot a
-    name resolves to.
+    name resolves to. Compared as lookup keys for the same reason as
+    :func:`test_aliases_unique_across_registry`; an alias that folds to its OWN
+    canonical name is just a second spelling of it and is allowed.
     """
     canonical = _all_canonical_names(registry)
     shadows: list[str] = []
     for name, info in registry.items():
         for alias in info.get("aliases", []) or []:
-            if alias in canonical and alias != name:
-                shadows.append(f"{name}.aliases contains {alias!r} which is a canonical robot name")
+            key = normalize_robot_name(alias)
+            if key in canonical and key != name:
+                shadows.append(f"{name}.aliases contains {alias!r}, the canonical robot name {key!r}")
     assert not shadows, "Alias shadows canonical:\n  " + "\n  ".join(shadows)
 
 

--- a/tests/registry/test_public_member_docstrings.py
+++ b/tests/registry/test_public_member_docstrings.py
@@ -55,6 +55,7 @@ _EXPECTED_FUNCTIONS = {
     "discovery.py::list_urdf_discoverable",
     "discovery.py::urdf_descriptions_module",
     "loader.py::invalidate_cache",
+    "loader.py::normalize_robot_name",
     "loader.py::reload",
     "policies.py::build_policy_kwargs",
     "policies.py::get_policy_provider",

--- a/tests/test_registry_integrity.py
+++ b/tests/test_registry_integrity.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+from strands_robots.registry import normalize_robot_name
+
 REGISTRY_PATH = Path(__file__).parent.parent / "strands_robots" / "registry" / "robots.json"
 
 
@@ -93,24 +95,23 @@ def _all_canonical_names(registry: dict) -> set[str]:
     return set(registry.keys())
 
 
-def _collect_aliases(registry: dict) -> dict[str, str]:
-    """Return mapping of alias → owning robot name."""
-    out: dict[str, str] = {}
-    for name, info in registry.items():
-        for alias in info.get("aliases", []) or []:
-            out.setdefault(alias, name)
-    return out
-
-
 def test_aliases_unique_across_registry(registry: dict) -> None:
-    """No two robots may declare the same alias - last-loaded would silently win."""
-    seen: dict[str, str] = {}
+    """No two robots may declare the same alias - last-loaded would silently win.
+
+    Compared as lookup keys (:func:`~strands_robots.registry.loader.normalize_robot_name`),
+    not as declared spellings: every reader folds a query before matching it, so
+    ``"My-Arm"`` and ``"my_arm"`` are one alias and comparing them raw passes the
+    very pair whose winner the merge order then decides.
+    """
+    seen: dict[str, tuple[str, str]] = {}
     collisions: list[str] = []
     for name, info in registry.items():
         for alias in info.get("aliases", []) or []:
-            if alias in seen and seen[alias] != name:
-                collisions.append(f"{alias!r} used by {seen[alias]} AND {name}")
-            seen[alias] = name
+            key = normalize_robot_name(alias)
+            if key in seen and seen[key][1] != name:
+                prior_alias, prior_name = seen[key]
+                collisions.append(f"{alias!r} used by {name} AND {prior_alias!r} by {prior_name} (one key: {key!r})")
+            seen[key] = (alias, name)
     assert not collisions, "Alias collisions:\n  " + "\n  ".join(collisions)
 
 
@@ -119,14 +120,17 @@ def test_no_alias_shadows_canonical_name(registry: dict) -> None:
 
     Shadowing causes resolution order to silently determine the winner, which
     is fragile - a future reorder of robots.json could flip which robot a
-    name resolves to.
+    name resolves to. Compared as lookup keys for the same reason as
+    :func:`test_aliases_unique_across_registry`; an alias that folds to its OWN
+    canonical name is just a second spelling of it and is allowed.
     """
     canonical = _all_canonical_names(registry)
     shadows: list[str] = []
     for name, info in registry.items():
         for alias in info.get("aliases", []) or []:
-            if alias in canonical and alias != name:
-                shadows.append(f"{name}.aliases contains {alias!r} which is a canonical robot name")
+            key = normalize_robot_name(alias)
+            if key in canonical and key != name:
+                shadows.append(f"{name}.aliases contains {alias!r}, the canonical robot name {key!r}")
     assert not shadows, "Alias shadows canonical:\n  " + "\n  ".join(shadows)
 
 


### PR DESCRIPTION
`resolve_name` folds a caller's query before looking it up - lowercase, trim, dash as underscore. Canonical robot names are stored folded, so they match. **Aliases were keyed as declared**, and the query is folded before it reaches the map.

![alias lookup-key fold, before and after](https://raw.githubusercontent.com/cagataycali/robots/b189fb59742578df843d68099e21cf11d375d388/.artifacts/alias-fold-before-after.png)

Measured on pristine `upstream/main` vs this branch: one alias, five declared spellings x five queried spellings.

## The two consequences

| | before | after |
|---|---|---|
| `aliases=["My-Arm-V2"]`, queried any way | reaches **no robot** - in every spelling, including the declared one | reaches `probe_arm` |
| `aliases=["Franka-Panda"]` on `probe_arm` | **accepted**; `resolve_name` answers `'panda'` and `get_robot(...)["description"]` is `'Franka Emika Panda (7-DOF + gripper)'` | refused: `Duplicate robot alias 'Franka-Panda': claimed by both 'panda' and 'probe_arm' ('franka_panda' and 'Franka-Panda' are one lookup key, 'franka_panda')` |
| 25 lookups reaching the declaring robot | 5/25 | 25/25 |

The second row is the one that matters: a name declared for one robot resolved to a *different* robot, so `Robot("Franka-Panda")` builds the Franka.

## Why it was reachable

The uniqueness constraints are the other half of the same rule. `_validate_robots` compared *declared spellings*, so two aliases that are one key to every reader passed validation and the alias map then kept whichever entry merged last (the user overlay). Both sides now compare under the fold, which is what lets the existing fail-closed check in `register_robot` refuse the alias at registration instead of persisting a lookup that lands on someone else - nothing is written for a refused registration.

An alias that folds to its **owner's** canonical name stays legal, the same carve-out `_validate_policies` already makes with `alias != provider_name`. The shipped registry declares exactly one (`reachy_mini` aliases `reachy-mini`), which is also the witness that hyphenated aliases are legitimate vocabulary here. All 121 shipped aliases are distinct under the fold and still resolve to their declaring robot.

## One owner

The fold had four hand-written copies (`discovery._normalize`, `robots.resolve_name`, and twice in `user_registry`). It is now `loader.normalize_robot_name`, exported from `strands_robots.registry` so a caller can predict which robot a name reaches, and the rule the map keys, the queries fold and the validator compares all read it.

## Tests

New `tests/registry/test_alias_lookup_keys_follow_the_query_fold.py`, 33 cells. Pre-fix (behavioural revert of the two halves, shared fold retained so the module imports): **24 failed / 9 passed**. The 9 green rows are the controls - the 5 matrix cells whose *declared* spelling is already folded, plus the shipped-registry and single-owner cells.

The two pre-existing graders in `test_registry_integrity.py` (and its copy at `tests/registry/test_integrity.py`) stated the general contract - "last-loaded would silently win", "shadowing causes resolution order to silently determine the winner" - while comparing raw spellings, so they passed the pair whose winner the merge order decides. Retargeted to compare lookup keys, not deleted; their dead `_collect_aliases` helper is dropped. The pre-existing alias grader in `test_user_registry.py` used `aliases=["my_bot", "tb"]`, both already folded - the one arrangement where the missing fold coincides - while its neighbour graded the same fold on the *name* axis with `"  My-Bot  "`.

## Gate

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean, 1880 files.
- `mypy strands_robots tests tests_integ`: 1 error in 1 file, identical on base and branch.
- `tests/registry` + every `tests/*.py` naming the registry (52 files): **3271 passed, 1 failed**; the failure is `test_docs_arm_compatibility_notes.py::test_every_declared_lerobot_type_is_one_lerobot_registers` (`rebot_b601` absent from the installed lerobot), byte-identical on base.

## Size

| | + | - |
|---|---|---|
| `strands_robots/registry/` (5 files) | 71 | 23 |
| tests (4 files) | 254 | 34 |
| docs + changelog (3 files) | 40 | 4 |

---

## Round 1

**Concern:** `call-test-lint` reported FAILURE. A regression in this diff, not a flake.

```
FAILED tests/policies/test_provider_alias_discovery.py::test_the_policy_alias_mapping_has_the_shape_the_robot_one_does
  - AssertionError: robot registry shape changed
    assert not ['reachy_mini']
```

Folding alias keys turned the one carve-out this PR documents - `reachy_mini`
declaring `reachy-mini` - into an alias map entry whose key equals its value.
That grader states the shape *both* registries answer in, and it is not
incidental: `list_aliases` is the public read of this map, and its policy
counterpart is pinned the same way two lines below (`:259`). A caller asking what
the alias means was being told it means itself.

**Change.** `_build_alias_map` skips an alias that folds onto its **owner's**
canonical name. Resolution is untouched, which is the point: `resolve_name`
answers a second spelling of a canonical name from `canonical_names`, so the
entry never carried a lookup that anything reached through it.

| query | before | after |
|---|---|---|
| `reachy-mini` | `reachy_mini` | `reachy_mini` |
| `Reachy-Mini` | `reachy_mini` | `reachy_mini` |
| `  REACHY-MINI  ` | `reachy_mini` | `reachy_mini` |
| `reachy_mini` | `reachy_mini` | `reachy_mini` |
| `list_aliases()` identity entries | `{'reachy_mini': 'reachy_mini'}` | `{}` |
| `list_aliases()` size | 121 | 120 |

`get_robot` still returns the entry for all four spellings. The carve-out stays
legal at validation - only the map emission changes.

**Pin.** One cell added to `TestTheShippedRegistryKeepsLoading`, the class that
already owns this carve-out:
`test_a_self_folding_alias_resolves_without_an_identity_map_entry`. Against a
behavioural revert it fails with the same witness CI reported
(`{'reachy_mini': 'reachy_mini'}`), so it grades the fix instead of restating it.
The file goes 33 -> 34 cells.

**Gate**, measured base vs branch over the 32 shared test files naming
`resolve_name` / `list_aliases` / `_build_alias_map` (33 on the branch, +1 new):

| | base | this branch |
|---|---|---|
| result | 76 failed / 934 passed / 94 skipped / 11 errors | 76 failed / **968 passed** / 94 skipped / 11 errors |
| FAILED+ERROR node set | 87 | 87, **byte-identical** (`diff` empty) |
| `tests/registry` + `test_registry_integrity.py` + the policy grader | | **932 passed / 14 skipped, 0 failed** |
| `ruff check` / `ruff format --check` | clean | clean |
| `mypy` errors located in `registry/robots.py` | none | none |

The +34 is exactly this file's cells. The 76 standing failures are absent
optional deps (`serial`, torch-family) and installed-lerobot drift.

### On the two CodeQL cyclic-import alerts

Measured rather than asserted. The module-level relative-import edge set of
`strands_robots/registry/`, base vs branch, differs by exactly one edge -
`discovery.py -> loader.py`, which is this PR replacing `discovery._normalize`
with the shared fold. **Neither flagged line is that edge:**

| flagged | on main | on this branch |
|---|---|---|
| `robots.py:11` | `from .loader import _load` | `+ normalize_robot_name` on the same line |
| `user_registry.py:50` | `from .loader import invalidate_cache` | `+ normalize_robot_name` on the same line |

Both files already imported `loader` at module level; the diff adds a name to an
existing import statement, and CodeQL re-reports a pre-existing condition because
the line changed.

The added edge closes no cycle either: `loader.py` has **zero** module-level
relative imports and contains no reference to `discovery` at any level, so it is a
module-level leaf and `X -> loader` cannot complete a module-level cycle. The cycle
CodeQL describes runs through the package `__init__`, which re-exports all five
submodules - so it holds for every submodule-to-submodule import in this package
as it stands on main, and moving the fold to a different module would not change
it. Not fixed here on that basis; happy to file it as its own issue about the
package's re-export layout if that is preferred.
