### PR TITLE
fix(policies/wbc): the seed a reset renders into its log line is escaped at the sink

### DIFF
--- a/changelog.d/3297-wbc-reset-seed-log-sink.md
+++ b/changelog.d/3297-wbc-reset-seed-log-sink.md
@@ -1,0 +1,13 @@
+### Fixed: the seed a `WBCPolicy.reset` renders into its log line is escaped at the sink
+
+`WBCPolicy.reset` rendered the `seed` it was handed into its debug record with
+`%r`. `PolicyServer` forwards the wire `seed` to `reset` verbatim - the policy
+owns the domain - so the value in that record is caller-side input, and CodeQL
+reported the sink as `py/log-injection` (alert 1159). A JSON-decoded value
+cannot carry a raw break through `repr`, so the escape was incidental to the
+wire's encoding rather than a decision at the sink - the same shape #2853
+measured at the two `%r` joint-state sinks. The rendered value now passes
+through `sanitize_log_value`, the one owner of that escape, and the sink is
+named in the census `tests/policies/test_log_sink_sanitizer.py` grades, beside
+the eight it joins. Pinned there: a seed whose `repr` spans two lines no longer
+splits the record.

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -62,6 +62,7 @@ from typing import Any
 
 import numpy as np
 
+from strands_robots.policies._log_safety import sanitize_log_value
 from strands_robots.policies.base import Policy
 from strands_robots.utils import finite_number_error, require_optional, sequence_length
 
@@ -412,7 +413,10 @@ class WBCPolicy(Policy):
         """
         self._history.reset()
         self._prev_action = np.zeros(self._config.num_actions, dtype=np.float64)
-        logger.debug("WBCPolicy.reset: cleared observation history + prev_action (seed=%r)", seed)
+        logger.debug(
+            "WBCPolicy.reset: cleared observation history + prev_action (seed=%s)",
+            sanitize_log_value(repr(seed)),
+        )
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/tests/policies/test_log_sink_sanitizer.py
+++ b/tests/policies/test_log_sink_sanitizer.py
@@ -68,6 +68,7 @@ from strands_robots.policies._log_safety import sanitize_log_value
 from strands_robots.policies.curobo.policy import CuroboPolicy
 from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
 from strands_robots.policies.moveit2.policy import MoveIt2Policy
+from strands_robots.policies.wbc.policy import WBCPolicy
 
 # A payload shaped like the thing an operator would see in a forged line: the
 # second half looks like a record this process never wrote.
@@ -309,6 +310,28 @@ def test_moveit2_joint_state_object_with_a_multiline_repr_cannot_split_the_recor
     assert "JointState(\\nWARNING:root:actuators disabled)" in rendered
 
 
+def test_wbc_reset_seed_with_a_multiline_repr_cannot_split_the_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Alert 1159. ``PolicyServer`` forwards the wire ``seed`` to ``reset``
+    verbatim, by design - the policy owns the domain - and this sink rendered
+    it with ``%r``. A JSON-decoded value cannot carry a raw break through
+    ``repr``, so the escape was incidental to the wire's encoding rather than
+    a decision at the sink; an in-process caller is bound by ``int | None``
+    in the annotation only, and one object with a two-line ``repr`` is what
+    the incidental escape does not survive."""
+    policy = _stub(
+        _history=_stub(reset=lambda: None),
+        _config=_stub(num_actions=15),
+    )
+    with caplog.at_level(logging.DEBUG, logger="strands_robots.policies.wbc.policy"):
+        WBCPolicy.reset(policy, MultilineRepr())  # type: ignore[arg-type]
+
+    rendered = _rendered(caplog)
+    assert not _has_raw_break(rendered), f"record still splits: {rendered!r}"
+    assert "seed=JointState(\\nWARNING:root:actuators disabled)" in rendered
+
+
 # --------------------------------------------------------------------------
 # Property cells: the escape was incidental at these sinks; state it there.
 # --------------------------------------------------------------------------
@@ -385,6 +408,13 @@ _SANITIZED_SINKS: dict[str, dict[str, list[str]]] = {
     },
     "moveit2/policy.py": {
         "MoveIt2Policy._extract_joint_state": ["e", "repr(state)"],
+    },
+    # Alert 1159, outside the #2853 census: the ``seed`` the inference server
+    # forwards verbatim off the wire (``PolicyServer`` owns no domain for it)
+    # reaches this ``reset`` and is rendered into a record. See
+    # :func:`test_wbc_reset_seed_with_a_multiline_repr_cannot_split_the_record`.
+    "wbc/policy.py": {
+        "WBCPolicy.reset": ["repr(seed)"],
     },
 }
 


### PR DESCRIPTION
## What

`WBCPolicy.reset` rendered the `seed` it was handed into its debug record with `%r`. `PolicyServer` forwards the wire `seed` to `reset` verbatim - by design, the policy owns the domain (`inference/server.py`, `MSG_RESET`) - so the value in that record is caller-side input, and CodeQL reports the sink as `py/log-injection`: **alert 1159**, open on `main` since 2026-09-04 at `error` severity.

