### PR TITLE
test(simulation): the GL gate on a render test has one owner

### DIFF
--- a/changelog.d/3289-one-owner-for-the-render-test-gl-gate.md
+++ b/changelog.d/3289-one-owner-for-the-render-test-gl-gate.md
@@ -1,0 +1,19 @@
+### Tests: a render test's GL gate is the shared probe's marker, not a local rebuild
+
+`ROBOT_TEST_MUJOCO=0` is the force-skip an operator sets to keep a known-bad
+runner from attempting GL at all -- the host class where a second offscreen
+renderer construction aborts the interpreter uncatchably instead of raising. It
+is read by `tests/simulation/mujoco/_gl_probe.gl_available` and by nothing else,
+so the 17 modules that rebuilt the gate locally from the private
+`strands_robots.simulation.mujoco.backend._can_render` never saw it: with the
+variable set, 56 GL-dependent cases across those modules still ran and
+constructed renderers. Those gates were also invisible to the render-gating scan
+in `tests/test_mujoco_render_assertions_are_gl_gated.py`, which recognises
+gating through the shared probe, so a render assertion added to any of them
+would have been reported as ungated.
+
+All 17 now take `requires_gl` from the shared probe, and
+`tests/test_the_gl_gate_on_a_render_test_has_one_owner.py` keeps it that way:
+exactly one module in the tree may build a GL-gating skip marker. Reading
+`_can_render` is unchanged and unreported -- its own contract tests do that; the
+discriminator is building a second gate out of it.

--- a/tests/simulation/mujoco/test_concurrency.py
+++ b/tests/simulation/mujoco/test_concurrency.py
@@ -23,13 +23,8 @@ import pytest
 
 mj = pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (headless without EGL/OSMesa)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 # Test robot XML (simple 3-DOF arm)
 

--- a/tests/simulation/mujoco/test_engine_locking_discipline.py
+++ b/tests/simulation/mujoco/test_engine_locking_discipline.py
@@ -32,13 +32,8 @@ import pytest
 mj = pytest.importorskip("mujoco")
 
 from strands_robots.policies.base import Policy  # noqa: E402
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (headless without EGL/OSMesa)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 _ARM_XML = """
 <mujoco model="lock_arm">

--- a/tests/simulation/mujoco/test_error_paths.py
+++ b/tests/simulation/mujoco/test_error_paths.py
@@ -24,12 +24,8 @@ import pytest
 mj = pytest.importorskip("mujoco")
 
 os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No GL context available (headless CI without EGL/OSMesa)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 # Inline robot XML - avoids network dependency on robot model repos
 _ROBOT_XML = """

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -9,14 +9,8 @@ import pytest
 pytest.importorskip("mujoco")
 import numpy as np  # noqa: E402
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No GL context available (headless CI without EGL/OSMesa)",
-)
-
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 
 @pytest.fixture

--- a/tests/simulation/mujoco/test_randomize_forwards_derived_state.py
+++ b/tests/simulation/mujoco/test_randomize_forwards_derived_state.py
@@ -22,13 +22,8 @@ import pytest
 
 mj = pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (headless without EGL/OSMesa)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/simulation/mujoco/test_recording_backends.py
+++ b/tests/simulation/mujoco/test_recording_backends.py
@@ -15,13 +15,9 @@ import pytest
 
 pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No GL context available (headless CI without EGL/OSMesa)",
-)
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 
 @pytest.fixture

--- a/tests/simulation/mujoco/test_renderer_hygiene.py
+++ b/tests/simulation/mujoco/test_renderer_hygiene.py
@@ -6,14 +6,8 @@ from __future__ import annotations
 
 import pytest
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No GL context available (headless CI without EGL/OSMesa)",
-)
-
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 
 @pytest.fixture

--- a/tests/simulation/mujoco/test_reset_forwards_derived_state.py
+++ b/tests/simulation/mujoco/test_reset_forwards_derived_state.py
@@ -20,13 +20,8 @@ import pytest
 
 mj = pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (headless without EGL/OSMesa)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/simulation/mujoco/test_set_obs_noise.py
