### PR TITLE
fix(policies/vera): a port means the same thing whichever spelling named it

### DIFF
--- a/changelog.d/3230-vera-server-port-env-falsy-override.md
+++ b/changelog.d/3230-vera-server-port-env-falsy-override.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- `VeraConfig` now applies its `VERA_SERVER_PORT` override because it is
+  present, not because it is truthy. `VERA_SERVER_PORT=0` was falsy, so the
+  override was discarded and the per-embodiment default applied in its place -
+  the same value `VeraConfig(server_port=0)` refuses by name, since the client
+  cannot learn which ephemeral port the kernel handed the server. A port now
+  gets one verdict whichever spelling named it, matching `vis_port` and
+  `render_width`, whose overrides already read for presence.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -165,7 +165,11 @@ it, the runner launches the server on it, and `VeraConfig.server_uri` reports it
 — so a value outside the range is not merely refused late but resolved
 differently by each of them. `vis_port = 0` is the one exception and disables the
 live viewer (`--vis-port` is omitted). The `VERA_*_PORT` overrides go through the
-same check.
+same check, including when the value they carry is `0`: an override is applied
+because it is present, not because it is truthy, so a port means the same thing
+whichever spelling named it. `VERA_SERVER_PORT=0` is refused exactly as
+`server_port=0` is, and `VERA_VIS_PORT=0` disables the viewer exactly as
+`vis_port=0` does.
 
 `motion_plan_scale` takes the same domain as the two IK scales below: a positive
 finite number, or `None` to leave the server's own scale alone. `0` is not the

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -124,13 +124,18 @@ class VeraConfig:
         embodiment: VERA embodiment - selects the WAN/DFoT planner + Jacobian
             IDM pair and the client-side action adapter.
         host: Policy-server hostname.
-        server_port: Policy-server websocket port. ``None`` applies the
-            per-embodiment default; any other value must be an ``int`` in
-            ``[1, 65535]``, because the client dials it and the server binds it.
-        vis_port: MJPEG live-viewer port. ``None`` applies the per-embodiment
-            default; ``0`` disables the viewer (the runner omits
-            ``--vis-port``); any other value must be an ``int`` in
-            ``[1, 65535]``.
+        server_port: Policy-server websocket port. ``None`` applies
+            ``VERA_SERVER_PORT`` else the per-embodiment default; any other
+            value must be an ``int`` in ``[1, 65535]``, because the client dials
+            it and the server binds it. That includes a value the environment
+            supplied: ``VERA_SERVER_PORT=0`` is refused rather than read as
+            "unset", so it cannot resolve to the default under a success.
+        vis_port: MJPEG live-viewer port. ``None`` applies ``VERA_VIS_PORT``
+            else the per-embodiment default; ``0`` disables the viewer (the
+            runner omits ``--vis-port``); any other value must be an ``int`` in
+            ``[1, 65535]``. ``0`` means the same through the environment as it
+            does through the keyword, which is why the override is read for its
+            presence and not for its truth.
         render_width: Per-view width, in pixels, each camera frame is resized
             to before it is sent to the planner. ``None`` applies
             ``VERA_RENDER_WIDTH`` else the per-embodiment default; any other
@@ -191,8 +196,21 @@ class VeraConfig:
     def __post_init__(self) -> None:
         # Apply per-embodiment port defaults when not explicitly set.
         default_policy, default_vis = _DEFAULT_PORTS.get(self.embodiment, (8800, 8801))
+        # Both env overrides are read with ``is not None``, never with ``or``.
+        # The two spellings are not interchangeable for a port: ``0`` is falsy,
+        # so the ``or`` this line used to carry discarded the override and
+        # applied the per-embodiment default in its place - the same discard
+        # that ``render_width`` below was converted away from. That made one
+        # value mean two things depending on how it was spelled:
+        # ``VeraConfig(server_port=0)`` was refused by the shared domain (the
+        # client has no way to learn which ephemeral port the kernel handed the
+        # server, so it cannot dial one), while ``VERA_SERVER_PORT=0`` reported
+        # success on the default. Reading the override for its presence rather
+        # than its truth sends both spellings to the one check below, so the
+        # caller who asked for 0 gets the refusal rather than port 8820.
         if self.server_port is None:
