### PR TITLE
fix(training): a hidden layer of width zero is not an architecture

### DIFF
--- a/changelog.d/3238-network-width-domain.md
+++ b/changelog.d/3238-network-width-domain.md
@@ -1,0 +1,39 @@
+### Fixed
+
+- **A hidden layer of width zero is no longer accepted as an architecture.**
+  `RLTrainSpec.hidden_dims` decides the shape of every network a from-scratch RL
+  run trains, and nothing judged it. All three RL backends (`ppo`, `fast_sac`,
+  `fast_td3`) expand the field identically, once per network they build - the
+  on-policy actor and critic, and off-policy the actor, its Polyak target and
+  all four Q heads - and `nn.Linear` accepts a width of zero as a legal layer.
+  `torch` only warns ("Initializing zero-element tensors is a no-op"), the layer
+  emits an empty activation, and the layer after it emits its bias alone, so the
+  network's output stops being a function of the observation.
+
+  Measured over a full `train()` on each backend, `hidden_dims=(16, 0)` returned
+  a bit-identical action for an all-zero observation and an all-`50` one, while
+  `train()` reported `status="success"` with a real `actor_loss` and a real
+  `actor_updates` count and exported `policy.pt` + `policy_meta.json` - a
+  deployable checkpoint whose actor commands one fixed action in every state the
+  robot can reach. Sweeping the joint observation over `[-5, 5]` rad, the
+  honored run's action spans `0.227` while the severed run's is exactly constant
+  at `0.0`. On hardware that is an arm driving to a single pose and staying
+  there, reported as a trained policy.
+
+  `validate()` now asks each width of the shared `positive_count_error` domain,
+  because a width is consumed directly as a tensor dimension: an integral float
+  raises `TypeError` inside `torch` rather than being coerced, and `bool` would
+  otherwise pass a bare `< 1` test as a silent width of one. That domain also
+  refuses `np.int64`, which is not an over-refusal even though `nn.Linear`
+  accepts it - `save_checkpoint` writes `list(spec.hidden_dims)` to
+  `policy_meta.json` and `json.dump` raises `TypeError: Object of type int64 is
+  not JSON serializable`, so such a run trains to completion and then loses the
+  whole run at the save.
+
+  The **empty** sequence stays accepted: it is the honest spelling of a linear
+  policy, and its action still varies with the observation. So the domain is per
+  element rather than on the length, and a problem names the offending index
+  (`hidden_dims[1] must be a positive integer, got 0.`). A value that is not a
+  sequence of widths at all - a bare `int`, `None`, a `str`, or a one-shot
+  generator, which is consumed by the first network built and leaves every later
+  critic a different shape - is refused as a whole.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -238,6 +238,31 @@ separately rather than against that shared domain, because the accepted sets
 differ: PPO parallelizes and accepts any count `>= 1`, while the MuJoCo-backed
 FastSAC is single-env and requires exactly `1`.
 
+`hidden_dims` must be a sequence of positive integer layer widths, checked by
+`validate()` on all three RL backends - each builds every network it trains by
+expanding the same field (the on-policy actor and critic; off-policy the actor,
+its Polyak target and all four Q heads). Nothing judged the widths, and
+`nn.Linear` does not either: a width of **zero** is a legal layer. `torch` only
+warns ("Initializing zero-element tensors is a no-op"), the layer emits an empty
+activation, and the layer after it therefore emits its bias alone - so the
+network's output stops being a function of the observation. Measured over a full
+`train()` on each backend, `hidden_dims=(16, 0)` returned a **bit-identical
+action** for an all-zero observation and an all-`50` one, while `train()`
+reported `status="success"` with a real `actor_loss` and exported
+`policy.pt` + `policy_meta.json`: a deployable checkpoint whose actor commands
+one fixed action in every state the robot can reach. A negative or non-integer
+width instead raised out of `torch` after the environment, the networks and the
+optimizers were built, and `np.int64` trained to completion and then lost the run
+at the save, because `save_checkpoint` JSON-encodes the field.
+
+The **empty** sequence stays accepted: it is the honest spelling of a linear
+policy (input straight to the output layer), and its action still varies with the
+observation. So the domain is per element rather than on the length, and a
+problem names the offending index (`hidden_dims[1] must be a positive integer`).
+A value that is not a sequence of widths at all - a bare `int`, `None`, a `str`,
+or a one-shot generator, which would be consumed by the first network built and
+leave every later critic a different shape - is refused as a whole.
+
 `gamma` must be a finite number in the closed interval `[0, 1]`, checked by
 `validate()` on both backends. It is the one coefficient both of them read (PPO
 discounts the GAE recursion with it, FastSAC its target-Q bootstrap) and a

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -138,6 +138,14 @@ noise is symmetric, so a negative scale is silently the identical
 distribution, zero silently removes the mechanism the field configures, and a
 non-finite value poisons the actions or the TD target. It is scoped like
 :func:`policy_delay_problems`: only the TD3 backend reads the three fields.
