### PR TITLE
fix(policies/kimodo): a per-call sampler knob is graded, not converted

### DIFF
--- a/changelog.d/3294-kimodo-per-call-sampler-knob-domain.md
+++ b/changelog.d/3294-kimodo-per-call-sampler-knob-domain.md
@@ -1,0 +1,19 @@
+### Fixed: a per-call Kimodo sampler knob is graded, not converted
+
+`KimodoPolicy.get_actions` read its documented `diffusion_steps` and
+`guidance_scale` overrides straight out of `kwargs` and converted them with
+`int()` / `float()`, which cannot refuse a value - only reinterpret it. An
+override reaches the sampler and the buffered-motion key without passing
+through `KimodoConfig`, so of 18 values the config field refuses, none were
+refused per call: 12 were admitted (`diffusion_steps=True` denoised once,
+`2.7` became 2, `1000` escaped the field's ceiling, `guidance_scale=nan`
+reached the sampler) and 6 escaped as a `TypeError`/`OverflowError` naming
+neither the surface nor the knob. Ten of the admitted values also discarded
+the motion being tracked to re-sample with a number the caller never named.
+
+Both overrides now consult the same domain their config field does - the new
+`diffusion_steps_error` owns the composite step-count domain (the shared whole
+number rule plus this provider's ceiling) - and are checked before the key is
+built, so a refused override leaves the held motion and the frame cursor
+exactly as they were, as the sibling `seed` override already did. Values the
+fields accept, including an integral float and a NumPy scalar, are unchanged.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -132,8 +132,8 @@ it, or a tuned PD law) is required, and is out of scope for this provider.
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `model_id` | str | `nvidia/Kimodo-G1-RP-v1` | HF model id |
-| `diffusion_steps` | int | 100 | 25–200 useful range |
-| `guidance_scale` | float | 7.5 | CFG weight |
+| `diffusion_steps` | int | 100 | 25–200 useful range, ≤500 (the count multiplies the cost of every sample) |
+| `guidance_scale` | float | 7.5 | CFG weight, positive and finite |
 | `num_frames` | int | 120 | ≤196 (RP-v1 max) |
 | `transition_frames` | int | 5 | Native frames a chained segment is eased over |
 | `native_fps` | int | 30 | Sampler native rate |
@@ -156,7 +156,9 @@ KimodoPolicy(config={"diffusion_steps": 25})           # a plain dict
 
 Precedence is per-field override > `config` field > the default in the table. A
 merged value is re-validated by `KimodoConfig`, so `diffusion_steps=0` is
-refused whichever way it arrives.
+refused whichever way it arrives - including as the per-call
+`get_actions(..., diffusion_steps=0)` override below, which reaches the sampler
+without passing through the config and so applies the field's domain itself.
 
 A misspelled knob is refused by the two keyword forms and dropped by the dict
 form. Neither `KimodoPolicy` nor `KimodoConfig` takes `**kwargs`, so
