### PR TITLE
fix(policies/microduck): slot two is the unit gravity direction the layout declares

### DIFF
--- a/changelog.d/3228-microduck-gravity-block-unit-direction.md
+++ b/changelog.d/3228-microduck-gravity-block-unit-direction.md
@@ -1,0 +1,24 @@
+### Fixed: the Microduck gravity block is the unit direction its layout declares
+
+Slot two of the Microduck observation vector is documented as "a UNIT gravity
+direction in the base frame", and `build_observation` held `base_quat` to a width
+and to finiteness on the way there but not to describing a rotation.
+`quat_rotate_inverse` evaluates a formula that is a rotation only for a unit
+quaternion - it mixes a term quadratic in the components with a linear one, so
+scaling does not cancel. A quaternion scaled by any positive factor encodes the
+same rotation, which is why the library's single orientation domain
+(`coerce_orientation_quaternion`) accepts any magnitude, on the stated ground
+that "every consumer either normalizes or is scale-invariant"; this was the one
+consumer that did neither. A 20 deg pitch offered at `|q| = 2` reached the graph
+as a 61 deg attitude of magnitude 1.56, and an all-zero quaternion - what an
+orientation that was never written or was dropped on the wire spells - was
+answered with world `-Z` unchanged, which is the gravity block of a perfectly
+upright base.
+
+The orientation is now normalized inside `quat_rotate_inverse`, and a norm below
+the shared `MIN_QUATERNION_NORM` floor is refused rather than read, matching the
+two same-layer siblings (`policies/wbc/control.quat_rotate_inverse`,
+`policies/protomotions/state_utils.quat_rotate_inverse`). A `nan`/`inf`
+component still flows through so the assembled-vector pass names it against the
+block it becomes, and for an exactly-unit quaternion the pre-existing expression
+is reproduced bit for bit.

--- a/strands_robots/policies/microduck/observation.py
+++ b/strands_robots/policies/microduck/observation.py
@@ -28,9 +28,12 @@ serves every policy in a bundle.
 
 CRITICAL: ``EmpiricalNormalization`` is baked INTO the exported ONNX graph, so
 the vector built here is fed RAW to the session. This module never rescales the
-assembled vector. The one normalisation it performs is inside
-:func:`raw_accel_gravity`, and that is the ``raw_accel`` export's own estimator -
-Pollen returns a unit gravity direction there - rather than a scaling choice.
+assembled vector. The two normalisations it performs are both inside slot two,
+and neither is a scaling choice: :func:`raw_accel_gravity` returns the unit
+direction the ``raw_accel`` export's own estimator returns, and
+:func:`quat_rotate_inverse` normalises the orientation it reads because its
+formula is a rotation only for a unit quaternion - a scaled quaternion encodes
+the same rotation and has to answer the same.
 """
 
 from __future__ import annotations
@@ -39,6 +42,8 @@ from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
+
+from strands_robots.utils import MIN_QUATERNION_NORM
 
 #: World gravity direction, rotated into the base frame to form the
 #: ``projected_gravity`` observation block.
@@ -82,10 +87,67 @@ def quat_rotate_inverse(quat: NDArray[np.float32], vec: NDArray[np.float32]) -> 
 
     Byte-for-byte the same formula Pollen's ``infer_policy.py`` uses to derive
     ``projected_gravity`` from the trunk orientation, so a rollout driven here
-    feeds the network the same gravity block it saw in training.
+    feeds the network the same gravity block it saw in training - read from the
+    rotation the quaternion encodes rather than from the quaternion itself.
+
+    The formula mixes a term quadratic in the components with a linear one, so
+    scaling does not cancel: it is a rotation only for a UNIT quaternion. A
+    quaternion scaled by any positive factor encodes the same rotation, which is
+    why the library's orientation domain
+    (:func:`~strands_robots.utils.coerce_orientation_quaternion`) accepts any
+    magnitude - on the stated ground that "every consumer either normalizes or
+    is scale-invariant". This is one of those consumers, so it normalizes: read
+    unnormalized, a base orientation 2x off unit turns world ``-Z`` 41 deg away
+    from the direction it encodes and hands the graph a slot-two block of
+    magnitude 1.56, where the layout declares a unit direction. Pollen's own
+    code needs no such step because it reads a fused-IMU orientation that is
+    already unit; the values reaching a provider are not all of that kind - an
+    IMU reading drifts off unit, and an orientation obtained by interpolating
+    two samples is short by up to ~8%.
+
+    A norm below :data:`~strands_robots.utils.MIN_QUATERNION_NORM` carries no
+    direction at all and cannot be repaired by scaling, so it is refused rather
+    than read. That case is the ``[0, 0, 0, 0]`` an unwritten or dropped
+    orientation field spells, and the formula answers it with ``vec``
+    unchanged - for world ``-Z``, exactly the gravity block of a PERFECTLY
+    UPRIGHT base, the one attitude a locomotion policy most needs to tell apart
+    from a fall. It passes the width guard in :func:`_require_base_block` and
+    the finiteness pass in :func:`_non_finite_observation_error`, so this is the
+    only place that sees it. The same-layer siblings refuse it the same way
+    (:func:`strands_robots.policies.wbc.control.quat_rotate_inverse`,
+    :func:`strands_robots.policies.protomotions.state_utils.quat_rotate_inverse`).
+
+    Args:
+        quat: Base orientation ``[w, x, y, z]``. Any magnitude is accepted and
+            normalized here, so a scaled quaternion answers the same as the
+            unit one it encodes.
+        vec: The world-frame 3-vector to express in the base frame.
+
+    Returns:
+        ``vec`` expressed in the base frame, ``float32`` - unit-length whenever
+        ``vec`` is. A ``nan``/``inf`` component propagates instead of being
+        refused here, so the assembled-vector pass names it through the block it
+        becomes.
+
+    Raises:
+        ValueError: If ``quat`` has no direction to recover (norm below
+            :data:`~strands_robots.utils.MIN_QUATERNION_NORM`).
     """
     q = np.asarray(quat, dtype=np.float32)
     v = np.asarray(vec, dtype=np.float32)
