### PR TITLE
fix(policies/wbc): an empty cmd_scale resolves from its owner table, not a bare 1.0

### DIFF
--- a/changelog.d/3251-wbc-cmd-scale-owner-table.md
+++ b/changelog.d/3251-wbc-cmd-scale-owner-table.md
@@ -1,0 +1,39 @@
+### Fixed: an empty `cmd_scale` resolves from its owner table, not from a bare `1.0`
+
+`WBCConfig.__post_init__` requires `cmd_scale` to carry exactly three entries
+`[vx, vy, omega]` *when provided*, and admits an EMPTY sequence as "not provided"
+(`if cmd_scale_length and cmd_scale_length != 3`). But this field's default is not
+empty - it is the full upstream triple `_DEFAULT_CMD_SCALE = (2.0, 2.0, 0.5)`. So
+omitting the argument and passing an empty sequence were two spellings of one
+request that resolved to different scales, because both command-block builders
+fell back to a bare unit scale for a vector too short to slice:
+`scale = cmd_scale[:n_vel] if cmd_scale.shape[0] >= n_vel else np.ones(n_vel)`.
+
+With `target_velocity=[0.5, -0.25, 2.0]`, omitting `cmd_scale` commanded
+`[1.0, -0.5, 1.0]` while `cmd_scale=[]` commanded `[0.5, -0.25, 2.0]` - `vx`/`vy`
+HALVED and `omega` DOUBLED - under a `success` result. A length-TWO `cmd_scale`
+was refused by name the whole time (`must have exactly 3 entries`), which is what
+made the empty one a hole rather than a policy: the one wrong length that was not
+reported is the one that silently substituted a scale no table states. Pre-fix,
+`cmd_scale=[]` and an explicitly stated `cmd_scale=[1, 1, 1]` produced an
+identical block, so "not stated" could not be told from "unit scale".
+
+That second fallback number is the failure the sibling scale field in the same
+module already fixed: `obs_scales` is completed from `_DEFAULT_OBS_SCALES` at
+construction, and `build_single_frame` resolves an omitted key from that same
+table rather than a bare `1.0`, because a second fallback "would silently
+multiply the 29 joint-velocity entries of the frame by 20 ... which the network
+reads as a malformed observation". The velocity scale is the other half of that
+idea, and the command block is the observation's FIRST `command_dim` entries, so
+a dense network carries it to all `num_actions` joint targets - measured over one
+`get_actions` tick, all 15 leg+waist targets differed between the two spellings
+(max 0.0134 rad), and now none do.
+
+`__post_init__` completes an empty `cmd_scale` from the upstream table, so
+`config.cmd_scale` is always the vector the block is built with, and both
+`_resolve_command` implementations resolve an unsupplied component from that
+table through one inherited `_velocity_scale` - replacing two byte-identical
+copies of the `np.ones` fallback, so the non-gait and gait blocks cannot be built
+with different scales. A `cmd_scale` a caller does state is still honored,
+including a deliberate unit scale, and every existing refusal (wrong non-empty
+length, scalar, non-finite component) is unchanged.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -106,6 +106,7 @@ than an error:
 | `action_scale` | finite `> 0` | The only path from the network to the joint targets. `0` (or `False`) makes `target_q == default_angles`, discarding the policy; a negative value inverts every offset. |
 | `kps`, `kds` | finite `>= 0`, per component | `kp = 0` with `kd > 0` is a pure-damping joint and stays valid; a *negative* gain makes `(target_q - q) * kp` drive the joint away from its target. |
 | `default_angles`, `cmd_scale`, `rpy_cmd` | finite, per component | Signed quantities (a stance angle, a yaw rate, a roll target), so only finiteness is constrained. |
+| `cmd_scale`, `obs_scales` (arity) | stated, or empty to mean the upstream default | An EMPTY `cmd_scale` means "not stated" and is completed with `(2.0, 2.0, 0.5)` at construction, so it cannot scale the velocity differently from omitting the argument. A wrong NON-empty length is still refused by name. |
 | `obs_scales` values, `height_cmd`, `freq_cmd` | finite | A non-finite scale poisons the observation frame the network is given. |
 
 A `nan`/`inf` anywhere reaches `data.ctrl` as a non-finite torque on all
