### PR TITLE
fix(dataset): a recorded length of zero is a frame count, not a missing column

### DIFF
--- a/changelog.d/3265-zero-length-episode-is-a-count.md
+++ b/changelog.d/3265-zero-length-episode-is-a-count.md
@@ -1,0 +1,24 @@
+### Fixed: `verify-dataset` grades a run whose every episode recorded zero frames
+
+`read_dataset_episode_indices` reports an empty `frames_per_episode` to mean the
+episodes parquet carries no usable `length`, and scored that availability as
+`any(f > 0 ...)`. So a collection run that wrote episode metadata and no frames
+at all answered "this dataset carries no lengths", and `verify_dataset` reads an
+empty list as nothing to compare and skipped its check 2 - the check whose whole
+subject is a zero-length episode.
+
+The gate was therefore non-monotonic in the damage it grades: a dataset holding
+`[5, 0, 0]` frames named its two empty episodes and exited 1, while the strictly
+worse `[0, 0, 0]` was certified `status="success"` (exit 0). The
+`meta/info.json total_frames` claim beside it went unreported too, because check
+3's frame comparison was gated on the parquet total being non-zero rather than on
+a length being available - and a parquet whose every episode is empty sums to
+exactly the zero that read as "no lengths".
+
+Availability is now whether a length was *read*: a present column with a
+recorded `0` is a frame count, so the empty episodes are named and the header
+drift is reported. A column that is absent, or present but wholly null, stays
+unavailable - a length nobody recorded is unknown, not zero - so neither gains a
+zero-length verdict, and `min_frames=0` remains the documented way to skip the
+check. `verify_dataset_episodes` keeps its count-only verdict and now shows the
+recorded zeros in its `total_frames_per_ep` diagnostic instead of an empty list.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -458,6 +458,17 @@ switch the check off and certify a dataset holding a zero-length episode. The
 same domain backs `verify_dataset_episodes(expected=...)`, so neither surface
 accepts an episode count the other refuses.
 
+The dataset can switch that check off the same way the threshold could: the
+length check runs only when the parquet carries per-episode lengths at all, and
+availability is whether a `length` was *read*, not whether one was positive. A
+run that wrote three episodes of zero frames is graded and named
+(`3 episode(s) below min_frames=1`), and its `meta/info.json total_frames` is
+still compared against the zero the parquet holds - previously the whole-run
+corruption read as "this writer omits the `length` column" and passed while the
+strictly better `[5, 0, 0]` failed. A column that is absent, or present but
+wholly null, remains unavailable: a length nobody recorded is unknown, not zero,
+so neither gains a zero-length verdict.
+
 `verify-dataset` always produces a report - it never crashes on the corruption
 it exists to flag. A corrupt or foreign `meta/episodes` parquet, a non-v3
 `video_path` template, or a truncated / unreadable MP4 is reported as a problem

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -1988,8 +1988,12 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
           - ``episode_indices``: sorted list of distinct ``episode_index`` values.
           - ``total_episodes``: number of distinct episodes (``len`` of above).
           - ``total_frames``: sum of per-episode ``length`` (0 if unavailable).
+            A dataset whose episodes all recorded 0 frames also sums to 0, so
+            read ``frames_per_episode`` to tell "no lengths" from "no frames".
           - ``frames_per_episode``: per-episode frame counts aligned to
-            ``episode_indices`` (empty list if the ``length`` column is absent).
+            ``episode_indices``. Empty when no episode carried a usable
+            ``length`` (the column is absent, or every value is null); a
+            recorded ``0`` is a frame count and is reported as one.
           - ``info_total_episodes``: the ``total_episodes`` recorded in
             ``meta/info.json`` (``None`` if that file is absent or unreadable, or
             if it declares no usable count - see ``info_problems``). Returned
@@ -2035,6 +2039,7 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
     seen: set[int] = set()
     unreadable_files: list[str] = []
     readable_files = 0
+    saw_length = False
     for pf in parquet_files:
         # A corrupt / truncated / foreign parquet raises ArrowInvalid (a
         # ValueError subclass); an unreadable one raises OSError. Damage is
@@ -2059,7 +2064,9 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
             if ep_int in seen:
                 continue
             seen.add(ep_int)
