### PR TITLE
fix(tools): a session record's pid is graded, not converted to a nearby process id

### DIFF
--- a/changelog.d/3304-session-record-pid-is-graded.md
+++ b/changelog.d/3304-session-record-pid-is-graded.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **A session record's pid is graded rather than converted.** `lerobot_teleoperate`
+  and `lerobot_train` read the pid of a detached session out of a JSON store, and
+  `int()` of a value that store should not hold names a different process:
+  `int(4321.5)` is `4321`, so `stop` signalled - and killed - whatever held that
+  number while reporting success under a number that is not a pid, and `true` is
+  pid 1. The same conversion raised `ValueError` / `OverflowError` / `TypeError`
+  out of reads documented to degrade to "no sessions", for values `json.load`
+  produces from a well-formed file, including the U+FFFD each store's decode
+  policy substitutes for a damaged byte. Both tools now read that field through
+  one owner, which answers the pid or "no pid recorded", so an unusable record
+  reads as stopped, is refused by name at `stop`, and is never signalled.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -73,6 +73,18 @@ read back by a later one: `/proc/stat`'s boot time is recomputed from the wall
 clock on every read, so a date would move under an NTP correction while the
 kernel's own start ticks do not.
 
+Before either question can be asked, the number has to *be* a process id, and it
+arrives from a file rather than from a caller. So it is graded, not converted:
+`int()` of a value the store should not hold answers about a different process -
+`int(4321.5)` is `4321`, and `true` is pid 1 - or raises on a value `json.load`
+produces from a well-formed file (`1e400`, `NaN`, or the U+FFFD the store's own
+decode policy substitutes for a damaged byte). A `pid` field holding anything but
+a positive integer within the platform's `pid_t` range therefore means "this
+record names no process": `list` and `status` report it as stopped, the teleop
+store prunes it like any other record with no live process, the training store
+keeps it and `stop` refuses it naming the type it found, and nothing is
+signalled either way.
+
 `lerobot_teleoperate` prunes a finished session:
 
 | What the probe reports | Verdict |

--- a/strands_robots/tools/_process_stop.py
+++ b/strands_robots/tools/_process_stop.py
@@ -21,6 +21,12 @@ stranger as the session, and the ``stop`` verb that verdict invites signals it.
 :func:`confirm_exit` already insists on - captured before the question is asked,
 because a freshly constructed :class:`psutil.Process` captures the identity it is
 being asked to check and so cannot contradict it.
