### PR TITLE
fix(simulation/isaac): the legacy timestep shortcut is graded before it is converted

### DIFF
--- a/changelog.d/3290-isaac-legacy-timestep-domain.md
+++ b/changelog.d/3290-isaac-legacy-timestep-domain.md
@@ -1,0 +1,22 @@
+### Fixed: the legacy Isaac timestep shortcut is graded before it is converted
+
+`IsaacSimulation(default_timestep=...)` is a second way to set
+`IsaacConfig.physics_dt`, and it wrote the field through `float(...)`. That
+conversion is exactly what the shared timestep domain cannot undo - its boolean
+arm exists because "`float(True)` is `1.0`, so the boolean is unrecoverable once
+coerced" - so `default_timestep=True` stored a one-second physics step, 120x the
+default, and `create_world()` reported `status="success"` on it, while the
+canonical `IsaacConfig(physics_dt=True)` spelling of the same value is refused
+there. `numpy.True_` behaved the same. A one-second `dt` is not a coarse
+simulation: replayed in MuJoCo, a 0.60 m fall completes between two consecutive
+observations - no trajectory for a policy to act on - and the contact resolves
+45x worse, the box settling 4.92 mm inside the floor. `nan` and `inf` were
+stored to be refused a call later under `physics_dt`, the knob the caller never
+spelled; `False`, `0`, `-inf` and `-0.002` were refused by the field's own
+`<= 0` test after conversion, so `False` was reported as `0.0`; and `[0.002]`
+raised `TypeError` out of `float()`, naming neither the parameter nor the class.
+All eleven unusable values now raise `ValueError` naming `default_timestep`, on
+the same `SimEngine._validate_timestep` domain `create_world` applies to the
+effective dt. Conversion happens only once the value is admitted, so nothing
+that worked stops working - including a numeric string, which that domain
+accepts.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -141,7 +141,7 @@ rejected eagerly. The commonly used fields:
 | `num_envs` | `int` | `1` | Parallel environments. Set to `1024`+ for fleet RL. A positive integer - the same domain `replicate(num_envs=...)` takes. |
 | `device` | `str` | `"cuda:0"` | CUDA device (`cuda:N`). Must be a CUDA device. |
 | `headless` | `bool` | `True` | Run without a GUI (required for cloud/CI). |
-| `physics_dt` | `float` | `1/120` | Physics timestep (seconds). |
+| `physics_dt` | `float` | `1/120` | Physics timestep (seconds). Positive and finite - the domain `create_world()` applies to the effective dt, and the one the legacy `IsaacSimulation(default_timestep=...)` shortcut that writes this field takes as well. |
 | `rendering_dt` | `float` | `1/30` | Rendering timestep (seconds). |
 | `render_mode` | `str` | `"headless"` | `"headless"`, `"rtx_realtime"` (raster), or `"rtx_pathtracing"` (photoreal). |
 | `gravity` | `tuple` | `(0, 0, -9.81)` | Gravity vector (Z-up). Three finite components, Z-aligned - the same domain `create_world(gravity=...)` takes. |

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -786,6 +786,33 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         # ``physics_dt`` / ``camera_width`` / ``camera_height`` fields so
         # downstream code only reads from one source of truth.
         if legacy_default_timestep is not None:
+            # Graded on the domain the surface that spends this quantity applies
+            # to it (:meth:`~strands_robots.simulation.base.SimEngine._validate_timestep`,
+            # which ``create_world`` runs over the effective dt and names
+            # ``physics_dt`` for), and graded *before* the conversion rather than
+            # after. The ``float(...)`` was not validation: it defeated that
+            # domain's boolean arm, whose own reason is that "``float(True)`` is
+            # ``1.0``, so the boolean is unrecoverable once coerced".
+            # ``IsaacSimulation(default_timestep=True)`` stored ``physics_dt =
+            # 1.0`` - a one-second physics step, 120x the default - and
+            # ``create_world()``, the only owner of this field that grades it,
+            # then reported ``status="success"``: the boolean it exists to refuse
+            # had already been converted away, while the canonical
+            # ``IsaacConfig(physics_dt=True)`` spelling of the same value is
+            # refused there. ``numpy.True_`` and ``numpy.bool_(True)`` did the
+            # same; ``nan`` and ``inf`` were stored to be refused a call later;
+            # and ``None``-past-the-sentinel or ``[0.002]`` raised ``TypeError``
+            # out of ``float()`` naming neither the parameter nor this class. The
+            # MuJoCo and Newton engines store their own ``default_timestep``
+            # unconverted for exactly this reason - the world builder can still
+            # see what the caller passed. Here the field is annotated ``float``
+            # and its ``<= 0`` test cannot read a numeric string, so the value is
+            # converted once admitted: a conversion that can only restate a value
+            # this domain already accepted, rather than one that decides it.
+            if (
+                dt_error := self._validate_timestep(legacy_default_timestep, type(self).__name__, "default_timestep")
+            ) is not None:
+                raise ValueError(dt_error["content"][0]["text"])
             config = dataclasses.replace(config, physics_dt=float(legacy_default_timestep))
         # The legacy spellings reach the same graded field the canonical name
         # does, so they cannot be the looser way in. The ``int(...)`` they used

