### PR TITLE
fix(tests): an abbreviated version floor is not below the floor it abbreviates

### DIFF
--- a/changelog.d/3236-abbreviated-version-floor.md
+++ b/changelog.d/3236-abbreviated-version-floor.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- The dependency-audit sweep no longer reports a version floor written without
+  its trailing zeros as undercutting itself. PEP 440 reads an absent release
+  component as zero, so `numpy>=1.21` and `numpy>=1.21.0` are one release and
+  pip resolves them identically; the comparison ordered the shorter key first
+  because a tuple that is a prefix of another sorts below it, which made the
+  abbreviation of every declared floor a reported offence.

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -708,12 +708,16 @@ def _declared_dependency_floors() -> dict[str, str]:
 
 
 def _version_key(raw: str) -> tuple[int, ...]:
-    """Order a release string by its numeric components.
+    """Read a release string as its numeric components, in order.
 
-    ``numpy>=2`` and ``numpy>=1.21.0`` are both written in the tree, so the
-    comparison pads rather than requiring equal arity: ``2`` sorts above
-    ``1.21.0``. A non-numeric component ends the read (``2.*``, ``1.0rc1``),
-    which keeps a pre-release from sorting above the release it precedes.
+    A non-numeric component ends the read (``2.*``, ``1.0rc1``), which keeps a
+    pre-release from sorting above the release it precedes.
+
+    The tuple is only as long as the string has components, so two keys are
+    comparable only once padded to a common width, which
+    :func:`_names_a_lower_release` does. Comparing them raw orders a key below
+    every longer key it is a prefix of, and ``numpy>=2`` and ``numpy>=1.21.0``
+    are both written in the tree.
     """
     parts: list[int] = []
     for component in raw.split("."):
@@ -722,6 +726,26 @@ def _version_key(raw: str) -> tuple[int, ...]:
             break
         parts.append(int(digits.group()))
     return tuple(parts)
+
+
+def _names_a_lower_release(written: str, floor: str) -> bool:
+    """Whether ``written`` names a release below ``floor``.
+
+    PEP 440 reads an absent release component as zero, so ``1.21`` and
+    ``1.21.0`` are one release, and a bound written either way admits exactly
+    the same environments -- ``pip install "numpy>=1.21"`` refuses 1.20.99 just
+    as ``>=1.21.0`` does. Padding to a common width is what makes an
+    abbreviation compare equal to the floor it abbreviates; comparing the parsed
+    keys raw ordered ``(1, 21)`` below ``(1, 21, 0)``, which reported every
+    declared floor as undercut by its own shorter spelling.
+    """
+    written_key, floor_key = _version_key(written), _version_key(floor)
+    width = max(len(written_key), len(floor_key))
+
+    def padded(key: tuple[int, ...]) -> tuple[int, ...]:
+        return key + (0,) * (width - len(key))
+
+    return padded(written_key) < padded(floor_key)
 
 
 def _below_floor_bounds(text: str, floors: dict[str, str]) -> list[tuple[str, str, str]]:
@@ -743,7 +767,7 @@ def _below_floor_bounds(text: str, floors: dict[str, str]) -> list[tuple[str, st
         floor = floors.get(_normalize_extra(name))
         if floor is None:
             continue
-        if _version_key(written) < _version_key(floor):
+        if _names_a_lower_release(written, floor):
             stale.append((name, written, floor))
     return stale
 
@@ -797,10 +821,21 @@ def test_written_version_bounds_are_not_below_the_declared_floor() -> None:
         # Below the floor: reported, with the floor it undercuts.
         ('pip install "strands-agents>=1.0"', [("strands-agents", "1.0", "1.7.0")]),
         ('pip install "strands-agents>=0.1"', [("strands-agents", "0.1", "1.7.0")]),
+        # Below the floor in a component the floor spells and the bound does
+        # not: the padding must not read the absent component as "no verdict".
+        ("pip install 'numpy>=1.20'", [("numpy", "1.20", "1.21.0")]),
         # At the floor, and above it: a stricter local requirement is correct.
         ('pip install "strands-agents>=1.7.0,<2.0.0"', []),
         ("pip install 'numpy>=1.24'", []),
         ("composes with numpy>=2", []),
+        # At the floor, written without its trailing zeros. PEP 440 reads the
+        # absent component as zero, so these name the floor itself rather than
+        # something below it.
+        ('pip install "strands-agents>=1.7"', []),
+        ("pip install 'numpy>=1.21'", []),
+        # And the same release spelled longer than the floor is not above it
+        # either, so it stays unreported for the same reason.
+        ("pip install 'numpy>=1.21.0.0'", []),
         # A distribution the manifest does not declare sets no floor to be below.
         ('pip install "gradio>=4,<7"', []),
         # A longer name is not read as a bound on its tail.
@@ -815,6 +850,41 @@ def test_the_written_bound_rule_can_both_accept_and_reject(line: str, expected: 
     """
     floors = {"strands-agents": "1.7.0", "numpy": "1.21.0"}
     assert _below_floor_bounds(line, floors) == expected
