### PR TITLE
fix(training): a dataset's declared task count is graded, not converted to the absent case

### DIFF
--- a/changelog.d/3301-task-count-one-owner.md
+++ b/changelog.d/3301-task-count-one-owner.md
@@ -1,0 +1,19 @@
+### Fixed: a dataset's declared task count is graded, not converted to the absent case
+
+A validation split is one `eval_split` FRACTION in lerobot, applied as
+`ceil(episodes_in_task * eval_split)` per task, so a global `val_episodes` count
+is only expressible on a single-task dataset. `validation_split_error` refuses
+the request otherwise -- but both readers of `meta/info.json`'s `total_tasks`
+converted the header first (`total if isinstance(total, int) and not
+isinstance(total, bool) else 0`), and 0 is the value that guard honors as "no
+task count recorded". Every declaration outside a bare `int` therefore arrived as
+the absent case: a three-task dataset whose header spelled its count `3.0` or
+`"3"` passed the guard written to refuse exactly that dataset, and lerobot then
+held out 3 episodes where 2 were asked for.
+
+The declaration now reaches the guard verbatim from both the `lerobot_train` tool
+and `LerobotTrainer`, and is graded by `declared_count` -- the one owner every
+reader of a LeRobot header count already shares. A header declaring something
+which is not a count is a third outcome, refused on its own terms and naming the
+value, rather than collapsed into the absent one. `0`, `1` and no header at all
+are still honored as single-task.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -106,7 +106,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `steps` / `global_batch_size` | the run size: optimizer steps x batch | each must be a positive integer; `validate()` refuses `0`, a fractional or non-finite value, and a `bool` (`True` would read as a silent one-step run) before anything is loaded |
 | `method` | `full` \| `lora` \| `expert_only` \| `frozen_backbone` | `lora`+`expert_only` are mutually exclusive |
 | `tune` | `{llm,visual,projector,diffusion}` | GR00T only |
-| `val_episodes` | hold out the LAST N episodes | deterministic split; must be a positive integer below the dataset's episode count, and that count must be readable from a local `meta/info.json` (see the Hub-source note below). `validate()` refuses `0` or a negative (they produced no split and no eval cadence at all - the run trained on everything and logged no validation loss), a `bool`, and a fractional value (`2.7` reserved 3 episodes, `0.5` reserved none while still evaluating); mutually exclusive with `streaming` |
+| `val_episodes` | hold out the LAST N episodes | deterministic split; must be a positive integer below the dataset's episode count, and that count must be readable from a local `meta/info.json` (see the Hub-source note below). `validate()` refuses `0` or a negative (they produced no split and no eval cadence at all - the run trained on everything and logged no validation loss), a `bool`, and a fractional value (`2.7` reserved 3 episodes, `0.5` reserved none while still evaluating); refused on a dataset whose `total_tasks` declares more than one task, or declares something that is not a task count, since lerobot's split is a per-task fraction; mutually exclusive with `streaming` |
 | `num_gpus` / `num_nodes` | multi-GPU / multi-node | selects the launcher; each must be a positive integer. `validate()` refuses `0`, a negative, a `bool` and a non-finite value (none of them read as greater than one, so the selector would route them to the single-process path and the run would proceed on a topology nobody asked for) and a fractional or integral float (`2.7`, `2.0` - greater than one, so they reach the launcher as the worker count) |
 | `seed` | reproducibility seed | must be a non-negative integer; `validate()` refuses a negative (`torch.manual_seed` would take it modulo `2**64`, so `-1` silently becomes `2**64 - 1`), a fractional or non-finite value, and a `bool`. `None` uses the backend's own default |
 | `extra["policy_type"]` | lerobot `--policy.type` | act/diffusion/smolvla/pi0/pi05/... |
@@ -449,6 +449,20 @@ than launch a run that trains on every episode and logs no validation loss. The
 refusal names the two ways to get the split: point `dataset_root` at a populated
 local copy of the dataset, or pass lerobot's own knobs directly with
 `extra={"dataset.eval_split": 0.1, "eval_steps": 1000}`.
