### PR TITLE
test(simulation): the render-gating rule reads a camera image out of an observation

### DIFF
--- a/changelog.d/3286-render-gating-sees-a-camera-image-read.md
+++ b/changelog.d/3286-render-gating-sees-a-camera-image-read.md
@@ -1,0 +1,19 @@
+### Tests: the render-gating rule reads a camera image out of an observation as the GL dependency it is
+
+`tests/test_mujoco_render_assertions_are_gl_gated.py` keeps a read that needs an
+offscreen GL context from reaching the suite ungated, so that a headless host
+reports a missing context rather than a bare failure about the contract under
+test. It matched one spelling of that dependency, `render*(...)["status"] ==
+"success"`, and a camera indexed out of `get_observation` is a second one.
+
+That spelling degrades worse. `_render_cameras` logs a per-camera failure at
+debug level and omits the key it could not produce, so the read raises
+`KeyError: 'camera1'` - naming neither GL, nor the contract, nor the fact that a
+render was attempted.
+
+The rule now reads both. The discriminator for the new spelling is the key, not
+the call: a subscript counts when its key is a camera the module registers, or
+the free view every world registers, and when the call did not pass
+`skip_images=True`. Sixteen modules index an observation and two of them name a
+camera; keying on the call would have reported seven reads across five modules
+whose keys are joint angles and base poses.

--- a/tests/test_mujoco_render_assertions_are_gl_gated.py
+++ b/tests/test_mujoco_render_assertions_are_gl_gated.py
@@ -1,4 +1,4 @@
-"""A MuJoCo render-success assertion must be gated on the shared GL probe.
+"""A MuJoCo read that needs an offscreen GL context must be gated on the shared probe.
 
 ``Simulation.render`` returns ``{"status": "error"}`` on a host with no usable
 offscreen GL context - headless without EGL/OSMesa - for a reason that has
@@ -8,21 +8,39 @@ under test with a host graphics capability: it passes only where a GL context
 happens to exist, and elsewhere it reports a bare ``'error' != 'success'`` that
 names neither GL nor the contract.
 
-:mod:`tests.simulation.mujoco._gl_probe` exists for exactly this and is the
-convention in ten sibling modules. This guard keeps it the convention: every
-render-success assertion in a module that requires ``mujoco`` must sit behind
-that probe, so a test added later cannot re-open the confusion.
+Indexing a camera out of an observation is the same dependency in a second
+spelling, and it degrades worse. ``get_observation`` renders each camera and
+``_render_cameras`` logs a per-camera failure at debug level and *omits the key
+it could not produce*, so ``get_observation(...)["camera1"]`` raises
+``KeyError: 'camera1'`` - which names neither GL nor the contract nor even the
+fact that a render was attempted. Both spellings are in scope here.
 
-Scope is the mujoco requirement, not a directory. A module that asserts a render
-succeeded *without* requiring ``mujoco`` renders through some other backend,
+:mod:`tests.simulation.mujoco._gl_probe` exists for exactly this and is the
+convention in its sibling modules. This guard keeps it the convention: every
+GL-dependent read in a module that requires ``mujoco`` must sit behind that
+probe, so a test added later cannot re-open the confusion.
+
+Scope is the mujoco requirement, not a directory. A module that reads a rendered
+value *without* requiring ``mujoco`` renders through some other backend,
 whose availability the MuJoCo probe does not describe - ``tests/simulation/newton``
 gates its own render tests on a Newton-availability marker instead. Keying on the
 requirement rather than on a path excludes those by construction, so this rule
 needs no exemption list.
 
-Three gating forms are accepted, all of which stop the assertion from running
-without a context: the probe's marker on the test function, the same marker on
-its class, or an in-function ``gl_available()`` skip. All three are in use.
+Three gating forms are accepted, all of which stop the read from running without
+a context: the probe's marker on the test function, the same marker on its
+class, or an in-function ``gl_available()`` skip. All three are in use.
+
+For the observation spelling the discriminator is the *key*, not the call. Sixteen
+modules index an observation and the key names a camera in two of them; the other
+fourteen read a joint angle or a base pose, or compute the key at runtime, and no
+graphics context is involved in producing any of those. Keying on the call would
+report seven such reads across five modules as needing a gate they do not need,
+which is the shape of a rule contributors learn to route around. So a subscript
+counts only when its key is a camera name the module itself registers - or the
+free view every world registers - and only when the call did not ask to skip
+images. A key computed at runtime is out of scope by construction, and both
+boundaries are pinned below rather than left to be rediscovered.
 
 The rule's own non-vacuity pin is keyed on modules, never on a count of
 assertions: splitting one render call into its own gated case is what the remedy
