### PR TITLE
fix(policies/vera): an unknown embodiment is refused, not resolved as mimicgen

### DIFF
--- a/changelog.d/3259-vera-embodiment-vocabulary.md
+++ b/changelog.d/3259-vera-embodiment-vocabulary.md
@@ -1,0 +1,41 @@
+### Fixed: `policies/vera` - an unknown embodiment is refused, not resolved as mimicgen
+
+`VeraConfig.embodiment` is the key every other per-embodiment default is looked
+up by, and it was the one field on the dataclass with no domain. Both default
+ports, the per-view `render_width`, the checkpoint-root variable that is probed,
+the container name and the server's own `--embodiment` flag are all derived from
+it, so a spelling no table has an entry for was not one wrong value but a whole
+configuration assembled from what each of those six readers does with an unknown
+key.
+
+The two table lookups made that silent rather than merely wrong. Each carried its
+own fallback - `_DEFAULT_PORTS.get(self.embodiment, (8800, 8801))` and
+`_DEFAULT_RENDER_WIDTH.get(self.embodiment, 128)` - and those literals are
+byte-for-byte `mimicgen`'s entries in the very tables they were fallbacks for. So
+`embodiment="PushT"` did not degrade, it resolved to a configuration
+indistinguishable from a deliberate `embodiment="mimicgen"`, and because
+`VeraServerRunner.start` opens with a port probe and returns early on a hit
+("Already serving (ours or someone else's) - reuse it"), a mistyped `pusht`
+dialed 8800, found a running mimicgen server, completed the metadata handshake
+and rolled out against the wrong embodiment's planner/IDM pair - reporting
+success throughout. The `--embodiment` flag that would have carried the typo to a
+server able to object was never used, because no server was launched. Measured
+over eight plausible misspellings, all eight resolved to `(8800, 8801, 128)`;
+`PushT` and `pushT` additionally probed `VERA_PUSHT_CKPT_ROOT`, so the readers
+did not even agree with each other on which embodiment had been asked for.
+
+`docker/entrypoint.sh` already refuses exactly this vocabulary
+(`ERROR: unknown embodiment`, `exit 2`), but that arm is reached only under
+`server_mode="docker"`, only once an image has started, and never at all for the
+subprocess runner or for `auto_launch_server=False`. The vocabulary was stated in
+shell and enforced in shell; the Python that computes the ports, the width and
+the `-e VERA_EMBODIMENT=` value it passes in did not hold it. It is now held at
+the config funnel - the one surface the `VeraPolicy` keyword, a pre-built config
+and the `VERA_*` overrides all pass through - and derived from `get_args`
+of the `Embodiment` alias, so an embodiment added there participates on arrival
+instead of being absorbed by a fallback.
+
+With the vocabulary held, both lookups index their tables directly: the second
+copy of a default is what made "not a known embodiment" and "mimicgen" the same
+request. A regression test also pins the shell `case` and the Python alias
+against each other, so the two enforcers of one vocabulary cannot drift.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -147,7 +147,7 @@ wins over code defaults):
 
 | kwarg | env var | maps to |
 |-------|---------|---------|
-| `embodiment` | — | `--embodiment` |
+| `embodiment` | — | `--embodiment` (`pusht` \| `mimicgen` \| `allegro` \| `droid`) |
 | `server_port` / `vis_port` | `VERA_SERVER_PORT` / `VERA_VIS_PORT` | `--port` / `--vis-port` |
 | `algo_config` | `VERA_ALGO_CONFIG` | `--algo-config` (swap to the omni planner) |
 | `dynamics_run_id` | `VERA_DYNAMICS_RUN_ID` | `--dynamics-run-id` |
@@ -158,6 +158,19 @@ wins over code defaults):
 | `motion_plan_scale` | `VERA_MOTION_PLAN_SCALE` | live `configure` |
 | `server_ready_timeout` | `VERA_SERVER_READY_TIMEOUT` | readiness wait budget, in seconds |
 | `server_mode` | `VERA_SERVER_MODE` | `subprocess` \| `docker` |
