### PR TITLE
fix(policies/vera): the host is the other half of the server URI, and takes a domain

### DIFF
--- a/changelog.d/3271-vera-dial-host-domain.md
+++ b/changelog.d/3271-vera-dial-host-domain.md
@@ -1,0 +1,18 @@
+### Fixed: the VERA policy host is the other half of the server URI, and takes a domain
+
+`VeraConfig.server_uri` is `ws://{host}:{port}`. The port half was held to the
+shared TCP-port domain; the host half was held to nothing, so a value that is not
+a host was resolved rather than refused. `host="127.0.0.1/foo"` and
+`host="ws://127.0.0.1"` re-cut the URI so the client dialed port **80**,
+discarding the validated port. `host=""` was the one unusable spelling the
+readiness probe accepted — it maps a bind-only host to loopback — so the runner
+reported `VERA server ready` and the client then raised `InvalidURI` past the
+`OSError` channel carrying its actionable hint. A non-string raised a
+`getaddrinfo` `TypeError` out of `start()`, past the runner's documented error
+channel.
+
+`host` is now checked in the same funnel the port passes through: a bare hostname
+or IP literal, with `[::1]` as the bracketed IPv6 spelling and `"0.0.0.0"` named
+in the refusal for `""` as the way to reach a server bound on every interface.
+Whether the host resolves is left to the readiness probe, the surface that can
+observe it.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -148,6 +148,7 @@ wins over code defaults):
 | kwarg | env var | maps to |
 |-------|---------|---------|
 | `embodiment` | — | `--embodiment` (`pusht` \| `mimicgen` \| `allegro` \| `droid`) |
+| `host` | — | `--host` (a bare hostname or IP literal; `[::1]` for IPv6) |
 | `server_port` / `vis_port` | `VERA_SERVER_PORT` / `VERA_VIS_PORT` | `--port` / `--vis-port` |
 | `algo_config` | `VERA_ALGO_CONFIG` | `--algo-config` (swap to the omni planner) |
 | `dynamics_run_id` | `VERA_DYNAMICS_RUN_ID` | `--dynamics-run-id` |
@@ -194,6 +195,25 @@ because it is present, not because it is truthy, so a port means the same thing
 whichever spelling named it. `VERA_SERVER_PORT=0` is refused exactly as
 `server_port=0` is, and `VERA_VIS_PORT=0` disables the viewer exactly as
 `vis_port=0` does.
+
+`host` is the other half of that URI, and it is checked in the same funnel for
+the same reason: `ws://{host}:{port}` is one expression, so a host a URI cannot
+carry does not name a bad address — it names a *different* address, and the port
+is the component it takes. It must be a bare hostname or IP literal, with no `/`,
+`?`, `#`, `@`, `:` (outside a bracketed IPv6 literal such as `[::1]`), whitespace
+or control character. `host="127.0.0.1/foo"` parses as host `127.0.0.1`, path
+`/foo:8820` and port **80**, and `host="ws://127.0.0.1"` — the shape a caller who
+pastes a URI supplies — parses as host `ws` on port 80: both discard the port the
+TCP-port domain just accepted, which the port half cannot see. `""` is refused
+naming `"0.0.0.0"` as the spelling that reaches a server bound on every
+interface, because `""` is the one unusable host the readiness probe *accepted* —
+it maps a bind-only host to loopback, so the runner reported `VERA server ready`
+and the client then raised `InvalidURI` past the `OSError` channel that carries
+its "could not reach the VERA policy server" hint. A non-string never reaches a
+URI at all: it is handed to `socket.getaddrinfo`, which answers with a `TypeError`
+naming neither the field nor a fix. Whether the host *resolves*, and whether
+anything is listening on it, are facts about the network that the constructor
+cannot know and that the readiness probe already reports.
 
 `server_ready_timeout` is the span the readiness wait allows the server to open
 its websocket: a positive finite number of seconds, the shared continuous-span

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -120,6 +120,93 @@ def _embodiment_error(value: Any, param: str, context: str) -> str | None:
     )
 
 
