### PR TITLE
fix(training/rl): the device every RL backend places its tensors on gets a domain

### DIFF
--- a/changelog.d/3270-rl-device-domain.md
+++ b/changelog.d/3270-rl-device-domain.md
@@ -1,0 +1,17 @@
+### Fixed: an RL `device` no torch build can parse is reported by `validate()` instead of aborting `setup()`
+
+All three from-scratch RL backends (`PpoTrainer`, `FastSacTrainer`, `FastTd3Trainer`)
+hand `RLTrainSpec.device` straight to `torch.device` in `setup()`, and every
+network, replay buffer and rollout tensor the run allocates is placed on the
+result. `device` was the one caller-supplied knob on that spec with no domain, so
+`validate()` returned `[]` -- which `Trainer.validate` documents as meaning the
+spec IS launchable -- for a spec that cannot launch: `"gpu"` and `"cuda:abc"`
+raised out of `setup()`, and a non-string ordinal such as `1` constructed on any
+host and then died at the first `.to()` with `CUDA error: invalid device ordinal`
+from a `torch/nn/modules/module.py` frame naming neither the field nor the run.
+
+The domain now lives in one place, `strands_robots.utils.torch_device_error`, which
+the RL preflight, `LerobotTrainer` and the `lerobot_train` tool all consult -- the
+same consolidation `step_cadence_error` already applies to the `save_freq` beside
+`device` in that tool's argv. Only the spelling is graded, never availability, and
+an unstated (falsy) device still resolves through each surface's documented default.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -136,6 +136,17 @@ device as the network (no cross-device tensor mismatch and no per-step
 host-to-device copies). Pass `device="cpu"` explicitly to keep everything on
 CPU even on a GPU machine.
 
+`validate()` refuses a `device` no torch build can parse, before `setup()` builds
+anything, on the same domain the `lerobot_train` tool and `LerobotTrainer` apply
+to the value they hand to lerobot. Only the *spelling* is graded, never
+availability: `device="cuda"` on a CPU-only host is a valid spec, because a
+queued or containerised run is written on one machine and executed on another. A
+non-string is refused without consulting torch at all -- `torch.device(1)`
+constructs on any host and then fails at the first `.to()` with `CUDA error:
+invalid device ordinal`, so asking torch about an ordinal would make one spec
+launch on a multi-GPU box and abort on a single-GPU one. Leaving `device` unset
+(or falsy) still selects the documented default above.
+
 ## FastSAC
 
 `FastSacTrainer` is the **off-policy** trainer: it keeps a replay buffer of past

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -44,6 +44,7 @@ from strands_robots.utils import (
     positive_count_error,
     stale_output_dir_is_clearable,
     step_cadence_error,
+    torch_device_error,
     validation_split_error,
     validation_split_fraction,
 )
@@ -533,43 +534,17 @@ def _torch_device_error(device: Any) -> str | None:
     the reason the run-size numerics in the same argv are refused up front, and
     ``device`` is the one token beside them that was carried through unchecked.
 
