### PR TITLE
fix(inference): a body name dropped from a declaration is a pose that never arrives

### DIFF
--- a/changelog.d/3239-advertised-required-bodies-domain.md
+++ b/changelog.d/3239-advertised-required-bodies-domain.md
@@ -1,0 +1,39 @@
+### Fixed
+
+- **Remote inference: a body name dropped from an advertised declaration is a pose
+  that never arrives.** `Policy.required_bodies` is the "policy declares, runtime
+  supplies" contract, and `collect_required_bodies` is its single owner - the
+  simulation runtime and `PolicyServer` both ask it, and its docstring is explicit
+  that the two "must not disagree". The `RemotePolicy` handshake mirrored the
+  advertised list through a filter instead: it kept the entries it could use and
+  dropped the rest, so a peer advertising `["torso_link", 42]` produced a proxy
+  declaring `("torso_link",)` - a declaration nobody made. Nothing downstream can
+  tell that from a peer that really asked for one body: the robot host resolves the
+  shorter set against its scene, merges poses for it, and reports a successful
+  rollout. Measured over a real `PolicyServer` driving a real MuJoCo rollout, a
+  policy declaring two anchor bodies reported `status="success"` with the second
+  body's `quat` arriving on 0 of 12 control steps - and a whole-body mimic tracker
+  whose anchor link goes unsupplied does not fail, it reads `base_quat`, the pelvis,
+  and silently tracks the wrong frame.
+
+  The shape rule now lives in `required_bodies_error`, the shared owner both
+  surfaces ask, and an unmirrorable declaration is refused in the handshake beside
+  the chunk counts and capability flags - `required_bodies` was the last field there
+  still coerced rather than checked, after the `int()` and `bool()` coercions were
+  removed for the same reason. A refusal names the field, quotes the offending entry
+  and its index, and leaves neither the mirror half-applied nor the connection
+  cached. A repeated name and an empty list stay accepted, because the local owner
+  accepts them - refusing those would be the same disagreement in the other
+  direction.
+
+  The local half gains attribution it lacked: a declaration that is not a sequence
+  raised a bare `'int' object is not iterable` naming no policy, and a `Mapping` was
+  read as its keys with its values silently discarded.
+
+  The regression grades
+  the advertised body list against `collect_required_bodies` itself rather than
+  against a list of values the test picked, so the two halves cannot drift apart, and
+  the accepting rows pin that the refusal is not an over-refusal. The pin that had
+  accepted the filter as intended posed only wholly-unusable values, never the mixed
+  list the filter answered with a shorter declaration; it is retargeted to the
+  refusal with that row added.

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -158,12 +158,18 @@ policy's introspection answers, so the handshake is where a locally-loaded
 checkpoint's constructor sits in the remote arrangement. `execution_horizon` and
 `actions_per_step` are slice bounds over the action chunk, so they share
 `chunk_count_error`'s domain with the constructor parameters they mirror - a
-positive `int`, nothing else - and `requires_images` / `supports_rtc` must be JSON
-booleans. Coercing instead is silent rather than lenient: an advertised `0` lands
-behind `execution_horizon`'s `max(1, ...)` floor, so a peer declaring a 16-action
-chunk is mirrored as single-step, `is_chunk_emitting()` answers `False`, and the
-rollout leaves the async-RTC path with nothing said; `bool("no")` is `True`, so a
-peer answering `"no"` turns a capability on. A field the handshake omits is not
+positive `int`, nothing else - `requires_images` / `supports_rtc` must be JSON
+booleans, and `required_bodies` is held to `required_bodies_error`, the same owner
+`collect_required_bodies` asks when the policy is local. Coercing instead is silent
+rather than lenient: an advertised `0` lands behind `execution_horizon`'s
+`max(1, ...)` floor, so a peer declaring a 16-action chunk is mirrored as
+single-step, `is_chunk_emitting()` answers `False`, and the rollout leaves the
+async-RTC path with nothing said; `bool("no")` is `True`, so a peer answering
+`"no"` turns a capability on; and filtering a body list keeps the entries it can
+use, so `["torso_link", 42]` becomes a proxy declaring `("torso_link",)` - a
+declaration nobody made, whose missing pose the served tracker replaces with
+`base_quat`, the pelvis. A repeated name is accepted, because the local owner
+de-duplicates it rather than refusing it. A field the handshake omits is not
 refused - the client keeps its own default, so a server advertising a subset stays
 usable - and a value it cannot mirror raises a `ConnectionError` naming the field,
 the value and the peer, without the connection being cached.

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -36,7 +36,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.inference import protocol
-from strands_robots.policies.base import Policy, chunk_count_error
+from strands_robots.policies.base import Policy, chunk_count_error, required_bodies_error
 from strands_robots.utils import name_list_error, positive_finite_number_error, tcp_port_error
 
 if TYPE_CHECKING:
@@ -81,6 +81,21 @@ def _metadata_refusal(metadata: Mapping[str, Any]) -> str | None:
     checkpoint and accepted by the server serving it", and this handshake is the
     place the server does the accepting.
 
+    ``required_bodies`` is held to
+    :func:`~strands_robots.policies.base.required_bodies_error` for the same
+    reason, and it is the field where reading unchecked was least visible: the
+    mirror used to KEEP the entries it could use and drop the rest, so a peer
+    advertising ``["torso_link", 42]`` became a proxy declaring
+    ``("torso_link",)`` - a declaration nobody made. The robot host then resolved
+    that shorter set against its scene, merged poses for it, and reported a
+    successful rollout, while the served tracker's second anchor link never
+    arrived. Dropping a body name is not a smaller request; it is a pose the
+    observation never carries, and the served policy reads ``base_quat`` - the
+    pelvis - in its place. A declaration the local owner refuses by name has to
+    be refused here too, which is the whole of what
+    :func:`~strands_robots.policies.base.collect_required_bodies` means by "two
+    surfaces ask it and must not disagree".
+
     A field the handshake omits is not refused - the client keeps its own
     default for it, which is what makes a peer advertising a subset of the
     metadata (an older server, a third-party implementation) still usable.
@@ -104,6 +119,10 @@ def _metadata_refusal(metadata: Mapping[str, Any]) -> str | None:
     if "provider_name" in metadata and not isinstance(metadata["provider_name"], str):
         name = metadata["provider_name"]
         return f"the served policy advertised provider_name={name!r} ({type(name).__name__}), which is not a string."
+    if "required_bodies" in metadata and (
+        error := required_bodies_error(metadata["required_bodies"], "required_bodies", "the served policy")
+    ):
+        return error
     return None
 
 
@@ -320,8 +339,10 @@ class RemotePolicy(Policy):
 
         The coercions this used to apply are gone with the check that replaces
         them: ``int()`` truncated an advertised ``8.9`` to ``8`` and parsed a
-        ``"16"`` that no local checkpoint would be allowed to pass, and
-        ``bool()`` turned the truthy string ``"no"`` into ``True``.
+        ``"16"`` that no local checkpoint would be allowed to pass, ``bool()``
+        turned the truthy string ``"no"`` into ``True``, and the
+        ``required_bodies`` filter kept the entries it could use while dropping
+        the rest, mirroring a declaration the peer never advertised.
 
         Args:
             metadata: The ``metadata`` payload of a ``ready`` handshake or of a
@@ -343,14 +364,13 @@ class RemotePolicy(Policy):
         self.actions_per_step = metadata.get("actions_per_step", self.actions_per_step)
         self.supports_rtc = metadata.get("supports_rtc", self.supports_rtc)
         self._execution_horizon = metadata.get("execution_horizon", self._execution_horizon)