-            length = int(lengths[i]) if lengths is not None and lengths[i] is not None else 0
+            recorded = lengths[i] if lengths is not None else None
+            saw_length = saw_length or recorded is not None
+            length = int(recorded) if recorded is not None else 0
             pairs.append((ep_int, length))
 
     if unreadable_files and readable_files == 0:
@@ -2071,7 +2078,15 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
     pairs.sort(key=lambda p: p[0])
     episode_indices = [p[0] for p in pairs]
     frames_per_episode = [p[1] for p in pairs]
-    has_lengths = any(f > 0 for f in frames_per_episode)
+    # Availability is whether a length was READ, not whether one was positive.
+    # A recorded 0 is a frame count - it is the zero-length episode
+    # verify_dataset's check 2 exists to flag - so scoring availability as
+    # ``any(f > 0 ...)`` reported the dataset whose every episode is empty as
+    # the dataset that carries no lengths at all, and that check reads an empty
+    # list as "nothing to compare" and does not run. The report was therefore
+    # non-monotonic in the damage: ``[5, 0, 0]`` named its two empty episodes
+    # while ``[0, 0, 0]`` passed. A column that is present but wholly null
+    # stays unavailable - a null length is unknown, not zero.
 
     # Read meta/info.json total_episodes as a second, independent metadata
     # source. A healthy LeRobot dataset has info.json.total_episodes equal to
