### PR TITLE
test(mesh): the pacing scan reads the parsed tree, not the source text

### DIFF
--- a/changelog.d/3281-pacing-scan-reads-the-parsed-tree.md
+++ b/changelog.d/3281-pacing-scan-reads-the-parsed-tree.md
@@ -1,0 +1,20 @@
+### Fixed: the mesh pacing graders read the parsed tree, not the source text
+
+`tests/test_mesh_state_loop_rate.py` scans the mesh publish loops for the
+`self._stop_event.wait(period)` pacing they were converted away from. Every
+converted loop's docstring explains that conversion by quoting the very call
+being banned, so the scan has to tell code from prose - and it did so
+textually, by removing `__doc__` from `inspect.getsource`.
+
+That assumes the two are byte-identical. Python 3.13 removes a docstring's
+common leading indentation at compile time, so `__doc__` stopped being a
+substring of the source, the removal matched nothing, and
+`Mesh._state_loop` was reported as pacing on a wait it does not contain -
+on a supported interpreter, with the loop unchanged, and with a message
+telling the reader to use the `Ticker` the loop already uses.
+
+All four scans in the file now read `ast.Call` nodes out of the parsed tree.
+A docstring is a constant expression there and a comment is not in the tree
+at all, so neither can be a hit on any interpreter, the per-line prose
+heuristics are gone, and a call wrapped over several lines - which the line
+pattern could not see - is found.

--- a/tests/test_mesh_state_loop_rate.py
+++ b/tests/test_mesh_state_loop_rate.py
@@ -333,8 +333,16 @@ def test_the_pacing_scan_reads_the_code_whatever_the_docstring_is(
     )
     if storage == "dedented":  # what Python 3.13 stores
         first, sep, rest = doc.partition("\n")
-        stored: str | None = first + sep + textwrap.dedent(rest)
-        assert stored != doc, "the docstring has no indented continuation, so this shape proves nothing"
+        dedented = first + sep + textwrap.dedent(rest)
+        # The precondition is against the SOURCE, not against ``doc``: on 3.13
+        # ``doc`` already is this shape, so comparing the two would refuse the
+        # cell on the one interpreter it was written for. What a textual strip
+        # searched was the source text, and that is indented on every version.
+        assert dedented not in inspect.getsource(Mesh._state_loop), (
+            "the dedented docstring is still a substring of the source, so a textual strip "
+            "would have found it and this shape proves nothing"
+        )
+        stored: str | None = dedented
     else:
         stored = None
 

