### PR TITLE
fix(training/rl): the counts a vectorized env is built from take the shared count domain

### DIFF
--- a/changelog.d/3284-vec-env-counts-take-the-shared-domain.md
+++ b/changelog.d/3284-vec-env-counts-take-the-shared-domain.md
@@ -1,0 +1,23 @@
+### Fixed: the counts `VecSimEnv` is built from are held to the shared count domain
+
+`VecSimEnv` is the class the RL trainers hand `RLTrainSpec.num_envs` to and the
+one that acts on it, calling `env_factory` once per environment and sizing one
+thread pool from `max_workers`. Every other owner of a parallel-environment
+count grades it through `positive_count_error` -- `RLTrainSpec` via the PPO,
+FastTD3 and FastSAC backends, and the Isaac backend's config and `replicate` --
+but this one hand-rolled `if num_envs < 1` and then coerced with `int()`, and
+`max_workers` had no domain at all.
+
+A bare `< 1` test followed by a coercion admits values no number of environments
+can honour: `num_envs=2.5` built two live engines, `4.0` built four and `True`
+built one, each a count the caller never asked for rather than a refusal.
+`float("inf")` and `"4"` left the constructor as `OverflowError` and
+`TypeError`, outside the documented `Raises: ValueError` and naming neither the
+class nor the parameter, and `max_workers=float("inf")` reached
+`ThreadPoolExecutor` as its pool size.
+
+Both counts now take the shared domain, so a count refused for a training spec
+cannot be accepted by the class that spends it, and a refusal is reported before
+any environment is built. The `int()` coercion is gone: the domain admits only a
+true `int`, so it could only restate the value, and while it was there it was
+what turned a `2.5` into two engines.

--- a/strands_robots/training/rl/vec_env.py
+++ b/strands_robots/training/rl/vec_env.py
@@ -29,6 +29,8 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from strands_robots.utils import positive_count_error
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from strands_robots.training.rl.env import SimEnv
 
@@ -40,16 +42,22 @@ class VecSimEnv:
         env_factory: Zero-arg callable returning a fresh :class:`SimEnv`. Called
             ``num_envs`` times. (Same contract the trainers already use for the
             single-env path, so existing factories work unchanged.)
-        num_envs: Number of parallel environments. Must be >= 1.
+        num_envs: Number of parallel environments, a positive integer. Held to
+            the shared count domain (:func:`~strands_robots.utils.positive_count_error`),
+            the same one the trainers apply to ``RLTrainSpec.num_envs`` before
+            handing it here - a count refused for a spec cannot be accepted by
+            the class that acts on it.
         device: Torch device for the stacked tensors. ``None`` inherits the
             first sub-env's device.
-        max_workers: Thread-pool size for stepping sub-envs. ``None`` uses
-            ``min(num_envs, 8)`` - MuJoCo releases the GIL during ``mj_step`` so
-            threads give real parallelism on the physics call. One executor is
-            created and reused for the env's lifetime (never per-step).
+        max_workers: Thread-pool size for stepping sub-envs, a positive integer
+            held to the same count domain. ``None`` uses ``min(num_envs, 8)`` -
+            MuJoCo releases the GIL during ``mj_step`` so threads give real
+            parallelism on the physics call. One executor is created and reused
+            for the env's lifetime (never per-step).
 
     Raises:
-        ValueError: ``num_envs < 1`` or the sub-envs disagree on obs/action dims.
+        ValueError: ``num_envs`` or ``max_workers`` is not a positive integer,
+            or the sub-envs disagree on obs/action dims.
     """
 
     def __init__(
@@ -60,9 +68,17 @@ class VecSimEnv:
         device: torch.device | str | None = None,
         max_workers: int | None = None,
     ) -> None:
-        if num_envs < 1:
-            raise ValueError(f"num_envs must be >= 1, got {num_envs}")
-        self.num_envs = int(num_envs)
+        if (error := positive_count_error(num_envs, "num_envs", type(self).__name__)) is not None:
+            raise ValueError(error)
+        if (
+            max_workers is not None
+            and (error := positive_count_error(max_workers, "max_workers", type(self).__name__)) is not None
+        ):
+            raise ValueError(error)
+        # No coercion: the domain above admits only a true ``int``, so an
+        # ``int(num_envs)`` here could only ever restate the value - and while it
+        # was there it was what silently turned a 2.5 into two live engines.
+        self.num_envs = num_envs
         self.envs: list[SimEnv] = [env_factory() for _ in range(self.num_envs)]
 
         first = self.envs[0]

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1058,7 +1058,7 @@ def step_aborted_msg(completed: int, requested: int, *, context: str = "step") -
 def positive_count_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive integer count.
 
-    Shared domain for three families of discrete quantity:
+    Shared domain for four families of discrete quantity:
 
     * The knobs that count iterations of a control or rollout loop - the
       simulation's ``n_episodes`` / ``max_steps`` / ``control_substeps`` /
@@ -1076,6 +1076,14 @@ def positive_count_error(value: Any, param: str, context: str) -> str | None:
       ``truncation=True``. The tokenizer takes it as a slice bound over the
       encoded instruction, so a count below one silently produces an EMPTY
       prompt rather than an error.
+    * A count of things to be built and run in parallel - the ``num_envs`` of
+      ``RLTrainSpec`` and of every RL backend that acts on it (the from-scratch
+      PPO / FastTD3 / FastSAC trainers, :class:`~strands_robots.training.rl.vec_env.VecSimEnv`,
+      the Isaac backend's ``replicate``), and the ``max_workers`` sizing the one
+      thread pool a vectorized env steps its sub-envs through. Each is spent
+      building live resources - a physics engine per environment, an OS thread
+      per worker - so a count the caller did not mean is not a bad number but
+      the wrong number of engines.
 
     It lives here rather than beside one of its callers because those callers
     sit in different layers (:mod:`strands_robots.hardware_robot` must not

--- a/tests/training/test_rl_vec_env.py
+++ b/tests/training/test_rl_vec_env.py
@@ -138,7 +138,9 @@ def test_num_envs_one_uses_no_executor() -> None:
 
 
 def test_rejects_bad_num_envs() -> None:
-    with pytest.raises(ValueError, match="num_envs must be >= 1"):
+    # Matched on the parameter the refusal names, not on wording, so the shared
+    # count domain can own the message (see test_vec_env_counts_take_the_shared_domain).
+    with pytest.raises(ValueError, match="num_envs"):
         VecSimEnv(_factory(), num_envs=0)
 
 

--- a/tests/training/test_vec_env_counts_take_the_shared_domain.py
+++ b/tests/training/test_vec_env_counts_take_the_shared_domain.py
@@ -14,7 +14,10 @@ This one hand-rolled ``if num_envs < 1`` and then coerced with ``int()``, and
 * ``float("inf")`` and ``"4"`` left the constructor as ``OverflowError`` and
   ``TypeError``, outside the documented ``Raises: ValueError``, naming neither
   the class nor the parameter.
-* ``max_workers=float("inf")`` reached ``ThreadPoolExecutor`` as its pool size.
+* ``max_workers=float("inf")`` reached ``ThreadPoolExecutor`` as its pool size,
+  and because the pool was built last, a pool size that *was* refused had
+  already built every environment - ``max_workers=0`` raised with two live
+  engines behind it and no handle to close them.
 
 These pin the domain, not the wording: a refusal is identified by the parameter
 it names, and the reference verdict is read from the shared helper itself so the
@@ -163,6 +166,28 @@ def test_a_refused_count_builds_no_environment() -> None:
             VecSimEnv(factory, value)
         assert factory.built == 0, f"{value!r} ({why}) built {factory.built} environment(s) before refusal"
     assert refused >= 8, f"roster no longer exercises the refusal path ({refused} refused)"
+
+
+def test_a_refused_pool_size_builds_no_environment_either() -> None:
+    """The pool size is graded before the environments, not after them.
+
+    ``max_workers`` used to be spent last, on the line constructing the pool -
+    after all N sub-envs had been built. A refused pool size therefore raised
+    out of the constructor with N live engines already built and no handle to
+    close them: ``max_workers=0`` and ``max_workers="4"`` each left two behind.
+    """
+    refused = 0
+    for value, why in _PROBES:
+        if value is _MAX_WORKERS_MEANS_UNSTATED:
+            continue
+        if positive_count_error(value, "max_workers", "VecSimEnv") is None:
+            continue
+        refused += 1
+        factory = _CountingFactory()
+        with pytest.raises(ValueError):
+            VecSimEnv(factory, 2, max_workers=value)
+        assert factory.built == 0, f"max_workers={value!r} ({why}) left {factory.built} environment(s) built"
+    assert refused >= 7, f"roster no longer exercises the refusal path ({refused} refused)"
 
 
 def test_an_admitted_count_is_the_number_of_environments_built() -> None:

--- a/tests/training/test_vec_env_counts_take_the_shared_domain.py
+++ b/tests/training/test_vec_env_counts_take_the_shared_domain.py
@@ -1,0 +1,200 @@
+"""The two counts ``VecSimEnv`` is constructed with take the shared count domain.
+
+``VecSimEnv`` is the class the RL trainers hand ``RLTrainSpec.num_envs`` to, and
+the one that acts on it: it calls ``env_factory`` once per environment, each
+building its own physics engine, and sizes one thread pool from ``max_workers``.
+Every other owner of a parallel-environment count grades it through
+:func:`~strands_robots.utils.positive_count_error` - ``RLTrainSpec`` via the PPO,
+FastTD3 and FastSAC backends, and the Isaac backend's config and ``replicate``.
+This one hand-rolled ``if num_envs < 1`` and then coerced with ``int()``, and
+``max_workers`` had no domain at all, so:
+
+* ``2.5``, ``4.0`` and ``True`` were admitted and silently built 2, 4 and 1
+  engines - a count the caller never asked for rather than a refusal.
+* ``float("inf")`` and ``"4"`` left the constructor as ``OverflowError`` and
+  ``TypeError``, outside the documented ``Raises: ValueError``, naming neither
+  the class nor the parameter.
+* ``max_workers=float("inf")`` reached ``ThreadPoolExecutor`` as its pool size.
+
+These pin the domain, not the wording: a refusal is identified by the parameter
+it names, and the reference verdict is read from the shared helper itself so the
+two cannot drift apart again.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from typing import Any, cast
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from strands_robots.training.rl import VecSimEnv  # noqa: E402 - after torch importorskip
+from strands_robots.training.rl.env import SimEnv  # noqa: E402
+from strands_robots.utils import positive_count_error  # noqa: E402
+
+
+class _StandInEnv:
+    """The narrowest thing ``VecSimEnv.__init__`` reads: three dims and a device.
+
+    Deliberately not a ``SimEnv`` - these cells grade what happens *before* any
+    environment is usable, so the stand-in exists only to be counted.
+    """
+
+    num_actor_obs = 4
+    num_critic_obs = 4
+    num_actions = 2
+
+    def __init__(self) -> None:
+        self.device = torch.device("cpu")
+
+
+class _CountingFactory:
+    """``env_factory`` that records how many environments were actually built."""
+
+    def __init__(self) -> None:
+        self.built = 0
+
+    def __call__(self) -> SimEnv:
+        self.built += 1
+        # The stand-in is intentionally looser than SimEnv; that looseness is
+        # the point of the cell, so the cast is deliberate.
+        return cast("SimEnv", _StandInEnv())
+
+
+# (value, why it is in the roster). A list of pairs rather than a mapping: as a
+# dict ``0``/``False`` and ``4.0``/``4`` would collapse onto one key each, and
+# those collapses are exactly the distinctions a count domain is about.
+_PROBES: list[tuple[Any, str]] = [
+    (2, "a plain count - the control, and it must keep working"),
+    (1, "the degenerate single-environment count"),
+    (True, "an int subclass a bare `< 1` admits as a silent count of 1"),
+    (2.5, "a fractional count no number of engines can honour"),
+    (4.0, "an integral float - spendable only after a coercion"),
+    (float("nan"), "not a number, and not orderable in the way `< 1` assumes"),
+    (float("inf"), "unbounded - int() of it overflows"),
+    ("4", "a count as text, e.g. straight off a CLI or an env var"),
+    (None, "unstated"),
+    (0, "no environments at all"),
+    (-1, "negative"),
+]
+_IDS = [repr(v) for v, _ in _PROBES]
+
+# One value is legitimately answered differently by the two parameters:
+# ``max_workers=None`` means "derive it from num_envs", so it is not a refusal
+# there. Recorded rather than silently skipped.
+_MAX_WORKERS_MEANS_UNSTATED = None
+
+
+def _refusal(**kwargs: Any) -> str | None:
+    """Construct through the public surface; return the refusal text or ``None``.
+
+    Any exception is reported, not just ``ValueError``, so a value leaving the
+    constructor outside its documented contract is visible as itself.
+    """
+    factory = _CountingFactory()
+    try:
+        vec = VecSimEnv(factory, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - the type IS the observation here
+        return f"{type(exc).__name__}: {exc}"
+    vec.close()
+    return None
+
+
+@pytest.mark.parametrize(("value", "why"), _PROBES, ids=_IDS)
+def test_num_envs_agrees_with_the_shared_count_domain(value: Any, why: str) -> None:
+    """A count the shared domain refuses is refused here, naming the parameter."""
+    expected = positive_count_error(value, "num_envs", "VecSimEnv")
+    got = _refusal(num_envs=value)
+    if expected is None:
+        assert got is None, f"{value!r} ({why}) is a usable count but was refused: {got}"
+    else:
+        assert got is not None, f"{value!r} ({why}) was admitted; the shared domain refuses it"
+        assert "num_envs" in got, f"the refusal of {value!r} does not name num_envs: {got}"
+
+
+@pytest.mark.parametrize(("value", "why"), _PROBES, ids=_IDS)
+def test_max_workers_agrees_with_the_shared_count_domain(value: Any, why: str) -> None:
+    """The pool size takes the same domain; ``None`` alone means "derive it"."""
+    if value is _MAX_WORKERS_MEANS_UNSTATED:
+        assert _refusal(num_envs=2, max_workers=value) is None, "None means derive from num_envs"
+        return
+    expected = positive_count_error(value, "max_workers", "VecSimEnv")
+    got = _refusal(num_envs=2, max_workers=value)
+    if expected is None:
+        assert got is None, f"{value!r} ({why}) is a usable pool size but was refused: {got}"
+    else:
+        assert got is not None, f"{value!r} ({why}) was admitted as a pool size"
+        assert "max_workers" in got, f"the refusal of {value!r} does not name max_workers: {got}"
+
+
+@pytest.mark.parametrize(("value", "why"), _PROBES, ids=_IDS)
+def test_a_count_leaves_the_constructor_only_as_a_value_error(value: Any, why: str) -> None:
+    """The documented contract is ``ValueError``; nothing else may escape.
+
+    ``float("inf")`` reached ``int()`` and raised ``OverflowError``; ``"4"`` and
+    ``None`` reached the ``< 1`` comparison and raised ``TypeError``.
+    """
+    for kwargs in ({"num_envs": value}, {"num_envs": 2, "max_workers": value}):
+        try:
+            vec = VecSimEnv(_CountingFactory(), **kwargs)
+        except ValueError:
+            continue
+        except BaseException as exc:  # noqa: BLE001 - reporting the escape
+            pytest.fail(f"{kwargs} ({why}) escaped as {type(exc).__name__}: {exc}")
+        vec.close()
+
+
+def test_a_refused_count_builds_no_environment() -> None:
+    """The count is graded before ``env_factory`` is called even once.
+
+    Each environment owns its own engine, so admitting a count the caller did
+    not mean is not a bad number stored - it is that many live engines built.
+    """
+    refused = 0
+    for value, why in _PROBES:
+        if positive_count_error(value, "num_envs", "VecSimEnv") is None:
+            continue
+        refused += 1
+        factory = _CountingFactory()
+        with pytest.raises(ValueError):
+            VecSimEnv(factory, value)
+        assert factory.built == 0, f"{value!r} ({why}) built {factory.built} environment(s) before refusal"
+    assert refused >= 8, f"roster no longer exercises the refusal path ({refused} refused)"
+
+
+def test_an_admitted_count_is_the_number_of_environments_built() -> None:
+    """An admitted count is published unchanged and spent exactly as given."""
+    exercised = []
+    for value, _why in _PROBES:
+        if positive_count_error(value, "num_envs", "VecSimEnv") is not None:
+            continue
+        exercised.append(value)
+        factory = _CountingFactory()
+        vec = VecSimEnv(factory, value)
+        assert factory.built == value
+        assert vec.num_envs == value
+        assert type(vec.num_envs) is int  # published as given, not coerced into shape
+        vec.close()
+    assert exercised == [2, 1], f"roster no longer exercises the accepting path ({exercised})"
+
+
+def test_an_admitted_pool_size_reaches_the_executor_as_an_integer() -> None:
+    """``max_workers`` sizes a real thread pool, so a non-integer cannot reach it."""
+    vec = VecSimEnv(_CountingFactory(), 2, max_workers=3)
+    try:
+        assert vec._executor is not None
+        assert type(vec._executor._max_workers) is int
+        assert vec._executor._max_workers == 3
+    finally:
+        vec.close()
+
+
+def test_the_constructor_asks_the_shared_domain_rather_than_re_deriving_it() -> None:
+    """Graded on the call graph, not on source text - a comment may quote either form."""
+    tree = ast.parse(inspect.getsource(VecSimEnv.__init__).strip())
+    called = {ast.unparse(n.func) for n in ast.walk(tree) if isinstance(n, ast.Call)}
+    assert "positive_count_error" in called, f"__init__ does not call the shared domain; calls {sorted(called)}"
+    assert "int" not in called, "int() coercion is back; it is what turned a 2.5 into two live engines"

--- a/tests/training/test_vec_env_counts_take_the_shared_domain.py
+++ b/tests/training/test_vec_env_counts_take_the_shared_domain.py
@@ -146,7 +146,7 @@ def test_a_count_leaves_the_constructor_only_as_a_value_error(value: Any, why: s
         except ValueError:
             continue
         except BaseException as exc:  # noqa: BLE001 - reporting the escape
-            pytest.fail(f"{kwargs} ({why}) escaped as {type(exc).__name__}: {exc}")
+            raise AssertionError(f"{kwargs} ({why}) escaped as {type(exc).__name__}: {exc}") from exc
         vec.close()
 
 


### PR DESCRIPTION
`VecSimEnv` is what the RL trainers hand `RLTrainSpec.num_envs` to, and what acts on it: one `env_factory()` call per environment, **each building its own physics engine**, plus one thread pool sized from `max_workers`. Every other owner of a parallel-environment count grades it through `positive_count_error` — `RLTrainSpec` via the PPO, FastTD3 and FastSAC backends, and the Isaac backend's config and `replicate`. This one hand-rolled `if num_envs < 1` and then coerced with `int()`, and `max_workers` had no domain at all.

![measured verdict table](https://raw.githubusercontent.com/cagataycali/robots/135145413005c56538ac3406581f9ce4c3ef4f27/assets/vec_env_counts.png)

## What the two owners disagreed about

A bare `< 1` followed by a coercion cannot refuse a count; it can only reinterpret it. Measured on `7046aa5`, 8 of 11 probe values disagreed with the shared domain, in three distinct ways:

| shape | values | what happened |
|---|---|---|
| admitted, then reinterpreted | `2.5`, `4.0`, `True` | built **2, 4 and 1** live engines — a count the caller never asked for, not a refusal |
| escaped the documented contract | `float("inf")`, `"4"`, `None` | left as `OverflowError` / `TypeError`, outside `Raises: ValueError`, naming neither the class nor the parameter |
| refused, but too late | `max_workers` = `0`, `-1`, `"4"` | the pool was built **last**, so the refusal raised with **2 live engines already built** and no handle to close them |

That last row is the load-bearing one: `max_workers` was spent on the line constructing the pool, after the `env_factory` loop. `VecSimEnv(f, 2, max_workers=0)` raised `ValueError` having already built every environment, and because the constructor did not return, the caller had nothing to `close()`.

## The change

Both counts take `positive_count_error` at the top of `__init__`, before any environment is built. `num_envs` is stored as given rather than through `int()` — the domain admits only a true `int`, so the coercion could only ever restate the value, and while it was there it *was* the mechanism that turned a `2.5` into two engines.

Nothing that worked stops working: the two admitting values (`2`, `1`) are unchanged, and `max_workers=None` still means "derive `min(num_envs, 8)`" — the one place the two parameters legitimately answer differently, recorded in the roster rather than skipped. The `positive_count_error` docstring enumerated three families of quantity while its callers were already four; the parallel-build family it was missing is now named.

## Tests

New `tests/training/test_vec_env_counts_take_the_shared_domain.py`, 38 cells. The reference verdict is read from `positive_count_error` itself, so the two owners cannot drift apart again, and a refusal is identified by the **parameter it names** rather than by wording. The roster is a list of `(value, reason)` pairs, not a mapping — as a dict, `0`/`False` and `4`/`4.0` collapse onto one key each, and those collapses are exactly what a count domain is about.

Four corners on `tests/training/`, CPython 3.12.3:

| | pre-existing cells | new cells |
|---|---|---|
| pre-fix `__init__` | 4979 passed | **19 failed** |
| this branch | 4979 passed | 5017 passed (4979 + 38) |

Both "builds no environment" cells are red pre-fix, and each looped cell carries a non-vacuity assert on how many roster values it actually exercised. The pre-existing `test_rejects_bad_num_envs` was retargeted from the old message text onto the parameter, matching its siblings; the structural cell grades the `ast.Call` set of `__init__` rather than source text, so a comment quoting either form cannot satisfy or break it.

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` | clean, 1923 files |
| mypy 1.20.2, same scope | 1 error, the pre-existing `simulation/ik.py:174`; 0 attributable |
| `tests/training/` | 5017 passed; the 7 failures + 9 errors are pre-existing and environmental, verified identical on a clean `main` worktree (absent `qpsolvers`, lerobot-source drift) |
| the 68 modules that read `utils.py` or this domain | 6442 passed, same 2 environmental failures as `main` |

## Size

+285 / −11 over 5 files. The 225-line test file is 124 executable lines, 58 docstring, 8 comment, 35 blank; production is +25/−9, of which the guard is 6 lines and the rest is the docstring stating the domain.

---

## §13 Review rounds

| Round | Concern | Fix commit | Pin test path |
|---|---|---|---|
| R1 | CodeQL `py/catch-base-exception` on the escape-detection handler -- `pytest.fail` is not a lexical re-raise, so the query flags it. Replaced with `raise AssertionError(...) from exc` which is lexically visible and preserves the chain. | `2bc02dc` | `tests/training/test_vec_env_counts_take_the_shared_domain.py::test_a_count_leaves_the_constructor_only_as_a_value_error` |