### PR TITLE
fix(simulation/isaac): the parallel environment count is a count at both owners

### DIFF
--- a/changelog.d/3277-isaac-env-count-domain.md
+++ b/changelog.d/3277-isaac-env-count-domain.md
@@ -1,0 +1,26 @@
+### Fixed: the Isaac parallel-environment count is a count at both of its owners
+
+`IsaacConfig.num_envs` is the configured default; `IsaacSimulation.replicate(num_envs=...)`
+is the per-call request honoured instead of it. Neither was held to the shared count
+domain `strands_robots.utils.positive_count_error`, which the sibling `camera_width` /
+`camera_height` fields in the same `__post_init__` already take.
+
+The field's hand-rolled `< 1` test read `True` as a count of 1 while refusing `False`,
+and accepted `4.0`, `2.7`, `nan` and `inf`; a `str`, `None` or a list raised `TypeError`
+from the comparison itself, naming neither the field nor a remedy. `IsaacSimulation`
+logs this field with `%d`, so a stored `2.7` was announced as `num_envs=2` and a stored
+`nan` made that logging call raise.
+
+The argument had no domain at all and resolved by truthiness, so a supplied `0` or
+`False` was read as "not supplied" and replicated to the configured count instead,
+announcing that count under `status: "success"` with the caller's request discarded.
+Every truthy value was stored and reported three times over -- by `replicate`, by
+`get_state`, and by `destroy` as `num_envs_released` -- and latched `_replicated`, which
+`add_robot` refuses on, so an unusable count locked the scene until `destroy`.
+`num_envs="4"` rendered as `"Replicated to 4 environments"`, byte-identical to what the
+int `4` produces, while the payload carried the `str`.
+
+Both owners now reach one verdict on the shared domain: the field raises `ValueError`
+like every other field in its `__post_init__`, the request reports `{"status": "error"}`
+through the channel its no-world and no-robot refusals already use, and `num_envs=None`
+still resolves to the configured count.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -138,7 +138,7 @@ rejected eagerly. The commonly used fields:
 
 | Kwarg | Type | Default | Description |
 |-------|------|---------|-------------|
-| `num_envs` | `int` | `1` | Parallel environments. Set to `1024`+ for fleet RL. |
+| `num_envs` | `int` | `1` | Parallel environments. Set to `1024`+ for fleet RL. A positive integer - the same domain `replicate(num_envs=...)` takes. |
 | `device` | `str` | `"cuda:0"` | CUDA device (`cuda:N`). Must be a CUDA device. |
 | `headless` | `bool` | `True` | Run without a GUI (required for cloud/CI). |
 | `physics_dt` | `float` | `1/120` | Physics timestep (seconds). |

--- a/strands_robots/simulation/isaac/config.py
+++ b/strands_robots/simulation/isaac/config.py
@@ -296,9 +296,24 @@ class IsaacConfig:
         if not self.device.startswith("cuda"):
             raise ValueError(f"Isaac Sim requires a CUDA device, got {self.device!r}. Use 'cuda:0', 'cuda:1', etc.")
 
-        # Validate num_envs
-        if self.num_envs < 1:
-            raise ValueError(f"num_envs must be >= 1, got {self.num_envs}")
+        # Validate num_envs on the shared count domain
+        # (:func:`strands_robots.utils.positive_count_error`) -- the same domain
+        # ``camera_width`` / ``camera_height`` take a few lines below, and the
+        # same one :meth:`~strands_robots.simulation.isaac.IsaacSimulation.replicate`
+        # applies to the ``num_envs`` *argument* it takes instead of this
+        # default, so the two owners of one environment count reach one verdict.
+        # The hand-rolled ``< 1`` test this replaces is the shape that domain's
+        # docstring warns about, and the shape ``RLTrainSpec.num_envs`` was
+        # moved off for the same reason: it tests only the floor, so it read
+        # ``True`` as a count of 1 while refusing ``False``, and let ``4.0``,
+        # ``2.7``, ``nan`` and ``inf`` through to be stored and reported as an
+        # environment count -- the init log formats this field with ``%d``, so a
+        # stored ``2.7`` was announced as ``num_envs=2`` and a stored ``nan``
+        # made that logging call raise. A ``str``, ``None`` or a list raised
+        # ``TypeError`` from the comparison itself, naming neither the field nor
+        # a remedy.
+        if (envs_err := positive_count_error(self.num_envs, "num_envs", type(self).__name__)) is not None:
+            raise ValueError(envs_err)
 
         # Validate physics_dt
         if self.physics_dt <= 0:

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -5837,12 +5837,25 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         Parameters
         ----------
         num_envs : int, optional
