### PR TITLE
fix(drivers/earthrover): the SDK base URL addresses the host the caller wrote

### DIFF
--- a/changelog.d/3299-earthrover-base-url-host.md
+++ b/changelog.d/3299-earthrover-base-url-host.md
@@ -1,0 +1,25 @@
+### Fixed: the EarthRover SDK base URL addresses the host the caller wrote
+
+`base_url_error` graded the *shape* of `port=` and never read the host out of it.
+Every endpoint the driver speaks is built from that one string, so a value whose
+authority names one host and resolves to another sent `POST /control` - a drive
+command - to a rover the caller never named, with `connect_eagerly()` reporting
+success whenever something answered there and `get_status()` reporting the base
+URL back verbatim, so the address an operator reads still contained the host they
+configured. Measured against a real HTTP server: a driver configured for
+`bot.local@127.0.0.1:<port>` connected and delivered `POST /control` to
+`127.0.0.1`. Two spellings do this and the transport refuses neither, reporting
+only the host it ended up with: userinfo (`bot.local@10.0.0.9:8001` dials
+`10.0.0.9`), and a foreign scheme (`ws://10.0.0.9:8001` was prefixed into
+`http://ws://10.0.0.9:8001`, whose authority is `ws:`, so the request went to the
+host `ws` on port 80 and the configured port was discarded). Both are now refused
+at construction, naming the host that would have been dialled. The
+case-sensitivity behind the second also broke `HTTP://10.0.0.9:8001`, a valid URL
+- a URI scheme is case-insensitive and `requests` fetches it identically - so the
+scheme test moved into one owner, `_declared_scheme`, that the validator and the
+constructor's normalisation both ask; that value now reaches the host it names.
+`dial_host_error` is deliberately not asked here, and a test pins why: it grades
+a bare host destined for `ws://{host}:{port}`, where an IPv6 literal needs its
+brackets, so it refuses the `::1` that `urlsplit` reports for the legitimate
+`http://[::1]:8001`. A URL that cannot be used at all is still left to the
+transport, which already names it.

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -162,6 +162,42 @@ soft-stop frame on the way out rather than cutting the motors dead. Poll
 `get_task_status()`; `stop_task()` reports honestly whether the loop actually
 joined.
 
+## Real hardware: the EarthRover native driver
+
+`earthrover` declares `hardware.lerobot_type`, so `mode="real"` builds the lerobot robot
+by default; `driver="strands"` selects the native driver instead. That driver talks to the
+vendor's [earth-rovers-sdk](https://github.com/frodobots-org/earth-rovers-sdk) over HTTP,
+which proxies to the rover, and `port=` is that SDK's base URL.
+
+```python
+from strands_robots import Robot
+
+rover = Robot("earthrover", mode="real", driver="strands", port="http://10.0.0.9:8001")
+if (reason := rover.connect_eagerly()) is not None:   # proves GET /data answers
+    raise SystemExit(reason)
+
+rover.send_action({"linear": 0.4, "angular": -0.2})    # each axis normalised to [-1, 1]
+rover.cleanup()                                        # sends a parting zero twist
+```
+
+Every endpoint - including `POST /control`, which *drives* - is built from that one
+string, so it has to address the host you wrote. A value whose authority names one host
+and resolves to another is refused at construction, because the transport does not refuse
+it: it reports only the host it ended up with, and `connect_eagerly()` reports success
+whenever something answers there.
+
+| `port=` | Result |
+|---|---|
+| omitted, `http://10.0.0.9:8001`, `10.0.0.9:8001`, `https://rover.local:8001` | Accepted. A bare `host:port` is prefixed with `http://`. |
+| `HTTP://10.0.0.9:8001`, `http://[::1]:8001`, `10.0.0.9:8001/rover-7` | Accepted - the scheme is case-insensitive, an IPv6 literal keeps its brackets, and a path prefix survives for an SDK behind a reverse proxy. |
+| `bot.local@10.0.0.9:8001` | **Refused.** Everything before the `@` is userinfo, so `10.0.0.9` is dialled while the address still reads as `bot.local`. |
+| `ws://10.0.0.9:8001` | **Refused.** The SDK is plain HTTP; left alone, `ws` becomes the host and the port you wrote is discarded. |
+| `/tmp/rover.sock` | **Refused** - that shape belongs to the serial arms. |
+
+A URL that cannot be used at all - `http://`, an out-of-range port, an embedded space -
+is left to `requests`, which already names it; `connect_eagerly()` returns that reason
+rather than raising.
+
 ## See also
 
 - [Humanoids](humanoids.md) - bipedal alternatives.