+# Characters that end the host inside ``ws://<host>:<port>``. Each one starts a
+# later URI component, so a host carrying one does not name a bad host - it names
+# a different URI. ``:`` is in the set because the port follows it, and a
+# bracketed IPv6 literal (``[::1]``) is the one place it belongs to the host.
+_URI_COMPONENT_DELIMITERS = frozenset("/?#@:[]\\")
+
+
+def _dial_host_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` cannot address the host half of the server URI.
+
+    ``host`` and ``server_port`` are the two halves of one expression,
+    :attr:`VeraConfig.server_uri`'s ``ws://{host}:{port}``. The port half is held
+    to :func:`~strands_robots.utils.tcp_port_error` because three consumers read
+    it under three coercions and an unusable value is *applied* as three
+    different ports. The host half reaches the same three consumers - it is
+    interpolated into that URI, handed to ``socket.create_connection`` by the
+    runner's readiness probe, and carried as ``--host`` on the server argv - and
+    was held to nothing, so a value that is not a host was not refused but
+    resolved, differently by each of them:
+
+    * A delimiter re-cuts the URI, and the port is what it takes.
+      ``host="127.0.0.1/foo"`` parses as host ``127.0.0.1``, path
+      ``/foo:8820`` and port **80**: the validated port is discarded, so the
+      client dials a port nobody configured. ``host="ws://127.0.0.1"`` - the
+      shape a caller who pastes a URI supplies - parses as host ``ws`` on
+      port 80.
+    * ``""`` is refused by the URI parse itself ("hostname isn't provided"),
+      which raises ``InvalidURI`` rather than the ``OSError`` the client
+      converts into its actionable "could not reach the VERA policy server"
+      hint. It is also the one spelling the readiness probe *accepts*, because
+      that probe maps a bind-only host to loopback: the runner reports "VERA
+      server ready" and the client then cannot build the URI at all.
+    * A non-string reaches ``socket.getaddrinfo`` before anything else and
+      raises ``TypeError: getaddrinfo() argument 1 must be string or None`` out
+      of ``start()``, past the ``TimeoutError``/``RuntimeError`` channel the
+      runner documents.
+
+    Only the shape a URI and a resolver can be *given* is decided here.
+    Whether the host resolves, and whether anything is listening on it, are
+    facts about the network that this constructor cannot know and that the
+    readiness probe already reports.
+
+    ``"0.0.0.0"`` stays accepted. It is the documented way to reach a server
+    bound on every interface, the readiness probe special-cases it, and it
+    interpolates and dials cleanly; ``""`` means the same thing to a ``bind``
+    call and nothing to a URI, so the refusal names ``"0.0.0.0"`` as the
+    spelling that works.
+
+    Args:
+        value: The caller-supplied host.
+        param: The field name it came from, used in the message.
+        context: Message prefix identifying the surface that received it.
+
+    Returns:
+        An error message, or ``None`` when the value can address a host.
+    """
+    if not isinstance(value, str):
+        return (
+            f"{context}: {param} must be a string hostname or IP literal, got {value!r} "
+            f"({type(value).__name__}). It is interpolated into the websocket URI the client "
+            "dials (ws://<host>:<port>) and handed to socket.create_connection, which refuses "
+            "a non-string with a getaddrinfo TypeError that names neither the field nor a fix."
+        )
+    bracketed = value.startswith("[") and value.endswith("]")
+    body = value[1:-1] if bracketed else value
+    if not body:
+        return (
+            f"{context}: {param} must name a host to dial, got {value!r}; "
+            f'ws://{value}:<port> is not a URI (the parse reports "hostname isn\'t provided"). '
+            "Use '0.0.0.0' to reach a server bound on every interface, or '127.0.0.1' for a local one."
+        )
+    own = frozenset(":") if bracketed else frozenset()
+    bad = sorted(
+        {c for c in body if (c in _URI_COMPONENT_DELIMITERS and c not in own) or not c.isprintable() or c.isspace()}
+    )
+    if bad:
+        hint = " Pass a bracketed literal for IPv6 (e.g. '[::1]')." if ":" in bad else ""
+        return (
+            f"{context}: {param} must be a bare hostname or IP literal, got {value!r}; "
+            f"{', '.join(map(repr, bad))} cannot appear in the host half of the websocket URI it is "
+            f"interpolated into (ws://<host>:<port>), so {f'ws://{value}:<port>'!r} names a "
+            "different URI rather than a host - a '/' puts the validated port in the path and the "
+            f"client dials :80 instead.{hint}"
+        )
+    return None
+
+
 def _viewer_port_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` cannot address the MJPEG live-viewer port.
 
