### PR TITLE
test(simulation): the GL-free half of the construct-then-spend case keeps running

### DIFF
--- a/changelog.d/3288-gl-free-half-of-the-construct-then-spend-case.md
+++ b/changelog.d/3288-gl-free-half-of-the-construct-then-spend-case.md
@@ -1,0 +1,17 @@
+### Tests: the GL-free half of the engine default-resolution case keeps running
+
+`test_every_engine_that_constructs_can_be_rendered_and_observed` was gated whole
+on the shared MuJoCo GL probe, and one of its assertions needs no OpenGL context:
+`create_world` copies the constructor's `default_width` onto the free camera's
+`SimCamera` entry, and that entry reads back the same value on a host with none.
+That copy is the second way into the field `add_camera` guards - the surface the
+domain was added for - so gating it together with the render left it unchecked
+exactly where `tests/simulation/mujoco/_gl_probe` records that GL-backed
+contracts used to go unverified. Measured by breaking only that propagation and
+counting the cells that fire: under `MUJOCO_GL=egl` the gated case reports 1 and
+the split reports 2; under MuJoCo's documented `MUJOCO_GL=disable` the gated case
+reports 0 and the split reports 1. The case is now two - the value the
+constructor stored, which runs wherever the suite runs, and `render` /
+`get_observation`, which stay behind the probe because `MUJOCO_GL=disable`
+reports `{"status": "error"}` for the first and omits the image key for the
+second, so reading it raises `KeyError: 'default'`.

--- a/tests/simulation/test_camera_pixel_count_domain.py
+++ b/tests/simulation/test_camera_pixel_count_domain.py
@@ -76,7 +76,7 @@ from __future__ import annotations
 import ast
 import inspect
 import types
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -757,6 +757,37 @@ def _isaac_construct(**kwargs: Any) -> Any:
     return IsaacSimulation(**kwargs)
 
 
+def _stored_width(engine: Any) -> Any:
+    """The default width as the engine *stored* it, on the free camera's entry."""
+    return engine._world.cameras["default"].width
+
+
+def _constructible_defaults() -> Iterator[tuple[Any, Any]]:
+    """Yield ``(engine, candidate)`` for every default dimension that constructs.
+
+    One owner for the candidate roster, the world build and the teardown, shared
+    by the two halves of "nothing that builds is unusable later" - the value the
+    constructor stored, which needs no GL context, and spending it on a render,
+    which does. Each half pins the same non-vacuity floor over what this yields,
+    so neither can go quietly vacuous if the roster changes.
+
+    ``5000`` is excluded from the roster rather than skipped inside it: it is
+    above MuJoCo's *offscreen framebuffer* cap, which is a property of the
+    compiled model and stays a render-time check - the shared rule is a floor,
+    as ``test_the_shared_rule_is_a_floor_and_not_a_ceiling`` pins.
+    """
+    for candidate in (*_BAD_DIMS, 1, 16, 640):
+        try:
+            sim = _mujoco_engine(default_width=candidate, default_height=480)
+        except ValueError:
+            continue
+        try:
+            sim.create_world(gravity=[0, 0, -9.81])
+            yield sim, candidate
+        finally:
+            sim.cleanup()
+
+
 #: The three constructors that own the same pair of numbers, keyed by the class
 #: named in the refusal. Newton is reachable here without ``newton`` / ``warp``
 #: because the guard precedes ``ensure_newton()`` - deliberately, so a caller
@@ -841,37 +872,47 @@ class TestTheEngineDefaultResolution:
             legacy = _construction_verdict("default_width", lambda bad=bad: _isaac_construct(default_width=bad))
             assert canonical == legacy == "refused", f"{bad!r}: canonical={canonical}, legacy={legacy}"
 
+    def test_every_default_that_constructs_reaches_the_camera_registry(self):
+        """Half one of "nothing that builds is unusable later": the value stored.
+
+        This is the second way into the field ``add_camera`` guards, and the one
+        this change is about: ``create_world`` copies the constructor's default
+        onto the free camera's ``SimCamera`` entry. It needs no GL context - the
+        entry reads back the same on a host with none - so it is its own case
+        rather than part of the gated one below, and goes on being checked
+        wherever the suite runs. Read back from the registry and not from the
+        attribute the caller passed: a value that round-tripped through the
+        attribute without reaching the camera entry would satisfy an attribute
+        check and leave that second way open.
+        """
+        pytest.importorskip("mujoco")
+        exercised = [candidate for sim, candidate in _constructible_defaults() if _stored_width(sim) == candidate]
+        assert exercised == [1, 16, 640], exercised
+
     @requires_gl
-    def test_every_engine_that_constructs_can_be_rendered_and_observed(self):
-        """The point of refusing here: nothing that builds is unusable later.
+    def test_every_default_that_constructs_can_be_rendered_and_observed(self):
+        """Half two: the stored value is spendable, which is what refusing buys.
 
         Runs the real MuJoCo engine, because the pre-fix failures were all
-        downstream of construction. ``5000`` is excluded rather than skipped: it
-        is above MuJoCo's *offscreen framebuffer* cap, which is a property of
-        the compiled model and stays a render-time check - the shared rule is a
-        floor, as ``test_the_shared_rule_is_a_floor_and_not_a_ceiling`` pins.
+        downstream of construction.
 
         Gated on the shared GL probe: ``render`` and ``get_observation`` both
         need an offscreen context, and on a headless host without EGL/OSMesa
