### PR TITLE
docs(agents): a cast string is a use of the name it names, and the exemption has a boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2415,6 +2415,55 @@ Corrections from code review that apply to all future contributions:
   that a record cannot split rather than the record's field layout, and keep the
   escape to `\r` and `\n`: these messages are read by a human diagnosing a
   binding, and a broader filter corrupts the diagnosis they exist for.
+- **`py/unused-import` does not read a string forward reference, so a
+  `TYPE_CHECKING` import consumed only by a `cast("X", ...)` is reported as
+  dead.** `cast`'s first argument is an ordinary runtime expression, so
+  `from __future__ import annotations` is not what makes it a string - the idiom
+  writes it as one, and a type checker resolves it against the module namespace,
+  which is where the `TYPE_CHECKING` block puts the name. The extractor reads
+  bare `Name` loads and a string carries none.
+
+  Do not answer the alert by reading it. Run the counterfactual - delete the
+  import and lint the file - because that is what separates the two cases, and
+  they need opposite actions:
+
+  | `ruff check` after deleting the import | meaning | action |
+  |---|---|---|
+  | `F821 Undefined name 'X'` at the cast | the import is the name's only binding, and load-bearing | dismiss as `false positive`, keep the import |
+  | clean | the name is bound at runtime too, so the import carries nothing | the alert is right: delete the import |
+
+  Measured on `strands_robots/training/rl/fast_td3.py` (alert 1160), where
+  `SimEnv` reaches nothing but `cast("SimEnv", self.env)`: `ruff` reports
+  `F821` at that line and `mypy` reports `Name "SimEnv" is not defined`
+  `[name-defined]`, both inside `call-test-lint / Test and Lint`. So the two
+  gates the repository actually runs refuse the edit the alert asks for, and the
+  remaining ways to take it anyway are a suppression or a runtime import - which
+  on that file also invites the `isinstance` narrow the comment above the cast
+  exists to refuse. Do not reach for the query filter either: the rule carries
+  live signal here, seven of its twelve alerts on `main` being open and
+  unadjudicated, and `tests/test_codeql_query_filters.py` pins that file at two
+  ids.
+
+  This is written down because the decision was already made once and did not
+  survive. Alert 599 was dismissed with this reasoning **32 minutes** after it
+  opened on 2026-07-02, and the reasoning went into the dismissal comment - 280
+  characters, in the Security tab, invisible from the tree. Two recurrences then
+  had nothing to point at:
+
+  | alert | site | cost before it was adjudicated |
+  |---|---|---|
+  | 599 | `tests/training/test_rl_truncation_bootstrap.py:27` | 32 minutes |
+  | 1138 | `tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py:24` | open on `main` for five days |
+  | 1160 | `strands_robots/training/rl/fast_td3.py:54` | a review thread held #3206 for twelve hours under `required_review_thread_resolution` |
+
+  A dismissal comment is a less durable home than the PR comment this file
+  already warns about, which is why the entry is here and not a fourth
+  dismissal. `tests/test_cast_string_imports_are_the_names_only_binding.py`
+  grades the boundary in the table above - it derives the sites from the tree
+  and refuses a `TYPE_CHECKING` import of a name the module also binds at
+  runtime, the one shape where this exemption would suppress a true finding and
+  the one direction `ruff` and `mypy` cannot report, since the cast string
+  resolves either way.
 - **Dependency Review hard-fails on high/critical CVEs in new deps.** If a PR
   needs a dep with a known critical CVE, the conversation is "do we need this
   dep" not "let's bypass the check."

--- a/changelog.d/3235-a-cast-string-is-a-use-of-the-name-it-names.md
+++ b/changelog.d/3235-a-cast-string-is-a-use-of-the-name-it-names.md
@@ -1,0 +1,23 @@
+### Docs: a `cast("X", ...)` string is a use of `X`, and the CodeQL exemption for it has a stated boundary
+
+CodeQL's `py/unused-import` reads bare `Name` loads, so a `TYPE_CHECKING` import
+consumed only by a string forward reference inside `typing.cast` is reported as
+dead. `AGENTS.md` now records the mechanism, the counterfactual that separates a
+false positive from a real finding -- delete the import and lint the file: `F821`
+at the cast means the import is the name's only binding, a clean `ruff check`
+means the name is bound at runtime too and the alert is right -- and why the rule
+is dismissed per instance rather than filtered.
+
+The entry exists because the adjudication had been made three times and never
+written down. Alert 599 was dismissed 32 minutes after it opened on 2026-07-02,
+with the reasoning in a dismissal comment capped at 280 characters and living
+outside the tree; alert 1138 then sat open on `main` for five days, and alert
+1160 opened a review thread that held a merge for twelve hours under
+`required_review_thread_resolution`.
+
+`tests/test_cast_string_imports_are_the_names_only_binding.py` grades the
+boundary rather than the prose. It derives the sites from the tree and refuses a
+`TYPE_CHECKING` import of a name the module also binds at runtime -- the one
+shape where this exemption would suppress a true finding, and the one direction
+`ruff` and `mypy` cannot report, since the cast string resolves either way. No
+production behaviour changes.