This PR routes the rendered value through `sanitize_log_value`, the one owner of that escape, and adds the sink to the census the wiring cell grades.

```python
# before
logger.debug("WBCPolicy.reset: ... (seed=%r)", seed)
# after
logger.debug("WBCPolicy.reset: ... (seed=%s)", sanitize_log_value(repr(seed)))
```

## Why this shape and not another

- **It is the #2853 class, one sink outside that census.** A JSON-decoded value cannot carry a raw break through `repr`, so the escape here was incidental to the wire's encoding rather than a decision at the sink - exactly what #2853 measured at the two `%r` joint-state sinks (alerts 711/712) and closed by wrapping. The `repr()`-then-escape spelling is the one those two sinks use, so the quoted form is kept.
- **Why not fix it at the source instead.** The server's verbatim forwarding is a documented decision (the two handlers above `MSG_RESET` explain why coercion at the wire launders a mis-typed parameter), so a type check there would be a new domain rule for `seed` across every provider, which is a different change. The sink-side escape is what the census already prescribes.
- **Why the other `seed=%r` sinks are not touched.** `curobo`, `moveit2`, `groot`, `motionbricks` and `_rng` render `seed` the same way and none is reported. The census rule is that a wrapper added somewhere new is argued for in the same diff; this diff argues for the one sink the analysis reaches. Widening to unreported sinks is a census decision, not this fix.

## Pinned

`tests/policies/test_log_sink_sanitizer.py`, both cells fail on pre-fix code:

- `test_wbc_reset_seed_with_a_multiline_repr_cannot_split_the_record` - drives `reset` with a seed whose `repr` spans two lines (the `MultilineRepr` probe the 711/712 cells use) and asserts the record does not split. Pre-fix: `record still splits: '... (seed=JointState(\nWARNING:root:actuators disabled))'`.
- `test_exactly_the_census_sinks_are_sanitized[wbc]` - the census now names `WBCPolicy.reset: ["repr(seed)"]`. Pre-fix: `assert {} == {'WBCPolicy.reset': ['repr(seed)']}`.

## Verification

- `ruff format` / `ruff check` / `mypy` clean on both files.
- `tests/policies/wbc` + `tests/policies/test_log_sink_sanitizer.py`: 659 passed, 4 skipped.
- Whole-tree graders (AGENTS.md step 2): the 107-grader roster run with the same `pytest` flags the script uses. 3953 passed; the 57 failures / 149 errors are byte-identical to `main` in this environment - 180 `mujoco` absent, 8 `awsiot`, 5 `json5`, 7 `lerobot`, 1 `msgpack`, and the 5 remaining ids re-run on `main` fail identically (`qpsolvers` metadata, `lerobot`, the torch mock). Two graders (`test_agent_tool_parameter_descriptions.py`, `test_agent_tool_parameters_reach_the_body.py`) could not be collected locally because they import `lerobot`; this diff touches no `@tool`, and CI's `call-test-lint` runs them.
- `tests/test_changelog_fragments.py` + `tests/test_changelog_format.py`: 32 passed with the fragment.
- Intake: `main` unmoved between clone and push; no open PR touches `wbc/policy.py`, `_log_safety.py` or the sanitizer test; `check_duplicate_claim.py --all-open` after push: `unique-additions` over 5 open / 10 pairs.

## Expected effect on the alert

The escape is the `ReplaceLineBreaksSanitizer` barrier CodeQL recognises (literal `"\n"` as the last `.replace` argument - the #2853 finding), so `Analyze (Python)` on this head should report alert 1159 fixed rather than re-opened at the new line. That is the thing to read back, not assume.

**Read back** after `Analyze (Python)` completed `SUCCESS` on `28f9a4b` (15:53 UTC), via `GET /code-scanning/alerts?ref=...&state=open` with `PAT_TOKEN`:

| ref | open `py/log-injection` alerts |
|---|---|
| `refs/pull/3297/head` | **0** |
| `refs/pull/3297/merge` | **0** |
| `refs/heads/main` | 1 - alert 1159 at `wbc/policy.py:415`, unchanged until this merges |

So the alert is not re-opened under a new id at the rewritten line, which is the #2852 failure mode this section exists to rule out. Alert 1159 stays `open` on `main` by construction and should transition to `fixed` on the next `main` analysis after the squash.

Refs #2853.

## Round changelog

- Round 0: opened as draft at `fecde31`; fragment `changelog.d/3297-wbc-reset-seed-log-sink.md` pushed as `28f9a4b`; marked ready. No review yet.
- Round 0 (cont.): approved 15:53 UTC, 0 review threads. CodeQL read-back recorded above. Auto-merge (squash) armed; the only remaining gate is the required `call-test-lint / Test and Lint` check, in progress since 15:48. No code change in this round.