+++ b/tests/simulation/mujoco/test_set_obs_noise.py
@@ -28,13 +28,8 @@ import pytest
 
 mj = pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (headless without EGL/OSMesa)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -21,14 +21,8 @@ import pytest
 mj = pytest.importorskip("mujoco")
 
 from strands_robots.simulation.mujoco import backend as backend_mod  # noqa: E402
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (headless without EGL/OSMesa)",
-)
-
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 # Test robot XML
 

--- a/tests/simulation/test_eval_policy_video.py
+++ b/tests/simulation/test_eval_policy_video.py
@@ -14,14 +14,9 @@ import pytest
 pytest.importorskip("mujoco")
 
 from strands_robots.simulation.benchmark import BenchmarkProtocol, StepInfo  # noqa: E402
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 from strands_robots.simulation.policy_runner import PolicyRunner  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (EGL/OSMesa required for offscreen rendering)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 ARM_XML = """
 <mujoco model="arm">

--- a/tests/simulation/test_evaluate_benchmark_video.py
+++ b/tests/simulation/test_evaluate_benchmark_video.py
@@ -26,13 +26,8 @@ from strands_robots.simulation.benchmark import (  # noqa: E402
     register_benchmark,
     unregister_benchmark,
 )
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (EGL/OSMesa required for offscreen rendering)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 ARM_XML = """
 <mujoco model="arm">

--- a/tests/simulation/test_recording_episode_loss_is_not_tolerated.py
+++ b/tests/simulation/test_recording_episode_loss_is_not_tolerated.py
@@ -42,9 +42,9 @@ pytest.importorskip("mujoco")
 from strands_robots.dataset_recorder import DatasetRecorder
 from strands_robots.policies.mock import MockPolicy
 from strands_robots.simulation.benchmark import BenchmarkProtocol, StepInfo
