### PR TITLE
fix(policies): the host is the other half of a dialled address, and takes the port's domain

### DIFF
--- a/changelog.d/3272-dial-host-domain.md
+++ b/changelog.d/3272-dial-host-domain.md
@@ -1,0 +1,23 @@
+### Fixed: the host half of a dialled websocket address is graded the way its port is
+
+Every caller-supplied port this package dials is held to one shared domain,
+`strands_robots.utils.tcp_port_error`, because an unusable port is not refused by
+the transport - it is applied, and surfaces later as an unreachable server that
+implicates the service the caller was trying to reach. The host beside it is
+interpolated into the same `ws://{host}:{port}` and was held to nothing on two of
+the three surfaces that build one, so a value that is not a host was resolved
+rather than refused - and the resolution discarded the port the shared domain had
+just approved. `host="127.0.0.1/foo"` parses as host `127.0.0.1`, path
+`/foo:<port>` and port **80**; `host="ws://127.0.0.1"` parses as host `ws` on
+port 80; `host=""` builds no URI at all and raises `InvalidURI` past the
+`OSError` channel these clients convert into an actionable hint; and a non-string
+is dialled verbatim, `None` as the DNS name `"none"`.
+
+The rule now lives beside the port domain it is the other half of, as
+`strands_robots.utils.dial_host_error`, and `RemotePolicy`,
+`Cosmos3Policy` and `VeraConfig` all read it - so one address cannot be refused
+by one client and dialled by the next. A stated `endpoint=` and an injected
+`client=` still own their own address, and `"0.0.0.0"` stays accepted as the way
+to reach a server bound on every interface. The ZMQ policy clients keep their
+transport's verdict: `tcp://` is not a URI, and zmq refuses each of these
+spellings at `connect` with the whole address in the message.

--- a/changelog.d/3272-dial-host-domain.md
+++ b/changelog.d/3272-dial-host-domain.md
@@ -21,3 +21,10 @@ by one client and dialled by the next. A stated `endpoint=` and an injected
 to reach a server bound on every interface. The ZMQ policy clients keep their
 transport's verdict: `tcp://` is not a URI, and zmq refuses each of these
 spellings at `connect` with the whole address in the message.
+
+Reaching that verdict reads the value's own characters, so the read is made
+behind the module's guarded-read layer and an unreadable host is refused rather
+than raised past: a `str` subclass whose `startswith` raises used to escape as a
+`RuntimeError` out of a call documented to report through `ValueError`. The
+refusal text is rendered through the shared renderers, so it cannot itself fail
+on the path that exists to answer an unusable value with text.

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -116,6 +116,15 @@ because a WebSocket target is only resolved on first use - an unusable port is
 not rejected by the transport, it surfaces later as an unreachable server and
 implicates the service you were trying to reach.
 