@@ -175,7 +262,16 @@ class VeraConfig:
             field is the key every other per-embodiment default is looked up by
             and an unknown one would otherwise resolve to another embodiment's
             ports and render width.
-        host: Policy-server hostname.
+        host: Policy-server hostname or IP literal, and the host half of
+            :attr:`server_uri`. Must be a bare host a URI can carry - no ``/``,
+            ``?``, ``#``, ``@``, ``:`` (outside a bracketed IPv6 literal such as
+            ``[::1]``), whitespace or control character - because those end the
+            host inside ``ws://<host>:<port>`` and the port is what they take:
+            ``"127.0.0.1/foo"`` dials port 80, discarding the port the shared
+            TCP-port domain just accepted. ``""`` is refused with ``"0.0.0.0"``
+            named as the spelling that reaches a server bound on every
+            interface. Whether the host resolves is left to the readiness probe,
+            which is the surface that can observe it.
         server_port: Policy-server websocket port. ``None`` applies
             ``VERA_SERVER_PORT`` else the per-embodiment default; any other
             value must be an ``int`` in ``[1, 65535]``, because the client dials
@@ -286,6 +382,16 @@ class VeraConfig:
         # second copy of a default is what made "not a known embodiment" and
         # "mimicgen" the same request.
         if (err := _embodiment_error(self.embodiment, "embodiment", type(self).__name__)) is not None:
+            raise ValueError(err)
+        # The other half of ``server_uri``. Checked here, in the same funnel the
+        # port half passes through, because the two are one expression: a URI
+        # cut apart by an unchecked host is not a bad address, it is a
+        # *different* address, and the port is the component it takes. Nothing
+        # downstream refuses it - the runner's probe reports a bind-only host as
+        # ready, the client raises ``InvalidURI`` past the ``OSError`` channel
+        # that carries its actionable hint, and a non-string surfaces as a
+        # ``getaddrinfo`` ``TypeError`` out of ``start()``.
+        if (err := _dial_host_error(self.host, "host", type(self).__name__)) is not None:
             raise ValueError(err)
         # Apply per-embodiment port defaults when not explicitly set.
         default_policy, default_vis = _DEFAULT_PORTS[self.embodiment]

--- a/strands_robots/policies/vera/server_runner.py
+++ b/strands_robots/policies/vera/server_runner.py
@@ -63,8 +63,11 @@ logger = logging.getLogger(__name__)
 
 def _port_open(host: str, port: int, timeout: float = 1.0) -> bool:
     """True if a TCP connection to ``host:port`` succeeds (server is listening)."""
-    # 0.0.0.0 is a bind address, not connectable - probe loopback instead.
-    probe_host = "127.0.0.1" if host in ("0.0.0.0", "") else host
+    # 0.0.0.0 is a bind address, not connectable - probe loopback instead. The
+    # empty string used to be mapped here too, and that arm is what let a host a
+    # URI cannot carry be reported as ready; ``VeraConfig`` now refuses it at
+    # construction, naming 0.0.0.0 as the spelling that binds every interface.
+    probe_host = "127.0.0.1" if host == "0.0.0.0" else host
     try:
         with socket.create_connection((probe_host, port), timeout=timeout):
             return True

