### PR TITLE
ci(test-lint): the device-connect source pin is measured in the test env, not announced

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -138,11 +138,24 @@ jobs:
           # UV_OVERRIDE entries with the pyproject [tool.uv] override-dependencies
           # (torch pins), so this redirects ONLY the device-connect packages to
           # source without disturbing anything else.
+          #
+          # Two consequences for whoever reads the log. The `pip install -e
+          # ".[all,dev]"` in the next step reads no UV_OVERRIDE, so it fetches
+          # and prints the PUBLISHED device-connect wheels - into the runner
+          # interpreter, which nothing under test imports from. That line is
+          # expected and is not evidence about the pin (#3222 read it as such).
+          # And hatch creates its env silently, so the log shows nothing about
+          # what the suite's interpreter resolved: the verify step after `Run
+          # lint` is what turns the announcement below into a measurement.
           cat > "${GITHUB_WORKSPACE}/dc-source-override.txt" <<EOF
           device-connect-edge @ git+https://github.com/${DEVICE_CONNECT_REPO}.git@${DEVICE_CONNECT_SOURCE_REF}#subdirectory=packages/device-connect-edge
           device-connect-agent-tools @ git+https://github.com/${DEVICE_CONNECT_REPO}.git@${DEVICE_CONNECT_SOURCE_REF}#subdirectory=packages/device-connect-agent-tools
           EOF
           echo "UV_OVERRIDE=${GITHUB_WORKSPACE}/dc-source-override.txt" >> "$GITHUB_ENV"
+          # Hand the verify step the same repo and ref this step announced, so
+          # it grades the claim actually made rather than a second copy of it.
+          echo "DEVICE_CONNECT_REPO=${DEVICE_CONNECT_REPO}" >> "$GITHUB_ENV"
+          echo "DEVICE_CONNECT_SOURCE_REF=${DEVICE_CONNECT_SOURCE_REF}" >> "$GITHUB_ENV"
           echo "Pinned device-connect packages to ${DEVICE_CONNECT_REPO}@${DEVICE_CONNECT_SOURCE_REF}"
 
       - name: Install dependencies
@@ -156,6 +169,22 @@ jobs:
         env:
           UV_TORCH_BACKEND: cpu
         run: hatch run lint
+
+      # The hatch env exists once `Run lint` has created it, and the suite has
+      # not started yet, so a pin that did not take is reported here, in under a
+      # second, rather than as a green 27-minute suite run against the wrong
+      # distribution. Runs THROUGH `hatch run` on purpose: the runner
+      # interpreter holds the published wheel from `Install dependencies`, so
+      # the same script under a bare `python` measures the wrong environment
+      # and fails for the wrong reason (#3222). Pinned by
+      # tests/test_device_connect_source_pin_is_verified.py.
+      - name: Verify the device-connect source pin reached the test env
+        if: steps.dc_changed.outputs.changed == 'true'
+        env:
+          UV_TORCH_BACKEND: cpu
+        run: |
+          hatch run python scripts/check_device_connect_source_pin.py \
+            --repo "${DEVICE_CONNECT_REPO}" --ref "${DEVICE_CONNECT_SOURCE_REF}"
 
       - name: Run tests
         env:

--- a/changelog.d/3222-device-connect-pin-is-verified.md
+++ b/changelog.d/3222-device-connect-pin-is-verified.md
@@ -1,0 +1,16 @@
+### CI: the device-connect source pin is measured in the test env rather than announced
+
+`test-lint.yml` redirects `device-connect-edge` and `device-connect-agent-tools`
+to `arm/device-connect@<ref>` when a pull request touches
+`strands_robots/device_connect/`, and printed `Pinned device-connect packages to
+...` as its only trace. Hatch creates the test env silently, so the job log
+carried no evidence of what the suite's interpreter resolved - while the outer
+`pip install -e ".[all,dev]"`, which reads no `UV_OVERRIDE` and installs nothing
+the suite imports, printed the published wheel's download in full view. #3222
+read that as the pin never being consulted; measured, it is consulted, and the
+defect was that CI could support the claim in neither direction. A new step runs
+`scripts/check_device_connect_source_pin.py` through `hatch run` between env
+creation and the suite: it reads each distribution's PEP 610 `direct_url.json`
+and fails, naming the origin actually loaded, unless both come from the
+announced repository and ref. Pinned by
+`tests/test_device_connect_source_pin_is_verified.py`.