+
+:func:`network_width_problems` is the seventeenth, on the *architecture* axis:
+``hidden_dims``, the hidden layer widths every from-scratch RL backend builds
+its actor and its critics from. It is scoped like
+:func:`learning_rate_problems` rather than like :func:`gae_lambda_problems` -
+all three RL backends read the field, for every network they construct - and it
+is the only one of these gates whose field is a *sequence*, so the domain is
+asked of each element in turn and the message names the offending index.
 """
 
 from __future__ import annotations
@@ -145,6 +153,7 @@ from __future__ import annotations
 import math
 import numbers
 import re
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.tools._path_validation import validate_save_path
@@ -1545,3 +1554,95 @@ def td3_noise_problems(spec: TrainSpec, *, context: str) -> list[str]:
         if error is not None:
             problems.append(error)
     return problems
+
+
+def network_width_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return hidden-layer-width problems for a from-scratch RL :class:`TrainSpec`.
+
+    ``hidden_dims`` is the only spec field that decides the *shape* of the
+    networks a run trains. Every RL backend expands it the same way, once per
+    network it builds - the on-policy actor and critic, and off-policy the actor,
+    its Polyak target and all four Q heads::
+
+        for h in spec.hidden_dims:
+            layers += [nn.Linear(last, h), nn.ReLU()]
+            last = h
+        layers.append(nn.Linear(last, out_dim))
+
+    Nothing judged the widths, and ``nn.Linear`` does not either: a width of
+    zero is a legal layer. It builds a ``(n, 0)`` weight - ``torch`` only warns
+    "Initializing zero-element tensors is a no-op" - and every forward pass
+    through it produces a ``(batch, 0)`` activation, so the next layer sees no
+    input and emits its bias alone. **The output stops being a function of the
+    observation.** Measured on the fake one-joint env, over a full ``train()``
+    on each backend, comparing the trained actor's action for an all-zero
+    observation against an all-``50`` one:
+
+    ======================  ==============  ==================================
+    ``hidden_dims``         Verdict         Outcome
+    ======================  ==============  ==================================
+    ``(16,)`` (a control)   accepted        actions differ: ``0.109`` / ``-0.869``
+    ``()``                  accepted        a linear policy; actions differ
+    ``(0,)``               **accepted**    every action bit-identical
+    ``(16, 0)``            **accepted**    every action bit-identical
+    ``(-1,)``               accepted        raises inside ``setup``
+    ``(16.0,)`` / ``(True,)`` accepted      raises inside ``setup``
+    ``np.int64(16)``        accepted        trains, then the checkpoint raises
+    ``16`` / ``None``       accepted        raises inside ``setup``
+    a generator             accepted        a different shape per network
+    ======================  ==============  ==================================
+
+    The two bold rows are why this is a gate rather than a lint. A zero width
+    anywhere in the sequence severs the policy from the robot: the run collects
+    its rollouts, the critics train against a constant, ``train()`` returns
+    ``status="success"`` with a real ``actor_loss`` and a real ``actor_updates``
+    count, and it exports ``policy.pt`` + ``policy_meta.json`` - a *deployable*
+    checkpoint whose actor emits one fixed action for every state the robot can
+    ever be in. On hardware that is an arm driving to a single pose and staying
+    there, reported as a trained policy. This is the same shape as
+    :func:`gradient_clip_problems` (a run that reports success having learned
+    nothing), reached through the one field that can make learning *impossible*
+    rather than merely ineffective.
+
+    The empty sequence is **not** in that class and stays accepted: it is the
+    honest spelling of a linear policy (input straight to output, no hidden
+    layer), and its action still varies with the observation. So the domain is
+    per element, not on the length.
+
+    Each width is asked of the shared :func:`~strands_robots.utils.positive_count_error`
+    domain, the same one the loop-bound counts use, because a width is consumed
+    directly as a tensor dimension: an integral float raises ``TypeError``
+    inside ``torch`` rather than being coerced, and ``bool`` would otherwise
+    pass a bare ``< 1`` test as a silent width of one. That domain also refuses
+    ``np.int64``, which is not an over-refusal here even though ``nn.Linear``
+    accepts it - ``save_checkpoint`` writes ``list(spec.hidden_dims)`` to
+    ``policy_meta.json`` and ``json.dump`` raises ``TypeError: Object of type
+    int64 is not JSON serializable``, so a run configured that way trains to
+    completion and then loses the whole run at the save.
+
+    The container is checked before its elements, since a field that is not a
+    sequence of widths has no elements to name: a bare ``int`` or ``None`` is
+    not iterable, a ``str`` iterates into characters, and a one-shot iterator is
+    worse than either - a generator is consumed by the first network built, so
+    the actor gets the requested architecture and every later critic silently
+    gets none (measured: 452 parameters for the first, 28 for the second).
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        One problem per unusable width (named by index), or a single problem
+        when ``hidden_dims`` is not a sequence of widths at all; empty when
+        every width can be honored.
+    """
+    widths = getattr(spec, "hidden_dims", ())
+    if isinstance(widths, str) or not isinstance(widths, Sequence):
+        return [f"{context}: hidden_dims must be a sequence of positive int layer widths, got {widths!r}"]
+    return [
+        error
+        for index, width in enumerate(widths)
+        if (error := positive_count_error(width, f"hidden_dims[{index}]", context)) is not None
+    ]

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -947,6 +947,44 @@ class Trainer(ABC):
 
         return td3_noise_problems(spec, context=self.provider_name)
 
