### PR TITLE
fix(training/lerobot): a fresh start clears an empty output_dir, not a directory that holds a checkpoint

### DIFF
--- a/changelog.d/3245-fresh-start-clears-only-an-empty-output-dir.md
+++ b/changelog.d/3245-fresh-start-clears-only-an-empty-output-dir.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **A fresh training start clears an empty `output_dir`, not a directory that holds a checkpoint.**
+  `LerobotTrainer.train()` cleared a stale `output_dir` on a fresh (`resume=False`)
+  start whenever no *resumable checkpoint* was visible, using a recursive
+  `shutil.rmtree(..., ignore_errors=True)` that reports neither what it took nor a
+  partial failure. The `lerobot_train` tool implements the same hygiene bounded to
+  an EMPTY directory, and "no resumable checkpoint" is strictly weaker than
+  "empty": lerobot's `save_checkpoint` writes `model.safetensors` before
+  `train_config.json`, so a run interrupted between the two leaves the trained
+  weights under a checkpoint no resume probe reports - and `output_dir` is a
+  caller-supplied path on both entry points, including the `train_policy` agent
+  tool. Measured on a real ACT checkpoint, a fresh start removed 1,239,111,004
+  bytes of trained weights and then refused the call for an unrelated reason,
+  having trained nothing. Both entry points now ask one owner,
+  `strands_robots.utils.stale_output_dir_is_clearable()`; a directory holding
+  anything is left for lerobot to refuse by name. Emptiness subsumes the
+  checkpoint probe, so the tool drops a redundant test and keeps its previous
+  verdict on every input.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -208,6 +208,32 @@ Check what a policy freezes by default before assuming `method="full"` trains
 all of it: `dataclasses.fields()` on its lerobot config class lists every knob
 and its default.
 