+
+The same `meta/info.json` decides whether the request is expressible at all.
+lerobot holds out `ceil(episodes_in_task * eval_split)` from **every task
+independently**, so one fraction reproduces a global episode count only on a
+single-task dataset: reserving 2 episodes of a three-task dataset would hold out
+3. `validate()` therefore refuses `val_episodes` when `total_tasks` declares more
+than one task, and points at the fraction instead. `total_tasks: 0`, `1`, or no
+such header mean the dataset records no task count - lerobot's own field defaults
+to 0 - and are honored as single-task. A header that declares something which is
+*not* a count (`3.0`, `"3"`, `true`, `-3`, `NaN`) is refused on its own terms and
+names the value it read: the count is what decides expressibility, so an unusable
+declaration is neither single-task nor multi-task, and reading it as the former
+is what let a multi-task dataset reach the per-task ceiling. Repair the header,
+or pass the fraction directly.
 
 `streaming` and `val_episodes` cannot both be honored, so `validate()` refuses
 the pair. lerobot holds out a validation split only on a **map-style** dataset:

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -477,20 +477,27 @@ class SessionManager:
         return self._load_sessions()
 
 
-def _read_total_tasks(dataset_root: str) -> int:
-    """Return ``total_tasks`` from a LeRobot v3 dataset's ``meta/info.json``.
+def _read_total_tasks(dataset_root: str) -> Any:
+    """Return what ``meta/info.json`` declares for ``total_tasks``, verbatim.
 
-    lerobot's own field defaults to 0, and older datasets may omit it entirely;
-    both mean "no task count recorded" and are returned as 0, which callers
-    treat as single-task.
+    ``None`` when there is no header to read - no ``info.json``, or no such key -
+    which :func:`~strands_robots.utils.validation_split_error` treats as
+    single-task, as lerobot's own field defaults to 0.
+
+    The declaration is handed over unconverted because that guard is where this
+    header's domain lives, and it is the only surface that can tell a usable
+    count from a declaration that is not one. Coercing an unusable declaration
+    to 0 here reported it as the absent case, which the guard honors as
+    single-task: a three-task dataset whose header spelled the count ``3.0`` (or
+    ``"3"``) passed the guard written to refuse exactly that dataset, and lerobot
+    then held out ``ceil(episodes_in_task * eval_split)`` from each of the three.
     """
     info_path = Path(dataset_root) / "meta" / "info.json"
     if not info_path.exists():
-        return 0
+        return None
     with open(info_path) as f:
         info = json.load(f)
-    total = info.get("total_tasks")
-    return total if isinstance(total, int) and not isinstance(total, bool) else 0
+    return info.get("total_tasks")
 
 
 def _read_total_episodes(dataset_root: str) -> int:

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -743,19 +743,30 @@ class LerobotTrainer(Trainer):
             "keep the stream."
         )
 
-    def _dataset_total_tasks(self, dataset_root: str) -> int:
-        """``total_tasks`` from ``meta/info.json``, or 0 when not recorded."""
+    def _dataset_total_tasks(self, dataset_root: str) -> Any:
+        """What ``meta/info.json`` declares for ``total_tasks``, verbatim.
+
+        ``None`` when there is no header to read - absent, unreadable, or no such
+        key - which :func:`~strands_robots.utils.validation_split_error` treats as
+        single-task, as lerobot's own field defaults to 0.
+
+        The declaration is not converted here: that guard owns this header's
+        domain and is the only surface that can tell a usable count from a
+        declaration that is not one. Coercing an unusable declaration to 0
+        reported it as the absent case, which the guard honors as single-task -
+        so a three-task dataset whose header spelled the count ``3.0`` reached
+        lerobot's per-task ceiling instead of being refused.
+        """
         from pathlib import Path
 
         info_path = Path(dataset_root) / "meta" / "info.json"
         if not info_path.exists():
-            return 0
+            return None
         try:
             with open(info_path) as f:
-                total = json.load(f).get("total_tasks")
-        except (OSError, ValueError):
-            return 0
-        return total if isinstance(total, int) and not isinstance(total, bool) else 0
+                return json.load(f).get("total_tasks")
+        except (OSError, ValueError, AttributeError):
+            return None
 
     def _relative_actions(self, spec: TrainSpec) -> bool:
         """Whether to train with relative (delta) actions (``extra['relative_actions']``).

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1378,9 +1378,10 @@ def declared_count(value: object) -> int | None:
     :func:`~strands_robots.dataset_recorder.read_dataset_episode_indices`, the
     metadata-drift check in
     :func:`~strands_robots.verify_dataset.verify_dataset`, the validation-split