+`host=` is the other half of that same URI and is held to the same terms: a bare
+hostname or IP literal, IPv6 bracketed (`"[::1]"`), with no `/`, `:`, scheme or
+credentials in it. Pass a full URL as `endpoint=` instead. This is not cosmetic -
+the parse hands a delimiter to a later URI component and takes the port with it,
+so `host="127.0.0.1/foo"` reads as host `127.0.0.1`, path `/foo:8765` and port
+**80**: the validated port ends up in the path and the client dials one nobody
+configured. `host="0.0.0.0"` still reaches a server bound on every interface.
+Whether the host resolves is left to the connect path, which already reports it.
+
 Then drive it exactly like a local policy. In simulation:
 
 ```python

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -28,8 +28,8 @@ python -m cosmos_framework.scripts.action_policy_server_robolab \
 ```python
 Cosmos3Policy(
     embodiment="droid",          # droid | umi | av | bridge | openarm
-    host="localhost",
-    port=8000,
+    host="localhost",         # bare hostname or IP literal; IPv6 bracketed "[::1]"
+    port=8000,                   # int in [1, 65535]
     action_space=None,
     observation_mapping=None,
     action_mapping=None,
@@ -43,6 +43,16 @@ Cosmos3Policy(
     model=None,                 # HF repo id / path for the diffusers backend
 )
 ```
+
+`host` and `port` are the two halves of the one address this client dials
+(`ws://<host>:<port>`), and both are refused before the endpoint is built rather
+than surfacing later as an unreachable server. `host` must be a bare hostname or
+IP literal - no `/`, `:`, scheme or credentials, IPv6 bracketed as `"[::1]"` -
+because the URI parse gives a delimiter to a later component and takes the port
+with it: `host="localhost/foo"` reads as port **80**, so the configured `8000`
+lands in the path. Both are read only when this constructor builds the client; an
+injected `client=` owns its own address. `host="0.0.0.0"` reaches a server bound
+on every interface.
 
 ## Embodiments
 

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -37,7 +37,12 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.inference import protocol
 from strands_robots.policies.base import Policy, chunk_count_error, required_bodies_error
-from strands_robots.utils import name_list_error, positive_finite_number_error, tcp_port_error
+from strands_robots.utils import (
+    dial_host_error,
+    name_list_error,
+    positive_finite_number_error,
+    tcp_port_error,
+)
 
 if TYPE_CHECKING:
     from websockets.sync.client import ClientConnection
@@ -132,7 +137,13 @@ class RemotePolicy(Policy):
     Args:
         endpoint: Full server URL, e.g. ``ws://gpu-box:8765``. When given it
             takes precedence over ``host``/``port``.
-        host: Server host (used when ``endpoint`` is not given).
+        host: Server host (used when ``endpoint`` is not given). Must be a bare
+            hostname or IP literal a URI can carry - no ``/``, ``:``, scheme or
+            credentials, and IPv6 bracketed (``"[::1]"``) - because it is
+            interpolated into ``ws://<host>:<port>`` and the parse gives a
+            delimiter to a later component, taking the validated ``port`` with
+            it. Pass a full URL as ``endpoint`` instead. ``"0.0.0.0"`` reaches a
+            server bound on every interface.
         port: Server port (used when ``endpoint`` is not given). Must be an
             ``int`` in ``[1, 65535]``: this client has to dial the port, so
             unlike :class:`~strands_robots.inference.PolicyServer` - which
@@ -158,7 +169,7 @@ class RemotePolicy(Policy):
     otherwise leave the client silently connected to the default endpoint.
 
     Raises:
-        ValueError: If ``port`` cannot address a server to dial, or if
+        ValueError: If ``host`` or ``port`` cannot address a server to dial, or if
             ``connect_timeout`` / ``request_timeout`` is not a positive finite
             number.
         ConnectionError: On first use, if the server cannot be reached.
@@ -181,8 +192,18 @@ class RemotePolicy(Policy):
         # the caller still holds the value, before ``uri`` exists at all.
         # ``endpoint`` supersedes ``host``/``port``, so the port is validated
         # only when it is the effective spelling.
-        if not endpoint and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
-            raise ValueError(port_error)
+        # ``host`` is the other half of that same URI and is carried into it
+        # verbatim, so it is graded on the same terms and refused first: a
+        # delimiter in the host gives the path everything after it, ``port``
+        # among it, and the parse then dials :80 - which makes the port's own
+        # verdict unreadable rather than wrong.
+        if not endpoint:
+            for _param, _address, _domain in (
+                ("host", host, dial_host_error),
+                ("port", port, tcp_port_error),
+            ):
+                if (error := _domain(_address, _param, type(self).__name__)) is not None:
+                    raise ValueError(error)
         # A timeout that names no budget is refused here, while the caller still
         # holds the value, because the transport's own reaction to one is
         # indistinguishable from an absent server: ``0``, a negative and ``True``

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -198,12 +198,10 @@ class RemotePolicy(Policy):
         # among it, and the parse then dials :80 - which makes the port's own
         # verdict unreadable rather than wrong.
         if not endpoint:
-            for _param, _address, _domain in (
-                ("host", host, dial_host_error),
-                ("port", port, tcp_port_error),
-            ):
-                if (error := _domain(_address, _param, type(self).__name__)) is not None:
-                    raise ValueError(error)
+            if (host_error := dial_host_error(host, "host", type(self).__name__)) is not None:
+                raise ValueError(host_error)
+            if (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+                raise ValueError(port_error)
         # A timeout that names no budget is refused here, while the caller still
         # holds the value, because the transport's own reaction to one is
         # indistinguishable from an absent server: ``0``, a negative and ``True``

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -66,7 +66,7 @@ import numpy as np
 
 from strands_robots.policies._state_keys import drop_velocity_siblings
 from strands_robots.policies.base import Policy
-from strands_robots.utils import name_list_error, tcp_port_error
+from strands_robots.utils import dial_host_error, name_list_error, tcp_port_error
 
 from .client import Cosmos3WebsocketClient
 from .embodiments import (
@@ -111,7 +111,15 @@ class Cosmos3Policy(Policy):
             a checkpoint post-trained on OpenArm episodes (see
             :mod:`strands_robots.policies.cosmos3.embodiments`), not a released
             zero-shot model.
-        host: Policy-server hostname.
+        host: Policy-server hostname or IP literal, and the host half of the
+            ``ws://<host>:<port>`` this client dials. Must be a bare host a URI
+            can carry - no ``/``, ``:``, scheme or credentials, and IPv6
+            bracketed (``"[::1]"``) - because the parse gives a delimiter to a
+            later component and takes the validated ``port`` with it. Read on
+            the same terms as ``port``: only when this constructor builds the
+            client. ``"0.0.0.0"`` reaches a server bound on every interface;
+            whether the host resolves is left to the connect path, which already
+            reports it.
         port: Policy-server WebSocket port, an ``int`` in ``[1, 65535]``.
             Read only when this constructor builds the client; an injected
             ``client`` owns its own address. A value outside the range is
@@ -344,13 +352,20 @@ class Cosmos3Policy(Policy):
                 mode,
             )
         else:
-            # ``port`` addresses the RoboLab policy server this client dials, so
-            # a value that cannot name one is refused before it reaches
-            # ``ws://<host>:<port>``. An injected ``client`` owns its own
-            # address, so the port is validated only when this constructor is
-            # the one that builds the endpoint.
-            if not client and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
-                raise ValueError(port_error)
+            # ``host`` and ``port`` are the two halves of the one address this
+            # client dials, so a value that cannot name one is refused before it
+            # reaches ``ws://<host>:<port>``. The host is graded first: a
+            # delimiter in it re-cuts the URI and the port is the component it
+            # takes, so a bad host makes the port's own verdict unreadable. An
+            # injected ``client`` owns its own address, so both are validated
+            # only when this constructor is the one that builds the endpoint.
+            if not client:
+                for _param, _value, _domain in (
+                    ("host", host, dial_host_error),
+                    ("port", port, tcp_port_error),
+                ):
+                    if (error := _domain(_value, _param, type(self).__name__)) is not None:
+                        raise ValueError(error)
             self._client = client or Cosmos3WebsocketClient(host=host, port=port, api_key=api_key, transport=transport)
             logger.info(
                 "Cosmos3Policy ready [embodiment=%s domain=%s action_space=%s chunk=%d backend=service ws://%s:%d]",

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -360,12 +360,10 @@ class Cosmos3Policy(Policy):
             # injected ``client`` owns its own address, so both are validated
             # only when this constructor is the one that builds the endpoint.
             if not client:
-                for _param, _value, _domain in (
-                    ("host", host, dial_host_error),
-                    ("port", port, tcp_port_error),
-                ):
-                    if (error := _domain(_value, _param, type(self).__name__)) is not None:
-                        raise ValueError(error)
+                if (host_error := dial_host_error(host, "host", type(self).__name__)) is not None:
+                    raise ValueError(host_error)
+                if (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+                    raise ValueError(port_error)
             self._client = client or Cosmos3WebsocketClient(host=host, port=port, api_key=api_key, transport=transport)
             logger.info(
                 "Cosmos3Policy ready [embodiment=%s domain=%s action_space=%s chunk=%d backend=service ws://%s:%d]",

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Literal, get_args
 
 from strands_robots.utils import (
+    dial_host_error,
     positive_finite_number_error,
     positive_whole_number_error,
     tcp_port_error,
@@ -118,93 +119,6 @@ def _embodiment_error(value: Any, param: str, context: str) -> str | None:
         "The embodiment selects the planner/IDM pair, both default ports and the render width, "
         "so an unknown one cannot be resolved to a configuration."
     )
-
-
-# Characters that end the host inside ``ws://<host>:<port>``. Each one starts a
-# later URI component, so a host carrying one does not name a bad host - it names
-# a different URI. ``:`` is in the set because the port follows it, and a
-# bracketed IPv6 literal (``[::1]``) is the one place it belongs to the host.
-_URI_COMPONENT_DELIMITERS = frozenset("/?#@:[]\\")
-
-
-def _dial_host_error(value: Any, param: str, context: str) -> str | None:
-    """Error text when ``value`` cannot address the host half of the server URI.
-
-    ``host`` and ``server_port`` are the two halves of one expression,
-    :attr:`VeraConfig.server_uri`'s ``ws://{host}:{port}``. The port half is held
-    to :func:`~strands_robots.utils.tcp_port_error` because three consumers read
-    it under three coercions and an unusable value is *applied* as three
-    different ports. The host half reaches the same three consumers - it is
-    interpolated into that URI, handed to ``socket.create_connection`` by the
-    runner's readiness probe, and carried as ``--host`` on the server argv - and
-    was held to nothing, so a value that is not a host was not refused but
-    resolved, differently by each of them:
-
-    * A delimiter re-cuts the URI, and the port is what it takes.
-      ``host="127.0.0.1/foo"`` parses as host ``127.0.0.1``, path
-      ``/foo:8820`` and port **80**: the validated port is discarded, so the
-      client dials a port nobody configured. ``host="ws://127.0.0.1"`` - the
-      shape a caller who pastes a URI supplies - parses as host ``ws`` on
-      port 80.
-    * ``""`` is refused by the URI parse itself ("hostname isn't provided"),
-      which raises ``InvalidURI`` rather than the ``OSError`` the client
-      converts into its actionable "could not reach the VERA policy server"
-      hint. It is also the one spelling the readiness probe *accepts*, because
-      that probe maps a bind-only host to loopback: the runner reports "VERA
-      server ready" and the client then cannot build the URI at all.
-    * A non-string reaches ``socket.getaddrinfo`` before anything else and
-      raises ``TypeError: getaddrinfo() argument 1 must be string or None`` out
-      of ``start()``, past the ``TimeoutError``/``RuntimeError`` channel the
-      runner documents.
-
-    Only the shape a URI and a resolver can be *given* is decided here.
-    Whether the host resolves, and whether anything is listening on it, are
-    facts about the network that this constructor cannot know and that the
-    readiness probe already reports.
-
-    ``"0.0.0.0"`` stays accepted. It is the documented way to reach a server
-    bound on every interface, the readiness probe special-cases it, and it
-    interpolates and dials cleanly; ``""`` means the same thing to a ``bind``
-    call and nothing to a URI, so the refusal names ``"0.0.0.0"`` as the
-    spelling that works.
-
-    Args:
-        value: The caller-supplied host.
-        param: The field name it came from, used in the message.
-        context: Message prefix identifying the surface that received it.
-
-    Returns:
-        An error message, or ``None`` when the value can address a host.
-    """
-    if not isinstance(value, str):
-        return (
-            f"{context}: {param} must be a string hostname or IP literal, got {value!r} "
-            f"({type(value).__name__}). It is interpolated into the websocket URI the client "
-            "dials (ws://<host>:<port>) and handed to socket.create_connection, which refuses "
-            "a non-string with a getaddrinfo TypeError that names neither the field nor a fix."
-        )
-    bracketed = value.startswith("[") and value.endswith("]")
-    body = value[1:-1] if bracketed else value
-    if not body:
-        return (
-            f"{context}: {param} must name a host to dial, got {value!r}; "
-            f'ws://{value}:<port> is not a URI (the parse reports "hostname isn\'t provided"). '
-            "Use '0.0.0.0' to reach a server bound on every interface, or '127.0.0.1' for a local one."
-        )
-    own = frozenset(":") if bracketed else frozenset()
-    bad = sorted(
-        {c for c in body if (c in _URI_COMPONENT_DELIMITERS and c not in own) or not c.isprintable() or c.isspace()}
-    )
-    if bad:
-        hint = " Pass a bracketed literal for IPv6 (e.g. '[::1]')." if ":" in bad else ""
-        return (
-            f"{context}: {param} must be a bare hostname or IP literal, got {value!r}; "
-            f"{', '.join(map(repr, bad))} cannot appear in the host half of the websocket URI it is "
-            f"interpolated into (ws://<host>:<port>), so {f'ws://{value}:<port>'!r} names a "
-            "different URI rather than a host - a '/' puts the validated port in the path and the "
-            f"client dials :80 instead.{hint}"
-        )
-    return None
 
 
 def _viewer_port_error(value: Any, param: str, context: str) -> str | None:
@@ -391,7 +305,7 @@ class VeraConfig:
         # ready, the client raises ``InvalidURI`` past the ``OSError`` channel
         # that carries its actionable hint, and a non-string surfaces as a
         # ``getaddrinfo`` ``TypeError`` out of ``start()``.
-        if (err := _dial_host_error(self.host, "host", type(self).__name__)) is not None:
+        if (err := dial_host_error(self.host, "host", type(self).__name__)) is not None:
             raise ValueError(err)
         # Apply per-embodiment port defaults when not explicitly set.
         default_policy, default_vis = _DEFAULT_PORTS[self.embodiment]

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1162,6 +1162,95 @@ def tcp_port_error(value: Any, param: str, context: str) -> str | None:
     return None
 
 
+# Characters that end the host inside ``<scheme>://<host>:<port>``. Each one
+# starts a later URI component, so a host carrying one does not name a bad host -
+# it names a different URI. ``:`` is in the set because the port follows it, and a
+# bracketed IPv6 literal (``[::1]``) is the one place it belongs to the host.
+_URI_COMPONENT_DELIMITERS = frozenset("/?#@:[]\\")
+
+
+def dial_host_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` cannot address the host half of a websocket URI.
+
+    The other half of :func:`tcp_port_error`. Every caller-supplied port this
+    package dials is held to that shared domain, for the reason its consumers
+    record: an unusable port is not refused by the transport, it is *applied*,
+    and surfaces much later as an unreachable server that implicates the service
+    the caller was trying to reach. The host beside it is interpolated into the
+    same expression - ``ws://{host}:{port}`` - and was held to nothing, so the
+    URI parse resolved a value that is not a host instead of refusing it:
+
+    * A URI delimiter re-cuts the URI, and the validated port is the component
+      it takes. ``host="127.0.0.1/foo"`` parses as host ``127.0.0.1``, path
+      ``/foo:<port>`` and port **80**, so the client dials a port nobody
+      configured - the port domain cannot see this, because it is the host half
+      that discards the port. ``host="ws://127.0.0.1"``, the shape a caller who
+      pastes a URI supplies, parses as host ``ws`` on port 80.
+    * ``""`` builds no URI at all: the parse reports "hostname isn't provided"
+      and raises ``InvalidURI``, which is not an ``OSError`` and so escapes the
+      channel these clients convert into their actionable "could not reach the
+      server" hint.
+    * A non-string is carried by the f-string verbatim. ``None`` reaches the
+      resolver as the DNS name ``"none"`` and an ``int`` as its digits, so the
+      client dials a name the caller never wrote.
+    * A resolver silently repairs some values rather than reporting them: a tab
+      inside a host is dropped, and a trailing NUL truncates the lookup.
+
+    Only the shape a URI and a resolver can be *given* is decided here. Whether
+    the host resolves, and whether anything is listening on it, are facts about
+    the network a constructor cannot know and that the connect path already
+    reports.
+
+    ``"0.0.0.0"`` stays accepted: it is the documented way to reach a server
+    bound on every interface, it interpolates and dials cleanly, and readiness
+    probes special-case it. ``""`` means the same thing to a ``bind`` call and
+    nothing to a URI, so the refusal for it names ``"0.0.0.0"`` as the spelling
+    that works.
+
+    A ZMQ endpoint is deliberately not held to this domain. ``tcp://`` is not a
+    URI, and ``zmq``'s own address parse refuses every delimiter spelling above
+    at ``connect`` with the whole address in the message, so the transport there
+    reports what this function would.
+
+    Args:
+        value: The caller-supplied host.
+        param: The field or parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it.
+
+    Returns:
+        An error message, or ``None`` when the value can address a host.
+    """
+    if not isinstance(value, str):
+        return (
+            f"{context}: {param} must be a string hostname or IP literal, got {value!r} "
+            f"({type(value).__name__}). It is interpolated into the websocket URI the client "
+            "dials (ws://<host>:<port>), which carries it verbatim, so the client dials a name "
+            "nobody wrote rather than reporting the value."
+        )
+    bracketed = value.startswith("[") and value.endswith("]")
+    body = value[1:-1] if bracketed else value
+    if not body:
+        return (
+            f"{context}: {param} must name a host to dial, got {value!r}; "
+            f'ws://{value}:<port> is not a URI (the parse reports "hostname isn\'t provided"). '
+            "Use '0.0.0.0' to reach a server bound on every interface, or '127.0.0.1' for a local one."
+        )
+    own = frozenset(":") if bracketed else frozenset()
+    bad = sorted(
+        {c for c in body if (c in _URI_COMPONENT_DELIMITERS and c not in own) or not c.isprintable() or c.isspace()}
+    )
+    if bad:
+        hint = " Pass a bracketed literal for IPv6 (e.g. '[::1]')." if ":" in bad else ""
+        return (
+            f"{context}: {param} must be a bare hostname or IP literal, got {value!r}; "
+            f"{', '.join(map(repr, bad))} cannot appear in the host half of the websocket URI it is "
+            f"interpolated into (ws://<host>:<port>), so {f'ws://{value}:<port>'!r} names a "
+            "different URI rather than a host - a '/' puts the validated port in the path and the "
+            f"client dials :80 instead.{hint}"
+        )
+    return None
+
+
 def non_negative_count_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable non-negative integer count.
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1169,6 +1169,42 @@ def tcp_port_error(value: Any, param: str, context: str) -> str | None:
 _URI_COMPONENT_DELIMITERS = frozenset("/?#@:[]\\")
 
 
+def _read_uri_host(value: str) -> tuple[tuple[str, str, list[str]] | None, str | None]:
+    """The host as a plain string, its body and its delimiters - or why it did not read.
+
+    :func:`dial_host_error`'s verdict is computed from the caller's own string
+    operations - ``startswith``, a slice, and a character scan - and a ``str``
+    subclass owes none of them an answer. That makes this the :func:`_read_name_list`
+    case rather than the :func:`_read_to_quote` one: the read *is* the verdict, so a
+    read that fails becomes one, and the guard refuses a host it could not inspect
+    instead of raising out of the path whose whole purpose is to answer an unusable
+    value with text.
+
+    A bracketed IPv6 literal is unwrapped here because the brackets decide whether
+    ``:`` belongs to the host, which is part of reading it rather than of judging it.
+
+    Args:
+        value: The caller-supplied host, already known to be a ``str``.
+
+    Returns:
+        ``((spelling, body, delimiters), None)`` when the read finished - ``spelling``
+        a plain ``str`` copy the refusal can interpolate, ``body`` unbracketed and
+        ``delimiters`` sorted - or ``(None, description)`` when it did not. Exactly
+        one side is ever populated.
+    """
+    try:
+        spelling = str(value)
+        bracketed = value.startswith("[") and value.endswith("]")
+        body = str(value[1:-1] if bracketed else value)
+        own = frozenset(":") if bracketed else frozenset()
+        bad = sorted(
+            {c for c in body if (c in _URI_COMPONENT_DELIMITERS and c not in own) or not c.isprintable() or c.isspace()}
+        )
+        return (spelling, body, bad), None
+    except Exception as exc:
+        return None, _describe_failed_read(exc)
+
+
 def dial_host_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` cannot address the host half of a websocket URI.
 
@@ -1220,33 +1256,38 @@ def dial_host_error(value: Any, param: str, context: str) -> str | None:
     Returns:
         An error message, or ``None`` when the value can address a host.
     """
+    shown = _refusal_repr(value)
     if not isinstance(value, str):
         return (
-            f"{context}: {param} must be a string hostname or IP literal, got {value!r} "
+            f"{context}: {param} must be a string hostname or IP literal, got {shown} "
             f"({type(value).__name__}). It is interpolated into the websocket URI the client "
             "dials (ws://<host>:<port>), which carries it verbatim, so the client dials a name "
             "nobody wrote rather than reporting the value."
         )
-    bracketed = value.startswith("[") and value.endswith("]")
-    body = value[1:-1] if bracketed else value
+    read, unreadable = _read_uri_host(value)
+    if read is None:
+        return (
+            f"{context}: {param} could not be read as a host ({unreadable}), got {shown}; "
+            "a value whose own string operations do not answer cannot be checked against the "
+            "host half of the websocket URI it would be interpolated into (ws://<host>:<port>). "
+            "Pass a plain hostname or IP literal, e.g. '127.0.0.1'."
+        )
+    spelling, body, bad = read
+    would_be = _refusal_repr(f"ws://{spelling}:<port>")
     if not body:
         return (
-            f"{context}: {param} must name a host to dial, got {value!r}; "
-            f'ws://{value}:<port> is not a URI (the parse reports "hostname isn\'t provided"). '
+            f"{context}: {param} must name a host to dial, got {shown}; "
+            f'{would_be} is not a URI (the parse reports "hostname isn\'t provided"). '
             "Use '0.0.0.0' to reach a server bound on every interface, or '127.0.0.1' for a local one."
         )
-    own = frozenset(":") if bracketed else frozenset()
-    bad = sorted(
-        {c for c in body if (c in _URI_COMPONENT_DELIMITERS and c not in own) or not c.isprintable() or c.isspace()}
-    )
     if bad:
         hint = " Pass a bracketed literal for IPv6 (e.g. '[::1]')." if ":" in bad else ""
         return (
-            f"{context}: {param} must be a bare hostname or IP literal, got {value!r}; "
-            f"{', '.join(map(repr, bad))} cannot appear in the host half of the websocket URI it is "
-            f"interpolated into (ws://<host>:<port>), so {f'ws://{value}:<port>'!r} names a "
-            "different URI rather than a host - a '/' puts the validated port in the path and the "
-            f"client dials :80 instead.{hint}"
+            f"{context}: {param} must be a bare hostname or IP literal, got {shown}; "
+            f"{_refusal_container_repr(bad)} cannot appear in the host half of the websocket URI it "
+            f"is interpolated into (ws://<host>:<port>), so {would_be} names a different URI rather "
+            "than a host - a '/' puts the validated port in the path and the client dials :80 "
+            f"instead.{hint}"
         )
     return None
 

--- a/tests/test_dial_host_is_graded_wherever_the_port_is.py
+++ b/tests/test_dial_host_is_graded_wherever_the_port_is.py
@@ -39,15 +39,21 @@ for an action.
 from __future__ import annotations
 
 import inspect
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
 import strands_robots.utils as utils_module
 from strands_robots.inference.client import RemotePolicy
-from strands_robots.policies.cosmos3.client import Cosmos3WebsocketClient
 from strands_robots.policies.cosmos3.policy import Cosmos3Policy
 from strands_robots.policies.vera import VeraConfig
+
+if TYPE_CHECKING:
+    # Reaches nothing but the `cast` below, which is a string, so the name needs
+    # to exist for a type checker and not at runtime. Under `TYPE_CHECKING` that
+    # is what it costs; imported at runtime it also loads the real client into a
+    # module whose whole point is that a stand-in is never asked to dial.
+    from strands_robots.policies.cosmos3.client import Cosmos3WebsocketClient
 
 # Hosts a URI cannot carry, grouped by what the value did instead of failing.
 # ``':'`` is a delimiter because the port follows it, so a bare IPv6 literal and

--- a/tests/test_dial_host_is_graded_wherever_the_port_is.py
+++ b/tests/test_dial_host_is_graded_wherever_the_port_is.py
@@ -1,0 +1,251 @@
+"""The host half of a dialled websocket address is graded the way its port is.
+
+Every caller-supplied port this package dials is held to one shared domain,
+:func:`strands_robots.utils.tcp_port_error`, for the reason its consumers record:
+an unusable port is not refused by the transport, it is *applied*, and surfaces
+much later as an unreachable server that implicates the service the caller was
+trying to reach. The host beside it is interpolated into the same expression,
+``ws://{host}:{port}``, and was held to nothing on two of the three surfaces that
+build one - so a value that is not a host was resolved rather than refused, and
+the resolution discarded the very port the shared domain had just approved:
+
+* ``host="127.0.0.1/foo"`` parses as host ``127.0.0.1``, path ``/foo:<port>`` and
+  port **80**. The validated port becomes part of the path and the client dials a
+  port nobody configured. The port domain cannot see this: it is the host half
+  that takes the port away.
+* ``host="ws://127.0.0.1"`` - the shape a caller who pastes a URI supplies -
+  parses as host ``ws`` on port 80.
+* ``host=""`` builds no URI at all, raising ``InvalidURI``, which is not an
+  ``OSError`` and so escapes the channel these clients convert into their
+  actionable "could not reach the server" hint.
+* A non-string is carried into the URI verbatim: ``None`` is dialled as the DNS
+  name ``"none"`` and an ``int`` as its digits.
+
+These pin the domain on all three surfaces at once, the shape of the harm against
+the real URI parser, the two documented asymmetries between a stated and an
+unstated address, and the over-reach control that every host a URI *can* carry is
+still accepted identically everywhere.
+
+The ZMQ policy clients are deliberately not held to this domain, and that is
+pinned here too rather than asserted: ``tcp://`` is not a URI, and a cell measures
+that ``zmq``'s own address parse refuses each delimiter spelling at ``connect``
+with the whole address in the message, so the transport there reports what the
+domain would.
+
+Everything here is offline - no server, no socket, and no policy is ever asked
+for an action.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, cast
+
+import pytest
+
+import strands_robots.utils as utils_module
+from strands_robots.inference.client import RemotePolicy
+from strands_robots.policies.cosmos3.client import Cosmos3WebsocketClient
+from strands_robots.policies.cosmos3.policy import Cosmos3Policy
+from strands_robots.policies.vera import VeraConfig
+
+# Hosts a URI cannot carry, grouped by what the value did instead of failing.
+# ``':'`` is a delimiter because the port follows it, so a bare IPv6 literal and
+# a host that already carries a port both re-cut the URI.
+RECUT_THE_URI: list[str] = [
+    "127.0.0.1/foo",
+    "ws://127.0.0.1",
+    "127.0.0.1:9999",
+    "::1",
+    "user@127.0.0.1",
+    "127.0.0.1?x=1",
+    "127.0.0.1#frag",
+]
+
+# Spellings that name no host at all: the parse reports "hostname isn't provided".
+NAME_NO_HOST: list[str] = ["", "[]"]
+
+# Values a resolver silently repairs rather than reporting.
+SILENTLY_REPAIRED: list[str] = ["my host", "my\thost", "127.0.0.1\x00"]
+
+# Non-strings, carried into the URI verbatim by the f-string.
+NOT_A_STRING: list[Any] = [None, 8000, 127.1, True, ["127.0.0.1"]]
+
+UNUSABLE_HOSTS: list[Any] = [*RECUT_THE_URI, *NAME_NO_HOST, *SILENTLY_REPAIRED, *NOT_A_STRING]
+
+# Every host a URI can carry. ``"0.0.0.0"`` is here on purpose: it is the
+# documented way to reach a server bound on every interface.
+USABLE_HOSTS: list[str] = ["127.0.0.1", "localhost", "gpu-box", "gpu-box.local", "[::1]", "0.0.0.0"]
+
+
+class _StandInClient:
+    """A client object that owns its own address, injected instead of built.
+
+    Deliberately not a real ``Cosmos3WebsocketClient``: the point of the cell it
+    serves is that the constructor never looks at the address when one is
+    injected, so a stand-in that would fail on any other use is the strongest
+    form of that claim.
+    """
+
+
+def _remote_policy_refusal(host: Any) -> str | None:
+    """Refusal :class:`~strands_robots.inference.client.RemotePolicy` gives ``host``."""
+    try:
+        RemotePolicy(host=host)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _cosmos3_refusal(host: Any) -> str | None:
+    """Refusal :class:`~strands_robots.policies.cosmos3.policy.Cosmos3Policy` gives ``host``."""
+    try:
+        Cosmos3Policy(embodiment="droid", host=host)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _vera_refusal(host: Any) -> str | None:
+    """Refusal :class:`~strands_robots.policies.vera.VeraConfig` gives ``host``."""
+    try:
+        VeraConfig(embodiment="pusht", host=host)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+# The surfaces that build ``ws://{host}:{port}`` from a caller-supplied host.
+# Read through each public constructor, not through the domain function, so the
+# cells grade the behaviour a caller gets rather than the wiring behind it.
+WEBSOCKET_SURFACES: dict[str, Any] = {
+    "RemotePolicy": _remote_policy_refusal,
+    "Cosmos3Policy": _cosmos3_refusal,
+    "VeraConfig": _vera_refusal,
+}
+
+
+@pytest.mark.parametrize("surface", sorted(WEBSOCKET_SURFACES))
+@pytest.mark.parametrize("host", UNUSABLE_HOSTS, ids=repr)
+def test_a_host_a_uri_cannot_carry_is_refused_by_every_websocket_surface(surface: str, host: Any) -> None:
+    """A value that cannot address a host is refused, not dialled as something else."""
+    message = WEBSOCKET_SURFACES[surface](host)
+    assert message is not None, f"{surface} accepted host={host!r}"
+    assert message.startswith(f"{surface}: host "), message
+    assert repr(host) in message, message
+
+
+@pytest.mark.parametrize("surface", sorted(WEBSOCKET_SURFACES))
+@pytest.mark.parametrize("host", USABLE_HOSTS)
+def test_every_host_a_uri_can_carry_is_still_accepted_everywhere(surface: str, host: str) -> None:
+    """The over-reach control: the domain refuses addresses, not deployments."""
+    assert WEBSOCKET_SURFACES[surface](host) is None
+
+
+def test_the_three_surfaces_give_the_same_verdict_on_the_same_host() -> None:
+    """One address cannot be refused by one client and dialled by the next."""
+    for host in [*UNUSABLE_HOSTS, *USABLE_HOSTS]:
+        verdicts = {name: refuse(host) is None for name, refuse in WEBSOCKET_SURFACES.items()}
+        assert len(set(verdicts.values())) == 1, f"host={host!r} split the surfaces: {verdicts}"
+
+
+@pytest.mark.parametrize("host", RECUT_THE_URI, ids=repr)
+def test_a_refused_delimiter_host_is_what_takes_the_validated_port(host: str) -> None:
+    """Measured against the real parser: the refusal is the port being discarded.
+
+    Pins the harm rather than restating the rule. ``websockets`` is the parser
+    these clients hand the URI to, so its reading of the pre-fix value is the
+    external oracle for what the host half did to the port beside it.
+    """
+    parse_uri = pytest.importorskip("websockets.uri").parse_uri
+    port = 8765
+    try:
+        parsed = parse_uri(f"ws://{host}:{port}")
+    except Exception:
+        # Some spellings the parse refuses outright; either way it is not a dial
+        # to the configured port, which is what the refusal exists to prevent.
+        return
+    assert (parsed.host, parsed.port) != (host, port), (
+        f"host={host!r} was expected to re-cut the URI, but parsed as the configured address"
+    )
+
+
+def test_a_zmq_endpoint_is_left_to_the_transport_that_already_refuses_it() -> None:
+    """The deferral is measured: ``zmq`` reports what the domain would.
+
+    The GR00T and MoveIt2 policy clients dial ``tcp://{host}:{port}``, not a URI,
+    and are deliberately outside this domain. That is only defensible if their
+    transport refuses the same spellings, so it is measured here instead of
+    assumed.
+    """
+    zmq = pytest.importorskip("zmq")
+    context = zmq.Context()
+    try:
+        for host in RECUT_THE_URI[:2] + SILENTLY_REPAIRED[:2]:
+            socket = context.socket(zmq.REQ)
+            socket.setsockopt(zmq.LINGER, 0)
+            endpoint = f"tcp://{host}:5556"
+            try:
+                with pytest.raises(zmq.ZMQError) as caught:
+                    socket.connect(endpoint)
+                # zmq names the whole endpoint it refused, escaping any
+                # non-printable in it - the report a caller needs to see which
+                # half of the address was wrong.
+                assert repr(endpoint)[1:-1] in str(caught.value), str(caught.value)
+            finally:
+                socket.close()
+    finally:
+        context.term()
+
+
+# Asymmetries between the surfaces, each with the reason it is one. A host is
+# only graded when it is the effective spelling of the address; a surface that
+# was handed the address some other way never reads it.
+STATED_ELSEWHERE: dict[str, str] = {
+    "RemotePolicy(endpoint=...)": (
+        "endpoint supersedes host/port and is the whole URI, so the host is not the spelling in use - "
+        "the same terms on which port is already left unread"
+    ),
+    "Cosmos3Policy(client=...)": (
+        "an injected client owns its own address, so this constructor never builds ws://<host>:<port> - "
+        "the same terms on which port is already left unread"
+    ),
+}
+
+
+def test_every_asymmetry_states_why_it_is_one() -> None:
+    """A surface left ungraded needs a recorded reason, not an omission."""
+    assert all(reason.strip() for reason in STATED_ELSEWHERE.values())
+
+
+def test_an_endpoint_supersedes_the_host_it_replaces() -> None:
+    """A stated URL is the address, so the unused host half is not graded."""
+    policy = RemotePolicy(endpoint="ws://gpu-box:8765", host="127.0.0.1/foo")
+    assert policy.uri == "ws://gpu-box:8765"
+
+
+def test_an_injected_client_owns_the_address_this_constructor_did_not_build() -> None:
+    """Cosmos 3 reads host only when it is the one building the endpoint."""
+    injected = cast("Cosmos3WebsocketClient", _StandInClient())
+    policy = Cosmos3Policy(embodiment="droid", host="127.0.0.1/foo", client=injected)
+    assert isinstance(policy, Cosmos3Policy)
+
+
+def test_the_domain_has_one_owner_and_no_consumer_restates_it() -> None:
+    """The rule lives beside the port domain it is the other half of.
+
+    A second copy is how the two halves drift apart: one surface would refuse an
+    address the next dials. The consumers are graded on calling the shared owner
+    rather than spelling the delimiter set themselves.
+    """
+    for domain in ("dial_host_error", "tcp_port_error"):
+        owner = getattr(utils_module, domain, None)
+        assert owner is not None, f"{domain} is not owned by {utils_module.__name__}"
+        assert owner.__module__ == utils_module.__name__
+    for module_name, source in (
+        ("cosmos3.policy", inspect.getsource(Cosmos3Policy.__init__)),
+        ("inference.client", inspect.getsource(RemotePolicy.__init__)),
+        ("vera.config", inspect.getsource(type(VeraConfig(embodiment="pusht")).__post_init__)),
+    ):
+        assert "dial_host_error" in source, module_name
+        assert "isprintable" not in source, f"{module_name} restates the host domain"

--- a/tests/test_dial_host_is_graded_wherever_the_port_is.py
+++ b/tests/test_dial_host_is_graded_wherever_the_port_is.py
@@ -314,3 +314,119 @@ def test_the_probe_really_refuses_the_read_the_guard_makes() -> None:
     assert isinstance(probe, str)
     with pytest.raises(RuntimeError, match="no read for you"):
         probe.startswith("[")
+
+
+class RefusesToBeCopied(str):
+    """A ``str`` subclass whose ``__str__`` raises."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("no read for you")
+
+
+class RefusesToBeSliced(str):
+    """A ``str`` subclass whose ``__getitem__`` raises."""
+
+    def __getitem__(self, index: Any) -> str:
+        raise RuntimeError("no read for you")
+
+
+#: ``(operation, host)`` for the operations the read performs on the caller's own
+#: value, beside the ``startswith`` the cell above covers. The slice is reached
+#: only for a bracketed literal, because that is the only host whose brackets are
+#: stripped - so each row needs the host that reaches it.
+OPERATIONS_THE_READ_MAKES: list[tuple[str, Any]] = [
+    ("__str__", RefusesToBeCopied("127.0.0.1")),
+    ("__getitem__", RefusesToBeSliced("[::1]")),
+]
+
+
+@pytest.mark.parametrize("surface", sorted(WEBSOCKET_SURFACES))
+@pytest.mark.parametrize(
+    ("operation", "host"), OPERATIONS_THE_READ_MAKES, ids=[operation for operation, _ in OPERATIONS_THE_READ_MAKES]
+)
+def test_no_operation_the_read_makes_escapes_the_try(surface: str, operation: str, host: Any) -> None:
+    """Each operation separately, because one probe only reaches the first of them.
+
+    Reading a host is three operations on the caller's object - a copy, a prefix
+    test and a slice - and a subclass may refuse any one of them. Covering only
+    the first leaves the other two: a read moved out of the ``try`` still answers
+    a value that refuses ``startswith`` and raises on one that refuses the
+    operation that moved.
+    """
+    message = WEBSOCKET_SURFACES[surface](host)
+    assert message is not None, f"{surface} accepted a host whose {operation} does not answer"
+    assert "could not be read" in message, message
+    assert "RuntimeError: no read for you" in message, message
+
+
+class RefusesToEndswith(str):
+    def endswith(self, *args: Any, **kwargs: Any) -> bool:
+        raise RuntimeError("never called")
+
+
+class RefusesToBeIterated(str):
+    def __iter__(self) -> Any:
+        raise RuntimeError("never called")
+
+
+class RefusesToBeRepred(str):
+    def __repr__(self) -> str:
+        raise RuntimeError("never called")
+
+
+#: ``(operation, host, why it is never reached)``. These are the string
+#: operations a reader of a host *could* make and this one does not, so a
+#: usable host carrying them is accepted rather than reported unreadable.
+OPERATIONS_THE_READ_AVOIDS: list[tuple[str, Any, str]] = [
+    ("endswith", RefusesToEndswith("127.0.0.1"), "'and' short-circuits when the value does not start with '['"),
+    ("__iter__", RefusesToBeIterated("127.0.0.1"), "the character scan runs over a plain str copy, not the value"),
+    ("__repr__", RefusesToBeRepred("127.0.0.1"), "the value is rendered through the shared guarded renderer"),
+]
+
+
+@pytest.mark.parametrize(
+    ("operation", "host", "why"),
+    OPERATIONS_THE_READ_AVOIDS,
+    ids=[operation for operation, _, _ in OPERATIONS_THE_READ_AVOIDS],
+)
+def test_an_operation_the_read_never_makes_leaves_a_usable_host_usable(operation: str, host: Any, why: str) -> None:
+    """The over-reach control, and the pin on how the read is narrow.
+
+    A refusal for every host that carries an unusual ``str`` subclass would be a
+    domain nobody could pass, so the reader must reach only what it needs. Each
+    row records the reason it does not reach this one; ``__iter__`` is the
+    load-bearing one, since it is unreachable only while the scanned body is a
+    copy the module made rather than the object it was handed.
+    """
+    assert utils_module.dial_host_error(host, "host", "Ctx") is None, (
+        f"a usable host was refused over {operation}, which the read does not make: {why}"
+    )
+
+
+# Each surface with BOTH halves of its address unusable at once. The port keyword
+# differs per surface (``port`` / ``server_port``), so the constructors are
+# written out rather than derived from one signature.
+BOTH_HALVES_UNUSABLE: dict[str, Any] = {
+    "RemotePolicy": lambda host: RemotePolicy(host=host, port=65536),
+    "Cosmos3Policy": lambda host: Cosmos3Policy(embodiment="droid", host=host, port=65536),
+    "VeraConfig": lambda host: VeraConfig(embodiment="pusht", host=host, server_port=65536),
+}
+
+
+@pytest.mark.parametrize("surface", sorted(BOTH_HALVES_UNUSABLE))
+@pytest.mark.parametrize("host", RECUT_THE_URI, ids=repr)
+def test_the_host_is_graded_before_the_port_it_would_have_taken(surface: str, host: str) -> None:
+    """A caller who gets both halves wrong is told about the host.
+
+    The two refusals sit in each constructor as consecutive statements, so which
+    one a caller sees is decided by their order - and it has to be the host: the
+    delimiter in it is what re-cuts the URI and carries the port away, so
+    reporting the port would name the component that was discarded rather than
+    the one that discarded it. Stated independently in all three constructors,
+    so it is pinned per surface rather than once.
+    """
+    with pytest.raises(ValueError) as caught:
+        BOTH_HALVES_UNUSABLE[surface](host)
+    message = str(caught.value)
+    assert "host" in message, f"{surface} refused the port before the host that would have taken it: {message}"
+    assert "65536" not in message, f"{surface} named the discarded port instead of the host: {message}"

--- a/tests/test_dial_host_is_graded_wherever_the_port_is.py
+++ b/tests/test_dial_host_is_graded_wherever_the_port_is.py
@@ -38,7 +38,9 @@ for an action.
 
 from __future__ import annotations
 
+import ast
 import inspect
+import textwrap
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -253,5 +255,62 @@ def test_the_domain_has_one_owner_and_no_consumer_restates_it() -> None:
         ("inference.client", inspect.getsource(RemotePolicy.__init__)),
         ("vera.config", inspect.getsource(type(VeraConfig(embodiment="pusht")).__post_init__)),
     ):
-        assert "dial_host_error" in source, module_name
+        called = _domains_called(source)
+        assert "dial_host_error" in called, f"{module_name} does not call dial_host_error: {sorted(called)}"
         assert "isprintable" not in source, f"{module_name} restates the host domain"
+
+
+def _domains_called(source: str) -> set[str]:
+    """Names this source *calls*, so a mere reference does not count as a check.
+
+    Read as a call graph rather than as text because a guard that collapses the
+    two halves into a table - ``for param, value, domain in ((...),)`` - still
+    contains both domain names while calling neither by name. That shape reads as
+    equivalent and is not: the sibling port guard in
+    ``tests/policies/test_service_port_domain.py`` grades provider constructors
+    on an ``ast.Call`` to ``tcp_port_error``, so a table would be reported there
+    as a provider shipping an unvalidated port. Both halves are pinned here on
+    the same terms as that guard uses for the port.
+    """
+    tree = ast.parse(textwrap.dedent(source))
+    return {node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)}
+
+
+class RefusesItsOwnRead(str):
+    """A ``str`` subclass that answers no string operation the guard performs.
+
+    Not hypothetical, and not a hostile-input exercise: a host arrives from a
+    config file, an env var or an agent tool, and any of those may hand over a
+    ``str`` subclass carrying provenance. It is a ``str`` by ``isinstance``, so it
+    reaches the character scan that decides the verdict, and the scan is the
+    caller's own code.
+    """
+
+    def startswith(self, *args: Any, **kwargs: Any) -> bool:
+        raise RuntimeError("no read for you")
+
+
+@pytest.mark.parametrize("surface", sorted(WEBSOCKET_SURFACES))
+def test_a_host_that_cannot_be_read_is_refused_rather_than_raised_past(surface: str) -> None:
+    """A host the guard cannot inspect is a refusal, on the channel refusals use.
+
+    The domain reports through a returned message that each constructor turns into
+    a ``ValueError``, so the read it makes to reach that verdict must not raise a
+    different exception out of the same call: a ``RuntimeError`` from a character
+    scan escapes every ``except ValueError`` a caller wrote for this parameter.
+    Unreadable is a refusal because the read *is* the verdict here - a host that
+    cannot be inspected cannot be certified as one a URI can carry.
+    """
+    message = WEBSOCKET_SURFACES[surface](RefusesItsOwnRead("127.0.0.1"))
+    assert message is not None, f"{surface} accepted a host it could not read"
+    assert message.startswith(f"{surface}: host "), message
+    assert "could not be read" in message, message
+    assert "RuntimeError: no read for you" in message, message
+
+
+def test_the_probe_really_refuses_the_read_the_guard_makes() -> None:
+    """Non-vacuity: a probe that had started answering would pass the cell above."""
+    probe = RefusesItsOwnRead("127.0.0.1")
+    assert isinstance(probe, str)
+    with pytest.raises(RuntimeError, match="no read for you"):
+        probe.startswith("[")


### PR DESCRIPTION
Every caller-supplied port this package dials is held to one shared domain, `strands_robots.utils.tcp_port_error`. Its consumers say why, in comments they wrote themselves:

> `port` addresses the RoboLab policy server this client dials, so a value that cannot name one is refused before it reaches `ws://<host>:<port>`. — `policies/cosmos3/policy.py`

> an unusable port is not rejected by the transport, it surfaces later as an unreachable server and implicates the service you were trying to reach. — `docs/inference/remote.md`

The **host** is the other half of that same expression. It was held to nothing on two of the three surfaces that build one — and the value it admits is what *discards the port the shared domain had just approved*.

![host domain, measured on both trees](https://raw.githubusercontent.com/cagataycali/robots/8035aa200731f04218e54b156da692127fb48801/pr3272/dial_host_domain.png)

**24 of 48 (host, surface) pairs dialled an address other than the one configured, or none at all → 0.** Every cell measured by constructing the real object on each tree; the right-hand column is `websockets.uri.parse_uri` and `socket.getaddrinfo`, the two things these clients actually hand the value to.

## What the host half did instead of failing

| `host=` beside `port=8765` | measured | 
|---|---|
| `"127.0.0.1/foo"` | host `127.0.0.1`, path `/foo:8765`, port **80** — the validated port is in the path |
| `"ws://127.0.0.1"` (a pasted URI) | host `ws`, port **80** |
| `"127.0.0.1?x=1"` | host `127.0.0.1`, port **80** |
| `"my\thost"` | tab silently dropped → dials `myhost` |
| `8000` (an int) | `getaddrinfo("8000")` → **`0.0.31.64`**, the digits read as a packed IPv4 address |
| `None` | dials the DNS name `"none"` |
| `"127.0.0.1\0"` | resolver truncates at the NUL |
| `""`, `"::1"`, `"user@…"`, `"127.0.0.1:9999"` | no URI at all — `InvalidURI`/`ValueError`, neither an `OSError`, so it escapes the channel these clients convert into their actionable "could not reach the server" hint |

The port domain cannot see any of this: it is the host half that takes the port away.

## Change

The rule moves to `strands_robots.utils.dial_host_error`, beside the port domain it is the other half of, and all three surfaces read it — `RemotePolicy`, `Cosmos3Policy`, `VeraConfig` (which had a private copy; it is deleted, not duplicated). One address can no longer be refused by one client and dialled by the next.

Only the shape a URI and a resolver can be *given* is decided. Whether the host resolves stays a fact about the network that the connect path already reports.

**Deliberately unchanged, each pinned as a cell with its reason:**

- `endpoint=` on `RemotePolicy` and an injected `client=` on `Cosmos3Policy` still own their own address — the same terms on which `port` is already left unread.
- `"0.0.0.0"` stays accepted: the documented way to reach a server bound on every interface. The refusal for `""` names it as the spelling that works.
- **The ZMQ policy clients (GR00T, MoveIt2) keep their transport's verdict**, and this is measured rather than assumed: `tcp://` is not a URI, and `zmq` refuses each of these spellings at `connect` with the whole address in the message (`ZMQError: Invalid argument (addr='tcp://127.0.0.1/foo:5556')`). A cell in the test measures that, so the boundary is a fact and not a preference.

## Tests

New `tests/test_dial_host_is_graded_wherever_the_port_is.py` — 116 cells, offline, no server and no socket. Read through each public constructor, never through the domain function, so the cells grade the behaviour a caller gets.

Re-measured at `558529f` against merge-base `a6e9943`, with production reverted and the test held:

| production | new test file |
|---|---|
| reverted to `main` | **62 F** / 54 P |
| as shipped | 116 P |

So 54 of the 116 cells are controls that already hold on `main`, and 62 fail without the change. The 3 standing failures in `tests/inference/test_a_stopped_server_stops_serving_its_clients.py` reproduce identically on a clean `upstream/main` worktree and are unrelated.

Gate: `ruff check` + `ruff format --check` clean; `mypy` adds no error (the one reported, `simulation/ik.py:174`, is pre-existing).

## Size

Measured with `git diff --numstat a6e9943 HEAD` (equals the API's 661 / 104 / 8):

| | + | − | net |
|---|---|---|---|
| production (4 files) | 178 | 104 | **+74** |
| test (1 new file) | 432 | 0 | +432 |
| docs + changelog | 51 | 2 | +49 |

Production is far smaller than the raw count suggests: by AST statement, excluding docstrings, the four files go 971 → 988, **+17 executable statements**. The shared owner is mostly its docstring, and deleting vera's private copy gives back 14 statements.

## 13. Review rounds

### Round 1 — `65d0fbd`

**Concern:** the stand-in-client cell's import of `Cosmos3WebsocketClient` was reported as unused.

The name is reached only through `cast("Cosmos3WebsocketClient", ...)` — a *string*, so the extractor behind that finding, which reads bare `Name` loads, sees no use. `AGENTS.md` prescribes answering this by counterfactual rather than by reading the alert, and the counterfactual puts it in the load-bearing column:

```
$ ruff check tests/test_dial_host_is_graded_wherever_the_port_is.py   # import deleted
F821 Undefined name `Cosmos3WebsocketClient`
  --> tests/test_dial_host_is_graded_wherever_the_port_is.py:228:22
```

So deleting it is refused by the two gates this repo actually runs (`ruff`, `mypy`, both inside `call-test-lint`). What the file *had* wrong is the other half: the import was at **runtime**, which `AGENTS.md` names as the workaround for this alert rather than the idiom — it pays a runtime load of the real client and still draws the finding. The three prior instances all use `if TYPE_CHECKING:`.

**Change:** the import moves under `if TYPE_CHECKING:`, with a comment stating why the name is type-only. Two consequences beyond silencing nothing:

- an offline module whose whole point is that a stand-in is *never asked to dial* no longer loads the real websocket client at import time;
- the name's sole binding is now the type-only import, which is the precondition `tests/test_cast_string_imports_are_the_names_only_binding.py` grades. This site now enters that grader's tree-derived population (16 sites, alongside `fast_td3.py` and the two prior test sites), so the finding is *read* as the already-adjudicated false positive instead of re-derived a fourth time.

**Verification:** `ruff check` + `ruff format --check` clean. `mypy` unchanged at 11 pre-existing errors (identical with the commit reverted). The four corners are identical with and without this commit — 13 failed / 1597 passed / 12 skipped both ways, every failure an absent optional dependency (`mujoco`, `msgpack`, `websockets`) rather than a moved assertion. The 102-grader whole-tree roster reports this file in no failure or error.

The finding recurred at the new line as alert 1167 and was dismissed `false positive`, which is the action the table in that `AGENTS.md` entry prescribes for the load-bearing column; its 274-character dismissal comment points back at `AGENTS.md` rather than restating the reasoning there.

Only the Size table above moved: test file +251 → **+257**.

### Round 2 — `51b24dd`, base merge `90c36f5`

Two concerns, and the first is the one the required check found.

**Concern 1: the port guard was invisible to the guard that enforces it.**
`call-test-lint` went red on `65d0fbd` at a grader this branch never edited:

```
FAILED tests/policies/test_service_port_domain.py::TestNoProviderShipsAnUnguardedPort::test_every_provider_taking_a_port_validates_it
  AssertionError: these provider constructors accept a port without validating it
  against strands_robots.utils.tcp_port_error: ['policy.py::Cosmos3Policy']
1 failed, 11622 passed, 35 skipped
```

That grader scans every `policies/*/policy.py` for an `ast.Call` whose `func` is an `ast.Name` of `tcp_port_error`. Round 1 spelled both domains as a table iterated over — `for _param, _value, _domain in (("host", host, dial_host_error), ("port", port, tcp_port_error))` — so the call site reads `_domain(...)`: the func name is the loop variable, both domains are *named* while neither is *called*, and `Cosmos3Policy` read there as a provider shipping an unvalidated port.

The refusal was correct rather than pedantic. That grader's stated purpose is that "a fifth provider cannot repeat this by copying a sibling constructor", so a constructor whose guard no scan can confirm defeats the invariant, and a provider copying this one would inherit the blindness. The table also bought nothing: two sequential `if`s are shorter and keep the host-first ordering the comment above them already explains.

Both surfaces now call each domain by name. `RemotePolicy` carried the same shape and was not failing — `inference/client.py` is not a `policies/*/policy.py`, so it sits outside that grader's population — but it is the same latent defect against the same convention, and all five port-domain graders in the tree key on a direct call, so both are spelled the same way rather than leaving one to be found later.

**Concern 2: the host domain computed its verdict from unguarded reads.**
`dial_host_error`'s answer comes from the caller's own string operations — `startswith`, a slice, a character scan — and a `str` subclass owes none of them one. The reads move into `_read_uri_host` behind the module's guarded-read layer, so a value whose own operations raise is *refused with the failed read described* instead of escaping as a `RuntimeError` out of a function documented to report through `ValueError`. The message renders through `_refusal_repr`, which is the contract `tests/test_refusal_messages_never_raise.py` states over this module rather than a preference.

Behaviour for every value the domain already decided is unchanged; what moves is the class that previously escaped the documented channel.

**Verification.** `tests/policies/test_service_port_domain.py` + `tests/test_dial_host_is_graded_wherever_the_port_is.py`: 154 passed, 14 skipped. Replicating the grader's AST predicate directly over its whole population reports no offender, and both constructors now answer `True` for a direct call to each domain. Affected areas (`tests/inference tests/policies/cosmos3 tests/policies/vera` + both graders): 1673 passed, the 13 failures all absent optional dependencies (`mujoco`) or the three standing `test_a_stopped_server_stops_serving_its_clients` failures this description already records. `ruff check` and `ruff format --check` clean on both changed files. The whole-tree roster was run twice, with and without the fix, and the failure set is byte-identical at 293 entries — every one an absent optional dependency in the local environment — so nothing moved.

**Correction to Round 1.** That entry claimed "the 102-grader whole-tree roster reports this file in no failure or error", and offered it as evidence the branch was clean. It was true and it was not evidence: `tests/policies/test_service_port_domain.py` is **not in that roster**, so a green preflight could not have said otherwise. Its walk root is derived as `Path(inspect.getfile(create_policy)).parent`, and `create_policy` is imported from `strands_robots.policies`, which only re-exports it — the one shape `AGENTS.md` step 2 names as resolving to nothing rather than to a guess. Measured with the script's own resolver, `walked_paths` returns `set()` and the file is absent from the 104-entry roster. So this branch is a live instance of the presentation `tests/test_whole_tree_graders_roster_is_complete.py` exists to prevent: a green `whole-tree-check` cited in a description beside a red required check, reached through a spelling the derivation cannot see. Filed as #3273 with the site and a proposed pin; it is a separate concern from this branch's host domain and is deliberately not folded in here.

### Round 3 — `558529f`

Round 2's two fixes are correct and this round adds nothing to either. It closes
the two properties they left ungraded. Both numbers below are measured against
Round 2's own tests, on `tests/test_refusal_messages_never_raise.py` +
`tests/policies/test_service_port_domain.py` +
`tests/test_dial_host_is_graded_wherever_the_port_is.py` (274 cells at `90c36f5`,
304 after):

| mutation of Round 2's code | fired before | fired after |
|---|---|---|
| `Cosmos3Policy` grades the port first | 0 | 7 |
| `RemotePolicy` grades the port first | 0 | 7 |
| both surfaces grade the port first | 0 | 14 |
| the `str()` copy hoisted out of the `try` | 0 | 3 |
| only the bracketed slice hoisted out of the `try` | 0 | 3 |
| the whole read hoisted out of the `try` | 9 | 9 |
| every `str` subclass reported unreadable | 12 | 12 |
| the plain-`str` body copy dropped | 0 | 1 |

**Which refusal a caller gets was unpinned.** Replacing the table with two
sequential `if`s made the order plain statement order, and nothing graded it — so
a later edit could swap them silently. It has to be the host: the delimiter in it
is what carries the port away, so naming the port would name the component that
was discarded rather than the one that discarded it. Pinned per surface, because
all three state the order independently.

**One probe reaches one of three reads.** `_read_uri_host` performs three
operations on the caller's object — `str()`, `startswith` and, for a bracketed
literal, a slice — and `RefusesItsOwnRead` overrides only `startswith`. Hoisting
either of the other two out of the `try` left the suite green. Each is now driven
by the host that reaches it.

**And three operations it deliberately does not make**, each with the reason,
because a domain that refused every unusual `str` subclass would be one nobody
could pass: `endswith` (the `and` short-circuits unless the value starts with
`[`), `__iter__` (the character scan runs over a plain `str` copy, not the object
handed in) and `__repr__` (rendered through the shared guarded renderer). The
`__iter__` row is load-bearing rather than decorative — dropping the `str(...)`
around the body is what makes it reachable, and that mutation fires exactly that
control and nothing else.

Test-only: `+116` lines, no production change.

**Verification.** `ruff check` + `ruff format --check` clean over
`strands_robots tests tests_integ`; `mypy` (1.20.2, the pinned version)
`Success: no issues found in 1915 source files`. The 463-file tree-walking guard
population — every test deriving its own population from the tree, a superset of
`scripts/check_whole_tree_graders.py`, and the selection `-x` never reaches once
an earlier failure stops the run — reports **7 failed, 24514 passed**, and all
seven reproduce with identical node ids on a clean `a6e9943` worktree (five
assert `rclpy` is absent where the host supplies it; two read an installed
`websockets` 16.0 against the `>=17.0` floor this package declares). Affected
areas (`tests/policies tests/inference tests/training` + both censuses):
**11572 passed**, the 5 failures the same environmental set.


Alert 1168 (`py/unexpected-raise-in-special-method`, note) opened on
`RefusesToBeSliced.__getitem__` and is dismissed `used in tests`, with the argument in
the review thread rather than in the 280-character comment. Two things in it are worth
having here, because the first is a correction to the reason this repo has on file.

The dismissal does **not** claim the suggested fix would break the cell. `AGENTS.md`
records that reason for the two prior instances of this rule id - `IndexError` is what
CPython's `seqiter` clears to end legacy-protocol iteration, so a conforming
`__getitem__` would leave the probe raising nothing - and measured against *this*
fixture it is false. `_read_uri_host` reads behind `except Exception`, so `RuntimeError`,
`IndexError` and `KeyError` are all converted to the same refusal; and this probe
subclasses `str`, which supplies `__iter__`, so the `seqiter` path the prior argument
turns on is never reached. That reason is scoped to #1890's `Sequence` probe and was not
restated here.

What a conforming `__getitem__` would cost is the property, not the assertion. The rule's
own help text names the harm as a caller's handler bypassed by an unconventional class,
which is the thing this file grades: `_read_uri_host` is documented on the premise that
"a `str` subclass owes none of them an answer". A `LookupError` models a value refusing
*within* the protocol, so the cell would grade conversion of an exception the protocol
already expects - green, and measuring strictly less than
`test_no_operation_the_read_makes_escapes_the_try` is there to measure. The population
confirms the alert reports the convention rather than a defect: the same file raises
`RuntimeError` from `__str__` (322), `__iter__` (368) and `__repr__` (374), and none of
the three is flagged.