+    def _network_width_problems(self, spec: TrainSpec) -> list[str]:
+        """Hidden-layer-width preflight for a from-scratch RL backend.
+
+        Returns a problem per unusable width in
+        :attr:`RLTrainSpec.hidden_dims`, named by index. A :meth:`validate`
+        implementation that builds its networks from the field MUST call this,
+        because the loop that expands it judges nothing and neither does
+        ``nn.Linear``: a width of zero is a legal layer whose activation is
+        empty, so the layer after it emits its bias alone and the network's
+        output stops depending on the observation at all. The run still
+        collects, still trains its critics against that constant, still returns
+        ``status="success"``, and still exports a deployable checkpoint - one
+        whose actor commands a single fixed action in every state. The empty
+        sequence is a genuine linear policy and stays accepted, so the domain
+        is per element rather than on the length.
+
+        Scoped like :meth:`_learning_rate_problems` rather than like
+        :meth:`_gae_lambda_problems`: every from-scratch RL backend builds its
+        actor and critics from this field, so there is no RL backend for which
+        reporting on it would be a false rejection. A supervised backend, which
+        fine-tunes a pretrained policy whose architecture comes from the
+        checkpoint rather than from the spec, does not read it and must not
+        report on it.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the module import graph one-way.
+
+        Args:
+            spec: The spec to preflight.
+
+        Returns:
+            One problem per width that cannot be honored, or a single problem
+            when the field is not a sequence of widths; empty when it is usable.
+        """
+        from strands_robots.training._validate import network_width_problems
+
+        return network_width_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -181,6 +181,13 @@ class FastSacTrainer(BaseRLAlgo):
         # the update loop after the env, networks, optimizers and buffer are
         # built, and raises TypeError itself on a string or None.
         problems.extend(self._rl_replay_problems(spec))
+        # hidden_dims is the shape of every network this backend builds - the
+        # actor and the critics alike. The expansion loop judges nothing and
+        # nn.Linear accepts a width of zero, which makes the activation after it
+        # empty and the next layer's output its bias alone: the policy stops
+        # being a function of the observation, and the run reports success while
+        # exporting a deployable checkpoint whose actor is one fixed action.
+        problems.extend(self._network_width_problems(spec))
         if not 0.0 < spec.tau <= 1.0:
             problems.append(f"tau must be in (0, 1], got {spec.tau}")
         # learning_starts >= batch_size is a relation between two counts, so BOTH

