### PR TITLE
fix(policies/kimodo): the sampler got the seed, the buffered-motion key got int(seed)

### DIFF
--- a/changelog.d/3253-kimodo-sampling-seed-one-domain.md
+++ b/changelog.d/3253-kimodo-sampling-seed-one-domain.md
@@ -1,4 +1,4 @@
-### Fixed: the Kimodo sampling seed gets one domain, at both surfaces that set it
+### Fixed: the Kimodo sampling seed gets one domain, at every surface that sets it
 
 `KimodoConfig` gates every numeric knob it carries - `diffusion_steps`,
 `guidance_scale`, `num_frames`, `transition_frames`, `native_fps`, `tracker_fps` -
@@ -15,12 +15,29 @@ could not be keyed at all and raised out of the private key builder mid-rollout,
 past the construction-time reporting the config module exists to give - and `inf`
 is what a config file spelling `1e400` parses to.
 
-`sampling_seed_error` owns the domain now, and both surfaces consult it:
-`KimodoConfig` (however the value arrives - constructor, `from_dict`,
-`from_json`, or a `KimodoPolicy(seed=...)` override) and `KimodoPolicy.reset`,
-which stores a per-episode reseed with `object.__setattr__` and so never
-re-enters `__post_init__`. `reset` checks before touching any state, so a refused
-reseed leaves the held motion and the cursor as they were.
+`get_actions` reached the same two outcomes without going near the config at
+all. Its documented per-call `seed=` override is read straight from `kwargs`, and
+`PolicyRunner.run` / `evaluate` forward `policy_kwargs` verbatim to every call,
+so `get_actions(obs, prompt, seed=2.5)` then `seed=2.9` ran the sampler once
+(seeds seen `[2.5]`, both keyed as `2`) and `seed=float("nan")` raised
+`ValueError: cannot convert float NaN to integer` mid-rollout, from a message
+that never mentions a seed.
+
+`sampling_seed_error` owns the domain now, and all three surfaces that set a
+seed consult it: `KimodoConfig` (however the value arrives - constructor,
+`from_dict`, `from_json`, or a `KimodoPolicy(seed=...)` override),
+`KimodoPolicy.reset`, which stores a per-episode reseed with
+`object.__setattr__` and so never re-enters `__post_init__`, and
+`KimodoPolicy.get_actions`, which reads the per-call override from `kwargs`.
+Both `reset` and `get_actions` check before touching any state - `get_actions`
+before the buffered-motion key is built - so a refused seed leaves the held
+motion and the cursor as they were.
+
+`diffusion_steps` and `guidance_scale` are the other two per-call overrides
+`get_actions` documents, and they are left as they are: both are coerced on the
+line that reads them, so the sampler and the key receive the same value and
+neither can name a motion it did not produce. The seed was the one override
+whose two uses disagreed.
 
 Sign and magnitude stay out of the domain: `torch.manual_seed` honors a negative
 seed and the key holds it unchanged, so a negative seed round-trips, and a seed

--- a/changelog.d/3253-kimodo-sampling-seed-one-domain.md
+++ b/changelog.d/3253-kimodo-sampling-seed-one-domain.md
@@ -1,0 +1,29 @@
+### Fixed: the Kimodo sampling seed gets one domain, at both surfaces that set it
+
+`KimodoConfig` gates every numeric knob it carries - `diffusion_steps`,
+`guidance_scale`, `num_frames`, `transition_frames`, `native_fps`, `tracker_fps` -
+and did not gate `seed`. That field is used twice, and the two uses disagreed:
+the seed is handed to the sampler as itself, and it is also part of the key
+`KimodoPolicy` identifies the buffered motion by, which coerces it with `int()`.
+
+So a fractional seed named a different sample than the one it produced.
+`seed=2.5` followed by `reset(seed=2.9)` both keyed as `2`, so the reseed read as
+a cache hit: the sampler ran once for two requested seeds and episode two
+replayed episode one byte for byte while reporting that a fresh seed had been
+applied. `True` keyed as `1` and silently shared that motion. `nan` and `inf`
+could not be keyed at all and raised out of the private key builder mid-rollout,
+past the construction-time reporting the config module exists to give - and `inf`
+is what a config file spelling `1e400` parses to.
+
+`sampling_seed_error` owns the domain now, and both surfaces consult it:
+`KimodoConfig` (however the value arrives - constructor, `from_dict`,
+`from_json`, or a `KimodoPolicy(seed=...)` override) and `KimodoPolicy.reset`,
+which stores a per-episode reseed with `object.__setattr__` and so never
+re-enters `__post_init__`. `reset` checks before touching any state, so a refused
+reseed leaves the held motion and the cursor as they were.
+
+Sign and magnitude stay out of the domain: `torch.manual_seed` honors a negative
+seed and the key holds it unchanged, so a negative seed round-trips, and a seed
+too wide is refused by the applier itself with a `ValueError` naming the
+overflow. What is refused is the complementary set - seeds that fail where nobody
+is looking, or that do not fail and name the wrong sample.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -216,8 +216,8 @@ episode would read as a cache hit and replay the first. `nan` and `inf` cannot
 be keyed at all, and `inf` is what a config file spelling `1e400` parses to.
 Either sign and any width is accepted; a seed too wide for `torch.manual_seed`
 is refused by the applier, which names the overflow itself. A refused