--- a/tests/test_cast_string_imports_are_the_names_only_binding.py
+++ b/tests/test_cast_string_imports_are_the_names_only_binding.py
@@ -1,0 +1,258 @@
+"""A ``cast("X", ...)`` string is a use of ``X``, and the exemption that says so has a precondition.
+
+``typing.cast``'s first argument is an ordinary runtime expression, and the idiom
+here writes it as a *string* so the name it refers to need exist only for a type
+checker::
+
+    if TYPE_CHECKING:
+        from strands_robots.training.rl import SimEnv
+    ...
+    env_factory=lambda: cast("SimEnv", _FakeTermEnv(terminated_flag))
+
+CodeQL's ``py/unused-import`` reads bare ``Name`` loads, and a string carries
+none, so it reports the import as dead. It has done so three times - alerts 599
+(``tests/training/test_rl_truncation_bootstrap.py``, 2026-07-02), 1138
+(``tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py``,
+2026-08-31) and 1160 (``strands_robots/training/rl/fast_td3.py``, 2026-09-05) -
+and all three were dismissed as false positives, the last one after its review
+thread had held a merge for twelve hours under
+``required_review_thread_resolution``. ``AGENTS.md`` records that adjudication so
+a fourth instance is read rather than re-derived.
+
+What this module grades is the precondition the adjudication rests on, which is
+the half no other gate can see. Taking the alert's advice is already refused:
+delete one of these imports and ``ruff`` reports ``F821 Undefined name`` at the
+cast while ``mypy`` reports ``name-defined``, both inside
+``call-test-lint / Test and Lint``. The direction with no gate is the opposite
+one. A ``TYPE_CHECKING`` import of a name the module *also* binds at runtime is
+genuinely dead: the cast string still resolves, so ``ruff`` and ``mypy`` stay
+silent, and there ``py/unused-import`` is right and the import should go. So the
+exemption is not "a cast string always excuses the import" - it holds while the
+``TYPE_CHECKING`` import is the name's only binding, and that is the property
+asserted below.
+
+Stated the other way round, this is the discriminator a reader needs at the
+alert: run the counterfactual rather than the query. ``F821`` means load-bearing
+and the alert is a false positive; a clean ``ruff check`` means the name is bound
+at runtime too and the alert is correct. The rule is not reliably wrong here -
+seven of its twelve alerts on ``main`` are open and unadjudicated - so an
+exemption that did not name its own boundary would suppress live signal.
+
+The population is derived from the tree rather than written down, so a site added
+by a later change is graded on arrival and one that stops qualifying leaves
+without an edit here.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+from functools import lru_cache
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Every top-level directory that ships Python. The idiom this grades is not
+# confined to one area: two of the three alerts above are under `tests/` and one
+# is in the package, and an `examples/` copy would be the shape a reader
+# reproduces. A directory added later that ships Python is swept by
+# `_swept_areas()` without an edit here.
+_AREAS = ("strands_robots", "tests", "tests_integ", "examples", "scripts")
+
+# A name that resolves to a builtin needs no import, so it is not evidence about
+# one. `cast("dict[str, Any]", ...)` contributes `dict` here and `Any`, which is
+# imported, is what the assertion is about.
+_BUILTIN_NAMES = frozenset(dir(builtins))
+
+
+class _CastStringName(NamedTuple):
+    """One name a ``cast`` string refers to, in the module whose import supplies it."""
+
+    path: str
+    name: str
+    cast_line: int
+    import_line: int
+
+
+def _module_level_bindings(tree: ast.Module) -> dict[str, set[str]]:
+    """Map each module-level name to the kinds of binding that supply it.
+
+    ``"typing"`` for a binding inside an ``if TYPE_CHECKING:`` block, which does
+    not exist at runtime, and ``"runtime"`` for every other module-level
+    binding - an import, a ``def``, a ``class``, or an assignment. A name can
+    carry both, and that is exactly the case this module refuses.
+    """
+    bindings: dict[str, set[str]] = {}
+
+    def bind(name: str, kind: str) -> None:
+        bindings.setdefault(name, set()).add(kind)
+
+    def visit(body: list[ast.stmt], *, typing_only: bool) -> None:
+        kind = "typing" if typing_only else "runtime"
+        for node in body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    bind((alias.asname or alias.name).split(".")[0], kind)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                bind(node.name, kind)
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        bind(target.id, kind)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                bind(node.target.id, kind)
+            elif isinstance(node, ast.If):
+                # `else:` runs when TYPE_CHECKING is false, so it is a runtime
+                # branch however the test reads.
+                visit(node.body, typing_only=typing_only or _is_type_checking_test(node.test))
+                visit(node.orelse, typing_only=typing_only)
+            elif isinstance(node, (ast.Try, ast.With)):
+                visit(node.body, typing_only=typing_only)
+                for handler in getattr(node, "handlers", []):
+                    visit(handler.body, typing_only=typing_only)
+                visit(getattr(node, "orelse", []), typing_only=typing_only)
+                visit(getattr(node, "finalbody", []), typing_only=typing_only)
+
+    visit(tree.body, typing_only=False)
+    return bindings
+
+
+def _is_type_checking_test(test: ast.expr) -> bool:
+    """Both spellings: a bare ``TYPE_CHECKING`` and a qualified ``typing.TYPE_CHECKING``."""
+    if isinstance(test, ast.Name):
+        return test.id == "TYPE_CHECKING"
+    return isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+
+
+def _type_checking_import_lines(tree: ast.Module) -> dict[str, int]:
+    """Map a name imported under ``TYPE_CHECKING`` to the line that imports it."""
+    lines: dict[str, int] = {}
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.If) and _is_type_checking_test(node.test)):
+            continue
+        for sub in ast.walk(node):
+            if isinstance(sub, (ast.Import, ast.ImportFrom)):
+                for alias in sub.names:
+                    lines.setdefault((alias.asname or alias.name).split(".")[0], sub.lineno)
+    return lines
+
+
+def _names_in_cast_strings(tree: ast.Module) -> set[tuple[str, int]]:
+    """Every ``(name, line)`` a string-literal first argument to ``cast`` refers to.
+
+    The string is parsed rather than split, so a subscripted reference
+    (``cast("Mapping[str, SimEnv]", ...)``) contributes both names and a
+    dotted one contributes its root, which is the name an import binds.
+    """
+    found: set[tuple[str, int]] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        called = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+        if called != "cast" or not node.args:
+            continue
+        first = node.args[0]
+        if not (isinstance(first, ast.Constant) and isinstance(first.value, str)):
+            continue
+        try:
+            reference = ast.parse(first.value, mode="eval")
+        except SyntaxError:
+            # Not a type expression at all. mypy reports that itself, and it is
+            # not evidence about any import.
+            continue
+        for sub in ast.walk(reference):
+            if isinstance(sub, ast.Name):
+                found.add((sub.id, node.lineno))
+    return found
+
+
+@lru_cache(maxsize=1)
+def _cast_string_names() -> tuple[_CastStringName, ...]:
+    """Every name a ``cast`` string refers to that a ``TYPE_CHECKING`` import supplies."""
+    collected: list[_CastStringName] = []
+    # The walk is spelled with the area held in the loop variable, which is the
+    # form `scripts/check_whole_tree_graders.py` resolves: this grader's input is
+    # the rest of the repository, so a diff-scoped selector collects it only
+    # through that roster.
+    for area in _AREAS:
+        for path in sorted((REPO_ROOT / area).rglob("*.py")):
+            source = path.read_text(encoding="utf-8", errors="ignore")
+            if "cast(" not in source:
+                continue
+            try:
+                tree = ast.parse(source)
+            except SyntaxError:
+                continue
+            import_lines = _type_checking_import_lines(tree)
+            if not import_lines:
+                continue
+            for name, cast_line in sorted(_names_in_cast_strings(tree)):
+                if name in _BUILTIN_NAMES or name not in import_lines:
+                    continue
+                collected.append(
+                    _CastStringName(
+                        path=str(path.relative_to(REPO_ROOT)),
+                        name=name,
+                        cast_line=cast_line,
+                        import_line=import_lines[name],
+                    )
+                )
+    return tuple(collected)
+
+
+class TestACastStringImportIsTheNamesOnlyBinding:
+    """The exemption for ``py/unused-import`` holds only while nothing binds the name at runtime."""
+
+    def test_no_module_binds_a_cast_string_name_both_ways(self) -> None:
+        """A name bound at runtime too makes the ``TYPE_CHECKING`` import genuinely dead.
+
+        This is the direction ``ruff`` and ``mypy`` cannot report: the cast
+        string resolves either way, so both stay silent while the import has
+        stopped carrying anything. ``py/unused-import`` is correct on that shape,
+        and dismissing it as the same false positive as alerts 599 / 1138 / 1160
+        would suppress a true finding. The remedy is to delete the
+        ``TYPE_CHECKING`` import, which is what the alert asks for.
+        """
+        redundant = []
+        for reference in _cast_string_names():
+            source = (REPO_ROOT / reference.path).read_text(encoding="utf-8")
+            bindings = _module_level_bindings(ast.parse(source))
+            if "runtime" in bindings.get(reference.name, set()):
+                redundant.append(
+                    f"{reference.path}:{reference.import_line} imports {reference.name!r} under "
+                    f"TYPE_CHECKING, and the module also binds it at runtime; the cast at line "
+                    f"{reference.cast_line} resolves without the import"
+                )
+        assert not redundant, (
+            "A TYPE_CHECKING import is only load-bearing behind a cast string while it is the "
+            "name's sole binding. These carry a runtime binding as well, so the import is dead "
+            "and py/unused-import is right about them - delete the import rather than dismissing "
+            "the alert: " + "; ".join(redundant)
+        )
+
+
+class TestThePopulationIsDerivedFromTheTree:
+    """A sweep that reaches nothing passes, so what it reaches is asserted separately."""
+
+    def test_every_named_area_ships_python(self) -> None:
+        """An area renamed or mistyped would silently drop out of the sweep."""
+        for area in _AREAS:
+            path = REPO_ROOT / area
+            assert path.is_dir(), f"{area} is named in _AREAS and is not a directory"
+            assert any(path.rglob("*.py")), f"{area} is named in _AREAS and ships no Python"
+
+    def test_the_sweep_finds_the_idiom_it_grades(self) -> None:
+        """The idiom is in the tree, so an empty population means the derivation broke.
+
+        Deliberately weaker than a count or a path list: the sites are ordinary
+        code that may be rewritten for reasons of their own, and pinning them
+        here would turn an unrelated refactor into a failure of this file. What
+        cannot happen quietly is the derivation matching nothing at all, which
+        is how a grader keeps passing after it has stopped grading.
+        """
+        assert _cast_string_names(), (
+            "No cast-string reference to a TYPE_CHECKING import was found anywhere in "
+            f"{', '.join(_AREAS)}. Either the idiom has left the tree - in which case delete this "
+            "module and the AGENTS.md entry it pins - or the derivation above no longer matches it."
+        )


### PR DESCRIPTION
## What

CodeQL's `py/unused-import` reads bare `Name` loads, so a `TYPE_CHECKING` import consumed only by a `cast("X", ...)` string looks dead to it. This records the adjudication in `AGENTS.md` and pins the one half of it that no existing gate can see.

No production code changes.

## Why now: the decision was made three times and never written down

| alert | site | adjudicated | cost first |
|---|---|---|---|
| 599 | `tests/training/test_rl_truncation_bootstrap.py:27` | 2026-07-02, 32 minutes after it opened | 32 minutes |
| 1138 | `tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py:24` | today | open on `main` for **five days** |
| 1160 | `strands_robots/training/rl/fast_td3.py:54` | today | a review thread held #3206 for **twelve hours** under `required_review_thread_resolution` |

599's reasoning went into the dismissal comment, which is capped at 280 characters and lives in the Security tab. The two recurrences had nothing to point at, so each was re-derived from scratch and one of them blocked a merge. That is the failure mode this file's own rule names -- a decision recorded outside it does not survive -- reached by a home even less durable than a PR comment.

## The discriminator, which is the useful half

The entry does not say "a cast string always excuses the import". It says run the counterfactual, because the two cases need opposite actions:

| `ruff check` after deleting the import | meaning | action |
|---|---|---|
| `F821 Undefined name 'X'` at the cast | the import is the name's only binding | dismiss as `false positive`, keep it |
| clean | the name is bound at runtime too | the alert is right: delete the import |

Measured on `fast_td3.py` at `db4cedcb`, deleting the flagged line and changing nothing else:

| tool | import present | import deleted |
|---|---|---|
| `ruff check` (0.15.22, repo config) | clean | `F821 Undefined name 'SimEnv'` at `315:21` |
| `mypy` (1.20.2), errors attributable to the file | 0 | `Name "SimEnv" is not defined  [name-defined]` |

Both gates the repository actually runs refuse the edit the alert asks for. The boundary matters because the rule is not reliably wrong here: seven of its twelve alerts on `main` are open and unadjudicated, so an unqualified exemption would suppress live signal. The entry also says not to reach for the query filter, which `tests/test_codeql_query_filters.py` pins at two ids.

## What the grader adds, and what it deliberately is not

`tests/test_cast_string_imports_are_the_names_only_binding.py` grades the boundary rather than the prose. It derives the sites from the tree -- 14 today across `strands_robots/` and `tests/` -- and refuses a `TYPE_CHECKING` import of a name the module *also* binds at runtime.

That is the one direction `ruff` and `mypy` cannot report: the cast string resolves either way, so both stay silent while the import has stopped carrying anything, and `py/unused-import` is *correct* on that shape. Measured against a probe of exactly it (a module importing `Policy` at runtime and again under `TYPE_CHECKING`, with `cast("Policy", obj)`):

```
pytest tests/test_cast_string_imports_are_the_names_only_binding.py   1 failed, 2 passed
ruff check examples/_zz_probe_redundant.py                            All checks passed!
```

So it is not a restatement of `ruff` -- it fails where `ruff` passes. Three deliberate limits:

- **It grades no list.** Pinning today's 14 sites would turn an unrelated refactor into a failure here, and would make #3206 landing (which adds a 15th) red on `main` -- the #1763 shape. The population is derived, so a new site is graded on arrival and a retired one leaves without an edit.
- **It does not assert the prose.** `AGENTS.md`'s CodeQL section is already text-asserted by `tests/test_codeql_query_filters.py`; a second copy of that idea would drift from it.
- **It does not re-check the deletion.** `F821` and `name-defined` already do, inside `call-test-lint / Test and Lint`.

The walk is spelled with the area in a loop variable so `scripts/check_whole_tree_graders.py` resolves it; the roster goes 101 -> 102 and names the module, which is what stops a diff-scoped selector reading green over it (#3105, #3111).

## The composition, run rather than argued

A whole-tree grader takes every open branch as its input, so the pairwise sweep cannot describe it (`check_merge_base_overlap.py` says so itself: a test resolving its population from a walk shares no path with the siblings it grades, #2561). #3206 is the live case -- it adds `fast_td3.py`, a 15th site -- so the composition was run rather than reasoned about:

```
git merge db4cedcb                  # #3206 head into this branch, clean
pytest tests/test_cast_string_imports_are_the_names_only_binding.py   3 passed
census on the composition           15 sites, including fast_td3.py:315 -> SimEnv
```

So either merge order leaves `main` green, and the 15th site is admitted by the derivation rather than needing an edit here.

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` on both changed files | clean |
| `mypy` on the new module | `Success: no issues found in 1 source file` |
| new module | 3 passed |
| `tests/test_codeql_query_filters.py` (asserts this AGENTS.md section) | passed |
| `test_whole_tree_graders_roster_is_complete.py`, `test_changelog_fragments.py`, `test_docstring_xref_roles_resolve.py` | 112 passed |
| `test_test_case_names_describe_behaviour.py`, `test_no_host_paths.py` | 66 passed with the two above |
| `scripts/assemble_changelog.py --check` | `changelog fragments OK (1176 pending)` |
| composition with #3206 | 3 passed, 15 sites |
| added lines non-ASCII | 0 |

The fragment landed as the second commit, before the pull request left draft, so it cannot arrive after an approval and cost a re-approval round.
