### PR TITLE
fix(drivers): the speed a serial bus is opened at takes the shared count domain

### DIFF
--- a/changelog.d/3292-serial-bus-speed-domain.md
+++ b/changelog.d/3292-serial-bus-speed-domain.md
@@ -1,0 +1,22 @@
+### Fixed: the speed a serial bus is opened at is graded wherever a caller states one
+
+`serial_tool` holds its `baudrate` to `positive_count_error` and records why: the
+option is "coerced rather than checked by pyserial (`2.7` becomes 2 baud)". The
+four constructors that reach the same `serial.Serial` held it to nothing -
+`FeetechDriver` and `DynamixelDriver` converted it with `int()`, `FeetechBus` and
+`pose_tool`'s motor controller stored it raw - so a speed that is not a count was
+applied rather than reported, and the tool refused values the driver beside it
+accepted.
+
+Measured on a real pty: `baud_rate=0` opened the port **successfully** at a speed
+no servo answers, so every read timed out indistinguishably from an unplugged arm;
+`True` opened it at 1 baud and `2.7` at 2, while `get_status` reported the
+converted number as the configured one; `-9600` / `None` / `[1_000_000]` reached
+pyserial's own `Not a valid baudrate`, and `nan` / `inf` an `int()` conversion
+error - each raised at connect time by a third library, naming neither the driver
+nor the parameter.
+
+All four now refuse a speed that is not a positive integer, naming the surface and
+the option, and the conversions are gone: a value the domain admits is already an
+`int`. `1_000_000.0` and `'1000000'` stop being accepted, which is the divergence
+this removes - the tool surface already refused both.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -137,6 +137,15 @@ members it is missing, so a half-built driver fails at the line that registers i
 than on the first agent call. `port=` stays polymorphic - a serial path, an IP address or a
 URL - because only the driver knows how to read it.
 
+`baud_rate=` does not stay polymorphic. Every surface that opens a serial bus - the Feetech
+and Dynamixel drivers, `FeetechBus`, and the `baudrate` of `serial_tool` and `pose_tool` -
+holds it to one domain, a positive integer, and refuses anything else by name at
+construction. pyserial takes the speed through its own `int()` and refuses only a negative,
+so an ungraded value is *applied*: `2.7` opens the port at 2 baud, and `0` opens it
+successfully at a speed no servo answers, after which every read times out exactly as an
+unplugged arm does. A refusal at the line that states the speed is the only place that
+reads as a caller mistake rather than as broken hardware.
+
 A driver has **two** ways to halt its robot and they are not the same contract. `stop_task()`
 returns a status envelope and decides an outcome, so that is what a caller reads. `stop()` is
 the lifecycle hook and is annotated `-> None`, so it carries no verdict at all - which makes

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -159,7 +159,7 @@ disagree about which address is a servo and which is the whole bus.
 | `motor_id` | integer in `[1, 254]`, or `[1, 253]` for an action that reads a reply | the frame carries the ID in one byte, of which `0xfd` is the highest a servo may hold and `0xfe` is the broadcast, while `0xff` is the header value |
 | `position` | integer in `[0, 4095]` | `Goal_Position` is 12-bit on the STS/SMS series - the same full scale the reported angle divides by |
 | `velocity` | integer in `[0, 32767]` | `Goal_Velocity` is sign-magnitude with bit 15 the direction bit, so a larger magnitude commands the opposite direction |
-| `baudrate` | positive integer | pyserial coerces rather than checks, so `2.7` opens the port at 2 baud |
+| `baudrate` | positive integer | pyserial coerces rather than checks, so `2.7` opens the port at 2 baud and `0` opens it at a speed no servo answers - the same domain every native serial driver holds its `baud_rate` to |
 | `read_bytes` | positive integer | pyserial's read loop is `while len(read) < size`, so a non-positive size returns no bytes and looks like a timeout |
 | `timeout` | finite number >= 0 | `0` is pyserial's non-blocking mode (return what is buffered); `nan` waits no time at all and `inf` overflows the deadline |
 

--- a/strands_robots/drivers/dynamixel/driver.py
+++ b/strands_robots/drivers/dynamixel/driver.py
@@ -48,6 +48,7 @@ from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.drivers.base import undeclared_verb_error
+from strands_robots.utils import positive_count_error
 
 if TYPE_CHECKING:
     from strands.types.tools import ToolSpec, ToolUse
