### PR TITLE
fix(dashboard): a one-shot motion grant names the call the human approved

### DIFF
--- a/changelog.d/3254-hitl-grant-names-the-motion-approved.md
+++ b/changelog.d/3254-hitl-grant-names-the-motion-approved.md
@@ -1,0 +1,35 @@
+### Fixed: a one-shot HITL motion grant names the call the human approved
+
+`MotionInterruptHook` deposits a grant when a human approves a physical motion,
+and that grant is spendable by exactly one call - so its key has to name that
+call. It was read from `action` / `target` / `instruction`, three fields that are
+constant for the two tools this layer is the *only* human gate for: `pose_tool`
+and `serial_tool` declare no `target` (their peer is the `port`, which is why
+`_resolve_target` reads that field instead) and carry the motion in fields rather
+than in an instruction string. Every call of one action therefore hashed to the
+same `tool|action||`. Measured over every gated action in `MOTION_ACTIONS`, 18 of
+20 calls sat on a shared key, and a yes for `motor_name=shoulder_pan
+position=2048` on `/dev/ttyACM0` was spendable by `motor_name=elbow_flex
+position=4095` on `/dev/ttyACM1` - a different joint, on a different arm, to a
+different angle, with no human asked.
+
+The gate had already resolved the port and shown the operator those very fields;
+the key was the one place that dropped them. `_grant_key` now reads the same
+facts `motion_intent` resolves, the same way it reads them: the tool, the action
+as the gate matched it (stripped), the target `_resolve_target` resolved, the
+instruction, and the call's own motion fields. It is the `repr` of a tuple rather
+than a `"|"` join, because these values are model-authored and a `"|"` inside one
+of them would otherwise shift a boundary and let two different calls agree. A
+per-build binding is not consulted and does not need to be: a bound proxy tool
+IS its peer, so the tool name already names the robot.
+
+`_DETAIL_FIELDS` was incomplete, which is the same root cause - the roster is
+what makes one call distinguishable, and `motor_id`, `velocity` and `hex_data`
+were absent from it. Those are the whole payload of `serial_tool`'s
+`feetech_velocity` and the second spelling of `send` / `send_read`, so three
+gated actions rendered as an empty detail line: the operator was asked to approve
+a raw bus write and shown nothing about what went on the wire. `duration` joins
+for the same reason on the `fleet` surface, since a yes for a five-second task
+was otherwise spendable by a ten-minute one. The roster now has a single reader,
+`_motion_fields`, so the line the operator reads and the identity their yes is
+recorded against cannot come to describe a call differently.

--- a/strands_robots/dashboard/agent_hitl.py
+++ b/strands_robots/dashboard/agent_hitl.py
@@ -10,7 +10,7 @@ import logging
 import os
 import threading
 from collections.abc import Callable, Mapping
-from typing import Any, cast
+from typing import Any
 
 from strands.hooks import BeforeToolCallEvent, HookProvider, HookRegistry
 