@@ -179,6 +180,17 @@ WBC reproduces the upstream `GearWbcController` loop (NVlabs/GR00T-WholeBodyCont
   changes what an unnamed sibling is scaled by. `config.obs_scales` is therefore
   always the complete map the frame is built with, whichever spelling the config
   used.
+
+  `cmd_scale` - the velocity scale of the command block - is completed the same
+  way and for the same reason: an empty sequence means "not stated" and resolves
+  to the upstream `(2.0, 2.0, 0.5)`, so `config.cmd_scale` is always the vector
+  the block is built with. Both `_resolve_command` implementations resolve a
+  component the config does not supply from that same table rather than from a
+  bare `1.0` - a second fallback number would scale `omega` by `1.0` where the
+  table says `0.5`, commanding a yaw rate DOUBLE the one asked for (and `vx`/`vy`
+  halved) in the observation's first `command_dim` entries, which a dense network
+  carries to all `num_actions` joint targets. A `cmd_scale` a caller does state is
+  always honored, including a deliberate unit scale.
 - **Action** - the network emits a 15-dim joint-position *offset*; the policy
   forms absolute targets `target_q = default_angles + action_scale * raw` and
   returns them keyed by actuator name. For torque-actuated MuJoCo, convert with

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -139,7 +139,11 @@ class WBCConfig:
             never changes what an unnamed sibling is scaled by.
         cmd_scale: Scale applied to the ``[vx, vy, omega]`` velocity command
             before it enters the observation's command block (upstream
-            ``cmd_scale = [2.0, 2.0, 0.5]``).
+            ``cmd_scale = [2.0, 2.0, 0.5]``). An empty sequence means "not
+            stated" and is completed with that upstream triple at construction,
+            so this attribute is always the vector the command block is built
+            with - passing an empty sequence never scales the velocity
+            differently from omitting the argument.
         height_cmd: Default target base height written to command slot [3]
             (upstream ``height_cmd = 0.74``). Overridable per call via the
             ``height`` kwarg.
@@ -304,6 +308,20 @@ class WBCConfig:
         # dataclass, so the normalised map is installed with object.__setattr__.
         if any(name not in self.obs_scales for name in _DEFAULT_OBS_SCALES):
             object.__setattr__(self, "obs_scales", {**_DEFAULT_OBS_SCALES, **self.obs_scales})
+        # The velocity scale gets the same completion, for the same reason. The
+        # length rule above admits an EMPTY cmd_scale as "not stated", but this
+        # field's default IS the full upstream triple - so omitting the argument
+        # and passing an empty sequence are two spellings of one request that
+        # resolved to different scales, because both _resolve_command
+        # implementations fall back to a bare unit scale for a vector too short
+        # to slice. That is the second fallback number the obs_scales table above
+        # exists to prevent, and here it lands on the command block the network
+        # reads: omega scaled by 1.0 where this table says 0.5, so a yaw rate the
+        # caller asked for arrives DOUBLED, and vx/vy arrive HALVED. Filling it
+        # here keeps cmd_scale the vector the command block is actually built
+        # with, exactly as obs_scales is the map the frame is built with.
+        if not cmd_scale_length:
+            object.__setattr__(self, "cmd_scale", list(_DEFAULT_CMD_SCALE))
 
     @property
     def num_obs(self) -> int:

--- a/strands_robots/policies/wbc/gait.py
+++ b/strands_robots/policies/wbc/gait.py
@@ -446,10 +446,8 @@ class WBCGaitPolicy(WBCPolicy):
         c = self._config.command_dim
         command = np.zeros(c, dtype=np.float64)
 
-        cmd_scale = np.asarray(self._config.cmd_scale, dtype=np.float64).ravel()
         n_vel = min(3, c)
-        scale = cmd_scale[:n_vel] if cmd_scale.shape[0] >= n_vel else np.ones(n_vel)
-        command[:n_vel] = raw_velocity[:n_vel] * scale
+        command[:n_vel] = raw_velocity[:n_vel] * self._velocity_scale(n_vel)
 
         if c > 3:
             height = kwargs.get("height")

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -65,7 +65,7 @@ import numpy as np
 from strands_robots.policies.base import Policy
 from strands_robots.utils import finite_number_error, require_optional, sequence_length
 
-from .config import WBCConfig
+from .config import _DEFAULT_CMD_SCALE, WBCConfig
 from .control import compute_targets, pd_control, projected_gravity
 from .observation import ObservationHistory, build_single_frame
 
@@ -523,10 +523,8 @@ class WBCPolicy(Policy):
         command = np.zeros(c, dtype=np.float64)
 
         # Slots [0:3]: velocity * cmd_scale (clamp the slice to whatever fits).
