### PR TITLE
fix(tests/tools): a stand-in the prune never consults left the verdict to the host

### DIFF
--- a/changelog.d/3250-prune-verdict-stand-in-seam.md
+++ b/changelog.d/3250-prune-verdict-stand-in-seam.md
@@ -1,0 +1,24 @@
+### Tests: the prune's stand-in has to sit where the verdict is answered
+
+`SessionManager._load_sessions` decides whether a teleop session's process is
+gone through `_process_stop.session_is_running`, which resolves `psutil` from
+its own module's globals. One case controlled the prune by rebinding
+`lerobot_teleoperate.psutil`, which that path does not read: the stand-in was
+consulted zero times and the verdict fell through to the real machine. With the
+record naming a hard-coded pid 4242 the case passed on a host where that pid
+was free and failed on one where it was taken, having graded neither -- and
+removing the `except psutil.NoSuchProcess: return False` handler its docstring
+named leaves it green, so it pinned nothing.
+
+The race it claimed is already pinned by
+`test_a_process_reaped_mid_probe_is_still_pruned`, which names a live pid,
+carries the recorded identity that makes the second probe reachable at all, and
+doubles both seams the verdict reads (the shared `psutil` object and the procfs
+identity read). The superseded case and its stand-in are removed, and the seam
+is pinned in the module that owns it: a census that no test controls a process
+probe by rebinding the name `psutil`, the measurement that such a rebinding is
+not consulted by the prune, and the control that setting the attribute on the
+module object is. The rule is scoped to that one name because rebinding a whole
+module in another module's globals is the right tool where that module is the
+reader, and usually is: 20 of the 21 such rebindings in the tree are sound, 15 of
+them installing a fake clock.

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -26,8 +26,10 @@ from tests.tool_result_contract import tool_json
 
 # Bind the public names off the single module handle rather than a second
 # ``from ... import`` of the same module (CodeQL: import + import-from of one
-# module). ``tele_mod`` is still needed directly so monkeypatch can rebind
-# module globals (``subprocess``/``psutil``/``os``/``time``/``SESSION_DIR``).
+# module). ``tele_mod`` is still needed directly so monkeypatch can rebind module
+# globals (``subprocess``/``os``/``time``/``SESSION_DIR``) and reach ``psutil`` by
+# setting an attribute on the module object it names -- rebinding the name itself
+# would be invisible to the prune, whose verdict is answered in another module.
 SessionManager = tele_mod.SessionManager
 build_lerobot_command = tele_mod.build_lerobot_command
 lerobot_teleoperate = tele_mod.lerobot_teleoperate
@@ -1016,39 +1018,10 @@ def test_dagger_dispatch_starts_session(monkeypatch: pytest.MonkeyPatch) -> None
 # Degrade + error contracts: the dispatcher must return a structured
 # ``{"status": "error"}`` (never raise past dispatch) for missing arguments,
 # command-build failures, and unexpected internal faults, and the SessionManager
-# must survive an unreadable/unwritable store and a vanished process.
+# must survive an unreadable/unwritable store. What the prune makes of a process
+# that has gone away is graded where that verdict is answered, in
+# ``tests.tools.test_teleop_session_store_keeps_a_live_pid``.
 # ---------------------------------------------------------------------------
