### PR TITLE
fix(drivers/feetech): a motor spelled twice is refused, not collapsed to one target

### DIFF
--- a/changelog.d/3223-feetech-one-target-per-motor.md
+++ b/changelog.d/3223-feetech-one-target-per-motor.md
@@ -1,0 +1,25 @@
+### Fixed: a Feetech motor spelled twice is refused rather than collapsed to one target
+
+`FeetechDriver.send_action` reduced every action key to the motor it names with
+`{str(key).removesuffix(".pos"): value}`. A mapping carrying both `"gripper"`
+and `"gripper.pos"` therefore became a single entry: insertion order decided
+which of the two targets survived, one motor went onto the SYNC_WRITE frame
+instead of two commands, and the envelope returned `success` naming only the
+survivor. `{"gripper": 0.0, "gripper.pos": 100.0}` opened the gripper fully;
+the same pair in the other order closed it.
+
+Both spellings are first class in this one driver, which is what makes the
+mixed mapping reachable rather than hypothetical.
+`strands_robots.bus_access.read_joints` takes its `bus.sync_read` fast path and
+returns `"<motor>.pos"` keys, while the tool schema (`"joint name -> degrees"`)
+and the success envelope's `commanded` block both speak the bare name -- so a
+caller that reads the arm, edits one joint by the name the envelope reported,
+and sends the result back holds both spellings of that motor.
+
+The reduction now has one owner. It refuses a doubled motor before anything is
+written, naming every motor spelled more than once and the keys that spell it,
+so a caller fixing one collision does not have to discover the next. The
+refusal does not depend on the two values agreeing: a rule that fires only when
+the targets differ is a rule an agent cannot plan against, and one motor takes
+one target either way. Every single-spelling path is unchanged, including the
+read-modify-send round trip that produces a mixed mapping in the first place.

--- a/strands_robots/drivers/feetech/driver.py
+++ b/strands_robots/drivers/feetech/driver.py
@@ -10,7 +10,8 @@ What works and what does not:
 
 * ``send_action`` - writes the commanded joints in one SYNC_WRITE frame.
   Targets are **degrees** (``gripper`` is percent open); a key may be spelled
-  ``shoulder_pan`` or ``shoulder_pan.pos``, matching lerobot's suffix.
+  ``shoulder_pan`` or ``shoulder_pan.pos``, matching lerobot's suffix - but only
+  one of the two per motor, because both name the same servo.
 * ``bus`` / ``is_connected`` - the pair
   :func:`strands_robots.bus_access.joint_read_source` resolves, so an SO-arm
   publishes ``joints`` on the mesh state topic without a wrapper. This is the
@@ -276,7 +277,10 @@ class FeetechDriver:
         Args:
             action: Joint name -> target. Degrees for every joint, percent open
                 for ``gripper``. A ``.pos`` suffix is accepted and stripped, so
-                a lerobot-shaped action dict works unchanged.
+                a lerobot-shaped action dict works unchanged. Each motor must be
+                spelled once: ``{"gripper": 0.0, "gripper.pos": 100.0}`` names one
+                motor twice with two different targets and is refused rather
+                than letting insertion order pick the winner.
             robot_name: Unused; this driver fronts exactly one arm.
 
         Returns:
@@ -287,7 +291,9 @@ class FeetechDriver:
         del robot_name
         if not isinstance(action, dict) or not action:
             return _refuse("send_action: pass a non-empty mapping of joint targets")
-        targets = {str(key).removesuffix(".pos"): value for key, value in action.items()}
+        targets, doubled = _motor_targets(action)
+        if doubled is not None:
+            return _refuse(doubled)
         try:
             with bus_lock(self):
                 self._connect_if_needed()
@@ -481,3 +487,38 @@ class FeetechDriver:
 def _refuse(message: str) -> dict[str, Any]:
     """Return an error envelope with ``message``, matching the "not wired" contract."""
     return {"status": "error", "content": [{"text": message}]}