-            self.server_port = _env_int("VERA_SERVER_PORT") or default_policy
+            env_port = _env_int("VERA_SERVER_PORT")
+            self.server_port = env_port if env_port is not None else default_policy
         if self.vis_port is None:
             env_vis = _env_int("VERA_VIS_PORT")
             self.vis_port = env_vis if env_vis is not None else default_vis

--- a/tests/policies/vera/test_vera_port_domain.py
+++ b/tests/policies/vera/test_vera_port_domain.py
@@ -18,6 +18,14 @@ asymmetry (``vis_port=0`` disables the viewer, so zero is a mode selector there
 and not a port), and the property the divergence was: every accepted port is
 named identically by all three consumers.
 
+They also pin that a port means the same thing however it was spelled. A field
+can be set as a keyword or through ``VERA_*_PORT``, and the two must reach the
+one check: ``VeraConfig(server_port=0)`` was refused while
+``VERA_SERVER_PORT=0`` reported success on the per-embodiment default, because
+the override was read for its truth (``or``) rather than for its presence, and
+``0`` is falsy. A deploy that asked for a port it cannot have was told it had
+got it, on a different port.
+
 Everything here is offline - no server, no socket, no ``vera`` package.
 """
 
@@ -53,6 +61,18 @@ UNUSABLE_PORTS: list[Any] = [
 # Ports every consumer can honor.
 USABLE_PORTS: list[int] = [1, 8800, 8820, 65535]
 
+# Env spellings of a ``server_port`` no consumer can honor. Every entry is one
+# ``_env_int`` really parses, so each reaches the shared domain rather than
+# stopping at the parser - a spelling the parser cannot read is swallowed by
+# design, pinned in
+# ``test_vera_unit.py::test_malformed_numeric_env_degrades_to_defaults``.
+# ``"0"`` and ``"-0"`` are the rows that need the override read for its
+# presence: they parse to a falsy int, which an ``or`` discards.
+REFUSED_ENV_SERVER_PORTS: list[str] = ["0", "-0", "-1", "65536", "70000"]
+
+# The same, for ``vis_port``, minus the documented zero exemption.
+REFUSED_ENV_VIEWER_PORTS: list[str] = ["-9", "-1", "65536", "70000"]
+
 
 def _config(**kwargs: Any) -> VeraConfig:
     """Build a config through the funnel, splatted so off-type values reach it.
@@ -67,6 +87,19 @@ def _argv_port(cfg: VeraConfig, flag: str) -> str | None:
     """The value the server launch argv carries for ``flag``, or None if absent."""
     cmd = VeraServerRunner(cfg)._build_command()
     return cmd[cmd.index(flag) + 1] if flag in cmd else None
+
+
+def _server_port_outcome(**kwargs: Any) -> tuple[str, int | None]:
+    """What the funnel did with a ``server_port``, comparable across spellings.
+
+    Either ``("refused", None)`` or ``("resolved", port)``, so one value set as a
+    keyword and the same value set through ``VERA_SERVER_PORT`` can be compared
+    for the same verdict rather than for the same exception text.
+    """
+    try:
+        return ("resolved", _config(embodiment="pusht", **kwargs).server_port)
+    except ValueError:
+        return ("refused", None)
 
 
 # --------------------------------------------------------------------------- #
@@ -182,16 +215,53 @@ class TestViewerPortDomain:
 # The environment override goes through the same guard
 # --------------------------------------------------------------------------- #
 class TestEnvironmentOverride:
-    def test_an_unusable_env_server_port_is_refused(self, monkeypatch):
-        """``VERA_SERVER_PORT`` writes the same field, so it is checked too."""
-        monkeypatch.setenv("VERA_SERVER_PORT", "70000")
+    @pytest.mark.parametrize("raw", REFUSED_ENV_SERVER_PORTS)
+    def test_an_unusable_env_server_port_is_refused(self, monkeypatch, raw):
+        """``VERA_SERVER_PORT`` writes the same field, so it is checked too.
+
+        Only the truthy rows were reachable while the override was read with
+        ``or``: ``"0"`` parsed to a falsy int, so the override was dropped and
+        the per-embodiment default (8820 on pusht) applied under a success.
+        """
+        monkeypatch.setenv("VERA_SERVER_PORT", raw)
         with pytest.raises(ValueError, match="server_port"):
             _config(embodiment="pusht")
 
