### PR TITLE
fix(simulation/isaac): a configured gravity takes the argument's domain

### DIFF
--- a/changelog.d/3266-configured-gravity-takes-the-argument-domain.md
+++ b/changelog.d/3266-configured-gravity-takes-the-argument-domain.md
@@ -1,0 +1,34 @@
+### Fixed: a configured Isaac gravity is honoured or refused, never silently reduced
+
+`IsaacSimulation.create_world` has two owners for one value - its own `gravity=`
+argument and `IsaacConfig.gravity`, the field it falls back to - and only the
+argument was validated. The field was read straight into
+`PhysicsContext.set_gravity`, which takes a signed scalar, so the z-component
+was picked out of whatever the field held and applied. Every verdict therefore
+depended on where the caller happened to spell the value.
+
+`IsaacConfig(gravity=(0.0, -9.81, 0.0))` - the exact off-axis vector the
+argument path documents refusing, because the physics context cannot aim
+gravity off the Z axis - configured **zero gravity** while the result reported
+`[0.0, -9.81, 0.0]` as if applied, so a world that was asked for lateral
+gravity ran with none and said so nowhere. `nan` and `inf` reached
+`set_gravity` unexamined; `("a", "b", "c")` reached it as the string `"c"`; a
+four-component vector was read at index 2 and was also silently zero gravity;
+and a two-component one raised `IndexError` past the method's
+`{"status": "error"}` contract. The same values passed as `gravity=` were each
+refused by name.
+
+`create_world` now resolves config-or-argument into one effective value before
+validating - the way `effective_timestep` immediately above it already does -
+so both owners take the shared gravity domain (three finite, non-boolean
+components) and this backend's Z-alignment constraint, and the source name is
+passed to the domain so the message names the owner to fix
+(`'IsaacConfig.gravity'` rather than `'gravity'`). With the value normalized on
+every path, the downstream scalar-or-vector branches that produced the
+index-2 read are gone.
+
+Two consequences worth stating. A real scalar set on the field is now accepted
+as the z-component, as `gravity=-9.81` always was, instead of raising a
+`TypeError` about a float not being iterable - one domain, one answer. And
+`gravity=None` remains the argument's spelling of "unstated, read the field",
+while `IsaacConfig(gravity=None)` is a stated non-vector and is refused.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -144,7 +144,7 @@ rejected eagerly. The commonly used fields:
 | `physics_dt` | `float` | `1/120` | Physics timestep (seconds). |
 | `rendering_dt` | `float` | `1/30` | Rendering timestep (seconds). |
 | `render_mode` | `str` | `"headless"` | `"headless"`, `"rtx_realtime"` (raster), or `"rtx_pathtracing"` (photoreal). |
-| `gravity` | `tuple` | `(0, 0, -9.81)` | Gravity vector (Z-up). |
+| `gravity` | `tuple` | `(0, 0, -9.81)` | Gravity vector (Z-up). Three finite components, Z-aligned - the same domain `create_world(gravity=...)` takes. |
 | `ground_plane` | `bool` | `True` | Add a ground plane on `create_world()`. |
 | `stage_path` | `str` | `"/World"` | USD stage path prefix. |
 | `nucleus_url` | `str \| None` | `None` | Override Omniverse Nucleus URL (env-resolvable). |

--- a/strands_robots/simulation/isaac/config.py
+++ b/strands_robots/simulation/isaac/config.py
@@ -124,7 +124,14 @@ class IsaacConfig:
         ``"rtx_pathtracing"``; one of ``("0", "false", "no", "off")``, empty or
         unset leaves the field alone, and any other spelling is refused.
     gravity : tuple[float, float, float]
-        Gravity vector. Default (0.0, 0.0, -9.81) (Z-up convention).
+        Gravity vector. Default (0.0, 0.0, -9.81) (Z-up convention). Read by
+        ``create_world()``, which applies the same domain to it as to its own
+        ``gravity=`` argument: three finite, non-boolean components, Z-aligned
+        (``x`` and ``y`` both zero), or a real scalar taken as the z-component.
+        The domain lives with the engine that spends the value - Isaac's
+        ``PhysicsContext.set_gravity`` takes a signed scalar - and is shared
+        with every other backend's gravity surface, so it is applied there
+        rather than restated here.
     ground_plane : bool
         Whether to add a ground plane on ``create_world()``. Default True.
     stage_path : str

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -981,7 +981,12 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         timestep : float, optional
             Override physics_dt from config.
         gravity : list[float], optional
