### PR TITLE
fix(scripts): check_merge_blockers names whether auto-merge will perform the merge it is waiting on

### DIFF
--- a/changelog.d/3316-merge-blockers-report-auto-merge.md
+++ b/changelog.d/3316-merge-blockers-report-auto-merge.md
@@ -1,0 +1,15 @@
+### Fixed: check_merge_blockers names whether auto-merge will perform the merge it is waiting on
+
+`scripts/check_merge_blockers.py` reported `required-check-pending` as owed by
+nobody and `no-unsatisfied-rule` with the remedy "attempt the merge", both of
+which assume a person merges once the rules are satisfied. On this repository
+29 of the last 30 merged pull requests had auto-merge armed and merged
+themselves the second the required check concluded, so a scheduled pass that
+read the report and polled the check in order to merge spent twenty minutes
+waiting to perform a merge that was never its to make.
+
+The report now reads `auto_merge.enabled_by` from the pulls payload it already
+held, prints an `auto-merge` row on every pull request and a column on the
+sweep, and on the two waiting outcomes adds a note saying GitHub performs the
+merge and that `merged` is the field to re-read first. No outcome, owner or
+exit status moves: auto-merge is not a rule.

--- a/scripts/check_merge_blockers.py
+++ b/scripts/check_merge_blockers.py
@@ -88,7 +88,10 @@ is*, so the outcomes group that way rather than by severity:
     sibling note below.
 
 ``required-check-pending``
-    Nobody. The answer is not in yet.
+    Nobody. The answer is not in yet. Whether the merge is then anybody's to
+    perform is a separate fact the report carries: with auto-merge armed,
+    GitHub performs it, and a poll-to-merge loop is redundant (29 of the 30
+    pull requests merged before 2026-09-08 03:30 were merged that way).
 
 ``merge-state-unknown``
     Nobody, for now, and the same shape as the entry above one field over.
@@ -347,6 +350,32 @@ _STALE_STATE_REMEDY: tuple[str, ...] = (
     "access token.",
 )
 
+# Printed beside, never instead of, the remedy above. Auto-merge is not a rule
+# and changes no outcome; it changes who performs the merge once the outcome
+# clears, which is the one thing the two waiting outcomes leave the reader to
+# decide. Formatted with the login so the row and the note name one account.
+_AUTO_MERGE_NOTE: tuple[str, ...] = (
+    "",
+    "### Auto-merge is armed",
+    "",
+    "{login} armed auto-merge, so GitHub performs the squash itself the moment",
+    "every rule is satisfied. A pass that polls the required check in order to",
+    "merge is waiting to perform a merge that is not its to make: measured on",
+    "#3314 and #3315, both landed within one second of `call-test-lint` going",
+    "green, twenty minutes into such a poll.",
+    "",
+    "If this reads `no-unsatisfied-rule` with auto-merge armed, re-read `merged`",
+    "before attempting anything: auto-merge has not fired either, which is more",
+    "often the terminal state arriving late than a stale computation. Only if the",
+    "pull request is still open is the manual attempt worth making, because its",
+    "REST refusal names the requirement auto-merge is also waiting on.",
+)
+
+# The outcomes whose remedy the note changes. Both wait for the rules to be
+# satisfied and then expect somebody to merge; with auto-merge armed, GitHub is
+# that somebody. Every other outcome is owed by a person regardless.
+_AUTO_MERGE_DECIDES: frozenset[str] = frozenset({REQUIRED_CHECK_PENDING, NO_UNSATISFIED_RULE})
+
 
 @dataclass(frozen=True)
 class Blocker:
@@ -433,6 +462,12 @@ class PullRequestState:
     # fixture describes an unblocked review state unchanged.
     change_requesters: tuple[str, ...] = ()
     pusher: str | None = None
+    # The account that armed auto-merge, or ``None``. Not a rule and never a
+    # blocker: it decides who performs the merge once every rule is satisfied,
+    # which is the one question the outcomes above leave open. Read because the
+    # remedy for ``required-check-pending`` and ``no-unsatisfied-rule`` is
+    # different when GitHub will perform the merge itself.
+    auto_merge_by: str | None = None
 
 
 # --------------------------------------------------------------------------
@@ -933,6 +968,12 @@ def resolve_state(repo: str, pr: int, token: str) -> PullRequestState:
         raise ValueError(f"unexpected payload for {repo}#{pr}")
     head_sha = ((payload.get("head") or {}).get("sha")) or ""
     base_ref = ((payload.get("base") or {}).get("ref")) or ""