@@ -40,19 +40,57 @@ MOTION_ACTIONS: dict[str, frozenset[str]] = {
 #: tools whose gated input names the motion in FIELDS, not an instruction string.
 DIRECT_SERIAL_TOOLS: frozenset[str] = frozenset({"pose_tool", "serial_tool"})
 
-#: the motion-bearing fields, in the order an operator reads them.
-_DETAIL_FIELDS = ("pose_name", "motor_name", "positions", "position", "delta", "steps", "data")
+#: The motion-bearing fields, in the order an operator reads them: which servo
+#: first, then what it is being told to do.
+#:
+#: Every gated action's payload must appear here, because this roster is what
+#: makes one call distinguishable from another -- it is read both by
+#: :func:`_direct_serial_detail`, for the line the operator is shown, and by
+#: :func:`_grant_key`, for the identity their yes is recorded against. A payload
+#: field missing from it is therefore invisible twice over: the human approves a
+#: motion the gate declined to describe, and their grant is deposited under a key
+#: some other call also owns.
+#:
+#: ``motor_id`` and ``velocity`` are the whole payload of ``serial_tool``'s
+#: ``feetech_velocity``, and ``hex_data`` is the second spelling of ``send`` /
+#: ``send_read`` -- the raw bytes that go on the bus. Absent, those three actions
+#: rendered as an empty detail line. ``duration`` is here for the same reason on
+#: the ``fleet`` surface: it is shown to the operator, and how long a robot moves
+#: is part of what they said yes to, so a yes for a five-second task was
+#: otherwise spendable by a ten-minute one.
+_DETAIL_FIELDS = (
+    "pose_name",
+    "motor_name",
+    "motor_id",
+    "positions",
+    "position",
+    "velocity",
+    "delta",
+    "steps",
+    "data",
+    "hex_data",
+    "duration",
+)
 
 
-def _direct_serial_detail(action: str, tool_input: dict) -> str:
+def _motion_fields(tool_input: Mapping[str, Any]) -> tuple[str, ...]:
+    """``field=value`` for each motion-bearing field this call carries, in roster order.
+
+    The one reading of :data:`_DETAIL_FIELDS`, so the operator's line and the
+    grant key cannot come to describe a call differently. An omitted field and an
+    empty one are the same thing here: neither names any motion.
+    """
+    return tuple(
+        f"{key}={tool_input[key]}"
+        for key in _DETAIL_FIELDS
+        if tool_input.get(key) is not None and tool_input.get(key) != ""
+    )
+
+
+def _direct_serial_detail(action: str, tool_input: Mapping[str, Any]) -> str:
     """The gated call's own motion fields as one readable line -- never invented."""
-    parts = [action]
-    for key in _DETAIL_FIELDS:
-        value = tool_input.get(key)
-        if value is None or value == "":
-            continue
-        parts.append(f"{key}={value}")
-    return " ".join(parts) if len(parts) > 1 else ""
+    fields = _motion_fields(tool_input)
+    return " ".join((action, *fields)) if fields else ""
 
 
 def _resolve_target(
@@ -136,7 +174,7 @@ def motion_intent(
     if not instruction and tool_name in DIRECT_SERIAL_TOOLS:
         # pose/serial inputs carry the motion in named fields, not an
         # instruction string; show the operator WHAT a yes moves, verbatim.
-        instruction = _direct_serial_detail(action, cast("dict[str, Any]", tool_input))
+        instruction = _direct_serial_detail(action, tool_input)
     reason: dict[str, Any] = {
         "tool": tool_name,
         "action": action,
@@ -183,13 +221,41 @@ _grants: set[str] = set()
 
 
 def _grant_key(tool_name: str, tool_input: Mapping[str, Any] | None) -> str:
+    """The identity a human yes is recorded against: what they were shown, verbatim.
+
+    A grant is spendable by exactly one call, so the key has to name that call.
+    Reading ``tool_input["target"]`` did not: the two tools this layer is the
+    ONLY human gate for do not declare a ``target`` at all -- their peer is the
+    ``port``, which is why :func:`_resolve_target` reads that field instead -- and
+    they carry the motion itself in :data:`_DETAIL_FIELDS`, not in an
+    ``instruction`` string. Three of the four parts were therefore constant for
+    them, and every ``pose_tool`` / ``serial_tool`` call of one action hashed to
+    the same ``tool|action||``. A yes for ``motor_name=shoulder_pan
+    position=2048`` on ``/dev/ttyACM0`` was spendable by ``motor_name=elbow_flex
+    position=4095`` on ``/dev/ttyACM1``: a different joint, on a different arm, to
+    a different angle, with no human asked. The gate had already resolved the
+    port and shown the operator those very fields -- the key was the one place
+    that dropped them.
+
+    So the parts are the facts :func:`motion_intent` resolves, read the same way
+    it reads them: the tool, the action as the gate matched it (stripped), the
+    target :func:`_resolve_target` resolved, the instruction, and the call's own
+    motion fields. A per-build binding is not consulted, and does not need to be:
+    a bound proxy tool IS its peer, so ``tool_name`` already names the robot.
+
+    Returns:
+        ``repr`` of the parts tuple. A tuple rather than a ``"|"`` join because
+        these values are model-authored: a ``"|"`` inside one of them would
+        otherwise shift a boundary and let two different calls agree.
+    """
     tool_input = tool_input or {}
-    return "|".join(
+    return repr(
         (
             tool_name,
-            str(tool_input.get("action") or ""),
-            str(tool_input.get("target") or ""),
+            str(tool_input.get("action") or "").strip(),
+            _resolve_target(tool_name, tool_input, None),
             str(tool_input.get("instruction") or tool_input.get("message") or ""),
+            *_motion_fields(tool_input),
         )
     )
 

--- a/tests/test_dashboard_agent_hitl.py
+++ b/tests/test_dashboard_agent_hitl.py
@@ -117,6 +117,88 @@ def test_grant_does_not_leak_to_a_different_call():
     assert consume_grant("fleet", TASK_INPUT) is True
 
 
+# --- a yes names the motion it approved --------------------------------------
+#
+# The grant above is spendable by exactly one call, so its key has to name that
+# call. ``pose_tool`` and ``serial_tool`` declare no ``target`` (their peer is the
+# ``port``) and carry the motion in fields rather than in an ``instruction``, so a
+# key read from action/target/instruction alone was constant across every call of
+# one action. These tools raise no interrupt of their own -- this layer is their
+# only human gate -- so a leak here spends a human's yes on a different joint, at
+# a different angle, on a different arm.
+#
+# One row per gated action, carrying the payload that action actually moves.
+
+GATED_CALLS: list[tuple[str, dict]] = [
+    ("fleet", {"action": "task", "target": "arm-1", "instruction": "wave", "duration": 5}),
+    ("fleet", {"action": "task", "target": "arm-1", "instruction": "wave", "duration": 600}),
+    ("fleet", {"action": "task", "target": "arm-2", "instruction": "wave", "duration": 5}),
+    ("pose_tool", {"action": "load_pose", "port": "/dev/ttyACM0", "pose_name": "tucked"}),
+    ("pose_tool", {"action": "load_pose", "port": "/dev/ttyACM0", "pose_name": "extended"}),
+    ("pose_tool", {"action": "move_motor", "port": "/dev/ttyACM0", "motor_name": "shoulder_pan", "position": 2048}),
+    ("pose_tool", {"action": "move_motor", "port": "/dev/ttyACM1", "motor_name": "elbow_flex", "position": 4095}),
+    ("pose_tool", {"action": "move_multiple", "port": "/dev/ttyACM0", "positions": {"shoulder_pan": 100}}),
+    ("pose_tool", {"action": "move_multiple", "port": "/dev/ttyACM0", "positions": {"shoulder_pan": 4000}}),
+    ("pose_tool", {"action": "incremental_move", "port": "/dev/ttyACM0", "motor_name": "wrist_roll", "delta": -30}),
+    ("pose_tool", {"action": "incremental_move", "port": "/dev/ttyACM0", "motor_name": "wrist_roll", "delta": 300}),
+    ("pose_tool", {"action": "reset_to_home", "port": "/dev/ttyACM0"}),
+    ("pose_tool", {"action": "reset_to_home", "port": "/dev/ttyACM1"}),
+    ("serial_tool", {"action": "send", "port": "/dev/ttyACM0", "data": "PING"}),
+    ("serial_tool", {"action": "send", "port": "/dev/ttyACM0", "hex_data": "FF FF 01 05 03 2A 00 08"}),
+    ("serial_tool", {"action": "send_read", "port": "/dev/ttyACM0", "hex_data": "FF FF 01 04 02 38 02"}),
+    ("serial_tool", {"action": "feetech_position", "port": "/dev/ttyACM0", "motor_id": 1, "position": 2000}),
+    ("serial_tool", {"action": "feetech_position", "port": "/dev/ttyACM0", "motor_id": 6, "position": 4000}),
+    ("serial_tool", {"action": "feetech_velocity", "port": "/dev/ttyACM0", "motor_id": 1, "velocity": 500}),
+    ("serial_tool", {"action": "feetech_velocity", "port": "/dev/ttyACM0", "motor_id": 6, "velocity": 3000}),
+]
+
+
+def test_every_gated_action_has_a_pinned_call():
+    """The table above must cover the gate's own roster, or a new action goes unpinned."""
+    pinned = {(tool, call["action"]) for tool, call in GATED_CALLS}
+    declared = {(tool, action) for tool, actions in MOTION_ACTIONS.items() for action in actions}
+    assert pinned == declared
+
+
+@pytest.mark.parametrize(("tool", "call"), GATED_CALLS, ids=lambda v: v["action"] if isinstance(v, dict) else v)
+def test_a_grant_is_not_spendable_by_a_call_that_moves_something_else(tool, call):
+    """A yes for one call authorises that call and nothing else on the table."""
+    deposit_grant(tool, call)
+    for other_tool, other in GATED_CALLS:
+        if (other_tool, other) == (tool, call):
+            continue
+        assert consume_grant(other_tool, other) is False, f"a yes for {tool} {call} was spent by {other_tool} {other}"
+    assert consume_grant(tool, call) is True, "the grant was not spendable by its own call"
+
+
+@pytest.mark.parametrize(("tool", "call"), GATED_CALLS, ids=lambda v: v["action"] if isinstance(v, dict) else v)
+def test_the_operator_is_shown_every_field_that_carries_the_motion(tool, call):
+    """The interrupt names what a yes moves; a payload field is never silently dropped.
+
+    ``fleet`` says it in the instruction it was given. A direct-serial call says
+    it in its fields -- and ``reset_to_home`` genuinely has none, so its motion is
+    the action name and the arm is the resolved port, both already on the reason.
+    """
+    reason = motion_intent(tool, dict(call), {"arm-1": REAL_PEER, "arm-2": REAL_PEER}, {})
+    assert reason is not None
+    payload = {k: v for k, v in call.items() if k not in ("action", "target", "port", "instruction", "duration")}
+    shown = reason["instruction"]
+    for key, value in payload.items():
+        assert key in shown, f"{tool} {call['action']}: the operator was not shown {key} ({shown!r})"
+        assert str(value) in shown, f"{tool} {call['action']}: the operator was not shown {key}={value} ({shown!r})"
+    if not payload:
+        assert reason["target"] == call.get("target") or reason["target"] == call.get("port")
+
+
+def test_a_pipe_inside_a_value_cannot_make_two_calls_agree():
+    """The parts are model-authored, so a separator in one must not shift a boundary."""
+    left = {"action": "task", "target": "arm-1", "instruction": "hold|then wave"}
+    right = {"action": "task", "target": "arm-1|hold", "instruction": "then wave"}
+    deposit_grant("fleet", left)
+    assert consume_grant("fleet", right) is False
+    assert consume_grant("fleet", left) is True
+
+
 # --- the hook against the real SDK event --------------------------------------
 
 


### PR DESCRIPTION
`MotionInterruptHook` pauses the agent before a tool call that would move real
hardware. A human yes deposits a one-shot grant the tool then consumes — so the
grant's key has to name the call it was given for. It did not.

![grant key before and after](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/pr-3254-hitl-grant.png)

Measured over every gated action in `MOTION_ACTIONS`, on `main` and on this branch:

| | main | this change |
|---|---|---|
| calls sitting on a shared grant key | **18 of 20** | 0 of 20 |
| a yes spent by a **different** call (ordered pairs) | **18 of 380** | 0 of 380 |
| gated motions the operator was shown nothing about | **6 of 20** | 0 of 20 |
| grant still spendable exactly once by its own call | 20 of 20 | 20 of 20 |

## What was wrong

`_grant_key` read `action` / `target` / `instruction`. Three of those four parts
are constant for the two tools this layer is the **only** human gate for
(`robot_mesh` raises its own interrupt; `pose_tool` and `serial_tool` raise
none):

* they declare no `target` — their peer is the `port`, which is exactly why
  `_resolve_target` reads that field instead, and why
  `test_a_model_written_target_cannot_stand_the_gate_down` exists;
* they carry the motion in fields, not in an `instruction` string.

So every call of one action hashed to `tool|action||`:

```
approved   pose_tool move_motor  port=/dev/ttyACM0  motor_name=shoulder_pan  position=2048
spent on   pose_tool move_motor  port=/dev/ttyACM1  motor_name=elbow_flex    position=4095
           -> consume_grant() == True
```

A different joint, on a different arm, to a different angle, with no human
asked. The gate had already resolved the port and shown the operator those very
fields — the key was the one place that dropped them.

`_DETAIL_FIELDS` was incomplete, which is the same root cause: the roster is
what makes one call distinguishable, and `motor_id`, `velocity` and `hex_data`
were missing. Those are the *whole* payload of `serial_tool`'s
`feetech_velocity` and the second spelling of `send` / `send_read`, so three
gated actions rendered as an empty line — the operator was asked to approve a
raw bus write and shown nothing about what went on the wire:

| gated call | operator was shown, on main | on this branch |
|---|---|---|
| `feetech_velocity motor_id=1 velocity=500` | `''` | `feetech_velocity motor_id=1 velocity=500` |
| `send hex_data=FF FF 01 05 03 2A 00 08` | `''` | `send hex_data=FF FF 01 05 03 2A 00 08` |
| `feetech_position motor_id=6 position=4000` | `feetech_position position=4000` | `feetech_position motor_id=6 position=4000` |

## The change

`_grant_key` reads the facts `motion_intent` already resolves, the same way it
reads them: the tool, the action as the gate matched it (stripped), the target
`_resolve_target` resolved, the instruction, and the call's own motion fields.
It is the `repr` of a tuple rather than a `"|"` join — these values are
model-authored, and a `"|"` inside one would otherwise shift a boundary and let
two different calls agree. `_DETAIL_FIELDS` gains the three missing payload
fields plus `duration` (a yes for a five-second task was spendable by a
ten-minute one), and gets a single reader, `_motion_fields`, so the line the
operator reads and the identity their yes is recorded against cannot come to
describe a call differently.

Deliberately unchanged: a per-build binding is not part of the key and does not
need to be — a bound proxy tool IS its peer, so the tool name already names the
robot. `reset_to_home` takes no parameters, so its detail line stays empty: the
action name is the motion and the arm is the resolved port, both already on the
reason (the two amber cells above).

## Tests

Four corners, `tests/test_dashboard_agent_hitl.py`:

| | old tests | new tests |
|---|---|---|
| **old code** | 35 passed | **25 failed**, 52 passed |
| **new code** | 35 passed | 77 passed |

`35 + 42 new = 77`, and `52 = 35 + 17` cells that are green on both trees
(controls: the two calls `main` already distinguished — a `fleet` task on
another peer, and `send_read`, the only row of its action — plus every
already-shown payload). The 25 red split 18 grant-leak cells / 6 detail cells /
1 separator cell.

One table, one row per gated action, driving both pins; a third test asserts the
table covers `MOTION_ACTIONS` itself, so a newly gated action cannot arrive
unpinned. `ruff check` + `ruff format --check` clean, `mypy` clean on the
changed files, and `-k "dashboard or hitl or pose_tool or serial_tool"` plus the
docstring/changelog graders: 2194 passed.

## Size

| file | +/− |
|---|---|
| `strands_robots/dashboard/agent_hitl.py` | +81 −15 |
| `tests/test_dashboard_agent_hitl.py` | +82 −0 |
| `changelog.d/…` | +35 −0 |

Of the 81 added production lines, 33 are docstring, 18 comment, 2 blank and 28
executable — and 13 of those 28 are the `_DETAIL_FIELDS` tuple spelled one field
per line. `_direct_serial_detail` shrank from 9 lines to 4 — 7 executable to 2 — by
delegating to the shared reader, and the `cast` it needed is gone.
