### PR TITLE
fix(dataset): the episode count meta/info.json declares gets one owner

### DIFF
--- a/changelog.d/3252-declared-episode-count-one-owner.md
+++ b/changelog.d/3252-declared-episode-count-one-owner.md
@@ -1,0 +1,31 @@
+### Fixed: the episode count `meta/info.json` declares gets one owner
+
+Five surfaces read that header and each graded it its own way, so one file got
+five verdicts. `int(2.5)` truncates to `2` -- exactly the count a two-episode
+parquet holds -- so a header no writer could have produced read as AGREEMENT
+between the two independent metadata sources, and `verify_dataset_episodes`
+returned `status="success"`, `sources_agree=True` on the inconsistent dataset
+that cross-check exists to catch. `int(1e400)` raises `OverflowError`: `1e400`
+is a well-formed JSON number that `json.load` parses to `inf`, so a perfectly
+readable file raised out of three readers whose documented answer for an
+unusable header is "unknown" -- and straight through a facade whose docstring
+says a corrupt dataset is "reported as this same error dict, never raised".
+`true` counted as one episode (`bool` is an `int` subclass) while the
+`total_tasks` reader in the same module already excluded it, and `"2"` was two
+episodes to three readers and unusable to the fourth.
+
+`utils.declared_count` is that one owner: a declaration outside its domain
+declares no count, never a nearby number. Because "no count declared" is also
+what an ABSENT header means -- and an absent header is agreement, the parquet
+being the sole truth then -- the readers that certify a dataset now report the
+difference rather than collapse it: `read_dataset_episode_indices` carries it in
+a new `info_problems` list, which `verify_dataset_episodes` surfaces as a
+MISMATCH envelope, and `verify_dataset` appends a problem for `total_episodes`
+and `total_frames` alike instead of silently skipping the comparison. A wrong
+COUNT is still reported as drift with its existing message, and an absent header
+still leaves the parquet as the sole truth.
+
+Measured on one real two-episode MuJoCo recording across eleven header
+spellings and all five readers: 25 of 55 verdicts were wrong before (four of
+them a certified dataset, five a raised `OverflowError`), 0 after, with the
+three healthy/unknown control rows unchanged.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -382,9 +382,20 @@ parquet disagrees with `info.json` (an internally inconsistent dataset, e.g. an
 interrupted finalize - `sources_agree` is then `False`), so a dataset that
 happens to match `expected` on one source but not the other still fails. The
 `{"json": {...}}` block carries `expected`, `actual`, `info_total_episodes`,
-`sources_agree`, `episode_indices`, and `total_frames` for programmatic CI
-gating. The pure-pyarrow `read_dataset_episode_indices(root)` exposes the same
-facts without instantiating a `LeRobotDataset`.
+`info_problems`, `sources_agree`, `episode_indices`, and `total_frames` for
+programmatic CI gating. The pure-pyarrow `read_dataset_episode_indices(root)`
+exposes the same facts without instantiating a `LeRobotDataset`.
+
+A header that is present but is not a count at all - `2.5`, `"2"`, `true`, or a
+JSON number outside double range such as `1e400` (which `json.load` parses to
+`inf`) - is a THIRD outcome, distinct from both a matching count and an absent
+header: `info_total_episodes` is `None`, the reason lands in `info_problems`, and
+`sources_agree` is `False`. Such a header is never coerced to a nearby number,
+because `int(2.5)` is `2` - exactly the count a two-episode parquet holds, so
+coercing it would certify the inconsistent dataset. Every reader of that header
+(this facade, `verify-dataset`, `read_dataset_episode_indices`, and the
+training-side validation split) shares one domain,
+`strands_robots.utils.declared_count`, so one file cannot get two verdicts.
 
 The same check runs from the shell against any LeRobot dataset on disk, with an
 exit code suitable for CI:
@@ -398,8 +409,8 @@ strands-robots verify-dataset /path/to/dataset --no-check-videos  # skip the per
 `verify-dataset` reuses the same pure-pyarrow `read_dataset_episode_indices`
 helper (no `lerobot` import) and flags five failure modes: the mega-episode
 (fewer distinct episodes than `--expected`), `meta/info.json` `total_episodes` /
