### PR TITLE
test(mesh): the loop source scan reads code, not its own prose

### DIFF
--- a/changelog.d/3283-loop-source-scan-reads-code.md
+++ b/changelog.d/3283-loop-source-scan-reads-code.md
@@ -1,0 +1,38 @@
+### Fixed: the mesh loop source scan reads code rather than its own documentation
+
+`tests/test_mesh_state_loop_rate.py` pins the mesh publish loops' conversion
+away from `self._stop_event.wait(period)` pacing by scanning each loop's source
+for that call. The converted loops legitimately *document* the call they stopped
+making, so the scan has to see code and not prose -- and it did that by
+subtracting `func.__doc__` from `inspect.getsource(func)`.
+
+That subtraction rests on two assumptions, and both are false. `getsource`
+includes `#` comments, which `__doc__` never contained, so a comment recording
+what a loop was converted from was already read as a pacing call on every
+interpreter. And `source.replace(func.__doc__, "")` assumes the compiler stored
+the docstring as a verbatim slice of the source: Python 3.13 strips the common
+leading indentation from docstrings at compile time, so an indented docstring is
+no longer a substring there and the replace removes nothing at all. The same
+holds on any interpreter for a docstring containing an escape sequence, which the
+compiler resolves and the source spells out literally.
+
+`requires-python` is `>=3.12` and 3.13 is a declared classifier, but every
+workflow pins 3.12, so this could not surface in CI. On 3.13 the one loop whose
+docstring names the banned call --- `Mesh._state_loop` --- failed its own grader
+with a message telling the reader to adopt `mesh.pacing.Ticker`, which that loop
+already uses. The other two parametrizations passed only because their prose
+happens not to spell the call, so the grader was one documentation edit away from
+the same failure.
+
+The scan now reads the definition through `ast`, drops the docstring node, and
+unparses the body. Comments are absent from the AST altogether and the docstring
+is removed as a node rather than as text, so neither assumption is made. The two
+graders that read a loop's source --- the three `Mesh` publish loops and the seven
+`SensorLoopsMixin` sensor loops --- share that one reader; the module-level
+inventory scans in the same file are unchanged, because they grade whole-file text
+for a shape rather than one function's body, and already filter prose by line.
+
+All ten loops keep every assertion they had, on both interpreters. The added
+coverage grades the reader against a comment and against a docstring the compiler
+did not store verbatim, both of which fail on 3.12 as well, so the fix is graded
+by CI rather than only by the interpreter that reported it.

--- a/tests/test_mesh_state_loop_rate.py
+++ b/tests/test_mesh_state_loop_rate.py
@@ -20,8 +20,12 @@ isolation must not run at all, and that applies to anything touching a Mesh.
 
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
 import threading
 import time
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -218,6 +222,40 @@ class TestTheStateLoopHitsItsNominalRate:
         )
 
 
+def _loop_code(func: Callable[..., object]) -> str:
+    """Return ``func``'s source with its prose removed, structurally.
+
+    The graders below scan a loop's source for a call it must no longer make,
+    and the converted loops DESCRIBE the call they stopped making - so the scan
+    has to read code and not documentation. Subtracting the prose textually does
+    not achieve that:
+
+    * ``inspect.getsource`` includes ``#`` comments, which ``__doc__`` never
+      contained, so removing ``__doc__`` leaves a comment that quotes the banned
+      call behind - on every interpreter, including the one CI runs.
+    * ``source.replace(func.__doc__, "")`` assumes ``__doc__`` is a byte-for-byte
+      substring of the source. Python 3.13 strips the common leading indentation
+      from docstrings at compile time, so an indented docstring is no longer a
+      substring there and the replace removes nothing. The same holds on any
+      interpreter for a docstring written with an escape sequence, which the
+      compiler resolves and the source spells out literally.
+
+    Parsing the definition and unparsing its body without the docstring node
+    drops prose of both kinds under neither assumption: comments are absent from
+    the AST altogether, and the docstring is removed as a node rather than as
+    text. What is left is the code, on any interpreter.
+    """
+    definition = ast.parse(textwrap.dedent(inspect.getsource(func))).body[0]
+    assert isinstance(definition, ast.FunctionDef | ast.AsyncFunctionDef), (
+        f"expected a function definition, parsed {type(definition).__name__}"
+    )
+    body = definition.body
+    first = body[0] if body else None
+    if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) and isinstance(first.value.value, str):
+        body = body[1:]
+    return "\n".join(ast.unparse(node) for node in body)
+
+
 @pytest.mark.parametrize("attr", ["_state_loop", "_heartbeat_loop", "_camera_loop"])
 def test_the_converted_loop_no_longer_paces_on_the_stop_event(attr: str) -> None:
     """Pin the conversion in source, so a later edit cannot quietly revert it.
@@ -226,17 +264,12 @@ def test_the_converted_loop_no_longer_paces_on_the_stop_event(attr: str) -> None
     heavily loaded machine their floors could in principle be met by luck. This
     one cannot be satisfied by luck.
     """
