### PR TITLE
fix(policies/cosmos3): a de-normalization quantile is graded in whatever spelling it arrives

### DIFF
--- a/changelog.d/3302-cosmos3-quantile-stats-domain.md
+++ b/changelog.d/3302-cosmos3-quantile-stats-domain.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **cosmos3**: the de-normalization quantiles handed to `denormalize_quantile`
+  (directly, or as `decode_cosmos_chunk_to_targets(stats=...)`) are held to the
+  shared numeric-vector domain, in whatever spelling they arrive. Only the
+  `action` was converted before, so the quantiles were dereferenced raw
+  (`q01.shape[-1]`): a `list` — the layout the bundled `stats/*_stats.json`
+  files store, and what a caller supplying an unbundled domain's own quantiles
+  holds — raised `AttributeError: 'list' object has no attribute 'shape'`
+  naming neither parameter, and pre-empted the width mismatch the comparison
+  behind it exists to report. A `nan`/`inf` component was accepted and spread
+  through every column of the chunk and every pose
+  `decode_pose_trajectory` composed from it, returning an all-`nan` SE3
+  trajectory as a successful result.

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -303,6 +303,14 @@ out = decode_cosmos_chunk_to_targets(
 )
 ```
 
+`stats` takes the quantiles in whatever form you have them — a list straight
+out of a JSON file (the layout the bundled `stats/*_stats.json` files use), a
+tuple, or a NumPy array. Every component must be a finite real number: the
+de-normalization is `0.5 * (a + 1) * (q99 - q01) + q01`, so one `nan` or `inf`
+quantile spreads across the whole chunk and every pose the trajectory composes
+from it, and `denormalize_quantile` refuses it naming the quantile and the
+component rather than returning an all-`nan` trajectory.
+
 `stats_domain` is required whenever `stats` is passed, and must match the
 embodiment's domain. It is not bookkeeping: `umi`, `droid_lerobot`,
 `bridge_orig_lerobot` and `openarm_lerobot` are all 10 columns, so the width

--- a/strands_robots/policies/cosmos3/action_decode.py
+++ b/strands_robots/policies/cosmos3/action_decode.py
@@ -33,8 +33,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+
+from strands_robots.utils import finite_vector_error
 
 # Bundled per-embodiment action normalization stats (q01/q99), copied verbatim
 # from cosmos_framework/data/vfm/action/datasets/stats/. Tiny JSON files; keyed
@@ -74,26 +77,63 @@ def load_action_stats(domain_name: str) -> dict[str, np.ndarray]:
     return {k: np.asarray(v, dtype=np.float32) for k, v in raw.items() if k in ("q01", "q99")}
 
 
-def denormalize_quantile(action: np.ndarray, q01: np.ndarray, q99: np.ndarray) -> np.ndarray:
+def denormalize_quantile(action: np.ndarray, q01: Any, q99: Any) -> np.ndarray:
     """Invert Cosmos 3 quantile normalization: ``[-1, 1]`` -> physical units.
 
     Mirrors ``cosmos_framework`` ``denormalize_action(method="quantile")``::
 
         denorm = 0.5 * (action + 1.0) * (q99 - q01) + q01
 
+    Both quantile vectors are held to the same domain as the action they
+    rescale. They are the only reference data in the decode, and either one
+    reaches every output column: a component that is not a finite real number
+    is not a physical range, and the arithmetic above spreads it across the
+    whole chunk, which :func:`decode_pose_trajectory` then composes into every
+    pose of the trajectory. A single ``nan`` quantile therefore yields a
+    full-length all-``nan`` SE3 trajectory that is returned as a result, and
+    the first thing to refuse it is
+    :meth:`~strands_robots.simulation.ik.MinkIKBridge.solve`, which names the
+    ``target_pose`` the decode built rather than the stat that poisoned it.
+
+    The check is :func:`~strands_robots.utils.finite_vector_error`, the shared
+    numeric-vector domain the sim setters and the other policy providers use,
+    so a refusal names the parameter and the component rather than restating
+    the rule here. Grading before converting is what lets the vectors be
+    written in *any* finite numeric sequence: the bundled stats files store
+    ``q01``/``q99`` as JSON arrays, so a caller supplying an unbundled domain's
+    own quantiles (:func:`load_action_stats` raises pointing at exactly that,
+    for the three registered embodiments with no bundled stats) holds plain
+    lists, which is the same content ``load_action_stats`` converts on the
+    bundled path. Only ``action`` was coerced before, so the file's own layout
+    raised ``AttributeError: 'list' object has no attribute 'shape'`` from the
+    width comparison below - naming neither parameter, and pre-empting the
+    width mismatch that comparison exists to report.
+
     Args:
         action: Normalized action of shape ``[..., D]`` (values nominally in
             ``[-1, 1]``).
-        q01: Per-column 1st-percentile stat of shape ``[D]``.
-        q99: Per-column 99th-percentile stat of shape ``[D]``.
+        q01: Per-column 1st-percentile stat, any sequence of ``D`` finite real
+            numbers (the shape :func:`load_action_stats` returns and the
+            bundled JSON files store).
+        q99: Per-column 99th-percentile stat, in the same form as ``q01``.
 
     Returns:
         De-normalized action with the same shape as ``action`` (``float32``).
 
     Raises:
-        ValueError: If the action's last dim does not match the stats width.
+        ValueError: If either quantile vector holds a component that is not a
+            finite real number, or if the action's last dim does not match the
+            stats width.
     """
     action = np.asarray(action, dtype=np.float32)
+    for _name, _vec in (("q01", q01), ("q99", q99)):
+        if error := finite_vector_error("denormalize_quantile", _name, _vec):
+            raise ValueError(error)
+    # Safe to convert now: the domain admits only a readable sequence of finite
+    # real numbers, so this normalizes the declared type without deciding
+    # anything, and the width comparison below is reachable for every spelling.
+    q01 = np.asarray(q01, dtype=np.float32)
+    q99 = np.asarray(q99, dtype=np.float32)
     if action.shape[-1] != q01.shape[-1] or action.shape[-1] != q99.shape[-1]:
         raise ValueError(
             f"action width {action.shape[-1]} does not match stats width "

--- a/tests/policies/cosmos3/test_quantile_stats_are_held_to_one_vector_domain.py
+++ b/tests/policies/cosmos3/test_quantile_stats_are_held_to_one_vector_domain.py
@@ -1,0 +1,196 @@
+"""The Cosmos 3 de-normalization quantiles are graded, in whatever spelling they arrive.
+
+:func:`~strands_robots.policies.cosmos3.action_decode.denormalize_quantile` is
+handed three arrays: the model's normalized ``action`` and the domain's ``q01`` /
+``q99`` physical quantiles. Only ``action`` was converted; the quantiles were
+dereferenced raw (``q01.shape[-1]``), which decided two things this module never
+meant to decide.
+
+* **The documented explicit-stats path did not work.** Three registered
+  embodiments ship no bundled quantiles, and ``load_action_stats`` raises telling
+  the caller to supply that domain's own via ``stats=``. The bundled files store
+  ``q01``/``q99`` as JSON arrays, so what a caller holds is a ``list`` - and a
+  list has no ``.shape``, so the same content ``load_action_stats`` converts on
+  the bundled path raised ``AttributeError: 'list' object has no attribute
+  'shape'``, naming neither parameter. The width comparison sits *after* that
+  dereference, so a wrong-width list was reported as a missing attribute rather
+  than as the mismatch that comparison exists to report.
+* **A non-finite quantile was accepted.** Every output column is
+  ``0.5 * (a + 1) * (q99 - q01) + q01``, so one ``nan`` component spreads across
+  the chunk, and :func:`decode_pose_trajectory` composes it into every pose:
+  pre-fix a single ``nan`` quantile returned a full-length all-``nan`` SE3
+  trajectory as a *result*. The first surface to refuse it was
+  ``MinkIKBridge.solve``, which names the ``target_pose`` the decode built, not
+  the stat that poisoned it.
+
+Both are one decision - which values are a physical range - so both quantiles go
+through :func:`~strands_robots.utils.finite_vector_error`, the shared vector
+domain ``MinkIKBridge.solve`` itself and the other policy providers use, and the
+conversion happens after the verdict rather than instead of it.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.cosmos3 import action_decode
+from strands_robots.policies.cosmos3.action_decode import (
+    decode_pose_trajectory,
+    denormalize_quantile,
+    load_action_stats,
+)
+
+_DOMAIN = "droid_lerobot"
+# Resolved from the installed module, not from the working directory, so the
+# spelling under test is read out of the file the library actually ships.
+_STATS_FILE = Path(str(action_decode.__file__)).parent / "stats" / f"{_DOMAIN}_stats.json"
+
+
+def _bundled_lists() -> tuple[list[float], list[float]]:
+    """The bundled quantiles exactly as ``json.load`` yields them: two lists.
+
+    Read from the shipped file rather than transcribed, so the spelling under
+    test stays the one a caller of the documented explicit-stats path actually
+    holds.
+    """
+    raw = json.loads(_STATS_FILE.read_text())
+    return raw["q01"], raw["q99"]
+
+
+def _action(width: int) -> np.ndarray:
+    """A deterministic normalized action chunk of ``width`` columns."""
+    return np.random.default_rng(0).uniform(-1.0, 1.0, size=(6, width)).astype(np.float32)
+
+
+# Spellings of one domain's quantiles that all describe the same physical ranges.
+# A list is what the bundled JSON file holds; an ndarray is what
+# ``load_action_stats`` builds from it. They must decode identically, because the
+# only difference between them is which of the two paths the caller took.
+def _accepted_spellings() -> list[tuple[str, Any, Any]]:
+    q01, q99 = _bundled_lists()
+    arr01, arr99 = np.asarray(q01, dtype=np.float32), np.asarray(q99, dtype=np.float32)
+    return [
+        ("list (the bundled file's own layout)", q01, q99),
+        ("tuple", tuple(q01), tuple(q99)),
+        ("ndarray (what load_action_stats builds)", arr01, arr99),
+    ]
+
+
+@pytest.mark.parametrize("label", [s[0] for s in _accepted_spellings()])
+def test_every_spelling_of_one_domains_quantiles_decodes_identically(label: str) -> None:
+    """A domain's quantiles rescale an action the same way however they are written."""
+    spelling = {s[0]: (s[1], s[2]) for s in _accepted_spellings()}[label]
+    bundled = load_action_stats(_DOMAIN)
+    action = _action(len(bundled["q01"]))
+
+    out = denormalize_quantile(action, *spelling)
+    reference = denormalize_quantile(action, bundled["q01"], bundled["q99"])
+
+    assert np.array_equal(out, reference), f"{label} decoded differently from the loader's arrays"
+    assert np.isfinite(out).all()
+
+
+# A value that cannot be a per-column physical range, and the parameter whose
+# name the refusal has to carry. Kept as tuples rather than a dict because
+# several entries differ only in which parameter holds the bad value.
+def _refused_spellings() -> list[tuple[str, Any, Any, str]]:
+    q01, q99 = _bundled_lists()
+    arr01, arr99 = np.asarray(q01, dtype=np.float32), np.asarray(q99, dtype=np.float32)
+    nan01 = list(q01)
+    nan01[0] = math.nan
+    inf99 = list(q99)
+    inf99[2] = math.inf
+    return [
+        ("nan component, as a list", nan01, q99, "q01"),
+        ("nan component, as an ndarray", np.asarray(nan01, dtype=np.float32), arr99, "q01"),
+        ("inf component, as a list", q01, inf99, "q99"),
+        ("inf component, as an ndarray", arr01, np.asarray(inf99, dtype=np.float32), "q99"),
+        ("a scalar instead of a vector", 0.0, 1.0, "q01"),
+        ("a 0-d ndarray", np.float32(0.0), np.float32(1.0), "q01"),
+        ("numeric strings", ["0.0"] * len(q01), q99, "q01"),
+        ("booleans", [False] * len(q01), q99, "q01"),
+        ("None", None, None, "q01"),
+        ("a generator, whose length cannot be read", (x for x in q01), q99, "q01"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("label", "q01", "q99", "named"),
+    [(s[0], s[1], s[2], s[3]) for s in _refused_spellings()],
+)
+def test_a_value_that_cannot_be_a_physical_range_is_refused_by_name(label: str, q01: Any, q99: Any, named: str) -> None:
+    """The refusal names the quantile parameter and the surface, not an attribute.
+
+    Pre-fix every one of these escaped as an ``AttributeError`` (or an
+    ``IndexError`` raised *inside* the width comparison, for a 0-d array),
+    naming neither ``q01`` nor ``q99``.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        denormalize_quantile(_action(10), q01, q99)
+
+    message = str(excinfo.value)
+    assert named in message, f"{label}: refusal does not name {named}: {message}"
+    assert "denormalize_quantile" in message, f"{label}: refusal does not name the surface: {message}"
+
+
+def test_the_same_bad_component_is_refused_the_same_way_in_either_quantile() -> None:
+    """Neither quantile is graded more leniently than the other.
+
+    They are read on one line and either one reaches every output column, so a
+    domain that held only ``q01`` to the check would leave half the defect in
+    place.
+    """
+    q01, q99 = _bundled_lists()
+    poisoned01 = list(q01)
+    poisoned01[4] = math.nan
+    poisoned99 = list(q99)
+    poisoned99[4] = math.nan
+
+    with pytest.raises(ValueError) as low:
+        denormalize_quantile(_action(len(q01)), poisoned01, q99)
+    with pytest.raises(ValueError) as high:
+        denormalize_quantile(_action(len(q01)), q01, poisoned99)
+
+    assert str(low.value).replace("q01", "Q") != str(high.value)
+    assert str(low.value).split("'q01'")[0] == str(high.value).split("'q99'")[0]
+
+
+def test_a_poisoned_quantile_never_reaches_the_pose_trajectory() -> None:
+    """No accepted decode can hand a non-finite pose to the IK bridge.
+
+    The pre-fix behaviour this pins out: one ``nan`` quantile de-normalized
+    without complaint and :func:`decode_pose_trajectory` composed it into all
+    seven poses of a six-step chunk, returning an all-``nan`` trajectory as a
+    successful result.
+    """
+    q01, q99 = _bundled_lists()
+    poisoned = list(q01)
+    poisoned[0] = math.nan
+    action = _action(len(q01))
+
+    with pytest.raises(ValueError):
+        denormalize_quantile(action, poisoned, q99)
+
+    clean = denormalize_quantile(action, q01, q99)
+    trajectory = decode_pose_trajectory(clean[:, :9], np.eye(4, dtype=np.float32))
+    assert trajectory.shape == (action.shape[0] + 1, 4, 4)
+    assert np.isfinite(trajectory).all()
+
+
+def test_a_wrong_width_list_reports_the_width_mismatch() -> None:
+    """The width comparison is reachable for a quantile vector that is not an ndarray.
+
+    Its whole job is to say that the stats do not describe every action column;
+    pre-fix a list got as far as ``AttributeError: 'list' object has no
+    attribute 'shape'`` instead.
+    """
+    q01, q99 = _bundled_lists()
+
+    with pytest.raises(ValueError, match=r"does not match stats width"):
+        denormalize_quantile(_action(len(q01)), q01[:4], q99[:4])


### PR DESCRIPTION
## The two decisions a missing `np.asarray` made

`denormalize_quantile(action, q01, q99)` is handed three arrays: the model's normalized action and the domain's physical quantiles. Only `action` was converted. The quantiles were dereferenced raw:

```python
action = np.asarray(action, dtype=np.float32)
if action.shape[-1] != q01.shape[-1] or action.shape[-1] != q99.shape[-1]:   # <- q01 is whatever the caller passed
```

**1. The documented explicit-stats path did not work.** Three registered embodiments (`umi`, `av`, `openarm`) ship no bundled quantiles, and `load_action_stats` raises telling the caller to *"pass this domain's own quantiles to `decode_cosmos_chunk_to_targets` as `stats=...`"*. The bundled `stats/*_stats.json` files store `q01`/`q99` as JSON arrays, so what a caller holds is a `list` — and a list has no `.shape`. The same content `load_action_stats` converts on the bundled path raised `AttributeError: 'list' object has no attribute 'shape'`, naming neither parameter. Because the width comparison sits *behind* that dereference, a wrong-width list was reported as a missing attribute rather than as the mismatch that comparison exists to report.

**2. A non-finite quantile was accepted.** Every output column is `0.5 * (a + 1) * (q99 - q01) + q01`, so one `nan` component spreads across the whole chunk, and `decode_pose_trajectory` composes it into every pose. Measured: one `nan` quantile turns a 6-step chunk into a `(7, 4, 4)` all-`nan` SE3 trajectory, **returned as a result**. The first surface to refuse it is `MinkIKBridge.solve`, whose `finite_vector_error` names the `target_pose` the decode built — not the stat that poisoned it.

![decoded EE trajectory, clean vs one nan quantile, plus the measured verdict table](https://raw.githubusercontent.com/cagataycali/robots/assets/quantile-stats-domain/docs/assets/quantile_stats_domain.png)

## The change

Both are one decision — which values are a per-column physical range — so both quantiles go through `finite_vector_error`, the shared numeric-vector domain `MinkIKBridge.solve` itself and the other policy providers already use, and the conversion happens *after* the verdict rather than instead of it:

```python
action = np.asarray(action, dtype=np.float32)
for _name, _vec in (("q01", q01), ("q99", q99)):
    if error := finite_vector_error("denormalize_quantile", _name, _vec):
        raise ValueError(error)
q01 = np.asarray(q01, dtype=np.float32)
q99 = np.asarray(q99, dtype=np.float32)
```

The conversion stays because the width comparison and the arithmetic want the declared type; grading first is what makes it a normalization rather than a decision, and what makes the width comparison reachable for every spelling.

`decode_cosmos_chunk_to_targets(stats=...)` passes `stats["q01"]`/`stats["q99"]` straight through, so the single guard covers both entry points.

## Measured, 16 spellings of one domain's quantiles

Each `before` column read from a clean worktree of `main`; each `after` from this branch. `refused: <name>` means the message names that parameter and the surface.

| stats spelling | before | after |
|---|---|---|
| `list` of D floats (the bundled file's own layout) | `AttributeError`, names neither | accepted |
| `tuple` of D floats | `AttributeError`, names neither | accepted |
| `ndarray` float32 (what `load_action_stats` builds) | accepted | accepted |
| `ndarray` of int | accepted | accepted |
| `q01` holds `nan` (list or ndarray) | **ACCEPTED**, all-`nan` trajectory | refused: `q01` |
| `q99` holds `inf` (list or ndarray) | **ACCEPTED**, all-`nan` trajectory | refused: `q99` |
| a scalar `float` | `AttributeError`, names neither | refused: `q01` |
| a 0-d `ndarray` | `IndexError` *inside* the width comparison | refused: `q01` |
| numeric strings / booleans | `AttributeError`, names neither | refused: `q01` |
| `None` | `AttributeError`, names neither | refused: `q01` |
| a generator (length unreadable) | `AttributeError`, names neither | refused: `q01` |
| `list` of 4 floats (wrong width) | `AttributeError`, names neither | refused: width mismatch |
| `ndarray` of 4 float32 (wrong width) | refused: width mismatch | refused: width mismatch |
| `ndarray` shaped `(1, D)` | accepted (broadcast) | refused: `q01` |

The accepted spellings decode **bit-identically** (`np.array_equal` against the loader's arrays) — the widening removes a divergence between the bundled and the explicit path, it does not add a second behaviour.

**One narrowing, stated plainly:** a `(1, D)`-shaped quantile array is now refused. `finite_vector_error` reads a 2-D argument's *rows* as its elements (the same reason `MinkIKBridge.solve` flattens its pose before the check). Both parameters are documented as "shape `[D]`", `load_action_stats` builds 1-D, and no stats file yields a 2-D layout — a redundant leading axis silently broadcasting past a width check is the shape confusion that check exists to catch.

## Tests

`tests/policies/cosmos3/test_quantile_stats_are_held_to_one_vector_domain.py`, 16 cells. Against pre-fix production code **15 fail**; the one that passes is the `ndarray` spelling, which this change deliberately leaves alone.

- every spelling of one domain's quantiles decodes identically to the loader's arrays;
- each value that cannot be a physical range is refused naming the parameter *and* the surface;
- the same bad component is refused in the same words in either quantile (neither is graded more leniently);
- no accepted decode can hand a non-finite pose to the IK bridge;
- a wrong-width `list` reports the width mismatch.

The quantiles are read from the shipped `droid_lerobot_stats.json` rather than transcribed, so the spelling under test stays the one a caller of the documented path actually holds.

## Gate

`ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1933 files). `mypy` 20 errors in 6 files — byte-identical to `main` (19 in `examples/isaac_gs`, 1 in `simulation/ik.py`). 99-module test net (`cosmos3|action_decode|denormalize|finite_vector_error|sim_ik|utils.py|MinkIKBridge`): **4907 passed, 49 skipped**, 3 failures reproduced identically on a clean `main` worktree (`qpsolvers` not installed; `websockets` 16.0 below the declared 17.0 floor).

## LOC

| file | +/- |
|---|---|
| `strands_robots/policies/cosmos3/action_decode.py` | +44 / -4 (12 lines of code, the rest docstring) |
| `tests/.../test_quantile_stats_are_held_to_one_vector_domain.py` | +196 |
| `docs/policies/cosmos3.md` | +8 |
| `changelog.d/3302-...md` | +14 |

Net **+262 / -4**. The production surface grows by 12 executable lines and shrinks the number of ways one function can fail without saying which argument was wrong.