### PR TITLE
fix(dashboard/auth): a narrowed session window is honoured or refused, never widened

### DIFF
--- a/changelog.d/3257-auth-duration-knobs-are-not-widened.md
+++ b/changelog.d/3257-auth-duration-knobs-are-not-widened.md
@@ -1,0 +1,31 @@
+### Fixed: a narrowed dashboard session window is honoured or refused, never widened
+
+`STRANDS_DASH_AUTH_TOKEN_TTL`, `..._SESSION_MAX_AGE` and `..._HANDOFF_TTL` are how
+an operator shortens the window in which a dashboard session can command real
+hardware: how long a session token lives, the absolute age past which no renewal
+extends it, and the lifetime of a token that rides in a LAN URL. Each was read
+with a bare `int(os.getenv(...))` under `except ValueError: return <the default>`.
+
+So every spelling that is not a plain integer resolved to the shipped default,
+and the shipped default is the WIDER value in all three cases. Measured end to
+end through the surface that spends each one, `TOKEN_TTL=1h` produced a 86400
+second session, `SESSION_MAX_AGE=1h` a 30-day renewal cap, and `HANDOFF_TTL=30s`
+a 300 second URL token - 24x, 720x and 10x what was asked for, with nothing
+logged. `15m`, `3600s`, `1 hour` and a trailing `# comment` all behaved the same
+way. Values at or below zero parsed cleanly instead, and mint tokens that are
+already expired when handed out, so nobody can sign in.
+
+The module already stated the rule this broke. `_challenge_cap` refuses a cap it
+cannot use precisely so that "an operator who narrowed a cap and mistyped it must
+hear about it, not silently be handed the wide default back", and `auth_enabled`
+reports an unrecognized boolean rather than letting a typo drop the guard. The
+duration knobs are now read through one `_duration()` domain with the same
+posture, resolved once at import so a misspelling stops the server rather than
+first surfacing as a failed login on a dashboard that is already serving. Their
+defaults live in one `_DURATION_DEFAULTS` table, so no reader can hand back a
+number the documentation does not state.
+
+An empty variable still means unset, whitespace and `3_600` are still accepted,
+and a maximum age below the token lifetime is still a legal pair - unlike the
+challenge caps, no cross-knob rule is imposed, because "tokens last a day but
+re-authenticate every hour" is a coherent request and the cap simply wins.

--- a/docs/dashboard/remote-access.md
+++ b/docs/dashboard/remote-access.md
@@ -147,7 +147,15 @@ Order of operations, and the reason for it:
 - The mesh is a separate trust domain from the web session. `--local-dev`
   disables mesh TLS for single-machine work; do not leave it on for a fleet
   that spans machines. See [Multi-robot Mesh](../mesh.md).
-- A session lasts `STRANDS_DASH_AUTH_TOKEN_TTL` seconds (default 86400).
+- A session lasts `STRANDS_DASH_AUTH_TOKEN_TTL` seconds (default 86400), cannot
+  be renewed past `STRANDS_DASH_AUTH_SESSION_MAX_AGE` seconds from the original
+  sign-in (default 2592000) and can be copied into a LAN URL for
+  `STRANDS_DASH_AUTH_HANDOFF_TTL` seconds (default 300). All three are a whole
+  number of **seconds**: `1h`, `30s` and `15m` are not units this reads. A value
+  it cannot use is refused at startup rather than replaced by the default,
+  because the default is the wider window in all three cases - shortening one of
+  these and being handed the long one back is the mistake worth failing loudly
+  over.
 - In-flight sign-in challenges are bounded by `STRANDS_DASH_AUTH_CHAL_MAX`
   (default 512) and `STRANDS_DASH_AUTH_CHAL_MAX_PER_IP` (default 16). The
   per-ip bound is what stops one client from filling the table and pushing out

--- a/strands_robots/dashboard/auth.py
+++ b/strands_robots/dashboard/auth.py
@@ -19,6 +19,14 @@ Configuration:
         so it must carry the scheme and any non-default port.
     ``STRANDS_DASH_AUTH_RP_ID``: pins the relying-party id when the hostname
         legitimately changed. See :func:`rp_id_verdict`.
