### PR TITLE
fix(dashboard/auth): a per-ip challenge cap at or above the global cap silently loses the fairness it exists for

### DIFF
--- a/changelog.d/3244-challenge-cap-pair-domain.md
+++ b/changelog.d/3244-challenge-cap-pair-domain.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **dashboard/auth**: the two caps on the pending-WebAuthn-challenge table,
+  `STRANDS_DASH_AUTH_CHAL_MAX` and `STRANDS_DASH_AUTH_CHAL_MAX_PER_IP`, are now read
+  through one domain that refuses a pair which cannot deliver the per-client fairness
+  the per-ip cap exists for. That fairness is a relation between the two caps rather
+  than a range on either alone: the per-ip cap only binds while it is the smaller of
+  the two, and the global cap's eviction is ip-blind. Measured over a 10x10 grid of
+  pairs, 55 of 100 previously accepted pairs let one client evict the operator's
+  pending login - including a narrowed `CHAL_MAX=8` left beside the default per-ip 16.
+  A non-integer setting now names the variable instead of raising a bare `int()`
+  `ValueError`, and an empty setting means unset, as it already did for the TTL
+  readers next door. Regression tests pin the refused pairs, the narrowest usable pair
+  (`CHAL_MAX=2`, `CHAL_MAX_PER_IP=1`), and the flood outcome that makes the relation
+  load-bearing.

--- a/docs/dashboard/remote-access.md
+++ b/docs/dashboard/remote-access.md
@@ -148,6 +148,11 @@ Order of operations, and the reason for it:
   disables mesh TLS for single-machine work; do not leave it on for a fleet
   that spans machines. See [Multi-robot Mesh](../mesh.md).
 - A session lasts `STRANDS_DASH_AUTH_TOKEN_TTL` seconds (default 86400).
+- In-flight sign-in challenges are bounded by `STRANDS_DASH_AUTH_CHAL_MAX`
+  (default 512) and `STRANDS_DASH_AUTH_CHAL_MAX_PER_IP` (default 16). The
+  per-ip bound is what stops one client from filling the table and pushing out
+  your pending login, so it must stay strictly below the global one; a pair
+  that cannot hold both is refused at startup rather than silently accepted.
   `GET /api/auth/credentials` lists enrolled passkeys and
   `DELETE /api/auth/credentials/{id}` revokes a lost phone.
 

--- a/strands_robots/dashboard/auth.py
+++ b/strands_robots/dashboard/auth.py
@@ -19,6 +19,13 @@ Configuration:
         so it must carry the scheme and any non-default port.
     ``STRANDS_DASH_AUTH_RP_ID``: pins the relying-party id when the hostname
         legitimately changed. See :func:`rp_id_verdict`.