--- a/strands_robots/training/rl/fast_td3.py
+++ b/strands_robots/training/rl/fast_td3.py
@@ -180,6 +180,13 @@ class FastTd3Trainer(BaseRLAlgo):
         # the update loop after the env, networks, optimizers and buffer are
         # built, and raises TypeError itself on a string or None.
         problems.extend(self._rl_replay_problems(spec))
+        # hidden_dims is the shape of every network this backend builds - the
+        # actor and the critics alike. The expansion loop judges nothing and
+        # nn.Linear accepts a width of zero, which makes the activation after it
+        # empty and the next layer's output its bias alone: the policy stops
+        # being a function of the observation, and the run reports success while
+        # exporting a deployable checkpoint whose actor is one fixed action.
+        problems.extend(self._network_width_problems(spec))
         if not 0.0 < spec.tau <= 1.0:
             problems.append(f"tau must be in (0, 1], got {spec.tau}")
         # learning_starts >= batch_size is a relation between two counts, so BOTH

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -180,6 +180,13 @@ class PpoTrainer(BaseRLAlgo):
         # it reads True, a fraction below one iteration, nan and inf as a single
         # iteration under a successful run.
         problems.extend(self._rl_run_size_problems(spec))
+        # hidden_dims is the shape of every network this backend builds - the
+        # actor and the critics alike. The expansion loop judges nothing and
+        # nn.Linear accepts a width of zero, which makes the activation after it
+        # empty and the next layer's output its bias alone: the policy stops
+        # being a function of the observation, and the run reports success while
+        # exporting a deployable checkpoint whose actor is one fixed action.
+        problems.extend(self._network_width_problems(spec))
         # num_envs is the third factor of that same product. Which *counts* are
         # usable is per-backend - this one parallelizes, so any positive count is,
         # while the single-env FastSAC requires exactly 1 - but that a count is