--- a/strands_robots/drivers/earthrover.py
+++ b/strands_robots/drivers/earthrover.py
@@ -62,6 +62,26 @@ CAMERA_VIEWS: tuple[str, ...] = ("front", "rear")
 #: Where the vendor's SDK listens when started as documented.
 DEFAULT_SDK_URL = "http://localhost:8001"
 
+#: The schemes this driver speaks. Compared case-insensitively, because a URI
+#: scheme is case-insensitive (RFC 3986 section 3.1) and ``requests`` honours
+#: that: ``HTTP://host:8001/data`` is fetched exactly like ``http://``.
+ACCEPTED_SCHEMES: tuple[str, ...] = ("http", "https")
+
+
+def _declared_scheme(value: str) -> str | None:
+    """The scheme ``value`` declares, lowercased, or ``None`` when it declares none.
+
+    The single owner of "does this value already carry a scheme?", so
+    :func:`base_url_error` and the constructor's normalisation cannot disagree
+    about where the scheme ends. They did while this was a literal
+    ``startswith(("http://", "https://"))`` in both places: the check was
+    case-sensitive, so ``HTTP://localhost:8001`` declared no scheme as far as
+    the normaliser was concerned and was prefixed into
+    ``http://HTTP://localhost:8001``.
+    """
+    scheme, separator, _ = value.partition("://")
+    return scheme.lower() if separator else None
+
 
 def _refuse(reason: str) -> dict[str, Any]:
     """One refusal envelope, so every refusal has the same shape."""
@@ -75,6 +95,36 @@ def base_url_error(value: object, param: str, context: str) -> str | None:
     on the DDS robots, a URL here - so the wrong *shape* is refused at the
     chokepoint with a sentence naming the shape that belongs elsewhere, not by
     ``requests`` failing with "No host supplied" one call later.
+
+    Beyond the shape, the base URL has to address *the host the caller wrote*.
+    Every endpoint below is built from it, so a value whose authority names one
+    host and dials another sends ``POST /control`` - a drive command - to a
+    rover the caller never named, and ``connect_eagerly`` reports success when
+    anything answers there. Two spellings do that, and neither is refused by
+    the transport, which reports only the host it ended up with:
+
+    * **Userinfo.** Everything before an ``@`` in the authority is credentials,
+      so ``bot.local@10.0.0.9:8001`` dials ``10.0.0.9`` while the address still
+      reads as ``bot.local`` - including in ``get_status``, which reports the
+      base URL back verbatim.
+    * **A foreign scheme.** ``ws://10.0.0.9:8001`` has no ``http`` prefix to
+      recognise, so it is prefixed into ``http://ws://10.0.0.9:8001``, whose
+      authority is ``ws:``. The request goes to the host ``ws`` on port 80 and
+      the port the caller wrote is discarded - the same way the host half of a
+      dialled address discards a validated port in
+      :func:`~strands_robots.utils.dial_host_error`.
+
+    That shared domain is deliberately *not* used here. It grades a bare host
+    destined for interpolation into ``ws://{host}:{port}``, where an IPv6
+    literal needs its brackets; the host inside a base URL has already been
+    parsed, so ``http://[::1]:8001`` presents as ``::1`` and would be refused
+    as "not a bare hostname or IP" - a legitimate base URL rejected.
+
+    Everything else unusable here is left to the transport, which already names
+    it: ``http:`` and ``//host`` raise ``InvalidURL: No host supplied``, and an
+    out-of-range port or an embedded space raises ``InvalidURL: Failed to
+    parse``. Both are ``ValueError`` subclasses, so ``connect_eagerly`` converts
+    them into its own reason.
 
     Args:
         value: The candidate base URL.
