### PR TITLE
fix(teleop): stop_teleoperate reached on the loop's own thread still releases the devices

### DIFF
--- a/changelog.d/3224-teleop-stop-on-the-loops-own-thread.md
+++ b/changelog.d/3224-teleop-stop-on-the-loops-own-thread.md
@@ -1,0 +1,54 @@
+### Fixed: `stop_teleoperate` reached on the loop's own thread still releases the devices
+
+`Robot.__del__` calls `cleanup()`, and `cleanup()` calls `stop_teleoperate()`.
+The teleop loop's `Thread` target is a closure over the robot -- `teleoperate`
+builds `loop = lambda: self._teleop_loop(...)` and hands it to
+`Thread(target=loop)` -- so that closure holds the last reference to the robot
+once the caller drops its handle. When the body returns, `Thread.run` releases
+it, and the finalizer, with the whole terminal teardown behind it, runs *on the
+teleop thread*.
+
+`thread.join()` there raises `RuntimeError: cannot join current thread`, which
+leaves `stop_teleoperate` from the middle of the method. Everything after the
+join is skipped: `_stop_publishers()` does not run, the attached teleoperators
+are not disconnected, and the thread handle is not cleared. `cleanup()` catches
+it, warns, and -- because a raise leaves the outcome unknown rather than
+positively reporting a live loop -- goes on to close the robot's own devices and
+log `cleanup completed`.
+
+Measured on a one-camera arm driven by a leader holding its own port, with both
+device nodes' exclusivity modelled:
+
+| teardown route | publishers stopped | leader `disconnect()` | leader port |
+| --- | --- | --- | --- |
+| finalized on its own teleop thread | no | 0 | held |
+| explicit `cleanup()` (control) | yes | 1 | released |
+
+So the robot's own bus and cameras were released and the *teleoperator's* port
+stayed held for the life of the process, under a `cleanup completed` report.
+That asymmetry is why it went unnoticed: the leak is in the one device group
+whose disconnect lives inside `stop_teleoperate` rather than in
+`_disconnect_devices`, and `cleanup()`'s docstring promises that after it runs
+"no device node stays held".
+
+A self-join is knowable rather than unknown, which is what makes carrying on
+the right answer instead of a guess: `_teleop_loop` never calls this verb, so
+the only way control reaches it on that thread is after the body has already
+returned, and there is no *other* thread that could still be writing -- so the
+failed-join branch's reason for leaving the devices connected cannot apply. The
+join is skipped, the rest of the teardown runs, and the handle is cleared as a
+real join clears it. The decision `cleanup()` makes about the robot's *own*
+devices is deliberately unchanged: it closed them on the raise path and it
+closes them now.
+
+The failed-join branch added in "report whether `stop_teleoperate` actually
+stopped the loop" is untouched -- a leader whose `get_action()` outlasts the 3 s
+budget still yields `status="error"` with `stopped: false`, still keeps its
+devices connected, and still keeps the handle for a second call to re-join.
+
+The finalizer's records are also how this surfaced. A finalizer runs at
+garbage-collection time, so its two records land in whatever code happens to be
+executing. Three cells that meant "this function warned about nothing" asserted
+`caplog.text == ""`, which grades every record in the process, at every level,
+for the whole test -- so a finalizer's report on another thread read as the
+subject speaking. They now grade the records of the logger they name.

--- a/docs/hardware/teleoperation.md
+++ b/docs/hardware/teleoperation.md
@@ -87,7 +87,7 @@ Every hardware `Robot` and `Simulation` host exposes:
 | `attach_teleop(device_or_spec, *, name=None, method=None, map_fn=None, **kwargs)` | Register an input stream (lazy - no hardware touched). `device_or_spec` is a built teleop instance **or** a type string built via `Teleoperator(**kwargs)`. |
 | `teleoperate(*, names=None, robot_name=None, hz=50.0, publish=False, block=False, duration=None)` | Run the control loop. |
 | `detach_teleop(name=None)` | Remove one (or all) attached streams. Stops the loop before touching a device when the detach would leave it with nothing to drive, and refuses with `detached: []` if that loop does not stop. |