+    ``STRANDS_DASH_AUTH_CHAL_MAX`` (default 512) and
+        ``STRANDS_DASH_AUTH_CHAL_MAX_PER_IP`` (default 16): bounds on the table of
+        in-flight WebAuthn challenges. The per-ip cap must stay strictly below the
+        global one -- it is what keeps one client off the global cap, whose eviction
+        is ip-blind. Both are read through :func:`_challenge_cap`, which refuses a
+        pair that cannot hold a flooding client's entries and the operator's pending
+        login at the same time.
 """
 
 from __future__ import annotations
@@ -562,10 +569,64 @@ _CHAL_TTL = 300.0
 
 # : Caps on the challenge table. Both are per-process and generous: a challenge : measures
 # ~0.5KB, so 512 of them is ~256KB.
-_CHAL_MAX = int(os.getenv("STRANDS_DASH_AUTH_CHAL_MAX", "512"))
+# :
 # : The property that actually matters: no single client may fill the table and : push out the
-# operator's pending login.
-_CHAL_MAX_PER_IP = int(os.getenv("STRANDS_DASH_AUTH_CHAL_MAX_PER_IP", "16"))
+# : operator's pending login. That property is a RELATION between the two caps, not a range on
+# : either alone. The per-ip cap is what keeps a flooder off the global one, so it only binds
+# : while it is the smaller of the two: at ``PER_IP >= MAX`` the global cap is reached first,
+# : and its eviction drops the oldest record in the table regardless of ip -- the operator's
+# : pending login, if theirs was stashed first. So the pair is read through one domain that
+# : refuses the values which defeat the guarantee, rather than accepting them and losing it.
+
+
+def _challenge_cap(name: str, default: int, minimum: int) -> int:
+    """Read one bound on the challenge table, refusing a value that cannot bound it.
+
+    Args:
+        name: Suffix of the environment variable, e.g. ``"CHAL_MAX"``.
+        default: Value used when the variable is unset or empty, matching how the
+            TTL readers in this module treat an empty setting.
+        minimum: Smallest value at which this cap can still do its job.
+
+    Returns:
+        The cap, as an ``int``.
+
+    Raises:
+        ValueError: The variable holds something that is not an integer, or an
+            integer below ``minimum``. Refused rather than defaulted because
+            these caps front routes that command real hardware: an operator who
+            narrowed a cap and mistyped it must hear about it, not silently be
+            handed the wide default back.
+    """
+    var = _ENV + name
+    raw = os.getenv(var, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"{var}={raw!r} is not an integer. It bounds the table of pending WebAuthn "
+            f"challenges, so it must be a whole number >= {minimum} (default {default})."
+        ) from None
+    if value < minimum:
+        raise ValueError(
+            f"{var}={value} cannot bound the table of pending WebAuthn challenges: it must "
+            f"be >= {minimum} (default {default}). Below that the table cannot hold both a "
+            "flooding client's entry and the operator's pending login."
+        )
+    return value
+
+
+_CHAL_MAX = _challenge_cap("CHAL_MAX", 512, 2)
+_CHAL_MAX_PER_IP = _challenge_cap("CHAL_MAX_PER_IP", 16, 1)
+if _CHAL_MAX_PER_IP >= _CHAL_MAX:
+    raise ValueError(
+        f"{_ENV}CHAL_MAX_PER_IP={_CHAL_MAX_PER_IP} must be below {_ENV}CHAL_MAX={_CHAL_MAX}. "
+        "The per-ip cap is what keeps one client off the global cap; at or above it the global "
+        "cap is reached first, and it evicts the oldest record in the table regardless of ip -- "
+        "the operator's pending login, if theirs was stashed first."
+    )
 
 
 def _evict_oldest(where: dict[str, dict[str, Any]], keep: int, ip: str | None = None) -> int:

--- a/tests/test_dashboard_auth_rpid_and_challenge_caps.py
+++ b/tests/test_dashboard_auth_rpid_and_challenge_caps.py
@@ -165,3 +165,100 @@ def test_the_client_ip_prefers_a_forwarded_header_for_fairness_only():
 
 def test_client_ip_never_raises_on_a_strange_object():
     assert auth._client_ip(object()) is None
+
+
+# --------------------------------------------------------------------------
+# Q11b - the caps are operator-set, and only some pairs give the property
+# --------------------------------------------------------------------------
+# Both caps are read from the environment at import. Every other number this
+# module reads has a domain; these two had none, so a pair that cannot deliver
+# per-client fairness was accepted and the guarantee above was silently lost.
+
+
+def _load_auth(monkeypatch, **env):
+    """Import a private copy of the auth module under ``env``.
+
+    A fresh module object rather than a reload, so a rejected pair cannot leave
+    ``strands_robots.dashboard.auth`` unusable for the rest of the session.
+    """
+    import importlib.util
+
+    for key, value in env.items():
+        monkeypatch.setenv(auth._ENV + key, value)
+    spec = importlib.util.spec_from_file_location("_auth_probe", auth.__file__)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_a_per_ip_cap_at_the_global_cap_costs_the_operator_their_login(monkeypatch):
+    """The premise: the pair is what carries the property, not either cap alone.
+
+    Holds on any version of the caps - it is ``_stash_challenge``'s eviction
+    order, which is ip-blind once the global cap binds. It is the reason the pair
+    needs a domain.
+    """
+    monkeypatch.setattr(auth, "_CHAL_MAX", 32)
+    monkeypatch.setattr(auth, "_CHAL_MAX_PER_IP", 32)
+    mine = auth._stash_challenge("auth", b"operator", {}, ip="192.0.2.5")
+    for _ in range(200):
+        auth._stash_challenge("reg", b"flood", {}, ip="198.51.100.7")
+    assert mine not in auth._challenges
+
+
+@pytest.mark.parametrize("spelling", ["lots", "16.0", "0x10", "sixteen", "1e3", "16 32"])
+def test_a_cap_that_is_not_an_integer_is_refused_by_name(spelling, monkeypatch):
+    monkeypatch.setenv(auth._ENV + "CHAL_MAX", spelling)
+    with pytest.raises(ValueError, match="CHAL_MAX"):
+        auth._challenge_cap("CHAL_MAX", 512, 2)
+
+
+@pytest.mark.parametrize(
+    ("name", "minimum", "value"),
+    [
+        ("CHAL_MAX", 2, 1),
+        ("CHAL_MAX", 2, 0),
+        ("CHAL_MAX", 2, -5),
+        ("CHAL_MAX_PER_IP", 1, 0),
+        ("CHAL_MAX_PER_IP", 1, -5),
+    ],
+)
+def test_a_cap_too_small_to_bound_the_table_is_refused(name, minimum, value, monkeypatch):
+    """Zero and negatives read as "no cap" but measure as a table of one entry."""
+    monkeypatch.setenv(auth._ENV + name, str(value))
+    with pytest.raises(ValueError, match=name):
+        auth._challenge_cap(name, 512, minimum)
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_an_empty_setting_means_unset(raw, monkeypatch):
+    """Matching how the TTL readers next door treat an empty variable."""
+    monkeypatch.setenv(auth._ENV + "CHAL_MAX", raw)
+    assert auth._challenge_cap("CHAL_MAX", 512, 2) == 512
+
+
+def test_a_usable_cap_is_honored_with_surrounding_whitespace(monkeypatch):
+    monkeypatch.setenv(auth._ENV + "CHAL_MAX", " 64 ")
+    assert auth._challenge_cap("CHAL_MAX", 512, 2) == 64
+
+
+@pytest.mark.parametrize(("cap_max", "cap_per_ip"), [("512", "512"), ("512", "513"), ("512", "100000"), ("8", "16")])
+def test_a_per_ip_cap_that_cannot_bind_is_refused_at_import(cap_max, cap_per_ip, monkeypatch):
+    """Including the last pair, where only the GLOBAL cap was narrowed."""
+    with pytest.raises(ValueError, match="CHAL_MAX_PER_IP"):
+        _load_auth(monkeypatch, CHAL_MAX=cap_max, CHAL_MAX_PER_IP=cap_per_ip)
+
+
+@pytest.mark.parametrize(("cap_max", "cap_per_ip"), [("2", "1"), ("32", "31"), ("512", "16"), ("100000", "64")])
+def test_a_pair_that_gives_the_property_still_loads(cap_max, cap_per_ip, monkeypatch):
+    """The narrowest usable pair is ``MAX=2, PER_IP=1`` - measured, not assumed."""
+    module = _load_auth(monkeypatch, CHAL_MAX=cap_max, CHAL_MAX_PER_IP=cap_per_ip)
+    assert (module._CHAL_MAX, module._CHAL_MAX_PER_IP) == (int(cap_max), int(cap_per_ip))
+
+
+def test_the_shipped_defaults_are_a_pair_that_gives_the_property(monkeypatch):
+    monkeypatch.delenv(auth._ENV + "CHAL_MAX", raising=False)
+    monkeypatch.delenv(auth._ENV + "CHAL_MAX_PER_IP", raising=False)
+    module = _load_auth(monkeypatch)
+    assert (module._CHAL_MAX, module._CHAL_MAX_PER_IP) == (512, 16)
+    assert module._CHAL_MAX_PER_IP < module._CHAL_MAX


### PR DESCRIPTION
## The two caps are a pair, and only the pair carries the guarantee

`dashboard/auth.py` bounds its table of in-flight WebAuthn challenges with two
operator-set numbers, both read at import:

```python
_CHAL_MAX = int(os.getenv("STRANDS_DASH_AUTH_CHAL_MAX", "512"))
_CHAL_MAX_PER_IP = int(os.getenv("STRANDS_DASH_AUTH_CHAL_MAX_PER_IP", "16"))
```

They were the only two numbers this module reads with no domain. Its three TTL
readers (`_token_ttl`, `_session_max_age`, `handoff_ttl`) each guard their own.

The comment above the per-ip cap states the guarantee it exists for: *"no single
client may fill the table and push out the operator's pending login."* That
guarantee is a **relation** between the two caps, not a range on either alone.
The per-ip cap only binds while it is the smaller of the two; once the global cap
is reached, `_evict_oldest(_challenges, _CHAL_MAX - 1)` drops the oldest record
in the table **regardless of ip** — the operator's, if theirs was stashed first.

![measured grid](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/chal-cap-domain.png)

Left panel: every pair in a 10x10 grid was accepted, and **55 of 100 lose the
operator's pending login** to a 250-challenge flood from one address. Right
panel: the accepted region after this change — it coincides with the measured
region where the property holds, **0 mismatches in 100 cells**.

## Values that were accepted

| setting | before | after |
| --- | --- | --- |
| `CHAL_MAX_PER_IP=512` (= default `CHAL_MAX`) | accepted; table 512, operator evicted | refused, naming both variables |
| `CHAL_MAX_PER_IP=100000` | accepted; operator evicted | refused |
| `CHAL_MAX=8` (per-ip left at default 16) | accepted; operator evicted | refused — only the *global* cap was narrowed |
| `CHAL_MAX=0` / `-5` | accepted; table held 1 entry | refused |
| `CHAL_MAX_PER_IP=0` / `-5` | accepted; behaved as 1, not as "none" | refused |
| `CHAL_MAX=lots` | `ValueError: invalid literal for int() with base 10: 'lots'` | names the variable, the domain and the default |
| `CHAL_MAX=` (empty) | `ValueError` at import | means unset, as it already did for the TTL readers |
| `CHAL_MAX=2, CHAL_MAX_PER_IP=1` | accepted | accepted — the narrowest usable pair, measured |

The domain is `CHAL_MAX >= 2`, `CHAL_MAX_PER_IP >= 1`, and
`CHAL_MAX_PER_IP < CHAL_MAX`. Each bound was measured, not assumed: at
`CHAL_MAX=1` no per-ip value saves the operator, and `PER_IP = MAX - 1` is the
largest value that still does.

Refused rather than defaulted, per `AGENTS.md` ("raise on fatal; no silent
defaults") and following this module's own reasoning for
`STRANDS_DASH_AUTH_ENABLED`: a value that decides whether the gate holds must not
be quietly dropped by a misspelling. These caps front routes that command real
hardware, and an operator who narrowed a cap and mistyped it should hear about it
rather than be handed the wide default back.

## Tests

Appended to `tests/test_dashboard_auth_rpid_and_challenge_caps.py`, whose Q11
section already owns this property.

| | cells |
| --- | --- |
| existing, unchanged | 19 |
| new, red before / green after | 18 |
| new controls, green on both trees | 6 |
| total | 43 |

19 + 24 = 43: no existing cell changed verdict. The 6 controls are the premise
cell (the flood outcome at `PER_IP == MAX`, a property of `_stash_challenge` on
either tree, which is *why* the relation needs a domain), the four usable pairs,
and the shipped defaults.

## Size

| file | +/- |
| --- | --- |
| `strands_robots/dashboard/auth.py` | +64 / -3 |
| `tests/…_rpid_and_challenge_caps.py` | +97 |
| `docs/dashboard/remote-access.md` | +5 |
| `changelog.d/3244-…md` | +15 |

Of the 64 added production lines, 21 are logic: 36 are the `_challenge_cap`
docstring (18), the roster comment explaining why the relation is the invariant
(7) and the three refusal messages (11), and 7 are blank.

## Gate

`ruff check` + `ruff format --check` clean over 1896 files. `mypy strands_robots
tests tests_integ` unchanged at its 20 standing errors, 0 in the four touched
files. `pytest -k "dashboard or changelog or docs or export or grader or
host_path"` → 2078 passed, 1 pre-existing failure unrelated to this change
(`test_every_declared_lerobot_type_is_one_lerobot_registers`, a registry/lerobot
version skew that reproduces on `main`).
