### PR TITLE
fix(packaging): the rover driver's HTTP transport is declared where an install reaches it

### DIFF
--- a/changelog.d/3315-earthrover-http-transport-declared.md
+++ b/changelog.d/3315-earthrover-http-transport-declared.md
@@ -1,0 +1,20 @@
+### Bug Fixes
+
+- **packaging**: the EarthRover native driver speaks HTTP to the vendor's
+  earth-rovers-sdk - `GET /data` is every read, `POST /control` is what drives
+  the rover - and no requirement named `requests`. The only bound the project
+  stated lived in `[tool.hatch.envs.default].dependencies`, a hatch development
+  environment that no install reaches. Measured against the lock, `requests` is
+  absent from the base install and from 26 of the 32 other extras; the six that
+  resolve to it reach it as a transitive of `lerobot` or `diffusers`, so
+  `[all]` supplied the rover transport by way of an unrelated machine learning
+  stack. A new `[earthrover]` extra declares it (folded into `[all]`: pure
+  Python, no build step), and `connect_eagerly()` now names that extra instead
+  of handing the reader a bare `pip install requests`. Pillow, msgpack and pyzmq
+  were pinned in the same development-only place; they are declared in
+  `[project.dependencies]`, `[groot-service]` and `[moveit2]`, so the duplicates
+  are gone and `tests/test_earthrover_http_extra_is_declared.py` refuses the
+  shape generally - a runtime distribution named only there is a second copy of
+  a bound that can drift from the one an install resolves, with `hatch run test`
+  green over the drift. No resolution changed: `uv lock` moves only the new
+  extra's entries.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ graph TB
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh |
 | `[mesh-iot]` | above + `awsiotsdk`, `awscrt`, `boto3` | AWS IoT Core transport |
-| `[all]` | 20 of the 32 extras - not a union; see [installation](getting-started/installation.md) for the 11 it leaves opt-in | CI / exploration |
+| `[all]` | 21 of the 33 extras - not a union; see [installation](getting-started/installation.md) for the 11 it leaves opt-in | CI / exploration |
 
 ## See also
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,14 +16,15 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 | `[lerobot]` | `lerobot>=0.6.1,<0.7.0`, `psutil>=6.0.0,<8.0.0` | `LerobotLocalPolicy` + dataset recording + the `lerobot_train` / `lerobot_teleoperate` session tools |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` (ZMQ to a GR00T container) |
 | `[cosmos3-service]` | `msgpack`, `websockets>=17.0` | `Cosmos3Policy` (WebSocket to Cosmos 3 server) |
+| `[earthrover]` | `requests>=2.28.0,<3.0.0` | `Robot("earthrover", mode="real", driver="strands")` - HTTP to the earth-rovers-sdk |
 | `[mesh]` | `eclipse-zenoh>=1.6.1,<2.0.0`, `json5` | Multi-robot mesh discovery + RPC |
 | `[mesh-iot]` | `mesh` + `awsiotsdk`, `awscrt`, `boto3` | AWS IoT Core transport for mesh |
-| `[all]` | 20 of the 32 extras - **not** a union. `[cosmos3-diffusers]`, `[cosmos3-service]`, `[cosmos3-sim]`, `[crazyflie]` (GPLv3), `[curobo]`, `[microduck]`, `[ros2]`, `[sim-gs]`, `[sim-isaac]`, `[sim-newton]` and `[vera-sim]` stay opt-in | Demos, CI, exploration |
+| `[all]` | 21 of the 33 extras - **not** a union. `[cosmos3-diffusers]`, `[cosmos3-service]`, `[cosmos3-sim]`, `[crazyflie]` (GPLv3), `[curobo]`, `[microduck]`, `[ros2]`, `[sim-gs]`, `[sim-isaac]`, `[sim-newton]` and `[vera-sim]` stay opt-in | Demos, CI, exploration |
 | `[dev]` | `pytest`, `pytest-cov`, `ruff`, `mypy`, `pytest-timeout` | Contributing |
 
 ```bash
 uv pip install "strands-robots[sim-mujoco]"                  # sim only