-        cmd_scale = np.asarray(self._config.cmd_scale, dtype=np.float64).ravel()
         n_vel = min(3, c)
-        scale = cmd_scale[:n_vel] if cmd_scale.shape[0] >= n_vel else np.ones(n_vel)
-        command[:n_vel] = raw_velocity[:n_vel] * scale
+        command[:n_vel] = raw_velocity[:n_vel] * self._velocity_scale(n_vel)
 
         # Slot [3]: target base height (per-call ``height`` overrides the config).
         if c > 3:
@@ -546,6 +544,45 @@ class WBCPolicy(Policy):
             command[4 : 4 + n_rpy] = rpy[:n_rpy]
 
         return command, raw_velocity
+
+    def _velocity_scale(self, n_vel: int) -> np.ndarray:
+        """Resolve the first ``n_vel`` components of the ``cmd_scale`` factor.
+
+        A component the config does not supply resolves from
+        :data:`~strands_robots.policies.wbc.config._DEFAULT_CMD_SCALE` - this
+        module's single owner of the upstream velocity scale - and not from a
+        bare ``1.0``, for the reason
+        :func:`~strands_robots.policies.wbc.observation.build_single_frame`
+        resolves an omitted ``obs_scales`` key from ``_DEFAULT_OBS_SCALES``: a
+        second fallback number scales the command block by something no table
+        states. Here that lands hardest on ``omega``, whose documented scale is
+        ``0.5``, so a unit fallback commands a yaw rate DOUBLE the one asked for
+        while ``vx``/``vy`` arrive halved - a wrong command rather than an error,
+        in the observation's first ``command_dim`` entries, which a dense network
+        carries to all ``num_actions`` joint targets.
+
+        :meth:`WBCConfig.__post_init__` completes an empty ``cmd_scale`` from the
+        same table, so a config built through it states every component and this
+        resolution is the identity. It is what answers for a config object
+        assembled AROUND that constructor - the input class the sibling fallback
+        in ``build_single_frame`` exists for.
+
+        Shared with :meth:`WBCGaitPolicy._resolve_command`, whose command block
+        scales the same velocity triple, so the two blocks cannot be built with
+        different scales.
+
+        Args:
+            n_vel: How many velocity components the command block has room for.
+                At most three, the width of the scale table.
+
+        Returns:
+            An ``(n_vel,)`` float64 array of scale factors.
+        """
+        cmd_scale = np.asarray(self._config.cmd_scale, dtype=np.float64).ravel()
+        return np.array(
+            [cmd_scale[i] if i < cmd_scale.shape[0] else _DEFAULT_CMD_SCALE[i] for i in range(n_vel)],
+            dtype=np.float64,
+        )
 
     def _extract_state(self, observation_dict: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Pull (qj, dqj, base_ang_vel, base_quat) out of the observation dict.

--- a/tests/policies/wbc/test_velocity_scale_resolves_from_the_owner_table.py
+++ b/tests/policies/wbc/test_velocity_scale_resolves_from_the_owner_table.py
@@ -1,0 +1,168 @@
+"""The velocity ``cmd_scale`` resolves from its owner table, not from a bare 1.0.
+
+:meth:`WBCConfig.__post_init__` requires ``cmd_scale`` to carry exactly three
+entries ``[vx, vy, omega]`` *when provided*, and admits an EMPTY sequence as "not
+provided" (``if cmd_scale_length and cmd_scale_length != 3``). But this field's
+default is not empty - it is the full upstream triple
+``_DEFAULT_CMD_SCALE = (2.0, 2.0, 0.5)``. So omitting the argument and passing an
+empty sequence are two spellings of ONE request, and they resolved to different
+scales: both command-block builders fell back to a bare unit scale for a vector
+too short to slice::
+
+    scale = cmd_scale[:n_vel] if cmd_scale.shape[0] >= n_vel else np.ones(n_vel)
+
+With ``target_velocity=[0.5, -0.25, 2.0]``, omitting ``cmd_scale`` commanded
+``[1.0, -0.5, 1.0]`` while ``cmd_scale=[]`` commanded ``[0.5, -0.25, 2.0]`` - so
+``vx``/``vy`` arrived HALVED and ``omega`` arrived DOUBLED, under a ``success``
+result. A length-TWO ``cmd_scale`` was refused by name the whole time
+(``must have exactly 3 entries``), which is what makes the empty one a hole
+rather than a policy: the one wrong length that is not reported is the one that
+silently substitutes a scale no table states.
+
+That second fallback number is exactly the failure the sibling scale field in the
+same module already fixed and documented at length. ``obs_scales`` is completed
+from ``_DEFAULT_OBS_SCALES`` at construction, and
+:func:`~strands_robots.policies.wbc.observation.build_single_frame` resolves an
+omitted key from that same table rather than a bare ``1.0``, because "a second
+fallback number ... would silently multiply the 29 joint-velocity entries of the
+frame by 20 for exactly the configs that name a sibling key, which the network
+reads as a malformed observation". The velocity scale is the other half of the
+same idea, and the command block is the observation's FIRST ``command_dim``
+entries - through a dense network it reaches all ``num_actions`` joint targets.
+
+Pinned here: an empty ``cmd_scale`` means the documented triple on both command
+blocks (:class:`WBCPolicy` and :class:`WBCGaitPolicy`, whose ``freq_cmd`` slot
+does not move the velocity slots), the config states the vector the block is
+built with, and a component the config DOES state still wins - so the completion
+cannot creep into ignoring a scale a caller legitimately chose, including a
+deliberate unit scale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc import config as wbc_config
+from strands_robots.policies.wbc.policy import WBCPolicy
+
+from .test_command_override_domains import _config, _gait, _resolve
+
+# The upstream velocity scale, spelled here as the contract rather than imported
+# as the implementation: a config that states nothing must command THIS, and the
+# agreement cell below pins that the module's own table still says so.
+DOCUMENTED_CMD_SCALE: tuple[float, float, float] = (2.0, 2.0, 0.5)
+
+# A velocity whose three components scale by three DIFFERENT factors, so a
+# substituted scale cannot coincide with the documented one on any axis: omega's
+# documented 0.5 against a unit fallback is the widest gap and the wrong
+# direction (a doubled yaw rate).
+VELOCITY: list[float] = [0.5, -0.25, 2.0]
+DOCUMENTED_BLOCK: list[float] = [v * s for v, s in zip(VELOCITY, DOCUMENTED_CMD_SCALE, strict=True)]
+
+# Every spelling of an empty cmd_scale the config accepts as "not stated".
+EMPTY_SPELLINGS: list[Any] = [[], (), np.array([])]
+_EMPTY_IDS = ["list", "tuple", "ndarray"]
+
+
+def _main(**cfg: Any) -> Any:
+    """A non-gait policy whose velocity slots are ``command[0:3]``."""
+    return WBCPolicy(config=_config(**cfg), walk=False, allow_missing_models=True)
+
+
+def _gait_surface(**cfg: Any) -> Any:
+    """A gait policy: its ``freq_cmd`` slot widens the block but not the velocity."""
+    return _gait(config=_config(command_dim=8, single_obs_dim=95, **cfg))
+
+
+# (label, factory) for the two independent command-block builders.
+SURFACES: list[tuple[str, Any]] = [("WBCPolicy", _main), ("WBCGaitPolicy", _gait_surface)]
+_SURFACE_IDS = [label for label, _ in SURFACES]
+
+
+def _block(policy: Any) -> list[float]:
+    """The velocity slots of one command block, built from :data:`VELOCITY`."""
+    command, _raw = _resolve(policy, target_velocity=VELOCITY)
+    return [float(x) for x in np.asarray(command)[:3]]
+
+
+class TestAnEmptyCmdScaleMeansTheDocumentedScale:
+    """ "Not stated" resolves from the owner table on both command blocks."""
+
+    @pytest.mark.parametrize("label,factory", SURFACES, ids=_SURFACE_IDS)
+    @pytest.mark.parametrize("empty", EMPTY_SPELLINGS, ids=_EMPTY_IDS)
+    def test_an_empty_cmd_scale_commands_the_documented_scale(self, label: str, factory: Any, empty: Any) -> None:
+        assert _block(factory(cmd_scale=empty)) == pytest.approx(DOCUMENTED_BLOCK)
+
+    @pytest.mark.parametrize("label,factory", SURFACES, ids=_SURFACE_IDS)
+    @pytest.mark.parametrize("empty", EMPTY_SPELLINGS, ids=_EMPTY_IDS)
+    def test_an_empty_cmd_scale_agrees_with_omitting_it(self, label: str, factory: Any, empty: Any) -> None:
+        """The two spellings of one request give one command block."""
+        assert _block(factory(cmd_scale=empty)) == pytest.approx(_block(factory()))
+
+
+class TestTheConfigStatesTheVectorTheBlockIsBuiltWith:
+    """``cmd_scale`` reads back as the scale actually applied, like ``obs_scales``."""
+
+    @pytest.mark.parametrize("empty", EMPTY_SPELLINGS, ids=_EMPTY_IDS)
+    def test_an_empty_cmd_scale_is_completed_at_construction(self, empty: Any) -> None:
+        assert list(_config(cmd_scale=empty).cmd_scale) == pytest.approx(list(DOCUMENTED_CMD_SCALE))
+
+    def test_the_module_table_is_the_documented_scale(self) -> None:
+        """The contract above is the module's own single owner of the scale."""
+        assert tuple(wbc_config._DEFAULT_CMD_SCALE) == DOCUMENTED_CMD_SCALE
+
+
+class TestAStatedScaleStillWins:
+    """The completion fills only what the config leaves out."""
+
+    @pytest.mark.parametrize("label,factory", SURFACES, ids=_SURFACE_IDS)
+    def test_a_stated_unit_scale_is_honored(self, label: str, factory: Any) -> None:
+        """A caller who ASKS for unit scale gets it - it is not read as "not stated"."""
+        assert _block(factory(cmd_scale=[1.0, 1.0, 1.0])) == pytest.approx(VELOCITY)
+
+    @pytest.mark.parametrize("label,factory", SURFACES, ids=_SURFACE_IDS)
+    def test_a_stated_scale_is_honored(self, label: str, factory: Any) -> None:
+        assert _block(factory(cmd_scale=[3.0, 4.0, 5.0])) == pytest.approx([1.5, -1.0, 10.0])
+
+    @pytest.mark.parametrize("label,factory", SURFACES, ids=_SURFACE_IDS)
+    def test_a_short_vector_reaching_the_block_fills_only_the_missing_components(
+        self, label: str, factory: Any
+    ) -> None:
+        """A config assembled AROUND the constructor is the fallback's input class.
+
+        ``__post_init__`` completes an empty vector, so a partial one reaches the
+        builder only on a config mutated past the constructor - which is the case
+        ``build_single_frame``'s ``obs_scales`` fallback answers for too. The
+        stated component wins; the rest resolve from the table, not from 1.0.
+        """
+        policy = factory()
+        object.__setattr__(policy._config, "cmd_scale", [3.0])
+        assert _block(policy) == pytest.approx([0.5 * 3.0, -0.25 * 2.0, 2.0 * 0.5])
+
+
+class TestTheSurroundingContractIsUnchanged:
+    """The refusals and the unscaled velocity the completion must not disturb."""
+
+    @pytest.mark.parametrize("bad", [[2.0, 2.0], [2.0], [2.0, 2.0, 0.5, 1.0]], ids=["two", "one", "four"])
+    def test_a_wrong_nonempty_length_is_still_refused_by_name(self, bad: list[float]) -> None:
+        with pytest.raises(ValueError, match=r"WBCConfig\.cmd_scale must have exactly 3 entries"):
+            _config(cmd_scale=bad)
+
+    def test_a_scalar_cmd_scale_is_still_refused_by_name(self) -> None:
+        with pytest.raises(ValueError, match=r"WBCConfig\.cmd_scale must be a sequence of 3 numbers"):
+            _config(cmd_scale=2.0)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), True, "2.0"], ids=repr)
+    def test_a_non_finite_component_is_still_refused_by_name(self, bad: Any) -> None:
+        with pytest.raises(ValueError, match=r"cmd_scale\[0\]"):
+            _config(cmd_scale=[bad, 2.0, 0.5])
+
+    @pytest.mark.parametrize("label,factory", SURFACES, ids=_SURFACE_IDS)
+    @pytest.mark.parametrize("spelling", [*EMPTY_SPELLINGS, [2.0, 2.0, 0.5]], ids=[*_EMPTY_IDS, "stated"])
+    def test_the_raw_velocity_is_never_scaled(self, label: str, factory: Any, spelling: Any) -> None:
+        """Walk-vs-main selection reads the UNSCALED triple, whatever the scale."""
+        _command, raw = _resolve(factory(cmd_scale=spelling), target_velocity=VELOCITY)
+        assert [float(x) for x in np.asarray(raw)] == pytest.approx(VELOCITY)


