### PR TITLE
fix(policies/vera): a docker query the readiness wait makes states a bound

### DIFF
--- a/changelog.d/3312-vera-docker-query-bound.md
+++ b/changelog.d/3312-vera-docker-query-bound.md
@@ -1,0 +1,18 @@
+### Fixed: the VERA docker readiness wait can reach its own deadline
+
+`DockerServerRunner._wait_until_ready` polls `while time.monotonic() < deadline`
+and made two blocking calls one line apart inside that loop: `_port_open`, bounded
+at 1 s, and `_container_running`, which ran `docker ps` with no bound. A docker
+client whose daemon has stopped answering blocks in that read, so the deadline was
+never re-evaluated - the wait that documents "or raise on timeout" could not reach
+its timeout, and because the raise is what calls `stop()`, the container it had
+just launched was never torn down. Measured with `server_ready_timeout=3.0` (a
+value every check on the config accepts) and an unresponsive daemon, the wait was
+still blocked at ten times the budget, having probed the port zero times.
+
+Every `docker` *query* now states the same 10 s bound `docker logs` already used,
+and a query that does not answer raises `docker did not answer 'ps' for container
+... within 10s, so whether it is running is unknown` and tears the container down.
+That is its own cause rather than the "exited before becoming ready" the wait
+reported from a `False` it never received. `docker run` is not a query and stays
+unbounded: it may pull the image, and it runs before any readiness budget starts.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -230,6 +230,18 @@ and instantly tears it down. `inf` is refused for the opposite reason: it makes
 `while time.monotonic() < deadline` unable to end, and the raise that ends it is
 what tears the launched server down.
 
+Under `server_mode="docker"` that budget also needs the loop's own calls to
+return. The wait probes the port (bounded at 1 s) and asks the daemon whether the
+container is still listed, and a docker client whose daemon has stopped answering
+— a wedged container runtime shim leaves the container running and the daemon
+mute — blocks in that second call, so the deadline is never re-read. Every
+`docker` *query* is therefore bounded at 10 s, and one that does not answer
+raises `docker did not answer 'ps' for container ... within 10s, so whether it is
+running is unknown` and tears down the container the runner launched. That is
+reported as its own cause rather than as the container having exited, which is an
+answer the query never got. `docker run` is not a query and stays unbounded: it
+may pull the image, and it runs before any readiness budget starts.
+
 `motion_plan_scale` takes the same domain as the two IK scales below: a positive
 finite number, or `None` to leave the server's own scale alone. `0` is not the
 opt-out — it scales the plan to nothing — so `None` is the off switch and `0` is

--- a/strands_robots/policies/vera/server_runner.py
+++ b/strands_robots/policies/vera/server_runner.py
@@ -61,6 +61,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Seconds one ``docker`` *query* may take to answer. A query asks the daemon
+# something (is this container listed, what did it log); it is not the container
+# doing work, so it either answers in well under a second or the daemon is not
+# answering at all - a wedged containerd or GPU runtime shim is the usual cause
+# on the hosts this server runs on, and the container it manages can keep
+# running through it. ``_tail_logs`` and ``stop`` already bound their queries;
+# this names the bound so the readiness wait can share it. The ``docker run``
+# that launches the container is deliberately NOT a query: it may pull the
+# image, which is legitimately long, and it happens before any readiness
+# budget starts.
+_DOCKER_QUERY_TIMEOUT = 10.0
+
 
 def _port_open(host: str, port: int, timeout: float = 1.0) -> bool:
     """True if a TCP connection to ``host:port`` succeeds (server is listening)."""
@@ -271,15 +283,35 @@ class DockerServerRunner:
         return self.config.docker_container_name or f"vera-server-{self.config.embodiment}"
 
     def _container_running(self) -> bool:
+        """True while the daemon lists the named container as running.
+
+        Raises:
+            RuntimeError: if the daemon does not answer within
+                :data:`_DOCKER_QUERY_TIMEOUT`. Whether the container is running
+                is then unknown, and ``False`` would be an answer this call did
+                not get: it is the one the readiness wait reports as "exited
+                before becoming ready", naming a cause that may not have
+                happened.
+        """
         import subprocess
 
         name = self._container_name()