@@ -40,6 +58,17 @@ import pytest
 #: raw arrays rather than a status envelope, so it cannot carry this assertion.
 RENDER_ATTRS = frozenset({"render", "render_depth", "render_all"})
 
+#: The observation entry point that renders every camera as a side effect.
+OBSERVATION_ATTR = "get_observation"
+
+#: Keyword that tells ``get_observation`` to render nothing, so a read from such
+#: a call carries no graphics dependency whatever key it names.
+SKIP_IMAGES_KEYWORD = "skip_images"
+
+#: The free view every MuJoCo world registers itself - ``create_world`` writes
+#: ``cameras["default"]`` - so a module reading it declares no camera of its own.
+IMPLICIT_CAMERA_NAMES = frozenset({"default"})
+
 #: Modules that require ``mujoco`` and assert a render succeeded. Pinned so a
 #: scan rooted somewhere unexpected fails loudly instead of reporting a clean
 #: sweep over nothing.
@@ -47,6 +76,7 @@ EXPECTED_IN_SCOPE = frozenset(
     {
         "tests/simulation/mujoco/test_entity_name_lookup_type_safety.py",
         "tests/simulation/mujoco/test_remove_camera_refused_recompile.py",
+        "tests/simulation/mujoco/test_reset_forwards_derived_state.py",
         "tests/simulation/test_camera_pixel_count_domain.py",
         "tests/simulation/test_unhashable_entity_name_is_reported.py",
     }
@@ -95,6 +125,63 @@ def render_success_assertions(tree: ast.AST) -> list[int]:
         if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) and call.func.attr in RENDER_ATTRS:
             lines.append(node.lineno)
     return lines