+    ``STRANDS_DASH_AUTH_TOKEN_TTL`` (default 86400), ``..._SESSION_MAX_AGE``
+        (default 2592000) and ``..._HANDOFF_TTL`` (default 300): how long a
+        session token lives, the absolute age past which no renewal extends it,
+        and the lifetime of a handoff token. All three are a whole number of
+        SECONDS, read through :func:`_duration`, which refuses a value it cannot
+        use rather than substituting the default: these are how the window in
+        which a session commands hardware gets narrowed, and every direction a
+        substituted default lands in is the wider one.
     ``STRANDS_DASH_AUTH_CHAL_MAX`` (default 512) and
         ``STRANDS_DASH_AUTH_CHAL_MAX_PER_IP`` (default 16): bounds on the table of
         in-flight WebAuthn challenges. The per-ip cap must stay strictly below the
@@ -104,11 +112,80 @@ def _rp_name() -> str:
     return os.getenv(_ENV + "RP_NAME", "strands robots dashboard")
 
 
-def _token_ttl() -> int:
+# Every duration this module reads, in seconds, with the value each falls back
+# to when its variable is unset. One table rather than a literal at each reader:
+# a second copy of a fallback is what lets a reader hand back a number no
+# documentation states.
+_DURATION_DEFAULTS = {"TOKEN_TTL": 86400, "SESSION_MAX_AGE": 2592000, "HANDOFF_TTL": 300}
+
+
+def _duration(name: str) -> int:
+    """Read one duration knob, in seconds, refusing a value it cannot use.
+
+    Args:
+        name: Suffix of the environment variable, e.g. ``"TOKEN_TTL"``. Must be
+            a key of :data:`_DURATION_DEFAULTS`, which supplies its fallback.
+
+    Returns:
+        The duration in seconds, as an ``int``.
+
+    Raises:
+        ValueError: The variable holds something that is not a whole number of
+            seconds, or a number below one second. Refused rather than
+            defaulted, for the same reason :func:`_challenge_cap` refuses a cap
+            it cannot use: these knobs are how an operator TIGHTENS the window
+            in which a session commands real hardware, and every direction the
+            old reader defaulted in was the wider one. ``TOKEN_TTL=1h`` is not
+            an hour, it is unparseable, and silently handing back the one-day
+            default means the operator who shortened the window keeps the long
+            one and is never told.
+    """
+    default = _DURATION_DEFAULTS[name]
+    var = _ENV + name
+    raw = os.getenv(var, "").strip()
+    if not raw:
+        return default
     try:
-        return int(os.getenv(_ENV + "TOKEN_TTL", "86400"))
+        value = int(raw)
     except ValueError:
-        return 86400
+        raise ValueError(
+            f"{var}={raw!r} is not a whole number of seconds (default {default}). "
+            "Durations here are plain integers: '1h', '30s' and '15m' are not "
+            "recognized units, and a window narrowed with one of them would be "
+            "dropped in favour of the wider default."
+        ) from None
+    if value < 1:
+        raise ValueError(
+            f"{var}={value} is not a usable lifetime: it must be >= 1 second "
+            f"(default {default}). At or below zero, every token minted under it "
+            "is already expired when it is handed out, so nobody can sign in."
+        )
+    return value
+
+
+def _validate_durations() -> None:
+    """Resolve every duration knob once, refusing the whole configuration if one
+    cannot be read.
+
+    Called at import so a misspelled duration stops the server, rather than
+    first surfacing as a failed login on a dashboard that is already serving.
+    The readers below re-read their own variable, so the environment stays the
+    source of truth.
+
+    Raises:
+        ValueError: Propagated from :func:`_duration` for the first knob that
+            holds a value it cannot use.
+    """
+    for knob in _DURATION_DEFAULTS:
+        _duration(knob)
+
+
+_validate_durations()
+
+
+def _token_ttl() -> int:
+    """Lifetime of a freshly minted session token (default 1 day)."""
+    return _duration("TOKEN_TTL")
 
 
 def _bootstrap_token() -> str:
@@ -735,10 +812,7 @@ def issue_token(
 
 def _session_max_age() -> int:
     """Absolute lifetime of a session, however often it is renewed (default 30 days)."""
-    try:
-        return int(os.getenv(_ENV + "SESSION_MAX_AGE", "2592000"))
-    except ValueError:
-        return 2592000
+    return _duration("SESSION_MAX_AGE")
 
 
 def renewal_verdict(
@@ -827,10 +901,7 @@ def session_is_valid(token: str) -> bool:
 def handoff_ttl() -> int:
     """Lifetime of a handoff token (default 5 minutes). It rides in a URL, so it must be
     short: URLs land in history, logs and screenshots."""
-    try:
-        return int(os.getenv(_ENV + "HANDOFF_TTL", "300"))
-    except ValueError:
-        return 300
+    return _duration("HANDOFF_TTL")
 
 
 def handoff_verdict(

--- a/tests/test_dashboard_auth_duration_knobs_are_not_widened.py
+++ b/tests/test_dashboard_auth_duration_knobs_are_not_widened.py
@@ -20,6 +20,7 @@ lifetime is still a legal pair.
 from __future__ import annotations
 
 import time
+from pathlib import Path
 
 import jwt
 import pytest
@@ -33,6 +34,36 @@ DOCUMENTED_DEFAULTS = {"TOKEN_TTL": 86400, "SESSION_MAX_AGE": 2592000, "HANDOFF_
 # Durations that mean something to a human and nothing to ``int()``. Each is a
 # plausible way to ask for one hour, or to annotate the number.
 UNIT_SPELLINGS = ["1h", "60m", "3600s", "1 hour", "3600 # one hour", "0x10", "1e3", "3600.0", "banana", ""]
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path, monkeypatch):
+    """Point every store reader in this file at a per-test file.
+
+    The surface cells below mint tokens, and :func:`auth.issue_token` /
+    :func:`auth.issue_handoff` sign with ``_jwt_secret()``, which reads the
+    credential store. :func:`auth._store_path` resolves an unset ``STORE`` to
+    ``~/.strands_dashboard/auth.json`` - the file that decides whether a
+    dashboard on this machine is sealed - so without this redirect these cells
+    both read and WRITE it: on a machine with no store they create one, and on
+    a machine whose store is unparseable :func:`auth._preserve_corrupt` renames
+    the operator's file aside and writes a fresh JWT secret, invalidating every
+    live session token. Both under a green report. A store that parses but
+    carries no ``jwt_secret`` makes two cells fail for a reason that has
+    nothing to do with a duration, so the verdict is decided by what the
+    machine already holds. ``$HOME`` is fresh in CI, so no gate reports any of
+    it. The ten sibling ``test_dashboard_auth_*`` modules that reach the store
+    all carry this redirect; AGENTS.md rule 15 states the same rule for the
+    dataset cache, for the same reason.
+
+    ``monkeypatch.setenv`` rather than a patched module attribute, because the
+    private module copies :func:`_load_auth` builds re-read ``STORE`` from the
+    environment and carry their own caches - an attribute patch would redirect
+    the shared module and leave every copy pointing at the real store.
+    """
+    monkeypatch.setenv(auth._ENV + "STORE", str(tmp_path / "auth.json"))
+    auth._cache = {}
+    yield
 
 
 def _load_auth(monkeypatch, **env):
@@ -100,6 +131,22 @@ KNOBS = {
 def test_every_duration_knob_this_module_reads_is_pinned_here():
     """A fourth duration knob must not arrive with its own bare int() and no pin."""
     assert set(KNOBS) == set(auth._DURATION_DEFAULTS) == set(DOCUMENTED_DEFAULTS)
+
+
+def test_no_module_path_in_this_file_reads_the_real_credential_store(tmp_path, monkeypatch):
+    """Neither module path here may resolve the store a real dashboard is sealed by.
+
+    Both are checked because they resolve it independently: the shared ``auth``
+    module, and the private copy :func:`_load_auth` builds, which re-reads
+    ``STORE`` from the environment. A redirect applied as a module attribute
+    would satisfy the first and leave the second on
+    ``~/.strands_dashboard/auth.json``, where minting a token writes.
+    """
+    home_store = (Path.home() / ".strands_dashboard" / "auth.json").resolve()
+    paths = {"the shared module": auth._store_path(), "_load_auth's copy": _load_auth(monkeypatch)._store_path()}
+    for which, path in paths.items():
+        assert path != home_store, f"{which} resolves the store to the operator's own file: {path}"
+        assert path.is_relative_to(tmp_path), f"{which} resolves the store outside this test's tmp_path: {path}"
 
 
 # --- the defect: a narrowing spelled with a unit resolved to the wide default --

--- a/tests/test_dashboard_auth_duration_knobs_are_not_widened.py
+++ b/tests/test_dashboard_auth_duration_knobs_are_not_widened.py
@@ -1,0 +1,193 @@
+"""The three auth duration knobs resolve through one domain, or are refused.
+
+``TOKEN_TTL``, ``SESSION_MAX_AGE`` and ``HANDOFF_TTL`` are how an operator
+NARROWS the window in which a dashboard session can command real hardware. Each
+was read with a bare ``int(os.getenv(...))`` under ``except ValueError: return
+<the default>``, so every spelling that is not a plain integer -- ``1h``,
+``30s``, ``15m``, a trailing comment -- resolved to the shipped default, and the
+default is the WIDER value in all three cases. The operator who shortened the
+window kept the long one and was told nothing.
+
+The module already states the rule this broke: :func:`auth._challenge_cap`
+refuses a cap it cannot use precisely so that "an operator who narrowed a cap
+and mistyped it must hear about it, not silently be handed the wide default
+back". These pins hold the duration knobs to the same rule, and hold the three
+things deliberately left alone: an EMPTY variable still means unset, a bare
+integer is still honoured end to end, and a maximum age below the token
+lifetime is still a legal pair.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+
+import strands_robots.dashboard.auth as auth
+
+# The documented contract, spelled here rather than imported, so these pins fail
+# if the shipped defaults move rather than moving with them.
+DOCUMENTED_DEFAULTS = {"TOKEN_TTL": 86400, "SESSION_MAX_AGE": 2592000, "HANDOFF_TTL": 300}
+
+# Durations that mean something to a human and nothing to ``int()``. Each is a
+# plausible way to ask for one hour, or to annotate the number.
+UNIT_SPELLINGS = ["1h", "60m", "3600s", "1 hour", "3600 # one hour", "0x10", "1e3", "3600.0", "banana", ""]
+
+
+def _load_auth(monkeypatch, **env):
+    """Import a private copy of the auth module under ``env``.
+
+    A fresh module object rather than a reload, so a refused configuration
+    cannot leave ``strands_robots.dashboard.auth`` unusable for the rest of the
+    session. Mirrors the helper the challenge-cap pins use.
+    """
+    import importlib.util
+
+    for key, value in env.items():
+        monkeypatch.setenv(auth._ENV + key, value)
+    spec = importlib.util.spec_from_file_location("_auth_duration_probe", auth.__file__)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- what each knob actually buys, measured through the surface that uses it --
+
+
+def _token_lifetime(module) -> int:
+    """Seconds a freshly minted session token is valid for."""
+    token = module.issue_token("cred1")
+    claims = jwt.decode(token, module._jwt_secret(), algorithms=["HS256"], options={"verify_exp": False})
+    return int(claims["exp"]) - int(claims["iat"])
+
+
+def _renewable_age(module) -> int:
+    """Largest age, in seconds, at which a session is still handed a fresh token."""
+    now = 1_000_000.0
+    ttl = 86400
+
+    def renewable(age: int) -> bool:
+        claims = {"sub": "c", "iat0": now - age, "iat": now - age, "exp": now + 1}
+        return "maximum age" not in module.renewal_verdict(claims, now, ttl=ttl)["reason"]
+
+    lo, hi = 0, 400 * 86400
+    if not renewable(0):
+        return 0
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        lo, hi = (mid, hi) if renewable(mid) else (lo, mid - 1)
+    return lo
+
+
+def _handoff_window(module) -> int:
+    """Seconds a minted handoff token, the one that rides in a URL, stays usable."""
+    now = time.time()
+    claims = {"sub": "c", "iat": now, "iat0": now, "exp": now + 10**7}
+    return int(module.issue_handoff(claims, now=now)["expires_in"])
+
+
+# knob -> (its reader, the surface that spends it). The domain is only worth
+# anything at the surface: a reader that refuses while its caller still resolves
+# the old way would pass a reader-only pin.
+KNOBS = {
+    "TOKEN_TTL": ("_token_ttl", _token_lifetime),
+    "SESSION_MAX_AGE": ("_session_max_age", _renewable_age),
+    "HANDOFF_TTL": ("handoff_ttl", _handoff_window),
+}
+
+
+def test_every_duration_knob_this_module_reads_is_pinned_here():
+    """A fourth duration knob must not arrive with its own bare int() and no pin."""
+    assert set(KNOBS) == set(auth._DURATION_DEFAULTS) == set(DOCUMENTED_DEFAULTS)
+
+
+# --- the defect: a narrowing spelled with a unit resolved to the wide default --
+
+
+@pytest.mark.parametrize("knob", sorted(KNOBS))
+@pytest.mark.parametrize("spelling", [s for s in UNIT_SPELLINGS if s])
+def test_a_duration_that_is_not_a_whole_number_of_seconds_is_refused_by_name(knob, spelling, monkeypatch):
+    reader, _surface = KNOBS[knob]
+    monkeypatch.setenv(auth._ENV + knob, spelling)
+    with pytest.raises(ValueError, match=knob):
+        getattr(auth, reader)()
+
+
+@pytest.mark.parametrize("knob", sorted(KNOBS))
+def test_the_refusal_names_the_value_and_the_default_it_would_have_used(knob, monkeypatch):
+    """The message has to carry both, or the operator cannot see the substitution
+    they were about to get."""
+    monkeypatch.setenv(auth._ENV + knob, "1h")
+    reader, _surface = KNOBS[knob]
+    with pytest.raises(ValueError) as exc:
+        getattr(auth, reader)()
+    assert "'1h'" in str(exc.value)
+    assert str(DOCUMENTED_DEFAULTS[knob]) in str(exc.value)
+
+
+@pytest.mark.parametrize("knob", sorted(KNOBS))
+@pytest.mark.parametrize("value", ["0", "-1", "-3600"])
+def test_a_lifetime_at_or_below_zero_is_refused(knob, value, monkeypatch):
+    """It parses, and it means every token minted under it is dead on arrival."""
+    monkeypatch.setenv(auth._ENV + knob, value)
+    reader, _surface = KNOBS[knob]
+    with pytest.raises(ValueError, match=knob):
+        getattr(auth, reader)()
+
+
+@pytest.mark.parametrize("knob", sorted(KNOBS))
+def test_a_misspelled_duration_stops_the_import_not_a_later_login(knob, monkeypatch):
+    """Where a deployment learns about it: startup, not the operator's sign-in on
+    a dashboard that is already serving."""
+    with pytest.raises(ValueError, match=knob):
+        _load_auth(monkeypatch, **{knob: "1h"})
+
+
+# --- controls: what the domain must NOT change --------------------------------
+
+
+@pytest.mark.parametrize("knob", sorted(KNOBS))
+def test_a_bare_integer_is_honoured_at_the_surface_that_spends_it(knob, monkeypatch):
+    """The narrowing the operator asked for reaches the token, not just the reader."""
+    _reader, surface = KNOBS[knob]
+    module = _load_auth(monkeypatch, **{knob: "3600"})
+    assert surface(module) == pytest.approx(3600, abs=1)
+
+
+@pytest.mark.parametrize("knob", sorted(KNOBS))
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_an_empty_variable_still_means_unset(knob, raw, monkeypatch):
+    """Unchanged, and cross-referenced by the challenge-cap pins next door."""
+    monkeypatch.setenv(auth._ENV + knob, raw)
+    reader, _surface = KNOBS[knob]
+    assert getattr(auth, reader)() == DOCUMENTED_DEFAULTS[knob]
+
+
+@pytest.mark.parametrize("knob", sorted(KNOBS))
+def test_an_unset_variable_resolves_to_the_documented_default(knob, monkeypatch):
+    monkeypatch.delenv(auth._ENV + knob, raising=False)
+    reader, _surface = KNOBS[knob]
+    assert getattr(auth, reader)() == DOCUMENTED_DEFAULTS[knob]
+
+
+@pytest.mark.parametrize("knob", sorted(KNOBS))
+def test_surrounding_whitespace_is_still_accepted(knob, monkeypatch):
+    monkeypatch.setenv(auth._ENV + knob, " 3600 ")
+    reader, _surface = KNOBS[knob]
+    assert getattr(auth, reader)() == 3600
+
+
+def test_a_maximum_age_below_the_token_lifetime_is_a_legal_pair(monkeypatch):
+    """Deliberately NOT a cross-knob rule, unlike the challenge-cap pair. "Tokens
+    last a day, but re-authenticate every hour" is a coherent request, and the
+    cap simply wins."""
+    module = _load_auth(monkeypatch, TOKEN_TTL="86400", SESSION_MAX_AGE="3600")
+    assert (module._token_ttl(), module._session_max_age()) == (86400, 3600)
+    assert _renewable_age(module) == pytest.approx(3600, abs=1)
+
+
+def test_the_underscore_grouping_python_accepts_is_still_a_whole_number(monkeypatch):
+    """``3_600`` is a bare integer to ``int()``; the domain does not narrow that."""
+    monkeypatch.setenv(auth._ENV + "TOKEN_TTL", "3_600")
+    assert auth._token_ttl() == 3600

--- a/tests/test_dashboard_auth_edges.py
+++ b/tests/test_dashboard_auth_edges.py
@@ -91,11 +91,21 @@ def test_begin_authentication_needs_enrollment_first():
     assert "no credentials" in str(e.value.detail)
 
 
-# --- bonus: a garbage TOKEN_TTL cannot break token minting --------------------
+# --- bonus: a garbage TOKEN_TTL is refused, and minting still works ----------
 
 
-def test_token_ttl_garbage_falls_back_to_default(monkeypatch):
+def test_token_ttl_garbage_is_refused_rather_than_widened(monkeypatch):
+    """This used to assert the fallback: ``banana`` resolved to the 86400 default
+    and minting carried on. Falling back is the WIDER direction for every one of
+    these knobs, so it is now refused by name - see
+    test_dashboard_auth_duration_knobs_are_not_widened.py. What this test came
+    here to protect is unchanged and asserted below: a usable setting still mints
+    a valid session, and the refusal lands at import (where a deployment sees it)
+    rather than turning a serving dashboard's logins into 500s.
+    """
     monkeypatch.setenv("STRANDS_DASH_AUTH_TOKEN_TTL", "banana")
-    assert auth._token_ttl() == 86400
-    token = auth.issue_token("cred1")
-    assert auth.session_is_valid(token)
+    with pytest.raises(ValueError, match="TOKEN_TTL"):
+        auth._token_ttl()
+    monkeypatch.setenv("STRANDS_DASH_AUTH_TOKEN_TTL", "3600")
+    assert auth._token_ttl() == 3600
+    assert auth.session_is_valid(auth.issue_token("cred1"))

--- a/tests/test_dashboard_auth_module.py
+++ b/tests/test_dashboard_auth_module.py
@@ -67,15 +67,17 @@ def test_store_hot_reloads_on_file_change(tmp_path):
     assert auth.list_credentials()[0]["name"] == "phone"
 
 
-def test_token_roundtrip_and_expiry(monkeypatch):
+def test_token_roundtrip_and_expiry():
     token = auth.issue_token("cred1", name="phone")
     claims = auth.verify_token(token)
     assert claims["sub"] == "cred1"
     assert auth.session_is_valid(token)
     assert not auth.session_is_valid("garbage")
     assert not auth.session_is_valid("")
-    monkeypatch.setenv("STRANDS_DASH_AUTH_TOKEN_TTL", "-10")
-    expired = auth.issue_token("cred1")
+    # Expiry is driven by the explicit ``exp`` argument issue_token() takes for
+    # exactly this, not by a negative TOKEN_TTL: a lifetime at or below zero is
+    # now refused, because every token minted under it is dead on arrival.
+    expired = auth.issue_token("cred1", exp=int(time.time()) - 10)
     with pytest.raises(HTTPException) as exc:
         auth.verify_token(expired)
     assert exc.value.status_code == 401


### PR DESCRIPTION
`STRANDS_DASH_AUTH_TOKEN_TTL`, `..._SESSION_MAX_AGE` and `..._HANDOFF_TTL` are how an
operator **shortens** the window in which a dashboard session can command real hardware.
All three were read with a bare `int(os.getenv(...))` under `except ValueError: return
<the default>`, so every spelling that is not a plain integer resolved to the shipped
default — and the shipped default is the **wider** value in all three cases.

![resolved session window, before and after](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/pr3257-auth-duration-grid.png)

Measured end to end through the surface that spends each knob (token `exp - iat`, the
oldest age `renewal_verdict` still extends, `issue_handoff`'s `expires_in`):

| set to | asked for | resolved to | |
|---|---|---|---|
| `TOKEN_TTL=1h` | 1 hour | **86400 s** | 24x longer |
| `SESSION_MAX_AGE=1h` | 1 hour cap | **2592000 s** | 720x longer |
| `HANDOFF_TTL=30s` | 30 s in a URL | **300 s** | 10x longer |
| `TOKEN_TTL=0` / `-3600` | — | **accepted** | every token dead on arrival |

`15m`, `3600s`, `1 hour` and a trailing `# comment` behave identically. Nothing is
logged, so the operator who shortened the window keeps the long one and is never told.
`handoff_ttl`'s own docstring argues the value "must be short: URLs land in history, logs
and screenshots" — that is the knob whose shortening was hardest to make stick.

## The rule the module already states

`_challenge_cap` refuses a cap it cannot use, and its docstring says why: *"an operator
who narrowed a cap and mistyped it must hear about it, not silently be handed the wide
default back."* `auth_enabled` likewise reports an unrecognized boolean rather than
letting a typo drop the guard. Three env-knob families, three postures — raise, report,
and silently substitute. Only the last one was reachable with a security consequence.

## Change

One `_duration()` domain for all three, same posture as `_challenge_cap`: a value that is
not a whole number of seconds, or is below one second, is refused by name and the message
carries both the offending value and the default it would have used. Defaults live in one
`_DURATION_DEFAULTS` table, so no reader can hand back a number the documentation does not
state. Resolved once at import, so a misspelling **stops the server** rather than first
surfacing as a failed login on a dashboard that is already serving — the posture
`_CHAL_MAX = _challenge_cap(...)` already takes at module scope.

Deliberately unchanged, each pinned as a control: an empty variable still means unset
(cross-referenced by the challenge-cap pins next door), whitespace and `3_600` are still
accepted, and a maximum age *below* the token lifetime is still a legal pair — no
cross-knob rule, unlike the cap pair, because "tokens last a day but re-authenticate every
hour" is coherent and the cap simply wins.

## Tests

`tests/test_dashboard_auth_duration_knobs_are_not_widened.py` is table-driven over
knob x spelling and asserts at the **surface that spends** each value, not just at the
reader — a reader that refuses while its caller still resolves the old way would pass a
reader-only pin. A roster cell pins that a fourth duration knob cannot arrive unpinned.

Selection below is every `tests/*.py` module that reaches `strands_robots.dashboard.auth`
(12 on `main`, 13 here):

| corner | tests | production | result |
|---|---|---|---|
| A | main | main | 216 pass |
| B | this PR | main | **44 fail** / 233 pass |
| C | this PR | this PR | 277 pass |
| D | main | this PR | 2 fail / 214 pass |

`216 + 61 = 277`; of the 61 new cells **43 fail pre-fix and 18 are both-trees-green
controls**. B's 44th failure and D's 2 are the two existing tests retargeted here, and no
others:

- `test_token_ttl_garbage_falls_back_to_default` pinned the silent widening as a coverage
  bonus. Its actual concern — minting must not break — is kept and asserted.
- `test_token_roundtrip_and_expiry` minted an expired token via `TOKEN_TTL=-10`; it now
  uses the explicit `exp=` argument `issue_token` takes for exactly this, which is
  tree-independent and passes on both.

### Test isolation

The surface cells mint tokens, so they reach `_jwt_secret()` -> `_load()`, and
`_store_path()` resolves an unset `STORE` to `~/.strands_dashboard/auth.json` — the file
that decides whether a dashboard on that machine is sealed. Measured per pre-existing
store, with `HOME` pointed at a scratch directory and the store read back from disk in a
fresh process:

| pre-existing store | without a redirect | with it |
|---|---|---|
| absent | 60 passed, **creates** it (140 B, fresh JWT secret) | still absent |
| valid, passkey enrolled | 60 passed, nothing touched | byte-identical |
| valid, no `jwt_secret` key | **2 failed** | 61 passed, byte-identical |
| `jwt_secret: null` | **2 failed** | 61 passed, byte-identical |
| top level a JSON list | **2 failed** | 61 passed, byte-identical |
| unparseable bytes | 60 passed, **renamed** to `auth.json.corrupt-<ts>`, fresh secret written | byte-identical |

Two costs, and the second is the one no gate reports. The write is destructive on the
unparseable row — the operator's file is relocated and a new `jwt_secret` invalidates
every live session token — and on three rows the **verdict is decided by what the machine
already holds**, failing locally and passing in CI while blaming duration knobs that are
fine. `$HOME` is fresh in CI. AGENTS.md rule 15 states the same rule for the dataset
cache.

So this file now carries the autouse `STRANDS_DASH_AUTH_STORE` redirect that the ten
sibling `test_dashboard_auth_*` modules reaching the store already carry, via
`monkeypatch.setenv` rather than an attribute patch: the private module copies `_load_auth`
builds re-read the variable, so an attribute patch would redirect the shared module and
leave every copy on the real store. Of the three modules that touch `dashboard.auth`
without a redirect, this was the only one that reached `_load()` at all — the other two
create nothing and move nothing under a scratch `HOME`, so nothing else needed changing.

One cell pins the redirect on both module paths, and it is the only cell of the 61 that
catches any of the three ways to weaken it:

| mutation | cells fired of 61 |
|---|---|
| control | 0 |
| the redirect is dropped | **1, the pin alone** (real `$HOME` write returns) |
| redirect via a module attribute, not the env | **1, the pin alone** (real `$HOME` write returns) |
| redirect to a fixed shared path, not `tmp_path` | **1, the pin alone** |

An ambient `SESSION_MAX_AGE=1h` aborts collection of all 13 modules, and a fixture cannot
help because it runs after collection. That is left alone as pre-existing rather than
introduced here: on `main`, an ambient `CHAL_MAX=1h` aborts collection of 12 modules with
the identical shape, because `_CHAL_MAX` is resolved at module scope too. Refusing to run
against a misconfigured environment is the intended behaviour.

Gate on the merged tree (`main` absorbed, zero overlapping paths between the two sides, 0
conflicts): `ruff check` / `ruff format --check` clean over 1905 files, `mypy` reports
`Success: no issues found in 1902 source files`, and 277 pass across all 13 auth modules.

## Size

+384 / -22 over 6 files. Production is +82 / -11 in `auth.py`, AST-classified as **29
executable**, 36 docstring, 4 comment, 13 blank, for an AST statement delta of 443 -> 457;
the 11 removed lines are the three `try/int/except` readers it replaces.
