### PR TITLE
fix(policies/protomotions): a declared smoothing factor that nothing read

### DIFF
--- a/changelog.d/3246-protomotions-action-ema-alpha.md
+++ b/changelog.d/3246-protomotions-action-ema-alpha.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **policies/protomotions**: `ProtoMotionsConfig.action_ema_alpha` is now applied
+  to the joint targets the PD loop receives, and is refused unless it is a finite
+  number in `(0, 1]`. The field was parsed from the checkpoint's
+  `unified_pipeline.yaml`, stored on the config and read by nothing, so the
+  emitted targets were byte-identical for every declared factor; having no reader
+  it also had no domain, so `0` (which freezes the commanded pose at the first
+  tick's target), a negative weight, a value above `1` and `nan` were all stored
+  and carried into the control path. `1.0` - the shipped checkpoint's own value -
+  remains bit-exact passthrough, the first tick of an episode seeds the filter
+  from the network's own output rather than from zeros, and the historical-actions
+  buffer keeps carrying the raw output because the graph's
+  `historical_processed_actions` input is defined over it.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -258,6 +258,7 @@ sidecar; omit it to use the defaults, which match the shipped export.
 | `root_body_index` | `0` (`pelvis`) | Floating base |
 | `control_dt` | `0.02` | Seconds per control tick (50 Hz) |
 | `future_step_indices` | `(1, 2, 4, 8)` | Lookahead offsets, in control steps |
+| `action_ema_alpha` | `1.0` | Smoothing weight on the emitted joint targets; `1.0` is passthrough |
 
 ### A body index has to address a body
 
@@ -286,6 +287,54 @@ The index also goes through the shared whole-number domain, so a yaml
 and a hand-built `ProtoMotionsConfig(...)` reports the same value the same way a
 sidecar does. An integral float such as `16.0` addresses a row and is kept,
 normalised to the row number both consumers index with.
+
+### Target smoothing
+
+`action_ema_alpha` is the weight the CURRENT network output carries in the target
+the PD loop receives:
+
+```text
+y[t] = alpha * x[t] + (1 - alpha) * y[t-1]
+```
+
+`1.0` - the shipped checkpoint's own value - is passthrough, and returns the
+network output unchanged and bit-exact rather than multiplying it by one. A
+smaller value weights the previous target more heavily, trading tracking lag for
+less per-tick jitter in the commanded pose. Measured on a tracker output carrying
+an alternating +/-0.11 rad per-tick component, the mean per-tick change in the
+emitted `left_hip_pitch_joint` target:
+
+| `action_ema_alpha` | mean per-tick change |
+| --- | --- |
+| `1.0` (passthrough) | 0.220 rad |
+| `0.5` | 0.074 rad |
+| `0.2` | 0.029 rad |
+| `0.05` | 0.010 rad |
+
+Two things the filter deliberately does not do. The first tick of an episode
+seeds from the network's own output rather than from zeros - a zero-seeded filter
+would command a pose between the origin and the first target, which on a 29-DOF
+humanoid holding a stance is a lurch toward the zero pose, and the smaller the
+alpha the further that first command would sit from the motion. And the
+historical-actions buffer keeps carrying the RAW output: it feeds the graph's own
+`historical_processed_actions` input, which is defined over it, so smoothing what
+the network reads back would change its input distribution.
+
+The factor must be a finite number in `(0, 1]`, refused when the config is built
+rather than when the filter reads it, and by the sidecar and a hand-built
+`ProtoMotionsConfig(...)` alike:
+
+```text
+ValueError: ProtoMotionsConfig: action_ema_alpha must be > 0, got 0.0.
+```
+
+`0` weights the current output at zero, freezing the commanded pose at the first
+tick's target for the whole clip - a tracker that reports every frame and moves
+through none of them. A negative weight drives each joint the opposite way from
+the motion, a value above `1` gives the previous target a negative weight and
+extrapolates past the motion instead of smoothing toward it, and `nan` enters the
+filter state and never leaves it, so every joint of every later tick is `nan`
+however good the network output is.
 
 ## Testing without weights
 

--- a/strands_robots/policies/protomotions/config.py
+++ b/strands_robots/policies/protomotions/config.py
@@ -25,7 +25,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from strands_robots.utils import non_negative_whole_number_error, require_optional
+from strands_robots.utils import (
+    non_negative_whole_number_error,
+    positive_finite_number_error,
+    require_optional,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -219,8 +223,15 @@ class ProtoMotionsConfig:
             physics_dt``).
         future_step_indices: Future-reference lookahead offsets in control
             steps.
-        action_ema_alpha: Optional exponential-moving-average smoothing on the
-            joint target output (``1.0`` = passthrough, upstream default).
+        action_ema_alpha: Exponential-moving-average smoothing applied to the
+            joint targets the PD loop receives, in ``(0, 1]``. ``1.0`` (the
+            upstream default) is passthrough; a smaller value weights the
+            previous target more heavily, trading tracking lag for less
+            per-tick jitter. Applied by
+            :meth:`~strands_robots.policies.protomotions.policy.\
+ProtoMotionsPolicy.get_actions`; the raw network output continues to feed the
+            historical-actions buffer, which is what the ONNX graph's
+            ``historical_processed_actions`` input is defined over.
         onnx_in_names: Input tensor names in the order the exported session
             declares them, so the session's ``get_inputs()`` order can be
             validated against this tuple at load.
@@ -265,7 +276,7 @@ class ProtoMotionsConfig:
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Refuse a body index that cannot address :attr:`body_names`.
+        """Refuse a body index, or a smoothing factor, no reader can honor.
 
         The two indices are the only fields this config resolves a body NAME
         from, and an index that misses is not a value the control path can
@@ -281,9 +292,22 @@ class ProtoMotionsConfig:
         yaml ``anchor_body_index: true`` into row 1 (``head``) and a ``2.7``
         into row 2 (``left_hip_pitch_link``).
 
+        :attr:`action_ema_alpha` is gated for the same reason and against the
+        same failure: the value is the weight the CURRENT network output carries
+        in the target the PD loop receives, so ``0`` weights it not at all and
+        freezes the commanded pose at the first tick's target for the whole
+        clip - a tracker that reports every frame and moves through none of
+        them. A negative weight drives the joint the opposite way from the
+        motion it is tracking, one above ``1`` over-extrapolates past it, and
+        ``nan`` propagates into the filter state and never leaves it, so every
+        joint of every later tick is ``nan`` however good the network output
+        is. None of the four is a smoothing factor, and all four used to be
+        stored and carried into the control path.
+
         Raises:
             ValueError: If either body index is not a non-negative whole number,
-                or is not a row of :attr:`body_names`.
+                or is not a row of :attr:`body_names`; or if
+                :attr:`action_ema_alpha` is not a finite number in ``(0, 1]``.
         """
         num_bodies = len(self.body_names)
         for name in ("anchor_body_index", "root_body_index"):
@@ -302,6 +326,24 @@ class ProtoMotionsConfig:
             # integral float the domain admits is stored as the row number the
             # observation lookup and the future-reference slice both index with.
             object.__setattr__(self, name, index)
+
+        # The shared positive-finite domain covers the sign, the finiteness, the
+        # non-real spellings and the ``bool`` that would act as a silent 1.0;
+        # only the upper bound is this field's own, so only it is spelled here.
+        if error := positive_finite_number_error(self.action_ema_alpha, "action_ema_alpha", "ProtoMotionsConfig"):
+            raise ValueError(error)
+        if float(self.action_ema_alpha) > 1.0:
+            raise ValueError(
+                "ProtoMotionsConfig: action_ema_alpha must be <= 1 (1.0 is the "
+                f"unsmoothed passthrough), got {self.action_ema_alpha!r}. The value is the "
+                "weight the current network output carries in the blend, so one above 1 "
+                "gives the previous target a negative weight and extrapolates past the "
+                "motion instead of smoothing toward it."
+            )
+        # Normalise to a plain float for the same reason the indices normalise
+        # to int: the filter multiplies with it every tick, and a NumPy scalar
+        # read from a config array would set the output dtype from the weight.
+        object.__setattr__(self, "action_ema_alpha", float(self.action_ema_alpha))
 
     # ------------------------------------------------------------------
     # Derived properties - computed on read, never stored, so a frozen
@@ -392,10 +434,10 @@ def load_config_from_yaml(path: str | Path) -> ProtoMotionsConfig:
         ValueError: If the file is not valid YAML, or holds a YAML value that
             is not a mapping, or contains an inconsistent dimension: a
             ``stiffness`` or ``damping`` length that is not the joint count, or
-            an ``anchor_body_index`` / ``root_body_index`` that is not a row of
-            ``body_names`` (refused by
-            :meth:`ProtoMotionsConfig.__post_init__`, so a config built by hand
-            reports the same value the same way).
+            an ``anchor_body_index`` / ``root_body_index`` that is not a row
+            of ``body_names``, or an ``action_ema_alpha`` outside ``(0, 1]``
+            (each refused by :meth:`ProtoMotionsConfig.__post_init__`, so a
+            config built by hand reports the same value the same way).
     """
     yaml = require_optional(
         "yaml",
@@ -435,7 +477,11 @@ def load_config_from_yaml(path: str | Path) -> ProtoMotionsConfig:
     control = data.get("control", {})
     stiffness = tuple(control.get("stiffness", data.get("default_joint_stiffness", _G1_STIFFNESS)))
     damping = tuple(control.get("damping", data.get("default_joint_damping", _G1_DAMPING)))
-    ema = float(control.get("action_ema_alpha", 1.0))
+    # Handed through raw for the reason the body indices are: the config's
+    # __post_init__ is the single owner of what a smoothing factor may be, and
+    # ``float()`` here first is what turned a yaml ``action_ema_alpha: true``
+    # into an unsmoothed 1.0 before the domain could see it.
+    ema = control.get("action_ema_alpha", 1.0)
 
     timing = data.get("timing", {})
     control_dt = float(timing.get("control_dt", GTP_G1_CONTROL_DT))

--- a/strands_robots/policies/protomotions/policy.py
+++ b/strands_robots/policies/protomotions/policy.py
@@ -25,7 +25,10 @@ Contract:
       the policy computes them from ``observation_dict``.
 
 * Output is a per-frame dict ``{joint_name: target_radians, ...}`` in the
-  action-value convention (``float`` per DOF, never ``np.ndarray``).
+  action-value convention (``float`` per DOF, never ``np.ndarray``), smoothed by
+  the config's
+  :attr:`~strands_robots.policies.protomotions.config.ProtoMotionsConfig.\
+action_ema_alpha` (``1.0`` = passthrough).
 
 Injection seam: pass ``session=`` implementing :class:`ProtoMotionsSession`
 to unit-test the observation -> future-window -> action-dict mapping without
@@ -171,6 +174,13 @@ class ProtoMotionsPolicy(Policy):
         # caller passes a new motion (which resets it).
         self._frame_cursor: int = 0
 
+        # EMA filter state for the emitted joint targets - the previous tick's
+        # smoothed target, or None before the first tick of an episode. Held
+        # separately from ``_action_history``: that buffer carries the RAW
+        # network output because it feeds the ONNX graph's
+        # ``historical_processed_actions`` input, which is defined over it.
+        self._ema_targets: NDArray[np.float32] | None = None
+
         self._motion_player: MotionPlayer | None = None
         if motion is not None:
             self.load_motion(motion)
@@ -264,9 +274,10 @@ class ProtoMotionsPolicy(Policy):
         else:
             raise TypeError(f"motion must be a MotionPlayer, cache dict, or path, got {type(motion).__name__}.")
 
-        # New clip -> reset playhead and history.
+        # New clip -> reset playhead, history and the target filter.
         self._frame_cursor = 0
         self._action_history[:] = 0.0
+        self._ema_targets = None
         logger.info(
             "ProtoMotionsPolicy loaded motion: %d frames @ %.0f Hz",
             self._motion_player.total_frames,
@@ -282,6 +293,13 @@ class ProtoMotionsPolicy(Policy):
         playhead would silently carry over and every episode after the first
         would replay from wherever the previous one stopped.
 
+        The :attr:`~strands_robots.policies.protomotions.config.\
+ProtoMotionsConfig.action_ema_alpha` filter state is cleared here for the same
+        reason: it holds the previous tick's smoothed target, so carrying it
+        across the boundary would blend the last pose of one episode into the
+        first tick of the next, and the second episode of an ``eval_policy``
+        run would start from wherever the first one stopped.
+
         Args:
             seed: Accepted for interface parity and ignored - the tracker is
                 deterministic given its reference motion and observation, so it
@@ -290,6 +308,7 @@ class ProtoMotionsPolicy(Policy):
         del seed  # deterministic tracker: no RNG state to reseed
         self._frame_cursor = 0
         self._action_history[:] = 0.0
+        self._ema_targets = None
 
     # ------------------------------------------------------------------
     # get_actions
@@ -406,11 +425,50 @@ class ProtoMotionsPolicy(Policy):
         self._action_history[-1] = actions_out.astype(np.float32)
         self._frame_cursor += 1
 
-        # 5. Wrap as the per-joint action-dict expected by the runtime.
+        # 5. Smooth the targets the PD loop receives, per the config's
+        #    action_ema_alpha. The history buffer above deliberately keeps the
+        #    RAW output: it feeds the network's own historical-actions input.
+        joint_pos_targets = self._smooth_targets(joint_pos_targets)
+
+        # 6. Wrap as the per-joint action-dict expected by the runtime.
         action_dict: dict[str, float] = {
             name: float(joint_pos_targets[i]) for i, name in enumerate(self._config.joint_names)
         }
         return [action_dict]
+
+    def _smooth_targets(self, targets: NDArray[np.float32]) -> NDArray[np.float32]:
+        """Blend ``targets`` with the previous tick's, per ``action_ema_alpha``.
+
+        ``y[t] = alpha * x[t] + (1 - alpha) * y[t-1]``, the standard first-order
+        exponential moving average. ``alpha`` is the weight of the CURRENT
+        network output, so ``1.0`` - the shipped checkpoint's own value - is
+        passthrough and returns ``targets`` unchanged and bit-exact rather than
+        multiplying it by one.
+
+        The first tick of an episode seeds the filter with the network's own
+        output instead of with zeros. A zero-seeded filter would command a pose
+        between the origin and the first target - on a 29-DOF humanoid holding a
+        stance that is a lurch toward the zero pose, not a smoothed start - and
+        the smaller the alpha the further that first command would sit from the
+        motion being tracked.
+
+        Args:
+            targets: This tick's raw ``joint_pos_targets`` from the tracker.
+
+        Returns:
+            The smoothed targets, which for ``alpha == 1.0`` is ``targets``
+            itself.
+        """
+        alpha = self._config.action_ema_alpha
+        if alpha == 1.0:
+            return targets
+        if self._ema_targets is None:
+            self._ema_targets = np.asarray(targets, dtype=np.float32)
+        else:
+            self._ema_targets = (
+                alpha * np.asarray(targets, dtype=np.float32) + (1.0 - alpha) * self._ema_targets
+            ).astype(np.float32)
+        return self._ema_targets
 
     # ------------------------------------------------------------------
     # ONNX session lifecycle

--- a/tests/policies/protomotions/test_action_ema_smooths_the_joint_targets.py
+++ b/tests/policies/protomotions/test_action_ema_smooths_the_joint_targets.py
@@ -1,0 +1,261 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A declared smoothing factor smooths the targets, and an unusable one is refused.
+
+``ProtoMotionsConfig.action_ema_alpha`` is parsed from the checkpoint's own
+``unified_pipeline.yaml`` (``control.action_ema_alpha``), stored on the frozen
+config, and documented as "exponential-moving-average smoothing on the joint
+target output". Measured against the shipped policy before the fix, the emitted
+targets were byte-identical for ``alpha`` of ``1.0``, ``0.5`` and ``0.2`` - mean
+per-tick change ``0.24000`` in all three cases - because nothing outside
+``config.py`` ever read the field. A caller who dialled smoothing in to tame
+per-tick jitter on a 29-DOF humanoid got a config that reported the value back
+and a PD loop that received the raw network output.
+
+Because the field had no reader it also had no domain, so it accepted every
+value that cannot be a weight in ``y[t] = a*x[t] + (1-a)*y[t-1]``:
+
+* ``0`` weights the current network output at zero, freezing the commanded pose
+  at the first tick's target for the whole clip - a tracker that reports every
+  frame and moves through none of them.
+* A negative weight drives each joint the opposite way from the motion.
+* Above ``1`` the previous target carries a negative weight, extrapolating past
+  the motion rather than smoothing toward it.
+* ``nan`` enters the filter state and never leaves it, so every joint of every
+  later tick is ``nan`` however good the network output is.
+
+The controls below are as load-bearing as the refusals: ``1.0`` (the shipped
+checkpoint's own value) must stay bit-exact passthrough, the first tick must
+seed from the network's output rather than from zeros, and the
+historical-actions buffer must keep carrying the RAW output - it feeds the ONNX
+graph's ``historical_processed_actions`` input, which is defined over it, so
+smoothing what the network reads back would change its input distribution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.protomotions import (
+    MotionPlayer,
+    ProtoMotionsConfig,
+    ProtoMotionsPolicy,
+)
+
+NUM_BODIES, NUM_DOFS = 33, 29
+JOINT = "left_hip_pitch_joint"  # index 0 of GTP_G1_JOINT_NAMES
+
+
+class _JitterSession:
+    """A tracker whose joint-0 output is a slow ramp plus alternating jitter.
+
+    The two components are what a smoothing factor has to tell apart: the ramp
+    is the motion being tracked, the alternating term is the per-tick noise.
+    ``raw`` records every output so a test can assert the emitted trace against
+    the EMA recursion over exactly what the network produced.
+    """
+
+    def __init__(self) -> None:
+        self.tick = 0
+        self.raw: list[float] = []
+        self.history_inputs: list[np.ndarray] = []
+
+    def run(self, output_names: list[str] | None, inputs: dict[str, np.ndarray]) -> list[np.ndarray]:
+        self.history_inputs.append(inputs["historical_processed_actions"].copy())
+        value = 0.3 * np.sin(2 * np.pi * self.tick / 40.0) + 0.12 * (1 if self.tick % 2 == 0 else -1)
+        self.tick += 1
+        self.raw.append(float(np.float32(value)))
+        vec = np.zeros(NUM_DOFS, dtype=np.float32)
+        vec[0] = np.float32(value)
+        return [
+            vec.reshape(1, NUM_DOFS),
+            vec.reshape(1, NUM_DOFS),
+            np.full((1, NUM_DOFS), 40.0, dtype=np.float32),
+            np.full((1, NUM_DOFS), 2.5, dtype=np.float32),
+        ]
+
+
+def _flat_motion(num_frames: int = 200) -> MotionPlayer:
+    return MotionPlayer(
+        {
+            "dof_pos": np.zeros((num_frames, NUM_DOFS), dtype=np.float32),
+            "dof_vel": np.zeros((num_frames, NUM_DOFS), dtype=np.float32),
+            "body_rot": np.tile(np.array([0, 0, 0, 1], dtype=np.float32), (num_frames, NUM_BODIES, 1)),
+            "body_pos": np.zeros((num_frames, NUM_BODIES, 3), dtype=np.float32),
+            "body_vel": np.zeros((num_frames, NUM_BODIES, 3), dtype=np.float32),
+            "body_ang_vel": np.zeros((num_frames, NUM_BODIES, 3), dtype=np.float32),
+            "control_dt": 0.02,
+            "num_frames": num_frames,
+        }
+    )
+
+
+def _sidecar(tmp_path: Path, declared: str) -> str:
+    """Write a sidecar declaring ``control.action_ema_alpha``, the caller's route."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / "unified_pipeline.yaml"
+    path.write_text(f"control:\n  action_ema_alpha: {declared}\n", encoding="utf-8")
+    return str(path)
+
+
+def _tick(policy: ProtoMotionsPolicy) -> float:
+    """Drive one control tick and return the joint-0 target the PD loop receives."""
+    actions = asyncio.run(
+        policy.get_actions(
+            {"observation.state": [0.0] * NUM_DOFS},
+            "",
+            anchor_rot_xyzw=[0.0, 0.0, 0.0, 1.0],
+            root_ang_vel_local=[0.0, 0.0, 0.0],
+            dof_pos=[0.0] * NUM_DOFS,
+            dof_vel=[0.0] * NUM_DOFS,
+        )
+    )
+    return actions[0][JOINT]
+
+
+def _run(alpha: str, tmp_path: Path, ticks: int = 60) -> tuple[list[float], _JitterSession]:
+    session = _JitterSession()
+    policy = ProtoMotionsPolicy(session=session, yaml_path=_sidecar(tmp_path, alpha), motion=_flat_motion())
+    return [_tick(policy) for _ in range(ticks)], session
+
+
+def _ema(raw: list[float], alpha: float) -> list[float]:
+    """The closed-form recursion, seeded from the first raw value."""
+    out = [raw[0]]
+    for value in raw[1:]:
+        out.append(float(np.float32(alpha * np.float32(value) + (1.0 - alpha) * np.float32(out[-1]))))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The declared factor reaches the targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("alpha", [1.0, 0.5, 0.2, 0.05])
+def test_declared_alpha_smooths_the_emitted_targets(tmp_path: Path, alpha: float) -> None:
+    """Every declared factor produces the EMA of what the network emitted.
+
+    ``1.0`` is included as the passthrough control: the recursion collapses to
+    the raw trace there, so one assertion covers both the honoured factors and
+    the default that must not change.
+    """
+    emitted, session = _run(str(alpha), tmp_path / str(alpha))
+    assert emitted == pytest.approx(_ema(session.raw, alpha), abs=1e-6)
+
+
+def test_a_smaller_alpha_admits_less_per_tick_jitter(tmp_path: Path) -> None:
+    """The factor's purpose, measured: less weight on the current output, less jitter.
+
+    Pre-fix all four traces were byte-identical, so the ordering below was
+    ``0.24 < 0.24 < 0.24 < 0.24`` and could not hold.
+    """
+    jitter = {}
+    for alpha in (1.0, 0.5, 0.2, 0.05):
+        emitted, _ = _run(str(alpha), tmp_path / f"j{alpha}")
+        jitter[alpha] = float(np.abs(np.diff(emitted)).mean())
+    assert jitter[1.0] > jitter[0.5] > jitter[0.2] > jitter[0.05]
+
+
+def test_the_first_tick_seeds_from_the_network_not_from_zero(tmp_path: Path) -> None:
+    """A zero-seeded filter would command a pose between the origin and the target.
+
+    On a humanoid holding a stance that first command is a lurch toward the zero
+    pose, and the smaller the alpha the further it sits from the motion. Control:
+    green before the fix too, since there was no filter to seed.
+    """
+    emitted, session = _run("0.05", tmp_path)
+    assert emitted[0] == pytest.approx(session.raw[0], abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Filter state is episode-scoped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("boundary", ["reset", "load_motion"])
+def test_the_filter_state_does_not_cross_an_episode_boundary(tmp_path: Path, boundary: str) -> None:
+    """Two episodes of one clip emit the same trace, however the boundary is spelled.
+
+    Carrying the previous tick's smoothed target across would blend the last pose
+    of one episode into the first tick of the next, which is the failure
+    :meth:`ProtoMotionsPolicy.reset` already documents for the playhead.
+    """
+    session = _JitterSession()
+    policy = ProtoMotionsPolicy(session=session, yaml_path=_sidecar(tmp_path, "0.2"), motion=_flat_motion())
+    first = [_tick(policy) for _ in range(20)]
+    session.tick = 0  # the clip replays, so the network sees the same frames again
+    if boundary == "reset":
+        policy.reset(seed=0)
+    else:
+        policy.load_motion(_flat_motion())
+    second = [_tick(policy) for _ in range(20)]
+    assert second == pytest.approx(first, abs=1e-6)
+
+
+def test_the_history_buffer_still_carries_the_raw_network_output(tmp_path: Path) -> None:
+    """Smoothing the emitted target must not change what the network reads back.
+
+    ``historical_processed_actions`` is defined over the graph's own ``actions``
+    output, so the buffer keeps the raw value while the PD loop gets the smoothed
+    one. Control: this held before the fix and must still hold.
+    """
+    emitted, session = _run("0.05", tmp_path, ticks=3)
+    fed_back = float(session.history_inputs[1].reshape(-1)[0])
+    assert fed_back == pytest.approx(session.raw[0], abs=1e-6)
+    assert emitted[1] != pytest.approx(session.raw[1], abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Domain - one weight, two spellings, one verdict
+# ---------------------------------------------------------------------------
+
+#: Values that cannot be the weight of the current output in the EMA blend.
+UNUSABLE = [
+    0,
+    0.0,
+    -0.5,
+    -3.0,
+    1.5,
+    2,
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    True,
+    "0.5",
+    None,
+    [0.5],
+    10**400,
+]
+
+#: Values that are, including both ends of the closed upper bound.
+USABLE = [1.0, 1, 0.5, 0.05, 1e-9, np.float32(0.25)]
+
+
+@pytest.mark.parametrize("value", UNUSABLE)
+def test_an_unusable_smoothing_factor_is_refused_by_name(value: object) -> None:
+    with pytest.raises(ValueError, match="action_ema_alpha"):
+        ProtoMotionsConfig(action_ema_alpha=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", USABLE)
+def test_a_usable_smoothing_factor_is_stored_as_a_plain_float(value: object) -> None:
+    """Accepted, and normalised - the filter multiplies with it every tick, so a
+    NumPy scalar would otherwise set the output dtype from the weight."""
+    config = ProtoMotionsConfig(action_ema_alpha=value)  # type: ignore[arg-type]
+    assert type(config.action_ema_alpha) is float
+    assert config.action_ema_alpha == pytest.approx(float(value))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("declared", ["0.0", "-0.5", "1.5", ".nan", ".inf", "true"])
+def test_a_sidecar_reports_the_same_verdict_as_a_config_built_by_hand(tmp_path: Path, declared: str) -> None:
+    """The yaml route is the only way a caller sets this field, so it is the route
+    that has to refuse. The loader hands the value through raw for the reason the
+    body indices are handed through raw: a ``float()`` there would launder a
+    ``true`` into an unsmoothed ``1.0`` before the domain could see it."""
+    with pytest.raises(ValueError, match="action_ema_alpha"):
+        ProtoMotionsPolicy(session=_JitterSession(), yaml_path=_sidecar(tmp_path, declared))


### PR DESCRIPTION
`ProtoMotionsConfig.action_ema_alpha` is parsed from the checkpoint's own `unified_pipeline.yaml` (`control.action_ema_alpha`), stored on the frozen config, logged as loaded — and read by nothing outside `config.py`. The targets handed to the PD loop were the raw network output whatever the sidecar declared.

![action_ema_alpha measured before and after](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/action_ema_alpha_before_after.png)

Left panel: four declared factors, one visible line. Measured through the policy on a tracker output carrying an alternating ±0.11 rad per-tick component, the emitted `left_hip_pitch_joint` trace was **byte-identical** for every factor.

| `action_ema_alpha` | before | after |
| --- | --- | --- |
| `1.0` (shipped default) | 0.21997 rad | 0.21997 rad — bit-exact, unchanged |
| `0.5` | 0.21997 rad | 0.07380 rad |
| `0.2` | 0.21997 rad | 0.02878 rad |
| `0.05` | 0.21997 rad | 0.01028 rad |

(mean per-tick change in the commanded target)

## The field had no reader, so it had no domain

Every value that cannot be the weight of the current output in `y[t] = a*x[t] + (1-a)*y[t-1]` was stored and carried into the control path — `0`, `-0.5`, `1.5`, `nan`, `inf`, `True`, `"0.5"` all accepted (bottom panel). `0` is the sharpest: it weights the current network output at zero, so the commanded pose freezes at the first tick's target for the whole clip — a tracker that reports every frame and moves through none of them. `nan` enters the filter state and never leaves it, so every joint of every later tick is `nan` however good the network output is.

## Change

`__post_init__` owns the domain, so a sidecar and a hand-built `ProtoMotionsConfig(...)` report the same value the same way; the loader now hands the value through raw for the reason the body indices already do — a `float()` there laundered a yaml `true` into an unsmoothed `1.0` before the domain could see it. The shared `positive_finite_number_error` covers the sign, finiteness, the non-real spellings and the `bool` that would act as a silent `1.0`; only the upper bound is this field's own.

Three things held deliberately fixed, each pinned as a control:

- `1.0` — the shipped checkpoint's value — returns the network output **unchanged and bit-exact**, not multiplied by one.
- The first tick of an episode seeds from the network's own output, not from zeros. A zero-seeded filter would command a pose between the origin and the first target; on a 29-DOF humanoid holding a stance that is a lurch toward the zero pose, and the smaller the alpha the further it sits from the motion.
- The historical-actions buffer keeps carrying the **raw** output — the graph's `historical_processed_actions` input is defined over it, so smoothing what the network reads back would change its input distribution.

Filter state is episode-scoped: cleared by `reset()` and `load_motion()` for the reason `reset()` already documents for the playhead, so the second episode of an `eval_policy` run does not start from wherever the first stopped.

## Tests

`tests/policies/protomotions/test_action_ema_smooths_the_joint_targets.py`, table-driven, 35 cells. Against the shipped production files: **27 fail, 8 pass**. The 8 green are exactly the controls — the `alpha=1.0` passthrough row, the seeding row, both episode-boundary rows, and the four usable values that were already plain floats. After: **35 pass**.

The emitted trace is asserted against the closed-form recursion over exactly what the stub network produced, so the pin is the filter's arithmetic and not a golden array.

## Size

| | added | deleted |
| --- | --- | --- |
| `strands_robots/` | 117 | 13 |
| `tests/` | 261 | 0 |
| `docs/` | 49 | 0 |

Of the +104 net production lines, **52 are statements** (26 per file, including the two multi-line refusal messages) and 52 are docstring, comment and blank.

## Gate

`ruff check` + `ruff format --check` clean across 1897 files. `tests/policies` + changelog fragments: **12 failed / 5667 passed** on `main` → **12 failed / 5702 passed** here, the +35 being exactly the new cells and the failing node-id sets identical (the 12 are pre-existing `molmoact2` optional-dependency-hint cells). Doc/export/architecture graders: 1624 passed.

**Correction to the mypy line this section carried.** It read "`mypy strands_robots tests tests_integ`: 20 errors in 6 files, unchanged from `main`", which presents a local reading as the gate's verdict. It is not one. That command is the third of `hatch run lint` (`pyproject.toml:785`), the script aborts on the first non-zero exit, and `hatch run lint` is what the required `call-test-lint / Test and Lint` check runs. That check is `SUCCESS` on every settled `main` commit in this branch's window — `cfe06a63c`, `8480aaf6`, `062a81f9`, `f548115f` — so on the gate's environment mypy exits 0 on `main`, and the abort-on-first-failure ordering is also what makes those four greens evidence that the two commands ahead of it were not skipped.

The 20 errors come from my local environment, whose installed extras differ from the gate's; I have not reproduced them there and am not asserting them as a property of `main`. The part of that line this change actually depends on is unchanged in either environment: none of the errors is in the two touched production files (`policies/protomotions/config.py`, `policies/protomotions/policy.py`).