-    import inspect
-
-    func = getattr(Mesh, attr)
-    source = inspect.getsource(func)
     # Scan the CODE, not the prose: the docstring of the converted loop explains
     # what it stopped doing and therefore contains the very string this test
     # bans. My first version failed on its own explanation - a source-scanning
-    # test that reads comments is a test that punishes documentation.
-    doc = func.__doc__
-    if doc:
-        source = source.replace(doc, "")
+    # test that reads comments is a test that punishes documentation. _loop_code
+    # removes both kinds of prose structurally, which a text subtraction cannot.
+    source = _loop_code(getattr(Mesh, attr))
     assert "_stop_event.wait(" not in source, (
         f"Mesh.{attr} is pacing on _stop_event.wait again - that wait adds the tick's work to "
         "the period, and is inflated further in a daemon-descended tree; use mesh.pacing.Ticker"
@@ -258,14 +291,139 @@ def test_every_sensor_loop_paces_through_the_shared_ticker_generator(loop: str) 
     robot while the other six were fixed, which is harder to notice than all
     seven being slow.
     """
-    import inspect
-
     from strands_robots.mesh import sensors as mesh_sensors
 
-    func = getattr(mesh_sensors.SensorLoopsMixin, loop)
-    source = inspect.getsource(func)
+    # Prose-free for the same reason as the Mesh loops above: these docstrings
+    # are free to name the call they no longer make.
+    source = _loop_code(getattr(mesh_sensors.SensorLoopsMixin, loop))
     assert "self._paced(" in source, f"{loop} does not pace through SensorLoopsMixin._paced"
     assert "_stop_event.wait(" not in source, f"{loop} paces on the inflated Event.wait again - see mesh.pacing"
+
+
+class _ProseProbes:
+    """Loops whose PROSE names the call the graders ban, in each shape prose takes.
+
+    Real functions, read with the same ``inspect.getsource`` the graders use, so
+    what is measured here is what happens to the mesh loops themselves.
+    """
+
+    def comment(self) -> int:
+        """Paced by a Ticker."""
+        # Converted from self._stop_event.wait(period), which added the tick's
+        # work to the period instead of subtracting it.
+        return 1
+
+    def escaped_docstring(self) -> int:
+        """Paced by a Ticker, no longer by ``self._stop_event.wait(period)``.
+
+        The rate is reported by whatever matches ``\\d+`` in the counter name; the
+        doubled backslash is why the compiler cannot store this docstring as a
+        verbatim slice of the source, on any interpreter.
+        """
+        return 1
+
+    def indented_docstring(self) -> int:
+        """Paced by a Ticker.
+
+        Converted from ``self._stop_event.wait(period)``: this continuation line
+        is indented, which is the shape Python 3.13 dedents at compile time.
+        """
+        return 1
+
+    def genuinely_paces(self) -> int:
+        """A loop that really does pace on the stop event."""
+        while True:
+            if self._stop_event.wait(0.1):  # type: ignore[attr-defined]
+                break
+        return 1
+
+
+class TestTheLoopScanReadsCodeAndNotProse:
+    """The scan must see code only, whatever shape the prose takes.
+
+    Every grader above that reads a loop's source has to ban a call the loop's
+    own documentation is free to NAME - the converted loops explain what they
+    stopped doing. Subtracting ``func.__doc__`` from ``inspect.getsource`` is the
+    obvious way to do that and it is wrong twice: it never removed comments, and
+    it assumes the compiler stored the docstring as a verbatim slice of the
+    source. Where either assumption fails the prose survives and the grader
+    reports it as code - a red cell about the loop, raised by its documentation,
+    telling the reader to adopt the pacer the loop already uses.
+    """
+
+    def test_a_comment_that_quotes_the_banned_call_is_not_read_as_code(self) -> None:
+        """A comment was never part of ``__doc__``, so subtracting it left this behind.
+
+        This holds on every interpreter, CI's included: the loop is correct, the
+        comment merely records what it was converted from.
+        """
+        code = _loop_code(_ProseProbes.comment)
+        assert "_stop_event.wait(" not in code, (
+            "a comment recording the converted-from call is being read as a pacing call - "
+            f"getsource includes comments and __doc__ never did. Code read: {code!r}"
+        )
+
+    def test_a_docstring_the_compiler_did_not_store_verbatim_is_still_removed(self) -> None:
+        """The textual subtraction assumes ``__doc__`` is a slice of the source.
+
+        A docstring documenting a regex breaks that on any interpreter, which is
+        the same assumption Python 3.13 breaks for every indented docstring. That
+        is why this cell is the one that grades the root cause rather than one
+        interpreter's symptom.
+        """
+        func = _ProseProbes.escaped_docstring
+        doc = func.__doc__
+        assert doc is not None and doc not in inspect.getsource(func), (
+            "premise: this probe's docstring must not be a verbatim slice of its source"
+        )
+        assert "_stop_event.wait(" not in _loop_code(func), (
+            "a docstring the compiler rewrote survived the strip, so the prose is being read as code"
+        )
+
+    def test_an_indented_docstring_is_removed_however_the_compiler_stores_it(self) -> None:
+        """The reported shape: an indented continuation line naming the call.
+
+        Python 3.13 strips the common leading indentation from docstrings at
+        compile time, so ``__doc__`` is dedented while ``getsource`` is not and
+        the textual subtraction removes nothing there. Reading the body through
+        the AST does not depend on which of the two the interpreter hands back.
+        """
+        assert "_stop_event.wait(" not in _loop_code(_ProseProbes.indented_docstring), (
+            "an indented docstring survived the strip - the scan is reading documentation as code"
+        )
+
+    def test_a_loop_that_still_paces_on_the_event_is_caught(self) -> None:
+        """The scan must not go blind: dropping prose is not dropping code.
+
+        Removing the prose is only correct if the call is still found where it is
+        real, so this is what separates the fix from disabling the graders.
+        """
+        assert "_stop_event.wait(" in _loop_code(_ProseProbes.genuinely_paces), (
+            "the scan no longer sees a genuine pacing wait - it has been made vacuous"
+        )
+
+    def test_the_pacer_the_loops_must_use_is_still_visible_to_the_scan(self) -> None:
+        """The graders also assert a REQUIRED call, which must survive the read."""
+        assert "Ticker(" in _loop_code(Mesh._state_loop), "the Ticker construction is no longer visible"
+        from strands_robots.mesh import sensors as mesh_sensors
+
+        assert "self._paced(" in _loop_code(mesh_sensors.SensorLoopsMixin._pose_loop), (
+            "the shared pacing generator call is no longer visible"
+        )
+
+    def test_the_state_loop_docstring_still_names_the_call_its_grader_bans(self) -> None:
+        """Non-vacuity: the prose path above is only exercised while this holds.
+
+        ``Mesh._state_loop`` is the one converted loop whose docstring spells the
+        banned call, so it is the only real target that exercises the strip at
+        all. If that sentence is ever reworded the graders stop reading prose,
+        this cell says so, and the probes above become the whole coverage.
+        """
+        doc = Mesh._state_loop.__doc__
+        assert doc is not None and "_stop_event.wait(" in doc, (
+            "Mesh._state_loop no longer documents the call its grader bans, so no real "
+            "target exercises the prose strip - the probes in this class are now its only cover"
+        )
 
 
 def test_only_the_shared_generator_owns_a_ticker_in_the_sensors_module() -> None:


### PR DESCRIPTION
Closes #3281.

`tests/test_mesh_state_loop_rate.py` bans `self._stop_event.wait(period)` in the mesh publish loops by scanning each loop's source. The converted loops legitimately **document** the call they stopped making, so the scan subtracted `func.__doc__` from `inspect.getsource(func)`. That subtraction rests on two assumptions and both are false, so the grader reads its own documentation as code.

![corner matrix](https://raw.githubusercontent.com/cagataycali/robots/d8ecdee9b2d8e94504cf457b506b844316a9cd08/corners.png)

## The two false assumptions

| assumption | why it fails | interpreter |
|---|---|---|
| `__doc__` contains the comments too | it never did; `getsource` includes `#` lines, so a comment recording the converted-from call is read as a pacing call | **every one, CI's included** |
| `__doc__` is a verbatim slice of the source | 3.13 strips the common leading indentation from docstrings at compile time, so an indented docstring is not a substring and `replace` removes nothing | 3.13 for indentation; **any** interpreter for a docstring holding an escape sequence |

Measured with one probe per shape, `OLD` = the textual subtraction, `NEW` = this change:

| probe | `__doc__ in getsource` | OLD leaks prose | NEW leaks prose |
|---|---|---|---|
| comment names the call | 3.12 `True` / 3.13 `True` | **yes / yes** | no / no |
| docstring holds `\d+` | `False` / `False` | **yes / yes** | no / no |
| indented docstring names the call | `True` / `True` | no / **yes** | no / no |
| body genuinely still paces | `True` / `True` | yes / yes | **yes / yes** |

The last row is the control: dropping prose must not drop code.

## What it looked like

`requires-python` is `>=3.12` and 3.13 is a declared classifier, but all ten workflows pin 3.12, so this cannot surface in CI. On 3.13:

```
FAILED tests/test_mesh_state_loop_rate.py::test_the_converted_loop_no_longer_paces_on_the_stop_event[_state_loop]
  AssertionError: Mesh._state_loop is pacing on _stop_event.wait again - ... use mesh.pacing.Ticker
  '_stop_event.wait(' is contained here:
       ``self._stop_event.wait(period)``, which is a delay where a rate needs a
            ...
            with Ticker(1.0 / STATE_HZ, self._stop_event) as ticker:
```

The excerpt the failure prints contains its own refutation: the loop is already on a `Ticker`. `_state_loop` is the only one of the three whose prose spells the call, so the other two passed by luck -- the grader was one documentation edit from the same failure.

## The change

One shared reader parses the definition, drops the docstring node, and unparses the body. Comments are absent from the AST altogether and the docstring goes as a node rather than as text, so neither assumption is made. Both graders that read a loop's body -- the three `Mesh` publish loops and the seven `SensorLoopsMixin` sensor loops -- now ask through it. Every assertion message is unchanged.

**Deliberately unchanged:** the two module-level inventory scans in the same file. They grade whole-file text for a *shape* with an allowlist keyed on line content, not one function's body, and they already filter prose per line -- a different concern, and neither is affected by either assumption above.

## Safety

All ten real loops keep both of their assertions (banned call absent, required pacer present) on 3.12 **and** 3.13 -- nothing that passed stops passing. Corner **D** above is the load-bearing cell: this change alone, adding no test, turns 3.13 from `1 failed, 16 passed` to `17 passed`.

Corner **B** is why the fix is gradeable here at all: the added cells fail on **3.12** as well as 3.13, because the comment probe and the escaped-docstring probe break the textual assumption on any interpreter. Without them the regression would only be observable on a version CI does not run.

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` | clean, 1922 files |
| `mypy` (1.20.2) | 0 attributable, diffed line-for-line against a `main` worktree |
| subject file, 3.12.3 and 3.13.7 | `23 passed` both |
| 465 source-walking / `inspect`-reading test modules | `7 failed, 24599 passed`; all 7 pre-existing and environmental in this checkout (`rclpy` resolvable where 5 cells assert it absent; `websockets` 16.0 against the `>=17.0` floor for 2) |

## Size

`+208 / -12` over 2 files. `changelog.d` is 38 of the additions and the docstrings explaining the two assumptions are another 83, so the executable growth is +50 AST statements, nearly all of it the six added cells and their probes. No production code is touched.