-    The admitted domain is torch's own, read by handing the value to
-    ``torch.device`` rather than by comparing against a copied list of device
-    types - the same "source the domain live" shape as
-    :func:`_expert_only_policy_types` and :func:`_policy_config_field_names`
-    above. A torch build that gains a backend is admitted here with no change,
-    and torch's own exception enumerates the types it accepts, so the refusal
-    names the admitted set without restating it.
-
-    Only the spelling is graded, never availability: ``torch.device("cuda")``
-    constructs on a CPU-only box and must keep building an argv there, because a
-    queued or containerised run legitimately names a device the dispatching
-    machine does not currently have. A non-``str`` is refused before torch is
-    consulted for that reason - ``torch.device(0)`` reads the accelerator
-    inventory (``Cannot access accelerator device when none is available``),
-    which would make the same request build here and refuse there.
-
-    When torch is not importable the domain is unknown and the value passes
-    through unguarded, as :func:`_policy_config_field_names` documents for its
-    own field set.
+    That reason is why the check happens *at this point in this tool*. The domain
+    itself belongs to neither surface - :class:`~strands_robots.training.lerobot.LerobotTrainer`
+    reaches the identical lerobot field in-process, and the from-scratch RL
+    backends hand the same quantity to ``torch.device`` directly - so it
+    delegates to :func:`~strands_robots.utils.torch_device_error`, the one owner
+    all three consult, exactly as :func:`_save_freq_error` below delegates the
+    cadence in this same argv. The value is asked about as given: this argv
+    carries whatever it is handed, so a falsy device is a token that names
+    nothing rather than a request for the default.
     """
-    if not isinstance(device, str):
-        return (
-            f"lerobot_train: device must be a torch device string, got {type(device).__name__}. "
-            "Pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
-        )
-    try:
-        import torch
-    except Exception:  # noqa: BLE001 - torch missing -> domain unknown, pass through
-        return None
-    try:
-        torch.device(device)
-    except (RuntimeError, ValueError) as e:
-        return (
-            f"lerobot_train: device={device!r} is not a torch device string ({e}). "
-            "Pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
-        )
-    return None
+    return torch_device_error(device, "device", "lerobot_train")
 
 
 def _save_freq_error(value: Any) -> str | None:

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -172,6 +172,7 @@ from strands_robots.utils import (
     positive_count_error,
     positive_finite_number_error,
     step_cadence_error,
+    torch_device_error,
 )
 
 if TYPE_CHECKING:
@@ -353,6 +354,62 @@ def rl_run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
         if error is not None:
             problems.append(error)
     return problems
+
+
+def torch_device_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return device problems for a from-scratch RL :class:`RLTrainSpec`.
+
+    All three RL backends resolve the device the same way in :meth:`setup`::
+
+        self.device = torch.device(spec.device or ("cuda" if torch.cuda.is_available() else "cpu"))
+
+    so ``device`` is spent by ``torch.device`` itself, which judges nothing on
+    this spec's behalf, and every network, buffer and rollout tensor the run
+    allocates is placed on the result. ``device`` was the one caller-supplied
+    knob on this spec with no domain - the sentence the sibling supervised
+    preflight already uses about its own surface - while the counts, the
+    interval coefficients, the loss weights, the learning rate, the seed, the
+    launch topology and the network width beside it are all held to one.
+
+    Measured on a 6-DoF SO-101 MuJoCo env with PPO, ``validate()`` returning
+    ``[]`` - which :meth:`~strands_robots.training.base.Trainer.validate`
+    documents as meaning the spec IS launchable - for each of these:
+
+    * ``"gpu"`` (the ordinary mistake: the word the rest of the world uses)
+      and ``"cuda:abc"`` raise ``RuntimeError`` out of ``setup`` from the
+      ``torch.device`` line itself, after the preflight passed.
+    * ``1`` is worse, and is why a non-``str`` is refused before torch is
+      consulted: ``torch.device(1)`` constructs on ANY host, so the run reaches
+      the first ``.to()`` and dies with ``CUDA error: invalid device ordinal``
+      raised from a ``torch/nn/modules/module.py`` frame that names neither the
+      field nor the run - and the same spec would train on a host with more
+      GPUs. One spec, two answers, decided by the machine's inventory.
+
+    The domain is :func:`~strands_robots.utils.torch_device_error`, the one owner
+    the ``lerobot_train`` tool and :class:`~strands_robots.training.lerobot.LerobotTrainer`
+    also consult, so a device the supervised trainer refuses is not accepted by
+    the RL backend beside it.
+
+    A falsy ``device`` is NOT refused: the ``spec.device or ...`` above documents
+    it as "resolve the default", exactly as the supervised trainer's constructor
+    does, so it never reaches ``torch.device`` as written and is not this gate's
+    to judge. Availability is not graded either - ``"cuda"`` on a CPU-only box is
+    a valid spec, because a queued run is written on one host and executed on
+    another.
+
+    Args:
+        spec: The spec to preflight.
+        context: Provider name, prefixed to the message.
+
+    Returns:
+        A single-element list when ``device`` cannot be honored; empty when it
+        can, when it is unstated, or when torch is not importable.
+    """
+    device = getattr(spec, "device", None)
+    if not device:
+        return []
+    problem = torch_device_error(device, "device", context)
+    return [] if problem is None else [problem]
 
 
 def rl_replay_problems(spec: TrainSpec, *, context: str) -> list[str]:

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -886,6 +886,31 @@ class Trainer(ABC):
 
         return polyak_coefficient_problems(spec, context=self.provider_name)
 
+    def _spec_device_problems(self, spec: TrainSpec) -> list[str]:
+        """Device preflight for a backend that places its tensors from the spec.
+
+        Returns a problem when :attr:`RLTrainSpec.device` is not a device string
+        torch can parse. Distinct from
+        :meth:`~strands_robots.training.lerobot.LerobotTrainer._device_problems`,
+        which grades that trainer's ``device`` *constructor* knob: this one grades
+        the field on the spec, which is where the from-scratch RL backends carry
+        it. Both consult one domain,
+        :func:`~strands_robots.utils.torch_device_error`.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+
+        Args:
+            spec: The spec to preflight.
+
+        Returns:
+            A single-element list when ``device`` cannot be honored; empty when
+            it can or when it is unstated.
+        """
+        from strands_robots.training._validate import torch_device_problems
+
+        return torch_device_problems(spec, context=self.provider_name)
+
     def _gradient_clip_problems(self, spec: TrainSpec) -> list[str]:
         """Gradient-clip preflight for a backend that clips before it steps.
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -64,6 +64,7 @@ from strands_robots.utils import (
     declared_count,
     lerobot_version,
     stale_output_dir_is_clearable,
+    torch_device_error,
     validation_split_error,
     validation_split_fraction,
 )
@@ -825,40 +826,17 @@ class LerobotTrainer(Trainer):
         ``dataset_repo_id`` against ``_HUB_REPO_ID_RE``. ``device`` was the one
         knob beside them with none.
 
-        The admitted domain is torch's own, read by handing the value to
-        ``torch.device`` rather than by comparing against a copied list of
-        device types, so a torch build that gains a backend is admitted here
-        with no change and torch's own exception enumerates the types it
-        accepts. Only the spelling is graded, never availability:
-        ``torch.device("cuda")`` constructs on a CPU-only box, and a spec
-        legitimately names a device the machine writing it does not have - a
-        queued or containerised run is dispatched from one host and executed on
-        another. A non-``str`` is refused before torch is consulted for that
-        same reason, because ``torch.device(0)`` reads the accelerator inventory
-        and would make one spec validate on a GPU box and fail on a CPU box.
+        What stays here is the reason the check happens on *this* surface. The
+        domain is :func:`~strands_robots.utils.torch_device_error`, the one owner
+        the ``lerobot_train`` tool and the from-scratch RL preflight also consult,
+        so a device this trainer refuses cannot be accepted by the tool that
+        builds an argv for the same pipeline or by the RL backend beside it.
 
-        When torch is not importable the domain is unknown and the value passes
-        through unguarded, which is the same posture the reward-model field set
-        takes when its registry cannot be read.
+        The falsy case never reaches the domain: ``__init__`` resolves it through
+        :func:`_auto_device` first, which is what the constructor documents, so
+        ``self.device`` is always a stated device by the time it is graded here.
         """
