### PR TITLE
fix(scripts): a standing request for changes is a blocker owed by the account that made it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -986,6 +986,34 @@ hatch run format            # ruff check --fix, ruff format
      `require_last_push_approval` then disqualifies the pushing account from
      re-supplying it, turning a one-approval merge into one that needs a second
      reviewer.
+
+     **`CHANGES_REQUESTED` is a fourth reading, and it is the one no approval
+     answers.** A standing request for changes holds the merge until *its own
+     author* approves or dismisses it, so an approval from anybody else
+     satisfies `required_approving_review_count` and leaves the pull request
+     `BLOCKED`. That makes it the opposite of every other value here: the party
+     it needs is not "a reviewer" but one named account, and asking a different
+     reviewer for the approval spends a round that cannot merge anything.
+
+     It is also the reading a resolved thread hides. #3205 sat at
+     `CHANGES_REQUESTED` for 15h44m with its one review thread **resolved**,
+     `call-test-lint` `SUCCESS`, and `check_thread_is_answered.py` reading
+     `nothing-owed` -- 12h51m of that after the fix had landed. Thread
+     resolution and review decision are separate objects and resolving the
+     thread does not retract the review, so the sweep that answers "does this
+     owe me anything" correctly said no while the decision went on blocking.
+     Nor does the requester's own follow-up reply clear it: a reply is a
+     `COMMENTED` review, which expresses no position, so it supersedes nothing.
+
+     `check_merge_blockers.py` reports this as `changes-requested`, owed by
+     `the reviewer who requested changes` and named account by account, ahead of
+     the approval rules it is not answerable by. It did not always: it modelled
+     the approval side alone, so it reported #3205 as `missing-approval` owed by
+     "a reviewer other than the pusher" -- a party whose approval could not have
+     merged it, which is the #1905 presentation reached from the review-decision
+     side rather than the last-push side. If you are the requester and the work
+     has landed, the remedy is to supersede your own review; that is a review,
+     not a push, and it costs the branch nothing.
    - *And that the head it names is the branch's tip.* A pull request has three
      answers to "what is the head commit" and they can disagree for hours. Two
      of them are the API's, and are the pair this bullet compares: `headRefOid`
@@ -1280,7 +1308,9 @@ hatch run format            # ruff check --fix, ruff format
    It reads the branch ruleset - so a rule that is changed in settings cannot
    drift from this file - and names every rule the pull request leaves
    unsatisfied together with the party who can clear it: a conflict or an