@@ -197,6 +199,12 @@ await policy.get_actions({}, "waving", diffusion_steps=25)          # samples
 policy.reset()                                                      # rewinds
 policy.reset(seed=7); await policy.get_actions({}, "waving")        # samples
 ```
+
+`diffusion_steps`, `guidance_scale` and `seed` are held to the same domains as
+the config fields when they arrive this way, and are checked before the key is
+built: a refused override raises `ValueError` naming
+`KimodoPolicy.get_actions` and leaves the motion in hand and the frame cursor
+exactly as they were, so it costs neither a diffusion run nor a frame.
 
 This is what makes a multi-episode `eval_policy` meaningful for a stochastic
 policy. `PolicyRunner.evaluate` derives a distinct seed per episode and forwards

--- a/strands_robots/policies/kimodo/config.py
+++ b/strands_robots/policies/kimodo/config.py
@@ -8,8 +8,13 @@ at construction time with a clear message rather than deep inside the sampler.
 
 Numeric domains follow the shared helpers in :mod:`strands_robots.utils`:
 
-* ``diffusion_steps`` - positive integer (Kimodo default 100, 25-200 useful range)
-* ``guidance_scale`` - positive finite number (Kimodo default 7.5)
+* ``diffusion_steps`` - positive integer (Kimodo default 100, 25-200 useful
+  range) bounded by :data:`_KIMODO_MAX_DIFFUSION_STEPS`, via
+  :func:`diffusion_steps_error`, which is also the domain
+  :meth:`KimodoPolicy.get_actions` applies to a per-call override
+* ``guidance_scale`` - positive finite number (Kimodo default 7.5), the shared
+  :func:`~strands_robots.utils.positive_finite_number_error` domain, which
+  :meth:`KimodoPolicy.get_actions` applies to a per-call override too
 * ``fps`` - positive integer (Kimodo emits at 30Hz native, upsampled to 50Hz
   for the G1 tracker via SLERP downstream)
 * ``num_frames`` - positive integer bounded by the model's max sequence length
@@ -38,6 +43,11 @@ from strands_robots.utils import positive_finite_number_error, positive_whole_nu
 
 _KIMODO_DEFAULT_MODEL_ID = "nvidia/Kimodo-G1-RP-v1"
 _KIMODO_MAX_FRAMES = 196
+# Kimodo's own sampler is useful at 25-200 denoising steps; the ceiling here
+# is deliberately well above that so an experiment is not blocked by it, and
+# exists because the step count is a per-sample compute multiplier - an
+# unbounded one makes a single get_actions call an unbounded diffusion run.
+_KIMODO_MAX_DIFFUSION_STEPS = 500
 _KIMODO_NATIVE_FPS = 30
 _KIMODO_TRACKER_FPS = 50
 # Kimodo's own sampler blends a multi-prompt sequence over its last
@@ -94,6 +104,53 @@ def _positive_float(name: str, value: float) -> float:
     if error := positive_finite_number_error(value, name, "KimodoConfig"):
         raise ValueError(error)
     return float(value)
+
+
+def diffusion_steps_error(value: Any, context: str) -> str | None:
+    """Return why a value cannot be a Kimodo denoising-step count.
+
+    The single owner of this domain, because the domain is a composite one and
+    a composite restated at two surfaces is a domain that can diverge: the sign,
+    integrality, ``bool`` and float-range rules come from
+    :func:`~strands_robots.utils.positive_whole_number_error`, and the ceiling
+    :data:`_KIMODO_MAX_DIFFUSION_STEPS` is this provider's own.
+
+    Two surfaces set the step count. :class:`KimodoConfig` validates the field
+    (directly, through :meth:`KimodoConfig.from_dict` /
+    :meth:`KimodoConfig.from_json`, or through a
+    ``KimodoPolicy(diffusion_steps=...)`` override, all of which re-enter
+    :meth:`__post_init__`); and :meth:`KimodoPolicy.get_actions`, whose
+    documented per-call ``diffusion_steps=`` override is read straight from
+    ``kwargs`` and reaches both the sampler and the buffered-motion key without
+    passing through the config at all. Both consult this function, so one value
+    gets one verdict whichever way it is spelled.
+
+    The step count is spent twice, and both uses are why the domain is not
+    merely advisory. It is handed to the sampler, where it is the number of
+    denoising iterations - ``0`` asks for a sample that was never denoised and
+    ``True`` asks for one iteration, neither of which is a motion a tracker
+    should be asked to follow. And it is part of the key
+    :class:`KimodoPolicy` identifies the buffered motion by, so a value that
+    differs from the one that produced the motion in hand discards that motion
+    and re-enters the sampler mid-rollout.
+
+    Args:
+        value: The caller-supplied step count.
+        context: Message prefix identifying the surface that received it - the
+            class name for a constructor field, the method name otherwise.
+
+    Returns:
+        ``None`` when the step count is usable, otherwise the reason as a string.
+    """
+    if error := positive_whole_number_error(value, "diffusion_steps", context):
+        return error
+    if value > _KIMODO_MAX_DIFFUSION_STEPS:
+        return (
+            f"{context}: diffusion_steps must be <= {_KIMODO_MAX_DIFFUSION_STEPS}, got {value} - "
+            "the step count multiplies the cost of every sample, so a run this long is a stall "
+            "rather than a better motion."
+        )
+    return None
 
 
 def sampling_seed_error(value: Any, context: str) -> str | None:
@@ -234,7 +291,8 @@ class KimodoConfig:
 
     def __post_init__(self) -> None:
         # Validate at construction so bad values fail loud.
-        _positive_int("diffusion_steps", self.diffusion_steps, upper=500)
+        if error := diffusion_steps_error(self.diffusion_steps, "KimodoConfig"):
+            raise ValueError(error)
         _positive_float("guidance_scale", self.guidance_scale)
         _positive_int("num_frames", self.num_frames, upper=_KIMODO_MAX_FRAMES)
         _positive_int("transition_frames", self.transition_frames, upper=_KIMODO_MAX_FRAMES)

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -67,8 +67,9 @@ from numpy.typing import NDArray
 
 from strands_robots.policies.base import Policy
 from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS
+from strands_robots.utils import positive_finite_number_error
 
-from .config import KimodoConfig, sampling_seed_error
+from .config import KimodoConfig, diffusion_steps_error, sampling_seed_error
 
 logger = logging.getLogger(__name__)
 
@@ -455,7 +456,9 @@ class KimodoPolicy(Policy):
                 input to the sampler, so supplying one that differs from the
                 value that produced the buffered motion re-samples; supplying
                 the same values drains the existing buffer rather than paying
-                for a run that would return identical frames.
+                for a run that would return identical frames. Each numeric one
+                is held to the same domain its config field is, because an
+                override reaches the sampler without passing through the config.
 
         Returns:
             A single-element list containing a dict mapping each of
@@ -466,12 +469,15 @@ class KimodoPolicy(Policy):
 
         Raises:
             ValueError: If neither ``instruction`` nor ``text_prompt`` supplies
-                a non-empty prompt, or if a per-call ``seed`` override is
-                outside the domain
+                a non-empty prompt, or if a per-call ``diffusion_steps``,
+                ``guidance_scale`` or ``seed`` override is outside the domain
+                its config field is held to -
+                :func:`~strands_robots.policies.kimodo.config.diffusion_steps_error`,
+                :func:`~strands_robots.utils.positive_finite_number_error` and
                 :func:`~strands_robots.policies.kimodo.config.sampling_seed_error`
-                states. The seed is checked before the buffered-motion key is
-                built, so a refused override leaves the held motion and the
-                frame cursor exactly as they were.
+                respectively. All three are checked before the buffered-motion
+                key is built, so a refused override leaves the held motion and
+                the frame cursor exactly as they were.
         """
         prompt = kwargs.get("text_prompt") or instruction
         if not prompt or not prompt.strip():
@@ -482,11 +488,31 @@ class KimodoPolicy(Policy):
 
         # (Re)sample on the first call, or whenever any input that determines
         # the motion differs from the one that produced the buffer we hold.
-        diffusion_steps = int(kwargs.get("diffusion_steps", self.config.diffusion_steps))
-        guidance_scale = float(kwargs.get("guidance_scale", self.config.guidance_scale))
+        #
+        # Every one of those inputs is graded here, against the same domain the
+        # matching config field applies, and before the key below is built: an
+        # override is read straight from kwargs and reaches the sampler and the
+        # key without passing through the frozen config, so this is the only
+        # place it can be refused. Grading precedes the conversions further down
+        # for the same reason the seed is graded before ``_sample_key`` coerces
+        # it - int(2.7) is 2 and float(True) is 1.0, so a coerced value is
+        # indistinguishable from one the caller meant, and it discards the held
+        # motion to re-enter the sampler with a number nobody asked for.
+        steps_value = kwargs.get("diffusion_steps", self.config.diffusion_steps)
+        if error := diffusion_steps_error(steps_value, "KimodoPolicy.get_actions"):
+            raise ValueError(error)
+        guidance_value = kwargs.get("guidance_scale", self.config.guidance_scale)
+        if error := positive_finite_number_error(guidance_value, "guidance_scale", "KimodoPolicy.get_actions"):
+            raise ValueError(error)
         seed = kwargs.get("seed", self.config.seed)
         if error := sampling_seed_error(seed, "KimodoPolicy.get_actions"):
             raise ValueError(error)
+        # Both domains admit an integral float (a 100.0 read from a config array
+        # passes, and the config field holds it as given), while the sampler and
+        # the key want the int and the float they are declared as. After the
+        # guards above these conversions can only restate the value.
+        diffusion_steps = int(steps_value)
+        guidance_scale = float(guidance_value)
         key = self._sample_key(prompt, diffusion_steps, guidance_scale, seed)
         if self._motion_buffer is None or key != self._buffer_key:
             self._synthesise(

--- a/tests/policies/kimodo/test_sampler_knobs_have_one_domain.py
+++ b/tests/policies/kimodo/test_sampler_knobs_have_one_domain.py
@@ -1,0 +1,251 @@
+"""One Kimodo sampler knob, one domain, whichever surface sets it.
+
+``diffusion_steps`` and ``guidance_scale`` are validated as config fields, and
+they are also documented per-call overrides of ``get_actions``. An override is
+read straight from ``kwargs`` and reaches the sampler and the buffered-motion
+key without passing through the frozen config, so the config's validation is
+not on that path - and ``PolicyRunner.run`` / ``evaluate`` forward
+``policy_kwargs`` verbatim to every ``get_actions`` call, so it is a routine
+path rather than a private one. The sibling ``seed`` override on the next line
+already consults its own domain owner (``test_sampling_seed_has_one_domain``);
+these two used to be converted with ``int()`` / ``float()`` instead, which
+cannot refuse a value, only reinterpret it.
+
+Both spendings of these knobs are why the domain is not advisory. Each is
+handed to the sampler - ``diffusion_steps=0`` asks for a sample that was never
+denoised, ``True`` for a single iteration, and a ``guidance_scale`` of ``nan``
+poisons every comparison the sampler makes with it. And each is part of the key
+the buffered motion is identified by, so a value that differs from the one that
+produced the motion in hand discards that motion and re-enters the sampler
+mid-rollout - which is what a coerced value did silently, with a number the
+caller never named.
+
+The ACCEPTED rows are controls that hold on both sides of the fix: every
+spelling of a usable knob the config field takes - including the integral float
+and the NumPy scalar the shared domains admit, and the ceiling value itself -
+still reaches the sampler as the ``int`` and ``float`` it is declared as.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.kimodo import KIMODO_G1_JOINTS, KimodoConfig, KimodoPolicy
+
+_NUM_JOINTS = len(KIMODO_G1_JOINTS)
+_ROOT = 7
+
+# The ceiling the config field applies to the step count, stated as the number
+# the reference documents rather than imported from the module under test - a
+# pin that reads the bound out of the code it grades cannot disagree with it.
+_MAX_STEPS = 500
+
+# One native frame per emitted frame, so a sampler run is countable directly.
+_FAST = {"num_frames": 6, "native_fps": 30, "tracker_fps": 30}
+
+#: The surface prefixes the two spellings report under.
+_CONFIG = "KimodoConfig"
+_PER_CALL = "KimodoPolicy.get_actions"
+
+
+class _KnobRecordingAgent:
+    """Record the knobs every sampler run was handed, and ramp per frame."""
+
+    def __init__(self) -> None:
+        self.knobs: list[tuple[object, object]] = []
+
+    def sample(self, prompt, num_frames, diffusion_steps, guidance_scale, seed):
+        self.knobs.append((diffusion_steps, guidance_scale))
+        out = np.zeros((num_frames, _ROOT + _NUM_JOINTS), dtype=np.float32)
+        out[:, 3] = 1.0  # identity quaternion, wxyz
+        out[:, _ROOT:] = 0.01 * np.arange(num_frames, dtype=np.float32)[:, None]
+        return out
+
+
+def _policy(**cfg_kwargs):
+    agent = _KnobRecordingAgent()
+    return KimodoPolicy(config=KimodoConfig(**_FAST, **cfg_kwargs), motion_agent=agent), agent
+
+
+def _pose(policy, **kwargs) -> tuple[float, ...]:
+    action = asyncio.run(policy.get_actions({}, "walk forward", **kwargs))[0]
+    return tuple(action[joint] for joint in KIMODO_G1_JOINTS)
+
+
+# Rosters are lists of (value, id) pairs rather than dicts or sets: ``0 ==
+# False`` and ``100 == 100.0``, so a mapping would collapse the exact
+# distinctions a coercion defect is about.
+#: Step counts no surface can honor. Each is refused as a config field today.
+UNUSABLE_STEPS = [
+    pytest.param(0, id="zero-a-sample-that-was-never-denoised"),
+    pytest.param(-5, id="negative"),
+    pytest.param(True, id="bool-an-int-subclass-that-would-denoise-once"),
+    pytest.param(2.7, id="fractional-step-count"),
+    pytest.param("100", id="numeric-string"),
+    pytest.param(_MAX_STEPS + 500, id="above-the-ceiling-the-field-applies"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(None, id="None"),
+    pytest.param([100], id="a-list"),
+]
+
+#: Guidance weights no surface can honor.
+UNUSABLE_GUIDANCE = [
+    pytest.param(0, id="zero-weight"),
+    pytest.param(-1.0, id="negative"),
+    pytest.param(True, id="bool-an-int-subclass-that-would-act-as-1"),
+    pytest.param("7.5", id="numeric-string"),
+    pytest.param(float("nan"), id="nan-poisons-every-comparison"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(None, id="None"),
+    pytest.param([7.5], id="a-list"),
+]
+
+#: Step counts that survive both uses. Controls: green before and after.
+USABLE_STEPS = [
+    pytest.param(25, 25, id="low-end-of-the-useful-range"),
+    pytest.param(200, 200, id="high-end-of-the-useful-range"),
+    pytest.param(_MAX_STEPS, _MAX_STEPS, id="the-ceiling-itself"),
+    pytest.param(100.0, 100, id="integral-float-from-a-config-array"),
+    pytest.param(np.int64(50), 50, id="numpy-integer"),
+    pytest.param(np.float64(50.0), 50, id="numpy-integral-float"),
+]
+
+#: Guidance weights that survive both uses.
+USABLE_GUIDANCE = [
+    pytest.param(1.0, 1.0, id="no-guidance"),
+    pytest.param(20.0, 20.0, id="strong-guidance"),
+    pytest.param(3, 3.0, id="whole-number-widens-to-the-declared-float"),
+    pytest.param(np.float32(7.5), 7.5, id="numpy-float"),
+]
+
+
+def _cases(*rosters):
+    """Flatten per-knob rosters into ``(knob, *columns)`` cases, ids prefixed."""
+    for knob, roster in rosters:
+        for case in roster:
+            yield pytest.param(knob, *case.values, id=f"{knob}-{case.id}")
+
+
+#: Every (knob, value) pair no surface can honor.
+UNUSABLE_CASES = list(_cases(("diffusion_steps", UNUSABLE_STEPS), ("guidance_scale", UNUSABLE_GUIDANCE)))
+
+#: Every (knob, value, value-as-spent) triple both surfaces must keep taking.
+USABLE_CASES = list(_cases(("diffusion_steps", USABLE_STEPS), ("guidance_scale", USABLE_GUIDANCE)))
+
+
+class TestBothSurfacesThatSetASamplerKnobShareOneDomain:
+    """A knob gets one verdict whether it is a config field or a per-call override."""
+
+    @pytest.mark.parametrize(("knob", "value"), UNUSABLE_CASES)
+    def test_the_config_field_refuses_it(self, knob, value):
+        with pytest.raises(ValueError, match=f"{knob} must be"):
+            KimodoConfig(**{knob: value})
+
+    @pytest.mark.parametrize(("knob", "value"), UNUSABLE_CASES)
+    def test_a_per_call_override_refuses_it(self, knob, value):
+        """The path a coercion used to take: read from kwargs, spent unchecked."""
+        policy, _ = _policy()
+        with pytest.raises(ValueError, match=f"{knob} must be"):
+            _pose(policy, **{knob: value})
+
+    @pytest.mark.parametrize(("knob", "value"), UNUSABLE_CASES)
+    def test_both_surfaces_state_the_same_reason_and_name_themselves(self, knob, value):
+        """One value, one verdict - and each message says which surface refused."""
+        with pytest.raises(ValueError) as from_field:
+            KimodoConfig(**{knob: value})
+        policy, _ = _policy()
+        with pytest.raises(ValueError) as from_override:
+            _pose(policy, **{knob: value})
+
+        field_text, override_text = str(from_field.value), str(from_override.value)
+        assert field_text.startswith(f"{_CONFIG}: ")
+        assert override_text.startswith(f"{_PER_CALL}: ")
+        assert field_text[len(_CONFIG) :] == override_text[len(_PER_CALL) :], (
+            "the two surfaces must state one domain, not two that agree today"
+        )
+
+
+class TestARefusedOverrideSpendsNothing:
+    """A refusal is not a partial application: the held motion survives it."""
+
+    @pytest.mark.parametrize(("knob", "value"), UNUSABLE_CASES)
+    def test_it_leaves_the_held_motion_the_cursor_and_the_sampler_alone(self, knob, value):
+        """What a coerced knob cost: a re-sample, and the motion in hand.
+
+        Pre-fix the admitted values here did not raise at all - they keyed a
+        different buffer, so the sampler ran again with a number the caller
+        never named and the motion being tracked was replaced mid-rollout.
+        """
+        policy, agent = _policy()
+        first = _pose(policy)
+        second = _pose(policy)
+        assert first != second, "the stub motion must advance, or a rewind is unobservable"
+
+        with pytest.raises(ValueError, match=f"{knob} must be"):
+            _pose(policy, **{knob: value})
+
+        assert len(agent.knobs) == 1, "a refused override must not run the sampler"
+        assert _pose(policy) != second, "the cursor must not have been rewound"
+
+    def test_the_ceiling_the_field_applies_is_not_escapable_per_call(self):
+        """The composite half of the domain: the shared rule plus this ceiling."""
+        policy, agent = _policy()
+        _pose(policy)
+        with pytest.raises(ValueError, match=f"diffusion_steps must be <= {_MAX_STEPS}"):
+            _pose(policy, diffusion_steps=_MAX_STEPS + 1)
+        assert len(agent.knobs) == 1, "a refused step count must not start a diffusion run"
+
+
+class TestAKnobTheDomainAcceptsSurvivesBothOfItsUses:
+    """The controls: the gate narrows nothing a caller could already ask for."""
+
+    #: What the sampler is declared to take for each knob, and the default the
+    #: other knob keeps while one is overridden.
+    _DECLARED = {"diffusion_steps": (int, 0, 7.5), "guidance_scale": (float, 1, 100)}
+
+    @pytest.mark.parametrize(("knob", "value", "reaches"), USABLE_CASES)
+    def test_an_accepted_override_reaches_the_sampler_as_the_declared_type(self, knob, value, reaches):
+        """The gate narrows nothing, and the conversion after it still normalises.
+
+        A NumPy scalar and an integral float are both inside the shared domains,
+        so they still pass - and the sampler is still handed the ``int`` and
+        ``float`` its signature declares rather than the caller's spelling.
+        """
+        declared, position, other = self._DECLARED[knob]
+        policy, agent = _policy()
+        _pose(policy, **{knob: value})
+
+        spent = agent.knobs[0][position]
+        assert spent == reaches
+        assert isinstance(spent, declared)
+        assert agent.knobs[0][1 - position] == other, "the knob not overridden keeps its config value"
+
+    @pytest.mark.parametrize(("knob", "value", "reaches"), USABLE_CASES)
+    def test_the_config_field_takes_it_too(self, knob, value, reaches):
+        """Neither surface may accept a spelling the other refuses."""
+        assert getattr(KimodoConfig(**{knob: value}), knob) == reaches
+
+    def test_a_changed_accepted_override_still_re_samples(self):
+        """Re-sampling on a changed knob is what the override is for."""
+        policy, agent = _policy()
+        _pose(policy)
+        _pose(policy, diffusion_steps=25)
+        assert agent.knobs == [(100, 7.5), (25, 7.5)]
+
+    def test_repeating_an_accepted_override_still_drains_the_buffer(self):
+        """The knob is part of the key, so an unchanged one must not re-sample."""
+        policy, agent = _policy()
+        _pose(policy, diffusion_steps=25, guidance_scale=3.0)
+        _pose(policy, diffusion_steps=25, guidance_scale=3.0)
+        assert agent.knobs == [(25, 3.0)]
+
+    def test_an_integral_float_names_the_same_motion_as_the_whole_number(self):
+        """``100`` and ``100.0`` are one step count, so they share one key."""
+        policy, agent = _policy()
+        _pose(policy, diffusion_steps=100)
+        _pose(policy, diffusion_steps=100.0)
+        assert agent.knobs == [(100, 7.5)], "the same count spelled two ways must not re-run the sampler"


### PR DESCRIPTION
`KimodoPolicy.get_actions` documents `diffusion_steps` and `guidance_scale` as per-call overrides, and read them straight out of `kwargs` through `int()` and `float()`. A conversion cannot refuse a value, only reinterpret it — and an override reaches the sampler and the buffered-motion key **without passing through the frozen `KimodoConfig`**, so the field's validation is not on that path. The sibling `seed` override on the very next line already consults its own domain owner.

The reference states the invariant that does not hold: *"A merged value is re-validated by `KimodoConfig`, so `diffusion_steps=0` is refused whichever way it arrives."* Measured, `get_actions(..., diffusion_steps=0)` is accepted and the sampler is asked for a sample that was never denoised.

![measured](https://raw.githubusercontent.com/cagataycali/robots/697b37ea18d3a353e0a56680d7541bdea507eef2/kimodo_knob_domain.png)

## Measured: 22 values, each offered to both surfaces that set a knob

| | as a config field | as a per-call override (before) | after |
|---|---|---|---|
| 18 values the fields refuse | refused, naming the knob | **0 refused** | 18 refused |
| — 12 admitted | | `True` denoised once, `2.7`→2, `-5`, `0`, `1000` (past the field's ceiling), `guidance_scale` `nan`/`inf`/`0`/`-1.0` reached the sampler | refused |
| — of which 10 | | also **discarded the motion being tracked** to re-sample with a number the caller never named | held motion intact |
| — the 2 numeric strings | | coerced to exactly the configured default, so indistinguishable from passing nothing | refused |
| — 6 escaped | | `TypeError`/`OverflowError`/`ValueError` naming neither the surface nor the knob | refused, naming both |
| 17 usable spellings | accepted | accepted | **0 narrowed** |

The bottom panels are one in-loop rollout with a single `diffusion_steps=True` at tick 15. Before: sampler runs `[100, 1, 100]` — one typo cost **two** extra diffusion runs and replaced the tracked motion twice (it thrashes back on the next tick, which has no override). After: `[100]`, and the call raises `KimodoPolicy.get_actions: diffusion_steps must be a positive whole number, got True.`

The path is routine, not private: `PolicyRunner.run` / `evaluate` forward `policy_kwargs` verbatim to every `get_actions` call, and the reference documents `await policy.get_actions({}, "waving", diffusion_steps=25)`.

## Change

Both overrides consult the domain their config field does, **before the key is built**, so a refused one leaves the held motion and the frame cursor exactly as they were — the ordering the `seed` override already documented.

- `diffusion_steps_error` is added as the single owner of that step count's composite domain: `positive_whole_number_error` plus this provider's ceiling, now the named `_KIMODO_MAX_DIFFUSION_STEPS`. A composite restated at two surfaces is one that can diverge, so `__post_init__` consults it too rather than restating `upper=500`.
- `guidance_scale` is the shared `positive_finite_number_error` domain at both surfaces, so it needs no owner of its own.
- The conversions stay, **after** the guards, where they can only restate a value: both domains admit an integral float (a `100.0` read from a config array) while the sampler's signature declares an `int` and a `float`. This is what `_sample_key`'s `int(seed)` already does for the same reason.

## Tests

`tests/policies/kimodo/test_sampler_knobs_have_one_domain.py` — 96 cells, table-driven over both knobs: each surface refuses every unusable value, both state one domain and name themselves, a refusal runs no sampler and rewinds no cursor, the ceiling is not escapable per call, and every usable spelling (the ceiling itself, an integral float, NumPy scalars) still reaches the sampler as the declared type.

Pre-fix **55 of the 96 fail**, all in the new file, none elsewhere; the other 41 are controls green on both sides. Toggling prod and tests independently over the 93 affected grader modules: 7657 passed with the fix, 7561 without the new file, identical standing failures in every green corner and no new ones. `ruff check`/`format` clean on `strands_robots tests tests_integ`; `mypy` unchanged.

LOC: +126 source/docs, +251 test.