-            Number of environments. Defaults to config.num_envs.
+            Number of environments, a positive integer on the shared count
+            domain (:func:`strands_robots.utils.positive_count_error`) -- the
+            same domain :class:`~strands_robots.simulation.isaac.IsaacConfig`
+            applies to the ``num_envs`` field this argument is checked
+            *instead of*, so the two owners of one environment count reach one
+            verdict. ``None`` (the default) takes ``config.num_envs``, decided
+            by membership rather than truthiness, so a supplied ``0`` is
+            refused as the count it is instead of read as "not supplied".
 
         Returns
         -------
         dict
-            Status dict with replication info.
+            Status dict with replication info, or ``{"status": "error"}``
+            naming ``num_envs`` when the requested count cannot be honored --
+            the same channel this method's no-world and no-robot refusals use.
+            The resolved count is reported back here, by :meth:`get_state` and
+            by :meth:`destroy` as ``num_envs_released``, and it locks the scene
+            against further ``add_robot`` calls, so a count that is not one
+            cannot be accepted and announced.
         """
         with self._lock:
             if not self._world_created:
@@ -5854,7 +5867,29 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                     "content": [{"text": "Add at least one robot first."}],
                 }
 
-            n = num_envs or self._config.num_envs
+            # Read the requested count by membership, not truthiness, and grade
+            # it before spending it. ``num_envs or self._config.num_envs`` read
+            # a supplied ``0`` as "not supplied" and replicated to the
+            # *configured* count instead, announcing that count under
+            # ``status: "success"`` -- the caller's explicit request discarded
+            # with nothing saying so. Every truthy value was stored unchecked
+            # and reported as an environment count three times over: by this
+            # method, by ``get_state``, and by ``destroy``'s
+            # ``num_envs_released``. ``'4'`` was the worst of them, rendering in
+            # the message below exactly as the int ``4`` does, so the text read
+            # as an ordinary success while the payload carried a ``str``. Every
+            # other config-defaulted argument on this backend already resolves
+            # this way -- ``physics_dt``, ``gravity``, and the ``width`` /
+            # ``height`` pair whose own comment states the rule: "``None`` still
+            # means 'take the config default'; membership decides that, not
+            # truthiness".
+            if (
+                num_envs is not None
+                and (envs_err := positive_count_error(num_envs, "num_envs", "replicate")) is not None
+            ):
+                return {"status": "error", "content": [{"text": envs_err}]}
+
+            n = self._config.num_envs if num_envs is None else num_envs
 
             t0 = time.perf_counter()
             # In full implementation: use omni.isaac.cloner.Cloner

--- a/tests/simulation/isaac/test_parallel_env_count_is_a_count_at_both_owners.py
+++ b/tests/simulation/isaac/test_parallel_env_count_is_a_count_at_both_owners.py
@@ -1,0 +1,278 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: both owners of the parallel-environment count carry a domain.
+
+An Isaac scene's environment count has two owners. ``IsaacConfig.num_envs`` is
+the configured default; ``IsaacSimulation.replicate(num_envs=...)`` is the
+per-call request that is honored *instead of* it. Neither was held to the shared
+count domain (:func:`~strands_robots.utils.positive_count_error`), which the
+sibling fields ``camera_width`` / ``camera_height`` in the same
+``__post_init__`` already take, and which ``RLTrainSpec.num_envs`` -- the other
+environment count in this library -- was moved onto for exactly this reason (see
+``tests/training/test_rl_env_count_domain.py``, whose docstring works through
+the same ``nan`` / ``inf`` / ``2.5`` / ``True`` values measured below).
+
+Measured before this gate existed, over ``IsaacConfig(num_envs=8)``:
+
+* The field's hand-rolled ``self.num_envs < 1`` tested only the floor, so it
+  read ``True`` as a count of 1 while refusing ``False``, and accepted ``4.0``,
+  ``2.7``, ``nan`` and ``inf`` to be stored and reported as an environment
+  count. ``IsaacSimulation.__init__`` logs this field with ``%d``, so a stored
+  ``2.7`` was announced as ``num_envs=2`` -- the log disagreeing with the config
+  it describes -- and a stored ``nan`` or ``inf`` made that logging call itself
+  raise. A ``str``, ``None`` or a list raised ``TypeError`` from the comparison,
+  naming neither the field nor a remedy. Seven of the thirteen values these
+  cells probe reached a verdict the shared domain does not.
+* The argument had no domain at all and was read by truthiness
+  (``num_envs or self._config.num_envs``), so every value in ``_REFUSED`` below
+  was accepted alongside the counts in ``_ACCEPTED`` -- ten spellings no scene
+  can replicate over, none refused. A supplied ``0`` or ``False`` was read as
+  "not supplied" and replicated to the *configured* 8, announcing
+  ``"Replicated to 8 environments"`` under ``status: "success"`` -- the caller's
+  explicit request discarded with nothing saying so. Every truthy value was
+  stored and reported three times over: by ``replicate``, by ``get_state``, and
+  by ``destroy`` as ``num_envs_released``. ``num_envs="4"`` was the worst of
+  them, rendering as ``"Replicated to 4 environments"`` -- byte-identical to
+  what the int ``4`` produces -- while the payload carried the ``str``.
+
+The count also latches: ``replicate`` sets ``_replicated``, and ``add_robot``
+refuses once it is set, so an unusable count locked the scene until ``destroy``.
+
+None of this needs Isaac Sim or a GPU. The domain is arithmetic, so the field
+cells construct ``IsaacConfig`` alone and the argument cells drive the unbound
+``replicate`` against the ``types.SimpleNamespace`` stand-in for ``self`` that
+the neighbouring Isaac tests already use.
+"""
+
+from __future__ import annotations
+
+import threading
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.utils import positive_count_error
+
+#: The configured default this scene carries, so a substituted count is
+#: distinguishable from any requested one.
+_CONFIGURED = 8
+
+#: Counts that can be honored and must keep working. ``1024`` is the value the
+#: Isaac page tells a fleet-RL caller to set, so it is the control that this is a
+#: domain on the *kind* of value and not a cap.
+_ACCEPTED = (1, 4, 1024)
+
+#: ``value -> the reason it is not a count``. ``0`` and ``False`` are the
+#: truthiness half: both are falsy, so both were read as "not supplied".
+_REFUSED: dict[str, Any] = {
+    "zero": 0,
+    "negative": -1,
+    "True reads as a flag, not a count of one": True,
+    "False is falsy and was read as unstated": False,
+    "an integral float still cannot index a range": 4.0,
+    "a fractional count": 2.7,
+    "not-a-number passes every ordered comparison": float("nan"),
+    "an unbounded count": float("inf"),
+    "the digits of a count are not a count": "4",
+    "a sequence holding a count is not one": [4],
+}
+
+
+def _config(**kwargs: Any) -> IsaacConfig:
+    """Construct through ``**Any`` so a deliberately off-type probe value type-checks.
+
+    The point of these cells is values the annotation forbids, so they are handed
+    over the way :meth:`IsaacConfig.from_kwargs` already accepts them rather than
+    each call site carrying a suppression.
+    """
+    return IsaacConfig(**kwargs)
+
+
+def _stub(configured: int = _CONFIGURED) -> types.SimpleNamespace:
+    """A stand-in for ``self`` carrying only what ``replicate`` reads."""
+    return types.SimpleNamespace(
+        _lock=threading.RLock(),
+        _world_created=True,
+        _world=None,
+        _config=IsaacConfig(num_envs=configured),
+        _robots={"arm": object()},
+        _objects={},
+        _cameras={},
+        _action_controllers={},
+        _prim_registry=[],
+        _replicated=False,
+        _num_envs_active=1,
+        _sim_time=0.0,
+        _step_count=0,
+    )
+
+
+def _field_refusal(value: Any) -> str | None:
+    """The configured owner's refusal for ``value``, read through the constructor."""
+    try:
+        _config(num_envs=value)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _argument_refusal(value: Any) -> str | None:
+    """The requested owner's refusal for ``value``, read through ``replicate``."""
+    result = IsaacSimulation.replicate(_stub(), num_envs=value)  # type: ignore[arg-type]
+    if result["status"] == "error":
+        return str(result["content"][0]["text"])
+    return None
+
+
+def test_the_probe_tables_are_populated() -> None:
+    """A domain graded over an empty table would report success having read nothing."""
+    assert len(_ACCEPTED) >= 3
+    assert len(_REFUSED) >= 10
+    assert all(reason.strip() for reason in _REFUSED)
+
+
+class TestACountThatCanBeHonoredIsAccepted:
+    """Both owners keep honoring the counts a caller actually replicates over."""
+
+    @pytest.mark.parametrize("count", _ACCEPTED)
+    def test_the_field_stores_it(self, count: int) -> None:
+        assert IsaacConfig(num_envs=count).num_envs == count
+
+    @pytest.mark.parametrize("count", _ACCEPTED)
+    def test_the_request_is_honored_and_reported(self, count: int) -> None:
+        stub = _stub()
+
+        result = IsaacSimulation.replicate(stub, num_envs=count)  # type: ignore[arg-type]
+
+        assert result["status"] == "success"
+        assert result["content"][0]["json"]["num_envs"] == count
+        assert stub._num_envs_active == count
+        assert f"Replicated to {count} environments" in result["content"][0]["text"]
+
+
+class TestACountThatCannotBeHonoredIsRefusedByBothOwners:
+    """The same value reaches the same verdict whichever owner is handed it."""
+
+    @pytest.mark.parametrize("value", list(_REFUSED.values()), ids=list(_REFUSED))
+    def test_the_field_refuses_it(self, value: Any) -> None:
+        refusal = _field_refusal(value)
+
+        assert refusal is not None, f"IsaacConfig accepted num_envs={value!r} as an environment count"
+        assert "num_envs" in refusal
+
+    @pytest.mark.parametrize("value", list(_REFUSED.values()), ids=list(_REFUSED))
+    def test_the_request_refuses_it(self, value: Any) -> None:
+        refusal = _argument_refusal(value)
+
+        assert refusal is not None, f"replicate accepted num_envs={value!r} as an environment count"
+        assert "num_envs" in refusal
+
+    @pytest.mark.parametrize("value", list(_REFUSED.values()), ids=list(_REFUSED))
+    def test_neither_owner_raises_the_bare_comparison_TypeError(self, value: Any) -> None:
+        """``'4' < 1`` named neither the field nor a remedy; a refusal names both."""
+        assert _field_refusal(value) is not None
+        assert _argument_refusal(value) is not None
+
+
+class TestBothOwnersQuoteTheSharedDomain:
+    """Routing is graded through the answer, so a hand-rolled copy cannot drift back."""
+
+    @pytest.mark.parametrize("value", list(_REFUSED.values()), ids=list(_REFUSED))
+    def test_the_field_message_is_the_domains_own(self, value: Any) -> None:
+        assert _field_refusal(value) == positive_count_error(value, "num_envs", "IsaacConfig")
+
+    @pytest.mark.parametrize("value", list(_REFUSED.values()), ids=list(_REFUSED))
+    def test_the_request_message_is_the_domains_own(self, value: Any) -> None:
+        assert _argument_refusal(value) == positive_count_error(value, "num_envs", "replicate")
+
+
+class TestAnUnstatedCountStillTakesTheConfiguredOne:
+    """``None`` is the one spelling of "not supplied", and it keeps its meaning."""
+
+    def test_it_replicates_to_the_configured_count(self) -> None:
+        stub = _stub()
+
+        result = IsaacSimulation.replicate(stub, num_envs=None)  # type: ignore[arg-type]
+
+        assert result["status"] == "success"
+        assert result["content"][0]["json"]["num_envs"] == _CONFIGURED
+        assert stub._num_envs_active == _CONFIGURED
+
+    def test_the_default_is_reached_without_naming_the_argument(self) -> None:
+        stub = _stub()
+
+        assert IsaacSimulation.replicate(stub)["content"][0]["json"]["num_envs"] == _CONFIGURED  # type: ignore[arg-type]
+
+
+class TestASuppliedZeroIsNotReadAsUnstated:
+    """The truthiness half: a falsy count is the count asked for, not a silence."""
+
+    @pytest.mark.parametrize("falsy", [0, False])
+    def test_it_is_refused_rather_than_substituted(self, falsy: Any) -> None:
+        stub = _stub()
+
+        result = IsaacSimulation.replicate(stub, num_envs=falsy)  # type: ignore[arg-type]
+
+        assert result["status"] == "error"
+        assert f"Replicated to {_CONFIGURED} environments" not in result["content"][0]["text"]
+        assert stub._num_envs_active != _CONFIGURED
+
+
+class TestARefusedCountIsNotPartiallyApplied:
+    """A refusal leaves the scene exactly as it was, replicable and extensible."""
+
+    @pytest.mark.parametrize("value", list(_REFUSED.values()), ids=list(_REFUSED))
+    def test_the_count_is_not_recorded(self, value: Any) -> None:
+        stub = _stub()
+
+        IsaacSimulation.replicate(stub, num_envs=value)  # type: ignore[arg-type]
+
+        assert stub._num_envs_active == 1
+        assert stub._replicated is False
+
+    def test_the_scene_is_not_locked_against_further_robots(self) -> None:
+        """``add_robot`` refuses once ``_replicated`` latches, so it must not latch."""
+        stub = _stub()
+
+        IsaacSimulation.replicate(stub, num_envs=2.7)  # type: ignore[arg-type]
+        added = IsaacSimulation.add_robot(stub, "second", data_config="panda")  # type: ignore[arg-type]
+
+        assert added["status"] == "success"
+
+    def test_a_later_usable_request_still_replicates(self) -> None:
+        stub = _stub()
+
+        assert IsaacSimulation.replicate(stub, num_envs="4")["status"] == "error"  # type: ignore[arg-type]
+        assert IsaacSimulation.replicate(stub, num_envs=4)["status"] == "success"  # type: ignore[arg-type]
+        assert stub._num_envs_active == 4
+
+
+class TestEachOwnerRefusesThroughItsOwnDocumentedChannel:
+    """One domain, two channels: the field is a constructor, the request is a verb.
+
+    The asymmetry is deliberate and is what each surface documents. ``IsaacConfig``
+    is a dataclass, so an unusable field cannot be reported -- there is no return
+    value -- and it raises ``ValueError`` like every other field in its
+    ``__post_init__``. ``replicate`` documents a status dict as its channel and
+    already answers its no-world and no-robot refusals that way, so it reports
+    rather than raising.
+    """
+
+    def test_the_field_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="num_envs"):
+            _config(num_envs=2.7)
+
+    def test_the_request_reports_and_does_not_raise(self) -> None:
+        result = IsaacSimulation.replicate(_stub(), num_envs=2.7)  # type: ignore[arg-type]
+
+        assert result["status"] == "error"
+
+    def test_the_request_channel_matches_its_sibling_refusals(self) -> None:
+        """A no-robot scene is refused the same way, so the count is not special."""
+        empty = _stub()
+        empty._robots = {}
+
+        assert IsaacSimulation.replicate(empty, num_envs=4)["status"] == "error"  # type: ignore[arg-type]