-    def test_an_unusable_env_viewer_port_is_refused(self, monkeypatch):
-        monkeypatch.setenv("VERA_VIS_PORT", "-9")
+    @pytest.mark.parametrize("raw", REFUSED_ENV_VIEWER_PORTS)
+    def test_an_unusable_env_viewer_port_is_refused(self, monkeypatch, raw):
+        monkeypatch.setenv("VERA_VIS_PORT", raw)
         with pytest.raises(ValueError, match="vis_port"):
             _config(embodiment="pusht")
+
+    def test_a_zero_env_viewer_port_disables_the_viewer_as_the_keyword_does(self, monkeypatch):
+        """The zero exemption is a property of the value, not of the spelling.
+
+        ``0`` selects "no viewer" through the environment too, and the runner
+        omits the flag exactly as it does for ``vis_port=0`` - which is what
+        reading the override for its presence preserves. Read for its truth,
+        ``VERA_VIS_PORT=0`` would resolve to the default port 8821 and the
+        viewer the caller switched off would be served.
+        """
+        monkeypatch.setenv("VERA_VIS_PORT", "0")
+        cfg = _config(embodiment="pusht")
+        assert cfg.vis_port == 0
+        assert _argv_port(cfg, "--vis-port") is None
+
+    @pytest.mark.parametrize("raw", ["0", "-1", "65536", "70000", "8899"])
+    def test_one_port_gets_one_verdict_whichever_spelling_named_it(self, monkeypatch, raw):
+        """A value the keyword refuses cannot be accepted from the environment.
+
+        The two spellings write one field through one check, so the outcome is a
+        property of the value: refused for the same reason, or resolved to the
+        same port. ``"0"`` is the row that separated them - the keyword was
+        refused by name while the environment reported success on 8820.
+        """
+        value = int(raw)
+        monkeypatch.delenv("VERA_SERVER_PORT", raising=False)
+        keyword = _server_port_outcome(server_port=value)
+        monkeypatch.setenv("VERA_SERVER_PORT", raw)
+        environment = _server_port_outcome()
+        assert keyword == environment
 
     def test_a_usable_env_override_still_applies(self, monkeypatch):
         monkeypatch.setenv("VERA_SERVER_PORT", "9999")


### PR DESCRIPTION
## The defect

`VeraConfig.__post_init__` read its port override with `or`. `0` is falsy, so an
override that parsed to zero was discarded and the per-embodiment default applied
in its place — under a success.

That made one value mean two things depending on how it was spelled. Measured on
`pusht` (defaults `(8820, 8821)`):

| spelling | before | after |
|---|---|---|
| `VeraConfig(server_port=0)` | **refused** — `invalid server_port: 0 (expected 1-65535)` | refused (unchanged) |
| `VERA_SERVER_PORT=0` | resolved **8820**, `uri=ws://127.0.0.1:8820` | **refused**, same message |
| `VERA_SERVER_PORT=-0` | resolved **8820** | **refused** |
| `VERA_SERVER_PORT=70000` | refused | refused (unchanged) |
| `VERA_SERVER_PORT=8899` | resolved 8899 | resolved 8899 (unchanged) |
| `VERA_VIS_PORT=0` | `vis_port=0`, `--vis-port` omitted | unchanged |
| `VERA_RENDER_WIDTH=0` | refused | unchanged |

`0` is in the refused set for `server_port` for a reason this suite already
states: the client has no way to learn which ephemeral port the kernel handed the
server, so it cannot dial one. A deploy that set `VERA_SERVER_PORT=0` was told it
had the port it asked for, on a different port — and `server_port` is read by
three consumers, so the value in the environment and the value the client dials,
the runner launches on and `server_uri` reports simply disagreed with nothing
reporting it.

## Why this line