@@ -91,6 +141,23 @@ def base_url_error(value: object, param: str, context: str) -> str | None:
         return (
             f"{context}: {param} is an HTTP base like {DEFAULT_SDK_URL!r}, got a filesystem "
             f"path {value!r} (that shape belongs to the serial arms or microduck's robotd socket)"
+        )
+    scheme = _declared_scheme(value)
+    if scheme is not None and scheme not in ACCEPTED_SCHEMES:
+        return (
+            f"{context}: {param} must be an {' or '.join(ACCEPTED_SCHEMES)} base URL like "
+            f"{DEFAULT_SDK_URL!r}, got the {scheme!r} address {value!r}. The SDK is plain HTTP, "
+            f"and this is not refused by the transport: {scheme!r} becomes the host, so the "
+            f"request goes to {scheme!r} on port 80 and the port above is discarded"
+        )
+    authority = (value.partition("://")[2] if scheme else value).partition("/")[0]
+    if "@" in authority:
+        named, _, dialled = authority.rpartition("@")
+        return (
+            f"{context}: {param} must name the SDK host directly, got {value!r}. Everything "
+            f"before the '@' is userinfo, so {named!r} is not the host: every request - including "
+            f"POST /control, a drive command - goes to {dialled!r} while the address still reads "
+            f"as {named!r}"
         )
     return None
 
@@ -157,7 +224,7 @@ class EarthRoverDriver:
         base = port or DEFAULT_SDK_URL
         if reason := base_url_error(base, "port", type(self).__name__):
             raise ValueError(reason)
-        if not base.startswith(("http://", "https://")):
+        if _declared_scheme(base) is None:
             base = "http://" + base
         if reason := positive_finite_number_error(timeout_s, "timeout_s", type(self).__name__):
             raise ValueError(reason)