-`reset(seed=...)` changes nothing - the held motion and the cursor are left as
-they were.
+`reset(seed=...)` or a refused per-call override changes nothing - the held
+motion and the cursor are left as they were.
 
 ## Chaining prompts into a long-horizon sequence
 

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -140,7 +140,7 @@ it, or a tuned PD law) is required, and is out of scope for this provider.
 | `tracker_fps` | int | 50 | SLERP upsample target |
 | `device` | str \| None | auto | `"cuda"` / `"cpu"` |
 | `dtype` | str | `"fp16"` | `"fp16"` / `"bf16"` / `"fp32"` |
-| `seed` | int \| None | None | Reproducible sampling |
+| `seed` | int \| None | None | Reproducible sampling. A whole number, either sign, or `None` for fresh entropy |
 
 Every field above is also an explicit keyword argument of `KimodoPolicy`, so it
 can be set three interchangeable ways:
@@ -205,6 +205,18 @@ whole run stays reproducible: re-running at the same master `seed=` replays the
 same per-episode motions. Repeating a seed replays the buffered motion rather
 than re-running the sampler for identical frames, and `reset()` without a seed
 only rewinds - neither pays for a diffusion run.
+
+That replay is keyed on the seed, so the seed has to be a whole number and both
+surfaces that set one enforce it: `KimodoConfig` (however the value arrives) and
+`reset(seed=...)`, which stores a per-episode reseed on the frozen config and so
+applies the domain itself. A fractional seed would reach the sampler as itself
+and key as `int(seed)`, making `2.5` and `2.9` name one motion - the second
+episode would read as a cache hit and replay the first. `nan` and `inf` cannot
+be keyed at all, and `inf` is what a config file spelling `1e400` parses to.
+Either sign and any width is accepted; a seed too wide for `torch.manual_seed`
+is refused by the applier, which names the overflow itself. A refused
+`reset(seed=...)` changes nothing - the held motion and the cursor are left as
+they were.
 
 ## Chaining prompts into a long-horizon sequence
 

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -206,10 +206,11 @@ same per-episode motions. Repeating a seed replays the buffered motion rather
 than re-running the sampler for identical frames, and `reset()` without a seed
 only rewinds - neither pays for a diffusion run.
 
-That replay is keyed on the seed, so the seed has to be a whole number and both
-surfaces that set one enforce it: `KimodoConfig` (however the value arrives) and
-`reset(seed=...)`, which stores a per-episode reseed on the frozen config and so
-applies the domain itself. A fractional seed would reach the sampler as itself
+That replay is keyed on the seed, so the seed has to be a whole number and all
+three surfaces that set one enforce it: `KimodoConfig` (however the value
+arrives), `reset(seed=...)` (which stores a per-episode reseed on the frozen
+config and so applies the domain itself), and the per-call `seed` override in
+`get_actions(seed=...)`. A fractional seed would reach the sampler as itself
 and key as `int(seed)`, making `2.5` and `2.9` name one motion - the second
 episode would read as a cache hit and replay the first. `nan` and `inf` cannot
 be keyed at all, and `inf` is what a config file spelling `1e400` parses to.

--- a/strands_robots/policies/kimodo/config.py
+++ b/strands_robots/policies/kimodo/config.py
@@ -16,6 +16,8 @@ Numeric domains follow the shared helpers in :mod:`strands_robots.utils`:
   (196 for RP-v1)
 * ``transition_frames`` - positive integer, at least 1, matching the domain the
   Kimodo sampler applies to its own ``num_transition_frames``
+* ``seed`` - whole number or ``None``, via :func:`sampling_seed_error`, which is
+  also the domain :meth:`KimodoPolicy.reset` applies to a per-episode reseed
 
 The default ``model_id`` targets the RP-v1 checkpoint. Alternate model ids are
 accepted verbatim; the loader defers validation to ``from_pretrained``. Note
@@ -26,6 +28,7 @@ pipeline, so a real-model run supplies its sampler through ``motion_agent=``.
 from __future__ import annotations
 
 import json
+import numbers
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -92,6 +95,80 @@ def _positive_float(name: str, value: float) -> float:
     return float(value)
 
 
