### PR TITLE
docs(utils): a shared numeric domain that counts its families enumerates that many

### DIFF
--- a/changelog.d/3293-domain-family-count-matches-its-list.md
+++ b/changelog.d/3293-domain-family-count-matches-its-list.md
@@ -1,0 +1,21 @@
+### Docs: a shared numeric domain that counts its families enumerates that many
+
+`non_negative_count_error` opened with "Shared domain for two families" above a
+list of three, and then explained that refusing `0` "would reject the common
+configuration for both". The third family - the episode counts of the
+dataset-integrity gate, spent by `verify_dataset`'s `expected` / `min_frames`
+and by `SimEngine.verify_dataset_episodes` - had been added to the list without
+the count above it or the sentence below it following. That count is what tells
+a reader arriving from one caller how far the domain reaches, and what tells the
+next author that a caller in a new family widens the list rather than just
+calling the function, so a count that disagrees with the list misstates both.
+The seed bullet named `TrainSpec.seed` alone and now also names
+`StreamingDatasetReader.open`, the other surface measured to spend it.
+
+`positive_count_error` drifted the same way earlier, saying "three" while
+listing four, so the claim is now graded against the list it sits above: a
+stated family count must have one top-level bullet per family. That also
+forbids the shape which made the drift invisible in the first place - a count
+enumerated in prose with nothing countable beneath it, which is how
+`non_negative_whole_number_error` stated "two families"; its two families are
+now bullets, matching its three siblings in the same file.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -914,13 +914,15 @@ def non_negative_whole_number_error(value: Any, param: str, context: str) -> str
     """Error text when ``value`` is not a usable non-negative whole number.
 
     Shared domain for two families of discrete quantity whose ``0`` is a real
-    setting rather than a degenerate one: the number of physics steps a caller
-    asks a simulation to advance - the ``n_steps`` of every backend's
-    :meth:`~strands_robots.simulation.base.SimEngine.step` - and the two
-    whole-number teleop knobs :mod:`~strands_robots.tools.lerobot_teleoperate`
-    puts on the lerobot CLI, where ``dataset_reset_time_s=0`` is "no operator
-    pause between recorded episodes" and ``replay_episode=0`` is the first
-    episode.
+    setting rather than a degenerate one:
+
+    * The number of physics steps a caller asks a simulation to advance - the
+      ``n_steps`` of every backend's
+      :meth:`~strands_robots.simulation.base.SimEngine.step`.
+    * The two whole-number teleop knobs
+      :mod:`~strands_robots.tools.lerobot_teleoperate` puts on the lerobot CLI,
+      where ``dataset_reset_time_s=0`` is "no operator pause between recorded
+      episodes" and ``replay_episode=0`` is the first episode.
 
     Not the only physics-step count in the tree, and the difference is the
     floor rather than the scalar policy: the ``n_substeps`` of
@@ -1303,7 +1305,7 @@ def dial_host_error(value: Any, param: str, context: str) -> str | None:
 def non_negative_count_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable non-negative integer count.
 
-    Shared domain for two families of discrete quantity whose ``0`` is a
+    Shared domain for three families of discrete quantity whose ``0`` is a
     first-class value rather than a degenerate one:
 
     * The number of control steps a loop executes while an inference request is
@@ -1311,12 +1313,14 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
       (:attr:`~strands_robots.policies.base.Policy.rtc_observed_delay_steps`).
       That count is exactly ``0`` in the dominant case: a synchronous eval loop
       pauses the world during inference, so no step elapses.
-    * A reproducibility seed
-      (:attr:`~strands_robots.training.base.TrainSpec.seed`), where ``0`` is
-      simply a seed. Its appliers disagree about everything outside this domain:
-      ``torch.manual_seed`` reduces a negative seed modulo ``2**64`` (so ``-1``
-      silently becomes ``2**64 - 1`` and collides with a seed a caller could
-      have named), while NumPy's legacy seeder refuses a negative or a float.
+    * A reproducibility seed -
+      :attr:`~strands_robots.training.base.TrainSpec.seed` and the ``seed`` of
+      :meth:`~strands_robots.streaming_dataset.StreamingDatasetReader.open` -
+      where ``0`` is simply a seed. Its appliers disagree about everything
+      outside this domain: ``torch.manual_seed`` reduces a negative seed modulo
+      ``2**64`` (so ``-1`` silently becomes ``2**64 - 1`` and collides with a
+      seed a caller could have named), while NumPy's legacy seeder refuses a
+      negative or a float.
     * The episode counts of the dataset-integrity gate
       (:func:`strands_robots.verify_dataset.verify_dataset`'s ``expected`` and
       ``min_frames``, and the sim facade's
@@ -1327,8 +1331,8 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
       only for a threshold above zero, so a negative or non-finite one disables
       the check instead of failing it.
 
-    Refusing ``0`` would reject the common configuration for both, which is why
-    this is a separate domain rather than a caller of
+    Refusing ``0`` would reject the common configuration for all three, which is
+    why this is a separate domain rather than a caller of
     :func:`positive_count_error`.
 
     In every other respect it mirrors :func:`positive_count_error`: only a true

--- a/tests/test_shared_domain_family_counts_match_their_lists.py
+++ b/tests/test_shared_domain_family_counts_match_their_lists.py
@@ -1,0 +1,122 @@
+"""A shared numeric domain that counts its families enumerates that many.
+
+Four helpers in :mod:`strands_robots.utils` open their docstring by stating how
+many families of quantity share the domain, then list them. The count is load
+bearing: it is how a reader arriving from one caller learns the guard is spent
+elsewhere too, and how the next author learns that adding a caller in a new
+family means widening the list rather than just calling the function.
+
+That count is also the one part of the docstring nothing rechecks. It goes
+stale in the quietest possible way - a fifth caller in a new family gets a
+bullet and the word above it keeps saying "four", so the sentence that exists
+to tell a reader how far the domain reaches now understates it, and the
+docstring contradicts the list directly beneath it. It has gone stale twice:
+``positive_count_error`` said "three" while listing four, and
+``non_negative_count_error`` said "two" while listing three.
+
+So the claim is graded against the list it sits above. A stated count must have
+a bullet per family - which also forbids the shape that made the drift
+invisible, a count enumerated in prose with nothing countable beneath it.
+
+Deliberately not a check that the bullets match the call sites: a family is a
+kind of quantity, not a call site, and several of these families have more than
+one caller (the seed family alone is spent by ``TrainSpec.seed`` and
+``StreamingDatasetReader.open``). The count of families is an editorial claim
+about the list, and the list is what it is checked against.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+import strands_robots
+
+_PACKAGE_DIR = Path(strands_robots.__file__).parent
+
+#: Spelled-out counts a docstring may open with. Only the words the house style
+#: actually uses - a digit would read as a value in these sentences, not a count.
+_SPELLED_COUNTS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+}
+
+#: The claim being graded: "Shared domain for <count> families of ...".
+_STATED_FAMILY_COUNT = re.compile(rf"\bfor ({'|'.join(_SPELLED_COUNTS)}) families\b", re.IGNORECASE)
+
+
+def _family_bullets(doc: str) -> list[str]:
+    """Top-level ``*`` bullets of *doc*, which is one per family.
+
+    Read off the CLEANED docstring :func:`ast.get_docstring` returns, whose
+    common indentation has been stripped - so a family bullet starts at column
+    ``0`` and a sub-bullet elaborating one family is still indented and is not
+    miscounted as another family.
+    """
+    return [line for line in doc.splitlines() if line.startswith("* ")]
+
+
+def _documented_family_counts() -> list[tuple[str, str, int, int]]:
+    """Every definition whose docstring states a family count, with both numbers.
+
+    Returns:
+        ``(location, name, stated, enumerated)`` per definition, where ``stated``
+        is the count the prose claims and ``enumerated`` the number of top-level
+        bullets under it.
+    """
+    found: list[tuple[str, str, int, int]] = []
+    for path in sorted(_PACKAGE_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                continue
+            doc = ast.get_docstring(node)
+            if not doc:
+                continue
+            match = _STATED_FAMILY_COUNT.search(doc)
+            if match is None:
+                continue
+            stated = _SPELLED_COUNTS[match.group(1).lower()]
+            location = f"{path.relative_to(_PACKAGE_DIR.parent)}:{node.lineno}"
+            found.append((location, node.name, stated, len(_family_bullets(doc))))
+    return found
+
+
+def test_the_scan_finds_the_domains_that_state_a_family_count() -> None:
+    """The population is non-empty and is the shared-domain helpers.
+
+    Without this the assertions below pass vacuously the moment the phrasing
+    drifts and the scan matches nothing.
+    """
+    found = _documented_family_counts()
+    assert [name for _, name, _, _ in found] == [
+        "positive_whole_number_error",
+        "non_negative_whole_number_error",
+        "positive_count_error",
+        "non_negative_count_error",
+    ], f"unexpected population: {found}"
+
+
+@pytest.mark.parametrize("location, name, stated, enumerated", _documented_family_counts())
+def test_a_stated_family_count_enumerates_that_many_families(
+    location: str, name: str, stated: int, enumerated: int
+) -> None:
+    """The count in the prose equals the number of families listed beneath it."""
+    assert enumerated == stated, (
+        f"{location}: {name} documents a shared domain 'for {stated} families' but lists "
+        f"{enumerated} of them. The count tells a reader how far the domain reaches and tells "
+        f"the next author that a caller in a new family widens the list; a count that "
+        f"disagrees with the list beneath it misstates both. Add the missing family as a "
+        f"top-level '* ' bullet, or correct the count."
+    )


### PR DESCRIPTION
## The claim and the list disagreed

`non_negative_count_error` opens by stating how many families of quantity share the domain, then lists them. It stated **two** and listed **three** — and the sentence below the list still read "refusing `0` would reject the common configuration for **both**".

The third family (the episode counts of the dataset-integrity gate — `verify_dataset`'s `expected` / `min_frames` and `SimEngine.verify_dataset_episodes`) had been added to the list without the count above it or the sentence below it following.

That count is load bearing. It is how a reader arriving from one caller learns the guard is spent elsewhere too, and how the next author learns that a caller in a *new* family widens the list rather than just calling the function. A count that disagrees with the list beneath it misstates both.

## Measured, all four shared domains in `utils.py`

| helper | stated | listed | before | after |
|---|---|---|---|---|
| `positive_whole_number_error` | two | 2 bullets | ok | ok |
| `positive_count_error` | four | 4 bullets | ok | ok |
| `non_negative_count_error` | **two** | **3 bullets** | **mismatch** | three / 3 |
| `non_negative_whole_number_error` | two | **0 bullets** (prose) | **uncountable** | two / 2 |

`positive_count_error` drifted the same way earlier — it said "three" while listing four. Two occurrences of one class, so the claim is now graded rather than re-read.

## The rule

A docstring that states `Shared domain for <count> families` must carry one top-level `*` bullet per family. That also forbids the shape which made the drift invisible in the first place: a count enumerated in prose with nothing countable beneath it. `non_negative_whole_number_error`'s two families are now bullets, matching its three siblings in the same file — no wording changed, only the shape.

Deliberately *not* graded against call sites: a family is a kind of quantity, not a call site, and several families have more than one caller. The seed family alone is spent by `TrainSpec.seed` and `StreamingDatasetReader.open` — the bullet named only the first, and now names both.

## Verification

The pin is red on the pre-fix docstrings and green after, on the two surfaces changed and not on the two that were already right:

```
pre-fix : 2 failed, 3 passed
          non_negative_whole_number_error  'for 2 families' but lists 0 of them
          non_negative_count_error         'for 2 families' but lists 3 of them
post-fix: 5 passed
```

A population assertion pins the four helpers by name, so the scan cannot pass vacuously if the phrasing drifts and it matches nothing.

Gate: `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ` (1925 files); mypy unchanged at its 20 pre-existing errors in 6 files, none in the files touched. The 509-module net that reads `utils.py`, these domain names or docstrings via `get_docstring`/`rglob` runs 25097 passed with 26 failures/errors — byte-identical to the same net on `main` (both `comm` directions empty), all lerobot 0.6.2 / absent-extra drift.

Docstring text only: no behaviour, no signature, no accepted value changes. LOC delta +163 / -16 (122 of the additions are the pin, 21 the changelog fragment).