--- a/tests/test_mesh_state_loop_rate.py
+++ b/tests/test_mesh_state_loop_rate.py
@@ -409,6 +409,63 @@ def test_only_a_wait_the_interpreter_would_execute_is_a_pacing_hit(label: str, p
 
 
 @pytest.mark.parametrize(
+    ("label", "planted", "constructions"),
+    [
+        (
+            "a docstring naming the construction",
+            'def _paced(self, period):\n    """Builds one Ticker(period, self._stop_event) for the caller."""\n'
+            "    yield\n",
+            0,
+        ),
+        (
+            "a comment naming the construction",
+            "def _paced(self, period):\n    # one Ticker(period, self._stop_event) per loop\n    yield\n",
+            0,
+        ),
+        (
+            "the construction on one line",
+            "def loop(self):\n    with Ticker(1.0, self._stop_event) as ticker:\n        ticker.wait()\n",
+            1,
+        ),
+        (
+            "the construction split over four lines",
+            "def loop(self):\n    with Ticker(\n        1.0,\n        self._stop_event,\n    ) as ticker:\n"
+            "        ticker.wait()\n",
+            1,
+        ),
+        (
+            "the construction through its module",
+            "def loop(self):\n    with pacing.Ticker(1.0, self._stop_event) as ticker:\n        ticker.wait()\n",
+            1,
+        ),
+        (
+            "a callee whose name merely ends in the text",
+            "def loop(self):\n    with FakeTicker(1.0, self._stop_event) as ticker:\n        ticker.wait()\n",
+            0,
+        ),
+    ],
+)
+def test_only_a_construction_the_interpreter_would_execute_is_a_ticker(
+    label: str, planted: str, constructions: int
+) -> None:
+    """The required-call half of the scan reads the same tree as the banned half.
+
+    ``_calls_named`` is what says a loop paces on a Ticker and what counts the
+    constructions in the sensors module, and a textual reading of it fails in
+    the same two directions the wait side used to: a docstring inside ``_paced``
+    that says what it builds becomes a second construction, so the exact-count
+    cell below goes red on a documentation edit; and a construction wrapped over
+    several lines is not found at all. The last two rows pin the callee match:
+    ``pacing.Ticker(...)`` is a construction and ``FakeTicker(...)`` is not,
+    where ``"Ticker(" in source`` gets both wrong.
+    """
+    found = _calls_named(planted, "Ticker")
+    assert len(found) == constructions, (
+        f"{label}: expected {constructions} Ticker construction(s), found {len(found)} at {found} in:\n{planted}"
+    )
+
+
+@pytest.mark.parametrize(
     "loop",
     ["_pose_loop", "_health_loop", "_imu_loop", "_odom_loop", "_lidar_loop", "_hand_loop", "_map_info_loop"],
 )

--- a/tests/test_mesh_state_loop_rate.py
+++ b/tests/test_mesh_state_loop_rate.py
@@ -20,6 +20,10 @@ isolation must not run at all, and that applies to anything touching a Mesh.
 
 from __future__ import annotations
 
+import ast
+import inspect
+import re
+import textwrap
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -218,6 +222,78 @@ class TestTheStateLoopHitsItsNominalRate:
         )
 
 
