### PR TITLE
test(rendering): reach the three outcomes the gsplat capability probe exists to distinguish

### DIFF
--- a/changelog.d/3226-gsplat-probe-outcomes-are-reached.md
+++ b/changelog.d/3226-gsplat-probe-outcomes-are-reached.md
@@ -1,0 +1,24 @@
+### Tests: the gsplat capability probe's three outcomes are reached, not assumed
+
+`gsplat_rasterizer_available` performs a one-gaussian trial rasterization
+rather than reporting on an import, because a plain `pip install gsplat` is
+importable on a host whose CUDA kernels can never build: gsplat JIT-compiles
+them through `nvcc` on first use, and a GPU image with the CUDA runtime but no
+toolkit disables the backend silently, so the first `rasterization` call raises
+`AttributeError: 'NoneType' object has no attribute 'CameraModelType'`.
+
+On any host without the `sim-gs` extra the probe answers from its import guard,
+so everything after that guard - the CUDA-device check, the trial
+rasterization, and the `except` that turns a disabled backend into a reason -
+was never executed by the suite. The one existing pin asserts the probe returns
+`(bool, non-empty str)` on whatever host it runs on, which a probe that
+returned `True` straight off the import would satisfy just as well.
+
+Standing `torch` and `gsplat` in makes all three outcomes reachable: no CUDA
+device, an importable rasterizer that cannot rasterize, and a working one. The
+`ok` case additionally asserts that a rasterization really ran - on the CUDA
+device, at a non-zero size - which is the half no import check can supply and
+the reason the function is not a `hasattr` probe.
+
+`strands_robots/rendering/backgrounds.py` goes from 97% to 100% statement
+coverage (15 uncovered lines to 0).