-        device = self.device
-        if not isinstance(device, str):
-            return [
-                f"device must be a torch device string, got {type(device).__name__}; "
-                "pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
-            ]
-        try:
-            import torch
-        except Exception:  # noqa: BLE001 - torch missing -> domain unknown, pass through
-            return []
-        try:
-            torch.device(device)
-        except (RuntimeError, ValueError) as e:
-            return [
-                f"device={device!r} is not a torch device string ({e}); "
-                "pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
-            ]
-        return []
+        return [p for p in (torch_device_error(self.device, "device", self.provider_name),) if p is not None]
 
     # ---- ABC ---------------------------------------------------------------
 

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -194,6 +194,13 @@ class FastSacTrainer(BaseRLAlgo):
         # being a function of the observation, and the run reports success while
         # exporting a deployable checkpoint whose actor is one fixed action.
         problems.extend(self._network_width_problems(spec))
+        # device is spent by torch.device itself, which judges nothing: every
+        # network, buffer and rollout tensor is placed on the result. "gpu" and
+        # "cuda:abc" raise out of setup after the preflight passed, and a
+        # non-str ordinal constructs on any host and then dies at the first
+        # .to() with "invalid device ordinal" - the same spec training fine on a
+        # box with more GPUs.
+        problems.extend(self._spec_device_problems(spec))
         # tau is the rate at which the target critics track the online ones,
         # spent as tp.mul_(1.0 - spec.tau).add_(spec.tau * p) per mirrored pair,
         # so it decides whether a separate target network exists at all. A bare

--- a/strands_robots/training/rl/fast_td3.py
+++ b/strands_robots/training/rl/fast_td3.py
@@ -187,6 +187,13 @@ class FastTd3Trainer(BaseRLAlgo):
         # being a function of the observation, and the run reports success while
         # exporting a deployable checkpoint whose actor is one fixed action.
         problems.extend(self._network_width_problems(spec))
+        # device is spent by torch.device itself, which judges nothing: every
+        # network, buffer and rollout tensor is placed on the result. "gpu" and
+        # "cuda:abc" raise out of setup after the preflight passed, and a
+        # non-str ordinal constructs on any host and then dies at the first
+        # .to() with "invalid device ordinal" - the same spec training fine on a
+        # box with more GPUs.
+        problems.extend(self._spec_device_problems(spec))
         # tau is the rate at which the target critics track the online ones,
         # spent as tp.mul_(1.0 - spec.tau).add_(spec.tau * p) per mirrored pair,
         # so it decides whether a separate target network exists at all. A bare

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -187,6 +187,13 @@ class PpoTrainer(BaseRLAlgo):
         # being a function of the observation, and the run reports success while
         # exporting a deployable checkpoint whose actor is one fixed action.
         problems.extend(self._network_width_problems(spec))
+        # device is spent by torch.device itself, which judges nothing: every
+        # network, buffer and rollout tensor is placed on the result. "gpu" and
+        # "cuda:abc" raise out of setup after the preflight passed, and a
+        # non-str ordinal constructs on any host and then dies at the first
+        # .to() with "invalid device ordinal" - the same spec training fine on a
+        # box with more GPUs.
+        problems.extend(self._spec_device_problems(spec))
         # num_envs is the third factor of that same product. Which *counts* are
         # usable is per-backend - this one parallelizes, so any positive count is,
         # while the single-env FastSAC requires exactly 1 - but that a count is

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1361,6 +1361,12 @@ def torch_device_error(value: Any, param: str, context: str) -> str | None:
     through unguarded, which is the posture every live-sourced domain in this
     module takes when its source cannot be read.
 
+    The refused value is rendered through :func:`_refusal_repr`, as every scalar
+    guard here is: ``repr`` can itself raise - on an ``int`` wider than
+    :func:`sys.get_int_max_str_digits`, or from any third-party ``__repr__`` - and
+    a guard that raises while building a refusal fails on exactly the path that
+    exists so it does not.
+
     Args:
         value: The caller-supplied device.
         param: Field name, quoted in the message so the refusal names the knob.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1383,7 +1383,7 @@ def torch_device_error(value: Any, param: str, context: str) -> str | None:
         torch.device(value)
     except (RuntimeError, ValueError) as e:
         return (
-            f"{context}: {param}={value!r} is not a torch device string ({e}). "
+            f"{context}: {param}={_refusal_repr(value)} is not a torch device string ({e}). "
             "Pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
         )
     return None

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1319,6 +1319,76 @@ def step_cadence_error(value: Any, param: str, context: str) -> str | None:
     return None
 
 
