### PR TITLE
fix(tools): a session record's start time is graded, not subtracted from the clock

### DIFF
--- a/changelog.d/3319-session-uptime-is-graded.md
+++ b/changelog.d/3319-session-uptime-is-graded.md
@@ -1,0 +1,15 @@
+### Bug Fixes
+
+- **tools**: a session record's `start_time` is now read by one owner,
+  `_process_stop.session_uptime`, instead of being subtracted from the clock at
+  four call sites in three different spellings. A record that stated no usable
+  start reported a duration the session never had - an absent `start_time`
+  defaulted to `0` in the arithmetic and rendered as `Uptime: 29813993.5 min`, a
+  little under fifty-seven years, under `status: success` and beside a correct
+  running flag; `NaN` rendered `nan min` and a stamp ahead of this clock rendered
+  a negative duration. `null`, a string, a list and a mapping raised out of the
+  `list` verb, which then reported none of the sessions the store holds, so
+  running sessions became invisible because one unrelated record was damaged. The
+  reported `Uptime` field now says which way a record did not state its start,
+  and the `uptime` seconds in the `json` block is `None` rather than a span the
+  reader could not measure. A real stamp renders exactly as before.

--- a/strands_robots/tools/_process_stop.py
+++ b/strands_robots/tools/_process_stop.py
@@ -27,12 +27,21 @@ from a JSON file rather than from a caller. :func:`recorded_pid` is the one
 reader of it, because converting instead of grading is how a record comes to
 name a process it was never written for: ``int(4321.5)`` is a pid the record does
 not carry, and ``int(True)`` is pid 1.
