### PR TITLE
fix(simulation/isaac): a stage path prefix is a USD prim path, not free text

### DIFF
--- a/changelog.d/3269-isaac-stage-path-is-a-prim-path.md
+++ b/changelog.d/3269-isaac-stage-path-is-a-prim-path.md
@@ -1,0 +1,22 @@
+### Fixed: `IsaacConfig.stage_path` must be a USD prim path
+
+Every prim the Isaac backend creates is addressed by a path interpolated from
+two caller-supplied components - `f"{stage_path}/Robots/{name}"`, and the same
+shape for `/Objects/` and `/Cameras/`. The `name` half was already refused on
+the shared `entity_name_error` domain; `stage_path` had none, so the values that
+half rejects by name were accepted through this one and the interpolated result
+was recorded in the cleanup registry `destroy()` releases and counts:
+`stage_path=None` recorded `None/Robots/arm`, `stage_path=7` recorded
+`7/Robots/arm`, `"World"` recorded a relative path `get_body_state` routes to
+the wrong branch, `"/World/"` recorded `/World//Robots/arm`, and `"/My World"`
+was recorded verbatim although USD transcodes a prim name outside its identifier
+alphabet, so the prim does not land at the recorded path.
+
+`stage_path` is now validated on construction - and therefore through
+`IsaacConfig(...)`, `from_kwargs()`, `dataclasses.replace()` and the
+`IsaacSimulation(stage_path=...)` shortcut - as an absolute USD prim path with
+at least one component, every component matching `[A-Za-z_][A-Za-z0-9_]*`. The
+refusal names the field and quotes the path the value would have produced. This
+widens one previously working spelling: a `PurePosixPath` rendered correctly but
+is not a `str`, and admitting a non-`str` that happens to render correctly is
+what admitted `None`, whose rendering is the literal text `None`.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -146,7 +146,7 @@ rejected eagerly. The commonly used fields:
 | `render_mode` | `str` | `"headless"` | `"headless"`, `"rtx_realtime"` (raster), or `"rtx_pathtracing"` (photoreal). |
 | `gravity` | `tuple` | `(0, 0, -9.81)` | Gravity vector (Z-up). Three finite components, Z-aligned - the same domain `create_world(gravity=...)` takes. |
 | `ground_plane` | `bool` | `True` | Add a ground plane on `create_world()`. |
-| `stage_path` | `str` | `"/World"` | USD stage path prefix. |
+| `stage_path` | `str` | `"/World"` | USD prim-path prefix every created prim is addressed under. Must be absolute, with at least one component, every component a prim name (`[A-Za-z_][A-Za-z0-9_]*`). |
 | `nucleus_url` | `str \| None` | `None` | Override Omniverse Nucleus URL (env-resolvable). |
 | `camera_width` / `camera_height` | `int` | `640` / `480` | Default camera resolution. |
 | `enable_rtx_sensors` | `bool` | `True` | Enable RTX-accelerated camera / LiDAR sensors. |
@@ -283,6 +283,19 @@ prunes its cleanup registry by that prefix. Unlike the MuJoCo backend there is
 no "derive a label from the model" short form: `name` is also the procedural
 lookup key, so `None` / `""` are refused rather than replaced with a generated
 label.
+
+`stage_path` is the other half of that same path and carries the same floor, so
+a path this backend records is one it can address whichever component the caller
+got wrong. It must be an absolute USD prim path with at least one component,
+every component a prim name (`[A-Za-z_][A-Za-z0-9_]*`). A non-`str` was
+previously interpolated as its rendered text (`stage_path=None` recorded
+`None/Robots/arm`); a relative prefix (`"World"`) recorded a path that
+`get_body_state` cannot take, because it distinguishes an absolute prim path
+from a `<robot>/<link>` pair by the leading `/`; a trailing or doubled separator
+(`"/World/"`) left an empty component; and a component outside USD's identifier
+alphabet (`"/My World"`) is transcoded by USD, so the prim does not land at the
+path recorded for it. The identifier rule applies to the prefix only - `name` is
+shared with backends whose entity names are not USD identifiers.
 
 The one deliberate difference in that list is `mass=0`. The Newton backend
 documents it as an alternative spelling of `is_static=True` and honours it, so it