-from strands_robots.simulation.mujoco.backend import _can_render
 from strands_robots.simulation.mujoco.simulation import Simulation
 from strands_robots.simulation.policy_runner import PolicyRunner
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 _FEATURES: dict[str, Any] = {
     "observation.state": {"dtype": "float32", "names": ["1", "2", "3", "4", "5", "6"]},
@@ -118,9 +118,6 @@ def _recording_sim(recorder: Any) -> Simulation:
     sim._world._backend_state["trajectory"] = []
     sim._world._backend_state["dataset_recorder"] = recorder
     return sim
-
-
-requires_gl = pytest.mark.skipif(not _can_render(), reason="No OpenGL context (EGL/OSMesa) for offscreen rendering")
 
 
 def _policy(sim: Simulation) -> MockPolicy:

--- a/tests/simulation/test_renderer_cache_eviction.py
+++ b/tests/simulation/test_renderer_cache_eviction.py
@@ -29,13 +29,8 @@ pytest.importorskip("mujoco")
 
 import mujoco as mj  # noqa: E402
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (EGL/OSMesa required for offscreen rendering)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 ARM_XML = """
 <mujoco model="arm">

--- a/tests/simulation/test_rollout_video_reports_the_rate_it_wrote.py
+++ b/tests/simulation/test_rollout_video_reports_the_rate_it_wrote.py
@@ -22,13 +22,8 @@ import pytest
 pytest.importorskip("imageio")
 pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (EGL/OSMesa required for offscreen rendering)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 ARM_XML = """
 <mujoco model="arm">

--- a/tests/simulation/test_video_camera_validation.py
+++ b/tests/simulation/test_video_camera_validation.py
@@ -14,13 +14,8 @@ import pytest
 
 pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (EGL/OSMesa required for offscreen rendering)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 ARM_XML = """
 <mujoco model="arm">

--- a/tests/simulation/test_video_config_validation.py
+++ b/tests/simulation/test_video_config_validation.py
@@ -20,14 +20,9 @@ import pytest
 
 pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 from strands_robots.simulation.policy_runner import VideoConfig  # noqa: E402
-
-requires_gl = pytest.mark.skipif(
-    not _can_render(),
-    reason="No OpenGL context available (EGL/OSMesa required for offscreen rendering)",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 ARM_XML = """
 <mujoco model="arm">

--- a/tests/test_the_gl_gate_on_a_render_test_has_one_owner.py
+++ b/tests/test_the_gl_gate_on_a_render_test_has_one_owner.py
@@ -1,0 +1,174 @@
+"""A render test's GL gate must be the shared probe's marker, not a local rebuild.
+
+:mod:`tests.simulation.mujoco._gl_probe` owns the answer to "can this host render
+offscreen" for the test suite. Its marker honours ``ROBOT_TEST_MUJOCO=0``, the
+force-skip an operator sets "to keep a known-bad runner from attempting GL at
+all" - the host class where a second renderer construction aborts the
+interpreter uncatchably rather than raising.
+
+A module that rebuilds the gate locally from
+``strands_robots.simulation.mujoco.backend._can_render`` answers the same
+question by a different route, and that route has no force-skip: the variable is
+read by :func:`gl_available` and by nothing else, so a module holding its own
+marker attempts GL on the runner that opted out. It also reaches into a private
+production symbol for a test-harness concern, and it is invisible to
+:mod:`tests.test_mujoco_render_assertions_are_gl_gated`, whose scan recognises
+gating through the shared probe and would report such a module's render
+assertion as ungated.
+
+So the rule is one owner: exactly one module in the tree may build a GL-gating
+skip marker, and it is the probe. The force-skip half is pinned where it lives -
+``tests/simulation/mujoco/test_gl_probe.py::test_robot_test_mujoco_zero_forces_no_gl``
+pins that the shared marker honours the variable - and composes with this rule to
+cover every gated render test in the tree. One case here measures that
+composition end to end through a child pytest, because the marker's condition is
+evaluated at import time and no in-process assertion can observe it.
+
+Reading ``_can_render`` is not itself the defect and is not reported:
+``tests/simulation/mujoco/test_backend.py`` and
+``tests/simulation/mujoco/test_software_render_warning.py`` are its contract
+tests. The discriminator is building a skip marker out of it.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+#: Names that answer "can this host render offscreen". A ``skipif`` condition
+#: mentioning one of these is a GL gate whichever spelling it uses.
+GL_CAPABILITY_NAMES = frozenset({"_can_render", "gl_available"})
+
+#: The single module allowed to build a GL-gating marker.
+GATE_OWNER = "tests/simulation/mujoco/_gl_probe.py"
+
+#: A module whose gate is the shared marker, used to measure the force-skip end
+#: to end. Any consolidated module would do; this one is the cheapest.
+A_GATED_MODULE = "tests/simulation/mujoco/test_renderer_hygiene.py"
+
+
+def _tests_root() -> pathlib.Path:
+    """This module's own directory - the tree the rule covers."""
+    return pathlib.Path(__file__).parent
+
+
+def gl_gating_markers(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``pytest.mark.skipif`` built from a GL probe."""
+    lines = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "skipif":
+            continue
+        condition = node.args[0] if node.args else None
+        if condition is None:
+            continue
+        for inner in ast.walk(condition):
+            if isinstance(inner, ast.Name) and inner.id in GL_CAPABILITY_NAMES:
+                lines.append(node.lineno)
+                break
+    return lines
+
+
+def survey(root: pathlib.Path) -> dict[str, list[int]]:
+    """Every module under *root* that builds a GL-gating marker, by path."""
+    found: dict[str, list[int]] = {}
+    for path in sorted(root.rglob("*.py")):
+        lines = gl_gating_markers(ast.parse(path.read_text(encoding="utf-8")))
+        if lines:
+            found[path.relative_to(root.parent).as_posix()] = lines
+    return found
+
+
+class TestOnlyTheProbeBuildsAGlGate:
+    def test_no_module_rebuilds_the_gate_locally(self) -> None:
+        rebuilt = {path: lines for path, lines in survey(_tests_root()).items() if path != GATE_OWNER}
+        assert not rebuilt, (
+            f"these modules build their own GL-gating skip marker instead of taking the shared "
+            f"one: {rebuilt}. A locally built gate does not honour ROBOT_TEST_MUJOCO=0, so it "
+            f"attempts GL on the runner that opted out, and it is invisible to the render-gating "
+            f"scan. Import requires_gl from tests.simulation.mujoco._gl_probe instead."
+        )
+
+    def test_the_probe_still_builds_the_one_gate(self) -> None:
+        """Non-vacuity: a scan that matched nothing would read as a clean tree."""
+        assert list(survey(_tests_root())) == [GATE_OWNER]
+
+
+_PLANTED_LOCAL_GATE = """
+import pytest
+
+from strands_robots.simulation.mujoco.backend import _can_render
+
+requires_gl = pytest.mark.skipif(not _can_render(), reason="no GL")
+"""
+
+_PLANTED_SHARED_GATE = """
+from tests.simulation.mujoco._gl_probe import requires_gl
+
+
+@requires_gl
+def test_planted(): ...
+"""
+
+_PLANTED_PROBE_CONTRACT_TEST = """
+from strands_robots.simulation.mujoco import backend
+
+
+def test_the_probe_reports_a_bool():
+    assert backend._can_render() in (True, False)
+"""
+
+
+class TestTheSurveyDetectsWhatItClaimsTo:
+    @pytest.mark.parametrize(
+        ("source", "reported"),
+        [
+            pytest.param(_PLANTED_LOCAL_GATE, True, id="local-gate"),
+            pytest.param(_PLANTED_SHARED_GATE, False, id="shared-gate"),
+            pytest.param(_PLANTED_PROBE_CONTRACT_TEST, False, id="probe-contract-test"),
+        ],
+    )
+    def test_the_discriminator_is_building_the_marker(
+        self, source: str, reported: bool, tmp_path: pathlib.Path
+    ) -> None:
+        """Reading the probe is fine; building a second gate out of it is not."""
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(source, encoding="utf-8")
+        assert bool(survey(root)) is reported
+
+
+class TestTheForceSkipReachesAGatedModule:
+    """The composition, measured: one owner plus a force-skip means every gate skips.
+
+    ``test_gl_probe.py`` pins that the shared marker honours the variable, and
+    the rule above pins that every gate is that marker. Nothing in-process can
+    check the two together, because a ``skipif`` condition is evaluated when the
+    module is imported - so this runs a child pytest over one gated module with
+    the variable set, which is the only place the composition is observable.
+    """
+
+    def test_a_gated_module_skips_under_the_force_skip(self) -> None:
+        root = _tests_root().parent
+        module = root / A_GATED_MODULE
+        assert module.is_file(), module
+        proc = subprocess.run(
+            [sys.executable, "-m", "pytest", A_GATED_MODULE, "-q", "--no-cov", "-p", "no:cacheprovider"],
+            capture_output=True,
+            text=True,
+            cwd=root,
+            env={**os.environ, "ROBOT_TEST_MUJOCO": "0", "PYTHONPATH": str(root)},
+            timeout=600,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert " passed" not in proc.stdout, (
+            f"{A_GATED_MODULE} ran GL-dependent cases under ROBOT_TEST_MUJOCO=0, so its gate is "
+            f"not the shared marker: {proc.stdout[-2000:]}"
+        )
+        assert " skipped" in proc.stdout, proc.stdout[-2000:]


### PR DESCRIPTION
`ROBOT_TEST_MUJOCO=0` is the force-skip `_gl_probe` documents "to keep a known-bad runner from attempting GL at all" - the host class where a second offscreen renderer construction aborts the interpreter uncatchably rather than raising. It is read by `gl_available()` and by nothing else.

17 modules rebuilt the gate locally from the private `strands_robots.simulation.mujoco.backend._can_render`, so the variable never reached them.

![one owner for the render-test GL gate](https://raw.githubusercontent.com/cagataycali/robots/a2bdd8d19c7509054e661cde26ce9bc6538363a5/assets/one-owner-gl-gate.png)

## The measurement

Same host, same 17 modules, `ROBOT_TEST_MUJOCO=0` set:

| | passed | skipped |
| --- | --- | --- |
| `main` | **468** | 0 |
| this branch | 412 | **56** |

56 GL-dependent cases ran and constructed offscreen renderers on the runner that had opted out of GL entirely. `412 + 56 = 468`, so nothing stopped being checked - the cases that moved are exactly the gated ones.

The two routes to the same question:

| | `_gl_probe.requires_gl` | local rebuild from `_can_render` |
| --- | --- | --- |
| honours `ROBOT_TEST_MUJOCO=0` | yes | **no** (measured above) |
| built from a private production symbol | no | **yes** |
| visible to the render-gating scan | yes | **no** |

The third row is the second harm. `tests/test_mujoco_render_assertions_are_gl_gated.py` decides whether a render assertion is gated by looking for names bound from `_gl_probe`, so a module holding its own marker reads as ungated: a `render(...)["status"] == "success"` assertion added to any of the 17 would have been reported by that guard even though the module does gate.

## Change

All 17 take `requires_gl` from `tests.simulation.mujoco._gl_probe` - the form already used by the other 15 consumers - and drop their `_can_render` import. Five slightly different `reason=` strings collapse into the probe's one, which names the escape hatch.

`tests/test_the_gl_gate_on_a_render_test_has_one_owner.py` keeps it that way: exactly one module in the tree may build a GL-gating skip marker. Reading `_can_render` is not the defect and is not reported - `test_backend.py` and `test_software_render_warning.py` are its contract tests, and a planted case pins that discriminator. The force-skip half stays pinned where it lives (`test_gl_probe.py::test_robot_test_mujoco_zero_forces_no_gl`); one case measures the composition end to end through a child pytest, because a `skipif` condition is evaluated at import time and nothing in-process can observe it.

## Tests

All three new cells are red on pre-fix code, one per harm:

| cell | verdict against `main` |
| --- | --- |
| `test_no_module_rebuilds_the_gate_locally` | `AssertionError` naming all 17 modules and their marker lines |
| `test_the_probe_still_builds_the_one_gate` | `assert [17 paths + the probe] == ['tests/simulation/mujoco/_gl_probe.py']` |
| `test_a_gated_module_skips_under_the_force_skip` | `... ran GL-dependent cases under ROBOT_TEST_MUJOCO=0`, child reports `8 passed` |

Four corners over the 17 modules plus this guard, `test_gl_probe.py` and the render-gating guard, under `MUJOCO_GL=egl`: production off / tests off **492 passed**, production off / tests on **3 failed 3 passed**, production on / tests on **498 passed** (`492 + 6`), production on / tests off identical to the first. The failure-name lists of the three green corners are identical, so nothing else moved.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` unchanged at its pre-existing count, none of it in these files. The 267 test modules that walk the tree or glob it - the population that contains this guard and which a path-scoped run does not collect - report 13 failed / 4 errors / 13542 passed against 13 failed / 4 errors / 13536 passed on a pristine `main` worktree; both `comm` directions over the normalised node ids are empty, and all 17 are environmental (`awsiot` absent, `lerobot` 0.6.2 drift, `qpsolvers` absent, installed `websockets` 16.0 under the declared floor).

## Size

| | added | removed |
| --- | --- | --- |
| 17 test modules | 17 | 101 |
| new guard | 174 | 0 |
| changelog fragment | 19 | 0 |

Net **-84 lines** across the consolidated modules: 17 copies of a four-line marker and its import become one import each. Test-only; no production line moves.