### PR TITLE
fix(policies/vera): the teacache threshold reaches the server in both launch modes

### DIFF
--- a/changelog.d/3261-teacache-threshold-reaches-both-server-modes.md
+++ b/changelog.d/3261-teacache-threshold-reaches-both-server-modes.md
@@ -1,0 +1,30 @@
+### Fixed: `policies/vera` - the teacache threshold reaches the server in both launch modes
+
+`VeraConfig` drives the VERA policy server through two vocabularies: the
+environment overlay `server_env()` returns, and the server's own launch flags.
+The subprocess runner composes those flags directly (`--sample-steps`,
+`--teacache-thresh`, ...); the container path has to get each value in front of
+the same flags indirectly, as `-e` variables `docker/entrypoint.sh` turns back
+into argv. `teacache_thresh` was carried by neither half - the `docker run`
+command named no variable for it and the entrypoint had no branch to emit it -
+while its `teacache` off-switch was carried as `-e VERA_NO_TEACACHE=1`.
+
+So one config ran the DiT cache at two thresholds depending on how the server
+happened to be launched: `VeraConfig(teacache_thresh=0.25)` passed
+`--teacache-thresh 0.25` under `server_mode="subprocess"` and started the
+container on the server's own default under `server_mode="docker"`. Nothing
+reported it. `docker run` has no opinion about an environment variable nobody
+passed it, and the value that decides how often the DiT is recomputed is exactly
+the quality/latency knob a caller reaches for after seeing a rollout - so the
+mode that ignored it looked like the threshold having no effect.
+
+Both halves now carry it: the container command forwards
+`-e VERA_TEACACHE_THRESH=<value>` in the same either/or shape as the subprocess
+argv, and the entrypoint translates it back into `--teacache-thresh`. An `-e`
+nothing in the container reads would have been inert, so the regression test runs
+the shipped entrypoint under bash with a stub interpreter and asserts on the argv
+the server would really have been started with. The headline check derives what
+must be carried from the subprocess argv itself, so a flag added to
+`_build_command` later is graded on arrival; `--host` (the container binds
+`0.0.0.0` by design) and `--algo-config` (a host path, which needs a bind-mount
+decision) are the two stated exclusions.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -154,10 +154,20 @@ wins over code defaults):
 | `text_prompt` | `VERA_TEXT_PROMPT` | `--text` |
 | `ckpt_root` | `VERA_CKPT_ROOT` | container `/ckpts` mount |
 | `sample_steps` | `VERA_SAMPLE_STEPS` | `--sample-steps` |
+| `teacache` / `teacache_thresh` | — | `--no-teacache` / `--teacache-thresh` |
 | `tracker_backend` | `VERA_TRACKER_BACKEND` | IDM tracker |
 | `motion_plan_scale` | `VERA_MOTION_PLAN_SCALE` | live `configure` |
 | `server_ready_timeout` | `VERA_SERVER_READY_TIMEOUT` | readiness wait budget, in seconds |
 | `server_mode` | `VERA_SERVER_MODE` | `subprocess` \| `docker` |
+
+The teacache pair travels as one either/or, and the container takes it the long
+way round: `-e VERA_NO_TEACACHE=1` or `-e VERA_TEACACHE_THRESH=<value>`, which the
+entrypoint turns back into the same `--no-teacache` / `--teacache-thresh` flags
+the subprocess mode passes directly. Both halves have to line up for a value to
+land — `docker run` accepts any environment it is handed, and an `-e` the
+entrypoint does not read is inert — and only the off-switch used to be carried,
+so a tuned `teacache_thresh` applied under `server_mode="subprocess"` and was
+dropped for the server's own default under `server_mode="docker"`.
 
 `embodiment` is checked against that vocabulary before anything is resolved from
 it, because it is the key the rest of the table is looked up by: both default

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -213,6 +213,12 @@ class VeraConfig:
             plan the IDM turns into actions.
         teacache: Enable the near-lossless DiT teacache speedup (default True).
         teacache_thresh: teacache rel_l1 threshold (>0.15 hits a quality cliff).
+            Carried to the server by both launch modes: as ``--teacache-thresh``
+            on the subprocess argv, and as ``-e VERA_TEACACHE_THRESH`` for the
+            container, which the entrypoint turns back into the same flag. Only
+            the ``teacache`` off-switch used to be forwarded to the container, so
+            a tuned threshold applied under ``server_mode="subprocess"`` and was
+            silently dropped under ``server_mode="docker"``.
         auto_launch_server: Launch + manage the server subprocess on first use.
         server_ready_timeout: Seconds the readiness wait allows the server
             websocket to come up before raising (WAN model load can be slow).