+
+Before either question can be asked there is the number itself, and it arrives
+from a JSON file rather than from a caller. :func:`recorded_pid` is the one
+reader of it, because converting instead of grading is how a record comes to
+name a process it was never written for: ``int(4321.5)`` is a pid the record does
+not carry, and ``int(True)`` is pid 1.
 """
 
 from __future__ import annotations
@@ -54,6 +60,15 @@ PID_STARTED_SINCE_BOOT = "pid_started_since_boot"
 # above that noise, and far below the lifetime of any session, which is the gap a
 # reused pid's own start offset differs by.
 _IDENTITY_TOLERANCE_S = 0.05
+
+#: Largest process id this platform can be asked about. A pid is a ``pid_t``,
+#: a signed 32-bit integer on Linux and macOS, and both ``psutil.pid_exists``
+#: and ``os.kill`` raise ``OverflowError`` above it rather than answering - so a
+#: larger number in a session record cannot name a process, and grading it out
+#: is what keeps that OverflowError from reaching a caller. The real ceiling is
+#: ``/proc/sys/kernel/pid_max``, but that is configurable at runtime, and a
+#: record written before it was lowered still names its process.
+_PID_T_MAX = 2**31 - 1
 
 #: Index of ``starttime`` among the ``/proc/<pid>/stat`` fields that follow the
 #: comm field - field 22 of the whole line, counting from 1. Everything up to and
@@ -146,16 +161,97 @@ def process_started_since_boot(pid: int) -> float | None:
         return None
 
 
+def recorded_pid(info: Mapping[str, Any]) -> int | None:
+    """The process id a session record names, or ``None`` when it names none.
+
+    The read-side counterpart of the pid a session's ``start`` verb wrote, in the
+    shape :func:`~strands_robots.utils.declared_count` uses for a count a file
+    declares: the store is JSON on disk, so the only two answers a reader can act
+    on are the pid itself and the absence of one. A value outside the domain is
+    ``None`` - never a nearby number - because ``int()`` of one aims a signal at a
+    process the record does not name:
+
+    * ``int(4321.5)`` is ``4321``. ``stop`` signals whatever holds that number,
+      which is not the session and need not be related to it at all.
+    * ``bool`` is an ``int`` subclass, so ``true`` is pid 1 - ``init`` on Linux.
+    * ``int("4321")`` and ``int(" 4321 ")`` both succeed, so a store spelling
+      ``psutil.pid_exists`` refuses outright is accepted here instead.
+    * ``int(1e400)`` raises ``OverflowError`` and ``int(float("nan"))``
+      ``ValueError``. Both are values ``json.load`` produces from a well-formed
+      file, and both escape readers whose documented answer for an unusable store
+      is "no sessions" rather than an exception.
+    * ``0`` and any negative number are refused because ``os.kill`` reads them as
+      process *groups*: ``0`` is every process in the caller's own group.
+    * A number above :data:`_PID_T_MAX` is refused because the platform cannot be
+      asked about it; see that constant.
+
+    Args:
+        info: A session record, read for its ``pid`` key.
+
+    Returns:
+        The recorded pid, or ``None`` when the record names no usable one. A
+        ``pid`` key that is present but is not a process id answers ``None`` too;
+        a caller that must tell those apart - to report the difference rather
+        than pass it over - compares against the raw value it read, as
+        :func:`unusable_pid_result` does.
+    """
+    pid = info.get("pid")
+    if isinstance(pid, bool) or not isinstance(pid, int):
+        return None
+    return pid if 0 < pid <= _PID_T_MAX else None
+
+
+def unusable_pid_result(session_name: str, recorded: Any) -> dict[str, Any]:
+    """Refuse a ``stop`` for a session record that names no process id.
+
+    Shared by both session tools so one unusable record reads the same whichever
+    one holds it, and split on whether the record carries the key at all: an
+    absent pid is the store's own "this record was never given one", while a
+    present value that is not a pid is a damaged or hand-edited record, and an
+    operator who cannot tell those apart cannot tell which file to look at.
+
+    The type is reported rather than the value, because the type is the mistake:
+    a ``float`` is a truncated pid, a ``str`` is a store written by something
+    other than these tools, and a ``bool`` is pid 1. The value itself is in the
+    file this message points the operator at.
+
+    Args:
+        session_name: Name the session is tracked under.
+        recorded: The raw value the record carried under ``pid``, or ``None``
+            when the key was absent.
+
+    Returns:
+        A tool error result whose ``json`` block carries ``pid_usable: False``.
+    """
+    if recorded is None:
+        text = f"No PID found for session '{session_name}'"
+    else:
+        text = (
+            f"Session '{session_name}' records a {type(recorded).__name__} as its PID, and a process id is "
+            f"a positive integer, so there is nothing this verb can signal. Recover the process from the "
+            f"session store and stop it with 'kill'."
+        )
+    return {
+        "status": "error",
+        "content": [
+            {"text": text},
+            {"json": {"session_name": session_name, "pid_usable": False, "stopped": False}},
+        ],
+    }
+
+
 def session_is_running(info: Mapping[str, Any]) -> bool:
     """Whether the process a session record names is still that process.
 
     Args:
-        info: A session record, read for its ``pid`` and for the identity
-            :data:`PID_STARTED_SINCE_BOOT` names.
+        info: A session record, read through :func:`recorded_pid` for its ``pid``
+            and for the identity :data:`PID_STARTED_SINCE_BOOT` names.
 
     Returns:
         ``True`` while the recorded pid exists *and* still holds the process the
-        record was written for.
+        record was written for. A record naming no usable pid is not running:
+        there is no process to ask about, and answering from a converted number
+        would answer about a different one.
 
         A record carrying no identity - one written before it was recorded - can
         only be answered by existence. Of the two ways the identity read can fail,