--- a/tests/policies/vera/test_dial_host_addresses_the_server_uri.py
+++ b/tests/policies/vera/test_dial_host_addresses_the_server_uri.py
@@ -1,0 +1,229 @@
+"""``host`` and ``server_port`` are the two halves of one URI, held to one funnel.
+
+:attr:`VeraConfig.server_uri` is ``ws://{host}:{port}``. The port half is held to
+the shared TCP-port domain, for a reason recorded at length: three consumers read
+it under three coercions, so an unusable value is not refused late but *applied*
+as three different ports. The host half reaches those same three consumers - the
+URI the client dials, the ``socket.create_connection`` the readiness probe makes,
+and the ``--host`` on the server argv - and was held to nothing. A value that is
+not a host was therefore resolved rather than refused:
+
+* A URI delimiter re-cuts the URI, and the validated port is the component it
+  takes. ``host="127.0.0.1/foo"`` parses as host ``127.0.0.1``, path
+  ``/foo:8820`` and port **80**, so the client dials a port nobody configured;
+  ``host="ws://127.0.0.1"`` - what a caller who pastes a URI supplies - parses as
+  host ``ws`` on port 80. The port domain cannot see this: it is the host half
+  that discards the port.
+* ``""`` is the one unusable spelling the readiness probe *accepted*, because the
+  probe maps a bind-only host to loopback. The runner logged "VERA server ready"
+  and the client then could not build a URI at all, raising ``InvalidURI`` past
+  the ``OSError`` channel that carries its actionable "could not reach the VERA
+  policy server" hint.
+* A non-string reached ``socket.getaddrinfo`` first and raised ``TypeError:
+  getaddrinfo() argument 1 must be string or None`` out of ``start()``, past the
+  ``TimeoutError``/``RuntimeError`` channel the runner documents.
+
+These pin the domain, the shape of the harm against the real URI parser, the two
+halves sharing one floor, the documented asymmetries between them, and the
+over-reach control: every host a URI can carry is still named identically by all
+three consumers - including ``"0.0.0.0"``, which the probe special-cases and
+which the refusal for ``""`` names as the spelling that binds every interface.
+
+Everything here is offline - no ``vera`` package, no server, and the one socket
+is a loopback listener this file opens itself.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.vera import VeraConfig, VeraPolicy, VeraServerRunner
+
+# Hosts a URI cannot carry, grouped by what the value did instead of failing.
+# ``':'`` outside brackets is here because the port follows it: a bare IPv6
+# literal (``"::1"``) and a host that already carries a port both re-cut the URI.
+RECUT_THE_URI: list[str] = [
+    "127.0.0.1/foo",
+    "ws://127.0.0.1",
+    "127.0.0.1:9999",
+    "::1",
+    "user@127.0.0.1",
+    "127.0.0.1?x=1",
+    "127.0.0.1#frag",
+]
+
+# Spellings that resolve to no host at all.
+NAME_NO_HOST: list[str] = ["", "[]"]
+
+# Values that never reach a URI, because ``getaddrinfo`` refuses them first.
+NOT_A_STRING: list[Any] = [None, 0, 8800, True, False, 3.5, ["127.0.0.1"], {}, b"127.0.0.1"]
+
+# Hosts whose only defect is a character a resolver cannot be handed.
+UNRESOLVABLE_SHAPE: list[str] = ["  ", "127.0.0.1 ", " 127.0.0.1", "127.0.0.1\x00", "my\thost"]
+
+# Hosts every consumer can honor. ``0.0.0.0`` is the documented way to reach a
+# server bound on every interface and ``[::1]`` is the bracketed IPv6 spelling a
+# URI requires; both are over-reach controls for the delimiter rule.
+USABLE_HOSTS: list[str] = ["127.0.0.1", "localhost", "0.0.0.0", "my-host.local", "[::1]", "vera-server"]
+
+# The floor the two halves of ``ws://{host}:{port}`` share: neither a host nor a
+# port can be one of these, so one funnel refuses both fields for the same value.
+SHARED_FLOOR: list[Any] = [True, False, 3.5, ["8800"], {}]
+
+# Where the two halves legitimately disagree, and why. A cell asserts every
+# reason is stated, so a future asymmetry has to be argued rather than absorbed.
+ASYMMETRIES: dict[str, str] = {
+    "None": (
+        "None is the port's documented 'apply the per-embodiment default' spelling; "
+        "host has a concrete default and no table to look one up in, so None is a "
+        "stated non-host rather than a request for the default"
+    ),
+    "'8800'": (
+        "a decimal string is a legal DNS label, so it is a host the URI can carry; "
+        "it is not a port, because the three port consumers coerce it three ways"
+    ),
+    "0": (
+        "zero is refused as a port because the client cannot learn which ephemeral "
+        "port the kernel handed the server; it is refused as a host only for being "
+        "an int, and '0' as text would be accepted"
+    ),
+}
+
+
+def _config(**kwargs: Any) -> VeraConfig:
+    """Build a config through the funnel, splatted so off-type values reach it.
+
+    mypy does not narrow a ``**dict[str, Any]`` splat, which is what lets one
+    test hand a deliberately wrong type to a typed field without an ignore.
+    """
+    return VeraConfig(**kwargs)
+
+
+def _refusal(**kwargs: Any) -> str | None:
+    """The funnel's refusal for these keywords, read through the public door.
+
+    Reading the message off the constructor rather than off the guard keeps this
+    file pinned to the behaviour a caller sees, so the check can move or be
+    renamed without a test edit.
+    """
+    try:
+        _config(**kwargs)
+    except ValueError as e:
+        return str(e)
+    return None
+
+
+def _argv_value(cfg: VeraConfig, flag: str) -> str | None:
+    """The value the subprocess argv carries for ``flag``, or ``None`` if absent."""
+    argv = VeraServerRunner(cfg)._build_command()
+    return next((v for a, v in zip(argv, [*argv[1:], ""], strict=True) if a == flag), None)
+
+
+class TestAHostThatIsNotAHostIsRefused:
+    @pytest.mark.parametrize("value", RECUT_THE_URI)
+    def test_a_host_that_recuts_the_uri_is_refused_by_name(self, value):
+        """The port half cannot catch this: the host half is what discards it."""
+        message = _refusal(embodiment="pusht", host=value)
+        assert message is not None
+        assert "host" in message
+        assert repr(f"ws://{value}:<port>") in message
+
+    @pytest.mark.parametrize("value", NAME_NO_HOST)
+    def test_a_spelling_that_names_no_host_is_refused_naming_the_one_that_works(self, value):
+        """``""`` was reported ready by the probe and then had no URI to dial."""
+        message = _refusal(embodiment="pusht", host=value)
+        assert message is not None
+        assert "host" in message
+        assert "0.0.0.0" in message
+
+    @pytest.mark.parametrize("value", NOT_A_STRING)
+    def test_a_non_string_host_is_refused_rather_than_handed_to_getaddrinfo(self, value):
+        message = _refusal(embodiment="pusht", host=value)
+        assert message is not None
+        assert "host" in message
+        assert type(value).__name__ in message
+
+    @pytest.mark.parametrize("value", UNRESOLVABLE_SHAPE)
+    def test_a_host_carrying_whitespace_or_a_control_character_is_refused(self, value):
+        message = _refusal(embodiment="pusht", host=value)
+        assert message is not None
+        assert "host" in message
+
+    def test_a_bare_ipv6_literal_is_refused_naming_the_bracketed_spelling(self):
+        """``"::1"`` is the mistake the bracket rule exists to answer."""
+        message = _refusal(embodiment="pusht", host="::1")
+        assert message is not None
+        assert "[::1]" in message
+
+
+class TestTheHarmAgainstTheRealUriParser:
+    """The consumer decides what a re-cut URI means, so the consumer is asked."""
+
+    @pytest.mark.parametrize("value", ["127.0.0.1/foo", "ws://127.0.0.1"])
+    def test_a_refused_host_would_have_discarded_the_validated_port(self, value):
+        parse_uri = pytest.importorskip("websockets.uri").parse_uri
+        assert parse_uri(f"ws://{value}:8820").port == 80
+
+    def test_the_empty_host_would_not_have_parsed_at_all(self):
+        websockets_uri = pytest.importorskip("websockets.uri")
+        with pytest.raises(websockets_uri.InvalidURI):
+            websockets_uri.parse_uri("ws://:8820")
+
+    @pytest.mark.parametrize("value", USABLE_HOSTS)
+    def test_every_accepted_host_keeps_the_port_it_was_configured_with(self, value):
+        """The property the refusals protect, stated positively."""
+        parse_uri = pytest.importorskip("websockets.uri").parse_uri
+        parsed = parse_uri(_config(embodiment="pusht", host=value).server_uri)
+        assert (parsed.port, parsed.path) == (8820, "")
+
+
+class TestEveryConsumerNamesTheSameHost:
+    @pytest.mark.parametrize("value", USABLE_HOSTS)
+    def test_client_uri_server_uri_and_argv_name_one_host(self, value):
+        policy = VeraPolicy(embodiment="pusht", host=value, auto_launch_server=False)
+        assert policy._client.uri == f"ws://{value}:8820"
+        assert policy.config.server_uri == f"ws://{value}:8820"
+        assert _argv_value(policy.config, "--host") == value
+
+    def test_the_default_host_is_named_identically_too(self):
+        policy = VeraPolicy(embodiment="pusht", auto_launch_server=False)
+        assert policy._client.uri == "ws://127.0.0.1:8820"
+        assert policy.config.server_uri == "ws://127.0.0.1:8820"
+        assert _argv_value(policy.config, "--host") == "127.0.0.1"
+
+
+class TestTheTwoHalvesOfTheUriShareOneFloor:
+    @pytest.mark.parametrize("value", SHARED_FLOOR)
+    def test_neither_half_accepts_what_the_other_refuses(self, value):
+        """One expression, one funnel: the halves cannot drift on this set."""
+        assert _refusal(embodiment="pusht", host=value) is not None
+        assert _refusal(embodiment="pusht", server_port=value) is not None
+
+    def test_every_documented_asymmetry_states_its_reason(self):
+        assert all(reason.strip() for reason in ASYMMETRIES.values())
+
+    def test_none_is_the_ports_default_spelling_and_not_a_host(self):
+        assert _config(embodiment="pusht", server_port=None).server_port == 8820
+        assert _refusal(embodiment="pusht", host=None) is not None
+
+    def test_a_decimal_string_is_a_host_but_not_a_port(self):
+        assert _config(embodiment="pusht", host="8800").host == "8800"
+        assert _refusal(embodiment="pusht", server_port="8800") is not None
+
+
+class TestTheReadinessProbeStillReusesABoundServer:
+    """The probe's bind-address arm keeps the spelling that can also be dialed."""
+
+    def test_a_server_listening_on_loopback_is_reused_for_host_0_0_0_0(self):
+        with socket.create_server(("127.0.0.1", 0)) as listener:
+            cfg = _config(embodiment="pusht", host="0.0.0.0", server_port=listener.getsockname()[1])
+            runner = VeraServerRunner(cfg)
+            runner.start()  # returns on the reuse path, without launching anything
+            assert runner.is_running() is False
+
+    def test_the_empty_spelling_can_no_longer_reach_that_arm(self):
+        """It was the only unusable host the probe mapped to loopback."""
+        assert _refusal(embodiment="pusht", host="") is not None


