### PR TITLE
docs(agents): the seqiter reason for a __getitem__ alert holds for one probe shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2346,10 +2346,46 @@ Corrections from code review that apply to all future contributions:
   Rewriting the flagged code to satisfy the query is the tempting fourth option
   and the one that costs: #1879 spent a round removing a `__float__` from a test
   fixture for a finding that gated nothing. It can also destroy the measurement
-  the code exists for. On #1890 the query asked for a `LookupError`; the one it
-  names first, `IndexError`, is what CPython's `seqiter` *clears* to terminate
-  legacy-protocol iteration, so taking the suggestion would have left the fixture
-  raising nothing and the test asserting nothing, still green.
+  the code exists for - but *which* rewrite does that is a fact about the probe
+  rather than about the rule, and the short version of this reason has now been
+  read onto a shape it is false of.
+
+  For `__getitem__` the query asks for "`KeyError` or `IndexError`" by name, and
+  those two are not interchangeable. Each row below is constructed and executed by
+  `TestTheGetItemRewriteIsNotOneBehaviour` in
+  `tests/test_codeql_query_filters.py`, which reads this table rather than
+  restating it, so a row that stops being true fails there:
+
+  | probe, `__getitem__` raising | `list(probe)` | the raise is swallowed |
+  |---|---|---|
+  | `_LegacySequence` (`__len__` and `__getitem__`, no `__iter__`), `IndexError` | `[]` | **yes** - `seqiter` clears it to end the protocol |
+  | `_LegacySequence`, `KeyError` | `KeyError` | no - it propagates, as a `RuntimeError` does |
+  | `_HostileStr` (a `str` subclass), `IndexError` | `['[', ':', ':', '1', ']']` | no - `str` supplies `__iter__`, so `seqiter` is never built |
+
+  Row 1 is the #1890 reason: `IndexError` is what CPython's `seqiter` *clears* to
+  terminate the legacy iteration protocol, so the probe is consulted, raises, and
+  the read completes empty - a cell asserting a refusal is no longer measuring the
+  read that failed. Rows 2 and 3 are the two ways that reason does not travel.
+  `KeyError` satisfies the same query and is not cleared, so one spelling of the
+  suggestion keeps the measurement intact. And a `str` subclass supplies its own
+  `__iter__`, so `seqiter` is never constructed and `__getitem__` is not consulted
+  at all - the mechanism is absent rather than adverse. That third row is alert
+  1168 on #3272, where this reason was reached for and measured false (#3276).
+
+  `list(probe)` is the whole discriminator, so run it before citing a mechanism.
+  The 280-character dismissal comment cites this file instead of restating an
+  argument, which is what makes a wrong reason here expensive: it becomes a wrong
+  claim in a dismissal that outlives the branch.
+
+  Refuse the rewrite on the **property** instead, because that holds for every
+  probe shape. The query's own help text gives the harm as a user of the class
+  meeting an exception the protocol did not lead them to expect, and a probe
+  written to be an unconventional class *is* that harm, under test on purpose. A
+  conforming `LookupError` models a value refusing *within* the protocol, which is
+  strictly weaker than what a guarded read documents itself as surviving. Then
+  check the population before calling it convention rather than defect: on #3272
+  the same file raised `RuntimeError` from `__str__`, `__iter__` and `__repr__`
+  and none of the three was flagged.
 - **One alert class clears under none of the three, and the question that settles
   it is which thread you marshal onto.** `py/catch-base-exception` never fires on
   cleanup-and-reraise: the query accepts a handler that re-raises *lexically*, and

