### PR TITLE
fix(device_connect): the host half of the Reachy Mini daemon address is graded beside the port

### DIFF
--- a/changelog.d/3287-reachy-dial-host-domain.md
+++ b/changelog.d/3287-reachy-dial-host-domain.md
@@ -1,0 +1,29 @@
+### Fixed: the host half of the Reachy Mini daemon address is graded beside the port
+
+`ReachyMiniDriver` grades the two other values its constructor takes -- `api_port`
+through the shared `tcp_port_error` domain and `prefix` through the key-prefix
+rule -- and stored `host` unchecked. All three are interpolated into targets the
+module builds itself: `http://<host>:<api_port>` in `reachy_transport.api` and
+`ws://<host>:<api_port>/ws/sdk` in `WebSocketLink`.
+
+The host half is what can discard the port half, so grading the port alone was
+not enough. `host="127.0.0.1/foo"` builds `http://127.0.0.1/foo:8000/...`, which
+resolves as host `127.0.0.1` with the validated port sitting in the *path*, so
+the driver dials `:80` -- a port nobody configured, and one the port domain
+cannot see, because it is the host that discards it. `"bot.local@evil.example"`
+resolves to `evil.example` on the configured port. A non-string is carried
+verbatim, so `None` reaches the resolver as the DNS name `"none"` and the device
+identity reports `Reachy Mini @ None`.
+
+None of these were refused downstream. `api` reports every failure as an
+`{"error": ...}` result rather than raising, so an unusable host surfaced as an
+unreachable daemon -- the same report a reachable host produces with the daemon
+down -- and `connect()` then read that result as the Wireless variant and logged
+a successful connection over Zenoh.
+
+`host` now takes the shared `dial_host_error` domain, beside the port it is
+dialled with, so it is refused where the caller names it and before any driver
+state is allocated. Nothing that addressed a Mini changes: `reachy-mini.local`,
+an IPv4 literal, `localhost`, `0.0.0.0` and `[::1]` are all still accepted. The
+documented fail-safe that treats an unreachable daemon as Wireless is unchanged
+-- a daemon that is down is not a caller mistake.

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -26,7 +26,7 @@ from strands_robots.device_connect.reachy_transport import (
 )
 from strands_robots.mesh.security import ValidationError, validate_mesh_identifier
 from strands_robots.tools.reachy import envelope_error
-from strands_robots.utils import finite_number_error, tcp_port_error
+from strands_robots.utils import dial_host_error, finite_number_error, tcp_port_error
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +203,12 @@ class ReachyMiniDriver(DeviceDriver):
         """Configure the driver for a Reachy Mini reachable at ``host``.
 
         Args:
-            host: Hostname or IP of the Reachy Mini daemon.
+            host: Hostname or IP of the Reachy Mini daemon. Must name a host: a
+                bare hostname or IP literal, since it is interpolated into the
+                daemon URL (``http://<host>:<api_port>``) beside ``api_port``.
+                A URI delimiter there re-cuts that URL and the validated port
+                becomes part of the path. ``reachy-mini.local`` and
+                ``192.168.1.42`` are accepted; ``127.0.0.1/foo`` is not.
             prefix: Zenoh key prefix used by the Wireless variant. Must be a
                 ``/``-joined sequence of mesh identifiers -- a Zenoh wildcard
                 (``*`` / ``**``) would widen the command key to every Mini
@@ -213,17 +218,40 @@ class ReachyMiniDriver(DeviceDriver):
                 Must name a port: an ``int`` in ``[1, 65535]``.
 
         Raises:
-            ValueError: If ``api_port`` cannot address a TCP port, or if
-                ``prefix`` cannot address a single robot's key expressions
-                (see :func:`_key_prefix_error`).
+            ValueError: If ``api_port`` cannot address a TCP port, if ``host``
+                cannot address the host half of the daemon URL (see
+                :func:`~strands_robots.utils.dial_host_error`), or if ``prefix``
+                cannot address a single robot's key expressions (see
+                :func:`_key_prefix_error`).
         """
         # Refused here rather than at first use, and before any base-class state
