### PR TITLE
fix(tools/run_policy): the parquet-truth counts are graded by their one owner

### DIFF
--- a/changelog.d/3300-parquet-truth-count-has-one-owner.md
+++ b/changelog.d/3300-parquet-truth-count-has-one-owner.md
@@ -1,0 +1,30 @@
+### Fixed: the rollout tool's parquet-truth counts are graded, not coerced
+
+`run_policy`'s parquet-truth gate exists to catch a fabricated episode count: it
+reads `meta/info.json` after `stop_recording` and reports `total_episodes` /
+`total_frames` as ground truth instead of trusting the loop's self-report. It
+read both headers through `int()`, which is the one thing that gate cannot
+afford, because a coerced number is what it then reports to the caller AS the
+truth it independently verified.
+
+`total_episodes: true` answered a one-episode request with `status=success` and
+`parquet-truth: total_episodes=1`, no warnings -- a boolean certifying the count.
+`2.5` truncated to `2` and `"2"` parsed to `2`, so each agreed with a two-episode
+request and the mismatch guard had nothing to compare. Every one of those files
+is already "metadata is corrupt" to `verify_dataset` and to
+`read_dataset_episode_indices`, which read the same two headers: one file, three
+answers. In the other direction `1e400` (a well-formed JSON number `json.load`
+parses to `inf`), `NaN` and `null` raised `OverflowError` / `ValueError` /
+`TypeError` out of a function documenting that it "returns a partial result on
+missing fields rather than raising", and past the tool envelope a caller reads.
+
+Both headers now go through `declared_count`, the one owner every reader of this
+file already shares. A declaration outside that domain is "no count declared":
+the count reads `-1` and the header is reported as corrupt metadata in the same
+words `verify_dataset` uses, so it flips the tool's status to `error` instead of
+certifying the rollout. The fabrication guard still fires on a genuine count that
+disagrees, and no longer names the `save_episode` boundary for a corrupt header
+-- that boundary may have fired for every episode. A header nothing declares is
+reported as unverifiable rather than as a mismatch, and a `meta/info.json`
+holding a JSON array instead of an object is an unreadable header rather than an
+`AttributeError`.

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -68,6 +68,14 @@ def _err(text: str) -> dict[str, Any]:
     return {"status": "error", "content": [{"text": text}]}
 
 
+#: Reported for a header the file declares no usable count under - an absent
+#: key, or a declaration outside the count domain. ``declared_count`` refuses
+#: every negative, so no real declaration can collide with this sentinel, and
+#: the gate below already initialises both totals to it for the case where
+#: there is no dataset to read at all.
+_NO_COUNT = -1
+
+
 def _read_parquet_truth(dataset_root: str | Path) -> dict[str, Any]:
     """Read ground-truth episode/frame counts from ``meta/info.json``.
 
@@ -77,9 +85,43 @@ def _read_parquet_truth(dataset_root: str | Path) -> dict[str, Any]:
     async-flushed and can lag (see HB#372 forensics + e2e verifier's
     two-phase wait pattern), so we explicitly DO NOT depend on them here.
 
+    Both headers are graded by :func:`~strands_robots.utils.declared_count`, the
+    one owner every reader of this file shares, rather than coerced with
+    ``int()``. Coercing was destructive in both directions at the one surface
+    that exists to catch a fabricated episode count:
+
+    * ``2.5`` truncated to ``2`` and ``true`` counted as one episode, so a
+      header no writer could have produced was reported to the caller AS parquet
+      truth - and agreed with the requested count, which is the silent collapse
+      this gate was written to catch. The same header is "metadata is corrupt"
+      to :func:`~strands_robots.verify_dataset.verify_dataset` and to
+      :func:`~strands_robots.dataset_recorder.read_dataset_episode_indices`.
+    * ``1e400`` (a well-formed JSON number ``json.load`` parses to ``inf``),
+      ``NaN`` and ``null`` raised ``OverflowError`` / ``ValueError`` /
+      ``TypeError`` out of this function and past the tool envelope, from a file
+      that was perfectly readable.
+
+    A header that declares something which is not a count is a third outcome,
+    distinct from both a usable count and an absent header, so it is reported in
+    ``info_problems`` - the spelling both other readers of this file already use
+    - rather than collapsing into either. The count itself then reads
+    :data:`_NO_COUNT`.
+
+    Args:
+        dataset_root: Dataset root holding ``meta/info.json``.
+
+    Returns:
+        ``info_present`` plus, when the header was readable, the two graded
+        counts, any ``info_problems`` naming a declaration that is not a count,
+        and the declared ``fps``.
+
     Returns a partial result on missing fields rather than raising, so the
     caller can surface a structured error instead of a stack trace.
     """
