### PR TITLE
test(policies/vera): the shared docker query bound is one a healthy daemon can meet

### DIFF
--- a/changelog.d/3314-vera-docker-query-bound-usable.md
+++ b/changelog.d/3314-vera-docker-query-bound-usable.md
@@ -1,0 +1,25 @@
+### Tests: the shared VERA docker query bound is held to a span a healthy daemon can meet
+
+`_DOCKER_QUERY_TIMEOUT` is what lets `DockerServerRunner`'s readiness wait reach
+its own deadline instead of merely writing it. That the queries state a bound, and
+that a daemon which does not answer inside it is reported rather than answered
+for, is graded. Two properties of the bound itself were not, both measured by
+mutating `server_runner.py` and running the existing file alone.
+
+A bound of `0.0` is an over-correction rather than a return to the old state:
+`subprocess.run(timeout=0.0)` raises `TimeoutExpired` before the child can answer,
+so every query fails against a perfectly healthy daemon and `server_mode="docker"`
+stops working altogether - and the twelve existing cells all still passed. It is
+invisible where the daemon is a callable standing in for `subprocess.run`, because
+no bound is ever applied to a real child; the control added here invokes a real
+executable that answers promptly, for both the running and the not-running
+verdict, which is what makes "bounded" distinguishable from "refuses everything".
+`None` is the other end of the same axis.
+
+The log read reverting to its own literal `10` also left all twelve passing,
+because `10 == 10.0` satisfies a cell comparing the value. The constant's comment
+describes the probe and the log read as sharing one bound, so a cell now holds
+them to it and a future change to the bound cannot leave one behind.
+
+`docker run` is still not a query and still states no bound, and the SIGTERM grace
+period `stop` waits out keeps its own larger one; neither is in scope.