-        # is allocated. This port is interpolated verbatim into both the daemon
-        # REST URL (``reachy_transport.api``) and the Lite WebSocket target, and
-        # neither refuses it: ``api`` reports every failure as an ``{"error":
-        # ...}`` result rather than raising, so an unusable port is reported as
-        # an unreachable daemon - identically to a reachable port with the
-        # daemon down. Naming the port is the only point a caller can act on.
+        # is allocated. This host and the port below are the two halves of one
+        # address, interpolated into the daemon REST URL
+        # (``reachy_transport.api`` builds ``http://<host>:<api_port><path>``)
+        # and into the Lite WebSocket target (``ws://<host>:<api_port>/ws/sdk``).
+        # Neither is refused downstream: ``api`` reports every failure as an
+        # ``{"error": ...}`` result rather than raising, so an unusable value is
+        # reported as an unreachable daemon - identically to a usable one with
+        # the daemon down - and ``connect()`` reads that result as the Wireless
+        # variant and logs a connection. Naming the value is the only point a
+        # caller can act on.
+        #
+        # The host is graded first, before the port it would have taken: a URI
+        # delimiter inside it re-cuts the URL, and the validated port is the
+        # component that gets discarded. ``host="127.0.0.1/foo"`` builds
+        # ``http://127.0.0.1/foo:8000/...``, which resolves as host
+        # ``127.0.0.1`` with the port in the *path*, so the driver dials :80 - a
+        # port nobody configured, and one the port domain cannot see, because it
+        # is the host half that takes it away. Reporting the port to a caller
+        # who got both wrong would name the component that was discarded rather
+        # than the one that discarded it. Userinfo redirects the dial outright
+        # (``"bot.local@evil.example"`` resolves to ``evil.example``), and a
+        # non-string is carried verbatim, so ``None`` reaches the resolver as
+        # the DNS name "none".
+        if (host_error := dial_host_error(host, "host", type(self).__name__)) is not None:
+            raise ValueError(host_error)
+        # The port half of that address, held to the shared domain for the same
+        # reason, and reported after the host that could have discarded it.
         if (port_error := tcp_port_error(api_port, "api_port", type(self).__name__)) is not None:
             raise ValueError(port_error)
         # Refused alongside the port, and for the same reason: this value is

--- a/tests/test_dial_host_is_graded_wherever_the_port_is.py
+++ b/tests/test_dial_host_is_graded_wherever_the_port_is.py
@@ -5,9 +5,9 @@ Every caller-supplied port this package dials is held to one shared domain,
 an unusable port is not refused by the transport, it is *applied*, and surfaces
 much later as an unreachable server that implicates the service the caller was
 trying to reach. The host beside it is interpolated into the same expression,
-``ws://{host}:{port}``, and was held to nothing on two of the three surfaces that
-build one - so a value that is not a host was resolved rather than refused, and
-the resolution discarded the very port the shared domain had just approved:
+``ws://{host}:{port}``, and was held to nothing on all but one of the surfaces
+that build one - so a value that is not a host was resolved rather than refused,
+and the resolution discarded the very port the shared domain had just approved:
 
 * ``host="127.0.0.1/foo"`` parses as host ``127.0.0.1``, path ``/foo:<port>`` and
   port **80**. The validated port becomes part of the path and the client dials a
@@ -21,7 +21,7 @@ the resolution discarded the very port the shared domain had just approved:
 * A non-string is carried into the URI verbatim: ``None`` is dialled as the DNS
   name ``"none"`` and an ``int`` as its digits.
 
-These pin the domain on all three surfaces at once, the shape of the harm against
+These pin the domain on every such surface at once, the shape of the harm against
 the real URI parser, the two documented asymmetries between a stated and an
 unstated address, and the over-reach control that every host a URI *can* carry is
 still accepted identically everywhere.
@@ -32,8 +32,15 @@ that ``zmq``'s own address parse refuses each delimiter spelling at ``connect``
 with the whole address in the message, so the transport there reports what the
 domain would.
 