+    # Lazy, like every other strands_robots import in this module: a caller who
+    # runs without recording pulls in no extra module.
+    from strands_robots.utils import declared_count
+
     info_path = Path(dataset_root) / "meta" / "info.json"
     if not info_path.is_file():
         return {"info_present": False, "info_path": str(info_path)}
@@ -88,11 +130,30 @@ def _read_parquet_truth(dataset_root: str | Path) -> dict[str, Any]:
             info = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
         return {"info_present": False, "info_path": str(info_path), "error": repr(e)}
+    if not isinstance(info, dict):
+        # A readable JSON document that is not an object carries no headers at
+        # all - the same "nothing to verify against" as an unreadable file.
+        # Reading it as one raised AttributeError past the tool envelope.
+        return {
+            "info_present": False,
+            "info_path": str(info_path),
+            "error": f"meta/info.json holds a JSON {type(info).__name__}, not an object",
+        }
+
+    counts: dict[str, int] = {}
+    info_problems: list[str] = []
+    for key in ("total_episodes", "total_frames"):
+        raw = info.get(key)
+        declared = declared_count(raw)
+        counts[key] = _NO_COUNT if declared is None else declared
+        if key in info and declared is None:
+            info_problems.append(f"meta/info.json {key}={raw!r} is not a count - metadata is corrupt")
     return {
         "info_present": True,
         "info_path": str(info_path),
-        "total_episodes": int(info.get("total_episodes", -1)),
-        "total_frames": int(info.get("total_frames", -1)),
+        "total_episodes": counts["total_episodes"],
+        "total_frames": counts["total_frames"],
+        "info_problems": info_problems,
         "fps": info.get("fps"),
     }
 