--- a/scripts/check_device_connect_source_pin.py
+++ b/scripts/check_device_connect_source_pin.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Report where the device-connect packages in *this* interpreter came from.
+
+Why this exists
+---------------
+``test-lint.yml`` redirects ``device-connect-edge`` and
+``device-connect-agent-tools`` to a git source when a pull request touches
+``strands_robots/device_connect/``, by writing a ``uv`` override file and
+exporting ``UV_OVERRIDE`` before the hatch test environment is created. The
+step then prints ``Pinned device-connect packages to <repo>@<ref>``.
+
+That line is an announcement, not a measurement. Nothing in the job log said
+which distribution the suite actually imported: hatch creates its environment
+silently, so no ``Resolved``/``Installed`` lines appear for it, while the
+*outer* ``pip install -e ".[all,dev]"`` into the runner interpreter - which
+reads no ``UV_OVERRIDE`` and installs nothing the suite imports - prints a
+``Downloading device_connect_edge-<version>-py3-none-any.whl`` line in full
+view. Issue #3222 read that line as proof the pin was never consulted. It was
+consulted (measured: a hatch ``installer = "uv"`` environment created under
+``UV_OVERRIDE`` records the git origin in the distribution's
+``direct_url.json``), but the log carried no evidence either way, and a claim
+CI cannot support is one a reviewer has to take on trust in both directions.
+
+This script is that evidence. Run it *inside* the environment under test::
+
+    hatch run python scripts/check_device_connect_source_pin.py \\
+        --repo arm/device-connect --ref main
+
+It reads each distribution's ``direct_url.json`` - the PEP 610 record every
+installer writes for a non-registry install and omits for a registry wheel - and
+exits 1 unless every distribution names the requested repository and revision.
+Run under the runner interpreter instead, it reports the wheel the outer
+``pip install`` fetched, and fails: that interpreter is not the one under test,
+which is exactly the misreading above. The workflow step therefore goes through
+``hatch run``, and ``tests/test_device_connect_source_pin_is_verified.py`` pins
+that it does.
+
+Outcomes
+--------
+``pinned-to-source``
+    ``direct_url.json`` is present, ``vcs`` is ``git``, the URL names
+    ``https://github.com/<repo>`` (with or without ``.git``) and
+    ``requested_revision`` is the requested ref.
+``registry-wheel``
+    The distribution is installed and carries no ``direct_url.json``, which is
+    what a wheel resolved from an index looks like.
+``other-source``
+    ``direct_url.json`` is present but names a different URL, revision or VCS.
+``not-installed``
+    No distribution of that name is importable from this interpreter.
+
+Only ``pinned-to-source`` passes. The report names the origin that was found so
+a red step says what *was* loaded rather than only that it was not the pin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import sys
+from dataclasses import dataclass
+
+#: The two distributions the workflow's override file redirects. The default for
+#: ``--distribution`` rather than a constant the caller cannot change, so the
+#: probe in the test module can point the same verdict at a small stand-in.
+DEFAULT_DISTRIBUTIONS = ("device-connect-edge", "device-connect-agent-tools")
+
+PINNED = "pinned-to-source"
+REGISTRY = "registry-wheel"
+OTHER = "other-source"
+MISSING = "not-installed"
+
+
+@dataclass(frozen=True)
+class Origin:
+    """Where one installed distribution came from, as its installer recorded it."""
+
+    distribution: str
+    outcome: str
+    version: str
+    detail: str
+
+
+def expected_urls(repo: str) -> frozenset[str]:
+    """The URL spellings that name ``repo`` on GitHub.
+
+    ``uv`` records the URL as the override spelled it, and the workflow spells it
+    with ``.git``; the bare form is accepted too so a later edit to the override
+    that drops the suffix is not read as a different repository.
+    """
+    base = f"https://github.com/{repo.strip('/')}"
+    return frozenset({base, f"{base}.git"})
+
+
+def classify(
+    distribution: str,
+    *,
+    repo: str,
+    ref: str,
+    version: str | None,
+    direct_url_text: str | None,
+) -> Origin:
+    """Classify one distribution from its version and ``direct_url.json`` text.
+
+    ``version`` is ``None`` when the distribution is not installed at all;
+    ``direct_url_text`` is ``None`` when it is installed with no PEP 610 record.
+    Pure so the test module can drive every outcome without an installer.
+    """
+    if version is None:
+        return Origin(distribution, MISSING, "", "no distribution of this name is importable")
+    if direct_url_text is None:
+        return Origin(distribution, REGISTRY, version, "no direct_url.json: a wheel resolved from an index")
+    try:
+        record = json.loads(direct_url_text)
+    except json.JSONDecodeError as exc:
+        return Origin(distribution, OTHER, version, f"direct_url.json is not JSON: {exc}")
+    url = str(record.get("url", ""))
+    vcs_info = record.get("vcs_info") or {}
+    vcs = str(vcs_info.get("vcs", ""))
+    requested = str(vcs_info.get("requested_revision", ""))
+    commit = str(vcs_info.get("commit_id", ""))
+    found = f"{vcs or 'non-vcs'} {url}@{requested or '<no requested_revision>'}"
+    if commit:
+        found += f" ({commit[:12]})"
+    if vcs == "git" and url in expected_urls(repo) and requested == ref:
+        return Origin(distribution, PINNED, version, found)
+    return Origin(distribution, OTHER, version, found)
+
+
+def inspect(distribution: str, *, repo: str, ref: str) -> Origin:
+    """Classify ``distribution`` as installed in the running interpreter."""
+    try:
+        dist = importlib.metadata.distribution(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return classify(distribution, repo=repo, ref=ref, version=None, direct_url_text=None)
+    return classify(
+        distribution,
+        repo=repo,
+        ref=ref,
+        version=dist.version,
+        direct_url_text=dist.read_text("direct_url.json"),
+    )
+
+
+def render(origins: list[Origin], *, repo: str, ref: str) -> str:
+    """Render the report as markdown, the shape the step summary renders."""
+    lines = [
+        "## Device-connect source pin",
+        "",
+        f"Expected every distribution below to come from `https://github.com/{repo}.git@{ref}`.",
+        f"Interpreter: `{sys.executable}`",
+        "",
+        "| distribution | outcome | version | origin found |",
+        "|---|---|---|---|",
+    ]
+    for origin in origins:
+        lines.append(f"| `{origin.distribution}` | {origin.outcome} | {origin.version or '-'} | {origin.detail} |")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", required=True, help="GitHub repository the pin names, e.g. arm/device-connect")
+    parser.add_argument("--ref", required=True, help="git ref the pin names, e.g. main")
+    parser.add_argument(
+        "--distribution",
+        action="append",
+        dest="distributions",
+        metavar="NAME",
+        help="distribution to inspect (repeatable; default: the two device-connect packages)",
+    )
+    args = parser.parse_args(argv)
+    names = tuple(args.distributions) if args.distributions else DEFAULT_DISTRIBUTIONS
+
+    origins = [inspect(name, repo=args.repo, ref=args.ref) for name in names]
+    print(render(origins, repo=args.repo, ref=args.ref))
+
+    failed = [origin for origin in origins if origin.outcome != PINNED]
+    for origin in failed:
+        print(
+            f"::error title=device-connect is not the pinned source::{origin.distribution} is "
+            f"{origin.outcome} ({origin.detail}); expected https://github.com/{args.repo}.git@{args.ref}. "
+            "If this ran outside `hatch run`, it measured the runner interpreter rather than the test env."
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_device_connect_source_pin_is_verified.py
+++ b/tests/test_device_connect_source_pin_is_verified.py
@@ -1,0 +1,285 @@
+"""The device-connect source pin is measured in the test env, not announced.
+
+``test-lint.yml`` redirects the two device-connect distributions to a git
+source when a pull request touches ``strands_robots/device_connect/``. It does so
+by exporting ``UV_OVERRIDE`` before the hatch test env is created, and it prints
+``Pinned device-connect packages to <repo>@<ref>``.
+
+Until #3222 that line was the only trace the pin left. Hatch creates its env
+silently, so the job log carried no ``Resolved``/``Installed`` evidence for the
+interpreter the suite runs in - while the *outer* ``pip install -e ".[all,dev]"``
+into the runner interpreter, which reads no ``UV_OVERRIDE`` and installs nothing
+the suite imports, printed ``Downloading device_connect_edge-0.2.5-...whl`` in
+full view. The issue read that as the pin never being consulted. Measured, the
+pin is consulted: a hatch ``installer = "uv"`` env created under ``UV_OVERRIDE``
+carrying ``six @ git+https://github.com/benjaminp/six.git@main`` records::
+
+    {"url": "https://github.com/benjaminp/six.git",
+     "vcs_info": {"vcs": "git", "commit_id": "c8e39406...", "requested_revision": "main"}}
+
+in ``six``'s ``direct_url.json``, while the same distribution in the runner
+interpreter carries no such file. So the defect was not the pin but the absence
+of any measurement of it - a claim CI could not support in either direction.
+
+``scripts/check_device_connect_source_pin.py`` is that measurement, and the
+workflow runs it between env creation and the suite. This module pins two
+things: the script's verdict over every origin an installer can leave behind,
+and the workflow's invocation of it - gated on the same condition as the pin,
+placed after the step that creates the env and before the suite, and run
+*through* ``hatch run``. The last is the one worth grading rather than trusting:
+a bare ``python`` measures the runner interpreter, where the published wheel
+lives, so it would fail on every pull request the pin applies to and report the
+wrong cause. That is the reading #3222 made from the log, arriving as a check.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_device_connect_source_pin.py"
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "test-lint.yml"
+
+_REPO = "arm/device-connect"
+_REF = "main"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("check_device_connect_source_pin", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+
+def _install_dist_info(site: Path, name: str, version: str, direct_url: dict[str, Any] | None) -> None:
+    """Leave the metadata an installer leaves, and nothing else.
+
+    ``importlib.metadata`` reads a ``*.dist-info`` directory off ``sys.path``, so
+    a fabricated one exercises the same code path a real install does - including
+    ``read_text`` returning ``None`` for a file the installer did not write, which
+    is what a registry wheel looks like.
+    """
+    info = site / f"{name.replace('-', '_')}-{version}.dist-info"
+    info.mkdir(parents=True)
+    (info / "METADATA").write_text(f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n")
+    if direct_url is not None:
+        (info / "direct_url.json").write_text(json.dumps(direct_url))
+
+
+def _git_record(url: str, ref: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "vcs_info": {"vcs": "git", "commit_id": "c8e394065cd541a16c040515dc0afb85cf22a7c3", "requested_revision": ref},
+    }
+
+
+class TestTheVerdictReadsTheInstallersRecord:
+    """Each origin an installer can leave is named, and only the pin passes."""
+
+    @pytest.fixture
+    def site(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        site = tmp_path / "site"
+        site.mkdir()
+        monkeypatch.syspath_prepend(str(site))
+        return site
+
+    def test_a_git_install_of_the_named_repo_and_ref_is_the_pin(self, site: Path) -> None:
+        _install_dist_info(site, "probe-edge", "0.2.5", _git_record(f"https://github.com/{_REPO}.git", _REF))
+        origin = mod.inspect("probe-edge", repo=_REPO, ref=_REF)
+        assert origin.outcome == mod.PINNED
+        assert origin.version == "0.2.5"
+        assert "c8e394065cd5" in origin.detail, "the commit actually loaded is part of the evidence"
+
+    def test_the_url_without_a_git_suffix_names_the_same_repository(self, site: Path) -> None:
+        _install_dist_info(site, "probe-bare", "0.2.5", _git_record(f"https://github.com/{_REPO}", _REF))
+        assert mod.inspect("probe-bare", repo=_REPO, ref=_REF).outcome == mod.PINNED
+
+    def test_a_wheel_from_an_index_is_a_registry_wheel(self, site: Path) -> None:
+        _install_dist_info(site, "probe-wheel", "0.2.5", None)
+        origin = mod.inspect("probe-wheel", repo=_REPO, ref=_REF)
+        assert origin.outcome == mod.REGISTRY
+        assert "direct_url.json" in origin.detail
+
+    @pytest.mark.parametrize(
+        ("record", "why"),
+        [
+            (_git_record(f"https://github.com/{_REPO}.git", "v0.2.5"), "the revision is not the one announced"),
+            (
+                _git_record("https://github.com/someone-else/device-connect.git", _REF),
+                "the repository is not the one announced",
+            ),
+            (
+                {"url": "file:///tmp/device-connect", "dir_info": {"editable": True}},
+                "a local path is not the source pin",
+            ),
+        ],
+    )
+    def test_a_different_source_is_named_rather_than_accepted(
+        self, site: Path, record: dict[str, Any], why: str
+    ) -> None:
+        _install_dist_info(site, "probe-other", "0.2.5", record)
+        origin = mod.inspect("probe-other", repo=_REPO, ref=_REF)
+        assert origin.outcome == mod.OTHER, why
+        assert record["url"] in origin.detail, "the report says what was found, not only that it was wrong"
+
+    def test_an_absent_distribution_is_reported_as_absent(self, site: Path) -> None:
+        origin = mod.inspect("probe-absent", repo=_REPO, ref=_REF)
+        assert origin.outcome == mod.MISSING
+        assert origin.version == ""
+
+    def test_unparseable_metadata_is_not_read_as_the_pin(self) -> None:
+        origin = mod.classify("probe", repo=_REPO, ref=_REF, version="0.2.5", direct_url_text="{not json")
+        assert origin.outcome == mod.OTHER
+
+
+class TestTheExitCodeIsTheVerdict:
+    """Any distribution that is not the pin fails the step, and the report says which."""
+
+    def _run(self, site: Path, *names: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT),
+                "--repo",
+                _REPO,
+                "--ref",
+                _REF,
+                *sum((["--distribution", n] for n in names), []),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={"PYTHONPATH": str(site), "PATH": "/usr/bin:/bin"},
+        )
+
+    def test_every_distribution_pinned_exits_zero(self, tmp_path: Path) -> None:
+        _install_dist_info(tmp_path, "edge", "0.2.5", _git_record(f"https://github.com/{_REPO}.git", _REF))
+        _install_dist_info(tmp_path, "tools", "0.1.2", _git_record(f"https://github.com/{_REPO}.git", _REF))
+        result = self._run(tmp_path, "edge", "tools")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::error" not in result.stdout
+
+    def test_one_registry_wheel_fails_and_is_named(self, tmp_path: Path) -> None:
+        _install_dist_info(tmp_path, "edge", "0.2.5", _git_record(f"https://github.com/{_REPO}.git", _REF))
+        _install_dist_info(tmp_path, "tools", "0.1.2", None)
+        result = self._run(tmp_path, "edge", "tools")
+        assert result.returncode == 1
+        assert "::error" in result.stdout
+        assert "tools is registry-wheel" in result.stdout
+        assert "edge is " not in result.stdout, "the distribution that IS the pin is not reported as a failure"
+
+    def test_the_default_distributions_are_the_two_the_override_redirects(self) -> None:
+        assert mod.DEFAULT_DISTRIBUTIONS == ("device-connect-edge", "device-connect-agent-tools")
+
+
+# --- the workflow ---------------------------------------------------------------
+
+_STEP_START = re.compile(r"^      - name: (?P<name>.+?)\s*$", re.MULTILINE)
+
+
+def _steps(text: str) -> list[tuple[str, str]]:
+    """Return ``(name, body)`` per step of the single job, in order.
+
+    A step begins at a six-space ``- name:`` and runs to the next one. The job
+    has one ``steps:`` list, so this is exact rather than approximate for this
+    file; the assertion in :func:`test_the_workflow_has_the_steps_this_module_reads`
+    is what says so.
+    """
+    starts = list(_STEP_START.finditer(text))
+    steps = []
+    for index, match in enumerate(starts):
+        end = starts[index + 1].start() if index + 1 < len(starts) else len(text)
+        steps.append((match.group("name"), text[match.end() : end]))
+    return steps
+
+
+def _step(steps: list[tuple[str, str]], predicate: Any) -> tuple[int, str, str]:
+    hits = [(i, n, b) for i, (n, b) in enumerate(steps) if predicate(n, b)]
+    assert len(hits) == 1, [n for _, n, _ in hits]
+    return hits[0]
+
+
+def _field(body: str, key: str) -> str:
+    match = re.search(rf"^        {key}: (?P<value>.+?)\s*$", body, re.MULTILINE)
+    assert match, f"step has no `{key}:`"
+    return match.group("value")
+
+
+@pytest.fixture(scope="module")
+def steps() -> list[tuple[str, str]]:
+    return _steps(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def pin(steps: list[tuple[str, str]]) -> tuple[int, str, str]:
+    return _step(steps, lambda n, b: "dc-source-override.txt" in b and "UV_OVERRIDE=" in b)
+
+
+@pytest.fixture(scope="module")
+def verify(steps: list[tuple[str, str]]) -> tuple[int, str, str]:
+    return _step(steps, lambda n, b: _SCRIPT.name in b)
+
+
+def test_the_workflow_has_the_steps_this_module_reads(steps: list[tuple[str, str]]) -> None:
+    names = [n for n, _ in steps]
+    assert "Install dependencies" in names
+    assert "Run lint" in names
+    assert "Run tests" in names
+
+
+class TestThePinIsVerifiedWhereTheSuiteRuns:
+    """The verify step grades the claim the pin step made, in the env the suite uses."""
+
+    def test_the_verify_step_is_gated_on_the_same_condition_as_the_pin(
+        self, pin: tuple[int, str, str], verify: tuple[int, str, str]
+    ) -> None:
+        assert _field(verify[2], "if") == _field(pin[2], "if")
+
+    def test_the_verify_step_runs_after_the_env_exists_and_before_the_suite(
+        self, steps: list[tuple[str, str]], verify: tuple[int, str, str]
+    ) -> None:
+        lint = _step(steps, lambda n, b: re.search(r"^\s+run: hatch run lint\s*$", b, re.MULTILINE) is not None)
+        tests = _step(steps, lambda n, b: "hatch run test " in b)
+        assert lint[0] < verify[0] < tests[0], (
+            "the hatch env is created by the first `hatch run`, which is `Run lint`; "
+            "before it there is nothing to inspect, and after `Run tests` the verdict arrives "
+            "27 minutes late"
+        )
+
+    def test_the_verify_step_runs_through_hatch(self, verify: tuple[int, str, str]) -> None:
+        run = verify[2]
+        assert re.search(rf"hatch run python scripts/{re.escape(_SCRIPT.name)}", run), run
+        assert not re.search(rf"^\s*python3? scripts/{re.escape(_SCRIPT.name)}", run, re.MULTILINE), (
+            "a bare interpreter measures the runner install, which holds the published wheel"
+        )
+
+    def test_the_verify_step_reads_the_repo_and_ref_the_pin_step_exported(
+        self, pin: tuple[int, str, str], verify: tuple[int, str, str]
+    ) -> None:
+        for name in ("DEVICE_CONNECT_REPO", "DEVICE_CONNECT_SOURCE_REF"):
+            assert re.search(rf'echo "{name}=\$\{{{name}\}}" >> "\$GITHUB_ENV"', pin[2]), (
+                f"the pin step must hand {name} to later steps; a second `vars.` read would be a second copy of the claim"
+            )
+        assert '--repo "${DEVICE_CONNECT_REPO}"' in verify[2]
+        assert '--ref "${DEVICE_CONNECT_SOURCE_REF}"' in verify[2]
+
+    def test_the_script_grades_every_distribution_the_override_redirects(self, pin: tuple[int, str, str]) -> None:
+        redirected = re.findall(r"^\s+(?P<name>[a-z0-9-]+) @ git\+https://", pin[2], re.MULTILINE)
+        assert redirected, "the override heredoc names no distribution"
+        assert tuple(redirected) == mod.DEFAULT_DISTRIBUTIONS, (
+            "a distribution added to the override without being added to the script's defaults "
+            "would be pinned and never verified"
+        )


### PR DESCRIPTION
Closes #3222

## What the issue got right, and what it did not

#3222 reports that `test-lint.yml` announces `Pinned device-connect packages to arm/device-connect@main` and then installs the published wheel. The evidence is the `pip install -e ".[all,dev]"` step's `Downloading device_connect_edge-0.2.5-py3-none-any.whl` line, and the issue concludes the override file is "written, exported, announced, and never consulted" because "this job does not run the suite in a hatch env".

That premise is wrong, and it decides which fix is right, so I measured it before writing one:

- **The suite does run in the hatch env.** Run 33944300007's own log: `Creating environment: default` at 04:23:44 with `UV_OVERRIDE` in the step env, `TORCH_DIAG file=/home/runner/.local/share/hatch/env/virtual/strands-robots/G063SSUK/.../torch/__init__.py`, and pytest's `platform` line naming that same interpreter. The pip line the issue cites is the *outer* install into the runner interpreter, which nothing under test imports from - exactly what the step's existing comment says.
- **A hatch `installer = "uv"` env does honour `UV_OVERRIDE`.** Reproduced on a minimal project with a dependency on `six` and an override file `six @ git+https://github.com/benjaminp/six.git@main`; `hatch run python -c ...` reports `six`'s `direct_url.json` as `{"url": "https://github.com/benjaminp/six.git", "vcs_info": {"vcs": "git", "commit_id": "c8e39406...", "requested_revision": "main"}}`. The same distribution in the runner interpreter carries no `direct_url.json`.

So the pin is consulted. What the issue is right about is the property whose absence let it sit: **the log cannot support the claim in either direction.** Hatch creates its env silently, so no `Resolved`/`Installed` line ever appears for the interpreter that matters, and the only line that does appear is about the wrong one. A reader who follows the log to a conclusion reaches the wrong one - which is what happened - and a pin that genuinely stopped taking (the repo going private, a hatch change, a typo in the override) would be a green suite against the wrong distribution, with nothing to say so.

## The change

One concern, one diff: make the announcement a measurement.

- `scripts/check_device_connect_source_pin.py` (stdlib only) reads each distribution's PEP 610 `direct_url.json` from the interpreter it runs in and exits 1 unless both `device-connect-edge` and `device-connect-agent-tools` name the announced repository and ref. It reports the origin actually found - `pinned-to-source`, `registry-wheel`, `other-source`, `not-installed` - so a red step says what *was* loaded, not only that it was not the pin.
- A new step, `Verify the device-connect source pin reached the test env`, runs it **through `hatch run`**, gated on the same `steps.dc_changed.outputs.changed == 'true'` as the pin, between `Run lint` (the first `hatch run`, which creates the env) and `Run tests`. A pin that did not take is red in under a second rather than green after a 27-minute suite. Running through `hatch run` is the load-bearing detail: a bare `python` measures the runner interpreter, where the published wheel lives, and would fail every pull request the pin applies to for the wrong reason - the issue's misreading, arriving as a check.
- The pin step hands the verify step the repo and ref it announced via `GITHUB_ENV`, so the check grades the claim actually made rather than a second `vars.` read of it.
- The step comment is corrected to say the outer pip line is expected and is not evidence about the pin. That sentence is the one that would have prevented #3222.

No change to the override mechanism, `Install dependencies`, or the suite.

## Regression pin

`tests/test_device_connect_source_pin_is_verified.py`:

- Every origin an installer can leave, driven through real `importlib.metadata` over a fabricated `*.dist-info` on `sys.path` (so `read_text` returning `None` for a registry wheel is the real code path, not a stub): git install of the named repo+ref (with and without `.git`) is the pin; a wheel from an index, a different ref, a different repository, a local editable path, unparseable metadata and an absent distribution are each named and each fail.
- The exit code: all pinned exits 0 with no `::error`; one registry wheel exits 1 and names *that* distribution and not the one that is the pin.
- The workflow: the verify step exists once, shares the pin step's `if:`, sits after `hatch run lint` and before `hatch run test`, invokes the script via `hatch run python` and not a bare interpreter, reads the `DEVICE_CONNECT_REPO` / `DEVICE_CONNECT_SOURCE_REF` the pin step exported, and the distribution set the override heredoc redirects equals the script's defaults - so a third package added to one and not the other fails here.

Fails on the base tree: with the workflow edit stashed, the verify-step fixture finds no matching step (`assert len(hits) == 1` -> `[]`).

## Verification

- `hatch run test tests/test_device_connect_source_pin_is_verified.py` - 17 passed.
- `hatch run lint` - ruff check, ruff format --check, mypy all clean.
- `hatch run whole-tree-check` - 4415 passed, 51 skipped, **1 failed**: `tests/test_mesh_state_loop_rate.py::test_the_converted_loop_no_longer_paces_on_the_stop_event[_state_loop]`. Zero delta - the same cell fails identically on the unmodified base `dfdb20a`. Cause is the local env's Python 3.13, not this diff: that grader strips the docstring via `source.replace(func.__doc__, "")`, and 3.13 dedents `__doc__` at compile time so the replace no longer matches the indented source and the prose mention of `_stop_event.wait(period)` is graded as code. CI runs 3.12.14, where it passes. Tracked separately.
- Script end-to-end against the `six` reproduction above: `pinned-to-source` exit 0 inside the hatch env; `other-source` for a wrong ref; `registry-wheel` / `not-installed` exit 1 from the runner interpreter.

This PR does not touch `strands_robots/device_connect/`, so the new step is skipped on its own CI (`dc_changed=false`), which is the correct behaviour and why the end-to-end evidence above is on a stand-in distribution. The first pull request that does touch the integration will exercise it live.

## Round log

- Round 0: opened.