### PR TITLE
fix(training/rl): the interval an RL run checkpoints at gets a domain

### DIFF
--- a/changelog.d/3256-rl-checkpoint-interval-one-domain.md
+++ b/changelog.d/3256-rl-checkpoint-interval-one-domain.md
@@ -1,0 +1,24 @@
+### Fixed: the interval an RL run checkpoints at is held to one shared domain
+
+`RLTrainSpec.log_interval` was documented as "iterations between progress logs",
+but no RL module emits a log line: the field is read in exactly one expression,
+and that expression decides whether `save_checkpoint` runs for the iteration. It
+is the RL run's checkpoint cadence - the same kind of value as
+`TrainSpec.save_freq`, consumed as the modulus of the same periodic-checkpoint
+test - and it reached that modulus with no domain, so a cadence refused for a
+supervised run was accepted for an RL one.
+
+Measured on the inherited loop over 20 iterations, against the
+`[1, 6, 11, 16, 20]` an `int` cadence of `5` writes: `True` wrote 20 checkpoints
+(a modulus of one), `2.5` wrote the schedule of `5`, `nan` wrote only the final
+one - silently the *disabled* mode, under `status="success"` - and `"5"` raised
+`TypeError` out of `train()` after `setup` had built the env, the networks and
+the optimizers, past a `validate` documented to return every problem a run has.
+For RL those intermediate checkpoints are not a convenience: return is
+non-monotonic in training, so the deployable policy is often an earlier
+iteration.
+
+All three RL backends now route the field through the shared
+`step_cadence_error` domain that already owns `save_freq`. Only the *type* is
+graded, so `0` remains the supported "no intermediate checkpoints" mode, and the
+spec entry now documents what the field paces.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -356,6 +356,42 @@ successful, deployable run whose objective was not the configured one:
 spelling of *do not clip* - and the two bounds share one domain helper rather
 than a copy each.
 
+`log_interval` must be a whole number of iterations, checked by `validate()` on
+all three backends. **It is the RL run's checkpoint cadence, not a logging one**:
+no RL module emits a progress log, and the field is read in exactly one
+expression - `it % log_interval == 0` - which decides whether `save_checkpoint`
+runs for that iteration. So it answers for an RL run what
+[`TrainSpec.save_freq`](overview.md) answers for a supervised one
+(RL reads this field and ignores that one), and it takes the same shared
+step-cadence domain, because the modulus judges the value no more than lerobot's
+does. Measured on the loop over 20 iterations, against the `[1, 6, 11, 16, 20]`
+an `int` cadence of `5` writes:
+
+| `log_interval` | Checkpoints written | Reading |
+|---|---|---|
+| `5` | 5, at 1/6/11/16/20 | the requested schedule |
+| `True` | **20** | a modulus of one - one every iteration |
+| `2.5` | 5, at 1/6/11/16/20 | the schedule of `5`, not of `2.5` |
+| `0.3` | **2**, at 1 and 20 | the periodic checkpoints are gone |
+| `nan` | **1**, at 20 | silently the *disabled* mode |
+| `inf` | **2**, at 1 and 20 | ditto |
+| `"5"` | **0** | `TypeError` out of `train()`, after `setup` |
+| `0` | 1, at 20 | the supported "no intermediate checkpoints" mode |
+| `-5` | 5, at 1/6/11/16/20 | the cadence of its magnitude |
+
+`nan` is the worst of them: it satisfies the truthiness guard, never satisfies
+the modulus, and so a long run that asked to checkpoint every few iterations
+keeps only its final one - under `status="success"`. For RL those intermediate
+checkpoints are not a convenience: return is non-monotonic in training, so the
+deployable policy is often an earlier iteration, and a run that silently kept
+only its last cannot be recovered without training again.
+
+Only the *type* is graded, so this domain has no floor: `0` disables the periodic
+checkpoints and leaves the end-of-run fallback to write exactly one final
+checkpoint. A negative is accepted for the same reason and is *not* the disabled
+mode here - unlike lerobot's `save_freq > 0` test, this loop guards on bare
+truthiness - so which spelling disables is the loop's business, not the domain's.
+
 ## Worked example
 
 `examples/training/train_ppo_reach.py` (on-policy) and `examples/training/train_fastsac_reach.py`

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -146,6 +146,15 @@ its actor and its critics from. It is scoped like
 all three RL backends read the field, for every network they construct - and it
 is the only one of these gates whose field is a *sequence*, so the domain is
 asked of each element in turn and the message names the offending index.
