### PR TITLE
fix(device_connect): only the integer-0 sentinel means the policy port was not supplied

### DIFF
--- a/changelog.d/3303-device-connect-policy-port-sentinel.md
+++ b/changelog.d/3303-device-connect-policy-port-sentinel.md
@@ -1,0 +1,11 @@
+### Bug Fixes
+
+- **device_connect**: the `execute` RPC read `policy_port` with `or`, so every
+  falsy spelling the wire can carry - not just the documented integer-`0`
+  sentinel - reached `start_task` as `None`. A supplied-but-unusable `0.0`,
+  `False`, `""` or `[]` was therefore reported as `"policy_port is required to
+  build a policy"` by a port-dialing provider, and silently dropped (task
+  started) by a port-less one, while the truthy malformed spellings were refused
+  by name. Only the integer `0` now maps onto "not supplied"; every other value
+  is handed to `Robot._policy_port_error`, the one surface that holds the port
+  to the shared `tcp_port_error` domain and names the value the caller supplied.

--- a/strands_robots/device_connect/robot_driver.py
+++ b/strands_robots/device_connect/robot_driver.py
@@ -78,6 +78,39 @@ def _stop_task_refusal(envelope: object) -> str | None:
     return None
 
 
+def _supplied_policy_port(policy_port: int) -> int | None:
+    """Map the ``execute`` RPC's ``policy_port`` onto the "not supplied" spelling.
+
+    ``execute`` declares ``policy_port: int = 0`` because a JSON-RPC signature
+    cannot spell ``None`` for a declared ``int``, so the integer ``0`` is this
+    surface's documented "use the provider default" sentinel and is the only
+    value that means it.
+
+    Every other value is handed on unchanged, so
+    :meth:`~strands_robots.hardware_robot.Robot._policy_port_error` - the guard
+    that holds ``policy_port`` to the shared
+    :func:`~strands_robots.utils.tcp_port_error` domain and names the value the
+    caller supplied - is the one surface that judges it. Reading the parameter
+    with ``or`` instead conflated the two: ``0.0``, ``False``, ``""`` and ``[]``
+    are falsy without being the sentinel, and once ``or`` had turned them into
+    ``None`` that guard could no longer tell a malformed port from a port that
+    was never sent. It answered "policy_port is required to build a policy" -
+    the report of "a port they had passed was missing" that guard's own
+    docstring says it was written to remove - while the truthy malformed
+    spellings (``5556.7``, ``"5556"``, ``-1``) were refused by name. Same
+    mistake, two answers, decided by truthiness.
+
+    Args:
+        policy_port: The value the RPC received.
+
+    Returns:
+        ``None`` for the integer-``0`` sentinel, else *policy_port* unchanged.
+    """
+    if isinstance(policy_port, int) and not isinstance(policy_port, bool) and policy_port == 0:
+        return None
+    return policy_port
+
+
 class RobotDeviceDriver(DeviceDriver):
     """Device Connect device driver wrapping a strands-robots Robot instance."""
 