+def torch_device_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a device string torch can parse.
+
+    Shared domain for every caller-supplied torch device this package spends. It
+    reaches torch from three surfaces that cannot be reconciled after the fact:
+    the ``lerobot_train`` tool interpolates it into ``--policy.device=`` in the
+    argv of a DETACHED process; :class:`~strands_robots.training.lerobot.LerobotTrainer`
+    assigns it onto ``policy_cfg.device`` for the same pipeline in-process; and
+    the from-scratch RL backends hand
+    :attr:`~strands_robots.training.rl.base_algo.RLTrainSpec.device` straight to
+    ``torch.device`` in :meth:`setup`. The domain lives here for the reason
+    :func:`step_cadence_error` gives for the cadence beside it in that same argv:
+    those callers sit in different layers, and the same device must not be
+    refused by one and accepted by another that wraps the identical pipeline.
+
+    The admitted set is torch's own, read by handing the value to
+    ``torch.device`` rather than by comparing against a copied list of device
+    types. A torch build that gains a backend is admitted here with no edit, and
+    torch's own exception enumerates the types it accepts, so a refusal names the
+    admitted set without restating it.
+
+    Only the *spelling* is graded, never availability. ``torch.device("cuda")``
+    constructs on a CPU-only box and must stay accepted, because a queued or
+    containerised run legitimately names a device the dispatching machine does
+    not have. That is also why a non-``str`` is refused before torch is
+    consulted at all: ``torch.device(0)`` reads the accelerator inventory, so
+    asking torch about it would make one spec validate on a GPU box and fail on a
+    CPU box - and an ordinal that does resolve is worse than one that does not,
+    because ``torch.device(1)`` constructs on any host and then fails at the
+    first ``.to()`` with ``CUDA error: invalid device ordinal``, from a
+    ``torch/nn/modules/module.py`` frame that names neither the parameter nor the
+    run that supplied it.
+
+    Whether an *unstated* device is refused belongs to the caller, not here: a
+    surface that documents a falsy value as "resolve the default" replaces it
+    before asking, and one that writes the value into an argv verbatim asks about
+    it as given. This function grades the value it is handed.
+
+    When torch is not importable the domain is unknown and the value passes
+    through unguarded, which is the posture every live-sourced domain in this
+    module takes when its source cannot be read.
+
+    Args:
+        value: The caller-supplied device.
+        param: Field name, quoted in the message so the refusal names the knob.
+        context: Public surface or provider name, prefixed to the message.
+
+    Returns:
+        An error message naming *context* and *param*, or ``None`` when torch can
+        parse the value.
+    """
+    if not isinstance(value, str):
+        return (
+            f"{context}: {param} must be a torch device string, got {type(value).__name__}. "
+            "Pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
+        )
+    try:
+        import torch
+    except Exception:  # noqa: BLE001 - torch missing -> domain unknown, pass through
+        return None
+    try:
+        torch.device(value)
+    except (RuntimeError, ValueError) as e:
+        return (
+            f"{context}: {param}={value!r} is not a torch device string ({e}). "
+            "Pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
+        )
+    return None
+
+
 #: Highest DDS domain id whose RTPS discovery ports fit the 16-bit port space.
 #:
 #: RTPS derives every discovery port from the domain id (RTPS 2.2 sec. 9.6.1.1):

--- a/tests/training/test_lerobot_trainer_device_domain.py
+++ b/tests/training/test_lerobot_trainer_device_domain.py
@@ -22,9 +22,12 @@ Two properties are deliberately NOT graded, and both have a control below:
   a queued or containerised run is dispatched from one host and executed on
   another.
 * **the tool surface's own answer** - ``tools.lerobot_train`` holds the same
-  value to the same domain for its own detached argv. The two live in layers that
-  cannot import each other, so the rule is stated twice; the parity test here is
-  what keeps the two admitted sets from drifting, rather than an alias.
+  value to the same domain for its own detached argv, and the from-scratch RL
+  backends hand the same quantity to ``torch.device`` directly. All three ask one
+  owner, :func:`~strands_robots.utils.torch_device_error`, for the reason
+  :func:`~strands_robots.utils.step_cadence_error` gives for the cadence beside
+  ``device`` in that same argv: the callers sit in different layers, so the domain
+  lives with neither of them. The parity test here still pins that they agree.
 """
 
 import json
@@ -142,13 +145,24 @@ class TestTheAdmittedDomainIsTorchsOwn:
         )
 
     def test_the_domain_is_read_from_torch_rather_than_a_copied_list(self) -> None:
-        """No device-type vocabulary is restated here, so a new backend needs no edit."""
+        """No device-type vocabulary is restated, so a new torch backend needs no edit.
+
+        The rule itself lives in :func:`~strands_robots.utils.torch_device_error`,
+        which this trainer asks; what is graded here is that asking it is all this
+        surface does, and that the owner reads the admitted set from torch instead
+        of enumerating it.
+        """
         import inspect
 
         src = inspect.getsource(LerobotTrainer._device_problems)