--- a/tests/drivers/test_earthrover_base_url_addresses_the_host.py
+++ b/tests/drivers/test_earthrover_base_url_addresses_the_host.py
@@ -1,0 +1,231 @@
+"""The EarthRover base URL has to address the host the caller wrote.
+
+Every endpoint the driver speaks is built from one string, so the host that
+string resolves to is the rover that moves. Two spellings resolved to a
+*different* host than the one they name, and neither is refused by the
+transport -- it reports only the host it ended up with:
+
+* ``bot.local@10.0.0.9:8001`` -- everything before the ``@`` is userinfo, so
+  ``10.0.0.9`` is dialled while the address still reads as ``bot.local``.
+* ``ws://10.0.0.9:8001`` -- no lowercase ``http`` prefix to recognise, so it was
+  prefixed into ``http://ws://10.0.0.9:8001``, whose authority is ``ws:``: the
+  request went to the host ``ws`` on port 80 and the configured port was
+  discarded.
+
+Unlike its sibling module these tests use a **real** ``http.server`` on an
+ephemeral port rather than a ``requests`` double, because the property under
+test is which host the transport actually connects to -- a double would answer
+whatever it was asked and could not tell "dialled the host we named" from
+"dialled a different one".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.earthrover import (
+    DEFAULT_SDK_URL,
+    EarthRoverDriver,
+    base_url_error,
+)
+from strands_robots.utils import dial_host_error
+
+requests = pytest.importorskip("requests")
+
+_TELEMETRY = {"battery": 88, "signal_level": 3, "lamp": 0}
+
+
+class _Recorder(BaseHTTPRequestHandler):
+    """Answer the two endpoints a connect-and-drive needs, recording each hit."""
+
+    received: list[tuple[str, str]] = []
+
+    def log_message(self, *args: Any) -> None:
+        """Silence the stdlib access log."""
+
+    def _answer(self, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler naming
+        """Record and serve ``GET /data``."""
+        type(self).received.append(("GET", self.path))
+        self._answer(dict(_TELEMETRY))
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler naming
+        """Record and acknowledge ``POST /control``."""
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        type(self).received.append(("POST", self.path))
+        self._answer({})
+
+
+@pytest.fixture
+def sdk() -> Iterator[tuple[int, list[tuple[str, str]]]]:
+    """A real SDK-shaped server on ``127.0.0.1``; yields its port and its log.
+
+    It stands in for "something is listening", which is the condition that turns
+    a misaddressed base URL from a failed connection into a drive command
+    delivered to the wrong rover.
+    """
+    _Recorder.received = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Recorder)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield server.server_address[1], _Recorder.received
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# Spellings whose authority names one host and dials another. Each is
+# (value template, the fragment the refusal must name).
+_MISADDRESSED: tuple[tuple[str, str], ...] = (
+    ("bot.local@127.0.0.1:{port}", "userinfo"),
+    ("http://bot.local@127.0.0.1:{port}", "userinfo"),
+    ("http://user:pw@127.0.0.1:{port}", "userinfo"),
+    ("ws://127.0.0.1:{port}", "'ws'"),
+    ("wss://127.0.0.1:{port}", "'wss'"),
+)
+
+
+class TestTheAuthorityMustNameTheHostThatIsDialled:
+    @pytest.mark.parametrize(("template", "needle"), _MISADDRESSED)
+    def test_a_misaddressed_base_is_refused_by_name(self, template: str, needle: str) -> None:
+        value = template.format(port=8001)
+        reason = base_url_error(value, "port", "EarthRoverDriver")
+        assert reason is not None, f"{value!r} names one host and dials another, so it is not a base URL"
+        assert needle in reason, reason
+        assert value in reason, reason
+
+    @pytest.mark.parametrize(("template", "needle"), _MISADDRESSED)
+    def test_the_constructor_refuses_before_a_session_exists(self, template: str, needle: str) -> None:
+        with pytest.raises(ValueError, match="port"):
+            EarthRoverDriver(port=template.format(port=8001))
+
+    @pytest.mark.parametrize(("template", "needle"), _MISADDRESSED)
+    def test_no_request_reaches_the_listening_server(
+        self, template: str, needle: str, sdk: tuple[int, list[tuple[str, str]]]
+    ) -> None:
+        """The refusal lands before the wire, so nothing is driven by mistake."""
+        port, received = sdk
+        with pytest.raises(ValueError):
+            EarthRoverDriver(port=template.format(port=port), timeout_s=0.5)
+        assert received == [], f"a refused address still reached the server: {received}"
+
+
+class TestThePremiseIsWhatTheTransportDoes:
+    """These hold on any tree: they measure ``requests``, not the driver."""
+
+    def test_userinfo_makes_requests_dial_the_host_after_the_at_sign(
+        self, sdk: tuple[int, list[tuple[str, str]]]
+    ) -> None:
+        port, received = sdk
+        response = requests.get(f"http://bot.local@127.0.0.1:{port}/data", timeout=5)
+        assert response.status_code == 200
+        assert received == [("GET", "/data")], (
+            "the request named bot.local and was served by 127.0.0.1, which is why "
+            "the authority has to be graded before it is dialled"
+        )
+
+    def test_a_double_scheme_makes_requests_dial_the_scheme_token(self) -> None:
+        with pytest.raises(requests.exceptions.ConnectionError) as caught:
+            requests.get("http://ws://127.0.0.1:8001/data", timeout=0.5)
+        assert "host='ws'" in str(caught.value), str(caught.value)
+        assert "port=80" in str(caught.value), "the configured port is discarded, not just the host"
+
+
+class TestTheAcceptedShapesAreUntouched:
+    @pytest.mark.parametrize(
+        ("port", "base"),
+        [
+            (None, DEFAULT_SDK_URL),
+            ("http://10.0.0.9:8001", "http://10.0.0.9:8001"),
+            ("10.0.0.9:8001", "http://10.0.0.9:8001"),
+            ("http://10.0.0.9:8001/", "http://10.0.0.9:8001"),
+            ("https://rover.local:8001", "https://rover.local:8001"),
+            ("10.0.0.9:8001/rover-7", "http://10.0.0.9:8001/rover-7"),
+            ("http://[::1]:8001", "http://[::1]:8001"),
+            ("0.0.0.0:8001", "http://0.0.0.0:8001"),
+            ("http://rover.local", "http://rover.local"),
+            ("HTTP://10.0.0.9:8001", "HTTP://10.0.0.9:8001"),
+        ],
+        ids=[
+            "default",
+            "http",
+            "bare-host-port",
+            "trailing-slash",
+            "https",
+            "path-prefix",
+            "ipv6-literal",
+            "every-interface",
+            "no-port",
+            "uppercase-scheme",
+        ],
+    )
+    def test_a_usable_base_still_constructs(self, port: str | None, base: str) -> None:
+        assert EarthRoverDriver(port=port)._base == base
+
+
+class TestTheSharedHostDomainIsTheWrongToolHere:
+    """Why ``dial_host_error`` is not asked, pinned rather than asserted in prose."""
+
+    def test_it_refuses_the_host_inside_a_legitimate_ipv6_base(self) -> None:
+        assert dial_host_error("::1", "port", "EarthRoverDriver") is not None, (
+            "if this ever becomes None the shared domain could be asked here directly"
+        )
+
+    def test_and_that_base_url_is_accepted(self) -> None:
+        assert EarthRoverDriver(port="http://[::1]:8001")._base == "http://[::1]:8001"
+
+
+class TestTheTransportKeepsTheCasesItAlreadyNames:
+    @pytest.mark.parametrize(
+        "value",
+        ["http://", "http://localhost:99999", "http://localhost:8001 x"],
+        ids=["scheme-only", "port-out-of-range", "embedded-space"],
+    )
+    def test_an_unusable_url_the_transport_reports_is_left_to_it(self, value: str) -> None:
+        assert base_url_error(value, "port", "EarthRoverDriver") is None
+        driver = EarthRoverDriver(port=value, timeout_s=0.5)
+        reason = driver.connect_eagerly()
+        assert reason is not None, f"{value!r} is unusable, so connect must report a reason"
+        assert "Invalid URL" in reason or "Failed to parse" in reason, reason
+        assert driver._base in reason, "the reason names the URL the driver actually tried"
+
+
+class TestTheUppercaseSchemeReachesTheHostItNames:
+    def test_it_connects_and_drives(self, sdk: tuple[int, list[tuple[str, str]]]) -> None:
+        """``HTTP://`` used to be prefixed into a URL whose host was ``http``."""
+        port, received = sdk
+        driver = EarthRoverDriver(port=f"HTTP://127.0.0.1:{port}", timeout_s=5.0)
+        assert driver.connect_eagerly() is None
+        assert driver.send_action({"linear": 0.5})["status"] == "success"
+        status = asyncio.run(driver.get_status())["content"][0]["json"]
+        assert status["connected"] is True
+        assert status["battery_pct"] == _TELEMETRY["battery"]
+        driver.cleanup()
+        assert ("GET", "/data") in received
+        assert ("POST", "/control") in received
+
+
+class TestTheSchemeOwnerIsShared:
+    def test_the_accepted_schemes_are_the_ones_the_validator_admits(self) -> None:
+        # Imported here rather than at module scope so this module still
+        # collects against a tree without the constant, which is what lets the
+        # cells above report the defect instead of a collection error.
+        from strands_robots.drivers.earthrover import ACCEPTED_SCHEMES  # noqa: PLC0415
+
+        assert ACCEPTED_SCHEMES == ("http", "https")
+        for scheme in ACCEPTED_SCHEMES:
+            assert base_url_error(f"{scheme}://rover.local:8001", "port", "t") is None