-`total_frames` drifting from the parquet ground truth (caught even without
-`--expected`), any episode below `--min-frames` (default 1), - unless
+`total_frames` drifting from the parquet ground truth - or declaring something
+that is not a count at all - (caught even without `--expected`), any episode below `--min-frames` (default 1), - unless
 `--no-check-videos` is passed - any per-episode video file that is missing or
 empty on disk, and - unless `--no-check-stats` is passed - a dead control
 column. The video check is the video-modality sibling of the

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -36,6 +36,7 @@ import numpy as np
 from strands_robots.utils import (
     boolean_flag_error,
     camera_schema_key,
+    declared_count,
     lerobot_version,
     name_list_error,
     non_negative_whole_number_error,
@@ -1990,10 +1991,15 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
           - ``frames_per_episode``: per-episode frame counts aligned to
             ``episode_indices`` (empty list if the ``length`` column is absent).
           - ``info_total_episodes``: the ``total_episodes`` recorded in
-            ``meta/info.json`` (``None`` if that file is absent or unreadable).
-            Returned alongside the parquet truth so callers can cross-check the
-            two metadata sources for agreement - a healthy dataset has
+            ``meta/info.json`` (``None`` if that file is absent or unreadable, or
+            if it declares no usable count - see ``info_problems``). Returned
+            alongside the parquet truth so callers can cross-check the two
+            metadata sources for agreement - a healthy dataset has
             ``info_total_episodes == total_episodes``.
+          - ``info_problems``: one message per ``meta/info.json`` declaration
+            that is present but is not a count (empty list for a healthy
+            dataset). A cross-check must fail on these rather than read the
+            ``None`` count as an absent header, which is agreement.
           - ``unreadable_files``: ``"<path relative to root>: <error>"`` for
             every ``meta/episodes`` parquet that could not be read (empty list
             for a healthy dataset). A partially-corrupt dataset - one truncated
@@ -2073,14 +2079,30 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
     # is internally inconsistent (e.g. an interrupted finalize), which
     # verify_dataset_episodes surfaces. Absent/corrupt info.json -> None (the
     # parquet remains the ground truth and is still reported).
+    # The declared count is graded by its one owner (``declared_count``) rather
+    # than coerced here. A header that declares something which is NOT a count is
+    # a third outcome, distinct from both a matching count and an absent header,
+    # so it is reported in ``info_problems`` instead of collapsing into the
+    # absent case - which a cross-check reads as agreement, the parquet being the
+    # sole truth then. Coercing instead was silently destructive both ways:
+    # ``int(2.5)`` is ``2``, the very count a two-episode parquet holds, and
+    # ``int(1e400)`` raises ``OverflowError`` out of this documented "unknown".
     info_total_episodes: int | None = None
+    info_problems: list[str] = []
     info_path = root_path / "meta" / "info.json"
     if info_path.is_file():
         try:
             with info_path.open() as f:
-                info_total_episodes = int(json.load(f)["total_episodes"])
+                raw_total = json.load(f)["total_episodes"]
         except (OSError, ValueError, KeyError, TypeError):
-            info_total_episodes = None
+            # Absent key, or a file no reader can parse: the documented unknown,
+            # indistinguishable from an absent header, and reported by
+            # verify_dataset's own meta/info.json check.
+            pass
+        else:
+            info_total_episodes = declared_count(raw_total)
+            if info_total_episodes is None:
+                info_problems.append(f"meta/info.json total_episodes={raw_total!r} is not an episode count")
 
     return {
         "episode_indices": episode_indices,
@@ -2088,5 +2110,6 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
         "total_frames": sum(frames_per_episode) if has_lengths else 0,
         "frames_per_episode": frames_per_episode if has_lengths else [],
         "info_total_episodes": info_total_episodes,
+        "info_problems": info_problems,
         "unreadable_files": unreadable_files,
     }

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -3675,7 +3675,8 @@ class SimEngine(ABC):
             Standard status dict. ``status`` is ``"success"`` when the parquet
             holds exactly ``expected`` episodes, else ``"error"``. The
             ``{"json": {...}}`` block carries ``expected``, ``actual``,
-            ``info_total_episodes``, ``sources_agree``, ``episode_indices``,
+            ``info_total_episodes``, ``info_problems``, ``sources_agree``,
+            ``episode_indices``,
             ``total_frames``, ``total_frames_per_ep``, ``unreadable_files`` and
             ``root`` so a caller (or CI) can fail loudly programmatically.
             ``status`` is ``"error"`` when the parquet count differs from
@@ -3726,6 +3727,7 @@ class SimEngine(ABC):
                             "expected": expected,
                             "actual": 0,
                             "info_total_episodes": None,
+                            "info_problems": [],
                             "sources_agree": False,
                             "episode_indices": [],
                             "total_frames": 0,
@@ -3741,6 +3743,7 @@ class SimEngine(ABC):
 
         actual = info["total_episodes"]
         info_total = info.get("info_total_episodes")
+        info_problems = info.get("info_problems") or []
         unreadable = info.get("unreadable_files") or []
 
         # Two independent truths must agree: the parquet episode count AND the
@@ -3749,7 +3752,11 @@ class SimEngine(ABC):
         # finalize), so a parquet-only check is not sufficient. sources_agree is
         # True when info.json is absent (parquet is then the sole truth) or when
         # the header matches the parquet.
-        sources_agree = info_total is None or info_total == actual
+        # A header that declares something which is not an episode count agrees
+        # with nothing: it is neither a matching count nor an absent header, and
+        # reading it as the latter (the parquet is then the sole truth) would
+        # certify the inconsistent dataset this cross-check exists to catch.
+        sources_agree = not info_problems and (info_total is None or info_total == actual)
         # A dataset with unreadable episode parquet files can never be certified:
         # the readable files are a LOWER BOUND on the episode count, so a count
         # that happens to equal ``expected`` proves nothing about the whole
@@ -3763,6 +3770,12 @@ class SimEngine(ABC):
                 f"parquet file(s) could not be read, so the {actual} episode(s) found "
                 f"are a lower bound (expected {expected}): {'; '.join(unreadable)}. "
                 f"Root: {root}"
+            )
+        elif info_problems:
+            text = (
+                f"verify_dataset_episodes: MISMATCH - {'; '.join(info_problems)}; the parquet "
+                f"holds {actual} episode(s) (expected {expected}), so the two metadata sources "
+                f"cannot be shown to agree. Root: {root}"
             )
         elif not sources_agree:
             verdict = "MISMATCH"