--- a/strands_robots/simulation/isaac/config.py
+++ b/strands_robots/simulation/isaac/config.py
@@ -7,6 +7,7 @@ device selection, physics parameters, rendering, and headless mode.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -89,6 +90,108 @@ def _env_switch(name: str) -> bool | None:
     )
 
 
+#: A single USD prim name: an ASCII identifier, first character a letter or
+#: underscore. This is the alphabet
+#: :func:`strands_robots.simulation.isaac.joint_names._tf_make_valid_identifier`
+#: already encodes as USD's own rule -- it replaces every character outside
+#: ``[A-Za-z0-9_]``, and a first character outside ``[A-Za-z_]``, with ``_`` --
+#: so the two spellings of the rule in this package agree by construction.
+_PRIM_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def _stage_path_error(value: Any) -> str | None:
+    """Return an error message if ``value`` cannot prefix a USD prim path.
+
+    Every prim :class:`~strands_robots.simulation.isaac.simulation.IsaacSimulation`
+    creates is addressed by a path interpolated from this prefix and an entity
+    name -- ``f"{stage_path}/Robots/{name}"``, and the same shape for
+    ``/Objects/`` and ``/Cameras/``. The name half of that f-string already has
+    a domain: ``add_robot`` refuses a name that cannot address the robot it
+    creates on the shared :func:`strands_robots.utils.entity_name_error`, which
+    rejects a non-``str``, the empty string, and a string containing a NUL.
+    This is the same domain for the other half, so a path the API records is
+    one the API can address regardless of which component the caller got wrong.
+
+    Args:
+        value: The candidate :attr:`IsaacConfig.stage_path`.
+
+    Returns:
+        ``None`` when ``value`` is an absolute USD prim path with at least one
+        component, every component a prim name; otherwise a message naming the
+        field, the value, and the path it would have produced.
+
+    Four spellings are refused, each measured against the unbound
+    ``add_robot`` / ``remove_robot`` (no Isaac Sim or GPU needed -- the
+    procedural branch touches no stage). Before this domain every one of them
+    reported ``status="success"`` and recorded the interpolated string in
+    ``_prim_registry``, which is what :meth:`destroy` releases and counts:
+
+    * **Not a ``str``.** The f-string has no type requirement, so the value's
+      ``repr``-ish text became part of the path: ``stage_path=None`` recorded
+      ``None/Robots/arm`` -- the literal four characters -- ``stage_path=7``
+      recorded ``7/Robots/arm``, and ``stage_path=["/World"]`` recorded
+      ``['/World']/Robots/arm``. ``entity_name_error`` refuses a non-``str``
+      name for the same reason; a non-``str`` prefix is the same value arriving
+      through the other half.
+    * **Not absolute.** ``stage_path="World"`` recorded ``World/Robots/arm``, a
+      relative path. :meth:`IsaacSimulation.get_body_state` routes on exactly
+      that distinction -- ``if body_name.startswith("/")`` takes the stage
+      lookup, and ``elif "/" in body_name`` reads the value as
+      ``robot_name/link_name`` -- so a caller handing back the path the API
+      recorded is routed to the wrong branch, where ``World`` is looked up as a
+      robot name. ``"/"`` alone is refused with it: the root names no
+      component, and prefixing it yields ``//Robots/arm``.
+    * **An empty component.** ``"/World/"`` recorded ``/World//Robots/arm`` and
+      ``"/World//Sub"`` recorded ``/World//Sub/Robots/arm``. A doubled
+      separator is not a path component, and a trailing separator is the
+      likeliest way to write one, because the field is documented as a
+      *prefix*.
+    * **A component that is not a prim name.** ``"/My World"`` and
+      ``"/World\x00x"`` were both recorded verbatim. This is the half that is
+      not merely cosmetic: USD transcodes a prim name outside its identifier
+      alphabet, so the prim does not land at the path that was recorded for it.
+      This package already relies on that transcoding being real and
+      deterministic -- ``demangle_usd_joint_names`` exists to undo it for
+      joint names, where the URDF joint ``1`` imports as ``tn__1_`` -- and a
+      recorded path the stage does not carry is a prim :meth:`destroy` counts
+      and does not release.
+
+    The three ``bool``/numeric-domain fields of this dataclass are validated in
+    :meth:`IsaacConfig.__post_init__` and so is this one: the property is
+    lexical, it needs no engine, and ``stage_path`` has exactly one consumer
+    package. It is kept in this module rather than
+    :mod:`strands_robots.utils` for the reason :data:`ENV_SWITCH_ON` states --
+    AGENTS.md Key Convention 11 -- no other backend has a stage.
+    """
+    if not isinstance(value, str):
+        return (
+            f"IsaacConfig.stage_path must be a str, got {type(value).__name__} {value!r}. "
+            f"Every prim path is interpolated from it, so this one would address "
+            f"robots at {f'{value}/Robots/<name>'!r}. Use an absolute USD prim path "
+            f"such as '/World'."
+        )
+    components = value.split("/")
+    if not value.startswith("/"):
+        return (
+            f"IsaacConfig.stage_path must be an absolute USD prim path starting with '/', "
+            f"got {value!r}, which would address robots at {f'{value}/Robots/<name>'!r} -- "
+            f"a relative path. get_body_state() distinguishes an absolute prim path from a "
+            f"'<robot>/<link>' pair by that leading '/', so a relative prefix makes the path "
+            f"this backend records unusable as the key it records it for. Use '/World'."
+        )
+    if bad := [c for c in components[1:] if not _PRIM_NAME_RE.match(c)]:
+        return (
+            f"IsaacConfig.stage_path={value!r} is not a USD prim path: component "
+            f"{bad[0]!r} is not a prim name (an ASCII identifier matching "
+            f"[A-Za-z_][A-Za-z0-9_]*). It would address robots at "
+            f"{f'{value}/Robots/<name>'!r}; USD transcodes a name outside that "
+            f"alphabet, so the prim would not land at the path recorded for it, and "
+            f"an empty component (a doubled or trailing '/') is not a component at "
+            f"all. Use '/World' or '/World/<Identifier>'."
+        )
+    return None
+
+
 @dataclass
 class IsaacConfig:
     """Configuration for :class:`IsaacSimulation`.
@@ -135,7 +238,15 @@ class IsaacConfig:
     ground_plane : bool
         Whether to add a ground plane on ``create_world()``. Default True.
     stage_path : str
-        USD stage path prefix. Default ``"/World"``.
+        USD stage path prefix, and the root every prim this backend creates is
+        addressed under (``{stage_path}/Robots/{name}``, and the same shape for
+        ``/Objects/`` and ``/Cameras/``). Default ``"/World"``. Must be an
+        absolute USD prim path with at least one component, every component a
+        prim name (an ASCII identifier matching ``[A-Za-z_][A-Za-z0-9_]*``) --
+        the same requirement the name half of that path already carries via
+        :func:`strands_robots.utils.entity_name_error`. A value outside that
+        domain is refused on construction rather than interpolated into a path
+        the stage cannot carry.
     nucleus_url : str | None
         Override Omniverse Nucleus server URL. Default from env var
         ``STRANDS_ISAAC_NUCLEUS_URL`` or None (use Isaac defaults).
@@ -192,6 +303,12 @@ class IsaacConfig:
         # Validate camera dimensions
         if self.camera_width < 1 or self.camera_height < 1:
             raise ValueError(f"camera dimensions must be >= 1, got {self.camera_width}x{self.camera_height}")
+
+        # Validate stage_path. It is the other half of every prim path this
+        # backend interpolates; the name half is already refused on the shared
+        # ``entity_name_error`` domain at each creation site.
+        if (stage_err := _stage_path_error(self.stage_path)) is not None:
+            raise ValueError(stage_err)
 
         # Resolve nucleus_url from environment if not explicitly set
         if self.nucleus_url is None:

--- a/tests/simulation/isaac/test_stage_path_prefixes_a_usd_prim_path.py
+++ b/tests/simulation/isaac/test_stage_path_prefixes_a_usd_prim_path.py
@@ -1,0 +1,269 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: both halves of an Isaac prim path carry a domain.
+
+Every prim ``IsaacSimulation`` creates is addressed by a path interpolated from
+two caller-supplied components -- ``f"{stage_path}/Robots/{name}"``, and the
+same shape for ``/Objects/`` and ``/Cameras/``. The ``name`` half has a domain:
+``add_robot`` refuses a name that cannot address the robot it creates on the
+shared ``entity_name_error``, whose own docstring gives the reason in terms of
+this very f-string. ``IsaacConfig.stage_path`` -- the other half of the same
+string -- had none, so the values that half refuses by name were accepted
+through this one, and the interpolated result was recorded in
+``_prim_registry``, which is what ``destroy`` releases and counts:
+
+* ``stage_path=None`` recorded ``None/Robots/arm`` -- the literal four
+  characters -- ``stage_path=7`` recorded ``7/Robots/arm``, and
+  ``stage_path=["/World"]`` recorded ``['/World']/Robots/arm``.
+* ``stage_path="World"`` recorded the relative path ``World/Robots/arm``.
+  ``get_body_state`` routes on exactly that distinction (``if
+  body_name.startswith("/")`` takes the stage lookup; ``elif "/" in body_name``
+  reads the value as ``robot_name/link_name``), so a caller handing back the
+  path this backend recorded is routed to the wrong branch.
+* ``stage_path="/World/"`` recorded ``/World//Robots/arm``: a doubled separator
+  is not a path component, and a trailing separator is the likeliest way to
+  write one, because the field is documented as a *prefix*.
+* ``stage_path="/My World"`` and ``"/World\\x00x"`` were recorded verbatim. USD
+  transcodes a prim name outside its identifier alphabet, so the prim does not
+  land at the path recorded for it. That transcoding is not hypothetical here:
+  ``demangle_usd_joint_names`` exists to undo it for joint names, and this
+  package carries ``_tf_make_valid_identifier``, a clone of USD's own mangle,
+  which is used below as the oracle for what each refused component becomes.
+
+None of this needs Isaac Sim or a GPU. The domain is lexical, so most cells
+construct ``IsaacConfig`` alone; the recorded-path cells drive the unbound
+``add_robot`` against the ``types.SimpleNamespace`` stand-in for ``self`` that
+the neighbouring Isaac prim-path tests already use, because the procedural
+branch touches no stage.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import threading
+import types
+
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.joint_names import _tf_make_valid_identifier
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.utils import entity_name_error
+
+#: Prefixes that address a prim and must keep working. ``/World`` is the
+#: declared default; ``/World/Robots`` is unusual but is a real USD path, so it
+#: is the control that the domain checks the path's *shape* and not a vocabulary
+#: of blessed roots.
+_ACCEPTED = ("/World", "/Root", "/World/Env_0", "/World/Robots", "/_private")
+
+#: ``value -> the reason it cannot prefix a prim path``. Every reason is
+#: asserted non-empty below, so a row cannot be added without stating why.
+_REFUSED: dict[object, str] = {
+    None: "not a str: the f-string renders it as the literal text 'None'",
+    7: "not a str: renders as '7', an int the tool surface never sends",
+    True: "not a str: a bool renders as 'True'",
+    "": "empty: names no root at all, and is what entity_name_error calls unaddressable",
+    "/": "the root names no component, and prefixing it yields '//Robots/<name>'",
+    "World": "relative: get_body_state routes on the leading '/'",
+    "World/Sub": "relative, and read as a '<robot>/<link>' pair instead",
+    "/World/": "trailing separator leaves an empty final component",
+    "/World//Sub": "doubled separator is not a path component",
+    "/My World": "a space is outside USD's prim-name alphabet",
+    "/World\x00x": "a NUL, which entity_name_error refuses in the name half by name",
+    "/1World": "a leading digit is not a valid first identifier character",
+    "/World-2": "a hyphen is outside USD's prim-name alphabet",
+    "/World/bad name": "a nested component is checked too, not only the first",
+}
+
+#: The floor both halves of the f-string share. ``entity_name_error`` documents
+#: exactly these three -- a non-``str``, the empty string, a string containing a
+#: NUL -- so a value one half refuses must not be accepted by the other.
+_SHARED_FLOOR = (None, 7, True, ["x"], "", "a\x00b")
+
+
+def _refusal(stage_path: object) -> str | None:
+    """The message ``IsaacConfig`` refuses ``stage_path`` with, or ``None``.
+
+    Read through the public constructor rather than the domain helper, so these
+    cells grade the behaviour a caller sees and stay valid if the check moves.
+    """
+    try:
+        IsaacConfig(stage_path=stage_path)  # type: ignore[arg-type]
+    except ValueError as e:
+        return str(e)
+    return None
+
+
+def _stub(stage_path: str) -> types.SimpleNamespace:
+    """A stand-in for ``self`` carrying only what ``add_robot`` reads."""
+    return types.SimpleNamespace(
+        _lock=threading.RLock(),
+        _world_created=True,
+        _world=None,
+        _config=IsaacConfig(stage_path=stage_path),
+        _robots={},
+        _objects={},
+        _cameras={},
+        _action_controllers={},
+        _replicated=False,
+        _prim_registry=[],
+    )
+
+
+class TestAnAddressablePrefixIsAccepted:
+    """The domain checks the path's shape, and shapes that address a prim pass."""
+
+    @pytest.mark.parametrize("stage_path", _ACCEPTED)
+    def test_it_constructs(self, stage_path):
+        assert IsaacConfig(stage_path=stage_path).stage_path == stage_path
+
+    @pytest.mark.parametrize("stage_path", _ACCEPTED)
+    def test_the_recorded_prim_path_is_the_prefix_plus_the_name(self, stage_path):
+        """The prefix reaches ``_prim_registry`` unchanged -- nothing is rewritten."""
+        stub = _stub(stage_path)
+
+        assert IsaacSimulation.add_robot(stub, "arm", data_config="panda")["status"] == "success"  # type: ignore[arg-type]
+
+        assert stub._prim_registry == [f"{stage_path}/Robots/arm"]
+
+
+class TestAPrefixThatCannotAddressAPrimIsRefused:
+    """Each refused spelling raises on construction, naming the field."""
+
+    @pytest.mark.parametrize("value", list(_REFUSED))
+    def test_it_raises_value_error(self, value):
+        with pytest.raises(ValueError, match="IsaacConfig.stage_path"):
+            IsaacConfig(stage_path=value)
+
+    def test_every_refused_row_states_a_reason(self):
+        """A row may not be added to the roster without saying why."""
+        assert all(reason.strip() for reason in _REFUSED.values())
+
+    @pytest.mark.parametrize("value", list(_REFUSED))
+    def test_the_message_quotes_the_path_the_value_would_have_produced(self, value):
+        """A refusal that does not show the resulting path does not say what is wrong.
+
+        The path is quoted with ``!r`` so that a value whose damage is invisible
+        in raw text -- a NUL, a trailing space -- is legible in the message.
+        """
+        message = _refusal(value)
+
+        assert message is not None
+        assert repr(f"{value}/Robots/<name>") in message
+
+
+class TestTheRefusedPrefixesAreTheOnesThatWereRecorded:
+    """The harm each refused spelling used to cause, stated as the recorded path."""
+
+    @pytest.mark.parametrize(
+        ("value", "recorded"),
+        [
+            (None, "None/Robots/arm"),
+            (7, "7/Robots/arm"),
+            (["/World"], "['/World']/Robots/arm"),
+            ("", "/Robots/arm"),
+            ("/", "//Robots/arm"),
+            ("World", "World/Robots/arm"),
+            ("/World/", "/World//Robots/arm"),
+            ("/My World", "/My World/Robots/arm"),
+        ],
+    )
+    def test_the_interpolation_is_what_reached_the_registry(self, value, recorded):
+        """Pins the pre-fix behaviour: ``add_robot`` recorded this string.
+
+        The interpolation itself is asserted rather than re-run through
+        ``add_robot``, because ``add_robot`` can no longer be reached with these
+        values -- the config refuses them first, which is the fix.
+        """
+        assert f"{value}/Robots/arm" == recorded
+
+    @pytest.mark.parametrize("value", ["/My World", "/World\x00x", "/1World", "/World-2"])
+    def test_usd_would_not_carry_the_recorded_path(self, value):
+        """The component USD keeps differs from the one that was recorded.
+
+        ``_tf_make_valid_identifier`` is this package's clone of USD's own
+        mangle, already relied on by ``demangle_usd_joint_names``. A component
+        it rewrites is a component the stage does not carry under the name
+        ``_prim_registry`` recorded, so ``destroy`` would count a prim it cannot
+        release.
+        """
+        component = value.split("/")[-1]
+
+        assert _tf_make_valid_identifier(component) != component
+
+    def test_a_component_usd_keeps_verbatim_is_accepted(self):
+        """The control for the cell above: the rule is USD's, not a stricter one."""
+        assert _tf_make_valid_identifier("Env_0") == "Env_0"
+        assert IsaacConfig(stage_path="/World/Env_0").stage_path == "/World/Env_0"
+
+
+class TestBothHalvesOfThePrimPathShareOneFloor:
+    """A value the name half refuses is not accepted through the prefix half.
+
+    The prim path is one string built from two components. Grading the two
+    domains against each other is what keeps them from drifting apart again:
+    ``entity_name_error`` documents a non-``str``, the empty string and an
+    embedded NUL as unaddressable, and gives ``{stage_path}/Robots/{name}`` as
+    the reason, so the prefix cannot accept what the name refuses.
+    """
+
+    @pytest.mark.parametrize("value", _SHARED_FLOOR)
+    def test_the_name_half_refuses_it(self, value):
+        assert entity_name_error("add_robot", "name", value) is not None
+
+    @pytest.mark.parametrize("value", _SHARED_FLOOR)
+    def test_the_prefix_half_refuses_it_too(self, value):
+        # A NUL arrives inside a component when it arrives through the prefix.
+        candidate = f"/{value}" if isinstance(value, str) and value else value
+
+        assert _refusal(candidate) is not None
+
+    def test_the_identifier_rule_is_the_prefix_halfs_alone(self):
+        """A deliberate asymmetry, recorded so it reads as a decision.
+
+        ``stage_path`` means one thing -- a USD prim path -- and has one
+        consumer package, so it takes USD's whole prim-name rule.
+        ``entity_name_error`` is shared with the MuJoCo and Newton backends,
+        whose entity names are not USD identifiers, so widening it to the
+        identifier alphabet is a cross-backend decision this domain does not
+        make. A name outside the alphabet stays accepted there.
+        """
+        assert entity_name_error("add_robot", "name", "My World") is None
+        assert _refusal("/My World") is not None
+
+
+class TestTheDomainIsReachedThroughEveryConstructionDoor:
+    """No door onto ``stage_path`` skips the domain."""
+
+    def test_the_dataclass_constructor(self):
+        with pytest.raises(ValueError, match="IsaacConfig.stage_path"):
+            IsaacConfig(stage_path="/World/")
+
+    def test_from_kwargs(self):
+        with pytest.raises(ValueError, match="IsaacConfig.stage_path"):
+            IsaacConfig.from_kwargs(stage_path="World")
+
+    def test_dataclasses_replace_on_a_valid_config(self):
+        """``IsaacSimulation.__init__`` merges shortcut kwargs this way."""
+        with pytest.raises(ValueError, match="IsaacConfig.stage_path"):
+            dataclasses.replace(IsaacConfig(), stage_path="/World//Sub")
+
+    def test_the_simulation_shortcut_kwarg(self):
+        with pytest.raises(ValueError, match="IsaacConfig.stage_path"):
+            IsaacSimulation(stage_path="/My World")
+
+    def test_a_path_object_is_refused_although_it_rendered_correctly(self):
+        """The one spelling this widens: a ``PurePosixPath`` used to work.
+
+        ``f"{PurePosixPath('/World')}"`` renders ``/World``, so the recorded
+        path was right and only the declared type was wrong. It is refused for
+        the same reason the name half refuses a non-``str`` name that renders
+        fine: the field is annotated ``str``, and admitting one non-``str`` that
+        happens to render correctly is what admits ``None``, whose rendering is
+        the literal text ``None``.
+        """
+        assert f"{pathlib.PurePosixPath('/World')}/Robots/arm" == "/World/Robots/arm"
+
+        with pytest.raises(ValueError, match="must be a str"):
+            IsaacConfig(stage_path=pathlib.PurePosixPath("/World"))