@@ -92,7 +93,9 @@ class DynamixelDriver:
     * ``port`` - a serial device path (``/dev/tty.usbserial-*``) for a single
       bus, or a sequence of them for a bimanual rig. Kept polymorphic:
       Aloha's ``ports=[...]`` and the single-bus ``port=`` both land here.
-    * ``baud_rate`` - integer, defaults to ``1_000_000``. The Robotis default.
+    * ``baud_rate`` - a positive integer, defaults to ``1_000_000``. The Robotis
+      default. Held to :func:`~strands_robots.utils.positive_count_error`, the
+      domain every surface that opens a serial bus shares.
     * ``motor_ids`` - the servo IDs on the bus, in wire order. Optional at
       construction; the bus discovers them on connect.
     """
@@ -124,7 +127,13 @@ class DynamixelDriver:
             self._ports = tuple(ports)
         else:
             self._ports = (port,)
-        self._baud_rate: int = int(kwargs.pop("baud_rate", 1_000_000))
+        # Graded, not coerced - the same reason :class:`FeetechDriver` states:
+        # pyserial takes the speed through its own ``int()`` and refuses only a
+        # negative, so a converted value is applied rather than reported.
+        baud_rate = kwargs.pop("baud_rate", 1_000_000)
+        if (reason := positive_count_error(baud_rate, "baud_rate", f"DynamixelDriver({tool_name!r})")) is not None:
+            raise ValueError(reason)
+        self._baud_rate: int = baud_rate
         self._motor_ids: tuple[int, ...] = tuple(kwargs.pop("motor_ids", ()))
         self._connected: bool = False
         self._connect_error: str | None = None

--- a/strands_robots/drivers/feetech/bus.py
+++ b/strands_robots/drivers/feetech/bus.py
@@ -45,7 +45,7 @@ from strands_robots.drivers.feetech.protocol import (
     read_packet,
     sync_write_packet,
 )
-from strands_robots.utils import require_optional
+from strands_robots.utils import positive_count_error, require_optional
 
 logger = logging.getLogger(__name__)
 
@@ -170,9 +170,16 @@ class FeetechBus:
     Args:
         port: Serial device path. ``None`` is accepted so a driver can be
             constructed before its port is known; :meth:`connect` refuses.
-        baud_rate: Bus speed. 1 Mbaud is the STS3215 default.
+        baud_rate: Bus speed, a positive integer. 1 Mbaud is the STS3215
+            default. Refused here rather than at :meth:`connect` because
+            pyserial coerces the speed through its own ``int()`` and refuses
+            only a negative, so an unusable value opens the port at a speed no
+            servo answers instead of reporting itself.
         motors: The servos on this bus, defaulting to :data:`SO_ARM_MOTORS`.
         timeout: Serial read timeout in seconds.
+
+    Raises:
+        ValueError: ``baud_rate`` is not a positive integer.
     """
 
     def __init__(
@@ -182,6 +189,8 @@ class FeetechBus:
         motors: dict[str, MotorSpec] | None = None,
         timeout: float = 1.0,
     ) -> None:
+        if (reason := positive_count_error(baud_rate, "baud_rate", type(self).__name__)) is not None:
+            raise ValueError(reason)
         self.port = port
         self.baud_rate = baud_rate
         self.motors = dict(SO_ARM_MOTORS if motors is None else motors)

--- a/strands_robots/drivers/feetech/driver.py
+++ b/strands_robots/drivers/feetech/driver.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 from strands_robots.bus_access import bus_lock
 from strands_robots.drivers.base import undeclared_verb_error
 from strands_robots.drivers.feetech.bus import SO_ARM_MOTORS, FeetechBus
-from strands_robots.utils import boolean_flag_error
+from strands_robots.utils import boolean_flag_error, positive_count_error
 
 logger = logging.getLogger(__name__)
 
@@ -106,9 +106,13 @@ class FeetechDriver:
 
     * ``port`` - a serial device path (``/dev/tty.usbserial-*``) for the SCS
       bus. Optional at construction; the bus opens it on connect.