+
+
+def _motor_targets(action: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Reduce every action key to the motor it names, once.
+
+    ``"<motor>"`` and ``"<motor>.pos"`` are two spellings of one motor, and
+    :func:`strands_robots.bus_access.read_joints` returns the suffixed one for
+    this driver while the tool schema and the success envelope both speak the
+    bare one - so a dict built from a read and then overridden by name carries
+    both. Reducing them silently would make one of the two targets win by
+    insertion order, write a single-motor frame, and report success naming only
+    the survivor: the caller's other command would be gone with nothing saying
+    so. One motor takes one target, so a doubled motor is refused instead.
+
+    Args:
+        action: The caller's mapping of joint name -> target, either spelling.
+
+    Returns:
+        ``(targets, None)`` keyed by motor name, or ``({}, message)`` naming
+        every motor that was spelled more than once and the keys that spell it.
+    """
+    targets: dict[str, Any] = {}
+    spellings: dict[str, list[str]] = {}
+    for key, value in action.items():
+        motor = str(key).removesuffix(".pos")
+        spellings.setdefault(motor, []).append(str(key))
+        targets[motor] = value
+    doubled = {motor: keys for motor, keys in spellings.items() if len(keys) > 1}
+    if doubled:
+        named = "; ".join(f"{sorted(keys)} all name {motor!r}" for motor, keys in sorted(doubled.items()))
+        return {}, (
+            f"send_action: one motor takes one target, but {named}. "
+            "A '.pos' suffix names the same motor as the bare joint, so spell each motor once."
+        )
+    return targets, None

--- a/tests/drivers/test_a_motor_commanded_twice_is_refused_not_collapsed.py
+++ b/tests/drivers/test_a_motor_commanded_twice_is_refused_not_collapsed.py
@@ -1,0 +1,155 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""One motor takes one target, whichever of its two names spells it.
+
+``FeetechDriver.send_action`` accepts a lerobot ``"<motor>.pos"`` key and the
+bare ``"<motor>"`` key for the same servo. Both vocabularies are first class in
+this one driver: :func:`strands_robots.bus_access.read_joints` takes the
+``bus.sync_read`` fast path for it and returns ``"<motor>.pos"`` keys, while the
+tool schema (``"joint name -> degrees"``) and the success envelope's
+``commanded`` block both speak the bare name. So a caller that reads the arm,
+edits one joint by the name the envelope reported, and sends the result back
+holds a mapping with both spellings of that motor.
+
+Reducing the two keys to one motor is what the driver must do; doing it
+silently is what it must not. A dict comprehension keyed on the stripped name
+lets insertion order decide which of two targets survives, writes a frame
+carrying one motor instead of two commands, and returns ``success`` naming only
+the survivor - so ``{"gripper": 0.0, "gripper.pos": 100.0}`` opened the gripper
+fully and reported success, and the same pair in the other order closed it.
+
+These cells pin both halves of the refusal: the envelope says which keys name
+one motor, and the write did not happen. The controls are the single-spelling
+paths that must keep working, including the full read-modify-send round trip
+that produces a mixed dict in the first place.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strands_robots.bus_access import read_joints
+from strands_robots.drivers.feetech import FeetechDriver
+from strands_robots.drivers.feetech.bus import SO_ARM_MOTORS
+from tests.drivers.conftest import FakeServoPort
+
+#: Servo ids the fake port answers for, all parked mid-scale.
+_PARKED = dict.fromkeys((1, 2, 3, 4, 5, 6), 2048)
+
+
+def _wired() -> FeetechDriver:
+    """A driver whose bus already holds a fake port, as if connected."""
+    driver = FeetechDriver(tool_name="so101", port="/dev/fake")
+    driver.bus._conn = FakeServoPort(dict(_PARKED))
+    return driver
+
+
+def _port(driver: FeetechDriver) -> FakeServoPort:
+    """The fake port behind ``driver``'s bus, narrowed to its recording surface."""
+    conn = driver.bus._conn
+    assert isinstance(conn, FakeServoPort)
+    conn.writes.clear()
+    return conn
+
+
+class TestADoubledMotorIsRefused:
+    """Two keys naming one motor are named back, and nothing is written."""
+
+    @pytest.mark.parametrize(
+        ("action", "motor"),
+        [
+            ({"gripper": 0.0, "gripper.pos": 100.0}, "gripper"),
+            ({"gripper.pos": 100.0, "gripper": 0.0}, "gripper"),
+            ({"gripper": 50.0, "gripper.pos": 50.0}, "gripper"),
+            ({"shoulder_pan": 10.0, "shoulder_pan.pos": -10.0, "gripper": 50.0}, "shoulder_pan"),
+        ],
+        ids=["bare-then-suffixed", "suffixed-then-bare", "same-target-twice", "doubled-among-others"],
+    )
+    def test_a_motor_spelled_twice_is_refused(self, action: dict[str, Any], motor: str) -> None:
+        """The refusal names the motor and both keys that spell it."""
+        driver = _wired()
+        _port(driver)
+
+        result = driver.send_action(action)
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert repr(motor) in text
+        for key in action:
+            if key.removesuffix(".pos") == motor:
+                assert repr(key) in text
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            {"gripper": 0.0, "gripper.pos": 100.0},
+            {"gripper.pos": 100.0, "gripper": 0.0},
+            {"shoulder_pan": 10.0, "shoulder_pan.pos": -10.0, "gripper": 50.0},
+        ],
+        ids=["bare-then-suffixed", "suffixed-then-bare", "doubled-among-others"],
+    )
+    def test_the_refused_command_never_reaches_the_wire(self, action: dict[str, Any]) -> None:
+        """A refusal after the write would still have moved the arm."""
+        driver = _wired()
+        port = _port(driver)
+
+        driver.send_action(action)
+
+        assert port.writes == []
+
+    def test_every_doubled_motor_is_named_not_just_the_first(self) -> None:
+        """A caller fixing one collision should not have to discover the next."""
+        driver = _wired()
+        _port(driver)
+
+        result = driver.send_action({"gripper": 0.0, "gripper.pos": 100.0, "wrist_roll": 5.0, "wrist_roll.pos": -5.0})
+
+        text = result["content"][0]["text"]
+        assert "'gripper'" in text and "'wrist_roll'" in text
+
+
+class TestOneSpellingPerMotorStillCommandsTheArm:
+    """The controls: neither vocabulary loses anything to the new refusal."""
+
+    @pytest.mark.parametrize(
+        ("action", "commanded"),
+        [
+            ({"shoulder_pan": 90.0, "gripper": 100.0}, {"shoulder_pan": 90.0, "gripper": 100.0}),
+            ({"shoulder_pan.pos": 0.0}, {"shoulder_pan": 0.0}),
+            (
+                {f"{name}.pos": 0.0 for name in SO_ARM_MOTORS},
+                dict.fromkeys(SO_ARM_MOTORS, 0.0),
+            ),
+        ],
+        ids=["bare", "suffixed", "every-motor-suffixed"],
+    )
+    def test_a_motor_spelled_once_is_commanded(self, action: dict[str, Any], commanded: dict[str, float]) -> None:
+        """The envelope reports the motors, keyed by their bare names."""
+        driver = _wired()
+        port = _port(driver)
+
+        result = driver.send_action(action)
+
+        assert result["status"] == "success"
+        assert result["content"][0]["json"]["commanded"] == commanded
+        assert len(port.writes) == 1
+
+    def test_a_read_sent_straight_back_is_accepted(self) -> None:
+        """The documented round trip: read the arm, command the same pose.
+
+        ``read_joints`` returns this driver's positions as ``"<motor>.pos"``,
+        which is exactly one spelling per motor - so the mapping a caller reads
+        is a mapping it can send.
+        """
+        driver = _wired()
+        joints = read_joints(driver)
+        assert set(joints) == {f"{name}.pos" for name in SO_ARM_MOTORS}
+        port = _port(driver)
+
+        result = driver.send_action(dict(joints))
+
+        assert result["status"] == "success"
+        assert set(result["content"][0]["json"]["commanded"]) == set(SO_ARM_MOTORS)
+        assert len(port.writes) == 1