### PR DESCRIPTION
Every prim `IsaacSimulation` creates is addressed by a path interpolated from **two** caller-supplied components: `f"{stage_path}/Robots/{name}"`, and the same shape for `/Objects/` and `/Cameras/`. The `name` half already has a domain -- `add_robot` refuses a name that cannot address the robot it creates on the shared `entity_name_error`, whose docstring gives *this very f-string* as the reason. `IsaacConfig.stage_path`, the other half of the same string, had none.

So the values that half refuses by name were accepted through this one, and the interpolated result was recorded in `_prim_registry` -- which is what `destroy()` releases and counts.

![stage_path domain, measured on both trees](https://raw.githubusercontent.com/cagataycali/pr-assets/main/isaac-stage-path-domain-3269.png)

21 prefixes driven through the unbound `add_robot` on both trees (the procedural branch touches no stage, so this needs no Isaac Sim and no GPU). 5 address a prim; **16 were accepted and recorded anyway**, 14 of them at a path USD does not carry. The right-hand column is the oracle: `_tf_make_valid_identifier`, this package's clone of USD's own mangle, already relied on by `demangle_usd_joint_names` to undo it for joint names.

## What each refused spelling did

| `stage_path` | recorded in `_prim_registry` | why it cannot address a prim |
|---|---|---|
| `None` | `None/Robots/arm` | the f-string has no type requirement, so the value's rendered text became the path -- here the literal four characters `None` |
| `7`, `True`, `['/World']` | `7/Robots/arm`, `True/...`, `['/World']/...` | same |
| `"World"` | `World/Robots/arm` | relative. `get_body_state` routes on exactly this distinction: `if body_name.startswith("/")` takes the stage lookup, `elif "/" in body_name` reads the value as `robot_name/link_name` -- so a caller handing back the path this backend recorded is routed to the wrong branch, looking up `World` as a robot |
| `"/World/"`, `"/World//Sub"`, `"/"` | `/World//Robots/arm` | a doubled separator is not a path component. A trailing separator is the likeliest way to write one, because the field is documented as a *prefix* |
| `"/My World"`, `"/World\x00x"`, `"/1World"`, `"/World-2"` | recorded verbatim | USD transcodes a prim name outside its identifier alphabet (`My World` -> `My_World`, `1World` -> `_World`), so the prim does not land at the path recorded for it -- a prim `destroy()` counts and cannot release |
| `""` | `/Robots/arm` | a valid path, but the empty string is exactly what `entity_name_error` refuses in the name half, and it names no root |

## The change

`stage_path` is validated in `IsaacConfig.__post_init__`, beside the `render_mode` / `device` / `num_envs` / `physics_dt` / camera-dimension domains, as an absolute USD prim path with at least one component, every component matching `[A-Za-z_][A-Za-z0-9_]*`. The property is lexical and needs no engine, and the domain is kept in this module for the reason `ENV_SWITCH_ON` already states (Key Convention 11) -- no other backend has a stage. Every door is covered and pinned: `IsaacConfig(...)`, `from_kwargs()`, `dataclasses.replace()` (how `IsaacSimulation.__init__` merges shortcut kwargs), and `IsaacSimulation(stage_path=...)`. Each refusal names the field and quotes, with `!r`, the path the value would have produced -- so a NUL or a trailing space is legible.

**One previously working spelling is now refused.** `PurePosixPath("/World")` rendered as `/World`, so the recorded path was correct and only the declared type was wrong. It is refused for the same reason the name half refuses a non-`str` name that renders fine: the field is annotated `str`, and admitting one non-`str` because it happens to render correctly is what admitted `None`, whose rendering is the literal text `None`. It is called out as its own class in the figure rather than painted as a defect. No caller in the tree sets `stage_path` to anything, so nothing in-tree changes behaviour.

**One deliberate asymmetry, pinned as a cell with its reason.** The identifier rule applies to the prefix only. `stage_path` means one thing -- a USD prim path -- and has one consumer package, so it takes USD's whole prim-name rule. `entity_name_error` is shared with the MuJoCo and Newton backends, whose entity names are not USD identifiers, so widening *it* to the identifier alphabet is a cross-backend decision this change does not make; `add_robot("My World")` stays accepted.

## Tests

`tests/simulation/isaac/test_stage_path_prefixes_a_usd_prim_path.py`, 70 cells, 0.14 s. Cells read the refusal through the public constructor rather than the domain helper, so they grade behaviour and stay valid if the check moves. The load-bearing one grades the two halves of the f-string **against each other** -- a non-`str`, the empty string and an embedded NUL are refused by `entity_name_error` *and* by the prefix -- so the two domains cannot drift apart again.

Four corners on `tests/simulation/isaac`:

| | old `config.py` | new `config.py` |
|---|---|---|
| **old tests** | 2009 passed | 2009 passed |
| **+ new test** | **40 failed**, 2039 passed | 2079 passed |

`2009 + 70 = 2079`; the bottom-left cell is identical to the top-left, so nothing existing moved, and 30 of the 70 cells are controls that hold on the old tree. The 40 failures are red *cells*, not a collection error.

Gate: `ruff check` / `ruff format --check` clean on both changed files; `mypy strands_robots tests tests_integ` unchanged at its 20 standing errors (19 in `examples/isaac_gs`, 1 in `simulation/ik.py`), none in these files; the wider net (`-k "isaac or docstring or docs or changelog or ascii or grader or export or host_path or architecture or xref or entity_name or stage"`) 5039 passed, with the one pre-existing `rebot_b601` registry-vs-lerobot row failing identically on `main`.

## Size

| | lines |
|---|---|
| `strands_robots/simulation/isaac/config.py` | +118 -1 |
| `tests/.../test_stage_path_prefixes_a_usd_prim_path.py` | +269 |
| `docs/simulation/isaac.md` | +14 -1 |
| `changelog.d/` | +22 |
| **total** | **+423 -2** |

The 118 prod lines are 41 code + 63 docstring + 9 comment + 5 blank; the code collapses to **13 executable statements** (the refusal messages are multi-line f-strings).