--- a/tests/drivers/test_earthrover_driver.py
+++ b/tests/drivers/test_earthrover_driver.py
@@ -142,8 +142,9 @@ class TestConstructionRefusesTheWrongShape:
             ("http://10.0.0.9:8001/", "http://10.0.0.9:8001"),
             ("10.0.0.9:8001", "http://10.0.0.9:8001"),
             ("https://rover.local:8001", "https://rover.local:8001"),
+            ("HTTP://10.0.0.9:8001", "HTTP://10.0.0.9:8001"),
         ],
-        ids=["default", "trailing-slash", "bare-host-port", "https"],
+        ids=["default", "trailing-slash", "bare-host-port", "https", "uppercase-scheme"],
     )
     def test_the_base_url_is_normalised(self, port: str | None, base: str) -> None:
         assert EarthRoverDriver(port=port)._base == base


### PR DESCRIPTION
## The defect

`base_url_error` graded the **shape** of `port=` — a non-empty string that is not a filesystem path — and never read the host out of it. Every endpoint the driver speaks is built from that one string, so a value whose authority names one host and resolves to another sends `POST /control` — a drive command — to a rover the caller never named.

```mermaid
graph LR
  A["port=<br/>bot.local@10.0.0.9:8001"] --> B{base_url_error}
  B -->|"string, not a path<br/>-> accepted"| C["_base"]
  C --> D["GET /data"]
  C --> E["POST /control"]
  C --> F["get_status<br/>sdk_url"]
  D --> G(["10.0.0.9<br/>a rover nobody named"])
  E --> G
  F --> H(["reads back as<br/>bot.local"])
  style G fill:#ffdddd,stroke:#cc0000
  style H fill:#ffdddd,stroke:#cc0000
```

