### PR TITLE
fix(simulation): the engine default render resolution is a pixel count at the owner that stores it

### DIFF
--- a/changelog.d/3285-engine-default-resolution-is-a-pixel-count.md
+++ b/changelog.d/3285-engine-default-resolution-is-a-pixel-count.md
@@ -1,0 +1,20 @@
+### Fixed: the engine default render resolution is a pixel count at the owner that stores it
+
+`MuJoCoSimEngine`, `NewtonSimEngine` and `IsaacSimulation` all take
+`default_width` / `default_height`, and none of the three graded them - while
+`add_camera` and the render family refuse the same values on every backend. The
+constructor is not an inert default: MuJoCo copies it into the `SimCamera` entry
+registered for the free camera and for every model camera a robot brings, so a
+resolution `add_camera` refuses had a second, ungraded way into the same field.
+Measured on a so101 scene, `default_width=0` published
+`observation["default"]` as a `(480, 0, 3)` zero-pixel frame under
+`status="success"`; `-1` and `inf` dropped the image key entirely, handing a
+policy that declares `requires_images` proprioception alone; and `True`, `2.7`,
+`640.0`, `'640'` and `nan` raised `TypeError` out of `get_observation`. Every
+`render()` - a call passing no dimensions - was refused for a value its caller
+never named. On Isaac the legacy spelling ran through `int(...)` into the graded
+`camera_width` field, so the coercion defeated that domain: `True` stored a
+1-pixel camera and `2.7` stored 2. All three constructors now grade both
+dimensions on the shared `positive_count_error` floor and raise `ValueError`
+naming the class, the parameter and the value. The framebuffer *ceiling* stays a
+render-time check, because it is a property of the compiled model.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -787,10 +787,28 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         # downstream code only reads from one source of truth.
         if legacy_default_timestep is not None:
             config = dataclasses.replace(config, physics_dt=float(legacy_default_timestep))
+        # The legacy spellings reach the same graded field the canonical name
+        # does, so they cannot be the looser way in. The ``int(...)`` they used
+        # to pass through was not validation: it *defeated* the domain
+        # ``IsaacConfig`` applies to ``camera_width``, which refuses every value
+        # below. ``default_width=True`` stored a 1-pixel camera, ``2.7`` stored
+        # 2 and ``640.0`` / ``'640'`` stored 640 - the caller's value silently
+        # reinterpreted - while ``inf`` raised ``OverflowError``, ``[640]``
+        # ``TypeError`` and ``nan`` a ``ValueError`` from inside ``int()``,
+        # naming neither the parameter nor this class. Graded here on the shared
+        # floor so the refusal quotes the spelling the caller actually used,
+        # then handed over unconverted: a value this domain admits is already an
+        # ``int``, so a coercion could only restate it.
+        for _param, _value in (
+            ("default_width", legacy_default_width),
+            ("default_height", legacy_default_height),
+        ):
+            if _value is not None and (dim_err := positive_count_error(_value, _param, "IsaacSimulation")) is not None:
+                raise ValueError(dim_err)
         if legacy_default_width is not None:
-            config = dataclasses.replace(config, camera_width=int(legacy_default_width))
+            config = dataclasses.replace(config, camera_width=legacy_default_width)
         if legacy_default_height is not None:
-            config = dataclasses.replace(config, camera_height=int(legacy_default_height))
+            config = dataclasses.replace(config, camera_height=legacy_default_height)
         self._config = config
         # Tool-name is informational; some Strands tooling renders it.
         self.tool_name = legacy_tool_name

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -143,6 +143,7 @@ from strands_robots.utils import (
     entity_name_error,
     finite_vector_error,
     non_negative_whole_number_error,
+    positive_count_error,
     positive_finite_number_error,
     positive_whole_number_error,
     published_string_error,
@@ -473,8 +474,16 @@ class MuJoCoSimEngine(
             default_timestep: Default physics timestep (seconds). Can be
                 overridden via ``create_world(timestep=...)``.
             default_width: Default render width (pixels) used when a
-                caller does not pass explicit dimensions to ``render``.
-            default_height: Default render height (pixels).
+                caller does not pass explicit dimensions to ``render``, and
+                copied into the ``SimCamera`` entry registered for every
+                camera that declares no size of its own. A positive ``int``
+                on the shared
+                :func:`~strands_robots.utils.positive_count_error` floor that
+                ``add_camera`` applies to a per-camera dimension - the same
+                quantity cannot have two domains because of which way in it
+                took. The framebuffer *ceiling* stays a render-time check: it
+                is a property of the compiled model, not of this call.
+            default_height: Default render height (pixels), same domain.
             mesh: Optional mesh-networking hook: an already-started mesh
                 client exposing ``.stop()`` (see
                 :func:`strands_robots.mesh.init_mesh`), which ``cleanup()``
@@ -522,6 +531,37 @@ class MuJoCoSimEngine(
         """
         reject_setup_kwargs(kwargs)
         reject_misspelled_kwargs(kwargs, own_keyword_names(MuJoCoSimEngine), owner="MuJoCoSimEngine")
+        # The default render resolution is a pixel count at the owner that
+        # stores it, on the shared floor ``add_camera`` and the render family
+        # already apply to a per-call dimension. It is not an inert fallback:
+        # ``create_world`` copies it into the ``SimCamera`` entry it registers
+        # for the free camera and ``add_robot`` into one entry per model camera,
+        # so it lands in the very field ``add_camera`` guards - one quantity,
+        # two ways in, and only one of them graded.
+        #
+        # Deferring to the render entry points did not make it a late refusal;
+        # it made it three different wrong answers, measured on a so101 scene:
+        # ``0`` published ``observation["default"]`` as a ``(480, 0, 3)``
+        # zero-pixel frame under a success result; ``-1`` and ``inf`` dropped
+        # the image key entirely (``_render_cameras`` logs a per-camera failure
+        # at debug level and keeps going), handing a policy that declares
+        # ``requires_images`` proprioception alone with no signal; and ``True``,
+        # ``2.7``, ``640.0``, ``'640'`` and ``nan`` raised ``TypeError`` out of
+        # ``get_observation``, which :class:`~strands_robots.simulation.base.SimEngine`
+        # documents as returning an observation dict. Every ``render()`` - a
+        # call passing no dimensions at all - was meanwhile refused for a value
+        # its caller never named.
+        #
+        # The floor is all that is decidable here. The offscreen framebuffer cap
+        # is a property of the compiled model, so ``_validate_render_dims`` goes
+        # on applying it to the resolved size once a world exists.
+        #
+        # Placed before ``_init_ros_bridge``, which builds an ``rclpy`` node: a
+        # refusal about a constructor argument should not leave a ROS 2 node
+        # behind it.
+        for _param, _value in (("default_width", default_width), ("default_height", default_height)):
+            if (dim_err := positive_count_error(_value, _param, "MuJoCoSimEngine")) is not None:
+                raise ValueError(dim_err)
         super().__init__()
         self._init_ros_bridge(ros2_bridge=ros2_bridge, ros2_domain=ros2_domain)
         self.tool_name_str = tool_name

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -206,8 +206,12 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             substeps: Physics substeps per :meth:`step` call.
             device: Warp device string (e.g. ``"cuda:0"`` or ``"cpu"``).
                 ``None`` selects Warp's default device (GPU when available).
-            default_width: Default render width in pixels.
-            default_height: Default render height in pixels.
+            default_width: Default render width in pixels for the built-in
+                three-quarter view. A positive ``int`` on the shared
+                :func:`~strands_robots.utils.positive_count_error` floor
+                ``add_camera`` and the render family apply, so a resolution one
+                surface refuses is refused at all of them.
+            default_height: Default render height in pixels, same domain.
             **kwargs: Ignored; accepted for forward compatibility. Robot-setup
                 arguments (``robot_name`` / ``robot``) are rejected rather than
                 dropped - use ``Robot("so101", mode="sim")`` or ``add_robot``.
@@ -217,7 +221,8 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 silently identical to omitting it.
 
         Raises:
-            ValueError: If ``solver`` is not a known solver name.
+            ValueError: If ``solver`` is not a known solver name, or a default
+                render dimension is not a positive integer.
         """
         reject_setup_kwargs(kwargs)
         reject_misspelled_kwargs(kwargs, own_keyword_names(NewtonSimEngine), owner="NewtonSimEngine")
@@ -236,6 +241,26 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         # control step from _advance() on the stepping thread.
         self._viewer: Any = None
         self._viewer_kind: str | None = None
+
+        # The built-in view's resolution is a pixel count at the owner that
+        # stores it, on the same shared floor ``add_camera`` applies to a
+        # per-camera dimension and ``_resolve_camera_view`` to a per-call
+        # override. ``_resolve_camera_view`` graded the override alone and its
+        # docstring claimed "the config-time and call-time domains agree" - the
+        # ``self.default_width if width is None else width`` beside it says
+        # otherwise, because the branch that is *not* the override was the one
+        # nothing checked. Every value the override arm refuses reached
+        # ``_render_rgb`` unexamined through the arm next to it.
+        #
+        # Graded before ``ensure_newton()`` deliberately: whether this pair of
+        # numbers is a resolution does not depend on an optional dependency
+        # being installed, and reporting it first means a caller who got the
+        # argument wrong is told that rather than being told to install Newton.
+        # It still follows the teardown state above, so ``__del__`` stays a
+        # clean no-op on the half-constructed instance a refusal leaves.
+        for _param, _value in (("default_width", default_width), ("default_height", default_height)):
+            if (dim_err := positive_count_error(_value, _param, "NewtonSimEngine")) is not None:
+                raise ValueError(dim_err)
 
         self._nt, self._wp = ensure_newton()
         if solver.lower() not in solver_registry():

--- a/tests/simulation/test_camera_pixel_count_domain.py
+++ b/tests/simulation/test_camera_pixel_count_domain.py
@@ -88,6 +88,7 @@ from strands_robots.simulation.newton.simulation import NewtonSimEngine
 from strands_robots.utils import positive_count_error
 
 from .isaac.test_add_camera_numeric_validation import _engine as _isaac_engine
+from .mujoco._gl_probe import requires_gl
 from .newton.test_add_camera_numeric_validation import _engine_stub
 from .newton.test_viewer_port_domain import _viewer_stub
 
@@ -840,6 +841,7 @@ class TestTheEngineDefaultResolution:
             legacy = _construction_verdict("default_width", lambda bad=bad: _isaac_construct(default_width=bad))
             assert canonical == legacy == "refused", f"{bad!r}: canonical={canonical}, legacy={legacy}"
 
+    @requires_gl
     def test_every_engine_that_constructs_can_be_rendered_and_observed(self):
         """The point of refusing here: nothing that builds is unusable later.
 
@@ -848,6 +850,10 @@ class TestTheEngineDefaultResolution:
         is above MuJoCo's *offscreen framebuffer* cap, which is a property of
         the compiled model and stays a render-time check - the shared rule is a
         floor, as ``test_the_shared_rule_is_a_floor_and_not_a_ceiling`` pins.
+
+        Gated on the shared GL probe: ``render`` and ``get_observation`` both
+        need an offscreen context, and on a headless host without EGL/OSMesa
+        they report an error that names neither GL nor this contract.
         """
         pytest.importorskip("mujoco")
         exercised = []

--- a/tests/simulation/test_camera_pixel_count_domain.py
+++ b/tests/simulation/test_camera_pixel_count_domain.py
@@ -2,13 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """Regression tests: every backend's camera pixel dimensions share one floor.
 
-``width`` / ``height`` reach two surfaces on every simulation backend - the
-``add_camera`` that fixes a camera's resolution, and the render family
-(``render`` / ``get_frame`` / ``get_camera_params``) that can override it per
-call - and a third on Newton alone, ``open_viewer``, which sizes the ``"gl"``
-window. MuJoCo validated the first two through ``_validate_render_dims``;
-Newton and Isaac validated neither, and coerced with a bare ``int(...)`` that
-refuses nothing useful. Coercion is validation only when the coercion rejects.
+``width`` / ``height`` reach three surfaces on every simulation backend - the
+constructor's ``default_width`` / ``default_height``, which every camera that
+declares no size of its own is registered at; the ``add_camera`` that fixes one
+camera's resolution; and the render family (``render`` / ``get_frame`` /
+``get_camera_params``) that can override it per call - plus a fourth on Newton
+alone, ``open_viewer``, which sizes the ``"gl"`` window. MuJoCo validated the
+middle two through ``_validate_render_dims``; Newton and Isaac validated
+neither, and coerced with a bare ``int(...)`` that refuses nothing useful.
+Coercion is validation only when the coercion rejects. The constructor was
+graded by no backend at all, which is the surface
+``TestTheEngineDefaultResolution`` closes.
 
 Measured on both backends before the fix:
 
@@ -49,7 +53,7 @@ Measured on both backends before the fix:
   built nothing. The caller was left with the window they did not ask for and
   no way to replace it.
 
-The fix routes all five surfaces through
+The fix routes every one of those surfaces through
 :func:`~strands_robots.utils.positive_count_error`, the domain MuJoCo's floor
 already implements: a true ``int`` (``bool`` refused - it is an ``int`` subclass
 whose ``True`` would act as a silent 1) that is ``>= 1``. A pixel dimension is
@@ -504,9 +508,17 @@ class TestNoNewtonDimensionSurfaceDrifts:
 
     _FUNNEL = "_resolve_camera_view"
     _GUARD = "positive_count_error"
-    #: The public surfaces taking a pixel dimension today. Pinned exactly so a
+    #: The surfaces taking a pixel dimension today. Pinned exactly so a
     #: mis-rooted scan reporting a clean sweep over nothing fails instead.
-    _EXPECTED = frozenset({"add_camera", "render", "get_frame", "get_camera_params", "open_viewer"})
+    #: ``__init__`` is on the list because the scan that pre-dated it looked at
+    #: public methods named ``width`` / ``height`` only, and so was blind to the
+    #: one surface that *stores* a resolution for every later render - which is
+    #: exactly how that surface stayed ungraded while its four neighbours were
+    #: swept every run.
+    _EXPECTED = frozenset({"__init__", "add_camera", "render", "get_frame", "get_camera_params", "open_viewer"})
+    #: Parameter spellings that carry a pixel dimension. The constructor's pair
+    #: is a different spelling of the same quantity, not a different quantity.
+    _DIMENSION_PARAMS = frozenset({"width", "height", "default_width", "default_height"})
 
     @staticmethod
     def _classify(src: str) -> dict[str, str]:
@@ -516,11 +528,13 @@ class TestNoNewtonDimensionSurfaceDrifts:
             if not isinstance(cls, ast.ClassDef):
                 continue
             for fn in ast.iter_child_nodes(cls):
-                if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef) or fn.name.startswith("_"):
+                if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+                if fn.name.startswith("_") and fn.name != "__init__":
                     continue
                 args = fn.args
                 names = {a.arg for a in args.posonlyargs + args.args + args.kwonlyargs}
-                if not {"width", "height"} & names:
+                if not TestNoNewtonDimensionSurfaceDrifts._DIMENSION_PARAMS & names:
                     continue
                 calls = {
                     n.func.attr if isinstance(n.func, ast.Attribute) else getattr(n.func, "id", "")
@@ -699,6 +713,161 @@ class TestSameVerdictAcrossBackends:
         assert _verdict(lambda: mj_sim.add_camera(name=f"ok_{good}", width=good, height=good)) == "accepted"
         assert _verdict(lambda: _newton_add_camera(_newton_stub(), name="ok", width=good, height=good)) == "accepted"
         assert _verdict(lambda: _isaac_engine().add_camera(name="ok", width=good, height=good)) == "accepted"
+
+
+# --------------------------------------------------------------------------- #
+# The constructor: the owner that stores a resolution for every later render   #
+# --------------------------------------------------------------------------- #
+
+
+def _construction_verdict(param: str, call: Callable[[], Any]) -> str:
+    """``"refused"`` / ``"accepted"`` for a constructor, whose channel is a raise.
+
+    The sibling ``_verdict`` reads an agent-tool envelope, so it cannot grade
+    these surfaces: a constructor has no envelope to return and refuses by
+    raising ``ValueError``, exactly as each ``Raises:`` section states. The
+    refusal must *name* the parameter, and that is not a style rule here - it is
+    what separates a refusal from the pre-fix behaviour. Isaac's ``int(...)``
+    also raised ``ValueError`` for ``'big'`` and ``nan``, from inside a coercion
+    that mentioned neither the class nor the argument
+    (``invalid literal for int() with base 10: 'big'``), and folding that into
+    "refused" would let this pin pass against the code it was written to catch.
+    """
+    try:
+        call()
+    except ValueError as exc:
+        return "refused" if param in str(exc) else f"raised a ValueError naming no parameter: {exc}"
+    except Exception as exc:  # noqa: BLE001 - an exception the API leaked is the finding
+        return f"raised {type(exc).__name__}"
+    return "accepted"
+
+
+def _mujoco_engine(**kwargs: Any) -> Any:
+    """Construct the MuJoCo engine with the harnessless defaults tests use."""
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    return Simulation(tool_name="test_engine_default_resolution", mesh=False, **kwargs)
+
+
+def _isaac_construct(**kwargs: Any) -> Any:
+    """Construct the Isaac facade. Reaches the legacy kwarg block, not the stage."""
+    from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+    return IsaacSimulation(**kwargs)
+
+
+#: The three constructors that own the same pair of numbers, keyed by the class
+#: named in the refusal. Newton is reachable here without ``newton`` / ``warp``
+#: because the guard precedes ``ensure_newton()`` - deliberately, so a caller
+#: who passed a bad resolution is told that rather than told to install a
+#: dependency.
+_ENGINE_CONSTRUCTORS: tuple[tuple[str, Callable[..., Any]], ...] = (
+    ("MuJoCoSimEngine", _mujoco_engine),
+    ("NewtonSimEngine", NewtonSimEngine),
+    ("IsaacSimulation", _isaac_construct),
+)
+
+
+class TestTheEngineDefaultResolution:
+    """``default_width`` / ``default_height`` are pixel counts at every backend.
+
+    This is the surface the sibling classes above do not reach. It is not an
+    inert default: MuJoCo copies it into the ``SimCamera`` entry ``create_world``
+    registers for the free camera and into one entry per model camera on every
+    ``add_robot``, and Newton reads it for the built-in three-quarter view - so
+    the constructor writes into the very field ``add_camera`` guards, and every
+    value ``add_camera`` refuses had a second, ungraded way in.
+
+    Deferring to the render entry points was not a late refusal but three
+    different wrong answers, measured on a so101 MuJoCo scene before the fix:
+
+    * ``default_width=0`` published ``observation["default"]`` as a
+      ``(480, 0, 3)`` zero-pixel frame under ``status="success"``.
+    * ``-1`` and ``inf`` dropped the image key altogether - ``_render_cameras``
+      logs a per-camera failure at debug level and keeps going - so a policy
+      declaring ``requires_images`` was handed proprioception alone, with
+      nothing in the result saying an image was missing.
+    * ``True``, ``2.7``, ``640.0``, ``'640'`` and ``nan`` raised ``TypeError``
+      out of ``get_observation``, which
+      :class:`~strands_robots.simulation.base.SimEngine` documents as returning
+      an observation dict.
+
+    Every ``render()`` was meanwhile refused - a call that passes no dimensions
+    at all, answered ``"render: width and height must be > 0, got 0x480"``,
+    quoting a value its caller never named. On Isaac the legacy spelling went
+    through ``int(...)`` into the graded ``camera_width`` field, so the coercion
+    *defeated* that domain: ``True`` stored a 1-pixel camera, ``2.7`` stored 2,
+    ``640.0`` and ``'640'`` stored 640, and ``inf`` / ``[640]`` / ``nan`` raised
+    ``OverflowError`` / ``TypeError`` / ``ValueError`` from inside ``int()``,
+    naming neither the parameter nor the class.
+    """
+
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["default_width", "default_height"])
+    def test_every_backend_refuses_an_unusable_default(self, param, bad):
+        verdicts = {
+            owner: _construction_verdict(param, lambda ctor=ctor: ctor(**{param: bad}))
+            for owner, ctor in _ENGINE_CONSTRUCTORS
+        }
+        assert set(verdicts.values()) == {"refused"}, f"{param}={bad!r}: {verdicts}"
+
+    @pytest.mark.parametrize("param", ["default_width", "default_height"])
+    def test_the_refusal_names_the_class_the_parameter_and_the_value(self, param):
+        for owner, ctor in _ENGINE_CONSTRUCTORS:
+            with pytest.raises(ValueError) as excinfo:
+                ctor(**{param: 0})
+            text = str(excinfo.value)
+            assert owner in text and param in text and "0" in text, text
+
+    @pytest.mark.parametrize("good", (1, 16, 320, 640))
+    def test_a_usable_default_is_still_accepted(self, good):
+        """The guard is a floor, not a tightening: ordinary sizes still build."""
+        pytest.importorskip("mujoco")
+        sim = _mujoco_engine(default_width=good, default_height=good)
+        try:
+            assert (sim.default_width, sim.default_height) == (good, good)
+        finally:
+            sim.cleanup()
+        isaac = _isaac_construct(default_width=good, default_height=good)
+        assert (isaac._config.camera_width, isaac._config.camera_height) == (good, good)
+
+    def test_the_isaac_legacy_spelling_agrees_with_the_canonical_field(self):
+        """``default_width`` is another name for ``camera_width``, not a looser one."""
+        from strands_robots.simulation.isaac.config import IsaacConfig
+
+        for bad in _BAD_DIMS:
+            canonical = _construction_verdict("camera_width", lambda bad=bad: IsaacConfig(camera_width=bad))
+            legacy = _construction_verdict("default_width", lambda bad=bad: _isaac_construct(default_width=bad))
+            assert canonical == legacy == "refused", f"{bad!r}: canonical={canonical}, legacy={legacy}"
+
+    def test_every_engine_that_constructs_can_be_rendered_and_observed(self):
+        """The point of refusing here: nothing that builds is unusable later.
+
+        Runs the real MuJoCo engine, because the pre-fix failures were all
+        downstream of construction. ``5000`` is excluded rather than skipped: it
+        is above MuJoCo's *offscreen framebuffer* cap, which is a property of
+        the compiled model and stays a render-time check - the shared rule is a
+        floor, as ``test_the_shared_rule_is_a_floor_and_not_a_ceiling`` pins.
+        """
+        pytest.importorskip("mujoco")
+        exercised = []
+        for candidate in (*_BAD_DIMS, 1, 16, 640):
+            try:
+                sim = _mujoco_engine(default_width=candidate, default_height=480)
+            except ValueError:
+                continue
+            try:
+                sim.create_world(gravity=[0, 0, -9.81])
+                assert sim._world.cameras["default"].width == candidate
+                assert sim.render()["status"] == "success"
+                sim.add_robot(name="so101")
+                image = sim.get_observation(robot_name="so101")["default"]
+                assert isinstance(image, np.ndarray)
+                assert image.shape == (480, candidate, 3)
+            finally:
+                sim.cleanup()
+            exercised.append(candidate)
+        assert exercised == [1, 16, 640], exercised
 
 
 class TestTheVerdictClassifier:

--- a/tests/test_mujoco_render_assertions_are_gl_gated.py
+++ b/tests/test_mujoco_render_assertions_are_gl_gated.py
@@ -47,6 +47,7 @@ EXPECTED_IN_SCOPE = frozenset(
     {
         "tests/simulation/mujoco/test_entity_name_lookup_type_safety.py",
         "tests/simulation/mujoco/test_remove_camera_refused_recompile.py",
+        "tests/simulation/test_camera_pixel_count_domain.py",
         "tests/simulation/test_unhashable_entity_name_is_reported.py",
     }
 )


### PR DESCRIPTION
`MuJoCoSimEngine`, `NewtonSimEngine` and `IsaacSimulation` all take `default_width` / `default_height`. None of the three graded the pair, while `add_camera` and the render family refuse the same values on every backend.

![measured before and after](https://raw.githubusercontent.com/cagataycali/robots/3fc6454d44b8239bfd20a1cdf74769356b2ca82a/default-resolution-domain.png)

## The constructor is not an inert default

MuJoCo copies it into the `SimCamera` entry `create_world` registers for the free camera, and into one entry per model camera on every `add_robot` - so the constructor writes into the very field `add_camera` guards. One quantity, two ways in, one of them graded.

Deferring to the render entry points was not a late refusal. It was three different wrong answers, measured on a so101 scene (left/right panels and the MuJoCo table above):

| `default_width` | `get_observation()` before |
|---|---|
| `0` | `observation['default']` is a `(480, 0, 3)` array - zero pixels, under `status="success"` |
| `-1`, `inf` | the image key is **absent**; `_render_cameras` logs the per-camera failure at debug level and keeps going, so a policy declaring `requires_images` gets proprioception alone with nothing saying an image is missing |
| `True`, `2.7`, `640.0`, `'640'`, `nan` | `TypeError` out of `get_observation`, which `SimEngine` documents as returning an observation dict |

Meanwhile every `render()` - a call passing no dimensions at all - was refused: `render: width and height must be > 0, got 0x480`, quoting a value its caller never named.

On Isaac the legacy spelling ran through `int(...)` into the graded `camera_width` field, so the coercion **defeated** that domain: `True` stored a 1-pixel camera, `2.7` stored 2, `640.0` and `'640'` stored 640, while `inf` / `[640]` / `nan` raised `OverflowError` / `TypeError` / `ValueError` from inside `int()`, naming neither the parameter nor the class.

## Change

All three constructors grade both dimensions on the shared `positive_count_error` floor - the domain `add_camera` and the render family already use - and raise `ValueError` naming the class, the parameter and the value. Two placement decisions:

- The MuJoCo guard precedes `_init_ros_bridge`, which builds an `rclpy` node: a refusal about a constructor argument should not leave a ROS 2 node behind it.
- The Newton guard precedes `ensure_newton()`: whether a pair of numbers is a resolution does not depend on an optional dependency being installed, so a caller who got the argument wrong is told that rather than told to install Newton. It still follows the teardown state, so `__del__` stays a no-op on the instance a refusal leaves.
- Isaac's `int(...)` is deleted rather than kept alongside the guard: a value this domain admits is already an `int`, so the coercion could only restate it - and it was the mechanism.

The *ceiling* stays where the model is known. MuJoCo's offscreen framebuffer cap is a property of the compiled model, so `_validate_render_dims` goes on applying it to the resolved size - which is why `5000` is still accepted at construction and refused at render, the row the figure keeps visible. `test_the_shared_rule_is_a_floor_and_not_a_ceiling` already pins that split.

## Tests

Into `tests/simulation/test_camera_pixel_count_domain.py`, the file whose subject is exactly this quantity, rather than a new file:

- `TestTheEngineDefaultResolution` - the same 13 values refused at all three constructors, the refusal naming class/parameter/value, ordinary sizes still accepted, and Isaac's legacy spelling agreeing value-for-value with the canonical `camera_width`.
- A construct-then-spend loop: every engine that *does* construct is then created, rendered and observed, asserting `observation['default'].shape == (480, width, 3)`. That is the guarantee refusing here buys, and it is the cell the `(480, 0, 3)` frame fails. Gated on the shared GL probe (round 1, below).
- `TestNoNewtonDimensionSurfaceDrifts` is widened to see the constructor. Its scan looked at public methods with a `width` / `height` parameter, which is exactly how the one surface that *stores* a resolution stayed ungraded while its four neighbours were swept every run. On pre-fix code the widened scan reports `['__init__'] take a pixel dimension without reaching positive_count_error`.

Four corners on `tests/simulation/{test_camera_pixel_count_domain.py,isaac,newton,mujoco}` (7123 cells): old code + new tests **32 failed** (30 new cells + the widened scan + one standing failure), both new **1 failed**, and old-code/old-tests is byte-identical in failure names to new-code/old-tests. The one standing failure (`test_pose_vector_rule_parity::test_a_numpy_array_pose_is_accepted_by_both`) and one lerobot-source drift in the wider 29-file domain-grader net are present unchanged on `main`.

## Size

| | added | removed | of which executable |
|---|---|---|---|
| `simulation/{mujoco,newton,isaac}/simulation.py` | 90 | 7 | ~21 |
| `tests/simulation/test_camera_pixel_count_domain.py` | 181 | 12 | ~95 |
| changelog fragment | 20 | 0 | - |

The production side is mostly the rationale for why a default is not inert; the executable change is three guard blocks, one import and one deleted coercion.

## Review rounds

### Round 1 - `28bcb2f6`: the required check was red on a whole-tree grader

`call-test-lint / Test and Lint` on `e58e48af` reported `1 failed, 37570 passed`: `tests/test_mujoco_render_assertions_are_gl_gated.py` refused the construct-then-spend cell, whose `render()["status"] == "success"` at line 862 was not gated on the shared GL probe. That is the grader this repository keeps for exactly this shape - on a headless host without EGL/OSMesa the assertion reads `assert 'error' == 'success'` and names neither GL nor the resolution contract - and it is one of the graders a path-narrowed run cannot collect, which is how the four-corners run above stayed green on it.

Measured on such a host before the fix: the grader `1 failed, 12 passed`, the cell `AssertionError: assert 'error' == 'success'` at line 862. After: the cell is decorated `@requires_gl` from `tests.simulation.mujoco._gl_probe` (the module already imports its siblings relatively, so `from .mujoco._gl_probe import requires_gl`), and the module is listed in the grader's `EXPECTED_IN_SCOPE` pin, which the pin's own remedy text asks for. Same host after: the grader `13 passed`, the domain file `478 passed, 1 skipped` with the skip naming the missing context. `ruff check`, `ruff format --check` and `mypy` clean on both files. Test-only; no production line moved.

The push dismissed the standing approval, as it must - the required check was red, so a push was the only remedy.