--- a/changelog.d/3278-getitem-rewrite-reason-scope.md
+++ b/changelog.d/3278-getitem-rewrite-reason-scope.md
@@ -1,0 +1,26 @@
+### Docs: the `seqiter` reason for refusing a `__getitem__` alert is scoped to the probe shape it holds on
+
+`AGENTS.md`'s CI Security Baseline refused the rewrite
+`py/unexpected-raise-in-special-method` suggests for a hostile `__getitem__` with one
+mechanism, stated as a general fact about the rule: `IndexError` is what CPython's
+`seqiter` clears to terminate legacy-protocol iteration, so taking the suggestion leaves
+the probe raising nothing and the cell measuring nothing.
+
+That holds for the #1890 probe -- a sequence reached through the legacy protocol -- and
+for neither of the two other shapes the rule keeps arriving on. `KeyError` is the other
+exception the query names for indexing and it is *not* cleared, so one spelling of the
+suggestion preserves the measurement intact. And a `str` subclass supplies its own
+`__iter__`, so `seqiter` is never constructed and the overridden `__getitem__` is not
+consulted at all -- the mechanism is absent rather than adverse. Alert 1168 on #3272 is
+that third shape, and because the 280-character dismissal comment cites this file instead
+of restating an argument, a reason that does not hold there becomes a false claim in a
+dismissal that outlives the branch.
+
+The passage now carries a three-row table of the measured behaviour, the one-line
+discriminator (`list(probe)`) a contributor can run before choosing a reason at all, and
+the argument that generalises: refuse the rewrite on the property under test -- the query's
+harm is a user of the class meeting an exception the protocol did not lead them to expect,
+which is exactly what a hostile probe exists to be -- rather than on a mechanism that
+depends on the probe's iteration protocol. The table is parsed and executed by
+`TestTheGetItemRewriteIsNotOneBehaviour` rather than transcribed, on the same terms as the
+`except BaseException` handler census below it, so a row that stops being true fails there.

--- a/tests/test_codeql_query_filters.py
+++ b/tests/test_codeql_query_filters.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import ast
 import re
+from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple
@@ -544,4 +545,253 @@ class TestTheMarshalBoxCensusIsDerivedFromTheTree:
             "column is what tells a contributor whether the handler they are looking at is the "
             "obliged case or the avoidable one, so it cannot be maintained by hand against a "
             "property this file already measures."