--- a/tests/rendering/test_gsplat_probe_rasterizes_rather_than_importing.py
+++ b/tests/rendering/test_gsplat_probe_rasterizes_rather_than_importing.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``gsplat_rasterizer_available`` answers by rasterizing, not by importing.
+
+A plain ``pip install gsplat`` is importable on a host whose CUDA kernels can
+never build: gsplat JIT-compiles them through ``nvcc`` on first use, and a GPU
+image that ships the CUDA runtime without the toolkit disables the backend
+silently. The first ``gsplat.rasterization`` call then raises
+``AttributeError: 'NoneType' object has no attribute 'CameraModelType'``. That
+is why
+:func:`~strands_robots.rendering.backgrounds.gsplat_rasterizer_available`
+performs a one-gaussian trial rasterization instead of reporting on the import,
+and why ``examples/isaac_gs/background.py`` can choose
+:class:`~strands_robots.rendering.PanoramaBackground` up front rather than
+erroring on every frame.
+
+The suite already pins that the probe never raises on the host it runs on, but
+a host without the ``sim-gs`` extra answers from the import guard alone, so the
+three outcomes the probe exists to distinguish - no CUDA device, an importable
+rasterizer that cannot rasterize, and a working one - were never reached. These
+tests reach all three by standing ``torch`` and ``gsplat`` in, which also pins
+the part a caller depends on and an import check cannot provide: a ``True``
+verdict means a rasterization really ran.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.rendering.backgrounds import gsplat_rasterizer_available
+
+# The documented failure of an importable-but-uncompiled gsplat: its CUDA
+# backend is None, so the first rasterization attribute lookup fails.
+_DISABLED_BACKEND = AttributeError("'NoneType' object has no attribute 'CameraModelType'")
+
+
+class _Tensor:
+    """Stand-in for a ``torch`` tensor: records how it was built, slices to itself."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def __getitem__(self, item: Any) -> _Tensor:
+        return _Tensor(f"{self.label}[{item!r}]")
+
+
+def _torch_stand_in(*, cuda_available: bool) -> types.ModuleType:
+    """A ``torch`` module exposing only what the probe reaches for."""
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(is_available=lambda: cuda_available)  # type: ignore[attr-defined]
+    torch.tensor = lambda data, device=None: _Tensor(f"tensor@{device}")  # type: ignore[attr-defined]
+    torch.full = lambda shape, value, device=None: _Tensor(f"full@{device}")  # type: ignore[attr-defined]
+    torch.ones = lambda *shape, device=None: _Tensor(f"ones@{device}")  # type: ignore[attr-defined]
+    torch.eye = lambda n, device=None: _Tensor(f"eye@{device}")  # type: ignore[attr-defined]
+    return torch
+
+
+def _gsplat_stand_in(raises: BaseException | None) -> tuple[types.ModuleType, list[dict[str, Any]]]:
+    """A ``gsplat`` module whose ``rasterization`` records each call.
+
+    Args:
+        raises: Exception the rasterization raises, or ``None`` for a working one.
+
+    Returns:
+        The module and the list its ``rasterization`` appends a record to.
+    """
+    calls: list[dict[str, Any]] = []
+
+    def rasterization(
+        means: Any,
+        quats: Any,
+        scales: Any,
+        opacities: Any,
+        colors: Any,
+        viewmats: Any,
+        Ks: Any,  # noqa: N803 -- gsplat's own parameter name for the intrinsics batch
+        width: int = 0,
+        height: int = 0,
+    ) -> str:
+        calls.append({"width": width, "height": height, "means": means.label})
+        if raises is not None:
+            raise raises
+        return "rasterized"
+
+    module = types.ModuleType("gsplat")
+    module.rasterization = rasterization  # type: ignore[attr-defined]
+    return module, calls
+
+
+@pytest.fixture
+def probe(monkeypatch):
+    """Build the probe's dependencies, returning ``(verdict, rasterization calls)``."""
+
+    def _probe(*, cuda_available: bool = True, raises: BaseException | None = None):
+        gsplat, calls = _gsplat_stand_in(raises)
+        monkeypatch.setitem(sys.modules, "torch", _torch_stand_in(cuda_available=cuda_available))
+        monkeypatch.setitem(sys.modules, "gsplat", gsplat)
+        return gsplat_rasterizer_available(), calls
+
+    return _probe
+
+
+class TestTheProbeAnswersByRasterizing:
+    """The three outcomes an import check cannot tell apart."""
+
+    def test_a_working_rasterizer_reports_ok_and_really_rasterized(self, probe) -> None:
+        """``True`` is earned by a completed rasterization, not by the import.
+
+        This is the half no import check can supply: a caller that skips
+        ``PanoramaBackground`` on this verdict is relying on a frame having
+        actually been produced.
+        """
+        (ok, reason), calls = probe()
+
+        assert (ok, reason) == (True, "ok")
+        assert len(calls) == 1, "an ok verdict must come from exactly one trial rasterization"
+        assert calls[0]["width"] > 0 and calls[0]["height"] > 0, (
+            f"the trial must rasterize a real image, got {calls[0]['width']}x{calls[0]['height']}"
+        )
+        assert calls[0]["means"] == "tensor@cuda", "the trial gaussian must be built on the CUDA device"
+
+    def test_an_importable_rasterizer_that_cannot_rasterize_is_reported_not_raised(self, probe) -> None:
+        """The uncompiled-kernel case: importable, and unusable."""
+        (ok, reason), calls = probe(raises=_DISABLED_BACKEND)
+
+        assert ok is False
+        assert "gsplat CUDA rasterizer unavailable" in reason
+        assert "AttributeError" in reason and "CameraModelType" in reason, (
+            f"the reason must name the failure a caller has to act on, got {reason!r}"
+        )
+        assert len(calls) == 1, "the verdict must come from an attempted rasterization"
+
+    def test_no_cuda_device_is_reported_before_anything_is_rasterized(self, probe) -> None:
+        """A host with no device is answered from the device check, not a failed trial."""
+        (ok, reason), calls = probe(cuda_available=False)
+
+        assert (ok, reason) == (False, "no CUDA device available to torch")
+        assert calls == [], "the probe must not attempt a rasterization without a CUDA device"
+
+    def test_an_absent_dependency_is_reported_as_an_import_failure(self, monkeypatch) -> None:
+        """The control: no ``sim-gs`` extra, so the import guard answers."""
+        monkeypatch.setitem(sys.modules, "torch", _torch_stand_in(cuda_available=True))
+        monkeypatch.setitem(sys.modules, "gsplat", None)
+
+        ok, reason = gsplat_rasterizer_available()
+
+        assert ok is False
+        assert "not importable" in reason, f"the reason must name the missing dependency, got {reason!r}"


### PR DESCRIPTION
## The probe rasterizes; the suite only ever watched it import