### PR DESCRIPTION
`WBCConfig` requires `cmd_scale` to carry exactly three entries `[vx, vy, omega]` *when provided*, and admits an EMPTY sequence as "not provided":

```python
if cmd_scale_length and cmd_scale_length != 3:   # empty is falsy -> skipped
```

But this field's default is not empty — it is the full upstream triple `_DEFAULT_CMD_SCALE = (2.0, 2.0, 0.5)`. So omitting the argument and passing an empty sequence are two spellings of ONE request, and they resolved to different scales, because both command-block builders fall back to a bare unit scale for a vector too short to slice:

```python
scale = cmd_scale[:n_vel] if cmd_scale.shape[0] >= n_vel else np.ones(n_vel)
```

![commanded velocity block and its propagation to the joint targets](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/wbc-cmd-scale-3251.png)

Every cell measured, both trees, `target_velocity=[0.5, -0.25, 2.0]`.

| `cmd_scale` | before | after | documented |
|---|---|---|---|
| omitted | `[1.0, -0.5, 1.0]` | `[1.0, -0.5, 1.0]` | `[1.0, -0.5, 1.0]` |
| `[]` | **`[0.5, -0.25, 2.0]`** | `[1.0, -0.5, 1.0]` | `[1.0, -0.5, 1.0]` |
| `()` | **`[0.5, -0.25, 2.0]`** | `[1.0, -0.5, 1.0]` | `[1.0, -0.5, 1.0]` |
| `[1, 1, 1]` (stated) | `[0.5, -0.25, 2.0]` | `[0.5, -0.25, 2.0]` | honored as stated |
| `[2.0, 2.0]` | refused by name | refused by name | — |

