### PR TITLE
fix(rendering): a preset scene download bounds every socket operation

### DIFF
--- a/changelog.d/3317-scene-download-socket-bound.md
+++ b/changelog.d/3317-scene-download-socket-bound.md
@@ -1,0 +1,43 @@
+### Fixed: a preset 3DGS scene download bounds every socket operation
+
+`download_gsplat_scene` fetched its asset with `urllib.request.urlretrieve`,
+whose signature is `url, filename, reporthook, data` -- there is no timeout
+parameter to pass. The fetch therefore ran on the process-global default socket
+timeout, which is `None` unless some unrelated import mutated it, so a peer that
+completed the connection, sent its headers and then stopped sending held the
+calling thread indefinitely.
+
+That is not merely slow, it defeats a documented fail-loud contract. The
+`isaac_gs` demo's `resolve_background` raises `RuntimeError` when the photoreal
+path cannot initialize -- a download failure included -- precisely so a user who
+asked for the captured scene never silently receives the procedural gradient,
+and `allow_fallback=True` restores that demotion "for every failure mode". A
+stalled host produced neither outcome. Measured against a loopback peer that
+answers with `Content-Length` and then goes quiet, `resolve_background(
+allow_fallback=True)` was still blocked after 90 seconds of observation: nothing
+raised, so nothing was demoted, and the flag whose whole purpose is to keep the
+demo rendering could not fire either. The `mujoco_gs` Gradio handler wedges the
+same way, after yielding its "Downloading ..." progress line.
+
+The body now streams through `urlopen(url, timeout=...)`, whose `timeout`
+reaches the connection object itself -- urllib's `AbstractHTTPHandler.do_open`
+forwards it as `http_class(host, timeout=req.timeout)` -- so it becomes the
+socket timeout and bounds each read of the body, not merely the connect and TLS
+handshake. Nothing process-global is mutated. The same stalled peer now raises
+`TimeoutError` at 60.1 seconds and the fallback path returns its
+`PanoramaBackground`.
+
+The bound is per socket operation rather than on the whole transfer, because
+these assets run to hundreds of megabytes and a slow link is not a stalled one;
+what no honest transfer needs is a minute of silence mid-body. It is a new
+`timeout` keyword argument on `download_gsplat_scene`, graded by the same
+`positive_finite_number_error` domain the rest of the tree uses for a span of
+time, so a bound of `0`, a negative one, `inf` or `nan` is refused rather than
+silently standing for no bound at all.
+
+`urlretrieve` also raised `ContentTooShortError` when the body came up short of
+the declared `Content-Length`; that check is kept, with the same
+`(filename, headers)` content attached, because the fetch renames its `.part`
+sidecar onto the cache path and a truncated scene cached as a complete one is
+worse than a download that failed -- every later call would read the short file
+straight out of the cache.

--- a/strands_robots/rendering/backgrounds.py
+++ b/strands_robots/rendering/backgrounds.py
@@ -37,7 +37,12 @@ from typing import Any, Protocol
 
 import numpy as np
 
-from strands_robots.utils import boolean_flag_error, finite_number_error, require_optional
+from strands_robots.utils import (
+    boolean_flag_error,
+    finite_number_error,
+    positive_finite_number_error,
+    require_optional,
+)
 
 from .camera import CameraParams
 
@@ -804,23 +809,126 @@ def gsplat_skybox_align_for(name_or_slug: str) -> dict[str, Any]:
     return dict(GSPLAT_SKYBOX_ALIGN.get(slug, {}))
 
 