## Measured, through the real consumer

Same script in two trees, against a real `http.server` on `127.0.0.1` standing in for "something is listening". Ports are ephemeral; `POST /control` carries `linear: 1.0`.

| `port=` | before: construct | before: `/control` delivered to the server | after: construct | after: `/control` |
|---|---|---|---|---|
| `bot.local@127.0.0.1:PORT` | accepted, connect reported success | **yes** | **refused** | none |
| `http://user:pw@127.0.0.1:PORT` | accepted, connect reported success | **yes** | **refused** | none |
| `ws://127.0.0.1:PORT` | accepted | no — dialled host `ws` port 80 | **refused** | none |
| `HTTP://127.0.0.1:PORT` | accepted | no — dialled host `http` port 80 | accepted | **yes** |
| `http://127.0.0.1:PORT` | accepted | yes | accepted | yes |
| `http://[::1]:PORT` | accepted | n/a (server is IPv4) | accepted | n/a |

On the first row `connect_eagerly()` returned `None` and `get_status()` reported `sdk_url` as `http://bot.local@127.0.0.1:PORT` — so the address an operator reads still contains the host they configured, while the requests went elsewhere.

## The two mechanisms, and what is left alone

Neither is refused by the transport, which reports only the host it ended up with:

- **Userinfo.** Everything before an `@` is credentials, so `bot.local@10.0.0.9:8001` dials `10.0.0.9`.
- **A foreign scheme.** `ws://10.0.0.9:8001` has no lowercase `http` prefix to recognise, so it was prefixed into `http://ws://10.0.0.9:8001`, whose authority is `ws:` — the request went to the host `ws` on **port 80**, discarding the port the caller wrote.