+
+The same is true of every other field the record carries, and the one a report
+reads is ``start_time``. :func:`session_uptime` is its one reader, for the same
+reason: subtracting an ungraded stamp from the clock turns a record that states
+no usable start into a duration - the ``0`` an absent key defaults to renders as
+the whole epoch, a little under fifty-seven years - and reports it beside a
+running flag that is correct.
 """
 
 from __future__ import annotations
 
+import math
 import os
 import sys
+import time
 from collections.abc import Mapping
 from typing import Any
 
@@ -199,6 +208,74 @@ def recorded_pid(info: Mapping[str, Any]) -> int | None:
     if isinstance(pid, bool) or not isinstance(pid, int):
         return None
     return pid if 0 < pid <= _PID_T_MAX else None
+
+
+def session_uptime(info: Mapping[str, Any]) -> tuple[float | None, str]:
+    """How long the session ``info`` describes has been running, and how to say so.
+
+    The read-side owner of the record's ``start_time``, in the shape
+    :func:`recorded_pid` uses for its ``pid``: the value, or the absence of one -
+    never a number derived from a stamp that is not one. It answers for both
+    consumers of that span in one read of the clock, so a report's ``Uptime``
+    line and the ``uptime`` its ``json`` block carries cannot disagree.
+
+    ``start_time`` is a wall-clock stamp, so the span is measured against
+    :func:`time.time` rather than :func:`time.monotonic`: the record is written
+    by one process and read by another, and a monotonic reading is a duration
+    since this machine booted, which the reading process cannot relate to the
+    writer's. That is also why a stamp cannot simply be trusted - the clock it
+    was taken from is the current opinion about the date, and an NTP correction
+    or a ``date -s`` between the write and the read moves the span by the step.
+    A step large enough to put the stamp in this clock's future is reported as
+    such rather than as a negative duration, which is what the subtraction
+    renders on its own.
+
+    The values refused are the ones a JSON file produces and the subtraction
+    does not survive:
+
+    * No ``start_time`` at all, and the ``null`` that says the same thing. Both
+      default to ``0`` in the arithmetic, and ``time.time() - 0`` is the epoch:
+      a session started minutes ago reads as one running since 1970.
+    * ``bool``, which is an ``int`` subclass, so ``true`` is one second past the
+      epoch and lands within a second of the same answer.
+    * A ``str``, a ``list`` or a ``dict``. ``time.time() - "1788000000"`` raises
+      ``TypeError``, and ``float()`` of that same string does not, so the two
+      verbs of one tool reach opposite conclusions about one record.
+    * ``NaN`` and the infinities, which ``json.load`` produces from a well-formed
+      file and which render as ``nan min`` and ``-inf min``.
+    * Any stamp at or before the epoch, because ``0`` is the value the absent
+      case used to default to and accepting it re-creates that report.
+
+    What is *not* refused is a positive stamp that is merely implausible: ``1``
+    is one second past the epoch and is measured as the span it states. The
+    boundary is deliberate, because the only non-arbitrary floor available is
+    this machine's boot time, and that is not a safe one to compare against - on
+    Linux it comes from the ``btime`` recorded in ``/proc/stat`` at boot, which a
+    later correction to the clock does not revise, so a backwards correction
+    leaves a genuine post-boot stamp reading as earlier than boot. This owner
+    grades what a value *is*, not whether a plausible clock produced it.
+
+    Args:
+        info: A session record, read for its ``start_time`` key.
+
+    Returns:
+        The span in seconds and the text a report's ``Uptime`` field carries. The
+        span is ``None`` whenever the record does not state a usable start, and
+        the text then says which way it did not, so a caller passes both on
+        without deciding anything: the number for a machine, the sentence for
+        whoever has to go and look at the file.
+    """
+    recorded = info.get("start_time")
+    if recorded is None:
+        return None, "unknown (this record states no start time)"
+    if isinstance(recorded, bool) or not isinstance(recorded, int | float):
+        return None, f"unknown (this record states a {type(recorded).__name__} as its start time)"
+    if not math.isfinite(recorded) or recorded <= 0:
+        return None, "unknown (this record's start time is not a wall-clock stamp)"
+    span = time.time() - float(recorded)
+    if span < 0:
+        return None, f"unknown (this record's start time is {-span / 60:.1f} min ahead of this clock)"
+    return span, f"{span / 60:.1f} min"
 
 
 def unusable_pid_result(session_name: str, recorded: Any) -> dict[str, Any]:

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -32,6 +32,7 @@ from strands_robots.tools._process_stop import (
     recorded_pid,
     reused_pid_result,
     session_is_running,
+    session_uptime,
     unstopped_result,
     unusable_pid_result,
 )
@@ -992,7 +993,8 @@ def lerobot_teleoperate(
             "command": "full_command_executed",
             "log_file": "/tmp/session.log",  # for background sessions
             "sessions": {...},  # for list action
-            "uptime": 123.45,  # session uptime in seconds
+            "uptime": 123.45,  # session uptime in seconds; None when the
+                               # record states no usable start time
             "is_running": true  # for status action
         }
     """