-        assert "torch.device(device)" in src
+        assert "torch_device_error" in src, "the trainer no longer routes through the shared owner"
+
+        from strands_robots.utils import torch_device_error
+
+        owner = inspect.getsource(torch_device_error)
+        assert "torch.device(value)" in owner
         for copied in ("xpu", "mkldnn", "opengl", "vulkan", "hpu"):
-            assert copied not in src, f"the domain restates a torch device type: {copied}"
+            assert copied not in owner, f"the domain restates a torch device type: {copied}"
 
 
 class TestWhatThisDeliberatelyDoesNotGrade:

--- a/tests/training/test_rl_trainer_device_domain.py
+++ b/tests/training/test_rl_trainer_device_domain.py
@@ -181,11 +181,18 @@ class TestTheDomainHasOneOwner:
         return names
 
     def test_no_consumer_re_implements_the_domain(self) -> None:
-        """Exactly one function calls ``torch.device``; the rest ask it."""
+        """Exactly one function calls ``torch.device``; the rest ask it.
+
+        The tool's guard is imported as a *function* rather than off its module:
+        a tool and its module share a name on the ``tools`` package, and
+        ``import strands_robots.tools.lerobot_train as mod`` binds by attribute
+        lookup on that package - so in a session that has already touched the
+        tool, ``mod`` is the ``DecoratedFunctionTool``, not the module.
+        """
         import inspect
 
-        import strands_robots.tools.lerobot_train as tool_mod
         from strands_robots import utils
+        from strands_robots.tools.lerobot_train import _torch_device_error as tool_device_error
         from strands_robots.training import _validate
         from strands_robots.training.lerobot import LerobotTrainer
 
@@ -194,7 +201,7 @@ class TestTheDomainHasOneOwner:
 
         for consumer in (
             _validate.torch_device_problems,
-            tool_mod._torch_device_error,
+            tool_device_error,
             LerobotTrainer._device_problems,
         ):
             calls = self._calls(inspect.getsource(consumer))