+        )
+
+
+#: The header of the ``__getitem__`` rewrite table in ``AGENTS.md``, whose rows are
+#: constructed and executed below rather than transcribed.
+_GETITEM_TABLE_HEADER = "| probe, `__getitem__` raising | `list(probe)` | the raise is swallowed |"
+
+#: The value ``_HostileStr`` carries. A bracketed IPv6 literal, because that is the
+#: shape a dialled-host guard slices - the read that met this rule on #3272.
+_HOSTILE_STR_VALUE = "[::1]"
+
+
+class _LegacySequence:
+    """A sequence by the legacy protocol: ``__len__`` and ``__getitem__``, no ``__iter__``.
+
+    This is the #1890 probe shape. CPython synthesises an iterator for such a value
+    (``seqiter``) and walks it by index, which is the path the passage's mechanism
+    lives on - and the only path it lives on.
+
+    The exception is supplied per instance rather than raised literally, which is
+    the idiom ``tests/training/test_gradient_clip_domain.py`` records for keeping a
+    hostile probe out of a merge gate: the type is not statically visible, so
+    ``py/unexpected-raise-in-special-method`` does not report the method that is
+    here to measure that rule's own advice. A literal ``raise RuntimeError`` would
+    open the alert this module documents how to adjudicate.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+        self.consulted = 0
+
+    def __len__(self) -> int:
+        return 3
+
+    def __getitem__(self, index: int) -> float:
+        self.consulted += 1
+        raise self._error
+
+
+class _HostileStr(str):
+    """A ``str`` subclass whose indexing refuses.
+
+    The shape alert 1168 on #3272 was opened on. It matters because ``str`` already
+    supplies ``__iter__``, so nothing here is reached through ``seqiter`` and the
+    mechanism row 1 turns on has no purchase - which is the correction #3276 is
+    about.
+
+    ``consulted`` is a list rather than a counter because ``str`` is immutable:
+    ``__new__`` builds the instance, so mutable per-instance state has to be an
+    object the method can mutate in place.
+    """
+
+    _error: Exception
+    consulted: list[None]
+
+    def __new__(cls, value: str, error: Exception) -> _HostileStr:
+        probe = super().__new__(cls, value)
+        probe._error = error
+        probe.consulted = []
+        return probe
+
+    def __getitem__(self, index: object, /) -> str:
+        self.consulted.append(None)
+        raise self._error
+
+
+class _Measured(NamedTuple):
+    """What ``list(probe)`` did, in the three terms the table's columns state."""
+
+    rendered: str
+    consulted: bool
+    swallowed: bool
+
+
+def _measure(probe: _LegacySequence | _HostileStr) -> _Measured:
+    """Run ``list(probe)`` and report it the way the table reads.
+
+    ``swallowed`` is deliberately a conjunction: the read completed *and* the
+    probe's ``__getitem__`` was consulted. Completion alone would report the
+    ``str`` subclass as swallowing its own exception, when in fact its
+    ``__getitem__`` is never reached - a different fact with the opposite
+    consequence for the reason a dismissal cites.
+    """
+    escaped: Exception | None = None
+    produced: list[object] = []
+    try:
+        produced = list(probe)  # type: ignore[arg-type]  # the legacy probe has no __iter__
+    except Exception as exc:  # noqa: BLE001 - the escape under measurement
+        escaped = exc
+
+    consulted = bool(probe.consulted) if isinstance(probe, _HostileStr) else probe.consulted > 0
+    return _Measured(
+        rendered=type(escaped).__name__ if escaped is not None else repr(produced),
+        consulted=consulted,
+        swallowed=escaped is None and consulted,
+    )
+
+
+def _getitem_table_rows() -> list[tuple[str, str, bool]]:
+    """The table's rows as ``(probe cell, expected list(probe), swallowed)``."""
+    text = _AGENTS_PATH.read_text(encoding="utf-8")
+    start = text.index(_GETITEM_TABLE_HEADER)
+    end = text.index("\n\n", start)
+    rows: list[tuple[str, str, bool]] = []
+    for line in text[start:end].splitlines()[2:]:
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        rows.append((cells[0], cells[1].strip("`"), "yes" in cells[-1]))
+    return rows
+
+
+#: The three rows, keyed by the two identifiers a row names. The probe is built per
+#: call because ``consulted`` is per-instance state a measurement consumes.
+_GETITEM_PROBES: tuple[tuple[str, str, Callable[[], _LegacySequence | _HostileStr]], ...] = (
+    ("_LegacySequence", "IndexError", lambda: _LegacySequence(IndexError("backing store unavailable"))),
+    ("_LegacySequence", "KeyError", lambda: _LegacySequence(KeyError("backing store unavailable"))),
+    ("_HostileStr", "IndexError", lambda: _HostileStr(_HOSTILE_STR_VALUE, IndexError("no read for you"))),
+)
+
+
+class TestTheGetItemRewriteIsNotOneBehaviour:
+    """The ``__getitem__`` rewrite table in ``AGENTS.md``, constructed and executed.
+
+    The passage tells a contributor whether the query's suggested rewrite would
+    destroy the measurement a hostile probe exists for. It used to answer that with
+    one mechanism, stated as a general fact about the rule: ``IndexError`` is what
+    ``seqiter`` clears, so taking the suggestion leaves the probe raising nothing.
+    On the #1890 probe that is true. It is false on the other two shapes the same
+    rule keeps arriving on, and #3276 was filed because the reason was reached for
+    on one of them - alert 1168 on #3272, a ``str`` subclass - and published in a
+    dismissal comment that cites this file rather than restating the argument. A
+    dismissal outlives the branch, so a wrong reason here is a durable wrong claim.
+
+    Two properties, and the second is why the table is parsed rather than
+    duplicated:
+
+    - the mechanism holds where the passage says it holds, and not elsewhere. This
+      is a claim about CPython, not about this repository, so it is executed - the
+      same reason :class:`TestTheNarrowingMeasurementStillHolds` executes the
+      ``SystemExit`` claim above;
+    - the table says what the measurement says. A row transcribed by hand is a row
+      that can go stale silently, which is exactly how the handler census below
+      came to count seven against a tree holding sixteen.
+
+    Three rows rather than one is itself the pin: collapsing the passage back to a
+    single unscoped mechanism fails
+    :meth:`test_the_table_names_the_three_probe_shapes` rather than reading
+    plausibly.
+    """
+
+    def test_the_table_names_the_three_probe_shapes(self) -> None:
+        """The scoping *is* the correction, so its absence is a failure, not a rewording."""
+        rows = _getitem_table_rows()
+        assert len(rows) == len(_GETITEM_PROBES), (
+            f"AGENTS.md's __getitem__ table has {len(rows)} rows and this test measures "
+            f"{len(_GETITEM_PROBES)}. The row count is load-bearing: the defect #3276 records is a "
+            "single mechanism stated as a general fact about the rule, so a table that names one "
+            "probe shape again is the same defect with a table around it. Add the row and its "
+            "measurement together, or remove both."
+        )
+        for probe_name, error_name, _ in _GETITEM_PROBES:
+            matches = [cell for cell, _, _ in rows if probe_name in cell and error_name in cell]
+            assert len(matches) == 1, (
+                f"exactly one row must name `{probe_name}` raising `{error_name}`; found "
+                f"{len(matches)}. Each row is matched to its probe by those two identifiers, so a "
+                "row that names neither, or two rows that name the same pair, leave a measurement "
+                "with nothing to grade."
+            )
+
+    def test_every_row_is_measured(self) -> None:
+        """Both stated columns, executed per row."""
+        rows = _getitem_table_rows()
+        for probe_name, error_name, build in _GETITEM_PROBES:
+            cell, expected_rendered, expected_swallowed = next(
+                row for row in rows if probe_name in row[0] and error_name in row[0]
+            )
+            measured = _measure(build())
+            assert measured.rendered == expected_rendered, (
+                f"AGENTS.md says `list(probe)` is `{expected_rendered}` for the row {cell!r}, and "
+                f"it is `{measured.rendered}`. That cell is the one-line discriminator the passage "
+                "tells a contributor to run before citing a mechanism, so it cannot be a "
+                "transcription."
+            )
+            assert measured.swallowed == expected_swallowed, (
+                f"AGENTS.md says the raise is "
+                f"{'swallowed' if expected_swallowed else 'not swallowed'} for the row {cell!r}, "
+                f"and it is {'swallowed' if measured.swallowed else 'not swallowed'} "
+                f"(consulted={measured.consulted}). This column decides whether the query's "
+                "suggested rewrite would destroy the measurement the probe exists for, which is "
+                "the whole question the passage answers."
+            )
+
+    def test_the_mechanism_is_the_legacy_protocol_and_the_exception_together(self) -> None:
+        """Row 1 against row 2, independent of the table's wording.
+
+        The query names ``KeyError`` and ``IndexError`` interchangeably and CPython
+        does not: only the second terminates the legacy protocol. So the reason on
+        file is about one spelling of the suggestion, and the other spelling would
+        have kept #1890's measurement - which is why the refusal has to rest on the
+        property rather than on this mechanism.
+        """
+        cleared = _measure(_LegacySequence(IndexError("backing store unavailable")))
+        assert cleared.consulted and cleared.rendered == "[]", (
+            "a legacy sequence whose __getitem__ raises IndexError must still be consulted and "
+            f"still read empty; measured {cleared}. If CPython stops clearing IndexError here, the "
+            "AGENTS.md row explaining #1890's dismissal has lost its reason and the passage should "
+            "be re-measured rather than kept."
+        )
+        propagated = _measure(_LegacySequence(KeyError("backing store unavailable")))
+        assert propagated.rendered == "KeyError" and not propagated.swallowed, (
+            "KeyError is the other exception py/unexpected-raise-in-special-method names for "
+            f"__getitem__, and it must still propagate; measured {propagated}. This is the row that "
+            "stops the mechanism being a general refusal of the query's advice."
+        )
+
+    def test_a_str_subclass_never_reaches_the_cleared_path(self) -> None:
+        """Row 3: the shape the reason was measured false on (#3276).
+
+        ``str`` supplies ``__iter__``, so iteration never consults ``__getitem__``
+        and there is no ``seqiter`` to clear anything. The characters are the
+        discriminator a contributor can run in one line, and the empty
+        ``consulted`` is why "the read completed" is not the same statement as "the
+        exception was swallowed".
+        """
+        measured = _measure(_HostileStr(_HOSTILE_STR_VALUE, IndexError("no read for you")))
+        assert measured.rendered == repr(list(_HOSTILE_STR_VALUE)), (
+            f"a str subclass must still iterate as its characters; measured {measured}. This is "
+            "the one-line discriminator AGENTS.md names, and it is what makes the #1890 reason "
+            "inapplicable here rather than merely unproven."
+        )
+        assert not measured.consulted, (
+            "iteration must not consult the overridden __getitem__ at all. 'Not consulted' is a "
+            "stronger statement than 'no exception escaped', and it is the one that separates this "
+            "row from row 1: nothing is being cleared, so the query's suggestion does not silence "
+            f"this probe. Measured {measured}."
+        )
+        assert not measured.swallowed, (
+            "so the raise is not swallowed on this shape. If this ever reports swallowed, the "
+            "AGENTS.md row is wrong and a dismissal citing it publishes a false claim - the cost "
+            "#3276 was filed about."
+        )
+
+    def test_the_discriminator_is_named_in_the_passage(self) -> None:
+        """A table without the one-line check is a lookup a contributor cannot extend."""
+        text = _AGENTS_PATH.read_text(encoding="utf-8")
+        assert "`list(probe)` is the whole discriminator" in text, (
+            "AGENTS.md must keep naming list(probe) as the check that separates these shapes. The "
+            "table covers the three probes the rule has arrived on so far; the discriminator is "
+            "what a contributor meeting a fourth can run before choosing a reason, and without it "
+            "the passage answers only the cases already in it."
         )


