### PR TITLE
fix(device_connect/reachy_mini): a motor selector that names no motor is refused, not widened to every motor

### DIFF
--- a/changelog.d/3305-reachy-motor-selector-names-no-motor.md
+++ b/changelog.d/3305-reachy-motor-selector-names-no-motor.md
@@ -1,0 +1,9 @@
+### Bug Fixes
+
+- **device_connect/reachy_mini**: `enableMotors` / `disableMotors` read the
+  comma-separated `motor_ids` selector by truthiness, so a non-empty selector
+  that names no motor - `","`, `" "`, `",,"` - parsed to `[]`, was coalesced to
+  the same `None` the documented `""` default resolves to, and torqued every
+  motor while the reply echoed the caller's own selector as the set acted on.
+  Such a selector is now refused by value before anything reaches the hardware
+  link; `""` still selects every motor and a well-formed list is unchanged.

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -185,6 +185,28 @@ def _motion_domain_error(rpc_name: str, values: dict[str, Any]) -> dict[str, str
     return None
 
 
+def _motor_selection(motor_ids: str) -> list[str] | None:
+    """Resolve the comma-separated ``motor_ids`` selector into the ids to command.
+
+    ``""``, the declared default, selects every motor and resolves to ``None``,
+    which is the spelling the firmware reads as "all". A non-empty selector that
+    names no motor - ``","``, ``" "``, ``",,"`` - is refused rather than widened:
+    read by truthiness it parsed to ``[]``, was coalesced to ``None`` and torqued
+    every motor, while the reply echoed the caller's own selector as the set
+    acted on. One resolver serves both torque verbs so the two cannot disagree
+    about which spellings select every motor.
+
+    Raises:
+        ValueError: ``motor_ids`` is non-empty and names no motor.
+    """
+    if motor_ids == "":
+        return None
+    ids = [s.strip() for s in motor_ids.split(",") if s.strip()]
+    if not ids:
+        raise ValueError(f"motor_ids names no motor: {motor_ids!r}; pass '' to select every motor")
+    return ids
+
+
 class ReachyMiniDriver(DeviceDriver):
     """Device Connect driver for Pollen Reachy Mini.
 
@@ -460,12 +482,16 @@ class ReachyMiniDriver(DeviceDriver):
         """Enable motors (torque on).
 
         Args:
-            motor_ids: Comma-separated motor IDs (empty = all)
+            motor_ids: Comma-separated motor IDs (empty = all). A non-empty
+                selector that names no motor is refused.
         """
         caller = get_rpc_source_device()
         if not is_authorized_caller(caller, scope="rpc", device=attached_runtime(self)):
             return authz_error(caller, "enableMotors")
-        ids = [s.strip() for s in motor_ids.split(",") if s.strip()] or None
+        try:
+            ids = _motor_selection(motor_ids)
+        except ValueError as exc:
+            return {"status": "error", "reason": str(exc)}
         await self._send_cmd({"torque": True, "ids": ids})
         return {"status": "success", "enabled": motor_ids or "all"}
 
@@ -480,9 +506,13 @@ class ReachyMiniDriver(DeviceDriver):
         to the caller rather than reporting a false ack.
 
         Args:
-            motor_ids: Comma-separated motor IDs (empty = all).
+            motor_ids: Comma-separated motor IDs (empty = all). A non-empty
+                selector that names no motor is refused.
         """
-        ids = [s.strip() for s in motor_ids.split(",") if s.strip()] or None
+        try:
+            ids = _motor_selection(motor_ids)
+        except ValueError as exc:
+            return {"status": "error", "reason": str(exc)}
         await self._send_cmd({"torque": False, "ids": ids})
         return {"status": "success", "disabled": motor_ids or "all"}
 
@@ -491,7 +521,8 @@ class ReachyMiniDriver(DeviceDriver):
         """Disable motors (torque off).
 
         Args:
-            motor_ids: Comma-separated motor IDs (empty = all)
+            motor_ids: Comma-separated motor IDs (empty = all). A non-empty
+                selector that names no motor is refused.
         """
         caller = get_rpc_source_device()
         if not is_authorized_caller(caller, scope="rpc", device=attached_runtime(self)):

--- a/tests/test_reachy_mini_driver.py
+++ b/tests/test_reachy_mini_driver.py
@@ -302,6 +302,30 @@ def test_disable_motors_defaults_to_all(rmd):
     assert drv._hw.send_cmd.await_args.args[0] == {"torque": False, "ids": None}
 
 
+@pytest.mark.parametrize(("verb", "torque"), [("enableMotors", True), ("disableMotors", False)])
+def test_an_explicit_empty_selector_still_selects_every_motor(rmd, verb, torque):
+    """Control for the refusal below: ``""`` is the declared default and the one
+    documented spelling of "all", so it must keep resolving to ``ids: None``."""
+    drv = _bare(rmd, _hw=AsyncMock())
+    res = _run(getattr(drv, verb)(""))
+    assert res["status"] == "success"
+    assert drv._hw.send_cmd.await_args.args[0] == {"torque": torque, "ids": None}
+
+
+@pytest.mark.parametrize("verb", ["enableMotors", "disableMotors"])
+@pytest.mark.parametrize("selector", [",", " ", ",,", " , "])
+def test_a_selector_naming_no_motor_is_refused_not_widened_to_every_motor(rmd, verb, selector):
+    """``","`` is not ``""``. Read by truthiness, a non-empty selector that names
+    no motor parsed to ``[]``, was coalesced to ``None`` and torqued every motor,
+    while the reply echoed the caller's own selector (``"enabled": ","``) as the
+    set acted on. The refusal names the value and nothing reaches the link."""
+    drv = _bare(rmd, _hw=AsyncMock())
+    res = _run(getattr(drv, verb)(selector))
+    assert res["status"] == "error"
+    assert repr(selector) in res["reason"], res
+    drv._hw.send_cmd.assert_not_awaited()
+
+
 # -- REST move / lifecycle RPCs --------------------------------------------
 
 


### PR DESCRIPTION
`ReachyMiniDriver.enableMotors` and `disableMotors` take `motor_ids: str = ""`, documented as "Comma-separated motor IDs (empty = all)", and resolved it as

```python
ids = [s.strip() for s in motor_ids.split(",") if s.strip()] or None
```

`""` is the declared sentinel for "every motor", and `None` is the wire spelling the firmware reads as "all". But the `or` reads the *parsed list* by truthiness, so a **non-empty** selector that names no motor - `","`, `" "`, `",,"`, `" , "` - parses to `[]` and is coalesced to that same `None`. The reply then reports `motor_ids or "all"`, which for a truthy `","` is `","`: the caller's own selector, echoed back as the set acted on.

This is the shape AGENTS.md records for `download_robots(names=",")` ("A subset selector is read by membership, never by truthiness"), one hop further down: a torque surface reached over `@rpc`, which splats wire parameters without coercion, and the offending values are strings, so nothing between the wire and the parse can turn them away. `disableMotors(",")` drops torque on the whole head; `enableMotors(",")` torques every motor.

## Measured

Driven through the real driver bound to the genuine `device_connect_edge` (the fixture `tests/test_reachy_mini_driver.py` already owns), `_hw.send_cmd` captured:

| `motor_ids` | before: sent | before: reply | after |
| --- | --- | --- | --- |
| `""` *(documented sentinel)* | `ids: None` | `"all"` | unchanged |
| `"1, 2 ,3"` | `ids: ["1","2","3"]` | `"1, 2 ,3"` | unchanged |
| `","` | **`ids: None`** (every motor) | **`","`** | refused, names `','`, nothing sent |
| `" "` | **`ids: None`** | **`" "`** | refused, names `' '`, nothing sent |
| `",,"` | **`ids: None`** | **`",,"`** | refused, nothing sent |
| `" , "` | **`ids: None`** | **`" , "`** | refused, nothing sent |

Same table for both verbs.

## Change

One module-level resolver, `_motor_selection(motor_ids) -> list[str] | None`, serves both verbs (and the un-gated `_disable_motors_impl` the e-stop handler calls with the default): `""` resolves to `None`, a selector naming at least one motor resolves to that list, and a non-empty selector naming none raises `ValueError` naming the value, which each RPC renders as its `{"status": "error", "reason": ...}` envelope before `_send_cmd` is reached. The three `Args:` entries state the refusal. The default and every well-formed spelling are byte-identical in what is sent and what is replied.

Deliberately not done: a non-`str` `motor_ids` (`0`, a list) still raises `AttributeError` from `.split` exactly as before. That is a type refusal rather than a selection widening, so it is a different rule and not this diff's concern.

## Tests

`tests/test_reachy_mini_driver.py` already owns motor-id parsing, so the cells go there.

- `test_a_selector_naming_no_motor_is_refused_not_widened_to_every_motor` - 4 selectors x 2 verbs: `status: error`, the reason quotes the selector, `send_cmd` never awaited.
- `test_an_explicit_empty_selector_still_selects_every_motor` - control: explicit `""` on both verbs still sends `ids: None`. The existing `"1, 2 ,3"` and no-argument cells are the other two controls.

| corner | result |
| --- | --- |
| main prod + new tests | **8 failed** / 50 passed |
| new prod + new tests | 58 passed |

The 8 are exactly the 4 x 2 refusal cells; all 50 pre-existing cells and both controls pass in both corners.

## Gate

`ruff check` / `ruff format --check` clean on both files. `mypy` on both files: `Success: no issues found in 2 source files`. Whole-tree grader roster (`scripts/check_whole_tree_graders.py`, 110 graders): 1007 passed with 44 skipped on the 107 collectable in this environment; the remaining failures/errors are the same node ids on `main` and on this head (**39 failed / 175 passed / 9 skipped in both corners**, delta 0), every one an `ImportError` for `mujoco` or `lerobot` which this environment does not install, and none under `device_connect`.

## Round changelog

- Round 0: opened as draft, changelog fragment `changelog.d/3305-reachy-motor-selector-names-no-motor.md` pushed, marked ready.