### PR TITLE
fix(tools/lerobot_camera): a batch selector that names no camera is refused, not widened to the default cameras

### DIFF
--- a/changelog.d/3309-camera-batch-selector-names-no-camera.md
+++ b/changelog.d/3309-camera-batch-selector-names-no-camera.md
@@ -1,0 +1,11 @@
+### Bug Fixes
+
+- **tools/lerobot_camera**: `capture_batch` read its `camera_ids` selector by
+  truthiness, so `[]` - the selection a filter that matched nothing produces -
+  was widened to the two default robot cameras and reported as "2/2 cameras"
+  under `status="success"`, a single id passed as a bare string was read one
+  camera per character (eleven one-character cameras for `"/dev/video4"`), a
+  mapping was iterated over its keys and a repeated id opened one device twice.
+  The selector is now read `is None`: omitting it still selects the defaults,
+  and every other shape is refused by value before the save directory, the
+  thread pool or any camera exists. A well-formed list is unchanged.

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import time
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Any
@@ -291,6 +292,95 @@ def _vocabulary_option_error(action: str, *, color_mode: Any, rotation: Any) -> 
     return None
 
 
+# The cameras ``capture_batch`` reads when the caller names none. Held in one
+# place so the documented default and the resolution below cannot drift apart.
+_DEFAULT_BATCH_CAMERA_IDS: tuple[int | str, ...] = (0, "/dev/video4")
+
+
+def _camera_ids_error(camera_ids: Any) -> str | None:
+    """Error text when ``camera_ids`` is not a usable selection of cameras.
+
+    ``camera_ids`` SELECTS the cameras one ``capture_batch`` call opens, and a
+    selection is read by membership, never by truthiness: ``None`` is the one
+    spelling of "the default robot cameras", so it is the caller's to skip and
+    never reaches here. Every other value is graded.
+
+    Read by truthiness, ``[]`` took the same branch as ``None`` and was widened
+    to the two default cameras, so a caller who selected no camera - which is
+    what a filter that matched nothing produces - had two devices opened and two
+    files written, under ``status="success"`` and a "2/2 cameras" summary
+    quoting a count the caller never asked for. The empty selection is refused
+    rather than widened, which is the verdict the shared name-list domain
+    (:func:`strands_robots.utils.name_list_error`) reserves for the caller. That
+    domain is not reused here because a camera id is legitimately an ``int``
+    index as well as a device-path string, and it accepts names only.
+
+    The other shapes fail the same way that domain describes. A bare string is
+    iterable per character, so ``"/dev/video4"`` opened eleven one-character
+    cameras on eleven threads and reported eleven verdicts about devices the
+    caller never named, instead of one about the parameter. A ``Mapping`` is
+    iterable over its keys, so its values were discarded. A repeated id opens
+    one device twice concurrently and writes two files for it. A one-shot
+    iterator is consumed by the ``len()`` that sizes the thread pool before the
+    loop that submits work reads it. A ``bool`` is an ``int`` subclass, so
+    ``True`` selected camera index 1 without the caller writing a 1.
+
+    Every refusal here precedes the save directory being created, the thread
+    pool being built and any camera being opened, so a refused selection has no
+    partial effect to undo.
+
+    Args:
+        camera_ids: The caller-supplied selection, anything but ``None``.
+
+    Returns:
+        An error message naming the shape and the accepted one, or ``None`` when
+        the selection can be honored as written.
+    """
+    prefix = "capture_batch: camera_ids"
+    accepted = (
+        "a list of distinct camera ids, each an int index or a device path string; "
+        "omit it (None) for the default robot cameras"
+    )
+    if isinstance(camera_ids, str):
+        return (
+            f"{prefix} must be {accepted}, not a single string ({camera_ids!r}). A "
+            f"string is read one camera per character, so pass [{camera_ids!r}] to "
+            f"name one camera."
+        )
+    if isinstance(camera_ids, bytes):
+        return f"{prefix} must be {accepted}, not bytes ({camera_ids!r})."
+    if isinstance(camera_ids, Mapping):
+        return f"{prefix} must be {accepted}, not a mapping - its values would be discarded."
+    if not isinstance(camera_ids, Sequence):
+        return (
+            f"{prefix} must be {accepted}, got {type(camera_ids).__name__}. A one-shot "
+            f"iterator is consumed before the cameras are opened."
+        )
+    ids = list(camera_ids)
+    if not ids:
+        return (
+            f"{prefix}=[] selects no camera, so there is nothing to capture. Omit "
+            f"camera_ids to select the default robot cameras "
+            f"{list(_DEFAULT_BATCH_CAMERA_IDS)!r}, or name the cameras to capture from."
+        )
+    for i, cam_id in enumerate(ids):
+        if isinstance(cam_id, bool) or not isinstance(cam_id, int | str):
+            return (
+                f"{prefix}[{i}] must be an int index or a device path string, got {cam_id!r} ({type(cam_id).__name__})."
+            )
+        if isinstance(cam_id, str) and not cam_id.strip():
+            return f"{prefix}[{i}] is blank ({cam_id!r}); a camera path must name a device."
+    seen: set[int | str] = set()
+    for cam_id in ids:
+        if cam_id in seen:
+            return (
+                f"{prefix} names {cam_id!r} more than once ({ids!r}); each camera is "
+                f"opened once per batch, so name each id once."
+            )
+        seen.add(cam_id)
+    return None
+
+
 @tool
 def lerobot_camera(
     action: str = "list",
@@ -330,7 +420,11 @@ def lerobot_camera(
         filename: Custom filename (without extension). Resolved inside
             save_path; a value naming a location outside it is refused rather
             than written there.
-        camera_ids: List of camera IDs for batch operations
+        camera_ids: Cameras to capture from in one capture_batch call - a list
+            of distinct ids, each an int index or a device path string. Omit it
+            for the default robot cameras. An empty list selects no camera and
+            is refused rather than widened to those defaults; a single id passed
+            as a bare string is refused rather than read one camera per character.
         width: Frame width in pixels (a positive whole number)
         height: Frame height in pixels (a positive whole number)
         fps: Frames per second (a positive whole number)
@@ -401,8 +495,14 @@ def lerobot_camera(
                 warmup,
             )
         elif action == "capture_batch":
-            if not camera_ids:
-                camera_ids = [0, "/dev/video4"]  # Default robot cameras
+            # Read ``is None``: camera_ids selects a SUBSET of the cameras, so
+            # only the absent spelling means the default robot cameras. An empty
+            # selection, a bare string, a mapping or a repeat is refused here,
+            # before the save directory, the thread pool or any camera exists.
+            if camera_ids is None:
+                camera_ids = list(_DEFAULT_BATCH_CAMERA_IDS)
+            elif selection_error := _camera_ids_error(camera_ids):
+                return {"status": "error", "content": [{"text": selection_error}]}
             return _capture_batch_images(
                 camera_type,
                 camera_ids,

--- a/tests/tools/test_lerobot_camera_batch_selection_is_read_by_membership.py
+++ b/tests/tools/test_lerobot_camera_batch_selection_is_read_by_membership.py
@@ -1,0 +1,232 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``capture_batch`` reads its camera selection by membership, never by truthiness.
+
+``camera_ids`` selects the cameras one ``lerobot_camera(action="capture_batch")``
+call opens. ``None`` is the documented spelling of "the default robot cameras",
+and the branch used to resolve it with ``if not camera_ids:`` - so every other
+falsy value took the same branch, and every truthy non-list was iterated as one.
+Measured on the pre-fix tree with the camera factory recording what it was asked
+to open:
+
+* ``camera_ids=[]`` - the selection a filter that matched nothing produces -
+  opened ``0`` and ``/dev/video4``, wrote two files, and reported
+  ``Success: 2/2 cameras`` under ``status="success"``;
+* ``camera_ids="/dev/video4"`` opened eleven one-character cameras on eleven
+  threads - ``/``, ``d``, ``e``, ``v`` ... - and reported eleven verdicts about
+  devices the caller never named rather than one about the parameter;
+* ``camera_ids=[0, 0]`` opened one device twice concurrently and wrote two files
+  for it, reported as two cameras;
+* ``camera_ids={"0": 1}`` was iterated over its keys, discarding the values.
+
+Each of those is refused now, by value, before the save directory is created,
+the thread pool is sized or a camera is opened. The controls pin what must not
+move: ``None`` still selects the two defaults, a well-formed list opens exactly
+the cameras it names, and an action that never reads ``camera_ids`` is not
+refused for it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+# The module object is needed for the factory seam the recorder replaces, so the
+# tool is reached through this alias rather than off the tools package.
+import strands_robots.tools.lerobot_camera as cam_mod
+
+
+class _Camera:
+    """A camera stand-in that answers a frame and nothing else."""
+
+    width = 8
+    height = 6
+    fps = 30
+
+    def connect(self, warmup: bool = True) -> None:
+        return None
+
+    def disconnect(self) -> None:
+        return None
+
+    def read(self) -> np.ndarray:
+        return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+    def async_read(self, timeout_ms: float = 1000) -> np.ndarray:
+        return self.read()
+
+
+@pytest.fixture
+def opened(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Replace the camera factory and record every camera id it is asked to open."""
+    ids: list[Any] = []
+
+    def _create(camera_type: str, camera_id: Any, *selectors: Any) -> _Camera:
+        ids.append(camera_id)
+        return _Camera()
+
+    monkeypatch.setattr(cam_mod, "_create_camera", _create)
+    return ids
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+def _capture_batch(save_path: Path, **kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool with agent-shaped values.
+
+    The values under test are deliberately outside the ``list[int | str] | None``
+    annotation - a bare string, a mapping, an iterator - so the one ``**kwargs:
+    Any`` funnel states that once rather than suppressing it per call.
+    """
+    return cam_mod.lerobot_camera(
+        action="capture_batch",
+        save_path=str(save_path),
+        async_mode=False,
+        **kwargs,
+    )
+
+
+# What ``None`` selected before and after: the documented default robot cameras.
+DEFAULT_ROBOT_CAMERAS: list[int | str] = [0, "/dev/video4"]
+
+# Every spelling the selection cannot honor as written, with the reason each is
+# refused for. ``0`` is a bare int: not a sequence, so it is refused for its shape
+# rather than iterated.
+UNHONORABLE: list[tuple[str, Any]] = [
+    ("an empty selection", []),
+    ("an empty tuple", ()),
+    ("a single path as a bare string", "/dev/video4"),
+    ("a single index as a bare string", "0"),
+    ("bytes", b"/dev/video0"),
+    ("a mapping", {"0": 1}),
+    ("a one-shot iterator", iter([0])),
+    ("a bare int", 0),
+    ("a repeated index", [0, 0]),
+    ("a repeated path", ["/dev/video0", "/dev/video0"]),
+    ("a bool entry", [True]),
+    ("a float entry", [1.5]),
+    ("a None entry", [None]),
+    ("a blank path entry", [""]),
+    ("a whitespace path entry", ["   "]),
+]
+
+
+class TestAnUnhonorableSelectionIsRefusedBeforeAnyCameraOpens:
+    @pytest.mark.parametrize(("reason", "camera_ids"), UNHONORABLE, ids=[r for r, _ in UNHONORABLE])
+    def test_refused_by_value(self, opened: list[Any], tmp_path: Path, reason: str, camera_ids: Any) -> None:
+        save_path = tmp_path / "captures"
+
+        result = _capture_batch(save_path, camera_ids=camera_ids)
+
+        assert result["status"] == "error", reason
+        text = _text(result)
+        assert "camera_ids" in text, text
+        assert "capture_batch" in text, text
+        # The refusal has no partial effect: no camera was opened and the save
+        # directory the batch would have created does not exist.
+        assert opened == [], (reason, opened)
+        assert not save_path.exists(), reason
+
+    def test_the_empty_selection_is_not_widened_to_the_defaults(self, opened: list[Any], tmp_path: Path) -> None:
+        result = _capture_batch(tmp_path / "captures", camera_ids=[])
+
+        text = _text(result)
+        assert "selects no camera" in text, text
+        # The remedy names the spelling that does select the defaults.
+        assert "Omit camera_ids" in text, text
+        assert opened == []
+
+    def test_a_bare_string_is_not_read_one_camera_per_character(self, opened: list[Any], tmp_path: Path) -> None:
+        result = _capture_batch(tmp_path / "captures", camera_ids="/dev/video4")
+
+        text = _text(result)
+        assert "one camera per character" in text, text
+        assert "['/dev/video4']" in text, text
+        assert opened == []
+
+    def test_a_repeat_names_the_id_repeated(self, opened: list[Any], tmp_path: Path) -> None:
+        result = _capture_batch(tmp_path / "captures", camera_ids=[2, "/dev/video0", 2])
+
+        text = _text(result)
+        assert "more than once" in text, text
+        assert "2" in text
+        assert opened == []
+
+
+class TestTheHonoredSpellingsAreUnchanged:
+    def test_none_selects_the_default_robot_cameras(self, opened: list[Any], tmp_path: Path) -> None:
+        result = _capture_batch(tmp_path / "captures", camera_ids=None)
+
+        assert result["status"] == "success", _text(result)
+        # The literal rather than the module constant: this is a control, so it
+        # must hold on the pre-fix tree too, where the constant did not exist.
+        assert sorted(map(str, opened)) == sorted(map(str, DEFAULT_ROBOT_CAMERAS))
+
+    def test_omitting_the_selector_is_the_same_as_none(self, opened: list[Any], tmp_path: Path) -> None:
+        result = _capture_batch(tmp_path / "captures")
+
+        assert result["status"] == "success", _text(result)
+        assert sorted(map(str, opened)) == sorted(map(str, DEFAULT_ROBOT_CAMERAS))
+
+    @pytest.mark.parametrize(
+        "camera_ids",
+        [
+            [0],
+            ["/dev/video0"],
+            [0, "/dev/video4"],
+            (3, 5),
+            [2, "/dev/video2"],
+        ],
+        ids=["one index", "one path", "the defaults spelled out", "a tuple", "an index and a path"],
+    )
+    def test_a_well_formed_selection_opens_exactly_the_cameras_it_names(
+        self, opened: list[Any], tmp_path: Path, camera_ids: Any
+    ) -> None:
+        result = _capture_batch(tmp_path / "captures", camera_ids=camera_ids)
+
+        assert result["status"] == "success", _text(result)
+        # Captures run on a thread pool, so the open order is not the list order;
+        # the SET of cameras opened, each once, is the claim.
+        assert sorted(map(str, opened)) == sorted(map(str, camera_ids))
+        assert f"Success: {len(camera_ids)}/{len(camera_ids)} cameras" in _text(result)
+
+    def test_the_refusal_quotes_the_defaults_the_tool_resolves(self) -> None:
+        """The message for ``[]`` names the cameras ``None`` selects, read from the one constant."""
+        assert list(cam_mod._DEFAULT_BATCH_CAMERA_IDS) == DEFAULT_ROBOT_CAMERAS
+
+        text = cam_mod._camera_ids_error([])
+
+        assert text is not None
+        assert repr(DEFAULT_ROBOT_CAMERAS) in text
+
+
+class TestOnlyTheActionThatReadsTheSelectorIsRefusedForIt:
+    def test_capture_ignores_camera_ids(self, opened: list[Any], tmp_path: Path) -> None:
+        """``capture`` reads ``camera_id``; an unusable ``camera_ids`` beside it is not its business."""
+        result = cam_mod.lerobot_camera(
+            action="capture",
+            camera_id=0,
+            camera_ids=[],
+            save_path=str(tmp_path / "captures"),
+            async_mode=False,
+        )
+
+        assert result["status"] == "success", _text(result)
+        assert opened == [0]
+
+    def test_list_ignores_camera_ids(self, opened: list[Any], tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            cam_mod, "_list_camera_details", lambda camera_type, camera_id: {"status": "success", "content": []}
+        )
+
+        # Off-annotation on purpose: the bare string capture_batch refuses.
+        unusable: Any = "/dev/video4"
+        result = cam_mod.lerobot_camera(action="list", camera_ids=unusable)
+
+        assert result["status"] == "success"
+        assert opened == []


### PR DESCRIPTION
`lerobot_camera(action="capture_batch")` resolved its `camera_ids` selector with `if not camera_ids:`. `None` is the documented spelling of "the default robot cameras", and truthiness put every other falsy value on that branch and iterated every truthy non-list as one. Same shape as #3305 an hour ago (a motor selector that names no motor), on an agent-callable tool.

## What was measured

Pre-fix tree (`94a3e04`), camera factory replaced with a recorder of what it was asked to open:

| `camera_ids` | cameras opened | tool result |
|---|---|---|
| `None` | `0`, `/dev/video4` | `success`, `2/2 cameras` (documented default) |
| `[]` | `0`, `/dev/video4` | `success`, `2/2 cameras` - **widened** |
| `"/dev/video4"` | `/ d e / v v i e o d 4` - eleven one-character cameras on eleven threads | `success`, `11/11 cameras` |
| `[0, 0]` | `0`, `0` - one device opened twice concurrently, two files | `success`, `2/2 cameras` |
| `{"0": 1}` | `"0"` - iterated over its keys, value discarded | `success`, `1/1 cameras` |

None of it is visible in the result: the request is honored, just not the one that was made. `[]` is the selection a filter that matched nothing produces, and a bare string is the spelling an agent most plausibly sends for one camera.

## The change

One site, `strands_robots/tools/lerobot_camera.py`:

- The branch reads `camera_ids is None` for the defaults, which move into `_DEFAULT_BATCH_CAMERA_IDS` so the documented default and the resolution cannot drift.
- Every other value goes through `_camera_ids_error`, local to the module (one caller, per AGENTS.md rule 11): a bare `str` or `bytes`, a `Mapping`, a non-`Sequence` (one-shot iterator), an empty selection, a `bool` or non-`int | str` entry, a blank path and a repeated id are each refused by value, naming the accepted shape and, for `[]`, the spelling that does select the defaults.
- The refusal precedes `validate_save_path` / `os.makedirs`, the `ThreadPoolExecutor` and `_create_camera`, so a refused selection has no partial effect.
- The tool's `Args:` entry for `camera_ids` states the emptiness verdict (rule 13: that entry is the schema the model reads).

`name_list_error` is deliberately not reused: a camera id is legitimately an `int` index as well as a path string, and that domain accepts names only. The docstring on the helper records that.

## Tests

`tests/tools/test_lerobot_camera_batch_selection_is_read_by_membership.py`, 28 cells:

| corner | tests | production | result |
|---|---|---|---|
| pre | pre | pre | 20 existing `lerobot_camera` cells green |
| B | **new** | pre | **19 failed**, 9 passed |
| C | new | new | 28 passed |
| D | pre | new | `tests/tools/ -k camera` + `Args:` parity graders: 542 passed, 1 skipped, 0 moved |

The 9 passing in B are the controls, and they must hold on both trees: `None` and an omitted selector still open exactly the two defaults (asserted against the literal, not the new constant), a well-formed list / tuple opens exactly the cameras it names, once each, and `capture` / `list` are not refused for a `camera_ids` they never read. The 15 unhonorable spellings each assert three things: `status == "error"`, zero cameras opened, and the save directory does not exist afterwards.

## Gate

| check | result |
|---|---|
| `ruff check` / `ruff format --check` on the two files | clean |
| `mypy` on the two files | `Success: no issues found` |
| `tests/test_log_strings_are_ascii.py`, `test_raises_docstring_completeness.py`, `test_agent_tool_parameter_descriptions.py` | 87 passed |
| `tests/test_changelog_fragments.py` | 28 passed |
| `scripts/check_whole_tree_graders.py` | 4238 passed; 47 failed / 149 errors, **identical set on `main`** (all `mujoco` absent on this host - 30 of the 47 are `test_unsized_value_is_refused_not_raised.py`, re-run on both trees: 30 failed / 62 passed each) |
| `check_duplicate_claim.py --all-open` | `unique-additions`, 6 open, 15 pairs |

## Siblings

#3307 also edits `lerobot_camera.py` - one line at `_configure_camera_settings` (`encoding="utf-8"` on a JSON write), ~1000 lines from this hunk. `git merge-tree --write-tree` of the two heads auto-merges with no conflict message, and neither change reads the other's.

## LOC

| file | +/- |
|---|---|
| `strands_robots/tools/lerobot_camera.py` | +104 / -3 (of which +12 executable; the rest is the helper's rationale and the `Args:` entry) |
| `tests/tools/test_lerobot_camera_batch_selection_is_read_by_membership.py` | +232 (new) |
| `changelog.d/3309-camera-batch-selector-names-no-camera.md` | +11 |

Opened as a draft and marked ready only after the fragment landed, so the fragment push cannot dismiss an approval (AGENTS.md step 3).