### PR TITLE
fix(policies/motionbricks): a facing goal is graded in either spelling

### DIFF
--- a/changelog.d/3295-heading-angle-goal-key-domain.md
+++ b/changelog.d/3295-heading-angle-goal-key-domain.md
@@ -1,0 +1,19 @@
+### Fixed: a facing goal is graded in either spelling
+
+`target_heading` is one well-known goal key with two spellings - a planar
+direction vector, or the same direction as an angle in radians via
+`target_heading_angle` - and both land in the same `facing_direction` field of
+the control signal the MotionBricks generator is handed. Only the vector was
+graded. The angle went through a bare `float()`, so `target_heading_angle=nan`
+produced a `facing_direction` of `[nan, nan, 0.0]` from a call that reported
+success (the outcome the vector spelling's own domain exists to prevent),
+`True` was read as a 1.0 rad heading, a numeric string was read as an angle,
+and `inf`, `10**400` and a list escaped as an unnamed `math domain error`,
+`OverflowError` or `TypeError`.
+
+The angle is now held to `finite_number_error` - the domain the sibling
+locomotion family already holds its own scalar goal kwarg to
+(`WBCPolicy._validate_height`) - so both spellings refuse the same seven value
+classes by name. Every angle a caller can mean resolves unchanged, and the
+asymmetry that is deliberate is unaffected: a bare number is a legal angle and
+an illegal direction, a two-entry sequence the reverse.

--- a/docs/policies/motionbricks.md
+++ b/docs/policies/motionbricks.md
@@ -142,7 +142,8 @@ policy = create_policy(
 | --- | --- | --- |
 | `style` / `mode` | `int` index or `str` name | Clip mode (e.g. `"walk"`, `"stealth_walk"`, `"walk_boxing"`, `"hand_crawling"`). |
 | `target_velocity` | 2 or 3 entries, every component a finite number | `[vx, vy]` (or `[vx, vy, vz]`) desired planar movement direction (world frame); only the direction is used, and a third entry is projected away. |
-| `target_heading` | 2 or 3 entries, every component a finite number | `[hx, hy]` facing direction, or `target_heading_angle` (radians, any finite float). |
+| `target_heading` | 2 or 3 entries, every component a finite number | `[hx, hy]` facing direction, or `target_heading_angle` (radians, any finite number). |
+| `target_heading_angle` | a finite number of either sign | The same facing direction as an angle in radians. Refused by name on the same grounds as the vector spelling: a `nan`, an `inf`, a `bool` or a numeric string raises `ValueError` naming this key. |
 
 An unknown style or out-of-range index raises `ValueError` listing the
 available modes. A missing `[motionbricks]` install or checkpoint raises

--- a/strands_robots/policies/motionbricks/observation.py
+++ b/strands_robots/policies/motionbricks/observation.py
@@ -25,7 +25,10 @@ The well-known goal kwargs a caller passes through ``get_actions`` are:
   Every component must be a finite number; a count outside two or three, a
   ``nan``/``inf`` component or a ``bool`` is refused by name.
 * ``target_heading`` - facing direction as ``[hx, hy]`` (or an angle in radians
-  via ``target_heading_angle``). Absent -> face the movement direction.
+  via ``target_heading_angle``). Absent -> face the movement direction. Both
+  spellings name the same quantity and are refused by name on the same grounds:
+  the vector's components and the angle must each be a finite number, so a
+  ``nan``, an ``inf`` or a ``bool`` is refused whichever spelling carries it.
 """
 
 from __future__ import annotations
@@ -35,7 +38,7 @@ from typing import Any
 
 import numpy as np
 
-from ...utils import finite_vector_error, sequence_length
+from ...utils import finite_number_error, finite_vector_error, sequence_length
 
 # Default movement / facing direction: walk straight ahead along +x (world).
 _DEFAULT_DIRECTION = (1.0, 0.0, 0.0)
@@ -236,9 +239,41 @@ def _unit_direction(vec: Any, default: tuple[float, float, float], *, method: st
 
 
 def _heading_to_direction(kwargs: dict[str, Any], movement_direction: list[float]) -> list[float]:
-    """Resolve the facing direction from kwargs, defaulting to the movement direction."""
+    """Resolve the facing direction from kwargs, defaulting to the movement direction.
+
+    ``target_heading_angle`` and ``target_heading`` are two spellings of one goal
+    key, and each is graded on the same grounds before it reaches the facing
+    field: a scalar angle against :func:`~strands_robots.utils.finite_number_error`,
+    a direction vector against the component domain in :func:`_unit_direction`.
+    Grading the angle is what makes the two spellings answer alike. A bare
+    ``float()`` read ``True`` as a 1.0 rad heading and a numeric string as an
+    angle, while ``nan`` passed straight through into a ``facing_direction`` of
+    ``[nan, nan, 0.0]`` from a call that reported success - which is the outcome
+    the vector spelling's own domain exists to prevent - and ``inf`` reached
+    :func:`math.cos` to raise a bare ``math domain error`` naming neither this
+    surface nor the key. The shared domain is the one the sibling locomotion
+    family already holds its scalar goal kwarg to
+    (:meth:`~strands_robots.policies.wbc.policy.WBCPolicy._validate_height`),
+    which is also where the grade-then-convert shape below comes from.
+
+    Args:
+        kwargs: The well-known goal kwargs, read for ``target_heading_angle``
+            then ``target_heading``.
+        movement_direction: Direction to face when neither key is given.
+
+    Returns:
+        A unit 3-vector in the world XY plane, as plain floats.
+
+    Raises:
+        ValueError: If ``target_heading_angle`` is not a finite number, or if
+            ``target_heading`` is not a usable planar direction.
+    """
     if kwargs.get("target_heading_angle") is not None:
-        angle = float(kwargs["target_heading_angle"])
+        raw = kwargs["target_heading_angle"]
+        reason = finite_number_error(raw, "target_heading_angle", "build_control_signals")
+        if reason is not None:
+            raise ValueError(reason)
+        angle = float(raw)
         return [math.cos(angle), math.sin(angle), 0.0]
     if kwargs.get("target_heading") is not None:
         return _unit_direction(

--- a/tests/policies/motionbricks/test_a_heading_goal_is_graded_in_either_spelling.py
+++ b/tests/policies/motionbricks/test_a_heading_goal_is_graded_in_either_spelling.py
@@ -1,0 +1,226 @@
+"""One facing goal, two spellings, one answer.
+
+``target_heading`` is a well-known goal key with two spellings of the same
+quantity: a planar direction vector, or the same direction as an angle in
+radians via ``target_heading_angle``. Both are read by
+:func:`~strands_robots.policies.motionbricks.observation._heading_to_direction`
+and both land in the same ``facing_direction`` field of the control signal the
+generator is handed. Only one of them was graded.
+
+The vector spelling is held to the shared component domain, and the argument for
+that domain is written down in the sibling grader beside this one
+(``test_direction_goal_keys_are_held_to_one_domain.py``): the near-zero fallback
+is a magnitude test, so it cannot cover a non-finite component, and a ``nan``
+fell straight through it to produce a direction of ``[nan, nan, nan]`` "handed to
+the generator, from a call that reported success".
+
+The angle spelling reached the same field through a bare ``float()``, so that
+outcome survived in it verbatim - ``target_heading_angle=nan`` produced a
+``facing_direction`` of ``[nan, nan, 0.0]``, reported as success. The other value
+classes the vector spelling refuses by name diverged too: ``True`` was read as a
+1.0 rad (57.3 degree) heading, a numeric string was read as an angle, and
+``inf`` reached :func:`math.cos` to raise a bare ``math domain error`` naming
+neither the surface nor the key, while ``[1.57]`` and ``10**400`` escaped as
+``TypeError`` / ``OverflowError`` from the coercion itself.
+
+The scalar spelling is now held to :func:`~strands_robots.utils.finite_number_error`,
+the domain the sibling locomotion family already holds its own scalar goal kwarg
+to (:meth:`~strands_robots.policies.wbc.policy.WBCPolicy._validate_height`,
+``height``). The cells below grade the two spellings against one roster of value
+classes and require the same answer from each, then pin the asymmetry that is
+deliberate: a bare number is a legal angle and an illegal direction, and a
+two-entry sequence is the reverse.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.policies.motionbricks.observation as observation
+from strands_robots.utils import finite_number_error
+
+_NAN = float("nan")
+_INF = float("inf")
+
+#: The two spellings of the one facing goal. Each must name itself when it refuses.
+_ANGLE_KEY = "target_heading_angle"
+_VECTOR_KEY = "target_heading"
+
+#: Value classes neither spelling can carry, in the shape each spelling takes.
+#: A list of tuples rather than a dict because ``True == 1`` and ``0 == False``
+#: collapse exactly the distinctions this file is about.
+_UNUSABLE_CLASSES: list[tuple[str, Any, Any]] = [
+    ("nan", _NAN, [_NAN, 0.0]),
+    ("inf", _INF, [_INF, 0.0]),
+    ("-inf", -_INF, [-_INF, 0.0]),
+    ("bool", True, [True, False]),
+    ("numeric-string", "1.5708", ["1.5708", "0.0"]),
+    ("past-float64", 10**400, [10**400, 0.0]),
+    ("non-number", [1.57], [None, 0.0]),
+]
+
+
+def _signals(**kwargs: Any) -> dict[str, Any]:
+    """Build one control-signal dict through the public builder."""
+    return observation.build_control_signals(
+        mode_idx=0, clip_token_specs=[None], min_token=1, max_token=1, kwargs=kwargs
+    )
+
+
+def _verdict(key: str, value: Any) -> str:
+    """What the builder does with ``value`` given under ``key``.
+
+    A refusal counts only when it names the key the caller spelled. Folding any
+    exception into "refused" would let these cells pass against the code they
+    were written to catch: the bare coercion also raised ``ValueError`` for
+    ``inf`` (``math domain error``), naming neither this surface nor the key.
+
+    Returns:
+        ``"refused"``, ``"accepted"`` or ``"escaped:<ExceptionType>"``.
+    """
+    try:
+        _signals(target_velocity=[1.0, 0.0], **{key: value})
+    except ValueError as exc:
+        return "refused" if key in str(exc) else f"escaped:ValueError({str(exc)[:40]})"
+    except Exception as exc:  # noqa: BLE001 - any escape is the defect, so report its type
+        return f"escaped:{type(exc).__name__}"
+    return "accepted"
+
+
+def _facing(key: str, value: Any) -> list[float]:
+    """The facing direction ``key`` resolves to, read from the field it drives."""
+    return list(_signals(target_velocity=[1.0, 0.0], **{key: value})["facing_direction"])
+
+
+class TestNeitherSpellingCarriesAnUnusableValue:
+    """One roster, two spellings, the same answer from each."""
+
+    @pytest.mark.parametrize(
+        ("scalar", "vector"),
+        [pytest.param(s, v, id=name) for name, s, v in _UNUSABLE_CLASSES],
+    )
+    def test_both_spellings_refuse_it_by_name(self, scalar: Any, vector: Any) -> None:
+        assert _verdict(_ANGLE_KEY, scalar) == "refused"
+        assert _verdict(_VECTOR_KEY, vector) == "refused"
+
+    def test_a_nan_angle_does_not_reach_the_generator_as_a_facing_direction(self) -> None:
+        # The specific outcome the vector spelling's domain exists to prevent,
+        # reached through the other spelling of the same key: a facing direction
+        # of [nan, nan, 0.0] from a call that reported success.
+        with pytest.raises(ValueError, match=_ANGLE_KEY):
+            _signals(target_velocity=[1.0, 0.0], target_heading_angle=_NAN)
+
+    def test_a_bool_is_not_read_as_a_one_radian_heading(self) -> None:
+        # 57.3 degrees off the movement direction, from a caller who passed a flag.
+        with pytest.raises(ValueError, match=_ANGLE_KEY):
+            _signals(target_velocity=[1.0, 0.0], target_heading_angle=True)
+
+
+class TestWhatIsUnchanged:
+    """Every angle a caller could legitimately pass still resolves the same way."""
+
+    @pytest.mark.parametrize(
+        ("angle", "expected"),
+        [
+            pytest.param(0.0, [1.0, 0.0, 0.0], id="zero-faces-plus-x"),
+            pytest.param(math.pi / 2, [0.0, 1.0, 0.0], id="quarter-turn"),
+            pytest.param(-math.pi, [-1.0, 0.0, 0.0], id="negative-angle"),
+            pytest.param(3 * math.pi, [-1.0, 0.0, 0.0], id="past-one-turn"),
+            pytest.param(0, [1.0, 0.0, 0.0], id="int"),
+            pytest.param(np.float64(math.pi / 2), [0.0, 1.0, 0.0], id="numpy-float64"),
+            pytest.param(np.float32(0.0), [1.0, 0.0, 0.0], id="numpy-float32"),
+        ],
+    )
+    def test_a_usable_angle_resolves_unchanged(self, angle: Any, expected: list[float]) -> None:
+        assert _facing(_ANGLE_KEY, angle) == pytest.approx(expected, abs=1e-9)
+
+    def test_the_angle_still_overrides_the_movement_direction(self) -> None:
+        # The behaviour test_policy.py grades: facing is independent of movement.
+        signals = _signals(target_velocity=[1.0, 0.0], target_heading_angle=math.pi / 2)
+        assert signals["movement_direction"] == pytest.approx([1.0, 0.0, 0.0])
+        assert signals["facing_direction"] == pytest.approx([0.0, 1.0, 0.0], abs=1e-9)
+
+    def test_omitting_the_angle_still_faces_the_movement_direction(self) -> None:
+        assert _signals(target_velocity=[0.0, 2.0])["facing_direction"] == pytest.approx([0.0, 1.0, 0.0])
+
+    def test_the_angle_still_wins_over_the_vector_spelling(self) -> None:
+        # Precedence is unchanged: the angle is read first.
+        signals = _signals(target_velocity=[1.0, 0.0], target_heading_angle=0.0, target_heading=[0.0, 1.0])
+        assert signals["facing_direction"] == pytest.approx([1.0, 0.0, 0.0])
+
+
+class TestTheAsymmetryThatIsDeliberate:
+    """The two spellings take different shapes, and that difference is not a bug."""
+
+    def test_a_bare_number_is_a_legal_angle_and_an_illegal_direction(self) -> None:
+        assert _verdict(_ANGLE_KEY, 1.5708) == "accepted"
+        assert _verdict(_VECTOR_KEY, 1.5708) == "refused"
+
+    def test_a_two_entry_sequence_is_a_legal_direction_and_an_illegal_angle(self) -> None:
+        assert _verdict(_VECTOR_KEY, [0.0, 1.0]) == "accepted"
+        assert _verdict(_ANGLE_KEY, [0.0, 1.0]) == "refused"
+
+    def test_the_two_spellings_agree_on_the_direction_they_name(self) -> None:
+        # Same quantity, so the same facing direction whichever way it arrives.
+        assert _facing(_ANGLE_KEY, math.pi / 2) == pytest.approx(_facing(_VECTOR_KEY, [0.0, 1.0]), abs=1e-9)
+
+
+class TestTheReaderIsSingleSourced:
+    """The domain is consulted, not restated, and the refusal names the key."""
+
+    def test_the_reader_consults_the_shared_scalar_domain(self) -> None:
+        # A local finiteness test here would be a second copy of a rule the
+        # library already owns, and the two could then disagree about a bool or
+        # a numpy scalar.
+        source = inspect.getsource(observation._heading_to_direction)
+        assert "finite_number_error(" in source
+        assert "isfinite" not in source
+
+    def test_the_call_site_passes_the_key_it_reads(self) -> None:
+        source = inspect.getsource(observation._heading_to_direction)
+        assert f'"{_ANGLE_KEY}"' in source
+
+
+class TestThePremises:
+    """Each of these is a fact the cells above depend on."""
+
+    def test_the_shared_scalar_domain_answers_for_these_values(self) -> None:
+        # The roster above expects this guard's verdicts, so the fix must be
+        # consulting it rather than restating it.
+        for _, scalar, _vector in _UNUSABLE_CLASSES:
+            assert finite_number_error(scalar, "p", "c") is not None
+        assert finite_number_error(math.pi / 2, "p", "c") is None
+        assert finite_number_error(np.float64(0.0), "p", "c") is None
+
+    def test_a_bare_coercion_could_not_have_refused_these(self) -> None:
+        # Why grading has to happen before the conversion: float() reinterprets
+        # three of the roster's classes rather than refusing them.
+        assert float(True) == 1.0
+        assert float("1.5708") == pytest.approx(1.5708)
+        assert math.isnan(float(_NAN))
+
+    def test_cosine_of_a_non_finite_angle_cannot_report_a_direction(self) -> None:
+        # The two ways the old path failed downstream of the coercion.
+        assert math.isnan(math.cos(_NAN))
+        with pytest.raises(ValueError, match="math domain error"):
+            math.cos(_INF)
+
+    def test_the_conversion_left_in_place_can_only_restate_the_value(self) -> None:
+        # float() stays after the guard, matching the sibling family's
+        # grade-then-convert shape, and for every value the domain admits it is
+        # a restatement rather than a decision.
+        for value in (1.57, 2, np.float64(1.57), np.float32(1.57)):
+            assert math.cos(value) == math.cos(float(value))
+
+    def test_the_sibling_family_holds_its_scalar_goal_kwarg_to_this_domain(self) -> None:
+        # The convention this fix follows, read off the sibling rather than
+        # asserted: wbc grades its own scalar goal kwarg with the same helper.
+        from strands_robots.policies.wbc.policy import WBCPolicy
+
+        with pytest.raises(ValueError, match="height"):
+            WBCPolicy._validate_height(_NAN)

--- a/tests/policies/motionbricks/test_direction_goal_keys_are_held_to_one_domain.py
+++ b/tests/policies/motionbricks/test_direction_goal_keys_are_held_to_one_domain.py
@@ -321,7 +321,9 @@ class TestWhatIsUnchanged:
 
     def test_a_heading_angle_is_untouched_by_this_domain(self) -> None:
         # target_heading_angle is a scalar, not a direction vector, so it does not
-        # go through this reader at all.
+        # go through this reader at all. It is not ungraded for that reason: the
+        # scalar spelling is held to the shared scalar domain instead, in
+        # test_a_heading_goal_is_graded_in_either_spelling.py.
         signals = _signals(target_heading_angle=math.pi / 2)
         assert signals["facing_direction"] == pytest.approx([0.0, 1.0, 0.0], abs=1e-9)
 


### PR DESCRIPTION
`target_heading` is one well-known goal key with **two spellings of the same quantity** - a planar direction vector, or the same direction as an angle in radians via `target_heading_angle`. Both are read by `_heading_to_direction` and both land in the same `facing_direction` field of the control signal the generator is handed. Only the vector spelling was graded.

![before/after](https://raw.githubusercontent.com/cagataycali/robots/3b4bcbe4719e9050244796603f2007d45f8e5498/heading_angle_domain.png)

The argument for the vector's domain is written down in the grader beside it (`test_direction_goal_keys_are_held_to_one_domain.py`): the near-zero fallback is a magnitude test, so it cannot cover a non-finite component, and a `nan` fell through it to produce a direction *"handed to the generator, from a call that reported success"*.

The angle spelling reached the same field through a bare `float()`, so **that outcome survived in it verbatim**: `target_heading_angle=nan` produced a `facing_direction` of `[nan, nan, 0.0]`, reported as success.

| value class | `target_heading_angle` before | after | `target_heading` (vector) |
| --- | --- | --- | --- |
| `nan` | **accepted** -> `[nan, nan, 0.0]` | refused by name | already refused by name |
| `inf` / `-inf` | escaped `ValueError: math domain error` | refused by name | already refused by name |
| `True` | **accepted** -> 57.3 deg heading | refused by name | already refused by name |
| `"1.5708"` | **accepted** -> 90 deg heading | refused by name | already refused by name |
| `10**400` | escaped `OverflowError` | refused by name | already refused by name |
| `[1.57]` | escaped `TypeError` | refused by name | already refused by name |

3 accepted, 4 escaped as an exception naming neither the surface nor the key, 0 refused by name - against a vector spelling that refused all 7 by name.

## Change

The angle is held to `finite_number_error` before it is converted. That is the domain the sibling locomotion family already holds its own **scalar** goal kwarg to (`WBCPolicy._validate_height`, `height`), which is also where the grade-then-convert shape comes from. `float()` stays after the guard and can now only restate the value - pinned: `math.cos(v) == math.cos(float(v))` for every value the domain admits.

## Nothing that worked stops working

Measured on both trees: all 4 legitimate angle classes (`0`, `pi/2`, `-pi`, `3pi`, plus `int` / `np.float64` / `np.float32`) resolve identically. Every value the shared domain refuses is one the **vector spelling of the same key already refused**, so the narrowing is the divergence being removed rather than a new restriction.

The asymmetry that is deliberate is pinned and its shape is unchanged: `1.5708` is a legal angle and an illegal direction; `[0.0, 1.0]` is a legal direction and an illegal angle - one value, two answers, decided by which spelling was given it. That second one moves from an escaped `TypeError` to a refusal naming the key.

## Tests

`tests/policies/motionbricks/test_a_heading_goal_is_graded_in_either_spelling.py` grades both spellings against one roster and requires the same answer from each. A refusal counts **only when it names the key** - folding any exception into "refused" would let the cells pass against the code they were written to catch, since the bare coercion also raised `ValueError` for `inf`.

| corner | prod | tests | result |
| --- | --- | --- | --- |
| A | new | new | 8885 passed |
| B | **old** | new | **11 failed** (all in the new file: 3 accepted, 4 escaped, 2 DID-NOT-RAISE, 1 asymmetry, 1 structural) |
| C | new | old | 8856 passed |
| D | old | old | 8856 passed, failure list **identical to C** |

8856 + 29 = 8885. C == D means the fix required no existing cell to change. The 9 failures in every corner are pre-existing and absent-dependency only (8 `mesh/test_iot_*` needing `awsiot`, 1 `test_dependency_audit` needing `qpsolvers`), verified identical on a clean worktree of `main`.

Gate: `ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`; mypy at the standing 20 errors / 6 files, none in these files.

Docs: the `target_heading_angle` row is now stated in `docs/policies/motionbricks.md` with its domain, and the sibling grader's exclusion comment points at where the scalar spelling *is* graded, so it is not read as a blessing of ungraded-ness.