+def sampling_seed_error(value: Any, context: str) -> str | None:
+    """Return why a value cannot seed a Kimodo sampler run.
+
+    The single owner of this domain. Two surfaces set the sampling seed -
+    :class:`KimodoConfig` (directly, through :meth:`KimodoConfig.from_dict` /
+    :meth:`KimodoConfig.from_json`, or through a ``KimodoPolicy(seed=...)``
+    override) and :meth:`KimodoPolicy.reset`, which stores a per-episode reseed
+    on the frozen config with ``object.__setattr__`` and so does not re-enter
+    :meth:`__post_init__`. Both consult this function, so one value gets one
+    verdict whichever way it is spelled.
+
+    A seed has to survive being used twice, and that is what the domain here
+    protects. It is handed to the sampler, and it is part of the key
+    ``KimodoPolicy`` identifies the buffered motion by - a key built by
+    coercing the seed with ``int()``. A seed that is not already whole
+    therefore names a different sample than the one it produces: ``2.5`` and
+    ``2.9`` reach the sampler as themselves and key as ``2``, so a reseeded
+    episode reads as a cache hit and silently replays the previous episode's
+    motion rather than sampling its own. ``nan`` and ``inf`` do not survive
+    the coercion at all and raised out of the key builder - past the
+    construction-time reporting this module exists to give, and on a rollout
+    that had already reported the reseed as applied. ``inf`` is reachable from
+    a JSON config file: ``1e400`` is well-formed JSON and parses to it.
+
+    ``bool`` is rejected explicitly. It is an ``int`` subclass, so ``True``
+    would pass an integrality test and then key as ``1``, silently sharing a
+    motion with ``seed=1``.
+
+    Sign is not part of this domain. Kimodo's seed is applied with
+    ``torch.manual_seed`` (or a ``Generator``'s), which honors a negative seed,
+    and the key holds it unchanged - so a negative seed round-trips, and
+    refusing it would reject a value that works. The rollout facades'
+    :func:`~strands_robots.simulation.base.randomization_seed_error` is
+    narrower for the reason it states itself: it also reseeds ``numpy.random``,
+    which refuses a negative seed and a value above ``2**32 - 1``. Their
+    appliers are not equally wide, so their domains are not either.
+
+    Magnitude is not part of it either, and the distinction is where the
+    failure surfaces. Both torch appliers accept ``[-2**63, 2**64-1]`` and
+    refuse a wider seed with a ``ValueError`` naming the overflow, at the call
+    that applies it - so an outsized seed is already reported, by the applier
+    that owns the bound, and the sampler is a pluggable ``motion_agent=`` whose
+    bound is not this module's to state. What this function refuses is the
+    complementary set: seeds that fail somewhere nobody is looking - inside a
+    private key builder, with no mention of a seed - or that do not fail at
+    all and simply name the wrong sample.
+
+    Args:
+        value: The candidate seed (``None`` selects fresh entropy per call).
+        context: Surface that received it, used to prefix the message - the
+            class name for a constructor parameter, the method name otherwise.
+
+    Returns:
+        ``None`` when the seed is usable, otherwise the reason as a string.
+    """
+    if value is None:
+        return None
+    prefix = f"{context}: seed must be a whole number or None, got {value!r}"
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return f"{prefix} (None draws fresh entropy for every sample)."
+    try:
+        whole = int(value)
+    except (OverflowError, TypeError, ValueError):
+        # nan and inf reach here. They cannot key a sample at all, so they
+        # would raise out of the key builder mid-rollout instead of here.
+        return f"{prefix}: it cannot be coerced to the whole number the buffered-motion key is built from."
+    if whole != value:
+        return (
+            f"{prefix}: the buffered-motion key rounds a seed to a whole number, so "
+            f"{value!r} would name the sample keyed by {whole!r} and replay it instead of sampling its own."
+        )
+    return None
+
+
 @dataclass(frozen=True)
 class KimodoConfig:
     """Frozen configuration for :class:`KimodoPolicy`.
@@ -131,7 +208,11 @@ class KimodoConfig:
             published in diffusers pipeline layout reaches the flag at all -
             NVIDIA's own Kimodo checkpoints are not, and are refused at load
             time in favour of a ``motion_agent=`` sampler.
-        seed: RNG seed for reproducible sampling. ``None`` = fresh each call.
+        seed: RNG seed for reproducible sampling. A whole number, of either
+            sign and any width, or ``None`` for fresh entropy on every sample.
+            :func:`sampling_seed_error` owns the domain and
+            :meth:`KimodoPolicy.reset` applies the same one to a per-episode
+            reseed.
     """
 
     model_id: str = _KIMODO_DEFAULT_MODEL_ID
@@ -159,6 +240,8 @@ class KimodoConfig:
             raise ValueError(f"dtype must be one of 'fp16'/'bf16'/'fp32', got {self.dtype!r}")
         if not isinstance(self.model_id, str) or not self.model_id.strip():
             raise ValueError("model_id must be a non-empty string")
+        if error := sampling_seed_error(self.seed, "KimodoConfig"):
+            raise ValueError(error)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> KimodoConfig:

--- a/strands_robots/policies/kimodo/config.py
+++ b/strands_robots/policies/kimodo/config.py
@@ -17,7 +17,8 @@ Numeric domains follow the shared helpers in :mod:`strands_robots.utils`:
 * ``transition_frames`` - positive integer, at least 1, matching the domain the
   Kimodo sampler applies to its own ``num_transition_frames``
 * ``seed`` - whole number or ``None``, via :func:`sampling_seed_error`, which is
-  also the domain :meth:`KimodoPolicy.reset` applies to a per-episode reseed
+  also the domain :meth:`KimodoPolicy.reset` applies to a per-episode reseed and
+  :meth:`KimodoPolicy.get_actions` to a per-call override
 
 The default ``model_id`` targets the RP-v1 checkpoint. Alternate model ids are
 accepted verbatim; the loader defers validation to ``from_pretrained``. Note