--- a/tests/training/test_network_width_domain.py
+++ b/tests/training/test_network_width_domain.py
@@ -1,0 +1,330 @@
+"""A hidden layer of width zero severs the policy from the observation.
+
+``hidden_dims`` is the one spec field that decides the *shape* of the networks a
+from-scratch RL run trains. All three RL backends expand it identically, once
+per network they build - the on-policy actor and critic, and off-policy the
+actor, its Polyak target and all four Q heads::
+
+    for h in spec.hidden_dims:
+        layers += [nn.Linear(last, h), nn.ReLU()]
+        last = h
+    layers.append(nn.Linear(last, out_dim))
+
+That loop judges nothing, and ``nn.Linear`` does not either: a width of zero is
+a legal layer. ``torch`` only warns ("Initializing zero-element tensors is a
+no-op"), the layer emits a ``(batch, 0)`` activation, and the layer after it
+therefore emits its bias alone - so the network's output stops being a function
+of its input. Measured over a full ``train()`` on each backend, the trained
+actor returned a bit-identical action for an all-zero observation and an
+all-``50`` one, while ``train()`` reported ``status="success"`` with a real
+``actor_loss`` and exported ``policy.pt`` + ``policy_meta.json``: a deployable
+checkpoint whose actor commands one fixed action in every state the robot can
+reach.
+
+The empty sequence is deliberately NOT in that class and stays accepted - it is
+the honest spelling of a linear policy, and its action still varies with the
+observation - so the domain is per element rather than on the length, and the
+message names the offending index.
+
+Every test reaches the real ``validate`` entry point, so the wiring into each
+backend is covered as well as the domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+from strands_robots.utils import positive_count_error
+from tests.training._spec_field_reads import reads_spec_field
+
+# The one field this domain owns.
+WIDTH_FIELD = "hidden_dims"
+
+# Every from-scratch RL backend builds its actor and critics from the field.
+RL_BACKENDS = ("ppo", "fast_sac", "fast_td3")
+
+# A backend whose architecture comes from a pretrained checkpoint, not the spec.
+NO_WIDTH_BACKENDS = ("mock",)
+
+# Widths no reading makes usable. Zero is the silent one - the network stops
+# depending on its input - negatives and non-ints raise inside ``setup`` after
+# the env is built, ``True`` would pass a bare ``< 1`` test as a width of one,
+# and ``np.int64`` builds but cannot be serialized into ``policy_meta.json``.
+UNUSABLE_WIDTHS: list[Any] = [
+    0,
+    -1,
+    -16,
+    True,
+    False,
+    16.0,
+    0.5,
+    float("nan"),
+    float("inf"),
+    "16",
+    None,
+    [16],
+    np.int64(16),
+]
+
+# Widths the expansion loop honors.
+USABLE_WIDTHS: list[Any] = [1, 8, 16, 128, 512]
+
+# Values that are not a sequence of widths at all, so no index can be named.
+NOT_A_SEQUENCE: list[Any] = [16, None, "16", {"a": 16}, 16.0]
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """An otherwise-valid RL spec, so only the field under test is exercised."""
+    return RLTrainSpec(
+        output_dir="/tmp/network_width_domain",
+        env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+    )
+
+
+def _width_reports(provider: str, spec: RLTrainSpec) -> list[str]:
+    """Problems the real ``validate`` entry point reports about ``hidden_dims``.
+
+    Filtered on the ``"{context}: hidden_dims"`` prefix rather than a bare
+    substring, so an unrelated problem can neither mask a missing refusal nor be
+    mistaken for one. The prefix carries no trailing space because a per-element
+    problem names its index (``hidden_dims[1] ...``) while a whole-container one
+    names the field (``hidden_dims must be a sequence ...``).
+    """
+    return [p for p in create_trainer(provider).validate(spec) if p.startswith(f"{provider}: {WIDTH_FIELD}")]
+
+
+class TestEveryRlBackendRefusesAnUnusableWidth:
+    """A width the expansion loop cannot honor is refused by all three."""
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE_WIDTHS, ids=repr)
+    def test_it_is_reported_as_a_problem(self, spec: RLTrainSpec, provider: str, value: Any) -> None:
+        spec.hidden_dims = (value,)  # type: ignore[assignment]
+        assert _width_reports(provider, spec), f"{provider} accepted hidden_dims=({value!r},)"
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE_WIDTHS, ids=repr)
+    def test_the_problem_names_the_index_and_the_value(self, spec: RLTrainSpec, provider: str, value: Any) -> None:
+        """A sequence field must say WHICH entry was refused."""
+        spec.hidden_dims = (128, value)  # type: ignore[assignment]
+        (problem,) = _width_reports(provider, spec)
+        assert problem.startswith(f"{provider}: hidden_dims[1] "), problem
+        assert repr(value) in problem, problem
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    def test_every_unusable_width_is_reported_at_once(self, spec: RLTrainSpec, provider: str) -> None:
+        """Two bad widths come back as two problems, not one per round."""
+        spec.hidden_dims = (0, 128, -4)  # type: ignore[assignment]
+        problems = _width_reports(provider, spec)
+        assert len(problems) == 2, problems
+        assert problems[0].startswith(f"{provider}: hidden_dims[0] ")
+        assert problems[1].startswith(f"{provider}: hidden_dims[2] ")
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", NOT_A_SEQUENCE, ids=repr)
+    def test_a_field_that_is_not_a_sequence_of_widths_is_refused(
+        self, spec: RLTrainSpec, provider: str, value: Any
+    ) -> None:
+        spec.hidden_dims = value  # type: ignore[assignment]
+        (problem,) = _width_reports(provider, spec)
+        assert problem == (f"{provider}: hidden_dims must be a sequence of positive int layer widths, got {value!r}"), (
+            problem
+        )
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    def test_a_one_shot_iterator_is_refused(self, spec: RLTrainSpec, provider: str) -> None:
+        """A generator is consumed by the first network built, so the rest get none."""
+        spec.hidden_dims = (w for w in (128, 128))  # type: ignore[assignment]
+        assert _width_reports(provider, spec), "a generator was accepted as hidden_dims"
+
+
+class TestTheUsableDomainIsUntouched:
+    """A width the loop honors is not newly refused."""
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", USABLE_WIDTHS, ids=repr)
+    def test_a_usable_width_reports_nothing(self, spec: RLTrainSpec, provider: str, value: Any) -> None:
+        spec.hidden_dims = (value, value)  # type: ignore[assignment]
+        assert _width_reports(provider, spec) == []
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    def test_the_shipped_default_reports_nothing(self, spec: RLTrainSpec, provider: str) -> None:
+        assert spec.hidden_dims == (128, 128)
+        assert _width_reports(provider, spec) == []
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("container", [(), []], ids=["tuple", "list"])
+    def test_no_hidden_layer_is_a_linear_policy_and_stays_accepted(
+        self, spec: RLTrainSpec, provider: str, container: Any
+    ) -> None:
+        """The one boundary value that IS a real configuration.
+
+        An empty sequence means "no hidden layer": the input feeds the output
+        layer directly. That policy still varies with the observation, so it is
+        not the severed-network class this gate exists for and must not be
+        swept up by a length check.
+        """
+        spec.hidden_dims = container
+        assert _width_reports(provider, spec) == []
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    def test_a_list_of_widths_is_accepted(self, spec: RLTrainSpec, provider: str) -> None:
+        """A config-loaded spec carries a list, not a tuple."""
+        spec.hidden_dims = [64, 64]  # type: ignore[assignment]
+        assert _width_reports(provider, spec) == []
+
+
+class TestABackendWithNoSpecArchitectureStaysQuiet:
+    """A backend whose shape comes from a checkpoint must not report on the field."""
+
+    @pytest.mark.parametrize("provider", NO_WIDTH_BACKENDS)
+    def test_it_reports_nothing_about_the_widths(self, spec: RLTrainSpec, provider: str) -> None:
+        spec.hidden_dims = (0,)  # type: ignore[assignment]
+        assert _width_reports(provider, spec) == []
+
+    @pytest.mark.parametrize("provider", NO_WIDTH_BACKENDS)
+    def test_silence_is_scoping_rather_than_an_empty_preflight(self, spec: RLTrainSpec, provider: str) -> None:
+        """The same spec's *own* learning rate is still refused by that backend."""
+        spec.learning_rate = 0.0
+        problems = create_trainer(provider).validate(spec)
+        assert any(p.startswith(f"{provider}: learning_rate ") for p in problems), problems
+
+
+class TestTheGateAddsNothingToTheSharedDomain:
+    """The per-element verdict is the shared rule's, so the two cannot drift."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_WIDTHS + USABLE_WIDTHS, ids=repr)
+    def test_the_verdict_matches_the_shared_domain(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.hidden_dims = (value,)  # type: ignore[assignment]
+        shared = positive_count_error(value, "hidden_dims[0]", "fast_td3")
+        assert _width_reports("fast_td3", spec) == ([shared] if shared is not None else [])
+
+
+class TestTheSilentReadingIsReal:
+    """The measured premises behind the domain."""
+
+    @staticmethod
+    def _mlp(hidden: Any) -> Any:
+        from strands_robots.training.rl.fast_td3 import _mlp
+
+        return _mlp(6, hidden, 4)
+
+    def test_a_zero_width_makes_the_output_independent_of_the_input(self) -> None:
+        """The premise: the layer after an empty activation emits its bias alone."""
+        torch = pytest.importorskip("torch")
+        net = self._mlp((16, 0))
+        with torch.no_grad():
+            quiet = net(torch.zeros(1, 6))
+            loud = net(torch.full((1, 6), 50.0))
+        assert torch.equal(quiet, loud), "premise: a zero width severs the output from the input"
+
+    def test_no_hidden_layer_keeps_the_output_dependent_on_the_input(self) -> None:
+        """The exemption's premise: a linear policy still responds to the state."""
+        torch = pytest.importorskip("torch")
+        net = self._mlp(())
+        with torch.no_grad():
+            quiet = net(torch.zeros(1, 6))
+            loud = net(torch.full((1, 6), 50.0))
+        assert not torch.equal(quiet, loud), "premise: an empty sequence is a usable architecture"
+
+    def test_a_one_shot_iterator_builds_a_different_shape_each_time(self) -> None:
+        """The premise for refusing the container: the critics would not match the actor."""
+        pytest.importorskip("torch")
+        widths = (w for w in (16, 16))
+        first = sum(p.numel() for p in self._mlp(widths).parameters())
+        second = sum(p.numel() for p in self._mlp(widths).parameters())
+        assert first != second, "premise: a generator is exhausted by the first network built"
+
+    def test_a_numpy_width_cannot_be_recorded_in_the_checkpoint(self) -> None:
+        """The premise for refusing ``np.int64``: ``save_checkpoint`` JSON-encodes the field."""
+        with pytest.raises(TypeError, match="not JSON serializable"):
+            json.dumps({"hidden_dims": list((np.int64(16),))})
+
+
+class TestTheRefusalReachesTheRunEntryPoint:
+    """A refused width stops the run rather than training a severed policy."""
+
+    def test_train_is_fail_closed_on_an_unusable_width(self, tmp_path: pathlib.Path) -> None:
+        pytest.importorskip("torch")
+        spec = RLTrainSpec(
+            output_dir=str(tmp_path),
+            env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+            hidden_dims=(16, 0),
+        )
+        result = create_trainer("fast_td3").train(spec)
+        assert result.status == "error"
+        assert "hidden_dims[1]" in result.message
+        assert not list(tmp_path.rglob("policy.pt")), "a refused run must not export a checkpoint"
+
+
+# --- one owner for the domain ------------------------------------------------
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module except the one that owns the gate."""
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = (root / "_validate.py").resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_widths(source: str) -> bool:
+    """Does *source* read ``hidden_dims`` off a spec, by name or through a table?"""
+    return reads_spec_field(source, (WIDTH_FIELD,))
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_network_width_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheNetworkWidthDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed, so
+    a fourth from-scratch RL backend fails this test until it routes through the
+    shared gate.
+    """
+
+    def test_every_module_that_reads_them_routes_through_the_shared_gate(self) -> None:
+        adrift = [
+            p.name
+            for p in _training_modules()
+            if _reads_the_widths(p.read_text()) and not _calls_the_gate(p.read_text())
+        ]
+        assert adrift == [], f"modules build networks from hidden_dims without the shared gate: {adrift}"
+
+    def test_the_reader_set_is_the_expected_one(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep over nothing."""
+        readers = {p.name for p in _training_modules() if _reads_the_widths(p.read_text())}
+        assert readers == {"ppo.py", "fast_sac.py", "fast_td3.py"}, readers
+
+    def test_the_scanner_detects_a_planted_reader(self) -> None:
+        """A module reading the field without the gate is really reported."""
+        planted = "def build(self):\n    return spec.hidden_dims\n"
+        assert _reads_the_widths(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        """A local comparison would drift from the shared rule."""
+        offenders = [
+            p.name
+            for p in _training_modules()
+            if f"len(spec.{WIDTH_FIELD})" in p.read_text() or f"spec.{WIDTH_FIELD} ==" in p.read_text()
+        ]
+        assert offenders == [], f"modules judge hidden_dims locally: {offenders}"

--- a/tests/training/test_spec_field_read_discovery.py
+++ b/tests/training/test_spec_field_read_discovery.py
@@ -74,6 +74,11 @@ FIELD_SCOPED_GATES: dict[str, tuple[str, ...]] = {
     "_clip_range_problems": ("clip_param",),
     "_policy_delay_problems": ("policy_delay",),
     "_td3_noise_problems": ("exploration_noise_std", "target_noise_std", "target_noise_clip"),
+    # The network-architecture gate. Its one field is a *sequence*, and it is
+    # scoped like the learning rate across the RL backends (all three build
+    # their actor and critics from it) while still being field-scoped overall,
+    # since a supervised backend takes its architecture from the checkpoint.
+    "_network_width_problems": ("hidden_dims",),
 }
 
 
@@ -186,6 +191,7 @@ class TestEveryFieldScopedGuardSeesBothFormsOfARead:
             "test_launch_topology_domain.py",
             "test_lora_hyperparameter_domain.py",
             "test_loss_weight_domain.py",
+            "test_network_width_domain.py",
             "test_optimization_epochs_domain.py",
             "test_policy_delay_domain.py",
             "test_rl_run_size_domain.py",


### PR DESCRIPTION
## `hidden_dims` decides the shape of every network an RL run trains, and nothing judged it

`nn.Linear` accepts a width of **zero** as a legal layer. `torch` only warns
("Initializing zero-element tensors is a no-op"), the layer emits an empty
`(batch, 0)` activation, and the layer after it emits its bias alone — so the
network's output stops being a function of the observation.

![measured](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/assets/network-width-domain.png)

Left: two `fast_td3` policies trained identically except for `hidden_dims`, then
swept over the joint observation. Both runs returned `status="success"`.

| | `hidden_dims=(16,)` | `hidden_dims=(16, 0)` |
|---|---|---|
| `train()` status | `success` | `success` |
| actor parameters | 65 | 49 |
| action span over `[-5, 5]` rad | **0.227** | **exactly 0.0** |
| exported `policy.pt` + `policy_meta.json` | yes | **yes** |

The right-hand run is a *deployable checkpoint whose actor commands one fixed
action in every state the robot can reach*. On hardware that is an arm driving to
a single pose and staying there, reported as a trained policy.

All three RL backends expand the field the same way, once per network they build
— the on-policy actor and critic, and off-policy the actor, its Polyak target
and all four Q heads — so all three were affected.

## Change

`network_width_problems`, the seventeenth shared gate, called from `ppo`,
`fast_sac` and `fast_td3`. Each element is asked of the shared
`positive_count_error` domain; the message names the offending index.

```
fast_td3: hidden_dims[1] must be a positive integer, got 0.
```

Measured verdicts, 6 spellings x 3 backends:

| `hidden_dims` | before | after | why |
|---|---|---|---|
| `(128, 128)` (default) | accepted | accepted | — |
| `()` | accepted | **accepted** | a linear policy; its action still varies |
| `(0,)` | accepted | refused | output independent of the observation |
| `(16, 0)` | accepted | refused | same, in a later layer |
| `(-1,)` | accepted | refused | raised inside `setup`, after env + optimizers were built |
| `np.int64(16)` | accepted | refused | trains, then `json.dump` raises at the save |

**12 of 18 wrong before, 0 after — only the unusable rows moved.**

## Two deliberate non-refusals

- **The empty sequence stays accepted.** It is the honest spelling of a linear
  policy (input straight to the output layer) and its action still varies with
  the observation, so the domain is per element, not on the length. Pinned in
  both directions: a cell asserts `()` and `[]` report nothing, and a premise
  cell asserts the built network's output *does* change with its input.
- **`np.int64` is refused even though `nn.Linear` accepts it.** Not an
  over-refusal: `save_checkpoint` writes `list(spec.hidden_dims)` to
  `policy_meta.json` and `json.dump` raises `TypeError: Object of type int64 is
  not JSON serializable`, so such a run trains to completion and then loses the
  whole run at the save.

A value that is not a sequence of widths at all is refused as a whole, including
a one-shot generator — it is consumed by the first network built, so the actor
gets the requested architecture and every later critic silently gets none
(measured: 452 parameters for the first, 28 for the second).

## Scope

Scoped like `_learning_rate_problems` rather than `_gae_lambda_problems`: every
from-scratch RL backend builds its networks from the field, so there is no RL
backend for which reporting on it would be a false rejection, while a supervised
backend takes its architecture from the checkpoint and must stay quiet (pinned,
including a control proving that silence is scoping and not an empty preflight).

Registered in `FIELD_SCOPED_GATES` so the existing
`test_spec_field_read_discovery` meta-guard holds the new gate to the
biconditional — that guard auto-discovered this file and demanded the entry.

## Tests

`tests/training/test_network_width_domain.py`, 155 cells, table-driven over the
three backends. Pre-fix on `upstream/main`: **114 failed / 41 passed**;
post-fix: **155 passed**. The biconditional cell names all three offenders
pre-fix (`['fast_sac.py', 'fast_td3.py', 'ppo.py']`). A `train()` cell pins that
the refusal is fail-closed and exports no checkpoint.

## Gate

- `ruff check` + `ruff format --check` clean on the CI scope (1895 files).
- mypy (CI scope, cold cache, both trees): **20 errors / 6 files, sets
  byte-identical**; 0 in any of the 9 changed files. The standing baseline is
  `examples/isaac_gs/*` plus `simulation/ik.py`, neither in CI's scope.
- `tests/training`: base **7 failed / 4358 passed**, this branch **7 failed /
  4515 passed** — failing node-id sets identical (pre-existing local `lerobot`
  drift), +157 passes.

Size: 9 files, +560 / -0. Additions are the gate (1 function), its `Trainer`
wrapper, 3 one-line call sites, the roster entry, the test module, docs and the
changelog fragment.