### PR DESCRIPTION
`VeraConfig.server_uri` is one expression, `ws://{host}:{port}`. The port half is held to the shared TCP-port domain, with a written rationale: three consumers read it under three coercions, so an unusable value is not refused late but *applied* as three different ports. The host half reaches the same three consumers - the URI the client dials, the `socket.create_connection` the readiness probe makes, and the `--host` on the server argv - and was held to nothing.

So the guard on the port could be defeated by the field beside it. `host="127.0.0.1/foo"` parses as host `127.0.0.1`, path `/foo:8820`, port **80**: the validated port is discarded and the client dials one nobody configured.

![host domain: before / after](https://raw.githubusercontent.com/cagataycali/robots/67ddce0ab6c3c39e8167ac13d6b22014afe9e907/vera-host-domain.png)

Every cell above is measured, on both trees, against `websockets.uri.parse_uri` and a real loopback listener. 18 of 24 spellings were accepted as a host and resolved into something else:

| what happened instead of a refusal | n | rows |
|---|---|---|
| the validated port is discarded, client dials `:80` | 3 | `127.0.0.1/foo`, `ws://127.0.0.1`, `127.0.0.1?x=1` |
| no URI at all - `InvalidURI`/`ValueError`, not the `OSError` channel that carries the client's actionable hint | 5 | `127.0.0.1:9999`, `::1`, `user@127.0.0.1`, `127.0.0.1#frag`, `[]` |
| the probe reports READY while the client addresses something else | 3 | `""`, `None`, `127.0.0.1\0` |
| `TypeError` out of `start()`, past the documented `TimeoutError`/`RuntimeError` channel | 4 | `0`, `True`, `3.5`, `["127.0.0.1"]` |
| carried to a resolver that mangles it or cannot read it | 3 | `"  "`, `"127.0.0.1 "`, `"my\thost"` |

The third row is the one that reports success. `_port_open` maps a bind-only host to loopback, so `host=""` found the listening server, logged `VERA server already listening ... reusing` / `VERA server ready`, and the client then raised `InvalidURI` - which is not an `OSError`, so the "could not reach the VERA policy server" hint never fired. `host=None` did the same and then dialed the DNS name `none`.

## Change

`host` is checked in the same funnel the port passes through: a bare hostname or IP literal, with no `/`, `?`, `#`, `@`, `:` (outside a bracketed IPv6 literal), whitespace or control character - the characters that end the host inside the URI, so a value carrying one names a different URI rather than a bad host.

Two deliberate boundaries:

* **`"0.0.0.0"` stays accepted.** It is the way to reach a server bound on every interface, the probe special-cases it, and it interpolates and dials cleanly. `""` means the same thing to a `bind` call and nothing to a URI, so its refusal names `"0.0.0.0"` as the spelling that works.
* **Resolution is not decided here.** Whether a host resolves, and whether anything listens on it, are facts about the network the constructor cannot know and the readiness probe already reports. Only the shape a URI and a resolver can be *given* is refused.

`_port_open`'s empty-host arm was the only thing that made an undialable host look ready; it is narrowed to `0.0.0.0`, the half it was written for, now that `""` cannot arrive from a config.

## Tests

`tests/policies/vera/test_dial_host_addresses_the_server_uri.py`, 50 cells, read through the public door (the constructor, not the guard):

* the four refusal families above, each pinned by name and by the message quoting the URI it would have built;
* the harm against the real parser - `parse_uri("ws://127.0.0.1/foo:8820").port == 80`, `ws://:8820` raises `InvalidURI` - and the property stated positively: every accepted host keeps the port it was configured with;
* the two halves share one floor (`True`, `False`, `3.5`, a list, a dict are refused for both fields) and the three legitimate asymmetries carry a stated reason (`None` is the port's default spelling; `"8800"` is a DNS label but not a port; `0`);
* over-reach controls: all six usable hosts, including `0.0.0.0` and `[::1]`, are still named identically by the client URI, `server_uri` and the `--host` argv, and a server listening on loopback is still reused for `host="0.0.0.0"`.

Measured four ways on `tests/policies/vera`: 1018 pass before / **31 of the 50 new cells fail on pre-fix code** / 1068 after / 1018 with the new file removed and the fix in (nothing existing moves). 19 of the 50 are controls that hold either way. Offline throughout - no `vera` package, no server, and the one socket is a loopback listener the file opens itself.

`ruff check`, `ruff format --check` and `mypy` clean on the touched trees; the wider `-k vera/docs/docstring/changelog/cosmos` net is 4730 pass (the one failure, a registry `rebot_b601` row LeRobot no longer registers, reproduces unchanged on `main`).

## Size

| | +/- |
|---|---|
| `policies/vera/config.py` | +107 / -1 |
| `policies/vera/server_runner.py` | +5 / -2 |
| test | +229 |
| docs + changelog | +38 |

Net +379 / -3. The `config.py` addition decomposes as **28 executable + 57 docstring + 12 comment + 10 blank** (28+57+12+10 = 107), so the code that changes behaviour is 28 lines and the rest is the rationale for the domain.