`vx`/`vy` arrived HALVED and `omega` DOUBLED, under a `success` result. Two things sharpen it:

- A length-TWO `cmd_scale` was refused by name the whole time (`must have exactly 3 entries`). The one wrong length that was *not* reported is the one that silently substitutes a scale no table states.
- Pre-fix, `cmd_scale=[]` and an explicitly stated `cmd_scale=[1, 1, 1]` produced an identical block — "not stated" could not be told from "unit scale".

The command block is the observation's first `command_dim` entries, so a dense network carries it to every joint target. Over one `get_actions` tick: **15/15 leg+waist targets differed** between the two spellings of one request (max 0.0134 rad); after, **0/15**.

## Why this shape

The sibling scale field in the same module already fixed exactly this and wrote down why — `obs_scales` is completed from `_DEFAULT_OBS_SCALES` at construction, and `build_single_frame` resolves an omitted key from that same table rather than a bare `1.0`, because a second fallback number "would silently multiply the 29 joint-velocity entries of the frame by 20 ... which the network reads as a malformed observation". The velocity scale is the other half of that idea.

So `__post_init__` completes an empty `cmd_scale` from the upstream table (`config.cmd_scale` is always the vector the block is built with), and both `_resolve_command` implementations resolve an unsupplied component from that table through one inherited `_velocity_scale` — replacing two byte-identical copies of the `np.ones` fallback, so the non-gait and gait blocks cannot be built with different scales.