--- a/strands_robots/policies/vera/docker/entrypoint.sh
+++ b/strands_robots/policies/vera/docker/entrypoint.sh
@@ -114,8 +114,12 @@ fi
 if [[ -n "${VERA_SAMPLE_STEPS:-}" ]]; then
     ARGS+=(--sample-steps "${VERA_SAMPLE_STEPS}")
 fi
+# Teacache is one either/or, matching the host-side runner: `--no-teacache`
+# turns the DiT cache off, and a threshold only means something while it is on.
 if [[ "${VERA_NO_TEACACHE:-0}" == "1" ]]; then
     ARGS+=(--no-teacache)
+elif [[ -n "${VERA_TEACACHE_THRESH:-}" ]]; then
+    ARGS+=(--teacache-thresh "${VERA_TEACACHE_THRESH}")
 fi
 
 if [[ "${USE_OFFLINE_RESOLVE}" == "1" ]]; then

--- a/strands_robots/policies/vera/server_runner.py
+++ b/strands_robots/policies/vera/server_runner.py
@@ -326,8 +326,19 @@ class DockerServerRunner:
             cmd += ["-e", f"VERA_TRACKER_BACKEND={cfg.tracker_backend}"]
         if cfg.sample_steps is not None:
             cmd += ["-e", f"VERA_SAMPLE_STEPS={cfg.sample_steps}"]
+        # The teacache pair is forwarded as one either/or, mirroring the
+        # subprocess argv above, because that is the shape the server takes: a
+        # threshold is meaningless once the cache is off. Only the "off" half
+        # used to be carried, so the threshold - a bare float, the most
+        # trivially forwardable value on the config, needing none of the
+        # host->container path translation that keeps `algo_config` off this
+        # list - reached the server in one launch mode and not the other. The
+        # entrypoint turns the variable back into `--teacache-thresh`; an `-e`
+        # nothing in the container reads would have been inert.
         if not cfg.teacache:
             cmd += ["-e", "VERA_NO_TEACACHE=1"]
+        else:
+            cmd += ["-e", f"VERA_TEACACHE_THRESH={cfg.teacache_thresh}"]
         if cfg.docker_extra_args:
             cmd += list(cfg.docker_extra_args)
         cmd += [cfg.docker_image]

--- a/tests/policies/vera/test_server_env_reaches_both_server_modes.py
+++ b/tests/policies/vera/test_server_env_reaches_both_server_modes.py
@@ -28,15 +28,38 @@ front of the server process:
 
 So the rule below counts a value as carried when the container command either
 names the variable in an ``-e`` flag or bind-mounts the value it holds.
