### PR TITLE
fix(simulation/isaac): a URDF joint that states no type is refused, not welded

### DIFF
--- a/changelog.d/3264-urdf-joint-type-is-required.md
+++ b/changelog.d/3264-urdf-joint-type-is-required.md
@@ -1,0 +1,26 @@
+### Fixed: `simulation/isaac` - a URDF joint that states no type is refused, not welded
+
+`type` is a required attribute of a URDF `<joint>`, so an absent one is missing
+information rather than a declaration of a default. Both of this package's URDF
+readers defaulted it to `"fixed"`: `load_urdf` emitted a `JointDef`
+byte-identical to the one a deliberate `type="fixed"` produces, and
+`urdf_joint_names` dropped the joint from the movable set. So a file that failed
+to declare a joint loaded as a robot with fewer actuated DOFs than it names, the
+load reporting success, and no caller able to tell it from an author welding
+that joint on purpose - the silent `joint_count` the module's failure semantics
+exist to convert into a message.
+
+The empty spelling of the same omission was already refused by name (`type=""`
+-> "unknown joint type"), so one file was refused and the other welded for the
+same missing declaration, decided by whether the attribute was written empty or
+left out. MuJoCo, which this loader already cites as its reference for the URDF
+`<axis>` default, refuses both spellings: `required attribute missing: 'type'`
+and `invalid joint type in URDF joint definition`.
+
+Both readers now refuse an absent `type` in their own voice, alongside the
+`name` refusal each already raised. A joint that STATES a type outside the
+movable set is still skipped by `urdf_joint_names` rather than refused - a
+declared type it has no named DOF for is not a malformed file, and `load_urdf`
+remains the reader that grades the vocabulary. MJCF is deliberately unchanged:
+that format documents `hinge` as the default for an omitted `type`, so an absent
+one there IS a declaration, and the regression test pins the contrast.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -227,7 +227,15 @@ open a window.
   parser can read: a URDF joint that omits the optional `<axis>` acts about
   **+X**, an MJCF `<joint>` that omits `axis` about **+Z**. Both are valid
   axes, so a joint read under the other format's default would be reported
-  acting in the perpendicular plane with the load still reporting success. Both
+  acting in the perpendicular plane with the load still reporting success. A
+  default applies only where the format declares one, which is why the two
+  formats answer an omitted `type` differently: MJCF documents `hinge` as the
+  default for a `<joint>`, so an MJCF joint with no `type` is read as a hinge,
+  while URDF requires `type` on every `<joint>`, so a URDF joint that omits it
+  is refused by name - by both readers, `load_urdf` and `urdf_joint_names`.
+  Reading it as `fixed` welded a joint the file never described and returned a
+  robot with fewer actuated DOFs than the file declares, indistinguishable from
+  a deliberate `type="fixed"`. Both
   of MJCF's spellings of a free joint are read - the dedicated `<freejoint>`
   element and `<joint type="free">`, which MuJoCo compiles to the same joint -
   so a floating base is reported rather than absent. `<freejoint>` is how every

--- a/strands_robots/simulation/isaac/joint_names.py
+++ b/strands_robots/simulation/isaac/joint_names.py
@@ -96,8 +96,11 @@ def urdf_joint_names(urdf_path: str) -> list[str]:
         If ``urdf_path`` does not exist.
     ValueError
         If the XML is malformed, the root element is not ``<robot>``, or a