@@ -164,14 +260,14 @@ def session_is_running(info: Mapping[str, Any]) -> bool:
         was already gone, while :class:`psutil.AccessDenied` means this user may
         not look - and being unable to look is no evidence that the session ended.
     """
-    pid = info.get("pid")
-    if not pid or not psutil.pid_exists(int(pid)):
+    pid = recorded_pid(info)
+    if pid is None or not psutil.pid_exists(pid):
         return False
     recorded = info.get(PID_STARTED_SINCE_BOOT)
     if isinstance(recorded, bool) or not isinstance(recorded, int | float):
         return True
     try:
-        started = _started_since_boot(int(pid))
+        started = _started_since_boot(pid)
     except psutil.NoSuchProcess:
         return False
     except psutil.AccessDenied:

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -29,9 +29,11 @@ from strands_robots.tools._process_stop import (
     SIGTERM_GRACE_S,
     confirm_exit,
     process_started_since_boot,
+    recorded_pid,
     reused_pid_result,
     session_is_running,
     unstopped_result,
+    unusable_pid_result,
 )
 from strands_robots.utils import (
     boolean_flag_error,
@@ -299,6 +301,14 @@ class SessionManager:
         recorded: a pruned record leaves the teleoperation process running with no
         supported way to stop it.
 
+        The pid itself is read through
+        :func:`~strands_robots.tools._process_stop.recorded_pid` rather than
+        converted, so a record whose ``pid`` field is not a process id is dropped
+        like any other with no live process instead of aborting the read: this
+        method's decode policy exists so a damaged store still degrades, and
+        ``int()`` of a damaged pid raises a ``ValueError`` that neither handler
+        below answers.
+
         Returns:
             The surviving session records, keyed by session name.
         """
@@ -317,11 +327,24 @@ class SessionManager:
             # Check if processes are still running and clean up dead sessions
             active_sessions = {}
             for name, info in sessions.items():
+                pid = recorded_pid(info)
+                if pid is None and info.get("pid") is not None:
+                    # The record carries a pid field that is not a process id, so
+                    # nothing here can name the process it was written for - and
+                    # converting it would name a different one. It is dropped like
+                    # any other record with no live process, and said out loud
+                    # because the drop is written back to disk below.
+                    logger.warning(
+                        "Teleop session '%s' records a %s as its PID, which is not a process id; "
+                        "dropping the record - read %s to recover the process it named",
+                        name,
+                        type(info.get("pid")).__name__,
+                        self.sessions_file,
+                    )
                 if not session_is_running(info):
                     continue
                 active_sessions[name] = info
-                pid = info.get("pid")
-                if PID_STARTED_SINCE_BOOT in info and process_started_since_boot(int(pid)) is None:
+                if pid is not None and PID_STARTED_SINCE_BOOT in info and process_started_since_boot(pid) is None:
                     # A record that carries an identity was nonetheless kept on
                     # existence alone, so the read was refused - a process that had
                     # gone away would not have been kept. Said out loud, because