-Everything here is offline - no server, no socket, and no policy is ever asked
-for an action.
+``ReachyMiniDriver`` is one of these surfaces on the same terms: its ``host`` and
+``api_port`` build the Lite variant's ``ws://<host>:<api_port>/ws/sdk`` target, and
+also the daemon REST URL beside it, so a delimiter in its host discards the port
+there identically. Its own module pins what that does to the daemon probe; the
+cells here are the ones it shares with the policy clients - one address cannot be
+refused by a policy client and dialled by a driver.
+
+Everything here is offline - no server, no socket, no daemon, and no policy is
+ever asked for an action.
 """
 
 from __future__ import annotations
@@ -123,6 +130,25 @@ def _vera_refusal(host: Any) -> str | None:
     return None
 
 
+def _reachy_mini_refusal(host: Any) -> str | None:
+    """Refusal ``ReachyMiniDriver`` gives ``host``.
+
+    The import is deferred into the call because sibling modules install
+    ``device_connect_edge`` stand-ins at import time; the shared helper restores
+    the real package, which is what binds the driver to the real base class.
+    """
+    from tests.test_reachy_mini_driver import _force_real_device_connect_edge
+
+    _force_real_device_connect_edge()
+    from strands_robots.device_connect.reachy_mini_driver import ReachyMiniDriver
+
+    try:
+        ReachyMiniDriver(host=host)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
 # The surfaces that build ``ws://{host}:{port}`` from a caller-supplied host.
 # Read through each public constructor, not through the domain function, so the
 # cells grade the behaviour a caller gets rather than the wiring behind it.
@@ -130,6 +156,7 @@ WEBSOCKET_SURFACES: dict[str, Any] = {
     "RemotePolicy": _remote_policy_refusal,
     "Cosmos3Policy": _cosmos3_refusal,
     "VeraConfig": _vera_refusal,
+    "ReachyMiniDriver": _reachy_mini_refusal,
 }
 
 
@@ -150,7 +177,7 @@ def test_every_host_a_uri_can_carry_is_still_accepted_everywhere(surface: str, h
     assert WEBSOCKET_SURFACES[surface](host) is None
 
 
-def test_the_three_surfaces_give_the_same_verdict_on_the_same_host() -> None:
+def test_every_surface_gives_the_same_verdict_on_the_same_host() -> None:
     """One address cannot be refused by one client and dialled by the next."""
     for host in [*UNUSABLE_HOSTS, *USABLE_HOSTS]:
         verdicts = {name: refuse(host) is None for name, refuse in WEBSOCKET_SURFACES.items()}
@@ -254,10 +281,21 @@ def test_the_domain_has_one_owner_and_no_consumer_restates_it() -> None:
         ("cosmos3.policy", inspect.getsource(Cosmos3Policy.__init__)),
         ("inference.client", inspect.getsource(RemotePolicy.__init__)),
         ("vera.config", inspect.getsource(type(VeraConfig(embodiment="pusht")).__post_init__)),
+        ("device_connect.reachy_mini_driver", _reachy_mini_driver_init_source()),
     ):
         called = _domains_called(source)
         assert "dial_host_error" in called, f"{module_name} does not call dial_host_error: {sorted(called)}"
         assert "isprintable" not in source, f"{module_name} restates the host domain"
+
+
+def _reachy_mini_driver_init_source() -> str:
+    """Source of ``ReachyMiniDriver.__init__``, bound to the real base class."""
+    from tests.test_reachy_mini_driver import _force_real_device_connect_edge
+
+    _force_real_device_connect_edge()
+    from strands_robots.device_connect.reachy_mini_driver import ReachyMiniDriver
+
+    return inspect.getsource(ReachyMiniDriver.__init__)
 
 
 def _domains_called(source: str) -> set[str]:
@@ -410,7 +448,18 @@ BOTH_HALVES_UNUSABLE: dict[str, Any] = {
     "RemotePolicy": lambda host: RemotePolicy(host=host, port=65536),
     "Cosmos3Policy": lambda host: Cosmos3Policy(embodiment="droid", host=host, port=65536),
     "VeraConfig": lambda host: VeraConfig(embodiment="pusht", host=host, server_port=65536),
+    "ReachyMiniDriver": lambda host: _reachy_mini_both_halves(host),
 }
+
+
+def _reachy_mini_both_halves(host: Any) -> None:
+    """Construct the driver with both halves of its daemon address unusable."""
+    from tests.test_reachy_mini_driver import _force_real_device_connect_edge
+
+    _force_real_device_connect_edge()
+    from strands_robots.device_connect.reachy_mini_driver import ReachyMiniDriver
+
+    ReachyMiniDriver(host=host, api_port=65536)
 
 
 @pytest.mark.parametrize("surface", sorted(BOTH_HALVES_UNUSABLE))

--- a/tests/test_dial_host_is_graded_wherever_the_port_is.py
+++ b/tests/test_dial_host_is_graded_wherever_the_port_is.py
@@ -441,6 +441,16 @@ def test_an_operation_the_read_never_makes_leaves_a_usable_host_usable(operation
     )
 
 
+def _reachy_mini_both_halves(host: Any) -> None:
+    """Construct the driver with both halves of its daemon address unusable."""
+    from tests.test_reachy_mini_driver import _force_real_device_connect_edge
+
+    _force_real_device_connect_edge()
+    from strands_robots.device_connect.reachy_mini_driver import ReachyMiniDriver
+
+    ReachyMiniDriver(host=host, api_port=65536)
+
+
 # Each surface with BOTH halves of its address unusable at once. The port keyword
 # differs per surface (``port`` / ``server_port``), so the constructors are
 # written out rather than derived from one signature.
@@ -450,16 +460,6 @@ BOTH_HALVES_UNUSABLE: dict[str, Any] = {
     "VeraConfig": lambda host: VeraConfig(embodiment="pusht", host=host, server_port=65536),
     "ReachyMiniDriver": _reachy_mini_both_halves,
 }
-
-
-def _reachy_mini_both_halves(host: Any) -> None:
-    """Construct the driver with both halves of its daemon address unusable."""
-    from tests.test_reachy_mini_driver import _force_real_device_connect_edge
-
-    _force_real_device_connect_edge()
-    from strands_robots.device_connect.reachy_mini_driver import ReachyMiniDriver
-
-    ReachyMiniDriver(host=host, api_port=65536)
 
 
 @pytest.mark.parametrize("surface", sorted(BOTH_HALVES_UNUSABLE))

--- a/tests/test_dial_host_is_graded_wherever_the_port_is.py
+++ b/tests/test_dial_host_is_graded_wherever_the_port_is.py
@@ -448,7 +448,7 @@ BOTH_HALVES_UNUSABLE: dict[str, Any] = {
     "RemotePolicy": lambda host: RemotePolicy(host=host, port=65536),
     "Cosmos3Policy": lambda host: Cosmos3Policy(embodiment="droid", host=host, port=65536),
     "VeraConfig": lambda host: VeraConfig(embodiment="pusht", host=host, server_port=65536),
-    "ReachyMiniDriver": lambda host: _reachy_mini_both_halves(host),
+    "ReachyMiniDriver": _reachy_mini_both_halves,
 }
 
 

--- a/tests/test_reachy_dial_host_domain.py
+++ b/tests/test_reachy_dial_host_domain.py
@@ -1,0 +1,270 @@
+"""``ReachyMiniDriver``'s ``host`` is the shared dialled-host domain.
+
+The port half of the address this driver dials is held to a shared domain, for
+the reason :mod:`tests.test_reachy_api_port_domain` records: nothing downstream
+refuses it, so an unusable port is reported as an unreachable daemon. ``host`` is
+interpolated into the same expression - ``http://<host>:<api_port>`` in
+:func:`strands_robots.device_connect.reachy_transport.api`, and
+``ws://<host>:<api_port>/ws/sdk`` in ``WebSocketLink`` - and was held to nothing.
+
+The host half is the stronger case, because it can discard the guarded port:
+
+* A URI delimiter re-cuts the URL and the validated port is the component it
+  takes. ``host="127.0.0.1/foo"`` builds ``http://127.0.0.1/foo:8000/...``, which
+  resolves as host ``127.0.0.1`` with the port in the path, so the driver dials
+  :80 - a port nobody configured. The port domain cannot see this, because it is
+  the host half that discards the port.
+* Userinfo redirects the dial outright: ``"bot.local@evil.example"`` resolves to
+  ``evil.example`` on the configured port.
+* A non-string is carried verbatim, so ``None`` reaches the resolver as the DNS
+  name ``"none"`` and is reported in the device identity as
+  ``"Reachy Mini @ None"``.
+
+``TestWhyTheConstructorOwnsTheDomain`` pins those premises rather than asserting
+them in prose; they hold on either tree, and they are what makes the constructor
+the right owner. What this surface shares with the policy clients that dial the
+same shape - that each unusable spelling is refused, that the refusal names the
+host, and that a caller who gets both halves wrong is told about the host and not
+the port it would have discarded - is pinned for all of them together in
+:mod:`tests.test_dial_host_is_graded_wherever_the_port_is` rather than restated
+here. The documented fail-safe that reads an unreachable daemon as the
+Wireless variant is deliberately unchanged - a daemon that is down is not a
+caller mistake.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import pytest
+
+import strands_robots
+from strands_robots.utils import dial_host_error
+from tests.test_reachy_api_port_domain import _exported_names
+from tests.test_reachy_mini_driver import _force_real_device_connect_edge
+
+# Values that cannot address the host half of the daemon URL, with what each one
+# does when interpolated into it anyway.
+UNUSABLE_HOSTS: list[Any] = [
+    "127.0.0.1/foo",  # path takes the validated port; dials :80
+    "bot.local?x=1",  # query delimiter, same discard
+    "http://bot.local",  # a pasted URI resolves to host "http"
+    "bot.local@evil.example",  # userinfo: resolves to evil.example
+    "bot.local:9999",  # a second port in the host half
+    "",  # names no host at all
+    "bot\tlocal",  # tab silently dropped by the resolver
+    "bot.local\x00",  # NUL truncates the lookup
+    None,  # carried verbatim as the DNS name "none"
+    8000,
+    ["bot.local"],
+]
+
+# Every spelling a Reachy Mini is actually reached by must keep working.
+USABLE_HOSTS = ["reachy-mini.local", "192.168.1.42", "localhost", "0.0.0.0", "[::1]"]
+
+# The values whose delimiter discards the guarded port, and the host each one
+# leaves the client dialling instead.
+PORT_DISCARDING_HOSTS = [("127.0.0.1/foo", "127.0.0.1"), ("bot.local?x=1", "bot.local"), ("http://bot.local", "http")]
+
+
+@pytest.fixture
+def rmd():
+    """The reachy_mini_driver module bound to the real device_connect_edge."""
+    _force_real_device_connect_edge()
+    import strands_robots.device_connect.reachy_mini_driver as module
+
+    return module
+
+
+class TestDialHostDomain:
+    """The constructor accepts exactly the hosts the shared domain accepts."""
+
+    @pytest.mark.parametrize("host", USABLE_HOSTS)
+    def test_a_usable_host_is_accepted_and_stored(self, rmd, host):
+        """Every host a Mini is reached by still constructs, carried verbatim."""
+        assert rmd.ReachyMiniDriver(host=host)._host == host
+
+    def test_the_default_host_is_usable(self, rmd):
+        """The documented default must satisfy the domain it now enforces."""
+        assert rmd.ReachyMiniDriver()._host == "reachy-mini.local"
+
+    @pytest.mark.parametrize("host", UNUSABLE_HOSTS + USABLE_HOSTS, ids=repr)
+    def test_the_accepted_domain_is_the_shared_dial_host_domain(self, rmd, host):
+        """The driver refuses a host iff the shared domain refuses it.
+
+        Asserted as an equivalence so the two cannot drift: the same value must
+        not be refused by one surface that dials a service and accepted by the
+        next.
+        """
+        shared_refuses = dial_host_error(host, "host", "ReachyMiniDriver") is not None
+        try:
+            rmd.ReachyMiniDriver(host=host)
+            driver_refuses = False
+        except ValueError:
+            driver_refuses = True
+        assert driver_refuses is shared_refuses
+
+
+class TestWhyTheConstructorOwnsTheDomain:
+    """Premises for the guard's placement. These hold on either tree."""
+
+    @pytest.mark.parametrize(("host", "resolved"), PORT_DISCARDING_HOSTS)
+    def test_a_delimiter_in_the_host_discards_the_validated_port(self, host, resolved):
+        """The guarded port lands in the path, so the client dials :80.
+
+        This is why the port domain beside it cannot cover this: the port it
+        validated is not the port that gets dialled.
+        """
+        url = urlsplit(f"http://{host}:8000/api/daemon/status")
+        assert url.hostname == resolved
+        assert url.port is None
+
+    def test_userinfo_in_the_host_redirects_the_dial(self):
+        """The authority is what follows ``@``, so another host is reached."""
+        assert urlsplit("http://bot.local@evil.example:8000/api/daemon/status").hostname == "evil.example"
+
+    @pytest.mark.parametrize("host", ["127.0.0.1/foo", None, 8000], ids=repr)
+    def test_the_daemon_url_interpolates_the_host_verbatim(self, monkeypatch, host):
+        """``api`` builds ``http://<host>:port/path`` with no coercion."""
+        from strands_robots.device_connect import reachy_transport
+
+        captured: list[str] = []
+
+        def spy(req, body=None, timeout=None, **kwargs):
+            captured.append(req.full_url)
+            raise urllib.error.URLError("test: never dialed")
+
+        monkeypatch.setattr(urllib.request, "urlopen", spy)
+        reachy_transport.api(host, 8000, "/api/daemon/status")
+        assert captured == [f"http://{host}:8000/api/daemon/status"]
+
+    def test_the_websocket_target_carries_the_same_value(self):
+        """The Lite link interpolates the host into its own ``ws://`` target."""
+        from strands_robots.device_connect import reachy_transport
+
+        assert reachy_transport.WebSocketLink("127.0.0.1/foo", 8000)._host == "127.0.0.1/foo"
+
+
+class TestTheRefusalPrecedesAnyState:
+    """A refused host allocates nothing and reaches nothing."""
+
+    def test_a_refused_host_allocates_no_base_driver_state(self, rmd, monkeypatch):
+        """The guard runs before ``DeviceDriver.__init__``."""
+        calls: list[int] = []
+        original = rmd.DeviceDriver.__init__
+
+        def recording_init(self, *args: Any, **kwargs: Any) -> None:
+            calls.append(1)
+            original(self, *args, **kwargs)
+
+        monkeypatch.setattr(rmd.DeviceDriver, "__init__", recording_init)
+
+        with pytest.raises(ValueError):
+            rmd.ReachyMiniDriver(host="127.0.0.1/foo")
+        assert calls == []
+
+        rmd.ReachyMiniDriver(host="bot.local")
+        assert calls == [1]
+
+    def test_a_usable_host_still_probes_the_daemon(self, rmd, monkeypatch):
+        """Control: the probe the guard protects still runs unchanged."""
+        urls: list[str] = []
+
+        def spy(req, body=None, timeout=None, **kwargs):
+            urls.append(req.full_url)
+            raise urllib.error.URLError("test: never dialed")
+
+        class _FakeZenoh:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            async def start(self, **kwargs: Any) -> None:
+                return None
+
+        monkeypatch.setattr(urllib.request, "urlopen", spy)
+        monkeypatch.setattr(rmd, "ZenohLink", _FakeZenoh)
+
+        asyncio.run(rmd.ReachyMiniDriver(host="bot.local", api_port=9001).connect())
+        assert urls == ["http://bot.local:9001/api/daemon/status"]
+
+
+def _exported_host_constructors(source: str, exported: list[str]) -> dict[str, list[str]]:
+    """Map each exported class to the host-ish ``__init__`` params it declares.
+
+    Scoped to classes the package exports, for the same reason the port scan is:
+    the hardware links are built only from an already-validated host, so making
+    them re-check it would institutionalize a second copy of the rule.
+    """
+    found: dict[str, list[str]] = {}
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.ClassDef) or node.name not in exported:
+            continue
+        for member in node.body:
+            if not isinstance(member, ast.FunctionDef) or member.name != "__init__":
+                continue
+            hosts = [
+                arg.arg
+                for arg in member.args.args + member.args.kwonlyargs
+                if arg.arg == "host" or arg.arg.endswith("_host")
+            ]
+            if hosts:
+                found[node.name] = hosts
+    return found
+
+
+def _validates_host(source: str, class_name: str) -> bool:
+    """True when the class's ``__init__`` calls the shared host domain."""
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for member in node.body:
+                if isinstance(member, ast.FunctionDef) and member.name == "__init__":
+                    return any(
+                        isinstance(call, ast.Call)
+                        and isinstance(call.func, ast.Name)
+                        and call.func.id == "dial_host_error"
+                        for call in ast.walk(member)
+                    )
+    return False
+
+
+class TestNoExportedDeviceConnectHostSurfaceDrifts:
+    """Every exported driver that takes a host routes it through one domain.
+
+    The port half already has this scan; it matches ``port``/``*_port`` only, so
+    it could not see the host beside it. This is that scan for the other half.
+    """
+
+    def _surfaces(self) -> dict[str, tuple[Path, list[str]]]:
+        package = Path(strands_robots.__file__).parent / "device_connect"
+        exported = _exported_names(package / "__init__.py")
+        surfaces: dict[str, tuple[Path, list[str]]] = {}
+        for module in sorted(package.rglob("*.py")):
+            source = module.read_text(encoding="utf-8")
+            for class_name, hosts in _exported_host_constructors(source, exported).items():
+                surfaces[class_name] = (module, hosts)
+        return surfaces
+
+    def test_the_scan_finds_the_known_host_surface(self):
+        """Non-vacuity: a scan resolving elsewhere would report nothing."""
+        assert {name: hosts for name, (_, hosts) in self._surfaces().items()} == {"ReachyMiniDriver": ["host"]}
+
+    def test_every_exported_host_constructor_validates_it(self):
+        """A future exported driver cannot dial a host unvalidated."""
+        adrift = {
+            name: hosts
+            for name, (module, hosts) in self._surfaces().items()
+            if not _validates_host(module.read_text(encoding="utf-8"), name)
+        }
+        assert adrift == {}, f"exported constructors taking a host without the shared domain: {adrift}"
+
+    def test_the_scan_detects_a_planted_unguarded_host(self):
+        """Meta: an empty result must mean clean sources, not a dead scanner."""
+        planted = 'class Planted:\n    def __init__(self, host: str = "bot.local"):\n        self._h = host\n'
+        assert _exported_host_constructors(planted, ["Planted"]) == {"Planted": ["host"]}
+        assert not _validates_host(planted, "Planted")