+# Every scan below reads the loops for the wait they were converted away from,
+# and every converted loop's docstring EXPLAINS that conversion by quoting the
+# very call being banned. So the scan has to tell code from prose, and doing that
+# textually does not work: these graders used to strip ``__doc__`` out of
+# ``inspect.getsource``, which assumes the two are byte-identical. Python 3.13
+# removes a docstring's common leading indentation at compile time, so ``__doc__``
+# stopped being a substring of the source, the strip removed nothing, and
+# ``_state_loop`` was reported as pacing on a wait it does not contain -- on a
+# supported interpreter, with the loop unchanged, and with a message telling the
+# reader to use the Ticker the loop already uses. The textual form also never
+# covered comments, which ``getsource`` includes and ``__doc__`` never did.
+#
+# ``ast`` draws the line where the compiler draws it: a docstring is a constant
+# expression and a comment is not in the tree at all, so neither can be a hit on
+# any interpreter, and a call split over several lines still is one.
+
+_STOP_FLAG = re.compile(r"^_[a-z_0-9]*(?:stop|shutdown|halt)[a-z_0-9]*$")
+
+
+def _code(source: str) -> ast.Module:
+    """Parse module source, or one function's source (still indented)."""
+    return ast.parse(textwrap.dedent(source))
+
+
+def _pacing_waits(source: str) -> list[int]:
+    """Line numbers of ``.wait(...)`` calls on a stop-flag attribute.
+
+    Matched on the shape rather than one spelling, because a spelling has
+    slipped past a narrower check before: the teleop apply loop was found last
+    of the twelve because its event is named ``_teleop_stop_event``. So any
+    attribute whose name reads as a stop flag counts, in any statement position,
+    with or without ``timeout=``.
+
+    Args:
+        source: Module source, or the source of a single function as
+            ``inspect.getsource`` returns it.
+
+    Returns:
+        The 1-based line of each such call within ``source``, in tree order.
+        Empty when the only mentions are in docstrings or comments.
+    """
+    return [
+        node.lineno
+        for node in ast.walk(_code(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "wait"
+        and isinstance(node.func.value, ast.Attribute)
+        and _STOP_FLAG.match(node.func.value.attr)
+    ]
+
+
+def _calls_named(source: str, name: str) -> list[int]:
+    """Line numbers of calls whose callee ends in ``name``.
+
+    ``Ticker(...)`` and ``pacing.Ticker(...)`` are one construction, so the match
+    is on the last segment of the callee.
+
+    Args:
+        source: Module source, or one function's source.
+        name: The trailing segment to match, e.g. ``"Ticker"`` or ``"_paced"``.
+
+    Returns:
+        The 1-based line of each matching call within ``source``.
+    """
+    return [
+        node.lineno
+        for node in ast.walk(_code(source))
+        if isinstance(node, ast.Call) and ast.unparse(node.func).rsplit(".", 1)[-1] == name
+    ]
+
+
 @pytest.mark.parametrize("attr", ["_state_loop", "_heartbeat_loop", "_camera_loop"])
 def test_the_converted_loop_no_longer_paces_on_the_stop_event(attr: str) -> None:
     """Pin the conversion in source, so a later edit cannot quietly revert it.
@@ -226,22 +302,102 @@ def test_the_converted_loop_no_longer_paces_on_the_stop_event(attr: str) -> None
     heavily loaded machine their floors could in principle be met by luck. This
     one cannot be satisfied by luck.
     """
-    import inspect
-
-    func = getattr(Mesh, attr)
-    source = inspect.getsource(func)
-    # Scan the CODE, not the prose: the docstring of the converted loop explains
-    # what it stopped doing and therefore contains the very string this test
-    # bans. My first version failed on its own explanation - a source-scanning
-    # test that reads comments is a test that punishes documentation.
-    doc = func.__doc__
-    if doc:
-        source = source.replace(doc, "")
-    assert "_stop_event.wait(" not in source, (
-        f"Mesh.{attr} is pacing on _stop_event.wait again - that wait adds the tick's work to "
-        "the period, and is inflated further in a daemon-descended tree; use mesh.pacing.Ticker"
+    source = inspect.getsource(getattr(Mesh, attr))
+    waits = _pacing_waits(source)
+    assert not waits, (
+        f"Mesh.{attr} is pacing on _stop_event.wait again (line {waits[0]} of its definition) - that "
+        "wait adds the tick's work to the period, and is inflated further in a daemon-descended tree; "
+        "use mesh.pacing.Ticker"
     )
-    assert "Ticker(" in source, f"Mesh.{attr} should pace on a Ticker"
+    assert _calls_named(source, "Ticker"), f"Mesh.{attr} should pace on a Ticker"
+
+
+@pytest.mark.parametrize("storage", ["dedented", "absent"])
+def test_the_pacing_scan_reads_the_code_whatever_the_docstring_is(
+    storage: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The verdict cannot depend on how the interpreter stores ``__doc__``.
+
+    The scan above used to separate code from prose by removing ``__doc__`` from
+    ``inspect.getsource`` textually. Python 3.13 dedents docstrings at compile
+    time, so on that interpreter the removal matched nothing, ``_state_loop``'s
+    own explanation of the conversion was read as code, and the grader failed on
+    documentation while the loop it grades was correct. Both storage shapes are
+    reproduced here on whatever interpreter runs the suite, so the environment
+    cannot decide the verdict and a textual strip cannot come back unnoticed.
+    """
+    doc = Mesh._state_loop.__doc__
+    assert doc and "_stop_event.wait(" in doc, (
+        "this pin rests on _state_loop's docstring quoting the banned call, which is the "
+        "documentation the scan must not read. If that prose is gone, so is the hazard."
+    )
+    if storage == "dedented":  # what Python 3.13 stores
+        first, sep, rest = doc.partition("\n")
+        stored: str | None = first + sep + textwrap.dedent(rest)
+        assert stored != doc, "the docstring has no indented continuation, so this shape proves nothing"
+    else:
+        stored = None
+
+    monkeypatch.setattr(Mesh._state_loop, "__doc__", stored)
+    test_the_converted_loop_no_longer_paces_on_the_stop_event("_state_loop")
+
+
+@pytest.mark.parametrize(
+    ("label", "planted", "is_a_pacer"),
+    [
+        (
+            "a docstring quoting the call it stopped making",
+            'def loop(self):\n    """Paced by a Ticker now, not by self._stop_event.wait(period)."""\n'
+            "    with Ticker(1.0, self._stop_event) as ticker:\n        ticker.wait()\n",
+            False,
+        ),
+        (
+            "prose on its own line, with no backticks to hide behind",
+            'def loop(self):\n    """Was paced by\n\n    self._stop_event.wait(period), now a Ticker.\n    """\n'
+            "    with Ticker(1.0, self._stop_event) as ticker:\n        ticker.wait()\n",
+            False,
+        ),
+        (
+            "a comment quoting the call",
+            "def loop(self):\n    # was: self._stop_event.wait(period)\n"
+            "    with Ticker(1.0, self._stop_event) as ticker:\n        ticker.wait()\n",
+            False,
+        ),
+        (
+            "the ticker's own wait, which is the cure",
+            "def loop(self):\n    with Ticker(1.0, self._stop_event) as ticker:\n        ticker.wait()\n",
+            False,
+        ),
+        (
+            "the real call on one line",
+            "def loop(self):\n    while not self._stop_event.wait(0.1):\n        pass\n",
+            True,
+        ),
+        (
+            "the real call split over three lines",
+            "def loop(self):\n    while not self._stop_event.wait(\n        period,\n    ):\n        pass\n",
+            True,
+        ),
+        (
+            "the real call under a differently named stop flag",
+            "def loop(self):\n    while not self._teleop_stop_event.wait(timeout=0.1):\n        pass\n",
+            True,
+        ),
+    ],
+)
+def test_only_a_wait_the_interpreter_would_execute_is_a_pacing_hit(label: str, planted: str, is_a_pacer: bool) -> None:
+    """Both halves of the scan's job, on source planted for the purpose.
+
+    The two rows the previous line-by-line reading got wrong are the point: a
+    docstring line with no backticks was flagged as a pacer, and a real call
+    split across lines was not flagged at all. A scan that reports documentation
+    trains its reader to ignore it, and one that misses a wrapped call leaves
+    exactly the loop it exists to find.
+    """
+    hits = _pacing_waits(planted)
+    assert bool(hits) is is_a_pacer, (
+        f"{label}: the scan {'missed' if is_a_pacer else 'flagged'} it (hits at {hits}) in:\n{planted}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -258,31 +414,25 @@ def test_every_sensor_loop_paces_through_the_shared_ticker_generator(loop: str) 
     robot while the other six were fixed, which is harder to notice than all
     seven being slow.
     """
-    import inspect
-
     from strands_robots.mesh import sensors as mesh_sensors
 
-    func = getattr(mesh_sensors.SensorLoopsMixin, loop)
-    source = inspect.getsource(func)
-    assert "self._paced(" in source, f"{loop} does not pace through SensorLoopsMixin._paced"
-    assert "_stop_event.wait(" not in source, f"{loop} paces on the inflated Event.wait again - see mesh.pacing"
+    source = inspect.getsource(getattr(mesh_sensors.SensorLoopsMixin, loop))
+    assert _calls_named(source, "_paced"), f"{loop} does not pace through SensorLoopsMixin._paced"
+    waits = _pacing_waits(source)
+    assert not waits, f"{loop} paces on the inflated Event.wait again (line {waits[0]}) - see mesh.pacing"
 
 
 def test_only_the_shared_generator_owns_a_ticker_in_the_sensors_module() -> None:
-    import inspect
-
+    """One pacer for the whole mixin, and no wait left beside it."""
     from strands_robots.mesh import sensors as mesh_sensors
 
     module_source = inspect.getsource(mesh_sensors)
-    # Strip docstrings' mention of the old call by counting real code lines only.
-    code_hits = [
-        line
-        for line in module_source.splitlines()
-        if "_stop_event.wait(" in line and not line.lstrip().startswith(("#", '"', "`"))
-    ]
-    assert not code_hits, f"pacing waits left in sensors.py: {code_hits}"
-    assert module_source.count("Ticker(") == 1, (
-        "exactly one Ticker construction belongs in this module - the one inside _paced"
+    waits = _pacing_waits(module_source)
+    assert not waits, f"pacing waits left in sensors.py at lines {waits}"
+    tickers = _calls_named(module_source, "Ticker")
+    assert len(tickers) == 1, (
+        "exactly one Ticker construction belongs in this module - the one inside _paced - "
+        f"but {len(tickers)} were built, at lines {tickers}"
     )
 
 
@@ -298,15 +448,15 @@ def test_no_publish_loop_in_the_mesh_still_paces_on_an_inflated_wait() -> None:
     like the one sensor that is genuinely slow.
 
     So the shape is "``.wait(...)`` on an attribute whose name reads as a stop
-    flag", in any statement position, with or without ``timeout=``. The keyword
-    form is included because a walk over the files is not enough on its own - the
-    regex is the part that misses things, not the ``rglob``.
+    flag", in any statement position, with or without ``timeout=``. It is read
+    out of the parsed tree rather than matched per line, because a walk over the
+    files is not the part that misses things: a per-line pattern cannot see a
+    call wrapped across lines, and it has to guess at which mentions are prose.
 
     Waits that are NOT pacing (a shutdown join, a settle window) are allowed:
     they run once, so the cost is paid once rather than on every tick of a
     stream. They are listed explicitly, so adding one is a deliberate act.
     """
-    import re
     from pathlib import Path
 
     root = Path(__file__).resolve().parent.parent / "strands_robots"
@@ -321,24 +471,16 @@ def test_no_publish_loop_in_the_mesh_still_paces_on_an_inflated_wait() -> None:
             "than spin_period is the intent. The happy path has no wait at all"
         ),
     }
-    # Any statement position (`while not ...`, `if ...`, bare), any attribute
-    # whose name reads as a stop flag (_stop_event, _teleop_stop_event,
-    # _stop_evt, _shutdown_event), keyword form included.
-    pattern = re.compile(r"self\._[a-z_0-9]*(?:stop|shutdown|halt)[a-z_0-9]*\.wait\(\s*(?:timeout\s*=\s*)?([^)]*)\)")
     offenders: list[str] = []
     for path in sorted(root.rglob("*.py")):
         if path.name == "pacing.py":
             continue
-        for lineno, line in enumerate(path.read_text().splitlines(), 1):
-            match = pattern.search(line)
-            if not match:
-                continue
-            # Prose is not a pacer. Several modules now DESCRIBE this bug in a
-            # comment or docstring quoting the offending call, and a scanner
-            # that flags its own documentation trains the reader to ignore it.
-            before = line[: match.start()]
-            if before.lstrip().startswith("#") or "``" in before or '"""' in before:
-                continue
+        lines = path.read_text().splitlines()
+        # Prose is not a pacer, and it does not need excluding by hand: several
+        # modules now DESCRIBE this bug in a comment or a docstring quoting the
+        # offending call, and neither is a call in the parsed tree.
+        for lineno in _pacing_waits("\n".join(lines)):
+            line = lines[lineno - 1]
             rel = str(path.relative_to(root))
             if any(rel == f and frag in line for (f, frag) in allowed):
                 continue


### PR DESCRIPTION
Closes #3281.

`tests/test_mesh_state_loop_rate.py` scans the mesh publish loops for the `self._stop_event.wait(period)` pacing they were converted away from. Every converted loop's docstring *explains* that conversion by quoting the very call being banned, so the scan has to tell code from prose. It did so textually - remove `__doc__` from `inspect.getsource`, then look for the string:

```python
source = inspect.getsource(func)
doc = func.__doc__
if doc:
    source = source.replace(doc, "")
assert "_stop_event.wait(" not in source
```

That assumes `__doc__` is a byte-for-byte substring of the source. Python 3.13 removes a docstring's common leading indentation at compile time, so it is not: the strip matches nothing, the explanation survives into the scanned text, and `Mesh._state_loop` is reported as pacing on a wait it does not contain - on a supported interpreter (`requires-python = ">=3.12"`), with the loop unchanged, and with a message telling the reader to use the `Ticker` the loop already uses.

![what each reading gets right](https://raw.githubusercontent.com/cagataycali/robots/bc34f0fa52e7f968b629e122228def9da6d95f79/assets/pacing_scan.png)

## What changed

All four scans in the file read `ast.Call` nodes out of the parsed tree through two helpers, `_pacing_waits(source)` and `_calls_named(source, name)`. `ast` draws the line where the compiler draws it: a docstring is a constant expression and a comment is not in the tree at all, so neither can be a hit on any interpreter, and the per-line prose heuristics (`before.lstrip().startswith("#") or "``" in before or '\"\"\"' in before`) are gone rather than tuned.

The tree-wide inventory keeps its shape rule - `.wait(...)` on any attribute whose name reads as a stop flag, in any statement position, `timeout=` included - and its allowlist of the two non-pacing waits, unchanged. Verified verdict-identical on today's tree: the same two allowlisted calls, no finding gained or lost.

| | `strands_robots/hardware_ros_bridge.py:215` | `strands_robots/mesh/core.py:3528` | new findings | lost findings |
|---|---|---|---|---|
| per-line pattern | allowlisted | allowlisted | - | - |
| parsed tree | allowlisted | allowlisted | 0 | 0 |

## Measured

`Mesh._state_loop`, unchanged production code, same checkout:

| | `__doc__ in getsource` | before | after |
|---|---|---|---|
| CPython 3.12.3 | `True` | passes | passes |
| CPython 3.13.12 | `False` | **fails on its own docstring** | passes |

`_heartbeat_loop` and `_camera_loop` pass on 3.13 today only because their docstrings happen not to spell the banned call, so the textual form was one documentation edit away from failing on those too.

## Tests

Four new parametrized tests, 17 -> 32 cells in the file.

- `test_the_pacing_scan_reads_the_code_whatever_the_docstring_is` reproduces both storage shapes - `__doc__` dedented exactly as 3.13 stores it, and `__doc__` absent - on whatever interpreter runs the suite, so the 3.13 failure is reproducible on 3.12 and a textual strip cannot come back unnoticed. Both parametrizations fail against the pre-fix scanner and pass after.
- `test_only_a_wait_the_interpreter_would_execute_is_a_pacing_hit` pins both halves of the scan's job over seven planted shapes, including the two rows the line-by-line reading got wrong: a docstring line with no backticks was flagged as a pacer, and a real call wrapped over three lines was not flagged at all.
- The `Ticker` construction checks moved off `"Ticker(" in source` / `.count("Ticker(")` onto the same call-graph read, and now report the lines they found.
- `test_only_a_construction_the_interpreter_would_execute_is_a_ticker` (round 2) pins that read over six planted shapes, so the required-call half is graded the same way as the banned half.

Four corners on `tests/test_mesh_state_loop_rate.py`, CPython 3.12.3:

| | pre-existing cells | new cells |
|---|---|---|
| **pre-fix scanner** | 17 passed | **2 failed** |
| **this branch** | 17 passed | 32 passed (17 + 15) |

## Gate

`ruff check` / `ruff format --check` on `strands_robots tests tests_integ` clean (ruff 0.15.22, 1921 files). `mypy 1.20.2`: no error in the changed file, repository total unchanged. The 32 graders that walk `tests/` plus all of `tests/mesh/` - 5496 passed - carry the same 22 pre-existing failures as `main` (all `tests/mesh/test_iot_*`, `awsiot` absent, plus `test_dependency_audit`); the failure name lists are identical, nothing new.

## Size

| file | + | - |
|---|---|---|
| `tests/test_mesh_state_loop_rate.py` | 232 | 47 |
| `changelog.d/3281-pacing-scan-reads-the-parsed-tree.md` | 20 | 0 |

Of the 232 added lines, the two planted-source tables (seven rows for waits, six for constructions) are most of the code. Net positive, and the additions are the two shared helpers plus the pins for the failure that was not caught; the four scans they replaced each carried their own reading of the source, and those readings are what came out.

## Review rounds

### Round 1 - `7149279`

One [MUST FIX] from review feedback: the new `dedented` pin's precondition `assert stored != doc` fails on CPython 3.13, where `__doc__` is already stored dedented so the dedent is a no-op - the file was red on the interpreter the PR exists to fix, one function below the fix. Reproduced independently on 3.13.15 before the change (`1 failed, 25 passed`, that cell alone).

The guard is now keyed on the source rather than on `__doc__`: `assert dedented not in inspect.getsource(Mesh._state_loop)`. A textual strip searched the source text, which carries the indented continuation on every version, so this is the precondition the pin actually rests on - it holds on 3.12 and 3.13 alike and still refuses the drift the old guard was for (a docstring with no indented continuation in source makes the dedented shape a substring again). Chosen over a `sys.version_info` branch so the cell does not have to know which interpreter it is on.

| | 3.13.15, pre-round | 3.13.15, `7149279` |
|---|---|---|
| `tests/test_mesh_state_loop_rate.py` | 1 failed, 25 passed | **26 passed** |
| `ruff check` / `ruff format --check` / `mypy` on the file | clean | clean |

+8/-1, one file. The thread is answered and resolved.

### Round 2 - `a4c197e`

Follow-up from review feedback on the mutation table: `_calls_named` - the required-call half of the scan, which says a loop paces on a `Ticker` and counts the constructions in the sensors module - had moved onto the parsed tree but nothing pinned that it had. Swapping its body for `name + "(" in source` left all 26 cells green. That reading fails in the two directions the wait side used to: a docstring inside `_paced` saying what it builds becomes a second construction, so `test_only_the_shared_generator_owns_a_ticker_in_the_sensors_module`'s exact count goes red on a documentation edit, and a construction wrapped over several lines is not found at all.

Six planted-source rows in the shape of the wait-side table:

| row | `Ticker` constructions |
|---|---|
| a docstring naming the construction | 0 |
| a comment naming the construction | 0 |
| the construction on one line | 1 |
| the construction split over four lines | 1 |
| the construction through its module, `pacing.Ticker(...)` | 1 |
| a callee whose name merely ends in the text, `FakeTicker(...)` | 0 |

Mutation table on 3.13.15, 32 cells, `collected` stable:

| `_calls_named` body | fires | rows |
|---|---|---|
| control (branch unmutated) | 0 | - |
| per-line `name + "(" in line` | 3 | docstring, comment, `FakeTicker` |
| whole-source `name + "(" in source` | 3 | same three |
| same-line regex with a word boundary | 3 | docstring, comment, the wrapped construction |

Every non-control row fires on at least one textual reading; the two one-line positive rows are the controls that hold on every reading.

| check | result |
|---|---|
| `tests/test_mesh_state_loop_rate.py`, CPython 3.13.15 | 32 passed |
| same file, CPython 3.12.3 | 32 passed |
| `scripts/check_whole_tree_graders.py` (105 graders, `[all]` installed) | **4490 passed, 52 skipped, 0 failed** |
| `ruff check` / `ruff format --check` / `mypy` on the file | clean |

+57/-0, one file, tests only. No approval was standing, so the push dismisses nothing.