### PR DESCRIPTION
`FeetechDriver.send_action` reduced every action key to the motor it names:

```python
targets = {str(key).removesuffix(".pos"): value for key, value in action.items()}
```

So a mapping carrying both `"gripper"` and `"gripper.pos"` became **one** entry. Insertion order picked the survivor, one motor went onto the SYNC_WRITE frame instead of two commands, and the envelope returned `success` naming only the survivor.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/5ca49244ce2247d029f4e2378c1eced5905ec081/.artifacts/feetech-doubled-motor.png)

## The same request, two answers

Measured through `tests/drivers/conftest.FakeServoPort`, so the codec and the frame are real:

| `action` | keys | before | gripper commanded | after |
| --- | --- | --- | --- | --- |
| `{"gripper": 0.0, "gripper.pos": 100.0}` | 2 | `success`, 1 motor on the wire | **100 % open** | refused, 0 frames |
| `{"gripper.pos": 100.0, "gripper": 0.0}` | 2 | `success`, 1 motor on the wire | **0 % open** | refused, 0 frames |
| `{"shoulder_pan": 10.0, "shoulder_pan.pos": -10.0, "gripper": 50.0}` | 3 | `success`, 2 motors on the wire | - | refused, 0 frames |
| `{"shoulder_pan": 90.0, "gripper": 100.0}` | 2 | `success`, 2 motors | 100 | unchanged |
| `{"shoulder_pan.pos": 0.0}` | 1 | `success`, 1 motor | - | unchanged |
| every motor, `.pos` | 6 | `success`, 6 motors | 0 | unchanged |
| `read_joints()` sent straight back | 6 | `success`, 6 motors | - | unchanged |