--- a/tests/training/test_rl_trainer_device_domain.py
+++ b/tests/training/test_rl_trainer_device_domain.py
@@ -1,0 +1,272 @@
+"""``RLTrainSpec.device`` is held to torch's device-string domain by ``validate``.
+
+All three from-scratch RL backends resolve the device the same way in
+:meth:`setup`::
+
+    self.device = torch.device(spec.device or ("cuda" if torch.cuda.is_available() else "cpu"))
+
+so ``device`` is spent by ``torch.device`` itself - which judges nothing on the
+spec's behalf - and every network, replay buffer and rollout tensor the run
+allocates is placed on the result. ``device`` was the one caller-supplied knob on
+this spec with no domain, while the counts, the interval coefficients, the loss
+weights, the learning rate, the seed, the launch topology and the network width
+beside it are all held to one. So
+:meth:`~strands_robots.training.base.Trainer.validate` returned ``[]`` - the one
+thing its contract says an empty list does not mean - for a spec that cannot
+launch.
+
+Measured on a 6-DoF SO-101 MuJoCo env with PPO before this gate, each under
+``validate() == []``:
+
+* ``"gpu"`` - the ordinary mistake, the word the rest of the world uses - and
+  ``"cuda:abc"`` raise ``RuntimeError`` out of ``setup`` from the
+  ``torch.device`` line itself.
+* ``1`` is worse, and is why a non-``str`` is refused before torch is consulted:
+  ``torch.device(1)`` constructs on ANY host, so the run reached the first
+  ``.to()`` and died with ``CUDA error: invalid device ordinal`` raised from a
+  ``torch/nn/modules/module.py`` frame naming neither the field nor the run - and
+  the same spec would train on a host with more GPUs. One spec, two answers,
+  decided by the machine's inventory.
+
+The domain is :func:`~strands_robots.utils.torch_device_error`, the one owner the
+``lerobot_train`` tool and
+:class:`~strands_robots.training.lerobot.LerobotTrainer` also consult. Two
+properties are deliberately NOT graded, and both have a control below:
+**availability** (a spec legitimately names a device the machine writing it does
+not have, because a queued run is dispatched from one host and executed on
+another) and **an unstated device** (``spec.device or ...`` documents a falsy
+value as "resolve the default", so it never reaches ``torch.device`` as written).
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl.base_algo import RLTrainSpec
+from strands_robots.training.rl.fast_sac import FastSacTrainer
+from strands_robots.training.rl.fast_td3 import FastTd3Trainer
+from strands_robots.training.rl.ppo import PpoTrainer
+
+#: The three backends that carry ``RLTrainSpec.device`` into ``torch.device``.
+BACKENDS = (PpoTrainer, FastSacTrainer, FastTd3Trainer)
+
+#: Measured against torch's own ``torch.device`` on this tree. ``'gpu'`` is the
+#: ordinary mistake; ``1`` and ``2.0`` are the non-``str`` case torch would
+#: answer by reading the accelerator inventory.
+UNUSABLE: tuple[Any, ...] = ("gpu", "CUDA", "nvidia", "cuda:abc", "  ", 1, 2.0, ["cuda"])
+
+#: A device type, optionally with an index. ``'mps'`` is here on a box that does
+#: not have it: the spelling is the domain, not the inventory.
+USABLE = ("cpu", "cuda", "cuda:0", "mps")
+
+
+def _spec(tmp_path: pathlib.Path, **overrides: Any) -> RLTrainSpec:
+    """A spec every backend's ``validate`` passes clean.
+
+    Deliberately loose in its annotation: the probes below pass values whose type
+    the field does not declare, which is the point of the gate under test.
+    """
+    fields: dict[str, Any] = {
+        "env_factory": lambda: None,
+        "total_timesteps": 64,
+        "rollout_steps": 4,
+        "num_envs": 1,
+        "num_mini_batches": 1,
+        "batch_size": 8,
+        "learning_starts": 8,
+        "output_dir": str(tmp_path / "out"),
+    }
+    fields.update(overrides)
+    return RLTrainSpec(**fields)
+
+
+def _device_problems(trainer: Trainer, spec: RLTrainSpec) -> list[str]:
+    return [p for p in trainer.validate(spec) if "device" in p]
+
+
+class TestAnUnusableDeviceIsReportedByThePreflight:
+    """The headline: ``validate`` no longer calls an unlaunchable spec launchable."""
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    @pytest.mark.parametrize("device", UNUSABLE)
+    def test_a_device_no_torch_build_can_parse_is_reported(
+        self, tmp_path: pathlib.Path, backend: type[Trainer], device: Any
+    ) -> None:
+        pytest.importorskip("torch")
+        problems = _device_problems(backend(), _spec(tmp_path, device=device))
+        assert problems, (
+            f"{backend.__name__}.validate() returned no device problem for device={device!r}, "
+            "which torch cannot parse; setup() hands it straight to torch.device, so the run "
+            "aborts after the preflight called the spec launchable"
+        )
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_the_report_names_the_backend_the_value_and_the_admitted_shape(
+        self, tmp_path: pathlib.Path, backend: type[Trainer]
+    ) -> None:
+        """A refusal an operator can act on: whose preflight, which value, what a device looks like."""
+        pytest.importorskip("torch")
+        trainer = backend()
+        (problem,) = _device_problems(trainer, _spec(tmp_path, device="gpu"))
+        assert problem.startswith(f"{trainer.provider_name}:"), problem
+        assert "'gpu'" in problem, problem
+        assert "cuda:0" in problem, f"the refusal does not show an indexed device: {problem}"
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_a_non_string_device_is_reported_without_consulting_torch(
+        self, tmp_path: pathlib.Path, backend: type[Trainer], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``torch.device(1)`` constructs on any host and dies at the first ``.to()``.
+
+        Consulting torch for a non-``str`` would make one spec validate on a GPU
+        box and fail on a CPU box, which is the availability coupling this gate
+        rules out. The stub below is what proves the order: it raises if the gate
+        reaches ``torch.device`` at all.
+        """
+        torch = pytest.importorskip("torch")
+
+        def _explode(*_a: Any, **_k: Any) -> Any:  # pragma: no cover - must not run
+            raise AssertionError("torch was consulted for a non-str device")
+
+        monkeypatch.setattr(torch, "device", _explode)
+        problems = _device_problems(backend(), _spec(tmp_path, device=1))
+        assert any("must be a torch device string" in p for p in problems), problems
+        assert any("int" in p for p in problems), problems
+
+
+class TestTheDomainHasOneOwner:
+    """The tool, the supervised trainer and the RL preflight admit the same set."""
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    @pytest.mark.parametrize("device", UNUSABLE + USABLE)
+    def test_every_surface_that_spends_the_value_agrees(
+        self, tmp_path: pathlib.Path, backend: type[Trainer], device: Any
+    ) -> None:
+        """One quantity reaching torch from three layers must have one admitted set.
+
+        ``lerobot_train`` builds a detached argv from it, ``LerobotTrainer``
+        assigns it onto a lerobot config in-process, and these backends hand it to
+        ``torch.device``. A device one refuses and another accepts is the drift
+        this shared owner removes.
+        """
+        pytest.importorskip("torch")
+        from strands_robots.tools.lerobot_train import _torch_device_error
+
+        tool_refuses = _torch_device_error(device) is not None
+        rl_refuses = bool(_device_problems(backend(), _spec(tmp_path, device=device)))
+        assert rl_refuses == tool_refuses, (
+            f"device={device!r}: the lerobot_train tool {'refuses' if tool_refuses else 'admits'} it "
+            f"and {backend.__name__} {'refuses' if rl_refuses else 'admits'} it"
+        )
+
+    @staticmethod
+    def _calls(source: str) -> set[str]:
+        """Every call in ``source``, as dotted names, read from the AST.
+
+        The AST rather than the text because these functions *document* the
+        ``torch.device(spec.device or ...)`` line they exist to bound, and a text
+        scan would read that prose as the implementation.
+        """
+        import ast
+        import textwrap
+
+        names: set[str] = set()
+        for node in ast.walk(ast.parse(textwrap.dedent(source))):
+            if isinstance(node, ast.Call):
+                names.add(ast.unparse(node.func))
+        return names
+
+    def test_no_consumer_re_implements_the_domain(self) -> None:
+        """Exactly one function calls ``torch.device``; the rest ask it."""
+        import inspect
+
+        import strands_robots.tools.lerobot_train as tool_mod
+        from strands_robots import utils
+        from strands_robots.training import _validate
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        owner_src = inspect.getsource(utils.torch_device_error)
+        assert "torch.device" in self._calls(owner_src), "the owner does not read the domain from torch"
+
+        for consumer in (
+            _validate.torch_device_problems,
+            tool_mod._torch_device_error,
+            LerobotTrainer._device_problems,
+        ):
+            calls = self._calls(inspect.getsource(consumer))
+            assert "torch_device_error" in calls, f"{consumer.__qualname__} does not route through the owner"
+            assert "torch.device" not in calls, f"{consumer.__qualname__} re-implements the domain"
+
+    def test_the_owner_states_no_device_vocabulary_of_its_own(self) -> None:
+        """A torch build that gains a backend is admitted with no edit here."""
+        import inspect
+
+        from strands_robots import utils
+
+        owner = inspect.getsource(utils.torch_device_error)
+        for copied in ("xpu", "mkldnn", "opengl", "vulkan", "hpu"):
+            assert copied not in owner, f"the domain restates a torch device type: {copied}"
+
+
+class TestWhatThisDeliberatelyDoesNotGrade:
+    """Controls: each fails for a specific over-tight fix."""
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    @pytest.mark.parametrize("device", USABLE)
+    def test_a_usable_spelling_still_validates_clean(
+        self, tmp_path: pathlib.Path, backend: type[Trainer], device: str
+    ) -> None:
+        pytest.importorskip("torch")
+        assert backend().validate(_spec(tmp_path, device=device)) == []
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_availability_is_not_graded(
+        self, tmp_path: pathlib.Path, backend: type[Trainer], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A device this machine does not have is still a valid spec.
+
+        Fails for a fix that reaches for ``torch.cuda.is_available()``.
+        """
+        torch = pytest.importorskip("torch")
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        assert backend().validate(_spec(tmp_path, device="cuda")) == []
+        assert backend().validate(_spec(tmp_path, device="cuda:7")) == []
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    @pytest.mark.parametrize("falsy", [None, "", 0])
+    def test_an_unstated_device_resolves_through_the_documented_default(
+        self, tmp_path: pathlib.Path, backend: type[Trainer], falsy: Any
+    ) -> None:
+        """``spec.device or (...)`` predates this gate and still owns the falsy case.
+
+        A falsy value never reaches ``torch.device`` as written - it is replaced by
+        the auto-resolved device - so it is not this gate's to judge. Fails for a
+        fix that refuses ``device=None``.
+        """
+        pytest.importorskip("torch")
+        assert backend().validate(_spec(tmp_path, device=falsy)) == []
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_an_absent_torch_leaves_the_value_unguarded(
+        self, tmp_path: pathlib.Path, backend: type[Trainer], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no torch the domain is unknown, so the value passes through.
+
+        Fails for a fix that refuses every device when torch cannot be imported,
+        which would make the preflight unusable on a dispatch-only host.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _no_torch(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "torch":
+                raise ImportError("no torch")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_torch)
+        assert _device_problems(backend(), _spec(tmp_path, device="gpu")) == []


### PR DESCRIPTION
## Problem

All three from-scratch RL backends resolve the learner device the same way in `setup()`:

```python
self.device = torch.device(spec.device or ("cuda" if torch.cuda.is_available() else "cpu"))
```

`torch.device` judges nothing on the spec's behalf, and every network, replay buffer and
rollout tensor the run allocates is placed on the result. `RLTrainSpec.device` was the one
caller-supplied knob on that spec with **no domain** — the counts, the interval coefficients,
the loss weights, the learning rate, the seed, the launch topology and the network width
beside it are all held to one. So `validate()` returned `[]`, which `Trainer.validate`
documents as meaning the spec **is** launchable, for specs that cannot launch.

Measured on a 6-DoF SO-101 MuJoCo env with `PpoTrainer`, each row under `validate() == []`:

| `device` | `validate()` | what `train()` actually did |
| --- | --- | --- |
| `"gpu"` | `[]` launchable | `RuntimeError` out of `setup()`, at `ppo.py:243` |
| `"cuda:abc"` | `[]` launchable | `RuntimeError` out of `setup()`, at `ppo.py:243` |
| `1` | `[]` launchable | `AcceleratorError: CUDA error: invalid device ordinal`, raised from `torch/nn/modules/module.py:1367` |

`1` is the worst of the three and is why a non-`str` must be refused *before* torch is
consulted: `torch.device(1)` constructs on **any** host, so the run gets all the way to the
first `.to()` before dying, from a frame that names neither the field nor the run — and the
same spec would train fine on a host with more GPUs. One spec, two answers, decided by the
machine's inventory.

## The value already had two owners, and the third surface had none

`device` reaches torch from three layers. Two of them bounded it with near-identical
hand-rolled copies; the RL preflight had nothing. Measured across all three, before → after:

| `device` | `lerobot_train` tool | `LerobotTrainer` | RL preflight (before) | RL preflight (after) |
| --- | --- | --- | --- | --- |
| `"gpu"` | refuse | refuse | **admit** | refuse |
| `"CUDA"` | refuse | refuse | **admit** | refuse |
| `"nvidia"` | refuse | refuse | **admit** | refuse |
| `"cuda:abc"` | refuse | refuse | **admit** | refuse |
| `"  "` | refuse | refuse | **admit** | refuse |
| `1` | refuse | refuse | **admit** | refuse |
| `2.0` | refuse | refuse | **admit** | refuse |
| `["cuda"]` | refuse | refuse | **admit** | refuse |
| `"cpu"` | admit | admit | admit | admit |
| `"cuda"` | admit | admit | admit | admit |
| `"cuda:0"` | admit | admit | admit | admit |
| `"mps"` | admit | admit | admit | admit |

8 of 12 disagreed; 0 do now. The four usable spellings are unchanged controls.

## Change

The domain moves to one owner, `strands_robots.utils.torch_device_error`, which all three
surfaces ask. This is the consolidation `step_cadence_error` already applies to the
`save_freq` sitting beside `device` in that same tool argv, and its docstring gives the
reason verbatim: the callers "sit in different layers … which is why the domain lives here
rather than beside one of them: the same cadence cannot be refused by the tool and accepted
by the trainer that wraps the identical pipeline."

```mermaid
graph LR
  subgraph before
    T1["lerobot_train tool"] --> C1["hand-rolled copy"] --> D1(("torch.device"))
    L1["LerobotTrainer"] --> C2["hand-rolled copy"] --> D1
    R1["PpoTrainer<br/>FastSacTrainer<br/>FastTd3Trainer"] -.->|"no domain"| D1
  end
  subgraph after
    T2["lerobot_train tool"] --> O["utils.torch_device_error"]
    L2["LerobotTrainer"] --> O
    R2["PpoTrainer<br/>FastSacTrainer<br/>FastTd3Trainer"] --> O
    O --> D2(("torch.device"))
  end
  style R1 stroke:#d33,stroke-width:2px
  style O stroke:#2a2,stroke-width:2px
```

Each surface keeps only the reason the check happens *there*; the rule itself is stated once.
The tool's refusal text is byte-identical to before.

## What is deliberately not graded

Both have a control that fails for the corresponding over-tight fix.

- **Availability.** `device="cuda"` on a CPU-only host stays a valid spec: a queued or
  containerised run is written on one machine and executed on another. Nothing reaches for
  `torch.cuda.is_available()`.
- **An unstated device.** `spec.device or (...)` documents a falsy value as "resolve the
  default", so `None` / `""` / `0` never reach `torch.device` as written and are not this
  gate's to judge — matching what `LerobotTrainer.__init__` already does with `_auto_device`.

## Tests

`tests/training/test_rl_trainer_device_domain.py`, parametrized over all three backends.
Same selection (`tests/training` + the two `lerobot_train` tool suites) in four corners:

| corner | production | tests | result |
| --- | --- | --- | --- |
| A | base | base | 5065 passed, **0 failed** |
| B | base | this PR's | **57 failed**, 5103 passed |
| C | this PR's | this PR's | **5160 passed, 0 failed** |
| D | this PR's | base | 1 failed, 5064 passed |

`5065 + 95 = 5160`; in B, `57 + 38 = 95`, the 38 being the controls that hold either way.
Corner D is the one pre-existing cell that asserted `"torch.device(device)" in` the trainer's
own source — it pinned the hand-rolled copy, so this PR retargets it (same property, now
graded on the owner) rather than deleting it, which is why that file is in the diff.

Controls re-run end to end on a real GPU, PPO on the SO-101 MuJoCo env:
`device="cuda"` / `"cuda:0"` / `"cpu"` each `validate() == []` → `status=success` with a
checkpoint written.

## Size

`+5` net executable statements across the eight production files; both hand-rolled copies
shrink.

| file | executable statements |
| --- | --- |
| `utils.py` (the new owner) | 441 → 451 (+10) |
| `training/_validate.py` | 166 → 172 (+6) |
| `training/base.py` | 121 → 124 (+3) |
| `training/lerobot.py` | 695 → 686 (**−9**) |
| `tools/lerobot_train.py` | 339 → 331 (**−8**) |
| `rl/ppo.py`, `rl/fast_sac.py`, `rl/fast_td3.py` | +1 each |
| **total** | **2577 → 2582 (+5)** |

## Gate

`ruff check` clean; `ruff format --check` 1915 files; `mypy strands_robots tests tests_integ`
-> `Success: no issues found in 1912 source files` (no new suppressions).
`tests/training` + `tests/tools` -> 8892 passed, 15 skipped, 0 failed.
A 462-file tree-walking guard selection -> 24385 passed, with 7 pre-existing
environment failures only (`rclpy` resolvable where those cells assert it is absent;
installed `websockets` 16.0 against the declared `>=17.0` floor).
Docs: `docs/training/rl.md` "Device selection".

`test_refusal_messages_never_raise` enrolled the new owner in its population and
asked for the shared renderer, since `repr` can itself raise -- on an `int` wider
than `sys.get_int_max_str_digits`, or from any third-party `__repr__` -- and a
guard that raises while building a refusal fails on exactly the path that exists so
it does not. The value is now rendered through `_refusal_repr` like every other
scalar guard there; the emitted text is unchanged for every renderable value, so
the tool's messages stay byte-identical.