+
+`embodiment` is checked against that vocabulary before anything is resolved from
+it, because it is the key the rest of the table is looked up by: both default
+ports, the render width, the checkpoint-root variable that is probed, the
+container name and the server's own `--embodiment` flag. Each of those six
+readers does something different with a name no table has an entry for, and the
+two lookups that carried their own fallback fell back on mimicgen's values, so an
+unrecognised spelling resolved to a configuration indistinguishable from
+`embodiment="mimicgen"` — and because the runner reuses a server that is already
+listening, a mistyped `pusht` would dial 8800 and roll out against a running
+mimicgen server under a success. `docker/entrypoint.sh` already refuses the same
+four-name vocabulary with `exit 2`, but only for `server_mode="docker"` and only
+after the image has started, so the config holds it too.
 
 Both ports take the shared TCP-port domain every port-dialing provider applies:
 an `int` in `[1, 65535]`, or `None` for the per-embodiment default. The value is

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import dataclasses
 import os
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 from strands_robots.utils import (
     positive_finite_number_error,
@@ -31,6 +31,12 @@ Embodiment = Literal["pusht", "mimicgen", "allegro", "droid"]
 # VERA's configurations/dataset/pusht.yaml), so it validates the
 # provider -> server -> action plumbing rather than producing a solving
 # rollout. "allegro"/"droid" are code-present but checkpoint-absent (Wave 2).
+
+# The embodiments this provider knows, derived from the type alias rather than
+# re-listed, so an embodiment added to :data:`Embodiment` participates in the
+# refusal below on arrival instead of being silently absorbed by a fallback.
+_EMBODIMENTS: tuple[str, ...] = get_args(Embodiment)
+
 
 # Per-embodiment default ports (policy, viz) - match the VERA examples
 # (PushT uses 8820/8821; everything else uses 8800/8801).
@@ -76,6 +82,42 @@ def _env_int(name: str) -> int | None:
         return int(v)
     except ValueError:
         return None
+
+
+def _embodiment_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not an embodiment this provider knows.
+
+    The embodiment is not one knob among the others: it is the field the other
+    per-embodiment defaults are *looked up by*. It selects both ports, the
+    per-view render width, the checkpoint-root variable that is probed, the
+    container name and the ``--embodiment`` flag the server itself is launched
+    with, so a spelling no table has an entry for is not a single wrong value -
+    it is a whole configuration assembled from whatever each of those six
+    readers does with an unknown key.
+
+    Refusing it here rather than downstream is what the package already does on
+    the other side of the container boundary: ``docker/entrypoint.sh`` ends its
+    per-embodiment ``case`` with ``ERROR: unknown embodiment`` and ``exit 2``,
+    listing the same four names. That refusal cannot stand in for this one,
+    because it is only reached in ``server_mode="docker"`` after an image has
+    been started, and it never runs at all for the subprocess runner or for a
+    server that is merely dialed (``auto_launch_server=False``).
+
+    Args:
+        value: The caller-supplied embodiment.
+        param: The field name it came from, used in the message.
+        context: Message prefix identifying the surface that received it.
+
+    Returns:
+        An error message, or ``None`` when the value is a known embodiment.
+    """
+    if value in _EMBODIMENTS:
+        return None
+    return (
+        f"{context}: {param} must be one of {', '.join(map(repr, _EMBODIMENTS))}, got {value!r}. "
+        "The embodiment selects the planner/IDM pair, both default ports and the render width, "
+        "so an unknown one cannot be resolved to a configuration."
+    )
 
 
 def _viewer_port_error(value: Any, param: str, context: str) -> str | None:
@@ -127,7 +169,12 @@ class VeraConfig:
 
     Args:
         embodiment: VERA embodiment - selects the WAN/DFoT planner + Jacobian
-            IDM pair and the client-side action adapter.
+            IDM pair and the client-side action adapter. Must be one of
+            ``pusht``, ``mimicgen``, ``allegro``, ``droid`` (the members of
+            :data:`Embodiment`); any other spelling is refused, because this
+            field is the key every other per-embodiment default is looked up by
+            and an unknown one would otherwise resolve to another embodiment's
+            ports and render width.
         host: Policy-server hostname.
         server_port: Policy-server websocket port. ``None`` applies
             ``VERA_SERVER_PORT`` else the per-embodiment default; any other
@@ -206,8 +253,27 @@ class VeraConfig:
     docker_extra_args: list[str] | None = None  # extra `docker run` args (list, no shell)
 
     def __post_init__(self) -> None:
+        # Checked first, because every per-embodiment default below is looked up
+        # BY this field. Both lookups used to carry their own fallback -
+        # ``_DEFAULT_PORTS.get(self.embodiment, (8800, 8801))`` and
+        # ``_DEFAULT_RENDER_WIDTH.get(self.embodiment, 128)`` - and those two
+        # literals are byte-for-byte mimicgen's entries, so every unrecognised
+        # spelling resolved to mimicgen's ports and mimicgen's width. That is
+        # not a degraded configuration, it is an indistinguishable one:
+        # ``VeraServerRunner.start`` reuses a server that is already listening
+        # ("ours or someone else's"), so ``embodiment="PushT"`` dialed 8800,
+        # found a running mimicgen server and ran the whole rollout against the
+        # wrong embodiment's planner/IDM pair under a success. A typo could not
+        # be told from a deliberate ``embodiment="mimicgen"``.
+        #
+        # With the vocabulary held here the tables are the single statement of
+        # what each embodiment defaults to, so they are indexed directly: a
+        # second copy of a default is what made "not a known embodiment" and
+        # "mimicgen" the same request.
+        if (err := _embodiment_error(self.embodiment, "embodiment", type(self).__name__)) is not None:
+            raise ValueError(err)
         # Apply per-embodiment port defaults when not explicitly set.
-        default_policy, default_vis = _DEFAULT_PORTS.get(self.embodiment, (8800, 8801))
+        default_policy, default_vis = _DEFAULT_PORTS[self.embodiment]
         # Both env overrides are read with ``is not None``, never with ``or``.
         # The two spellings are not interchangeable for a port: ``0`` is falsy,
         # so the ``or`` this line used to carry discarded the override and
@@ -264,7 +330,7 @@ class VeraConfig:
         # for it is owed the refusal below, not 128 under a success.
         if self.render_width is None:
             env_width = _env_int("VERA_RENDER_WIDTH")
-            self.render_width = env_width if env_width is not None else _DEFAULT_RENDER_WIDTH.get(self.embodiment, 128)
+            self.render_width = env_width if env_width is not None else _DEFAULT_RENDER_WIDTH[self.embodiment]
         if (err := positive_whole_number_error(self.render_width, "render_width", type(self).__name__)) is not None:
             raise ValueError(err)
         # Normalized to a plain ``int`` here because the domain accepts any real

--- a/tests/policies/vera/test_vera_embodiment_vocabulary.py
+++ b/tests/policies/vera/test_vera_embodiment_vocabulary.py
@@ -1,0 +1,253 @@
+"""``VeraConfig.embodiment`` is the key every other per-embodiment default is looked up by.
+
+Every other unusable value on this dataclass is refused by name at the config
+funnel - both ports, ``render_width``, ``motion_plan_scale`` and
+``server_ready_timeout`` each carry a domain and a written rationale for holding
+it there. ``embodiment`` carried none, even though it is not one knob among
+those: it is the field they are *selected by*. Six readers consume it, and each
+does something different with a name no table has an entry for::
+
+    _DEFAULT_PORTS.get(self.embodiment, (8800, 8801))      # bare-literal fallback
+    _DEFAULT_RENDER_WIDTH.get(self.embodiment, 128)        # bare-literal fallback
+    f"VERA_{self.embodiment.upper()}_CKPT_ROOT"            # probed variable name
+    f"vera-server-{self.embodiment}"                       # container name
+    ["--embodiment", str(cfg.embodiment)]                  # subprocess argv
+    ["-e", f"VERA_EMBODIMENT={cfg.embodiment}"]            # container env
+
+The two fallbacks are what make this silent rather than merely wrong.
+``(8800, 8801)`` and ``128`` are byte-for-byte ``mimicgen``'s entries in the two
+tables they are fallbacks for, so an unrecognised spelling does not resolve to a
+degraded configuration - it resolves to one that cannot be told from a
+deliberate ``embodiment="mimicgen"``.
+
+Measured on ``6ce7facc0``, one ``VeraConfig(embodiment=X)`` per row, no ``VERA_*``
+in the environment, no ``vera`` package, no server:
+
+| ``embodiment=`` | ports | width | same triple as |
+| --- | --- | --- | --- |
+| ``"pusht"``     | 8820 / 8821 | 252 | itself (declared) |
+| ``"mimicgen"``  | 8800 / 8801 | 128 | itself (declared) |
+| ``"allegro"``   | 8802 / 8803 | 128 | itself (declared) |
+| ``"droid"``     | 8804 / 8805 | 128 | itself (declared) |
+| ``"PushT"``     | 8800 / 8801 | 128 | **mimicgen** |
+| ``"pushT"``     | 8800 / 8801 | 128 | **mimicgen** |
+| ``"pusht "``    | 8800 / 8801 | 128 | **mimicgen** |
+| ``"push_t"``    | 8800 / 8801 | 128 | **mimicgen** |
+| ``"Mimicgen"``  | 8800 / 8801 | 128 | **mimicgen** |
+| ``"mimicgen2"`` | 8800 / 8801 | 128 | **mimicgen** |
+| ``"franka"``    | 8800 / 8801 | 128 | **mimicgen** |
+| ``""``          | 8800 / 8801 | 128 | **mimicgen** |
+
+The consequence is not a failed launch. ``VeraServerRunner.start`` opens with a
+port probe and returns early on a hit - "Already serving (ours or someone
+else's) - reuse it" - so a mistyped ``pusht`` dialed 8800, found a running
+mimicgen server, completed the metadata handshake and rolled out against the
+wrong embodiment's planner/IDM pair, reporting success throughout. The
+``--embodiment`` flag that would have carried the typo to a server that could
+object was never used, because no server was launched.
+
+Nor does the container's refusal cover it. ``docker/entrypoint.sh`` ends its
+per-embodiment ``case`` with ``ERROR: unknown embodiment`` / ``exit 2`` over the
+same four names, but that arm is reached only under ``server_mode="docker"``,
+only once an image has started, and never at all for the subprocess runner or
+for ``auto_launch_server=False``. The vocabulary was stated in shell and
+enforced in shell; the Python that computes the ports, the width and the
+``-e VERA_EMBODIMENT=`` value it passes in did not hold it.
+
+With the vocabulary held at the funnel the two tables become the single
+statement of what each embodiment defaults to, so both lookups index them
+directly: the second copy of a default is what made "not a known embodiment"
+and "mimicgen" the same request.
+
+Everything here is offline - no server, no socket, no ``vera`` package, no GPU.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import get_args
+
+import pytest
+
+from strands_robots.policies.vera.config import (
+    _DEFAULT_PORTS,
+    _DEFAULT_RENDER_WIDTH,
+    Embodiment,
+    VeraConfig,
+)
+
+VOCABULARY = get_args(Embodiment)
+
+# Spellings a caller plausibly reaches for that no table has an entry for: case
+# variants of a real name, a separator variant, a trailing space, a
+# near-miss, an unrelated robot name, and the empty string.
+UNKNOWN_SPELLINGS = (
+    "PushT",
+    "pushT",
+    "pusht ",
+    "push_t",
+    "Mimicgen",
+    "mimicgen2",
+    "franka",
+    "",
+)
+
+# Non-string values the field could hold from a keyword. ``None`` is included
+# because the field has a default rather than being optional: passing it
+# explicitly is a request for an embodiment, not for the default.
+UNKNOWN_TYPES = (None, 0, 1, True, 2.5, ["pusht"], {"pusht": 1})
+
+
+@pytest.fixture(autouse=True)
+def _no_vera_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve every field from the keyword and the tables, never the environment."""
+    for name in (
+        "VERA_SERVER_PORT",
+        "VERA_VIS_PORT",
+        "VERA_RENDER_WIDTH",
+        "VERA_SERVER_READY_TIMEOUT",
+        "VERA_MOTION_PLAN_SCALE",
+        "VERA_DOCKER_CONTAINER",
+        "VERA_CKPT_ROOT",
+        "VERA_SERVER_MODE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def resolved(embodiment: str) -> tuple[int | None, int | None, int | None]:
+    """The triple that decides which server is dialed and what is sent to it."""
+    cfg = VeraConfig(embodiment=embodiment)  # type: ignore[arg-type]
+    return cfg.server_port, cfg.vis_port, cfg.render_width
+
+
+class TestAnUnknownEmbodimentIsRefused:
+    """A spelling no table has an entry for cannot resolve to a configuration."""
+
+    @pytest.mark.parametrize("spelling", UNKNOWN_SPELLINGS)
+    def test_unknown_spelling_raises_naming_field_and_vocabulary(self, spelling: str) -> None:
+        """The message names the field, the value and every accepted name."""
+        with pytest.raises(ValueError) as excinfo:
+            VeraConfig(embodiment=spelling)  # type: ignore[arg-type]
+        message = str(excinfo.value)
+        assert "embodiment" in message
+        assert repr(spelling) in message
+        for name in VOCABULARY:
+            assert repr(name) in message, f"vocabulary member {name!r} missing from {message!r}"
+
+    @pytest.mark.parametrize("value", UNKNOWN_TYPES)
+    def test_non_string_value_raises_rather_than_resolving(self, value: object) -> None:
+        """A value that is not a name at all is refused, not looked up."""
+        with pytest.raises(ValueError, match="embodiment"):
+            VeraConfig(embodiment=value)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("spelling", UNKNOWN_SPELLINGS)
+    def test_unknown_spelling_no_longer_resolves_to_mimicgen(self, spelling: str) -> None:
+        """The property that made the typo silent: it is refused, not aliased.
+
+        Pre-fix every row of this parametrization returned ``mimicgen``'s
+        triple, because the two lookups' fallbacks were ``mimicgen``'s entries.
+        """
+        with pytest.raises(ValueError):
+            resolved(spelling)
+
+    def test_the_refusal_reaches_the_provider_keyword(self) -> None:
+        """``VeraPolicy(embodiment=...)`` funnels through the same check.
+
+        The provider declares the field as a plain ``str`` and forwards it, so
+        the config is the one place the vocabulary can be held for both the
+        keyword and a pre-built config handed to it.
+        """
+        provider = pytest.importorskip("strands_robots.policies.vera.provider")
+        with pytest.raises(ValueError, match="embodiment"):
+            provider.VeraPolicy(embodiment="PushT", auto_launch_server=False)
+
+
+class TestDeclaredEmbodimentsResolveFromTheirOwnTable:
+    """Controls: every accepted name still gets its own entry, not a fallback."""
+
+    @pytest.mark.parametrize("embodiment", VOCABULARY)
+    def test_ports_and_width_come_from_the_owner_tables(self, embodiment: str) -> None:
+        """Removing the fallbacks did not change what a known name resolves to."""
+        expected_ports = _DEFAULT_PORTS[embodiment]
+        expected_width = _DEFAULT_RENDER_WIDTH[embodiment]
+        assert resolved(embodiment) == (*expected_ports, expected_width)
+
+    def test_pusht_keeps_the_entry_the_fallback_used_to_hide(self) -> None:
+        """``pusht`` is the one name whose entry differs from the old fallbacks.
+
+        It is therefore the row that proves the tables, not the literals, are
+        being read: ``(8820, 8821, 252)`` against the old ``(8800, 8801, 128)``.
+        """
+        assert resolved("pusht") == (8820, 8821, 252)
+
+    @pytest.mark.parametrize("embodiment", VOCABULARY)
+    def test_an_explicit_value_still_wins_over_the_table(self, embodiment: str) -> None:
+        """The gate refuses names, it does not start overriding supplied values."""
+        cfg = VeraConfig(embodiment=embodiment, server_port=9100, vis_port=0, render_width=64)  # type: ignore[arg-type]
+        assert (cfg.server_port, cfg.vis_port, cfg.render_width) == (9100, 0, 64)
+
+
+class TestEveryEmbodimentHasAnEntryInBothTables:
+    """Indexing the tables directly is only safe while they cover the vocabulary."""
+
+    @pytest.mark.parametrize(
+        ("table", "name"),
+        [(_DEFAULT_PORTS, "_DEFAULT_PORTS"), (_DEFAULT_RENDER_WIDTH, "_DEFAULT_RENDER_WIDTH")],
+    )
+    def test_table_keys_are_exactly_the_vocabulary(self, table: dict, name: str) -> None:
+        """A fifth embodiment cannot arrive without its defaults, or vice versa."""
+        assert set(table) == set(VOCABULARY), f"{name} does not cover {Embodiment}"
+
+    def test_the_two_tables_agree_on_which_names_exist(self) -> None:
+        """One table gaining a name without the other is the drift to catch."""
+        assert set(_DEFAULT_PORTS) == set(_DEFAULT_RENDER_WIDTH)
+
+    def test_every_declared_port_pair_is_distinct(self) -> None:
+        """Two embodiments sharing a port is what let a typo attach to a server.
+
+        The defaults must keep each embodiment on its own port, so a config
+        resolved for one name can never dial the server another launched.
+        """
+        pairs = list(_DEFAULT_PORTS.values())
+        assert len(set(pairs)) == len(pairs), f"duplicate default ports: {_DEFAULT_PORTS}"
+        every_port = [port for pair in pairs for port in pair]
+        assert len(set(every_port)) == len(every_port), f"a port is reused: {_DEFAULT_PORTS}"
+
+
+class TestTheContainerAndTheConfigRefuseTheSameNames:
+    """The vocabulary is stated twice - in Python and in shell - and must agree.
+
+    ``docker/entrypoint.sh`` dispatches on ``VERA_EMBODIMENT``, which the docker
+    runner sets from this field. Two enforcers of one vocabulary is exactly the
+    shape that drifts, so the shell ``case`` is read here rather than trusted.
+    """
+
+    ENTRYPOINT = Path(__file__).resolve().parents[3] / "strands_robots/policies/vera/docker/entrypoint.sh"
+
+    def _case_arms(self) -> set[str]:
+        """Embodiment names the entrypoint's ``case`` has an arm for."""
+        script = self.ENTRYPOINT.read_text(encoding="utf-8")
+        block = script.split('case "${EMBODIMENT}" in', 1)
+        assert len(block) == 2, "entrypoint.sh no longer dispatches on ${EMBODIMENT}"
+        body = block[1].split("esac", 1)[0]
+        names: set[str] = set()
+        for line in body.splitlines():
+            match = re.match(r"\s*([a-z0-9_|]+)\)\s*$", line)
+            if match:
+                names.update(match.group(1).split("|"))
+        return names
+
+    def test_the_entrypoint_exists_where_the_runner_expects_it(self) -> None:
+        """The cross-language pin is only meaningful while the script is there."""
+        assert self.ENTRYPOINT.is_file(), self.ENTRYPOINT
+
+    def test_the_shell_case_covers_exactly_the_python_vocabulary(self) -> None:
+        """Neither side may gain or lose a name alone."""
+        assert self._case_arms() == set(VOCABULARY)
+
+    def test_the_entrypoint_still_refuses_an_unmatched_name(self) -> None:
+        """The config's refusal complements the container's; it does not replace it."""
+        script = self.ENTRYPOINT.read_text(encoding="utf-8")
+        assert "unknown embodiment" in script
+        assert "exit 2" in script


### PR DESCRIPTION
`VeraConfig.embodiment` is the key every *other* per-embodiment default is looked up by — and it was the one field on the dataclass with no domain. Six readers consume it, and each does something different with a name no table has an entry for.

![embodiment reader grid](https://raw.githubusercontent.com/cagataycali/pr-assets/main/vera-embodiment-vocabulary-3259.png)

## The two fallbacks were mimicgen's own entries

```python
_DEFAULT_PORTS.get(self.embodiment, (8800, 8801))   # == _DEFAULT_PORTS["mimicgen"]
_DEFAULT_RENDER_WIDTH.get(self.embodiment, 128)     # == _DEFAULT_RENDER_WIDTH["mimicgen"]
```

So an unrecognised spelling did not resolve to a *degraded* configuration — it resolved to one **indistinguishable from a deliberate `embodiment="mimicgen"`**. All eight measured misspellings produced the same `(8800, 8801, 128)`:

| `embodiment=` | ports | width | reads as |
|---|---|---|---|
| `"pusht"` | 8820 / 8821 | 252 | itself |
| `"mimicgen"` | 8800 / 8801 | 128 | itself |
| `"allegro"` | 8802 / 8803 | 128 | itself |
| `"droid"` | 8804 / 8805 | 128 | itself |
| `"PushT"` `"pushT"` `"pusht "` `"push_t"` | 8800 / 8801 | 128 | **mimicgen** |
| `"Mimicgen"` `"mimicgen2"` `"franka"` `""` | 8800 / 8801 | 128 | **mimicgen** |

`PushT` and `pushT` additionally probed `VERA_PUSHT_CKPT_ROOT`, so the readers did not even agree with **each other** about which embodiment had been asked for — 27 of 72 measured cells resolved to another embodiment's value, 21 more carried the unknown spelling verbatim.

## Why it was silent rather than a failed launch

`VeraServerRunner.start` opens with a port probe and returns early on a hit:

> `# Already serving (ours or someone else's) - reuse it.`

So a mistyped `pusht` dialed 8800, found a running mimicgen server, completed the metadata handshake and rolled out against the wrong planner/IDM pair — reporting success throughout. The `--embodiment` flag that would have carried the typo to a server able to object was never used, because no server was launched.

Nor did the container's refusal cover it. `docker/entrypoint.sh` already ends its per-embodiment `case` with `ERROR: unknown embodiment` / `exit 2` over the same four names — but that arm is reached only under `server_mode="docker"`, only once an image has started, and never at all for the subprocess runner or `auto_launch_server=False`. The vocabulary was stated in shell and enforced in shell; the Python that computes the ports, the width and the `-e VERA_EMBODIMENT=` value it passes in did not hold it.

## Change

Hold the vocabulary at the config funnel — the one surface the `VeraPolicy` keyword, a pre-built config and the `VERA_*` overrides all pass through — derived from `get_args(Embodiment)` so an embodiment added to the alias participates on arrival instead of being absorbed by a fallback. With the vocabulary held, both lookups index their tables directly: **the second copy of a default is what made "not a known embodiment" and "mimicgen" the same request.**

The refusal is scoped to names, not values — `VeraConfig(embodiment="pusht", server_port=9100, render_width=64)` still honours all three.

## Tests

New `tests/policies/vera/test_vera_embodiment_vocabulary.py` (40 cells, 0.20s, fully offline — no server, socket, `vera` package or GPU). Four corners measured on `tests/policies/vera`:

| | old tests | new tests |
|---|---|---|
| **pre-fix prod** | 934 pass | **24 fail** + 950 pass |
| **this prod** | 934 pass | 974 pass |

`934 + 40 = 974`, and `950 = 934 + 16` controls — so 24 of the 40 new cells fail on `main` and the 16 that pass pre-fix are the intended controls. Corner D (old tests / new prod) is identical to corner A, so no existing test moved.

One pin is cross-language: the entrypoint's shell `case` arms are parsed and asserted equal to `get_args(Embodiment)`, so the two enforcers of one vocabulary cannot drift. Another pins that no two embodiments share a default port — the property that let a typo attach to another embodiment's server.

## Size

| file | +/- |
|---|---|
| `strands_robots/policies/vera/config.py` | +70 / −4 |
| `tests/policies/vera/test_vera_embodiment_vocabulary.py` | +253 |
| `changelog.d/3259-vera-embodiment-vocabulary.md` | +41 |
| `docs/policies/vera.md` | +14 / −1 |

**+378 / −5.** Of config.py's 70 added lines only **14 are executable** (28 docstring, 20 comment, 8 blank).

## Gate

`ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1905 files); pinned `mypy` reports 0 errors in the touched files (20 pre-existing errors in 6 unrelated files, unchanged); `tests/policies/vera tests/registry` 1897 pass; `tests/policies` 5873 pass with only the 12 pre-existing lerobot-0.6.2 drift failures (`lerobot_async`, `molmoact2`), identical on `main`.