-| `stop_teleoperate()` | Stop the loop, any mesh publishers, and disconnect devices. Reports `status="error"` with `stopped: false` when the loop outlasts its 3 s join budget - the devices are left connected rather than torn down mid-write, and a second call re-joins the same loop. |
+| `stop_teleoperate()` | Stop the loop, any mesh publishers, and disconnect devices. Reports `status="error"` with `stopped: false` when the loop outlasts its 3 s join budget - the devices are left connected rather than torn down mid-write, and a second call re-joins the same loop. Reached on the loop's own thread - which `Robot.__del__` does, since the thread's target is a closure over the robot - there is nothing to join, and it stops the publishers and disconnects as any clean stop does. |
 
 ### `attach_teleop`
 

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -710,6 +710,15 @@ class TeleopMixin:
         refuses for the same reason, and the thread handle is kept when the join
         fails so a later call re-joins that loop instead of reporting an idle
         session.
+
+        Reached *on* the loop's own thread there is nothing to join, and this
+        stops the publishers and disconnects the devices as any clean stop does.
+        ``Robot.__del__`` arrives that way -- the thread's target is a closure
+        over the robot, so the finalizer runs on the teleop thread once the body
+        returns and releases it -- and ``join()`` there raises
+        ``RuntimeError: cannot join current thread``, which would abandon the
+        rest of the teardown and leave the teleoperator's port held. The loop
+        never calls this verb itself, so that arrival is always post-return.
         """
         self._ensure_teleop_state()
 
@@ -723,12 +732,34 @@ class TeleopMixin:
         thread = self._teleop_thread
         joined = True
         if thread is not None:
-            thread.join(timeout=_TELEOP_JOIN_TIMEOUT_S)
-            joined = not thread.is_alive()
-            if joined:
-                # Cleared only on a real join: the handle is the only route by
-                # which a later call, or a status read, can still see the loop.
+            if thread is threading.current_thread():
+                # This call is running *on* the loop's own thread, which
+                # ``Robot.__del__`` reaches: the thread's target is a closure
+                # over the robot, so once the caller drops its handle that
+                # closure holds the last reference, and ``Thread.run`` releasing
+                # it when the body returns runs the finalizer -- and the
+                # ``cleanup()`` behind it -- here. ``join()`` would raise
+                # ``RuntimeError: cannot join current thread`` from the middle of
+                # this method, taking ``_stop_publishers()`` and the device
+                # disconnect below with it and leaving the teleoperator's port
+                # held for the life of the process under a "cleanup completed"
+                # report.
+                #
+                # Nothing is left to wait for, which is why this carries on
+                # rather than reporting a live loop: ``_teleop_loop`` never calls
+                # this verb, so the only way control reaches it on that thread is
+                # after the body has returned. Nor can the failed-join branch's
+                # reason apply -- there is no *other* thread that could still be
+                # writing, so the devices are not being torn down under a live
+                # writer. Clear the handle, as a real join does.
                 self._teleop_thread = None
+            else:
+                thread.join(timeout=_TELEOP_JOIN_TIMEOUT_S)
+                joined = not thread.is_alive()
+                if joined:
+                    # Cleared only on a real join: the handle is the only route by
+                    # which a later call, or a status read, can still see the loop.
+                    self._teleop_thread = None
 
         self._stop_publishers()
 

--- a/tests/mesh/test_non_hub_session_topology.py
+++ b/tests/mesh/test_non_hub_session_topology.py
@@ -129,4 +129,7 @@ def test_unrecognised_fallback_mode_warns_and_stays_client(
         assert "STRANDS_MESH_FALLBACK_MODE" in caplog.text
     else:
         # An empty value is "unset", not a typo, so it warrants no warning.
-        assert caplog.text == ""
+        # Scoped to the module's own logger: ``caplog`` captures every record in the
+        # process, at every level, for the whole test, so a background thread's record
+        # would otherwise read as this module reporting.
+        assert [r.getMessage() for r in caplog.records if r.name == mod.logger.name] == []

--- a/tests/mesh/test_stream_hz_domain.py
+++ b/tests/mesh/test_stream_hz_domain.py
@@ -146,7 +146,11 @@ class TestAnUnusableValueIsReportedAndDisablesPublishing:
 
         # 0 is a request, not a mistake; warning about it trains operators to
         # ignore the warning that does mean something.
-        assert caplog.text == ""
+        # Scoped to the session module's own logger: ``caplog`` captures every record in
+        # the process, at every level, for the whole test, so a background thread's
+        # record -- a finalizer's teardown report, say -- would otherwise read as
+        # that module reporting.
+        assert [r.getMessage() for r in caplog.records if r.name == "strands_robots.mesh.session"] == []
 
 
 class TestNeitherCallSiteDividesTheRawEnvValue:

--- a/tests/test_dashboard_auth_enabled_flag_domain.py
+++ b/tests/test_dashboard_auth_enabled_flag_domain.py
@@ -85,7 +85,11 @@ class TestAnUnrecognizedValueCannotDisableAnEnrolledGate:
         monkeypatch.setenv("STRANDS_DASH_AUTH_ENABLED", "false")
         with caplog.at_level(logging.WARNING, logger="strands_robots.dashboard.auth"):
             assert auth.auth_enabled() is False
-        assert caplog.text == ""
+        # Scoped to this function's own logger: ``caplog`` captures every record in
+        # the process, at every level, for the whole test, so a background thread's
+        # record -- a finalizer's teardown report, say -- would otherwise read as
+        # this function reporting.
+        assert [r.getMessage() for r in caplog.records if r.name == auth.logger.name] == []
 
 
 class TestTheRecognizedVocabulariesStillOverride:

--- a/tests/test_teleop_stop_releases_the_devices_when_the_loop_is_the_caller.py
+++ b/tests/test_teleop_stop_releases_the_devices_when_the_loop_is_the_caller.py
@@ -1,0 +1,350 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``stop_teleoperate`` reached on the loop's own thread must still release the devices.
+
+``Robot.__del__`` calls ``cleanup()``, and ``cleanup()`` calls
+``stop_teleoperate()``. The loop's ``Thread`` target is a closure over the robot
+(``teleoperate`` builds ``loop = lambda: self._teleop_loop(...)`` and hands it to
+``Thread(target=loop)``), so that closure is the last reference to the robot once
+the caller drops its handle. When the body returns, ``Thread.run`` does
+``del self._target``, the reference goes, and the finalizer -- with the whole
+terminal teardown behind it -- runs *on the teleop thread*.
+
+``thread.join()`` there raises ``RuntimeError: cannot join current thread``. The
+raise leaves ``stop_teleoperate`` from the middle of the method, so everything
+after the join is skipped: the mesh publishers are not stopped, the attached
+teleoperators are not disconnected, and the thread handle is not cleared.
+``cleanup()`` catches it, warns, and -- because a raise leaves the outcome
+unknown rather than positively reporting a live loop -- goes on to close the
+robot's own devices and log ``cleanup completed``.
+
+Measured on a one-camera arm driven by a leader holding its own port, with both
+device nodes' exclusivity modelled:
+
+    teardown route                       publishers stopped   leader disconnect   leader port
+    finalized on its own teleop thread          no                   0             held
+    explicit cleanup() (control)                yes                  1             released
+
+So the robot's own bus and cameras were released and the *teleoperator's* port
+was not -- which is why this went unnoticed: the leak is in the one device group
+whose disconnect lives inside ``stop_teleoperate`` rather than in
+``_disconnect_devices``. ``cleanup()``'s docstring says it disconnects "the
+motors bus and every camera -- so no device node stays held"; on this route one
+stayed held for the life of the process, under a ``cleanup completed`` report.
+
+There is nothing to wait for on that route, which is what makes carrying on the
+right answer rather than a guess: ``_teleop_loop`` never calls this verb (graded
+below), so the only way control reaches it on the loop's thread is after the
+body has already returned, and no other thread can be writing -- so the "do not
+tear the bus down under a live writer" reason the failed-join branch exists for
+cannot apply. The decision ``cleanup()`` makes about the robot's *own* devices is
+deliberately unchanged: it closed them on the raise path and it closes them now.
+
+The records the raise produced are also how this surfaced. A finalizer runs at
+garbage-collection time, so its two records land in whatever code happens to be
+executing -- an unrelated test, in a suite with daemon threads. A cell that means
+"this function warned about nothing" and asserts ``caplog.text == ""`` grades
+every record in the process at every level for the whole test, so it reads a
+finalizer on another thread as its own subject speaking. The three cells that
+made that claim now grade the records of the logger they name; the pytest
+behaviour that makes the distinction necessary is pinned here.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import pathlib
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import strands_robots.teleop_mixin as tm
+from strands_robots.hardware_robot import Robot as HwRobot
+from tests.test_hardware_cleanup_disconnects import _arm, _make_robot, _Port
+
+# Short enough to keep every cell fast. The shipped budget is pinned by
+# ``test_stop_teleoperate_reports_the_join_outcome``; what matters here is only
+# that a join can be attempted and can fail.
+_FAST_JOIN_S = 0.3
+
+# The cells that claim a named logger stayed quiet. Held as a literal so a
+# fourth one cannot join the claim without joining the rule.
+QUIET_LOGGER_CLAIMS = (
+    "tests/test_dashboard_auth_enabled_flag_domain.py",
+    "tests/mesh/test_non_hub_session_topology.py",
+    "tests/mesh/test_stream_hz_domain.py",
+)
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _fast_join(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tm, "_TELEOP_JOIN_TIMEOUT_S", _FAST_JOIN_S)
+
+
+class _LeaderPort:
+    """The teleoperator's own device node: exclusive, like the follower's."""
+
+    def __init__(self) -> None:
+        self.held_by: str | None = None
+
+    def open(self, holder: str) -> None:
+        if self.held_by is not None:
+            raise OSError(f"[Errno 16] Device or resource busy: held by {self.held_by}")
+        self.held_by = holder
+
+    def close(self) -> None:
+        self.held_by = None
+
+
+class _Leader:
+    """A teleoperator holding a port, released only inside ``stop_teleoperate``."""
+
+    def __init__(self, port: _LeaderPort) -> None:
+        self.port = port
+        self.is_connected = False
+        self.disconnects = 0
+
+    def connect(self) -> None:
+        self.port.open("leader")
+        self.is_connected = True
+
+    def get_action(self) -> dict[str, float]:
+        return {"j0.pos": 0.5}
+
+    def disconnect(self) -> None:
+        self.disconnects += 1
+        self.port.close()
+        self.is_connected = False
+
+
+class _Observables:
+    """Everything a cell asserts on, none of it referring back to the robot."""
+
+    def __init__(self) -> None:
+        self.follower_port = _Port()
+        self.leader_port = _LeaderPort()
+        self.leader = _Leader(self.leader_port)
+        self.driver: Any = None
+        self.thread: threading.Thread | None = None
+        self.publishers_stopped: list[str] = []
+        self.body_returned = threading.Event()
+        self.release = threading.Event()
+
+
+def _register_session(obs: _Observables, *, keep: bool, stop_from_the_loop: list[Any] | None = None) -> Any:
+    """Start a teleop session in its own frame, as ``teleoperate`` does.
+
+    The robot is built and the thread started here so that when this frame
+    returns the loop's closure is the only reference left -- which is the
+    reference topology ``teleoperate`` creates and the reason the finalizer can
+    land on the teleop thread.
+
+    Args:
+        obs: Handles the caller keeps; none of them reference the robot.
+        keep: Return the robot too, so the caller pins it alive (the ordinary
+            route, where the finalizer never runs on the loop's thread).
+        stop_from_the_loop: When given, the loop body calls
+            ``stop_teleoperate()`` itself and appends the envelope -- or the
+            exception -- here. That is the same arrival as the finalizer's,
+            deterministically and without a garbage-collection step.
+
+    Returns:
+        The robot when ``keep``, else ``None``.
+    """
+    driver = _arm(obs.follower_port)
+    self = _make_robot(driver)
+    driver.connect()
+    obs.driver = driver
+    self._ensure_teleop_state()
+    obs.leader.connect()
+    self._teleops = {"leader": type("_Att", (), {"device": obs.leader})()}
+    self._teleop_robot_name = "test_arm"
+    self._teleop_running = True
+    self._teleop_start_mono = time.monotonic()
+
+    body_returned, release = obs.body_returned, obs.release
+
+    def body(robot: Any) -> None:
+        while robot._teleop_running and not robot._teleop_stop_event.is_set():
+            release.wait(10.0)
+            break
+        if stop_from_the_loop is not None:
+            try:
+                stop_from_the_loop.append(robot.stop_teleoperate())
+            except Exception as exc:  # noqa: BLE001 - the raise IS what this cell grades
+                stop_from_the_loop.append(exc)
+        body_returned.set()
+
+    # teleop_mixin.teleoperate: a local closure over the robot, handed to Thread.
+    loop = lambda: body(self)  # noqa: E731
+    self._teleop_thread = threading.Thread(target=loop, name=f"teleop-{self.tool_name_str}", daemon=True)
+    obs.thread = self._teleop_thread
+    self._teleop_thread.start()
+    return self if keep else None
+
+
+def _drop_and_finalize(obs: _Observables) -> None:
+    """Let the loop return with its closure holding the last robot reference."""
+    obs.release.set()
+    assert obs.body_returned.wait(5.0), "premise: the loop body never returned"
+    assert obs.thread is not None
+    obs.thread.join(5.0)
+    assert not obs.thread.is_alive(), "premise: the teleop thread never exited"
+
+
+def _records(caplog: pytest.LogCaptureFixture, name: str) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.name == name]
+
+
+def _watch_publisher_stop(monkeypatch: pytest.MonkeyPatch, seen: list[str]) -> None:
+    """Record which thread stopped the session's publishers, and let it run.
+
+    ``_stop_publishers`` is the first thing after the join, so it is the step a
+    ``RuntimeError`` from ``join()`` silently takes with it.
+    """
+    original = HwRobot._stop_publishers
+
+    def recorded(self: Any) -> None:
+        seen.append(threading.current_thread().name)
+        original(self)
+
+    monkeypatch.setattr(HwRobot, "_stop_publishers", recorded)
+
+
+class TestThePremise:
+    """Why a self-join means the body has returned, and how it is reached."""
+
+    def test_the_loop_never_calls_the_stop_verb_itself(self) -> None:
+        """So control on the loop's thread can only be post-return."""
+        tree = ast.parse(inspect.getsource(tm))
+        loops = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "_teleop_loop"]
+        assert len(loops) == 1, "the loop body moved; this premise needs re-deriving"
+        called = {
+            (c.func.attr if isinstance(c.func, ast.Attribute) else getattr(c.func, "id", ""))
+            for c in ast.walk(loops[0])
+            if isinstance(c, ast.Call)
+        }
+        assert called, "no calls found in the loop body: this scan is looking in the wrong place"
+        assert "stop_teleoperate" not in called
+
+    def test_the_finalizer_runs_the_terminal_teardown(self) -> None:
+        """``__del__`` -> ``cleanup()`` -> ``stop_teleoperate()`` is the route."""
+        assert "cleanup" in inspect.getsource(HwRobot.__del__)
+        assert "stop_teleoperate" in inspect.getsource(HwRobot.cleanup)
+
+
+class TestTheDevicesAreReleasedWhenTheLoopIsTheCaller:
+    """The regression: reached on its own thread, the teardown still runs."""
+
+    def test_the_stop_verb_returns_an_envelope_instead_of_raising(self) -> None:
+        """``join()`` on the calling thread raised ``RuntimeError`` from mid-method."""
+        obs = _Observables()
+        outcome: list[Any] = []
+        robot = _register_session(obs, keep=True, stop_from_the_loop=outcome)
+        assert robot is not None
+        obs.release.set()
+        assert obs.body_returned.wait(5.0)
+        assert obs.thread is not None
+        obs.thread.join(5.0)
+
+        assert len(outcome) == 1, "the loop never reached the stop verb"
+        assert not isinstance(outcome[0], Exception), f"the verb raised: {outcome[0]!r}"
+        assert outcome[0]["status"] in {"success", "error"}
+        assert robot._teleop_thread is None, "the handle was left pointing at a finished loop"
+
+    def test_the_teleoperator_port_is_released(self) -> None:
+        obs = _Observables()
+        _register_session(obs, keep=False)
+        _drop_and_finalize(obs)
+        assert obs.leader.disconnects == 1, "the teleoperator was never disconnected"
+        assert obs.leader_port.held_by is None, "the teleoperator's device node is still held"
+
+    def test_the_session_publishers_are_stopped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        obs = _Observables()
+        _watch_publisher_stop(monkeypatch, obs.publishers_stopped)
+        _register_session(obs, keep=False)
+        _drop_and_finalize(obs)
+        assert obs.publishers_stopped, "the publishers the session started were never stopped"
+
+    def test_the_teardown_does_not_report_a_raise(self, caplog: pytest.LogCaptureFixture) -> None:
+        obs = _Observables()
+        with caplog.at_level(logging.DEBUG):
+            _register_session(obs, keep=False)
+            _drop_and_finalize(obs)
+        raised = [r.getMessage() for r in caplog.records if "raised during cleanup" in r.getMessage()]
+        assert raised == []
+
+    def test_the_robots_own_devices_are_still_closed(self) -> None:
+        """Unchanged: ``cleanup()`` closed them on the raise path and still does."""
+        obs = _Observables()
+        _register_session(obs, keep=False)
+        _drop_and_finalize(obs)
+        assert obs.follower_port.held_by is None
+        assert obs.driver.bus.is_connected is False
+
+
+class TestTheCrossThreadPathIsUnchanged:
+    """The ordinary route keeps reporting its join outcome honestly."""
+
+    def test_a_clean_stop_still_joins_and_disconnects(self) -> None:
+        obs = _Observables()
+        robot = _register_session(obs, keep=True)
+        assert robot is not None
+        obs.release.set()
+        assert obs.body_returned.wait(5.0)
+        envelope = robot.stop_teleoperate()
+        payload: dict[str, Any] = next((b["json"] for b in envelope["content"] if "json" in b), {})
+        assert payload.get("stopped", True) is True
+        assert robot._teleop_thread is None
+        assert obs.leader.disconnects == 1
+        assert obs.leader_port.held_by is None
+
+    def test_a_wedged_loop_still_reports_that_it_did_not_stop(self) -> None:
+        obs = _Observables()
+        robot = _register_session(obs, keep=True)
+        assert robot is not None
+        envelope = robot.stop_teleoperate()  # the body is parked in release.wait()
+        payload = next(b["json"] for b in envelope["content"] if "json" in b)
+        assert envelope["status"] == "error"
+        assert payload["stopped"] is False
+        assert robot._teleop_thread is not None, "the handle must survive a failed join"
+        assert obs.leader_port.held_by == "leader", "a live writer keeps its devices"
+        obs.release.set()
+        assert obs.body_returned.wait(5.0)
+
+
+class TestAQuietLoggerClaimGradesItsOwnLogger:
+    """Why the three quiet-logger cells cannot be written against ``caplog.text``."""
+
+    def test_caplog_text_carries_every_logger_from_every_thread(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The pytest behaviour that makes the scoping necessary."""
+        subject, foreign = "strands_robots.test_subject", "strands_robots.test_foreign"
+        with caplog.at_level(logging.WARNING, logger=subject):
+            pass  # the subject is asked nothing, so it says nothing
+        # A finalizer's record, on the thread a finalizer runs on. ``cleanup()``
+        # emits exactly this shape: a WARNING and an INFO on another thread, at
+        # garbage-collection time, inside whatever test is executing.
+        emitted = threading.Thread(target=lambda: logging.getLogger(foreign).warning("from a finalizer"))
+        emitted.start()
+        emitted.join(5.0)
+
+        assert caplog.text != "", "premise: an unrelated logger's record is captured"
+        assert _records(caplog, foreign), "premise: the foreign record reached caplog"
+        assert _records(caplog, subject) == [], "the subject said nothing, and that is the claim"
+
+    @pytest.mark.parametrize("relative", QUIET_LOGGER_CLAIMS)
+    def test_the_claim_is_graded_against_a_named_logger(self, relative: str) -> None:
+        path = _REPO_ROOT / relative
+        assert path.exists(), f"{relative} moved; this rule needs re-pointing"
+        text = path.read_text(encoding="utf-8")
+        assert "caplog.records" in text, f"{relative} makes a quiet-logger claim without naming one"
+        assert 'caplog.text == ""' not in text, (
+            f"{relative} grades every record in the process, so a finalizer on another "
+            "thread reads as its own subject speaking"
+        )


### PR DESCRIPTION
`Robot.__del__` calls `cleanup()`, and `cleanup()` calls `stop_teleoperate()`. The teleop loop's `Thread` target is a closure over the robot (`teleoperate` builds `loop = lambda: self._teleop_loop(...)` and hands it to `Thread(target=loop)`), so once the caller drops its handle that closure holds the last reference to the robot. When the body returns, `Thread.run` releases it -- and the finalizer, with the whole terminal teardown behind it, runs **on the teleop thread**.

`thread.join()` there raises `RuntimeError: cannot join current thread`, leaving the method from the middle.

```mermaid
flowchart LR
  subgraph B["before"]
    direction TB
    B1["_teleop_running = False<br/>_teleop_stop_event.set()"] --> B2["thread.join()"]
    B2 -->|"self -> RuntimeError"| BX(["escapes mid-method"])
    B2 -.->|"never reached"| B3["_stop_publishers()"]
    B3 -.-> B4["teleoperator.disconnect()"]
    B4 -.-> B5["return envelope"]
    BX --> B6["cleanup(): warn,<br/>then 'cleanup completed'"]
  end
  subgraph A["after"]
    direction TB
    A1["_teleop_running = False<br/>_teleop_stop_event.set()"] --> A2{"thread is<br/>current_thread()?"}
    A2 -->|"yes: nothing to join"| A3["clear the handle"]
    A2 -->|"no"| A7["thread.join(3 s)<br/>report the outcome"]
    A3 --> A4["_stop_publishers()"]
    A7 --> A4
    A4 --> A5["teleoperator.disconnect()"]
    A5 --> A6["return envelope"]
  end
```

## What it cost

Measured on a one-camera arm driven by a leader holding its own port, with both device nodes' exclusivity modelled. Same script, two trees:

| teardown route | publishers stopped | leader `disconnect()` | **leader port** | follower port / bus |
| --- | --- | --- | --- | --- |
| finalized on its own teleop thread — **before** | no | 0 | **held** | released |
| finalized on its own teleop thread — **after** | yes | 1 | **released** | released |
| explicit `cleanup()` (control) — before | yes | 1 | released | released |
| explicit `cleanup()` (control) — after | yes | 1 | released | released |

So the robot's *own* bus and cameras were released and the **teleoperator's port stayed held for the life of the process**, under a `cleanup completed` report. That asymmetry is why this went unnoticed: the leak is in the one device group whose disconnect lives inside `stop_teleoperate` rather than in `_disconnect_devices`, and `cleanup()`'s docstring promises that after it runs "no device node stays held".

The control row is **identical on both trees** — the ordinary cross-thread route is untouched.

## Why carrying on is the right answer, not a guess

A self-join is *knowable*, not "outcome unknown":

- `_teleop_loop` never calls this verb (AST-graded in the new file), so the only way control reaches it on that thread is **after the body has returned**;
- there is no *other* thread that could still be writing, so the failed-join branch's reason for leaving the devices connected cannot apply.

So the join is skipped, the rest of the teardown runs, and the handle is cleared as a real join clears it.

**Deliberately unchanged.** `cleanup()`'s decision about the robot's own devices: `teleop_stopped` stayed `True` through the exception path, so it closed them before and closes them now. And the failed-join branch from "report whether `stop_teleoperate` actually stopped the loop" (#2809) is untouched — a leader whose `get_action()` outlasts the 3 s budget still yields `status="error"` with `stopped: false`, still keeps its devices connected, and still keeps the handle for a second call to re-join. Both are pinned as controls.

## The records are how this surfaced

A finalizer runs at garbage-collection time, so its two records land in whatever code happens to be executing:

```
WARNING  strands_robots.hardware_robot:2811  test_arm: stop_teleoperate() raised during cleanup: cannot join current thread
INFO     strands_robots.hardware_robot:2868  test_arm cleanup completed
```

Three cells that meant *"this function warned about nothing"* asserted `caplog.text == ""`. `caplog` captures every record in the process, at every level, for the whole test — the `logger=` argument to `at_level` only sets that logger's level, it does not scope the capture — so a finalizer's report on another thread read as the subject speaking. Those three now grade the records of the logger they name, and the pytest behaviour that makes the distinction necessary is pinned.

The two halves ship together because fixing only the first leaves the assertion able to fail on any background record, and fixing only the second leaves the port leak.

## Tests

`tests/test_teleop_stop_releases_the_devices_when_the_loop_is_the_caller.py`, against pristine `main` vs this branch:

| | pre-fix | post-fix |
| --- | --- | --- |
| regression cells | **7 failed** | 13 passed |
| controls (2 premise, 2 cross-thread, 1 unchanged-devices, 1 caplog behaviour) | 6 passed | 6 passed |

Each pre-fix failure names the defect: `the verb raised: RuntimeError('cannot join current thread')`, `the teleoperator was never disconnected`, `the publishers the session started were never stopped`.

## Gate

| check | result |
| --- | --- |
| `ruff check` / `format --check` (`strands_robots tests tests_integ`) | clean, 1881 files |
| `mypy` (1.20.2) | **0 attributable** (error sets diffed against `main`) |
| every guard that walks the tree (224 files, incl. the `py/catch-base-exception` census) | **11209 passed** |
| `tests/mesh` + every teleop / hardware / cleanup / detach / robot-factory / finalizer suite | **6361 passed, 0 failed** |

The new file's one `try/except` catches `Exception`, not `BaseException`, so it stays out of the `py/catch-base-exception` census that `AGENTS.md` keeps at a single construct.

## Size

| file | +/- |
| --- | --- |
| `strands_robots/teleop_mixin.py` | +36 / -5 — **+2 executable statements** (334 → 336 by AST); the rest is comment and docstring |
| `docs/hardware/teleoperation.md` | +1 / -1 |
| 3 quiet-logger cells | +14 / -3 |
| new test file | +350 |
| changelog fragment | +54 |