+
+The overlay is one of two vocabularies the config drives the server with. The
+other is the server's own **launch flags**: ``VeraServerRunner._build_command``
+composes ``--embodiment``, ``--port``, ``--sample-steps``, ``--teacache-thresh``
+and friends directly, while the container path has to get each of those values
+in front of the same flags indirectly - as ``-e`` variables the entrypoint turns
+back into argv. That indirection is where a flag goes missing without a word
+from anyone: ``docker run`` accepts any environment it is handed, and an ``-e``
+the entrypoint does not read is inert, so both halves have to line up before a
+value actually reaches the server.
+
+``teacache_thresh`` was the flag neither half carried. The subprocess argv passed
+``--teacache-thresh 0.25``; the container command named no variable for it and
+the entrypoint had no branch to emit it, so the same config ran the DiT cache at
+the caller's threshold under ``server_mode="subprocess"`` and at the server's own
+default under ``server_mode="docker"`` - reporting success either way. It is a
+bare float, needing none of the host->container path translation that keeps
+``algo_config`` out of the sweep, so nothing about it was hard to carry.
 """
 
 from __future__ import annotations
 
 import inspect
+import os
+import shutil
+import subprocess
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+from strands_robots.policies.vera import server_runner as server_runner_module
 from strands_robots.policies.vera.config import VeraConfig
 from strands_robots.policies.vera.server_runner import (
     DockerServerRunner,
@@ -55,6 +78,28 @@ FULLY_CONFIGURED: dict[str, Any] = {
     "tracker_backend": "cotracker",
     "text_prompt": "stack the cube",
     "sample_steps": 10,
+    # Deliberately not the 0.10 default: a forwarded value has to be the one the
+    # caller asked for, and a default would pass even if the server chose it.
+    "teacache_thresh": 0.25,
+}
+
+# The shipped container entrypoint, located from the module that launches it so
+# a move is a failure here rather than a silently skipped check.
+ENTRYPOINT = Path(server_runner_module.__file__).with_name("docker") / "entrypoint.sh"
+
+# Launch flags the container path deliberately does NOT carry verbatim, each with
+# the reason it differs. Anything else the subprocess argv can compose must reach
+# the container command, or the two modes launch different servers.
+FLAGS_NOT_CARRIED_VERBATIM: dict[str, str] = {
+    "--host": (
+        "the container binds 0.0.0.0 and publishes the port, so the host-side "
+        "address is the client's business and not the server's"
+    ),
+    "--algo-config": (
+        "a host filesystem path, which a container can only be given under a "
+        "bind mount; picking that mount point (and how it interacts with the "
+        "entrypoint's own per-embodiment default) is a separate decision"
+    ),
 }
 
 # Non-vacuity floor for the headline sweep: the overlay must really be
@@ -92,6 +137,50 @@ def _env_flags(argv: list[str]) -> dict[str, str]:
 def _mounted_host_paths(argv: list[str]) -> set[str]:
     """The host side of every ``-v <host>:<container>[:opts]`` bind mount."""
     return {payload.split(":", 1)[0] for flag, payload in zip(argv, argv[1:], strict=False) if flag == "-v"}
+
+
+def _subprocess_flags(cfg: VeraConfig) -> dict[str, str]:
+    """The ``--flag value`` pairs of the subprocess launch argv, keyed by flag.
+
+    A bare switch (``--no-teacache``) maps to the empty string, so presence and
+    payload stay distinguishable.
+    """
+    runner = make_server_runner(cfg)
+    assert isinstance(runner, VeraServerRunner), f"server_mode={cfg.server_mode!r} chose {type(runner).__name__}"
+    argv = runner._build_command()
+    flags: dict[str, str] = {}
+    for token, following in zip(argv, [*argv[1:], ""], strict=True):
+        if token.startswith("--"):
+            flags[token] = "" if following.startswith("--") else following
+    return flags
+
+
+def _entrypoint_server_argv(tmp_path: Path, **overrides: str) -> list[str]:
+    """Run the shipped entrypoint under bash and return the server argv it execs.
+
+    Nothing model-sized runs: a stub ``python`` earlier on ``PATH`` echoes the
+    arguments it was handed and exits, so what comes back is the argv the
+    container would really have started the policy server with. ``pusht`` is
+    used because it is the fully-local embodiment - no WAN base to find.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "python"
+    stub.write_text('#!/bin/sh\nfor a in "$@"; do echo "ARG:$a"; done\n')
+    stub.chmod(0o755)
+    ckpts = tmp_path / "ckpts"
+    ckpts.mkdir()
+    env = {
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "VERA_EMBODIMENT": "pusht",
+        "VERA_CKPT_ROOT": str(ckpts),
+        **overrides,
+    }
+    done = subprocess.run(  # noqa: S603 - list args, no shell
+        ["bash", str(ENTRYPOINT)], capture_output=True, text=True, env=env, timeout=120
+    )
+    assert done.returncode == 0, f"entrypoint exited {done.returncode}: {done.stderr}"
+    return [line[len("ARG:") :] for line in done.stdout.splitlines() if line.startswith("ARG:")]
 
 
 def _unreachable_in_docker(cfg: VeraConfig) -> dict[str, str]:
@@ -197,3 +286,99 @@ class TestNothingElseMoved:
         argv = _docker_argv(_config("docker"))
         assert all(isinstance(token, str) for token in argv)
         assert argv[-1] == VeraConfig(server_mode="docker", embodiment="mimicgen").docker_image