-        out = subprocess.run(  # noqa: S603 - list args, no shell
-            [self._docker(), "ps", "--filter", f"name=^{name}$", "--format", "{{.Names}}"],
-            capture_output=True,
-            text=True,
-            errors="replace",
-        )
+        try:
+            out = subprocess.run(  # noqa: S603 - list args, no shell
+                [self._docker(), "ps", "--filter", f"name=^{name}$", "--format", "{{.Names}}"],
+                capture_output=True,
+                text=True,
+                errors="replace",
+                timeout=_DOCKER_QUERY_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(
+                f"docker did not answer 'ps' for container {name} within "
+                f"{_DOCKER_QUERY_TIMEOUT:.0f}s, so whether it is running is unknown. "
+                "The daemon is unresponsive - check 'docker info' and the docker "
+                "service; a wedged container runtime shim does not stop the "
+                "container, only the daemon's answers about it."
+            ) from e
         return name in out.stdout.split()
 
     def _build_run_command(self) -> list[str]:
@@ -353,7 +385,16 @@ class DockerServerRunner:
     # -- lifecycle ----------------------------------------------------------
 
     def is_running(self) -> bool:
-        """Return True while the server container is running."""
+        """Return True while the server container is running.
+
+        Raises:
+            RuntimeError: if the ``docker`` daemon does not answer the query
+                within :data:`_DOCKER_QUERY_TIMEOUT` (see
+                :meth:`_container_running`). The subprocess runner's
+                :meth:`VeraServerRunner.is_running` reads ``Popen.poll()`` and
+                cannot block; this one asks another process, so it can only
+                report an answer it actually got.
+        """
         return self._container_running()
 
     def start(self) -> None:
@@ -387,11 +428,22 @@ class DockerServerRunner:
         assert timeout is not None  # guaranteed by VeraConfig.__post_init__
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if self._started_container and not self._container_running():
-                logs = self._tail_logs()
-                raise RuntimeError(
-                    f"VERA container {self._container_name()} exited before becoming ready. Last logs:\n{logs}"
-                )
+            if self._started_container:
+                try:
+                    alive = self._container_running()
+                except RuntimeError:
+                    # The daemon stopped answering. Both blocking calls in this
+                    # loop body are bounded so the deadline above is reached and
+                    # not merely written, and giving up here tears down the
+                    # container this runner launched for the same reason the
+                    # timeout below does.
+                    self.stop()
+                    raise
+                if not alive:
+                    logs = self._tail_logs()
+                    raise RuntimeError(
+                        f"VERA container {self._container_name()} exited before becoming ready. Last logs:\n{logs}"
+                    )
             if _port_open(cfg.host, int(cfg.server_port or 0)):
                 logger.info("VERA server ready on %s:%s", cfg.host, cfg.server_port)
                 return
@@ -412,7 +464,7 @@ class DockerServerRunner:
                 capture_output=True,
                 text=True,
                 errors="replace",
-                timeout=10,
+                timeout=_DOCKER_QUERY_TIMEOUT,
             )
             return (out.stdout + out.stderr).strip()
         except Exception as e:  # noqa: BLE001