-def download_gsplat_scene(name: str, cache_dir: str | Path | None = None) -> Path:
+#: Seconds any single socket operation of a preset-scene download may take.
+#:
+#: This bounds a STALLED peer - a wedged CDN edge, a captive-portal proxy that
+#: completes the connection and then says nothing - not a slow one. The presets
+#: are tens to hundreds of megabytes, so a legitimately slow link needs an
+#: unbounded total transfer time; what no honest transfer needs is a minute of
+#: silence mid-body. The deadline therefore applies per socket operation
+#: (connect, and each read of the streamed body), which is exactly the
+#: distinction between a peer that is sending slowly and one that has stopped.
+_SCENE_SOCKET_TIMEOUT_S: float = 60.0
+
+#: Bytes requested per read while streaming a scene body to its ``.part`` file.
+_SCENE_CHUNK_BYTES: int = 1 << 20
+
+
+def _stream_scene_to_file(url: str, dest: Path, timeout: float) -> None:
+    """Stream *url* into *dest*, bounding every socket operation by *timeout*.
+
+    ``urllib.request.urlretrieve`` - what this replaces - accepts no timeout at
+    all (its signature is ``url, filename, reporthook, data``), so it inherits
+    the process-global default socket timeout. That default is ``None``, i.e.
+    block forever, unless some unrelated import mutated it. A peer that accepts
+    the connection and then stops sending held the calling thread indefinitely.
+
+    ``urlopen``'s ``timeout`` reaches the connection object itself - urllib's
+    ``AbstractHTTPHandler.do_open`` forwards it as
+    ``http_class(host, timeout=req.timeout)`` - so it becomes the socket
+    timeout and bounds each ``recv`` of the streamed body, not merely the
+    connect and TLS handshake. Nothing process-global is mutated, so a
+    concurrent download or an unrelated socket in another thread keeps its own
+    deadline; that is the same posture as
+    :mod:`strands_robots.mesh.iot.provision`'s bounded CA fetch.
+
+    ``urlretrieve`` also raised ``ContentTooShortError`` when the body came up
+    short of the declared ``Content-Length``. That check is kept, because the
+    caller renames *dest* onto the cache path and a truncated scene cached as a
+    complete one is worse than a download that failed: every later call reads
+    the short file straight out of the cache. A peer that declares a
+    non-numeric length has declared nothing checkable, and the transfer is
+    accepted on its own terms rather than refused for the header's sake.
+
+    Args:
+        url: the scene's source URL.
+        dest: the ``.part`` sidecar to write the body into.
+        timeout: seconds allowed for any single socket operation.
+
+    Raises:
+        TimeoutError: a socket operation took longer than *timeout*.
+        urllib.error.ContentTooShortError: the body was shorter than the
+            ``Content-Length`` the peer declared.
+        OSError: any other transport or filesystem failure, including the
+            ``urllib.error.URLError`` / ``HTTPError`` subclasses.
+    """
+    import urllib.error
+    import urllib.request
+
+    written = 0
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        headers = response.headers
+        declared = headers.get("Content-Length")
+        with dest.open("wb") as handle:
+            while chunk := response.read(_SCENE_CHUNK_BYTES):
+                handle.write(chunk)
+                written += len(chunk)
+    try:
+        expected = int(declared) if declared is not None else None
+    except ValueError:
+        # An unparseable length is not a truncation signal in either
+        # direction; nothing else spends it, so the body stands on its own.
+        expected = None
+    if expected is not None and written < expected:
+        # The ``(filename, headers)`` pair is the same content ``urlretrieve``
+        # attached to this exception, so a caller that inspected it still can.
+        raise urllib.error.ContentTooShortError(
+            f"retrieval incomplete: got only {written} of {expected} bytes from {url}",
+            (str(dest), headers),
+        )
+
+
+def download_gsplat_scene(
+    name: str,
+    cache_dir: str | Path | None = None,
+    *,
+    timeout: float = _SCENE_SOCKET_TIMEOUT_S,
+) -> Path:
     """Download (and cache) a preset 3DGS scene; return its local path.
 
     The cached file keeps the source URL's extension (``.spz`` or ``.ply``) so
-    the loader can dispatch correctly.
+    the loader can dispatch correctly. The body streams into a ``.part``
+    sidecar that is renamed onto the cache path only once the transfer is
+    complete, so an interrupted download never leaves a truncated file where a
+    later call would read it as a finished one.
+
+    Every socket operation is bounded by ``timeout`` (60 seconds by default):
+    a peer that accepts the connection and then stops sending raises
+    ``TimeoutError`` instead of blocking the calling thread forever. The bound
+    is per operation rather than on the whole transfer because these assets run
+    to hundreds of megabytes, and a slow link is not a stalled one.
 
     Args:
         name: a key of :data:`GSPLAT_SCENES`.
         cache_dir: where to cache (default ``~/.cache/strands_robots/gsplat_scenes``).
+        timeout: seconds allowed for any single socket operation of the fetch.
+            Must be positive and finite - a bound of ``0``, a negative one or
+            ``inf`` states no bound at all.
 
     Returns:
         Local path to the cached scene file.
-    """
-    import urllib.request
 