`gsplat_rasterizer_available()` exists because *importable is not usable*: gsplat JIT-compiles its CUDA kernels through `nvcc` on first use, so an image with the CUDA runtime but no toolkit imports fine and then raises `AttributeError: 'NoneType' object has no attribute 'CameraModelType'` on the first `rasterization` call. The function therefore runs a one-gaussian trial rasterization, and `examples/isaac_gs/background.py` picks `PanoramaBackground` up front on a `False` verdict instead of erroring on every frame.

On any host without the `sim-gs` extra the function returns from its import guard, so nothing after that guard ran:

```mermaid
flowchart LR
  A["import torch, gsplat"] -->|ImportError| B["(False, 'not importable')"]
  A --> C{"torch.cuda.is_available()"}
  C -->|no| D["(False, 'no CUDA device available to torch')"]
  C -->|yes| E["trial rasterization<br/>1 gaussian, 16x16"]
  E -->|raises| F["(False, 'gsplat CUDA rasterizer unavailable (...)')"]
  E -->|returns| G["(True, 'ok')"]
  style B fill:#d7f8d7,stroke:#2a2
  style D fill:#ffd7d7,stroke:#a22
  style F fill:#ffd7d7,stroke:#a22
  style G fill:#ffd7d7,stroke:#a22
```

Green = reached by the suite before this change. The one existing pin asserts the return is `(bool, non-empty str)` on whatever host it runs on — which a probe that answered `True` straight off the import would satisfy just as well.

## Change

One new test file. Standing `torch` and `gsplat` in reaches all three unreached outcomes, and the `ok` case asserts the part no import check can supply: a rasterization really ran, on the CUDA device, at a non-zero size.

| cell | arrangement | pinned |
| --- | --- | --- |
| `test_a_working_rasterizer_reports_ok_and_really_rasterized` | rasterization returns | `(True, "ok")`, exactly 1 call, 16x16 > 0, trial gaussian built on `cuda` |
| `test_an_importable_rasterizer_that_cannot_rasterize_is_reported_not_raised` | rasterization raises the documented `AttributeError` | `False`, reason names `AttributeError` + `CameraModelType`, 1 call attempted |
| `test_no_cuda_device_is_reported_before_anything_is_rasterized` | `cuda.is_available()` is `False` | `(False, "no CUDA device available to torch")` and **zero** rasterization calls |
| `test_an_absent_dependency_is_reported_as_an_import_failure` | control: no `sim-gs` extra | `False`, reason names the import failure |

## The pin has teeth

Weakening the probe to answer from the import alone (deleting the 15 lines after the import guard, `return True, "ok"`) — the failure mode the function was written to prevent:

| suite | on the weakened probe |
| --- | --- |
| pre-existing `test_gsplat_rasterizer_available_is_a_nonraising_capability_probe` | **passes** |
| this PR's 4 cells | **3 fail**, 1 passes (the import-failure control, which is unaffected) |

```
FAILED ...::test_no_cuda_device_is_reported_before_anything_is_rasterized
  AssertionError: assert (True, 'ok') == (False, 'no CUDA device available to torch')
```

## Coverage

| file | before | after |
| --- | --- | --- |
| `strands_robots/rendering/backgrounds.py` | 448 stmts, **15 missed, 97%** (`319-333`) | 448 stmts, **0 missed, 100%** |

Measured with the project's configured scope (`--cov=strands_robots`) over `tests/rendering`: 859 passed before, 863 passed after.

## Gate

| check | result |
| --- | --- |
| `ruff check` + `ruff format --check` on `strands_robots tests tests_integ` | clean, 1883 files |
| `mypy strands_robots tests tests_integ` | 20 errors in 6 files — unchanged from `main`, none in the new file |
| `pytest tests/rendering tests/test_changelog_format.py tests/test_changelog_fragments.py` | 895 passed, 5 skipped |
| `scripts/check_whole_tree_graders.py` | 4372 passed; the 13 failures + 4 errors are the pre-existing absent-dependency / installed-lerobot-drift set, identical on `main` |

## Size

Test-only, no production change.

| | files | + | - |
| --- | --- | --- | --- |
| | 2 | 176 | 0 |

No visual artifact: no policy, sim behaviour, rendering output, recording or asset changes — the rendered pixels are untouched.