### PR TITLE
fix(simulation/isaac): a typeless MJCF geom takes the format's documented default

### DIFF
--- a/changelog.d/3267-typeless-mjcf-geom-takes-the-format-default.md
+++ b/changelog.d/3267-typeless-mjcf-geom-takes-the-format-default.md
@@ -1,0 +1,13 @@
+### Fixed: a typeless MJCF `<geom>` reads as the sphere the format documents
+
+MJCF gives `<geom>` a default type of `sphere`, so `<geom size="0.03"/>` is a
+30 mm ball. The Isaac description loader read that attribute in two places and
+they disagreed: the scene-object AABB reader used `sphere`, the robot-link
+reader used `box`. Read as a box, such a geom lost its stated `size` as well as
+its shape - the box branch needs three components and a ball declares one - so a
+link written `<geom size="0.03"/>` reported a 0.05 m box, and a 60 mm ball
+spawned as a 100 mm cube under a successful load. Both readers now resolve the
+default through one name, so the two cannot answer one element differently.
+
+A body with no `<geom>` at all is unchanged: there is no geometry to name, so it
+keeps the no-geometry box proxy.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -465,6 +465,12 @@ def _parse_sphere_size(el: ET.Element) -> tuple[float, ...]:
 # MJCF's default joint axis: a <joint> that omits ``axis`` acts about +Z.
 _MJCF_DEFAULT_JOINT_AXIS = (0.0, 0.0, 1.0)
 