## Why a mixed mapping is reachable

Both spellings are first class in this one driver:

```mermaid
flowchart LR
  A["read_joints(driver)"] -->|"bus.sync_read fast path"| B["{'gripper.pos': 42.0, ...}"]
  B --> C["caller edits one joint by the name<br/>the schema and envelope report"]
  C --> D["{'gripper.pos': 42.0, ..., 'gripper': 0.0}"]
  D --> E["send_action"]
```

`bus_access.read_joints` returns `"<motor>.pos"` keys for a driver that owns its bus, while the tool schema (`"joint name -> degrees"`) and the success envelope's `commanded` block speak the bare name. A read-modify-send round trip therefore yields both spellings of the edited motor, and nothing between the caller and the servo said one command had been dropped.

## Change

The reduction gets one owner, `_motor_targets`, which refuses a doubled motor **before** anything is written and names every motor spelled more than once together with the keys that spell it:

```
send_action: one motor takes one target, but ['gripper', 'gripper.pos'] all name 'gripper'.
A '.pos' suffix names the same motor as the bare joint, so spell each motor once.
```

The refusal does not branch on whether the two values agree. A rule that fires only when the targets differ is a rule an agent cannot plan against, and one motor takes one target either way; being refused for a redundant key costs a retry, while a dropped gripper command does not announce itself.

## Tests

`tests/drivers/test_a_motor_commanded_twice_is_refused_not_collapsed.py`, 12 cells, table-driven over the doubled spellings. Both halves of the refusal are pinned - the envelope names the keys, **and** `port.writes == []`, since a refusal arriving after the write would still have moved the arm. Four controls cover the single-spelling paths, including the read-modify-send round trip.

Pre-fix on `upstream/main` (6d5162715): **8 failed / 4 passed**, every failure naming an ungated doubled motor and all four controls green. Post-fix: 12 passed.

## Gate

| check | result |
| --- | --- |
| `ruff check` + `format --check` | clean, 1881 files |
| `mypy strands_robots tests tests_integ` | 20 errors in 6 files, byte-identical to `main` |
| `pytest tests/drivers` | 2367 -> **2379** passed, 7 skipped (+12 = the new cells) |
| `scripts/check_whole_tree_graders.py` | 4372 passed; the 13 failures + 4 errors are set-identical to `main` (absent optional deps, installed-lerobot drift) |

Size: +224 / -3 across 3 files (source +44/-3, test +155, changelog fragment +25).