-        they report an error that names neither GL nor this contract.
+        they report an error that names neither GL nor this contract. Measured
+        under MuJoCo's documented ``MUJOCO_GL=disable``: ``render`` reports
+        ``{"status": "error"}`` carrying "Rendering unavailable (no OpenGL
+        context)", and ``get_observation`` omits the image key altogether, so
+        reading it raises ``KeyError: 'default'`` - naming this contract even
+        less than the bare ``'error' != 'success'`` the probe exists to prevent.
         """
         pytest.importorskip("mujoco")
         exercised = []
-        for candidate in (*_BAD_DIMS, 1, 16, 640):
-            try:
-                sim = _mujoco_engine(default_width=candidate, default_height=480)
-            except ValueError:
-                continue
-            try:
-                sim.create_world(gravity=[0, 0, -9.81])
-                assert sim._world.cameras["default"].width == candidate
-                assert sim.render()["status"] == "success"
-                sim.add_robot(name="so101")
-                image = sim.get_observation(robot_name="so101")["default"]
-                assert isinstance(image, np.ndarray)
-                assert image.shape == (480, candidate, 3)
-            finally:
-                sim.cleanup()
+        for sim, candidate in _constructible_defaults():
+            assert sim.render()["status"] == "success"
+            sim.add_robot(name="so101")
+            image = sim.get_observation(robot_name="so101")["default"]
+            assert isinstance(image, np.ndarray)
+            assert image.shape == (480, candidate, 3)
             exercised.append(candidate)
         assert exercised == [1, 16, 640], exercised
 


### PR DESCRIPTION
Follow-up to #3285. `test_every_engine_that_constructs_can_be_rendered_and_observed` is gated whole on the shared MuJoCo GL probe, and one of its assertions needs no OpenGL context at all.

That assertion is the one the domain was added for. `create_world` copies the constructor's `default_width` onto the free camera's `SimCamera` entry - the second way into the field `add_camera` guards, and the reason a constructor default was not inert. It reads back the same value on a host with no context, so gating it together with the render stops it being checked there.

## The measurement

Break only that propagation - build the free camera's entry from a literal instead of `self.default_width`, leaving the `default_width` attribute intact - and count the cells that fire:

| | `MUJOCO_GL=egl` | `MUJOCO_GL=disable` |
| --- | --- | --- |
| `main` (case gated whole) | 1 | **0** |
| this branch (split) | 2 | **1** |

On a host with no GL, breaking the constructor-to-registry copy currently goes unnoticed. `tests/simulation/mujoco/_gl_probe` was written against exactly that outcome: a blunt gate meant "GL-backed contracts ... went unverified anywhere `CI` was set unless a human remembered to export `ROBOT_TEST_MUJOCO=1`". The probe fixed that for the assertions that need a context; this restores it for the one that does not.

## What stays behind the gate, and why

```mermaid
graph LR
  A["engine constructs at width W"] --> B["free camera SimCamera entry == W"]
  A --> C["render() status == success"]
  A --> D["observation image shape == (480, W, 3)"]
  B -.->|"no GL context needed"| E["runs wherever the suite runs"]
  C -.->|"needs a context"| F["@requires_gl"]
  D -.->|"needs a context"| F
```

Both gated assertions genuinely need a context, measured under MuJoCo's documented `MUJOCO_GL=disable`:

| surface | `MUJOCO_GL=egl` | `MUJOCO_GL=disable` |
| --- | --- | --- |
| free camera registry entry | `640` | `640` |
| `render()` | `{"status": "success"}` | `{"status": "error"}`, `"Rendering unavailable (no OpenGL context)"` |
| `get_observation()` image key | present, `(480, 640, 3)` | **absent** - reading it raises `KeyError: 'default'` |

The `get_observation` row is worth naming: the guard in `tests/test_mujoco_render_assertions_are_gl_gated.py` matches `render*(...)["status"] == "success"` and cannot see an image read, so that assertion needed the same gate for a reason nothing reports. It keeps it.

## Change

The case becomes two, and `_constructible_defaults` owns the candidate roster, the world build and the teardown for both. Each half asserts the same `[1, 16, 640]` floor over what that yields, so neither can go vacuous if the roster changes. `5000` stays excluded there rather than skipped inside a loop - it is above MuJoCo's offscreen framebuffer cap, which is a property of the compiled model and stays a render-time check.

The gate and the `EXPECTED_IN_SCOPE` entry from #3285 are unchanged, as is its relative import of the probe.

## Tests

Both halves still fail on pre-fix production code (the three constructors reverted to their state before #3285), so the split costs no regression coverage:

| half | verdict against pre-#3285 production |
| --- | --- |
| `..._reaches_the_camera_registry` | `AssertionError: [0, -4, -1, 2.7, 640.0, True, ...]` - the bad values construct and reach the registry |
| `..._can_be_rendered_and_observed` | `AssertionError: assert 'error' == 'success'` |

And on a host with no GL the split behaves as intended: `test_every_default_that_constructs_reaches_the_camera_registry` PASSED, `test_every_default_that_constructs_can_be_rendered_and_observed` SKIPPED with the skip naming the missing context.

Gate: `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` `Success: no issues found in 1920 source files`. The subject file plus its whole-tree guard: 493 passed under `MUJOCO_GL=egl`, 492 passed / 1 skipped under `MUJOCO_GL=disable`. The 471 test modules that walk the tree or read source - the population that contains this guard, and which a path-scoped run does not collect - report 6 failed / 24739 passed, the 6 being `rclpy` resolving where four cells assert it is absent and an installed `websockets` 16.0 under the declared `>=17.0` floor; identical node ids on a pristine `main` worktree, both `comm` directions empty.

## Size

| | added | removed | of which executable |
| --- | --- | --- | --- |
| `tests/simulation/test_camera_pixel_count_domain.py` | 64 | 23 | +11 statements (380 -> 391 by AST) |
| changelog fragment | 17 | 0 | - |

One new case: the file collects 479 cells on `main` and 480 here. Test-only; no production line moves.