+
+:func:`rl_checkpoint_interval_problems` is the eighteenth, and the second gate on
+the *cadence* axis :func:`checkpoint_cadence_problems` opened: ``log_interval``,
+the field the RL loop paces ``save_checkpoint`` by. It shares that gate's
+:func:`~strands_robots.utils.step_cadence_error` domain because the two fields
+are consumed identically - as the modulus of a periodic-checkpoint test - and
+differ only in which spec names them, so a cadence refused for a supervised run
+cannot be accepted for an RL one. It is scoped like
+:func:`network_width_problems`: all three RL backends run that loop.
 """
 
 from __future__ import annotations
@@ -1646,3 +1655,79 @@ def network_width_problems(spec: TrainSpec, *, context: str) -> list[str]:
         for index, width in enumerate(widths)
         if (error := positive_count_error(width, f"hidden_dims[{index}]", context)) is not None
     ]
+
+
+def rl_checkpoint_interval_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return checkpoint-cadence problems for an RL :class:`RLTrainSpec`.
+
+    ``log_interval`` is how often an RL run writes a checkpoint. Its name and
+    its :class:`RLTrainSpec` entry both said "iterations between progress logs",
+    but no RL module emits a log line at all - the field is read in exactly one
+    expression, the one that decides whether an intermediate checkpoint is
+    written, and all three backends share it::
+
+        if spec.log_interval and (it % spec.log_interval == 0 or it == num_iters - 1):
+            ckpt_dir = self.save_checkpoint(spec.output_dir, iteration=it + 1)
+
+    So it is the same *kind* of value as
+    :attr:`~strands_robots.training.base.TrainSpec.save_freq` - a periodic
+    checkpoint cadence consumed as a modulus - and it reached that modulus with
+    no domain at all, while the supervised field beside it on the same spec has
+    one. Measured on the inherited loop over a 20-iteration run, against the
+    ``[1, 6, 11, 16, 20]`` an ``int`` cadence of 5 writes:
+
+    ====================  ==============  ====================================
+    ``log_interval``      Verdict         Outcome
+    ====================  ==============  ====================================
+    ``5`` (a control)     accepted        5 checkpoints, at 1, 6, 11, 16, 20
+    ``True``             **accepted**     20 checkpoints - one every iteration
+    ``2.5``              **accepted**     5, at 1, 6, 11, 16, 20 - the schedule
+                                          of ``5``, not of ``2.5``
+    ``0.3``              **accepted**     2, at 1 and 20
+    ``nan``              **accepted**     1, at 20 - the *disabled* mode
+    ``inf``              **accepted**     2, at 1 and 20
+    ``"5"``              **accepted**     ``TypeError`` out of ``train()``
+    ``0``                 accepted        1, at 20 - the documented disable
+    ``-5``                accepted        5, at 1, 6, 11, 16, 20
+    ====================  ==============  ====================================
+
+    The bold rows are why this is a gate. ``nan`` is the worst of them: it
+    satisfies the truthiness guard, never satisfies the modulus, and so silently
+    becomes the disabled mode - a long run that asked to checkpoint every 5
+    iterations keeps only the final one, under ``status="success"``. For RL the
+    intermediate checkpoints are not a convenience: return is non-monotonic in
+    training, so the deployable policy is often an earlier one, and a run that
+    kept only its last iteration cannot be recovered without training again.
+    ``True`` is the opposite failure at the same seam (a modulus of one, a full
+    checkpoint every iteration), ``2.5`` is indistinguishable from the ``5`` a
+    caller who wanted twice as many checkpoints did not write, and ``"5"``
+    raises out of the training loop *after* ``setup`` has built the env, the
+    networks and the optimizers - from a lifecycle whose whole contract is to
+    report a failure as :class:`~strands_robots.training.base.TrainResult`, and
+    past a :meth:`~strands_robots.training.base.Trainer.validate` documented to
+    return every problem a run has.
+
+    Only the *type* is graded, exactly as for :func:`checkpoint_cadence_problems`,
+    and the two disabling spellings are first-class: ``0`` disables periodic
+    saving and leaves the end-of-run fallback in
+    :meth:`~strands_robots.training.rl.base_algo.BaseRLAlgo.train` to write the
+    single final checkpoint, a configuration that loop's own contract tests
+    already pin. A negative is accepted for the same
+    no-floor reason and is *not* the disabled mode here - unlike lerobot's
+    ``save_freq > 0`` test, this loop's guard is bare truthiness, so ``-5`` is
+    the cadence of its magnitude (measured above). Which spelling disables is
+    therefore the loop's own business; the domain's business is that the value
+    is a whole number of iterations.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single problem when ``log_interval`` is not a whole number of
+        iterations; empty otherwise.
+    """
+    error = step_cadence_error(getattr(spec, "log_interval", 0), "log_interval", context)
+    return [] if error is None else [error]

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -518,6 +518,45 @@ class Trainer(ABC):
 
         return checkpoint_cadence_problems(spec, context=self.provider_name)
 
