### PR TITLE
fix(packaging): the UR driver's RTDE client is declared where an install reaches it

### DIFF
--- a/changelog.d/3318-ur-rtde-extra-declared.md
+++ b/changelog.d/3318-ur-rtde-extra-declared.md
@@ -1,0 +1,23 @@
+### Bug Fixes
+
+- **packaging**: the UR native driver is an adapter onto two importables -
+  `rtde_control` (`servoJ`, `speedJ`, the dashboard verbs) and `rtde_receive`
+  (joint positions and velocities, the TCP pose, the safety and robot mode
+  words) - and no requirement named the `ur_rtde` distribution both come from.
+  Measured against the lock: absent from the base install and from all 33
+  declared extras, so no install of this project could move a UR arm, and the
+  remedy `_resolve_rtde()` printed was a bare `pip install ur_rtde` - the last
+  place in the drivers tree handing a reader a package whose version this project
+  does not bound. A new `[ur]` extra declares `ur-rtde>=1.6.0,<2.0.0` and the
+  refusal names it. Deliberately not folded into `[all]`: ur_rtde is a compiled
+  Boost binding whose wheels cover manylinux x86_64/i686 and win_amd64 only, up
+  to cp312, so on Python 3.13 or aarch64 an install builds from the sdist and
+  needs a C++ toolchain - a cost every `[all]` install would pay for a capability
+  the driver already degrades cleanly without.
+  `tests/test_ur_rtde_extra_is_declared.py` refuses the shape generally: no
+  driver refusal may hand a reader a distribution when an extra could supply it,
+  and the two that legitimately do say why (`panda-py` is not on PyPI at all;
+  `booster_robotics_sdk_python` is a vendor wheel pinned to the robot's
+  firmware). The lock walk two of these packaging rules each kept a private copy
+  of - and this one would have made a third - now has one owner in
+  `tests/uv_lock_closure.py`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ graph TB
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh |
 | `[mesh-iot]` | above + `awsiotsdk`, `awscrt`, `boto3` | AWS IoT Core transport |