@@ -1178,10 +1201,12 @@ def lerobot_teleoperate(
                 return {"status": "error", "content": [{"text": f"Session '{session_name}' not found"}]}
 
             pid = session_info.get("pid")
-            if not pid:
-                return {"status": "error", "content": [{"text": f"No PID found for session '{session_name}'"}]}
-
-            pid_int = int(pid)
+            pid_int = recorded_pid(session_info)
+            if pid_int is None:
+                # Not a pid, so there is no process this verb could be about. The
+                # signals below would go to whatever ``int()`` of it happened to
+                # name - pid 1 for ``true``, and a live stranger for ``4321.5``.
+                return unusable_pid_result(session_name, pid)
             if psutil.pid_exists(pid_int) and not session_is_running(session_info):
                 # The pid exists but no longer holds the process this record was
                 # written for, so the session is over and the signals below would

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -35,9 +35,11 @@ from strands_robots.tools._process_stop import (
     SIGTERM_GRACE_S,
     confirm_exit,
     process_started_since_boot,
+    recorded_pid,
     reused_pid_result,
     session_is_running,
     unstopped_result,
+    unusable_pid_result,
 )
 from strands_robots.utils import (
     declared_count,
@@ -371,7 +373,14 @@ class SessionManager:
         return sessions
 
     def _report_uninspectable(self, sessions: dict[str, Any]) -> None:
-        """Warn for each session whose process exists but cannot be inspected.
+        """Warn for each session this store holds but cannot inspect.
+
+        Two records read that way. One names a pid that exists and may not be
+        read; the other names no pid at all - its ``pid`` field holds something
+        that is not a process id, which
+        :func:`~strands_robots.tools._process_stop.recorded_pid` answers rather
+        than converting, because ``psutil.pid_exists`` raises a ``TypeError`` on a
+        ``str`` or a ``float`` and aborts the action that asked.
 
         ``psutil.pid_exists`` answers existence with a signal; reading the process
         reads ``/proc``, which can be refused. When it raises
@@ -389,8 +398,23 @@ class SessionManager:
             sessions: The loaded records. Inspected only; never modified.
         """
         for name, info in sessions.items():
-            pid = info.get("pid")
-            if not (pid and psutil.pid_exists(pid)):
+            pid = recorded_pid(info)
+            if pid is None:
+                if info.get("pid") is not None:
+                    # A pid field that is not a process id. Nothing can inspect
+                    # it, and converting it would inspect a different process, so
+                    # it is reported for the same reason a denial is: ``list`` and
+                    # ``status`` will read this record as not running, and this is
+                    # the operator's only clue that the run may still be holding
+                    # the GPU under a pid this store no longer names.
+                    logger.warning(
+                        "Training session '%s' records a %s as its PID, which is not a process id; "
+                        "its record is kept, but the run can only be stopped by hand",
+                        name,
+                        type(info.get("pid")).__name__,
+                    )
+                continue
+            if not psutil.pid_exists(pid):
                 continue
             try:
                 # Called for what it raises, not for what it returns: the
@@ -1113,10 +1137,12 @@ def lerobot_train(
             if not session_info:
                 return {"status": "error", "content": [{"text": f"Session '{session_name}' not found"}]}
             pid = session_info.get("pid")
-            if not pid:
-                return {"status": "error", "content": [{"text": f"No PID found for session '{session_name}'"}]}
-
-            pid_int = int(pid)
+            pid_int = recorded_pid(session_info)
+            if pid_int is None:
+                # Not a pid, so there is no process this verb could be about. The
+                # signals below would go to whatever ``int()`` of it happened to
+                # name - pid 1 for ``true``, and a live stranger for ``4321.5``.
+                return unusable_pid_result(session_name, pid)
             if psutil.pid_exists(pid_int) and not session_is_running(session_info):
                 # The pid exists but no longer holds the process this record was
                 # written for, so the run is over and the signals below would go

--- a/tests/tools/test_session_record_pid_is_graded_not_converted.py
+++ b/tests/tools/test_session_record_pid_is_graded_not_converted.py
@@ -1,0 +1,318 @@
+"""A session record's pid is graded, not converted into a nearby process id.
+
+Both session tools keep their sessions in a JSON file, and every verb that
+reports on or stops one starts by reading a ``pid`` out of it. That value is a
+file's declaration rather than a caller's argument, and converting it is how a
+record comes to name a process it was never written for: ``int(4321.5)`` is
+``4321``, and ``bool`` is an ``int`` subclass, so ``true`` is pid 1 - ``init`` on
+Linux. Measured before the fix these tests pin, a store whose ``pid`` field held
+``true`` read as a live session and ``stop`` handed ``os.kill`` pid 1, while a
+record spelling a live stranger's pid with ``.5`` after it got that stranger
+killed and reported success naming a number that is not a pid.
+
+The same conversion is the other way a record goes wrong. ``int()`` raises for
+values ``json.load`` produces from a well-formed file - ``ValueError`` for a
+string carrying the U+FFFD the store's own decode policy substitutes for a
+damaged byte, ``OverflowError`` for ``1e400``, ``ValueError`` for ``NaN`` - and
+neither store's read handles either, so a read documented to degrade to "no
+sessions" aborted the action that asked instead.
+
+:func:`~strands_robots.tools._process_stop.recorded_pid` is the one reader of
+that field for both tools, in the shape
+:func:`~strands_robots.utils.declared_count` uses for a count a file declares:
+the pid, or ``None`` for no usable one. These tests pin the domain, that no
+spelling raises anywhere, that nothing outside it is ever signalled, and that
+the one spelling a writer produces still stops its session.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import psutil
+import pytest
+
+import strands_robots.tools.lerobot_teleoperate as tele_mod
+import strands_robots.tools.lerobot_train as train_mod
+from strands_robots.tools import _process_stop
+from strands_robots.tools._process_stop import session_is_running
+
+#: A pid this process certainly holds, so "exists" is settled and the only thing
+#: under test is the spelling it is written down in.
+LIVE_PID = os.getpid()
+
+#: Spellings of a pid a store can carry, with the reason each is refused. A list
+#: of pairs rather than a dict because ``0 == False`` and ``4321 == 4321.0``
+#: collapse in a mapping exactly the distinctions a conversion defect is about.
+UNUSABLE: list[tuple[str, Any, str]] = [
+    ("true", True, "bool is an int subclass, so int() of it is pid 1 - init on Linux"),
+    ("half above a live pid", float(LIVE_PID) + 0.5, "int() truncates to a pid the record does not carry"),
+    ("str digits", str(LIVE_PID), "psutil.pid_exists raises TypeError on a str, so int() hid a store it refuses"),
+    ("padded str digits", f" {LIVE_PID} ", "int() strips whitespace, so two spellings of one store are accepted"),
+    ("str with a replaced byte", "12\ufffd", "what the store's errors='replace' decode leaves in a damaged pid"),
+    ("inf", float("inf"), "1e400 is a well-formed JSON number; int() of it raises OverflowError"),
+    ("nan", float("nan"), "int() of it raises ValueError"),
+    ("zero", 0, "os.kill reads 0 as every process in the caller's own process group"),
+    ("negative", -LIVE_PID, "os.kill reads a negative number as a process group"),
+    ("above pid_t", 2**31, "psutil.pid_exists and os.kill raise OverflowError above the signed 32-bit ceiling"),
+    ("a list", [LIVE_PID], "int() of it raises TypeError"),
+    ("absent", None, "the record was never given a pid"),
+]
+UNUSABLE_IDS = [row[0] for row in UNUSABLE]
+
+
+def _record(pid: Any) -> dict[str, Any]:
+    """A session record carrying ``pid``, or none at all when it is ``None``."""
+    info: dict[str, Any] = {"action": "teleoperate", "start_time": 0.0}
+    if pid is not None:
+        info["pid"] = pid
+    return info
+
+
+@pytest.fixture(autouse=True)
+def _isolate_both_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point both tools' session stores at a temp dir, never the tree."""
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(tele_mod, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(train_mod, "SESSION_DIR", session_dir)
+    return session_dir
+
+
+def _write_store(session_dir: Path, name: str, pid: Any) -> None:
+    """Write a one-record store, the way a hand-edited or damaged file reads."""
+    (session_dir / "active_sessions.json").write_text(json.dumps({name: _record(pid)}))
+
+
+class _RecordingOs:
+    """The real ``os`` module with ``kill`` recorded instead of sent.
+
+    ``monkeypatch.setattr(os, "kill", ...)`` is not usable here: psutil answers
+    ``pid_exists`` on POSIX by asking ``os.kill(pid, 0)``, so the recorder would
+    also be answering the existence probe these verbs take first. Replacing the
+    tool module's own ``os`` name leaves psutil's reference alone.
+    """
+
+    def __init__(self, real: Any) -> None:
+        self._real = real
+        self.sent: list[tuple[Any, int]] = []
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+    def kill(self, pid: Any, sig: int) -> None:
+        self.sent.append((pid, int(sig)))
+        raise ProcessLookupError(3, "recorded, not sent")
+
+
+@pytest.fixture
+def recorded_signals(monkeypatch: pytest.MonkeyPatch) -> _RecordingOs:
+    """Record what the teleop stop verb hands ``os.kill``, without sending it."""
+    proxy = _RecordingOs(os)
+    monkeypatch.setattr(tele_mod, "os", proxy)
+    return proxy
+
+
+# --------------------------------------------------------------------------- #
+# the domain                                                                  #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(("_label", "pid", "_why"), UNUSABLE, ids=UNUSABLE_IDS)
+def test_a_spelling_outside_the_domain_names_no_pid(_label: str, pid: Any, _why: str) -> None:
+    """Every unusable spelling answers "no pid", never a nearby number."""
+    assert _process_stop.recorded_pid(_record(pid)) is None
+
+
+def test_the_spelling_a_writer_produces_is_the_pid() -> None:
+    """An integer pid passes through unchanged - the domain narrows nothing real.
+
+    Both tools write ``proc.pid`` into the store, so this is the only spelling a
+    record can be born with, and it must survive the grading intact.
+    """
+    assert _process_stop.recorded_pid(_record(LIVE_PID)) == LIVE_PID
+
+
+# --------------------------------------------------------------------------- #
+# no spelling raises, and none of them reads as running                       #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(("_label", "pid", "_why"), UNUSABLE, ids=UNUSABLE_IDS)
+def test_an_unusable_pid_is_not_running_rather_than_an_exception(_label: str, pid: Any, _why: str) -> None:
+    """The running question has an answer for every spelling a store can hold.
+
+    Before the fix four of these raised out of ``session_is_running``
+    (``ValueError``, ``OverflowError``, ``TypeError``) and three answered
+    ``True`` on the strength of a converted number.
+    """
+    assert session_is_running(_record(pid)) is False
+
+
+def test_a_live_integer_pid_still_reads_as_running() -> None:
+    """The one spelling that names a process is still answered from the process."""
+    assert session_is_running(_record(LIVE_PID)) is True
+
+
+# --------------------------------------------------------------------------- #
+# both stores degrade rather than aborting the action that asked              #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(("_label", "pid", "_why"), UNUSABLE, ids=UNUSABLE_IDS)
+def test_the_teleop_store_drops_an_unusable_record_without_raising(
+    _isolate_both_stores: Path, _label: str, pid: Any, _why: str
+) -> None:
+    """A record naming no process is pruned like any other with none live.
+
+    That store prunes on every read and writes the prune back, so the classifying
+    question has to be answerable for every spelling. It was not: four of these
+    aborted the read.
+    """
+    _write_store(_isolate_both_stores, "arm", pid)
+
+    assert tele_mod.SessionManager().list_sessions() == {}
+
+
+@pytest.mark.parametrize(("_label", "pid", "_why"), UNUSABLE, ids=UNUSABLE_IDS)
+def test_the_training_store_keeps_an_unusable_record_without_raising(
+    _isolate_both_stores: Path, _label: str, pid: Any, _why: str
+) -> None:
+    """The training store drops nothing, so it must read every spelling too.
+
+    Its retention is the point: the record is the only place a detached run's pid
+    is written down. Before the fix ``psutil.pid_exists`` was handed the raw
+    value and raised ``TypeError`` for a ``str``, a ``float`` and a ``list`` -
+    including two spellings the teleop store accepted as live, so one record read
+    as a running session in one tool and as an aborted read in the other.
+    """
+    _write_store(_isolate_both_stores, "run", pid)
+
+    assert list(train_mod.SessionManager().list_sessions()) == ["run"]
+
+
+def test_a_store_whose_pid_field_is_undecodable_degrades_to_no_sessions(_isolate_both_stores: Path) -> None:
+    """The bytes the decode policy was chosen for reach the pid, and still degrade.
+
+    Both stores are read with ``errors="replace"`` precisely so a damaged file
+    degrades instead of raising, and both document that. The substitute lands in
+    whichever field carried the damaged byte, and when that field is the pid,
+    ``int()`` of the result raised ``ValueError`` - which neither read handles.
+    """
+    store = _isolate_both_stores / "active_sessions.json"
+    store.write_bytes(b'{"arm": {"pid": "12\xff34", "action": "teleoperate", "start_time": 0.0}}')
+
+    # The training store first: the teleop read below prunes the record and
+    # writes the pruned map back over the same file.
+    assert list(train_mod.SessionManager().list_sessions()) == ["arm"]
+    assert tele_mod.SessionManager().list_sessions() == {}
+
+
+# --------------------------------------------------------------------------- #
+# nothing outside the domain is signalled                                     #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(("_label", "pid", "_why"), UNUSABLE, ids=UNUSABLE_IDS)
+def test_stop_signals_nothing_for_a_record_that_names_no_pid(
+    _isolate_both_stores: Path, recorded_signals: _RecordingOs, _label: str, pid: Any, _why: str
+) -> None:
+    """No spelling outside the domain reaches a signal.
+
+    ``true`` reached ``os.kill(1, SIGTERM)`` before the fix - measured, with the
+    signal recorded rather than sent, which is also why this test records it.
+    """
+    _write_store(_isolate_both_stores, "arm", pid)
+
+    result = tele_mod.lerobot_teleoperate(action="stop", session_name="arm")
+
+    assert result["status"] == "error"
+    assert recorded_signals.sent == [], f"a record spelling its pid as {_label} was signalled"
+
+
+def test_stop_still_signals_a_session_whose_pid_is_an_integer(
+    _isolate_both_stores: Path, recorded_signals: _RecordingOs
+) -> None:
+    """The control the refusals are measured against: a real pid is still stopped.
+
+    Without this the assertion above passes on a verb that signals nothing at
+    all.
+    """
+    _write_store(_isolate_both_stores, "arm", LIVE_PID)
+
+    tele_mod.lerobot_teleoperate(action="stop", session_name="arm")
+
+    assert recorded_signals.sent == [(LIVE_PID, int(signal.SIGTERM))]
+
+
+def test_a_live_stranger_is_not_killed_by_a_record_that_spells_its_pid_as_a_float(
+    _isolate_both_stores: Path,
+) -> None:
+    """The harm, with real signals: a process nothing here started stays alive.
+
+    ``int(4321.5)`` is a pid, so ``stop`` used to signal whatever held it, wait
+    for it to exit, and report success quoting ``PID: 4321.5`` - a number that is
+    not a process id. Pinned against a child of this test rather than a mock,
+    because "the process died" is the claim.
+    """
+    stranger = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        for _ in range(50):  # let it reach the sleep, so an exit means a signal
+            if psutil.pid_exists(stranger.pid):
+                break
+            time.sleep(0.02)
+        _write_store(_isolate_both_stores, "arm", float(stranger.pid) + 0.5)
+
+        tele_mod.lerobot_teleoperate(action="stop", session_name="arm")
+        time.sleep(0.3)
+
+        assert stranger.poll() is None, "stop killed a process the session record does not name"
+    finally:
+        stranger.kill()
+        stranger.wait(timeout=5)
+
+
+# --------------------------------------------------------------------------- #
+# what the operator is told                                                   #
+# --------------------------------------------------------------------------- #
+def test_an_absent_pid_and_an_unusable_one_are_refused_in_their_own_words(_isolate_both_stores: Path) -> None:
+    """Two records, two reports: never given a pid, versus given a damaged one.
+
+    The training store keeps both, so both refusals are reachable there. An
+    operator who cannot tell them apart cannot tell whether to look for a running
+    process at all.
+    """
+    (_isolate_both_stores / "active_sessions.json").write_text(
+        json.dumps({"nopid": _record(None), "bad": _record(4321.5)})
+    )
+
+    absent = train_mod.lerobot_train(action="stop", dataset_root="/x", session_name="nopid")
+    unusable = train_mod.lerobot_train(action="stop", dataset_root="/x", session_name="bad")
+
+    assert absent["status"] == unusable["status"] == "error"
+    assert "No PID found for session 'nopid'" in absent["content"][0]["text"]
+    assert "records a float as its PID" in unusable["content"][0]["text"], "the type is the mistake"
+    assert unusable["content"][1]["json"] == {"session_name": "bad", "pid_usable": False, "stopped": False}
+
+
+# --------------------------------------------------------------------------- #
+# one reader, and it stays the only one                                       #
+# --------------------------------------------------------------------------- #
+def test_no_session_tool_converts_a_recorded_pid() -> None:
+    """No module reads a stored pid through ``int()``, so the domain cannot be bypassed.
+
+    An AST scan rather than a list of the modules known today: the two session
+    tools and their shared stop helper all held ``int(pid)``, and a third tool
+    keeping a session store would have to be added to a hand-written roster
+    before this could catch it.
+    """
+    tools_dir = Path(train_mod.__file__).parent
+    converts: list[str] = []
+    for module in sorted(tools_dir.rglob("*.py")):
+        for node in ast.walk(ast.parse(module.read_text())):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "int"):
+                continue
+            if node.args and "pid" in ast.unparse(node.args[0]).lower():
+                converts.append(f"{module.name}:{node.lineno}: {ast.unparse(node)}")
+
+    assert converts == [], "a stored pid is converted rather than graded: " + "; ".join(converts)


### PR DESCRIPTION
![measured verdicts](https://raw.githubusercontent.com/cagataycali/robots/assets/session-pid-domain/docs/assets/session-pid-domain.png)

`lerobot_teleoperate` and `lerobot_train` keep detached sessions in `active_sessions.json` and read the pid back out with `int(pid)`. That value is a file's declaration, not a caller's argument, and converting it answers about a **different process**.

The store's own docstring already says why it matters: it is the only place a detached session's pid is written down, and it is read with `errors="replace"` specifically so a damaged file degrades instead of raising. `int()` breaks both halves of that.

## What was measured

The table above is the same script run twice - once against `f6df557`, once against that tree with this change. Two harms, opposite in kind:

**Silent.** `true` is truthy and `bool` is an `int` subclass, so `int(True)` is `1`: the record read as a live session and `stop` handed `os.kill` **pid 1**. `4321.5` truncates to `4321`. With real signals, a record spelling a live `sleep 30` child's pid half a unit high got that child **killed**, and `stop` reported success quoting `PID: 2034221.5` - a number that is not a process id.

**Loud.** For values `json.load` produces from a well-formed file, `int()` raises out of reads documented to answer "no sessions": `ValueError` for `NaN` and for the `U+FFFD` the decode policy substitutes for a damaged byte - the case that policy exists for - `OverflowError` for `1e400`, `TypeError` for a list. The training store took it worse still, handing the raw value to `psutil.pid_exists`, which raises `TypeError` on a `str` or a `float`: two spellings the teleop store accepted as *live* aborted the read in the other tool, so one record read as a running session in one and as an unreadable store in the other.

## The change

`recorded_pid(info) -> int | None` in `_process_stop.py`, the module that already exists so this rule is stated once rather than per verb. Same shape as `declared_count` for a count a file declares: the pid, or `None` when the record names none. It refuses `bool`, non-`int`, `<= 0` (`os.kill` reads `0` and negatives as process *groups*) and anything above `pid_t` (`psutil.pid_exists` raises `OverflowError` at `2**31`).

Every reader of that field now goes through it - `session_is_running`, both store reads, both `stop` verbs, and the training store's inspection pass - and `unusable_pid_result` reports the two cases in their own words: `No PID found` for a record never given one (wording unchanged), and the type for a record given something that is not a pid.

Nothing is narrowed: `proc.pid` is the only spelling either tool writes, and it passes through unchanged - the shaded row is identical on both sides, and `stop` still signals it.

## Tests

`tests/tools/test_session_record_pid_is_graded_not_converted.py`, 67 cells, table-driven over the 12 spellings: **47 red on pre-fix code, all green after.** The control - a real integer pid still reaching `os.kill` with `SIGTERM` - is green on both sides, so the refusals are not passing against a verb that signals nothing. The stranger-survives cell uses a real child process, because "the process died" is the claim. A closing AST scan asserts no module under `strands_robots/tools/` converts a stored pid, so a third session store cannot reintroduce it.

Measuring `os.kill` needed one non-obvious thing: patching `os.kill` globally also answers psutil's `pid_exists`, which asks `os.kill(pid, 0)` on POSIX. The recorder replaces the tool module's own `os` name instead.

## LOC

| file | +/- |
|---|---|
| `strands_robots/tools/_process_stop.py` | +102 / -6 |
| `strands_robots/tools/lerobot_teleoperate.py` | +31 / -6 |
| `strands_robots/tools/lerobot_train.py` | +33 / -7 |
| `docs/hardware/tools.md` | +12 |
| `tests/tools/test_session_record_pid_is_graded_not_converted.py` | +318 (new) |
| `changelog.d/3304-...` | +13 |

The production change is +166/-19; most of it is the two shared helpers and their rationale. Local gate: `ruff check`/`format` clean on 1935 files, `mypy` unchanged (20 pre-existing errors, none in these files), and the 53-module test net around these surfaces shows an identical standing-failure set before and after with +67 passes - exactly the new cells.