-class _RaisingProcessPsutil:
-    """psutil stand-in whose ``Process`` lookup raises ``NoSuchProcess``.
-
-    Models the race where ``pid_exists`` is briefly true but the process is
-    reaped before ``Process()`` inspects it - the prune loop must drop the
-    session rather than propagate the exception.
-    """
-
-    NoSuchProcess = Exception  # replaced below with the real class handles
-    AccessDenied = Exception
-
-    @staticmethod
-    def pid_exists(pid: int) -> bool:
-        return True
-
-    @staticmethod
-    def Process(pid: int):  # noqa: N802 - mirror psutil.Process
-        raise _RaisingProcessPsutil.NoSuchProcess(pid)
-
-
-def test_load_sessions_drops_process_that_vanished_mid_prune(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A session whose process disappears between ``pid_exists`` and
-    ``Process()`` is pruned, not surfaced, and does not raise."""
-    mgr = SessionManager()
-    mgr.sessions_file.write_text(json.dumps({"racy": {"pid": 4242}}))
-    _RaisingProcessPsutil.NoSuchProcess = tele_mod.psutil.NoSuchProcess
-    _RaisingProcessPsutil.AccessDenied = tele_mod.psutil.AccessDenied
-    monkeypatch.setattr(tele_mod, "psutil", _RaisingProcessPsutil)
-    assert mgr.list_sessions() == {}
-
-
 def test_save_sessions_swallows_oserror(tmp_path, caplog: pytest.LogCaptureFixture) -> None:
     """``_save_sessions`` logs and returns when the store path is unwritable
     (parent directory missing) instead of raising."""

--- a/tests/tools/test_teleop_session_store_keeps_a_live_pid.py
+++ b/tests/tools/test_teleop_session_store_keeps_a_live_pid.py
@@ -31,8 +31,10 @@ one prunes it.
 
 from __future__ import annotations
 
+import ast
 import json
 import os
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -58,6 +60,19 @@ def _live_pid() -> int:
     pid = os.getpid()
     assert tele_mod.psutil.pid_exists(pid), "premise: the test process must exist"
     return pid
+
+
+def _free_pid() -> int:
+    """A PID no process holds, so the host's own verdict for it is "finished".
+
+    Taken from the top of the kernel's range rather than a fixed low number: a
+    low one is exactly what a busy machine is likely to have handed out, which is
+    how a test's verdict comes to depend on the host it runs on.
+    """
+    for candidate in range(4194303, 4194303 - 256, -1):
+        if not tele_mod.psutil.pid_exists(candidate):
+            return candidate
+    raise AssertionError("premise: some PID near the top of the range must be free")
 
 
 #: Start offset a seeded record claims for its process. Any value does: what the
@@ -285,3 +300,110 @@ def test_a_pid_held_by_another_process_is_still_pruned(monkeypatch: pytest.Monke
 # checked from here, but only through ``list_sessions`` - a read - and that
 # store's prune reaches disk through ``add_session``/``remove_session``, so the
 # read alone could not see it drop the record. The write paths are graded there.
+
+
+# ---------------------------------------------------------------------------
+# The double has to sit where the verdict is read.
+# ---------------------------------------------------------------------------
+class TestTheVerdictIsControlledWhereItIsAnswered:
+    """A stand-in for the probes above only counts if the prune consults it.
+
+    ``session_is_running`` resolves ``psutil`` from :mod:`strands_robots.tools._process_stop`'s
+    own globals, so rebinding ``lerobot_teleoperate.psutil`` installs a stand-in
+    the prune never looks at. The verdict then falls through to the real host and
+    the record's fate is decided by whether this machine happens to hold the PID
+    the test named -- a pass where it is free, a failure where it is taken, and a
+    grade of nothing either way. ``NoSuchProcess`` had a case written that way,
+    which is why the one above it is worth keeping honest.
+
+    Rebinding a whole module in another module's globals is the right tool when
+    that module is the reader, and it usually is: of the 21 such rebindings in this
+    tree, 20 are sound, 15 of them installing a fake clock. So the census below
+    asks only about ``psutil``, whose answer a second module owns.
+    """
+
+    def test_no_test_reaches_the_prune_by_rebinding_psutil(self) -> None:
+        """No test controls a process probe by rebinding the name ``psutil``."""
+        root = Path(__file__).resolve().parents[2]
+        offenders = []
+        accepted = 0
+        for path in sorted((root / "tests").rglob("*.py")):
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if not (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "setattr"
+                    and len(node.args) >= 2
+                ):
+                    continue
+                target, name = node.args[0], node.args[1]
+                if isinstance(target, ast.Attribute) and target.attr == "psutil":
+                    accepted += 1
+                elif (
+                    isinstance(target, ast.Name)
+                    and isinstance(name, ast.Constant)
+                    and name.value == "psutil"
+                    # This module carries the one occurrence there is a reason for:
+                    # the case below installs such a stand-in in order to assert
+                    # that the prune does not consult it.
+                    and path.name != Path(__file__).name
+                ):
+                    offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+        assert accepted, "premise: some test must reach psutil for this rule to be about anything"
+        assert not offenders, (
+            "a stand-in installed as <module>.psutil is not consulted by the prune, whose "
+            "verdict is answered in strands_robots.tools._process_stop; set the attribute on "
+            "the psutil module object instead, and the identity read at "
+            f"_process_stop._started_since_boot, as _raise_on_probe does: {offenders}"
+        )
+
+    def test_a_rebinding_in_the_tool_module_is_not_consulted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Rebinding ``tele_mod.psutil`` leaves the prune reading the real host.
+
+        The stand-in would keep the record -- it reports the PID as existing, and a
+        record carrying no identity is answered on existence alone. The record is
+        pruned anyway, and the stand-in is never asked: both halves say the verdict
+        came from the host.
+        """
+        consulted: list[str] = []
+
+        class _WouldKeepIt:
+            NoSuchProcess = tele_mod.psutil.NoSuchProcess
+            AccessDenied = tele_mod.psutil.AccessDenied
+
+            @staticmethod
+            def pid_exists(pid: int) -> bool:
+                consulted.append("pid_exists")
+                return True
+
+            @staticmethod
+            def Process(pid: int):  # noqa: N802 - mirror psutil.Process
+                consulted.append("Process")
+                raise _WouldKeepIt.NoSuchProcess(pid)
+
+        mgr = SessionManager()
+        mgr.add_session("unidentified", {"pid": _free_pid(), "action": "teleoperate", "start_time": 0.0})
+        monkeypatch.setattr(tele_mod, "psutil", _WouldKeepIt)
+
+        assert mgr.list_sessions() == {}, "the stand-in would have kept this record"
+        assert consulted == [], f"the prune must not be reachable this way, but consulted {consulted}"
+
+    def test_the_module_object_is_the_seam_the_prune_reads(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Setting the attribute on the shared psutil object does reach the prune.
+
+        The control for the census above: the rule is about how a double is
+        installed, not about leaving the probes alone.
+        """
+        asked: list[int] = []
+
+        def pid_exists(pid: int) -> bool:
+            asked.append(int(pid))
+            return False
+
+        pid = _live_pid()
+        mgr = SessionManager()
+        mgr.add_session("live", _identified(pid))
+        monkeypatch.setattr(tele_mod.psutil, "pid_exists", pid_exists)
+
+        assert mgr.list_sessions() == {}
+        assert pid in asked, f"the prune must read the module object, but asked {asked}"


### PR DESCRIPTION
`main` went red at `7f8aae61d` with `Run lint: success` / `Run tests: failure` on
`tests/tools/test_lerobot_teleoperate.py::test_load_sessions_drops_process_that_vanished_mid_prune`:

```
AssertionError: assert {'racy': {'pid': 4242}} == {}
```

The case did not regress. It had never graded anything, and its verdict was
decided by the machine it ran on.

## The seam

`SessionManager._load_sessions` asks whether a session's process is gone through
`_process_stop.session_is_running`, which resolves `psutil` from **its own**
module's globals. The case installed its stand-in as `lerobot_teleoperate.psutil`
-- a name on the prune path nobody reads.

```mermaid
flowchart LR
    subgraph tool["strands_robots.tools.lerobot_teleoperate"]
        LOAD["SessionManager._load_sessions"]
        TP["its name<br/>psutil"]
    end
    subgraph owner["strands_robots.tools._process_stop"]
        V["session_is_running"]
        OP["its name<br/>psutil"]
    end
    HOST[("the host<br/>pid_exists, /proc/&lt;pid&gt;/stat")]
    LOAD --> V --> OP --> HOST
    STUB["stand-in installed as<br/>lerobot_teleoperate.psutil"] -.-> TP
    TP -.-> NEVER["never consulted"]
```

Instrumenting the stand-in and running the prune: **0 consultations**. The
verdict fell through to the real `psutil.pid_exists(4242)`, so the outcome was
whatever the host made of a hard-coded pid:

| host | `psutil.pid_exists(4242)` | prune | result |
| --- | --- | --- | --- |
| pid free | `False` | drops the record | **1 passed** |
| pid taken | `True` | keeps it | **1 failed**, byte-identical to CI |

`4242` is squarely inside the range a busy machine hands out (`pid_max` is
4194304), so this is a latent flake on every branch, not a one-off.

## It graded nothing

The case's docstring names the handler it claims to pin. Removing it:

| `except psutil.NoSuchProcess: return False` | this case | `test_a_process_reaped_mid_probe_is_still_pruned` |
| --- | --- | --- |
| present (control) | passed | passed |
| **`NoSuchProcess` reads as running** | **passed** | **failed** |

Two independent reasons it could not see the race: the stand-in is not on the
path, and the record `{"pid": 4242}` carries no `pid_started_since_boot`, so
`session_is_running` answers on existence alone and never reaches the second
probe at all.

The sibling gets all of it right -- a live pid asserted as a premise, a record
carrying the identity, and doubles on **both** seams the verdict reads (the
shared `psutil` object and `_started_since_boot`, whose procfs read bypasses a
`psutil` double entirely; its own comment says so).

## Change

Remove the superseded case and its `_RaisingProcessPsutil` stand-in, and pin the
seam in the module that owns this property:

- **census** -- no test controls a process probe by rebinding the name `psutil`;
  the failure names the file, the line, and both seams to use instead.
- **measurement** -- a stand-in that *would keep* the record is not consulted,
  and the record is pruned anyway. Both halves say the verdict came from the host.
- **control** -- setting the attribute on the shared `psutil` object *is* read by
  the prune, so the rule is about how a double is installed, not about leaving
  the probes alone.

Scoped to that one name deliberately: rebinding a whole module in another
module's globals is the right tool where that module is the reader, and usually
is: of the 21 such rebindings in the tree, **20 are sound** -- 15 of them
installing a fake clock -- and the `psutil` one was the exception. The stale header comment listing `psutil` among the globals this file
rebinds -- which is what licensed the wrong pattern -- is corrected too.

## Verification

Pre/post on the new cells: **1 failed, 2 passed** with the offender present
(naming `tests/tools/test_lerobot_teleoperate.py:1048`) -> **12 passed** without
it. The 2 that pass either way are the controls.

| mutation | fires | cell |
| --- | --- | --- |
| control | 0 | - |
| the removed case restored | 1 | census |
| self-exemption dropped | 1 | census |
| scan root with no `psutil` doubles | 1 | census non-vacuity floor |
| verdict snapshots `pid_exists` at import | 1 | module-object seam |
| prune reads `psutil` from the tool module | 1 | rebinding-not-consulted |

5 mutations, all detected, each firing exactly one distinct cell, `collected`
stable at 3.

`ruff` 0.15.20 clean over 1899 files; `mypy` 1.20.2 `Success: no issues found in
1896 source files`; `tests/tools/` **3848 passed, 11 skipped** (collected 3857 ->
3859: one case removed, three added); `scripts/check_whole_tree_graders.py`
**4410 passed** with 7 pre-existing failures whose node-id set is identical on a
pristine `main` worktree (a ROS install supplying the `rclpy` 5 cells assert is
absent, and `websockets` 16.0 against the declared `>=17.0` floor).

Size: +153 / -34 over 3 files, no production code.