--- a/tests/simulation/test_timestep_domain_across_surfaces.py
+++ b/tests/simulation/test_timestep_domain_across_surfaces.py
@@ -69,6 +69,16 @@ which is False for ``nan`` and ``inf`` and lets a boolean through. So
 the only thing between that object and a world built on a dt no integrator can
 advance by.
 
+Which is why the second writer of that field mattered. The legacy
+``IsaacSimulation(default_timestep=...)`` shortcut sets ``physics_dt``, and it
+converted the value with ``float()`` first - so ``default_timestep=True`` stored
+``1.0`` and the effective-dt check, the one thing left, accepted it: the boolean
+it refuses had been converted away, exactly as its own reason says ("*the boolean
+is unrecoverable once coerced*"). One backend's two spellings of one dt, one of
+them holding a domain and the other outrunning it. Both MuJoCo and Newton store
+their ``default_timestep`` unconverted, which is what keeps their builder's
+verdict meaningful.
+
 Solver-free: ``NewtonSimEngine.set_timestep`` validates and writes before it
 touches the solver, so the engine here is built via ``__new__`` with only the
 attributes that path reads. The pre-existing Newton pins for this method live in
@@ -555,3 +565,141 @@ class TestTheEngineDefaultSentinelIsArgumentOnly:
     def test_none_is_still_refused_by_the_setter(self) -> None:
         """The setter has no sentinel, so its domain is the stricter one."""
         assert _set(_newton_engine(), None)["status"] == "error"
+
+
+def _legacy_isaac(value: Any) -> Any:
+    """Construct an Isaac engine through the legacy ``default_timestep`` shortcut.
+
+    The shortcut is popped out of ``**kwargs`` in ``IsaacSimulation.__init__`` and
+    written onto ``IsaacConfig.physics_dt``, so it is a second way to set the very
+    field ``create_world`` reads. One funnel, so the off-domain values - which the
+    ``float`` the field is annotated with does not describe - need a single
+    documented ``Any``.
+    """
+    from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+    return IsaacSimulation(default_timestep=value)
+
+
+def _engine_holding(config: Any) -> Any:
+    """An Isaac world builder carrying an already-constructed config.
+
+    Same skeleton as :func:`_isaac_engine` - ``create_world`` reads
+    ``self._config.physics_dt`` before the lock - but fed the config a real
+    constructor produced, so what is measured is the value that survived
+    construction rather than one written by the test.
+    """
+    from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = config
+    return engine
+
+
+def _builder_verdict(engine: Any) -> str:
+    """``"refused"`` or ``"accepted"`` for the dt this engine's config carries.
+
+    An accepted dt proceeds past the guard into the lock the skeleton omits, which
+    is the same signal :class:`TestARefusedWorldBuilderCostsNoSolverWork` rests
+    on; reading it here means acceptance is observed rather than inferred from the
+    absence of a refusal.
+    """
+    try:
+        result = _create_world(engine)
+    except AttributeError:
+        return "accepted"
+    return "refused" if result["status"] == "error" else "accepted"
+
+
+class TestTheIsaacLegacyDefaultCannotOutrunTheWorldBuilder:
+    """The legacy ``default_timestep=`` shortcut writes the field the builder reads.
+
+    ``IsaacSimulation(default_timestep=...)`` is a second owner of
+    ``IsaacConfig.physics_dt``, and it converted the caller's value with
+    ``float()`` before storing it. That conversion is precisely what the shared
+    domain's boolean arm cannot undo - its own reason is that *"``float(True)`` is
+    ``1.0``, so the boolean is unrecoverable once coerced"* - so the check
+    :class:`TestTheConfigGuardCannotSeeEveryUnusableDefault` calls the only thing
+    between a constructed object and an unusable world was blind to whatever the
+    shortcut had already converted. Measured over the roster above:
+
+    * ``True`` and ``numpy.True_`` stored ``physics_dt = 1.0`` and
+      ``create_world()`` then accepted it - a one-second physics step, 120x the
+      default, installed by a value that is not a number, while the canonical
+      ``IsaacConfig(physics_dt=True)`` spelling of that same value is refused
+      there. The module docstring measures what a one-second dt does to a fall:
+      the whole 0.54 m happens between two consecutive observations and the
+      contact resolves 45x worse.
+    * ``nan`` and ``inf`` were stored to be refused one call later, under
+      ``physics_dt`` - the knob the caller never spelled.
+    * ``False``, ``0``, ``0.0``, ``-inf`` and ``-0.002`` were refused, but by the
+      field's own ``<= 0`` test after the conversion, so the message named
+      ``physics_dt`` - the spelling the caller did not use - and quoted the
+      converted value: ``False`` was reported as ``0.0``.
+    * ``[0.002]`` raised ``TypeError`` out of ``float()``, naming neither the
+      parameter nor the class.
+
+    All eleven unusable values below reached a verdict this shortcut's own domain
+    does not: five accepted at construction (three of them into a world the
+    builder accepted too), five refused under the other spelling's name, one
+    ``TypeError``. The four usable ones are unchanged, including the numeric
+    string ``"0.002"``: the shared domain coerces anything ``float()`` accepts,
+    so grading before converting narrows nothing.
+
+    No Isaac install and no GPU: the domain is arithmetic, and the builder
+    skeleton is the one the sibling cells above use.
+    """
+
+    #: ``None`` is the "not supplied" sentinel for this shortcut - it is popped
+    #: from ``kwargs`` with that default - so it is excluded here and pinned as
+    #: the asymmetry it is in :meth:`test_an_unstated_default_leaves_the_field_alone`.
+    UNUSABLE_DEFAULTS = [value for value in UNUSABLE if value is not None]
+
+    @pytest.mark.parametrize("value", UNUSABLE_DEFAULTS, ids=repr)
+    def test_an_unusable_default_is_refused_under_the_spelling_used(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="default_timestep"):
+            _legacy_isaac(value)
+
+    @pytest.mark.parametrize("value", BOOLEANS, ids=repr)
+    def test_a_boolean_default_cannot_reach_a_world_the_builder_accepts(self, value: Any) -> None:
+        """The end-to-end claim: the builder's boolean arm is not outrun.
+
+        Either the shortcut refuses the value, or the builder does. Before the
+        conversion moved behind the domain, neither did: ``physics_dt`` held the
+        ``1.0`` that ``float(True)`` produced and the builder had nothing left to
+        recognise.
+        """
+        try:
+            sim = _legacy_isaac(value)
+        except ValueError:
+            return
+        assert _builder_verdict(_engine_holding(sim._config)) == "refused", (
+            f"default_timestep={value!r} was stored as "
+            f"physics_dt={sim._config.physics_dt!r} and the world builder accepted it"
+        )
+
+    @pytest.mark.parametrize("value", BOOLEANS, ids=repr)
+    def test_both_spellings_of_one_default_reach_one_verdict(self, value: Any) -> None:
+        """The canonical field and the shortcut are two names for one dt."""
+        canonical = _builder_verdict(_isaac_engine(value))
+        try:
+            _legacy_isaac(value)
+        except ValueError:
+            legacy = "refused"
+        else:
+            legacy = "accepted"
+        assert canonical == legacy == "refused"
+
+    @pytest.mark.parametrize("value", USABLE, ids=repr)
+    def test_a_usable_default_is_still_installed(self, value: Any) -> None:
+        """The control: grading before converting must refuse nothing that worked."""
+        sim = _legacy_isaac(value)
+        assert float(sim._config.physics_dt) == pytest.approx(float(value))
+        assert _builder_verdict(_engine_holding(sim._config)) == "accepted"
+
+    def test_an_unstated_default_leaves_the_field_alone(self) -> None:
+        """``None`` is this shortcut's "not supplied", so the field keeps its default."""
+        from strands_robots.simulation.isaac.config import IsaacConfig
+
+        sim = _legacy_isaac(None)
+        assert sim._config.physics_dt == pytest.approx(IsaacConfig().physics_dt)


### PR DESCRIPTION
`IsaacSimulation(default_timestep=...)` is a second owner of `IsaacConfig.physics_dt`, and it wrote the field through `float(...)`. That conversion is exactly what the shared timestep domain's boolean arm cannot undo - its own reason is that *"`float(True)` is `1.0`, so the boolean is unrecoverable once coerced"* - so `default_timestep=True` stored a **one-second physics step** and `create_world()`, the only owner of this field that grades it, then accepted it. The canonical `IsaacConfig(physics_dt=True)` spelling of that same value is refused there.

![what the laundered timestep installs, and every verdict it changed](https://raw.githubusercontent.com/cagataycali/robots/a6e6e8b54fb743201ffb15249c25ac8e402d4dbc/isaac-legacy-timestep.png)

The two frames are the same scene at `t = 1.0 s`, rendered headless in MuJoCo: a 1 kg 0.12 m box released with its centre 0.60 m above the floor (rest height 0.060 m).

| | dt = 1.0 s (from `default_timestep=True`) | dt = 1/120 s (config default) |
|---|---|---|
| physics steps in 2 s | 2 | 240 |
| samples while airborne | **1** | 39 |
| box centre z at `t = 1 s` | **-9.2100 m** | +0.0599 m |
| contact with the floor | never resolved - it passes through | resolved, at rest |

## The verdicts

Measured over the roster the timestep grader already carries, on `main` and on this branch:

| `default_timestep=` | before | `create_world()` then | after |
|---|---|---|---|
| `True`, `np.True_`, `np.bool_(True)` | accepted, stored `physics_dt = 1.0` | **accepted** | refused, names `default_timestep` |
| `nan`, `inf` | accepted, stored as given | refused, names `physics_dt` | refused, names `default_timestep` |
| `False`, `0`, `0.0`, `-inf`, `-0.002` | refused by the field's `<= 0` after conversion, so it names `physics_dt` and quotes the converted value (`False` reported as `0.0`) | not reached | refused, names `default_timestep` |
| `[0.002]` | `TypeError` out of `float()`, naming neither the parameter nor the class | not reached | refused, names `default_timestep` |
| `0.002`, `0.5`, `np.float64(0.002)`, `"0.002"` | accepted | accepted | unchanged |

All 11 unusable values reached a verdict this shortcut's own domain does not give; 5 were accepted at construction, 3 of those into a world the builder accepted too. All 4 usable values are unchanged - including the numeric string, which the shared domain accepts.

## The change

The value is graded on `SimEngine._validate_timestep` - the domain `create_world` applies to the effective dt - **before** the conversion instead of after, and raises `ValueError` naming the spelling the caller used. Conversion happens only once the value is admitted, so it can no longer decide anything: it restates a value the domain already accepted, which the field needs because `physics_dt` is annotated `float` and its `<= 0` test cannot read a numeric string. MuJoCo and Newton already store their own `default_timestep` unconverted, which is what keeps their builder's verdict meaningful.

## Tests

Pinned in `tests/simulation/test_timestep_domain_across_surfaces.py`, the module that already owns this quantity's domain across backends - its docstring called the effective-dt check *"the only thing between that object and a world built on a dt no integrator can advance by"*, and this is the writer that outran it, so the paragraph is corrected there too. 22 new cells: every unusable value refused under the spelling used, the end-to-end claim that a boolean cannot reach a world the builder accepts, both spellings reaching one verdict, every usable value still installed, and `None` still meaning "not supplied".

17 of them fail on `main` (`148 passed` -> `17 failed, 148 passed`), all 165 pass here. Restoring the pre-change test file against the new code leaves `2342 passed` - the fix needed no existing cell changed. `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` unchanged at its 20 pre-existing errors in 6 untouched files; the 139-module net that reads this backend or this quantity is `7290 passed` with one pre-existing environment failure (`test_dependency_audit`, `qpsolvers` not installed) that fails identically on `main`.

LOC delta: +176 / -1 (production +27, tests +148, docs +1).