### PR DESCRIPTION
`ReachyMiniDriver.__init__` grades two of the three values it takes — `api_port` through the shared `tcp_port_error` domain, `prefix` through the key-prefix rule — and stored `host` unchecked. All of them are interpolated into targets the module builds itself: `http://<host>:<api_port><path>` in `reachy_transport.api`, and `ws://<host>:<api_port>/ws/sdk` in `WebSocketLink`.

![host verdicts before and after, and the same address across every surface that builds one](https://raw.githubusercontent.com/cagataycali/robots/f1f296b38fb811dd893113398c10d0a9b5e468d8/reachy-dial-host-domain.png)

## The host half is what discards the port half

Grading the port alone is not enough, because a delimiter in the host takes the port away — measured against `urllib`, with `api_port=8000` validated in both trees:

| `host` | resolves as | port dialled |
|---|---|---|
| `"127.0.0.1/foo"` | `127.0.0.1` | **`:80`** — the validated port is in the *path* |
| `"bot.local?x=1"` | `bot.local` | **`:80`** |
| `"http://bot.local"` | `http` | **`:80`** |
| `"bot.local@evil.example"` | **`evil.example`** | `:8000` |
| `None` | `none` (a DNS name) | `:8000` |

None of these were refused downstream. `api` reports every failure as an `{"error": ...}` result rather than raising, so an unusable host surfaced as an unreachable daemon — byte-identical to a reachable host with the daemon down — and `connect()` then read that result as the Wireless variant and logged a successful Zenoh connection. The device identity reported `Reachy Mini @ None`.

That is the argument the `api_port` guard beside it already records in a comment ("an unusable port is reported as an unreachable daemon … naming the port is the only point a caller can act on"), and it holds for the host with the port-discard on top.

## Change

`host` now takes the shared `dial_host_error` domain, **before** the port: the delimiter in the host is what re-cuts the URL, so reporting the port to a caller who got both halves wrong would name the component that was discarded rather than the one that discarded it. That ordering rule is the one the existing cross-surface pin already states for the three policy clients; the driver now honours it too. The refusal precedes `DeviceDriver.__init__`, so a refused address allocates nothing.

This driver is added to `tests/test_dial_host_is_graded_wherever_the_port_is.py` as a fourth surface rather than getting its own copy of those cells, so one address cannot be refused by a policy client and dialled by a driver. Its stale "two of the three surfaces" wording is corrected in the same change. Pre-fix, that file's cross-surface cell reports the split exactly:

```
host='127.0.0.1/foo' split the surfaces:
  {'RemotePolicy': False, 'Cosmos3Policy': False, 'VeraConfig': False, 'ReachyMiniDriver': True}
```

`tests/test_reachy_dial_host_domain.py` keeps only what is specific to this surface: the equivalence with the shared domain, the premises (the daemon URL interpolates the host verbatim, the delimiter discards the port, userinfo redirects the dial, the Lite link carries the same value), that the refusal precedes any state, and a drift scan for the *host* half of exported `device_connect` constructors — the sibling port scan matches `port`/`*_port` only, which is why the host beside it stayed ungraded.

## Nothing that addressed a Mini changes

`reachy-mini.local` (the documented default), `192.168.1.42`, `localhost`, `0.0.0.0` and `[::1]` are all still accepted — 0 of 5 narrowed. The documented fail-safe that treats an unreachable daemon as the Wireless variant is unchanged: a daemon that is down is not a caller mistake.

## Verification

Four corners over the 67-module affected net (`dial_host_error|reachy|device_connect`):

| | prod | tests | result |
|---|---|---|---|
| A | fixed | new | 3F / 4282P |
| B | pre-fix | new | **45F** / 4240P — 42 new red cells |
| C | fixed | pre-fix | 3F / 4214P |
| D | pre-fix | pre-fix | 3F / 4214P |

`4214 + 68 = 4282`; A ≡ C ≡ D failure-name lists are identical, and the 3 are standing on a clean `upstream/main` worktree (2 `device_connect_hardening` mock-interplay, 1 `docs_arm_compatibility_notes` lerobot registry drift). C ≡ D shows the fix required no existing test to change. `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`; mypy unchanged at its 20 standing errors (`examples/isaac_gs`, `simulation/ik.py`), none in the touched files.

LOC: +394 / −18, of which 270 is the new pin and 29 the changelog fragment; production is +39 / −11 (the guard plus the comment recording why it is there and why it is first).

## Review rounds

**Round 1** (`3f731e5`) — CodeQL `py/unnecessary-lambda` on the `ReachyMiniDriver` entry of `BOTH_HALVES_UNUSABLE`: the lambda wrapper was replaced with a direct reference to `_reachy_mini_both_halves`. Test-file-only.

**Round 2** (`88a62eb`) — that replacement introduced a `NameError` at module import: the lambda had deferred the name lookup to call time, and the bare reference is resolved when the dict literal is evaluated, four lines above the `def`. The module failed collection, `ruff` reported `F821`, and the required check went red on `3f731e5`. The `def` now precedes the dict, matching how `_reachy_mini_refusal` is defined ahead of `WEBSOCKET_SURFACES` in the same file. No cell changes. Root cause of the round-1 miss: the CodeQL fix was verified through a selected cell rather than by importing the module, so a module-exec-time failure never ran.