+# MJCF's default geom type: a <geom> that omits ``type`` is a sphere, and
+# ``size`` then holds its radius. Both readers of the attribute resolve the
+# default through this name, because the two answering one element differently
+# is how a link declared as a ball came to be reported as a box.
+_MJCF_DEFAULT_GEOM_TYPE = "sphere"
+
 _MJCF_JOINT_TYPE_MAP = {
     "hinge": "revolute",
     "slide": "prismatic",
@@ -702,13 +708,25 @@ def _extract_mjcf_shape(
     All three attributes are read through :func:`_class_attrs`, because a geom
     need not spell any of them itself - ``<default>`` inheritance may supply
     them, and a link whose class declares ``type="capsule"`` reads as the
-    fallback box if the element is asked directly.
+    typeless default if the element is asked directly.
+
+    A ``<geom>`` that states no ``type`` at all takes MJCF's documented default
+    (:data:`_MJCF_DEFAULT_GEOM_TYPE`, a sphere), which is also what
+    :func:`_geom_aabb` reads it as - the two answering one element differently
+    is a link reported as a shape its own file does not describe. Read as a box,
+    such a geom loses its stated ``size`` as well as its shape, because the box
+    branch needs three components and a ball declares one.
+
+    A body with no ``<geom>`` at all is the separate case: there is no geometry
+    to name, so it keeps the module's no-geometry box proxy, the same one
+    :func:`_extract_urdf_shape` returns for a link with no ``<visual>`` or
+    ``<collision>``.
     """
     geom = body_el.find("geom")
     if geom is None:
         return "box", (0.05, 0.05, 0.05)
     attrs = _class_attrs(geom, defaults, childclass)
-    gtype = attrs.get("type", "box")
+    gtype = attrs.get("type", _MJCF_DEFAULT_GEOM_TYPE)
     size_str = attrs.get("size", "")
     sizes: list[float] = []
     if size_str:
@@ -1456,7 +1474,7 @@ def _mjcf_class_defaults(root: ET.Element, base_dir: str, tag: str) -> dict[str,
     # elements rather than restarting at each one, because MuJoCo merges them.
     # Starting from ``{}`` per element lets the last one REPLACE the others, so a
     # ``type`` only the first declares is dropped and every geom resolving
-    # against the root reports the fallback box under a successful load.
+    # against the root reports the 0.05 m fallback proxy under a successful load.
     root_attrs: dict[str, str] = {}
     for el in _mjcf_model_toplevel(root, base_dir):
         if el.tag == "default":
@@ -1470,7 +1488,7 @@ def _mjcf_class_defaults(root: ET.Element, base_dir: str, tag: str) -> dict[str,
             # whole model when the two disagree, and they disagree in shipped
             # assets: Menagerie's ``pal_tiago_dual`` writes ``class="main"`` and
             # gives none of its 46 geoms a class, so 34 of them report the
-            # fallback box for the ``type="mesh"`` that class declares.
+            # 0.05 m fallback proxy for the ``type="mesh"`` that class declares.
             #
             # Registering both spellings cannot shadow a different class,
             # because neither name is available to one: MuJoCo refuses a nested
@@ -1984,7 +2002,8 @@ def _refuse_non_finite_geom(attrs: Mapping[str, str], attribute: str, values: Se
         ValueError: If any component of ``values`` is not finite.
     """
     name = attrs.get("name")
-    where = f"geom {name!r}" if name else f'unnamed <geom type="{attrs.get("type", "sphere")}">'
+    gtype = attrs.get("type", _MJCF_DEFAULT_GEOM_TYPE)
+    where = f"geom {name!r}" if name else f'unnamed <geom type="{gtype}">'
     _refuse_non_finite_placement(where, attribute, values)
 
 
@@ -2046,7 +2065,7 @@ def _geom_aabb(
             (:func:`_refuse_non_finite_geom`).
     """
     attrs = _class_attrs(geom, defaults, childclass)
-    gtype = attrs.get("type", "sphere")
+    gtype = attrs.get("type", _MJCF_DEFAULT_GEOM_TYPE)
     pos = _parse_xyz(attrs.get("pos"))
     _refuse_non_finite_geom(attrs, "pos", pos)
     size_str = attrs.get("size", "")

--- a/tests/simulation/isaac/test_a_typeless_mjcf_geom_reads_as_the_documented_default.py
+++ b/tests/simulation/isaac/test_a_typeless_mjcf_geom_reads_as_the_documented_default.py
@@ -111,8 +111,7 @@ class TestATypelessGeomTakesTheFormatsDefault:
         assert shape == "sphere"
         # A ball is its own rotation: the half-extent is the radius on each axis.
         assert half == pytest.approx((shape_size[0],) * 3), (
-            f"the link reader reported {(shape, shape_size)} and the AABB reader {half} "
-            "for one <geom size='0.03'/>"
+            f"the link reader reported {(shape, shape_size)} and the AABB reader {half} for one <geom size='0.03'/>"
         )
 
     def test_the_default_is_the_one_the_compiler_applies(self, tmp_path):

--- a/tests/simulation/isaac/test_a_typeless_mjcf_geom_reads_as_the_documented_default.py
+++ b/tests/simulation/isaac/test_a_typeless_mjcf_geom_reads_as_the_documented_default.py
@@ -1,0 +1,161 @@
+"""A ``<geom>`` that states no ``type`` is a sphere, and both readers say so.
+
+MJCF gives ``<geom>`` a default type, and it is ``sphere``: ``<geom size="0.03"/>``
+compiles to a 0.03 m ball, with ``size`` holding the radius. Two functions in
+:mod:`strands_robots.simulation.isaac.loaders` resolve that attribute -
+``_extract_mjcf_shape`` for a robot link's ``BodyDef``, and ``_geom_aabb`` for a
+scene object's bound - and they disagreed about the default: the AABB reader used
+``sphere``, the link reader used ``box``.
+
+Read as a box, such a geom loses its ``size`` as well as its shape, because the
+box branch needs three components and a ball declares one: a link written
+``<geom size="0.03"/>`` reported a 0.05 m box, so a 60 mm ball spawned as a
+100 mm cube and nothing in the load reported a problem. The two readers also
+answered the same element two different ways, which is the shape this file pins
+shut - both resolve the default through one name now, so neither can drift.
+
+MuJoCo is the oracle throughout: the expected primitive and size are read back
+off a compiled ``MjModel`` rather than restated, and the default itself is
+asserted against what the compiler does with a typeless geom.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from strands_robots.simulation.isaac import loaders as mod
+from strands_robots.simulation.isaac.loaders import load_mjcf
+
+mujoco = pytest.importorskip("mujoco")
+
+_GEOM_TYPE_NAMES = {
+    int(mujoco.mjtGeom.mjGEOM_SPHERE): "sphere",
+    int(mujoco.mjtGeom.mjGEOM_CAPSULE): "capsule",
+    int(mujoco.mjtGeom.mjGEOM_CYLINDER): "cylinder",
+    int(mujoco.mjtGeom.mjGEOM_BOX): "box",
+    int(mujoco.mjtGeom.mjGEOM_ELLIPSOID): "ellipsoid",
+    int(mujoco.mjtGeom.mjGEOM_PLANE): "plane",
+}
+
+_MODEL = """<mujoco model="m">
+  <worldbody>
+    <body name="link" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="link_g" {type_attr} size="{size}"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# (label, ``type`` spelling, ``size``, expected reading). The expected primitive
+# is checked against MuJoCo as well; it is stated here so a row that stops
+# exercising what it names fails rather than following the code.
+_ROWS = [
+    ("type unstated, one size", "", "0.03", ("sphere", (0.03,))),
+    ("type unstated, three sizes", "", "0.03 0.04 0.05", ("sphere", (0.03,))),
+    ('type="sphere"', 'type="sphere"', "0.03", ("sphere", (0.03,))),
+    ('type="box"', 'type="box"', "0.03 0.04 0.05", ("box", (0.03, 0.04, 0.05))),
+    ('type="capsule"', 'type="capsule"', "0.02 0.1", ("capsule", (0.02, 0.1))),
+]
+
+
+def _write(tmp_path, name, body):
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _compiled_geom(path, geom_name="link_g"):
+    """MuJoCo's own ``(type, size)`` for a named geom - the oracle."""
+    model = mujoco.MjModel.from_xml_path(str(path))
+    gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+    assert gid >= 0, f"premise: MuJoCo compiled no geom named {geom_name!r}"
+    # int(): a pybind11 enum does not match a numpy integer as a dict key.
+    return _GEOM_TYPE_NAMES[int(model.geom_type[gid])], tuple(float(x) for x in model.geom_size[gid])
+
+
+class TestATypelessGeomTakesTheFormatsDefault:
+    """One element, one shape - whichever reader is asked, and MuJoCo agrees."""
+
+    @pytest.mark.parametrize(("label", "type_attr", "size", "expected"), _ROWS, ids=[r[0] for r in _ROWS])
+    def test_the_link_reads_as_the_shape_mujoco_compiles(self, tmp_path, label, type_attr, size, expected):
+        path = _write(tmp_path, "m.xml", _MODEL.format(type_attr=type_attr, size=size))
+        compiled_type, compiled_size = _compiled_geom(path)
+        assert compiled_type == expected[0], f"premise: MuJoCo reads {label} as {compiled_type!r}"
+
+        body = next(b for b in load_mjcf(str(path)).bodies if b.name == "link")
+        assert body.shape == compiled_type, (
+            f"{label}: MuJoCo compiles a {compiled_type!r} and the link reported "
+            f"{body.shape!r} with size {body.shape_size}"
+        )
+        assert body.shape_size == pytest.approx(expected[1]), (
+            f"{label}: the file states size={size!r} and the link reported {body.shape_size}"
+        )
+        # The declared extent has to survive, not just the primitive's name: a
+        # ball read as a box fell back to 0.05 m on every axis.
+        assert body.shape_size[0] == pytest.approx(compiled_size[0])
+
+    def test_both_readers_answer_one_element_the_same_way(self, tmp_path):
+        """The link extent and the scene-object bound describe the same geom."""
+        path = _write(tmp_path, "agree.xml", _MODEL.format(type_attr="", size="0.03"))
+        root = mod.ET.parse(str(path)).getroot()
+        body_el = root.find(".//body")
+
+        shape, shape_size = mod._extract_mjcf_shape(body_el, {}, "")
+        aabb = mod._geom_aabb(body_el.find("geom"), {}, "")
+        assert aabb is not None, "premise: the AABB reader resolves a typeless geom"
+        _, half = aabb
+
+        assert shape == "sphere"
+        # A ball is its own rotation: the half-extent is the radius on each axis.
+        assert half == pytest.approx((shape_size[0],) * 3), (
+            f"the link reader reported {(shape, shape_size)} and the AABB reader {half} "
+            "for one <geom size='0.03'/>"
+        )
+
+    def test_the_default_is_the_one_the_compiler_applies(self, tmp_path):
+        """The constant is graded against MuJoCo, not against its own spelling."""
+        path = _write(tmp_path, "default.xml", _MODEL.format(type_attr="", size="0.03"))
+        assert mod._MJCF_DEFAULT_GEOM_TYPE == _compiled_geom(path)[0]
+
+    def test_neither_reader_spells_the_default_itself(self):
+        """Two spellings of one default is how the two readers came to disagree."""
+        readers = (mod._extract_mjcf_shape, mod._geom_aabb, mod._refuse_non_finite_geom)
+        for fn in readers:
+            src = inspect.getsource(fn)
+            assert 'attrs.get("type", _MJCF_DEFAULT_GEOM_TYPE)' in src, (
+                f"{fn.__name__} resolves the geom type; it must do so through the shared default"
+            )
+            assert 'get("type", "' not in src, f"{fn.__name__} spells the MJCF geom default itself"
+
+    def test_a_body_with_no_geom_keeps_the_no_geometry_proxy(self, tmp_path):
+        """An absent element is not an absent attribute: there is no shape to name.
+
+        A ``<geom>`` that omits ``type`` still describes geometry, so the format's
+        default applies. A body with no ``<geom>`` at all describes none, and keeps
+        the module's no-geometry box proxy - the same reading a URDF link with
+        neither ``<visual>`` nor ``<collision>`` gets.
+        """
+        mjcf = """<mujoco model="m"><worldbody>
+          <body name="empty"><joint name="j" type="hinge"/></body>
+        </worldbody></mujoco>"""
+        body = next(b for b in load_mjcf(str(_write(tmp_path, "empty.xml", mjcf))).bodies if b.name == "empty")
+        assert (body.shape, body.shape_size) == ("box", (0.05, 0.05, 0.05))
+
+    def test_a_class_supplied_type_still_wins_over_the_default(self, tmp_path):
+        """The default applies to an unstated type, not to an unstated attribute."""
+        mjcf = """<mujoco model="m">
+          <default>
+            <default class="seg"><geom type="capsule" size="0.02 0.1"/></default>
+          </default>
+          <worldbody>
+            <body name="link"><geom name="link_g" class="seg"/></body>
+          </worldbody>
+        </mujoco>"""
+        path = _write(tmp_path, "cls.xml", mjcf)
+        compiled_type, _ = _compiled_geom(path)
+        assert compiled_type == "capsule", "premise: the class supplies the type"
+        body = next(b for b in load_mjcf(str(path)).bodies if b.name == "link")
+        assert (body.shape, body.shape_size) == ("capsule", (0.02, 0.1))


### PR DESCRIPTION
MJCF gives `<geom>` a default type, and it is `sphere`: `<geom size="0.03"/>` is a 30 mm ball, with `size` holding the radius. `simulation/isaac/loaders.py` resolves that attribute in two places and they disagreed - `_geom_aabb` (scene-object bound) used `sphere`, `_extract_mjcf_shape` (robot-link `BodyDef`) used `box`.

Read as a box, such a geom loses its stated `size` as well as its shape, because the box branch needs three components and a ball declares one. So a link written `<geom size="0.03"/>` reported `("box", (0.05, 0.05, 0.05))` - the fallback extent, with the declared 0.03 discarded - and `load_mjcf` reported success.

![declared ball vs reported box](https://raw.githubusercontent.com/cagataycali/pr-assets/main/mjcf-typeless-geom-shape-34046209599.png)

Rendered headless in MuJoCo from the two readings of that one element. Left is what the compiler makes of it; right is what the link reported. 1.131e-04 m^3 against 1.000e-03 m^3, 8.8x the volume.

## What the two readers said

![verdict grid, both trees](https://raw.githubusercontent.com/cagataycali/pr-assets/main/mjcf-typeless-geom-grid-34046209599.png)

Measured on both trees. The compiler column is the oracle; 2 of 12 cells disagreed with it before, 0 after. The unstated-type row with three sizes is the second: MuJoCo makes a ball of `size[0]`, the link reader built an anisotropic box out of components a sphere does not use.

The `ellipsoid` row is the module's documented box proxy for types it derives no analytic reading for, and is deliberately unchanged.

## Change

One module-level `_MJCF_DEFAULT_GEOM_TYPE = "sphere"`, joining the sibling `_MJCF_DEFAULT_JOINT_AXIS`, and all three readers of the attribute resolve the default through it (the third is the error locator in `_refuse_non_finite_geom`, which spelled it a third time). Two spellings of one default is how the two came to disagree, so a test asserts neither reader spells it itself.

**A body with no `<geom>` at all is unchanged.** An absent element is not an absent attribute: there is no geometry to name, so it keeps the module's no-geometry box proxy - the same reading a URDF link with neither `<visual>` nor `<collision>` gets. Only a `<geom>` that omits `type` changes.

A typeless geom with no `size` now reads as `("sphere", (0.05,))` rather than the box proxy. MuJoCo refuses that model outright (`size 0 must be positive in geom`), so it is not a shape either reading describes; the sphere reading matches the existing `type="sphere" size=""` row.

## Tests

`tests/simulation/isaac/test_a_typeless_mjcf_geom_reads_as_the_documented_default.py`, 10 cells, MuJoCo as the oracle throughout - the expected primitive and size are read back off a compiled `MjModel`, and the default itself is graded against what the compiler does with a typeless geom rather than restated.

| corner | `tests/simulation/isaac` |
|---|---|
| A: current `loaders.py`, without the new file | 1965 passed |
| B: current `loaders.py`, with it | **5 failed**, 1970 passed |
| C: this PR | 1975 passed |
| D: this PR, without the new file | 1965 passed |

D matching A is what shows no existing pin moved; 5 of the 10 new cells are controls that already hold pre-fix (a stated `sphere`/`box`/`capsule`, a class-supplied type, a body with no geom). The red ones:

```
type unstated, one size: MuJoCo compiles a 'sphere' and the link reported 'box' with size (0.05, 0.05, 0.05)
type unstated, three sizes: MuJoCo compiles a 'sphere' and the link reported 'box' with size (0.03, 0.04, 0.05)
both readers answer one element the same way: assert 'box' == 'sphere'
```

Wider: `tests/simulation tests/registry` 15116 passed, plus one failure (`test_pose_vector_rule_parity.py::test_a_numpy_array_pose_is_accepted_by_both`) that reproduces identically in a clean `main` worktree and is untouched here. ruff clean, mypy unchanged at its existing 20 errors in 6 files (`examples/isaac_gs`, `simulation/ik.py`), none in this diff.

## Size

| | lines |
|---|---|
| `loaders.py` | +25 / -6 |
| new test | +160 |
| changelog fragment | +13 |

Of the 25 production lines: 5 executable (against 3 removed, so +2 net - the constant and one extra local), 11 docstring, 6 comment, 3 blank. The two comment edits name the 0.05 m fallback by its extent rather than by a primitive that is no longer what it is.