+
+
+def test_a_declared_floor_written_without_its_trailing_zeros_is_not_read_as_undercutting_itself() -> None:
+    """Every declared floor, abbreviated, must be read as that floor.
+
+    A release bound may be written without its trailing zeros -- ``numpy>=1.21``
+    and ``numpy>=1.21.0`` are one release under PEP 440, and pip resolves them
+    identically -- so prose and install lines across the tree spell floors both
+    ways. Reading the abbreviation as an undercut is a false report on the one
+    axis this sweep exists to police, and it fires on *every* declared
+    dependency rather than some unusual corner:
+
+        numpy: floor 1.21.0, written >=1.21 -> reported as below 1.21.0
+
+    The live manifest is the fixture so the cell cannot go stale against a floor
+    that gains or loses a component.
+    """
+    floors = _declared_dependency_floors()
+    assert floors, "no lower bound read from [project.dependencies]; the manifest reader has drifted"
+
+    graded = 0
+    for name, floor in floors.items():
+        components = floor.split(".")
+        # Drop trailing zero components one at a time: 1.21.0 -> 1.21, and
+        # 8.0.0 -> 8.0 -> 8. Each is the same release as the floor.
+        for width in range(len(components) - 1, 0, -1):
+            if any(part != "0" for part in components[width:]):
+                break
+            abbreviated = ".".join(components[:width])
+            graded += 1
+            assert _below_floor_bounds(f'pip install "{name}>={abbreviated}"', floors) == [], (
+                f"{name}>={abbreviated} names the declared floor {floor} itself, not a release below it"
+            )
+
+    assert graded >= len(floors), f"only {graded} abbreviations graded for {len(floors)} declared floors"
 
 
 # Headers that mean "the extra you install". A column merely containing the word


### PR DESCRIPTION
The written-bound sweep in `tests/test_dependency_audit.py` compared parsed release keys as **raw tuples**, so a key that is a prefix of another sorted below it. `numpy>=1.21` measured as `(1, 21) < (1, 21, 0)` and was reported as undercutting the `1.21.0` the manifest declares.

PEP 440 reads an absent release component as zero, so those spell **one release** and pip resolves them identically:

```
>>> Version("1.21") == Version("1.21.0")
True
>>> Version("1.20.99") in SpecifierSet(">=1.21")     # the short spelling
False
>>> Version("1.20.99") in SpecifierSet(">=1.21.0")   # the long one
False
```

So the report was false — under a message that tells the reader the install "leaves an environment this package refuses and still exits 0", which is the one thing an equal bound cannot do.

## It was false for every declared floor

![verdict matrix](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/assets/floor-abbreviation-matrix.png)

16 verdicts measured against both trees: **4 wrong before, 0 after** — exactly one per declared dependency, and only the abbreviation column moved.

| dependency | declared floor | abbreviated | before | after |
| --- | --- | --- | --- | --- |
| `numpy` | 1.21.0 | `>=1.21` | reported below floor | silent |
| `pillow` | 8.0.0 | `>=8.0` | reported below floor | silent |
| `opencv-python-headless` | 4.5.0 | `>=4.5` | reported below floor | silent |
| `strands-agents` | 1.13.0 | `>=1.13` | reported below floor | silent |

This is a required check, so the false positive refuses a correct spelling outright. It is currently what blocks #3234, whose three flagged lines quote the declared range as `` `numpy>=1.21,<3.0` `` — all three are clean under this fix.

## The docstring already claimed the fix

`_version_key` said the comparison "pads rather than requiring equal arity". It never padded; its own example (`2` sorting above `1.21.0`) holds only because the leading component decides it, which is why the claim went unnoticed. The padding now happens, in `_names_a_lower_release`, and the docstring says where.

## Not an over-fix

Padding only makes prefix-equal keys equal, so every genuine undercut still reports. Dropping a component that is **not** zero is a real undercut and stays reported:

| written | vs floor | verdict |
| --- | --- | --- |
| `numpy>=1` | 1.21.0 | reported below floor |
| `numpy>=1.20` | 1.21.0 | reported below floor |
| `pillow>=7` | 8.0.0 | reported below floor |
| `strands-agents>=1.12` | 1.13.0 | reported below floor |

The parse is left alone, so the documented tolerance for `2.*` and `1.0rc1` is unchanged. All 16 real bound mentions in the swept tree are purely numeric, so no live site changes verdict.

## Tests

Retargeted `test_the_written_bound_rule_can_both_accept_and_reject`: its "at the floor" rows only ever posed an **equal-arity** (`>=1.7.0`) or strictly-greater (`>=1.24`, `>=2`) spelling, never the equal-but-shorter one, which is why the rule shipped wrong. Added the abbreviation in both arities plus `numpy>=1.20` as a control that must still fire.

Added `test_a_declared_floor_written_without_its_trailing_zeros_is_not_read_as_undercutting_itself`, which walks the **live manifest** and grades every declared floor's abbreviations, so it cannot go stale against a floor that gains or loses a component.

Pre-fix, with only the comparison reverted: **3 failed** (`>=1.7`, `>=1.21`, and the manifest sweep). The two control rows pass on both trees.

## Gate

| check | result |
| --- | --- |
| `ruff check` + `format --check` (`strands_robots tests tests_integ`) | clean, 1888 files |
| `mypy` 1.20.2, same scope | 20 errors / 6 files, **error set identical to `upstream/main`**; changed file absent |
| `pytest tests/test_dependency_audit.py` | 79 passed → 163 passed across the floor-test family (base 158, **+5** = 4 rows + 1 cell) |

The one local failure, `test_declared_qp_backends_are_real_qpsolvers_extras`, is `qpsolvers` missing from this environment and is byte-identical on `upstream/main`; it passes in CI.

## Size

`+84 / -6`, one test module plus a changelog fragment. The additions are 4 parametrize rows, one manifest-driven cell, and the padded comparison with the docstring that now matches it.