@@ -1272,8 +1274,7 @@ def lerobot_teleoperate(
 
             if sessions:
                 for name, info in sessions.items():
-                    uptime = time.time() - info.get("start_time", 0)
-                    uptime_min = uptime / 60
+                    _, uptime_text = session_uptime(info)
                     pid = info.get("pid")
                     is_running = session_is_running(info)
 
@@ -1282,7 +1283,7 @@ def lerobot_teleoperate(
                             f"**{name}**",
                             f"   - Action: {info.get('action', 'Unknown')}",
                             f"   - PID: {pid}",
-                            f"   - Uptime: {uptime_min:.1f} min",
+                            f"   - Uptime: {uptime_text}",
                             f"   - Status: {'Running' if is_running else 'Stopped'}",
                             f"   - Robot: {info.get('robot_type', 'Unknown')}",
                             f"   - Teleop: {info.get('teleop_type', 'Unknown')}",
@@ -1309,16 +1310,14 @@ def lerobot_teleoperate(
                 return {"status": "error", "content": [{"text": f"Session '{session_name}' not found"}]}
 
             pid = session_info.get("pid")
-            start_time: float = float(session_info.get("start_time") or 0)
-            uptime = time.time() - start_time
-            uptime_min = uptime / 60
+            uptime, uptime_text = session_uptime(session_info)
             is_running = session_is_running(session_info)
 
             content_lines = [
                 f"**Session Status: `{session_name}`**",
                 f"PID: {pid}",
                 f"Action: {session_info.get('action', 'Unknown')}",
-                f"Uptime: {uptime_min:.1f} min",
+                f"Uptime: {uptime_text}",
                 f"Status: {'Running' if is_running else 'Stopped'}",
                 f"Robot: {session_info.get('robot_type', 'Unknown')}",
                 f"Teleop: {session_info.get('teleop_type', 'Unknown')}",

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -38,6 +38,7 @@ from strands_robots.tools._process_stop import (
     recorded_pid,
     reused_pid_result,
     session_is_running,
+    session_uptime,
     unstopped_result,
     unusable_pid_result,
 )
@@ -987,7 +988,10 @@ def lerobot_train(
         Dict with ``status`` ("success" or "error") and a ``content`` list of
         ``{"text": ...}`` items, plus action-specific keys (``session_name``,
         ``pid``, ``command``, ``log_file``, ``output_dir``, ``sessions``,
-        ``is_running``, ``uptime``).
+        ``is_running``, ``uptime``). ``uptime`` is seconds, and is ``None`` when
+        the session record states no usable start time - see
+        :func:`~strands_robots.tools._process_stop.session_uptime`, which is what
+        the reported ``Uptime`` field says instead.
     """
     session_manager = SessionManager()
 
@@ -1199,7 +1203,7 @@ def lerobot_train(
             lines = [f"**Active Training Sessions** ({len(sessions)})", ""]
             if sessions:
                 for name, info in sessions.items():
-                    uptime_min = (time.time() - info.get("start_time", 0)) / 60
+                    _, uptime_text = session_uptime(info)
                     pid = info.get("pid")
                     is_running = session_is_running(info)
                     lines.extend(
@@ -1207,7 +1211,7 @@ def lerobot_train(
                             f"**{name}**",
                             f"   - Action: {info.get('action', 'Unknown')}",
                             f"   - PID: {pid}",
-                            f"   - Uptime: {uptime_min:.1f} min",
+                            f"   - Uptime: {uptime_text}",
                             f"   - Status: {'Running' if is_running else 'Stopped'}",
                             f"   - Policy: {info.get('policy_type', 'Unknown')}",
                             f"   - Output: {info.get('output_dir', 'Unknown')}",
@@ -1232,13 +1236,13 @@ def lerobot_train(
                 return {"status": "error", "content": [{"text": f"Session '{session_name}' not found"}]}
 
             pid = session_info.get("pid")
-            uptime = time.time() - float(session_info.get("start_time") or 0)
+            uptime, uptime_text = session_uptime(session_info)
             is_running = session_is_running(session_info)
             lines = [
                 f"**Session Status: `{session_name}`**",
                 f"PID: {pid}",
                 f"Action: {session_info.get('action', 'Unknown')}",
-                f"Uptime: {uptime / 60:.1f} min",
+                f"Uptime: {uptime_text}",
                 f"Status: {'Running' if is_running else 'Stopped'}",
                 f"Policy: {session_info.get('policy_type', 'Unknown')}",
                 f"Output dir: {session_info.get('output_dir', 'Unknown')}",

--- a/tests/tools/test_session_uptime_is_graded_not_subtracted.py
+++ b/tests/tools/test_session_uptime_is_graded_not_subtracted.py
@@ -1,0 +1,326 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A session record's start time is graded, not subtracted from the clock.
+
+Both session tools keep their sessions in a JSON file, and ``list`` and
+``status`` report each one's ``Uptime`` by subtracting the record's
+``start_time`` from :func:`time.time`. That stamp is a file's declaration rather
+than a caller's argument, and subtracting one that is not a stamp is how a
+report comes to state a duration the session never had.
+
+Measured against the code these tests pin, every spelling a session store can
+hold other than a real stamp was reported wrongly, in one of three ways:
+
+* A record with **no** ``start_time`` at all defaulted to ``0`` in the
+  arithmetic, so ``time.time() - 0`` reported ``Uptime: 29813993.5 min``, a
+  little under fifty-seven years, under ``status: success`` and beside a running
+  flag that was right. ``true`` and ``0`` landed on the same answer.
+* ``NaN`` reported ``Uptime: nan min``, ``Infinity`` reported ``-inf min``, and a
+  stamp ahead of this clock - what a backwards NTP correction between the write
+  and the read leaves behind - reported ``Uptime: -10.0 min``.
+* ``null``, a ``str`` and a ``list`` raised out of the verb: ``list`` answered
+  ``Tool execution failed: unsupported operand type(s) for -: 'float' and
+  'NoneType'``, naming neither the session nor the field nor a remedy.
+
+The two verbs of one tool also disagreed about one record, because they spelled
+the same read differently - ``info.get("start_time", 0)`` in ``list`` against
+``float(session_info.get("start_time") or 0)`` in ``status``. A store holding
+``"1788000000"`` made ``list`` abort while ``status`` reported ``13993.5 min``,
+nine and a half days, which is an entirely ordinary length for a training run.
+
+The abort is the reach of it. A store holds every tracked session, and its own
+load step is documented to degrade to empty rather than raise so that a record
+damaged outside its pid still stops. One damaged ``start_time`` among three
+records made ``list`` answer ``status: error`` and report **none** of them, so
+two sessions that were genuinely running became invisible to the verb that
+enumerates them.
+
+:func:`~strands_robots.tools._process_stop.session_uptime` is the one reader of
+that field for both tools, in the shape
+:func:`~strands_robots.tools._process_stop.recorded_pid` uses for the ``pid``
+beside it: the span, or ``None`` for no usable one, plus the sentence saying
+which way the record did not state it. These tests pin the domain, that all four
+surfaces reach the same verdict, that no spelling raises anywhere, that a
+damaged record no longer hides its healthy neighbours, that the ``json`` block
+carries no span the reader could not measure, and that a real stamp still
+renders exactly as it did.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.tools import _process_stop
+from strands_robots.tools._process_stop import PID_STARTED_SINCE_BOOT, process_started_since_boot
+
+
+def session_uptime(info: Any) -> tuple[float | None, str]:
+    """Reach the owner through the module.
+
+    Bound here rather than imported by name so that a tree without the owner
+    fails each cell below with what is missing, instead of failing to collect the
+    file and grading nothing.
+    """
+    return _process_stop.session_uptime(info)  # type: ignore[no-any-return]
+
+
+train_mod = importlib.import_module("strands_robots.tools.lerobot_train")
+teleop_mod = importlib.import_module("strands_robots.tools.lerobot_teleoperate")
+
+#: The two tool modules whose verbs report a session's uptime, and the callable
+#: to reach each one through. ``@tool`` wraps the function, so the undecorated
+#: body is reached through ``original`` where the decorator provides it.
+_TOOLS: tuple[tuple[str, Any, dict[str, Any]], ...] = (
+    ("lerobot_train", train_mod, {"dataset_root": "/tmp/nonexistent-dataset"}),
+    ("lerobot_teleoperate", teleop_mod, {}),
+)
+
+#: Spellings a session store can hold under ``start_time``, with the fragment the
+#: refusal must carry. ``<<ABSENT>>`` means the key is not written at all.
+UNUSABLE: tuple[tuple[str, Any, str], ...] = (
+    ("absent", "<<ABSENT>>", "states no start time"),
+    ("null", None, "states no start time"),
+    ("true", True, "states a bool"),
+    ("false", False, "states a bool"),
+    ("a stamp as a string", "1788000000", "states a str"),
+    ("an unparsable string", "soon", "states a str"),
+    ("a list", [], "states a list"),
+    ("a mapping", {}, "states a dict"),
+    ("the epoch itself", 0, "not a wall-clock stamp"),
+    ("before the epoch", -1.0, "not a wall-clock stamp"),
+    ("NaN", float("nan"), "not a wall-clock stamp"),
+    ("Infinity", float("inf"), "not a wall-clock stamp"),
+    ("negative Infinity", float("-inf"), "not a wall-clock stamp"),
+)
+
+
+def _record(value: Any = "<<ABSENT>>", **extra: Any) -> dict[str, Any]:
+    """A session record for this process, carrying ``value`` as its start time.
+
+    The pid is this test's own, with the identity the running verdict needs
+    captured beside it, so the record reads as a live session without any probe
+    being stood in for - the uptime read is what is under test, not the pid.
+    """
+    pid = os.getpid()
+    info: dict[str, Any] = {
+        "action": "train",
+        "pid": pid,
+        "command": "lerobot-train",
+        "log_file": "/dev/null",
+        PID_STARTED_SINCE_BOOT: process_started_since_boot(pid),
+        "policy_type": "act",
+        "output_dir": "/tmp/out",
+        "robot_type": "so101_follower",
+        "teleop_type": "so101_leader",
+        **extra,
+    }
+    if value != "<<ABSENT>>":
+        info["start_time"] = value
+    return info
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+def _uptime_lines(result: dict[str, Any]) -> list[str]:
+    return [line.strip() for line in _texts(result).splitlines() if "Uptime" in line]
+
+
+def _json_block(result: dict[str, Any]) -> dict[str, Any]:
+    for item in result.get("content", []):
+        if isinstance(item, dict) and "json" in item:
+            return dict(item["json"])
+    return {}
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point both tools' session stores at one file under ``tmp_path``.
+
+    Both modules read a module-level ``SESSION_DIR`` when a manager is built, so
+    redirecting the attribute on each is what keeps the verbs off the store of
+    whatever machine runs this.
+    """
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(train_mod, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(teleop_mod, "SESSION_DIR", session_dir)
+    path = session_dir / "active_sessions.json"
+
+    def write(records: dict[str, Any]) -> None:
+        path.write_text(json.dumps(records), encoding="utf-8")
+
+    return write
+
+
+def _call(module: Any, extra: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    """Invoke a tool module's verb, reaching the undecorated body."""
+    tool = getattr(module, module.__name__.rsplit(".", 1)[-1])
+    fn = getattr(tool, "original", tool)
+    return fn(**extra, **kwargs)  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# The domain
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(("label", "value", "fragment"), UNUSABLE, ids=[case[0] for case in UNUSABLE])
+def test_a_record_that_states_no_usable_stamp_measures_no_span(label: str, value: Any, fragment: str) -> None:
+    """Nothing outside the domain becomes a duration, and the text says which way."""
+    span, text = session_uptime(_record(value))
+    assert span is None, f"{label} was subtracted from the clock and reported as {span} s"
+    assert text.startswith("unknown ("), f"{label} produced {text!r}, which does not read as an absence"
+    assert fragment in text, f"{label} produced {text!r}, which does not name how the record went wrong"
+
+
+def test_a_real_stamp_is_the_span_it_states() -> None:
+    """The one spelling a writer produces is measured, and rendered as it always was."""
+    span, text = session_uptime(_record(time.time() - 600.0))
+    assert span is not None
+    assert 590.0 < span < 660.0, f"a stamp ten minutes old measured {span} s"
+    assert text == f"{span / 60:.1f} min"
+
+
+def test_a_stamp_ahead_of_this_clock_is_not_a_negative_duration() -> None:
+    """A backwards clock step is reported as one, not rendered as negative uptime."""
+    span, text = session_uptime(_record(time.time() + 600.0))
+    assert span is None, "a start time in the future was reported as a duration"
+    assert "ahead of this clock" in text
+    assert "-" not in text, f"a negative duration reached the report: {text!r}"
+
+
+def test_the_bool_refusal_is_about_the_type_not_the_number_it_carries() -> None:
+    """``true`` is refused as a bool; the ``1`` it subclasses is a stamp and is measured.
+
+    The accepted boundary, pinned so a later change cannot quietly turn this
+    owner into a plausibility check. ``1`` is one second past the epoch and no
+    writer produces it, but the only non-arbitrary floor above the epoch is this
+    machine's boot time, and comparing against that mis-refuses a genuine stamp
+    after a backwards clock correction - see :func:`session_uptime`.
+    """
+    span, text = session_uptime(_record(True))
+    assert span is None
+    assert "bool" in text, f"true was refused, but not as a bool: {text!r}"
+    span, text = session_uptime(_record(1))
+    assert span is not None, "a positive stamp is a span, however implausible the date"
+    assert text.endswith(" min")
+
+
+# ---------------------------------------------------------------------------
+# Both tools, both verbs
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(("label", "value", "fragment"), UNUSABLE, ids=[case[0] for case in UNUSABLE])
+@pytest.mark.parametrize("verb", ["list", "status"])
+@pytest.mark.parametrize("tool", _TOOLS, ids=[case[0] for case in _TOOLS])
+def test_every_verb_of_every_tool_reaches_the_same_verdict(
+    tool: tuple[str, Any, dict[str, Any]],
+    verb: str,
+    label: str,
+    value: Any,
+    fragment: str,
+    store: Any,
+) -> None:
+    """No surface raises, and none of them reports a span for a record without one."""
+    name, module, extra = tool
+    store({"s1": _record(value)})
+    kwargs = {"action": verb} | ({"session_name": "s1"} if verb == "status" else {})
+    result = _call(module, extra, **kwargs)
+    assert result["status"] == "success", f"{name} {verb} refused the whole verb over {label}: {_texts(result)}"
+    lines = _uptime_lines(result)
+    assert lines, f"{name} {verb} dropped the uptime field entirely for {label}"
+    for line in lines:
+        assert fragment in line, f"{name} {verb} reported {line!r} for {label}"
+
+
+@pytest.mark.parametrize("verb", ["list", "status"])
+@pytest.mark.parametrize("tool", _TOOLS, ids=[case[0] for case in _TOOLS])
+def test_every_verb_of_every_tool_still_reports_a_real_span(
+    tool: tuple[str, Any, dict[str, Any]], verb: str, store: Any
+) -> None:
+    """The control: a record a writer produced reads the same on all four surfaces."""
+    name, module, extra = tool
+    store({"s1": _record(time.time() - 1800.0)})
+    kwargs = {"action": verb} | ({"session_name": "s1"} if verb == "status" else {})
+    result = _call(module, extra, **kwargs)
+    assert result["status"] == "success"
+    assert any("30.0 min" in line for line in _uptime_lines(result)), (
+        f"{name} {verb} did not report a stamp half an hour old: {_uptime_lines(result)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# What the abort cost
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("tool", _TOOLS, ids=[case[0] for case in _TOOLS])
+def test_one_damaged_record_does_not_hide_the_running_ones(tool: tuple[str, Any, dict[str, Any]], store: Any) -> None:
+    """``list`` enumerates every tracked session, damaged neighbour or not."""
+    name, module, extra = tool
+    store(
+        {
+            "healthy": _record(time.time() - 1800.0),
+            "damaged": _record(None),
+            "also_healthy": _record(time.time() - 60.0),
+        }
+    )
+    result = _call(module, extra, action="list")
+    assert result["status"] == "success", f"{name} list aborted over one damaged record"
+    text = _texts(result)
+    for expected in ("healthy", "damaged", "also_healthy"):
+        assert expected in text, f"{name} list omitted '{expected}': {text}"
+    assert "30.0 min" in text and "1.0 min" in text, f"{name} list lost a healthy session's span: {text}"
+
+
+@pytest.mark.parametrize("tool", _TOOLS, ids=[case[0] for case in _TOOLS])
+def test_the_status_json_carries_no_span_it_could_not_measure(
+    tool: tuple[str, Any, dict[str, Any]], store: Any
+) -> None:
+    """A machine reading ``uptime`` gets ``null``, not the epoch as a duration."""
+    name, module, extra = tool
+    store({"s1": _record(None)})
+    block = _json_block(_call(module, extra, action="status", session_name="s1"))
+    assert "uptime" in block, f"{name} status stopped reporting an uptime key"
+    assert block["uptime"] is None, f"{name} status published {block['uptime']} s for a record with no start time"
+
+
+# ---------------------------------------------------------------------------
+# One owner
+# ---------------------------------------------------------------------------
+def _start_time_reads(module: Any) -> list[str]:
+    """Every expression in ``module`` that reads ``start_time`` out of a record."""
+    tree = ast.parse(inspect.getsource(module))
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "get":
+            if node.args and isinstance(node.args[0], ast.Constant) and node.args[0].value == "start_time":
+                found.append(ast.unparse(node))
+    return found
+
+
+@pytest.mark.parametrize("tool", _TOOLS, ids=[case[0] for case in _TOOLS])
+def test_no_verb_reads_the_stamp_itself(tool: tuple[str, Any, dict[str, Any]]) -> None:
+    """The grading is not bypassable by a second reader of the same field.
+
+    The field went wrong in the first place because two verbs of one tool each
+    read it their own way, so a tool reading it again is the drift this closes.
+    Writing it stays the tool's own business; only the read is owned.
+    """
+    name, module, _ = tool
+    reads = _start_time_reads(module)
+    assert not reads, f"{name} reads start_time directly instead of through session_uptime: {reads}"
+
+
+def test_the_owner_is_the_one_that_reads_it() -> None:
+    """Non-vacuity: the rule above is satisfied by delegation, not by nobody reading."""
+    assert _start_time_reads(_process_stop), "session_uptime no longer reads start_time, so the rule above is empty"
+    for name, module, _ in _TOOLS:
+        source = inspect.getsource(module)
+        assert "session_uptime(" in source, f"{name} does not ask the owner for its uptime"


### PR DESCRIPTION
Both session tools report a session's `Uptime` by subtracting the record's `start_time` from `time.time()`. That stamp arrives from a JSON file rather than from a caller, and it was read raw at four call sites in three different spellings.

![the verdict matrix](https://raw.githubusercontent.com/cagataycali/robots/assets/session-uptime/docs/assets/session_uptime_matrix.png)

Every cell above was measured by driving the real tool against a real session store, on this branch and on a pristine `upstream/main` worktree. The two tools agreed with each other on every row in both trees, so one column stands for both. **Of 28 readings before, 26 were wrong; the single correct row is the control.**

## What went wrong

| the record's `start_time` | `list` before | `status` before |
| --- | --- | --- |
| a real stamp (control) | `Uptime: 10.0 min` | `Uptime: 10.0 min` |
| absent | `Uptime: 29813993.5 min` | `Uptime: 29813993.5 min` |
| `null` | aborted the verb | `Uptime: 29813993.5 min` |
| `true` / `false` | `Uptime: 29813993.5 min` | `Uptime: 29813993.5 min` |
| `"1788000000"` | aborted the verb | `Uptime: 13993.5 min` |
| `"soon"` | aborted the verb | aborted the verb |
| `[]` / `{}` | aborted the verb | `Uptime: 29813993.5 min` |
| `0` | `Uptime: 29813993.5 min` | `Uptime: 29813993.5 min` |
| `NaN` | `Uptime: nan min` | `Uptime: nan min` |
| `Infinity` | `Uptime: -inf min` | `Uptime: -inf min` |
| ahead of this clock | `Uptime: -10.0 min` | `Uptime: -10.0 min` |

`29813993.5 min` is **56.7 years**, reported under `status: success` beside a running flag that was correct. `0` is what the absent case defaulted to (`info.get("start_time", 0)`), so an absent key and a stored zero were the same fifty-seven-year report.

Three things are worth separating out.

**The two verbs of one tool disagreed about one record.** `list` spelled the read `info.get("start_time", 0)` and `status` spelled it `float(session_info.get("start_time") or 0)`. A store holding `"1788000000"` therefore made `list` abort while `status` reported `13993.5 min` - nine and a half days, an entirely ordinary length for a training run.

**One damaged record hid the healthy ones.** A store holds every tracked session, and its own load step is documented to degrade to empty rather than raise, so that a record damaged outside its pid still stops. Measured with three records, one of them carrying `null`:

| | `list` reports | sessions reported |
| --- | --- | --- |
| before | `status: error` | **0 of 3** |
| after | `status: success` | 3 of 3, the damaged one saying why |

The two healthy sessions were genuinely running. The abort's message was `Tool execution failed: unsupported operand type(s) for -: 'float' and 'NoneType'`, which names neither the session, nor the field, nor a remedy.

**The `json` block published the same number.** `status` carries `uptime` in seconds for a machine to read; for a record with no start time it published `1788839823.73`.

## The change

`_process_stop.session_uptime` is now the one reader of that field for both tools, in the shape `recorded_pid` already uses for the `pid` beside it in the same record: the span, or the absence of one, plus the sentence saying which way the record did not state it. It answers both consumers from one read of the clock, so the reported line and the `json` block cannot disagree.

```
Uptime: unknown (this record states no start time)
Uptime: unknown (this record states a str as its start time)
Uptime: unknown (this record's start time is not a wall-clock stamp)
Uptime: unknown (this record's start time is 10.0 min ahead of this clock)
```

A stamp ahead of this clock - what a backwards NTP correction or a `date -s` between the write and the read leaves behind - is reported as that rather than rendered as a negative duration.

**The accepted boundary is deliberate and pinned.** A positive stamp that is merely implausible (`1`, one second past the epoch) is measured as the span it states. The only non-arbitrary floor above the epoch is this machine's boot time, and that is not safe to compare against: on Linux it comes from the `btime` recorded in `/proc/stat` at boot, which a later correction to the clock does not revise, so a backwards correction leaves a genuine post-boot stamp reading as earlier than boot. This owner grades what a value *is*, not whether a plausible clock produced it.

`start_time` stays a wall-clock stamp rather than moving to `time.monotonic()`: the record is written by one process and read by another, and a monotonic reading is a duration since this machine booted, which the reading process cannot relate to the writer's.

## Size

| file | +/- | executable statements (AST) |
| --- | --- | --- |
| `tools/_process_stop.py` | +77 / -0 | 64 -> 78 (+14) |
| `tools/lerobot_train.py` | +9 / -5 | 334 -> 334 (0) |
| `tools/lerobot_teleoperate.py` | +7 / -8 | 336 -> 333 (**-3**) |
| **production total** | **+93 / -13** | **734 -> 745 (+11)** |
| `tests/tools/test_session_uptime_is_graded_not_subtracted.py` | +326 | new |
| `changelog.d/` | +15 | new |

The two callers are net **-3** statements: the owner absorbs the arithmetic they were each doing themselves. Most of the +77 in the owner is the docstring.

## Tests

`tests/tools/test_session_uptime_is_graded_not_subtracted.py`, 79 cells: the domain, all four surfaces reaching the same verdict on every spelling, no spelling raising anywhere, the damaged record no longer hiding its neighbours, the `json` block carrying no span the reader could not measure, the accepted boundary above, and an AST rule that no verb reads the stamp itself (with a non-vacuity cell asserting the owner does, so the rule is satisfied by delegation rather than by nobody reading).

| corner | result |
| --- | --- |
| new test on **pre-fix** production | **75 failed / 4 passed** |
| new test on this branch | 79 passed |

The 4 that pass both ways are exactly the controls - `a real stamp still reports the same span on all four surfaces` - which is what shows the working path is untouched.

Every pre-fix failure names the defect, e.g.

```
lerobot_train list aborted over one damaged record
lerobot_train status published 1788840029.87 s for a record with no start time
lerobot_train reads start_time directly instead of through session_uptime:
  ["info.get('start_time', 0)", "session_info.get('start_time')"]
```

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean, 1946 files.
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1943 source files`. No suppressions added.
- 59-module net covering both tools, the shared owner, the session stores and the tool-result contract: **4076 passed on main -> 4155 passed here**, `4076 + 79 = 4155`, zero failures on either side, so no existing cell changed verdict.
- 490-module tree-walking grader population (every module that walks the tree, reads source, or resolves the repo root): 25344 passed, 7 failed - all seven pre-existing and environmental, with byte-identical node ids on a pristine `upstream/main` worktree. Five assert `rclpy` is absent where `/opt/ros/jazzy` supplies it; two read the installed `websockets` 16.0 against the declared `>=17.0` floor.
- Changelog graders: 91 passed.