+
+
+def camera_names(tree: ast.AST) -> set[str]:
+    """Camera names *tree* can read an image for: those it registers, plus the free view."""
+    found = set(IMPLICIT_CAMERA_NAMES)
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "add_camera":
+            continue
+        positional = node.args[0] if node.args else None
+        if isinstance(positional, ast.Constant) and isinstance(positional.value, str):
+            found.add(positional.value)
+        for keyword in node.keywords:
+            value = keyword.value
+            if keyword.arg == "name" and isinstance(value, ast.Constant) and isinstance(value.value, str):
+                found.add(value.value)
+    return found
+
+
+def _skips_images(call: ast.Call) -> bool:
+    """True when *call* passes ``skip_images=True``, so it rendered nothing."""
+    for keyword in call.keywords:
+        if keyword.arg != SKIP_IMAGES_KEYWORD:
+            continue
+        return isinstance(keyword.value, ast.Constant) and keyword.value.value is True
+    return False
+
+
+def camera_image_reads(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``<x>.get_observation(...)[<camera name>]`` subscript.
+
+    The key carries the dependency, not the call: a subscript naming a joint is
+    proprioception and needs no context, which is why this is not simply every
+    ``get_observation`` index. A key the module cannot be shown to be a camera -
+    computed, or a name this module never registers - is left out rather than
+    guessed at.
+    """
+    cameras = camera_names(tree)
+    lines = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript):
+            continue
+        call = node.value
+        if not (isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)):
+            continue
+        if call.func.attr != OBSERVATION_ATTR or _skips_images(call):
+            continue
+        key = node.slice
+        if isinstance(key, ast.Constant) and key.value in cameras:
+            lines.append(node.lineno)
+    return lines
+
+
+def gl_dependent_reads(tree: ast.AST) -> list[int]:
+    """Every line in *tree* whose value cannot be produced without a GL context."""
+    return sorted(set(render_success_assertions(tree)) | set(camera_image_reads(tree)))
 
 
 def probe_names(tree: ast.AST) -> set[str]:
@@ -150,13 +237,13 @@ def is_gated(tree: ast.AST, lineno: int, names: set[str]) -> bool:
 
 
 def survey(root: pathlib.Path) -> tuple[dict[str, list[int]], dict[str, list[int]], list[str]]:
-    """Return (ungated, gated, out-of-scope) render-success assertions under *root*."""
+    """Return (ungated, gated, out-of-scope) GL-dependent reads under *root*."""
     ungated: dict[str, list[int]] = {}
     gated: dict[str, list[int]] = {}
     other_backend: list[str] = []
     for path in sorted(root.rglob("test_*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"))
-        lines = render_success_assertions(tree)
+        lines = gl_dependent_reads(tree)
         if not lines:
             continue
         label = path.relative_to(root.parent).as_posix()
@@ -182,15 +269,16 @@ def unaccounted_modules(gated: dict[str, list[int]], expected: frozenset[str]) -
     return set(expected) - set(gated), set(gated) - set(expected)
 
 
-class TestEveryMuJoCoRenderAssertionIsGated:
-    def test_no_module_asserts_a_render_succeeded_without_the_probe(self) -> None:
+class TestEveryMuJoCoGlDependentReadIsGated:
+    def test_no_module_reads_a_rendered_value_without_the_probe(self) -> None:
         ungated, _, _ = survey(_tests_root())
         assert not ungated, (
-            f"these modules assert a MuJoCo render succeeded without gating it on the shared "
-            f"GL probe: {ungated}. On a headless host without EGL/OSMesa render reports an "
-            f"error for a reason unrelated to the contract under test, so the assertion fails "
-            f"there and names neither cause. Import requires_gl from "
-            f"tests.simulation.mujoco._gl_probe and split the render assertion into its own case."
+            f"these modules read a value that needs an offscreen GL context without gating it "
+            f"on the shared GL probe: {ungated}. On a headless host without EGL/OSMesa a render "
+            f"reports an error and an observation omits the camera key, for a reason unrelated "
+            f"to the contract under test, so the read fails there as 'error' != 'success' or as "
+            f"a bare KeyError and names neither cause. Import requires_gl from "
+            f"tests.simulation.mujoco._gl_probe and split the GL-dependent read into its own case."
         )
 
     def test_every_module_the_survey_covers_contributes_a_gated_assertion(self) -> None:
@@ -205,7 +293,7 @@ class TestEveryMuJoCoRenderAssertionIsGated:
         missing, unexpected = unaccounted_modules(gated, EXPECTED_IN_SCOPE)
         assert not missing and not unexpected, (
             f"the survey no longer accounts for EXPECTED_IN_SCOPE: {sorted(missing)} contribute no "
-            f"gated render assertion, and {sorted(unexpected)} are not listed. Add or drop the "
+            f"gated GL-dependent read, and {sorted(unexpected)} are not listed. Add or drop the "
             f"module path. Adding a second gated assertion to a module already listed is not a "
             f"change to this pin."
         )
@@ -336,3 +424,163 @@ class TestThePinIsKeyedOnModulesNotOnAnAssertionCount:
         missing, unexpected = unaccounted_modules(gated, frozenset())
         assert not missing
         assert unexpected == {"tests/test_planted.py"}
+
+
+_PLANTED_UNGATED_CAMERA_READ = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+
+def test_planted(sim):
+    sim.add_camera(name="cam1", position=[1, 0, 1])
+    assert sim.get_observation(robot_name="arm")["cam1"].shape == (128, 128, 3)
+"""
+
+_PLANTED_GATED_CAMERA_READ = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
+
+
+@requires_gl
+def test_planted(sim):
+    sim.add_camera(name="cam1", position=[1, 0, 1])
+    assert sim.get_observation(robot_name="arm")["cam1"].shape == (128, 128, 3)
+"""
+
+_PLANTED_PROPRIOCEPTION_READ = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+
+def test_planted(sim):
+    sim.add_camera(name="cam1", position=[1, 0, 1])
+    assert sim.get_observation(robot_name="arm")["yaw"] == 0.0
+"""
+
+_PLANTED_FREE_VIEW_READ = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+
+def test_planted(sim):
+    assert sim.get_observation(robot_name="arm")["default"].shape == (480, 640, 3)
+"""
+
+_PLANTED_SKIPPED_IMAGE_READ = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+
+def test_planted(sim):
+    sim.add_camera(name="cam1", position=[1, 0, 1])
+    assert sim.get_observation(robot_name="arm", skip_images=True)["cam1"] is None
+"""
+
+_PLANTED_COMPUTED_KEY_READ = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+
+def test_planted(sim, camera_name):
+    sim.add_camera(name="cam1", position=[1, 0, 1])
+    assert sim.get_observation(robot_name="arm")[camera_name].shape == (128, 128, 3)
+"""
+
+
+class TestACameraImageReadIsTheSameDependency:
+    """``get_observation(...)[<camera>]`` needs a context exactly as ``render`` does.
+
+    It fails worse, though: ``_render_cameras`` omits a key it could not produce,
+    so the read raises ``KeyError`` rather than reporting a missing context.
+    """
+
+    def _survey_one(self, tmp_path: pathlib.Path, source: str) -> tuple[dict[str, list[int]], dict[str, list[int]]]:
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(source, encoding="utf-8")
+        ungated, gated, _ = survey(root)
+        return ungated, gated
+
+    def test_a_planted_ungated_camera_image_read_is_reported(self, tmp_path: pathlib.Path) -> None:
+        ungated, gated = self._survey_one(tmp_path, _PLANTED_UNGATED_CAMERA_READ)
+        assert list(ungated) == ["tests/test_planted.py"]
+        assert not gated
+
+    def test_the_same_read_behind_the_probe_is_accepted(self, tmp_path: pathlib.Path) -> None:
+        ungated, gated = self._survey_one(tmp_path, _PLANTED_GATED_CAMERA_READ)
+        assert not ungated
+        assert list(gated) == ["tests/test_planted.py"]
+
+    def test_the_free_view_needs_no_declaration(self, tmp_path: pathlib.Path) -> None:
+        """``create_world`` registers ``cameras["default"]``, so no ``add_camera`` precedes it."""
+        ungated, _ = self._survey_one(tmp_path, _PLANTED_FREE_VIEW_READ)
+        assert list(ungated) == ["tests/test_planted.py"]
+
+
+class TestTheKeyIsTheDiscriminatorNotTheCall:
+    """Why this is not simply every ``get_observation`` subscript.
+
+    Sixteen modules index an observation and the key names a camera in two of
+    them. Reporting every literal key instead - the widening this rule does not
+    take - reports seven reads across five modules whose keys are joint angles and
+    base poses, so the rule would refuse reads no graphics context is involved in
+    producing. These cells pin the three clauses that keep it from doing so.
+    """
+
+    def _ungated(self, tmp_path: pathlib.Path, source: str) -> dict[str, list[int]]:
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(source, encoding="utf-8")
+        ungated, _, _ = survey(root)
+        return ungated
+
+    def test_a_proprioception_key_is_not_a_camera_read(self, tmp_path: pathlib.Path) -> None:
+        """The module registers a camera and reads a joint: not a graphics dependency."""
+        assert self._ungated(tmp_path, _PLANTED_PROPRIOCEPTION_READ) == {}
+
+    def test_a_skipped_image_read_is_not_a_graphics_dependency(self, tmp_path: pathlib.Path) -> None:
+        """``skip_images=True`` renders nothing, so no key it returns needed a context."""
+        assert self._ungated(tmp_path, _PLANTED_SKIPPED_IMAGE_READ) == {}
+
+    def test_a_computed_key_is_out_of_scope(self, tmp_path: pathlib.Path) -> None:
+        """The boundary, pinned rather than left to be discovered.
+
+        A key is a runtime string in general. This rule reads the ones it can
+        prove are cameras and says so, instead of guessing at the rest.
+        """
+        assert self._ungated(tmp_path, _PLANTED_COMPUTED_KEY_READ) == {}
+
+    def test_only_a_camera_this_module_registers_counts(self) -> None:
+        tree = ast.parse(_PLANTED_UNGATED_CAMERA_READ)
+        assert camera_names(tree) == {"cam1", "default"}
+        assert camera_image_reads(tree) == [9]
+        assert render_success_assertions(tree) == []
+        assert gl_dependent_reads(tree) == [9]
+
+
+class TestTheRuleCoversTheTreesCameraImageReads:
+    """The real tree, not a planted one: both spellings reach the same rule."""
+
+    def test_the_reset_render_readiness_read_is_in_scope_and_gated(self) -> None:
+        """Deleting its ``@requires_gl`` left this guard green before the rule read the key."""
+        path = _tests_root() / "simulation/mujoco/test_reset_forwards_derived_state.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        assert camera_image_reads(tree), "the camera-image read this module is listed for is gone"
+        assert not render_success_assertions(tree), "no render envelope here - the read is the whole dependency"
+        _, gated, _ = survey(_tests_root())
+        assert "tests/simulation/mujoco/test_reset_forwards_derived_state.py" in gated
+
+    def test_a_proprioception_read_in_the_tree_is_not_in_scope(self) -> None:
+        """The measured discriminator, on a real module that reads ``base_pos`` ungated."""
+        path = _tests_root() / "simulation/test_base_pose_is_the_robots_own_free_joint.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        assert camera_image_reads(tree) == []
+        assert gl_dependent_reads(tree) == []


### PR DESCRIPTION
Closes #3286.

`tests/test_mujoco_render_assertions_are_gl_gated.py` keeps a read that needs an offscreen GL context from reaching the suite ungated, so that a headless host reports a missing context rather than a bare failure about whatever contract the calling test is pinning. It matched one spelling of that dependency. A camera indexed out of `get_observation` is a second one, and it degrades worse.

```mermaid
graph LR
  A["one host requirement:<br/>an offscreen GL context"] --> B["render(...)['status'] == 'success'"]
  A --> C["get_observation(...)['camera1']"]
  B -->|matched| R{{"the render-gating rule"}}
  C -.->|"before: not matched"| R
  C ==>|"this change"| R
```

## The second spelling

`_render_cameras` logs a per-camera failure at debug level and **omits the key it could not produce**, so the read raises `KeyError` - naming neither GL, nor the contract, nor the fact that a render was attempted. Measured on a so101 scene under MuJoCo's own switch:

| read | `MUJOCO_GL=egl` | `MUJOCO_GL=disable` |
|---|---|---|
| `cameras["default"].width` | `640` | `640` - needs no context |
| `render()["status"]` | `success` | `error`, *"Rendering unavailable (no OpenGL context)"* |
| `get_observation(...)["camera1"]` | `ndarray(480, 640, 3)` | **`KeyError: 'camera1'`** |

## This is a prevention rule, and this is what it prevents

Said plainly because #3286 asks for it: there is **no ungated instance in the tree**. Both camera-image reads in `tests/` are gated today and both stay green here. What was missing is that nothing kept them that way. The rule never read that spelling, so neither module was accounted for by it - and deleting a gate is invisible to the required check:

| | this guard | the case under `MUJOCO_GL=disable` |
|---|---|---|
| gate present | 13 passed | 1 passed, **1 skipped** |
| **`@requires_gl` deleted** | **13 passed** | **`KeyError: 'camera1'`** |

Four corners on `61454ba17`, toggling the rule and the gate independently:

| | gate present | gate deleted |
|---|---|---|
| rule as on `main` | 13 passed | **13 passed** |
| this branch | **22 passed** | **3 failed** |

`13 + 9 = 22`. Corner B's 19 passing cells are 11 of the 13 pre-existing plus 8 of the 9 new ones - only one new cell is a regression cell, the rest are controls and boundaries that hold either way. The two `main` corners being equal is the whole report.

With the gate deleted, the rule now names the module, both lines and the remedy:

```
AssertionError: these modules read a value that needs an offscreen GL context without
gating it on the shared GL probe:
{'tests/simulation/mujoco/test_reset_forwards_derived_state.py': [112, 115]}. On a
headless host without EGL/OSMesa a render reports an error and an observation omits
the camera key, for a reason unrelated to the contract under test, so the read fails
there as 'error' != 'success' or as a bare KeyError and names neither cause. Import
requires_gl from tests.simulation.mujoco._gl_probe and split the GL-dependent read
into its own case.
```

One correction to the issue, already noted in its thread and repeated here so the reasoning is in one place: its reproduction made `mujoco.Renderer` fail in process, and `_can_render()` probes in a **subprocess**, so that patch never reached the gate. The gate is effective. It was unverified.

## Why the key, and not the call

#3286 costs three shapes; this is its option (1), because it is the only one that stays a rule as the suite grows. Measured over `tests/`:

| | modules | reads |
|---|---|---|
| index an observation at all | 16 | - |
| key names a camera (in scope here) | **2** | 3 |
| key names a joint, a base pose, or is computed | 14 | - |
| **would be reported by option (2)**, every literal key | 5 | **7** |

Option (2) reports `["yaw"]`, `["base_pos"]`, `["joint1"]`, `["Elbow"]` - values no graphics context is involved in producing - which is the shape of a rule contributors learn to route around. So a subscript counts on three clauses:

1. the key is a camera the module registers with `add_camera`, **or** the free view every world registers (`create_world` writes `cameras["default"]`, so a module reading it declares nothing);
2. the call did not pass `skip_images=True`, which renders nothing - 84 such calls exist and every one reads proprioception;
3. the key is a literal. A computed key is out of scope **by construction**, and that boundary is pinned rather than left to be rediscovered.

Each clause is load-bearing, and the mutation table is how I know rather than how I hope. Seven mutations, control 0 fires, `collected` stable at 22 on every row, every row a distinct set:

| mutation | fires | cells |
|---|---|---|
| control | 0 | - |
| `survey` ignores the new reader | 5 | the planted pair, the free view, the tree cell, non-vacuity |
| `EXPECTED_IN_SCOPE` loses the module | 1 | non-vacuity |
| the free view is not implicit | 2 | free-view, `camera_names` |
| `skip_images=True` ignored | 1 | skipped-image control |
| **every literal key (option 2)** | 2 | proprioception control, **the rule itself** |
| the live `@requires_gl` is deleted | 3 | the rule, non-vacuity, the tree cell |

## Composition with #3289

They are two halves of one premise and neither is sufficient. #3289 put every render test on the one shared probe, which is what lets `probe_names` *see* the gate in `test_reset_forwards_derived_state.py`; this lets the rule see the *read*. Without #3289 the widened scan would report a module whose gate is already correct, so this is deliberately based on top of it. The other in-scope module, `tests/simulation/test_camera_pixel_count_domain.py`, contributes a gated `["default"]` read from #3288 and was already listed - so `EXPECTED_IN_SCOPE` grows by exactly one entry.

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` | clean, 1924 files |
| `mypy` 1.20.2, same scope | `Success: no issues found in 1921 source files` |
| the guard, `_gl_probe`, and both in-scope modules | 521 passed |
| `scripts/check_whole_tree_graders.py` | 4500 passed, 50 skipped, 7 failed |
| the 473 modules that walk the tree or read source - the population holding this guard, which a path-scoped run does not collect | 24797 passed, 68 skipped, 7 failed |

The same 7 in both, and all environmental in this checkout rather than moved assertions: `rclpy` resolves from a system ROS install where five cells assert it is absent, and the installed `websockets` is 16.0 - `websockets.asyncio.server.Server` has no `shutdown` attribute at all - against the `>=17.0` floor the `cosmos3-service` and `inference` extras declare.

## Size

| | added | removed |
|---|---|---|
| `tests/test_mujoco_render_assertions_are_gl_gated.py` | 267 | 19 |
| changelog fragment | 19 | 0 |

Test-only; no production line moves. Of the 267 added lines, 60 are blank and 5 are comments, and the six new planted-source fixtures are ~66 - the file's existing idiom for this, extending the three already there. AST statements go 181 -> 291 and cells 13 -> 22. It is net positive, which for a prevention rule is worth justifying rather than glossing: what it buys is that the required check now refuses a deleted gate on either spelling, and the 8 new cells beyond the regression one are the three discriminator clauses and the two boundaries, each measured above to fire on its own.