+    Raises:
+        KeyError: ``name`` is not a preset in :data:`GSPLAT_SCENES`.
+        ValueError: ``timeout`` is not a positive finite number of seconds.
+        TimeoutError: a socket operation took longer than ``timeout``.
+        OSError: the transfer or the write failed (including a body shorter
+            than the peer's declared ``Content-Length``).
+    """
     if name not in GSPLAT_SCENES:
         raise KeyError(f"Unknown scene {name!r}. Known: {list(GSPLAT_SCENES)}")
+    if error := positive_finite_number_error(timeout, "timeout", "download_gsplat_scene"):
+        raise ValueError(error)
     url = GSPLAT_SCENES[name]
     cache = Path(cache_dir) if cache_dir else Path.home() / ".cache" / "strands_robots" / "gsplat_scenes"
     cache.mkdir(parents=True, exist_ok=True)
@@ -831,7 +939,7 @@ def download_gsplat_scene(name: str, cache_dir: str | Path | None = None) -> Pat
         return dest
     logger.info("Downloading 3DGS scene %r -> %s", name, dest)
     tmp = dest.with_suffix(ext + ".part")
-    urllib.request.urlretrieve(url, tmp)
+    _stream_scene_to_file(url, tmp, timeout)
     tmp.rename(dest)
     logger.info("Downloaded %s (%.0f MB)", dest.name, dest.stat().st_size / 1e6)
     return dest

--- a/tests/rendering/test_backgrounds.py
+++ b/tests/rendering/test_backgrounds.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Background renderer contracts (panorama path: zero ML deps)."""
 
-from pathlib import Path
+import io
 
 import numpy as np
 import pytest
@@ -48,6 +48,27 @@ def test_panorama_missing_image_path_falls_back_to_procedural(tmp_path) -> None:
     assert rgb.shape == (12, 16, 3)
 
 
+class _FakeResponse:
+    """Minimal ``urlopen`` return value: a context manager over a body.
+
+    Carries ``headers`` (so the fetch can read ``Content-Length``) and serves
+    ``read(n)`` in chunks, which is how the body reaches the ``.part`` file.
+    """
+
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None) -> None:
+        self._buffer = io.BytesIO(body)
+        self.headers = {"Content-Length": str(len(body))} if headers is None else headers
+
+    def read(self, amount: int | None = None) -> bytes:
+        return self._buffer.read(amount)
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._buffer.close()
+
+
 def test_download_gsplat_scene_rejects_unknown_name(tmp_path) -> None:
     with pytest.raises(KeyError, match="Unknown scene"):
         download_gsplat_scene("not-a-scene", cache_dir=tmp_path)
@@ -55,15 +76,15 @@ def test_download_gsplat_scene_rejects_unknown_name(tmp_path) -> None:
 
 def test_download_gsplat_scene_returns_cached_file_without_downloading(tmp_path, monkeypatch) -> None:
     # A present, non-empty cache file short-circuits the network fetch: the
