### PR TITLE
test: a walk root derived from a re-exported symbol is refused, not silently unrostered

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,7 +383,9 @@ hatch run format            # ruff check --fix, ruff format
    all of those resolve. The one shape that does not is a symbol imported from
    a module that only *re-exports* it: the import does not say which file the
    symbol came from, so it resolves to nothing rather than to a guess. Import
-   from the defining module.
+   from the defining module. A pin screens the whole tree for that shape and
+   names the module to import from, so a site that breaks the rule fails the
+   required check instead of dropping out of the roster unnoticed (#3273).
 3. Record the change as a news fragment: `changelog.d/<pr-number>-<slug>.md`
    (see [`changelog.d/README.md`](changelog.d/README.md)). **Never append to
    `## [Unreleased]` in `CHANGELOG.md` directly** - every branch inserts at the

--- a/changelog.d/3274-re-export-walk-root.md
+++ b/changelog.d/3274-re-export-walk-root.md
@@ -1,0 +1,28 @@
+### Fixed: a grader deriving its walk root from a re-exported symbol is refused rather than silently unrostered
+
+`AGENTS.md` asks a whole-tree grader to derive its walk root from an imported
+symbol, and states the one spelling that does not resolve: a symbol imported
+from a module that only re-exports it, where the import does not say which file
+the symbol came from. Nothing refused a site that broke the rule, and the
+failure is silent in the reassuring direction -- the root resolves to nothing,
+so the module drops out of the preflight roster entirely and
+`scripts/check_whole_tree_graders.py` reports a clean run over the graders it
+can see while collecting none of that one.
+
+`tests/policies/test_service_port_domain.py` broke it, deriving the scan root
+for `TestNoProviderShipsAnUnguardedPort` from `create_policy` imported out of
+`strands_robots.policies` rather than out of
+`strands_robots.policies.factory`, which defines it. It now imports from the
+defining module; `inspect.getfile` answers the same object either way, so the
+files the grader scans do not change.
+
+`tests/test_whole_tree_graders_roster_is_complete.py` gains a cell that screens
+every module under `tests/` for the shape and names the module to import from,
+so the rule is enforced rather than only written down. The resolver's half was
+already pinned on planted source; a correct resolver cannot keep the shape out
+of the tree, which is what this cell adds.
+
+`check_whole_tree_graders.module_file` and
+`check_whole_tree_graders.MODULE_FILE_FUNCS` are public, so the pin screens with
+the derivation's own resolver instead of restating what "the module that defines
+it" means.

--- a/scripts/check_whole_tree_graders.py
+++ b/scripts/check_whole_tree_graders.py
@@ -198,7 +198,7 @@ PACKAGE = "strands_robots"
 _WALK_METHODS = frozenset({"rglob", "glob", "iterdir", "walk"})
 
 #: Callables that answer "the file this module was loaded from".
-_MODULE_FILE_FUNCS = frozenset({"getfile", "getsourcefile"})
+MODULE_FILE_FUNCS = frozenset({"getfile", "getsourcefile"})
 
 #: Parsed top-level name sets, keyed by module file. A first-party module is
 #: read at most once per process however many graders import a symbol from it.
@@ -274,7 +274,7 @@ def _top_level_names(path: Path) -> frozenset[str]:
     return found
 
 
-def _module_file(dotted: str, root: Path) -> Path | None:
+def module_file(dotted: str, root: Path) -> Path | None:
     """Return the file a first-party dotted name loads from, if any.
 
     Both a module and a *member* a module defines resolve, because
@@ -300,7 +300,7 @@ def _module_file(dotted: str, root: Path) -> Path | None:
         if candidate.is_file():
             return candidate
     package, _, member = dotted.rpartition(".")
-    defining = _module_file(package, root) if member else None
+    defining = module_file(package, root) if member else None
     if defining is not None and member in _top_level_names(defining):
         return defining
     return None
@@ -321,12 +321,12 @@ def _imported_module_files(tree: ast.Module, root: Path) -> dict[str, Path]:
             for alias in node.names:
                 # ``import a.b`` binds ``a``; ``import a.b as c`` binds ``c``.
                 dotted = alias.name if alias.asname else alias.name.split(".")[0]
-                found = _module_file(dotted, root)
+                found = module_file(dotted, root)
                 if found is not None:
                     bindings[alias.asname or dotted] = found
         elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
             for alias in node.names:
-                found = _module_file(f"{node.module}.{alias.name}", root)
+                found = module_file(f"{node.module}.{alias.name}", root)
                 if found is not None:
                     bindings[alias.asname or alias.name] = found
     return bindings
@@ -408,7 +408,7 @@ def _resolve_module_file(node: ast.AST, module_path: Path, bindings: dict[str, P
     if isinstance(node, ast.Call):
         func = node.func
         name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
-        if name in _MODULE_FILE_FUNCS and len(node.args) == 1 and isinstance(node.args[0], ast.Name):
+        if name in MODULE_FILE_FUNCS and len(node.args) == 1 and isinstance(node.args[0], ast.Name):
             return bindings.get(node.args[0].id)
     resolved = _resolve(node, module_path, bindings, root)
     return resolved if isinstance(resolved, Path) else None

--- a/tests/policies/test_service_port_domain.py
+++ b/tests/policies/test_service_port_domain.py
@@ -27,7 +27,7 @@ from typing import Any
 import numpy as np
 import pytest
 
-from strands_robots.policies import create_policy
+from strands_robots.policies.factory import create_policy
 from strands_robots.utils import tcp_port_error
 
 # Ports no TCP transport can address. ``0`` asks the kernel for an ephemeral
@@ -244,6 +244,12 @@ def _policy_module_paths() -> list[Path]:
     resolved elsewhere would make the scan below silently empty, which is what
     the "these four classes were seen" assertion in
     :class:`TestNoProviderShipsAnUnguardedPort` exists to catch.
+
+    ``create_policy`` is imported from ``strands_robots.policies.factory``, the
+    module that defines it, rather than from the package that re-exports it.
+    ``inspect.getfile`` answers the same object either way, so the walk below is
+    unchanged; the import spelling is what lets a static reader see which file
+    the root comes from.
     """
     root = Path(inspect.getfile(create_policy)).parent
     return sorted(root.glob("*/policy.py"))

--- a/tests/test_whole_tree_graders_roster_is_complete.py
+++ b/tests/test_whole_tree_graders_roster_is_complete.py
@@ -71,6 +71,7 @@ that no longer exists.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import tomllib
 from pathlib import Path
@@ -582,6 +583,120 @@ def test_a_symbol_the_named_module_does_not_define_is_not_resolved() -> None:
         "re-exports it. That file is not the one the running grader walks "
         "from, so the path it yields is a guess, and here the guess is a "
         "whole-tree area where the truth is a subpackage."
+    )
+
+
+def _root_symbols_that_resolve_to_nothing(module_path: Path) -> dict[str, str]:
+    """Return the symbols ``module_path`` hands to ``inspect.getfile`` in vain.
+
+    Keys are the local names the import bound, values the dotted spelling it
+    used. A symbol appears only when the import names a first-party module that
+    does not *define* it, which is exactly when
+    :func:`check_whole_tree_graders.module_file` refuses it and any root derived
+    from it resolves to nothing.
+
+    :param module_path: The test module to read.
+    """
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    unresolved: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not node.module or node.level:
+            continue
+        if node.module != _cwtg.PACKAGE and not node.module.startswith(f"{_cwtg.PACKAGE}."):
+            continue
+        for alias in node.names:
+            dotted = f"{node.module}.{alias.name}"
+            if _cwtg.module_file(dotted, _REPO_ROOT) is None:
+                unresolved[alias.asname or alias.name] = dotted
+    handed: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in _cwtg.MODULE_FILE_FUNCS or not node.args:
+            continue
+        argument = node.args[0]
+        if isinstance(argument, ast.Name) and argument.id in unresolved:
+            handed[argument.id] = unresolved[argument.id]
+    return handed
+
+
+def _defining_module(dotted: str) -> str | None:
+    """Return the dotted module that defines ``dotted``'s final component.
+
+    Searched with the preflight's own resolver rather than by re-reading the
+    tree, so "defines it" means the same thing in the remedy as in the
+    derivation. Shallower candidates are tried first, so a symbol a package
+    re-exports from a direct sibling resolves to that sibling.
+
+    :param dotted: A ``package.member`` spelling whose package only re-exports.
+    :returns: The importable module, or ``None`` if no module in the package
+        defines the name at its own top level.
+    """
+    package, _, member = dotted.rpartition(".")
+    re_exporter = _cwtg.module_file(package, _REPO_ROOT)
+    if re_exporter is None:
+        return None
+    candidates = sorted(re_exporter.parent.rglob("*.py"), key=lambda path: (len(path.parts), path.parts))
+    for candidate in candidates:
+        relative = candidate.relative_to(_REPO_ROOT).with_suffix("")
+        parts = relative.parts[:-1] if relative.name == "__init__" else relative.parts
+        if _cwtg.module_file(f"{'.'.join(parts)}.{member}", _REPO_ROOT) is not None:
+            return ".".join(parts)
+    return None
+
+
+def test_no_grader_derives_a_walk_root_from_a_re_exported_symbol() -> None:
+    """No module in this tree derives a walk root from a symbol it re-imported.
+
+    The cell above pins the resolver's half: a re-exported symbol resolves to
+    nothing rather than to the file that re-exports it, because that file is
+    not the one the running grader walks from. This cell pins the tree's half,
+    and the two are not the same guarantee - the resolver can be right about a
+    shape no planted source is enough to keep out of the tree. ``AGENTS.md``
+    (*PR Workflow* step 2) already asks for the import that resolves:
+
+        The one shape that does not is a symbol imported from a module that
+        only re-exports it: the import does not say which file the symbol came
+        from, so it resolves to nothing rather than to a guess. Import from the
+        defining module.
+
+    Nothing refused a site that broke it, and the shape is silent in the
+    reassuring direction: the module drops out of the roster entirely, so the
+    preflight reports a clean run over the graders it *can* see while
+    collecting none of that one. That is the presentation issue #2940 exists to
+    prevent, reached through a spelling rather than through a narrow selector.
+
+    Screening the whole tree rather than a named list is deliberate, for the
+    reason this module's docstring gives about #3111: a pin that grades only
+    the graders an issue names cannot see a gap its own named graders survive
+    by accident.
+    """
+    offenders: list[str] = []
+    for path in sorted((_REPO_ROOT / "tests").rglob("test_*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            handed = _root_symbols_that_resolve_to_nothing(path)
+        except SyntaxError:
+            # A module pytest cannot collect is reported by the run that
+            # collects it, not here.
+            continue
+        for local, dotted in sorted(handed.items()):
+            remedy = _defining_module(dotted)
+            fix = (
+                f"from {remedy} import {dotted.rpartition('.')[2]}"
+                if remedy
+                else "import it from the module that defines it"
+            )
+            offenders.append(f"  - {path.relative_to(_REPO_ROOT).as_posix()}: {dotted} ({local}) -> {fix}")
+    assert not offenders, (
+        "these modules hand a re-exported symbol to inspect.getfile to derive "
+        "a walk root. The import does not say which file the symbol came from, "
+        "so the root resolves to nothing and the module is invisible to "
+        "scripts/check_whole_tree_graders.py - a green preflight that never "
+        "collected it. Import from the defining module instead; "
+        "inspect.getfile answers the same object either way, so the walk the "
+        "test performs does not change:\n" + "\n".join(offenders)
     )
 
 


### PR DESCRIPTION
Closes #3273.

![resolution](https://raw.githubusercontent.com/cagataycali/robots/ff35ac7da3e286ae2bcb36fdcfb835df2136adb6/reexport_walk_root.png)

## The gap

`AGENTS.md` (*PR Workflow* step 2) states the one import spelling a derived walk root cannot use:

> The one shape that does not is a symbol imported from a module that only *re-exports* it: the import does not say which file the symbol came from, so it resolves to nothing rather than to a guess. **Import from the defining module.**

The rule was written; nothing refused a site that broke it. `tests/policies/test_service_port_domain.py` derived the scan root for `TestNoProviderShipsAnUnguardedPort` from `create_policy` imported out of `strands_robots.policies`, which only re-exports it — `strands_robots/policies/factory.py` defines it.

The direction is what makes it worth a refusal: the root resolves to **nothing**, not to a wrong directory, so the module drops out of the roster entirely and `scripts/check_whole_tree_graders.py` reports a clean run over the graders it *can* see while collecting none of that one. That is the presentation #2940 exists to prevent, reached through a spelling instead of through a narrow selector — and the grader in question is the guard that stops a fifth policy provider shipping an unvalidated service port by copying a sibling constructor.

## The change

| | |
|---|---|
| **The site** | `from strands_robots.policies.factory import create_policy`. `inspect.getfile` answers the same function object either way, so the runtime walk root stays `strands_robots/policies` and the 11 provider `policy.py` files the grader scans are unchanged. Only the static read starts working. |
| **The pin** | `tests/test_whole_tree_graders_roster_is_complete.py` gains a cell that screens every module under `tests/` for the shape and **names the module to import from**, so the failure is a copy-pasteable remedy rather than a dead end. |
| **The resolver** | `check_whole_tree_graders.module_file` and `MODULE_FILE_FUNCS` are public, so the pin screens with the derivation's own resolver instead of restating what "the module that defines it" means. Rename in place, no alias. |

The resolver's half was already pinned (`test_a_symbol_the_named_module_does_not_define_is_not_resolved`, on planted source). These are not the same guarantee: a correct resolver cannot keep the shape out of the tree. Screening the whole tree rather than a named list is the lesson #3111 already paid for — a pin that grades only the graders an issue names cannot see a gap its own named graders survive by accident.

### Measured

| | before | after |
|---|---|---|
| `module_file("strands_robots.policies.create_policy")` | `None` | — |
| `module_file("…policies.factory.create_policy")` | — | `strands_robots/policies/factory.py` |
| `walked_paths(the site)` | `set()` | `{strands_robots/policies}` |
| modules handing a symbol to `inspect.getfile` | 134 | 134 |
| of those, breaking the rule | **1** | **0** |
| preflight roster | 104 | **105** |
| cells the preflight collected | 4394 | **4454** (+60) |

The roster grew by `tests/test_whole_tree_graders_roster_is_complete.py` itself: it never syntactically walked, so the module that grades the roster was invisible to the preflight it grades. The tree-wide screen gives it a `tests/` walk, which is what makes `hatch run whole-tree-check` enforce this rule rather than only `pytest tests/`.

### Verification

Four corners on `tests/test_whole_tree_graders_roster_is_complete.py tests/policies` (12 failures are pre-existing on `upstream/main` — `lerobot_async` roundtrip and `molmoact2` install-hint cells, identical set on both trees, verified in a clean worktree):

| corner | pin cell | site | result |
|---|---|---|---|
| A | old | old | 12F / 6090P (baseline) |
| B | **new** | old | **13F** / 6090P — the cell goes red and names the remedy |
| C | new | new | 12F / **6091P** |
| D | old | new | 12F / 6090P — identical to A, nothing existing moved |

Red-pre-fix output:

```
E  AssertionError: these modules hand a re-exported symbol to inspect.getfile to derive
   a walk root. … Import from the defining module instead; inspect.getfile answers the
   same object either way, so the walk the test performs does not change:
E      - tests/policies/test_service_port_domain.py: strands_robots.policies.create_policy
         (create_policy) -> from strands_robots.policies.factory import create_policy
```

`ruff check` + `ruff format --check` clean on the touched files. `mypy strands_robots tests tests_integ` = 20 errors in 6 files, byte-identical to the pre-change baseline (19 `examples/isaac_gs`, 1 `simulation/ik.py`), none in the touched files. `python scripts/check_whole_tree_graders.py` runs all 105 graders: 4454 passed, same 13 failures / 4 errors as the 104-grader baseline.

### Size

`5 files changed, +155 / -8`. The pin file's 111 added lines are 49 executable, 46 docstring, 2 comment, 14 blank; `scripts/` is 6/6, a pure rename.

### On the remaining half of #3273

The issue notes the remedy leaves the runtime root at `strands_robots/policies`, and that is measured here: after the fix the site resolves, but `strands_robots/policies` is a subpackage, and `walk_targets` is the repository root plus its **top-level** areas. So this grader is still not on the roster — deliberately, per `test_a_symbol_the_named_module_does_not_define_is_not_resolved`'s own words about the `simulation` subpackage being "deliberately not one". Whether a subpackage walk should count is a scope decision about what "the rest of the repository" means, not a resolver bug, so it is left to the issue with the measurement attached rather than folded in here.