+
+
+requires_bash = pytest.mark.skipif(shutil.which("bash") is None, reason="the container entrypoint is a bash script")
+
+
+class TestTheLaunchFlagsAreCarriedByBothModes:
+    """The server's own flags, the second vocabulary the config drives it with."""
+
+    def test_the_flag_sweep_grades_more_than_one_flag(self):
+        """Premise: a clean sweep below has to be about a real set of flags."""
+        graded = {
+            f: v for f, v in _subprocess_flags(_config("subprocess")).items() if f not in FLAGS_NOT_CARRIED_VERBATIM
+        }
+        assert len(graded) >= 5, graded
+
+    def test_the_container_command_carries_every_launch_flag_value(self):
+        """The headline: no launch flag's value is dropped on the container path.
+
+        Derived from the subprocess argv rather than from a copied list, so a
+        seventh flag added to ``_build_command`` is graded here on arrival.
+        Pre-fix this reports ``--teacache-thresh``.
+        """
+        argv = _docker_argv(_config("docker"))
+        carried = set(_env_flags(argv).values()) | _mounted_host_paths(argv)
+        dropped = {
+            flag: value
+            for flag, value in _subprocess_flags(_config("subprocess")).items()
+            if value and flag not in FLAGS_NOT_CARRIED_VERBATIM and value not in carried
+        }
+        assert not dropped, (
+            "the subprocess mode launches the server with these flags, and the docker run "
+            f"command carries their values by no route: {dropped}. The container would start "
+            "on the server's own default for each one, under a success."
+        )
+
+    @pytest.mark.parametrize("thresh", [0.05, 0.15, 0.25])
+    def test_the_threshold_reaches_the_container(self, thresh):
+        """A tuned threshold is named for the container, not left behind."""
+        cfg = _config("docker", teacache_thresh=thresh)
+        assert _env_flags(_docker_argv(cfg))["VERA_TEACACHE_THRESH"] == str(thresh)
+
+    @requires_bash
+    def test_the_entrypoint_turns_the_variable_into_the_flag(self, tmp_path):
+        """An ``-e`` nothing in the container reads would be inert.
+
+        The other half of the fix: the shipped entrypoint has to translate the
+        variable back into the flag the server takes, so this runs it.
+        """
+        argv = _entrypoint_server_argv(tmp_path, VERA_TEACACHE_THRESH="0.25")
+        assert "--teacache-thresh" in argv, argv
+        assert argv[argv.index("--teacache-thresh") + 1] == "0.25"
+
+    @requires_bash
+    def test_both_modes_launch_the_server_on_the_same_threshold(self, tmp_path):
+        """End to end: one config, two launch modes, one server argv value."""
+        subprocess_value = _subprocess_flags(_config("subprocess"))["--teacache-thresh"]
+        container_env = _env_flags(_docker_argv(_config("docker")))
+        argv = _entrypoint_server_argv(tmp_path, VERA_TEACACHE_THRESH=container_env["VERA_TEACACHE_THRESH"])
+        assert argv[argv.index("--teacache-thresh") + 1] == subprocess_value == "0.25"
+
+
+class TestTheTeacachePairStaysOneEitherOr:
+    """Controls: the off-switch keeps its meaning, and the exclusions are stated."""
+
+    def test_disabling_teacache_names_no_threshold_in_the_container(self):
+        """A threshold means nothing once the cache is off, so none is sent."""
+        argv = _docker_argv(_config("docker", teacache=False))
+        named = _env_flags(argv)
+        assert named["VERA_NO_TEACACHE"] == "1"
+        assert "VERA_TEACACHE_THRESH" not in named
+
+    def test_disabling_teacache_names_no_threshold_in_the_subprocess_argv(self):
+        """The mode that already worked keeps the same either/or."""
+        flags = _subprocess_flags(_config("subprocess", teacache=False))
+        assert "--no-teacache" in flags
+        assert "--teacache-thresh" not in flags
+
+    @requires_bash
+    def test_the_off_switch_wins_in_the_container(self, tmp_path):
+        """Both variables set is still one request: the cache is off."""
+        argv = _entrypoint_server_argv(tmp_path, VERA_NO_TEACACHE="1", VERA_TEACACHE_THRESH="0.25")
+        assert "--no-teacache" in argv
+        assert "--teacache-thresh" not in argv
+
+    def test_each_excluded_flag_states_why_it_differs(self):
+        """An exclusion without a reason is how the dropped flag stayed dropped."""
+        assert all(reason.strip() for reason in FLAGS_NOT_CARRIED_VERBATIM.values())
+        assert set(FLAGS_NOT_CARRIED_VERBATIM) <= set(
+            _subprocess_flags(_config("subprocess", algo_config="/data/algo.yaml"))
+        )
+
+    def test_the_container_binds_every_interface_by_design(self):
+        """``--host`` is the one flag the container is meant to disagree on."""
+        cfg = _config("docker", host="127.0.0.1")
+        assert _env_flags(_docker_argv(cfg))["VERA_HOST"] == "0.0.0.0"
+        assert f"{cfg.server_port}:{cfg.server_port}" in _docker_argv(cfg)