-| `[all]` | 21 of the 33 extras - not a union; see [installation](getting-started/installation.md) for the 11 it leaves opt-in | CI / exploration |
+| `[all]` | 21 of the 34 extras - not a union; see [installation](getting-started/installation.md) for the 12 it leaves opt-in | CI / exploration |
 
 ## See also
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,9 +17,10 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` (ZMQ to a GR00T container) |
 | `[cosmos3-service]` | `msgpack`, `websockets>=17.0` | `Cosmos3Policy` (WebSocket to Cosmos 3 server) |
 | `[earthrover]` | `requests>=2.28.0,<3.0.0` | `Robot("earthrover", mode="real", driver="strands")` - HTTP to the earth-rovers-sdk |
+| `[ur]` | `ur-rtde>=1.6.0,<2.0.0` | `Robot("ur5e", mode="real", driver="strands")` - RTDE to a UR controller |
 | `[mesh]` | `eclipse-zenoh>=1.6.1,<2.0.0`, `json5` | Multi-robot mesh discovery + RPC |
 | `[mesh-iot]` | `mesh` + `awsiotsdk`, `awscrt`, `boto3` | AWS IoT Core transport for mesh |
-| `[all]` | 21 of the 33 extras - **not** a union. `[cosmos3-diffusers]`, `[cosmos3-service]`, `[cosmos3-sim]`, `[crazyflie]` (GPLv3), `[curobo]`, `[microduck]`, `[ros2]`, `[sim-gs]`, `[sim-isaac]`, `[sim-newton]` and `[vera-sim]` stay opt-in | Demos, CI, exploration |
+| `[all]` | 21 of the 34 extras - **not** a union. `[cosmos3-diffusers]`, `[cosmos3-service]`, `[cosmos3-sim]`, `[crazyflie]` (GPLv3), `[curobo]`, `[microduck]`, `[ros2]`, `[sim-gs]`, `[sim-isaac]`, `[sim-newton]`, `[ur]` (compiled binding) and `[vera-sim]` stay opt-in | Demos, CI, exploration |
 | `[dev]` | `pytest`, `pytest-cov`, `ruff`, `mypy`, `pytest-timeout` | Contributing |
 
 ```bash

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -113,7 +113,8 @@ arm.send_action({"elbow_joint": 1.40})     # one servoJ setpoint, radians
 arm.run_policy(policy, n_steps=500)        # streamed rollout at control_frequency
 ```
 
-Needs the SDK: `pip install ur_rtde`. `port=` is the controller's address; the RTDE
+Needs the SDK: `pip install 'strands-robots[ur]'`, which declares the `ur_rtde`
+build the driver's two interfaces come from. `port=` is the controller's address; the RTDE
 port is fixed at 30004 by the protocol, so a different suffix is refused rather than
 dialled.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,24 @@ microduck = [
 crazyflie = [
     "cflib>=0.1.25,<0.2.0",
 ]
+# Universal Robots RTDE client for the UR native driver
+# (strands_robots/drivers/ur.py). ur_rtde is the single distribution that supplies
+# both importables the driver resolves -- rtde_control (servoJ, speedJ, the
+# freedrive and dashboard verbs) and rtde_receive (joint positions and velocities,
+# the TCP pose, the safety and robot mode words) -- so one requirement is the
+# remedy for either name.
+#
+# Deliberately NOT a member of [all]: ur_rtde is a compiled Boost/pybind11
+# binding whose published wheels cover manylinux x86_64/i686 and win_amd64 only,
+# up to cp312. On a Python 3.13 interpreter or an aarch64 host -- the edge
+# machines this project runs on -- pip falls back to the sdist and needs a C++
+# toolchain plus Boost to build it, so folding it into [all] would put a compiler
+# in front of `pip install strands-robots[all]`. The driver degrades cleanly
+# without the SDK (_resolve_rtde returns a reason naming this extra), so [all]
+# still imports, registers and tests it. See docs/robots/arms.md.
+ur = [
+    "ur-rtde>=1.6.0,<2.0.0",
+]
 # HTTP transport for the EarthRover Mini Plus native driver
 # (strands_robots/drivers/earthrover.py). The driver talks to the vendor's
 # earth-rovers-sdk over HTTP -- GET /data for telemetry, POST /control to drive --

--- a/strands_robots/drivers/ur.py
+++ b/strands_robots/drivers/ur.py
@@ -249,9 +249,9 @@ def _resolve_rtde() -> tuple[Any, Any] | str:
 
     Returns:
         ``(rtde_control, rtde_receive)`` on success, or a reason naming the
-        module that failed and the package that supplies it. Both modules come
-        from the single ``ur_rtde`` distribution, so one pip line is the remedy
-        for either name.
+        module that failed and the extra that supplies it. Both modules come
+        from the single ``ur_rtde`` distribution, which ``[ur]`` declares, so one
+        install line is the remedy for either name.
     """
     import importlib
 
@@ -261,7 +261,7 @@ def _resolve_rtde() -> tuple[Any, Any] | str:
     except ImportError as exc:
         return (
             f"the ur_rtde SDK is not importable ({exc}). It supplies both rtde_control and "
-            "rtde_receive; install it with 'pip install ur_rtde'."
+            "rtde_receive; install it with: pip install 'strands-robots[ur]'"
         )
     return control, receive
 

--- a/tests/test_earthrover_http_extra_is_declared.py
+++ b/tests/test_earthrover_http_extra_is_declared.py
@@ -56,10 +56,10 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from strands_robots.drivers.earthrover import EarthRoverDriver
+from tests.uv_lock_closure import lock_closure
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
-_LOCK = _REPO_ROOT / "uv.lock"
 
 #: The extra that owns the transport, and the bundle that folds it in. Both must
 #: resolve to it: the first is the remedy the driver prints, the second is what
@@ -81,40 +81,6 @@ def _development_environment_dependencies() -> list[Requirement]:
         data = tomllib.load(handle)
     declared = data["tool"]["hatch"]["envs"]["default"].get("dependencies", [])
     return [Requirement(text) for text in declared]
-
-
-def _lock_closure(extra: str) -> frozenset[str]:
-    """Distributions an install of *extra* resolves to, walked over ``uv.lock``.
-
-    uv's own resolution of this manifest, so the claim that an extra supplies the
-    transport is checked rather than asserted, and offline. Markers are not
-    evaluated, which makes the result a superset -- the safe direction for a rule
-    that fails a manifest.
-    """
-    with _LOCK.open("rb") as handle:
-        locked = tomllib.load(handle)["package"]
-    by_name: dict[str, list[dict]] = {}
-    for package in locked:
-        by_name.setdefault(package["name"], []).append(package)
-
-    seen: set[tuple[str, tuple[str, ...]]] = set()
-    pending: list[tuple[str, tuple[str, ...]]] = [("strands-robots", (extra,))]
-    while pending:
-        name, extras = pending.pop()
-        if (name, extras) in seen:
-            continue
-        seen.add((name, extras))
-        for package in by_name.get(name, []):
-            entries = list(package.get("dependencies", []))
-            optional = package.get("optional-dependencies", {})
-            for group in extras:
-                entries += optional.get(group, [])
-            for entry in entries:
-                # uv spells the requested-extras key `extra`, singular.
-                requested = entry.get("extra", ())
-                asked = tuple(requested) if isinstance(requested, list) else (requested,)
-                pending.append((entry["name"], asked))
-    return frozenset(str(canonicalize_name(name)) for name, _ in seen)
 
 
 def test_the_extra_declares_the_http_transport() -> None:
@@ -150,7 +116,7 @@ def test_the_bundle_folds_the_extra_in() -> None:
 @pytest.mark.parametrize("extra", _EXTRAS_SHIPPING_THE_TRANSPORT)
 def test_an_install_of_the_extra_locks_the_transport(extra: str) -> None:
     """Each extra that must ship the transport resolves to it in the lock."""
-    closure = _lock_closure(extra)
+    closure = lock_closure(extra)
     assert "requests" in closure, (
         f"[{extra}] locks {len(closure)} distributions and requests is not among "
         "them, so an install of it ships the EarthRover driver and no transport for it"

--- a/tests/test_session_process_dependency_is_declared.py
+++ b/tests/test_session_process_dependency_is_declared.py
@@ -66,10 +66,10 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 import strands_robots
+from tests.uv_lock_closure import lock_closure
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
-_LOCK = _REPO_ROOT / "uv.lock"
 
 #: The shipped package, reached through the imported module so a layout change
 #: cannot silently narrow the scan to nothing.
@@ -133,50 +133,10 @@ def _requirements(extra: str | None) -> list[Requirement]:
     return [Requirement(text) for text in declared]
 
 
-def _locked_packages() -> dict[str, list[dict]]:
-    with _LOCK.open("rb") as handle:
-        locked = tomllib.load(handle)["package"]
-    by_name: dict[str, list[dict]] = {}
-    for package in locked:
-        by_name.setdefault(package["name"], []).append(package)
-    return by_name
-
-
-def _requested_extras(entry: dict) -> tuple[str, ...]:
-    """Extras a lock dependency entry asks for. uv spells the key ``extra``."""
-    requested = entry.get("extra", ())
-    return tuple(requested) if isinstance(requested, list) else (requested,)
-
-
-def _lock_closure(extra: str | None) -> frozenset[str]:
-    """Distributions an install of *extra* resolves to (``None`` for the base set).
-
-    Walked over ``uv.lock`` rather than resolved live, so the check is offline.
-    Markers are not evaluated, which makes the result a superset -- see the
-    module docstring for why that direction is the safe one here.
-    """
-    by_name = _locked_packages()
-    root_extras: tuple[str, ...] = () if extra is None else (extra,)
-    seen: set[tuple[str, tuple[str, ...]]] = set()
-    pending: list[tuple[str, tuple[str, ...]]] = [("strands-robots", root_extras)]
-    while pending:
-        name, extras = pending.pop()
-        if (name, extras) in seen:
-            continue
-        seen.add((name, extras))
-        for package in by_name.get(name, []):
-            entries = list(package.get("dependencies", []))
-            optional = package.get("optional-dependencies", {})
-            for group in extras:
-                entries += optional.get(group, [])
-            pending += [(entry["name"], _requested_extras(entry)) for entry in entries]
-    return frozenset(str(canonicalize_name(name)) for name, _ in seen)
-
-
 def _every_closure() -> dict[str | None, frozenset[str]]:
     extras: list[str | None] = [None]
     extras += sorted(_manifest()["optional-dependencies"])
-    return {extra: _lock_closure(extra) for extra in extras}
+    return {extra: lock_closure(extra) for extra in extras}
 
 
 def _module_scope_imports(source: Path) -> set[str]:
@@ -226,7 +186,7 @@ def test_the_lerobot_extra_declares_the_process_dependency() -> None:
 @pytest.mark.parametrize("extra", _EXTRAS_REACHING_THE_SESSION_TOOLS)
 def test_every_extra_that_ships_the_session_tools_locks_psutil(extra: str) -> None:
     """Each extra carrying the session tools' stack resolves to a psutil."""
-    closure = _lock_closure(extra)
+    closure = lock_closure(extra)
     assert "psutil" in closure, (
         f"[{extra}] locks {len(closure)} distributions and psutil is not among "
         "them, so an install of that extra ships the session tools and none of "

--- a/tests/test_ur_rtde_extra_is_declared.py
+++ b/tests/test_ur_rtde_extra_is_declared.py
@@ -1,0 +1,218 @@
+"""The UR driver's RTDE client is declared by an extra whose bound this project owns.
+
+``strands_robots/drivers/ur.py`` drives a Universal Robots e-Series arm through
+the controller's Real-Time Data Exchange interface, and the whole driver is an
+adapter onto two importables: ``rtde_control`` (``servoJ``, ``speedJ``, the
+dashboard verbs) and ``rtde_receive`` (joint positions and velocities, the TCP
+pose, the safety and robot mode words). Both come from one distribution,
+``ur_rtde`` - and no requirement named it. Measured against the checked-in lock,
+it was absent from the base install and from every one of the 33 declared extras,
+so no install of this project could move a UR arm.
+
+What a reader got instead was ``pip install ur_rtde``: a bare distribution, the
+last place in the drivers tree that handed a reader a package whose version this
+project does not bound. The two remedies beside it name an extra
+(``[crazyflie]``, ``[earthrover]``), which is the form that stays correct when the
+requirement moves - the reader installs a capability and the manifest decides the
+version.
+
+So ``[ur]`` declares it at the range the driver's own calls need. It is
+deliberately left out of ``[all]``: ur_rtde is a compiled Boost/pybind11 binding
+whose wheels cover manylinux x86_64/i686 and win_amd64 only, up to cp312, so on a
+Python 3.13 interpreter or an aarch64 host pip falls back to the sdist and needs a
+C++ toolchain plus Boost. ``[all]`` is the bundle CI and exploration install, and
+putting a compiler in front of it would cost every one of those installs. The
+driver degrades cleanly without the SDK, so ``[all]`` still imports, registers and
+tests it.
+
+The last rule here is the general one rather than a fourth assertion about
+``ur_rtde``: **no driver refusal may hand a reader a distribution when an extra
+could supply it.** Two hints legitimately name a distribution and both say why -
+``panda-py`` is not published on PyPI at all (the Franka binding ships as a
+release asset, and a direct URL requirement is denylisted by
+``tests/test_dependency_audit.py``), and ``booster_robotics_sdk_python`` is a
+vendor wheel pinned to the robot's firmware, so the installed build's vocabulary
+is an input rather than something this project bounds. Anything else is the defect
+this file fixes, and the next native driver to land will be graded by it.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+
+from strands_robots.drivers.ur import URDriver
+from tests.uv_lock_closure import lock_closure
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_DRIVERS = _REPO_ROOT / "strands_robots" / "drivers"
+
+#: The extra that owns the RTDE client, and the distribution it must declare.
+_EXTRA = "ur"
+_CLIENT = "ur-rtde"
+
+#: A written install hint, and the target it hands the reader. Quoted forms are
+#: read whole because the extra spelling needs them (a bare ``strands-robots[ur]``
+#: is two shell words to zsh). A hint with no target - the prose "no ``pip
+#: install`` supplies a module" - matches nothing, which is correct: it names no
+#: package.
+_HINT = re.compile(r"pip install\s+(?:'(?P<quoted>[^']+)'|\"(?P<dquoted>[^\"]+)\"|(?P<bare>[A-Za-z][A-Za-z0-9._-]*))")
+
+#: Distributions a driver refusal may name directly, each with the reason no
+#: extra can carry it. Not a waiver list: both reasons are properties of the
+#: distribution, so a new entry has to state one.
+_UNDECLARABLE = {
+    "panda-py": (
+        "not published on PyPI - the Franka binding ships as a release asset, and a direct "
+        "URL requirement is denylisted by test_pyproject_has_no_direct_reference_dependency"
+    ),
+    "booster-robotics-sdk-python": (
+        "a vendor wheel pinned to the robot's firmware, so the installed build's vocabulary is "
+        "an input rather than a version this project bounds (strands_robots/drivers/booster.py)"
+    ),
+}
+
+
+def _optional_dependencies() -> dict[str, list[str]]:
+    with _PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)["project"]["optional-dependencies"]
+
+
+def _requirements(extra: str) -> list[Requirement]:
+    """Requirement objects *extra* declares, or a failure naming what is missing."""
+    declared = _optional_dependencies()
+    assert extra in declared, (
+        f"the manifest declares no [{extra}] extra, so `pip install 'strands-robots[{extra}]'` "
+        f"exits 0 and installs nothing. Declared: {sorted(declared)}"
+    )
+    return [Requirement(text) for text in declared[extra]]
+
+
+def _declared_client() -> Requirement:
+    """The ``[ur]`` requirement on the RTDE client, or a failure naming the extra."""
+    declared = [req for req in _requirements(_EXTRA) if canonicalize_name(req.name) == _CLIENT]
+    assert declared, (
+        f"[{_EXTRA}] does not name {_CLIENT}, so the driver's own remedy installs an environment "
+        f"where rtde_control and rtde_receive still cannot be imported. Declared: "
+        f"{[str(req) for req in _requirements(_EXTRA)]}"
+    )
+    return declared[0]
+
+
+def test_the_extra_declares_the_rtde_client_at_a_bounded_range() -> None:
+    """``[ur]`` names ur_rtde, and states a range rather than "any release"."""
+    specifier = SpecifierSet(str(_declared_client().specifier))
+    assert specifier, (
+        f"{_CLIENT} is declared unbounded in [{_EXTRA}], so an install can resolve a build with "
+        "neither interface the driver calls"
+    )
+    assert any(clause.operator in (">=", "==", "~=") for clause in specifier), (
+        f"{specifier} states no floor, so a release predating servoJ's signature satisfies it"
+    )
+
+
+def test_an_install_of_the_extra_resolves_the_client() -> None:
+    """The lock agrees that ``[ur]`` ships the client - the manifest is not taken on trust."""
+    closure = lock_closure(_EXTRA)
+    assert _CLIENT in closure, (
+        f"[{_EXTRA}] locks {len(closure)} distributions and {_CLIENT} is not among them, so an "
+        "install of it ships the UR driver and no client for it"
+    )
+    assert _CLIENT not in lock_closure(None), (
+        f"{_CLIENT} is in the base install, so the extra grades nothing - every install would "
+        "carry a compiled binding nobody asked for"
+    )
+
+
+def test_the_bundle_puts_no_compiler_in_front_of_itself() -> None:
+    """``[all]`` does not fold ``[ur]`` in, so the bundle stays wheel-only.
+
+    ur_rtde publishes no aarch64 wheel and none for cp313, so on the hosts this
+    project runs on an install of it builds from the sdist and needs a C++
+    toolchain plus Boost. ``[all]`` is what CI and an exploring reader install;
+    the driver reports a reason and stays usable without the SDK, so the capability
+    is opt-in rather than a cost every one of those installs pays.
+    """
+    assert f"strands-robots[{_EXTRA}]" not in _optional_dependencies()["all"], (
+        f"[all] folds in [{_EXTRA}], so every install of the bundle now needs a C++ toolchain on "
+        "any host ur_rtde publishes no wheel for. If that is intended, this rule is the place to "
+        "say so."
+    )
+    assert _CLIENT not in lock_closure("all"), (
+        f"[all] resolves {_CLIENT} through some other requirement, so the bundle carries the "
+        "compiled binding whether or not it names the extra"
+    )
+
+
+def test_the_absent_client_refuses_by_naming_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the SDK the driver reports the extra that supplies it, and stays usable.
+
+    Drives the driver's own resolution rather than reading the source: a ``None``
+    entry in ``sys.modules`` is what makes ``importlib.import_module`` raise
+    ``ImportError`` for a name, which is the absence an install without the extra
+    has.
+    """
+    monkeypatch.setitem(sys.modules, "rtde_control", None)
+    monkeypatch.setitem(sys.modules, "rtde_receive", None)
+    driver = URDriver(tool_name="ur5e", port="192.168.1.10")
+
+    reason = driver.connect_eagerly()
+
+    assert reason is not None, "connect_eagerly reported success with no RTDE client to speak"
+    assert f"strands-robots[{_EXTRA}]" in reason, (
+        "the refusal does not name the extra that supplies the client, so the reader is handed a "
+        f"distribution whose bound this project does not own. Got: {reason!r}"
+    )
+    assert "pip install ur_rtde" not in reason, (
+        f"the refusal still hands the reader the bare distribution. Got: {reason!r}"
+    )
+    # The degrade is the contract, not a side effect: no raise past the envelope.
+    assert not driver.is_connected
+    assert driver.send_action({"elbow_joint": 1.4})["status"] == "error"
+    assert driver.state()["status"] == "error"
+
+
+def test_no_driver_refusal_hands_a_reader_an_undeclarable_distribution() -> None:
+    """Every written install hint in the drivers tree names an extra, or says why not.
+
+    The general rule. An extra is a capability whose version this project owns, so
+    a hint naming one keeps working when the requirement moves; a hint naming a
+    distribution pins the reader to a decision the manifest never made.
+    """
+    extras = {re.sub(r"[-_.]+", "-", name).lower() for name in _optional_dependencies()}
+    offenders: list[str] = []
+    hints = 0
+    modules: set[str] = set()
+    for source in sorted(_DRIVERS.rglob("*.py")):
+        rel = source.relative_to(_REPO_ROOT).as_posix()
+        for lineno, line in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
+            for match in _HINT.finditer(line):
+                target = match.group("quoted") or match.group("dquoted") or match.group("bare")
+                hints += 1
+                modules.add(rel)
+                named = re.fullmatch(r"strands-robots(?:\[([a-z0-9,_-]+)\])?", target.strip())
+                if named is None:
+                    if canonicalize_name(target) not in _UNDECLARABLE:
+                        offenders.append(f"{rel}:{lineno} names the distribution {target!r} -- {line.strip()[:90]}")
+                    continue
+                for part in (named.group(1) or "").split(","):
+                    if part and re.sub(r"[-_.]+", "-", part).lower() not in extras:
+                        offenders.append(f"{rel}:{lineno} names the undeclared extra [{part}]")
+
+    # Non-vacuity: a sweep reading nothing would agree with every manifest.
+    assert hints >= 6 and len(modules) >= 4, (
+        f"the sweep found {hints} hints across {len(modules)} modules; the drivers tree or the hint pattern has drifted"
+    )
+    assert not offenders, (
+        "these refusals hand a reader a distribution instead of an extra whose bound this project "
+        f"owns. Declare it and name the extra, or record why no extra can carry it in "
+        f"_UNDECLARABLE. Currently recorded: {sorted(_UNDECLARABLE)}\n" + "\n".join(offenders)
+    )

--- a/tests/uv_lock_closure.py
+++ b/tests/uv_lock_closure.py
@@ -1,0 +1,80 @@
+"""Distributions an install of one extra resolves to, read from ``uv.lock``.
+
+Several packaging rules ask the same question - does an install of this extra
+really ship the dependency the manifest claims for it - and each answered it with
+its own copy of the same walk. One owner, because a copy that drifts answers a
+different question under the same name.
+
+The walk reads the checked-in lock rather than resolving live, so a rule that
+grades the manifest stays offline and deterministic. Markers are deliberately not
+evaluated: the result is a superset of what any one platform installs, which is
+the safe direction for a rule that fails a manifest - it never reports a
+distribution absent that some environment does resolve.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.utils import canonicalize_name
+
+_LOCK = Path(__file__).resolve().parents[1] / "uv.lock"
+
+#: The project's own name in the lock, and the root every walk starts from.
+ROOT = "strands-robots"
+
+
+def locked_packages() -> dict[str, list[dict]]:
+    """Every ``[[package]]`` entry in the lock, grouped by distribution name.
+
+    A name can carry several entries - uv records one per resolution fork (the
+    ``[vera-sim]`` conflict declaration produces two ``gymnasium`` entries) - so
+    the value is a list and the walk reads all of them.
+    """
+    with _LOCK.open("rb") as handle:
+        locked = tomllib.load(handle)["package"]
+    by_name: dict[str, list[dict]] = {}
+    for package in locked:
+        by_name.setdefault(package["name"], []).append(package)
+    return by_name
+
+
+def requested_extras(entry: dict) -> tuple[str, ...]:
+    """Extras a lock dependency entry asks for. uv spells the key ``extra``.
+
+    Singular, and easy to mistake for ``extras``: reading the plural silently
+    drops every ``package[extra]`` requirement from the walk, which reports a
+    transitively supplied distribution as absent.
+    """
+    requested = entry.get("extra", ())
+    return tuple(requested) if isinstance(requested, list) else (requested,)
+
+
+def lock_closure(extra: str | None) -> frozenset[str]:
+    """Canonical names an install of *extra* resolves to (``None`` = base install).
+
+    Args:
+        extra: One entry of ``[project.optional-dependencies]``, or ``None`` for
+            the unconditional ``[project.dependencies]`` alone.
+
+    Returns:
+        Every distribution reachable from that root, canonicalized, including the
+        root itself.
+    """
+    by_name = locked_packages()
+    root_extras: tuple[str, ...] = () if extra is None else (extra,)
+    seen: set[tuple[str, tuple[str, ...]]] = set()
+    pending: list[tuple[str, tuple[str, ...]]] = [(ROOT, root_extras)]
+    while pending:
+        name, extras = pending.pop()
+        if (name, extras) in seen:
+            continue
+        seen.add((name, extras))
+        for package in by_name.get(name, []):
+            entries = list(package.get("dependencies", []))
+            optional = package.get("optional-dependencies", {})
+            for group in extras:
+                entries += optional.get(group, [])
+            pending += [(entry["name"], requested_extras(entry)) for entry in entries]
+    return frozenset(str(canonicalize_name(name)) for name, _ in seen)

--- a/uv.lock
+++ b/uv.lock
@@ -5013,6 +5013,9 @@ smolvla = [
     { name = "lerobot", extra = ["dataset", "feetech", "smolvla"], marker = "extra == 'extra-14-strands-robots-all' or extra == 'extra-14-strands-robots-lerobot' or extra == 'extra-14-strands-robots-lerobot-async' or extra == 'extra-14-strands-robots-molmoact2' or extra == 'extra-14-strands-robots-smolvla' or extra != 'extra-14-strands-robots-vera-sim'" },
     { name = "psutil" },
 ]
+ur = [
+    { name = "ur-rtde" },
+]
 vera-sim = [
     { name = "gym-pusht" },
     { name = "gymnasium", version = "0.29.1", source = { registry = "https://pypi.org/simple" } },
@@ -5163,6 +5166,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'cosmos3-diffusers'", specifier = ">=4.40" },
     { name = "transformers", marker = "extra == 'kimodo'", specifier = ">=4.40.0" },
     { name = "trimesh", marker = "extra == 'sim-newton'", specifier = ">=4.0.0,<5.0.0" },
+    { name = "ur-rtde", marker = "extra == 'ur'", specifier = ">=1.6.0,<2.0.0" },
     { name = "usd-core", marker = "extra == 'sim-isaac'", specifier = ">=25.5,<27.0.0" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.27,<1.0" },
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.27,<1.0" },
@@ -5175,7 +5179,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'cosmos3-service'", specifier = ">=17.0" },
     { name = "websockets", marker = "extra == 'inference'", specifier = ">=17.0" },
 ]
-provides-extras = ["all", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "crazyflie", "curobo", "dashboard", "dev", "device-connect", "earthrover", "groot-service", "inference", "kimodo", "lerobot", "lerobot-async", "mesh", "mesh-iot", "microduck", "molmoact2", "motionbricks", "moveit2", "ollama", "protomotions", "ros2", "rosbridge", "sagemaker", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "smolvla", "vera-sim", "wbc"]
+provides-extras = ["all", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "crazyflie", "curobo", "dashboard", "dev", "device-connect", "earthrover", "groot-service", "inference", "kimodo", "lerobot", "lerobot-async", "mesh", "mesh-iot", "microduck", "molmoact2", "motionbricks", "moveit2", "ollama", "protomotions", "ros2", "rosbridge", "sagemaker", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "smolvla", "ur", "vera-sim", "wbc"]
 
 [[package]]
 name = "sympy"
@@ -5660,6 +5664,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/76/ec/8e3802fc4a4e31e817b972bbb0e704a484d8c75ec349b3feb45fa9fb54c4/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2862f81af44b3a7e74c5d80caa118d736be1991ce6f1d5c723716fa403060cc6", size = 54938, upload-time = "2026-06-14T22:36:32.051Z" },
     { url = "https://files.pythonhosted.org/packages/4a/48/d0e3e511039b86fd1ecfe2bf761c800552d273ef8f19e71de93bf38a909e/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c16e07581172f08585b409246f4535dab13ee85af0e3d3cfa8684b653ca44fa8", size = 56115, upload-time = "2026-06-14T22:36:33.349Z" },
     { url = "https://files.pythonhosted.org/packages/81/b5/689613037fe691d18eae075cd141089f3a3156146be14512df92d8a9ae8f/ujson-5.13.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:9bd0f2dd05937c3b089af316884de18c6f6182ddb8ffce597d2e7c7a9ba9f447", size = 41802, upload-time = "2026-06-14T22:36:34.523Z" },
+]
+
+[[package]]
+name = "ur-rtde"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/11/5f3dc66a5ba608830ffa83bdaa8808562172b6332f8aaf9bdafeb22e2df2/ur_rtde-1.6.5.tar.gz", hash = "sha256:3d5b6c6bf73346b806d146f128537abd2afb1d769f4a9c8b3ef5a884fab0bcfa", size = 3428886, upload-time = "2026-08-09T07:52:33.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/6a/d61e5e016d6637b5c425ead983573caff143d91a2342e4fdd45a30b12f58/ur_rtde-1.6.5-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a9b39a82d731bf7b2cca91fd2218246c22331e4d060e287cc257352d24594a7", size = 4997458, upload-time = "2026-08-09T07:51:49.215Z" },
+    { url = "https://files.pythonhosted.org/packages/69/28/d96a5ba6e759f010d61229d70fed508ef19fe89302d486b26c207c4086d6/ur_rtde-1.6.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5aeddaba7b7ba99d9edb0e25c3a9ff8f7d5b5641aa4396a5380d884840b6870", size = 4922384, upload-time = "2026-08-09T07:51:51.352Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f6/d55fb42416633d6a4319dc2088430b107b6d28f3dcd3b8a3041f15ca9b03/ur_rtde-1.6.5-cp312-cp312-win_amd64.whl", hash = "sha256:e2fb0b71b9c9a5969695db29bafb1e22f6aac529595cf5001b3114890b34d8ba", size = 2573217, upload-time = "2026-08-09T07:51:53.036Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
![before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/ur-rtde-extra/docs/assets/ur_rtde_extra.png)

The UR native driver is an adapter onto two importables - `rtde_control` (`servoJ`, `speedJ`, the dashboard verbs) and `rtde_receive` (joint positions and velocities, the TCP pose, the safety and robot mode words). Both come from one distribution, `ur_rtde`, and no requirement named it. Walked over the checked-in lock: absent from the base install and from all 33 declared extras, so no install of this project could move a UR arm - and the remedy `_resolve_rtde()` printed was a bare `pip install ur_rtde`, the last place in the drivers tree handing a reader a package whose version this project does not bound.

| | before | after |
|---|---|---|
| extras naming `ur_rtde` | none of 33 | `[ur]`, of 34 |
| `strands-robots[ur]` locks | 53 pkgs, no client (pip exits 0 on an unknown extra) | 54 pkgs, client present |
| `strands-robots[all]` locks | 207 pkgs, no client | 207 pkgs, no client |
| the refusal says | `pip install ur_rtde` | `pip install 'strands-robots[ur]'` |

### Why `[ur]` is opt-in rather than a member of `[all]`

`ur-rtde` 1.6.5 publishes manylinux `x86_64`/`i686` and `win_amd64` wheels for cp312 and below - no aarch64 wheel, none for cp313 - so on those hosts an install builds from the sdist and needs a C++ toolchain plus Boost. `[all]` is the bundle CI and an exploring reader install, and the driver already reports a reason and stays usable without the SDK, so the capability is opt-in instead of a compiler in front of every `[all]` install. `[all]`'s closure is 207 distributions before and after; only `[ur]` moves.

### The general rule

`tests/test_ur_rtde_extra_is_declared.py`'s last cell is the rule rather than a fourth assertion about `ur_rtde`: **no driver refusal may hand a reader a distribution when an extra could supply it.** Two hints legitimately name a distribution and each says why - `panda-py` is not published on PyPI at all (the Franka binding ships as a release asset, and a direct URL requirement is denylisted by `test_pyproject_has_no_direct_reference_dependency`), and `booster_robotics_sdk_python` is a vendor wheel pinned to the robot's firmware, so the installed build's vocabulary is an input rather than a version this project bounds. The next native driver to land is graded by it.

### Tests

5 cells, 4 of which fail on this base and one that passes there on purpose (`[all]` never carried the client - the rule does not just fail everything):

```
test_the_extra_declares_the_rtde_client_at_a_bounded_range  FAIL  the manifest declares no [ur] extra ...
test_an_install_of_the_extra_resolves_the_client            FAIL  [ur] locks 53 distributions and ur-rtde is not among them
test_the_absent_client_refuses_by_naming_the_extra          FAIL  ... install it with 'pip install ur_rtde'.
test_no_driver_refusal_hands_a_reader_an_undeclarable_...   FAIL  drivers/ur.py:264 names the distribution 'ur_rtde'
test_the_bundle_puts_no_compiler_in_front_of_itself         PASS
```

The refusal cell drives the driver's own resolution (a `None` entry in `sys.modules`, which is the absence an install without the extra has) and pins the degrade: `connect_eagerly()` reports, `send_action()` and `state()` answer the error envelope, nothing raises past it.

91-module net around packaging, the lock, the docs pages and the UR driver, run on this base and on the branch: **8 failed / 2851 passed** -> **8 failed / 2856 passed**, +5 = exactly the new cells, failure-name sets identical in both directions. The 8 are pre-existing environment drift (absent `qpsolvers`/`awsiot`, a websockets floor, lerobot 0.6.2 dataset shapes). `scripts/check_whole_tree_graders.py`: 4692 passed, same standing set. `ruff check`/`format` clean on `strands_robots tests tests_integ`; `mypy` unchanged. `uv lock` moves only the new extra's rows (+16/-1) and `scripts/check_lockfile_parity.py` reports 0 findings.

### LOC

+369 / -87. The additions are the extra, the manifest comment, the 5 cells and their reasoning; the deletions are two private copies of the lock walk (`tests/test_earthrover_http_extra_is_declared.py`, `tests/test_session_process_dependency_is_declared.py`) that now share one owner in `tests/uv_lock_closure.py` - this rule would have made a third.