@@ -2107,8 +2122,8 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
     return {
         "episode_indices": episode_indices,
         "total_episodes": len(episode_indices),
-        "total_frames": sum(frames_per_episode) if has_lengths else 0,
-        "frames_per_episode": frames_per_episode if has_lengths else [],
+        "total_frames": sum(frames_per_episode) if saw_length else 0,
+        "frames_per_episode": frames_per_episode if saw_length else [],
         "info_total_episodes": info_total_episodes,
         "info_problems": info_problems,
         "unreadable_files": unreadable_files,

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -230,8 +230,13 @@ def verify_dataset(
                 f"meta/info.json total_episodes={decl_eps} disagrees with parquet "
                 f"({info['total_episodes']} distinct episode(s)) - metadata/parquet drift"
             )
-        # Frame totals only meaningful when parquet carries per-episode lengths.
-        if decl_frames is not None and info["total_frames"] and decl_frames != info["total_frames"]:
+        # Frame totals only meaningful when parquet carries per-episode lengths,
+        # and that availability is ``frames_per_episode`` rather than the total
+        # being non-zero: a parquet whose every episode recorded 0 frames sums
+        # to 0, so gating on the total read the worst dataset in this class as
+        # one carrying no lengths and dropped the comparison on exactly the
+        # header that claims frames the dataset does not hold.
+        if decl_frames is not None and info["frames_per_episode"] and decl_frames != info["total_frames"]:
             problems.append(
                 f"meta/info.json total_frames={decl_frames} disagrees with parquet ({info['total_frames']} frame(s))"
             )

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -38,7 +38,7 @@ from strands_robots.verify_dataset import main as verify_main
 def _write_dataset(
     root: Path,
     episode_indices: list[int],
-    frames_per_episode: list[int] | None = None,
+    frames_per_episode: list[int | None] | None = None,
     info: dict | None = None,
 ) -> Path:
     """Write a minimal LeRobot v3 dataset (episodes parquet + optional info.json).
@@ -46,7 +46,9 @@ def _write_dataset(
     Args:
         root: Dataset root (the dir that will contain ``meta/``).
         episode_indices: Distinct ``episode_index`` values to write.
-        frames_per_episode: Per-episode ``length`` column (omitted if None).
+        frames_per_episode: Per-episode ``length`` column (omitted if None). A
+            ``None`` entry writes a null, a length nobody recorded rather than
+            a recorded zero.
         info: Optional ``meta/info.json`` payload.
 
     Returns:

--- a/tests/test_verify_dataset_zero_length_is_a_count.py
+++ b/tests/test_verify_dataset_zero_length_is_a_count.py
@@ -1,0 +1,203 @@
+"""A recorded length of zero is a frame count, not a missing ``length`` column.
+
+:func:`~strands_robots.dataset_recorder.read_dataset_episode_indices` reports
+per-episode frame counts, and an empty ``frames_per_episode`` is documented to
+mean the ``length`` column is unavailable. It scored that availability as
+``any(f > 0 for f in frames_per_episode)``, so the one dataset whose every
+episode recorded zero frames answered "this dataset carries no lengths" - and
+:func:`~strands_robots.verify_dataset.verify_dataset` reads an empty list as
+"nothing to compare" and skips its check 2, the check whose entire subject is a
+zero-length episode (module docstring, item 2).
+
+The gate was therefore non-monotonic in the damage it grades. A dataset holding
+``[5, 0, 0]`` frames named its two empty episodes and exited 1; the strictly
+worse ``[0, 0, 0]`` - a whole collection run that wrote metadata and no frames -
+was certified ``status="success"``, CLI exit 0, and the header claiming
+``total_frames: 900`` beside it went unreported too, because the drift half of
+check 3 was gated on the parquet total being non-zero rather than on a length
+being available. Adding an episode with real frames was the way to make the gate
+notice.
+
+Availability is now whether a length was *read*: a present column with a
+recorded ``0`` is a count, while an absent column - and one present but wholly
+null, a length that is unknown rather than zero - stays unavailable, so neither
+gains a false zero-length verdict. ``min_frames=0`` remains the documented way
+to skip the length check.
+
+Fixtures are pyarrow-only (no lerobot, no mujoco) and every assertion is on
+observable behaviour: the report's ``status`` / ``problems``, the CLI exit code,
+and the counts the reader is handed.
+"""
+
+from __future__ import annotations
+
+import re
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+from strands_robots.dataset_recorder import read_dataset_episode_indices
+from strands_robots.simulation.base import SimEngine
+from strands_robots.verify_dataset import main as verify_main
+from strands_robots.verify_dataset import verify_dataset
+
+from .test_verify_dataset import _write_dataset
+
+#: A header claiming frames the parquet does not hold, so check 3's frame-drift
+#: half has something to disagree with in every dataset below.
+_DECLARES_900_FRAMES = {"total_episodes": 3, "total_frames": 900}
+
+
+def _verify(root: Path, **kwargs: Any) -> dict[str, Any]:
+    """Run the gate on the count checks alone (no video or stats fixtures)."""
+    return verify_dataset(root, check_videos=False, check_stats=False, **kwargs)
+
+
+def _named_short_episodes(report: dict[str, Any]) -> str:
+    """The check-2 problem string, or ``""`` when the check did not report one."""
+    return next((p for p in report["problems"] if "frame(s)" in p and "min_frames" in p), "")
+
+
+def _short_episode_indices(report: dict[str, Any]) -> list[int]:
+    """Which episodes check 2 actually named as short, in the order reported."""
+    return [int(n) for n in re.findall(r"episode (\d+)=", _named_short_episodes(report))]
+
+
+def _frame_drift(report: dict[str, Any]) -> str:
+    """The check-3 frame-total problem string, or ``""`` when absent."""
+    return next((p for p in report["problems"] if "total_frames=900 disagrees" in p), "")
+
+
+class TestEveryEpisodeZeroLength:
+    """The whole-run corruption is graded, not read as an absent column."""
+
+    def test_the_recorded_zeros_are_reported_as_counts(self, tmp_path: Path) -> None:
+        info = read_dataset_episode_indices(_write_dataset(tmp_path, [0, 1, 2], [0, 0, 0]))
+        assert info["frames_per_episode"] == [0, 0, 0]
+        assert info["total_frames"] == 0
+        assert info["total_episodes"] == 3
+
+    def test_the_gate_names_every_empty_episode(self, tmp_path: Path) -> None:
+        report = _verify(_write_dataset(tmp_path, [0, 1, 2], [0, 0, 0]), min_frames=1)
+        assert report["status"] == "error", report
+        problem = _named_short_episodes(report)
+        assert "3 episode(s) below min_frames=1" in problem, report["problems"]
+        for episode in (0, 1, 2):
+            assert f"episode {episode}=0 frame(s)" in problem
+
+    def test_the_header_that_claims_frames_is_reported(self, tmp_path: Path) -> None:
+        """Check 3's frame comparison survives a parquet total of zero."""
+        root = _write_dataset(tmp_path, [0, 1, 2], [0, 0, 0], info=_DECLARES_900_FRAMES)
+        report = _verify(root, min_frames=1)
+        assert "parquet (0 frame(s))" in _frame_drift(report), report["problems"]
+
+    def test_the_cli_exits_non_zero(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _write_dataset(tmp_path, [0, 1, 2], [0, 0, 0])
+        assert verify_main([str(tmp_path), "--no-check-videos", "--no-check-stats"]) == 1
+        assert "min_frames" in capsys.readouterr().out
+
+    def test_the_worse_dataset_is_not_the_one_that_passes(self, tmp_path: Path) -> None:
+        """Monotonicity: emptying the one good episode cannot buy a pass."""
+        mixed = _verify(_write_dataset(tmp_path / "mixed", [0, 1, 2], [5, 0, 0]), min_frames=1)
+        emptied = _verify(_write_dataset(tmp_path / "emptied", [0, 1, 2], [0, 0, 0]), min_frames=1)
+        assert mixed["status"] == "error"
+        assert emptied["status"] == "error"
+        assert _short_episode_indices(mixed) == [1, 2]
+        assert _short_episode_indices(emptied) == [0, 1, 2]
+
+    def test_a_single_zero_length_episode_is_graded_too(self, tmp_path: Path) -> None:
+        """The degenerate one-episode run, where every length is also zero."""
+        report = _verify(_write_dataset(tmp_path, [0], [0]), min_frames=1)
+        assert report["status"] == "error", report
+        assert "episode 0=0 frame(s)" in _named_short_episodes(report)
+
+
+class TestAnUnavailableLengthStaysUnavailable:
+    """A length nobody recorded is not a zero, and must not be graded as one."""
+
+    def test_an_absent_column_reports_no_lengths(self, tmp_path: Path) -> None:
+        info = read_dataset_episode_indices(_write_dataset(tmp_path, [0, 1, 2]))
+        assert info["frames_per_episode"] == []
+        assert info["total_frames"] == 0
+
+    def test_a_wholly_null_column_reports_no_lengths(self, tmp_path: Path) -> None:
+        """Present but never written: unknown per episode, not zero."""
+        info = read_dataset_episode_indices(_write_dataset(tmp_path, [0, 1, 2], [None, None, None]))
+        assert info["frames_per_episode"] == []
+        assert info["total_frames"] == 0
+
+    @pytest.mark.parametrize(
+        "lengths",
+        [pytest.param(None, id="absent-column"), pytest.param([None, None, None], id="wholly-null-column")],
+    )
+    def test_no_length_check_verdict_is_invented(self, tmp_path: Path, lengths: list[Any] | None) -> None:
+        report = _verify(_write_dataset(tmp_path, [0, 1, 2], lengths), min_frames=1)
+        assert report["status"] == "success", report
+        assert _named_short_episodes(report) == ""
+
+    @pytest.mark.parametrize(
+        "lengths",
+        [pytest.param(None, id="absent-column"), pytest.param([None, None, None], id="wholly-null-column")],
+    )
+    def test_no_frame_drift_is_invented(self, tmp_path: Path, lengths: list[Any] | None) -> None:
+        """Nothing to compare the header against, so nothing is reported."""
+        root = _write_dataset(tmp_path, [0, 1, 2], lengths, info=_DECLARES_900_FRAMES)
+        report = _verify(root, min_frames=1)
+        assert _frame_drift(report) == "", report["problems"]
+
+    def test_one_recorded_length_makes_the_column_available(self, tmp_path: Path) -> None:
+        """A partially-written column is read, and its nulls read as zero."""
+        info = read_dataset_episode_indices(_write_dataset(tmp_path, [0, 1], [None, 4]))
+        assert info["frames_per_episode"] == [0, 4]
+        assert info["total_frames"] == 4
+
+
+class TestTheDocumentedSkipAndTheHealthyCaseAreUntouched:
+    """The two behaviours a reader of this gate already relies on."""
+
+    def test_min_frames_zero_still_skips_the_length_check(self, tmp_path: Path) -> None:
+        report = _verify(_write_dataset(tmp_path, [0, 1, 2], [0, 0, 0]), min_frames=0)
+        assert report["status"] == "success", report
+        assert _named_short_episodes(report) == ""
+
+    def test_a_healthy_dataset_still_passes(self, tmp_path: Path) -> None:
+        root = _write_dataset(tmp_path, [0, 1, 2], [5, 5, 5], info={"total_episodes": 3, "total_frames": 15})
+        assert _verify(root, min_frames=1)["status"] == "success"
+
+    def test_an_agreeing_frame_total_is_still_not_a_problem(self, tmp_path: Path) -> None:
+        root = _write_dataset(tmp_path, [0, 1, 2], [5, 5, 5], info={"total_episodes": 3, "total_frames": 15})
+        assert _verify(root, min_frames=1)["problems"] == []
+
+
+class TestTheEpisodeCountFacadeReportsTheZerosItDoesNotGrade:
+    """``verify_dataset_episodes`` answers the count question, and only that.
+
+    Its verdict is deliberately left on the episode count and the two metadata
+    sources agreeing - the frame lengths are diagnostics there, and the gate
+    above owns the length verdict. What changes is that the diagnostic is now
+    populated for this dataset: an operator reading ``total_frames_per_ep``
+    sees three empty episodes rather than the empty list that used to mean the
+    recording carried no lengths at all.
+    """
+
+    @staticmethod
+    def _facade_json(root: Path, expected: int) -> dict[str, Any]:
+        stub = types.SimpleNamespace(_active_dataset_root=lambda: root)
+        result = SimEngine.verify_dataset_episodes(stub, expected)  # type: ignore[arg-type]
+        return next(block["json"] for block in result["content"] if "json" in block)
+
+    def test_the_per_episode_diagnostic_shows_the_empty_episodes(self, tmp_path: Path) -> None:
+        payload = self._facade_json(_write_dataset(tmp_path, [0, 1, 2], [0, 0, 0]), 3)
+        assert payload["total_frames_per_ep"] == [0, 0, 0]
+        assert payload["total_frames"] == 0
+
+    def test_the_count_verdict_is_unchanged(self, tmp_path: Path) -> None:
+        """The boundary, stated: three episodes recorded is three episodes."""
+        root = _write_dataset(tmp_path, [0, 1, 2], [0, 0, 0], info={"total_episodes": 3})
+        stub = types.SimpleNamespace(_active_dataset_root=lambda: root)
+        result = SimEngine.verify_dataset_episodes(stub, 3)  # type: ignore[arg-type]
+        assert result["status"] == "success"


### PR DESCRIPTION
`read_dataset_episode_indices` reports per-episode frame counts, and an empty `frames_per_episode` is documented to mean the episodes parquet carries no usable `length`. It scored that availability as `any(f > 0 for f in frames_per_episode)`, so the one dataset whose every episode recorded **zero** frames answered "this dataset carries no lengths" -- and `verify_dataset` reads an empty list as nothing to compare:

```
verify_dataset.py:192   if min_frames > 0 and info["frames_per_episode"]:      # check 2 does not run
verify_dataset.py:234   if decl_frames is not None and info["total_frames"]:   # check 3's frame half does not run
```

Check 2's entire subject is a zero-length episode (module docstring, item 2: *"flags any zero-length episode"*), so the gate skipped exactly the class it exists to detect, on the worst member of that class: a collection run that wrote episode metadata and no frames at all.

## The gate was non-monotonic in the damage it grades

Same three-episode dataset, same `meta/info.json` claiming `total_frames: 900`, only the recorded lengths differ. `--no-check-videos --no-check-stats`, `min_frames=1`:

| recorded lengths | `frames_per_episode` | status | problems reported |
|---|---|---|---|
| `[5, 0, 0]` | `[5, 0, 0]` | `error` (exit 1) | 2 empty episodes named; frame-total drift |
| **`[0, 0, 0]`** | **`[]`** | **`success` (exit 0)** | **none** |
| absent column | `[]` | `success` | none (correct -- nothing was recorded to compare) |

Emptying the one episode that still held frames is what bought the pass. An operator's way to make the gate notice a run that captured nothing was to add an episode that captured something.

The silence is doubled by the second gate: the header claiming 900 frames beside a parquet holding 0 also went unreported, because check 3's frame comparison was gated on the parquet **total** being non-zero rather than on a length being available -- and a parquet whose every episode is empty sums to exactly the 0 that reads as "no lengths".

This is the dataset-side sibling of what #3197-era work closed on the threshold side: `tests/test_verify_dataset_numeric_domains.py` exists because a `min_frames` outside its domain *switched check 2 off* rather than failing loudly. The threshold can no longer do that. The dataset still could.

## Change

Availability is now whether a length was **read**, not whether one was positive: `read_dataset_episode_indices` records `saw_length` as it walks the rows, and the two returned keys are gated on that. A present column with a recorded `0` is a frame count, so the empty episodes are named and the header drift is reported. `verify_dataset`'s frame comparison is gated on `frames_per_episode` (availability) rather than on the total being truthy.

Boundaries kept deliberately, each one a passing control in the new file:

- **An absent `length` column** stays unavailable -- `frames_per_episode == []`, no length verdict, no frame-drift verdict. Some writers omit the column and this gate must not invent a zero-length episode for them.
- **A column present but wholly null** stays unavailable too: a length nobody recorded is *unknown*, not zero. That is why availability keys on a non-null value rather than on the column existing.
- **A partially-written column** (`[None, 4]`) is available and its null reads as `0`, unchanged -- that was already the behaviour whenever a sibling episode held frames.
- **`min_frames=0`** remains the documented way to skip the length check, including on an all-zero dataset.
- **`verify_dataset_episodes`** keeps its count-only verdict: three episodes recorded is three episodes, whatever their lengths. What changes there is the diagnostic -- `total_frames_per_ep` now shows `[0, 0, 0]` instead of the `[]` that used to mean "this recording carried no lengths at all". The length verdict belongs to the gate above and is not duplicated here.

The two `total_frames` senses ("no lengths" and "no frames") are now distinguishable by the caller, and the docstring says which key to read.

## Tests

New `tests/test_verify_dataset_zero_length_is_a_count.py`, 18 cells, pyarrow-only fixtures reused from `tests/test_verify_dataset.py` (no lerobot, no mujoco). Assertions are on observable behaviour: report `status` / `problems`, which episodes check 2 actually named, the CLI exit code, and the counts a caller is handed.

Four corners over `tests/test_verify_dataset.py`, `tests/test_verify_dataset_numeric_domains.py`, `tests/test_dataset_recorder.py` and the new file (4 failures on every corner are pre-existing on this box: three `huggingface_hub` cells and one `lerobot` cell, both absent here):

| | old tests | new tests |
|---|---|---|
| **old code** | 4F / 255P | **7F / 11P** |
| **new code** | 4F / 255P | 0F / **18P** |

Bottom-left equals top-left, so nothing existing moved.

Six mutations of the fix, graded against the new file (`collected 18` on every row, 5 distinct firing sets):

| mutation | cells fired |
|---|---|
| control (unmutated) | 0 |
| availability back to `any(f > 0 ...)` | 7 |
| frame-drift gate back to a non-zero total | **1** |
| availability = the column is *present* | 3 |
| availability always true (over-reach) | 6 |
| a null length read as a recorded zero (availability unconditional too) | 6 |

The single-cell row is what earns the one-line `verify_dataset` change its own test. The two over-reach rows fire only the unavailability controls -- a fix that graded an absent or never-written column as three empty episodes fails here rather than passing quietly -- and they fire an identical set because they are the same behaviour reached two ways.

## Size

`dataset_recorder.py` +20/-5 lines = 10 comment + 5 docstring prose + **5 executable** (587 -> 589 statements by AST, +2). `verify_dataset.py` +7/-2 = 6 comment + **1 executable** (280 -> 280 statements: one condition edited, none added). 241 added lines across 4 files, of which 203 are the new test and 11 the `docs/recording.md` paragraph.

## Gate

`ruff check` and `ruff format --check` clean on all four paths. Targeted suite above: 255 passed / 4 pre-existing environmental failures, and the new file 18/18. Whole-tree graders (`scripts/check_whole_tree_graders.py` roster, 104 graders) run here minus the two `strands_robots.tools` parameter graders that need `lerobot` to import at all on this box: the docstring-xref, `Args:`/`Raises:` completeness, ASCII, host-path, changelog-fragment, test-case-naming and grader-roster graders all pass. Every remaining failure on this box is an absent optional dependency (`mujoco`, `lerobot`, `rclpy`) in a path this branch does not touch.

## Out of scope, noted

- Check 5 (per-episode video frame counts) reads the `length` column from the parquet itself rather than through this helper, so it is unaffected either way; a video file mapped from three zero-length episodes expects 0 frames both before and after.
- `read_dataset_episode_indices` still takes the **first-seen** length for a duplicated `episode_index`. That is pre-existing, pinned by `tests/test_dataset_recorder.py`, and a separate decision from this one.

## Round 2 - verified against a dataset the recorder wrote

Two gaps in the evidence above, both now closed on a second machine where the
optional dependencies (`mujoco`, `lerobot`, `huggingface_hub`) are installed.

**The suite had never run in CI.** `Run lint` failing *skips* `Run tests`, so the
whole 265-line diff went ungraded on every push before this one. Run to
completion with the dependencies present:

| suite | result |
|---|---|
| `test_verify_dataset` + `_numeric_domains` + `_zero_length_is_a_count` + `test_dataset_recorder` | **288 passed / 0 failed** |
| tree-walking guard population (234 files: every test that walks the tree, parses source or reads docstrings - a superset of the 104-grader roster) | 12370 passed, 7 failed |

The 7 are environmental and byte-identical on a pristine `main` worktree (same
node ids, both `comm` directions empty): 5 assert `rclpy` is absent where it
resolves from a system ROS install, and 2 read `websockets` 16.0 against the
`cosmos3-service` floor of `>=17.0`. None is attributable to this branch, and
the 4 absent-dependency failures reported in the sections above do not occur
here at all.

**The argument was fixture-only.** Every case above is a hand-written pyarrow
table, which leaves "can the recorder actually produce this state" unanswered.
So the gate was run on a real recorded dataset instead: a 30-step SmolVLA
rollout of the `so101` arm in MuJoCo, three cameras, recorded through
`start_recording` / `run_policy` / `stop_recording`. It reopens as 1 episode /
30 frames / 30 fps with `observation.images.camera{1,2,3}` at `[3, 256, 256]`
and `action` at `(6,)`.

Variants rewrite **only** the `length` column of the parquet the recorder wrote.
`meta/info.json` keeps the recorder's own `total_frames: 30`, so the header is
the one the recorder emitted, not one composed for the test:

| the recorded `length` column | `main` | this branch |
|---|---|---|
| as recorded, `[30]` | exit 0, no problems | exit 0, no problems - **unchanged** |
| zeroed, `[0]` | **exit 0, silent** | **exit 1** - `1 episode(s) below min_frames=1: episode 0=0 frame(s)` and `meta/info.json total_frames=30 disagrees with parquet (0 frame(s))` |
| nulled, `[None]` | exit 0, silent | exit 0, silent - correctly unavailable |

The middle row is the defect on a real artifact: a dataset whose metadata claims
30 frames beside a parquet holding none certified clean, with both the
zero-length verdict and the header-drift verdict withheld. The first row is
identical on both trees, which is the whole safety argument - nothing that
already passed changed its answer. The third confirms the deliberate boundary
survives contact with a real dataset: a null length is unknown, not zero.

**Mutation table regraded independently.** Five of the six rows reproduce
exactly (`collected 18` on every row, control 0), including the single-cell
`frame-drift gate back to a non-zero total` row that earns the one-line
`verify_dataset` change its own test. The last row is spelling-dependent and the
table should say so: mutating `saw_length` to *also* accept a null as a recorded
zero while leaving an **absent** column unavailable fires **3**, not 6 - the
wholly-null cells only. It reaches 6 only when availability is made
unconditional as well, which is the row above it. The tests distinguish the two,
which is stronger than one shared count suggested.

## Review rounds

**Round 1** - the lint leg was red on the head, and the cause was in this branch's own fixtures.

`mypy` reported four `[list-item]` errors on
`tests/test_verify_dataset_zero_length_is_a_count.py:129` and `:154`, the two
cells that write an *unrecorded* length: the wholly-null column and the
partially-written one. `_write_dataset` hands `frames_per_episode` straight to
`pa.table`, which writes a `None` as a null, but the helper's annotation was
`list[int] | None` -- narrower than the helper's own behaviour, and narrower
than this branch needs, since the unknown-vs-zero distinction is the thing
being fixed.

Widened to `list[int | None] | None`, with the `Args:` entry now stating that a
`None` writes a null rather than a zero. `_write_video_dataset` is deliberately
left at `list[int]`: no fixture writes a null through it, and a type should not
admit a value no caller passes.

| | `[list-item]` errors | targeted suite |
|---|---|---|
| before | **4** | 273 passed / 4 pre-existing |
| after | **0** | 273 passed / 4 pre-existing |

No executable line changed -- one annotation and three docstring lines, in a
test fixture. The suite total and the 4 absent-dependency failures
(3 `huggingface_hub`, 1 `lerobot`) are identical either side, so nothing moved
behaviourally. `ruff check` / `ruff format --check` clean.