### PR DESCRIPTION
Closes #3276.

`AGENTS.md`'s CI Security Baseline tells a contributor whether the rewrite `py/unexpected-raise-in-special-method` suggests for a hostile `__getitem__` would destroy the measurement the probe exists for. It answered with one mechanism, stated as a general fact about the rule:

> On #1890 the query asked for a `LookupError`; the one it names first, `IndexError`, is what CPython's `seqiter` *clears* to terminate legacy-protocol iteration, so taking the suggestion would have left the fixture raising nothing and the test asserting nothing, still green.

That is true of the #1890 probe. It is false of the other two shapes the same rule keeps arriving on, and the failure is not academic: the dismissal comment is capped at 280 characters, so it **cites this file** instead of restating an argument. A run that reaches for the recorded reason on the wrong shape publishes a false claim in a dismissal that outlives the branch. The rule id has now been dismissed seven times (590, 852, 855-857, 859, 1168).

## Measured

Three probes, plain CPython 3.13, no repository code involved. `swallowed` is deliberately a **conjunction** -- the read completed *and* the probe's `__getitem__` was consulted -- because completion alone reports the `str` subclass as swallowing an exception whose method is in fact never reached, which is a different fact with the opposite consequence for a dismissal.

| probe, `__getitem__` raising | `list(probe)` | `__getitem__` consulted | the raise is swallowed |
|---|---|---|---|
| `_LegacySequence` (`__len__` + `__getitem__`, no `__iter__`), `IndexError` | `[]` | yes | **yes** -- `seqiter` clears it |
| `_LegacySequence`, `KeyError` | raises `KeyError` | yes | no |
| `_HostileStr` (a `str` subclass), `IndexError` | `['[', ':', ':', '1', ']']` | **no** | no |

