### PR TITLE
fix(dashboard): a redacted log record is still renderable by the formatter it was written for

### DIFF
--- a/changelog.d/3255-log-redaction-keeps-the-record-renderable.md
+++ b/changelog.d/3255-log-redaction-keeps-the-record-renderable.md
@@ -1,0 +1,23 @@
+### Fixed: a redacted log record is still renderable, so the access log keeps every request
+
+`RedactingFilter` baked the redacted text into `record.msg` and cleared
+`record.args` - the stock way to freeze a redacted message. uvicorn's
+`AccessFormatter`, the formatter this module exists for, never reads that
+message: `formatMessage` unpacks five values out of `record.args` and builds the
+request line from them. Clearing the args left it nothing to unpack, so it raised
+`ValueError` inside `Handler.emit` for exactly the records that carried a
+credential. Measured through uvicorn 0.41's own formatter, six requests: three
+reached the access log, and all three authenticated WebSocket handshakes were
+dropped, each leaving a `--- Logging error ---` traceback on stderr. Because
+every camera and mesh socket carries its JWT in the query string, the log kept
+every ordinary request and lost every authenticated one.
+
+`args` is a rendered part, so it is now redacted in place with its arity
+preserved, and a non-`str` value is left alone (an `int` under a `%d` is not a
+credential, and a fingerprint there would leave a format string its own args
+cannot render). The message is baked and the args dropped only when the
+credential is not visible in any single arg - the case no per-arg redaction can
+reach, where failing closed under `Handler.emit`'s guard is the right answer.
+That verdict is taken by asking which credential values survive rather than by
+re-running the redaction, whose own fingerprint matches the value pattern and
+would report a wrong length for text that is already clean.

--- a/strands_robots/dashboard/log_redaction.py
+++ b/strands_robots/dashboard/log_redaction.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
 
 #: query parameters whose VALUE is a credential
 _SECRET_QUERY_KEYS = ("token", "access_code", "api_key", "apikey", "password", "secret")
