### PR TITLE
fix(rosbridge): the host half of a dialled address is graded before a pattern is offered it

### DIFF
--- a/changelog.d/3279-rosbridge-host-domain.md
+++ b/changelog.d/3279-rosbridge-host-domain.md
@@ -1,0 +1,21 @@
+### Fixed: the host half of a rosbridge address is graded before a pattern is offered it
+
+`use_rosbridge` and `RosbridgeRobot` interpolate a caller-supplied host and port
+into one websocket address, `ws://<host>:<port>`. The port half was graded twice -
+by `tcp_port_error`, the domain every port in the package shares, and then by the
+transport's own ceiling - while the host half went straight to the transport's
+allowlist pattern. A pattern can only be offered a string, so every non-string
+host (`9090`, `True`, `b"localhost"`, a list from a JSON tool call) raised
+`TypeError` out of `re`: out of a tool whose every other refusal is a result
+dict, and out of a constructor documented to report a malformed host as
+`ValueError`. The message named neither the tool nor the parameter - the same
+defect the transport's port ceiling already records, with `re`'s text in place of
+a bare `assert`.
+
+Both surfaces now read `dial_host_error` ahead of the allowlist, the same two
+stages the port half beside them has. The set of hostnames accepted is unchanged:
+the shared domain refuses none of the hostnames the allowlist admits, and the
+allowlist keeps narrowing what the domain admits, because which hostnames this
+ROS transport accepts is its own posture rather than the shared domain's. The
+truthiness check that used to catch `""` is gone; the domain owns that value and
+names the address it cannot build.