+    def _rl_checkpoint_interval_problems(self, spec: TrainSpec) -> list[str]:
+        """Checkpoint-cadence preflight for the RL loop, on its own field.
+
+        Returns a problem when :attr:`RLTrainSpec.log_interval` is not a whole
+        number of iterations, against the same shared step-cadence domain
+        :meth:`_checkpoint_cadence_problems` holds ``save_freq`` to. A
+        :meth:`validate` implementation whose loop paces ``save_checkpoint`` on
+        ``it % log_interval`` MUST call this: the field is the RL run's
+        checkpoint cadence, and the modulus judges it no more than lerobot's
+        does. ``nan`` satisfies the truthiness guard and never the modulus, so a
+        run that asked to checkpoint every few iterations silently keeps only
+        its final one and still reports ``status="success"`` - the reading that
+        matters most for RL, where return is non-monotonic and the deployable
+        policy is often an earlier checkpoint. ``True`` is a cadence of one, a
+        fraction is a silently different cadence, and a string raises
+        ``TypeError`` out of the loop after ``setup`` has built the env, the
+        networks and the optimizers. Only the type is graded: ``0`` is the
+        documented "no intermediate checkpoints" mode.
+
+        Scoped like :meth:`_network_width_problems` rather than like
+        :meth:`_gae_lambda_problems`: all three RL backends run the same loop
+        over the same field, so there is no RL backend for which reporting on it
+        would be a false rejection. A supervised backend does not read it and
+        MUST NOT report on it - it has ``save_freq`` for the same question.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+
+        Args:
+            spec: The spec to preflight.
+
+        Returns:
+            A single problem when the cadence cannot be honored; empty
+            otherwise.
+        """
+        from strands_robots.training._validate import rl_checkpoint_interval_problems
+
+        return rl_checkpoint_interval_problems(spec, context=self.provider_name)
+
     def _validation_episodes_problems(self, spec: TrainSpec) -> list[str]:
         """Held-out-validation preflight shared by every backend that reads it.
 

--- a/strands_robots/training/rl/base_algo.py
+++ b/strands_robots/training/rl/base_algo.py
@@ -81,7 +81,22 @@ class RLTrainSpec(TrainSpec):
         normalize_obs: Wrap observations in ``EmpiricalNormalization``.
         normalize_advantage: Standardize advantages per batch.
         device: Torch device (``"cpu"`` / ``"cuda"``); ``None`` auto-selects.
-        log_interval: Iterations between progress logs.
+        log_interval: Iterations between checkpoints. This is the RL loop's
+            checkpoint cadence, not a logging one - no RL module emits a
+            progress log, and the field is read in exactly one expression,
+            ``it % log_interval == 0``, which decides whether
+            :meth:`BaseRLAlgo.save_checkpoint` runs for that iteration. So it
+            answers for an RL run what :attr:`TrainSpec.save_freq` answers for a
+            supervised one (RL reads this field and ignores that one), and it
+            takes the same whole-number domain for the same reason: a backend
+            MUST check it through
+            :meth:`Trainer._rl_checkpoint_interval_problems` rather than forward
+            it, because the modulus judges nothing. ``nan`` never satisfies the
+            test and silently keeps only the final checkpoint of a successful
+            run, ``True`` writes one every iteration, ``2.5`` is the schedule of
+            ``5``, and a string raises ``TypeError`` from inside the loop.
+            ``0`` is the supported "no intermediate checkpoints" mode - the
+            end-of-run fallback still writes exactly one final checkpoint.
         buffer_size: Off-policy replay-buffer capacity (SAC / TD3).
         batch_size: Transitions sampled per gradient step (SAC / TD3).
         learning_starts: Env steps of random warmup collected into the

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -217,6 +217,15 @@ class FastSacTrainer(BaseRLAlgo):
                 f"learning_starts ({spec.learning_starts}) must be >= batch_size ({spec.batch_size}) "
                 "so the first gradient step can sample a full batch"
             )
+        # log_interval is this loop's checkpoint cadence - the modulus of the one
+        # test that decides whether an intermediate checkpoint is written - so it
+        # answers the same question save_freq does for a supervised run and takes
+        # the same shared domain. The modulus judges it not at all: nan never
+        # satisfies it and silently keeps only the final checkpoint of a
+        # successful run, True writes one every iteration, a fraction is a
+        # silently different cadence, and a str raises out of the loop after
+        # setup has built the env, the networks and the optimizers.
+        problems.extend(self._rl_checkpoint_interval_problems(spec))
         return problems
 
     def setup(self, spec: RLTrainSpec) -> None:

--- a/strands_robots/training/rl/fast_td3.py
+++ b/strands_robots/training/rl/fast_td3.py
@@ -213,6 +213,15 @@ class FastTd3Trainer(BaseRLAlgo):
                 f"learning_starts ({spec.learning_starts}) must be >= batch_size ({spec.batch_size}) "
                 "so the first gradient step can sample a full batch"
             )
+        # log_interval is this loop's checkpoint cadence - the modulus of the one
+        # test that decides whether an intermediate checkpoint is written - so it
+        # answers the same question save_freq does for a supervised run and takes
+        # the same shared domain. The modulus judges it not at all: nan never
+        # satisfies it and silently keeps only the final checkpoint of a
+        # successful run, True writes one every iteration, a fraction is a
+        # silently different cadence, and a str raises out of the loop after
+        # setup has built the env, the networks and the optimizers.
+        problems.extend(self._rl_checkpoint_interval_problems(spec))
         return problems
 
     def setup(self, spec: RLTrainSpec) -> None:

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -221,6 +221,15 @@ class PpoTrainer(BaseRLAlgo):
             problems.append(
                 f"rollout_steps ({spec.rollout_steps}) must be divisible by num_mini_batches ({spec.num_mini_batches})"
             )
+        # log_interval is this loop's checkpoint cadence - the modulus of the one
+        # test that decides whether an intermediate checkpoint is written - so it
+        # answers the same question save_freq does for a supervised run and takes
+        # the same shared domain. The modulus judges it not at all: nan never
+        # satisfies it and silently keeps only the final checkpoint of a
+        # successful run, True writes one every iteration, a fraction is a
+        # silently different cadence, and a str raises out of the loop after
+        # setup has built the env, the networks and the optimizers.
+        problems.extend(self._rl_checkpoint_interval_problems(spec))
         return problems
 
     def setup(self, spec: RLTrainSpec) -> None:

--- a/tests/training/test_rl_checkpoint_interval_domain.py
+++ b/tests/training/test_rl_checkpoint_interval_domain.py
@@ -1,0 +1,379 @@
+"""The interval an RL run checkpoints at is the same shared step-cadence domain.
+
+:attr:`~strands_robots.training.rl.base_algo.RLTrainSpec.log_interval` is what
+the RL loop paces :meth:`BaseRLAlgo.save_checkpoint` by. Its name and its spec
+entry both said "iterations between progress logs", but no RL module emits a log
+line at all: the field is read in exactly one expression, and that expression
+decides whether an intermediate checkpoint is written::
+
+    if spec.log_interval and (it % spec.log_interval == 0 or it == num_iters - 1):
+        ckpt_dir = self.save_checkpoint(spec.output_dir, iteration=it + 1)
+
+So it is the same *kind* of value as
+:attr:`~strands_robots.training.base.TrainSpec.save_freq` - a periodic
+checkpoint cadence consumed as the modulus of a step test - and it reached that
+modulus with no domain at all, while the supervised field beside it on the same
+spec has one (``tests/training/test_checkpoint_cadence_domain.py``). One spec
+therefore meant two readings: a cadence refused for a supervised run was
+accepted for an RL one.
+
+Nothing downstream judges it. Measured on the inherited loop over a
+20-iteration run, against the ``[1, 6, 11, 16, 20]`` an ``int`` cadence of 5
+writes:
+
+* ``True`` wrote 20 checkpoints - one every iteration, a modulus of one.
+* ``2.5`` wrote the schedule of ``5``, so a caller who halved the cadence to
+  double the checkpoints got the same five.
+* ``nan`` wrote 1, at the final iteration: the modulus is never satisfied, so
+  the field silently became the *disabled* mode under ``status="success"``.
+  ``0.3`` and ``inf`` lose the periodic checkpoints the same way.
+* ``"5"`` raised ``TypeError`` out of ``train()`` - past a ``validate``
+  documented to return every problem a run has, and after ``setup`` had built
+  the env, the networks and the optimizers.
+
+For RL those intermediate checkpoints are not a convenience: return is
+non-monotonic in training, so the deployable policy is often an earlier
+iteration, and a run that silently kept only its last cannot be recovered
+without training again.
+
+The tests below pin the contract in both directions, against the same value sets
+the supervised half uses - imported from that guard rather than restated, so the
+two fields cannot drift on to two domains.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import textwrap
+from typing import Any
+
+import pytest
+
+from strands_robots.training._validate import rl_checkpoint_interval_problems
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.mock import MockTrainer
+from strands_robots.training.rl.base_algo import BaseRLAlgo, RLTrainSpec
+from strands_robots.training.rl.fast_sac import FastSacTrainer
+from strands_robots.training.rl.fast_td3 import FastTd3Trainer
+from strands_robots.training.rl.ppo import PpoTrainer
+
+# The smallest legal BaseRLAlgo, reused rather than copied: its stubbed hooks let
+# the *inherited* train loop run, which is the consumer this cadence reaches.
+from tests.training._spec_field_reads import reads_spec_field
+
+# One domain, so one value set: imported from the supervised guard rather than
+# restated, which is what stops the two fields drifting on to two rules.
+from tests.training.test_checkpoint_cadence_domain import (
+    A_FRACTIONAL_CADENCE,
+    A_STRING_CADENCE,
+    CHECKPOINTING_BACKENDS,
+    RAISED_IN_THE_CONSUMER,
+    UNUSABLE,
+    USABLE,
+)
+from tests.training.test_rl_base_lifecycle_contract import _BareRLAlgo
+
+# Every RL backend checkpoints from the field - all three inherit the one loop.
+RL_BACKENDS = (PpoTrainer, FastSacTrainer, FastTd3Trainer)
+
+# Iterations in the measured run, and the cadence a caller writes. Sized so a
+# wrong reading shows up as a different number of checkpoints.
+RL_ITERS = 20
+A_REQUESTED_CADENCE = 5
+# What that cadence really writes, measured on the inherited loop.
+THE_REQUESTED_SCHEDULE = [1, 6, 11, 16, 20]
+
+# The shape the shared domain emits: ``"{context}: log_interval must be ..."``.
+_NAMES_THE_INTERVAL = ": log_interval "
+
+
+@pytest.fixture
+def spec(tmp_path: pathlib.Path) -> RLTrainSpec:
+    """A launchable RL spec whose ``log_interval`` is the only thing under test.
+
+    ``validate`` may report unrelated problems; every assertion below filters for
+    the field name, so an unrelated problem can neither mask nor fake a verdict.
+    """
+    return RLTrainSpec(
+        env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+        output_dir=str(tmp_path / "out"),
+        total_timesteps=RL_ITERS,
+    )
+
+
+def _interval_problems_of(trainer: Trainer, spec: TrainSpec) -> list[str]:
+    """``validate`` problems about ``log_interval``."""
+    return [p for p in trainer.validate(spec) if _NAMES_THE_INTERVAL in p]
+
+
+def _checkpoint_iterations(cadence: Any) -> list[int | None]:
+    """Iterations the inherited RL loop writes a checkpoint at, for *cadence*.
+
+    Drives the real :meth:`BaseRLAlgo.train` over stubbed hooks, so the schedule
+    is the loop's own reading of the field rather than a restatement of it. The
+    stub's ``validate`` reports nothing, which is what lets a value the gate now
+    refuses still be measured against the consumer it used to reach.
+    """
+    algo = _BareRLAlgo()
+    algo.train(RLTrainSpec(total_timesteps=RL_ITERS, log_interval=cadence, output_dir="/tmp/rl-out"))
+    return list(algo.saved_iterations)
+
+
+class TestEveryRLBackendRefusesAnUnusableInterval:
+    """First half of the biconditional: a backend that checkpoints must refuse."""
+
+    @pytest.mark.parametrize("trainer_cls", RL_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: RLTrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.log_interval = value
+        assert _interval_problems_of(trainer_cls(), spec) != []
+
+    @pytest.mark.parametrize("trainer_cls", RL_BACKENDS)
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: RLTrainSpec, trainer_cls: type[Trainer]) -> None:
+        trainer = trainer_cls()
+        spec.log_interval = A_FRACTIONAL_CADENCE
+        problems = _interval_problems_of(trainer, spec)
+        assert problems and problems[0].startswith(f"{trainer.provider_name}: ")
+
+    @pytest.mark.parametrize("trainer_cls", RL_BACKENDS)
+    @pytest.mark.parametrize("value", RAISED_IN_THE_CONSUMER)
+    def test_an_unusable_interval_is_a_problem_not_an_exception(
+        self, spec: RLTrainSpec, trainer_cls: type[Trainer], value: Any
+    ) -> None:
+        """``validate`` is documented to *return* problems, for every spelling.
+
+        A str or a list reaches the loop's ``%`` as an operand it cannot take, so
+        a preflight that compared the value itself would raise here instead.
+        """
+        spec.log_interval = value
+        assert _interval_problems_of(trainer_cls(), spec) != []
+
+    @pytest.mark.parametrize("trainer_cls", RL_BACKENDS)
+    @pytest.mark.parametrize("value", USABLE)
+    def test_a_usable_interval_is_not_a_problem(
+        self, spec: RLTrainSpec, trainer_cls: type[Trainer], value: int
+    ) -> None:
+        """Including ``0`` and a negative: this domain has no floor."""
+        spec.log_interval = value
+        assert _interval_problems_of(trainer_cls(), spec) == []
+
+    @pytest.mark.parametrize("trainer_cls", RL_BACKENDS)
+    def test_the_default_interval_is_not_a_problem(self, spec: RLTrainSpec, trainer_cls: type[Trainer]) -> None:
+        assert _interval_problems_of(trainer_cls(), spec) == []
+
+
+class TestASupervisedBackendReportsNothingAboutIt:
+    """Second half of the biconditional: a non-reader must not report.
+
+    Per :class:`~strands_robots.training.base.TrainSpec` a backend ignores the
+    fields it does not support, so a supervised backend reporting on the RL
+    loop's interval would be a false rejection - it has ``save_freq`` for the
+    same question.
+    """
+
+    @pytest.mark.parametrize("trainer_cls", (*CHECKPOINTING_BACKENDS, MockTrainer))
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_says_nothing(self, spec: RLTrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.log_interval = value
+        assert _interval_problems_of(trainer_cls(), spec) == []
+
+
+class TestWhatTheLoopDoesWithAnUnusableInterval:
+    """Ground every refusal in the schedule the loop really writes."""
+
+    def test_the_requested_cadence_is_the_reference(self) -> None:
+        """Non-vacuity: an int cadence writes the schedule the others are read against."""
+        assert _checkpoint_iterations(A_REQUESTED_CADENCE) == THE_REQUESTED_SCHEDULE
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_does_not_write_the_requested_schedule(self, value: Any) -> None:
+        try:
+            written = _checkpoint_iterations(value)
+        except TypeError:
+            return  # raised out of the loop - pinned by its own test below
+        assert written != THE_REQUESTED_SCHEDULE
+
+    def test_a_boolean_interval_checkpoints_every_single_iteration(self) -> None:
+        """``True`` is a modulus of one: 20 checkpoints in a 20-iteration run."""
+        assert _checkpoint_iterations(True) == list(range(1, RL_ITERS + 1))
+
+    @pytest.mark.parametrize("value", (float("nan"), 0.3, float("inf")))
+    def test_a_non_integral_interval_silently_loses_the_periodic_checkpoints(self, value: float) -> None:
+        """The worst reading: only the final checkpoint survives, under success.
+
+        ``nan`` never satisfies the modulus, so only the ``it == num_iters - 1``
+        arm fires. For RL that is the whole point of the field - return is
+        non-monotonic, so the deployable policy is often an earlier iteration.
+        """
+        written = _checkpoint_iterations(value)
+        assert written[-1] == RL_ITERS
+        assert len(written) < len(THE_REQUESTED_SCHEDULE)
+
+    def test_a_fractional_interval_is_the_schedule_of_a_different_integer(self) -> None:
+        """``2.5`` is indistinguishable from the ``5`` the caller did not write.
+
+        The conflation a type check catches and a range check cannot.
+        """
+        assert _checkpoint_iterations(2.5) == _checkpoint_iterations(5) == THE_REQUESTED_SCHEDULE
+
+    @pytest.mark.parametrize("value", RAISED_IN_THE_CONSUMER)
+    def test_a_non_numeric_interval_raises_inside_the_training_loop(self, value: Any) -> None:
+        """Not a ``TrainResult``: a traceback out of ``train()``, after ``setup``.
+
+        The lifecycle's whole contract is to report a failed run as a terminal
+        ``TrainResult``; this escaped it with the env, the networks and the
+        optimizers already built.
+        """
+        with pytest.raises(TypeError):
+            _checkpoint_iterations(value)
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_every_value_inside_the_domain_is_honored(self, value: int) -> None:
+        written = _checkpoint_iterations(value)
+        assert written and written[-1] == RL_ITERS
+
+    def test_zero_disables_the_periodic_checkpoints_and_a_negative_does_not(self) -> None:
+        """Which spelling disables is the loop's business, not the domain's.
+
+        Unlike lerobot's ``save_freq > 0`` test, this loop guards on bare
+        truthiness: ``0`` leaves only the single end-of-run checkpoint, while a
+        negative is the cadence of its magnitude. Both are inside the domain -
+        it has no floor - so this pins the asymmetry rather than hiding it.
+        """
+        assert _checkpoint_iterations(0) == [RL_ITERS]
+        assert _checkpoint_iterations(-A_REQUESTED_CADENCE) == THE_REQUESTED_SCHEDULE
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module, minus the one that defines the shared gate.
+
+    Rooted at the module that defines :class:`Trainer` rather than at the RL
+    package, so a supervised module that starts reading the field is in scope
+    too. The module that *defines* the gate is excluded - derived from the gate
+    itself rather than named, so the exclusion cannot drift - because it reads
+    the field as its owner, not as a consumer.
+    """
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(rl_checkpoint_interval_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_interval(source: str) -> bool:
+    """Does *source* read ``spec.log_interval``, by name or through a table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read.
+    """
+    return reads_spec_field(source, ("log_interval",))
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_rl_checkpoint_interval_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _concrete_rl_backends() -> set[type[BaseRLAlgo]]:
+    """Every shipped :class:`BaseRLAlgo` subclass, discovered rather than listed.
+
+    The subclasses are only ever read here (their ``validate`` source is
+    inspected, never instantiated), which is why holding the abstract base's
+    ``type`` is sound.
+    """
+    # type-abstract: the base is an ABC, and these are held rather than called.
+    shipped = [c for c in BaseRLAlgo.__subclasses__() if c.__module__.startswith("strands_robots.")]
+    return set(shipped)  # type: ignore[type-abstract]
+
+
+class TestOneOwnerForTheRLCheckpointInterval:
+    """No RL backend may skip the domain, and none may re-implement it.
+
+    Scope is derived from the class hierarchy, not from the text, because a
+    *textual* read is not what puts a backend in scope here: FastSAC and FastTD3
+    override ``train`` and so name the field, while PPO inherits
+    :meth:`BaseRLAlgo.train` and never mentions it - yet PPO runs the identical
+    loop over the identical field. A scan keyed on the attribute access would
+    report a clean sweep with PPO's interval ungated. What every backend in scope
+    shares is that it *is* a ``BaseRLAlgo``, so that is the derivation, and a
+    fourth RL backend fails these tests until its ``validate`` routes through the
+    gate.
+    """
+
+    def test_the_discovery_finds_every_shipped_rl_backend(self) -> None:
+        """Non-vacuity, and the agreement cell: a new backend cannot arrive unpinned."""
+        assert sorted(c.__name__ for c in _concrete_rl_backends()) == sorted(c.__name__ for c in RL_BACKENDS)
+
+    def test_every_rl_backend_routes_through_the_shared_gate(self) -> None:
+        adrift = sorted(
+            cls.__name__
+            for cls in _concrete_rl_backends()
+            if not _calls_the_gate(textwrap.dedent(inspect.getsource(cls.validate)))
+        )
+        assert adrift == [], f"RL backends whose validate skips the shared gate: {adrift}"
+
+    def test_the_loop_that_consumes_the_interval_is_the_inherited_one(self) -> None:
+        """Why the hierarchy is the right scope: PPO reads the field by inheriting.
+
+        Pins the asymmetry the derivation is built on, so a refactor that moves
+        the loop cannot quietly invalidate it.
+        """
+        readers = {p.name for p in _training_modules() if _reads_the_interval(p.read_text())}
+        assert readers == {"base_algo.py", "fast_sac.py", "fast_td3.py"}
+        assert PpoTrainer.train is BaseRLAlgo.train
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        offenders: list[str] = []
+        for path in _training_modules():
+            for line in path.read_text().splitlines():
+                if "spec.log_interval" in line and ("int(" in line or "isinstance" in line):
+                    offenders.append(f"{path.name}: {line.strip()}")
+        assert offenders == [], f"local domain checks on spec.log_interval: {offenders}"
+
+    def test_the_scanners_detect_a_planted_defect(self) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        planted = "def validate(self, spec):\n    return [f'--log_every={spec.log_interval}']\n"
+        assert _reads_the_interval(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_the_scanners_detect_a_table_driven_defect(self) -> None:
+        """A backend that forwards the field by name is a reader too."""
+        planted = (
+            'FIELDS = ("log_interval",)\ndef validate(self, spec):\n    return [getattr(spec, f) for f in FIELDS]\n'
+        )
+        assert _reads_the_interval(planted)
+        assert not _calls_the_gate(planted)
+
+
+class TestTheSharedDomainSurface:
+    """The gate itself, called directly."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_refuses_what_the_supervised_gate_refuses(self, value: Any) -> None:
+        assert rl_checkpoint_interval_problems(RLTrainSpec(log_interval=value), context="acme") != []
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_it_accepts_what_the_supervised_gate_accepts(self, value: int) -> None:
+        assert rl_checkpoint_interval_problems(RLTrainSpec(log_interval=value), context="acme") == []
+
+    def test_it_reports_one_problem_at_a_time_naming_its_own_field(self) -> None:
+        problems = rl_checkpoint_interval_problems(RLTrainSpec(log_interval=A_FRACTIONAL_CADENCE), context="acme")
+        assert len(problems) == 1
+        assert problems[0].startswith("acme: log_interval must be an integer number of steps, got 2.7.")
+
+    def test_it_reports_the_context_it_was_given(self) -> None:
+        problems = rl_checkpoint_interval_problems(RLTrainSpec(log_interval=A_STRING_CADENCE), context="acme")
+        assert problems and problems[0].startswith("acme: ")
+
+    def test_a_spec_without_the_field_reports_nothing(self) -> None:
+        """``log_interval`` lives on ``RLTrainSpec``, so a plain spec carries no interval.
+
+        Read defensively for the same reason the other RL-only gates are: the
+        signature is the shared ``TrainSpec`` one.
+        """
+        assert rl_checkpoint_interval_problems(TrainSpec(), context="acme") == []

--- a/tests/training/test_spec_field_read_discovery.py
+++ b/tests/training/test_spec_field_read_discovery.py
@@ -74,6 +74,12 @@ FIELD_SCOPED_GATES: dict[str, tuple[str, ...]] = {
     "_clip_range_problems": ("clip_param",),
     "_policy_delay_problems": ("policy_delay",),
     "_td3_noise_problems": ("exploration_noise_std", "target_noise_std", "target_noise_clip"),
+    # The RL checkpoint-interval gate. Its field lives on ``RLTrainSpec`` and no
+    # provider forwards it, so it is graded on the reader scan only - and that
+    # scan is the *secondary* derivation for this guard, whose primary scope is
+    # the BaseRLAlgo hierarchy: PPO inherits the loop that reads the field and
+    # never names it.
+    "_rl_checkpoint_interval_problems": ("log_interval",),
     # The network-architecture gate. Its one field is a *sequence*, and it is
     # scoped like the learning rate across the RL backends (all three build
     # their actor and critics from it) while still being field-scoped overall,
@@ -195,6 +201,7 @@ class TestEveryFieldScopedGuardSeesBothFormsOfARead:
             "test_optimization_epochs_domain.py",
             "test_policy_delay_domain.py",
             "test_rl_run_size_domain.py",
+            "test_rl_checkpoint_interval_domain.py",
             "test_rl_replay_domain.py",
             "test_seed_domain.py",
             "test_td3_noise_domain.py",


### PR DESCRIPTION
`RLTrainSpec.log_interval` is documented as "iterations between progress logs".
No RL module emits a log line. The field is read in exactly one expression, and
that expression decides whether a checkpoint is written:

```python
if spec.log_interval and (it % spec.log_interval == 0 or it == num_iters - 1):
    ckpt_dir = self.save_checkpoint(spec.output_dir, iteration=it + 1)
```

So it is the RL run's **checkpoint cadence** - the same kind of value as
`TrainSpec.save_freq`, consumed as the modulus of the same periodic-checkpoint
test. `save_freq` has a documented shared domain and five backends routing
through it; `log_interval` reached that modulus with no domain at all, so a
cadence refused for a supervised run was accepted for an RL one.

![measured](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/pr-3256-rl-log-interval.png)

## What the loop did with it

Measured on `BaseRLAlgo.train` over 20 iterations, against the
`[1, 6, 11, 16, 20]` an `int` cadence of `5` writes:

| `log_interval` | Checkpoints | Reading |
|---|---|---|
| `5` | 5, at 1/6/11/16/20 | the requested schedule |
| `True` | **20** | a modulus of one - one every iteration |
| `2.5` | 5, at 1/6/11/16/20 | the schedule of `5`, not of `2.5` |
| `0.3` | **2**, at 1 and 20 | the periodic checkpoints are gone |
| `nan` | **1**, at 20 | silently the *disabled* mode |
| `inf` | **2**, at 1 and 20 | ditto |
| `"5"` | **0** | `TypeError` out of `train()`, after `setup` |
| `0` | 1, at 20 | the supported "no intermediate checkpoints" mode |
| `-5` | 5, at 1/6/11/16/20 | the cadence of its magnitude |

`nan` is the worst: it satisfies the truthiness guard, never satisfies the
modulus, so a long run that asked to checkpoint every few iterations keeps only
its final one - under `status="success"`. For RL those intermediate checkpoints
are not a convenience: return is non-monotonic in training, so the deployable
policy is often an earlier iteration, and a run that silently kept only its last
cannot be recovered without training again. `"5"` is the other end: a traceback
out of a lifecycle whose whole contract is to report a failed run as a terminal
`TrainResult`, past a `validate` documented to return every problem a run has.

## The change

All three RL backends route the field through the shared
`step_cadence_error` domain that already owns `save_freq`, via a new
`Trainer._rl_checkpoint_interval_problems`. `validate()` verdicts, measured:
**0 of 30 refused before -> 21 of 30 after** (7 unusable spellings x 3 backends;
the 3 usable spellings stay accepted, and no supervised backend reports on the
field).

Only the *type* is graded, so the domain has no floor - `0` stays the supported
disable mode, which this loop's own contract tests already pin. A negative is
accepted for the same reason and is **not** the disabled mode here: unlike
lerobot's `save_freq > 0` test, this loop guards on bare truthiness, so `-5` is
the cadence of its magnitude. Which spelling disables is the loop's business;
the domain's business is that the value is a whole number of iterations. That
asymmetry is pinned rather than hidden.

The scope derivation is the `BaseRLAlgo` hierarchy, not a text scan: FastSAC and
FastTD3 override `train` and name the field, while **PPO inherits the loop and
never mentions it** - a scan keyed on `spec.log_interval` reports a clean sweep
with PPO's cadence ungated. A fourth RL backend fails the guard until its
`validate` routes through the gate.

Deliberately **not** changed: which field wins. Making RL honour the inherited
`save_freq` instead is a design decision, not a cleanup, so this fixes the field
the code actually consumes and documents it.

## Tests

New guard `tests/training/test_rl_checkpoint_interval_domain.py`, following the
one-file-per-field-scoped-domain shape (its value sets are imported from the
`save_freq` guard rather than restated, so the two fields cannot drift on to two
rules). Four corners, on the guard plus the meta-guard it registers with:

| | old tests | new tests |
|---|---|---|
| **consumers at `main`** | 129 passed | **31 failed**, 162 passed |
| **with the gate** | 129 passed | 193 passed |

The bottom-left corner is what proves no existing cell moved. Full
`tests/training` is unchanged against `main` at 8 failed / 9 errors, all
pre-existing lerobot-version drift unrelated to this change (`eval_split`,
`make_train_eval_datasets`, `_require_package_cache`), with +132 passing cells
added. `ruff check` / `format --check` clean over 1903 files; `mypy` back to its
baseline 20 errors in 6 files, none in the files touched here.

## Size

613 insertions, 1 deletion over 10 files. Of the 167 added production lines,
**9 are executable** - the rest is 130 docstring, 24 comment, 4 blank:

| | + | notes |
|---|---|---|
| `training/_validate.py` | 85 | the gate: 3 executable, 80 docstring (the measured table) |
| `training/base.py` | 39 | the `Trainer` delegation: 3 executable |
| `training/rl/{ppo,fast_sac,fast_td3}.py` | 9 each | 1 call + 8 comment lines each |
| `training/rl/base_algo.py` | 16/-1 | the spec entry, corrected to what the field paces |
| `tests/` | 386 | the new guard + its registration |
| `docs/training/rl.md` | 36 | the domain, with the measured table |
| `changelog.d/` | 24 | |
