### PR TITLE
fix(examples): the SO-101 reference pick reports a refused primitive instead of a 0 mm lift

### DIFF
--- a/changelog.d/3225-so101-pick-reports-a-refused-primitive.md
+++ b/changelog.d/3225-so101-pick-reports-a-refused-primitive.md
@@ -1,0 +1,16 @@
+### Fixed: the SO-101 reference pick reports a refused primitive instead of a 0 mm lift
+
+`examples/18_so101_pick_and_lift.py` composed ten simulation primitives and
+discarded every envelope, returning a hard-coded `status="success"`. With the
+`[sim-mujoco]` IK solver absent all three `move_to` calls are refused - each
+naming the install that fixes them - and the run still summarised a completed
+pick and printed `PICK FAILED - cube lifted only 0.0 mm`. That is the one
+outcome the module docstring spends three paragraphs saying to expect (a
+friction pinch holds nothing, "0 mm lift with the fingers in contact"), so a
+reader who hits the dependency gap concludes the reference is the known-broken
+friction case and never sees the remedy the library already produced.
+
+Each call now goes through `_ok()`, which raises on an error envelope;
+`run_pick()` catches it once and returns `status="error"` carrying the refused
+step and the refusal's own text, and `main()` prints it and exits non-zero. The
+successful path is unchanged - the same rollout still lifts the cube 150.3 mm.

--- a/examples/18_so101_pick_and_lift.py
+++ b/examples/18_so101_pick_and_lift.py
@@ -30,6 +30,14 @@ during a welded carry contains an idealized transport segment; label or gate
 such episodes accordingly (the same caveat the ``attach_bodies`` docstring
 carries).
 
+Every primitive here returns a tool envelope, and this example checks each one:
+a refused step is reported with the refusal's own text rather than carried past.
+Without that check the ``[sim-mujoco]`` IK solver being absent - which refuses
+all three ``move_to`` calls, each naming the install that fixes it - was
+indistinguishable from the friction limitation described above, because the run
+still summarised ``status="success"`` and printed "PICK FAILED - cube lifted
+only 0.0 mm".
+
 Dependencies: pip install "strands-robots[sim-mujoco]"
 Expected output: "PICK OK - cube lifted NNN mm" (NNN is ~150).
 Runtime: ~3 seconds on CPU (a few more if --video is passed).
@@ -52,6 +60,40 @@ CUBE_HALF = 0.025  # 25 mm cube edge (full extent passed to add_object)
 LIFT_HEIGHT = 0.18  # how far above the table to raise the cube (metres)
 
 
+class _Refused(RuntimeError):
+    """A simulation primitive answered with an error envelope.
+
+    Raised by :func:`_ok` and caught once in :func:`run_pick`, which renders it
+    as the error summary the caller receives. The step name is carried because
+    that summary is the only thing a caller sees.
+    """
+
+    def __init__(self, step: str, result: dict) -> None:
+        self.step = step
+        self.detail = "; ".join(
+            item["text"] for item in result.get("content", []) if isinstance(item, dict) and item.get("text")
+        )
+        super().__init__(f"{step}: {self.detail}")
+
+
+def _ok(step: str, result: dict) -> dict:
+    """Return *result*, or raise :class:`_Refused` when it is an error envelope.
+
+    Args:
+        step: What was attempted, named as it should read in the summary.
+        result: The envelope the primitive returned.
+
+    Returns:
+        *result* unchanged, so a call site reads as the primitive it wraps.
+
+    Raises:
+        _Refused: When ``result["status"]`` is ``"error"``.
+    """
+    if result.get("status") == "error":
+        raise _Refused(step, result)
+    return result
+
+
 def _cube_z(sim) -> float:
     """Current world z of the cube's body origin (metres)."""
     return sim.get_body_state("cube")["content"][-1]["json"]["position"][2]
@@ -65,79 +107,119 @@ def run_pick(video_path: str | None = None) -> dict:
             MP4 there (needs a GL backend; run headless with ``MUJOCO_GL=egl``).
 
     Returns:
-        A summary dict: ``{"status", "lifted_mm", "success", "frames"}``.
-        ``success`` is True when the cube rises at least 80 mm.
+        A summary dict. On a completed run: ``{"status": "success", "lifted_mm",
+        "success", "frames"}``, where ``success`` is True when the cube rises at
+        least 80 mm. If any primitive refuses, ``status`` is ``"error"`` and the
+        summary also carries ``step`` (which one) and ``detail`` (the refusal's
+        own text, which names the remedy) - so a refusal is never reported as a
+        completed pick that merely failed to lift.
     """
     # Robot("so101") defaults to mode="sim": the factory has already called
     # create_world() and added the "so101" arm, so the scene is ready.
     sim = Robot("so101", mesh=False)
     rest_on_table = CUBE_HALF / 2  # a 25 mm cube rests with its centre 12.5 mm up
-    sim.add_object(
-        name="cube",
-        shape="box",
-        position=[CUBE_XY[0], CUBE_XY[1], rest_on_table],
-        size=[CUBE_HALF, CUBE_HALF, CUBE_HALF],
-        color=[0.9, 0.2, 0.2, 1],
-        mass=0.02,
-    )
 
     frames: list = []
     record = video_path is not None
-    if record:
-        import imageio.v3 as iio
-        import numpy as np
 
-        sim.add_camera(
-            name="side",
-            position=[0.32, -0.55, 0.30],
-            target=[CUBE_XY[0], CUBE_XY[1], 0.08],
-            fov=52,
-            width=480,
-            height=368,
+    try:
+        _ok(
+            "add_object(cube)",
+            sim.add_object(
+                name="cube",
+                shape="box",
+                position=[CUBE_XY[0], CUBE_XY[1], rest_on_table],
+                size=[CUBE_HALF, CUBE_HALF, CUBE_HALF],
+                color=[0.9, 0.2, 0.2, 1],
+                mass=0.02,
+            ),
         )
 
-        def snap():
-            png = sim.render(camera_name="side")["content"][1]["image"]["source"]["bytes"]
-            frames.append(np.asarray(iio.imread(png, extension=".png")))
-    else:
+        if record:
+            import imageio.v3 as iio
+            import numpy as np
 
-        def snap():
-            return None
+            _ok(
+                "add_camera(side)",
+                sim.add_camera(
+                    name="side",
+                    position=[0.32, -0.55, 0.30],
+                    target=[CUBE_XY[0], CUBE_XY[1], 0.08],
+                    fov=52,
+                    width=480,
+                    height=368,
+                ),
+            )
 
-    # Let the cube settle onto the table before we read its rest height.
-    sim.step(200)
-    snap()
-    z_rest = _cube_z(sim)
+            def snap() -> None:
+                rendered = _ok("render(side)", sim.render(camera_name="side"))
+                png = rendered["content"][1]["image"]["source"]["bytes"]
+                frames.append(np.asarray(iio.imread(png, extension=".png")))
 
-    # --- pick sequence, public API only -------------------------------------
-    sim.set_gripper(robot_name="so101", state="open")
-    snap()
-    # 1. approach: hover 10 cm above the cube
-    sim.move_to(robot_name="so101", position=[CUBE_XY[0], CUBE_XY[1], z_rest + 0.10], tol=0.02)
-    snap()
-    # 2. descend to the cube (tol 2 cm: a 5-DOF arm cannot also pin orientation)
-    sim.move_to(robot_name="so101", position=[CUBE_XY[0], CUBE_XY[1], z_rest + 0.005], tol=0.02)
-    snap()
-    # 3. close the fingers on the cube
-    sim.set_gripper(robot_name="so101", state="close")
-    snap()
-    # 4. grasp-assist: hold the cube's current pose relative to the gripper.
-    #    NOT a physical grasp - see the module docstring.
-    sim.attach_bodies(parent="so101/gripper", child="cube", mode="weld")
-    snap()
-    # 5. lift
-    sim.move_to(robot_name="so101", position=[CUBE_XY[0], CUBE_XY[1], z_rest + LIFT_HEIGHT], tol=0.02)
-    snap()
-    z_top = _cube_z(sim)
-    lifted_mm = 1000.0 * (z_top - z_rest)
+        else:
 
-    # 6. place back down and release, so the scene ends clean
-    sim.move_to(robot_name="so101", position=[CUBE_XY[0] + 0.06, CUBE_XY[1], z_rest + 0.02], tol=0.02)
-    snap()
-    sim.detach_bodies(parent="so101/gripper", child="cube")
-    sim.set_gripper(robot_name="so101", state="open")
-    sim.step(100)
-    snap()
+            def snap() -> None:
+                return None
+
+        # Let the cube settle onto the table before we read its rest height.
+        _ok("step(settle)", sim.step(200))
+        snap()
+        z_rest = _cube_z(sim)
+
+        # --- pick sequence, public API only ---------------------------------
+        _ok("set_gripper(open)", sim.set_gripper(robot_name="so101", state="open"))
+        snap()
+        # 1. approach: hover 10 cm above the cube
+        _ok(
+            "move_to(hover)",
+            sim.move_to(robot_name="so101", position=[CUBE_XY[0], CUBE_XY[1], z_rest + 0.10], tol=0.02),
+        )
+        snap()
+        # 2. descend to the cube (tol 2 cm: a 5-DOF arm cannot also pin orientation)
+        _ok(
+            "move_to(descend)",
+            sim.move_to(robot_name="so101", position=[CUBE_XY[0], CUBE_XY[1], z_rest + 0.005], tol=0.02),
+        )
+        snap()
+        # 3. close the fingers on the cube
+        _ok("set_gripper(close)", sim.set_gripper(robot_name="so101", state="close"))
+        snap()
+        # 4. grasp-assist: hold the cube's current pose relative to the gripper.
+        #    NOT a physical grasp - see the module docstring.
+        _ok("attach_bodies(weld)", sim.attach_bodies(parent="so101/gripper", child="cube", mode="weld"))
+        snap()
+        # 5. lift
+        _ok(
+            "move_to(lift)",
+            sim.move_to(robot_name="so101", position=[CUBE_XY[0], CUBE_XY[1], z_rest + LIFT_HEIGHT], tol=0.02),
+        )
+        snap()
+        z_top = _cube_z(sim)
+        lifted_mm = 1000.0 * (z_top - z_rest)
+
+        # 6. place back down and release, so the scene ends clean
+        _ok(
+            "move_to(place)",
+            sim.move_to(robot_name="so101", position=[CUBE_XY[0] + 0.06, CUBE_XY[1], z_rest + 0.02], tol=0.02),
+        )
+        snap()
+        _ok("detach_bodies", sim.detach_bodies(parent="so101/gripper", child="cube"))
+        _ok("set_gripper(release)", sim.set_gripper(robot_name="so101", state="open"))
+        _ok("step(settle)", sim.step(100))
+        snap()
+    except _Refused as refused:
+        # The refusal carries its own remedy; a summary that dropped it would
+        # leave "lifted 0.0 mm" as the only evidence, which is the friction
+        # limitation this example exists to work around - a different cause
+        # with a different fix.
+        return {
+            "status": "error",
+            "step": refused.step,
+            "detail": refused.detail,
+            "lifted_mm": 0.0,
+            "success": False,
+            "frames": len(frames),
+        }
 
     if record and frames:
         import imageio.v3 as iio
@@ -159,6 +241,9 @@ def main() -> None:
     args = ap.parse_args()
 
     result = run_pick(video_path=args.video)
+    if result["status"] == "error":
+        print(f"PICK REFUSED at {result['step']}: {result['detail']}")
+        raise SystemExit(1)
     if result["success"]:
         print(f"PICK OK - cube lifted {result['lifted_mm']} mm")
     else:

--- a/tests/test_examples_so101_pick_reports_a_refused_primitive.py
+++ b/tests/test_examples_so101_pick_reports_a_refused_primitive.py
@@ -1,0 +1,110 @@
+"""A refused primitive in the SO-101 reference pick is reported, not carried past.
+
+``examples/18_so101_pick_and_lift.py`` composes ten simulation primitives, each
+of which answers with a tool envelope. Measured on ``ca57d58d`` with the
+``[sim-mujoco]`` IK solver absent, the example discarded all ten envelopes and
+returned a hard-coded ``status="success"``::
+
+    move_to hover   -> error   move_to: IK bridge unavailable: The mink IK bridge
+                               needs 'mink' + 'mujoco' + a qpsolvers backend...
+                               uv pip install 'strands-robots[sim-mujoco]'
+    move_to descend -> error   (same)
+    move_to lift    -> error   (same)
+
+    run_pick() -> {'status': 'success', 'lifted_mm': 0.0, 'success': False}
+    printed    -> "PICK FAILED - cube lifted only 0.0 mm"
+
+Three refusals, each naming the install that fixes them, and the run reported a
+completed pick that merely failed to lift. That is the *one* outcome the module
+docstring spends three paragraphs saying to expect - a friction pinch holds
+nothing, "0 mm lift with the fingers in contact" - so a reader who hits the
+dependency gap concludes the reference itself is the known-broken friction case
+and never sees the remedy the library already produced.
+
+``lifted_mm >= 80`` in the sibling behavioural pin
+``tests/test_examples_so101_pick_lifts.py`` cannot catch this: a refused run
+lifts 0 mm, which is exactly what that test's own failure message attributes to
+"a friction-only regression". And its first assertion, ``result["status"] ==
+"success"``, was vacuous while ``status`` was a literal - it could not fail. This
+module grades the envelope handling, which is the half that reads the refusals;
+that module remains the half that pins the lift.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+_EXAMPLE = Path(__file__).resolve().parent.parent / "examples" / "18_so101_pick_and_lift.py"
+
+# The refusal text the absent-IK envelope actually carries, abbreviated. The
+# remedy is the part a discarded envelope costs the reader, so it is what the
+# summary is checked for.
+_REMEDY = "uv pip install 'strands-robots[sim-mujoco]'"
+_REFUSAL = {
+    "status": "error",
+    "content": [{"text": f"move_to: IK bridge unavailable: needs 'mink' + a qpsolvers backend. {_REMEDY}"}],
+}
+
+# One primitive per stage of the sequence: the first call, the mid-sequence IK
+# step that the absent solver really refuses, and the grasp-assist step after
+# it. A guard that only checked the first call would pass on the first row
+# alone.
+_REFUSABLE_STEPS = ["add_object", "move_to", "attach_bodies"]
+
+
+def _load_example() -> Any:
+    """Load the example by path (a leading digit makes it unimportable by name)."""
+    spec = importlib.util.spec_from_file_location("so101_pick_and_lift", _EXAMPLE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestARefusedPrimitiveReachesTheSummary:
+    """The summary names the refused step and carries the refusal's own text."""
+
+    @pytest.mark.parametrize("step", _REFUSABLE_STEPS)
+    def test_the_summary_reports_the_refusal_instead_of_a_completed_pick(
+        self, step: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refused step is an error summary, not ``success`` with a 0 mm lift."""
+        from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+        monkeypatch.setattr(MuJoCoSimEngine, step, lambda *a, **k: _REFUSAL, raising=True)
+
+        result = _load_example().run_pick()
+
+        assert result["status"] == "error", result
+        assert step in result["step"], result
+        assert _REMEDY in result["detail"], result
+        assert result["success"] is False, result
+
+    def test_a_success_envelope_passes_through_unchanged(self) -> None:
+        """Over-reach control: the guard must not refuse a healthy envelope.
+
+        Keeps the parametrized rows above from passing for the wrong reason - a
+        guard that treated every envelope as a refusal would satisfy them all
+        while breaking the pick entirely. Unit-level on the helper so it needs
+        no IK solver, which is the dependency the rows above stand in for.
+        """
+        module = _load_example()
+        envelope = {"status": "success", "content": [{"text": "'cube' added"}]}
+
+        assert module._ok("add_object(cube)", envelope) is envelope
+
+    def test_the_refusal_detail_is_the_envelope_text_and_not_the_step_label(self) -> None:
+        """The remedy survives into ``detail``; the label alone would not help."""
+        module = _load_example()
+
+        with pytest.raises(module._Refused) as caught:
+            module._ok("move_to(lift)", _REFUSAL)
+
+        assert caught.value.step == "move_to(lift)"
+        assert _REMEDY in caught.value.detail


### PR DESCRIPTION
`examples/18_so101_pick_and_lift.py` is the starter-kit reference pick. It composes ten simulation primitives, **checks none of their envelopes**, and returns a hard-coded `status="success"`.

![before/after](https://raw.githubusercontent.com/cagataycali/robots/6420a9b0a03343afedd7919f7832d51b80c6a8c8/.artifacts/so101_pick_refusal.png)

## The defect

With the `[sim-mujoco]` IK solver absent, measured on `ca57d58d`:

| step | envelope | example's reaction |
|---|---|---|
| `set_gripper(open)` | success | - |
| `move_to(hover)` | **error** - `IK bridge unavailable ... uv pip install 'strands-robots[sim-mujoco]'` | discarded |
| `move_to(descend)` | **error** - same | discarded |
| `set_gripper(close)` | success | - |
| `attach_bodies(weld)` | success (welds the cube 24 cm from the gripper) | - |
| `move_to(lift)` | **error** - same | discarded |

```
run_pick() -> {'status': 'success', 'lifted_mm': 0.0, 'success': False, 'frames': 0}
printed    -> PICK FAILED - cube lifted only 0.0 mm      (exit 0)
```

Three refusals, each already naming the install that fixes it, reported as a completed pick that merely failed to lift.

That is the *one* outcome this module's own docstring spends three paragraphs saying to expect - a friction pinch holds nothing, "0 mm lift with the fingers in contact" (#2167, #2145). So a reader who hits the dependency gap concludes the reference is the known-broken friction case, and never sees the remedy the library produced.

## The change

Every call goes through `_ok(step, envelope)`, which raises `_Refused` on an error envelope. `run_pick()` catches it once and returns `status="error"` with the refused `step` and `detail` (the refusal's own text); `main()` prints it and exits non-zero. Matches the idiom the sibling examples already use (`17_pour_task.py`, `07_post_tune_any_policy.py`, `03_record_dataset.py`).

```
PICK REFUSED at move_to(hover): move_to: IK bridge unavailable: ... Install the sim extra:
  uv pip install 'strands-robots[sim-mujoco]'                                    (exit 1)
```

## Tests

New `tests/test_examples_so101_pick_reports_a_refused_primitive.py` (5 cells), table-driven over the refused step (first call / mid-sequence IK / grasp-assist) plus an over-reach control that a healthy envelope passes through untouched.

| tree | result |
|---|---|
| `upstream/main` + new test | **5 failed** - `assert 'success' == 'error'` with `lifted_mm: 0.0`, and `-0.7` for the `attach_bodies` row (the cube moved *down* and it still reported success) |
| this branch | **5 passed** |

The sibling `tests/test_examples_so101_pick_lifts.py` cannot catch this: a refused run lifts 0 mm, which is exactly what that test's own failure message attributes to "a friction-only regression". Its first assertion, `result["status"] == "success"`, was also vacuous while `status` was a literal - it could not fail. It stays as the behavioural half that pins the lift; this module reads the refusals.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` - clean (1883 files)
- `mypy strands_robots tests tests_integ` (1.20.2) - 1 pre-existing error, error sets **identical** to base
- 957 passed / 0 failed across every `tests/test_examples_*.py` plus the docstring and test-name graders
- `scripts/check_whole_tree_graders.py` - failing node-id set **identical** to `upstream/main` (16 ≡ 16, all environmental: installed-lerobot drift, websockets below the declared floor)
- Happy path re-verified end to end with the IK solver installed: `PICK OK - cube lifted 150.3 mm`, 9 frames

## Size

| | files | + | - |
|---|---|---|---|
| example + regression test + changelog | 3 | 272 | 61 |

Rollout rendered in MuJoCo headless (`MUJOCO_GL=egl`); [MP4](https://raw.githubusercontent.com/cagataycali/robots/6420a9b0a03343afedd7919f7832d51b80c6a8c8/.artifacts/so101_pick_lift.mp4).