### PR TITLE
fix(mesh/input): an achieved rate is measured over the window its counter covers

### DIFF
--- a/changelog.d/3240-mesh-input-rate-window.md
+++ b/changelog.d/3240-mesh-input-rate-window.md
@@ -1,0 +1,35 @@
+### Fixed
+
+- **A restarted mesh teleop stream no longer reports a rate it never ran at.**
+  Both sides of the input stream report an achieved rate beside a frame total -
+  `InputPublisher.stats` as `{"frames": N, "hz_actual": ..., "hz_target": hz}`,
+  `InputReceiver.stats` as `{"frames_received": N, "hz_actual": ...}` - and
+  `get_teleop_status()` prints both lines from those keys, so one reading is
+  compared against one `hz_target`. `hz_actual` was `frame_count / elapsed`, and
+  its two operands were measured over different windows: the counter is
+  cumulative for the life of the object (both `stats` docstrings say so, and the
+  receiver's sampled safety audit keys its cadence on that count) while
+  `_start_mono` is re-stamped by every `start()`.
+
+  Restart is a supported flow, not a corner: the publisher's `start()` clears
+  the stop event its `stop()` set, the receiver's re-declares the subscription
+  `Mesh.stop` drops ("a caller that rejoins the mesh re-declares its own
+  subscriptions"), and `InputPublisher.stop` documents retrying a join that timed
+  out. Measured over a real 30 Hz stream between two Zenoh peers, each driving a
+  MuJoCo SO-101 arm: session one reported `30.07` Hz, and after a stop and a
+  restart **every one of the 24 status polls during session two reported a rate
+  above the 30 Hz the stream was running at** - `994,648` Hz at the first poll
+  (a full session's frames divided by a window microseconds old), `115.74` Hz two
+  seconds in, and still `60.44` Hz six seconds in. A rate above `hz_target` is
+  the one reading no averaging of an achieved rate can produce, and `hz_actual`
+  against `hz_target` is the documented way to judge a teleop link, so a
+  degraded link after a rejoin read as a healthy one.
+
+  `start()` now records the frame count beside the clock stamp, and the
+  arithmetic has one owner (`_achieved_hz`) because both sides report it under
+  the same key. The numerator covers the window the denominator does; every
+  reported total stays cumulative, so the receiver's audit cadence and the
+  `errors == frames_received` signature a fully-refusing follower shows are
+  unchanged. The same run reported `29.44` Hz two seconds into the restarted
+  session, with one of 24 polls `1.97` Hz over target - ordinary jitter within a
+  quarter-second sampling window.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -284,6 +284,13 @@ follower.stop_teleop("leader")
 
 `get_teleop_status()` on either side inspects current teleop state.
 
+The counts it reports -- `frames` / `frames_received`, `errors`, `rejected` and the
+rest -- are cumulative for the life of the publisher or receiver, while
+`hz_actual` is the rate achieved by the session running now: `start()` opens a
+new measurement window, so a stream stopped and started again reports the rate it
+is running at rather than one averaged over both sessions. Compare `hz_actual`
+against `hz_target` to judge a link; read the totals to judge the device.
+
 Each published frame carries the operator's control signals from the
 teleoperator's `get_teleop_events()` - `terminate_episode`, `success`,
 `rerecord_episode`, `is_intervention` - alongside the joint action. Reading them

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -163,6 +163,44 @@ def _refusal_text(envelope: dict[str, Any]) -> str:
     return "; ".join(texts) if texts else "no reason given"
 
 
+def _achieved_hz(frames: int, window_start_frames: int, start_mono: float) -> float:
+    """Frames per second over the CURRENT session, for both input stream sides.
+
+    The one owner of this arithmetic, because both sides report it under the same
+    ``hz_actual`` key and a caller compares it against one ``hz_target``.
+
+    ``frames`` is cumulative for the life of the object - the totals the two
+    ``stats`` surfaces report say so, and the receiver's sampled safety audit
+    keys its cadence on that count. ``start_mono`` is NOT: every ``start()``
+    re-stamps it, which is what makes a restarted session's rate measurable at
+    all (``start()`` clears the publisher's stop event and re-declares the
+    receiver's subscription precisely so a stopped stream can be started again).
+    Dividing the cumulative count by one session's elapsed time therefore mixes
+    two windows and reports a rate the stream never ran at: a 30 Hz stream
+    restarted after 180 frames reads ~118 Hz two seconds in, four times the
+    ``hz_target`` it was asked for and above the cap the loop paces itself
+    against - which no reading of "achieved rate" can produce.
+
+    ``window_start_frames`` is the count when the current window opened, so the
+    numerator covers the same window as the denominator while every reported
+    total stays cumulative.
+
+    Args:
+        frames: Cumulative frames the side has published / received.
+        window_start_frames: ``frames`` when the current session started.
+        start_mono: Monotonic stamp taken by that ``start()``, ``0.0`` before
+            the first one.
+
+    Returns:
+        The achieved rate in Hz, or ``0.0`` before a session has started or
+        within the same instant one did.
+    """
+    elapsed = time.monotonic() - start_mono if start_mono else 0.0
+    if elapsed <= 0:
+        return 0.0
+    return (frames - window_start_frames) / elapsed
+
+
 class InputPublisher:
     """Publishes teleoperator actions to the mesh at a fixed rate.
 
@@ -222,6 +260,10 @@ class InputPublisher:
         self._event_read_error_count = 0
         self._frame_count = 0
         self._start_mono = 0.0
+        # ``frames``/``frames_received`` stay cumulative; this is the count when
+        # the current session's clock started, so ``_achieved_hz`` measures its
+        # numerator over the same window as ``_start_mono``.
+        self._window_start_frames = 0
 
     def __repr__(self) -> str:
         try:
@@ -255,7 +297,6 @@ class InputPublisher:
         Without the second reading a caller polling after a stop would be told
         ``running=False`` about a loop that is still publishing.
         """
-        elapsed = time.monotonic() - self._start_mono if self._start_mono else 0
         return {
             "device": self.device_name,
             "method": self.method,
@@ -264,7 +305,7 @@ class InputPublisher:
             "frames": self._frame_count,
             "errors": self._error_count,
             "event_read_errors": self._event_read_error_count,
-            "hz_actual": self._frame_count / elapsed if elapsed > 0 else 0,
+            "hz_actual": _achieved_hz(self._frame_count, self._window_start_frames, self._start_mono),
             "hz_target": self.hz,
         }
 
@@ -274,7 +315,9 @@ class InputPublisher:
             return
         self._running = True
         self._stop_event.clear()
+        # Stamped together - see ``_achieved_hz``.
         self._start_mono = time.monotonic()
+        self._window_start_frames = self._frame_count
         self._thread = threading.Thread(
             target=self._publish_loop,
             name=f"mesh-input-{self.device_name}",
@@ -503,6 +546,10 @@ class InputReceiver:
         self._value_abs_by_key: dict[str, float] = {}
         self._envelope_resolved = False
         self._start_mono = 0.0
+        # ``frames``/``frames_received`` stay cumulative; this is the count when
+        # the current session's clock started, so ``_achieved_hz`` measures its
+        # numerator over the same window as ``_start_mono``.
+        self._window_start_frames = 0
 
     def __repr__(self) -> str:
         try:
@@ -550,7 +597,6 @@ class InputReceiver:
         non-finite or past the magnitude bound). ``rejected`` always equals
         their sum.
         """
-        elapsed = time.monotonic() - self._start_mono if self._start_mono else 0
         return {
             "source": self.source_peer_id,
             "device": self.device_name,
@@ -564,7 +610,7 @@ class InputReceiver:
             **{f"rejected_{cause}": n for cause, n in self._rejected_by_cause.items()},
             "rate_dropped": self._rate_dropped,
             "slew_rejected": self._slew_rejected,
-            "hz_actual": self._frame_count / elapsed if elapsed > 0 else 0,
+            "hz_actual": _achieved_hz(self._frame_count, self._window_start_frames, self._start_mono),
         }
 
     def start(self) -> None:
@@ -572,7 +618,9 @@ class InputReceiver:
         if self._running:
             return
         self._running = True
+        # Stamped together - see ``_achieved_hz``.
         self._start_mono = time.monotonic()
+        self._window_start_frames = self._frame_count
         self._sub_name = self.mesh.subscribe(
             self.topic,
             callback=self._on_input,

--- a/tests/mesh/test_input_rate_window_matches_its_counter.py
+++ b/tests/mesh/test_input_rate_window_matches_its_counter.py
@@ -1,0 +1,271 @@
+"""``hz_actual`` must measure its numerator over the window its denominator covers.
+
+Both sides of the mesh input stream report an achieved rate beside a cumulative
+frame total::
+
+    InputPublisher.stats -> {"frames": N,          "hz_actual": ..., "hz_target": hz}
+    InputReceiver.stats  -> {"frames_received": N, "hz_actual": ...}
+
+and ``teleop_mixin.get_teleop_status`` prints both lines from those two keys, so
+one reading is compared against one ``hz_target``.
+
+``frames`` is cumulative for the life of the object: both ``stats`` docstrings
+say so, and the receiver's sampled safety audit keys its cadence on that count.
+``_start_mono`` is not - every ``start()`` re-stamps it, which is exactly what
+makes a *restarted* session's rate measurable, and restart is a supported flow:
+the publisher's ``start()`` clears the stop event its ``stop()`` set, and the
+receiver's re-declares the subscription that ``Mesh.stop`` drops ("a caller that
+rejoins the mesh re-declares its own subscriptions").
+
+Taking the rate as ``frames / elapsed`` therefore divided a lifetime numerator by
+one session's denominator, and reported a rate the stream never ran at - above
+the ``hz`` the publisher paces itself against, which no reading of "achieved
+rate" can produce. The local teleop session in ``teleop_mixin`` already resets
+its counter and its stamp together; these two did not.
+
+The contract is pinned on the reported numbers, so a future refactor cannot
+satisfy it by renaming a field: a restarted session reports the rate it ran at,
+a first session is unchanged, and every reported TOTAL stays cumulative.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh import input as mesh_input
+
+#: Both sides report ``hz_actual``, so both are held to it.
+SIDES = ("publisher", "receiver")
+
+TARGET_HZ = 30.0
+#: A first session long enough that its frames dominate a short second one.
+FIRST_SESSION_S = 6.0
+SECOND_SESSION_S = 2.0
+
+
+class _MonotonicClock:
+    """A monotonic clock the test advances by a known amount.
+
+    Only ``monotonic`` is used by the code under test; ``time`` is present
+    because the receiver's freshness check reads it on the frame path, which
+    these cells do not drive.
+    """
+
+    def __init__(self) -> None:
+        self._elapsed = 0.0
+
+    def advance(self, seconds: float) -> None:
+        self._elapsed += seconds
+
+    def monotonic(self) -> float:
+        return 1000.0 + self._elapsed
+
+    def time(self) -> float:
+        return 1_700_000_000.0 + self._elapsed
+
+
+class _StubTransport:
+    """Mesh stand-in that declares and drops subscriptions like the real one."""
+
+    peer_id = "test-peer"
+
+    def __init__(self) -> None:
+        self.subscribed: list[str] = []
+        self.unsubscribed: list[str] = []
+
+    def subscribe(self, topic: str, **_kwargs: Any) -> str:
+        self.subscribed.append(topic)
+        return f"sub-{len(self.subscribed)}"
+
+    def unsubscribe(self, name: str) -> None:
+        self.unsubscribed.append(name)
+
+
+def _build(kind: str, monkeypatch: pytest.MonkeyPatch, clock: _MonotonicClock) -> Any:
+    """One started-and-stoppable input side, with the loop body left out.
+
+    The frame counters are driven directly (``_frame_count``), the way the
+    sibling clock-domain suite drives them: what is under test is the
+    arithmetic ``stats`` reports over a window, not the loop that fills it.
+    """
+    monkeypatch.setattr(mesh_input, "time", clock)
+    transport = _StubTransport()
+    side: Any
+    if kind == "publisher":
+        side = mesh_input.InputPublisher(
+            mesh=transport,  # type: ignore[arg-type]
+            teleoperator=object(),
+            device_name="leader",
+            hz=TARGET_HZ,
+        )
+        # The publish loop is not under test; without this its thread would
+        # poll a teleoperator that has no get_action().
+        monkeypatch.setattr(side, "_publish_loop", lambda: None)
+    else:
+        side = mesh_input.InputReceiver(
+            mesh=transport,  # type: ignore[arg-type]
+            robot=object(),
+            source_peer_id="leader-peer",
+            device_name="leader",
+        )
+    return side
+
+
+def _rate(side: Any) -> float:
+    return float(side.stats["hz_actual"])
+
+
+def _total(side: Any) -> int:
+    stats = side.stats
+    return int(stats["frames"] if "frames" in stats else stats["frames_received"])
+
+
+def _run_session(side: Any, clock: _MonotonicClock, seconds: float, hz: float) -> None:
+    """Run one session of ``seconds`` at ``hz``, then stop."""
+    side.start()
+    clock.advance(seconds)
+    side._frame_count += round(seconds * hz)
+    side.stop()
+
+
+@pytest.fixture
+def clock() -> _MonotonicClock:
+    return _MonotonicClock()
+
+
+@pytest.mark.parametrize("kind", SIDES)
+def test_a_restarted_session_reports_the_rate_it_ran_at(
+    kind: str, clock: _MonotonicClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The frames of a previous session must not be charged to this one's clock."""
+    side = _build(kind, monkeypatch, clock)
+    _run_session(side, clock, FIRST_SESSION_S, TARGET_HZ)
+
+    side.start()
+    clock.advance(SECOND_SESSION_S)
+    side._frame_count += round(SECOND_SESSION_S * TARGET_HZ)
+    try:
+        assert _rate(side) == pytest.approx(TARGET_HZ), (
+            f"a {kind} restarted after {round(FIRST_SESSION_S * TARGET_HZ)} frames reported "
+            f"{_rate(side):.2f}Hz for a stream running at {TARGET_HZ}Hz - the first session's "
+            "frames were divided by the second session's elapsed time"
+        )
+    finally:
+        side.stop()
+
+
+@pytest.mark.parametrize("kind", SIDES)
+def test_the_reported_rate_never_exceeds_the_rate_the_stream_ran_at(
+    kind: str, clock: _MonotonicClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rate above the paced one is unreachable, so reporting one is a defect.
+
+    Stated as the invariant rather than a number: an achieved rate is bounded by
+    the rate the frames were produced at, whichever session is being measured.
+    """
+    side = _build(kind, monkeypatch, clock)
+    for _ in range(3):
+        _run_session(side, clock, FIRST_SESSION_S, TARGET_HZ)
+        # Idle between sessions: real time passes with no frames on the wire.
+        clock.advance(11.0)
+
+    side.start()
+    try:
+        for _ in range(5):
+            clock.advance(1.0)
+            side._frame_count += round(TARGET_HZ)
+            assert _rate(side) <= TARGET_HZ + 1e-6, (
+                f"a {kind} reported {_rate(side):.2f}Hz, above the {TARGET_HZ}Hz the stream ran at"
+            )
+    finally:
+        side.stop()
+
+
+def test_a_frame_the_loop_published_after_stop_is_not_charged_to_the_next_session(
+    clock: _MonotonicClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The window opens where the session does, which is why ``start()`` stamps it.
+
+    ``InputPublisher.stop`` documents that a teleoperator whose ``get_action()``
+    blocks past the join budget "leaves the loop free to publish one more frame
+    after this call returns", so the counter can still move between a stop and
+    the next start. Stamping the window at ``stop()`` instead would be
+    indistinguishable on every other path and would charge those frames to the
+    session that had not begun when they went out.
+    """
+    side = _build("publisher", monkeypatch, clock)
+    _run_session(side, clock, FIRST_SESSION_S, TARGET_HZ)
+    # The documented case: the loop outlived the join and put one more frame out.
+    side._frame_count += 1
+
+    side.start()
+    clock.advance(1.0)
+    side._frame_count += round(TARGET_HZ)
+    try:
+        assert _rate(side) == pytest.approx(TARGET_HZ), (
+            f"a frame published after stop() returned was charged to the next session: "
+            f"{_rate(side):.2f}Hz for a stream running at {TARGET_HZ}Hz"
+        )
+    finally:
+        side.stop()
+
+
+@pytest.mark.parametrize("kind", SIDES)
+def test_a_first_session_is_unchanged(kind: str, clock: _MonotonicClock, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Control: with no restart the two operands already agreed."""
+    side = _build(kind, monkeypatch, clock)
+    side.start()
+    clock.advance(SECOND_SESSION_S)
+    side._frame_count += round(SECOND_SESSION_S * TARGET_HZ)
+    try:
+        assert _rate(side) == pytest.approx(TARGET_HZ)
+    finally:
+        side.stop()
+
+
+@pytest.mark.parametrize("kind", SIDES)
+def test_the_reported_frame_total_stays_cumulative_across_a_restart(
+    kind: str, clock: _MonotonicClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Control: the totals are lifetime counts, so the fix must not reset one.
+
+    Zeroing the counter would satisfy the rate cells above and silently turn a
+    documented cumulative total - the one the receiver's sampled safety audit
+    keys its cadence on - into a per-session one.
+    """
+    side = _build(kind, monkeypatch, clock)
+    _run_session(side, clock, FIRST_SESSION_S, TARGET_HZ)
+    first = _total(side)
+    assert first == round(FIRST_SESSION_S * TARGET_HZ), "premise: the first session was counted"
+
+    _run_session(side, clock, SECOND_SESSION_S, TARGET_HZ)
+    assert _total(side) == first + round(SECOND_SESSION_S * TARGET_HZ), (
+        f"a {kind}'s reported total dropped the first session's frames"
+    )
+
+
+@pytest.mark.parametrize("kind", SIDES)
+def test_restarting_a_stopped_side_is_a_supported_flow(
+    kind: str, clock: _MonotonicClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Premise: the cells above measure a flow the classes implement on purpose.
+
+    The publisher's ``start()`` clears the stop event its ``stop()`` set, and the
+    receiver's re-declares a subscription - neither is reachable unless a stopped
+    side is meant to be started again.
+    """
+    side = _build(kind, monkeypatch, clock)
+    side.start()
+    side.stop()
+    assert side.stats["running"] is False
+    side.start()
+    try:
+        assert side.stats["running"] is True, f"a stopped {kind} could not be restarted"
+        if kind == "publisher":
+            assert not side._stop_event.is_set(), "the restart left the stop event set"
+        else:
+            assert len(side.mesh.subscribed) == 2, "the restart did not re-declare the subscription"
+    finally:
+        side.stop()


### PR DESCRIPTION
## Problem

Both sides of the mesh input stream report an achieved rate beside a frame total, and `get_teleop_status()` prints both lines from those two keys:

```python
InputPublisher.stats -> {"frames": N,          "hz_actual": ..., "hz_target": hz}
InputReceiver.stats  -> {"frames_received": N, "hz_actual": ...}
```

`hz_actual` was `frame_count / elapsed`, and its two operands were measured over **different windows**:

| operand | scope | set by |
|---|---|---|
| `_frame_count` | cumulative for the life of the object | `__init__` only |
| `_start_mono` | the current session | **every** `start()` |

The counter is deliberately cumulative — `InputPublisher.stats` documents "cumulative `frames` published", and the receiver's sampled safety audit keys its cadence on that count. So a restarted stream divided a lifetime numerator by one session's denominator.

Restart is a supported flow, not a corner. The publisher's `start()` clears the stop event its own `stop()` set; the receiver's re-declares the subscription `Mesh.stop` drops (`Mesh.subscribe`: *"a caller that rejoins the mesh re-declares its own subscriptions"*); and `InputPublisher.stop` documents retrying a join that timed out.

The local teleop session already gets this right — `teleop_mixin.start_teleoperate` resets `_teleop_frames` and stamps `_teleop_start_mono` together, and `get_teleop_status()` prints all three readings side by side.

## Measured

A real 30 Hz stream between two Zenoh peers, each driving a MuJoCo SO-101 arm through the real `InputPublisher` / `InputReceiver`; the reported `hz_actual` sampled every 250 ms across a session, a stop, and a restart of the same objects.

![reported hz_actual across a restart](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/assets/mesh-input-hz-actual-restart.png)

| reading (publisher) | before | after |
|---|---|---|
| session 1, 6 s in | 30.07 Hz | 30.07 Hz |
| restart, first status poll | **994,648 Hz** | 0.00 Hz |
| restart, 2 s in | **115.74 Hz** | 29.44 Hz |
| restart, 6 s in | **60.44 Hz** | 29.71 Hz |
| session-2 polls above the rate the stream ran at | **24 of 24** | 1 of 24 |
| `frames` reported at the end | 351 | 353 |

The receiver reports the same shape (`116.40` Hz → `26.48` Hz two seconds into a restart). Session 1 is unchanged, and the cumulative totals are unchanged.

A rate **above `hz_target`** is the one reading no averaging of an achieved rate can produce, and `hz_actual` against `hz_target` is the documented way to judge a teleop link — so a degraded link after a rejoin read as a healthy one.

## Change

`start()` records the frame count beside the clock stamp, and the arithmetic gets one owner (`_achieved_hz`) because both sides report it under the same key and a caller compares both against one `hz_target`:

```python
elapsed = time.monotonic() - start_mono if start_mono else 0.0
return (frames - window_start_frames) / elapsed
```

The numerator now covers the window the denominator does. **No reported total becomes per-session**: zeroing `_frame_count` instead would satisfy the rate but silently turn a documented cumulative count — the one the receiver's audit cadence reads — into a session count, so that is pinned as a control.

The stamp belongs in `start()` rather than `stop()`: `InputPublisher.stop` documents that a teleoperator blocking past the join budget "leaves the loop free to publish one more frame after this call returns", and those frames belong to the session that produced them.

`+52 / -4` in `strands_robots/mesh/input.py`, of which **+8 executable statements** by AST count (278 → 286); the rest is the owner's docstring and two comments. The duplicated `elapsed` local is gone from both `stats`.

## Tests

`tests/mesh/test_input_rate_window_matches_its_counter.py`, parametrized over both sides. Against `upstream/main` — **5 failed, 6 passed**:

```
a_restarted_session_reports_the_rate_it_ran_at[publisher]  120.00Hz for a 30.0Hz stream
a_restarted_session_reports_the_rate_it_ran_at[receiver]   120.00Hz for a 30.0Hz stream
the_reported_rate_never_exceeds_the_rate_the_stream_ran_at[publisher]  570.00Hz
the_reported_rate_never_exceeds_the_rate_the_stream_ran_at[receiver]   570.00Hz
a_frame_the_loop_published_after_stop_is_not_charged_to_the_next_session  211.00Hz
```

The 6 that pass either way are the controls and the premise: a first session is unchanged, the reported totals stay cumulative across a restart, and restarting a stopped side is a supported flow.

Every mutation of the fix is detected, by a distinct set, with `collected` stable at 11:

| mutation | cells that fire |
|---|---|
| control (unmutated) | 0 of 11 |
| publisher does not stamp the window | 3 |
| receiver does not stamp the window | 2 |
| owner ignores the window (the pre-fix arithmetic) | 5 |
| zero the counter instead of stamping the window | 2 — the *cumulative-total* controls |
| stamp the window on `stop()` not `start()` | 1 — the post-stop-frame cell |
| drop the zero-elapsed guard | 2 — the premise cells |

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ`
- `mypy strands_robots tests tests_integ` → `Success: no issues found in 1893 source files`, zero suppressions added
- `tests/mesh` → **4882 passed**, 10 skipped (`upstream/main`: 4871 — exactly the 11 new cells)
- 229 tree-walking guard files → 11,949 passed; the 7 failures are environmental and node-id-identical on a pristine `upstream/main` worktree (`rclpy` resolvable where 5 cells assert it is absent; installed `websockets` 16.0 against the declared `>=17.0` floor, where `Server.shutdown` does not exist at all)
- docs graders + `tests/test_markdown_links_resolve.py` → 245 passed; changelog graders → 91 passed

## Out of scope

`hz_actual` still decays while a stopped side is polled, because `elapsed` keeps growing against a frozen count. That is symmetric across all three surfaces — the local teleop session behaves the same way — so it is a reading to decide rather than an asymmetry to correct, and it is pinned unchanged here.