+    # ``auto_merge`` is null when nothing is armed and an object naming the
+    # account otherwise. A shape that is neither reads as not armed: the field
+    # decides only who performs the merge, so it must not fail the read.
+    auto_merge = payload.get("auto_merge") or {}
+    enabled_by = (auto_merge.get("enabled_by") or {}) if isinstance(auto_merge, dict) else {}
+    login = enabled_by.get("login") if isinstance(enabled_by, dict) else None
     reviews = resolve_reviews(repo, pr, token)
     return PullRequestState(
         number=pr,
@@ -948,6 +989,7 @@ def resolve_state(repo: str, pr: int, token: str) -> PullRequestState:
         approvers=current_approvers(reviews),
         change_requesters=current_change_requesters(reviews),
         pusher=resolve_pusher(repo, head_sha, token) if head_sha else None,
+        auto_merge_by=str(login) if login else None,
     )
 
 
@@ -1025,6 +1067,7 @@ def _next_action(blockers: Sequence[Blocker]) -> list[str]:
 
 def render(state: PullRequestState, rules: Ruleset, blockers: Sequence[Blocker], repo: str) -> str:
     """Render one pull request's blockers, the party owing each named first."""
+    auto_merge = f"armed by {state.auto_merge_by}" if state.auto_merge_by else "not armed"
     lines = [
         "## Merge blockers",
         "",
@@ -1043,6 +1086,7 @@ def render(state: PullRequestState, rules: Ruleset, blockers: Sequence[Blocker],
         f"| unresolved review threads | {state.unresolved_threads} |",
         f"| current approvals | {_join(state.approvers)} |",
         f"| head pushed by | {state.pusher or '(undetermined)'} |",
+        f"| auto-merge | {auto_merge} |",
         "",
         "| unsatisfied rule | owed by | detail |",
         "|---|---|---|",
@@ -1060,6 +1104,8 @@ def render(state: PullRequestState, rules: Ruleset, blockers: Sequence[Blocker],
         ]
     if any(b.outcome == NO_UNSATISFIED_RULE for b in blockers):
         lines += list(_STALE_STATE_REMEDY)
+    if state.auto_merge_by and any(b.outcome in _AUTO_MERGE_DECIDES for b in blockers):
+        lines += [line.format(login=state.auto_merge_by) for line in _AUTO_MERGE_NOTE]
     return "\n".join(lines)
 
 
@@ -1078,6 +1124,8 @@ class SweepRow:
 
     pr: int
     blockers: tuple[Blocker, ...]
+    # Carried so the sweep can say which waiting rows GitHub will merge itself.
+    auto_merge_by: str | None = None
 
     @property
     def is_finding(self) -> bool:
@@ -1108,7 +1156,7 @@ def sweep(repo: str, token: str) -> tuple[list[SweepRow], list[int], Ruleset]:
                 cache[state.base_ref] = resolve_ruleset(repo, state.base_ref, token)
             rules = cache[state.base_ref]
             last = rules
-            rows.append(SweepRow(pr, evaluate(state, rules)))
+            rows.append(SweepRow(pr, evaluate(state, rules), state.auto_merge_by))
         except (urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
             print(
                 f"check_merge_blockers: {repo}#{pr} lookup failed, not evaluated: {exc}",
@@ -1163,12 +1211,13 @@ def render_sweep(rows: Sequence[SweepRow], skipped: Sequence[int], repo: str) ->
             "",
         ]
     lines += [
-        "| pull request | unsatisfied rule(s) | owed by |",
-        "|---|---|---|",
+        "| pull request | unsatisfied rule(s) | owed by | auto-merge |",
+        "|---|---|---|---|",
     ]
     for row in rows:
         outcomes = ", ".join(b.outcome for b in row.blockers)
-        lines.append(f"| #{row.pr} | {outcomes} | {row.primary.owed_by} |")
+        armed = "armed" if row.auto_merge_by else "-"
+        lines.append(f"| #{row.pr} | {outcomes} | {row.primary.owed_by} | {armed} |")
     if skipped:
         lines += [
             "",

--- a/tests/test_merge_blockers.py
+++ b/tests/test_merge_blockers.py
@@ -1155,9 +1155,162 @@ def test_no_report_string_carries_a_non_ascii_character() -> None:
         mod.render_sweep([mod.SweepRow(1, mod.evaluate(state(unresolved_threads=1), MAIN))], [2], "o/r"),
         mod.render_sweep([], [], "o/r"),
         "\n".join(mod._STALE_STATE_REMEDY),
+        "\n".join(mod._AUTO_MERGE_NOTE),
     ]
     for report in reports:
         report.encode("ascii")
+
+
+# --------------------------------------------------------------------------
+# Auto-merge. Not a rule and never a blocker: it decides who performs the merge
+# once every rule is satisfied, which is the one question the two waiting
+# outcomes leave open. Measured 2026-09-08: 29 of the last 30 merged pull
+# requests carried ``autoMergeRequest`` (SQUASH), and a scheduled pass polled
+# #3314 and #3315 for twenty minutes in order to merge them; both merged
+# themselves the second ``call-test-lint`` went green (03:21:42 and 03:28:07).
+# --------------------------------------------------------------------------
+
+
+def _resolve_state_with_payload(monkeypatch: pytest.MonkeyPatch, payload: dict[str, Any]) -> Any:
+    """Run ``resolve_state`` against one pull request payload, transport stubbed."""
+    monkeypatch.setattr(mod, "_get", lambda url, token: payload)
+    monkeypatch.setattr(mod, "resolve_reviews", lambda *a: [])
+    monkeypatch.setattr(mod, "resolve_unresolved_threads", lambda *a: 0)
+    monkeypatch.setattr(mod, "resolve_check_conclusions", lambda *a: {REQUIRED: None})
+    monkeypatch.setattr(mod, "resolve_check_suites", lambda *a: (None,))
+    monkeypatch.setattr(mod, "resolve_pusher", lambda *a: "the-author")
+    return mod.resolve_state("o/r", 3314, "t")
+
+
+def test_the_resolved_state_carries_the_account_that_armed_auto_merge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The read is the fix, as with ``merged``: the key was in the payload all along.
+
+    ``GET /repos/{owner}/{repo}/pulls/{n}`` returns ``auto_merge`` as an object
+    naming the account that armed it, in the same response ``resolve_state``
+    was already taking six keys from. This is the shape #3314 and #3315 read
+    while the pass polled them.
+    """
+    resolved = _resolve_state_with_payload(
+        monkeypatch,
+        {
+            "head": {"sha": "b6c49eca"},
+            "base": {"ref": "main"},
+            "draft": False,
+            "merged": False,
+            "mergeable": True,
+            "mergeable_state": "blocked",
+            "auto_merge": {"enabled_by": {"login": "octocat"}, "merge_method": "squash"},
+        },
+    )
+    assert resolved.auto_merge_by == "octocat"
+
+
+@pytest.mark.parametrize(
+    "auto_merge",
+    [None, {}, {"enabled_by": None}, "absent"],
+    ids=["null", "empty-object", "null-enabled-by", "key-absent"],
+)
+def test_a_null_auto_merge_field_reads_as_not_armed(monkeypatch: pytest.MonkeyPatch, auto_merge: Any) -> None:
+    """``auto_merge: null`` is the documented unarmed shape; a malformed one must not raise.
+
+    The field decides only who performs the merge, so a shape this check does
+    not recognise reads as not armed rather than failing the whole read and
+    reporting nothing about a pull request whose rules it could evaluate.
+    """
+    payload: dict[str, Any] = {
+        "head": {"sha": "b6c49eca"},
+        "base": {"ref": "main"},
+        "draft": False,
+        "merged": False,
+        "mergeable": True,
+        "mergeable_state": "blocked",
+    }
+    if auto_merge != "absent":
+        payload["auto_merge"] = auto_merge
+    assert _resolve_state_with_payload(monkeypatch, payload).auto_merge_by is None
+
+
+def test_a_pending_check_under_auto_merge_says_the_merge_is_not_the_readers_to_make() -> None:
+    """The defect: ``required-check-pending`` owed by nobody invites a poll-to-merge loop.
+
+    On #3314 and #3315 the check was the only unsatisfied rule and auto-merge
+    was armed, so the merge was GitHub's to perform and it did, within a second
+    of the check going green. The outcome is unchanged -- the answer is still
+    not in -- but the report now says whose merge it will be.
+    """
+    st = state(auto_merge_by="octocat", check_conclusions={REQUIRED: None})
+    blockers = mod.evaluate(st, MAIN)
+    rendered = mod.render(st, MAIN, blockers, "o/r")
+    assert outcomes(blockers) == [mod.REQUIRED_CHECK_PENDING]
+    assert f"Outcome: **{mod.REQUIRED_CHECK_PENDING}**" in rendered
+    assert "| auto-merge | armed by octocat |" in rendered
+    assert "not its to make" in rendered
+    assert "#3314 and #3315" in rendered
+
+
+def test_the_auto_merge_note_is_absent_when_nothing_is_armed() -> None:
+    """The control: the same pending check with nothing armed keeps its original report."""
+    st = state(auto_merge_by=None, check_conclusions={REQUIRED: None})
+    rendered = mod.render(st, MAIN, mod.evaluate(st, MAIN), "o/r")
+    assert "| auto-merge | not armed |" in rendered
+    assert "Auto-merge is armed" not in rendered
+    assert "not its to make" not in rendered
+
+
+def test_the_auto_merge_note_is_not_printed_for_an_outcome_it_does_not_change() -> None:
+    """Auto-merge does not resolve a thread: the #2566 owner is the author regardless.
+
+    The row still says who armed it, because that is a fact about the pull
+    request; the note is withheld, because it would tell the reader to stand
+    back from a merge that is not going to happen until the author acts.
+    """
+    st = state(auto_merge_by="octocat", unresolved_threads=1)
+    blockers = mod.evaluate(st, MAIN)
+    rendered = mod.render(st, MAIN, blockers, "o/r")
+    assert outcomes(blockers) == [mod.UNRESOLVED_THREADS]
+    assert "| auto-merge | armed by octocat |" in rendered
+    assert "Auto-merge is armed" not in rendered
+    assert mod.primary(blockers).owed_by == mod.AUTHOR
+
+
+def test_the_stale_state_case_under_auto_merge_says_to_re_read_merged_first() -> None:
+    """The #2574 remedy stands, and gains a first step where auto-merge is armed.
+
+    Every rule satisfied, still ``blocked``, auto-merge armed: auto-merge has
+    not fired either, which is more often ``merged`` arriving late than a stale
+    computation. The existing remedy is kept, because the REST refusal names the
+    requirement auto-merge is also waiting on -- but only if the pull request is
+    still open, which is what the re-read establishes.
+    """
+    st = state(auto_merge_by="octocat")
+    blockers = mod.evaluate(st, MAIN)
+    rendered = mod.render(st, MAIN, blockers, "o/r")
+    assert outcomes(blockers) == [mod.NO_UNSATISFIED_RULE]
+    assert "Attempt the merge." in rendered
+    assert "re-read `merged`" in rendered
+    # The note follows the remedy it qualifies rather than displacing it.
+    assert rendered.index("Attempt the merge.") < rendered.index("re-read `merged`")
+
+
+def test_auto_merge_changes_no_outcome_owner_or_finding() -> None:
+    """Precedence lives in the evaluator, and auto-merge is not a rule it evaluates.
+
+    The same fixtures with and without the field must produce identical
+    blockers: a change to any outcome, owner or finding here would make the
+    exit status depend on a fact that is not a rule.
+    """
+    for overrides in (
+        {},
+        {"check_conclusions": {REQUIRED: None}},
+        {"check_conclusions": {REQUIRED: None}, "approvers": ()},
+        {"unresolved_threads": 1},
+        {"mergeable": False},
+    ):
+        armed = mod.evaluate(state(auto_merge_by="octocat", **overrides), MAIN)
+        unarmed = mod.evaluate(state(**overrides), MAIN)
+        assert armed == unarmed
 
 
 # --------------------------------------------------------------------------
@@ -1174,6 +1327,19 @@ def test_the_sweep_separates_the_author_clearable_rows(capsys: pytest.CaptureFix
     assert "1 blocked on something no reviewer can clear:** #1035" in rendered
     assert f"| #1035 | {mod.MERGE_CONFLICT} | {mod.AUTHOR} |" in rendered
     assert f"| #2497 | {mod.MISSING_APPROVAL} | {mod.OTHER_REVIEWER} |" in rendered
+
+
+def test_the_sweep_marks_which_rows_are_armed() -> None:
+    """A sweep that polls waiting rows to merge them needs to know which ones GitHub will merge."""
+    pending = mod.evaluate(state(check_conclusions={REQUIRED: None}), MAIN)
+    rows = [
+        mod.SweepRow(3314, pending, auto_merge_by="octocat"),
+        mod.SweepRow(2480, pending),
+    ]
+    rendered = mod.render_sweep(rows, [], "o/r")
+    assert "| pull request | unsatisfied rule(s) | owed by | auto-merge |" in rendered
+    assert f"| #3314 | {mod.REQUIRED_CHECK_PENDING} | {mod.NOBODY} | armed |" in rendered
+    assert f"| #2480 | {mod.REQUIRED_CHECK_PENDING} | {mod.NOBODY} | - |" in rendered
 
 
 def test_a_clean_sweep_says_so_rather_than_printing_a_bare_table() -> None:


### PR DESCRIPTION
`check_merge_blockers.py` answers *whose move it is*. Two of its outcomes leave one question open: `required-check-pending` is owed by `nobody`, and `no-unsatisfied-rule` prints "attempt the merge". Both assume that once the rules are satisfied, a person merges. On this repository that assumption is false most of the time, and the field that says so is already in the payload the script reads.

## Measured

**29 of the last 30 merged pull requests had auto-merge armed** (`autoMergeRequest.mergeMethod: SQUASH`, #3282 through #3315; the exception is #3305). Each of them merged itself the instant `call-test-lint / Test and Lint` concluded.

The cost is what a scheduled pass does with the current report. This morning it read `required-check-pending / nobody` for #3314 and #3315, then polled the required check for **20 minutes** (03:09 to 03:28 UTC) in order to merge them:

| pull request | `call-test-lint` concluded | `mergedAt` | gap |
| --- | --- | --- | --- |
| #3314 | 03:21:42 | 03:21:42 | 0 s |
| #3315 | 03:28:07 | 03:28:07 | 0 s |

Both merges were GitHub's, not the poller's. The poll was waiting to perform a merge that was never its to make, and nothing in the report said so - `GET /repos/{owner}/{repo}/pulls/{n}` carries `auto_merge: {"enabled_by": {"login": ...}, "merge_method": ...}` or `null`, and `resolve_state` was already holding that payload and taking six keys off it.

The second half is `no-unsatisfied-rule`. With auto-merge armed, every-rule-satisfied-and-still-blocked is not the #2574 stale-computation case first: auto-merge has the same view of the rules and has not fired either, so the more common reading is that the pull request merged between the check going green and the read - the `merged` field AGENTS.md step 8 already says to consult. The manual attempt is still right when the pull request is genuinely open, because the REST refusal names the requirement both parties are waiting on. So the existing remedy is kept and the note orders the two reads.

## Change

- `PullRequestState.auto_merge_by: str | None` - the login that armed it, read from the pulls payload with guards on both levels (`null`, `{}`, `{"enabled_by": null}`, absent key and a non-dict shape all read as not armed; the field decides only who merges, so it must not fail the read).
- `render`: one table row `| auto-merge | armed by <login> |` / `not armed`, and a section `### Auto-merge is armed` printed **beside, never instead of** `_STALE_STATE_REMEDY`, and only when an outcome in `{required-check-pending, no-unsatisfied-rule}` is present. An `unresolved-threads` row with auto-merge armed gets the table row and no note: the author still owes the resolve.
- `SweepRow.auto_merge_by` and a fourth `auto-merge` column (`armed` / `-`) in `render_sweep`, so the `--all-open` health read says which waiting rows GitHub will land itself.
- Module docstring: one sentence under `required-check-pending`.

Auto-merge is not a rule. **No outcome, owner, finding, gating or terminal set moves**; `evaluate`, `primary` and `_next_action` are untouched, and a test asserts `evaluate()` returns identical blockers with and without the field across five fixtures. Exit status is unchanged.

## Tests

Eight behaviour-named cells in `tests/test_merge_blockers.py`: the resolved state carries the arming account; four null-ish shapes read as not armed; the pending-check note names the account and says the merge is not the reader's to make while the `Outcome:` line is unchanged; the note is absent when nothing is armed; the note is absent on an outcome it does not change; the #2574 fixture with auto-merge armed keeps `Attempt the merge.` and adds `re-read \`merged\``; the sweep marks armed rows; and the invariance cell above. `_AUTO_MERGE_NOTE` is added to the existing ASCII guard's list.

On the unmodified script the 11 new test ids (7 functions, one parametrized over 4 shapes) all fail with `AttributeError`/`TypeError` on `auto_merge_by`; with it, `tests/test_merge_blockers.py` is **111 passed**.

## Gate

- `ruff check` / `ruff format --check` on the two files: clean.
- `mypy scripts/check_merge_blockers.py tests/test_merge_blockers.py`: `Success: no issues found in 2 source files`.
- Tree graders that read this file: `test_test_case_names_describe_behaviour.py`, `test_no_host_paths.py`, `test_log_strings_are_ascii.py` - 49 passed.

## Size

| file | + | - |
| --- | --- | --- |
| `scripts/check_merge_blockers.py` | 59 | 5 |
| `tests/test_merge_blockers.py` | 166 | 0 |

## Out of scope

AGENTS.md step 8 already tells a reader to confirm `merged` after a merge mutation; it does not tell a *pre*-merge poll to check whether the merge is its own to make. That is one sentence in a 200 KB file with a review round attached, and the report now says it at the moment it matters, which is the cheaper place. If the report's wording proves out over a few cycles, the sentence can follow.