--- a/tests/policies/vera/test_docker_daemon_queries_are_bounded.py
+++ b/tests/policies/vera/test_docker_daemon_queries_are_bounded.py
@@ -1,0 +1,220 @@
+"""A ``docker`` query the readiness wait makes is bounded, like the port probe beside it.
+
+:meth:`~strands_robots.policies.vera.server_runner.DockerServerRunner._wait_until_ready`
+polls ``while time.monotonic() < deadline``, and its loop body makes two
+blocking calls one line apart: ``_port_open``, which carries ``timeout=1.0``,
+and ``_container_running``, which ran ``docker ps`` with no bound at all. A
+docker client whose daemon has stopped answering blocks in that read, so the
+deadline was never re-evaluated: the wait that documents "or raise on timeout"
+could not reach its own timeout, and because the raise is what calls
+:meth:`stop`, the container it had just launched was never torn down either.
+
+That is the same harm ``test_vera_server_ready_timeout_domain`` closed for
+``inf`` and ``nan`` budgets, reachable here with a budget that passes every
+check :class:`~strands_robots.policies.vera.VeraConfig` makes. Measured on
+``977019449`` with ``server_ready_timeout=3.0`` (legal, resolved, checked) and a
+``docker`` executable that never returns:
+
+| tree | outcome | wall time | port probes |
+| --- | --- | --- | --- |
+| before | **still blocked** | stopped observing at 5x the budget | 0 |
+| after | ``RuntimeError`` "docker did not answer 'ps' ... within 10s" | 40.0 s | 0 |
+
+Zero probes both ways because the daemon query is the *first* statement in the
+loop body: the readiness check the wait exists to perform never ran once. The
+40 s is one query bound (10 s) plus the teardown's own pre-existing
+``docker stop`` bound (30 s, which logs a warning and does not extend); both
+are finite, which is the whole difference.
+
+The two remaining docker calls in the class were already bounded (``docker
+logs`` at 10 s, ``docker stop`` at 30 s), so this is the one query on the
+budgeted path that was not. ``docker run`` stays unbounded on purpose: it may
+pull the image, which is legitimately long, and it happens before any readiness
+budget starts.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import subprocess
+import time
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.vera import VeraConfig
+from strands_robots.policies.vera import server_runner as sr
+
+# A budget every check on the config accepts, short enough that a wait which
+# honours it cannot be confused with one that hangs.
+LEGAL_BUDGET = 3.0
+
+
+class _UnboundedQuery(AssertionError):
+    """Raised in place of the block a real unbounded docker query performs.
+
+    A test cannot wait out the real thing, so the fake stands in for it: a
+    query that states no bound is one the daemon can keep forever, and the
+    substitute says so instead of hanging the suite.
+    """
+
+
+def _daemon_that_never_answers(seen: list[dict[str, Any]]):
+    """A ``subprocess.run`` whose child never answers, honouring any bound given."""
+
+    def _run(cmd, **kwargs):
+        seen.append({"cmd": list(cmd), **kwargs})
+        timeout = kwargs.get("timeout")
+        if timeout is None:
+            raise _UnboundedQuery(
+                f"{' '.join(str(c) for c in cmd)} states no timeout, so this call "
+                "never returns while the daemon is unresponsive"
+            )
+        time.sleep(min(float(timeout), 0.01))
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    return _run
+
+
+def _recording_run(seen: list[dict[str, Any]]):
+    """A ``subprocess.run`` that answers immediately and records its kwargs."""
+
+    def _run(cmd, **kwargs):
+        seen.append({"cmd": list(cmd), **kwargs})
+        return _FakeCompleted()
+
+    return _run
+
+
+class _FakeCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _runner(**overrides) -> sr.DockerServerRunner:
+    cfg = VeraConfig(embodiment="pusht", server_mode="docker", **overrides)
+    runner = sr.DockerServerRunner(cfg)
+    runner._docker = lambda: "/usr/bin/docker"  # type: ignore[method-assign]
+    return runner
+
+
+class TestEveryQueryStatesABound:
+    """A call that asks the daemon a question states how long it will wait."""
+
+    @pytest.mark.parametrize("verb", ["ps", "logs"])
+    def test_query_passes_the_shared_bound(self, monkeypatch, verb):
+        seen: list[dict[str, Any]] = []
+        monkeypatch.setattr(sr.subprocess, "run", _recording_run(seen))
+        runner = _runner()
+        if verb == "ps":
+            runner.is_running()
+        else:
+            runner._tail_logs()
+        (call,) = [c for c in seen if verb in c["cmd"]]
+        assert call["timeout"] == sr._DOCKER_QUERY_TIMEOUT
+
+    def test_the_launch_is_not_a_query_and_states_no_bound(self, monkeypatch):
+        # `docker run` may pull the image, so it has no defensible bound and is
+        # not on the budgeted loop. Pinned so the asymmetry is a decision.
+        seen: list[dict[str, Any]] = []
+        monkeypatch.setattr(sr, "_port_open", lambda *a, **k: False)
+        monkeypatch.setattr(sr.subprocess, "run", _recording_run(seen))
+        runner = _runner(docker_image="vera:latest")
+        monkeypatch.setattr(runner, "_container_running", lambda: False)
+        monkeypatch.setattr(runner, "_wait_until_ready", lambda: None)
+        runner.start()
+        (launch,) = [c for c in seen if "run" in c["cmd"]]
+        assert "timeout" not in launch
+
+    def test_no_docker_query_in_the_module_omits_a_timeout(self):
+        """Completeness: every ``docker <verb>`` argv built inline states a bound.
+
+        A query names its verb as a literal in the argv it passes; the launch
+        builds its argv in ``_build_run_command`` and so is not matched here.
+        """
+        source = pathlib.Path(inspect.getfile(sr)).read_text(encoding="utf-8")
+        verbs = {"ps", "logs", "stop", "inspect", "kill", "rm"}
+        unbounded, queries = [], []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "run"):
+                continue
+            if not node.args or not isinstance(node.args[0], ast.List):
+                continue
+            named = {e.value for e in node.args[0].elts if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+            if not named & verbs:
+                continue
+            queries.append(sorted(named & verbs))
+            if "timeout" not in {kw.arg for kw in node.keywords}:
+                unbounded.append((node.lineno, sorted(named & verbs)))
+        assert len(queries) >= 3, f"matcher found only {queries}; the roster cannot be empty"
+        assert unbounded == [], f"unbounded docker queries: {unbounded}"
+
+
+class TestTheWaitEndsWhenTheDaemonStopsAnswering:
+    def _wait_with_dead_daemon(self, monkeypatch) -> tuple[sr.DockerServerRunner, list[Any], list[Any]]:
+        seen: list[dict[str, Any]] = []
+        stopped: list[Any] = []
+        probes: list[float] = []
+        runner = _runner(server_ready_timeout=LEGAL_BUDGET)
+        runner._started_container = True  # we launched it, so we own teardown
+        monkeypatch.setattr(sr.subprocess, "run", _daemon_that_never_answers(seen))
+
+        def _never_open(*_a: Any, **_k: Any) -> bool:
+            probes.append(time.monotonic())
+            return False
+
+        monkeypatch.setattr(sr, "_port_open", _never_open)
+        monkeypatch.setattr(runner, "stop", lambda: stopped.append(True))
+        return runner, stopped, probes
+
+    def test_it_raises_instead_of_polling_forever(self, monkeypatch):
+        runner, _stopped, _probes = self._wait_with_dead_daemon(monkeypatch)
+        with pytest.raises(RuntimeError, match=r"docker did not answer 'ps'"):
+            runner._wait_until_ready()
+
+    def test_an_answer_it_never_got_is_not_reported_as_a_container_that_exited(self, monkeypatch):
+        runner, _stopped, _probes = self._wait_with_dead_daemon(monkeypatch)
+        with pytest.raises(RuntimeError) as excinfo:
+            runner._wait_until_ready()
+        assert "exited before becoming ready" not in str(excinfo.value)
+        assert "unresponsive" in str(excinfo.value)
+
+    def test_giving_up_tears_down_the_container_it_launched(self, monkeypatch):
+        runner, stopped, _probes = self._wait_with_dead_daemon(monkeypatch)
+        with pytest.raises(RuntimeError):
+            runner._wait_until_ready()
+        assert stopped == [True], "the documented timeout path stops what it started; so must this one"
+
+    def test_a_container_we_did_not_launch_is_never_queried(self, monkeypatch):
+        runner, _stopped, probes = self._wait_with_dead_daemon(monkeypatch)
+        runner._started_container = False
+        runner.config.server_ready_timeout = 1.0  # nothing to query, so nothing to wait out
+        with pytest.raises(TimeoutError, match="did not become ready"):
+            runner._wait_until_ready()
+        assert probes, "the port must still be probed for a pre-existing container"
+
+
+class TestADaemonThatAnswersIsUnchanged:
+    @pytest.mark.parametrize(
+        ("stdout", "expected"),
+        [("vera-server-pusht\n", True), ("other\n", False), ("", False)],
+    )
+    def test_running_verdict_reads_the_same_output(self, monkeypatch, stdout, expected):
+        monkeypatch.setattr(sr.subprocess, "run", lambda *a, **k: _FakeCompleted(stdout=stdout))
+        assert _runner().is_running() is expected
+
+    def test_a_container_that_really_exited_still_reports_its_logs(self, monkeypatch):
+        runner = _runner(server_ready_timeout=LEGAL_BUDGET)
+        runner._started_container = True
+        monkeypatch.setattr(sr, "_port_open", lambda *a, **k: False)
+        monkeypatch.setattr(sr.subprocess, "run", lambda *a, **k: _FakeCompleted(stdout="other\n"))
+        monkeypatch.setattr(runner, "_tail_logs", lambda lines=40: "boom: CUDA OOM")
+        with pytest.raises(RuntimeError, match="exited before becoming ready"):
+            runner._wait_until_ready()


### PR DESCRIPTION
## The wait could not reach its own deadline

`DockerServerRunner._wait_until_ready` polls `while time.monotonic() < deadline`, and its loop body makes **two blocking calls one line apart**:

```python
while time.monotonic() < deadline:
    if self._started_container and not self._container_running():   # docker ps  -- no bound
        ...
    if _port_open(cfg.host, int(cfg.server_port or 0)):             # timeout=1.0
        return
    time.sleep(2.0)
```

A docker client whose daemon has stopped answering blocks in that first read, so the deadline is never re-evaluated. The wait that documents *"or raise on timeout"* cannot reach its own timeout, and because the raise is what calls `stop()`, the container it had just launched is never torn down either.

![measured timeline](https://raw.githubusercontent.com/cagataycali/robots/assets/vera-docker-query-bound/docs/assets/vera-docker-query-bound.png)

Measured with `server_ready_timeout=3.0` -- a value every check `VeraConfig.__post_init__` makes accepts -- and a `docker` executable that never returns. Same child script both columns, only the tree differs:

| tree | outcome | wall time | port probes |
| --- | --- | --- | --- |
| before | **still blocked** | observation stopped at 30.0 s (10x the budget) | 0 |
| after | `RuntimeError` at 10 s, returns at **40.03 s** | 40.03 s | 0 |

Zero probes both ways because the daemon query is the *first* statement in the loop body: the readiness check the wait exists to perform never ran once. The 40 s is one query bound (10 s) plus the teardown's own pre-existing `docker stop` bound (30 s, which logs a warning and does not extend). Both are finite, which is the whole difference.

This is the harm `tests/policies/vera/test_vera_server_ready_timeout_domain.py` closed for `inf` and `nan` budgets -- *"`deadline` becomes infinite, so `while time.monotonic() < deadline` cannot end ... the server it had just launched is never torn down"* -- reachable through the wall clock instead of the config, with a budget that passes every check.

## Change

The class already bounded its other two daemon queries (`docker logs` at 10 s, `docker stop` at 30 s). The one on the budgeted path did not.

- `_DOCKER_QUERY_TIMEOUT = 10.0` names the bound a *query* takes -- asking the daemon something, not the container doing work -- and `_tail_logs` now uses it instead of a bare `10`.
- `_container_running` passes it, and a query the daemon does not answer raises `docker did not answer 'ps' for container ... within 10s, so whether it is running is unknown` instead of returning `False`. `False` is an answer this call did not get, and it is the one the wait reports as `exited before becoming ready` -- naming a cause that may not have happened, since a wedged runtime shim silences the daemon without stopping the container.
- `_wait_until_ready` tears the container down before re-raising, as the documented timeout path does.
- `is_running()` documents that it can raise: the subprocess runner's reads `Popen.poll()` and cannot block, this one asks another process and can only report an answer it got.
- `docker run` stays unbounded on purpose -- it may pull the image, and it runs before any readiness budget starts. Pinned as a decision, not an omission.

## Tests

`tests/policies/vera/test_docker_daemon_queries_are_bounded.py`, 12 cells, **6 red on `977019449`**:

| pre-fix | cell |
| --- | --- |
| `KeyError: 'timeout'` | `docker ps` states the shared bound |
| `AttributeError: _DOCKER_QUERY_TIMEOUT` | `docker logs` states the shared bound |
| `unbounded docker queries: [(277, ['ps'])]` | AST completeness: no `docker <verb>` argv in the module omits a bound |
| never returns | the wait raises instead of polling forever |
| never returns | an answer it never got is not reported as a container that exited |
| never returns | giving up tears down the container it launched |

The other 6 are the controls and pass both ways -- the launch is not a query, a container we did not launch is never queried, and a daemon that answers gives the same three verdicts and still reports a real exit with its logs. A test cannot wait out a genuinely unbounded call, so the fake `subprocess.run` raises `_UnboundedQuery("... states no timeout, so this call never returns while the daemon is unresponsive")` in its place; the wall-clock numbers above come from a real hanging child.

## Gate

`ruff check` + `ruff format --check` clean (1942 files). `mypy` 20 errors / 6 files, unchanged from base. 58-module net (`policies.vera|VeraConfig|server_runner|_port_open|_wait_until_ready|server_ready_timeout`): base **1F/2001P**, this branch **1F/2013P** (+12 = exactly the new cells), the one failure identical both ways (`qpsolvers` not installed locally). `scripts/check_whole_tree_graders.py`: 4674 passed, 17 known drift rows (`awsiot`/`qpsolvers` absent, `websockets` floor, lerobot 0.6.2 dataset drift), none in `vera` or touching `docker`.

**LOC** +315 / -13. Production change is +65/-13 in `server_runner.py`; the rest is the pin (220), the docs paragraph (12) and the fragment (18).