### PR DESCRIPTION
## The threshold was applied in one launch mode and dropped in the other

`VeraConfig` drives the VERA policy server through two vocabularies: the environment overlay `server_env()` returns, and the server's own **launch flags**. `VeraServerRunner` composes those flags directly; the container path has to get each value in front of the same flags indirectly — as `-e` variables `docker/entrypoint.sh` turns back into argv. `teacache_thresh` was carried by **neither half**, while its `teacache` off-switch *was* carried as `-e VERA_NO_TEACACHE=1`.

![the argv the policy server is launched with, per mode](https://raw.githubusercontent.com/cagataycali/pr-assets/main/vera-teacache-thresh-34034015551.png)

One `VeraConfig(teacache_thresh=0.25)`, both launch modes, measured by running the shipped entrypoint under `bash` with a stub interpreter so the right-hand column is the argv the container would really have started the server with:

```
subprocess mode  ... --sample-steps 10 --teacache-thresh 0.25
docker  (before) ... --sample-steps 10                          <- threshold gone
docker  (after)  ... --sample-steps 10 --teacache-thresh 0.25
```

Nothing reported it. `docker run` has no opinion about an environment variable nobody passed it, so the container simply started on the server's own default — and the value that decides how often the DiT is recomputed is exactly the quality/latency knob a caller reaches for after watching a rollout, so the mode that ignored it looked like the threshold having no effect. It is a bare float, needing none of the host→container path translation that keeps `algo_config` off that list.

## Change

Both halves now carry it, in the same either/or shape the subprocess argv already had (a threshold means nothing once the cache is off):

| | subprocess mode | docker mode |
|---|---|---|
| cache off | `--no-teacache` | `-e VERA_NO_TEACACHE=1` -> `--no-teacache` |
| cache on | `--teacache-thresh <v>` | `-e VERA_TEACACHE_THRESH=<v>` -> `--teacache-thresh <v>` |

An `-e` nothing in the container reads would have been inert, which is why the entrypoint half is part of the same change and why the test executes the shell rather than grepping it.

## Tests

`tests/policies/vera/test_server_env_reaches_both_server_modes.py` already grades the *overlay* vocabulary across both modes; it now grades the *flag* vocabulary the same way. The headline check derives what must be carried from the subprocess argv itself, so a flag added to `_build_command` later is graded on arrival. Two exclusions are stated with their reason: `--host` (the container binds `0.0.0.0` by design and publishes the port) and `--algo-config` (a host path, which a container can only take under a bind mount — picking that mount point is a separate decision).

Four corners, `tests/policies/vera`, no `vera` package installed, no server, no container:

| tests | production | result |
|---|---|---|
| main | main | 974 passed |
| **this PR** | main | **6 failed**, 980 passed |
| this PR | this PR | 986 passed |
| main | this PR | 974 passed |

`974 + 12 = 986`, and `980 = 974 + 6` — of the 12 new cells, 6 are red pre-fix and 6 are controls that hold either way (the off-switch keeps its meaning in both modes; both variables set is still one request; `--host` really does resolve to `0.0.0.0`).

Local gate: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` unchanged at the pre-existing 20 errors in 6 files (all `examples/isaac_gs` + `simulation/ik.py`), and `pytest -k "vera or docs or docstring or changelog or ascii or grader or export or host_path or architecture"` = 4048 passed with the one pre-existing `rebot_b601` registry row failing on `main` too.

## Size

+246 / -0 across 6 files, of which **21 lines are production** (9 comment + 6 docstring + 4 executable: one `else` branch in the runner, one `elif` branch in the entrypoint):

| | lines |
|---|---|
| `policies/vera/server_runner.py` | +11 |
| `policies/vera/config.py` (docstring) | +6 |
| `policies/vera/docker/entrypoint.sh` | +4 |
| `tests/policies/vera/test_server_env_reaches_both_server_modes.py` | +185 |
| `docs/policies/vera.md` | +10 |
| `changelog.d/` | +30 |