-    * ``baud_rate`` - integer, defaults to ``1_000_000``. The Feetech default
-      for STS3215 arms; SCS-series can also run at 500_000 or below and a
-      caller who knows better passes it here.
+    * ``baud_rate`` - a positive integer, defaults to ``1_000_000``. The Feetech
+      default for STS3215 arms; SCS-series can also run at 500_000 or below and
+      a caller who knows better passes it here. Held to
+      :func:`~strands_robots.utils.positive_count_error` - the domain
+      :mod:`~strands_robots.tools.serial_tool` holds its own ``baudrate`` to -
+      because pyserial coerces the speed rather than checking it, so a value
+      that is not a count is applied instead of refused.
     * ``motor_ids`` - the servo IDs on the bus, in wire order. Optional at
       construction; the bus discovers them on connect.
     """
@@ -139,7 +143,17 @@ class FeetechDriver:
                 f"multi-bus rigs are not part of {SUPPORTED_ROBOTS}",
             )
         self._port: str | None = port
-        self._baud_rate: int = int(kwargs.pop("baud_rate", 1_000_000))
+        # Graded, not coerced. pyserial takes the speed through its own
+        # ``int()`` and refuses only a negative, so a value this constructor
+        # converted was applied rather than reported: ``2.7`` opened the port at
+        # 2 baud and ``0`` opened it successfully at a speed no servo answers,
+        # while ``get_status`` reported the converted number as the configured
+        # one. The same domain :mod:`~strands_robots.tools.serial_tool` holds
+        # its ``baudrate`` to, because the two reach the same ``serial.Serial``.
+        baud_rate = kwargs.pop("baud_rate", 1_000_000)
+        if (reason := positive_count_error(baud_rate, "baud_rate", f"FeetechDriver({tool_name!r})")) is not None:
+            raise ValueError(reason)
+        self._baud_rate: int = baud_rate
         self._motor_ids: tuple[int, ...] = tuple(kwargs.pop("motor_ids", ()))
         # ``motor_ids`` narrows the arm to a subset of SO_ARM_MOTORS. Honoured
         # rather than recorded: a keyword that changes nothing is worse than one

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -533,6 +533,22 @@ class MotorController:
     """Low-level motor control for fine movements."""
 
     def __init__(self, port: str, baudrate: int = 1000000):
+        """Bind a controller to one serial port.
+
+        Args:
+            port: Serial device path; opened by :meth:`connect`.
+            baudrate: Bus speed, a positive integer. Refused here rather than at
+                :meth:`connect`, which reports a failure to open as a reason
+                string: pyserial coerces the speed through its own ``int()`` and
+                refuses only a negative, so an unusable value opens the port at a
+                speed no servo answers and every read then times out, which is
+                indistinguishable from an unplugged arm.
+
+        Raises:
+            ValueError: ``baudrate`` is not a positive integer.
+        """
+        if (reason := positive_count_error(baudrate, "baudrate", type(self).__name__)) is not None:
+            raise ValueError(reason)
         self.port = port
         self.baudrate = baudrate
         self.serial_conn: serial.Serial | None = None

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1058,7 +1058,7 @@ def step_aborted_msg(completed: int, requested: int, *, context: str = "step") -
 def positive_count_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive integer count.
 
-    Shared domain for four families of discrete quantity:
+    Shared domain for five families of discrete quantity:
 
     * The knobs that count iterations of a control or rollout loop - the
       simulation's ``n_episodes`` / ``max_steps`` / ``control_substeps`` /
@@ -1084,6 +1084,16 @@ def positive_count_error(value: Any, param: str, context: str) -> str | None:
       building live resources - a physics engine per environment, an OS thread
       per worker - so a count the caller did not mean is not a bad number but
       the wrong number of engines.
+    * The speed a serial bus is opened at - the ``baudrate`` of
+      :mod:`~strands_robots.tools.serial_tool` and the ``baud_rate`` of every
+      surface that opens one: :class:`~strands_robots.drivers.feetech.driver.FeetechDriver`,
+      :class:`~strands_robots.drivers.dynamixel.driver.DynamixelDriver`,
+      :class:`~strands_robots.drivers.feetech.bus.FeetechBus` and
+      ``pose_tool``'s motor controller. They all reach one ``serial.Serial``,
+      which takes the speed through its own ``int()`` and refuses only a
+      negative - so a speed that is not a count is applied rather than
+      reported: ``2.7`` opens the port at 2 baud and ``0`` opens it
+      successfully at a speed no servo answers.
 
     It lives here rather than beside one of its callers because those callers
     sit in different layers (:mod:`strands_robots.hardware_robot` must not

--- a/tests/test_bus_speed_is_graded_wherever_a_port_is_opened.py
+++ b/tests/test_bus_speed_is_graded_wherever_a_port_is_opened.py
@@ -1,0 +1,238 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The speed a serial bus is opened at is graded on every surface that takes one.
+
+:mod:`~strands_robots.tools.serial_tool` holds its ``baudrate`` to
+:func:`~strands_robots.utils.positive_count_error` and says why in its own module
+docstring: the option is "coerced rather than checked by pyserial (``2.7`` becomes
+2 baud)". The four constructors that reach the same ``serial.Serial`` took the same
+quantity and held it to nothing - two converted it with ``int()`` and two stored it
+raw - so a speed that is not a count was *applied* rather than reported, and the
+tool refused a value the driver beside it accepted.
+
+What the ungraded value did, measured rather than argued (:class:`TestPyserialCoerces`
+pins the third-party half against a real pty):
+
+* ``baud_rate=0`` opened the port **successfully**, at a speed no servo answers.
+  Every read then times out, which is indistinguishable from an unplugged arm.
+* ``baud_rate=True`` opened it at 1 baud and ``baud_rate=2.7`` at 2 - a different
+  speed from the one asked for, while ``get_status`` reported the converted number
+  as the configured one.
+* ``baud_rate=-9600`` / ``None`` / ``[1_000_000]`` reached pyserial's own
+  ``ValueError: Not a valid baudrate``, and ``nan`` / ``inf`` an ``int()``
+  conversion error - each raised at connect time by a third library, naming
+  neither the driver nor the parameter.
+* ``1_000_000.0`` and ``'1000000'`` were converted to the speed the caller meant.
+  They are refused now, which is the one narrowing here: the tool surface already
+  refuses both, and that divergence between a tool and the driver it drives is
+  what this domain removes.
+
+:class:`TestEverySurfaceThatOpensAPortIsRostered` keeps the roster honest by
+reading the syntax tree for ``serial.Serial`` calls, so a fifth surface cannot
+open a port at an ungraded speed without failing here.
+:mod:`~strands_robots.teleoperator` is deliberately absent: it forwards
+``baud_rate`` into a lerobot config dataclass and never opens the port itself, so
+the domain that applies is lerobot's.
+
+Everything here is offline. The only port opened is a pty this file creates.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+import strands_robots
+from strands_robots.drivers.dynamixel.driver import DynamixelDriver
+from strands_robots.drivers.feetech.bus import FeetechBus
+from strands_robots.drivers.feetech.driver import FeetechDriver
+from strands_robots.tools.pose_tool import MotorController
+from strands_robots.tools.serial_tool import serial_tool
+
+_PORT = "/dev/ttyTEST-never-opened"
+
+# Every surface that accepts a bus speed from a caller: how one is built, the
+# attribute the accepted speed lands in, and the parameter a refusal must name.
+_SURFACES: tuple[tuple[str, Callable[[Any], Any], str, str], ...] = (
+    ("FeetechDriver", lambda v: FeetechDriver(tool_name="so101", baud_rate=v), "_baud_rate", "baud_rate"),
+    ("DynamixelDriver", lambda v: DynamixelDriver(tool_name="koch", baud_rate=v), "_baud_rate", "baud_rate"),
+    ("FeetechBus", lambda v: FeetechBus(port=_PORT, baud_rate=v), "baud_rate", "baud_rate"),
+    ("MotorController", lambda v: MotorController(_PORT, v), "baudrate", "baudrate"),
+)
+_SURFACE_IDS = [name for name, _, _, _ in _SURFACES]
+
+# Speeds that are not a count, grouped by what each one did instead of failing.
+# Kept as (value, what it did) pairs rather than a set: ``0 == False`` and
+# ``1_000_000 == 1_000_000.0``, so a mapping keyed on the value would silently
+# collapse the exact distinctions this domain is about.
+_UNUSABLE: tuple[tuple[Any, str], ...] = (
+    (0, "opened the port successfully, at a speed no servo answers"),
+    (True, "opened it at 1 baud - a bool is an int, so a bare `< 1` test admits it"),
+    (2.7, "opened it at 2 baud, the value serial_tool's docstring names"),
+    (-9600, "reached pyserial's own 'Not a valid baudrate', naming no parameter"),
+    (float("nan"), "escaped as 'cannot convert float NaN to integer'"),
+    (float("inf"), "escaped as an OverflowError from int()"),
+    (None, "reached pyserial's own 'Not a valid baudrate: None'"),
+    ([1_000_000], "reached pyserial's own 'Not a valid baudrate: [1000000]'"),
+    (1_000_000.0, "was converted to the speed meant; the tool surface refuses it"),
+    ("1000000", "was converted to the speed meant; the tool surface refuses it"),
+)
+_UNUSABLE_VALUES = [value for value, _ in _UNUSABLE]
+_UNUSABLE_IDS = [repr(value) for value, _ in _UNUSABLE]
+
+# Speeds a servo bus really runs at, plus the extremes of the accepted domain.
+# The rule is a floor on the type, not a whitelist of standard rates: a caller
+# with a servo configured to something unusual is not second-guessed.
+_USABLE: tuple[int, ...] = (1, 9600, 57600, 115200, 500_000, 1_000_000, 4_000_000)
+
+
+def _refusal(param: str, build: Callable[[Any], Any], value: Any) -> str | None:
+    """The refusal text a surface produced, or ``None`` when it accepted.
+
+    A ``ValueError`` whose message does not name ``param`` is not a refusal by
+    this domain - it is the pre-fix behaviour, where the conversion itself failed
+    and reported neither the surface nor the option. Grading those as refusals
+    would let this file pass against the code it was written to catch.
+    """
+    try:
+        build(value)
+    except ValueError as error:
+        if param in str(error):
+            return str(error)
+        pytest.fail(f"{param}={value!r} raised a ValueError naming neither surface nor option: {error}")
+    except BaseException as error:  # noqa: BLE001 - any escape is the defect
+        pytest.fail(f"{param}={value!r} escaped as {type(error).__name__}: {error}")
+    return None
+
+
+class TestAnUnusableSpeedIsRefusedEverywhere:
+    """No surface may apply a speed that is not a positive integer count."""
+
+    @pytest.mark.parametrize(("value", "did"), _UNUSABLE, ids=_UNUSABLE_IDS)
+    @pytest.mark.parametrize(("name", "build", "attr", "param"), _SURFACES, ids=_SURFACE_IDS)
+    def test_it_is_refused_by_name(
+        self,
+        name: str,
+        build: Callable[[Any], Any],
+        attr: str,
+        param: str,
+        value: Any,
+        did: str,
+    ) -> None:
+        del attr
+        refusal = _refusal(param, build, value)
+        assert refusal is not None, f"{name} accepted {param}={value!r}, which {did}"
+        assert param in refusal and "positive integer" in refusal
+
+    def test_the_refusal_names_the_surface_that_received_it(self) -> None:
+        """A message naming only the option sends the caller to the wrong layer."""
+        for name, build, _attr, param in _SURFACES:
+            refusal = _refusal(param, build, 0)
+            assert refusal is not None
+            assert name in refusal, f"{name}'s refusal does not name it: {refusal}"
+
+
+class TestAUsableSpeedIsAcceptedUnchanged:
+    """The over-reach control: nothing that worked stops working, or is rewritten."""
+
+    @pytest.mark.parametrize("value", _USABLE, ids=[str(v) for v in _USABLE])
+    @pytest.mark.parametrize(("name", "build", "attr", "param"), _SURFACES, ids=_SURFACE_IDS)
+    def test_it_is_stored_exactly_as_supplied(
+        self, name: str, build: Callable[[Any], Any], attr: str, param: str, value: int
+    ) -> None:
+        del param
+        stored = getattr(build(value), attr)
+        assert stored == value and type(stored) is int, f"{name} stored {stored!r} for a supplied {value!r}"
+
+    def test_the_documented_default_is_within_the_domain(self) -> None:
+        """A domain that refuses its own default is the one real risk here."""
+        for name, build, attr, _param in _SURFACES:
+            del name
+            assert getattr(build(1_000_000), attr) == 1_000_000
+
+
+class TestTheToolAndTheDriverAgree:
+    """The divergence this domain removes: one speed, one answer."""
+
+    @pytest.mark.parametrize("value", _UNUSABLE_VALUES, ids=_UNUSABLE_IDS)
+    def test_the_tool_refuses_what_the_drivers_refuse(self, value: Any) -> None:
+        result = serial_tool(action="send", port=_PORT, data="x", baudrate=value)
+        assert result["status"] == "error"
+        assert "baudrate" in result["content"][0]["text"]
+
+    def test_a_usable_speed_gets_past_the_tools_option_check(self) -> None:
+        """So the cell above measures the option and not the missing port."""
+        result = serial_tool(action="send", port=_PORT, data="x", baudrate=1_000_000)
+        assert "baudrate" not in result["content"][0]["text"]
+
+
+class TestPyserialCoerces:
+    """The premise every docstring here rests on, measured against a real pty.
+
+    If a future pyserial starts refusing these itself, this fails and the reason
+    the domain gives for existing needs rewriting.
+    """
+
+    @pytest.mark.parametrize(
+        ("value", "applied"),
+        [(0, 0), (True, 1), (2.7, 2), ("1000000", 1_000_000)],
+        ids=["0", "True", "2.7", "'1000000'"],
+    )
+    def test_a_speed_that_is_not_a_count_is_applied_not_refused(self, value: Any, applied: int) -> None:
+        serial = pytest.importorskip("serial")
+        master, follower = os.openpty()
+        try:
+            conn = serial.Serial(os.ttyname(follower), value, timeout=0.1)
+            try:
+                assert conn.baudrate == applied
+            finally:
+                conn.close()
+        finally:
+            os.close(master)
+            os.close(follower)
+
+
+class TestEverySurfaceThatOpensAPortIsRostered:
+    """A fifth surface cannot open a port at a speed nothing graded."""
+
+    #: Modules the scan below is allowed to find. ``serial_tool`` grades its
+    #: ``baudrate`` as a tool option rather than at a constructor, so it is named
+    #: here instead of in ``_SURFACES``.
+    _EXPECTED = frozenset(
+        {
+            "strands_robots/tools/serial_tool.py",
+            "strands_robots/tools/pose_tool.py",
+            "strands_robots/drivers/feetech/bus.py",
+        }
+    )
+
+    @staticmethod
+    def _modules_opening_a_port() -> set[str]:
+        root = pathlib.Path(strands_robots.__file__).parent
+        found: set[str] = set()
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and ast.unparse(node.func).endswith("serial.Serial"):
+                    found.add(f"strands_robots/{path.relative_to(root).as_posix()}")
+        return found
+
+    def test_the_scan_finds_the_surfaces_the_roster_accounts_for(self) -> None:
+        assert self._modules_opening_a_port() == self._EXPECTED, (
+            "a module opens a serial port that this file does not account for; "
+            "give its speed a domain and add it to _SURFACES"
+        )
+
+    def test_every_rostered_constructor_is_exercised(self) -> None:
+        """The roster cannot fall behind the surfaces it claims to grade."""
+        assert {name for name, _, _, _ in _SURFACES} == {
+            "FeetechDriver",
+            "DynamixelDriver",
+            "FeetechBus",
+            "MotorController",
+        }

--- a/tests/test_bus_speed_is_graded_wherever_a_port_is_opened.py
+++ b/tests/test_bus_speed_is_graded_wherever_a_port_is_opened.py
@@ -105,7 +105,11 @@ def _refusal(param: str, build: Callable[[Any], Any], value: Any) -> str | None:
         if param in str(error):
             return str(error)
         pytest.fail(f"{param}={value!r} raised a ValueError naming neither surface nor option: {error}")
-    except BaseException as error:  # noqa: BLE001 - any escape is the defect
+    except Exception as error:
+        # Any other escape is the defect under test - pre-fix, `inf` left a
+        # constructor as OverflowError - so the class is reported rather than
+        # asserted. Exception, not BaseException: an interrupt or a pytest
+        # outcome is not something a surface did with the value.
         pytest.fail(f"{param}={value!r} escaped as {type(error).__name__}: {error}")
     return None
 


### PR DESCRIPTION
`serial_tool` holds its `baudrate` to `positive_count_error`, and its module docstring says why: the option is *"coerced rather than checked by pyserial (`2.7` becomes 2 baud)"*. Four constructors reach the same `serial.Serial` and held that quantity to nothing — `FeetechDriver` and `DynamixelDriver` converted it with `int()`, `FeetechBus` and `pose_tool`'s `MotorController` stored it raw.

![one quantity, five owners](https://raw.githubusercontent.com/cagataycali/robots/783f65f81d6ed67260ceaf5cf2764af492561c13/assets/baud-domain.png)

Every cell above is measured (`4 surfaces x 13 values`, plus what a real pty does with each value). **Before: 0 of 52 refused by name.** After: 40 refused, 12 accepted — the 3 usable speeds on all 4 surfaces. Disagreements with the tool surface beside them: **40 -> 0**.

## What the ungraded value did

| `baud_rate` | pyserial | pre-fix outcome |
|---|---|---|
| `0` | **opens the port at 0 baud** | accepted; every read then times out, indistinguishable from an unplugged arm |
| `True` | opens at 1 baud | `int()` stored `1` — a bool is an `int`, so a bare `< 1` test admits it |
| `2.7` | opens at 2 baud | `int()` stored `2`, and `get_status` reported `baud_rate: 2` as the configured speed |
| `-9600` / `None` / `[1000000]` | `ValueError: Not a valid baudrate` | stored, then raised at *connect* by a third library naming neither driver nor option |
| `nan` / `inf` | — | escaped `__init__` as `cannot convert float NaN to integer` / `OverflowError` |
| `1000000.0` / `'1000000'` | opens at 1000000 | converted to the speed meant — while the tool surface refused both |

The last row is the whole point: one quantity, two answers, decided by whether the caller reached it through the tool or through the driver the tool drives.

## Change

All four surfaces now take `positive_count_error` and name themselves in the refusal:

```
FeetechDriver('so101'): baud_rate must be a positive integer, got 2.7.
FeetechBus: baud_rate must be a positive integer, got 0.
```

The `int()` conversions are **deleted** rather than moved behind the guard: a value the domain admits is already an `int`, so the coercion could only restate it — and it was the mechanism. `positive_count_error`'s family list said "four families" while its callers were already five; it now names the serial-bus speed as the fifth.

One narrowing, deliberate: `1000000.0` and `'1000000'` stop being accepted at the drivers. Nothing in the tree passes a non-`int` bus speed, and the tool surface already refused both — removing that divergence is the change.

## Tests

`tests/test_bus_speed_is_graded_wherever_a_port_is_opened.py`, 87 cells, offline (the only port opened is a pty it creates):

- every unusable speed refused **by name** at every surface, and the refusal names the surface — **41 cells fail pre-fix**;
- over-reach control: 7 usable speeds stored *exactly as supplied* (`type(stored) is int`), and each surface's documented default `1_000_000` constructs;
- the tool and the drivers now answer identically on all 13 values;
- `pyserial` really coerces — measured against a pty, so the premise every docstring here rests on is pinned rather than asserted;
- a syntax-tree scan for `serial.Serial` calls, so a fifth surface cannot open a port at an ungraded speed without failing here. `teleoperator` is deliberately out of scope: it forwards `baud_rate` into a lerobot config and never opens the port.

A refusal graded as such only when the message names the parameter — pre-fix code *also* raised `ValueError` from the failed conversion, and folding those in would let the file pass against the code it was written to catch.

## Gate

`ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ` (1925 files); `mypy` adds no error (20 standing, none in these files). 102-module net around the touched surfaces: pre-fix baseline `3F/7018P`, with the fix `3F/7105P` = `7018 + 87`, failure names identical — 3 standing (`qpsolvers` absent, two lerobot-from-source drifts). Same net with the fix but without the new file: identical to baseline, so no existing cell changed.

Docs: the `baud_rate=` domain in `docs/getting-started/robot-factory.md` beside the `port=` polymorphism it deliberately does not share, and the `baudrate` row in `docs/hardware/tools.md`.

## Review rounds

**Round 1** — `4907e8c`. One concern, one commit: the `_refusal` helper in the new test file caught `BaseException` to report any escape as the defect under test. That is the shape `py/catch-base-exception` reports, and `tests/test_codeql_query_filters.py` holds the tree to exactly one such handler (the Isaac cross-thread marshal box), so at `7eae064` the required check was red on that census and a CodeQL thread sat on the same line. Narrowed to `Exception`, which is also the correct scope — pre-fix `inf` left a constructor as `OverflowError`, which is what the cell reports, while an interrupt or a pytest outcome is not something a surface did with the value. The `# noqa: BLE001` went with it (`BLE` is not in the ruff select set). Census grader 1F -> 0F; the 87 cells unchanged; whole-tree roster identical to base on every environmental failure. The push dismisses the round-0 approval by rule; the diff a re-review needs to read is those five lines.