Deliberately unchanged, each pinned as a control: a stated `cmd_scale` still wins including a deliberate unit scale; a wrong NON-empty length, a scalar and a non-finite component are still refused by name; the unscaled `[vx, vy, omega]` that drives walk-vs-main selection is untouched.

## Tests

`tests/policies/wbc/test_velocity_scale_resolves_from_the_owner_table.py`, table-driven over both command-block builders (`WBCPolicy` and `WBCGaitPolicy`, whose `freq_cmd` slot widens the block but not the velocity slots).

| corner | tests | production | result |
|---|---|---|---|
| A | old | old | 686 pass |
| B | **new** | **old** | **17 fail** / 707 pass |
| C | new | new | 38 pass (file alone) |
| D | old | new | 686 pass |

`686 + 38 = 724 = 17F + 707P`, and `707 = 686 + 21` — so 21 of the 38 new cells are green on BOTH trees (the controls above) and 17 are the defect. Full `tests/policies/wbc` on this branch: **724 passed**.

## Size

| file | +/- |
|---|---|
| `strands_robots/policies/wbc/config.py` | +19 −1 |
| `strands_robots/policies/wbc/policy.py` | +41 −4 |
| `strands_robots/policies/wbc/gait.py` | +1 −3 |
| `docs/policies/wbc.md` | +12 −0 |
| `tests/.../test_velocity_scale_resolves_from_the_owner_table.py` | +168 −0 |
| `changelog.d/3251-*.md` | +39 −0 |

Of the 61 added production lines, **11 are executable** (2 config + 8 policy + 1 gait); the rest is 32 docstring, 12 comment, 6 blank. Net executable production change is +11 −8 = **+3 lines**, and the duplicated fallback drops from two copies to one.