+    # float64 for the norm alone: the components stay in the caller's float32,
+    # matching the dtype the ONNX graph is fed.
+    norm = float(np.linalg.norm(np.asarray(q, dtype=np.float64)))
+    if norm < MIN_QUATERNION_NORM:
+        raise ValueError(
+            f"quat_rotate_inverse: the base orientation {np.asarray(q, dtype=np.float64).tolist()} "
+            f"has norm {norm!r} and describes no rotation, so the gravity block it reduces "
+            f"to carries no direction either. An all-zero quaternion is what an orientation "
+            f"that was never written spells, and rotating world -Z by it returns world -Z - "
+            f"the gravity block of a perfectly upright base. Supply the base's real wxyz "
+            f"orientation (MuJoCo reports it as base_quat in get_observation)."
+        )
+    q = (q / np.float32(norm)).astype(np.float32)
     w = q[0]
     xyz = q[1:4]
     t = np.cross(xyz, v) * 2.0
@@ -93,7 +155,21 @@ def quat_rotate_inverse(quat: NDArray[np.float32], vec: NDArray[np.float32]) -> 
 
 
 def projected_gravity(base_quat: NDArray[np.float32]) -> NDArray[np.float32]:
-    """World ``-Z`` expressed in the base frame, from the base quaternion (wxyz)."""
+    """World ``-Z`` expressed in the base frame, from the base quaternion (wxyz).
+
+    A UNIT direction for any ``base_quat`` magnitude: the rotation is read from
+    the orientation the quaternion encodes, not from its components (see
+    :func:`quat_rotate_inverse`).
+
+    Args:
+        base_quat: Base orientation ``[w, x, y, z]``, any magnitude.
+
+    Returns:
+        The unit gravity direction in the base frame (``float32``, 3).
+
+    Raises:
+        ValueError: If ``base_quat`` describes no rotation (~zero norm).
+    """
     return quat_rotate_inverse(base_quat, _WORLD_GRAVITY)
 
 