--- a/tests/policies/vera/test_docker_query_bound_is_usable.py
+++ b/tests/policies/vera/test_docker_query_bound_is_usable.py
@@ -1,0 +1,102 @@
+"""The bound a ``docker`` query states must be one a healthy daemon can meet.
+
+:data:`~strands_robots.policies.vera.server_runner._DOCKER_QUERY_TIMEOUT` is what
+stops an unresponsive daemon from leaving ``DockerServerRunner``'s readiness wait
+unable to reach its own deadline. That the queries *state* a bound, and that a
+daemon which does not answer inside it is reported rather than answered for, is
+graded by ``test_docker_daemon_queries_are_bounded``. Two properties of the bound
+itself were not, and both were measured by mutating ``server_runner.py`` and
+running that file alone -- nine mutations, control 0, ``collected`` stable at 12:
+
+| mutation | cells it fired there |
+| --- | --- |
+| probe unbounded again | 5 |
+| timeout answered ``False`` instead of reported | 3 |
+| over-reach: bound the launch too | 1 |
+| raw ``TimeoutExpired`` escapes | 3 |
+| drop the launched-container teardown | 1 |
+| the bound is ``None`` | 3 |
+| ``_tail_logs`` back on its own literal ``10`` | **0** |
+| the bound is ``0.0`` | **0** |
+
+**A bound of ``0.0``** is the one worth a cell, because it is an over-correction
+rather than a return to the old state: ``subprocess.run(timeout=0.0)`` raises
+``TimeoutExpired`` before the child can answer, so every query fails against a
+perfectly healthy daemon and ``server_mode="docker"`` stops working altogether.
+It goes unseen where the daemon is a callable standing in for ``subprocess.run``,
+because no real bound is ever applied to a real child; the control below runs a
+real executable that answers promptly, which is what makes the difference between
+"bounded" and "refuses everything" observable. ``None`` is the other end of the
+same axis and is caught by the same assertion.
+
+**``_tail_logs`` back on a literal** passes there because ``10 == 10.0``, so a log
+read that stops reading the constant still satisfies a cell comparing its value.
+The constant's own comment describes the two reads as sharing one bound; this
+holds them to it.
+
+The launch keeps no bound, and the SIGTERM grace period ``stop`` waits out keeps
+its own larger one -- neither is a query, and neither is in scope here.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from strands_robots.policies.vera import VeraConfig
+from strands_robots.policies.vera import server_runner as sr
+
+
+def _docker_that_answers(tmp_path: Path, stdout: str) -> Path:
+    """A real executable that answers ``docker ps`` promptly on stdout.
+
+    A real child is the point: the bound is handed to ``subprocess.run``, so only
+    a real process being waited on can tell a usable bound from one that refuses
+    every answer before it arrives.
+    """
+    exe = tmp_path / "docker"
+    exe.write_text(f"#!/bin/sh\nprintf '{stdout}\\n'\n", encoding="utf-8")
+    exe.chmod(0o755)
+    return exe
+
+
+def _runner(exe: Path) -> sr.DockerServerRunner:
+    runner = sr.DockerServerRunner(VeraConfig(embodiment="pusht", server_mode="docker"))
+    runner._docker = lambda: str(exe)  # type: ignore[method-assign]
+    return runner
+
+
+class TestTheBoundIsOneAHealthyDaemonCanMeet:
+    """A bound that no answer can arrive inside refuses the daemon, not the wedge."""
+
+    def test_the_bound_is_a_positive_finite_span_of_seconds(self) -> None:
+        """``None`` is no bound at all and ``0`` refuses every query."""
+        bound = sr._DOCKER_QUERY_TIMEOUT
+        assert isinstance(bound, float), f"the shared query bound is {bound!r}, which states no span"
+        assert bound > 0, (
+            f"a query bound of {bound!r} raises TimeoutExpired before any answer can arrive, so "
+            "every docker query fails against a healthy daemon"
+        )
+
+    @pytest.mark.parametrize("running", [True, False])
+    def test_a_daemon_that_answers_promptly_is_still_read(self, running: bool, tmp_path: Path) -> None:
+        """The control, driven through a real child so the bound is really applied.
+
+        Both verdicts matter: an unusable bound refuses the answer whatever it
+        would have said, so a cell that only checked the running case would read
+        an inverted verdict as success.
+        """
+        listed = "vera-server-pusht" if running else "some-other-container"
+        assert _runner(_docker_that_answers(tmp_path, listed)).is_running() is running
+
+
+class TestBothDaemonReadsShareTheOneBound:
+    """The probe and the log read are one bound, so neither drifts from the other."""
+
+    def test_the_log_read_reads_the_constant(self) -> None:
+        body = inspect.getsource(sr.DockerServerRunner._tail_logs)
+        assert "_DOCKER_QUERY_TIMEOUT" in body, (
+            "the log read carries its own literal, so raising or lowering the shared bound silently leaves it behind"
+        )


### PR DESCRIPTION
Follow-up to #3312. That change gave every `docker` *query* in `DockerServerRunner` a shared bound, `_DOCKER_QUERY_TIMEOUT`, so the readiness wait can reach its own deadline instead of merely writing it. Its suite grades that the queries state a bound and that an unresponsive daemon is reported rather than answered for. Two properties of the bound *itself* are not graded, and one of them is the failure mode a bound introduces.

Test-only: no production change.

## Measured: what the existing twelve cells cannot see

Nine mutations of `server_runner.py`, each run against `test_docker_daemon_queries_are_bounded.py` alone on `1603dc0a4`. Control 0, `collected` stable at 12 on every row.

| mutation of `server_runner.py` | existing cells fired |
| --- | --- |
| control | 0 |
| probe unbounded again | 5 |
| timeout answered `False` instead of reported | 3 |
| over-reach: bound the launch too | 1 |
| raw `TimeoutExpired` escapes | 3 |
| drop the launched-container teardown | 1 |
| `_DOCKER_QUERY_TIMEOUT = None` | 3 |
| **`_tail_logs` back on its own literal `10`** | **0** |
| **`_DOCKER_QUERY_TIMEOUT = 0.0`** | **0** |

## Why `0.0` is the one worth a cell

It is not a regression to the pre-#3312 state; it is the over-correction a bound makes possible. `subprocess.run(timeout=0.0)` raises `TimeoutExpired` before the child can answer, so **every** query fails against a perfectly healthy daemon, `is_running()` raises for both verdicts, and `server_mode="docker"` stops working altogether — with all twelve cells still green.

It is invisible there because the daemon stand-in is a callable substituted for `subprocess.run`, so no bound is ever applied to a real process. The control added here invokes a **real executable** that answers promptly, for both the running and the not-running verdict, which is what makes "bounded" distinguishable from "refuses every answer". `None` is the other end of the same axis and the same assertion covers it.

`_tail_logs` reverting to a literal also leaves all twelve green, because `10 == 10.0` satisfies a cell comparing the value. The constant's own comment describes the probe and the log read as sharing one bound ("this names the bound so the readiness wait can share it"); a cell now holds them to it, so raising or lowering the bound cannot silently leave one behind.

## Split, measured on `main` (`69440de9f`)

| tree | these 4 cells | the existing 12 |
| --- | --- | --- |
| unmodified | 4 passed | 12 passed |
| `_DOCKER_QUERY_TIMEOUT = 0.0` | **3 failed** | 12 passed |
| `_DOCKER_QUERY_TIMEOUT = None` | **1 failed** | 3 failed |
| `_tail_logs` on its own literal `10` | **1 failed** | 12 passed |

The `None` row is the one the existing suite already catches; this adds a second, naming fire rather than the only one. Each row fires a distinct set.

## Deliberately out of scope

`docker run` is still not a query and still states no bound — it may pull the image, and it runs before any readiness budget starts. The SIGTERM grace period `stop` waits out keeps its own larger bound. Both remain as #3312 left them.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1940 source files`.
- New file: 4 passed in 0.24 s.
- 488-file selection (every test that walks the tree or reads source, plus all of `tests/policies/vera`): **9 failed, 25992 passed, 68 skipped**. All 9 reproduce byte-identically on an unmodified `upstream/main` checkout and are environment-shaped — five assert `rclpy` is absent where it resolves, two read an installed `websockets` below the declared floor, two need a `docker` binary that is not present. None is attributable.

## Size

| file | + | - |
| --- | --- | --- |
| `tests/policies/vera/test_docker_query_bound_is_usable.py` | 102 | 0 |
| `changelog.d/3314-vera-docker-query-bound-usable.md` | 25 | 0 |

No production statements added or removed.