-    denominator in ``strands_robots.training.lerobot``, and the episode count the
-    ``lerobot_train`` tool splits - so the answer lives here: one file, one
-    value, one verdict.
+    denominator in ``strands_robots.training.lerobot``, the episode count the
+    ``lerobot_train`` tool splits, and the task count
+    :func:`validation_split_error` decides that split against - so the answer
+    lives here: one file, one value, one verdict.
 
     A declaration outside the domain is ``None`` (the header declares no count),
     never a nearby number, because every alternative is silently destructive at
@@ -1394,8 +1395,8 @@ def declared_count(value: object) -> int | None:
       a perfectly readable file raises out of readers whose documented answer for
       an unusable header is "unknown", and past a tool envelope.
     * ``bool`` is an ``int`` subclass, so a bare type test reads ``true`` as a
-      one-episode dataset; the neighbouring ``total_tasks`` reader in
-      ``strands_robots.tools.lerobot_train`` already excludes it for that reason.
+      one-episode dataset - and, at the sibling ``total_tasks`` header this same
+      domain grades, as a single-task one.
     * A ``str`` digit and an integral ``float`` are refused rather than coerced,
       because coercing is what let the readers disagree: one accepted ``"2"`` as
       two episodes while another refused it as unusable.
@@ -2980,12 +2981,21 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str, *,
     number of episodes than asked, callers refuse and point at the fraction,
     which addresses the per-task behaviour directly.
 