@@ -3788,6 +3801,7 @@ class SimEngine(ABC):
                         "expected": expected,
                         "actual": actual,
                         "info_total_episodes": info_total,
+                        "info_problems": list(info_problems),
                         "sources_agree": sources_agree,
                         "episode_indices": info["episode_indices"],
                         "total_frames": info["total_frames"],

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -40,6 +40,7 @@ from strands_robots.tools._process_stop import (
     unstopped_result,
 )
 from strands_robots.utils import (
+    declared_count,
     positive_count_error,
     stale_output_dir_is_clearable,
     step_cadence_error,
@@ -504,9 +505,10 @@ def _read_total_episodes(dataset_root: str) -> int:
     with open(info_path) as f:
         info = json.load(f)
     total = info.get("total_episodes")
-    if not isinstance(total, int) or total <= 0:
+    declared = declared_count(total)
+    if declared is None or declared <= 0:
         raise ValueError(f"info.json has no usable 'total_episodes' (got {total!r})")
-    return total
+    return declared
 
 
 def _has_resumable_checkpoint(output_dir: str) -> Path | None:

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -61,6 +61,7 @@ from typing import TYPE_CHECKING, Any
 from strands_robots.training._inproc import call_callable, elastic_launch_callable, resume_argv
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
 from strands_robots.utils import (
+    declared_count,
     lerobot_version,
     stale_output_dir_is_clearable,
     validation_split_error,
@@ -551,11 +552,19 @@ class LerobotTrainer(Trainer):
         return f"policy:{self._resolve_policy_type(spec)}"
 
     def _dataset_total_episodes(self, dataset_root: str) -> int | None:
+        """Episode count declared by a local dataset's ``meta/info.json``, or None.
+
+        The count is graded by :func:`~strands_robots.utils.declared_count`, the
+        one owner every reader of this header shares, so the validation split
+        cannot be computed from a denominator another surface refuses. ``None``
+        is the unknown case - an absent, unreadable or unusable header - and
+        every caller here already treats it as "no split can be derived".
+        """
         info = os.path.join(dataset_root, "meta", "info.json")
         try:
             with open(info, encoding="utf-8") as f:
-                return int(json.load(f).get("total_episodes"))
-        except (OSError, ValueError, TypeError):
+                return declared_count(json.load(f).get("total_episodes"))
+        except (OSError, ValueError, AttributeError):
             return None
 
     def _resume_config_path(self, output_dir: str) -> str | None:

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1214,6 +1214,56 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
     return None
 
 
+def declared_count(value: object) -> int | None:
+    """The count a dataset's ``meta/info.json`` declares, or ``None`` for none.
+
+    Read-side counterpart of :func:`non_negative_count_error`, and the same type
+    and floor rule: that domain grades a count a CALLER passed and reports why it
+    was refused, while this one grades a count a FILE declares, where the only
+    answers a reader can act on are the count itself and the absence of one.
+    Every reader of a LeRobot header count asks that question of the same file -
+    the parquet cross-check in
+    :func:`~strands_robots.dataset_recorder.read_dataset_episode_indices`, the
+    metadata-drift check in
+    :func:`~strands_robots.verify_dataset.verify_dataset`, the validation-split
+    denominator in ``strands_robots.training.lerobot``, and the episode count the
+    ``lerobot_train`` tool splits - so the answer lives here: one file, one
+    value, one verdict.
+
+    A declaration outside the domain is ``None`` (the header declares no count),
+    never a nearby number, because every alternative is silently destructive at
+    surfaces that certify datasets:
+
+    * ``int(2.5)`` truncates to ``2``, which is exactly the count a two-episode
+      parquet holds - so a header no writer could have produced reads as
+      agreement between the two independent metadata sources.
+    * ``int(1e400)`` raises ``OverflowError``. ``1e400`` is a well-formed JSON
+      number (RFC 8259 bounds no range) that ``json.load`` parses to ``inf``, so
+      a perfectly readable file raises out of readers whose documented answer for
+      an unusable header is "unknown", and past a tool envelope.
+    * ``bool`` is an ``int`` subclass, so a bare type test reads ``true`` as a
+      one-episode dataset; the neighbouring ``total_tasks`` reader in
+      ``strands_robots.tools.lerobot_train`` already excludes it for that reason.
+    * A ``str`` digit and an integral ``float`` are refused rather than coerced,
+      because coercing is what let the readers disagree: one accepted ``"2"`` as
+      two episodes while another refused it as unusable.
+
+    A reader that must report an unusable declaration rather than pass it over
+    compares against the raw value it read: ``None`` here with the key present
+    means the file declares something that is not a count.
+
+    Args:
+        value: The value the metadata file carried under the count's key, or
+            ``None`` when the key is absent.
+
+    Returns:
+        The declared count, or ``None`` when the file declares no usable one.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
 def step_cadence_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable cadence in training steps.
 

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -57,7 +57,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from strands_robots.utils import non_negative_count_error
+from strands_robots.utils import declared_count, non_negative_count_error
 
 logger = logging.getLogger(__name__)
 
@@ -211,17 +211,27 @@ def verify_dataset(
             declared = json.loads(info_json_path.read_text(encoding="utf-8"))
         except (OSError, ValueError) as e:
             problems.append(f"could not read meta/info.json: {e}")
-        decl_eps = declared.get("total_episodes")
-        decl_frames = declared.get("total_frames")
+        # Both headers are graded by their one owner rather than an inline type
+        # test, and a declaration that is not a count is REPORTED rather than
+        # passed over: a header no writer could have produced is exactly the
+        # metadata drift this check exists to find, and the inline test skipped
+        # it silently (``true`` even compared equal to a one-episode parquet).
+        raw_eps = declared.get("total_episodes")
+        raw_frames = declared.get("total_frames")
+        decl_eps = declared_count(raw_eps)
+        decl_frames = declared_count(raw_frames)
         report["info_total_episodes"] = decl_eps
         report["info_total_frames"] = decl_frames
-        if isinstance(decl_eps, int) and decl_eps != info["total_episodes"]:
+        for key, raw, decl in (("total_episodes", raw_eps, decl_eps), ("total_frames", raw_frames, decl_frames)):
+            if key in declared and decl is None:
+                problems.append(f"meta/info.json {key}={raw!r} is not a count - metadata is corrupt")
+        if decl_eps is not None and decl_eps != info["total_episodes"]:
             problems.append(
                 f"meta/info.json total_episodes={decl_eps} disagrees with parquet "
                 f"({info['total_episodes']} distinct episode(s)) - metadata/parquet drift"
             )
         # Frame totals only meaningful when parquet carries per-episode lengths.
-        if isinstance(decl_frames, int) and info["total_frames"] and decl_frames != info["total_frames"]:
+        if decl_frames is not None and info["total_frames"] and decl_frames != info["total_frames"]:
             problems.append(
                 f"meta/info.json total_frames={decl_frames} disagrees with parquet ({info['total_frames']} frame(s))"
             )

--- a/tests/simulation/test_run_policy_episode_contract.py
+++ b/tests/simulation/test_run_policy_episode_contract.py
@@ -43,6 +43,10 @@ def sim():
     s.cleanup()
 
 
+#: Header spellings a two-episode dataset could carry that are not counts.
+UNUSABLE_HEADERS = ["2.5", "1e400", "true", '"2"']
+
+
 def _record(sim: Simulation, root: str, *, n_episodes: int, n_steps: int = 4) -> dict:
     """Drive a full start -> run_policy -> stop recording cycle; return run json."""
     shutil.rmtree(root, ignore_errors=True)
@@ -245,6 +249,36 @@ class TestInfoParquetCrossCheck:
         assert vj["actual"] == 2
         assert vj["info_total_episodes"] == 99
         assert vj["sources_agree"] is False
+
+    @pytest.mark.parametrize("declaration", ["2.5", "1e400", "true", '"2"'])
+    def test_verify_errors_when_the_header_is_not_an_episode_count(self, sim, tmp_path, declaration):
+        """A header that is not a count is a MISMATCH envelope, never agreement.
+
+        The parquet holds exactly ``expected`` episodes, so the only way this can
+        pass is by believing the header. Each spelling failed differently before
+        the count had one owner: ``2.5`` truncated to ``2`` and CERTIFIED the
+        dataset, ``"2"`` and ``true`` were coerced to a count, and ``1e400`` (a
+        well-formed JSON number that ``json.load`` parses to ``inf``) raised
+        ``OverflowError`` straight through this facade - which documents that a
+        corrupt dataset is "reported as this same error dict, never raised".
+        """
+        root = tmp_path / f"decl-{UNUSABLE_HEADERS.index(declaration)}"
+        _record(sim, str(root), n_episodes=2, n_steps=3)
+
+        info_path = root / "meta" / "info.json"
+        meta = json.loads(info_path.read_text())
+        meta["total_episodes"] = "@@declaration@@"
+        info_path.write_text(json.dumps(meta).replace('"@@declaration@@"', declaration))
+
+        result = sim.verify_dataset_episodes(expected=2)
+        assert result["status"] == "error", "a header no writer could produce must not certify"
+        assert "MISMATCH" in result["content"][0]["text"]
+        vj = _json_block(result)
+        assert vj["actual"] == 2
+        assert vj["info_total_episodes"] is None
+        assert vj["sources_agree"] is False
+        assert len(vj["info_problems"]) == 1
+        assert "total_episodes" in vj["info_problems"][0]
 
     def test_verify_treats_parquet_as_sole_truth_when_info_json_absent(self, sim, tmp_path):
         """Missing info.json -> parquet is the sole truth; verify still passes."""

--- a/tests/test_declared_episode_count_has_one_owner.py
+++ b/tests/test_declared_episode_count_has_one_owner.py
@@ -1,0 +1,178 @@
+"""The episode count a dataset's ``meta/info.json`` declares has ONE verdict.
+
+Four surfaces read ``meta/info.json``'s ``total_episodes`` header: the parquet
+cross-check in :func:`~strands_robots.dataset_recorder.read_dataset_episode_indices`,
+the drift check in :func:`~strands_robots.verify_dataset.verify_dataset`, the
+validation-split denominator in ``strands_robots.training.lerobot``, and the
+episode count ``strands_robots.tools.lerobot_train`` splits. Each graded the same
+value its own way, so one file got four answers - and two of those answers were
+silently destructive:
+
+* ``int(2.5)`` truncates to ``2``, which is exactly the count a two-episode
+  parquet holds, so a header no writer could have produced read as AGREEMENT
+  between the two independent metadata sources.
+* ``int(1e400)`` raises ``OverflowError``. ``1e400`` is a well-formed JSON number
+  that ``json.load`` parses to ``inf``, so a readable file raised out of readers
+  whose documented answer is "unknown" - and past the ``verify_dataset_episodes``
+  envelope, which documents that a corrupt dataset is "reported as this same
+  error dict, never raised".
+* ``true`` counted as one episode (``bool`` is an ``int`` subclass), while the
+  ``total_tasks`` reader in the SAME module already excluded it.
+* ``"2"`` was two episodes to three readers and unusable to the fourth.
+
+:func:`~strands_robots.utils.declared_count` is that one owner. A declaration
+outside its domain is "no count declared", and a reader that must not read that
+as an absent header reports it: the recorder's helper carries it in
+``info_problems``, verify_dataset appends a problem.
+
+Fixtures are pyarrow + a raw ``info.json`` string (not ``json.dumps``, which
+cannot write ``1e400`` or ``NaN`` from a Python value), so these tests need
+neither lerobot nor mujoco. The agent-callable facade is pinned against a real
+recorded dataset in ``tests/simulation/test_run_policy_episode_contract.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import strands_robots.tools.lerobot_train as lerobot_train_tool
+from strands_robots.dataset_recorder import read_dataset_episode_indices
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.utils import declared_count
+from strands_robots.verify_dataset import verify_dataset
+
+#: Every spelling a two-episode dataset's header could carry that is not a
+#: count. ``2.0`` and ``"2"`` are the "right number, wrong type" pair; ``2.5``
+#: is the one that truncated INTO agreement; ``1e400`` is the one that raised.
+UNUSABLE_DECLARATIONS = ["2.0", "2.5", "true", '"2"', "1e400", "NaN", "-2", "null"]
+
+
+def _dataset(root: Path, *, declaration: str | None, episodes: int = 2) -> str:
+    """Write a two-episode dataset whose header declares ``declaration`` verbatim.
+
+    Args:
+        root: Dataset root to create.
+        declaration: Raw JSON text for ``total_episodes``, or ``None`` to omit
+            the key entirely (the documented "header declares nothing" case).
+        episodes: Number of distinct episodes to write into the parquet.
+
+    Returns:
+        The dataset root as a string, ready for every reader under test.
+    """
+    ep_dir = root / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        pa.table({"episode_index": list(range(episodes)), "length": [4] * episodes}),
+        ep_dir / "episodes_000.parquet",
+    )
+    body = "" if declaration is None else f', "total_episodes": {declaration}'
+    (root / "meta" / "info.json").write_text('{"codebase_version": "v3.0"' + body + "}")
+    return str(root)
+
+
+class TestDeclaredCountDomain:
+    """The owner answers with the count, or with "none declared"."""
+
+    @pytest.mark.parametrize("value", [2.0, 2.5, True, False, "2", float("inf"), float("nan"), -1, None, {}, [2]])
+    def test_a_value_that_is_not_a_count_declares_none(self, value: object) -> None:
+        assert declared_count(value) is None
+
+    @pytest.mark.parametrize("value", [0, 2, 99])
+    def test_a_non_negative_int_is_the_count_it_declares(self, value: int) -> None:
+        assert declared_count(value) == value
+
+
+class TestEveryReaderReachesTheSameVerdict:
+    """One header, one verdict - across all four readers of the file."""
+
+    @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
+    def test_the_parquet_cross_check_declares_no_count_and_says_why(self, declaration: str, tmp_path: Path) -> None:
+        """No count, and a problem naming the header - never a nearby number.
+
+        The problem is what stops a cross-check reading the ``None`` as an absent
+        header, which is agreement (the parquet is then the sole truth).
+        """
+        info = read_dataset_episode_indices(_dataset(tmp_path, declaration=declaration))
+        assert info["info_total_episodes"] is None
+        assert len(info["info_problems"]) == 1
+        assert "total_episodes" in info["info_problems"][0]
+        assert info["total_episodes"] == 2, "the parquet truth is still reported"
+
+    @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
+    def test_the_validation_split_denominator_is_unknown(self, declaration: str, tmp_path: Path) -> None:
+        root = _dataset(tmp_path, declaration=declaration)
+        assert LerobotTrainer()._dataset_total_episodes(root) is None
+
+    @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
+    def test_the_train_tool_refuses_the_count_by_name(self, declaration: str, tmp_path: Path) -> None:
+        root = _dataset(tmp_path, declaration=declaration)
+        with pytest.raises(ValueError, match="total_episodes"):
+            lerobot_train_tool._read_total_episodes(root)
+
+    @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
+    def test_the_drift_check_reports_the_corrupt_header(self, declaration: str, tmp_path: Path) -> None:
+        report = verify_dataset(_dataset(tmp_path, declaration=declaration))
+        assert report["ok"] is False
+        assert report["info_total_episodes"] is None
+        assert any("is not a count" in p for p in report["problems"]), report["problems"]
+
+    @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
+    def test_no_reader_raises_on_a_readable_file(self, declaration: str, tmp_path: Path) -> None:
+        """``1e400`` parses to ``inf`` and ``int(inf)`` raises ``OverflowError``.
+
+        The file is readable, so the answer must be a verdict, not an exception
+        escaping from three readers that document "unknown".
+        """
+        root = _dataset(tmp_path, declaration=declaration)
+        read_dataset_episode_indices(root)
+        LerobotTrainer()._dataset_total_episodes(root)
+        verify_dataset(root)
+
+    def test_a_frame_total_that_is_not_a_count_is_reported_too(self, tmp_path: Path) -> None:
+        """The sibling header in the same check shares the domain."""
+        root = tmp_path / "frames"
+        ep_dir = root / "meta" / "episodes" / "chunk-000"
+        ep_dir.mkdir(parents=True)
+        pq.write_table(pa.table({"episode_index": [0, 1], "length": [4, 4]}), ep_dir / "episodes_000.parquet")
+        (root / "meta" / "info.json").write_text('{"total_episodes": 2, "total_frames": 8.5}')
+        report = verify_dataset(str(root))
+        assert report["info_total_frames"] is None
+        assert any("total_frames=8.5 is not a count" in p for p in report["problems"]), report["problems"]
+
+
+class TestTheHealthyAndUnknownCasesAreUnchanged:
+    """Controls: the values a writer really produces keep their verdicts."""
+
+    def test_a_matching_int_header_agrees_everywhere(self, tmp_path: Path) -> None:
+        root = _dataset(tmp_path, declaration="2")
+        info = read_dataset_episode_indices(root)
+        assert info["info_total_episodes"] == 2
+        assert info["info_problems"] == []
+        assert LerobotTrainer()._dataset_total_episodes(root) == 2
+        assert lerobot_train_tool._read_total_episodes(root) == 2
+        report = verify_dataset(root)
+        assert report["info_total_episodes"] == 2
+        assert not any("total_episodes" in p for p in report["problems"]), report["problems"]
+
+    def test_a_wrong_int_header_is_still_reported_as_drift(self, tmp_path: Path) -> None:
+        """The existing drift message is unchanged - a wrong COUNT is not corrupt."""
+        report = verify_dataset(_dataset(tmp_path, declaration="99"))
+        assert report["info_total_episodes"] == 99
+        assert any("total_episodes=99 disagrees with parquet" in p for p in report["problems"])
+        assert not any("is not a count" in p for p in report["problems"])
+
+    def test_an_absent_header_stays_the_unknown_case(self, tmp_path: Path) -> None:
+        """No declaration is not a corrupt declaration: the parquet is sole truth."""
+        root = _dataset(tmp_path, declaration=None)
+        info = read_dataset_episode_indices(root)
+        assert info["info_total_episodes"] is None
+        assert info["info_problems"] == []
+        assert LerobotTrainer()._dataset_total_episodes(root) is None
+        assert not any("total_episodes" in p for p in verify_dataset(root)["problems"])


### PR DESCRIPTION
`meta/info.json`'s `total_episodes` header is read by five surfaces, and each graded the same value its own way. One file, five verdicts - measured on one real two-episode dataset recorded in MuJoCo (headless EGL):

![one header, five verdicts](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/pr-3252-declared-count-grid.png)

## The two that are silently destructive

| header | what happened | why it matters |
| --- | --- | --- |
| `2.5` | `int(2.5)` -> `2` | `2` is exactly what a two-episode parquet holds, so the two independent metadata sources "agreed": `verify_dataset_episodes` returned `status="success"`, `sources_agree=True`. `"2"` and `2.0` certified the same way. |
| `1e400` | `int(inf)` -> `OverflowError` | `1e400` is a well-formed JSON number (RFC 8259 bounds no range) that `json.load` parses to `inf`. A perfectly readable file raised out of three readers whose documented answer is "unknown", and past the facade whose docstring says a corrupt dataset is "reported as this same error dict, never raised". |
| `true` | counted as 1 episode | `bool` is an `int` subclass, and `isinstance(x, int)` lets it through. The `total_tasks` reader in the *same module* already excludes it. |

## The change

`utils.declared_count` is now the one owner - same type and floor rule as its caller-side counterpart `non_negative_count_error`, but answering the read-side question ("the count, or none declared") instead of producing a refusal message. All five readers ask it.

"No count declared" is also what an **absent** header means, and an absent header is *agreement* (the parquet is then the sole truth) - so the surfaces that certify a dataset must not collapse the two. They report the difference instead:

```mermaid
flowchart LR
    H["meta/info.json<br/>total_episodes"] --> D{declared_count}
    D -->|"int >= 0"| C["compare with parquet<br/>(drift check unchanged)"]
    D -->|"key absent"| A["unknown: parquet is<br/>the sole truth -> agree"]
    D -->|"present, not a count"| P["info_problems<br/>-> MISMATCH envelope"]
```

* `read_dataset_episode_indices` gains `info_problems`; `verify_dataset_episodes` reports it as a MISMATCH error dict, never a raise.
* `verify_dataset` reports it as a problem for `total_episodes` **and** `total_frames`, instead of silently skipping the comparison (its inline `isinstance` test made a corrupt header invisible - the CLI exited 0 on `2.5`).
* `training.lerobot` and the `lerobot_train` tool reach the same verdict, so a validation-split denominator one surface accepts cannot be refused by the other.

Controls kept: a matching int still agrees, a wrong count is still reported as drift **with its existing message**, an absent header still leaves the parquet as the sole truth.

## Verification

Four corners, all measured:

| corner | result |
| --- | --- |
| old tests / old code | 138 passed |
| new tests / old code | **31 failed** / 47 passed (incl. `OverflowError: cannot convert float infinity to integer`) |
| new tests / new code | 78 passed |
| old tests / new code | 138 passed - no existing test moved |

31 of the 62 new cells are red pre-fix; the other 31 are controls green on both trees (the owner's own domain, plus the readers that already happened to agree). Wider scope on the new code: `tests/simulation -k "record or verify or episode or dataset"` 1494 passed; `tests/test_dataset_recorder.py tests/test_verify_dataset.py tests/tools/test_lerobot_train.py tests/training` clean apart from 16 pre-existing lerobot-0.6.2 drift failures identical on both trees. `ruff check` + `ruff format --check` clean over 1901 files; `mypy` adds no error.

The facade pin lives in `TestInfoParquetCrossCheck`, whose fixtures were all well-formed ints - the reason a non-count header was never graded there.

## Size

| | + | - |
| --- | --- | --- |
| production (6 files) | 124 | 16 |
| tests (2 files) | 212 | 0 |
| docs + changelog | 47 | 5 |

Of the 124 added production lines, 40 are executable (55 docstring, 20 comment, 9 blank).