-    # helper must return the cached path and never call urlretrieve. (The .spz
+    # helper must return the cached path and never open a connection. (The .spz
     # scene derives slug "tabletop" + ".spz" from its source URL.)
     cached = tmp_path / "tabletop.spz"
     cached.write_bytes(b"already-on-disk")
 
     def _must_not_download(*args, **kwargs):
-        raise AssertionError("urlretrieve must not run on a cache hit")
+        raise AssertionError("the transport must not be opened on a cache hit")
 
-    monkeypatch.setattr("urllib.request.urlretrieve", _must_not_download)
+    monkeypatch.setattr("urllib.request.urlopen", _must_not_download)
 
     dest = download_gsplat_scene("tabletop (indoor room)", cache_dir=tmp_path)
     assert dest == cached
@@ -77,34 +98,44 @@ def test_download_gsplat_scene_fetches_via_atomic_part_rename(tmp_path, monkeypa
     # under a ``.spz`` extension.
     from strands_robots.rendering import backgrounds
 
-    calls: list[tuple[str, str]] = []
+    calls: list[str] = []
+    mid_transfer: list[list[str]] = []
 
-    def _fake_urlretrieve(url, filename):
-        calls.append((url, str(filename)))
-        Path(filename).write_bytes(b"SPLAT-BYTES")
+    def _fake_urlopen(url, timeout=None):
+        calls.append(url)
+        response = _FakeResponse(b"SPLAT-BYTES")
+        streamed = response.read
 
-    monkeypatch.setattr("urllib.request.urlretrieve", _fake_urlretrieve)
+        def _observing_read(amount=None):
+            # Runs while the body is streaming, which is the only moment the
+            # sidecar is observable: the successful path renames it away.
+            mid_transfer.append(sorted(entry.name for entry in tmp_path.iterdir()))
+            return streamed(amount)
+
+        response.read = _observing_read
+        return response
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
 
     name = "tabletop (indoor room)"
     dest = download_gsplat_scene(name, cache_dir=tmp_path)
 
     assert dest == tmp_path / "tabletop.spz"
     assert dest.read_bytes() == b"SPLAT-BYTES"
-    assert len(calls) == 1
-    fetched_url, part_path = calls[0]
-    assert fetched_url == backgrounds.GSPLAT_SCENES[name]
-    # Downloaded to the temp sidecar, not straight to the final path.
-    assert part_path.endswith(".spz.part")
+    assert calls == [backgrounds.GSPLAT_SCENES[name]]
+    # Mid-transfer the bytes were in the sidecar and the final cache path did
+    # not exist, so no reader could take a partial body for a complete scene.
+    assert mid_transfer[0] == ["tabletop.spz.part"]
     # The sidecar was renamed away, leaving only the final cached file.
-    assert not (tmp_path / "tabletop.spz.part").exists()
+    assert [entry.name for entry in tmp_path.iterdir()] == ["tabletop.spz"]
 
 
 def test_download_gsplat_scene_maps_ply_url_to_ply_extension(tmp_path, monkeypatch) -> None:
     # A .ply source URL must cache under a ``.ply`` extension so the loader
     # dispatches to the PLY reader (not the SPZ reader). "bonsai" ships as .ply.
     monkeypatch.setattr(
-        "urllib.request.urlretrieve",
-        lambda url, filename: Path(filename).write_bytes(b"ply-bytes"),
+        "urllib.request.urlopen",
+        lambda url, timeout=None: _FakeResponse(b"ply-bytes"),
     )
     dest = download_gsplat_scene("bonsai (indoor tabletop)", cache_dir=tmp_path)
     assert dest == tmp_path / "bonsai.ply"

--- a/tests/rendering/test_scene_download_states_a_socket_bound.py
+++ b/tests/rendering/test_scene_download_states_a_socket_bound.py
@@ -1,0 +1,291 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A preset 3DGS scene download bounds every socket operation.
+
+:func:`strands_robots.rendering.download_gsplat_scene` fetched its asset with
+``urllib.request.urlretrieve``, whose signature is ``url, filename, reporthook,
+data`` - there is no timeout parameter to pass. The fetch therefore ran on the
+process-global default socket timeout, which is ``None`` unless some unrelated
+import mutated it, so a peer that completed the connection and then stopped
+sending held the calling thread indefinitely.
+
+That is not merely slow, it defeats a documented fail-loud contract. The
+``isaac_gs`` demo's ``resolve_background`` raises ``RuntimeError`` when the
+photoreal path cannot initialize - a download failure included - precisely so a
+user who asked for the captured scene never silently receives the procedural
+gradient, and ``allow_fallback=True`` restores that demotion "for every failure
+mode". A stalled peer produces neither outcome: nothing raises, so nothing is
+demoted, and the fallback flag whose whole purpose is to keep the demo
+rendering cannot fire either. The equivalent Gradio handler in the
+``mujoco_gs`` demo wedges after yielding its "Downloading ..." progress line.
+
+These tests pin the corrected contract:
+
+* a peer that stops mid-body raises inside the stated bound and leaves the
+  cache path empty, measured against a real stalled listener rather than a
+  double, with the assertion made on a worker thread so an unbounded fetch
+  renders as a failure instead of hanging the suite;
+* the bound is a caller-stated positive finite number of seconds, graded by the
+  same domain the rest of the tree uses for a span of time, and the default is
+  itself finite;
+* the cache path is never handed a partial body - a body short of the peer's
+  declared ``Content-Length`` fails the fetch and leaves nothing to read;
+* no module in the package fetches through ``urlretrieve``, which cannot be
+  bounded at all.
+
+No network access: the stalled peer is a loopback socket, and the transport
+doubles stand in for ``urlopen`` everywhere else.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+import socket
+import threading
+import urllib.error
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.rendering import backgrounds, download_gsplat_scene
+
+#: A preset whose source URL ends in ``.ply``; its slug is "bonsai".
+PRESET = "bonsai (indoor tabletop)"
+
+#: Bound handed to the fetch in the stalled-peer test. Small enough to keep the
+#: test quick, and the peer never sends again, so the only ways out are the
+#: bound firing or the thread never finishing.
+STATED_BOUND_S = 0.5
+
+#: How long the assertion waits for the fetch to come back. Twenty times the
+#: stated bound, so a bounded fetch cannot fail this for being slow while an
+#: unbounded one still reports promptly.
+GRACE_S = STATED_BOUND_S * 20
+
+
+@pytest.fixture
+def stalled_peer():
+    """A loopback listener that answers with headers, then stops sending.
+
+    This is the failure a bound exists for: the connection is established and
+    the response line and headers arrive, so nothing about the transport looks
+    broken, and then the body never comes. Yields the URL to fetch.
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    release = threading.Event()
+    connections: list[socket.socket] = []
+
+    def serve() -> None:
+        try:
+            conn, _ = listener.accept()
+        except OSError:  # pragma: no cover - listener closed before a client came
+            return
+        connections.append(conn)
+        try:
+            conn.recv(65536)
+            # A complete, entirely plausible response head promising a body...
+            conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 4194304\r\n\r\n")
+            conn.sendall(b"PLY-PREFIX")
+            # ... and then silence, until teardown lets the thread go.
+            release.wait(120)
+        except OSError:  # pragma: no cover - client hung up first
+            pass
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{listener.getsockname()[1]}/scene.ply"
+    finally:
+        # Releasing the peer closes the socket, which unblocks any fetch still
+        # waiting on it, so a failing (unbounded) run leaves nothing wedged.
+        release.set()
+        for conn in connections:
+            conn.close()
+        listener.close()
+        thread.join(GRACE_S)
+
+
+def _fetch_on_a_thread(**kwargs: Any) -> tuple[threading.Thread, list[Exception], list[Path]]:
+    """Run the fetch on a worker thread, capturing its outcome.
+
+    An unbounded fetch never returns, and a test that calls it directly hangs
+    the suite instead of failing it. Running it here turns "never came back"
+    into an assertion the caller can make.
+    """
+    raised: list[Exception] = []
+    returned: list[Path] = []
+
+    def attempt() -> None:
+        try:
+            returned.append(download_gsplat_scene(**kwargs))
+        except Exception as exc:  # noqa: BLE001 - which exception it is IS the measurement
+            raised.append(exc)
+
+    thread = threading.Thread(target=attempt, daemon=True)
+    thread.start()
+    return thread, raised, returned
+
+
+class TestAStalledPeerDoesNotHoldTheCaller:
+    def test_a_peer_that_stops_mid_body_raises_inside_the_stated_bound(
+        self, tmp_path, monkeypatch, stalled_peer
+    ) -> None:
+        monkeypatch.setitem(backgrounds.GSPLAT_SCENES, PRESET, stalled_peer)
+
+        thread, raised, returned = _fetch_on_a_thread(name=PRESET, cache_dir=tmp_path, timeout=STATED_BOUND_S)
+        thread.join(GRACE_S)
+
+        assert not thread.is_alive(), (
+            f"the fetch did not come back within {GRACE_S}s against a peer that stopped "
+            f"sending, having been given a {STATED_BOUND_S}s bound: the bound never "
+            "reached the socket, so the caller waits on the peer indefinitely"
+        )
+        assert not returned, "a peer that never sent the body must not yield a cached scene"
+        assert isinstance(raised[0], TimeoutError), f"expected a timeout, got {raised[0]!r}"
+        # The bound firing is only useful if the next call refetches: the ten
+        # bytes the peer did send must not be sitting at the cache path, where
+        # every later call would read them as the whole scene.
+        assert list(tmp_path.iterdir()) == [tmp_path / "bonsai.ply.part"]
+
+
+class TestTheBoundIsACallerStatedDomain:
+    @pytest.mark.parametrize(
+        "unusable",
+        [0, 0.0, -1.0, math.inf, -math.inf, math.nan, True, None, "5"],
+        ids=["zero", "zero-float", "negative", "inf", "-inf", "nan", "bool", "none", "str"],
+    )
+    def test_a_bound_that_bounds_nothing_is_refused(self, tmp_path, unusable) -> None:
+        # A bound of 0 or a negative one is not a deadline, inf states no
+        # deadline, nan loses every comparison it reaches, and True would act
+        # as a silent 1 second. Refused before any socket is opened.
+        with pytest.raises(ValueError, match="timeout"):
+            download_gsplat_scene(PRESET, cache_dir=tmp_path, timeout=unusable)
+        assert list(tmp_path.iterdir()) == []
+
+    def test_an_unknown_preset_is_still_refused_before_the_bound_is_read(self, tmp_path) -> None:
+        # Naming the scene is the caller's first mistake to hear about; the
+        # timeout domain must not preempt it.
+        with pytest.raises(KeyError, match="Unknown scene"):
+            download_gsplat_scene("not-a-scene", cache_dir=tmp_path, timeout=0)
+
+    def test_a_fractional_bound_reaches_the_transport(self, tmp_path, monkeypatch) -> None:
+        seen = _record_bounds(monkeypatch)
+        download_gsplat_scene(PRESET, cache_dir=tmp_path, timeout=0.25)
+        assert seen == [0.25]
+
+    def test_the_default_bound_is_finite_and_positive(self, tmp_path, monkeypatch) -> None:
+        # A caller who states nothing must still get a deadline: the default is
+        # what every existing call site in the tree and the demos rely on.
+        seen = _record_bounds(monkeypatch)
+        download_gsplat_scene(PRESET, cache_dir=tmp_path)
+        assert len(seen) == 1
+        assert isinstance(seen[0], float)
+        assert 0 < seen[0] < math.inf
+
+
+class TestTheCachePathNeverSeesAPartialBody:
+    def test_a_body_short_of_the_declared_length_fails_the_fetch(self, tmp_path, monkeypatch) -> None:
+        # urlretrieve raised ContentTooShortError for this; losing that check
+        # would trade a hang for a truncated scene cached as a complete one.
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda url, timeout=None: _body(b"short", declared="4194304"),
+        )
+        with pytest.raises(urllib.error.ContentTooShortError):
+            download_gsplat_scene(PRESET, cache_dir=tmp_path)
+        assert not (tmp_path / "bonsai.ply").exists()
+
+    def test_a_peer_that_declares_no_usable_length_is_taken_at_its_word(self, tmp_path, monkeypatch) -> None:
+        # A chunked response carries no Content-Length, and a non-numeric one
+        # is not a truncation signal in either direction. Neither is a reason
+        # to refuse a body that arrived.
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda url, timeout=None: _body(b"ply-bytes", declared=None),
+        )
+        assert download_gsplat_scene(PRESET, cache_dir=tmp_path).read_bytes() == b"ply-bytes"
+
+        (tmp_path / "bonsai.ply").unlink()
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda url, timeout=None: _body(b"ply-bytes", declared="not-a-number"),
+        )
+        assert download_gsplat_scene(PRESET, cache_dir=tmp_path).read_bytes() == b"ply-bytes"
+
+    def test_a_body_longer_than_declared_is_not_refused(self, tmp_path, monkeypatch) -> None:
+        # Only a SHORT body is evidence of truncation; a peer that undersold
+        # the length still delivered everything it sent.
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda url, timeout=None: _body(b"ply-bytes", declared="2"),
+        )
+        assert download_gsplat_scene(PRESET, cache_dir=tmp_path).read_bytes() == b"ply-bytes"
+
+
+class TestNoFetchInThePackageIsUnboundable:
+    def test_no_module_downloads_through_urlretrieve(self) -> None:
+        """``urlretrieve`` takes no timeout, so any call to it is unbounded.
+
+        Unlike a missing ``timeout=`` argument, this is not a call that forgot
+        to state a bound - it is a call that cannot state one, so the whole
+        package is held to the stronger rule.
+        """
+        package = Path(backgrounds.__file__).resolve().parent.parent
+        scanned = 0
+        offenders: list[str] = []
+        for module in sorted(package.rglob("*.py")):
+            scanned += 1
+            tree = ast.parse(module.read_text(encoding="utf-8"), filename=str(module))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Attribute) and node.attr == "urlretrieve":
+                    offenders.append(f"{module.relative_to(package)}:{node.lineno}")
+                elif isinstance(node, ast.Name) and node.id == "urlretrieve":
+                    offenders.append(f"{module.relative_to(package)}:{node.lineno}")
+        # The rule is only worth anything if the scan actually reached the tree.
+        assert scanned > 100, f"the scan visited only {scanned} modules; the roster rule is vacuous"
+        assert offenders == []
+
+
+def _record_bounds(monkeypatch: pytest.MonkeyPatch) -> list[float | None]:
+    """Stub the transport, returning the list of bounds it is handed."""
+    seen: list[float | None] = []
+
+    def _recording_urlopen(url: str, timeout: float | None = None) -> Any:
+        seen.append(timeout)
+        return _body(b"ply-bytes")
+
+    monkeypatch.setattr("urllib.request.urlopen", _recording_urlopen)
+    return seen
+
+
+def _body(payload: bytes, declared: str | None = "") -> Any:
+    """A urlopen double serving *payload*, declaring *declared* bytes.
+
+    ``declared=""`` (the default) means "declare the real length"; ``None``
+    means send no ``Content-Length`` at all.
+    """
+
+    class _Response:
+        def __init__(self) -> None:
+            self._remaining = payload
+            if declared is None:
+                self.headers: dict[str, str] = {}
+            else:
+                self.headers = {"Content-Length": declared or str(len(payload))}
+
+        def read(self, amount: int | None = None) -> bytes:
+            chunk, self._remaining = self._remaining, b""
+            return chunk
+
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+    return _Response()


### PR DESCRIPTION
![measured stalled-peer behaviour](https://raw.githubusercontent.com/cagataycali/robots/assets/scene-download-bound/docs/assets/scene_download_bound.png)

`download_gsplat_scene` fetched its asset with `urllib.request.urlretrieve`, whose signature is `url, filename, reporthook, data` — there is no timeout parameter to pass. The fetch therefore ran on the process-global default socket timeout, which is `None` unless some unrelated import mutated it, so a peer that completed the connection, sent its headers and then stopped sending held the calling thread indefinitely.

## Why that is more than "slow"

It defeats a documented fail-loud contract. `resolve_background` raises `RuntimeError` when the photoreal path cannot initialize — a download failure included — precisely so a caller who asked for the captured scene never silently receives the procedural gradient, and `allow_fallback=True` restores that demotion "for every failure mode". A stalled host produces **neither** outcome: nothing raises, so nothing is demoted, and the flag whose whole purpose is to keep the demo rendering cannot fire either.

Measured against a loopback peer that answers `200` with a `Content-Length`, sends ten bytes and then goes quiet (top panel):

| | `upstream/main` | this change |
|---|---|---|
| `download_gsplat_scene(preset)` | still blocked at 90.0s (observation stopped, not the wait) | `TimeoutError` at 60.1s |
| `resolve_background(allow_fallback=True)` | still blocked at 90.0s | `PanoramaBackground` at 60.1s |

The `mujoco_gs` Gradio handler wedges the same way, after yielding its `Downloading 3DGS scene ...` progress line.

## The change

The body streams through `urlopen(url, timeout=...)`. That `timeout` reaches the connection object itself — urllib's `AbstractHTTPHandler.do_open` forwards it as `http_class(host, timeout=req.timeout)` — so it becomes the socket timeout and bounds each read of the body, not merely the connect and TLS handshake. Nothing process-global is mutated, so a concurrent download or an unrelated socket in another thread keeps its own deadline.

The bound is **per socket operation**, not on the whole transfer: these assets run to hundreds of megabytes, so a legitimately slow link needs an unbounded total time, while no honest transfer needs a minute of silence mid-body. It is a `timeout` keyword argument (60s default) graded by `positive_finite_number_error`, the same domain the tree already uses for a span of time, so `0`, a negative value, `inf` or `nan` is refused rather than silently standing for no bound at all.

`urlretrieve` also raised `ContentTooShortError` when the body came up short of the declared `Content-Length`. That check is kept, with the same `(filename, headers)` content attached, because the fetch renames its `.part` sidecar onto the cache path — a truncated scene cached as a complete one is worse than a download that failed, since every later call reads the short file straight out of the cache.

## Tests

`tests/rendering/test_scene_download_states_a_socket_bound.py` — 17 cells, **17 failed / 0 passed** on `main`, 17 passed here. The headline cell measures a real stalled loopback peer and makes its assertion on a worker thread, so an unbounded fetch renders as a failure instead of hanging the suite. A package-wide AST scan pins that nothing fetches through `urlretrieve` at all — unlike a missing `timeout=` argument, that is a call which *cannot* state a bound; pre-fix it named `rendering/backgrounds.py:834`.

The three existing fetch-path tests in `tests/rendering/test_backgrounds.py` stubbed `urlretrieve`; they now stub `urlopen`, and the `.part` assertion got stronger — it observes mid-transfer that the bytes are in the sidecar and the final cache path does not yet exist.

Gate: `ruff check` / `ruff format` clean; `mypy` at its 20 pre-existing errors in 6 files, none in the touched files; full `tests/` run on this branch and on `main` side by side — identical failure-name sets (`comm` empty both directions), `+17` passed.