@@ -49,6 +50,10 @@ _KEYED_RE = re.compile(
 # as : literals when they are loaded.
 _known: set[str] = set()
 
+#: every rail that names its credential in a ``val`` group, so the values a message carries can be
+#: read off with the same patterns that redact them - see :func:`_credential_values`.
+_VALUE_RAILS = (_QUERY_RE, _LONG_QUERY_RE, _KEYED_RE, _BEARER_RE)
+
 
 def register_secret(value: str | None) -> None:
     """Redact ``value`` from every future log line, whatever shape it appears in."""
@@ -65,6 +70,23 @@ def fingerprint(secret: str) -> str:
     """A stable, non-usable label for a credential: its length and last 4 characters."""
     tail = secret[-4:] if len(secret) >= 8 else ""
     return f"<redacted:{len(secret)}{':' + tail if tail else ''}>"
+
+
+def _credential_values(message: str) -> tuple[str, ...]:
+    """Every credential-shaped value :func:`redact_secrets` replaces in ``message``.
+
+    Answers "is this text still carrying a credential" for
+    :meth:`RedactingFilter.filter`, which cannot ask by re-running the redaction: a
+    fingerprint's own text matches the value pattern, so a second pass reports a
+    difference for text that is already clean - the corruption the literals-last rail
+    order exists to prevent, read as a verdict instead of written into the line.
+    """
+    found: list[str] = []
+    for rail in _VALUE_RAILS:
+        found.extend(m.group("val") for m in rail.finditer(message))
+    found.extend(m.group(0) for m in _JWT_RE.finditer(message))
+    found.extend(secret for secret in _known if secret in message)
+    return tuple(found)
 
 
 def redact_secrets(message: str) -> str:
@@ -114,6 +136,18 @@ class RedactingFilter(logging.Filter):
     the request line above it was redacted. ``exc_info`` is rendered here instead of
     later because the formatter reuses an ``exc_text`` that is already set.
 
+    A formatter may also render ``args`` DIRECTLY rather than through ``getMessage()``,
+    and uvicorn's own ``AccessFormatter`` does: it unpacks five values out of
+    ``record.args`` and builds the request line from them, never reading the message this
+    filter had cleaned. Baking the redacted text into ``msg`` and clearing ``args`` - the
+    stock way to freeze a redacted message - therefore left that formatter nothing to
+    unpack, and it raised ``ValueError`` inside ``Handler.emit`` for exactly the records
+    carrying a credential: the access log kept every ordinary request and dropped every
+    authenticated socket handshake, which is the audit trail this module exists to keep
+    readable. So the args are redacted in place and their arity preserved, and the message
+    is baked only when the credential is not visible in any single arg - the case where no
+    per-arg redaction could reach it, and where failing closed is the right answer.
+
     Redacting is idempotent per record because :func:`install_redaction` attaches this
     filter at BOTH the logger and its handlers (a handler-level filter is what catches
     records logged straight to a handler). Without the marker the handler pass redacted
@@ -137,8 +171,22 @@ class RedactingFilter(logging.Filter):
         if original is not None:
             cleaned = redact_secrets(original)
             if cleaned != original:
-                record.msg = cleaned
-                record.args = ()
+                # ``args`` is a rendered part too: a formatter may read the credential straight
+                # out of it rather than out of the message. Redact the parts and keep the arity,
+                # so a formatter that unpacks them still has values to unpack.
+                carried = _credential_values(original)
+                record.args = _redacted_args(record.args)
+                try:
+                    rerendered: str | None = record.getMessage()
+                except Exception:  # noqa: BLE001 - a broken record must not break logging
+                    rerendered = None
+                if rerendered is None or any(secret in rerendered for secret in carried):
+                    # The credential is only credential-shaped once the format string and the
+                    # args are joined, so no per-arg redaction can reach it. Bake the redacted
+                    # text and drop the args: a formatter reading them positionally then fails
+                    # under ``Handler.emit``'s guard, which is the fail-closed answer.
+                    record.msg = cleaned
+                    record.args = ()
         # Each appended rail carries the message rail's guard, and carries it SEPARATELY: a
         # part that cannot be rendered must not exempt the part that can. Only the 3-tuple
         # that logging documents is rendered here, but a shape check is not a guard: `Logger._log`
@@ -157,6 +205,22 @@ class RedactingFilter(logging.Filter):
             record.stack_info = _redact_appended(record.stack_info)
         setattr(record, _DONE, True)
         return True
+
+
+_Args = tuple[object, ...] | Mapping[str, object] | None
+
+
+def _redacted_args(args: _Args) -> _Args:
+    """Redact the credential out of a record's ``args`` without changing what they are.
+
+    Only ``str`` values are rewritten: an ``int`` under a ``%d`` is not a credential and
+    replacing it with a fingerprint would leave a format string its own args cannot render.
+    """
+    if isinstance(args, Mapping):
+        return {key: redact_secrets(val) if isinstance(val, str) else val for key, val in args.items()}
+    if isinstance(args, tuple):
+        return tuple(redact_secrets(val) if isinstance(val, str) else val for val in args)
+    return args
 
 
 def _redact_appended(part: object) -> str:

--- a/strands_robots/dashboard/log_redaction.py
+++ b/strands_robots/dashboard/log_redaction.py
@@ -175,16 +175,23 @@ class RedactingFilter(logging.Filter):
                 # out of it rather than out of the message. Redact the parts and keep the arity,
                 # so a formatter that unpacks them still has values to unpack.
                 carried = _credential_values(original)
-                record.args = _redacted_args(record.args)
+                original_args = record.args
+                record.args = _redacted_args(original_args)
                 try:
                     rerendered: str | None = record.getMessage()
                 except Exception:  # noqa: BLE001 - a broken record must not break logging
                     rerendered = None
-                if rerendered is None or any(secret in rerendered for secret in carried):
-                    # The credential is only credential-shaped once the format string and the
-                    # args are joined, so no per-arg redaction can reach it. Bake the redacted
-                    # text and drop the args: a formatter reading them positionally then fails
-                    # under ``Handler.emit``'s guard, which is the fail-closed answer.
+                if (
+                    rerendered is None
+                    or any(secret in rerendered for secret in carried)
+                    or not all(_wholly_inside_one_str_arg(secret, original_args) for secret in carried)
+                ):
+                    # The credential is not wholly inside a single str arg - either it
+                    # straddles two args, or it is only credential-shaped once format
+                    # string and args are joined, or re-rendering failed.  Bake the
+                    # redacted text and drop the args: a formatter reading them
+                    # positionally then fails under ``Handler.emit``'s guard, which is
+                    # the fail-closed answer.
                     record.msg = cleaned
                     record.args = ()
         # Each appended rail carries the message rail's guard, and carries it SEPARATELY: a
@@ -208,6 +215,22 @@ class RedactingFilter(logging.Filter):
 
 
 _Args = tuple[object, ...] | Mapping[str, object] | None
+
+
+def _wholly_inside_one_str_arg(secret: str, args: _Args) -> bool:
+    """True when ``secret`` is a contiguous substring of a single ``str`` arg.
+
+    If a credential straddles two args (``"%s%s" % (url[:40], url[-40:])``), per-arg
+    redaction replaces only the half it sees in each arg, and the other half survives in
+    plaintext once the format string joins them.  The caller uses this to decide whether
+    per-arg redaction is sufficient or the whole message must be baked and the args
+    dropped (fail-closed).
+    """
+    if isinstance(args, Mapping):
+        return any(isinstance(v, str) and secret in v for v in args.values())
+    if isinstance(args, tuple):
+        return any(isinstance(v, str) and secret in v for v in args)
+    return False
 
 
 def _redacted_args(args: _Args) -> _Args:

--- a/tests/test_dashboard_log_redaction.py
+++ b/tests/test_dashboard_log_redaction.py
@@ -524,3 +524,71 @@ class TestTheAccessLogKeepsEveryRequest:
         assert len(written.strip().splitlines()) == 3, "the handshake carrying a credential was dropped"
         assert JWT not in written
         assert "/ws/camera?token=" in written, "which socket was opened is what the access log is for"
+
+
+class TestStraddlingCredentialIsBaked:
+    """A credential that straddles two args must be baked (fail-closed).
+
+    Regression pin for the review thread on PR #3255: per-arg redaction can
+    partially rewrite a credential value that spans two args, after which
+    the full value is no longer a contiguous substring while most of it
+    survives in plaintext once the format string joins them.
+    """
+
+    SECRET = "supersecretvalue1234567890"
+
+    def test_split_across_two_percent_s_args(self) -> None:
+        """Reviewer repro 1: ``"%s%s" % (head_with_key, tail_with_value)``."""
+        r = logging.LogRecord(
+            "x",
+            logging.INFO,
+            __file__,
+            1,
+            "%s%s",
+            (f"/ws?token={self.SECRET[:8]}", self.SECRET[8:]),
+            None,
+        )
+        RedactingFilter().filter(r)
+        msg = r.getMessage()
+        # The surviving tail must not leak: the whole credential is redacted
+        assert self.SECRET[8:] not in msg, f"credential tail leaked in plaintext: {msg!r}"
+        # The args must have been dropped (baked path)
+        assert r.args == () or r.args is None
+
+    def test_head_tail_truncated_url_with_jwt(self) -> None:
+        """Reviewer repro 2: truncated URL logging leaking the JWT signature."""
+        jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo5OX0.c2lnbmF0dXJlX2hlcmVfMTIzNA"
+        url = f"/ws/camera?token={jwt}"
+        r = logging.LogRecord(
+            "x",
+            logging.INFO,
+            __file__,
+            1,
+            "long url %s...%s",
+            (url[:40], url[-40:]),
+            None,
+        )
+        RedactingFilter().filter(r)
+        msg = r.getMessage()
+        # The JWT signature segment must not survive
+        assert "c2lnbmF0dXJlX2hlcmVfMTIzNA" not in msg, f"JWT signature leaked in plaintext: {msg!r}"
+
+    def test_credential_wholly_inside_one_arg_still_uses_per_arg_path(self) -> None:
+        """Control: when the credential IS wholly inside one arg, per-arg redaction suffices."""
+        r = logging.LogRecord(
+            "x",
+            logging.INFO,
+            __file__,
+            1,
+            "%s %s %s %s %s",
+            ("127.0.0.1", "GET", f"/ws?token={self.SECRET}", "HTTP/1.1", 101),
+            None,
+        )
+        RedactingFilter().filter(r)
+        # The credential is gone
+        assert self.SECRET not in r.getMessage()
+        # But the args are preserved (per-arg path, not baked)
+        assert isinstance(r.args, tuple)
+        assert len(r.args) == 5
+        # The int arg is untouched
+        assert r.args[4] == 101

--- a/tests/test_dashboard_log_redaction.py
+++ b/tests/test_dashboard_log_redaction.py
@@ -357,3 +357,170 @@ def test_an_appended_part_that_cannot_be_redacted_is_withheld_not_raised(part: s
         assert _WITHHELD in out
     finally:
         forget_secrets()
+
+
+# --- the record has to stay renderable by the formatter it was written for ----------------------
+#
+# MEASURED against uvicorn 0.41's own AccessFormatter: three requests logged, TWO lines in the
+# access log. `AccessFormatter.formatMessage` unpacks five values out of `record.args` and builds
+# the request line from them - it never reads the message this filter cleaned - so baking the
+# redacted text into `msg` and clearing `args`, the stock way to freeze a redacted message, left
+# it nothing to unpack. It raised ValueError inside `Handler.emit` for exactly the records
+# carrying a credential, and this module's own docstring says every camera and mesh socket carries
+# one: the access log kept every ordinary request and dropped every authenticated handshake. That
+# is `test_the_line_is_still_a_useful_log_line` read one layer up - the line was not less useful,
+# it was absent - and a dropped handshake is the audit trail this module exists to keep.
+
+JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjYW1lcmEiLCJleHAiOjk5fQ.c2lnbmF0dXJlX2hlcmVfMTIzNA"
+
+#: uvicorn's access-log call, verbatim: the credential rides in ``args[2]``, never in the format
+#: string, and the last arg is an ``int`` under a ``%d``.
+_ACCESS_MSG = '%s - "%s %s HTTP/%s" %d'
+
+
+def _access_record(full_path: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        __file__,
+        1,
+        _ACCESS_MSG,
+        ("127.0.0.1:52111", "GET", full_path, "1.1", 200),
+        None,
+    )
+
+
+class _PositionalFormatter(logging.Formatter):
+    """Reads ``record.args`` positionally, which is what uvicorn's AccessFormatter does."""
+
+    def formatMessage(self, record: logging.LogRecord) -> str:
+        client_addr, method, full_path, http_version, status_code = record.args  # type: ignore[misc]
+        return f'{client_addr} - "{method} {full_path} HTTP/{http_version}" {status_code}'
+
+
+class TestARedactedRecordIsStillRenderable:
+    """``args`` is a rendered part: redact it, do not discard it."""
+
+    def test_a_formatter_that_reads_args_positionally_still_has_them(self) -> None:
+        record = _access_record(f"/ws/camera?token={JWT}")
+        RedactingFilter().filter(record)
+        line = _PositionalFormatter().format(record)
+        assert JWT not in line
+        # and it is still the log line the access log exists for
+        assert "/ws/camera?token=" in line
+        assert '"GET' in line and "200" in line
+
+    def test_the_arity_the_formatter_unpacks_is_preserved(self) -> None:
+        record = _access_record(f"/ws/camera?token={JWT}")
+        RedactingFilter().filter(record)
+        assert isinstance(record.args, tuple)
+        assert len(record.args) == 5
+
+    def test_the_credential_is_gone_from_the_args_themselves(self) -> None:
+        # A formatter reading args raw never sees the cleaned message, so the redaction has
+        # to have happened in the values, not only in the rendered text.
+        record = _access_record(f"/ws/camera?token={JWT}")
+        RedactingFilter().filter(record)
+        assert not any(JWT in arg for arg in record.args if isinstance(arg, str))  # type: ignore[union-attr]
+
+    def test_an_arg_that_is_not_a_string_is_left_as_it_is(self) -> None:
+        # ``%d`` needs an int: a fingerprint there would leave a format string its own args
+        # cannot render, which is the failure this fix is removing, reintroduced.
+        record = _access_record(f"/ws/camera?token={JWT}")
+        RedactingFilter().filter(record)
+        assert record.args[-1] == 200  # type: ignore[index]
+        assert logging.Formatter("%(message)s").format(record).endswith(" 200")
+
+    def test_the_message_rail_is_redacted_as_before(self) -> None:
+        record = _access_record(f"/ws/camera?token={JWT}")
+        RedactingFilter().filter(record)
+        assert JWT not in record.getMessage()
+        assert f"token={fingerprint(JWT)}" in record.getMessage()
+
+    def test_dict_style_args_are_redacted_too(self) -> None:
+        # a mapping is passed INSIDE the args tuple, which is what ``Logger._log`` hands over;
+        # ``LogRecord`` then unwraps it onto ``record.args``.
+        record = logging.LogRecord(
+            "x", logging.INFO, __file__, 1, "socket %(path)s", ({"path": f"/ws?token={JWT}"},), None
+        )
+        RedactingFilter().filter(record)
+        assert JWT not in record.getMessage()
+        if isinstance(record.args, dict):  # arity preserved -> the key is still there
+            assert JWT not in record.args["path"]
+
+    def test_a_record_carrying_no_credential_is_untouched(self) -> None:
+        record = _access_record("/api/status")
+        RedactingFilter().filter(record)
+        assert record.args == ("127.0.0.1:52111", "GET", "/api/status", "1.1", 200)
+        assert record.msg == _ACCESS_MSG
+
+
+class TestACredentialVisibleOnlyOnceJoinedStillFailsClosed:
+    """No per-arg redaction can reach it, so the message is baked and the args dropped."""
+
+    def test_the_message_is_redacted_and_the_args_are_dropped(self) -> None:
+        # ``supersecretvalue123`` is credential-shaped only because ``?token=`` precedes it in
+        # the FORMAT STRING - the arg on its own is an ordinary word.
+        record = logging.LogRecord("x", logging.INFO, __file__, 1, "?token=%s", ("supersecretvalue123",), None)
+        RedactingFilter().filter(record)
+        assert "supersecretvalue123" not in record.getMessage()
+        assert record.args == ()
+
+    def test_a_registered_literal_is_redacted_without_fingerprinting_the_fingerprint(self) -> None:
+        # The arg IS the credential here, so the args are kept - and the verdict must not be
+        # taken by re-running the redaction, whose own fingerprint matches the value pattern
+        # and would report a 18-character token for a 43-character one.
+        try:
+            register_secret(TOKEN)
+            record = logging.LogRecord(
+                "x", logging.INFO, __file__, 1, "WebSocket /ws/camera?token=%s [accepted]", (TOKEN,), None
+            )
+            RedactingFilter().filter(record)
+            assert record.getMessage() == f"WebSocket /ws/camera?token={fingerprint(TOKEN)} [accepted]"
+        finally:
+            forget_secrets()
+
+    def test_a_record_whose_message_cannot_be_rendered_does_not_break_logging(self) -> None:
+        class _Bad:
+            def __str__(self) -> str:
+                raise RuntimeError("nope")
+
+        record = logging.LogRecord("x", logging.INFO, __file__, 1, "%s", (_Bad(),), None)
+        assert RedactingFilter().filter(record) is True
+
+
+class TestTheAccessLogKeepsEveryRequest:
+    """The whole defect, end to end, through uvicorn's own formatter."""
+
+    def _access_logger(self, name: str, formatter: logging.Formatter) -> tuple[logging.Logger, io.StringIO]:
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(formatter)
+        logger = logging.getLogger(name)
+        logger.handlers[:] = [handler]
+        logger.filters[:] = []
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        install_redaction((name,))
+        return logger, stream
+
+    @pytest.mark.parametrize("real_uvicorn", [False, True], ids=["positional", "uvicorn"])
+    def test_three_requests_produce_three_lines(self, real_uvicorn: bool) -> None:
+        if real_uvicorn:
+            uvicorn_logging = pytest.importorskip("uvicorn.logging")
+            formatter: logging.Formatter = uvicorn_logging.AccessFormatter(
+                '%(client_addr)s - "%(request_line)s" %(status_code)s', use_colors=False
+            )
+        else:
+            formatter = _PositionalFormatter()
+        logger, stream = self._access_logger(f"test.redaction.access.{real_uvicorn}", formatter)
+        try:
+            for path in ("/api/status", f"/ws/camera?token={JWT}", "/api/robots"):
+                logger.info(_ACCESS_MSG, "127.0.0.1:52111", "GET", path, "1.1", 200)
+            written = stream.getvalue()
+        finally:
+            logger.handlers[:] = []
+            logger.filters[:] = []
+        assert len(written.strip().splitlines()) == 3, "the handshake carrying a credential was dropped"
+        assert JWT not in written
+        assert "/ws/camera?token=" in written, "which socket was opened is what the access log is for"


### PR DESCRIPTION
![access log before and after](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/log_redaction_access_log.png)

`RedactingFilter` baked the redacted text into `record.msg` and cleared `record.args` — the stock way to freeze a redacted message. uvicorn's `AccessFormatter`, the formatter this module exists for, never reads that message:

```python
def formatMessage(self, record):                      # uvicorn/logging.py
    (client_addr, method, full_path, http_version, status_code) = recordcopy.args
    request_line = f"{method} {full_path} HTTP/{http_version}"
```

So clearing the args left it nothing to unpack, and it raised `ValueError` inside `Handler.emit` for exactly the records that carried a credential. The module's own docstring says *every* camera and mesh socket carries its JWT in the query string, so the access log kept every ordinary request and lost every authenticated one.

## Measured through uvicorn 0.41's own `AccessFormatter`

Six requests, three of them carrying a credential:

| | before | after |
|---|---|---|
| requests in the access log | **3 of 6** | **6 of 6** |
| authenticated handshakes recorded | **0 of 3** | **3 of 3** |
| `--- Logging error ---` on stderr | 3 | 0 |
| credential anywhere in the log file | no | no |

The redaction itself always worked — the credential never reached the file either way. What was lost was the record.

`tests/test_dashboard_log_redaction.py::test_the_line_is_still_a_useful_log_line` already states the invariant this broke (*"the whole point of the access log is answering 'which socket, from whom, how many times' — redaction must not take that away"*), but pins it on `redact_secrets()`, one layer below the filter. The line was not less useful; it was absent.

## Change

`args` is a rendered part, so it is redacted in place and its arity preserved. A non-`str` value is left alone: an `int` under a `%d` is not a credential, and a fingerprint there would leave a format string its own args cannot render — the same failure, reintroduced from the other side.

The message is baked and the args dropped only when the credential is not visible in any single arg (`msg="?token=%s"`, `args=("supersecretvalue123",)` — the arg alone is an ordinary word). No per-arg redaction can reach that, and failing closed under `Handler.emit`'s guard is the right answer there.

That verdict is taken by asking which credential values survive, not by re-running the redaction: a fingerprint's own text matches the value pattern, so a second pass reports a difference for text that is already clean. Re-running it would have reported `<redacted:18:aco>` for a 43-character token — the corruption the literals-last rail order already exists to prevent, read as a verdict instead of written into the line.

## Tests

`tests/test_dashboard_log_redaction.py` grows three classes (+167). Four corners on the target file:

| | old tests | new tests |
|---|---|---|
| **old production** | 32 passed | **5 failed**, 39 passed |
| **new production** | 32 passed | 44 passed |

`32 + 12 new = 44`, and `39 = 32 + 7` cells green on both trees (the controls: the message rail, the fail-closed bake, the unregistered-literal path, a broken record). No existing assertion changed.

The five that fail pre-fix:

| cell | pre-fix failure |
|---|---|
| `test_a_formatter_that_reads_args_positionally_still_has_them` | `ValueError: not enough values to unpack (expected 5, got 0)` |
| `test_the_arity_the_formatter_unpacks_is_preserved` | `assert 0 == 5` |
| `test_an_arg_that_is_not_a_string_is_left_as_it_is` | `IndexError: tuple index out of range` |
| `test_three_requests_produce_three_lines[positional]` | the handshake carrying a credential was dropped |
| `test_three_requests_produce_three_lines[uvicorn]` | the handshake carrying a credential was dropped |

The end-to-end cell is parametrized over a formatter that reads `args` positionally (the general contract) and uvicorn's real `AccessFormatter` behind `importorskip` (the proof it is not hypothetical, since `uvicorn` is only in the `dashboard` extra).

## Size

| file | + | - |
|---|---|---|
| `strands_robots/dashboard/log_redaction.py` | 66 | 2 |
| `tests/test_dashboard_log_redaction.py` | 167 | 0 |
| `changelog.d/3255-*.md` | 23 | 0 |

Of the 66 added production lines, 25 are executable/declaration and 41 are docstring (25), comment (9) and blank (7). No new public symbol: `_credential_values` and `_redacted_args` are private, and the new behaviour is described in `RedactingFilter`'s own docstring, which is this module's documentation (no `docs/` page references it).

Gate: `ruff check` / `format --check` clean over `strands_robots tests tests_integ`; `mypy` at its pre-existing 20 errors in 6 files, none in these files; `pytest -k "dashboard or redact or docstring or ascii or changelog or docs or grader or export or host_path"` 2277 passed with the one pre-existing `rebot_b601` registry/LeRobot drift failure, which reproduces on a clean `main`.

---

## §13 Review rounds

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R1 | Straddling credential regression: per-arg redaction partially rewrites a credential value spanning two args, leaking the remainder in plaintext | `a050bd9` | `tests/test_dashboard_log_redaction.py::TestStraddlingCredentialIsBaked` |