Both siblings in the same `__post_init__` were already converted, for exactly
this reason. `vis_port` reads its override with `is not None`, and
`render_width`'s comment records the conversion verbatim:

> The env override is read with `is not None`, matching `vis_port` above rather
> than the `or` this line used to carry. […] `VERA_RENDER_WIDTH=0` is falsy, so
> the override was discarded and the per-embodiment default silently applied in
> its place — a width of 0 cannot be honored, and the caller who asked for it is
> owed the refusal below, not 128 under a success.

`server_port` was the odd one out, and a tree-wide sweep found it is the only
numeric env override still read for its truth rather than its presence (every
other `or` on an env read is a string or a path, where empty and unset spell the
same thing).

`docs/policies/vera.md` already asserted "The `VERA_*_PORT` overrides go through
the same check" — true only for truthy values. The fix makes the existing claim
correct; the doc now says so explicitly for `0`.

## The change

```diff
-        if self.server_port is None:
-            self.server_port = _env_int("VERA_SERVER_PORT") or default_policy
+        if self.server_port is None:
+            env_port = _env_int("VERA_SERVER_PORT")
+            self.server_port = env_port if env_port is not None else default_policy
```

One expression, matching the two lines below it. No new domain, no new field, no
signature change: the value now reaches the `tcp_port_error` check the class
already performs.

## Tests

`tests/policies/vera/test_vera_port_domain.py`, table-driven in the classes that
already own these axes.

The existing grader stated the general contract — *"`VERA_SERVER_PORT` writes the
same field, so it is checked too"* — but posed only `"70000"`, a **truthy**
unusable value, which is the one spelling an `or` cannot discard. It is retargeted
rather than replaced: parametrized over the refusable spellings `_env_int` really
parses, so the falsy rows are covered by the cell that always claimed them.

Added:

- `test_one_port_gets_one_verdict_whichever_spelling_named_it` — one value set as
  a keyword and as an env var must reach the same verdict. Pre-fix the `"0"` row
  reads `assert ('refused', None) == ('resolved', 8820)`.
- `test_a_zero_env_viewer_port_disables_the_viewer_as_the_keyword_does` — the
  documented zero exemption is a property of the value, not of the spelling, and
  reading for presence is what preserves it. A guard against fixing this by
  refusing every zero.

Pre-fix control (behavioural line reverted, tests and docstrings kept):

```
FAILED …::test_an_unusable_env_server_port_is_refused[0]  - DID NOT RAISE ValueError
FAILED …::test_an_unusable_env_server_port_is_refused[-0] - DID NOT RAISE ValueError
FAILED …::test_one_port_gets_one_verdict_whichever_spelling_named_it[0]
            - AssertionError: assert ('refused', None) == ('resolved', 8820)
3 failed, 98 passed
```

Exactly the falsy rows fail; every truthy refusal, the usable override, the
viewer-zero exemption and the non-zero symmetry rows stay green.

## Deliberately out of scope

`_env_int` returns `None` for a spelling it cannot parse, so `VERA_SERVER_PORT=abc`
and `=2.7` still fall back to the default. That behaviour is uniform across all
five numeric knobs and is pinned as a decision in
`test_vera_unit.py::test_malformed_numeric_env_degrades_to_defaults` ("deploy/CI
environments frequently carry typo'd or empty numeric knobs"). Changing it is a
separate decision, not this defect — this PR only stops a value the parser
*successfully read* from being thrown away.

## Gate

| check | result |
|---|---|
| `ruff check` + `format --check` | clean, 1887 files |
| `mypy strands_robots tests tests_integ` (pinned `<2.0`) | 20 errors / 6 files — the unchanged baseline; **neither changed file appears** |
| `pytest tests/policies tests/test_doc*.py tests/test_args_docstring_completeness.py` | base `15F/6585P` → `15F/6598P`, failed node ids **set-identical**, `+13` = exactly the new cells |
| pre-fix | 3 failed / 98 passed, all controls green |

The 15 standing failures are absent optional deps and installed-lerobot drift,
identical on `main`.

**Size:** 4 files, +115 / −14. Production: one expression; the rest is the
regression table, two field docstrings and one doc sentence.