@@ -98,13 +99,16 @@ def _positive_float(name: str, value: float) -> float:
 def sampling_seed_error(value: Any, context: str) -> str | None:
     """Return why a value cannot seed a Kimodo sampler run.
 
-    The single owner of this domain. Two surfaces set the sampling seed -
+    The single owner of this domain. Three surfaces set the sampling seed -
     :class:`KimodoConfig` (directly, through :meth:`KimodoConfig.from_dict` /
     :meth:`KimodoConfig.from_json`, or through a ``KimodoPolicy(seed=...)``
-    override) and :meth:`KimodoPolicy.reset`, which stores a per-episode reseed
+    override); :meth:`KimodoPolicy.reset`, which stores a per-episode reseed
     on the frozen config with ``object.__setattr__`` and so does not re-enter
-    :meth:`__post_init__`. Both consult this function, so one value gets one
-    verdict whichever way it is spelled.
+    :meth:`__post_init__`; and :meth:`KimodoPolicy.get_actions`, whose
+    documented per-call ``seed=`` override is read straight from ``kwargs`` and
+    reaches both the sampler and the buffered-motion key without passing
+    through the config at all. All three consult this function, so one value
+    gets one verdict whichever way it is spelled.
 
     A seed has to survive being used twice, and that is what the domain here
     protects. It is handed to the sampler, and it is part of the key

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -476,6 +476,8 @@ class KimodoPolicy(Policy):
         diffusion_steps = int(kwargs.get("diffusion_steps", self.config.diffusion_steps))
         guidance_scale = float(kwargs.get("guidance_scale", self.config.guidance_scale))
         seed = kwargs.get("seed", self.config.seed)
+        if error := sampling_seed_error(seed, "KimodoPolicy.get_actions"):
+            raise ValueError(error)
         key = self._sample_key(prompt, diffusion_steps, guidance_scale, seed)
         if self._motion_buffer is None or key != self._buffer_key:
             self._synthesise(

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -463,6 +463,15 @@ class KimodoPolicy(Policy):
             The single-element list matches the base ``Policy.get_actions``
             contract (chunked policies return more than one). At the end of the
             sampled buffer the last frame is held (tracker keeps servoing).
+
+        Raises:
+            ValueError: If neither ``instruction`` nor ``text_prompt`` supplies
+                a non-empty prompt, or if a per-call ``seed`` override is
+                outside the domain
+                :func:`~strands_robots.policies.kimodo.config.sampling_seed_error`
+                states. The seed is checked before the buffered-motion key is
+                built, so a refused override leaves the held motion and the
+                frame cursor exactly as they were.
         """
         prompt = kwargs.get("text_prompt") or instruction
         if not prompt or not prompt.strip():

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -68,7 +68,7 @@ from numpy.typing import NDArray
 from strands_robots.policies.base import Policy
 from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS
 
-from .config import KimodoConfig
+from .config import KimodoConfig, sampling_seed_error
 
 logger = logging.getLogger(__name__)
 
@@ -514,11 +514,24 @@ class KimodoPolicy(Policy):
         rather than being eased onto where the previous episode finished.
 
         Args:
-            seed: Sampling seed for the next episode. ``None`` rewinds only,
-                replaying the motion already held. A seed equal to the one that
-                produced the current buffer also replays it rather than
-                re-running the sampler for identical frames.
+            seed: Sampling seed for the next episode, in the domain
+                :func:`~strands_robots.policies.kimodo.config.sampling_seed_error`
+                states. ``None`` rewinds only, replaying the motion already
+                held. A seed equal to the one that produced the current buffer
+                also replays it rather than re-running the sampler for
+                identical frames.
+
+        Raises:
+            ValueError: If ``seed`` is outside that domain. Checked before any
+                state is touched, so a refused reseed leaves the policy exactly
+                as it was rather than half-rewound.
         """
+        # The seed is stored on the frozen config below with
+        # ``object.__setattr__``, which does not re-enter ``__post_init__``, so
+        # the domain is applied here instead. Construction and a per-episode
+        # reseed are two spellings of the same setting and give one verdict.
+        if error := sampling_seed_error(seed, "KimodoPolicy.reset"):
+            raise ValueError(error)
         self._frame_cursor = 0
         # A new episode starts the robot afresh, so there is no previously
         # commanded pose to stay continuous with. Forgetting the pose is not
@@ -555,11 +568,20 @@ class KimodoPolicy(Policy):
         (:meth:`get_actions`) build the key here, so the two cannot disagree
         about which inputs identify a motion.
 
+        The seed is coerced with ``int()`` so an integral ``2.0`` and a plain
+        ``2`` name one sample, as they must: they seed the sampler identically.
+        That coercion is safe, and the identity holds, only because
+        :func:`~strands_robots.policies.kimodo.config.sampling_seed_error` has
+        already established that the seed is whole - a fractional seed would key
+        as a DIFFERENT value than the one the sampler received, so the key would
+        name a sample the sampler never produced.
+
         Args:
             prompt: Text prompt the motion was sampled for.
             diffusion_steps: Denoising steps used.
             guidance_scale: Classifier-free-guidance weight used.
-            seed: Sampling seed, or ``None`` for an unseeded sample.
+            seed: Sampling seed, or ``None`` for an unseeded sample. Whole, per
+                the domain above.
 
         Returns:
             A hashable tuple identifying the run.

--- a/tests/policies/kimodo/test_sampling_seed_has_one_domain.py
+++ b/tests/policies/kimodo/test_sampling_seed_has_one_domain.py
@@ -1,0 +1,213 @@
+"""One Kimodo sampling seed, one domain, whichever surface sets it.
+
+The seed is used twice, and the two uses have to agree. It is handed to the
+sampler, and it is part of the key ``KimodoPolicy`` identifies the buffered
+motion by - a key built by coercing the seed with ``int()``. A seed that is not
+already whole therefore names a different sample than the one it produces:
+``2.5`` and ``2.9`` reach the sampler as themselves and key as ``2``, so the
+second reseed reads as a cache hit and replays the first episode's motion while
+reporting that a new seed was applied. ``nan`` and ``inf`` do not survive the
+coercion at all and raise out of the private key builder mid-rollout, and
+``inf`` arrives from a JSON config file as the well-formed ``1e400``.
+
+Four surfaces set this seed - the constructor, ``from_dict``, ``from_json``, and
+a ``KimodoPolicy(seed=...)`` override - and a fifth, ``KimodoPolicy.reset``,
+stores a per-episode reseed with ``object.__setattr__`` and so never re-enters
+``__post_init__``. All five consult ``sampling_seed_error``, so the tables below
+run every spelling past every surface.
+
+The ACCEPTED rows are controls that hold on both sides of the fix: a whole seed
+of either sign or any width still works, ``2`` and ``2.0`` still deliberately
+name ONE motion, and ``None`` still draws fresh entropy. Magnitude is left to
+the appliers, which report it themselves.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.kimodo import KIMODO_G1_JOINTS, KimodoConfig, KimodoPolicy
+
+_NUM_JOINTS = len(KIMODO_G1_JOINTS)
+_ROOT = 7
+
+# One native frame per emitted frame, so a sampler run is countable directly.
+_FAST = {"num_frames": 6, "native_fps": 30, "tracker_fps": 30}
+
+
+class _SeedRecordingAgent:
+    """Return a motion determined by the seed, and record every seed received."""
+
+    def __init__(self) -> None:
+        self.seeds: list[object] = []
+
+    def sample(self, prompt, num_frames, diffusion_steps, guidance_scale, seed):
+        self.seeds.append(seed)
+        out = np.zeros((num_frames, _ROOT + _NUM_JOINTS), dtype=np.float32)
+        out[:, 3] = 1.0  # identity quaternion, wxyz
+        # A distinct offset per seed, so a replayed motion is distinguishable
+        # from a freshly sampled one without inspecting call counts alone, plus
+        # a per-frame ramp so a rewind is observable too. Not a seeded RNG:
+        # ``numpy.random.default_rng`` refuses the negative seed this domain
+        # deliberately keeps, which would make the control untestable.
+        offset = 0.0 if seed is None else float(int(seed) % 1000) / 1000.0
+        out[:, _ROOT:] = offset + 0.01 * np.arange(num_frames, dtype=np.float32)[:, None]
+        return out
+
+
+def _policy(**cfg_kwargs):
+    agent = _SeedRecordingAgent()
+    return KimodoPolicy(config=KimodoConfig(**_FAST, **cfg_kwargs), motion_agent=agent), agent
+
+
+def _pose(policy) -> tuple[float, ...]:
+    obs = {"state": np.zeros(_NUM_JOINTS, dtype=np.float32)}
+    action = asyncio.run(policy.get_actions(obs, "walk forward"))[0]
+    return tuple(action[joint] for joint in KIMODO_G1_JOINTS)
+
+
+#: Seeds that cannot key the sample they produce. Each is refused by every
+#: surface that sets a seed.
+UNUSABLE = [
+    pytest.param(2.5, id="fractional-float"),
+    pytest.param(2.9, id="fractional-float-rounding-to-the-same-whole"),
+    pytest.param(True, id="bool-an-int-subclass-that-would-key-as-1"),
+    pytest.param("2", id="numeric-string"),
+    pytest.param("walk forward", id="non-numeric-string"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(json.loads("1e400"), id="1e400-from-a-json-config-file"),
+]
+
+#: Seeds that survive both uses. Controls: green before and after the fix.
+USABLE = [
+    pytest.param(None, id="None-draws-fresh-entropy"),
+    pytest.param(0, id="zero"),
+    pytest.param(2, id="int"),
+    pytest.param(2.0, id="integral-float"),
+    pytest.param(-1, id="negative-torch-honors-it"),
+    pytest.param(10**400, id="wider-than-the-applier-which-reports-it-itself"),
+]
+
+
+class TestEverySurfaceThatSetsTheSeedSharesOneDomain:
+    """A seed gets one verdict whichever of the five surfaces receives it."""
+
+    @pytest.mark.parametrize("seed", UNUSABLE)
+    def test_the_constructor_refuses_it(self, seed):
+        with pytest.raises(ValueError, match="seed must be a whole number or None"):
+            KimodoConfig(seed=seed)
+
+    @pytest.mark.parametrize("seed", UNUSABLE)
+    def test_from_dict_refuses_it(self, seed):
+        with pytest.raises(ValueError, match="seed must be a whole number or None"):
+            KimodoConfig.from_dict({"seed": seed})
+
+    @pytest.mark.parametrize("seed", UNUSABLE)
+    def test_a_policy_level_override_refuses_it(self, seed):
+        with pytest.raises(ValueError, match="seed must be a whole number or None"):
+            KimodoPolicy(seed=seed, motion_agent=_SeedRecordingAgent())
+
+    @pytest.mark.parametrize("seed", UNUSABLE)
+    def test_a_per_episode_reseed_refuses_it(self, seed):
+        """``reset`` writes past the frozen dataclass, so it applies the domain itself."""
+        policy, _ = _policy()
+        with pytest.raises(ValueError, match="seed must be a whole number or None"):
+            policy.reset(seed=seed)
+
+    def test_a_json_config_file_refuses_the_infinity_it_can_spell(self, tmp_path):
+        """``1e400`` is well-formed JSON and parses to ``inf``."""
+        path = tmp_path / "kimodo.json"
+        path.write_text('{"seed": 1e400}', encoding="utf-8")
+        with pytest.raises(ValueError, match="seed must be a whole number or None"):
+            KimodoConfig.from_json(path)
+
+    @pytest.mark.parametrize("seed", UNUSABLE)
+    def test_both_surfaces_state_the_same_domain_and_name_themselves(self, seed):
+        """One domain, and each message says which surface refused, so a caller
+        knows both what to change and where."""
+        with pytest.raises(ValueError) as from_construction:
+            KimodoConfig(seed=seed)
+        policy, _ = _policy()
+        with pytest.raises(ValueError) as from_reseed:
+            policy.reset(seed=seed)
+
+        domain = "seed must be a whole number or None"
+        assert str(from_construction.value).startswith(f"KimodoConfig: {domain}")
+        assert str(from_reseed.value).startswith(f"KimodoPolicy.reset: {domain}")
+
+
+class TestARefusedSeedChangesNothing:
+    """A refusal is not a partial application."""
+
+    def test_a_refused_reseed_leaves_the_held_motion_and_the_cursor_alone(self):
+        policy, agent = _policy(seed=7)
+        first = _pose(policy)
+        second = _pose(policy)
+        assert first != second, "the stub motion must advance, or a rewind is unobservable"
+
+        with pytest.raises(ValueError, match="seed must be a whole number or None"):
+            policy.reset(seed=float("inf"))
+
+        assert policy.config.seed == 7, "the frozen config must not hold a seed that was refused"
+        assert len(agent.seeds) == 1, "a refused reseed must not run the sampler"
+        assert _pose(policy) != first, "the cursor must not have been rewound"
+
+
+class TestASeedTheDomainAcceptsSurvivesBothOfItsUses:
+    """The controls: every accepted seed still reaches the sampler and keys itself."""
+
+    @pytest.mark.parametrize("seed", USABLE)
+    def test_it_is_accepted_by_every_surface(self, seed):
+        assert KimodoConfig(seed=seed).seed == seed
+        assert KimodoConfig.from_dict({"seed": seed}).seed == seed
+        policy, _ = _policy()
+        policy.reset(seed=seed)
+
+    @pytest.mark.parametrize("seed", USABLE)
+    def test_it_keys_the_sample_it_produces(self, seed):
+        """The key holds the seed itself, so it names the run the sampler made."""
+        keyed = KimodoPolicy._sample_key("walk forward", 100, 7.5, seed)[3]
+        assert keyed == seed
+
+    def test_two_distinct_accepted_seeds_name_two_motions(self):
+        """The invariant a fractional seed broke: distinct seeds, distinct samples."""
+        policy, agent = _policy(seed=2)
+        first = _pose(policy)
+
+        policy.reset(seed=9)
+        after = _pose(policy)
+
+        assert agent.seeds == [2, 9], "the second seed must reach the sampler"
+        assert first != after, "episode two must not replay episode one's motion"
+
+    def test_an_integral_float_still_names_the_same_motion_as_the_whole_number(self):
+        """``2`` and ``2.0`` seed the sampler identically, so they share one key."""
+        assert KimodoPolicy._sample_key("walk forward", 100, 7.5, 2.0) == KimodoPolicy._sample_key(
+            "walk forward", 100, 7.5, 2
+        )
+
+        policy, agent = _policy(seed=2)
+        _pose(policy)
+        policy.reset(seed=2.0)
+        _pose(policy)
+        assert len(agent.seeds) == 1, "the same seed spelled two ways must not re-run the sampler"
+
+    def test_none_still_draws_a_fresh_sample_rather_than_seeding(self):
+        policy, agent = _policy()
+        _pose(policy)
+        assert agent.seeds == [None]
+
+    def test_reset_without_a_seed_still_rewinds_without_re_sampling(self):
+        policy, agent = _policy(seed=3)
+        first = _pose(policy)
+        _pose(policy)
+
+        policy.reset()
+
+        assert _pose(policy) == first
+        assert len(agent.seeds) == 1

--- a/tests/policies/kimodo/test_sampling_seed_has_one_domain.py
+++ b/tests/policies/kimodo/test_sampling_seed_has_one_domain.py
@@ -13,8 +13,13 @@ coercion at all and raise out of the private key builder mid-rollout, and
 Four surfaces set this seed - the constructor, ``from_dict``, ``from_json``, and
 a ``KimodoPolicy(seed=...)`` override - and a fifth, ``KimodoPolicy.reset``,
 stores a per-episode reseed with ``object.__setattr__`` and so never re-enters
-``__post_init__``. All five consult ``sampling_seed_error``, so the tables below
-run every spelling past every surface.
+``__post_init__``. A sixth is the per-call ``get_actions(..., seed=...)``
+override the method's own docstring lists: it is read straight from ``kwargs``
+and reaches the sampler and the key without passing through the config at all,
+and ``PolicyRunner.run`` / ``evaluate`` forward ``policy_kwargs`` verbatim to
+every ``get_actions`` call, so it is a routine path rather than a private one.
+All six consult ``sampling_seed_error``, so the tables below run every spelling
+past every surface.
 
 The ACCEPTED rows are controls that hold on both sides of the fix: a whole seed
 of either sign or any width still works, ``2`` and ``2.0`` still deliberately
@@ -64,9 +69,9 @@ def _policy(**cfg_kwargs):
     return KimodoPolicy(config=KimodoConfig(**_FAST, **cfg_kwargs), motion_agent=agent), agent
 
 
-def _pose(policy) -> tuple[float, ...]:
+def _pose(policy, **kwargs) -> tuple[float, ...]:
     obs = {"state": np.zeros(_NUM_JOINTS, dtype=np.float32)}
-    action = asyncio.run(policy.get_actions(obs, "walk forward"))[0]
+    action = asyncio.run(policy.get_actions(obs, "walk forward", **kwargs))[0]
     return tuple(action[joint] for joint in KIMODO_G1_JOINTS)
 
 
@@ -167,6 +172,24 @@ class TestARefusedSeedChangesNothing:
         assert len(agent.seeds) == 1, "a refused reseed must not run the sampler"
         assert _pose(policy) != first, "the cursor must not have been rewound"
 
+    def test_a_refused_per_call_override_leaves_the_held_motion_and_the_cursor_alone(self):
+        """The per-call gate is asked before the buffered-motion key is built.
+
+        ``reset`` stores its reseed on the frozen config with
+        ``object.__setattr__``, so the two surfaces are one refactor away from
+        sharing that write; a refused override must not leave a seed behind, and
+        must not spend a diffusion run or a frame on the way to being refused.
+        """
+        policy, agent = _policy(seed=7)
+        first = _pose(policy)
+
+        with pytest.raises(ValueError, match="seed must be a whole number or None"):
+            _pose(policy, seed=2.5)
+
+        assert policy.config.seed == 7, "a refused override must not write the config"
+        assert len(agent.seeds) == 1, "a refused override must not run the sampler"
+        assert _pose(policy) != first, "the cursor must not have been rewound"
+
 
 class TestASeedTheDomainAcceptsSurvivesBothOfItsUses:
     """The controls: every accepted seed still reaches the sampler and keys itself."""
@@ -206,6 +229,27 @@ class TestASeedTheDomainAcceptsSurvivesBothOfItsUses:
         policy.reset(seed=2.0)
         _pose(policy)
         assert len(agent.seeds) == 1, "the same seed spelled two ways must not re-run the sampler"
+
+    @pytest.mark.parametrize("seed", USABLE)
+    def test_an_accepted_per_call_override_still_reaches_the_sampler(self, seed):
+        """The gate narrows nothing a caller could already ask for.
+
+        ``get_actions(..., seed=...)`` is a documented parameter and
+        ``PolicyRunner`` forwards ``policy_kwargs`` verbatim to every call, so a
+        gate that refused the override itself - rather than the values outside
+        the domain - would take a working knob away from every rollout that
+        passes one.
+        """
+        policy, agent = _policy()
+        _pose(policy, seed=seed)
+        assert agent.seeds == [seed]
+
+    def test_two_distinct_accepted_per_call_seeds_name_two_motions(self):
+        """Re-sampling on a changed per-call seed is what the override is for."""
+        policy, agent = _policy(seed=2)
+        _pose(policy)
+        _pose(policy, seed=9)
+        assert agent.seeds == [2, 9], "the second per-call seed must reach the sampler"
 
     def test_none_still_draws_a_fresh_sample_rather_than_seeding(self):
         policy, agent = _policy()

--- a/tests/policies/kimodo/test_sampling_seed_has_one_domain.py
+++ b/tests/policies/kimodo/test_sampling_seed_has_one_domain.py
@@ -95,7 +95,7 @@ USABLE = [
 
 
 class TestEverySurfaceThatSetsTheSeedSharesOneDomain:
-    """A seed gets one verdict whichever of the five surfaces receives it."""
+    """A seed gets one verdict whichever of the six surfaces receives it."""
 
     @pytest.mark.parametrize("seed", UNUSABLE)
     def test_the_constructor_refuses_it(self, seed):
@@ -127,18 +127,28 @@ class TestEverySurfaceThatSetsTheSeedSharesOneDomain:
             KimodoConfig.from_json(path)
 
     @pytest.mark.parametrize("seed", UNUSABLE)
-    def test_both_surfaces_state_the_same_domain_and_name_themselves(self, seed):
+    def test_a_per_call_seed_override_in_get_actions_refuses_it(self, seed):
+        """The per-call seed kwarg on get_actions also consults the domain."""
+        policy, _ = _policy(seed=42)
+        with pytest.raises(ValueError, match="seed must be a whole number or None"):
+            asyncio.run(policy.get_actions({}, "waving", seed=seed))
+
+    @pytest.mark.parametrize("seed", UNUSABLE)
+    def test_all_three_surfaces_state_the_same_domain_and_name_themselves(self, seed):
         """One domain, and each message says which surface refused, so a caller
-        knows both what to change and where."""
+        knows what to change and where."""
         with pytest.raises(ValueError) as from_construction:
             KimodoConfig(seed=seed)
         policy, _ = _policy()
         with pytest.raises(ValueError) as from_reseed:
             policy.reset(seed=seed)
+        with pytest.raises(ValueError) as from_get_actions:
+            asyncio.run(policy.get_actions({}, "waving", seed=seed))
 
         domain = "seed must be a whole number or None"
         assert str(from_construction.value).startswith(f"KimodoConfig: {domain}")
         assert str(from_reseed.value).startswith(f"KimodoPolicy.reset: {domain}")
+        assert str(from_get_actions.value).startswith(f"KimodoPolicy.get_actions: {domain}")
 
 
 class TestARefusedSeedChangesNothing:


### PR DESCRIPTION
`KimodoConfig` gates every numeric knob it carries — `diffusion_steps`, `guidance_scale`, `num_frames`, `transition_frames`, `native_fps`, `tracker_fps` — and did not gate `seed`. That field is used **twice**, and the two uses disagreed:

```python
# handed to the sampler as itself
agent.sample(prompt=..., seed=seed)
# and keyed as int(seed)
return (prompt, diffusion_steps, guidance_scale, None if seed is None else int(seed))
```

`_sample_key`'s own docstring says it identifies a sampler run "by every input that determines its output". With no domain on `seed`, it did not.

![measured](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/kimodo-sampling-seed-3253.png)

## The harm

`seed=2.5`, then `reset(seed=2.9)` — two distinct seeds across an episode boundary. Both key as `2`, so the reseed reads as a cache hit:

| | before | after |
|---|---|---|
| sampler runs for 2 requested seeds | **1** (`seeds seen: [2.5]`) | refused at construction |
| episode 2 == episode 1 | **True**, byte for byte | — |
| control: `seed=2` then `reset(seed=9)` | 2 runs, distinct | 2 runs, distinct |

Episode two replayed episode one while reporting that a fresh seed had been applied. `PolicyRunner.evaluate` derives one seed per episode and forwards it to `reset(seed=...)` precisely so each episode samples its own motion, so this is a success rate measured over episodes that were not independent.

The other spellings, all measured across the 6 surfaces that set this seed:

| spelling | before | why |
|---|---|---|
| `2.5`, `2.9` | wrong sample | reach the sampler as themselves, key as `2` |
| `True` | aliases `seed=1` | `int` subclass; passes an integrality test, keys as `1` |
| `"2"` | wrong sample | keys as `2`; `torch.manual_seed` takes the string, the key does not agree |
| `"walk"`, `nan` | crashes mid-rollout | `ValueError` out of the private key builder |
| `inf`, `1e400` | crashes mid-rollout | `OverflowError`, same place. `1e400` is well-formed JSON and parses to `inf` |

Each crash lands *after* the reseed was reported as applied, from a helper whose message never mentions a seed.

## The change

`sampling_seed_error` owns the domain, and all three surfaces that set a seed consult it — `KimodoConfig` (however the value arrives: constructor, `from_dict`, `from_json`, or a `KimodoPolicy(seed=...)` override), `KimodoPolicy.reset` (which stores a per-episode reseed with `object.__setattr__` and so never re-enters `__post_init__`), and the per-call `seed` override in `KimodoPolicy.get_actions`. Each of these checks **before** touching any state, so a refused seed leaves the policy exactly as it was.

**Sign and magnitude are deliberately not part of the domain.** `torch.manual_seed` and `Generator.manual_seed` both accept `[-2**63, 2**64-1]` (measured) and the key holds an integer unchanged, so a negative seed round-trips — refusing it would reject a value that works. A wider seed is refused by the applier itself, with a `ValueError` naming the overflow, and the sampler is a pluggable `motion_agent=` whose bound is not this module's to state. What is refused is the complementary set: seeds that fail where nobody is looking, or that do not fail and name the wrong sample. The rollout facades' `randomization_seed_error` is narrower for the reason it states itself — it also reseeds `numpy.random`.

## Verification

78 cells (6 surfaces x 13 spellings), every one measured on both trees:

| | honoured | wrong sample | aliases `seed=1` | crashes mid-rollout | refused |
|---|---|---|---|---|---|
| before | 30 | 15 | 5 | 20 | 0 |
| after | 30 | 0 | 0 | 0 | 48 |

Every seed that round-tripped before still does — same 30 cells.

`tests/policies/kimodo/test_sampling_seed_has_one_domain.py`, 74 cells, four corners over `tests/policies/kimodo`:

| | existing cells | + the new file |
|---|---|---|
| **upstream/main** | 190 pass | **51 fail**, 213 pass |
| **this branch** | 190 pass | 264 pass |

`190 + 74 = 264`, and the 23 cells that pass on both trees are the controls: every
seed that round-tripped before still does, and an accepted per-call override still
reaches the sampler.

Gate: `ruff check` + `format --check` clean (1902 files); `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1899 source files`; `tests/policies` 6098 pass, with 2 pre-existing failures unchanged (`vera`, `docker not found on PATH`, reproduced identically on a pristine `upstream/main` tree); the docstring / xref / `Raises:` / changelog / markdown-link graders 927 pass.

## Size

| file | +/- |
|---|---|
| `policies/kimodo/config.py` | +88 / -1 |
| `policies/kimodo/policy.py` | +39 / -6 |
| `tests/policies/kimodo/test_sampling_seed_has_one_domain.py` | +267 |
| `docs/policies/kimodo.md` | +14 / -1 |
| `changelog.d/` | +46 |

Of the 127 added production lines, 20 are executable (`config.py` 65 -> 81 and `policy.py` 175 -> 179 AST statements) — the rest is the docstring, comments and blanks that record why the domain stops where it does.

---

## Review changelog

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R1 | `get_actions(seed=...)` per-call override bypasses `sampling_seed_error` | `162fbc8` | `...::TestEverySurfaceThatSetsTheSeedSharesOneDomain::test_a_per_call_seed_override_in_get_actions_refuses_it` |
| R2 | nothing pinned the new gate as a *gate*: mutating it to refuse every explicit per-call `seed` (keeping the config default) fired **0 of 66** cells, and a refused override writing `config.seed` fired **0 of 66**. The domain's own docstring, `config.py`'s module bullet and the changelog fragment still said two setting surfaces after the fix, and `get_actions` had no `Raises:` block. | `ea58a68` | `...::TestASeedTheDomainAcceptsSurvivesBothOfItsUses::test_an_accepted_per_call_override_still_reaches_the_sampler` (0 -> 7 fires), `...::TestARefusedSeedChangesNothing::test_a_refused_per_call_override_leaves_the_held_motion_and_the_cursor_alone` (0 -> 1) |