Two distinct ways the recorded reason does not travel:

- **`KeyError` is not cleared.** The query's own help text says of indexing: *"Raise `KeyError` or `IndexError`"* -- it names them interchangeably and CPython does not. So one spelling of the suggestion would have kept #1890's measurement entirely, which means the mechanism was never a general refusal of the query's advice.
- **A `str` subclass never reaches the cleared path.** `str` supplies `__iter__`, so `seqiter` is never constructed and the overridden `__getitem__` is not consulted at all -- the mechanism is *absent* rather than adverse. This is alert 1168 on #3272, the shape the reason was reached for and measured false on.

## Change

The passage now carries the table above, the one-line discriminator (`list(probe)` -- characters or elements means the value's own `__iter__` is in play and nothing is being cleared; `[]` means `seqiter` swallowed it), and the reason that generalises: refuse the rewrite on the **property**. The query's help text gives the harm as a user of the class meeting an exception the protocol did not lead them to expect, and a probe written to be an unconventional class *is* that harm, under test on purpose. A conforming `LookupError` models a value refusing *within* the protocol, which is strictly weaker than what a guarded read documents itself as surviving.

The table is **parsed and executed**, not transcribed. `TestTheGetItemRewriteIsNotOneBehaviour` reads the rows out of `AGENTS.md`, matches each to its probe on the two identifiers the row names, constructs it and measures both stated columns. That is the shape the handler census immediately below it in the same file already uses (`_census_table_rows`), and it exists for a reason recorded there: the previous hand-maintained census counted seven handlers against a tree holding sixteen while every assertion passed.

Three rows rather than one is itself the pin. Collapsing the passage back to a single unscoped mechanism fails `test_the_table_names_the_three_probe_shapes` instead of reading plausibly.

**The probes raise a per-instance exception rather than a literal one.** That is the idiom `tests/training/test_gradient_clip_domain.py` records for keeping a hostile probe out of a merge gate: the type is not statically visible, so this rule does not report the methods that are here to measure its own advice. A literal `raise IndexError` would open the alert this module documents how to adjudicate.

**One smaller correction, folded in because it is the same sentence.** The old text ended "and the test asserting nothing, still green". Measured on the #1890 fixture, `finite_vector_error('raycast', 'origin', GetItemOnly())` returns `None` under `IndexError` -- no refusal at all -- so the cell asserting `message is not None` goes *red*, not green. The replacement claims neither: it says the probe is consulted, raises, and the read completes empty, which is what the pin measures.

## Verification

**Every cell is load-bearing.** Each mutation below was applied to this branch and the whole module re-run:

| mutation | cells that fire |
|---|---|
| row 3 claims the `str` raise is swallowed | 1 -- `test_every_row_is_measured` |
| row 1's `list(probe)` cell is wrong | 1 -- `test_every_row_is_measured` |
| row 2's swallowed cell is wrong | 1 -- `test_every_row_is_measured` |
| the table collapses to one mechanism | 2 -- `+ test_the_table_names_the_three_probe_shapes` |
| the discriminator sentence is dropped | 1 -- `test_the_discriminator_is_named_in_the_passage` |
| `swallowed` drops the `and consulted` conjunction | 2 -- `+ test_a_str_subclass_never_reaches_the_cleared_path` |
| the consulted read is hard-coded true | 2 -- same pair |
| the legacy probe supplies its own `__iter__` | 2 -- `+ test_the_mechanism_is_the_legacy_protocol_and_the_exception_together` |

The last row is there because that cell is a *floor-change* detector rather than a doc-drift one -- no edit to this branch can fire it, only CPython changing can, which is the same standing as `TestTheNarrowingMeasurementStillHolds`' `SystemExit` claim above it. The mutation shows it is not vacuous.

**Gates.** `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean, 1918 files already formatted. `mypy` (1.20.2, pinned) over the same three trees: **33 errors in 16 files, byte-identical to the same run with this branch reverted**, none in the touched file.

**Module:** 22 cells before, **27 after**, all passing.

**Whole-tree preflight** (`AGENTS.md` step 2, because the run above is a narrow selection): 102 of the roster's 104 graders. The two omitted (`tests/tools/test_agent_tool_parameter_descriptions.py` and its importer) cannot be *collected* in this environment -- `strands_robots.tools.lerobot_camera` raises at import without `lerobot`, so no selection reaches them. Over the 102: **3837 passed, 57 failed, 140 skipped, 149 errors**, and the failure/error set is **byte-identical at 206 node ids** to the same command with the change stashed. Every entry is an absent optional dependency (`mujoco`, `lerobot`, `torch`) in this environment, not a moved assertion.

## Size

`2 files changed, +290 / -4`. No production change. `AGENTS.md` is +40/-4 (one sentence becomes a table, three paragraphs and the property argument); the test file is +250, of which 6 are cells and the rest are three probe classes, two helpers and the docstrings recording why each measurement is shaped as it is.