### PR DESCRIPTION
An Isaac scene's parallel-environment count has two owners, and neither graded it.

![num_envs verdicts at both owners, before and after](https://raw.githubusercontent.com/cagataycali/robots/d59a42377a9834a360f6b6d432eb450a007aee68/assets/isaac-env-count-both-owners.png)

## The two owners

`IsaacConfig.num_envs` is the configured default. `IsaacSimulation.replicate(num_envs=...)` is the per-call request honoured *instead of* it. The sibling `camera_width` / `camera_height` fields in the same `__post_init__` already take the shared count domain `positive_count_error`; `num_envs` sat three lines above them on a hand-rolled `< 1`, and the argument had no domain at all.

| owner | before | after |
|---|---|---|
| `IsaacConfig.num_envs` | `if self.num_envs < 1: raise` | `positive_count_error(...)` |
| `replicate(num_envs=...)` | `n = num_envs or self._config.num_envs` | graded, then resolved by membership |

Measured over `IsaacConfig(num_envs=8)`, 13 values (full grid in the figure):

- **The request accepted 13 of 13 and refused none**, and latched `_replicated` on every one — `add_robot` refuses once `replicate()` has run, so an unusable count locked the scene until `destroy()`.
- **`0` and `False` were read as "not supplied"** and replicated to the configured `8`, announcing `"Replicated to 8 environments"` under `status: "success"`. The caller's explicit request was discarded with nothing saying so.
- **`num_envs="4"` reported `"Replicated to 4 environments"`** — byte-identical to what the int `4` produces — while `get_state()`'s payload carried the `str`. One reader sees an ordinary success; the other gets a type it cannot do arithmetic on.
- Every truthy value was reported three times over: by `replicate`, by `get_state`, and by `destroy` as `num_envs_released`.
- **The field disagreed with the shared domain on 7 of 13.** It read `True` as a count of 1 while refusing `False`, and accepted `4.0`, `2.7`, `nan`, `inf`. `IsaacSimulation` logs this field with `%d`, so a stored `2.7` was announced as `num_envs=2` — the log disagreeing with the config it describes — and a stored `nan` or `inf` made that logging call itself raise. A `str`, `None` or a list raised `TypeError` from the comparison, naming neither the field nor a remedy.

## Why this domain, and why membership

Both halves are established elsewhere in the tree rather than invented here.

`RLTrainSpec.num_envs` — the other environment count in this library — was moved onto `positive_count_error` for exactly this reason. `tests/training/test_rl_env_count_domain.py` works through the same `nan` / `inf` / `2.5` / `True` values and states the distinction this change applies: *"That reason covers which counts are usable. It does not cover whether the value **is a count**."*

The membership read is the rule this backend already follows everywhere else. `isaac/simulation.py` resolves 15 other config-defaulted arguments as `X if arg is None else arg` — `physics_dt`, `gravity`, `camera_width`, `camera_height` — and `_render_frame`'s own comment states it outright: *"`None` still means 'take the config default'; membership decides that, not truthiness."* `num_envs` was the one argument on truthiness. `HybridCompositor.render` carries the same comment for the same bug.

The two channels stay as each surface documents them: the field raises `ValueError` like every other field in its `__post_init__` (a dataclass has no return value to report through), the request returns `{"status": "error"}` through the channel its own no-world and no-robot refusals already use. That asymmetry is pinned with its reason.

## Tests

`tests/simulation/isaac/test_parallel_env_count_is_a_count_at_both_owners.py` — 76 cells, 13 of them controls that hold on both trees. Needs no Isaac Sim or GPU: the domain is arithmetic, so the field cells construct `IsaacConfig` alone and the argument cells drive the unbound `replicate` against the `types.SimpleNamespace` stand-in the neighbouring Isaac tests already use.

Four corners over `tests/simulation/isaac/`, holding tests and production constant in turn:

| | tests before | tests after |
|---|---|---|
| **production before** | 2153 passed | **63 failed**, 2166 passed |
| **production after** | 2153 passed | 2229 passed |

`2153 + 76 = 2229`; `2166 = 2153 + 13` controls. The bottom-left corner equals the top-left, so no pre-existing cell pinned the old behaviour. The failing corner goes red in cells rather than at collection — the file imports only pre-existing symbols and reads every refusal through the public door.

Beyond the accepted/refused grid the cells pin: both refusals are byte-identical to the domain's own output (so a hand-rolled copy cannot drift back); `num_envs=None` and the bare `replicate()` still resolve to the configured count; a falsy count is refused rather than substituted; and a refusal is not partially applied — `_num_envs_active` is unchanged, `_replicated` does not latch, `add_robot` still succeeds, and a later usable request still replicates.

## Size

| file | +/- | executable |
|---|---|---|
| `simulation/isaac/config.py` | +18 / -3 | **+0** AST statements (79 -> 79) |
| `simulation/isaac/simulation.py` | +38 / -3 | **+2** AST statements (2071 -> 2073) |
| `docs/simulation/isaac.md` | +1 / -1 | — |
| new test file | +278 | 128 executable, 71 docstring, 70 blank, 9 comment |
| changelog fragment | +26 | — |

**+2 executable statements** for the whole production change; the rest of those 56 added lines is the comment and docstring recording what each owner accepted and why the read is by membership. `positive_count_error` was already imported in both files, so this is pure routing.

## Gate

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1919 files). `mypy strands_robots tests tests_integ` — **0 errors**, no suppressions added (a deliberately off-type probe value is handed over through a `**kwargs: Any` helper, the idiom the sibling suites use). `tests/simulation/isaac/` 2229 passed / 15 skipped. The full tree-walking guard population (463 files) 24442 passed with 7 failures, all environmental and unrelated: 5 assert `rclpy` is absent where it resolves from a system ROS install, 2 read an installed `websockets` 16.0 against the `>=17.0` floor the `cosmos3-service` extra declares.

## Deliberately unchanged

`tests/simulation/isaac/test_isaac_backend.py` asserts `IsaacConfig(num_envs=0)` raises naming `num_envs`, and still does — `0` is the one value the old comparison got right, which is why that cell never saw this. It stays as-is: it remains true, and its coverage is now a strict subset of the parametrized table above. That is also why the bottom-left corner equals the top-left.

Every in-tree caller passes a plain positive `int` (`1`, `4`, `128`, `1024`, `4096`), so no existing call site changes verdict. `positive_count_error` refuses an integral float, which is the narrowing this brings to the field: the value is spent as an environment count and an array dimension, where `4.0` raises rather than being coerced — the reason that domain exists separately from `positive_whole_number_error`.