The same case-sensitivity behind the second also broke `HTTP://10.0.0.9:8001`, a valid URL a caller may write: a URI scheme is case-insensitive (RFC 3986 §3.1) and `requests` fetches it identically (verified: HTTP 200 against the same server). The scheme test therefore moves into one owner, `_declared_scheme`, which the validator and the constructor's normalisation both ask — so they cannot disagree about where the scheme ends, which is what produced this row.

Everything else unusable is **left to the transport, which already names it** — so this is not a general URL validator:

| `port=` | still accepted here, reported by `connect_eagerly()` as |
|---|---|
| `http://` | `InvalidURL: No host supplied` |
| `http://localhost:99999` | `InvalidURL: Failed to parse` |
| `http://localhost:8001 x` | `InvalidURL: Failed to parse` |

Both are `ValueError` subclasses, which `connect_eagerly` already converts into its own reason.

## Why `dial_host_error` is not asked

The shared domain for the host half of a dialled address grades a **bare host** destined for interpolation into `ws://{host}:{port}`, where an IPv6 literal needs its brackets. The host inside a base URL has already been parsed, so `http://[::1]:8001` presents as `::1` and would be refused as "not a bare hostname or IP" — a legitimate base URL rejected. Two cells pin exactly that, so if the domain ever widens the coupling is visible rather than a comment.

## Tests

`tests/drivers/test_earthrover_base_url_addresses_the_host.py` uses a **real** `http.server` on an ephemeral port rather than the sibling module's `requests` double: the property under test is which host the transport connects to, and a double answers whatever it is asked. It pins the refusals by name, that **nothing reaches a listening server** for a refused address, that the ten usable shapes still construct, that the uppercase scheme now connects and drives, and — as premises that hold on any tree — what `requests` itself does with userinfo and a double scheme.

Four corners over `tests/drivers/test_earthrover_{driver,default_resolution}.py` plus the new file:

| | production | tests | result |
|---|---|---|---|
| A | base | base | 77 passed |
| B | base | new | **19 failed**, 93 passed |
| C | new | new | 112 passed |
| D | new | base | 77 passed — identical to A |

`77 + 35 = 112`, and `93 = 112 − 19`. D equalling A is the statement that no existing cell changed behaviour. Corner B's uppercase failure quotes the pre-fix behaviour directly: `HTTPConnectionPool(host='http', port=80)`.

## Gate

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ` clean (1931 files); `mypy strands_robots tests tests_integ` → `Success: no issues found in 1927 source files`.
- `tests/drivers` 2404 passed / 17 skipped.
- Every `tests/test_docs*.py` plus `tests/test_markdown_links_resolve.py` 245 passed. `test_docs_robot_attribute_reads_resolve` caught a false claim in the first draft of the docs section — `earthrover` declares `hardware.lerobot_type`, not `driver: "strands"`, so the example needs `driver="strands"` to reach this driver; corrected.
- The 477-file tree-walking grader population plus `tests/drivers`: 26480 passed, 7 failed — all environmental on this host and unrelated to this change (5 assert `rclpy` is absent where it resolves from `/opt/ros/jazzy`; 2 read installed `websockets` 16.0 against the `>=17.0` floor the `cosmos3-service` extra declares).

## Size

362 insertions across 5 files. The production change is **+11 executable statements** (203 → 214 by AST); the remaining 56 lines of `earthrover.py` are the docstring recording the two mechanisms and why the shared domain does not fit. `docs/robots/mobile.md` gains the driver's first prose section — the accepted and refused `port=` shapes, which had no documented contract.

## Reachability

`Robot("earthrover", mode="real", driver="strands", port=...)` builds this driver and the refusal reaches through that factory. The six `@tool` verbs in `strands_robots/tools/earthrover.py` take a live driver handle, so they inherit the guard at the point the handle is constructed.