### PR TITLE
fix(registry/assets): a stored model path is contained wherever it is joined

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,11 @@ metadata:
                   asset_dir="~/robots/my_arm", joints=7, category="arm")
    ```
 
+   `model_xml` and `scene_xml` name a file *inside* `asset_dir` - that is how
+   every reader joins them back - so a value that leaves it (absolute, or `../`)
+   is refused at registration rather than validated against a file the loader
+   will not open.
+
 ## Tools reference
 
 Import any of these and pass to `Agent(tools=[...])`. Each is a Strands

--- a/changelog.d/3298-registry-asset-path-containment.md
+++ b/changelog.d/3298-registry-asset-path-containment.md
@@ -1,0 +1,17 @@
+### Fixed: a registry-stored asset path is contained wherever it is joined
+
+`model_xml` and `scene_xml` are stored relative to a robot's asset directory and
+every reader joins them back through `safe_join`, but three writers joined them
+raw and so answered questions about files the readers never open:
+
+- `register_robot` validated existence with `resolved_dir / model_xml`, and an
+  absolute value discards `resolved_dir` entirely - any existing host file
+  satisfied the check, and the deferred `add_robot()` failure that check exists
+  to prevent came back with the entry already persisted. Such a value is now
+  refused at registration, naming which of the two paths to correct.
+- `_needs_download` read `search_dir / asset_dir / xml_file`, so a readable
+  model outside every search path made a robot report as present and needing no
+  fetch while the resolver found nothing.
+- `_download_via_robot_descriptions` validated a freshly linked directory with
+  `dst / model_xml`, so an absolute value reported `downloaded` for a link that
+  holds no model at all.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -47,7 +47,7 @@ from strands_robots.registry import (
 | `list_aliases()` | All 121 aliases, keyed by `normalize_robot_name` (so every key is a spelling a folded query can produce), including every GR00T `data_config` spelling (so `data_config` names resolve as robot names). |
 | `normalize_robot_name(name)` | The fold every registry lookup applies: lowercase, trimmed, dashes as underscores. Canonical names, aliases and the uniqueness constraints over both are all keyed by it, so this is the rule that predicts which robot a name reaches. |
 | `format_robot_table()` | Pretty-printed robot table. |
-| `register_robot(name, entry)` | Add user-defined robot at runtime. |
+| `register_robot(name, entry)` | Add user-defined robot at runtime. `model_xml`/`scene_xml` must name a file inside `asset_dir`. |
 | `unregister_robot(name)` | Remove a runtime-registered robot. |
 | `list_user_robots()` | Names from `register_robot`. |
 | `user_registry_source()` | Raw bytes of `user_robots.json`, or `None` when absent. What the loader keys its hot-reload cache on, so an edit by another writer is seen even when it lands inside one filesystem timestamp tick. |

--- a/strands_robots/assets/download.py
+++ b/strands_robots/assets/download.py
@@ -251,7 +251,17 @@ def _needs_download(name: str, info: dict[str, Any] | None, force: bool = False)
     xml_file, asset_dir = asset["model_xml"], asset["dir"]
 
     for search_dir in get_search_paths():
-        model_path = search_dir / asset_dir / xml_file
+        try:
+            model_path = safe_join(search_dir, f"{asset_dir}/{xml_file}")
+        except ValueError:
+            # The resolver makes this same join
+            # (:func:`~strands_robots.assets.manager._resolve_candidates`) and
+            # yields no candidate for an entry that escapes its search path, so
+            # no file on disk can make this robot present. Fetch rather than
+            # report it as already there - the two readings of one entry are
+            # what :func:`_mjcf_missing_meshes` exists to keep together.
+            logger.warning("assets: path traversal blocked for %s: %r", name, f"{asset_dir}/{xml_file}")
+            return True
         if not model_path.exists():
             continue
         try:
@@ -374,8 +384,12 @@ def _download_via_robot_descriptions(robots: dict[str, dict], dest_dir: Path) ->
 
             dst = safe_join(dest_dir, asset_dir)
             if dst.is_symlink() and dst.resolve() == package_path.resolve():
-                # Validate existing symlink still has the expected XML
-                expected_xml = dst / info["asset"]["model_xml"]
+                # Validate existing symlink still has the expected XML.
+                # Joined through ``safe_join`` so the validation cannot be
+                # satisfied by a file outside the linked directory: raw, an
+                # absolute ``model_xml`` discards *dst* and any existing host
+                # file passes this check for a link that holds no model at all.
+                expected_xml = safe_join(dst, str(info["asset"]["model_xml"]))
                 if expected_xml.exists():
                     results[name] = "downloaded"
                     continue
@@ -392,7 +406,7 @@ def _download_via_robot_descriptions(robots: dict[str, dict], dest_dir: Path) ->
                 shutil.copytree(str(package_path), str(dst), dirs_exist_ok=True)
 
             # Validate: expected XML must exist in the linked/copied dir
-            expected_xml = dst / info["asset"]["model_xml"]
+            expected_xml = safe_join(dst, str(info["asset"]["model_xml"]))
             if not expected_xml.exists():
                 logger.warning(
                     "robot_descriptions module '%s' linked for %s but "

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -45,7 +45,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from strands_robots.utils import get_base_dir, resolve_asset_path
+from strands_robots.utils import get_base_dir, resolve_asset_path, safe_join
 
 from .loader import invalidate_cache, normalize_robot_name
 
@@ -125,6 +125,37 @@ def get_user_robots() -> dict[str, Any]:
     return parse_user_robots(user_registry_source())
 
 
+def _asset_relative(resolved_dir: Path, param: str, value: str) -> Path:
+    """Join a registry-stored asset path onto its directory, refusing escapes.
+
+    ``model_xml`` and ``scene_xml`` are stored relative to the robot's asset
+    directory, and every reader joins them back through
+    :func:`~strands_robots.utils.safe_join` - both branches of
+    :func:`~strands_robots.assets.manager.resolve_model_path` and of
+    :func:`~strands_robots.assets.manager.is_robot_asset_present`. Registration
+    makes the same join, so a value the readers refuse is refused here.
+
+    Args:
+        resolved_dir: The robot's asset directory.
+        param: Name of the registration parameter being joined, quoted in the
+            refusal so the caller knows which of the two values to correct.
+        value: The path the caller supplied.
+
+    Returns:
+        The joined path, inside *resolved_dir*.
+
+    Raises:
+        ValueError: *value* escapes *resolved_dir* - it is absolute (a raw join
+            would discard *resolved_dir* entirely) or it traverses out of it.
+    """
+    try:
+        return safe_join(resolved_dir, value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{param}={value!r} must name a file inside the asset directory {resolved_dir}: {exc}"
+        ) from exc
+
+
 def register_robot(
     name: str,
     *,
@@ -183,6 +214,10 @@ def register_robot(
             ``aliases`` entry collides with an existing canonical robot name or
             another robot's alias (the same constraint the loader enforces at
             read time, checked here so the registration cannot brick lookups).
+            Also raised when ``model_xml`` or ``scene_xml`` escapes the asset
+            directory they are declared relative to (see
+            :func:`_asset_relative`), since the readers refuse such a path and
+            the registration would persist a robot that cannot be loaded.
         FileNotFoundError: If ``model_xml`` doesn't exist at the resolved path.
 
     Example::
@@ -231,7 +266,20 @@ def register_robot(
     # dirs that didn't exist yet and surfaced a confusing error only at
     # ``add_robot()`` time.  Now we fail-closed on both conditions so the
     # user gets an immediate, actionable error at registration time.
-    model_path = resolved_dir / model_xml
+    #
+    # The join is the reader's join (:func:`_asset_relative`), so a value that
+    # leaves the asset directory is refused here rather than validated against
+    # a file outside it. Joined raw, an absolute ``model_xml`` discards
+    # ``resolved_dir`` entirely and any existing host file satisfies the check,
+    # and the deferred ``add_robot()`` failure above comes back - now with the
+    # entry already persisted, and with ``_user_asset_path`` naming a directory
+    # the stored path does not live in.
+    model_path = _asset_relative(resolved_dir, "model_xml", model_xml)
+    if scene_xml is not None:
+        # Not existence-checked (a scene is optional and may be authored later),
+        # but contained: it is stored and read back the same way ``model_xml``
+        # is, by ``resolve_model_path(prefer_scene=True)``.
+        _asset_relative(resolved_dir, "scene_xml", scene_xml)
     if not resolved_dir.exists():
         raise FileNotFoundError(
             f"Asset directory does not exist: {resolved_dir}\n"

--- a/tests/registry/test_asset_paths_stay_inside_the_asset_dir.py
+++ b/tests/registry/test_asset_paths_stay_inside_the_asset_dir.py
@@ -1,0 +1,169 @@
+"""A registry-stored asset path is joined the same way wherever it is joined.
+
+``register_robot`` stores ``model_xml``/``scene_xml`` relative to the robot's
+asset directory, and every *reader* joins them back through
+:func:`strands_robots.utils.safe_join` - both branches of
+:func:`~strands_robots.assets.manager.resolve_model_path` and of
+:func:`~strands_robots.assets.manager.is_robot_asset_present`. Three writers and
+deciders joined the same value raw, so each of them answered a question about a
+file the readers will never open:
+
+* ``register_robot`` validated existence with ``resolved_dir / model_xml``. An
+  absolute value discards ``resolved_dir`` entirely, so any existing host file
+  satisfied the check the registration exists to make - and the deferred
+  ``add_robot()`` failure it was added to prevent came back, now with the entry
+  persisted and ``_user_asset_path`` naming a directory the stored path is not in.
+* :func:`~strands_robots.assets.download._needs_download` read
+  ``search_dir / asset_dir / xml_file``, so an out-of-tree model made a robot
+  read as present and needing no fetch while the resolver found nothing - the
+  two readings of one entry that :func:`_mjcf_missing_meshes` exists to keep
+  together.
+* :func:`~strands_robots.assets.download._download_via_robot_descriptions`
+  validated a freshly linked directory with ``dst / model_xml``, so an absolute
+  value reported ``downloaded`` for a link holding no model at all.
+
+These pin the containment, that the refusal names which of the two values to
+correct, and that the documented relative shapes are untouched.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from strands_robots.assets import download as dl
+from strands_robots.assets.manager import is_robot_asset_present, resolve_model_path
+from strands_robots.registry.user_registry import get_user_robots, register_robot
+
+# A minimal model with no mesh references: present on disk means present, so a
+# containment verdict is never confused with a missing-mesh verdict.
+_MJCF = '<mujoco model="probe"><worldbody><geom type="box" size="1 1 1"/></worldbody></mujoco>'
+
+# Kept as a list of pairs, not a dict: the reason is what a failure should read
+# out, and two values may share one.
+_ESCAPING = [
+    ("../outsider.xml", "traverses one level out of the asset directory"),
+    ("../../../../../../etc/hostname", "traverses out to a host file that exists"),
+    ("/etc/hostname", "absolute: a raw join discards the asset directory"),
+    ("nested/../../outsider.xml", "escapes after a legal-looking first component"),
+]
+
+_CONTAINED = [
+    ("bot.xml", "the documented shape: a file in the asset directory"),
+    ("xml/bot.xml", "a nested component, still inside"),
+]
+
+
+@pytest.fixture
+def asset_dir(tmp_path: Path) -> Path:
+    """A robot asset directory, with an XML one level outside it that exists."""
+    root = tmp_path / "assets" / "probe_arm"
+    (root / "xml").mkdir(parents=True)
+    (root / "bot.xml").write_text(_MJCF)
+    (root / "xml" / "bot.xml").write_text(_MJCF)
+    (root.parent / "outsider.xml").write_text(_MJCF)
+    return root
+
+
+@pytest.mark.parametrize(("value", "why"), _ESCAPING, ids=[v for v, _ in _ESCAPING])
+def test_register_robot_refuses_a_model_xml_outside_the_asset_dir(value: str, why: str, asset_dir: Path) -> None:
+    """The existence check cannot be satisfied by a file the readers refuse."""
+    with pytest.raises(ValueError, match="model_xml") as excinfo:
+        register_robot(name="probe_arm", model_xml=value, asset_dir=str(asset_dir), joints=6)
+    assert value in str(excinfo.value), f"the refusal does not quote the value ({why})"
+    assert "probe_arm" not in get_user_robots(), "an escaping registration was persisted anyway"
+
+
+def test_register_robot_refuses_a_scene_xml_outside_the_asset_dir(asset_dir: Path) -> None:
+    """A scene is read back the same way, so it is contained the same way.
+
+    It is not existence-checked (a scene may be authored after registration),
+    which is why the refusal has to name it: the model beside it is valid.
+    """
+    with pytest.raises(ValueError, match="scene_xml") as excinfo:
+        register_robot(
+            name="probe_arm",
+            model_xml="bot.xml",
+            scene_xml="../outsider.xml",
+            asset_dir=str(asset_dir),
+            joints=6,
+        )
+    assert "model_xml" not in str(excinfo.value), "the refusal names the wrong value"
+    assert "probe_arm" not in get_user_robots()
+
+
+@pytest.mark.parametrize(("value", "why"), _CONTAINED, ids=[v for v, _ in _CONTAINED])
+def test_a_contained_model_path_registers_and_resolves(value: str, why: str, asset_dir: Path) -> None:
+    """Containment refuses only what the readers already refused."""
+    entry = register_robot(name="probe_arm", model_xml=value, asset_dir=str(asset_dir), joints=6)
+    assert entry["asset"]["model_xml"] == value, why
+    resolved = resolve_model_path("probe_arm", allow_download=False)
+    assert resolved == asset_dir / value, f"registered but not resolvable ({why})"
+    assert is_robot_asset_present("probe_arm") is True
+
+
+def test_a_model_outside_the_search_path_is_not_read_as_already_present(tmp_path: Path) -> None:
+    """The fetch decision and the resolver agree about one entry.
+
+    A hand-edited ``user_robots.json`` reaches
+    :func:`~strands_robots.assets.download._needs_download` without passing
+    ``register_robot``, and an absolute ``model_xml`` pointed it at a readable
+    model outside every search path: no meshes missing, so nothing to fetch,
+    for a robot :func:`~strands_robots.assets.manager.resolve_model_path`
+    cannot resolve.
+    """
+    outside = tmp_path / "outside.xml"
+    outside.write_text(_MJCF)
+    info = {"asset": {"dir": "probe_arm", "model_xml": str(outside), "scene_xml": str(outside)}}
+
+    assert dl._needs_download("probe_arm", info) is True, (
+        "a model outside every asset search path read as present and needing no fetch"
+    )
+
+
+def test_a_robot_descriptions_link_is_not_validated_by_a_file_outside_it(tmp_path: Path, monkeypatch) -> None:
+    """``downloaded`` means the linked directory holds the declared model."""
+    package = tmp_path / "rd_package"
+    package.mkdir()  # the linked robot_descriptions package holds no model at all
+    outside = tmp_path / "outside.xml"
+    outside.write_text(_MJCF)
+    monkeypatch.setitem(
+        sys.modules,
+        "robot_descriptions.fake_mj_description",
+        SimpleNamespace(PACKAGE_PATH=str(package)),
+    )
+    dest = tmp_path / "assets"  # STRANDS_ASSETS_DIR, from the shared isolation fixture
+    info = {
+        "asset": {
+            "dir": "faker",
+            "model_xml": str(outside),
+            "scene_xml": str(outside),
+            "robot_descriptions_module": "fake_mj_description",
+        }
+    }
+
+    result = dl._download_via_robot_descriptions({"faker": info}, dest)
+
+    assert not result["faker"].startswith("downloaded"), f"a link holding no model reported {result['faker']!r}"
+
+
+def test_no_stored_asset_path_is_joined_raw() -> None:
+    """No ``/`` join of a stored asset path is left in the package.
+
+    A scan rather than a roster of modules, so a fourth writer of the same
+    field cannot be added without either using ``safe_join`` or failing here.
+    """
+    package = Path(dl.__file__).parent.parent
+    raw: list[str] = []
+    for path in sorted(package.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+                joined = ast.unparse(node)
+                if any(field in joined for field in ("model_xml", "scene_xml", "xml_file")):
+                    raw.append(f"{path.relative_to(package)}:{node.lineno}: {joined}")
+
+    assert not raw, "join these through strands_robots.utils.safe_join:\n" + "\n".join(raw)


### PR DESCRIPTION
![measured verdicts + a custom robot that still resolves](https://raw.githubusercontent.com/cagataycali/robots/assets/registry-model-path-containment/docs/assets/registry-model-path-containment.png)

`model_xml`/`scene_xml` are stored relative to a robot's asset directory, and every *reader* joins them back through `safe_join` - both branches of `resolve_model_path` and of `is_robot_asset_present`. Three writers joined the same value raw, so each answered a question about a file the readers never open.

| join site | question it answers | before | after |
|---|---|---|---|
| `user_registry.register_robot` | does the model exist? | `'/etc/hostname'` **registered** (the join discards `resolved_dir`; `resolve_model_path` then returned `None`) | refused, naming `model_xml` |
| `download._needs_download` | fetch, or already present? | a readable model outside every search path read as **present, nothing to fetch** | fetch |
| `download._download_via_robot_descriptions` | does the link hold the model? | a link holding **no model at all** reported `downloaded` | failed |

The registration check is the one that matters most: it was added so the user gets an error at registration instead of a confusing one at `add_robot()` time. Joined raw, an absolute value satisfies it against any existing host file - so the deferred failure came back, now with the entry persisted and `_user_asset_path` naming a directory the stored path does not live in.

`_needs_download` and the resolver are also the pair `_mjcf_missing_meshes` exists to keep from "judging the same model present and absent" - they judged it on different joins.

## Not a narrowing

Every value now refused is one the readers already refused. Measured both ways: `'bot.xml'` and the nested `'xml/bot.xml'` register, resolve and load unchanged (right panel: registered, resolved through `safe_join`, added and rendered in MuJoCo headless/EGL). No `model_xml` or `scene_xml` anywhere in the tree, tests included, is absolute or traverses.

## Tests

`tests/registry/test_asset_paths_stay_inside_the_asset_dir.py` - 10 cells, **8 red pre-fix**, the 2 green ones being the contained shapes that must pass either way. The last cell is an AST scan of the package rather than a roster of modules, so a fourth writer of the same field cannot appear without using `safe_join`; pre-fix it prints the four sites verbatim:

```
assets/download.py:254: search_dir / asset_dir / xml_file
assets/download.py:378: dst / info['asset']['model_xml']
assets/download.py:395: dst / info['asset']['model_xml']
registry/user_registry.py:234: resolved_dir / model_xml
```

Local gate: `ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`; mypy unchanged from base. 170-module net around registry/assets/`safe_join`: **6784 passed before, 6794 after** (+10 new), same single pre-existing failure both ways (`rebot_b601`, a LeRobot registry drift unrelated to this change), and prod-new-with-base-tests matches base exactly.

LOC: +260 / -7, of which the production change is +68 / -6; the rest is the pin (+169), docs (+6) and the changelog fragment (+17).