@@ -134,7 +195,10 @@ def run_policy(
        ``total_episodes`` / ``total_frames`` read from
        ``meta/info.json`` AFTER ``stop_recording`` returns, NOT
        self-reported by the loop. Mismatch with ``n_episodes`` is surfaced
-       as ``warnings=[...]`` for the verifier to act on.
+       as ``warnings=[...]`` for the verifier to act on. Both counts are
+       graded by ``declared_count``, so a header that declares something
+       which is not a count reads ``-1`` and is reported as corrupt
+       metadata rather than coerced into agreement with the request.
 
     Args:
         simulation: Live ``Simulation`` (or compatible) handle.
@@ -230,8 +294,8 @@ def run_policy(
 
             {
                 "n_episodes_requested": int,
-                "n_episodes_actual": int,      # parquet-truth
-                "n_frames_actual": int,        # parquet-truth
+                "n_episodes_actual": int,      # parquet-truth, -1 if unread
+                "n_frames_actual": int,        # parquet-truth, -1 if unread
                 "dataset_root": str | None,
                 "warnings": [str, ...],        # mismatch flags
                 "episodes": [
@@ -489,8 +553,8 @@ def run_policy(
                 )
 
     # ---- 5. Parquet-truth gate -----------------------------------------
-    n_actual_eps = -1
-    n_actual_frames = -1
+    n_actual_eps = _NO_COUNT
+    n_actual_frames = _NO_COUNT
     warnings_: list[str] = []
     truth: dict[str, Any] = {}
 
@@ -505,7 +569,18 @@ def run_policy(
         else:
             n_actual_eps = truth["total_episodes"]
             n_actual_frames = truth["total_frames"]
-            if n_actual_eps != n_episodes:
+            # A header that declares something which is not a count is reported
+            # as itself. The guard below can only compare a COUNT, and naming
+            # the save_episode boundary for a corrupt header would report the
+            # wrong cause - that boundary may have fired for every episode.
+            warnings_.extend(truth["info_problems"])
+            if n_actual_eps == _NO_COUNT:
+                if not truth["info_problems"]:
+                    warnings_.append(
+                        f"meta/info.json under {dataset_root!r} declares no "
+                        "total_episodes - cannot verify the episode count."
+                    )
+            elif n_actual_eps != n_episodes:
                 warnings_.append(
                     f"FABRICATION GUARD: requested {n_episodes} episodes, "
                     f"meta/info.json:total_episodes={n_actual_eps}. The "

--- a/tests/test_declared_episode_count_has_one_owner.py
+++ b/tests/test_declared_episode_count_has_one_owner.py
@@ -1,12 +1,14 @@
 """The episode count a dataset's ``meta/info.json`` declares has ONE verdict.
 
-Four surfaces read ``meta/info.json``'s ``total_episodes`` header: the parquet
+Five surfaces read ``meta/info.json``'s ``total_episodes`` header: the parquet
 cross-check in :func:`~strands_robots.dataset_recorder.read_dataset_episode_indices`,
 the drift check in :func:`~strands_robots.verify_dataset.verify_dataset`, the
-validation-split denominator in ``strands_robots.training.lerobot``, and the
-episode count ``strands_robots.tools.lerobot_train`` splits. Each graded the same
-value its own way, so one file got four answers - and two of those answers were
-silently destructive:
+validation-split denominator in ``strands_robots.training.lerobot``, the
+episode count ``strands_robots.tools.lerobot_train`` splits, and the parquet-truth
+gate in ``strands_robots.tools.run_policy`` - the agent-callable rollout tool that
+exists to catch a fabricated episode count. Each graded the same value its own
+way, so one file got five answers - and two of those answers were silently
+destructive:
 
 * ``int(2.5)`` truncates to ``2``, which is exactly the count a two-episode
   parquet holds, so a header no writer could have produced read as AGREEMENT
@@ -23,7 +25,15 @@ silently destructive:
 :func:`~strands_robots.utils.declared_count` is that one owner. A declaration
 outside its domain is "no count declared", and a reader that must not read that
 as an absent header reports it: the recorder's helper carries it in
-``info_problems``, verify_dataset appends a problem.
+``info_problems``, verify_dataset appends a problem, and the rollout tool warns
+(which flips its status to ``error``).
+
+The rollout tool is where coercion cost the most, because a coerced count is the
+number it reports to the caller AS parquet truth: ``total_episodes: true``
+answered a one-episode request with ``status=success`` and
+``parquet-truth: total_episodes=1``, no warnings - a boolean certifying the very
+count the tool was written to verify independently, on a file its two sibling
+readers both call corrupt.
 
 Fixtures are pyarrow + a raw ``info.json`` string (not ``json.dumps``, which
 cannot write ``1e400`` or ``NaN`` from a Python value), so these tests need
@@ -44,6 +54,7 @@ import pyarrow.parquet as pq
 
 import strands_robots.tools.lerobot_train as lerobot_train_tool
 from strands_robots.dataset_recorder import read_dataset_episode_indices
+from strands_robots.tools.run_policy import run_policy as run_policy_tool
 from strands_robots.training.lerobot import LerobotTrainer
 from strands_robots.utils import declared_count
 from strands_robots.verify_dataset import verify_dataset
@@ -75,6 +86,29 @@ def _dataset(root: Path, *, declaration: str | None, episodes: int = 2) -> str:
     body = "" if declaration is None else f', "total_episodes": {declaration}'
     (root / "meta" / "info.json").write_text('{"codebase_version": "v3.0"' + body + "}")
     return str(root)
+
+
+class _RecordingSim:
+    """Rollout stand-in for the agent-callable tool: succeeds, records nothing.
+
+    The tool reads its parquet truth off disk, so the dataset :func:`_dataset`
+    wrote is the whole input - no engine, no lerobot, no mujoco.
+    """
+
+    def run_policy(self, **kwargs: object) -> dict[str, object]:
+        return {"status": "success", "content": [{"text": "rollout"}]}
+
+    def start_recording(self, **kwargs: object) -> dict[str, object]:
+        return {"status": "success", "content": [{"text": "recording started"}]}
+
+    def stop_recording(self, **kwargs: object) -> dict[str, object]:
+        return {"status": "success", "content": [{"text": "recording stopped"}]}
+
+
+def _rollout(root: str, *, n_episodes: int = 2) -> dict:
+    """Drive the rollout tool against ``root`` and flatten its reported payload."""
+    result = run_policy_tool(_RecordingSim(), n_episodes=n_episodes, n_steps=4, dataset_root=root)
+    return {"status": result["status"], **result["content"][1]["json"]}
 
 
 class TestDeclaredCountDomain:
@@ -124,16 +158,63 @@ class TestEveryReaderReachesTheSameVerdict:
         assert any("is not a count" in p for p in report["problems"]), report["problems"]
 
     @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
+    def test_the_rollout_tool_reports_the_corrupt_header(self, declaration: str, tmp_path: Path) -> None:
+        """No count, a warning naming the header, and an error status.
+
+        The warning is what stops the tool reporting a coerced number to its
+        caller as the parquet truth it independently verified.
+        """
+        payload = _rollout(_dataset(tmp_path, declaration=declaration))
+        assert payload["n_episodes_actual"] == -1
+        assert any("total_episodes" in w and "is not a count" in w for w in payload["warnings"]), payload["warnings"]
+        assert payload["status"] == "error"
+
+    @pytest.mark.parametrize(
+        ("declaration", "requested"),
+        [("2.0", 2), ("2.5", 2), ('"2"', 2), ("true", 1)],
+        ids=["integral_float", "truncates_into_agreement", "digit_string", "bool_is_one_episode"],
+    )
+    def test_a_header_that_is_not_a_count_never_certifies_the_rollout(
+        self, declaration: str, requested: int, tmp_path: Path
+    ) -> None:
+        """Requested exactly what the coercion would have produced.
+
+        These four are the spellings whose coerced value EQUALS the request, so
+        the mismatch gate had nothing to compare and the rollout was reported
+        ``status=success`` on a header no writer could have produced.
+        """
+        payload = _rollout(_dataset(tmp_path, declaration=declaration), n_episodes=requested)
+        assert payload["status"] == "error"
+        assert payload["n_episodes_actual"] == -1
+        assert not any("FABRICATION GUARD" in w for w in payload["warnings"]), (
+            "a corrupt header is not evidence the save_episode boundary missed"
+        )
+
+    def test_the_rollout_tools_frame_total_shares_the_domain(self, tmp_path: Path) -> None:
+        """The sibling header the same gate reports, with the count healthy."""
+        root = tmp_path / "frames"
+        (root / "meta").mkdir(parents=True)
+        (root / "meta" / "info.json").write_text('{"total_episodes": 2, "total_frames": 8.5}')
+        payload = _rollout(str(root))
+        assert payload["n_episodes_actual"] == 2
+        assert payload["n_frames_actual"] == -1
+        assert any("total_frames=8.5 is not a count" in w for w in payload["warnings"]), payload["warnings"]
+        assert payload["status"] == "error"
+
+    @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
     def test_no_reader_raises_on_a_readable_file(self, declaration: str, tmp_path: Path) -> None:
         """``1e400`` parses to ``inf`` and ``int(inf)`` raises ``OverflowError``.
 
         The file is readable, so the answer must be a verdict, not an exception
-        escaping from three readers that document "unknown".
+        escaping from four readers that document "unknown" - and the fifth is a
+        Strands tool, which must return its error envelope rather than raise
+        past dispatch.
         """
         root = _dataset(tmp_path, declaration=declaration)
         read_dataset_episode_indices(root)
         LerobotTrainer()._dataset_total_episodes(root)
         verify_dataset(root)
+        assert _rollout(root)["status"] == "error"
 
     def test_a_frame_total_that_is_not_a_count_is_reported_too(self, tmp_path: Path) -> None:
         """The sibling header in the same check shares the domain."""
@@ -160,6 +241,9 @@ class TestTheHealthyAndUnknownCasesAreUnchanged:
         report = verify_dataset(root)
         assert report["info_total_episodes"] == 2
         assert not any("total_episodes" in p for p in report["problems"]), report["problems"]
+        payload = _rollout(root)
+        assert payload["n_episodes_actual"] == 2
+        assert payload["status"] == "success", payload["warnings"]
 
     def test_a_wrong_int_header_is_still_reported_as_drift(self, tmp_path: Path) -> None:
         """The existing drift message is unchanged - a wrong COUNT is not corrupt."""
@@ -176,3 +260,10 @@ class TestTheHealthyAndUnknownCasesAreUnchanged:
         assert info["info_problems"] == []
         assert LerobotTrainer()._dataset_total_episodes(root) is None
         assert not any("total_episodes" in p for p in verify_dataset(root)["problems"])
+        # The tool cannot verify a count nothing declared, and says so - without
+        # calling the header corrupt or blaming the save_episode boundary.
+        payload = _rollout(root)
+        assert payload["n_episodes_actual"] == -1
+        assert any("declares no total_episodes" in w for w in payload["warnings"]), payload["warnings"]
+        assert not any("is not a count" in w for w in payload["warnings"])
+        assert not any("FABRICATION GUARD" in w for w in payload["warnings"])


### PR DESCRIPTION
`run_policy`'s parquet-truth gate exists to catch a **fabricated** episode count: it reads `meta/info.json` after `stop_recording` and reports `total_episodes` / `total_frames` as ground truth rather than trusting the loop's self-report. It read both headers through `int()` — which is the one thing that gate cannot afford, because a coerced number is what it then reports to the caller **as** the truth it independently verified.

```python
"total_episodes": int(info.get("total_episodes", -1)),
"total_frames":   int(info.get("total_frames", -1)),
```

## Measured on a real recorded dataset

A 2-episode / 50-frame dataset recorded in MuJoCo (headless) through the tool itself — header written `total_episodes=2, total_frames=50`, `status=success`. Only the `total_episodes` spelling is then re-written; everything else is the recorder's own output. Frames in the figure are read back out of the dataset's own `observation.images.default` video.

![parquet-truth verdicts](https://raw.githubusercontent.com/cagataycali/robots/assets/parquet-truth-count/docs/assets/parquet-truth-count-verdicts.png)

| `total_episodes` | what it is | before | after |
| --- | --- | --- | --- |
| `2` | what the recorder wrote | `2`, success | `2`, success |
| `2.0` | integral float | `2`, **success** | `-1`, error |
| `2.5` | truncates *into* agreement | `2`, **success** | `-1`, error |
| `"2"` | digit string | `2`, **success** | `-1`, error |
| `true` | `bool` is an `int` subclass | `1`, certifies a 1-episode request | `-1`, error |
| `1e400` | JSON number → `inf` | **raised `OverflowError`** | `-1`, error |
| `NaN` | JSON number, not finite | **raised `ValueError`** | `-1`, error |
| `null` | key present, no value | **raised `TypeError`** | `-1`, error |
| `-2` | negative | reported `-2` as a count | `-1`, error |

The sharpest case, verbatim from the tool on that dataset:

```
total_episodes: true, n_episodes=1
  before: status=success | run_policy: 1/1 episodes ok | parquet-truth: total_episodes=1, total_frames=4   warnings=[]
  after : status=error   | warnings=['meta/info.json total_episodes=True is not a count - metadata is corrupt']
```

A boolean certified the very count the tool exists to verify. `2.5`, `2.0` and `"2"` do the same for a two-episode request: the coerced value *equals* the request, so the mismatch guard had nothing to compare.

## One file, three answers

`verify_dataset` and `read_dataset_episode_indices` read the same two headers and both already grade them with `declared_count`. On one dataset with `total_episodes: 2.5`:

| reader | verdict |
| --- | --- |
| `verify_dataset` | `ok=False` — `total_episodes=2.5 is not a count - metadata is corrupt` |
| `read_dataset_episode_indices` | `info_total_episodes=None`, problem reported |
| `run_policy` (before) | `status=success`, `n_episodes_actual=2` |

`declared_count`'s docstring names the readers of this header and states the rule as "one file, one value, one verdict" — this gate was outside it.

## Change

Both headers go through `declared_count`. A declaration outside that domain is "no count declared": the count reads `-1` and the header is reported as corrupt metadata in the same words `verify_dataset` uses, which flips the tool's status to `error` instead of certifying the rollout. Also:

- the fabrication guard still fires on a genuine count that disagrees, but no longer names the `save_episode` boundary for a corrupt header — that boundary may have fired for every episode;
- a header nothing declares is reported as unverifiable rather than as a mismatch;
- a `meta/info.json` holding a JSON array instead of an object is an unreadable header rather than an `AttributeError` past the tool envelope.

No narrowing: every value newly refused is one both sibling readers already refuse, and the header the recorder really writes still certifies.

## Tests

The tree already had a roster grader for this class, `tests/test_declared_episode_count_has_one_owner.py`, opening "Four surfaces read `meta/info.json`'s `total_episodes` header". This gate was the unlisted fifth, so it joins the roster (count corrected to five) rather than getting a duplicate file. +13 cells; pre-fix **20 failed / 51 passed**, failing with exactly the harm classes:

```
test_a_header_that_is_not_a_count_never_certifies_the_rollout[integral_float]           assert 'success' == 'error'
test_a_header_that_is_not_a_count_never_certifies_the_rollout[truncates_into_agreement] assert 'success' == 'error'
test_a_header_that_is_not_a_count_never_certifies_the_rollout[digit_string]             assert 'success' == 'error'
test_a_header_that_is_not_a_count_never_certifies_the_rollout[bool_is_one_episode]      assert 'success' == 'error'
test_the_rollout_tool_reports_the_corrupt_header[1e400]  OverflowError: cannot convert float infinity to integer
test_the_rollout_tool_reports_the_corrupt_header[NaN]    ValueError: cannot convert float NaN to integer
test_the_rollout_tool_reports_the_corrupt_header[null]   TypeError: int() argument must be ... not 'NoneType'
test_an_absent_header_stays_the_unknown_case             FABRICATION GUARD ... total_episodes=-1 ... save_episode boundary did not fire
```

Controls kept: the healthy `2` header certifies at every reader, a *wrong* integer count is still drift and not corruption, and an absent header stays the unknown case.

## Gate

- 246-module net (`run_policy` / `declared_count` / `verify_dataset` / `info.json` / `parquet`): base **7F/13E/9440P** → branch **7F/13E/9453P** (= 9440 + the 13 new cells), failure-name sets **identical** (`comm -3` empty). All standing failures are lerobot API drift in `tests/training/` (`DatasetConfig.eval_split`, `make_train_eval_datasets`, `_require_package_cache`).
- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean (1932 files).
- `mypy strands_robots tests tests_integ`: 20 errors / 6 files, all pre-existing (`examples/isaac_gs`, `simulation/ik.py`) — none in the changed files.

LOC: `strands_robots/tools/run_policy.py` +83/-8 (61 of the additions are the docstring stating why the value is graded rather than coerced), tests +98/-7, changelog +30.