+#### `output_dir` on a fresh start
+
+lerobot refuses a pre-existing `output_dir` unless it is resuming:
+
+```
+FileExistsError: Output directory /tmp/ft_out already exists and resume is
+False. Please change your output directory so that /tmp/ft_out is not
+overwritten.
+```
+
+So a fresh (`resume=False`) start clears a leftover `output_dir` first - but
+**only when it is empty**. A directory holding anything at all is left for
+lerobot to refuse by name, because the removal is a recursive
+`shutil.rmtree(..., ignore_errors=True)` that reports neither what it took nor a
+partial failure. Both entry points - `train_policy` / `LerobotTrainer.train()`
+and the `lerobot_train` tool - ask
+`strands_robots.utils.stale_output_dir_is_clearable()`, so they cannot disagree
+about it.
+
+Emptiness rather than "holds no resumable checkpoint" is the bound because a
+checkpoint is not always visible to a resume probe: lerobot's `save_checkpoint`
+writes `model.safetensors` before `train_config.json`, so a run interrupted
+between the two leaves the trained weights under a checkpoint that answers "not
+resumable". Point a fresh run at a new `output_dir`, or pass `resume=True` to
+continue in place.
+
 #### RA-BC sample weighting (reward-aligned behavior cloning)
 
 Reward-Aligned Behavior Cloning reweights the per-sample loss so high-progress

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -41,6 +41,7 @@ from strands_robots.tools._process_stop import (
 )
 from strands_robots.utils import (
     positive_count_error,
+    stale_output_dir_is_clearable,
     step_cadence_error,
     validation_split_error,
     validation_split_fraction,
@@ -1016,13 +1017,12 @@ def lerobot_train(
             # Default output_dir lives next to the dataset so artifacts are colocated.
             resolved_output_dir = output_dir or str(Path(dataset_root).resolve().parent / "train_out" / job_name)
 
-            # Clear a stale EMPTY output_dir on a fresh (non-resumable) start so
-            # lerobot's "already exists" guard does not crash. Never delete a dir
-            # that holds checkpoints.
-            out_path = Path(resolved_output_dir)
-            if out_path.is_dir() and not _has_resumable_checkpoint(resolved_output_dir):
-                if not any(out_path.iterdir()):
-                    shutil.rmtree(out_path, ignore_errors=True)
+            # Clear a stale EMPTY output_dir on a fresh start so lerobot's
+            # "already exists" guard does not crash. Never delete a dir that
+            # holds checkpoints - the emptiness bound the shared owner applies
+            # subsumes the checkpoint probe that used to be asked here.
+            if stale_output_dir_is_clearable(resolved_output_dir):
+                shutil.rmtree(resolved_output_dir, ignore_errors=True)
 
             if extra_flags:
                 gate_err = _gate_extra_flags(extra_flags, tool_context)

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -60,7 +60,12 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.training._inproc import call_callable, elastic_launch_callable, resume_argv
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
-from strands_robots.utils import lerobot_version, validation_split_error, validation_split_fraction
+from strands_robots.utils import (
+    lerobot_version,
+    stale_output_dir_is_clearable,
+    validation_split_error,
+    validation_split_fraction,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from lerobot.configs.train import TrainPipelineConfig
@@ -1709,10 +1714,13 @@ class LerobotTrainer(Trainer):
         parent = os.path.dirname(os.path.abspath(spec.output_dir)) or "."
         os.makedirs(parent, exist_ok=True)
 
-        # Fresh-start hygiene: clear a stale output_dir with no resumable ckpt.
-        if not spec.resume and os.path.isdir(spec.output_dir):
-            if self.latest_checkpoint(spec.output_dir) is None:
-                shutil.rmtree(spec.output_dir, ignore_errors=True)
+        # Fresh-start hygiene: clear a stale EMPTY output_dir so lerobot's
+        # "already exists" guard does not refuse the run. Asked through the one
+        # owner of that bound, which the lerobot_train tool asks too: a directory
+        # holding anything is left for lerobot to refuse by name, because the
+        # removal is recursive and reports neither what it took nor a failure.
+        if not spec.resume and stale_output_dir_is_clearable(spec.output_dir):
+            shutil.rmtree(spec.output_dir, ignore_errors=True)
 
         job_id = f"lerobot-{int(time.time())}"
         log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2630,6 +2630,42 @@ def published_string_error(value: Any, param: str, context: str) -> str | None:
     )
 
 
+def stale_output_dir_is_clearable(output_dir: str) -> bool:
+    """True when ``output_dir`` exists and holds nothing, so clearing it is free.
+
+    Both LeRobot training entry points clear a stale ``output_dir`` on a fresh
+    (non-resuming) start, because lerobot's own ``TrainPipelineConfig.validate``
+    refuses a pre-existing one unless ``resume=True``. This is the single owner
+    of the bound on that hygiene, so the two cannot disagree about what a fresh
+    start is allowed to remove.
+
+    Emptiness is the bound because the removal is a recursive
+    ``shutil.rmtree(..., ignore_errors=True)``: it reports neither what it took
+    nor a partial failure, and nothing it takes is recoverable. A directory with
+    nothing in it is the only one where that is free.
+
+    Emptiness also SUBSUMES the "no resumable checkpoint" test, so this needs no
+    checkpoint probe: a directory holding a checkpoint is not empty, whatever
+    layout the checkpoint is in. That matters because a checkpoint is not always
+    visible to a resume probe - lerobot's ``save_checkpoint`` writes
+    ``model.safetensors`` before ``train_config.json``, so a run interrupted
+    between the two leaves the trained weights on disk under a checkpoint no
+    resume probe reports, and a checkpoint-keyed bound clears exactly that.
+
+    Args:
+        output_dir: Path a run is about to write checkpoints into.
+
+    Returns:
+        ``True`` only when the path is an existing directory with no entries.
+        ``False`` for a path that does not exist (there is nothing to clear), is
+        not a directory, or holds anything at all.
+    """
+    path = Path(output_dir)
+    if not path.is_dir():
+        return False
+    return not any(path.iterdir())
+
+
 def validation_split_fraction(val_episodes: int, total_episodes: int) -> float:
     """``dataset.eval_split`` that holds out exactly ``val_episodes`` episodes.
 

--- a/tests/test_fresh_start_clears_only_an_empty_output_dir.py
+++ b/tests/test_fresh_start_clears_only_an_empty_output_dir.py
@@ -1,0 +1,317 @@
+"""A fresh training start clears an EMPTY ``output_dir``, and nothing else.
+
+Both LeRobot training entry points clear a stale ``output_dir`` on a fresh
+(non-resuming) start, because lerobot's own ``TrainPipelineConfig.validate``
+refuses a pre-existing one unless ``resume=True``::
+
+    FileExistsError: Output directory <dir> already exists and resume is False.
+    Please change your output directory so that <dir> is not overwritten.
+
+The two implemented the same rule with different bounds. ``lerobot_train``
+required the directory to be EMPTY and said why ("Never delete a dir that holds
+checkpoints"); :meth:`LerobotTrainer.train` required only that no *resumable
+checkpoint* was visible, and cleared whatever else was there with a recursive
+``shutil.rmtree(..., ignore_errors=True)`` that reports neither what it took nor
+a partial failure.
+
+"No resumable checkpoint" is a strictly weaker bound than "empty", and the gap
+is where a caller's data lives:
+
+* A checkpoint a resume probe cannot see. lerobot's ``save_checkpoint`` writes
+  ``model.safetensors`` before ``train_config.json``, so a run interrupted
+  between the two leaves the trained weights on disk under a checkpoint that
+  answers "not resumable" -- and a checkpoint-keyed bound clears exactly that.
+* A directory that is not a run at all. ``output_dir`` is a caller-supplied
+  path on both entry points, including the ``train_policy`` agent tool.
+
+The removal also ran ahead of refusals that follow it: ``build_config`` raises
+on an unusable ``extra`` after the hygiene step, so the call could take the
+directory and then report an error, having trained nothing.
+
+Emptiness SUBSUMES the checkpoint probe -- a directory holding a checkpoint is
+not empty, whatever layout the checkpoint is in -- so the shared owner needs no
+checkpoint probe, and the ``lerobot_train`` side keeps its previous verdict on
+every input while dropping the redundant test.
+"""
+
+import ast
+import inspect
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.lerobot_train as tool_mod
+import strands_robots.training.lerobot as trainer_mod
+from strands_robots.tools.lerobot_train import lerobot_train
+from strands_robots.training.base import TrainSpec
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.utils import stale_output_dir_is_clearable
+
+# The directory shapes an ``output_dir`` can be in when a fresh start looks at
+# it. ``clearable`` is the verdict BOTH entry points must reach.
+#   empty              - the only shape a recursive removal costs nothing on
+#   leftover-file      - a stale run's logs/plots, or a directory that is
+#                        not a run at all
+#   intact-checkpoint  - a checkpoint a resume probe reports
+#   headless-checkpoint- lerobot writes model.safetensors BEFORE
+#                        train_config.json, so an interrupted save leaves the
+#                        trained weights under a checkpoint no resume probe
+#                        reports
+_SHAPES: tuple[tuple[str, bool], ...] = (
+    ("empty", True),
+    ("leftover-file", False),
+    ("leftover-subdir", False),
+    ("intact-checkpoint", False),
+    ("headless-checkpoint", False),
+)
+
+
+def _make(root: Path, shape: str) -> Path:
+    """Materialise one ``_SHAPES`` entry at ``root`` and return it."""
+    root.mkdir(parents=True, exist_ok=True)
+    if shape == "empty":
+        return root
+    if shape == "leftover-file":
+        (root / "loss.png").write_bytes(b"\x89PNG stale plot")
+        return root
+    if shape == "leftover-subdir":
+        run = root / "wandb" / "run-1"
+        run.mkdir(parents=True)
+        # A FILE, not just the directories: the census below counts files, so a
+        # tree of empty directories would make this row grade nothing.
+        (run / "output.log").write_text("step 1 loss 0.4\n")
+        return root
+    ckpt = root / "checkpoints" / "000100" / "pretrained_model"
+    ckpt.mkdir(parents=True)
+    (ckpt / "model.safetensors").write_bytes(b"trained weights")
+    (ckpt / "config.json").write_text("{}")
+    if shape == "intact-checkpoint":
+        (ckpt / "train_config.json").write_text("{}")
+        (root / "checkpoints" / "last").symlink_to(ckpt.parent, target_is_directory=True)
+    elif shape != "headless-checkpoint":  # pragma: no cover - guards the table
+        raise AssertionError(f"unknown shape {shape!r}")
+    return root
+
+
+def _survivors(root: Path) -> list[str]:
+    """Every file still under ``root``, relative and sorted."""
+    if not root.exists():
+        return []
+    return sorted(str(f.relative_to(root)) for f in root.rglob("*") if f.is_file())
+
+
+def _write_dataset(root: Path) -> Path:
+    """A minimal LeRobot v3 dataset root: what both entry points read."""
+    (root / "meta").mkdir(parents=True, exist_ok=True)
+    (root / "meta" / "info.json").write_text(json.dumps({"total_episodes": 4}))
+    return root
+
+
+class _FakeProc:
+    """Stands in for the detached training process the tool launches."""
+
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(tool_mod, "SESSION_DIR", session_dir)
+
+
+class TestTheSharedBoundIsEmptiness:
+    """The owner answers True for an empty directory and nothing else."""
+
+    @pytest.mark.parametrize(("shape", "clearable"), _SHAPES, ids=[s for s, _ in _SHAPES])
+    def test_only_an_empty_directory_is_clearable(self, tmp_path: Path, shape: str, clearable: bool) -> None:
+        out = _make(tmp_path / "out", shape)
+        assert stale_output_dir_is_clearable(str(out)) is clearable
+
+    def test_a_path_that_does_not_exist_is_not_clearable(self, tmp_path: Path) -> None:
+        """Nothing to clear, so the caller must not be told there is."""
+        assert stale_output_dir_is_clearable(str(tmp_path / "absent")) is False
+
+    def test_a_file_is_not_clearable(self, tmp_path: Path) -> None:
+        """A non-directory is never a run's output_dir; leave it to lerobot."""
+        target = tmp_path / "not-a-dir"
+        target.write_text("data")
+        assert stale_output_dir_is_clearable(str(target)) is False
+
+    def test_emptiness_subsumes_the_checkpoint_probe(self, tmp_path: Path) -> None:
+        """Premise for dropping the probe: an empty dir holds no checkpoint.
+
+        Holds on both trees by construction - it is why the shared owner needs
+        no checkpoint probe of its own, not a claim about the fix.
+        """
+        empty = _make(tmp_path / "empty", "empty")
+        assert tool_mod._has_resumable_checkpoint(str(empty)) is None
+        assert LerobotTrainer(device="cpu").latest_checkpoint(str(empty)) is None
+
+    def test_an_interrupted_save_hides_the_weights_from_both_resume_probes(self, tmp_path: Path) -> None:
+        """Premise: the weights are there and neither probe reports them.
+
+        Also holds on both trees - it establishes that a checkpoint-keyed bound
+        and an emptiness bound genuinely disagree on this shape.
+        """
+        out = _make(tmp_path / "out", "headless-checkpoint")
+        assert (out / "checkpoints" / "000100" / "pretrained_model" / "model.safetensors").exists()
+        assert tool_mod._has_resumable_checkpoint(str(out)) is None
+        assert LerobotTrainer(device="cpu").latest_checkpoint(str(out)) is None
+
+
+class TestBothEntryPointsReachTheSameVerdict:
+    """One rule, two entry points, one verdict per directory shape."""
+
+    @staticmethod
+    def _trainer_verdict(tmp_path: Path, shape: str, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        out = _make(tmp_path / "trainer_out", shape)
+        spec = TrainSpec(
+            dataset_root=str(_write_dataset(tmp_path / "ds")),
+            output_dir=str(out),
+            steps=2,
+            global_batch_size=2,
+            save_freq=1,
+            extra={"policy_type": "act"},
+        )
+        trainer = LerobotTrainer(device="cpu")
+        monkeypatch.setattr(trainer, "validate", lambda s: [])
+        monkeypatch.setattr(trainer, "build_config", lambda s: object())
+        import lerobot.scripts.lerobot_train as lt
+
+        monkeypatch.setattr(lt, "train", lambda cfg, **kw: None)
+        trainer.train(spec)
+        return _survivors(out)
+
+    @staticmethod
+    def _tool_verdict(tmp_path: Path, shape: str, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        out = _make(tmp_path / "tool_out", shape)
+        monkeypatch.setattr(tool_mod.subprocess, "Popen", lambda *a, **k: _FakeProc())
+        result = lerobot_train(
+            action="start",
+            dataset_root=str(_write_dataset(tmp_path / "ds")),
+            output_dir=str(out),
+            policy_type="act",
+            session_name=f"parity_{shape}",
+        )
+        assert result["status"] == "success", result
+        return _survivors(out)
+
+    @pytest.mark.parametrize(("shape", "clearable"), _SHAPES, ids=[s for s, _ in _SHAPES])
+    def test_the_two_entry_points_keep_the_same_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, shape: str, clearable: bool
+    ) -> None:
+        expected = [] if clearable else _survivors(_make(tmp_path / "reference", shape))
+        assert self._trainer_verdict(tmp_path, shape, monkeypatch) == expected
+        assert self._tool_verdict(tmp_path, shape, monkeypatch) == expected
+
+    def test_the_trainer_still_clears_an_empty_directory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The hygiene the bound exists to allow still happens.
+
+        Control: a bound that refused every shape would satisfy the rows above
+        and break the reason the removal is there at all.
+        """
+        out = _make(tmp_path / "trainer_out", "empty")
+        self._trainer_verdict(tmp_path, "empty", monkeypatch)
+        assert not out.exists()
+
+    def test_a_resuming_start_clears_nothing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``resume=True`` keeps the checkpoints the run is resuming from."""
+        out = _make(tmp_path / "trainer_out", "intact-checkpoint")
+        before = _survivors(out)
+        spec = TrainSpec(
+            dataset_root=str(_write_dataset(tmp_path / "ds")),
+            output_dir=str(out),
+            steps=2,
+            global_batch_size=2,
+            save_freq=1,
+            resume=True,
+            extra={"policy_type": "act"},
+        )
+        trainer = LerobotTrainer(device="cpu")
+        monkeypatch.setattr(trainer, "validate", lambda s: [])
+        monkeypatch.setattr(trainer, "build_config", lambda s: object())
+        import lerobot.scripts.lerobot_train as lt
+
+        monkeypatch.setattr(lt, "train", lambda cfg, **kw: None)
+        trainer.train(spec)
+        assert _survivors(out) == before
+
+
+class TestARefusalAfterTheHygieneCostsNothing:
+    """A refusal that follows the removal must not have cost the caller data."""
+
+    def test_a_build_config_failure_leaves_a_non_empty_directory_intact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        out = _make(tmp_path / "out", "headless-checkpoint")
+        before = _survivors(out)
+        spec = TrainSpec(
+            dataset_root=str(_write_dataset(tmp_path / "ds")),
+            output_dir=str(out),
+            steps=2,
+            global_batch_size=2,
+            save_freq=1,
+            extra={"policy_type": "act"},
+        )
+        trainer = LerobotTrainer(device="cpu")
+        monkeypatch.setattr(trainer, "validate", lambda s: [])
+
+        def _refuse(_spec: TrainSpec) -> Any:
+            raise ValueError("extra['sample_weighting'] does not support field(s) ['no_such_field']")
+
+        monkeypatch.setattr(trainer, "build_config", _refuse)
+        result = trainer.train(spec)
+
+        assert result.status == "error"
+        assert "failed to build lerobot TrainPipelineConfig" in result.message
+        assert _survivors(out) == before, "a refused call removed the caller's files"
+
+
+class TestTheBoundHasOneOwner:
+    """Neither entry point re-implements the bound beside its removal."""
+
+    @pytest.mark.parametrize("module", (trainer_mod, tool_mod), ids=("trainer", "tool"))
+    def test_every_output_dir_removal_is_guarded_by_the_shared_owner(self, module: Any) -> None:
+        """Read the NEAREST enclosing ``if`` of each removal, not any of them.
+
+        Graded on the call rather than the source text so a second copy of the
+        bound cannot drift back in beside a removal under another name.
+        """
+        tree = ast.parse(inspect.getsource(module))
+        parents: dict[ast.AST, ast.AST] = {}
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                parents[child] = node
+
+        removals = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and getattr(node.func, "attr", None) == "rmtree"
+        ]
+        assert len(removals) == 1, f"{module.__name__}: expected one shutil.rmtree, found {len(removals)}"
+
+        for removal in removals:
+            guard: ast.AST | None = removal
+            while guard is not None and not isinstance(guard, ast.If):
+                guard = parents.get(guard)
+            assert isinstance(guard, ast.If), f"{module.__name__}: the removal is not guarded at all"
+            names = {n.id for n in ast.walk(guard.test) if isinstance(n, ast.Name)}
+            assert "stale_output_dir_is_clearable" in names, (
+                f"{module.__name__}: a shutil.rmtree of the output dir is guarded by "
+                f"{ast.unparse(guard.test)!r} instead of the shared bound"
+            )
+
+    def test_the_removal_is_still_recursive_and_silent(self) -> None:
+        """Premise for the bound: what makes it unsafe on a non-empty dir.
+
+        Holds on both trees - the point is the bound, not the removal, and a
+        reader needs to know the removal reports nothing.
+        """
+        assert shutil.rmtree is trainer_mod.shutil.rmtree
+        source = inspect.getsource(trainer_mod.LerobotTrainer.train)
+        assert "ignore_errors=True" in source

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -822,11 +822,27 @@ class TestTrainOrchestration:
         assert "lerobot train raised RuntimeError" in result.message
         assert "CUDA OOM" in result.message
 
-    def test_fresh_start_clears_stale_output_dir(self, spec, monkeypatch, tmp_path):
+    @pytest.mark.parametrize(
+        ("leftover", "cleared"),
+        [(None, True), ("leftover.txt", False)],
+        ids=("empty", "holds-a-file"),
+    )
+    def test_fresh_start_clears_only_an_empty_output_dir(self, spec, monkeypatch, tmp_path, leftover, cleared):
+        """A stale EMPTY output_dir is cleared; one holding anything is kept.
+
+        lerobot refuses a pre-existing output_dir unless resume=True, so a fresh
+        start clears a leftover directory rather than launch into that refusal.
+        The bound is emptiness, because the removal is a recursive
+        ``rmtree(ignore_errors=True)``: a directory holding a stale run's plots,
+        its wandb dir, or a checkpoint no resume probe can see is left for
+        lerobot to refuse by name instead. Owned by
+        ``strands_robots.utils.stale_output_dir_is_clearable`` and shared with
+        the ``lerobot_train`` tool.
+        """
         out = tmp_path / "stale_out"
         out.mkdir()
-        sentinel = out / "leftover.txt"
-        sentinel.write_text("old")
+        if leftover is not None:
+            (out / leftover).write_text("old")
         spec.output_dir = str(out)
         spec.resume = False
 
@@ -838,8 +854,9 @@ class TestTrainOrchestration:
 
         monkeypatch.setattr(lt, "train", lambda cfg, **kw: None)
         trainer.train(spec)
-        # Stale dir (no resumable checkpoint) is wiped before training.
-        assert not sentinel.exists()
+        assert out.exists() is not cleared
+        if leftover is not None:
+            assert (out / leftover).exists()
 
     def test_multi_gpu_uses_elastic_launch(self, spec, monkeypatch):
         spec.num_gpus = 2


### PR DESCRIPTION
## Problem

`LerobotTrainer.train()` clears a stale `output_dir` on a fresh (`resume=False`)
start, because lerobot refuses a pre-existing one:

```
FileExistsError: Output directory /tmp/ft_out already exists and resume is False.
Please change your output directory so that /tmp/ft_out is not overwritten.
```

The bound on that removal was "no **resumable checkpoint** is visible":

```python
if not spec.resume and os.path.isdir(spec.output_dir):
    if self.latest_checkpoint(spec.output_dir) is None:
        shutil.rmtree(spec.output_dir, ignore_errors=True)
```

The `lerobot_train` tool implements the same rule with a different bound - the
directory must be **empty** - and says why in a comment: *"Never delete a dir
that holds checkpoints."*

"No resumable checkpoint" is strictly weaker than "empty", and the gap is where
a caller's data lives:

- **A checkpoint no resume probe reports.** lerobot's `save_checkpoint` writes
  `model.safetensors` before `train_config.json` (`lerobot.common.train_utils`),
  so a run interrupted between the two leaves the trained weights on disk under
  a checkpoint that answers "not resumable" - exactly the directory a
  checkpoint-keyed bound clears.
- **A directory that is not a run at all.** `output_dir` is a caller-supplied
  path on both entry points, including the `train_policy` agent tool where it is
  documented only as "Where checkpoints + logs go".

The removal is `shutil.rmtree(..., ignore_errors=True)`: recursive, and it
reports neither what it took nor a partial failure. It also runs *ahead of*
refusals that follow it - `build_config` raises on an unusable `extra` after the
hygiene step - so a call could take the directory and then report an error,
having trained nothing.

## Measured

Real LeRobotDataset (1 episode / 40 frames, recorded from a MuJoCo SO-101
rollout), real ACT checkpoints trained with lerobot 0.6.2, `validate()`
reporting no problems on every row.

![fresh-start bound, before and after](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/pr3245/fresh_start_bound.png)

| `output_dir` contents | `train()` before | `train()` after | `lerobot_train` tool |
|---|---|---|---|
| checkpoint a resume probe sees | kept (1,239,125,674 B) | kept | kept |
| weights, no `train_config.json` | **removed (1,239,111,004 B lost)** | kept | kept |
| `notes.md` + `plots/loss.png` | **removed (34 B lost)** | kept | kept |
| empty | cleared | cleared | cleared |

Both removing rows returned `status="error"` with
`failed to build lerobot TrainPipelineConfig: extra['sample_weighting'] does not
support field(s) ['no_such_field']` - the directory was taken, the run never
started, and the message says nothing about the removal.

After the fix a non-empty `output_dir` reaches lerobot, which refuses it by name
and tells the caller what to do (`FileExistsError` above). A stale **empty**
`output_dir` is still cleared and the run still proceeds: same fixture, valid
spec, `status="success"`, `checkpoint_dir=.../checkpoints/last/pretrained_model`,
1,239,125,674 B written.

## Change

One owner for the bound, `strands_robots.utils.stale_output_dir_is_clearable()`,
asked by both entry points. Emptiness **subsumes** the checkpoint probe - a
directory holding a checkpoint is not empty, whatever layout it is in - so the
owner needs no probe of its own and the tool drops the redundant one it was
making, keeping its previous verdict on every input.

Both call sites shrank; the fix is **+3 net executable statements** across the
three production files (`training/lerobot.py` −1, `tools/lerobot_train.py` −2,
`utils.py` +6 by AST statement count).

## Tests

`tests/test_fresh_start_clears_only_an_empty_output_dir.py` (new) grades the
shared bound's domain, drives **both** entry points over the same table of
directory shapes and asserts they keep the same files, pins that a refusal
following the hygiene costs nothing, and reads the AST so a second copy of the
bound cannot drift back in beside a removal.

`tests/training/test_lerobot.py::test_fresh_start_clears_stale_output_dir` wrote
`leftover.txt` into the directory and asserted it was **gone** - it pinned the
behaviour being fixed. Retargeted (not deleted) into a two-row table: `empty` is
cleared, `holds-a-file` is kept.

Pre-fix / post-fix, reverting only the trainer's bound:

```
6 failed, 182 passed   ->   237 passed
```

The six failures are the three non-empty parity rows, the refusal-costs-nothing
cell, the one-owner cell for the trainer, and the retargeted `holds-a-file` row.
Green on both trees: the `empty` and `intact-checkpoint` parity rows, the
`resume=True` row, the still-clears-an-empty-dir control, both premise cells,
and every `lerobot_train` row (the change is one-sided).

## Gate

- `ruff check strands_robots tests tests_integ` - all checks passed
- `ruff format --check strands_robots tests tests_integ` - 1897 files formatted
- `mypy strands_robots tests tests_integ` - `Success: no issues found in 1894 source files`
- 229 tree-walking guard files + the new file: `7 failed, 11970 passed, 50 skipped`.
  The 7 are pre-existing and environmental (5 assert `rclpy` is absent where
  `/opt/ros/jazzy` supplies it; 2 read `websockets` 16.0 against the declared
  `>=17.0` floor) - byte-identical node ids on a pristine `main` worktree at
  `cfe06a63c`, so nothing is attributable.