-uv pip install "strands-robots[all]"                         # the 20-extra bundle
+uv pip install "strands-robots[all]"                         # the 21-extra bundle
 uv pip install "strands-robots[sim-mujoco,cosmos3-service]"  # Cosmos 3
 uv pip install "strands-robots[sim-mujoco,lerobot,mesh]"     # pick and choose
 ```

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -169,6 +169,10 @@ by default; `driver="strands"` selects the native driver instead. That driver ta
 vendor's [earth-rovers-sdk](https://github.com/frodobots-org/earth-rovers-sdk) over HTTP,
 which proxies to the rover, and `port=` is that SDK's base URL.
 
+That transport is `requests`, supplied by `pip install 'strands-robots[earthrover]'`
+(a member of `[all]`). Without it the driver still imports and registers, and
+`connect_eagerly()` returns a reason naming the extra rather than raising.
+
 ```python
 from strands_robots import Robot
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,20 @@ microduck = [
 crazyflie = [
     "cflib>=0.1.25,<0.2.0",
 ]
+# HTTP transport for the EarthRover Mini Plus native driver
+# (strands_robots/drivers/earthrover.py). The driver talks to the vendor's
+# earth-rovers-sdk over HTTP -- GET /data for telemetry, POST /control to drive --
+# so `requests` is what makes a rover move, not a developer convenience. It is
+# gated (the module imports and registers without it, and connect_eagerly()
+# returns a reason naming this extra), which is why it is an extra rather than a
+# core dependency; but nothing else declares it, so before this extra existed the
+# only bound the project stated lived in [tool.hatch.envs.default], an
+# environment no install reaches. A member of [all]: pure Python, no build step,
+# and the driver's URL-property tests import requests to drive a real
+# http.server, so they run only where an install declares it.
+earthrover = [
+    "requests>=2.28.0,<3.0.0",
+]
 lerobot = [
     # [dataset] bundles the read-back stack the streaming data loop needs:
     # datasets + pandas + pyarrow (parquet streaming) + av + torchcodec
@@ -679,6 +693,7 @@ all = [
     "strands-robots[inference]",
     "strands-robots[rosbridge]",
     "strands-robots[sagemaker]",
+    "strands-robots[earthrover]",
     "strands-robots[dashboard]",
 ]
 dev = [
@@ -708,16 +723,20 @@ packages = ["strands_robots"]
 [tool.hatch.envs.default]
 installer = "uv"
 features = ["all"]
+# Development tooling only. `features = ["all"]` above installs the project and
+# every extra the bundle folds in, so a runtime distribution named here would be
+# a second copy of a bound that can drift from the one an install resolves --
+# with this environment (which is what `hatch run test` runs) staying green over
+# the drift. Pillow, msgpack, pyzmq and requests were such copies; they are
+# declared in [project.dependencies] and the [groot-service], [moveit2] and
+# [earthrover] extras respectively. Graded by
+# tests/test_earthrover_http_extra_is_declared.py.
 dependencies = [
     "pytest>=6.0,<10.0.0",
     "pytest-cov>=4.0.0,<6.0.0",
     "pytest-timeout>=2.0.0,<3.0.0",
     "ruff>=0.15.12,<0.16.0",
     "mypy>=1.0.0,<2.0.0",
-    "Pillow>=8.0.0,<13.0.0",
-    "requests>=2.28.0,<3.0.0",
-    "msgpack>=1.0.0,<2.0.0",
-    "pyzmq>=27.0.0,<28.0.0",
 ]
 
 # ---------------------------------------------------------------------------

--- a/strands_robots/drivers/earthrover.py
+++ b/strands_robots/drivers/earthrover.py
@@ -13,8 +13,11 @@ rover over WebRTC/RTM, and exposes four endpoints this driver speaks:
   ``{camera}_frame`` field.
 * ``POST /speak`` - text out of the rover's speaker.
 
-``requests`` is imported lazily so the module loads without it; a real
-connection needs it and a running SDK.
+``requests`` is the transport, declared by the ``[earthrover]`` extra
+(``pip install 'strands-robots[earthrover]'``, a member of ``[all]``). It is
+imported lazily so the module loads and registers without it; a real connection
+needs it and a running SDK, and :meth:`EarthRoverDriver.connect_eagerly` reports
+the absent extra rather than raising.
 
 Safety note: a rover is VELOCITY-commanded - unlike an arm, it does not hold
 still when you stop talking to it, and whether the firmware times a twist out
@@ -346,7 +349,10 @@ class EarthRoverDriver:
         try:
             import requests  # noqa: PLC0415 - lazy: the module must load without it
         except ImportError as exc:
-            self._connect_error = f"requests is not installed: {exc}. Install it with: pip install requests"
+            self._connect_error = (
+                f"cannot import requests ({exc}); the EarthRover native driver speaks HTTP to the "
+                "earth-rovers-sdk. Install it with: pip install 'strands-robots[earthrover]'"
+            )
             return self._connect_error
 
         session = requests.Session()

--- a/tests/test_earthrover_http_extra_is_declared.py
+++ b/tests/test_earthrover_http_extra_is_declared.py
@@ -1,0 +1,220 @@
+"""The rover driver's HTTP transport is declared where an install reaches it.
+
+``strands_robots/drivers/earthrover.py`` speaks HTTP to the vendor's
+earth-rovers-sdk: ``GET /data`` is the telemetry every read returns and
+``POST /control`` is what drives the rover. ``requests`` is that transport, so it
+is a requirement of using the driver at all -- and no requirement named it. The
+only bound the project stated lived in ``[tool.hatch.envs.default].dependencies``,
+a hatch development environment that no install reaches, alongside three more
+runtime distributions in the same shape.
+
+What that left, measured against the checked-in lock: ``requests`` is absent from
+the base install and from 26 of the 32 extras other than ``[all]``, and the six
+that do resolve to it -- ``[lerobot]``, ``[lerobot-async]``, ``[molmoact2]``,
+``[smolvla]``, ``[kimodo]`` and ``[cosmos3-diffusers]`` -- reach it as a
+transitive of an unrelated machine learning stack (``lerobot`` itself, or
+``diffusers``). So a rover install
+(``strands-robots``, or ``[mesh,device-connect]`` for a fleet) shipped the driver
+and none of its transport: ``connect_eagerly()`` returned "requests is not
+installed", every read answered its empty cache, every write refused "not
+connected", and the remedy printed was a bare ``pip install requests`` -- the only
+place in the drivers tree that hands a reader a distribution rather than an extra
+whose bound the project owns.
+
+The same gap reached the tests. ``tests/drivers/test_earthrover_base_url_addresses_the_host.py``
+opens ``pytest.importorskip("requests")`` and drives a real ``http.server`` to
+measure *which host* the driver dials -- the property behind the userinfo and
+``ws://`` refusals. Thirty-four cells sit behind that gate, and they ran because
+the development environment pinned the distribution and because ``[all]`` happens
+to carry ``diffusers``. Neither is a declaration, and the failure mode is quiet:
+with requests absent the whole module collapses to one ``1 skipped`` line, which
+reads the same as a suite that has nothing to say.
+
+So ``[earthrover]`` declares it, ``[all]`` folds it in (pure Python, no build
+step, and CI installs that bundle), the refusal names the extra the way
+``[crazyflie]``'s does, and the development environment is left with development
+tooling only. The last cell here is the general rule rather than the four names:
+**every distribution that environment declares must be tooling the ``[dev]``
+extra also declares.** A runtime distribution there is a second copy of a bound
+that can drift from the one an install resolves, with ``hatch run test`` -- the
+environment CI runs the suite in -- staying green over the drift.
+``tests/test_dashboard_extra_is_declared.py`` pins that shape for the five
+dashboard distributions after it shipped once; this generalizes it, because the
+next re-pin will not be one of those five.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+from strands_robots.drivers.earthrover import EarthRoverDriver
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_LOCK = _REPO_ROOT / "uv.lock"
+
+#: The extra that owns the transport, and the bundle that folds it in. Both must
+#: resolve to it: the first is the remedy the driver prints, the second is what
+#: CI installs and therefore what decides whether the URL-property cells run.
+_EXTRAS_SHIPPING_THE_TRANSPORT = ("earthrover", "all")
+
+
+def _manifest() -> dict:
+    with _PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)["project"]
+
+
+def _requirements(extra: str) -> list[Requirement]:
+    return [Requirement(text) for text in _manifest()["optional-dependencies"][extra]]
+
+
+def _development_environment_dependencies() -> list[Requirement]:
+    with _PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    declared = data["tool"]["hatch"]["envs"]["default"].get("dependencies", [])
+    return [Requirement(text) for text in declared]
+
+
+def _lock_closure(extra: str) -> frozenset[str]:
+    """Distributions an install of *extra* resolves to, walked over ``uv.lock``.
+
+    uv's own resolution of this manifest, so the claim that an extra supplies the
+    transport is checked rather than asserted, and offline. Markers are not
+    evaluated, which makes the result a superset -- the safe direction for a rule
+    that fails a manifest.
+    """
+    with _LOCK.open("rb") as handle:
+        locked = tomllib.load(handle)["package"]
+    by_name: dict[str, list[dict]] = {}
+    for package in locked:
+        by_name.setdefault(package["name"], []).append(package)
+
+    seen: set[tuple[str, tuple[str, ...]]] = set()
+    pending: list[tuple[str, tuple[str, ...]]] = [("strands-robots", (extra,))]
+    while pending:
+        name, extras = pending.pop()
+        if (name, extras) in seen:
+            continue
+        seen.add((name, extras))
+        for package in by_name.get(name, []):
+            entries = list(package.get("dependencies", []))
+            optional = package.get("optional-dependencies", {})
+            for group in extras:
+                entries += optional.get(group, [])
+            for entry in entries:
+                # uv spells the requested-extras key `extra`, singular.
+                requested = entry.get("extra", ())
+                asked = tuple(requested) if isinstance(requested, list) else (requested,)
+                pending.append((entry["name"], asked))
+    return frozenset(str(canonicalize_name(name)) for name, _ in seen)
+
+
+def test_the_extra_declares_the_http_transport() -> None:
+    """``[earthrover]`` names requests, with the bound the project owns."""
+    declared = [
+        requirement for requirement in _requirements("earthrover") if canonicalize_name(requirement.name) == "requests"
+    ]
+    assert declared, (
+        "the earthrover extra does not name requests, so the driver's own remedy "
+        "installs an environment where GET /data and POST /control still cannot be "
+        f"spoken. Declared: {[str(r) for r in _requirements('earthrover')]}"
+    )
+    specifiers = SpecifierSet(str(declared[0].specifier))
+    assert specifiers, f"requests is declared unbounded ({declared[0]}), so no install resolves a graded version"
+
+
+def test_the_bundle_folds_the_extra_in() -> None:
+    """``[all]`` declares the transport instead of inheriting it.
+
+    ``[all]`` already resolved to requests, through ``diffusers`` and ``lerobot``
+    -- an accident of an unrelated stack, and the reason the driver's URL-property
+    cells ran at all. Folding the extra in makes that a declaration, so dropping a
+    machine learning dependency cannot silently turn thirty-four measurements into
+    one skip.
+    """
+    assert "strands-robots[earthrover]" in _manifest()["optional-dependencies"]["all"], (
+        "[all] does not fold in [earthrover], so the bundle CI installs supplies "
+        "the rover transport only as long as some unrelated dependency keeps "
+        "pulling requests"
+    )
+
+
+@pytest.mark.parametrize("extra", _EXTRAS_SHIPPING_THE_TRANSPORT)
+def test_an_install_of_the_extra_locks_the_transport(extra: str) -> None:
+    """Each extra that must ship the transport resolves to it in the lock."""
+    closure = _lock_closure(extra)
+    assert "requests" in closure, (
+        f"[{extra}] locks {len(closure)} distributions and requests is not among "
+        "them, so an install of it ships the EarthRover driver and no transport for it"
+    )
+
+
+def test_the_installed_transport_satisfies_the_declared_bound() -> None:
+    """The requests an install resolves is inside the bound the extra states."""
+    requests = pytest.importorskip("requests")
+    declared = [
+        requirement for requirement in _requirements("earthrover") if canonicalize_name(requirement.name) == "requests"
+    ]
+    assert declared, "the earthrover extra declares no requests, so there is no bound to grade"
+    specifiers = SpecifierSet(str(declared[0].specifier))
+    assert Version(requests.__version__) in specifiers, (
+        f"the installed requests {requests.__version__} is outside the declared "
+        f"{specifiers}, so the bound describes a version no install resolves"
+    )
+
+
+def test_the_absent_transport_refuses_by_naming_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without requests the driver reports what supplies it, not a distribution.
+
+    Drives the real gate rather than reading the source: a ``None`` entry in
+    ``sys.modules`` is what makes ``import requests`` raise ``ImportError`` for an
+    installed module, which is the absence an install without the extra has.
+    """
+    monkeypatch.setitem(sys.modules, "requests", None)
+    driver = EarthRoverDriver(port="http://10.0.0.9:8001")
+
+    reason = driver.connect_eagerly()
+
+    assert reason is not None, "connect_eagerly reported success with no transport to speak"
+    assert "strands-robots[earthrover]" in reason, (
+        "the refusal does not name the extra that supplies requests, so the reader "
+        f"is handed a distribution whose bound this project does not own. Got: {reason!r}"
+    )
+    # The degrade is the documented contract, not a side effect: the driver stays
+    # usable and answers from its empty cache.
+    assert driver.read_state() == {}, "a driver that could not connect must read as empty, not raise"
+
+
+def test_the_development_environment_names_only_development_tooling() -> None:
+    """A runtime distribution in the hatch environment is a bound no install reaches.
+
+    The general rule, and why this file is not four assertions about four names.
+    That environment sets ``features = ["all"]``, so everything the suite needs at
+    runtime already arrives through a declared extra; a literal pin beside it is a
+    second copy that can drift from the one an install resolves, with
+    ``hatch run test`` green over the drift. Tooling is exempt because ``[dev]``
+    declares it and no install is expected to carry it.
+    """
+    tooling = {str(canonicalize_name(requirement.name)) for requirement in _requirements("dev")}
+    declared = _development_environment_dependencies()
+
+    # Non-vacuity: an environment declaring nothing would agree with everything.
+    assert len(declared) >= 5, f"the hatch environment declares only {[str(r) for r in declared]}; the scan has drifted"
+
+    runtime = sorted(
+        str(requirement) for requirement in declared if str(canonicalize_name(requirement.name)) not in tooling
+    )
+    assert not runtime, (
+        f"{runtime} are declared in [tool.hatch.envs.default].dependencies, which no "
+        "install reaches. Declare each in [project.dependencies] or in the extra "
+        "whose capability needs it -- otherwise the bound the suite is exercised "
+        f"against can drift from the bound an install resolves. Tooling: {sorted(tooling)}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -4851,6 +4851,7 @@ all = [
     { name = "pyyaml" },
     { name = "pyzmq" },
     { name = "qpsolvers", extra = ["daqp"], marker = "extra == 'extra-14-strands-robots-all' or extra == 'extra-14-strands-robots-lerobot' or extra == 'extra-14-strands-robots-lerobot-async' or extra == 'extra-14-strands-robots-molmoact2' or extra == 'extra-14-strands-robots-smolvla' or extra != 'extra-14-strands-robots-vera-sim'" },
+    { name = "requests" },
     { name = "robot-descriptions" },
     { name = "roslibpy" },
     { name = "scipy" },
@@ -4898,6 +4899,9 @@ dev = [
 device-connect = [
     { name = "device-connect-agent-tools" },
     { name = "device-connect-edge" },
+]
+earthrover = [
+    { name = "requests" },
 ]
 groot-service = [
     { name = "msgpack" },
@@ -5133,6 +5137,8 @@ requires-dist = [
     { name = "qpsolvers", extras = ["daqp"], marker = "extra == 'sim-mujoco'", specifier = ">=4.0.0" },
     { name = "qpsolvers", extras = ["daqp"], marker = "extra == 'sim-newton'", specifier = ">=4.0.0" },
     { name = "qpsolvers", extras = ["quadprog"], marker = "extra == 'cosmos3-sim'", specifier = ">=4.0.0" },
+    { name = "requests", marker = "extra == 'all'", specifier = ">=2.28.0,<3.0.0" },
+    { name = "requests", marker = "extra == 'earthrover'", specifier = ">=2.28.0,<3.0.0" },
     { name = "robosuite", marker = "extra == 'vera-sim'", specifier = "==1.4.1" },
     { name = "robot-descriptions", marker = "extra == 'all'", specifier = ">=1.23.0,<2.0.0" },
     { name = "robot-descriptions", marker = "extra == 'sim'", specifier = ">=1.23.0,<2.0.0" },
@@ -5169,7 +5175,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'cosmos3-service'", specifier = ">=17.0" },
     { name = "websockets", marker = "extra == 'inference'", specifier = ">=17.0" },
 ]
-provides-extras = ["all", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "crazyflie", "curobo", "dashboard", "dev", "device-connect", "groot-service", "inference", "kimodo", "lerobot", "lerobot-async", "mesh", "mesh-iot", "microduck", "molmoact2", "motionbricks", "moveit2", "ollama", "protomotions", "ros2", "rosbridge", "sagemaker", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "smolvla", "vera-sim", "wbc"]
+provides-extras = ["all", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "crazyflie", "curobo", "dashboard", "dev", "device-connect", "earthrover", "groot-service", "inference", "kimodo", "lerobot", "lerobot-async", "mesh", "mesh-iot", "microduck", "molmoact2", "motionbricks", "moveit2", "ollama", "protomotions", "ros2", "rosbridge", "sagemaker", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "smolvla", "vera-sim", "wbc"]
 
 [[package]]
 name = "sympy"


### PR DESCRIPTION
The EarthRover native driver speaks HTTP to the vendor's earth-rovers-sdk: `GET /data` is every read the rover answers, `POST /control` is **what drives it**. That transport is `requests`, and **no requirement named it**. The only bound the project stated lived in `[tool.hatch.envs.default].dependencies` - a hatch development environment that no install reaches - alongside three more runtime distributions in the same shape.

![measured verdicts](https://raw.githubusercontent.com/cagataycali/robots/assets/earthrover-transport-declared/docs/assets/earthrover_transport_declared.png)

## Measured (against the checked-in lock, and by driving the gate)

`requests` is absent from the base install and from **26 of the 32 extras other than `[all]`**. The six that resolve to it - `[lerobot]`, `[lerobot-async]`, `[molmoact2]`, `[smolvla]`, `[kimodo]`, `[cosmos3-diffusers]` - reach it as a transitive of an unrelated machine learning stack:

```
lerobot           -> strands-robots[lerobot] -> lerobot[dataset,feetech] -> requests
all               -> strands-robots[all]     -> diffusers                -> requests
cosmos3-diffusers -> strands-robots[...]     -> diffusers                -> requests
```

So a rover install - plain `strands-robots`, or `[mesh,device-connect]` for a fleet - shipped the driver and none of its transport, and `[all]` supplied it by way of `diffusers`. The remedy printed was a bare `pip install requests`, the one place in the drivers tree that hands a reader a distribution instead of an extra whose bound this project owns (`[crazyflie]`'s sibling refusal names `strands-robots[crazyflie]`).

The same gap reached the suite. `tests/drivers/test_earthrover_base_url_addresses_the_host.py` opens `pytest.importorskip("requests")` and drives a real `http.server` to measure **which host** the driver dials - the property behind the `bot.local@10.0.0.9:8001` and `ws://` refusals. **34 cells** sit behind that gate; with requests absent the module collapses to one `1 skipped` line, which reads the same as a suite that has nothing to say. They ran because the development environment pinned the distribution and because `[all]` happens to carry `diffusers`. Neither is a declaration.

## Change

| | |
| --- | --- |
| `[earthrover]` | declares `requests>=2.28.0,<3.0.0` - the bound that previously existed only in the dev environment - and is folded into `[all]` (pure Python, no build step, and CI installs that bundle) |
| `connect_eagerly()` | names the extra: `cannot import requests (...); the EarthRover native driver speaks HTTP to the earth-rovers-sdk. Install it with: pip install 'strands-robots[earthrover]'` |
| dev environment | `Pillow`, `msgpack`, `pyzmq`, `requests` deleted - declared in `[project.dependencies]`, `[groot-service]`, `[moveit2]` and `[earthrover]` respectively |
| docs | installation matrix row + derived `[all]` counts (21 of 33), the mobile-robots native-driver section, and the driver's module docstring |

The degrade is unchanged and still the documented contract: the module imports and registers without the transport, every read answers the empty cache, every write refuses "not connected". What changed is the remedy.

**No resolution changed.** The four deleted pins carried bounds identical to the declarations that already covered them, so `uv lock` moves only the new extra's entries (+7/-1 lines: the `[earthrover]` group, two `requires-dist` rows, `provides-extras`, and `requests` joining `all`). `scripts/check_lockfile_parity.py`: 146 declared / 146 recorded, 0 findings.

## Tests

`tests/test_earthrover_http_extra_is_declared.py` - the extra declares the transport; `[all]` folds it in rather than inheriting it; both closures resolve it in `uv.lock` (offline, uv's own resolution); the installed `requests` is inside the declared bound; and the refusal is driven through the **real gate** (`sys.modules["requests"] = None`, which is what makes an installed module raise `ImportError`) with the empty-cache degrade asserted alongside it.

The last cell is the general rule rather than the four names: **every distribution `[tool.hatch.envs.default].dependencies` declares must be tooling `[dev]` also declares.** A runtime distribution there is a second copy of a bound that can drift from the one an install resolves, with `hatch run test` - the environment CI runs the suite in - green over the drift. `tests/test_dashboard_extra_is_declared.py` pins that shape for the five dashboard distributions after it shipped once; this generalizes it, because the next re-pin will not be one of those five.

On unmodified `main` the new file is **6 failed / 1 passed**. The one that passes is `[all]` resolving requests - the accident, and exactly the asymmetry this PR removes reliance on.

## LOC

| | +/- |
| --- | --- |
| `pyproject.toml` | +23 / -4 |
| driver (message + module docstring) | +11 / -2 |
| pin | +220 |
| docs | +8 / -3 |
| `uv.lock` + changelog fragment | +27 / -1 |

Local gate: `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ` (1944 files); `mypy` unchanged (20 pre-existing errors in 6 files, none touched here). Full `tests/` run on this branch and on `main` concurrently: **identical** failure sets (101 pre-existing failures/errors, all optional-dependency and lerobot 0.6.2 drift), 50502 passed here vs 50495 there - `+7`, exactly the new cells.