@@ -161,7 +194,7 @@ class RobotDeviceDriver(DeviceDriver):
         # in policy_provider), so bind them explicitly to their target fields.
         return self._robot.start_task(
             instruction,
-            policy_port=policy_port or None,
+            policy_port=_supplied_policy_port(policy_port),
             policy_host="localhost",
             policy_provider=policy_provider,
             duration=duration,

--- a/tests/test_hardware_policy_port_domain.py
+++ b/tests/test_hardware_policy_port_domain.py
@@ -36,6 +36,7 @@ path is a recording stub, and the policy is a structural stub.
 from __future__ import annotations
 
 import ast
+import importlib.util
 import inspect
 import pathlib
 import threading
@@ -465,3 +466,139 @@ class TestTheRegistryDeclarationMatchesTheConstructor:
         from strands_robots.registry.policies import port_reading_providers
 
         assert set(port_reading_providers()) == set(PORT_READING_PROVIDERS)
+
+
+# ── The Device Connect ``execute`` relay ──────────────────────────────────────
+
+#: Falsy ``policy_port`` spellings that are NOT the ``execute`` RPC's integer
+#: ``0`` sentinel. JSON carries every one of them and no policy can be built
+#: from any of them, so each must be reported as invalid rather than as "not
+#: supplied". ``0`` is excluded: it is the documented sentinel, covered on its
+#: own below.
+FALSY_NON_SENTINEL_PORTS: list[Any] = [0.0, False, "", []]
+
+
+def _relay_surfaces() -> dict[str, tuple[bool, bool]]:
+    """:func:`_policy_port_surfaces` applied to the Device Connect relay.
+
+    The module is located with ``find_spec`` and read as text rather than
+    imported: the driver needs the ``[device-connect]`` extra, while this is a
+    source-level rule that holds whether or not that extra is installed.
+    """
+    spec = importlib.util.find_spec("strands_robots.device_connect.robot_driver")
+    assert spec is not None and spec.origin is not None, "the Device Connect relay module is missing"
+    return _policy_port_surfaces(pathlib.Path(spec.origin).read_text(encoding="utf-8"))
+
+
+class TestTheDeviceConnectRelayIsAccountedFor:
+    """The RPC that relays ``policy_port`` to ``start_task`` joins the census.
+
+    :class:`TestEveryPortTakingSurfaceIsAccountedFor` states its rule for "a new
+    task entry point" but reads only :mod:`strands_robots.hardware_robot`, so the
+    Device Connect ``execute`` RPC - which declares ``policy_port`` and hands it
+    to ``start_task`` - was outside the population it scans. Its predicate needs
+    no change to judge it: a bare name, or one wrapped in a call, forwards; a
+    ``policy_port or None`` is neither a check nor a forward.
+    """
+
+    def test_the_relay_hands_the_value_on(self) -> None:
+        surfaces = _relay_surfaces()
+        assert "execute" in surfaces, f"the relay no longer declares policy_port: {sorted(surfaces)}"
+        checks, forwards = surfaces["execute"]
+        assert checks or forwards, (
+            "device_connect execute neither checks policy_port nor hands it on unchanged; "
+            "a value collapsed here cannot be judged by Robot._policy_port_error"
+        )
+
+    def test_a_truthiness_collapse_is_reported(self) -> None:
+        """Non-vacuity: the shape this class exists to catch reads as neither."""
+        planted = (
+            "class D:\n"
+            "    async def execute(self, instruction, policy_port=0):\n"
+            "        return self._robot.start_task(instruction, policy_port=policy_port or None)\n"
+        )
+        assert _policy_port_surfaces(planted) == {"execute": (False, False)}
+
+
+class TestTheDeviceConnectRelayDoesNotCollapseTheValue:
+    """A malformed port sent over Device Connect is named, not called missing.
+
+    ``execute`` reads ``policy_port`` to decide between "a port was supplied"
+    and "use the provider default". Reading it with ``or`` answered that
+    question with truthiness, so every falsy spelling the wire can carry - not
+    just the documented ``0`` - became "not supplied":
+
+    * against a port-dialing provider the arm reported ``"policy_port is
+      required to build a policy"``, the "a port they had passed was missing"
+      report :meth:`Robot._policy_port_error` exists to remove;
+    * against a port-less provider the malformed value was dropped and the task
+      *started*, while a well-formed ``5556`` that provider cannot read was
+      correctly refused - the surface accepted what it could not use and
+      refused what it could.
+
+    Driven through the real ``@rpc`` dispatch (``invoke``), which splats the
+    wire parameters into the method without coercing them to the annotation, so
+    a non-``int`` really does arrive. No hardware is touched: the robot is a
+    recorder that delegates the port decision to the shipped guard.
+    """
+
+    @staticmethod
+    def _relay(port: Any, provider: str = "groot") -> tuple[Any, dict[str, Any]]:
+        """Invoke the real ``execute`` RPC; report what ``start_task`` saw."""
+        from tests.test_device_connect_hardening import _force_real_device_connect_edge, _run
+
+        _force_real_device_connect_edge()
+        from strands_robots.device_connect.robot_driver import RobotDeviceDriver
+
+        seen: list[Any] = []
+
+        class _Recorder:
+            tool_name_str = "so100"
+
+            def start_task(
+                self,
+                instruction: str,
+                policy_port: Any = None,
+                policy_host: str = "localhost",
+                policy_provider: str = "groot",
+                duration: float = 30.0,
+                **kw: Any,
+            ) -> dict[str, Any]:
+                seen.append(policy_port)
+                error = HwRobot._policy_port_error(policy_port, "start_task", policy_provider)
+                return error if error is not None else {"status": "success"}
+
+        result = _run(
+            RobotDeviceDriver(_Recorder()).invoke(
+                "execute",
+                instruction="pick up the cube",
+                policy_provider=provider,
+                policy_port=port,
+                source_device="op-1",
+            )
+        )
+        return (seen[0] if seen else "<start_task not reached>"), result
+
+    @pytest.mark.parametrize("port", FALSY_NON_SENTINEL_PORTS, ids=repr)
+    def test_a_falsy_non_sentinel_port_is_named_not_called_missing(self, port: Any) -> None:
+        forwarded, result = self._relay(port)
+        assert repr(forwarded) == repr(port), f"the relay collapsed {port!r} to {forwarded!r}"
+        text = _text(result)
+        assert "is required" not in text, f"a supplied {port!r} was reported as missing: {text}"
+        assert "policy_port" in text and repr(port) in text, text
+
+    @pytest.mark.parametrize("port", FALSY_NON_SENTINEL_PORTS, ids=repr)
+    def test_a_port_less_provider_does_not_start_on_a_malformed_port(self, port: Any) -> None:
+        _, result = self._relay(port, provider="mock")
+        assert result["status"] == "error", f"a task started on policy_port={port!r}: {result}"
+
+    def test_the_integer_zero_sentinel_still_means_not_supplied(self) -> None:
+        """The documented sentinel is unchanged - it is what the ``int`` signature has instead of ``None``."""
+        forwarded, result = self._relay(0, provider="mock")
+        assert forwarded is None
+        assert result["status"] == "success", result
+
+    def test_a_usable_port_is_handed_on_unchanged(self) -> None:
+        forwarded, result = self._relay(5556, provider="groot")
+        assert forwarded == 5556
+        assert result["status"] == "success", result


### PR DESCRIPTION
`RobotDeviceDriver.execute` declares `policy_port: int = 0` — a JSON-RPC signature cannot spell `None` for a declared `int`, so the integer `0` is that surface's documented "use the provider default" sentinel. It read the parameter with `or`:

```python
policy_port=policy_port or None,
```

Truthiness answers a different question than "is this the sentinel". Every falsy spelling the wire can carry reached `start_task` as `None`, which is the one thing `Robot._policy_port_error` cannot judge — and that guard's own docstring says it exists to remove exactly this report:

> A supplied-but-unusable `0` / `False` used to be reported as `"policy_port is required for robot operation"`: falsy, so `_get_policy` read it as absent and **told the caller a port they had passed was missing**.

```mermaid
graph LR
  W["wire: policy_port"] --> E["execute RPC"]
  E -->|"0 → sentinel"| N["None"]
  E -->|"0.0 False '' [] → or"| N
  E -->|"5556.7 '5556' -1 → truthy"| G["_policy_port_error"]
  N --> R["'policy_port is required'"]
  G --> V["named: invalid policy_port: 5556.7"]
  style N fill:#f8d7da
  style R fill:#f8d7da
```

## Measured

Driven through the real `@rpc` dispatch (`invoke`), which splats wire parameters into the method without coercing them to the annotation — so a non-`int` really does arrive. 22 rows (11 values x 2 providers); **8 changed**, all in the falsy-non-sentinel band.

| `policy_port` on the wire | reached `start_task` | before | after |
| --- | --- | --- | --- |
| `5556` | `5556` | accepted | accepted |
| `0` *(documented sentinel)* | `None` | not supplied | not supplied |
| `0.0` | `None` → `0.0` | **"policy_port is required"** | refused, names `0.0` |
| `False` | `None` → `False` | **"policy_port is required"** | refused, names `False` |
| `""` | `None` → `""` | **"policy_port is required"** | refused, names `""` |
| `[]` | `None` → `[]` | **"policy_port is required"** | refused, names `[]` |
| `True` `5556.7` `'5556'` `-1` `99999` | unchanged | refused by name | refused by name |

Against a **port-less** provider the same four spellings were worse than mislabelled — they were dropped and the task *started*:

| provider `mock` | before | after |
| --- | --- | --- |
| `0.0` `False` `""` `[]` | **`status: success`** (task started, value discarded) | refused, names the value |
| `5556` (well-formed, provider reads no port) | refused by name | refused by name |

So the surface accepted what it could not use and refused what it could, decided by truthiness. The same `policy_port` field over the mesh `execute` verb is held to `[1, 65535]` by `validate_command`, which refuses all four by name — one field, two transports, two answers.

## Change

`_supplied_policy_port` makes the sentinel explicit and hands everything else on, leaving `Robot._policy_port_error` the one surface that judges a port and names the caller's value. **+5 executable statements** in `robot_driver.py` (117 → 122 AST statements); the rest of the diff is the docstring and the tests.

`0` is unchanged on both providers, and every truthy spelling keeps its existing message and response shape.

## Tests

`tests/test_hardware_policy_port_domain.py` already owns this domain, so the cells go there rather than into a new file.

- **Behaviour** — the four falsy non-sentinel spellings are named rather than called missing, and no longer start a task on a port-less provider. The `0` sentinel and a usable `5556` are the controls, and pass either way.
- **Census** — `TestEveryPortTakingSurfaceIsAccountedFor` states its rule for "a new task entry point" but reads only `strands_robots.hardware_robot`, so this relay sat outside the population it scans. Its predicate needed no change to judge it: pre-fix `execute` reads `(checks=False, forwards=False)`, post-fix `(False, True)`. The module is located with `find_spec` and read as text, so the rule holds without the `[device-connect]` extra installed.

| corner | result |
| --- | --- |
| main prod + new tests | **9 failed** / 103 passed |
| new prod + new tests | 112 passed |

The 9 are 4 + 4 behaviour + 1 census. All 100 pre-existing cells pass in both corners, so no existing cell pinned the old behaviour.

## Gate

`ruff check` / `ruff format --check` clean (1932 files) · `mypy strands_robots tests tests_integ` → `Success: no issues found in 1929 source files` · `tests/test_device_connect*` + `tests/test_hardware*` + `tests/test_estop*` + `tests/device_connect/` + `tests/registry/` + `tests/drivers/` + the mesh command-validation suites → **5476 passed, 24 skipped** · the 478-file tree-walking grader population → **25032 passed**, with 7 pre-existing environmental failures (5 cells assert `rclpy` is absent where it resolves from `/opt/ros/jazzy`; 2 read installed `websockets` 16.0 against the declared `>=17.0` floor).