@@ -127,6 +203,10 @@ def raw_accel_gravity(base_acc: NDArray[np.float32], base_quat: NDArray[np.float
 
     Returns:
         A unit ``float32`` gravity direction in the base frame.
+
+    Raises:
+        ValueError: If the reading is degenerate AND ``base_quat`` describes no
+            rotation, so neither estimator carries a direction.
     """
     negated = -np.asarray(base_acc, dtype=np.float32)
     magnitude = float(np.linalg.norm(negated))
@@ -149,8 +229,9 @@ def _require_base_block(observation_dict: dict[str, Any], key: str, expected_len
     directions. One component short, ``q[1:4]`` is a 2-vector that ``np.cross``
     reads as planar, so ``base_quat`` silently loses its ``z``: the gravity block
     is still three finite components at the documented width, 7.5 degrees from the
-    truth for a small-yaw pose at a norm of 0.991 - inside a percent of unity, and
-    this module normalises nothing - rising to 20.7 degrees at 0.935. Over-long, a
+    truth for a small-yaw pose at a norm of 0.991 - inside a percent of unity, so the
+    normalisation :func:`quat_rotate_inverse` performs does not flag it either - rising
+    to 20.7 degrees at 0.935. Over-long, a
     7-element ``[base_pos, base_quat]`` slice is read as a quaternion made of
     positions, 70.9 degrees off. A short ``base_ang_vel`` instead narrowed the
     returned vector below the documented ``48 + len(command)``, handing the graph
@@ -311,7 +392,11 @@ def build_observation(
             vector is not finite - the offending blocks are named, and a joint
             block names the joint. A ``nan``/``inf`` reaches the graph
             otherwise, which propagates it and makes ``get_actions`` refuse it
-            as ``'the ONNX action'``.
+            as ``'the ONNX action'``. Or if ``base_quat`` describes no rotation
+            (~zero norm, the spelling of an orientation that was never written):
+            the width and finiteness passes both accept it while the gravity
+            block it reduces to reads as a perfectly upright base, so
+            :func:`quat_rotate_inverse` refuses it instead.
     """
     if gravity_source not in _GRAVITY_SOURCES:
         raise ValueError(

--- a/tests/policies/microduck/test_microduck_gravity_block_is_a_unit_direction.py
+++ b/tests/policies/microduck/test_microduck_gravity_block_is_a_unit_direction.py
@@ -1,0 +1,274 @@
+"""Slot two of the Microduck observation is the unit direction the layout declares.
+
+``build_observation`` documents slot two as "a UNIT gravity direction in the base
+frame", and holds ``base_quat`` to two properties on the way there: a width
+(``_require_base_block``) and finiteness (``_non_finite_observation_error``). It
+did not hold it to the third - that the four components describe a rotation - and
+:func:`~strands_robots.policies.microduck.observation.quat_rotate_inverse`
+implements a formula that is a rotation only for a UNIT quaternion: it mixes a
+term quadratic in the components with a linear one, so scaling does not cancel.
+
+A quaternion scaled by any positive factor encodes the SAME rotation. That is why
+the library's single orientation domain
+(:func:`~strands_robots.utils.coerce_orientation_quaternion`) accepts any
+magnitude, and it says why in as many words: "every consumer either normalizes or
+is scale-invariant". Measured on ``3c30c4b4`` for a 20 deg pitch about world +Y,
+reading the same rotation at several magnitudes:
+
+===============  =======================  ==========  =====================
+``base_quat``    slot two                 magnitude   direction vs the unit
+===============  =======================  ==========  =====================
+unit             ``[ 0.342, 0, -0.940]``  1.000       0.000 deg
+x 1.01           ``[ 0.349, 0, -0.938]``  1.001       0.393 deg
+x 0.5            ``[ 0.086, 0, -0.985]``  0.989       15.038 deg
+x 2              ``[ 1.368, 0, -0.759]``  1.564       40.986 deg
+x 10             ``[34.202, 0,  5.031]``  34.570      78.368 deg
+all zero         ``[ 0.000, 0, -1.000]``  1.000       upright, 20 deg off
+===============  =======================  ==========  =====================
+
+The last row is the worst of them: an all-zero quaternion is what an orientation
+that was never written or was dropped on the wire spells, the formula returns the
+vector it was handed unchanged, and for world ``-Z`` that is exactly the gravity
+block of a PERFECTLY UPRIGHT base - the one attitude a locomotion policy most
+needs to tell apart from a fall. It passes the width guard (4 components) and the
+finiteness pass (all finite), so nothing else in the module sees it.
+
+The contract was already settled everywhere else. Four world-to-body helpers
+normalise internally - ``policies/wbc/control.quat_rotate_inverse``,
+``policies/protomotions/state_utils.quat_rotate_inverse``,
+``simulation/predicates._quat_rotate_inverse_wxyz`` and the Newton backend's copy
+- and the two same-layer policy siblings refuse the degenerate case rather than
+answering with a made-up rotation. This module was the fifth helper and the one
+that had neither. ``TestTheSiblingHelpersAgree`` grades that agreement so the
+family cannot drift apart again.
+
+Normalising does not move the happy path: for a unit quaternion the divisor is
+1.0 and the pre-existing formula is reproduced exactly, which
+``test_a_unit_quaternion_is_answered_bit_for_bit`` pins against a local copy of
+the pre-fix expression.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.microduck import (
+    MICRODUCK_DEFAULT_POSE,
+    MICRODUCK_JOINT_NAMES,
+    build_observation,
+    projected_gravity,
+    quat_rotate_inverse,
+)
+from strands_robots.policies.microduck.observation import _BASE_QUAT_LEN
+from strands_robots.utils import MIN_QUATERNION_NORM
+
+#: World gravity, the vector slot two is world ``-Z`` rotated from.
+WORLD_GRAVITY = np.array([0.0, 0.0, -1.0], dtype=np.float32)
+
+#: A 20 deg pitch about world +Y, wxyz - a plausible Microduck trunk attitude.
+PITCH_20_DEG = 20.0
+Q_PITCH_20 = np.array(
+    [math.cos(math.radians(PITCH_20_DEG) / 2.0), 0.0, math.sin(math.radians(PITCH_20_DEG) / 2.0), 0.0],
+    dtype=np.float32,
+)
+
+#: The magnitudes the same rotation is offered at. ``1.01`` is IMU drift, ``0.924``
+#: is the norm a linear interpolation of two 90-deg-apart samples leaves behind.
+SCALES = (0.5, 0.923879, 1.01, 2.0, 10.0)
+
+#: The spellings of an orientation that carries no direction.
+NO_DIRECTION = (
+    ("all zero", [0.0, 0.0, 0.0, 0.0]),
+    ("below the shared floor", [MIN_QUATERNION_NORM / 10.0, 0.0, 0.0, 0.0]),
+)
+
+
+def _reference_world_to_body(quat_wxyz: np.ndarray, vec: np.ndarray) -> np.ndarray:
+    """``R(q)^T @ vec`` built from the rotation matrix, normalising explicitly.
+
+    An independent oracle: it constructs the matrix rather than reusing the
+    Rodrigues-form expansion the helper under test evaluates.
+    """
+    w, x, y, z = (np.asarray(quat_wxyz, dtype=np.float64) / np.linalg.norm(quat_wxyz)).tolist()
+    rot = np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - w * z), 2 * (x * z + w * y)],
+            [2 * (x * y + w * z), 1 - 2 * (x * x + z * z), 2 * (y * z - w * x)],
+            [2 * (x * z - w * y), 2 * (y * z + w * x), 1 - 2 * (x * x + y * y)],
+        ]
+    )
+    return rot.T @ np.asarray(vec, dtype=np.float64)
+
+
+def _tilt_degrees(gravity: np.ndarray) -> float:
+    """Angle between a base-frame gravity block and straight down, in degrees."""
+    g = np.asarray(gravity, dtype=np.float64)
+    cos = float(-g[2] / np.linalg.norm(g))
+    return math.degrees(math.acos(max(-1.0, min(1.0, cos))))
+
+
+def _obs_dict(base_quat: object) -> dict[str, object]:
+    """A complete projected-gravity observation dict carrying ``base_quat``."""
+    obs: dict[str, object] = {"base_ang_vel": [0.0, 0.0, 0.0], "base_quat": base_quat}
+    for name in MICRODUCK_JOINT_NAMES:
+        obs[name] = 0.0
+        obs[f"{name}.vel"] = 0.0
+    return obs
+
+
+def _slot_two(base_quat: object) -> np.ndarray:
+    """The gravity block ``build_observation`` writes for ``base_quat``."""
+    observation = build_observation(
+        _obs_dict(base_quat),
+        joint_names=list(MICRODUCK_JOINT_NAMES),
+        default_pose=MICRODUCK_DEFAULT_POSE,
+        last_action=np.zeros(len(MICRODUCK_JOINT_NAMES), dtype=np.float32),
+        command=np.zeros(3, dtype=np.float32),
+    )
+    return np.asarray(observation[3:6], dtype=np.float64)
+
+
+class TestASlotTwoBlockIsAUnitDirection:
+    """The declared property of slot two, at every magnitude of one rotation."""
+
+    @pytest.mark.parametrize("scale", SCALES)
+    def test_the_block_is_unit_length(self, scale: float) -> None:
+        block = _slot_two((Q_PITCH_20 * scale).tolist())
+        assert float(np.linalg.norm(block)) == pytest.approx(1.0, abs=1e-6), (
+            f"base_quat scaled by {scale} (|q| = {float(np.linalg.norm(Q_PITCH_20 * scale)):.4f}) "
+            f"put a gravity block of magnitude {float(np.linalg.norm(block)):.4f} into slot two, "
+            f"which build_observation documents as a unit direction"
+        )
+
+    @pytest.mark.parametrize("scale", SCALES)
+    def test_the_block_names_the_attitude_the_quaternion_encodes(self, scale: float) -> None:
+        block = _slot_two((Q_PITCH_20 * scale).tolist())
+        assert _tilt_degrees(block) == pytest.approx(PITCH_20_DEG, abs=1e-3), (
+            f"a base pitched {PITCH_20_DEG} deg, with base_quat scaled by {scale}, "
+            f"reported an attitude {_tilt_degrees(block):.3f} deg off vertical"
+        )
+
+    @pytest.mark.parametrize("scale", SCALES)
+    def test_the_helper_matches_an_independent_rotation_matrix(self, scale: float) -> None:
+        expected = _reference_world_to_body(Q_PITCH_20, WORLD_GRAVITY)
+        got = np.asarray(quat_rotate_inverse((Q_PITCH_20 * scale).tolist(), WORLD_GRAVITY), dtype=np.float64)
+        assert got == pytest.approx(expected, abs=1e-6), (
+            f"scaled by {scale}, world -Z body-framed to {got.tolist()} instead of {expected.tolist()}"
+        )
+
+
+class TestAnOrientationThatWasNeverWrittenIsRefused:
+    """A quaternion with no direction is refused, not read as upright."""
+
+    @pytest.mark.parametrize(("label", "quat"), NO_DIRECTION, ids=[label for label, _ in NO_DIRECTION])
+    def test_the_helper_refuses_it(self, label: str, quat: list[float]) -> None:
+        with pytest.raises(ValueError, match="describes no rotation"):
+            quat_rotate_inverse(quat, WORLD_GRAVITY)
+
+    @pytest.mark.parametrize(("label", "quat"), NO_DIRECTION, ids=[label for label, _ in NO_DIRECTION])
+    def test_build_observation_refuses_it(self, label: str, quat: list[float]) -> None:
+        with pytest.raises(ValueError, match="describes no rotation"):
+            _slot_two(quat)
+
+    def test_the_refusal_names_what_the_block_would_have_claimed(self) -> None:
+        """The message has to say why a zero orientation is not a harmless one."""
+        with pytest.raises(ValueError, match="perfectly upright"):
+            projected_gravity(np.zeros(_BASE_QUAT_LEN, dtype=np.float32))
+
+    def test_the_width_and_finiteness_passes_do_accept_it(self) -> None:
+        """Premise: no other guard in the module sees a zero quaternion.
+
+        Both existing passes hold - it is four components and every one is
+        finite - so this rule cannot be delegated to either of them.
+        """
+        zero = np.zeros(_BASE_QUAT_LEN, dtype=np.float32)
+        assert zero.shape[0] == _BASE_QUAT_LEN, "premise: a zero quaternion is the declared width"
+        assert bool(np.isfinite(zero).all()), "premise: a zero quaternion is finite"
+
+
+class TestTheUnchangedBehaviour:
+    """Controls: everything that held before still holds."""
+
+    def test_a_unit_quaternion_is_answered_bit_for_bit(self) -> None:
+        """The formula on the domain Pollen operates in is untouched."""
+        for quat in ([1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.5, 0.5, 0.5, 0.5]):
+            q = np.asarray(quat, dtype=np.float32)
+            assert float(np.linalg.norm(np.asarray(q, dtype=np.float64))) == 1.0, (
+                f"premise: {quat} is exactly unit, so normalising divides by 1.0"
+            )
+            v = WORLD_GRAVITY
+            # The pre-fix expression, evaluated locally.
+            t = np.cross(q[1:4], v) * 2.0
+            pre_fix = (v - q[0] * t + np.cross(q[1:4], t)).astype(np.float32)
+            got = quat_rotate_inverse(q, v)
+            assert np.array_equal(got, pre_fix), f"{quat}: {got.tolist()} != pre-fix {pre_fix.tolist()}"
+
+    def test_a_non_finite_component_still_reaches_the_assembled_vector_pass(self) -> None:
+        """A ``nan`` is named through the block it becomes, not refused here.
+
+        The norm of a ``nan`` quaternion is ``nan``, which is not below the
+        floor, so the value flows on and the assembled-vector pass reports it
+        against ``projected_gravity (from base_quat)`` as it always has.
+        """
+        with pytest.raises(ValueError, match=r"projected_gravity \(from base_quat\)"):
+            _slot_two([1.0, float("nan"), 0.0, 0.0])
+
+    def test_an_identity_orientation_still_reads_as_world_gravity(self) -> None:
+        assert _slot_two([1.0, 0.0, 0.0, 0.0]) == pytest.approx([0.0, 0.0, -1.0], abs=1e-7)
+
+
+class TestTheSiblingHelpersAgree:
+    """The five world-to-body helpers read one rotation the same way."""
+
+    def test_every_helper_is_scale_invariant(self) -> None:
+        from strands_robots.policies.protomotions.state_utils import (
+            quat_rotate_inverse as protomotions_helper,
+        )
+        from strands_robots.policies.wbc.control import quat_rotate_inverse as wbc_helper
+        from strands_robots.simulation.newton.simulation import (
+            _quat_rotate_inverse_wxyz as newton_helper,
+        )
+        from strands_robots.simulation.predicates import _quat_rotate_inverse_wxyz as predicates_helper
+
+        q_wxyz = Q_PITCH_20.astype(np.float64)
+        q_xyzw = np.array([q_wxyz[1], q_wxyz[2], q_wxyz[3], q_wxyz[0]])
+        vec = np.array([0.0, 0.0, -1.0])
+        helpers = {
+            "microduck": lambda s: np.asarray(quat_rotate_inverse((q_wxyz * s).astype(np.float32), WORLD_GRAVITY)),
+            "wbc": lambda s: np.asarray(wbc_helper(q_wxyz * s, vec)),
+            "protomotions": lambda s: np.asarray(protomotions_helper((q_xyzw * s).astype(np.float32), vec)),
+            "predicates": lambda s: np.asarray(predicates_helper(list(q_wxyz * s), list(vec))),
+            "newton": lambda s: np.asarray(newton_helper(list(q_wxyz * s), list(vec))),
+        }
+        expected = _reference_world_to_body(q_wxyz, vec)
+        for name, helper in helpers.items():
+            for scale in (1.0, 2.0):
+                got = np.asarray(helper(scale), dtype=np.float64)
+                assert got == pytest.approx(expected, abs=1e-6), (
+                    f"{name} read a quaternion scaled by {scale} as a different rotation: "
+                    f"{got.tolist()} instead of {expected.tolist()}"
+                )
+
+    def test_both_policy_layer_helpers_refuse_a_zero_orientation(self) -> None:
+        """The two same-layer siblings agree that a zero quaternion is refused."""
+        from strands_robots.policies.protomotions.state_utils import (
+            quat_rotate_inverse as protomotions_helper,
+        )
+        from strands_robots.policies.wbc.control import quat_rotate_inverse as wbc_helper
+
+        for name, call in (
+            ("microduck", lambda: quat_rotate_inverse(np.zeros(4, dtype=np.float32), WORLD_GRAVITY)),
+            ("wbc", lambda: wbc_helper(np.zeros(4), np.array([0.0, 0.0, -1.0]))),
+            (
+                "protomotions",
+                lambda: protomotions_helper(
+                    np.zeros(4, dtype=np.float32), np.array([0.0, 0.0, -1.0], dtype=np.float32)
+                ),
+            ),
+        ):
+            with pytest.raises(ValueError):
+                call()
+            assert name  # the loop variable names the helper in a failure

--- a/tests/policies/microduck/test_microduck_gravity_block_is_a_unit_direction.py
+++ b/tests/policies/microduck/test_microduck_gravity_block_is_a_unit_direction.py
@@ -54,6 +54,7 @@ import math
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 from strands_robots.policies.microduck import (
     MICRODUCK_DEFAULT_POSE,
@@ -79,10 +80,11 @@ Q_PITCH_20 = np.array(
 #: is the norm a linear interpolation of two 90-deg-apart samples leaves behind.
 SCALES = (0.5, 0.923879, 1.01, 2.0, 10.0)
 
-#: The spellings of an orientation that carries no direction.
+#: The spellings of an orientation that carries no direction, in the float32 the
+#: module's own ``_require_base_block`` hands the helper.
 NO_DIRECTION = (
-    ("all zero", [0.0, 0.0, 0.0, 0.0]),
-    ("below the shared floor", [MIN_QUATERNION_NORM / 10.0, 0.0, 0.0, 0.0]),
+    ("all zero", np.zeros(_BASE_QUAT_LEN, dtype=np.float32)),
+    ("below the shared floor", np.array([MIN_QUATERNION_NORM / 10.0, 0.0, 0.0, 0.0], dtype=np.float32)),
 )
 
 
@@ -124,7 +126,7 @@ def _slot_two(base_quat: object) -> np.ndarray:
     observation = build_observation(
         _obs_dict(base_quat),
         joint_names=list(MICRODUCK_JOINT_NAMES),
-        default_pose=MICRODUCK_DEFAULT_POSE,
+        default_pose=np.array(MICRODUCK_DEFAULT_POSE, dtype=np.float32),
         last_action=np.zeros(len(MICRODUCK_JOINT_NAMES), dtype=np.float32),
         command=np.zeros(3, dtype=np.float32),
     )
@@ -164,12 +166,12 @@ class TestAnOrientationThatWasNeverWrittenIsRefused:
     """A quaternion with no direction is refused, not read as upright."""
 
     @pytest.mark.parametrize(("label", "quat"), NO_DIRECTION, ids=[label for label, _ in NO_DIRECTION])
-    def test_the_helper_refuses_it(self, label: str, quat: list[float]) -> None:
+    def test_the_helper_refuses_it(self, label: str, quat: NDArray[np.float32]) -> None:
         with pytest.raises(ValueError, match="describes no rotation"):
             quat_rotate_inverse(quat, WORLD_GRAVITY)
 
     @pytest.mark.parametrize(("label", "quat"), NO_DIRECTION, ids=[label for label, _ in NO_DIRECTION])
-    def test_build_observation_refuses_it(self, label: str, quat: list[float]) -> None:
+    def test_build_observation_refuses_it(self, label: str, quat: NDArray[np.float32]) -> None:
         with pytest.raises(ValueError, match="describes no rotation"):
             _slot_two(quat)
 

--- a/tests/policies/microduck/test_microduck_observation_refuses_a_wrong_width_base_block.py
+++ b/tests/policies/microduck/test_microduck_observation_refuses_a_wrong_width_base_block.py
@@ -63,6 +63,7 @@ import pytest
 
 from strands_robots.policies.microduck import build_observation, decode_action, projected_gravity
 from strands_robots.policies.microduck import observation as obs_mod
+from strands_robots.utils import MIN_QUATERNION_NORM
 
 #: The command width the shipped alpha policies declare (twist 3 + head 4 + body 6).
 _ALPHA_COMMAND_WIDTH = 13
@@ -373,15 +374,19 @@ class TestThePremisesTheDefectRestedOn:
         cos = float(np.clip(np.dot(right, wrong) / (np.linalg.norm(right) * np.linalg.norm(wrong)), -1.0, 1.0))
         assert np.degrees(np.arccos(cos)) > min_tilt_deg
 
-    def test_the_only_norm_this_module_reads_is_the_accelerometer_estimator(self) -> None:
+    def test_no_norm_this_module_reads_can_judge_a_width(self) -> None:
         """So the norm drift is still not a signal anything acts on.
 
-        :func:`raw_accel_gravity` reads a norm to turn the accelerometer into the
+        Two functions read a norm, and neither reads one to judge a WIDTH.
+        :func:`raw_accel_gravity` reads one to turn the accelerometer into the
         unit gravity direction Pollen's ``get_raw_accelerometer`` returns - the
         estimator's own arithmetic, on a block whose width the reader already
-        held. Nothing reads a norm to JUDGE a block, so a wrong-width
-        ``base_quat`` still produces no signal any code acts on, which is the
-        premise the measurement above rests on.
+        held. :func:`quat_rotate_inverse` reads one to rotate by the orientation
+        a quaternion encodes rather than by its components, and the only norm it
+        refuses is a ~zero one, which carries no direction at all. A short
+        ``base_quat`` stays within a percent of unity - the measurement above -
+        so it is a usable direction to both of them and the width guard cannot
+        be delegated to either, which is the premise this class rests on.
         """
         source = inspect.getsource(obs_mod)
         norm_readers = sorted(
@@ -389,7 +394,14 @@ class TestThePremisesTheDefectRestedOn:
             for node in ast.parse(source).body
             if isinstance(node, ast.FunctionDef) and "linalg.norm" in ast.unparse(node)
         )
-        assert norm_readers == ["raw_accel_gravity"], norm_readers
+        assert norm_readers == ["quat_rotate_inverse", "raw_accel_gravity"], norm_readers
+        # The norm that IS a judgement clears a short read: three components of a
+        # unit quaternion still describe a direction, just the wrong one.
+        short = np.asarray([0.9098, -0.0665, 0.1604], dtype=np.float32)
+        assert float(np.linalg.norm(short)) > MIN_QUATERNION_NORM, "premise: a short read is not degenerate"
+        assert bool(np.all(np.isfinite(projected_gravity(short)))), (
+            "a wrong-width base_quat is still answered, so only the width guard can refuse it"
+        )
         # Whitespace-normalised: the claim spans a line wrap in the docstring, so a
         # raw substring match would grade the wrapping rather than the sentence.
         assert "This module never rescales the assembled vector." in " ".join(source.split())


### PR DESCRIPTION
## Problem

Slot two of the Microduck observation vector is documented three times as **"a UNIT gravity direction in the base frame"**. `build_observation` holds `base_quat` to two properties on the way there - a width (`_require_base_block`) and finiteness (`_non_finite_observation_error`) - but not to the third: that the four components describe a rotation.

`quat_rotate_inverse` evaluates a formula that is a rotation **only for a unit quaternion**: it mixes a term quadratic in the components with a linear one, so scaling does not cancel. A quaternion scaled by any positive factor encodes the *same* rotation - which is exactly why the library's single orientation domain accepts any magnitude, and it says why in as many words:

> A quaternion is a DIRECTION with a magnitude the target buffers ignore, so any non-unit value is fine [...] **every consumer either normalizes or is scale-invariant.**
> -- `utils.coerce_orientation_quaternion`

This was the one consumer that did neither.

![the pose the robot is in vs the pose slot two described](https://raw.githubusercontent.com/cagataycali/robots/5c3853d01f5ecc520d21f903273ee1bd1e13b160/.artifacts/microduck-gravity-block-unit-direction.png)

## Measured

One rotation - a 20 deg pitch about world +Y - offered at several magnitudes, on `3c30c4b4`:

| `base_quat` | slot two | \|slot two\| | attitude it reports |
|---|---|---|---|
| unit | `[ 0.342, 0, -0.940]` | 1.000 | 20.0 deg (correct) |
| x 1.01 (IMU drift) | `[ 0.349, 0, -0.938]` | 1.001 | 20.4 deg |
| x 0.924 (a lerp of two samples) | `[ 0.292, 0, -0.949]` | 0.992 | 17.1 deg |
| x 0.5 | `[ 0.086, 0, -0.985]` | 0.989 | 5.0 deg |
| x 2 | `[ 1.368, 0, -0.759]` | **1.564** | **61.0 deg** |
| x 10 | `[34.202, 0,  5.031]` | **34.570** | **98.4 deg** |
| `[0, 0, 0, 0]` | `[ 0.000, 0, -1.000]` | 1.000 | **0.0 deg - upright** |

The last row is the worst of them. An all-zero quaternion is what an orientation that was never written, or was dropped on the wire, spells; the formula returns the vector it was handed unchanged, and for world `-Z` that is precisely the gravity block of a **perfectly upright base** - the one attitude a locomotion policy most needs to tell apart from a fall. It passes the width guard (4 components) and the finiteness pass (all finite), so nothing else in the module ever sees it.

## The family

The contract was already settled everywhere else. Five helpers body-frame a world vector from a quaternion; the two same-layer policy siblings even refuse the degenerate case explicitly, with the rationale written out ("every direction is equally consistent with it - so it is refused instead of silently standing in for one").

| helper | normalizes | refuses ~zero norm |
|---|---|---|
| `policies/wbc/control.quat_rotate_inverse` | yes | yes |
| `policies/protomotions/state_utils.quat_rotate_inverse` | yes | yes |
| `simulation/predicates._quat_rotate_inverse_wxyz` | yes | passes `vec` through (documented) |
| `simulation/newton/simulation._quat_rotate_inverse_wxyz` | yes | passes `vec` through (documented) |
| **`policies/microduck/observation.quat_rotate_inverse`** | **no** | **no** |

## Change

Normalize the orientation inside `quat_rotate_inverse` and refuse a norm below the shared `utils.MIN_QUATERNION_NORM` floor - the same threshold `_quaternion_direction_error` already owns, so it stops being spelled a fifth time.

Two behaviours are deliberately preserved:

- A `nan`/`inf` component is **not** refused here. Its norm is `nan`, which is not below the floor, so it flows on and `_non_finite_observation_error` names it against `projected_gravity (from base_quat)` as it always has.
- For an exactly-unit quaternion the divisor is `1.0` and the pre-existing expression is reproduced **bit for bit** - the domain Pollen's own `infer_policy.py` operates in is untouched. Pinned against a local copy of the pre-fix expression.

Docstrings that asserted the old state are corrected in the same change: the module docstring's normalization inventory ("the one normalisation it performs") and `_require_base_block`'s aside that "this module normalises nothing".

## Tests

`tests/policies/microduck/test_microduck_gravity_block_is_a_unit_direction.py` - the magnitude and the encoded attitude at 5 scales, graded against an independent rotation-matrix oracle; the two degenerate spellings refused at both the helper and `build_observation`; `TestTheSiblingHelpersAgree` grades all five helpers on one rotation so the family cannot drift apart again; controls for the bit-for-bit unit case, the `nan` path and identity.

| tree | `tests/policies/microduck` |
|---|---|
| `3c30c4b4` + this test file | **22 failed**, 481 passed |
| with the fix | **503 passed**, 0 failed |

Every pre-fix failure names the defect; every control is green on both trees. One existing structural cell (`test_the_only_norm_this_module_reads_is_the_accelerometer_estimator`) asserted that nothing reads a norm to *judge* a block - true before, and the premise its class rests on is really that a norm cannot judge a **width**. Retargeted in place to grade that, with a cell showing a short read still clears the floor.

The fixtures spell `base_quat` in the `float32` `_require_base_block` returns, and `default_pose` with the `np.array(MICRODUCK_DEFAULT_POSE, dtype=np.float32)` wrap `MicroduckPolicy` uses at `policies/microduck/policy.py:436` - two `arg-type` errors on the first head came from posing them as `list[float]` / the public `tuple[float, ...]`, spellings no producer in the module emits.

Full gate: `ruff check` + `ruff format --check` clean on 1886 files; `mypy strands_robots tests tests_integ` reports nothing in the changed files, and its 20-error / 6-file remainder here is the base tree's set unchanged (absent `mink`, plus `examples/isaac_gs`); `tests/policies` failing-node-id set identical base vs dev (12, all absent optional deps / installed-lerobot drift); `scripts/check_whole_tree_graders.py` 13 failed / 4372 passed / 4 errors, the standing set.

## Size

| | |
|---|---|
| files | 4 |
| insertions | 411 |
| deletions | 14 |

61 of the insertions are the fix and its docstring; the rest is the regression file and the changelog fragment. Rollouts and figure rendered in MuJoCo headless (EGL).