-   unresolved thread or a failing check (the author), a missing approval (any
+   unresolved thread or a failing check (the author), a standing request for
+   changes (only the account that made it, by approving or dismissing its own
+   review -- no other reviewer's approval clears it), a missing approval (any
    reviewer), an approval only its own pusher supplied (a different reviewer,
    per #1905), a required check absent because a fork run is held at
    `action_required` (a maintainer, by approving each run), a required check

--- a/changelog.d/3268-changes-requested-is-a-blocker-with-its-own-party.md
+++ b/changelog.d/3268-changes-requested-is-a-blocker-with-its-own-party.md
@@ -1,0 +1,42 @@
+### Fixed: a standing request for changes is named as its own merge blocker
+
+`scripts/check_merge_blockers.py` modelled only the approval side of a pull
+request's review decision, so a pull request sitting at `CHANGES_REQUESTED` was
+reported as `missing-approval`, owed by `a reviewer other than the pusher`.
+That party cannot clear it: with required reviews in force a standing request
+for changes holds the merge until **its own author** approves or dismisses it,
+so another account's approval satisfies `required_approving_review_count` and
+the pull request stays `BLOCKED`. The report therefore named a reviewer whose
+approval could not have merged it -- the presentation issue #1905 records,
+reached from the review-decision side rather than the last-push side.
+
+Every other sweep reads clean on the shape, which is what made it expensive.
+Measured on #3205: `reviewDecision` `CHANGES_REQUESTED` and `mergeStateStatus`
+`BLOCKED`, with its one review thread **resolved**, `call-test-lint` SUCCESS,
+`check_pr_head_is_current.py` reading `current`, and
+`check_thread_is_answered.py` reading `nothing-owed`. Thread resolution and the
+review decision are separate objects, so resolving the thread does not retract
+the review and the thread sweep was right to say nothing was owed; the
+requester's own follow-up reply is a `COMMENTED` review, which expresses no
+position and supersedes nothing. It stood 15h44m, of which 12h51m was after the
+fix had landed and the thread was resolved.
+
+The new `changes-requested` outcome is owed by `the reviewer who requested
+changes`, names each holding account in its detail rather than only the role,
+and is reported ahead of the approval rules it is not answerable by. It is
+scoped to a ruleset that actually requires approving reviews, for the same
+reason the pusher discount is, and is deliberately neither gating nor a finding:
+a failing required check beside it is still independently the author's to fix,
+and an outcome that fires whenever a review is in progress fires on the ordinary
+state.
+
+Standing is resolved by `check_last_push_approval.py`, which gains
+`current_change_requesters` beside `current_approvers` over one shared
+`_latest_positions`, so the rule that a `COMMENTED` review retracts nothing
+cannot hold for approvals and lapse for requests. The sweep binds that resolver
+rather than deriving standing itself, as it already did for approvals.
+
+`AGENTS.md` gains `CHANGES_REQUESTED` as the fourth reading of `reviewDecision`
+beside the existing `null`, `APPROVED` and `REVIEW_REQUIRED` ones, and the
+enumeration of parties the sweep names gains this outcome so the file cannot
+drift from the tool.

--- a/scripts/check_last_push_approval.py
+++ b/scripts/check_last_push_approval.py
@@ -265,8 +265,8 @@ def _join(names: Sequence[str]) -> str:
     return ", ".join(names[:-1]) + " and " + names[-1]
 
 
-def current_approvers(reviews: Iterable[Review]) -> tuple[str, ...]:
-    """Return the accounts whose latest position on the change is an approval.
+def _latest_positions(reviews: Iterable[Review]) -> dict[str, Review]:
+    """Return each account's most recent review that expresses a position.
 
     Mirrors how ``reviewDecision`` is computed: a reviewer's standing is their
     most recent review that expresses a position, so ``COMMENTED`` is skipped
@@ -274,6 +274,11 @@ def current_approvers(reviews: Iterable[Review]) -> tuple[str, ...]:
     sequence as returned by the API, which is chronological, with
     ``submitted_at`` only as a tiebreak -- two reviews can share a timestamp to
     the second, and the later one in the list is the later one.
+
+    Held as one function because "whose standing counts" is a single rule with
+    more than one question asked of it -- an approval and a request for changes
+    are the two positions that gate a merge, and resolving them separately is
+    how the two come to disagree about whether a ``COMMENTED`` review retracts.
     """
     latest: dict[str, Review] = {}
     for order, review in enumerate(reviews):
@@ -284,7 +289,29 @@ def current_approvers(reviews: Iterable[Review]) -> tuple[str, ...]:
         held = latest.get(review.author)
         if held is None or (keyed.submitted_at, keyed._order) >= (held.submitted_at, held._order):
             latest[review.author] = keyed
-    return tuple(sorted(a for a, r in latest.items() if r.state == "APPROVED"))
+    return latest
+
+
+def current_approvers(reviews: Iterable[Review]) -> tuple[str, ...]:
+    """Return the accounts whose latest position on the change is an approval."""
+    return tuple(sorted(a for a, r in _latest_positions(reviews).items() if r.state == "APPROVED"))
+
+
+def current_change_requesters(reviews: Iterable[Review]) -> tuple[str, ...]:
+    """Return the accounts whose latest position on the change requests changes.
+
+    A standing ``CHANGES_REQUESTED`` is a merge blocker in its own right and one
+    that only its own author can clear, by approving or by dismissing. It is
+    **not** answerable by an approval from anyone else: with required reviews in
+    force, another account's approval satisfies the count and the pull request
+    stays blocked. So this is a different question from ``current_approvers``
+    with a different owed party, and reading only the approval side reports a
+    reviewer who cannot clear it.
+
+    ``DISMISSED`` is a position and supersedes an earlier request for changes,
+    which is why the shared resolution above is the one that decides standing.
+    """
+    return tuple(sorted(a for a, r in _latest_positions(reviews).items() if r.state == "CHANGES_REQUESTED"))
 
 
 def classify(pusher: str | None, reviews: Iterable[Review]) -> Verdict:

--- a/scripts/check_merge_blockers.py
+++ b/scripts/check_merge_blockers.py
@@ -243,6 +243,7 @@ _approval = _load_sibling()
 current_approvers = _approval.current_approvers
 resolve_pusher = _approval.resolve_pusher
 resolve_reviews = _approval.resolve_reviews
+current_change_requesters = _approval.current_change_requesters
 
 
 # Outcome names. Ordered here the way they bind in practice, which is also the
@@ -258,6 +259,7 @@ REQUIRED_CHECK_CANCELLED = "required-check-cancelled"
 REQUIRED_CHECK_ABSENT = "required-check-absent"
 CHECK_SUITE_ABSENT = "check-suite-absent"
 UNRESOLVED_THREADS = "unresolved-threads"
+CHANGES_REQUESTED = "changes-requested"
 MISSING_APPROVAL = "missing-approval"
 PUSHER_ONLY_APPROVAL = "pusher-only-approval"
 NO_UNSATISFIED_RULE = "no-unsatisfied-rule"
@@ -266,6 +268,7 @@ NO_UNSATISFIED_RULE = "no-unsatisfied-rule"
 AUTHOR = "the author"
 REVIEWER = "any reviewer"
 OTHER_REVIEWER = "a reviewer other than the pusher"
+REQUESTING_REVIEWER = "the reviewer who requested changes"
 MAINTAINER = "a maintainer"
 NOBODY = "nobody"
 ANYONE = "anyone, by attempting the merge"
@@ -281,6 +284,7 @@ _OWED_BY: dict[str, str] = {
     REQUIRED_CHECK_ABSENT: MAINTAINER,
     CHECK_SUITE_ABSENT: MAINTAINER,
     UNRESOLVED_THREADS: AUTHOR,
+    CHANGES_REQUESTED: REQUESTING_REVIEWER,
     MISSING_APPROVAL: REVIEWER,
     PUSHER_ONLY_APPROVAL: OTHER_REVIEWER,
     NO_UNSATISFIED_RULE: ANYONE,
@@ -422,6 +426,12 @@ class PullRequestState:
     # silently pick one.
     check_suite_conclusions: tuple[str | None, ...] | None = None
     approvers: tuple[str, ...] = ()
+    # Accounts whose latest position requests changes. Read separately from
+    # ``approvers`` because the two name different parties: a standing request
+    # for changes is clearable only by its own author, and no approval from
+    # anyone else clears it. Defaults to ``()`` so every existing caller and
+    # fixture describes an unblocked review state unchanged.
+    change_requesters: tuple[str, ...] = ()
     pusher: str | None = None
 
 
@@ -643,6 +653,29 @@ def evaluate(state: PullRequestState, rules: Ruleset) -> tuple[Blocker, ...]:
         )
 
     if rules.required_approving_review_count:
+        if state.change_requesters:
+            # Reported ahead of the approval rules, and separately from them,
+            # because an approval does not answer it. With required reviews in
+            # force a standing CHANGES_REQUESTED holds the merge until its own
+            # author approves or dismisses it, so another account's approval
+            # satisfies the count and the pull request stays BLOCKED. Reading
+            # the approval side alone therefore names a reviewer who cannot
+            # clear it -- measured on #3205, which this check reported as
+            # `missing-approval` owed by "a reviewer other than the pusher"
+            # while the only account that could clear it was the one that had
+            # requested the changes. It stood 15h44m, of which 12h51m was after
+            # the fix had landed and the thread was resolved.
+            found.append(
+                Blocker(
+                    CHANGES_REQUESTED,
+                    "required_approving_review_count",
+                    f"{_join(sorted(state.change_requesters))} "
+                    f"{'has' if len(state.change_requesters) == 1 else 'have'} a standing "
+                    f"request for changes. Only that account can clear it, by approving or "
+                    f"by dismissing its own review; an approval from anyone else is necessary "
+                    f"but not sufficient while it stands.",
+                )
+            )
         # The pusher's own approval is discounted only when the branch actually
         # carries require_last_push_approval. Filtering unconditionally would
         # invent a blocker on a branch that permits a self-approved head.
@@ -913,6 +946,7 @@ def resolve_state(repo: str, pr: int, token: str) -> PullRequestState:
         check_conclusions=resolve_check_conclusions(repo, head_sha, token) if head_sha else {},
         check_suite_conclusions=resolve_check_suites(repo, head_sha, token) if head_sha else None,
         approvers=current_approvers(reviews),
+        change_requesters=current_change_requesters(reviews),
         pusher=resolve_pusher(repo, head_sha, token) if head_sha else None,
     )
 

--- a/tests/test_last_push_approval.py
+++ b/tests/test_last_push_approval.py
@@ -52,6 +52,10 @@ def commented(author: str, at: str = "2026-08-01T00:00:00Z") -> Any:
     return Review(author=author, state="COMMENTED", submitted_at=at)
 
 
+def requested_changes(author: str, at: str = "2026-08-01T00:00:00Z") -> Any:
+    return Review(author=author, state="CHANGES_REQUESTED", submitted_at=at)
+
+
 # --------------------------------------------------------------------------
 # The four measured pull requests.
 #
@@ -741,3 +745,84 @@ def test_the_sweep_report_stays_ascii():
     ]
     mod.render_sweep(rows, [1900], "strands-labs/robots").encode("ascii")
     mod.render_sweep([], [], "strands-labs/robots").encode("ascii")
+
+
+# --------------------------------------------------------------------------
+# A standing request for changes is a separate question with a separate party.
+# --------------------------------------------------------------------------
+
+
+def test_a_standing_request_for_changes_is_reported_beside_the_approval_it_does_not_answer():
+    """The two positions name different parties, so they are read separately.
+
+    Measured on #3205: one account held a standing CHANGES_REQUESTED and no
+    account had approved. Reading the approval side alone answers "nobody has
+    approved", which points at any reviewer -- and an approval from any other
+    reviewer leaves the pull request blocked, because only the requesting
+    account can clear its own review.
+    """
+    reviews = [requested_changes("the-reviewer", "2026-09-06T01:24:59Z")]
+    assert mod.current_approvers(reviews) == ()
+    assert mod.current_change_requesters(reviews) == ("the-reviewer",)
+
+
+def test_a_commented_review_does_not_retract_a_request_for_changes():
+    """Symmetric with the approval side: COMMENTED expresses no position.
+
+    This is the #3205 shape exactly -- the requesting account replied on the
+    thread describing the fix it had pushed, which is a COMMENTED review. If
+    that counted as a retraction the request would read as cleared while it went
+    on holding the merge.
+    """
+    reviews = [
+        requested_changes("the-reviewer", "2026-09-06T01:24:59Z"),
+        commented("the-reviewer", "2026-09-06T04:17:25Z"),
+    ]
+    assert mod.current_change_requesters(reviews) == ("the-reviewer",)
+
+
+@pytest.mark.parametrize("clearing", ["APPROVED", "DISMISSED"])
+def test_the_requesting_account_clears_its_own_request_either_way(clearing):
+    """The two remedies that belong to the requester, and nothing else does."""
+    reviews = [
+        requested_changes("the-reviewer", "2026-09-06T01:24:59Z"),
+        Review(author="the-reviewer", state=clearing, submitted_at="2026-09-06T17:09:17Z"),
+    ]
+    assert mod.current_change_requesters(reviews) == ()
+
+
+def test_another_accounts_approval_does_not_clear_a_request_for_changes():
+    """The whole point of reading the two separately.
+
+    An approval satisfies ``required_approving_review_count`` and leaves the
+    request standing, so a report that collapses them sends the reader to a
+    party whose approval cannot merge anything.
+    """
+    reviews = [
+        requested_changes("the-reviewer", "2026-09-06T01:24:59Z"),
+        approved("another-reviewer", "2026-09-06T09:00:00Z"),
+    ]
+    assert mod.current_approvers(reviews) == ("another-reviewer",)
+    assert mod.current_change_requesters(reviews) == ("the-reviewer",)
+
+
+def test_both_questions_resolve_standing_the_same_way():
+    """One owner for "whose position counts", asked twice.
+
+    Derived rather than asserted per case: whatever the shared resolution
+    decides, an account appears in at most one of the two answers. A second copy
+    of the ordering rule is how the two come to disagree.
+    """
+    reviews = [
+        requested_changes("alice", "2026-01-01T00:00:00Z"),
+        approved("alice", "2026-01-02T00:00:00Z"),
+        approved("bob", "2026-01-01T00:00:00Z"),
+        requested_changes("bob", "2026-01-02T00:00:00Z"),
+        commented("carol", "2026-01-03T00:00:00Z"),
+    ]
+    approvers = set(mod.current_approvers(reviews))
+    requesters = set(mod.current_change_requesters(reviews))
+    assert approvers == {"alice"}
+    assert requesters == {"bob"}
+    assert not approvers & requesters
+    assert "carol" not in approvers | requesters

--- a/tests/test_merge_blockers.py
+++ b/tests/test_merge_blockers.py
@@ -1306,3 +1306,109 @@ def test_the_step_summary_receives_the_report(monkeypatch: pytest.MonkeyPatch, t
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
     mod._emit("## a report")
     assert "## a report" in summary.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# A standing request for changes, measured on #3205.
+#
+# It read `missing-approval` owed by "a reviewer other than the pusher" while
+# `reviewDecision` was CHANGES_REQUESTED and the only account that could clear
+# it was the one that had requested the changes. The named party's approval
+# could not have merged it. It stood 15h44m, 12h51m of that after the fix had
+# landed and the thread was resolved.
+# --------------------------------------------------------------------------
+
+
+def test_3205_a_standing_request_for_changes_names_the_account_that_can_clear_it() -> None:
+    """The defect: the report named a party whose approval could not clear it.
+
+    Both rules really are unsatisfied here -- nobody has approved, and a request
+    for changes stands -- but they are owed by different people, and only one of
+    them can move the pull request. So the request must own the next action.
+    """
+    blockers = mod.evaluate(state(approvers=(), change_requesters=("the-reviewer",)), MAIN)
+    assert outcomes(blockers) == [mod.CHANGES_REQUESTED, mod.MISSING_APPROVAL]
+    assert mod.primary(blockers).outcome == mod.CHANGES_REQUESTED
+    assert mod.primary(blockers).owed_by == mod.REQUESTING_REVIEWER
+    # The pre-fix answer, which is the one that misled.
+    assert mod.primary(blockers).owed_by != mod.OTHER_REVIEWER
+
+
+def test_a_third_partys_approval_does_not_clear_a_standing_request_for_changes() -> None:
+    """The count is satisfied and the pull request is still blocked.
+
+    This is the case that makes the two questions genuinely different rather
+    than two spellings of one: with an eligible approval present there is no
+    approval rule left to report, so a check that models only approvals reports
+    nothing at all and the reader concludes the branch is ready.
+    """
+    blockers = mod.evaluate(
+        state(approvers=("another-reviewer",), change_requesters=("the-reviewer",)),
+        MAIN,
+    )
+    assert outcomes(blockers) == [mod.CHANGES_REQUESTED]
+    assert mod.primary(blockers).owed_by == mod.REQUESTING_REVIEWER
+    assert mod.primary(blockers).outcome != mod.NO_UNSATISFIED_RULE
+
+
+def test_a_request_for_changes_is_reported_but_is_not_a_finding() -> None:
+    """Owed by a reviewer, so it is not a state an author-side pass can act on.
+
+    Same reasoning as ``missing-approval``: a finding that fires whenever a
+    review is in progress fires on the ordinary state and stops meaning
+    anything. The report is the point; the exit status is not.
+    """
+    blocker = mod.evaluate(state(change_requesters=("the-reviewer",)), MAIN)[0]
+    assert blocker.outcome == mod.CHANGES_REQUESTED
+    assert blocker.is_finding is False
+    assert blocker.is_gating is False
+
+
+def test_a_request_for_changes_names_the_account_in_its_detail() -> None:
+    """The party is a role; the reason has to say which account holds it.
+
+    ``the reviewer who requested changes`` is not actionable on its own -- the
+    reader has to know who to ask, and on a pull request with several reviewers
+    the report is the only place that is written down.
+    """
+    detail = mod.evaluate(state(change_requesters=("the-reviewer",)), MAIN)[0].detail
+    assert "the-reviewer" in detail
+    blockers = mod.evaluate(state(change_requesters=("alice", "bob")), MAIN)
+    assert "alice" in blockers[0].detail and "bob" in blockers[0].detail
+
+
+def test_no_request_for_changes_reports_no_such_blocker() -> None:
+    """The control. The default fixture is an unblocked review state."""
+    assert mod.CHANGES_REQUESTED not in outcomes(mod.evaluate(state(), MAIN))
+    assert mod.CHANGES_REQUESTED not in outcomes(mod.evaluate(state(change_requesters=()), MAIN))
+
+
+def test_a_request_for_changes_is_not_reported_where_reviews_are_not_required() -> None:
+    """A branch carrying no approval requirement is not blocked by a review.
+
+    Scoped to the rule for the same reason the pusher discount is: reporting it
+    unconditionally would invent a blocker on a branch whose ruleset does not
+    hold the merge for a review at all.
+    """
+    no_reviews = mod.parse_ruleset([])
+    blockers = mod.evaluate(state(approvers=(), change_requesters=("the-reviewer",)), no_reviews)
+    assert mod.CHANGES_REQUESTED not in outcomes(blockers)
+
+
+def test_the_request_for_changes_semantics_come_from_the_sibling_check() -> None:
+    """One owner for "whose position counts", as for the approval side.
+
+    The sweep binds the sibling's resolver rather than deriving standing itself,
+    so the rule that a COMMENTED review retracts nothing cannot hold on one side
+    and lapse on the other.
+    """
+    assert mod.current_change_requesters is not None
+    reviews = [
+        mod.resolve_reviews.__globals__["Review"](
+            author="the-reviewer", state="CHANGES_REQUESTED", submitted_at="2026-09-06T01:24:59Z"
+        ),
+        mod.resolve_reviews.__globals__["Review"](
+            author="the-reviewer", state="COMMENTED", submitted_at="2026-09-06T04:17:25Z"
+        ),
+    ]
+    assert mod.current_change_requesters(reviews) == ("the-reviewer",)


### PR DESCRIPTION
## What

`scripts/check_merge_blockers.py` modelled only the approval side of the review decision. A pull request sitting at `reviewDecision: CHANGES_REQUESTED` was therefore reported as `missing-approval`, owed by `a reviewer other than the pusher` -- and that party's approval cannot clear it.

With required reviews in force, a standing request for changes holds the merge until **its own author** approves or dismisses it. Another account's approval satisfies `required_approving_review_count` and the pull request stays `BLOCKED`. So this is the #1905 presentation reached from the review-decision side rather than the last-push side: a state that reads as ordinary reviewer latency, needs one specific named account, and gets a round spent on a reviewer who cannot move it.

Adds a `changes-requested` outcome, owed by `the reviewer who requested changes`, reported ahead of the approval rules it is not answerable by.

## Why nothing caught it

Every sweep this repository has reads clean on the shape. Measured on #3205:

| signal | reading while it was blocked |
|---|---|
| `reviewDecision` | `CHANGES_REQUESTED` |
| `mergeStateStatus` | `BLOCKED` |
| review threads | 1, **resolved** |
| `check_thread_is_answered.py --pr 3205` | `nothing-owed` |
| `check_merge_blockers.py` | `missing-approval`, owed by a reviewer who could not clear it |
| `check_pr_head_is_current.py` | `current` |
| `call-test-lint / Test and Lint` | SUCCESS |

Thread resolution and the review decision are separate objects: resolving the thread does not retract the review, so the sweep that answers "does this owe me anything" was correct to say no while the decision went on blocking. And the requester's own follow-up reply is a `COMMENTED` review, which expresses no position and supersedes nothing -- so the one account that could clear it had already said everything it was going to say.

It stood **15h44m**, of which **12h51m** was after the fix had landed and the thread was resolved.

## Shape

- **Standing has one owner.** `current_change_requesters` lives beside `current_approvers` in `check_last_push_approval.py` and both read one shared `_latest_positions`, so the rule that a `COMMENTED` review retracts nothing cannot hold on one side and lapse on the other. The sweep binds the sibling's resolver rather than deriving standing itself, exactly as it already does for approvals.
- **Reported, not gated.** `changes-requested` is deliberately absent from `_FINDINGS`, on the same reasoning that keeps `missing-approval` out: it is owed by a reviewer, and a finding that fires whenever a review is in progress fires on the ordinary state and stops meaning anything.
- **Not gating either.** It does not claim the rules beside it are unassessable -- a failing required check is independently the author's to fix, and `_next_action`'s gating language would misdescribe that.
- **Scoped to the rule.** Only reported where the ruleset actually requires approving reviews, for the same reason the pusher discount is: reporting it unconditionally would invent a blocker on a branch whose ruleset does not hold the merge for a review at all.
- **Names the account, not just the role.** `the reviewer who requested changes` is not actionable on its own; the detail line names each holding account, since on a pull request with several reviewers the report is the only place that is written down.

## Tests

13 new cells, **all 13 fail on pre-fix code** (7 over the sweep's verdict, 6 over the shared resolver):

```
scripts reverted to main, new pins run:  13 failed, 139 passed
with the change:                         152 passed
```

The #3205 cell is the counterfactual itself -- it asserts the primary blocker is `changes-requested` owed by `REQUESTING_REVIEWER`, and explicitly that it is **not** `OTHER_REVIEWER`, which was the pre-fix answer. The third-party-approval cell is the one that shows the two questions are genuinely different rather than two spellings of one: with an eligible approval present there is no approval rule left to report, so a check modelling only approvals reports nothing at all and the reader concludes the branch is ready.

## Gate

| check | result |
|---|---|
| `pytest tests/test_merge_blockers.py tests/test_last_push_approval.py` | 152 passed (was 139) |
| new pins against pre-fix scripts | 13 failed, as intended |
| `ruff check` | clean |
| `ruff format --check` | clean |
| `mypy scripts/check_merge_blockers.py scripts/check_last_push_approval.py` | `Success: no issues found in 2 source files` |
| whole-tree graders (104), base vs head | **0 attributable** -- 110 failed / 2139 passed on both, node-id sets identical in both directions |
| non-ASCII sweep on changed Python | clean |
| `behind_by` vs `main` | 0 |

The 110 failures and 178 collection errors in the grader roster are environmental in this sandbox (no `torch`, `mujoco`, `zenoh`) and reproduce byte-identically on the unmerged base, which is why the claim is the delta and not the count.

## Docs

`AGENTS.md` gains `CHANGES_REQUESTED` as the fourth reading of `reviewDecision`, beside the existing `null` / `APPROVED` / `REVIEW_REQUIRED` ones, and the sweep's enumeration of parties gains this outcome so the file cannot drift from the tool.

Advances the #1905 class. Claims no issue.

## Round log

- **Round 1** -- opened. Draft first so the changelog fragment lands before a review can arrive, per PR Workflow step 3.