--- a/docs/rosbridge-integration.md
+++ b/docs/rosbridge-integration.md
@@ -119,6 +119,19 @@ robot = RosbridgeRobot(
 
 All parameters are optional except `node_name`, `cmd_vel_topic`, and `odom_topic`.
 
+### Address contract
+
+`host` and `port` are the two halves of one websocket address, `ws://<host>:<port>`,
+and each is graded twice: by the domain every dialled address in the package
+shares, then by this transport's own narrower rule. For the port that is the
+16-bit space followed by autobahn's ceiling of 65534; for the host it is "a string
+a websocket URI can carry" followed by the bare-hostname allowlist, which is
+stricter than the shared domain and refuses spellings a URI would accept (a
+bracketed IPv6 literal, for one). Either half being unusable is reported the same
+way whichever it is - `use_rosbridge` returns an error result and `RosbridgeRobot`
+raises `ValueError` - and both are refused before a socket is dialled, so the
+caller learns the same thing whether or not `roslibpy` is installed.
+
 ### Drive contract
 
 `drive()` takes the fleet-standard `(linear, angular, duration, count)` shape,

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -38,6 +38,7 @@ from strands_robots.mesh._mobile_base import LATCHED_VELOCITY, failed_halt_error
 from strands_robots.mesh.ros_bridge import _check_topic
 from strands_robots.tools.use_rosbridge import _HOST_RE, _transport_port_error, use_rosbridge
 from strands_robots.utils import (
+    dial_host_error,
     finite_number_error,
     partial_construction_repr,
     positive_finite_number_error,
@@ -96,7 +97,15 @@ class RosbridgeRobot:
         self.cmd_vel_topic = _check_topic("cmd_vel_topic", cmd_vel_topic)
         self.odom_topic = _check_topic("odom_topic", odom_topic)
         self.scan_topic = _check_topic("scan_topic", scan_topic) if scan_topic else None
-        if not host or not _HOST_RE.match(host):
+        # Two stages, the same pair the port below has: the shared domain every
+        # dialled host in this package shares, then the transport's own narrower
+        # allowlist. The allowlist is a pattern, so offering it the caller's
+        # value directly raised ``TypeError`` for a non-string host, out of a
+        # constructor whose contract is to report a malformed host as
+        # ``ValueError``.
+        if (host_error := dial_host_error(host, "host", type(self).__name__)) is not None:
+            raise ValueError(host_error)
+        if not _HOST_RE.match(host):
             raise ValueError(f"invalid host: {host!r}")
         if (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
             raise ValueError(port_error)

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -53,13 +53,33 @@ from strands.types.tools import ToolContext
 
 from strands_robots.tools._command_gate import gate_command
 from strands_robots.tools._numeric_options import numeric_option_error
-from strands_robots.utils import tcp_port_error
+from strands_robots.utils import dial_host_error, tcp_port_error
 
 logger = logging.getLogger(__name__)
 
 # Graph names: same allowlist posture as use_ros. Types are ROS1 two-segment.
 _NAME_RE = re.compile(r"^[A-Za-z0-9_/~]+\Z")
 _TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/[A-Za-z0-9_]+\Z")
+
+# The host allowlist is this transport's own narrowing, applied *after* the
+# shared ``dial_host_error`` domain - the same two stages the port half of the
+# address beside it already has, where ``tcp_port_error`` establishes the 16-bit
+# space and ``_transport_port_error`` places the transport's own ceiling in it.
+#
+# A pattern can only be offered a string. Matched against the caller's value
+# directly this raised ``TypeError`` from ``re`` for every non-string host -
+# ``9090``, ``True``, ``b"localhost"`` - out of a tool whose every other refusal
+# is a result dict, and out of a constructor documented to report a malformed
+# host as ``ValueError``: the same defect the port ceiling below records, with
+# ``re``'s message in place of a bare ``assert``, naming neither the tool nor the
+# parameter. The port half never had it, because a shared domain graded the value
+# before anything spent it.
+#
+# With the shared domain ahead of it the value reaching this pattern is always a
+# string a websocket URI can carry, so what is left here is the narrower question
+# of which of those hostnames this ROS transport admits - a posture that belongs
+# beside the transport, not to the domain every dialled host in the package
+# shares.
 _HOST_RE = re.compile(r"^[A-Za-z0-9._-]+\Z")
 
 # The top of the 16-bit port space is a legal TCP port that this transport cannot
@@ -318,7 +338,9 @@ def use_rosbridge(
     Args:
         action: One of ``status``, ``list_topics``, ``list_services``,
             ``echo``, ``publish``, ``service_call``.
-        host: rosbridge server hostname or IP.
+        host: rosbridge server hostname or IP. Held to the shared domain every
+            dialled host in this package shares, then to this transport's own
+            narrower allowlist.
         port: rosbridge WebSocket port (default 9090).
         topic: Topic name (``echo``, ``publish``). Held to the same name rule
             as ``service``.
@@ -345,7 +367,9 @@ def use_rosbridge(
     """
     fields = fields or {}
 
-    if not host or not _HOST_RE.match(host):
+    if (host_error := dial_host_error(host, "host", action)) is not None:
+        return _err(host_error)
+    if not _HOST_RE.match(host):
         return _err(f"invalid host: {host!r}")
     if (port_error := tcp_port_error(port, "port", action)) is not None:
         return _err(port_error)

--- a/tests/mesh/test_rosbridge_robot.py
+++ b/tests/mesh/test_rosbridge_robot.py
@@ -46,7 +46,9 @@ def _rover(**overrides: Any) -> RosbridgeRobot:
 def test_invalid_names_rejected() -> None:
     with pytest.raises(ValueError, match="invalid cmd_vel_topic"):
         _rover(cmd_vel_topic="/cmd vel")
-    with pytest.raises(ValueError, match="invalid host"):
+    # The host is graded by the shared dial domain ahead of this transport's own
+    # allowlist, so the refusal is pinned on the parameter it names.
+    with pytest.raises(ValueError, match="host"):
         _rover(host="bad host")
     with pytest.raises(ValueError, match="invalid port"):
         _rover(port=0)

--- a/tests/tools/test_rosbridge_host_domain.py
+++ b/tests/tools/test_rosbridge_host_domain.py
@@ -1,0 +1,152 @@
+"""The host half of a rosbridge address is graded before anything spends it.
+
+Both rosbridge surfaces interpolate a caller-supplied host and port into one
+websocket address, ``ws://<host>:<port>``. The port half is graded twice: by
+:func:`~strands_robots.utils.tcp_port_error`, the domain every port in the
+package shares, and then by the transport's own narrower ceiling. The host half
+beside it went straight to the transport's allowlist pattern, and a pattern can
+only be offered a string - so every non-string host raised ``TypeError`` out of
+``re``, out of a tool whose every other refusal is a result dict and out of a
+constructor documented to report a malformed host as ``ValueError``.
+
+These pins hold the two halves against each other: an unusable value is
+*reported* by whichever half it was given to, the shared domain refuses no host
+the transport admits, and the transport keeps the narrower allowlist that is
+its own posture rather than the domain's.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import itertools
+import string
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh.rosbridge_robot import RosbridgeRobot
+from strands_robots.tools.use_rosbridge import use_rosbridge
+from strands_robots.utils import dial_host_error
+
+# Values a tool call carries verbatim from JSON, an env read or an agent, none of
+# which a websocket URI can name a host with.
+NON_STRING_HOSTS: list[Any] = [None, 9090, True, 1.5, ["localhost"], b"localhost", {"host": "x"}]
+
+# Hosts the shared domain admits as a string a URI can carry, and that this
+# transport's allowlist narrows anyway. The narrowing is the transport's own
+# posture - the same reason its port ceiling sits beside it and not in the shared
+# domain - so it is pinned as a deliberate asymmetry, not repaired.
+ADMITTED_BY_DOMAIN_NARROWED_BY_TRANSPORT = ["[::1]", "host!", "*", "h\u00e9llo", "host%2f"]
+
+# Values neither half of the address can carry. ``9090`` is deliberately absent:
+# it is a legal port and not a host, which is the asymmetry itself - one value,
+# two answers, decided by which half of ``ws://<host>:<port>`` it was given to.
+UNUSABLE_FOR_EITHER_HALF: list[Any] = [None, True, 1.5, ["localhost"], b"localhost", {"host": "x"}]
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(part.get("text", "") for part in result["content"])
+
+
+def _tool_host_verdict(host: Any) -> str | None:
+    """Return the tool's refusal text for ``host``, or ``None`` when admitted.
+
+    Read through the public tool with an action it does not offer: the host is
+    graded ahead of the action, so an admitted host reports the unknown action
+    and no host is ever dialled - the verdict is observed without a backend and
+    without reaching into the module's private pattern.
+    """
+    result = use_rosbridge(action="__no_such_action__", host=host)
+    assert result["status"] == "error", result
+    text = _text(result)
+    return None if "unknown action" in text else text
+
+
+def _constructor_host_verdict(host: Any) -> str | None:
+    """Return ``RosbridgeRobot``'s refusal text for ``host``, or ``None``."""
+    try:
+        RosbridgeRobot("node", "/cmd_vel", "/odom", host=host)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+@pytest.mark.parametrize("host", NON_STRING_HOSTS)
+def test_a_non_string_host_is_reported_as_a_result_not_raised(host: Any) -> None:
+    """The tool reports it, rather than raising ``re``'s TypeError past dispatch."""
+    verdict = _tool_host_verdict(host)
+    assert verdict is not None
+    assert "host" in verdict
+
+
+@pytest.mark.parametrize("host", NON_STRING_HOSTS)
+def test_a_non_string_host_is_the_valueerror_the_constructor_documents(host: Any) -> None:
+    """``RosbridgeRobot`` documents a malformed host as ``ValueError``; a
+    non-string one used to leave as ``TypeError`` instead."""
+    verdict = _constructor_host_verdict(host)
+    assert verdict is not None
+    assert "host" in verdict
+
+
+@pytest.mark.parametrize("value", UNUSABLE_FOR_EITHER_HALF)
+def test_both_halves_of_one_address_report_the_same_unusable_value(value: Any) -> None:
+    """Host and port are interpolated into one address, so a value neither can
+    carry is reported the same way whichever half it is given to."""
+    host_half = use_rosbridge(action="__no_such_action__", host=value)
+    port_half = use_rosbridge(action="__no_such_action__", port=value)
+    assert host_half["status"] == "error"
+    assert port_half["status"] == "error"
+    assert "host" in _text(host_half)
+    assert "port" in _text(port_half)
+
+
+def test_the_shared_domain_refuses_no_host_this_transport_admits() -> None:
+    """Consolidating onto the shared domain narrows nothing: every hostname the
+    transport allowlist admits is a hostname the domain admits too."""
+    alphabet = string.ascii_letters + string.digits + "._-"
+    probes = list(alphabet)
+    probes += ["".join(pair) for pair in itertools.product(alphabet, repeat=2)]
+    probes += ["localhost", "0.0.0.0", "127.0.0.1", "my-robot.local", "a" * 63]
+    admitted = [probe for probe in probes if _tool_host_verdict(probe) is None]
+    assert len(admitted) > 4000, "the allowlist probe set collapsed; the oracle is not reading it"
+    refused_by_domain = [probe for probe in admitted if dial_host_error(probe, "host", "x") is not None]
+    assert refused_by_domain == []
+
+
+@pytest.mark.parametrize("host", ADMITTED_BY_DOMAIN_NARROWED_BY_TRANSPORT)
+def test_the_transport_keeps_its_own_narrower_host_allowlist(host: Any) -> None:
+    """The allowlist is this transport's posture, not the shared domain's: it
+    still refuses hostnames a websocket URI could carry."""
+    assert dial_host_error(host, "host", "x") is None, "probe no longer isolates the transport's narrowing"
+    assert _tool_host_verdict(host) is not None
+    assert _constructor_host_verdict(host) is not None
+
+
+def test_an_empty_host_is_still_refused_by_the_domain_that_replaced_the_falsiness_check() -> None:
+    """A truthiness test used to catch ``""`` ahead of the pattern; the shared
+    domain owns it now, and names the address it cannot build."""
+    for verdict in (_tool_host_verdict(""), _constructor_host_verdict("")):
+        assert verdict is not None
+        assert "host" in verdict
+
+
+@pytest.mark.parametrize(
+    ("module_name", "owner"),
+    [
+        ("strands_robots.tools.use_rosbridge", "use_rosbridge"),
+        ("strands_robots.mesh.rosbridge_robot", "__init__"),
+    ],
+)
+def test_both_surfaces_read_the_shared_host_domain(module_name: str, owner: str) -> None:
+    """Graded on the call graph rather than the source text: a domain named but
+    not called - in a table, say - reads as consolidated while grading nothing."""
+    module = importlib.import_module(module_name)
+    tree = ast.parse(inspect.getsource(module))
+    owners = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == owner]
+    assert owners, f"{owner} not found in {module_name}"
+    called = {
+        node.func.id for node in ast.walk(owners[0]) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "dial_host_error" in called, f"{module_name}:{owner} does not read the shared host domain"

--- a/tests/tools/test_use_rosbridge.py
+++ b/tests/tools/test_use_rosbridge.py
@@ -225,9 +225,12 @@ def test_valid_ros1_type_accepted_shapewise(fake_roslibpy: _types.ModuleType) ->
 
 @pytest.mark.parametrize("bad_host", ["bad host", "h;st", ""])
 def test_invalid_host_rejected(bad_host: str) -> None:
+    # Two owners grade the host - the shared dial domain, then this transport's
+    # narrower allowlist - so the pin names the parameter the caller has to fix
+    # rather than which of the two spoke for a given spelling.
     result = use_rosbridge(action="status", host=bad_host)
     assert result["status"] == "error"
-    assert "invalid host" in _texts(result)
+    assert "host" in _texts(result)
 
 
 @pytest.mark.parametrize("bad_port", [0, -1, 70000])


### PR DESCRIPTION
`use_rosbridge` and `RosbridgeRobot` interpolate a caller-supplied host and port into one websocket address, `ws://<host>:<port>`. The port half is graded twice - by `tcp_port_error`, the domain every port in the package shares, then by the transport's own ceiling. The host half beside it went straight to the transport's allowlist pattern.

A pattern can only be offered a string.

![host/port verdicts, measured before and after](https://raw.githubusercontent.com/cagataycali/robots/c096782f2d73a95af924124e3cc2418119698ed0/assets/rosbridge-host-domain.png)

## What the red cells were

Every non-string host raised `TypeError` out of `re` - `expected string or bytes-like object, got 'int'` - naming neither the surface nor the parameter:

| surface | contract | what a non-string host did |
|---|---|---|
| `use_rosbridge` | returns `{"status": "error", "content": [...]}` | raised past dispatch |
| `RosbridgeRobot.__init__` | documents `Raises: ValueError ... when the host or the port is malformed` | raised `TypeError` instead |

This is the same defect `_TRANSPORT_MAX_PORT` already records one screen above, where autobahn's `assert` refused port 65535: *"an agent driving the tool got an exception where every other refusal is a result dict, and the exception named neither the tool nor the parameter."* The port half no longer has it, because a shared domain grades the value before anything spends it. The host half never got that floor.

`9090` is the row worth reading twice: the same value is a legal port and, handed to the half beside it, an exception.

## The change

Both surfaces read `dial_host_error` ahead of the allowlist - the same two stages the port half has:

```python
if (host_error := dial_host_error(host, "host", action)) is not None:
    return _err(host_error)
if not _HOST_RE.match(host):
    return _err(f"invalid host: {host!r}")
```

The truthiness test that used to catch `""` is gone: the domain owns that value and names the address it cannot build (`'ws://:<port>' is not a URI`), rather than reporting it as a malformed hostname.

**Nothing that worked stops working.** Measured, not asserted: across the allowlist's whole alphabet the shared domain refuses **0 of 4295** hostnames the transport admits, and the accepted set in the table above is identical before and after. The allowlist keeps narrowing what the domain admits - `[::1]` is a hostname a websocket URI can carry and this ROS transport still refuses it - because which hostnames this transport accepts is its own posture, the same reason its port ceiling sits beside it instead of in the shared domain.

## Tests

`tests/tools/test_rosbridge_host_domain.py`, 29 cells, read through the public surfaces only - an action the tool does not offer passes the host gate and reports the unknown action, so a verdict is observed without a backend and without touching the module's private pattern.

| corner | result |
|---|---|
| fix + new pin | **141 passed** |
| **pin without the fix** | **19 failed** / 122 passed |
| fix, pin removed | 112 passed |
| neither | 112 passed |

`112 + 29 = 141`. The last two corners are equal because the three pre-existing cells were retargeted onto the parameter the refusal names rather than which of the two owners spoke - they hold either way, so it is the new file that pins the fix.

Beyond the escape, the pins hold the two halves against each other: a value neither half can carry is reported the same way whichever it is given to; the shared domain refuses no host the transport admits; and the transport's narrowing is pinned as deliberate. The consolidation cell is graded on the **call graph** rather than the source text, so a domain named but not called cannot read as consolidated.

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; mypy unchanged; `tests/tools/ tests/mesh/` shows the same 61 pre-existing environment failures (absent optional extras) before and after.

Size: 7 files, +230/-6, of which +152 is the new pin and +21 the changelog fragment; 27 executable lines change in `strands_robots/`.