-        # A JSON array of names. Coerced to the shape the robot host's runtime
-        # validates rather than trusted verbatim, so a peer sending something
-        # else cannot make the local resolver report the proxy as the declaring
-        # class; a server built on this release refuses a malformed declaration
-        # before it advertises one.
-        advertised = metadata.get("required_bodies")
-        if isinstance(advertised, list | tuple):
-            self._required_bodies = tuple(name for name in advertised if isinstance(name, str) and name.strip())
+        # A JSON array of names, applied verbatim: the refusal above already held
+        # it to the domain the robot host's runtime validates, so there is
+        # nothing left to coerce and no entry to drop. Mirroring it exactly is
+        # what makes this proxy the declaring class for the set the peer really
+        # advertised - see ``collect_required_bodies``.
+        if "required_bodies" in metadata:
+            self._required_bodies = tuple(metadata["required_bodies"])
 
     def close(self) -> None:
         """Close the WebSocket connection. Safe to call more than once."""

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -41,6 +41,7 @@ from strands_robots.policies.base import (
     Policy,
     align_action_values,
     chunk_count_error,
+    required_bodies_error,
     resolve_chunk_length,
 )
 
@@ -74,6 +75,7 @@ __all__ = [
     "resolve_chunk_length",
     "align_action_values",
     "chunk_count_error",
+    "required_bodies_error",
     "MockPolicy",
     "Cosmos3Policy",
     "CompositePolicy",

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -694,6 +694,64 @@ def iter_policy_tree(policy: Policy) -> Iterator[Policy]:
         stack.extend(reversed(tuple(getattr(current, "children", ()))))
 
 
+def required_bodies_error(value: object, param: str, context: str) -> str | None:
+    """Error text when a required-bodies declaration is not a usable list of body names.
+
+    Shared domain for :attr:`Policy.required_bodies` however it is stated: as a
+    property on a policy class, read by :func:`collect_required_bodies`, or as
+    the ``required_bodies`` entry of a
+    :class:`~strands_robots.inference.server.PolicyServer` handshake, mirrored by
+    :class:`~strands_robots.inference.client.RemotePolicy` so the host driving
+    the rollout declares what the policy behind the wire needs.
+
+    It lives here, beside the property it grades, because those two surfaces must
+    not disagree: the same declaration cannot be refused for a policy loaded
+    in-process and accepted for the server serving it. A second copy of the rule
+    on the wire side is how the mirror came to accept declarations the local
+    owner refuses - a mixed list was filtered down to the entries that happened
+    to be well-formed, so the proxy declared a subset the peer never advertised,
+    and the runtime supplied poses for that subset while reporting success.
+
+    Every entry is graded rather than the list as a whole for the same reason
+    :func:`chunk_count_error` refuses a count instead of flooring it: a dropped
+    body name is not a smaller declaration, it is a pose the observation never
+    carries. A whole-body mimic tracker whose anchor link goes unsupplied does
+    not fail - it reads ``base_quat``, the pelvis, and silently tracks the wrong
+    frame (see :attr:`Policy.required_bodies`).
+
+    A repeated name is accepted, unlike :func:`~strands_robots.utils.name_list_error`'s
+    domain: the single consumer here de-duplicates it (``owner.setdefault``
+    below), so a repeat is honored exactly as written rather than being either
+    doubled or collapsed. That is the whole difference between the two domains,
+    and it is why this list of names does not go through that function.
+
+    Args:
+        value: The declaration, as stated by the property or advertised on the wire.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that stated it - the
+            declaring class name, or the peer for an advertised value.
+
+    Returns:
+        An error message naming the offending value, or ``None`` when every
+        entry is a body name the runtime can resolve.
+    """
+    if isinstance(value, str | bytes):
+        return (
+            f"{context}: {param} must be a sequence of body names, not a bare "
+            f"{type(value).__name__} ({value!r}) - a string iterates into one entry per "
+            f"character. Wrap it in a list: [{value!r}]."
+        )
+    if not isinstance(value, Sequence):
+        return (
+            f"{context}: {param} must be a sequence of body names, got {value!r} "
+            f"({type(value).__name__}). Pass the names as a list."
+        )
+    for index, name in enumerate(value):
+        if not isinstance(name, str) or not name.strip():
+            return f"{context}: {param} entries must be non-empty body-name strings, got {name!r} at index {index}."
+    return None
+
+
 def collect_required_bodies(policy: Policy | None) -> dict[str, str]:
     """Body names a policy TREE declares, mapped to the class that declared each.
 
@@ -728,8 +786,12 @@ def collect_required_bodies(policy: Policy | None) -> dict[str, str]:
 
     Raises:
         TypeError: If any policy in the tree declares ``required_bodies`` that
-            is not a sequence of non-empty strings. A bare ``str`` is refused
-            explicitly rather than iterated into one entry per character.
+            is not a sequence of non-empty strings, per
+            :func:`required_bodies_error` - the shared owner of that shape rule,
+            so the wire half of this contract refuses the same declarations. A
+            bare ``str`` is refused explicitly rather than iterated into one
+            entry per character, and a ``Mapping`` rather than read as its keys
+            with its values discarded.
     """
     owner: dict[str, str] = {}
     for member in () if policy is None else iter_policy_tree(policy):
@@ -737,14 +799,8 @@ def collect_required_bodies(policy: Policy | None) -> dict[str, str]:
         if not declared:
             continue
         who = type(member).__name__
-        if isinstance(declared, str):
-            raise TypeError(
-                f"{who}.required_bodies must be a sequence of body names, "
-                f"not a bare str ({declared!r}) - a str iterates into one entry per character. "
-                f"Use a tuple: ('{declared}',)."
-            )
+        if error := required_bodies_error(declared, "required_bodies", who):
+            raise TypeError(error)
         for name in declared:
-            if not isinstance(name, str) or not name.strip():
-                raise TypeError(f"{who}.required_bodies entries must be non-empty body-name strings, got {name!r}.")
             owner.setdefault(name, who)
     return owner

--- a/tests/inference/test_advertised_metadata_is_held_to_the_local_domain.py
+++ b/tests/inference/test_advertised_metadata_is_held_to_the_local_domain.py
@@ -23,6 +23,18 @@ capability flags through a bare ``bool()``, which is silent rather than lenient:
   string...`` out of the middle of a connect, naming neither the field nor the
   peer.
 
+``required_bodies`` arrived through a filter, which is quieter still: the mirror
+KEPT the entries it could use and dropped the rest, so a peer advertising
+``["torso_link", 42]`` produced a proxy declaring ``("torso_link",)`` -- a
+declaration nobody made. Nothing downstream can tell that from a peer that
+really asked for one body: the robot host resolves the shorter set against its
+scene, merges poses for it, and reports a successful rollout, while the served
+tracker's other anchor link never arrives and it reads ``base_quat`` -- the
+pelvis -- in its place. The local owner
+:func:`~strands_robots.policies.base.collect_required_bodies` refuses that same
+list by name, and its docstring is explicit that the two surfaces "must not
+disagree".
+
 The sibling module ``test_remote_policy_handshake_contract.py`` pins the loud
 seams of a misbehaving peer; these pin the quiet ones.
 """
@@ -32,7 +44,8 @@ from typing import Any
 import pytest
 
 from strands_robots.inference import RemotePolicy, protocol
-from strands_robots.policies.base import chunk_count_error
+from strands_robots.policies.base import chunk_count_error, collect_required_bodies
+from strands_robots.policies.mock import MockPolicy
 
 #: Every mirrored field, with the value a compliant peer sends.
 _COMPLIANT: dict[str, Any] = {
@@ -41,7 +54,35 @@ _COMPLIANT: dict[str, Any] = {
     "actions_per_step": 16,
     "supports_rtc": False,
     "execution_horizon": 16,
+    "required_bodies": ["torso_link", "pelvis"],
 }
+
+#: ``(advertised required_bodies, the fragment a refusal must quote, what the
+#: filter mirrored instead)``. The last column is measured on the pre-fix client.
+#: The first two rows are the ones the filter got WRONG rather than merely quiet:
+#: it answered with a shorter declaration instead of none at all.
+_UNMIRRORABLE_BODIES: list[tuple[Any, str, str]] = [
+    (["torso_link", 42], "42", "mirrored ('torso_link',): a declaration the peer never sent"),
+    (["torso_link", "  "], "'  '", "mirrored ('torso_link',): the blank name dropped"),
+    (["torso_link", None], "None", "mirrored ('torso_link',): the null name dropped"),
+    ("torso_link", "'torso_link'", "mirrored (): a bare str is not a list, so nothing applied"),
+    (42, "42", "mirrored (): not a list, so nothing applied"),
+    ({"torso_link": 1}, "{'torso_link': 1}", "mirrored (): a JSON object, so nothing applied"),
+    ([42, None], "42", "mirrored (): every entry unusable"),
+]
+
+
+class _Declaring(MockPolicy):
+    """A local policy stating ``required_bodies`` exactly as handed in."""
+
+    def __init__(self, declared: Any) -> None:
+        super().__init__()
+        self._declared = declared
+
+    @property
+    def required_bodies(self) -> Any:
+        return self._declared
+
 
 #: ``(field, advertised value, what reading it unchecked produced)``. The last
 #: column is measured on the pre-fix client and is what the refusal replaces.
@@ -122,6 +163,7 @@ def test_compliant_metadata_is_still_mirrored(monkeypatch: pytest.MonkeyPatch) -
     assert client.requires_images is True
     assert client.supports_rtc is False
     assert client.remote_provider_name == "lerobot_local"
+    assert client.required_bodies == ("torso_link", "pelvis")
     assert client.is_chunk_emitting() is True
 
 
@@ -132,6 +174,7 @@ def test_metadata_omitting_a_field_keeps_this_client_s_default(monkeypatch: pyte
     assert client.requires_images is False
     assert client.execution_horizon == 1
     assert client.actions_per_step == 1
+    assert client.required_bodies == ()
 
 
 def test_a_refused_handshake_leaves_the_mirror_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -197,3 +240,73 @@ def test_the_wire_and_the_constructor_agree_about_a_chunk_count(monkeypatch: pyt
         wire_refuses = True
 
     assert wire_refuses is constructor_refuses
+
+
+@pytest.mark.parametrize(("advertised", "quoted", "filtered"), _UNMIRRORABLE_BODIES, ids=lambda v: str(v)[:24])
+def test_a_declaration_this_client_cannot_mirror_is_refused_by_name(
+    monkeypatch: pytest.MonkeyPatch, advertised: Any, quoted: str, filtered: str
+) -> None:
+    """A body name the runtime could not resolve is a named refusal, not a shorter list."""
+    client, _ = _advertising(monkeypatch, "required_bodies", advertised)
+
+    with pytest.raises(ConnectionError, match="required_bodies") as raised:
+        _ = client.required_bodies
+
+    assert quoted in str(raised.value), f"the refusal does not quote the offending value ({filtered})"
+
+
+def test_a_refused_declaration_does_not_leave_the_connection_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rejected connection is closed and dropped, exactly as for a refused count."""
+    client, fake = _advertising(monkeypatch, "required_bodies", ["torso_link", 42])
+
+    with pytest.raises(ConnectionError):
+        _ = client.required_bodies
+
+    assert fake.closed is True
+    assert client._ws is None
+    assert client._required_bodies == (), "a refused handshake half-applied the declaration"
+
+
+@pytest.mark.parametrize(
+    "declared",
+    [
+        ["torso_link", "pelvis"],
+        ["torso_link"],
+        [],
+        ["torso_link", "torso_link"],
+        ["torso_link", 42],
+        ["torso_link", "  "],
+        ["torso_link", None],
+        "torso_link",
+        42,
+        {"torso_link": 1},
+        [42, None],
+    ],
+    ids=repr,
+)
+def test_the_wire_and_the_local_declaration_agree_about_a_body_list(
+    monkeypatch: pytest.MonkeyPatch, declared: Any
+) -> None:
+    """One declaration, one verdict: what a local policy may not declare, the wire refuses.
+
+    Graded against ``collect_required_bodies`` -- the owner the simulation
+    runtime and ``PolicyServer`` both ask -- rather than against a list of values
+    this test picked, so the two halves cannot drift apart. The accepting rows
+    matter as much as the refusing ones: an empty list and a repeated name are
+    both things a policy may declare in-process, so refusing them on the wire
+    would be the same disagreement in the other direction.
+    """
+    try:
+        collect_required_bodies(_Declaring(declared))
+        local_refuses = False
+    except TypeError:
+        local_refuses = True
+
+    client, _ = _advertising(monkeypatch, "required_bodies", declared)
+    try:
+        _ = client.required_bodies
+        wire_refuses = False
+    except ConnectionError:
+        wire_refuses = True
+
+    assert wire_refuses is local_refuses

--- a/tests/inference/test_required_bodies_survive_the_wire.py
+++ b/tests/inference/test_required_bodies_survive_the_wire.py
@@ -159,13 +159,21 @@ class TestTheHandshakeCarriesTheDeclaration:
 
     @pytest.mark.parametrize(
         "advertised",
-        ["torso_link", 7, {"torso_link": 1}, ["", "  ", 3, None]],
-        ids=["bare_str", "int", "mapping", "unusable_entries"],
+        ["torso_link", 7, {"torso_link": 1}, ["", "  ", 3, None], [ANCHOR, 3]],
+        ids=["bare_str", "int", "mapping", "unusable_entries", "one_unusable_entry"],
     )
-    def test_a_peer_advertising_something_unusable_is_ignored(self, advertised):
-        """A value the runtime could not validate never becomes this half's declaration."""
+    def test_a_peer_advertising_something_unusable_is_refused(self, advertised):
+        """A value the runtime could not validate never becomes this half's declaration.
+
+        The last row is why refusing beats filtering: the entries that happened
+        to be well-formed used to be kept, so this half declared a subset of what
+        the peer sent and the rollout supplied poses for it and reported success.
+        ``test_advertised_metadata_is_held_to_the_local_domain`` owns the full
+        table and grades it against ``collect_required_bodies``.
+        """
         client = RemotePolicy(host="127.0.0.1", port=1)
-        client._apply_metadata({"required_bodies": advertised})
+        with pytest.raises(ConnectionError, match="required_bodies"):
+            client._apply_metadata({"required_bodies": advertised})
         assert client._required_bodies == ()
 
 


### PR DESCRIPTION
![required_bodies wire domain](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/assets/required-bodies-wire-domain.png)

Measured on a real `PolicyServer` driving a real MuJoCo rollout (headless EGL), a policy declaring two anchor bodies, peer advertising `required_bodies=["cube", 42]`:

| | mirrored declaration | rollout status | `body.cube.quat` | `body.marker.quat` |
|---|---|---|---|---|
| compliant peer `["cube","marker"]` | `('cube','marker')` | `success` | 12/12 ticks | 12/12 ticks |
| **before** | `('cube',)` -- nobody sent this | **`success`** | 12/12 ticks | **0/12 ticks** |
| **after** | refused at handshake | `refused` | - | - |

## The defect

`Policy.required_bodies` is the "policy declares, runtime supplies" contract, and `collect_required_bodies` is its single owner. Its docstring says so outright: "Two surfaces ask it and must not disagree: the simulation runtime ... and `PolicyServer`, which advertises the served tree's declaration in its handshake so a `RemotePolicy` driving the rollout on another host declares the same bodies the policy behind it does."

The handshake did not ask it. `_apply_metadata` mirrored the advertised list through a filter:

```python
advertised = metadata.get("required_bodies")
if isinstance(advertised, list | tuple):
    self._required_bodies = tuple(name for name in advertised if isinstance(name, str) and name.strip())
```

So the entries that happened to be well-formed were **kept** and the rest dropped. `["torso_link", 42]` became a proxy declaring `("torso_link",)`. Nothing downstream can tell that from a peer that really asked for one body: the robot host resolves the shorter set against its scene, merges poses for it, and reports a successful rollout. The served tracker's other anchor pose simply never arrives -- and per `required_bodies`' own docstring it does not fail, it reads `base_quat`, the pelvis, which "differs from it by the three waist joints, so a tracker written against `base_quat` silently feeds the network the wrong frame".

`required_bodies` was the last field in this handshake still coerced rather than checked. The `int()` and `bool()` coercions beside it were already removed for exactly this reason (`int()` truncated `8.9`, `bool("no")` was `True`), and `_metadata_refusal`'s docstring states the principle: "Reading them unchecked is not merely lenient, it is silent."

One declaration, two spellings, one verdict -- 6 of 9 shapes disagreed:

| advertised | `collect_required_bodies` | wire before | wire after |
|---|---|---|---|
| `["torso_link","pelvis"]` | accept | accept | accept |
| `["torso_link","torso_link"]` | accept (de-duplicates) | accept | accept |
| `[]` | accept | accept | accept |
| `["torso_link", 42]` | refuse, names `42` | `('torso_link',)` | refuse |
| `["torso_link", "  "]` | refuse | `('torso_link',)` | refuse |
| `["torso_link", null]` | refuse | `('torso_link',)` | refuse |
| `"torso_link"` | refuse (bare `str`) | `()` | refuse |
| `42` | `'int' object is not iterable` | `()` | refuse, names the policy |
| `{"torso_link": 1}` | accept -- read as its keys | `()` | refuse |

## The change

`required_bodies_error(value, param, context)` in `policies/base.py`, beside the property it grades, is now the single owner of the shape rule; `collect_required_bodies` and `_metadata_refusal` both ask it. The mirror applies the advertised list verbatim, because there is nothing left to coerce.

A refusal names the field, quotes the offending entry **and its index**, and leaves neither the mirror half-applied nor the connection cached (the existing `_connect` teardown already covers it; pinned).

Deliberately unchanged: **a repeated name and an empty list stay accepted**, because the local owner accepts them -- it de-duplicates a repeat via `owner.setdefault` rather than refusing it. That is why this list of names does not go through `name_list_error`, whose domain refuses duplicates, and the difference is documented on the new function. Refusing them here would be the same disagreement in the other direction.

The local half also gains attribution it lacked: a non-`Sequence` raised a bare `'int' object is not iterable` naming no policy, and a `Mapping` was read as its keys with its values silently discarded -- the reason `name_list_error` refuses one.

## Tests

`tests/inference/test_advertised_metadata_is_held_to_the_local_domain.py` -- the module that already owns this contract for the chunk counts and flags -- grades the advertised body list **against `collect_required_bodies` itself** rather than against a list of values the test picked, so the two halves cannot drift apart. The accepting rows are graded too, so an over-refusal fails here.

The pin that had accepted the filter as intended (`test_a_peer_advertising_something_unusable_is_ignored`) posed only *wholly*-unusable values -- `"torso_link"`, `7`, `{...}`, `["", "  ", 3, None]` -- never the mixed list, the one class where the filter answered with a shorter declaration instead of none. It is retargeted to the refusal with that row added, not deleted.

Two isolating mutations of production, run against both the old and the new test file:

| mutation | old tests | new tests |
|---|---|---|
| A -- restore the wire filter | pass | **15 failed / 30 passed** |
| B -- restore the local owner's pre-fix rules | pass | **1 failed** (`{'torso_link': 1}` -- wire refuses, local accepted its keys) |

## Gate

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean, 1894 files
- `mypy strands_robots tests tests_integ` (CI pin 1.20.2): 20 errors / 6 files, byte-identical to `main`, **none in the changed files** (all pre-existing in `examples/isaac_gs` + `simulation/ik.py`)
- `MUJOCO_GL=egl pytest tests/inference tests/policies tests/simulation/test_policy_required_bodies_observation.py`: `main` 5824 passed / 15 failed -> this branch **5844 passed / 15 failed**, failing node-id set **identical** (all pre-existing absent-dependency rows: `molmoact2` dep hints, `lerobot_async` `feature_utils`)
- doc + export + changelog graders: 651 passed; `assemble_changelog.py --check` OK

**Size: +277 / -33 across 7 files.** Net positive, and the additions are the shared owner (one function, replacing two inline copies of the rule), its docstring, the graded rows, and the doc paragraph the code now honours -- `docs/inference/remote.md` already claimed "Advertised metadata is held to the same domain the local property is", which was false for the one field it devotes a paragraph to.

Closes nothing; found while auditing the handshake's mirrored-field roster.