-            Override gravity vector from config. [gx, gy, gz].
+            Gravity vector ``[gx, gy, gz]``, or a real scalar taken as the
+            z-component. Omitted, :attr:`IsaacConfig.gravity` is used; either
+            way the value takes the same domain - three finite, non-boolean
+            components, Z-aligned - because this backend's
+            ``PhysicsContext.set_gravity`` takes a signed scalar and cannot
+            honour an off-axis vector.
         ground_plane : bool
             Whether to add a ground plane. Default True.
         terrain : str, optional
@@ -1063,37 +1068,48 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         # while the result echoed the full input vector as if applied. Validate
         # up front and reject anything the backend cannot honour, rather than
         # applying a gravity the caller never asked for.
-        if gravity is not None:
-            # Normalize through the shared domain first, so the component count,
-            # the numeric domain and the boolean refusal are the ones every
-            # other gravity surface applies. The local copy coerced a scalar
-            # with ``float()``, and bool is an int subclass, so
-            # ``create_world(gravity=True)`` configured a +1 m/s^2 gravity
-            # pointing *up*; it also keyed on ``isinstance(gravity, (list, tuple))``,
-            # so a NumPy vector - which the other backends accept - was refused
-            # as "not a scalar or vector". The Z-alignment constraint below is
-            # this backend's own and is applied to the normalized components.
-            components, gravity_error = self._normalize_gravity(gravity, "create_world")
-            if components is None:
-                return cast("dict[str, Any]", gravity_error)
-            if components[0] != 0.0 or components[1] != 0.0:
-                return {
-                    "status": "error",
-                    "content": [
-                        {
-                            "text": (
-                                f"create_world: the Isaac backend only supports Z-aligned gravity "
-                                f"(its PhysicsContext.set_gravity takes a signed scalar); a non-Z-aligned "
-                                f"vector like {gravity!r} cannot be honoured. Pass a scalar or a "
-                                f"[0, 0, gz] vector, or use create_simulation(backend='mujoco') for "
-                                f"arbitrary-direction gravity."
-                            )
-                        }
-                    ],
-                }
-            # Store the normalized components so what the result reports and
-            # what the physics context receives are the same value.
-            gravity = components
+        # Resolved from config-or-argument first, the way ``effective_timestep``
+        # above is: ``IsaacConfig.gravity`` is the same value from the other
+        # owner, and gating the argument alone left every verdict below to
+        # whether the caller happened to spell the value at the call site. Read
+        # from the field, ``(0, -9.81, 0)`` still reached ``set_gravity(0.0)``
+        # and the result still echoed the full vector, a non-finite or
+        # non-numeric component still reached the physics context unexamined,
+        # and a 2-component field raised ``IndexError`` past this method's
+        # structured-error contract. ``gravity_param`` follows the source so the
+        # message names the owner to fix.
+        effective_gravity = self._config.gravity if gravity is None else gravity
+        gravity_param = "gravity" if gravity is not None else "IsaacConfig.gravity"
+        # Normalize through the shared domain, so the component count, the
+        # numeric domain and the boolean refusal are the ones every other
+        # gravity surface applies. The local copy coerced a scalar with
+        # ``float()``, and bool is an int subclass, so
+        # ``create_world(gravity=True)`` configured a +1 m/s^2 gravity pointing
+        # *up*; it also keyed on ``isinstance(gravity, (list, tuple))``, so a
+        # NumPy vector - which the other backends accept - was refused as "not a
+        # scalar or vector". The Z-alignment constraint below is this backend's
+        # own and is applied to the normalized components.
+        components, gravity_error = self._normalize_gravity(effective_gravity, "create_world", gravity_param)
+        if components is None:
+            return cast("dict[str, Any]", gravity_error)
+        if components[0] != 0.0 or components[1] != 0.0:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"create_world: the Isaac backend only supports Z-aligned gravity "
+                            f"(its PhysicsContext.set_gravity takes a signed scalar); a non-Z-aligned "
+                            f"vector like {effective_gravity!r} in {gravity_param!r} cannot be honoured. "
+                            f"Pass a scalar or a [0, 0, gz] vector, or use "
+                            f"create_simulation(backend='mujoco') for arbitrary-direction gravity."
+                        )
+                    }
+                ],
+            }
+        # Store the normalized components so what the result reports and
+        # what the physics context receives are the same value.
+        gravity = components
         with self._lock:
             if self._world_created:
                 return {
@@ -1124,7 +1140,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                     from omni.isaac.core import World  # type: ignore[import-not-found]
 
                 dt = timestep if timestep is not None else self._config.physics_dt
-                grav = gravity if gravity is not None else list(self._config.gravity)
+                grav = gravity
 
                 # Create World
                 self._world = World(
@@ -1136,7 +1152,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 # Set gravity
                 # Isaac Sim 5.1: set_gravity takes a scalar magnitude, not a vector.
                 # Extract the Z-component (convention: gravity points along -Z).
-                gravity_magnitude = grav[2] if isinstance(grav, (list, tuple)) else grav
+                gravity_magnitude = grav[2]
                 self._world.get_physics_context().set_gravity(gravity_magnitude)
 
                 # Add ground plane
@@ -1165,7 +1181,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 world_info = {
                     "physics_dt": dt,
                     "rendering_dt": self._config.rendering_dt,
-                    "gravity": list(grav) if isinstance(grav, (list, tuple)) else [0.0, 0.0, float(grav)],
+                    "gravity": list(grav),
                     "ground_plane": bool(ground_plane and self._config.ground_plane),
                     "stage_path": self._config.stage_path,
                     "stage_units_in_meters": 1.0,

--- a/tests/simulation/isaac/test_configured_gravity_takes_the_argument_domain.py
+++ b/tests/simulation/isaac/test_configured_gravity_takes_the_argument_domain.py
@@ -1,0 +1,303 @@
+"""A configured gravity takes the same domain as the ``create_world`` argument.
+
+``create_world`` has two owners for one value: its own ``gravity=`` argument and
+:attr:`IsaacConfig.gravity`, the field it falls back to. The argument was
+normalized through the shared gravity domain and then checked against this
+backend's own Z-alignment constraint; the field was read straight into
+``PhysicsContext.set_gravity``. Every verdict therefore depended on whether the
+caller happened to spell the value at the call site rather than in the config:
+
+* ``(0.0, -9.81, 0.0)`` - the exact vector the argument path documents refusing,
+  because ``set_gravity`` takes a signed scalar and cannot aim off-axis - reached
+  ``set_gravity(0.0)``, so the world ran in **zero gravity** while the result
+  echoed the full vector as if applied.
+* ``(0.0, 0.0, nan)`` and ``(0.0, 0.0, inf)`` reached ``set_gravity`` unexamined.
+* ``("a", "b", "c")`` reached it as the string ``"c"``.
+* ``(0.0, 0.0, 0.0, -9.81)`` - four components - was read at index 2, so a
+  mis-shaped vector was also silently zero gravity.
+* ``(0.0, 0.0)`` raised ``IndexError`` out of a method whose contract is a
+  ``{"status": "error"}`` dict.
+
+The fix resolves config-or-argument into one effective value before validating,
+the way ``effective_timestep`` immediately above it already does, and passes the
+source name to the domain so the message names the owner to fix. These tests
+pin the parity, the refusals, and the values that must keep working.
+
+Nothing here needs Isaac Sim: the refusals happen before any Kit import, and the
+applied cases run against a fake ``isaacsim`` tree that records what
+``set_gravity`` received.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from strands_robots.simulation.isaac import simulation as isaac_simulation
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+# ---------------------------------------------------------------------------
+# Fake Isaac tree: enough of it to reach set_gravity and record the argument.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingPhysicsContext:
+    """Records the single value ``set_gravity`` was called with."""
+
+    def __init__(self) -> None:
+        self.gravity_calls: list[object] = []
+
+    def set_gravity(self, magnitude: object) -> None:
+        self.gravity_calls.append(magnitude)
+
+
+class _FakeScene:
+    def add_default_ground_plane(self) -> None:
+        return None
+
+
+class _FakeWorld:
+    """Stands in for ``isaacsim.core.api.World``, exposing the physics context."""
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.physics_context = _RecordingPhysicsContext()
+        self.scene = _FakeScene()
+
+    def get_physics_context(self) -> _RecordingPhysicsContext:
+        return self.physics_context
+
+    def reset(self) -> None:
+        return None
+
+
+@pytest.fixture()
+def fake_isaacsim(monkeypatch):
+    """Fake ``isaacsim`` tree covering every import ``create_world`` performs."""
+    monkeypatch.setattr(isaac_simulation, "_SIMULATION_APP", None)
+    monkeypatch.setattr(isaac_simulation, "_SIMULATION_APP_LAUNCH", None)
+    mods = {}
+    for name in ("isaacsim", "isaacsim.core", "isaacsim.core.api"):
+        module = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, module)
+        mods[name] = module
+    mods["isaacsim"].SimulationApp = lambda launch=None: types.SimpleNamespace(launch=launch)
+    mods["isaacsim"].core = mods["isaacsim.core"]
+    mods["isaacsim.core"].api = mods["isaacsim.core.api"]
+    mods["isaacsim.core.api"].World = _FakeWorld
+    return mods
+
+
+def _world_from_config(gravity: object) -> tuple[dict, list[object]]:
+    """Create a world with ``gravity`` set on the config, not passed as an argument.
+
+    Returns:
+        The ``create_world`` result and the list of values ``set_gravity``
+        received (empty when the value was refused before the world was built).
+    """
+    sim = IsaacSimulation(config=IsaacConfig(gravity=gravity))  # type: ignore[arg-type]
+    result = sim.create_world()
+    world = sim._world
+    return result, list(world.get_physics_context().gravity_calls) if world is not None else []
+
+
+def _world_from_argument(gravity: object) -> tuple[dict, list[object]]:
+    """Create a world with ``gravity`` passed as the ``create_world`` argument."""
+    sim = IsaacSimulation()
+    result = sim.create_world(gravity=gravity)  # type: ignore[arg-type]
+    world = sim._world
+    return result, list(world.get_physics_context().gravity_calls) if world is not None else []
+
+
+# Values whose verdict must not depend on which owner carried them. Each is a
+# spelling a caller can reach either way; the applied ones are the values the
+# backend can honour, the refused ones the values ``set_gravity`` cannot.
+SHARED_DOMAIN_VALUES = (
+    (0.0, 0.0, -9.81),
+    [0.0, 0.0, -9.81],
+    (0.0, 0.0, 0.0),
+    -9.81,
+    (0.0, -9.81, 0.0),
+    (-9.81, 0.0, 0.0),
+    (0.0, 0.0, float("nan")),
+    (0.0, 0.0, float("inf")),
+    True,
+    (0.0, 0.0),
+    (0.0, 0.0, 0.0, -9.81),
+    ("a", "b", "c"),
+    (0.0, True, -9.81),
+    {"z": -9.81},
+)
+
+# The one value whose verdict legitimately differs between the two owners, with
+# the reason. ``gravity=None`` as an argument is the spelling of "not stated" -
+# it is the parameter's default and means "use the field" - while ``None`` set
+# on the field is a stated value that is not a gravity vector.
+OWNER_SPECIFIC_VALUES: dict[object, str] = {
+    None: (
+        "as an argument None is the default and means 'unstated, read the field'; "
+        "as a field value it is a stated non-vector and is refused"
+    ),
+}
+
+
+class TestOneDomainForOneValue:
+    """Both owners of the gravity value take the same domain."""
+
+    @pytest.mark.parametrize("value", SHARED_DOMAIN_VALUES, ids=repr)
+    def test_the_two_owners_reach_the_same_verdict(self, value, fake_isaacsim):
+        """The config field and the argument agree on accept-or-refuse.
+
+        Pre-fix seven of these values were refused as an argument and applied
+        from the field, so a caller could get a world the backend cannot honour
+        purely by moving the value from the call site into the config.
+        """
+        from_config, _ = _world_from_config(value)
+        from_argument, _ = _world_from_argument(value)
+        assert from_config["status"] == from_argument["status"], (
+            f"gravity={value!r} is {from_argument['status']} as an argument but "
+            f"{from_config['status']} from IsaacConfig.gravity: "
+            f"config said {from_config['content'][0]['text']!r}"
+        )
+
+    @pytest.mark.parametrize("value", SHARED_DOMAIN_VALUES, ids=repr)
+    def test_an_applied_value_reaches_the_physics_context_identically(self, value, fake_isaacsim):
+        """When accepted, both owners hand ``set_gravity`` the same scalar.
+
+        Agreeing on the verdict is not enough: the value the physics context
+        receives - and the vector the result reports - must also be the same,
+        or the two owners honour the same request differently.
+        """
+        from_config, config_calls = _world_from_config(value)
+        from_argument, argument_calls = _world_from_argument(value)
+        if from_argument["status"] != "success":
+            pytest.skip(f"{value!r} is refused by the shared domain")
+        assert config_calls == argument_calls
+        assert from_config["content"][0]["json"]["gravity"] == from_argument["content"][0]["json"]["gravity"]
+
+    def test_every_owner_specific_value_states_why(self):
+        """The asymmetry roster is deliberate, not a leftover.
+
+        A value may only be exempt from the parity above with a written reason,
+        so a future exemption is a decision rather than a quietly widened list.
+        """
+        assert OWNER_SPECIFIC_VALUES
+        for value, reason in OWNER_SPECIFIC_VALUES.items():
+            assert reason.strip(), f"{value!r} is exempt from gravity parity with no reason"
+
+    def test_an_unstated_argument_reads_the_field(self, fake_isaacsim):
+        """``None`` as the argument is 'unstated' and takes the configured value."""
+        sim = IsaacSimulation(config=IsaacConfig(gravity=(0.0, 0.0, -1.62)))
+        result = sim.create_world(gravity=None)
+        assert result["status"] == "success", result
+        assert sim._world.get_physics_context().gravity_calls == [-1.62]
+
+    def test_a_stated_argument_outranks_the_field(self, fake_isaacsim):
+        """An explicit argument still overrides the configured gravity."""
+        sim = IsaacSimulation(config=IsaacConfig(gravity=(0.0, 0.0, -9.81)))
+        result = sim.create_world(gravity=[0.0, 0.0, -1.62])
+        assert result["status"] == "success", result
+        assert sim._world.get_physics_context().gravity_calls == [-1.62]
+
+
+class TestAConfiguredGravityTheBackendCannotHonour:
+    """What the field-sourced refusals say, and that nothing was applied."""
+
+    def test_an_off_axis_field_is_refused_not_reduced_to_zero(self, fake_isaacsim):
+        """The documented off-axis defect, reached through the config field.
+
+        ``PhysicsContext.set_gravity`` takes a signed scalar, so the y-component
+        cannot be applied. Pre-fix the z-component was read instead, making this
+        a request for lateral gravity that ran as zero gravity while the result
+        reported ``[0.0, -9.81, 0.0]`` as if applied.
+        """
+        result, calls = _world_from_config((0.0, -9.81, 0.0))
+        assert result["status"] == "error"
+        text = result["content"][0]["text"].lower()
+        assert "z-aligned" in text
+        assert calls == [], f"set_gravity was called with {calls!r} for a gravity that was refused"
+
+    @pytest.mark.parametrize("value", [(0.0, 0.0, float("nan")), (0.0, 0.0, float("inf"))], ids=["nan", "inf"])
+    def test_a_non_finite_field_is_refused(self, value, fake_isaacsim):
+        """A non-finite z reached the physics context unexamined pre-fix."""
+        result, calls = _world_from_config(value)
+        assert result["status"] == "error"
+        assert "finite" in result["content"][0]["text"]
+        assert calls == []
+
+    def test_a_non_numeric_component_is_refused_before_the_physics_context(self, fake_isaacsim):
+        """``("a", "b", "c")`` reached ``set_gravity("c")`` pre-fix."""
+        result, calls = _world_from_config(("a", "b", "c"))
+        assert result["status"] == "error"
+        assert calls == []
+
+    def test_a_mis_shaped_field_is_reported_not_raised(self, fake_isaacsim):
+        """A 2-component field raised ``IndexError`` past the error contract.
+
+        ``create_world`` returns a status dict for every failure it knows about;
+        reading index 2 of a 2-vector escaped that contract as an exception the
+        surrounding ``except`` clauses deliberately do not catch.
+        """
+        result, calls = _world_from_config((0.0, 0.0))
+        assert result["status"] == "error"
+        assert "3-element" in result["content"][0]["text"]
+        assert calls == []
+
+    def test_a_four_component_field_is_refused_not_read_at_index_two(self, fake_isaacsim):
+        """Four components silently became zero gravity pre-fix, not an error."""
+        result, calls = _world_from_config((0.0, 0.0, 0.0, -9.81))
+        assert result["status"] == "error"
+        assert "3-element" in result["content"][0]["text"]
+        assert calls == []
+
+    def test_the_message_names_the_owner_that_carried_the_value(self, fake_isaacsim):
+        """A refusal has to say which of the two spellings to go and fix.
+
+        The domain takes the parameter name to quote, so the field-sourced
+        message names ``IsaacConfig.gravity`` and the argument-sourced one names
+        ``gravity`` - otherwise both read as a complaint about the call site.
+        """
+        from_config, _ = _world_from_config((0.0, 0.0))
+        from_argument, _ = _world_from_argument((0.0, 0.0))
+        assert "IsaacConfig.gravity" in from_config["content"][0]["text"]
+        assert "IsaacConfig.gravity" not in from_argument["content"][0]["text"]
+        assert "'gravity'" in from_argument["content"][0]["text"]
+
+
+class TestTheValuesThatMustKeepWorking:
+    """Controls: the fix refuses what the backend cannot honour, and no more."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ((0.0, 0.0, -9.81), -9.81),
+            ([0.0, 0.0, -1.62], -1.62),
+            ((0.0, 0.0, 0.0), 0.0),
+            ((0.0, 0.0, 5.0), 5.0),
+            (-9.81, -9.81),
+        ],
+        ids=["default", "moon_list", "zero_g", "inverted", "scalar"],
+    )
+    def test_a_z_aligned_field_still_reaches_the_physics_context(self, value, expected, fake_isaacsim):
+        """Z-aligned, finite gravity is applied and reported as three components.
+
+        A real scalar is included on purpose: the shared domain reads it as the
+        z-component, which the ``gravity=`` argument has always accepted, so the
+        field now accepts the same spelling rather than raising an unrelated
+        ``TypeError`` about a float not being iterable.
+        """
+        result, calls = _world_from_config(value)
+        assert result["status"] == "success", result
+        assert calls == [expected]
+        assert result["content"][0]["json"]["gravity"] == [0.0, 0.0, expected]
+
+    def test_the_default_configuration_is_earth_gravity(self, fake_isaacsim):
+        """The out-of-the-box world still falls at 9.81 m/s^2 along -Z."""
+        sim = IsaacSimulation()
+        result = sim.create_world()
+        assert result["status"] == "success", result
+        assert sim._world.get_physics_context().gravity_calls == [-9.81]
+        assert result["content"][0]["json"]["gravity"] == [0.0, 0.0, -9.81]


### PR DESCRIPTION
`IsaacSimulation.create_world` has two owners for one value - its own `gravity=` argument and `IsaacConfig.gravity`, the field it falls back to - and only the argument was validated. The field was read straight into `PhysicsContext.set_gravity`, which takes a signed scalar, so component 2 was picked out of whatever the field held and applied.

![owner parity](https://raw.githubusercontent.com/cagataycali/pr-assets/main/isaac-gravity-3266/isaac_gravity_owner_parity.png)

Every verdict depended on where the caller happened to spell the value. Measured, 15 values x 2 owners, before and after:

| value | `IsaacConfig(gravity=...)` before | `create_world(gravity=...)` |
| --- | --- | --- |
| `(0, -9.81, 0)` | `set_gravity(0.0)`, reported `[0.0, -9.81, 0.0]` | refused: only Z-aligned gravity |
| `(-9.81, 0, 0)` | `set_gravity(0.0)`, reported the full vector | refused: only Z-aligned gravity |
| `(0, 0, nan)` / `(0, 0, inf)` | `set_gravity(nan)` / `set_gravity(inf)` | refused: components must be finite |
| `('a', 'b', 'c')` | `set_gravity('c')` | refused: must be numbers |
| `(0, 0, 0, -9.81)` | `set_gravity(0.0)` - read at index 2 | refused: must be 3 elements, got 4 |
| `(0, True, -9.81)` | `set_gravity(-9.81)`, y=True ignored | refused: must be a number, not a bool |
| `(0, 0)` | `IndexError` raised | refused: must be 3 elements, got 2 |
| `True` | `Failed to create world: 'bool' object is not iterable` | refused: must be a number, not a bool |
| `-9.81` (scalar) | `Failed to create world: 'float' object is not iterable` | applied as the z-component |

The first row is the defect the argument path already documents fixing: the physics context cannot aim gravity off the Z axis, so a request for lateral gravity ran the world with **no gravity at all** while the result echoed `[0.0, -9.81, 0.0]` as if applied.

![zero gravity](https://raw.githubusercontent.com/cagataycali/pr-assets/main/isaac-gravity-3266/isaac_gravity_zero_g.png)

(Rendered in MuJoCo, headless EGL, so both requests can be shown as motion - a free body released at rest travels 0.439 m in 0.30 s under the gravity that was asked for, and 0.000 m under the one that was applied.)

## The change

`create_world` resolves config-or-argument into one effective value before validating - the way `effective_timestep` four lines above it already does - so both owners take the shared gravity domain (three finite, non-boolean components) and then this backend's own Z-alignment constraint. The source name is passed through to the domain, so a field-sourced refusal names `'IsaacConfig.gravity'` and an argument-sourced one names `'gravity'`; otherwise both read as a complaint about the call site.

```mermaid
flowchart LR
  A["create_world(gravity=...)"] --> R["effective_gravity"]
  B["IsaacConfig.gravity"] -."was: read straight through".-> G
  B --> R
  R --> N["_normalize_gravity\n3 finite non-bool components"]
  N --> Z["Z-alignment: x == y == 0"]
  Z --> G["PhysicsContext.set_gravity(z)"]
```

With the value normalized on every path, the downstream `isinstance(grav, (list, tuple))` branches that produced the index-2 read are dead and are gone.

The domain is applied here rather than in `IsaacConfig.__post_init__` on purpose: it is `SimEngine`'s, shared with every other backend's gravity surface, and `config.py` deliberately imports nothing from the engine. Restating it in the config would be a second implementation of one domain, free to drift from the first.

Two consequences worth stating plainly. A real scalar set on the field is now **accepted** as the z-component, exactly as `gravity=-9.81` always was, instead of raising a `TypeError` about a float not being iterable - one domain, one answer. And `gravity=None` remains the argument's spelling of "unstated, read the field", while `IsaacConfig(gravity=None)` is a stated non-vector and is refused; that is the one deliberate asymmetry, and the test carries it in a roster with its reason.

## Tests

`tests/simulation/isaac/test_configured_gravity_takes_the_argument_domain.py` - 34 cells, table-driven over the 14 values above. It pins that both owners reach the same verdict, that an accepted value reaches `set_gravity` and the reported vector identically, that each refusal happens before the physics context is touched (`set_gravity` call list empty), that the mis-shaped field is reported rather than raised, that the message names the owner, and that Z-aligned finite gravity - default, moon, zero-g, inverted, scalar - still applies. No Isaac Sim needed: the refusals precede every Kit import, and the applied cases run against a fake `isaacsim` tree that records what `set_gravity` received.

Four corners on `tests/simulation/isaac`:

| prod | tests | result |
| --- | --- | --- |
| old | old | 1939 passed |
| old | **new** | **21 failed**, 1954 passed |
| new | new | 1973 passed |
| new | old | 1939 passed |

1939 + 34 = 1973; the 15 cells that pass pre-fix are the controls. The last row is identical to the first, so no existing behaviour moved.

Wider: `tests/simulation` 14198 passed (1 pre-existing failure, `test_pose_vector_rule_parity.py::test_a_numpy_array_pose_is_accepted_by_both`, reproduced unchanged on `main`); docs/changelog/grader net 4714 passed (1 pre-existing failure, the `rebot_b601` registry row). `ruff check` and `ruff format --check` show no delta against `main`; `mypy strands_robots tests tests_integ` unchanged at the standing 20 errors in `examples/isaac_gs` + `simulation/ik.py`.

## Size

| | added | removed |
| --- | --- | --- |
| `simulation/isaac/simulation.py` | 51 | 35 |
| `simulation/isaac/config.py` | 8 | 1 |
| `docs/simulation/isaac.md` | 1 | 1 |
| `changelog.d/` | 34 | 0 |
| test | 303 | 0 |
| **total** | **397** | **37** |

Of the 59 added production lines, 12 are executable (the resolve-then-validate lines and the un-nested gate); 26 are docstring and 21 are the comment explaining why the field is resolved before the check.