-        joint carries no ``name`` attribute - the same fail-loud contract as
-        :func:`strands_robots.simulation.isaac.loaders.load_urdf`.
+        joint omits either of the attributes URDF requires of it - ``name`` or
+        ``type`` - the same fail-loud contract as
+        :func:`strands_robots.simulation.isaac.loaders.load_urdf`. A joint that
+        STATES a type outside the movable set is skipped rather than refused;
+        the loader is the reader that grades the vocabulary.
     """
     try:
         tree = ET.parse(urdf_path)
@@ -109,7 +112,19 @@ def urdf_joint_names(urdf_path: str) -> list[str]:
 
     names: list[str] = []
     for joint_el in root.findall("joint"):
-        jtype = joint_el.get("type", "fixed")
+        # Both of a URDF joint's required attributes are refused when absent,
+        # for the same reason and in the same words: neither has a default to
+        # stand in for it. Reading an absent ``type`` as ``fixed`` dropped the
+        # joint from the candidate pool silently, so a DOF the importer really
+        # named kept its mangled USD name - the #1900 leak this module exists to
+        # close - for a file whose only fault was an omitted attribute. A joint
+        # that STATES a type outside the movable set is still skipped rather
+        # than refused: that is a declared type this function has no named DOF
+        # for, and :func:`~strands_robots.simulation.isaac.loaders.load_urdf` is
+        # the reader that grades the vocabulary.
+        jtype = joint_el.get("type")
+        if jtype is None:
+            raise ValueError(f"URDF joint-name parse: <joint> without type attribute in {urdf_path}")
         if jtype not in _MOVABLE_URDF_JOINT_TYPES:
             continue
         jname = joint_el.get("name")

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -26,6 +26,13 @@ on parse failure):
     * Missing path -> :class:`FileNotFoundError`.
     * Malformed XML / unparseable document -> :class:`ValueError` with the
       file path and the offending element / parser message.
+    * A required attribute the document omits -> :class:`ValueError` naming the
+      element and the attribute. Never a default standing in for it: a URDF
+      ``<joint>`` must declare ``name`` and ``type``, and reading an absent
+      ``type`` as ``fixed`` welded a joint the file never described. An
+      attribute the format itself documents a default for (an MJCF ``<joint>``
+      ``type``, a URDF ``<axis>``) is a declaration of that default and is read
+      as one.
     * Empty document (zero links / zero joints / zero bodies) ->
       :class:`ValueError`. Loaders never silently return a phantom robot.
 
@@ -295,7 +302,26 @@ def load_urdf(path: str) -> ProceduralRobot:
         if not jname:
             raise ValueError(f"URDF loader: <joint> without name attribute in {path}")
 
-        urdf_type = joint_el.get("type", "fixed")
+        # ``type`` is a REQUIRED attribute of a URDF ``<joint>``, so an absent one
+        # is missing information rather than a declaration of a default - unlike
+        # the optional ``<axis>`` below, and unlike MJCF's ``type``, which the
+        # format documents as defaulting to ``hinge``. Defaulting it to ``fixed``
+        # here produced a JointDef byte-identical to the one a deliberate
+        # ``type="fixed"`` produces, so a joint the file failed to declare was
+        # indistinguishable from one the author welded on purpose: the robot came
+        # back with fewer actuated DOFs than the file names, and the load
+        # reported success - the silent ``joint_count`` this module's failure
+        # semantics exist to convert into a message. The empty spelling
+        # (``type=""``) was already refused by name below, so one file was
+        # refused and the other welded for the same missing declaration. Both are
+        # refused now, which is also what MuJoCo - this loader's reference for
+        # the ``<axis>`` default - does with either spelling.
+        urdf_type = joint_el.get("type")
+        if urdf_type is None:
+            raise ValueError(
+                f"URDF loader: <joint name='{jname}'> in {path} states no 'type' attribute; "
+                f"URDF requires it (one of {sorted(_URDF_JOINT_TYPE_MAP)})"
+            )
         jtype = _URDF_JOINT_TYPE_MAP.get(urdf_type)
         if jtype is None:
             raise ValueError(

--- a/tests/simulation/isaac/test_urdf_joint_type_is_required.py
+++ b/tests/simulation/isaac/test_urdf_joint_type_is_required.py
@@ -1,0 +1,240 @@
+"""A URDF joint that states no type is refused, not read as a fixed joint.
+
+``type`` is a required attribute of a URDF ``<joint>``. An absent one is
+therefore missing information, not a declaration of a default - which is the
+distinction :mod:`strands_robots.simulation.isaac.loaders` already draws for
+``<axis>``, an attribute URDF *does* give a default (``+X``), and for MJCF's
+``type``, which MuJoCo documents as defaulting to ``hinge``.
+
+Both of this package's URDF readers defaulted it to ``"fixed"``:
+
+* :func:`~strands_robots.simulation.isaac.loaders.load_urdf` emitted a
+  ``JointDef`` identical to the one a deliberate ``type="fixed"`` produces, so
+  the robot came back with fewer actuated DOFs than the file names and the load
+  reported success. That is the silent ``joint_count`` the loader's documented
+  failure semantics exist to convert into a message.
+* :func:`~strands_robots.simulation.isaac.joint_names.urdf_joint_names` dropped
+  the joint from the movable set, so its name never entered the candidate pool
+  :func:`~strands_robots.simulation.isaac.joint_names.demangle_usd_joint_names`
+  translates a mangled DOF name through.
+
+The empty spelling of the same omission was already refused by name in the
+loader (``type=""`` -> "unknown joint type"), so one file was refused and the
+other welded for the same missing declaration, decided only by whether the
+attribute was written empty or left out. MuJoCo refuses both, and this module
+already cites MuJoCo as its reference for the URDF ``<axis>`` default; the
+cross-parser class here checks that against the real parser rather than
+restating it.
+
+Neither reader needs an Isaac Kit install or ``pxr``: both are stdlib XML
+parsers.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from strands_robots.simulation.isaac import joint_names as jn
+from strands_robots.simulation.isaac import loaders
+
+# URDF's declared joint types, stated here rather than read from the code so
+# these tests are an independent oracle rather than a restatement of it.
+URDF_DECLARED_TYPES = ("revolute", "continuous", "prismatic", "fixed", "floating", "planar")
+
+# The declared types the loader reads as moving - the DOFs a file loses when a
+# joint is welded by a default instead of being refused.
+URDF_MOVING_TYPES = ("revolute", "continuous", "prismatic")
+
+#: The two ways a URDF ``<joint>`` can fail to state a type, and the substring
+#: each refusal must carry. Both are one missing declaration; before the fix
+#: only the second was refused.
+UNSTATED_TYPE_SPELLINGS = {
+    "omitted": ("", "type"),
+    "empty": ('type=""', "type"),
+}
+
+
+def _arm_urdf(tmp_path: pathlib.Path, shoulder_attrs: str, name: str = "arm.urdf") -> str:
+    """Write a three-link arm whose shoulder joint carries ``shoulder_attrs``.
+
+    The elbow is always a plain ``revolute``, so every file here is a robot the
+    readers can load apart from the one attribute under test - which keeps the
+    refusals below attributable to that attribute and lets the accepted cases
+    show what the shoulder contributes.
+    """
+    path = tmp_path / name
+    path.write_text(
+        '<robot name="r">'
+        '<link name="base"/><link name="mid"/><link name="tip"/>'
+        f'<joint name="shoulder" {shoulder_attrs}>'
+        '<parent link="base"/><child link="mid"/><axis xyz="0 0 1"/>'
+        "</joint>"
+        '<joint name="elbow" type="revolute">'
+        '<parent link="mid"/><child link="tip"/><axis xyz="0 0 1"/>'
+        "</joint>"
+        "</robot>"
+    )
+    return str(path)
+
+
+def _moving_joint_names(robot: object) -> list[str]:
+    """The names ``load_urdf`` reported as something other than a weld."""
+    return [j.name for j in robot.joints if j.joint_type != "fixed"]  # type: ignore[attr-defined]
+
+
+class TestBothReadersRefuseAJointThatStatesNoType:
+    """The headline: neither reader answers for an attribute the file omits."""
+
+    @pytest.mark.parametrize("spelling", sorted(UNSTATED_TYPE_SPELLINGS))
+    def test_the_loader_refuses_it(self, tmp_path: pathlib.Path, spelling: str) -> None:
+        attrs, expected = UNSTATED_TYPE_SPELLINGS[spelling]
+        path = _arm_urdf(tmp_path, attrs)
+        with pytest.raises(ValueError) as excinfo:
+            loaders.load_urdf(path)
+        message = str(excinfo.value)
+        assert expected in message, message
+        assert "shoulder" in message, f"the refusal does not name the joint: {message}"
+
+    def test_the_name_reader_refuses_the_omitted_spelling(self, tmp_path: pathlib.Path) -> None:
+        """``urdf_joint_names`` refuses the omission it used to skip.
+
+        Only the omitted spelling: ``type=""`` is a STATED type this function
+        has no named DOF for, which it skips like any other non-movable type -
+        the loader is the reader that grades the vocabulary.
+        """
+        path = _arm_urdf(tmp_path, "")
+        with pytest.raises(ValueError, match="type"):
+            jn.urdf_joint_names(path)
+
+    def test_the_refusal_is_raised_before_the_joint_becomes_a_weld(self, tmp_path: pathlib.Path) -> None:
+        """No partial robot is returned alongside the refusal.
+
+        The loader collects joints into a list and validates the kinematic tree
+        at the end, so a refusal raised mid-loop must not have produced a
+        ``ProceduralRobot`` at all - the caller gets an exception or a complete
+        robot, never a robot missing a joint it asked about.
+        """
+        with pytest.raises(ValueError):
+            loaders.load_urdf(_arm_urdf(tmp_path, ""))
+
+
+class TestWhatTheDefaultUsedToCost:
+    """The same file, with the shoulder type stated, keeps its DOF.
+
+    These cells are the measurement the refusal replaces: an omitted ``type``
+    used to produce exactly the ``fixed`` reading below, so the robot lost the
+    shoulder DOF with the load reporting success.
+    """
+
+    @pytest.mark.parametrize("joint_type", URDF_MOVING_TYPES)
+    def test_a_stated_moving_type_keeps_the_shoulder(self, tmp_path: pathlib.Path, joint_type: str) -> None:
+        robot = loaders.load_urdf(_arm_urdf(tmp_path, f'type="{joint_type}"'))
+        assert _moving_joint_names(robot) == ["shoulder", "elbow"]
+        assert jn.urdf_joint_names(_arm_urdf(tmp_path, f'type="{joint_type}"')) == ["shoulder", "elbow"]
+
+    def test_a_stated_fixed_type_welds_it_and_is_still_accepted(self, tmp_path: pathlib.Path) -> None:
+        """The reading an omission used to be indistinguishable from.
+
+        A deliberate ``type="fixed"`` is a legitimate request and stays
+        accepted, which is what made the default silent: the two files produced
+        the same answer, so no caller could tell a malformed URDF from a welded
+        joint.
+        """
+        path = _arm_urdf(tmp_path, 'type="fixed"')
+        robot = loaders.load_urdf(path)
+        assert [(j.name, j.joint_type) for j in robot.joints] == [("shoulder", "fixed"), ("elbow", "revolute")]
+        assert jn.urdf_joint_names(path) == ["elbow"]
+
+
+class TestEveryDeclaredTypeStillLoads:
+    """Unchanged behaviour: the refusal is scoped to an absent attribute.
+
+    Every cell here held before the fix too. A type URDF declares is still
+    accepted by the loader, and the two readers still agree about which of them
+    move.
+    """
+
+    @pytest.mark.parametrize("joint_type", URDF_DECLARED_TYPES)
+    def test_the_loader_accepts_it(self, tmp_path: pathlib.Path, joint_type: str) -> None:
+        robot = loaders.load_urdf(_arm_urdf(tmp_path, f'type="{joint_type}"'))
+        assert [j.name for j in robot.joints] == ["shoulder", "elbow"]
+
+    @pytest.mark.parametrize("joint_type", URDF_DECLARED_TYPES)
+    def test_the_two_readers_agree_about_whether_it_moves(self, tmp_path: pathlib.Path, joint_type: str) -> None:
+        path = _arm_urdf(tmp_path, f'type="{joint_type}"')
+        robot = loaders.load_urdf(path)
+        assert ("shoulder" in _moving_joint_names(robot)) == ("shoulder" in jn.urdf_joint_names(path))
+
+    def test_a_declared_type_outside_the_movable_set_is_skipped_not_refused(self, tmp_path: pathlib.Path) -> None:
+        """``urdf_joint_names`` still answers for a stated non-movable type.
+
+        The scoping sentence of the fix: an omitted attribute is a malformed
+        file, a stated ``planar`` is a joint this function has no named DOF for.
+        """
+        assert jn.urdf_joint_names(_arm_urdf(tmp_path, 'type="planar"')) == ["elbow"]
+
+
+class TestMjcfKeepsItsOwnDefault:
+    """MJCF is deliberately unchanged, because MJCF declares the default.
+
+    MuJoCo documents ``hinge`` as the type of a ``<joint>`` that states none, so
+    an absent ``type`` there IS a declaration and reading it as a hinge is
+    correct. This is the contrast that makes the URDF refusal a statement about
+    the format rather than a blanket rule about missing attributes.
+    """
+
+    def test_an_mjcf_joint_with_no_type_is_a_hinge(self, tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "arm.xml"
+        path.write_text(
+            '<mujoco model="r"><worldbody>'
+            '<body name="base"><body name="mid">'
+            '<joint name="shoulder" axis="0 0 1"/>'
+            "</body></body>"
+            "</worldbody></mujoco>"
+        )
+        robot = loaders.load_mjcf(str(path))
+        assert [(j.name, j.joint_type) for j in robot.joints] == [("shoulder", "revolute")]
+
+    def test_the_mjcf_default_is_the_one_the_format_declares(self) -> None:
+        """Stated as a fact about MJCF, so the two answers stay traceable."""
+        assert loaders._MJCF_JOINT_TYPE_MAP["hinge"] == "revolute"
+
+
+class TestTheReferenceParserRefusesTheSameFile:
+    """MuJoCo, cited by this loader for the ``<axis>`` default, agrees.
+
+    An oracle rather than a restatement: the requiredness of ``type`` is a
+    property of URDF, and the parser the module already defers to on the
+    format's defaults is the cheapest independent witness to it. Skipped where
+    ``mujoco`` is not installed - the readers under test never need it.
+    """
+
+    @staticmethod
+    def _mujoco_urdf(tmp_path: pathlib.Path, shoulder_attrs: str) -> str:
+        """A two-link URDF with the mass/limit data MuJoCo's compiler requires."""
+        inertial = "<inertial><mass value='1'/><inertia ixx='1' iyy='1' izz='1' ixy='0' ixz='0' iyz='0'/></inertial>"
+        path = tmp_path / "mj.urdf"
+        path.write_text(
+            '<robot name="r">'
+            f'<link name="base">{inertial}</link><link name="tip">{inertial}</link>'
+            f'<joint name="shoulder" {shoulder_attrs}>'
+            '<parent link="base"/><child link="tip"/><axis xyz="0 0 1"/>'
+            "<limit lower='-1' upper='1' effort='1' velocity='1'/>"
+            "</joint>"
+            "</robot>"
+        )
+        return str(path)
+
+    def test_it_loads_a_stated_type(self, tmp_path: pathlib.Path) -> None:
+        mujoco = pytest.importorskip("mujoco")
+        model = mujoco.MjModel.from_xml_path(self._mujoco_urdf(tmp_path, 'type="revolute"'))
+        assert model.njnt == 1
+
+    @pytest.mark.parametrize("spelling", sorted(UNSTATED_TYPE_SPELLINGS))
+    def test_it_refuses_a_joint_that_states_no_type(self, tmp_path: pathlib.Path, spelling: str) -> None:
+        mujoco = pytest.importorskip("mujoco")
+        attrs, _ = UNSTATED_TYPE_SPELLINGS[spelling]
+        with pytest.raises(ValueError, match="type"):
+            mujoco.MjModel.from_xml_path(self._mujoco_urdf(tmp_path, attrs))

--- a/tests/simulation/isaac/test_urdf_joint_type_vocabulary.py
+++ b/tests/simulation/isaac/test_urdf_joint_type_vocabulary.py
@@ -64,8 +64,15 @@ def _one_joint_urdf(tmp_path: pathlib.Path, joint_type: str) -> str:
 
 
 def _loader_reads_as_moving(joint_type: str) -> bool:
-    """Whether ``load_urdf`` maps ``joint_type`` onto a moving ``JointDef``."""
-    return loaders._URDF_JOINT_TYPE_MAP.get(joint_type, "fixed") != "fixed"
+    """Whether ``load_urdf`` maps ``joint_type`` onto a moving ``JointDef``.
+
+    Indexed rather than defaulted: the only caller iterates the map's own keys,
+    and a ``"fixed"`` fallback here was a third copy of the one the loader used
+    to apply to an absent ``type`` attribute - now refused, so a fallback
+    standing in for a missing declaration should not survive in the tests that
+    grade the vocabulary either.
+    """
+    return loaders._URDF_JOINT_TYPE_MAP[joint_type] != "fixed"
 
 
 class TestTheLoaderRecordsTheFormat:


### PR DESCRIPTION
## The DOF the default cost

Same URDF, rendered in MuJoCo (headless EGL). Top: the two joints the file declares. Bottom: what an omitted `<joint type>` loaded as - `njnt=2` becomes `njnt=1`, and the load reported success.

![the DOF an omitted joint type used to cost](https://raw.githubusercontent.com/cagataycali/pr-assets/main/3264/urdf_type_render.png)

## What changed

`type` is a **required** attribute of a URDF `<joint>`, so an absent one is missing information - not a declaration of a default. Both of this package's URDF readers defaulted it to `"fixed"`:

| reader | an omitted `type` produced |
|---|---|
| `loaders.load_urdf` | a `JointDef` identical to a deliberate `type="fixed"` - the joint welded, the robot short one actuated DOF |
| `joint_names.urdf_joint_names` | the joint dropped from the movable set, so its name never entered the `demangle_usd_joint_names` candidate pool |

So a file that failed to declare a joint loaded as a robot with fewer DOFs than it names, with no caller able to tell it from an author welding that joint on purpose. That is the silent `joint_count` the loader's own documented failure semantics exist to convert into a message.

The **empty** spelling of the same omission was already refused by name (`type=""` -> `unknown joint type`). One file was refused and the other welded for the same missing declaration, decided only by whether the attribute was written empty or left out.

![before/after verdict grid](https://raw.githubusercontent.com/cagataycali/pr-assets/main/3264/urdf_type_grid.png)

Measured on both trees: exactly one row moves. Every declared type answers identically before and after.

## The reference parser already agreed

This loader cites MuJoCo for the URDF `<axis>` default ("MuJoCo, which parses URDF, reads an absent `<axis>` as +X"). Measured against `mujoco.MjModel.from_xml_path`, 3.5.0:

| the same file | MuJoCo |
|---|---|
| `type="revolute"` | loads, `njnt=1` |
| `type=""` | `XML Error: invalid joint type in URDF joint definition` |
| no `type` attribute | `XML Error: required attribute missing: 'type'` |

The fix makes both readers agree with the parser the module already defers to on the format's defaults. The regression test pins that against the real parser (`importorskip`) rather than restating it, so the requiredness stays an independently checked fact.

## Scope, and what is deliberately unchanged

- **MJCF is untouched.** MuJoCo documents `hinge` as the default for a `<joint>` that states no `type`, so there an absent one *is* a declaration. `_MJCF_JOINT_TYPE_MAP`'s `"hinge"` default stays, and a cell pins the contrast - the URDF refusal is a statement about URDF, not a blanket rule about missing attributes.
- **A joint that STATES a type outside the movable set is still skipped, not refused, by `urdf_joint_names`.** A declared `planar` is a joint it has no named DOF for, which is not a malformed file; `load_urdf` remains the reader that grades the vocabulary. Pinned as a passing cell.
- Each reader refuses in its own voice, alongside the `name` refusal each already raised - the shape this package already uses for that attribute.
- The third copy of the removed fallback lived in `test_urdf_joint_type_vocabulary.py`'s helper (`.get(joint_type, "fixed")`); it now indexes the map its only caller iterates.

## Verification

Four corners on `tests/simulation/isaac`:

| | old tests | new tests |
|---|---|---|
| **old prod** | 1939 passed | **3 failed**, 1962 passed |
| **new prod** | 1939 passed | 1965 passed |

`1939 + 26 = 1965`. The 3 red cells are the two reader refusals plus the no-partial-robot cell; the other 23 hold on old prod too (controls). New prod against old tests equals baseline exactly, so nothing existing moved.

Wider: `tests/simulation tests/registry` 15106 passed / 1 pre-existing failure (`test_pose_vector_rule_parity.py`, reproduced identically on `upstream/main`). Docs/docstring/changelog grader net 1755 passed / 1 pre-existing (`rebot_b601`). `ruff check` + `ruff format --check` clean on the touched trees; `mypy` unchanged (20 pre-existing errors, all `examples/isaac_gs` + `simulation/ik.py`, none here).

## Size

| | lines |
|---|---|
| production | +45 (9 executable, 12 docstring, 24 comment) |
| regression test | +240 |
| sibling test dedup | +9 / -2 |
| docs + changelog | +35 |
| **total** | **+329 / -7** |

The production change is nine executable lines: two refusals and the removal of two defaults. The rest is the reason.