-    A ``total_tasks`` of 0 or ``None`` means the dataset does not record a task
-    count (lerobot's own field defaults to 0), which is treated as single-task.
+    A ``total_tasks`` of 0, or no header at all, means the dataset does not
+    record a task count (lerobot's own field defaults to 0), which is treated as
+    single-task. A header that declares something which is NOT a count is a
+    THIRD outcome and refused on its own terms: the count is what decides
+    whether the request is expressible, so an unusable declaration is neither
+    single-task nor multi-task, and honoring it as the former is exactly how a
+    multi-task dataset reached lerobot's per-task ceiling. The declaration is
+    graded by :func:`declared_count`, the one owner every reader of a LeRobot
+    header count shares, so callers hand this the value their ``meta/info.json``
+    carried rather than a number of their own.
 
     Args:
         val_episodes: The requested held-out episode count, for the message.
-        total_tasks: ``total_tasks`` from the dataset's ``meta/info.json``.
+        total_tasks: The value the dataset's ``meta/info.json`` carried under
+            ``total_tasks``, verbatim, or ``None`` when there is no header.
         context: Caller label the message is prefixed with.
         passthrough_param: Name of the caller's own raw-flag passthrough
             parameter, interpolated into the remedy. Required rather than
@@ -2998,11 +3008,25 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str, *,
     Returns:
         The error text, or None when the count can be honored exactly.
     """
-    if not isinstance(total_tasks, int) or isinstance(total_tasks, bool) or total_tasks <= 1:
+    if total_tasks is None:
+        return None
+    declared = declared_count(total_tasks)
+    if declared is None:
+        return (
+            f"{context}: val_episodes={val_episodes} cannot be checked against a dataset whose "
+            f"meta/info.json declares total_tasks={_refusal_repr(total_tasks)}, which is not a "
+            "task count. Whether one global count is expressible depends on how many tasks the "
+            "dataset holds - lerobot holds out ceil(episodes_in_task * eval_split) from every "
+            "task - so a header declaring no usable count is neither single-task nor multi-task, "
+            "and reading it as single-task is what let a three-task dataset spelling its count "
+            "3.0 past this guard. Repair meta/info.json, or pass the fraction directly, e.g. "
+            f"{passthrough_param}={{'dataset.eval_split': 0.1, 'eval_steps': 1000}}."
+        )
+    if declared <= 1:
         return None
     return (
         f"{context}: val_episodes={val_episodes} cannot be reserved exactly on a "
-        f"dataset with {_refusal_str(total_tasks)} tasks. A validation split is a per-task "
+        f"dataset with {_refusal_str(declared)} tasks. A validation split is a per-task "
         "fraction in lerobot (it holds out ceil(episodes_in_task * eval_split) "
         "from every task), so a single global count is not expressible: the "
         "ceiling would be applied once per task. Pass the fraction directly, "

--- a/tests/test_declared_task_count_has_one_owner.py
+++ b/tests/test_declared_task_count_has_one_owner.py
@@ -1,0 +1,199 @@
+"""The task count a dataset's ``meta/info.json`` declares has ONE verdict.
+
+``total_tasks`` decides whether a global held-out episode COUNT is expressible
+at all. lerobot applies a validation split as one ``eval_split`` FRACTION and
+holds out ``ceil(episodes_in_task * eval_split)`` from every task independently
+(``lerobot.datasets.factory.make_train_eval_datasets``), so a single fraction
+reproduces a requested global count only on a single-task dataset.
+:func:`~strands_robots.utils.validation_split_error` is the guard that refuses
+the request rather than quietly reserving a different number of episodes.
+
+Two surfaces read the header and hand it to that guard: the ``lerobot_train``
+tool and :class:`~strands_robots.training.lerobot.LerobotTrainer`. Both used to
+convert it first - ``total if isinstance(total, int) and not isinstance(total,
+bool) else 0`` - and 0 is the value the guard honors as "no task count
+recorded", so every declaration outside a bare ``int`` arrived as the absent
+case. A three-task dataset whose header spelled its count ``3.0`` or ``"3"``
+passed the guard written to refuse exactly that dataset, and lerobot then took
+the ceiling once per task.
+
+The declaration is now graded by :func:`~strands_robots.utils.declared_count`,
+the one owner every reader of a LeRobot header count already shares, and a
+header that declares something which is not a count is a THIRD outcome - refused
+on its own terms rather than collapsed into the absent case.
+
+Fixtures are raw ``info.json`` text (not ``json.dumps``, which cannot write
+``1e400`` or ``NaN`` from a Python value), so these tests need no dataset files
+beyond the metadata.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots
+from strands_robots.tools.lerobot_train import _read_total_tasks, build_train_command
+from strands_robots.utils import validation_split_error
+
+#: Requested held-out episode count, and the dataset the request is made against.
+VAL_EPISODES = 2
+TOTAL_EPISODES = 10
+#: Episodes per task of a three-task, ten-episode dataset. lerobot's per-task
+#: ceiling holds out 3 of these for the fraction that reserves exactly 2
+#: globally, which is why the request is refused rather than reinterpreted.
+TASK_SIZES = (3, 3, 4)
+
+#: Every spelling of a three-task count that is not a usable task count. ``3.0``
+#: and ``"3"`` are "right number, wrong type" - the pair a writer plausibly
+#: produces and the pair that read as an ABSENT header. The rest are not three at
+#: all, and were honored as single-task just the same.
+UNUSABLE_DECLARATIONS = ["3.0", '"3"', "2.5", "true", "1e400", "NaN", "-3"]
+
+#: Declarations that mean "this dataset records no task count", which lerobot's
+#: own field spells 0. These are honored as single-task and must stay so.
+NO_COUNT_DECLARATIONS = ["0", "1", "null", None]
+
+
+def _dataset(root: Path, declaration: str | None) -> str:
+    """Write a ten-episode dataset whose header declares ``declaration`` verbatim.
+
+    Args:
+        root: Dataset root to create.
+        declaration: Raw JSON text for ``total_tasks``, or ``None`` to omit the
+            key entirely (the "no header" case).
+
+    Returns:
+        The dataset root as a string, ready for either surface under test.
+    """
+    meta = root / "meta"
+    meta.mkdir(parents=True, exist_ok=True)
+    body = f'"total_episodes": {TOTAL_EPISODES}'
+    if declaration is not None:
+        body += f', "total_tasks": {declaration}'
+    (meta / "info.json").write_text("{" + body + "}")
+    return str(root)
+
+
+def _spec_problems(root: str) -> list[str]:
+    """``LerobotTrainer.validate`` problems for a ``val_episodes`` request."""
+    pytest.importorskip("lerobot")
+    from strands_robots.training.base import TrainSpec
+    from strands_robots.training.lerobot import LerobotTrainer
+
+    spec = TrainSpec(dataset_root=root, output_dir=str(Path(root) / "out"), val_episodes=VAL_EPISODES, steps=10)
+    return LerobotTrainer(device="cpu").validate(spec)
+
+
+def _emitted_split(cmd: list[str]) -> float | None:
+    """The single ``--dataset.eval_split`` value in ``cmd``, or None."""
+    hits = [c.split("=", 1)[1] for c in cmd if c.startswith("--dataset.eval_split=")]
+    assert len(hits) <= 1, f"eval_split emitted {len(hits)} times: {hits}"
+    return float(hits[0]) if hits else None
+
+
+class TestADeclarationThatIsNotACountIsRefused:
+    """The third outcome: neither a usable count nor an absent header."""
+
+    @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
+    def test_the_train_tool_refuses_it_by_name(self, declaration: str, tmp_path: Path) -> None:
+        root = _dataset(tmp_path / "ds", declaration)
+        with pytest.raises(ValueError, match="not a task count"):
+            build_train_command(dataset_root=root, policy_type="act", val_episodes=VAL_EPISODES)
+
+    @pytest.mark.parametrize("declaration", UNUSABLE_DECLARATIONS)
+    def test_the_trainspec_backend_reports_the_same_problem(self, declaration: str, tmp_path: Path) -> None:
+        root = _dataset(tmp_path / "ds", declaration)
+        assert any("not a task count" in problem for problem in _spec_problems(root))
+
+    def test_the_refusal_renders_the_declaration_and_the_remedy(self) -> None:
+        error = validation_split_error(VAL_EPISODES, "3", "lerobot_train", passthrough_param="extra_flags")
+        assert error is not None
+        assert error.startswith("lerobot_train: ")
+        assert "total_tasks='3'" in error, error
+        assert "extra_flags={'dataset.eval_split': 0.1" in error
+
+
+class TestTheDeclarationReachesTheGuardUnconverted:
+    """A reader that converts first hands the guard a value it cannot grade."""
+
+    @pytest.mark.parametrize("declaration", [*UNUSABLE_DECLARATIONS, "3", "0"])
+    def test_the_tool_reader_returns_what_the_header_carried(self, declaration: str, tmp_path: Path) -> None:
+        root = _dataset(tmp_path / "ds", declaration)
+        declared = _read_total_tasks(root)
+        # Compared by repr so 3.0 is not indistinguishable from 3, and True not
+        # from 1: those collapses are the reason the guard could not see them.
+        assert repr(declared) == repr(_json_value(declaration))
+
+    def test_no_header_is_the_absent_case(self, tmp_path: Path) -> None:
+        assert _read_total_tasks(_dataset(tmp_path / "ds", None)) is None
+
+    def test_a_dataset_without_metadata_is_the_absent_case(self, tmp_path: Path) -> None:
+        assert _read_total_tasks(str(tmp_path / "nothing-here")) is None
+
+
+class TestBothSurfacesSpendTheOneVerdict:
+    """No surface may grade this header for itself."""
+
+    def test_exactly_the_two_known_surfaces_consult_the_guard(self) -> None:
+        package = Path(strands_robots.__file__).parent
+        callers = set()
+        for module in package.rglob("*.py"):
+            tree = ast.parse(module.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and ast.unparse(node.func).endswith("validation_split_error"):
+                    callers.add(module.relative_to(package).as_posix())
+        assert callers == {"tools/lerobot_train.py", "training/lerobot.py"}, callers
+
+    @pytest.mark.parametrize("declaration", [*UNUSABLE_DECLARATIONS, *NO_COUNT_DECLARATIONS, "3"])
+    def test_the_two_surfaces_reach_the_same_verdict(self, declaration: str | None, tmp_path: Path) -> None:
+        root = _dataset(tmp_path / "ds", declaration)
+        try:
+            build_train_command(dataset_root=root, policy_type="act", val_episodes=VAL_EPISODES)
+        except ValueError as exc:
+            tool_refused: str | None = str(exc)
+        else:
+            tool_refused = None
+        spec_refused = [p for p in _spec_problems(root) if "task count" in p or "reserved exactly" in p]
+        assert (tool_refused is None) == (not spec_refused), (declaration, tool_refused, spec_refused)
+
+
+class TestTheHonoredCasesAreUnchanged:
+    """A recorded count of 0/1, and no header at all, still take the split."""
+
+    @pytest.mark.parametrize("declaration", NO_COUNT_DECLARATIONS)
+    def test_a_split_is_still_emitted(self, declaration: str | None, tmp_path: Path) -> None:
+        root = _dataset(tmp_path / "ds", declaration)
+        cmd = build_train_command(dataset_root=root, policy_type="act", val_episodes=VAL_EPISODES)
+        fraction = _emitted_split(cmd)
+        assert fraction is not None
+        # Single task, so lerobot's one ceiling reserves exactly what was asked.
+        assert math.ceil(TOTAL_EPISODES * fraction) == VAL_EPISODES
+
+    def test_a_truthful_multi_task_count_is_still_refused_as_such(self, tmp_path: Path) -> None:
+        root = _dataset(tmp_path / "ds", "3")
+        with pytest.raises(ValueError, match="cannot be reserved exactly"):
+            build_train_command(dataset_root=root, policy_type="act", val_episodes=VAL_EPISODES)
+
+    def test_the_multi_task_refusal_still_names_the_count(self) -> None:
+        error = validation_split_error(VAL_EPISODES, 3, "ctx", passthrough_param="extra")
+        assert error is not None and "dataset with 3 tasks" in error
+
+    def test_the_fraction_a_three_task_dataset_would_have_taken_overshoots(self) -> None:
+        """Why the request is refused rather than reinterpreted, in episodes."""
+        from strands_robots.utils import validation_split_fraction
+
+        fraction = validation_split_fraction(VAL_EPISODES, TOTAL_EPISODES)
+        held_out = sum(math.ceil(size * fraction) for size in TASK_SIZES)
+        assert held_out != VAL_EPISODES
+
+
+def _json_value(declaration: str) -> Any:
+    """The Python value ``json.load`` produces for raw JSON text."""
+    import json
+
+    return json.loads(declaration)

--- a/tests/tools/test_val_episodes_yields_validation_loss.py
+++ b/tests/tools/test_val_episodes_yields_validation_loss.py
@@ -113,9 +113,15 @@ class TestCountThatCannotBeHonoredIsRefused:
         with pytest.raises(ValueError, match="cannot be reserved exactly"):
             build_train_command(dataset_root=str(root), policy_type="act", val_episodes=2)
 
-    @pytest.mark.parametrize("tasks", [0, 1, None, True, "2"])
+    @pytest.mark.parametrize("tasks", [0, 1, None])
     def test_absent_or_single_task_count_is_honored(self, tasks: object) -> None:
-        """0 / None mean 'no task count recorded', which lerobot treats as one task."""
+        """0 / None mean 'no task count recorded', which lerobot treats as one task.
+
+        ``True`` and ``"2"`` are NOT in this list: a header declaring something
+        which is not a task count is a third outcome, refused on its own terms
+        rather than read as an absent one, and pinned in
+        ``tests/test_declared_task_count_has_one_owner.py``.
+        """
         assert validation_split_error(2, tasks, "ctx", passthrough_param="extra_flags") is None
 
     def test_refusal_names_the_task_count_and_the_direct_knobs(self) -> None:


### PR DESCRIPTION
A validation split is one `eval_split` FRACTION in lerobot, applied as `ceil(episodes_in_task * eval_split)` **per task** (`lerobot/datasets/factory.py::make_train_eval_datasets`), so a global `val_episodes` count is expressible only on a single-task dataset. `validation_split_error` exists to refuse the request otherwise.

Both readers of `meta/info.json`'s `total_tasks` converted the header before handing it over:

```python
total = info.get("total_tasks")
return total if isinstance(total, int) and not isinstance(total, bool) else 0
```

`0` is the value that guard honors as *no task count recorded*. So every declaration outside a bare `int` arrived as the **absent** case, and the guard written to refuse a multi-task dataset was defeated by a multi-task dataset -- one whose header spelled its count `3.0` or `"3"`.

![measured verdicts](https://raw.githubusercontent.com/cagataycali/robots/assets/task-count-one-owner/docs/assets/task_count_verdicts.png)

Measured on both surfaces (`build_train_command` and `LerobotTrainer.validate`), `val_episodes=2` against a 10-episode dataset:

| `total_tasks` declares | before | after |
| --- | --- | --- |
| `3` | refused (multi-task) | refused (multi-task) |
| `3.0`, `"3"` | **accepted**, `eval_split=0.15` | refused (not a task count) |
| `2.5`, `true`, `1e400`, `NaN`, `-3` | **accepted**, `eval_split=0.15` | refused (not a task count) |
| `0`, `1`, `null`, no key | accepted, `eval_split=0.15` | accepted, `eval_split=0.15` |

On the real three-task dataset (tasks of 3/3/4 episodes) that `0.15` makes lerobot hold out `ceil(3*.15)+ceil(3*.15)+ceil(4*.15)` = **3 episodes for a 2-episode request** -- exactly the quiet reinterpretation the guard's docstring says callers refuse rather than perform. `1e400` is a well-formed JSON number `json.load` parses to `inf`; `-3` is not a count in either direction.

## Change

- `validation_split_error` grades the declaration through `declared_count`, the one owner every reader of a LeRobot header count already shares, and gains a **third outcome**: a header that declares something which is not a count is refused on its own terms, naming the value, instead of collapsing into the absent case. `None`/`0`/`1` stay single-task; the existing multi-task refusal is unchanged (still rendered through `_refusal_str`, so an arbitrary-precision JSON integer cannot raise out of it).
- `_read_total_tasks` (tool) and `_dataset_total_tasks` (`LerobotTrainer`) return the declaration verbatim, `None` when there is no header. Nothing is converted at the reader -- the domain lives with the surface that spends it, which is the only one that can tell a usable count from a declaration that is not one. The backend reader also catches `AttributeError`, matching its `total_episodes` sibling, so a top-level JSON array is the absent case rather than a traceback.
- `declared_count`'s docstring now names the sibling `total_tasks` header among the readers it owns (it previously cited that reader as an example of correct `bool` exclusion, which is no longer where the exclusion happens).

## Tests

`tests/test_declared_task_count_has_one_owner.py` (46 cells), the sibling of `test_declared_episode_count_has_one_owner.py`: every unusable spelling refused at **both** surfaces, the two surfaces agreeing on every spelling, the reader returning the declaration compared **by repr** (so `3.0` is not indistinguishable from `3`, nor `True` from `1` -- those collapses are why the guard could not see them), the honored cases still emitting a fraction that reserves exactly N, and an AST scan pinning that exactly two modules consult the guard, so the roster cannot fall behind. On `main` 23 of the 46 fail.

One existing parametrize shrank: `test_absent_or_single_task_count_is_honored` listed `True` and `"2"` alongside `0`/`1`/`None`, which its own docstring described only as "no task count recorded". Those two are the third outcome now, and the cell says where they are pinned.

## Gate

`ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ` (20 pre-existing errors, all in `examples/isaac_gs` + `simulation/ik.py`, unchanged). A 139-module test net around the header, the split and the training surfaces: **7914 -> 7958 passed** (+44 = 46 new cells minus the 2 dropped params), with an identical failure/error name set before and after (9F/9E, all pre-existing lerobot-0.6.2 API drift).

LOC: +309 / -29 -- production +68/-26, the rest the regression pin (+199), a changelog fragment and docs.
