### PR TITLE
fix(rendering): an MP4 request without an MP4 backend is refused as the missing dependency

### DIFF
--- a/changelog.d/3320-mp4-backend-required.md
+++ b/changelog.d/3320-mp4-backend-required.md
@@ -1,0 +1,46 @@
+### Fixed: an MP4 request without an MP4 backend is refused as the missing dependency
+
+Every writer here probed `imageio` before writing, and `imageio` is two
+dependencies: the package, and the plugin that encodes the container. `imageio`
+declares that plugin - `imageio_ffmpeg` - as an optional extra of its own, so an
+install can supply the module the encoders import and still have no MP4 writer
+behind it. The `[vera-sim]` extra is such an install (it declares `imageio`
+alone), and its own MimicGen example records with an `.mp4` default.
+
+With the plugin absent `imageio` did not refuse the `.mp4` request. It fell
+through to whatever other plugin claimed the container, and the libx264 knobs
+reached a writer that had never heard of them, so the request failed as
+`PyAVPlugin.write() got an unexpected keyword argument 'quality'` - a `TypeError`
+naming a writer the caller never asked for, which is neither what the encoder
+documents nor what its callers handle. Measured at all three writers:
+
+- `stop_cameras_recording` (MuJoCo), on a real recording holding 8 buffered
+  frames: `status="success"` with 0 frames written, a 0-byte `clip__cam_a.mp4`
+  left on disk and the recording deregistered - all 8 frames lost under a
+  success verdict. The `except ImportError` branch that keeps the recording
+  registered for a retry was unreachable for this condition.
+- `stop_cameras_recording` (Isaac) catches only `ImportError`, `RuntimeError`
+  and `ValueError`, so there the `TypeError` escaped a method documented never
+  to raise, after the recording state had already been cleared.
+- `run_policy(video=...)`: the rollout ran to completion and reported
+  `Policy failed: PyAVPlugin.write() got an unexpected keyword argument
+  'quality'` beside a 0-byte MP4.
+
+The container now decides which modules must be present, and one function
+decides it - `require_clip_encoder` (`strands_robots.rendering`), which every
+writer routes its probe through instead of repeating the rule: `.gif` needs no
+plugin (Pillow writes it, and `imageio` hard-requires Pillow), anything else is
+MP4 and requires `imageio_ffmpeg`. The refusal comes from `require_optional`, so
+it names the module actually absent and `pip install
+'strands-robots[sim-mujoco]'` - the extra whose bounds this project owns -
+rather than two bare distributions. It is raised before the frames are read, so
+a caller keeps its iterable and can install and retry.
+
+Consequently the same MuJoCo recording now reports `status="error"` with the
+recording still registered holding all 8 frames, and a second stop with the
+plugin installed encodes them; the rollout returns
+`_RolloutVideoWriter.open`'s error envelope - like every other setup failure
+there - before the loop runs, writing nothing. Both camera flushes quote that
+refusal instead of their own fixed `"imageio not installed. pip install imageio
+imageio-ffmpeg"` line, which named the wrong module whenever it was the plugin
+that was missing.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -510,6 +510,19 @@ it, and neither start verb probes the encoder, so the flush is the first call
 that needs one. It reports before opening any writer, so every buffer is intact
 and installing the encoder and calling again writes them.
 
+"No encoder" covers two modules, not one: `imageio` declares the plugin that
+actually writes MP4 -- `imageio_ffmpeg` -- as an optional extra of its own, so an
+install can have `imageio` and still no MP4 writer (`[vera-sim]` declares
+`imageio` alone). The flush requires both, and quotes whichever is missing, so
+the remedy it prints is the one that works:
+
+```
+'imageio_ffmpeg' is required for MP4 video encoding (encode_clip)
+Install with:
+  pip install 'strands-robots[sim-mujoco]'
+  pip install imageio-ffmpeg
+```
+
 ```python
 result = sim.stop_cameras_recording()
 if result["status"] == "error":

--- a/strands_robots/rendering/__init__.py
+++ b/strands_robots/rendering/__init__.py
@@ -17,7 +17,9 @@ The library home of the Gaussian-splat hybrid-render layer (issue #1537):
   lighting derived from the background scene (issue #2323), plus the
   :mod:`~strands_robots.rendering.color` helpers that pin the layer
   color-space contract.
-* :func:`encode_clip` / :func:`mjpeg_frames` -- shared media utilities.
+* :func:`encode_clip` / :func:`mjpeg_frames` -- shared media utilities,
+  with :func:`require_clip_encoder` as the one owner of which encoder
+  modules a given output container needs.
 """
 
 from .backgrounds import (
@@ -43,7 +45,7 @@ from .ibl import (
     environment_map_cache_path,
     render_environment_map,
 )
-from .video import encode_clip, mjpeg_frames
+from .video import encode_clip, mjpeg_frames, require_clip_encoder
 
 __all__ = [
     "GSPLAT_SCENES",
@@ -72,5 +74,6 @@ __all__ = [
     "plane_depth",
     "relative_luminance",
     "render_environment_map",
+    "require_clip_encoder",
     "srgb_to_linear",
 ]

--- a/strands_robots/rendering/video.py
+++ b/strands_robots/rendering/video.py
@@ -40,6 +40,79 @@ logger = logging.getLogger(__name__)
 _MIN_CLIP_QUALITY = 1
 _MAX_CLIP_QUALITY = 10
 
+#: The ``imageio`` plugin that writes MP4. ``imageio`` declares it as an
+#: optional ``ffmpeg`` extra of its own, so an install can supply ``imageio``
+#: and still have no MP4 backend behind it - this package's ``[vera-sim]`` extra
+#: is exactly that install, declaring ``imageio`` alone. With the plugin absent
+#: ``imageio`` falls through to whatever other plugin claims the requested
+#: container, and the libx264 knobs every MP4 writer here passes reach a writer
+#: that has never heard of them, so the request fails as a ``TypeError`` naming
+#: a writer the caller never asked for
+#: (``PyAVPlugin.write() got an unexpected keyword argument 'quality'``, or
+#: ``TiffWriter.write() got an unexpected keyword argument 'fps'`` when PyAV is
+#: absent too) rather than as the missing dependency it is.
+_MP4_BACKEND_MODULE = "imageio_ffmpeg"
+
+#: The extra of this package that declares ``imageio`` and its MP4 plugin at the
+#: versions the encoders here are tested against. Named in every refusal, so a
+#: caller is sent to a bounded install rather than to two bare distributions.
+_ENCODER_EXTRA = "sim-mujoco"
+
+#: The one container written without the MP4 plugin: Pillow writes GIF, and
+#: ``imageio`` hard-requires Pillow (this package depends on it outright).
+_GIF_SUFFIX = ".gif"
+
+
+def require_clip_encoder(path: str | Path, purpose: str = "video encoding") -> Any:
+    """Require the encoder modules a clip at ``path`` needs, and return ``imageio``.
+
+    ``imageio`` is not one dependency but two: the package, and the plugin that
+    encodes the container. ``imageio`` declares the MP4 plugin as an optional
+    extra of its own, so probing ``imageio`` alone accepts an install that
+    cannot write an MP4 at all - and ``imageio`` then does not refuse the
+    request either, it falls through to another plugin, which rejects the
+    libx264 knobs as a ``TypeError`` naming a writer the caller never asked for.
+
+    So the container decides which modules have to be present, and this is the
+    one place that decides it: every writer in this package routes its
+    optional-dependency probe through here rather than repeating the rule, which
+    is how the rule came to hold for one writer and not the next.
+
+    Args:
+        path: The intended output path. Only its extension is read:
+            :data:`_GIF_SUFFIX` needs no plugin, anything else is MP4 and needs
+            :data:`_MP4_BACKEND_MODULE`.
+        purpose: What the encoder is being imported for, shown in the refusal so
+            a caller can tell which of several media paths refused.
+
+    Returns:
+        The imported top-level ``imageio`` module. A caller that wants the
+        ``imageio.v2`` API imports it itself; what is returned is the module
+        whose presence this call established.
+
+    Raises:
+        ImportError: naming the module actually absent - which of the two it is
+            depends on the install, so no fixed diagnosis is correct - the
+            distribution that supplies it, and the extra of this package that
+            pins that distribution at a version these encoders are tested
+            against. ``name`` is set to the absent module, so a caller can
+            report it without parsing the message.
+    """
+    module = require_optional(
+        "imageio",
+        pip_install="imageio imageio-ffmpeg",
+        extra=_ENCODER_EXTRA,
+        purpose=purpose,
+    )
+    if Path(path).suffix.lower() != _GIF_SUFFIX:
+        require_optional(
+            _MP4_BACKEND_MODULE,
+            pip_install="imageio-ffmpeg",
+            extra=_ENCODER_EXTRA,
+            purpose=f"MP4 {purpose}",
+        )
+    return module
+
 
 def _clip_quality_error(quality: Any) -> str | None:
     """Error text when ``quality`` is outside the range the clip encoder honors.
@@ -119,8 +192,13 @@ def encode_clip(
         The output path.
 
     Raises:
-        ImportError: if ``imageio`` (and, for MP4, ``imageio-ffmpeg``) is not
-            installed.
+        ImportError: if ``imageio`` is not installed, or - for any container
+            other than ``.gif`` - if ``imageio_ffmpeg``, the plugin that writes
+            MP4, is not installed (``imageio`` declares it as an optional extra
+            of its own, so one can be present without the other). Both are
+            probed before the frames are read and before any writer is opened,
+            so a caller that catches this can install the dependency and retry
+            the same frames.
         ValueError: if ``frames`` is empty, if ``fps`` or ``macro_block_size``
             is not a positive whole number, or if ``quality`` is not a finite
             number in ``[1, 10]`` -- each would silently produce a corrupt,
@@ -145,21 +223,18 @@ def encode_clip(
     # the same reason ``quality`` is not left to the writer's own assert.
     if text := positive_whole_number_error(macro_block_size, "macro_block_size", "encode_clip"):
         raise ValueError(text)
-    require_optional(
-        "imageio",
-        pip_install="imageio imageio-ffmpeg",
-        extra="sim-mujoco",
-        purpose="video encoding (encode_clip)",
-    )
+    # Probed before the frames are read, so a caller whose install cannot write
+    # this container keeps its iterable and can retry after installing.
+    out = Path(path)
+    require_clip_encoder(out, purpose="video encoding (encode_clip)")
     import imageio.v2 as imageio
 
     frame_list: list[Any] = [np.asarray(f) for f in frames]
     if not frame_list:
         raise ValueError(f"encode_clip: no frames to encode for {path}")
-    out = Path(path)
     if out.parent and not out.parent.exists():
         out.parent.mkdir(parents=True, exist_ok=True)
-    if out.suffix.lower() == ".gif":
+    if out.suffix.lower() == _GIF_SUFFIX:
         # Pillow's GIF writer takes per-frame duration (ms), not fps.
         imageio.mimsave(str(out), frame_list, duration=1000.0 / int(fps))
     else:

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -5717,10 +5717,19 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 try:
                     encode_clip(frames_buffer, path, fps=state["fps"])
                     frames_written = len(frames_buffer)
-                except ImportError:
+                except ImportError as exc:
+                    # Quote the encoder's own refusal rather than asserting
+                    # which module is missing: ``encode_clip`` needs both
+                    # ``imageio`` and the MP4 plugin ``imageio`` itself leaves
+                    # optional, and it raises through ``require_optional``,
+                    # which names the one actually absent plus the extra of
+                    # this package that supplies it. A fixed
+                    # "imageio not installed" line claims the wrong module
+                    # whenever it is the plugin that is missing, and sends the
+                    # caller to an install that changes nothing.
                     return {
                         "status": "error",
-                        "content": [{"text": "imageio not installed. pip install imageio imageio-ffmpeg"}],
+                        "content": [{"text": f"{exc}"}],
                     }
                 except (RuntimeError, ValueError) as e:
                     # ``encode_clip`` refused the clip: ``RuntimeError`` when it

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -2612,7 +2612,7 @@ class RenderingMixin:
                 try:
                     encode_clip(to_encode, path, fps=state["fps"])
                     frames_written = len(to_encode)
-                except ImportError:
+                except ImportError as exc:
                     # Fires on the first camera holding frames, before any
                     # writer is opened, so nothing is encoded and no buffer is
                     # touched. Report it the way the expired-join refusal
@@ -2621,13 +2621,23 @@ class RenderingMixin:
                     # here can follow that advice for the same reason: the
                     # recording is left registered. See
                     # :meth:`_flush_and_deregister_cameras_recording`.
+                    #
+                    # The encoder's own text is quoted rather than a fixed
+                    # "imageio not installed" diagnosis: two different modules
+                    # can be the one missing (``imageio``, or the MP4 plugin it
+                    # leaves optional), so a fixed line names the wrong one half
+                    # the time and prescribes a remedy that leaves the encode
+                    # exactly as impossible. ``encode_clip`` raises through
+                    # ``require_optional``, which names the module actually
+                    # absent and the extra of this package that supplies it at
+                    # the version it is tested against.
                     buffered = {_c: len(state["buffers"][_c]) for _c in state["cameras"]}
                     return {
                         "status": "error",
                         "content": [
                             {
                                 "text": (
-                                    "imageio not installed. pip install imageio imageio-ffmpeg\n"
+                                    f"{exc}\n"
                                     f"Nothing was encoded and nothing was dropped: camera recording "
                                     f"{state['name']!r} is left registered holding {buffered}. Install "
                                     f"the encoder and call stop_cameras_recording() again to flush it."

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -48,13 +48,13 @@ import numpy as np
 from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.dataset_recorder import RecordingFrameError
 from strands_robots.policies.base import collect_required_bodies, resolve_chunk_length
+from strands_robots.rendering.video import require_clip_encoder
 from strands_robots.utils import (
     non_negative_whole_number_error,
     positive_count_error,
     positive_finite_number_error,
     positive_whole_number_error,
     process_rss_mb,
-    require_optional,
 )
 
 if TYPE_CHECKING:
@@ -566,12 +566,22 @@ class _RolloutVideoWriter:
                 ],
             }
 
-        imageio = require_optional(
-            "imageio",
-            pip_install="imageio imageio-ffmpeg",
-            extra="sim-mujoco",
-            purpose="video recording",
-        )
+        # Through the shared owner rather than a local ``imageio`` probe: the
+        # writer below passes libx264 knobs, so this rollout needs the MP4
+        # plugin ``imageio`` leaves optional, not merely ``imageio``. Probing
+        # only the latter accepted an install where ``get_writer`` then routed
+        # the ``.mp4`` to another plugin and rejected ``quality`` as a
+        # ``TypeError``, which reached the caller as "Policy failed: ..." beside
+        # a 0-byte MP4.
+        #
+        # Returned as this method's error envelope, like every other setup
+        # failure above it: an absent encoder is a fact about the install, and
+        # the rollout is what the caller asked for - it can proceed without the
+        # recording only if it is told, and told before the loop runs.
+        try:
+            imageio = require_clip_encoder(resolved, purpose="video recording")
+        except ImportError as exc:
+            return None, {"status": "error", "content": [{"text": f"video recording: {exc}"}]}
         os.makedirs(os.path.dirname(os.path.abspath(resolved)), exist_ok=True)
         # A rollout renders at most one frame per applied control step, so the
         # video cannot carry more than ``control_frequency`` unique frames per

--- a/tests/rendering/test_encode_clip_requires_the_mp4_backend.py
+++ b/tests/rendering/test_encode_clip_requires_the_mp4_backend.py
@@ -1,0 +1,390 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""An MP4 request without an MP4 backend is refused as the missing dependency.
+
+:func:`~strands_robots.rendering.encode_clip` probes ``imageio`` before it
+writes, and ``imageio`` is not one dependency but two: the package itself, and
+the plugin that actually encodes the container. ``imageio`` declares that plugin
+-- ``imageio_ffmpeg`` -- as an optional extra of its own, so an install can
+supply the module ``encode_clip`` imports and still have no MP4 writer behind
+it. This package's ``[vera-sim]`` extra is exactly that install: it declares
+``imageio>=2.28.0,<3.0.0`` and no ``imageio-ffmpeg``.
+
+With the plugin absent ``imageio`` does not refuse the ``.mp4`` request. It
+falls through to whatever other plugin claims the container, and the libx264
+knobs then reach a writer that has never heard of them, so the request fails as
+``PyAVPlugin.write() got an unexpected keyword argument 'quality'`` -- or
+``TiffWriter.write() got an unexpected keyword argument 'fps'`` when PyAV is
+absent too. That is a ``TypeError`` naming a writer the caller never asked for,
+and it is neither what ``encode_clip`` documents (``ImportError``) nor what its
+callers handle:
+
+* ``SimulationRendering._flush_cameras_recording_state`` (MuJoCo) has one
+  ``except ImportError`` branch that keeps the recording registered with every
+  buffered frame, so the caller can install the encoder and stop again. A
+  ``TypeError`` misses it, lands in the best-effort ``except Exception``, and
+  the frames are dropped under ``status="success"`` instead.
+* ``IsaacSimulation.stop_cameras_recording`` documents that it never raises,
+  and catches ``ImportError``, ``RuntimeError`` and ``ValueError``. A
+  ``TypeError`` escapes the tool envelope entirely -- after the recording state
+  has already been cleared, so no second stop can recover the buffers.
+
+The rollout recorder is the third writer with the same shape:
+``_RolloutVideoWriter.open`` probed ``imageio`` and then handed
+``imageio.get_writer`` the same libx264 knobs, which is the path
+``run_policy(video=...)`` takes -- and the ``[vera-sim]`` MimicGen example
+records through it with an ``.mp4`` default.
+
+So the container decides which modules have to be present, one place decides it
+(:func:`~strands_robots.rendering.require_clip_encoder`), and every writer routes
+its probe through that instead of repeating the rule -- which is how the rule
+came to hold for one writer and not the next. GIF needs no plugin (Pillow writes
+it, ``imageio`` hard-requires Pillow and this package depends on it outright),
+which is the control here: the same absent plugin must leave a GIF encode
+working.
+
+The second half is the report. Both flushes used to answer with a fixed
+``"imageio not installed. pip install imageio imageio-ffmpeg"`` line, which
+names the wrong module whenever it is the plugin that is missing, and hands over
+two unbounded distributions instead of the extra whose bounds this project owns.
+They quote the encoder's own refusal now, which ``require_optional`` builds from
+the module actually absent.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+imageio = pytest.importorskip("imageio", reason="imageio not installed - pip install imageio imageio-ffmpeg")
+
+from strands_robots import utils  # noqa: E402
+from strands_robots.rendering import encode_clip  # noqa: E402
+
+#: The ``imageio`` plugin that writes MP4, spelled out here rather than imported
+#: from the encoder: what a caller experiences is this module being absent, and
+#: a pin that reads the name from the code under test would agree with it
+#: whatever it said.
+_MP4_BACKEND_MODULE = "imageio_ffmpeg"
+#: The distribution that supplies it, and the extra of this package that pins
+#: that distribution - what a caller must be told, rather than the import name.
+_MP4_BACKEND_DISTRIBUTION = "imageio-ffmpeg"
+_ENCODER_EXTRA = "sim-mujoco"
+
+#: The claim the old fixed line made. Reachable only when ``imageio`` itself is
+#: gone, so a refusal about the plugin must not repeat it.
+_WRONG_DIAGNOSIS = "imageio not installed"
+
+
+def _frames(n: int = 4, w: int = 32, h: int = 24) -> list[np.ndarray]:
+    """``n`` distinct RGB frames of one shape."""
+    return [np.full((h, w, 3), (i * 40) % 256, dtype=np.uint8) for i in range(n)]
+
+
+@contextmanager
+def _no_mp4_backend() -> Iterator[None]:
+    """An install with ``imageio`` but not its MP4 plugin, for one block.
+
+    Two steps, because :func:`~strands_robots.utils.require_optional` memoises a
+    module it has already imported: the ``sys.modules`` entry is what makes the
+    import fail, and dropping the cache entry is what stops an earlier import in
+    the same session from answering instead. Mirrors
+    ``tests/simulation/mujoco/test_camera_recorder_stop_reports_the_join.py``'s
+    absent-``imageio`` block.
+    """
+    cached = utils._lazy_modules.pop(_MP4_BACKEND_MODULE, None)
+    saved = sys.modules.get(_MP4_BACKEND_MODULE, "absent")
+    sys.modules[_MP4_BACKEND_MODULE] = None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        if saved == "absent":
+            del sys.modules[_MP4_BACKEND_MODULE]
+        else:
+            sys.modules[_MP4_BACKEND_MODULE] = saved  # type: ignore[assignment]
+        if cached is not None:
+            utils._lazy_modules[_MP4_BACKEND_MODULE] = cached
+
+
+@pytest.fixture
+def no_mp4_backend() -> Iterator[None]:
+    """:func:`_no_mp4_backend` for a whole cell."""
+    with _no_mp4_backend():
+        yield
+
+
+class TestAnMp4RequestNeedsTheMp4Backend:
+    """The plugin is a dependency of the request, refused before any writer opens."""
+
+    # Every container this module routes to the MP4 writer: the suffix check is
+    # "not .gif", so the case of the extension and the container name are both
+    # part of the domain.
+    @pytest.mark.parametrize("suffix", [".mp4", ".MP4", ".mkv"])
+    def test_the_refusal_names_the_absent_plugin_and_the_extra_that_supplies_it(
+        self, tmp_path: Path, no_mp4_backend: None, suffix: str
+    ) -> None:
+        """An ImportError about the plugin, not a TypeError about a foreign writer."""
+        out = tmp_path / f"clip{suffix}"
+        with pytest.raises(ImportError) as excinfo:
+            encode_clip(_frames(), out, fps=10)
+        exc = excinfo.value
+        assert exc.name == _MP4_BACKEND_MODULE, (
+            f"the refusal reports {exc.name!r}, so a caller cannot tell which module is missing"
+        )
+        text = str(exc)
+        assert _MP4_BACKEND_MODULE in text, text
+        assert f"pip install 'strands-robots[{_ENCODER_EXTRA}]'" in text, text
+        assert _MP4_BACKEND_DISTRIBUTION in text, text
+        assert _WRONG_DIAGNOSIS not in text, f"the refusal blames a module that is installed: {text}"
+        assert not out.exists(), f"a refused encode left a file at {out}"
+
+    def test_the_frames_are_not_read_before_the_refusal(self, tmp_path: Path, no_mp4_backend: None) -> None:
+        """The caller keeps its buffer, so installing the plugin and retrying works.
+
+        ``frames`` is an iterable: consuming it to build the frame list and only
+        then discovering the encoder is unusable would exhaust a generator the
+        caller cannot rewind.
+        """
+        read = 0
+
+        def counted() -> Iterator[np.ndarray]:
+            nonlocal read
+            for frame in _frames():
+                read += 1
+                yield frame
+
+        with pytest.raises(ImportError):
+            encode_clip(counted(), tmp_path / "clip.mp4", fps=10)
+        assert read == 0, f"the refusal consumed {read} frames from the caller's iterable"
+
+    def test_a_present_backend_still_encodes_an_mp4(self, tmp_path: Path) -> None:
+        """The premise: nothing about the guard refuses an install that can encode."""
+        pytest.importorskip(_MP4_BACKEND_MODULE)
+        out = encode_clip(_frames(), tmp_path / "clip.mp4", fps=10)
+        assert out.exists() and out.stat().st_size > 0
+
+
+class TestAGifNeedsNoMp4Backend:
+    """The control: the guard is the container's, not the module's."""
+
+    @pytest.mark.parametrize("suffix", [".gif", ".GIF"])
+    def test_a_gif_encodes_with_the_mp4_plugin_absent(self, tmp_path: Path, no_mp4_backend: None, suffix: str) -> None:
+        """Pillow writes GIF, so an absent MP4 plugin has nothing to do with it."""
+        pytest.importorskip("PIL.Image")
+        out = encode_clip(_frames(), tmp_path / f"clip{suffix}", fps=10)
+        assert out.exists() and out.stat().st_size > 0
+
+
+class TestEveryCameraFlushQuotesTheEncoder:
+    """A flush reports the refusal it caught, not a fixed guess at its cause."""
+
+    # The backend modules that flush buffered camera frames through
+    # ``encode_clip`` - the same roster as
+    # ``tests/simulation/test_camera_flush_encoder_refusal.py``.
+    _FLUSH_MODULES = ("mujoco/rendering.py", "isaac/simulation.py")
+
+    @staticmethod
+    def _import_handlers(module_path: Path) -> list[ast.ExceptHandler]:
+        """Every ``except ImportError`` inside a function that calls ``encode_clip``."""
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        handlers: list[ast.ExceptHandler] = []
+        for func in ast.walk(tree):
+            if not isinstance(func, ast.FunctionDef):
+                continue
+            calls_encoder = any(
+                isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "encode_clip"
+                for node in ast.walk(func)
+            )
+            if not calls_encoder:
+                continue
+            for node in ast.walk(func):
+                if isinstance(node, ast.Try):
+                    handlers += [
+                        h for h in node.handlers if h.type is not None and "ImportError" in ast.unparse(h.type)
+                    ]
+        return handlers
+
+    def test_no_flush_substitutes_its_own_diagnosis_for_the_encoders(self) -> None:
+        """Two modules can be the missing one; only the encoder knows which."""
+        import strands_robots.simulation as simulation_pkg
+
+        package_dir = Path(simulation_pkg.__file__).parent
+        checked = 0
+        for relative in self._FLUSH_MODULES:
+            module_path = package_dir / relative
+            assert module_path.exists(), f"{relative} moved; update this guard"
+            handlers = self._import_handlers(module_path)
+            assert handlers, f"{relative} no longer guards the encoder import; update this guard"
+            for handler in handlers:
+                body = "\n".join(ast.unparse(stmt) for stmt in handler.body)
+                assert handler.name, (
+                    f"{relative}:{handler.lineno} discards the encoder's refusal, so it cannot report "
+                    "which module is missing"
+                )
+                assert handler.name in body, f"{relative}:{handler.lineno} binds {handler.name!r} without reporting it"
+                assert _WRONG_DIAGNOSIS not in body, (
+                    f"{relative}:{handler.lineno} asserts {_WRONG_DIAGNOSIS!r}, which is false when it is "
+                    "the MP4 plugin that is absent"
+                )
+                checked += 1
+        assert checked >= len(self._FLUSH_MODULES)
+
+
+def _render_result(width: int, height: int) -> dict[str, Any]:
+    """A ``render()`` envelope carrying a real PNG the recorder can decode.
+
+    A gradient rather than a flat fill: the recorder's warmup discards frames
+    whose per-column standard deviation reads as a cold GL gradient. Same shape
+    as ``tests/simulation/mujoco/test_daemon_camera_recording.py``'s harness, so
+    no GL context is needed.
+    """
+    from PIL import Image
+
+    row = np.linspace(0, 255, width, dtype=np.uint8)
+    arr = np.repeat(row[None, :], height, axis=0)
+    arr = np.stack([arr, arr[::-1], arr], axis=-1).astype(np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")
+    return {
+        "status": "success",
+        "content": [
+            {"text": f"{width}x{height}"},
+            {"image": {"format": "png", "source": {"bytes": buf.getvalue()}}},
+        ],
+    }
+
+
+class TestTheMujocoFlushKeepsTheFramesItCannotEncode:
+    """The consequence at the caller, on a real daemon recording."""
+
+    @pytest.fixture
+    def recording(self, tmp_path: Path) -> Iterator[Any]:
+        """A started camera recording holding real buffered frames."""
+        pytest.importorskip("mujoco", reason="mujoco not installed - pip install strands-robots[sim-mujoco]")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        sim.create_world()
+        sim.add_robot("arm", data_config="so101", position=[0.0, 0.0, 0.0])
+        sim.add_camera("cam_a", position=[-0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+        sim.render = lambda camera_name, width=None, height=None, **_kw: _render_result(  # type: ignore[method-assign]
+            width or 32, height or 24
+        )
+        started = sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), fps=30, name="clip")
+        assert started["status"] == "success", started
+        deadline = time.monotonic() + 30.0
+        while len((sim._cams_rec_state or {}).get("buffers", {}).get("cam_a", [])) < 3:
+            assert time.monotonic() < deadline, "premise: the recorder buffers frames"
+            time.sleep(0.02)
+        try:
+            yield sim
+        finally:
+            sim.stop_cameras_recording()
+            sim.destroy()
+
+    def test_the_stop_refuses_and_leaves_the_recording_registered(self, recording: Any, tmp_path: Path) -> None:
+        """The buffers survive an install the encoder cannot use, and are recoverable."""
+        with _no_mp4_backend():
+            result = recording.stop_cameras_recording()
+
+        assert result["status"] == "error", result
+        payload = next(block["json"] for block in result["content"] if "json" in block)
+        assert payload["stopped"] is False, payload
+        assert payload["buffered_frames"]["cam_a"] >= 3, payload
+        text = result["content"][0]["text"]
+        assert _MP4_BACKEND_MODULE in text, text
+        assert f"pip install 'strands-robots[{_ENCODER_EXTRA}]'" in text, text
+        assert _WRONG_DIAGNOSIS not in text, f"the flush blames a module that is installed: {text}"
+        assert not list(tmp_path.glob("*.mp4")), "a refused flush wrote a clip"
+        assert recording._cams_rec_state is not None, "the recording was deregistered with its frames unencoded"
+
+    def test_a_second_stop_with_the_backend_present_encodes_the_same_frames(
+        self, recording: Any, tmp_path: Path
+    ) -> None:
+        """What the refusal promises: install the plugin, stop again, get the clip."""
+        pytest.importorskip(_MP4_BACKEND_MODULE)
+        with _no_mp4_backend():
+            buffered = recording.stop_cameras_recording()
+        frames = next(b["json"] for b in buffered["content"] if "json" in b)["buffered_frames"]["cam_a"]
+
+        result = recording.stop_cameras_recording()
+
+        assert result["status"] == "success", result
+        clips = list(tmp_path.glob("*.mp4"))
+        assert len(clips) == 1 and clips[0].stat().st_size > 0, clips
+        written = next(b["json"] for b in result["content"] if "json" in b)
+        assert written["artifacts"][0]["frames"] == frames, written
+
+
+class TestTheRolloutRecorderNeedsItToo:
+    """``run_policy(video=...)`` writes MP4 through the same libx264 knobs."""
+
+    def test_a_rollout_reports_the_absent_plugin_and_writes_nothing(self, tmp_path: Path, no_mp4_backend: None) -> None:
+        """The envelope names the module and the extra, before the loop runs.
+
+        ``_RolloutVideoWriter.open`` returns every other setup failure - a bad
+        path, an unrenderable camera - as this envelope, so the one condition
+        that is a fact about the install answers the same way. Previously the
+        rollout ran, the foreign writer refused ``quality`` mid-loop, and the
+        caller was told ``Policy failed: PyAVPlugin.write() got an unexpected
+        keyword argument 'quality'`` beside a 0-byte MP4.
+        """
+        pytest.importorskip("mujoco", reason="mujoco not installed - pip install strands-robots[sim-mujoco]")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        sim.create_world()
+        sim.add_robot("arm", data_config="so101", position=[0.0, 0.0, 0.0])
+        sim.add_camera("cam_a", position=[-0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+        try:
+            result = sim.run_policy(
+                robot_name="arm",
+                policy_provider="mock",
+                n_steps=6,
+                control_frequency=20.0,
+                video={"path": str(tmp_path / "rollout.mp4"), "fps": 20, "camera": "cam_a"},
+            )
+        finally:
+            sim.destroy()
+
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert _MP4_BACKEND_MODULE in text, text
+        assert f"pip install 'strands-robots[{_ENCODER_EXTRA}]'" in text, text
+        assert _WRONG_DIAGNOSIS not in text, f"the rollout blames a module that is installed: {text}"
+        assert not list(tmp_path.iterdir()), f"a refused rollout left files behind: {list(tmp_path.iterdir())}"
+
+
+class TestOneOwnerDecidesWhichEncoderModulesAContainerNeeds:
+    """The rule lives in one function, so a new writer cannot get it wrong."""
+
+    def test_no_writer_probes_imageio_on_its_own(self) -> None:
+        """Every ``require_optional("imageio")`` in the package is the shared owner's."""
+        import strands_robots
+
+        package_dir = Path(strands_robots.__file__).parent
+        owner = package_dir / "rendering" / "video.py"
+        offenders = []
+        for module_path in sorted(package_dir.rglob("*.py")):
+            tree = ast.parse(module_path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                    continue
+                if node.func.id != "require_optional" or not node.args:
+                    continue
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and first.value == "imageio" and module_path != owner:
+                    offenders.append(f"{module_path.relative_to(package_dir)}:{node.lineno}")
+        assert not offenders, (
+            "these sites probe imageio without deciding which backend their container needs, "
+            f"so an MP4 request reaches a writer that refuses its knobs: {offenders}"
+        )

--- a/tests/rendering/test_public_member_docstrings.py
+++ b/tests/rendering/test_public_member_docstrings.py
@@ -65,6 +65,7 @@ _EXPECTED_FUNCTIONS = {
     "ibl.py::derive_key_light",
     "video.py::encode_clip",
     "video.py::mjpeg_frames",
+    "video.py::require_clip_encoder",
 }
 
 

--- a/tests/simulation/test_rollout_video_realtime_fps.py
+++ b/tests/simulation/test_rollout_video_realtime_fps.py
@@ -44,7 +44,11 @@ def _open_and_capture_fps(monkeypatch, tmp_path, requested_fps, control_frequenc
         return _FakeWriter()
 
     fake_imageio = types.SimpleNamespace(get_writer=_fake_get_writer)
-    monkeypatch.setattr(policy_runner, "require_optional", lambda *a, **k: fake_imageio)
+    # The rollout recorder resolves its encoder through the shared owner
+    # (``strands_robots.rendering.require_clip_encoder``), which decides which
+    # modules the output container needs; substituting it here is what keeps
+    # this cell about the fps arithmetic rather than about the install.
+    monkeypatch.setattr(policy_runner, "require_clip_encoder", lambda *a, **k: fake_imageio)
 
     video = VideoConfig(path=str(tmp_path / "out.mp4"), fps=requested_fps)
     writer, err = _RolloutVideoWriter.open(_FakeSim(), video, control_frequency)

--- a/tests/test_imageio_floor_honors_the_clip_frame_duration.py
+++ b/tests/test_imageio_floor_honors_the_clip_frame_duration.py
@@ -75,6 +75,11 @@ _DISTRIBUTION = "imageio"
 #: and by the ``require_optional("imageio", ...)`` probe.
 _MODULE = "<module>"
 
+#: The media layer's owner of which encoder modules an output container needs.
+#: It returns the top-level ``imageio`` module, so a name it binds reaches for
+#: imageio exactly as ``require_optional("imageio", ...)`` does.
+_CLIP_ENCODER_OWNER = "require_clip_encoder"
+
 #: The releases probed to produce the table in the module docstring, oldest first.
 _PROBED_RELEASES = (
     "2.9.0",
@@ -147,7 +152,11 @@ def _imported_imageio_names(source: str) -> set[tuple[str, str]]:
     * ``from imageio import ...``;
     * ``imageio = require_optional("imageio", ...)`` followed by
       ``imageio.get_writer`` - the package's own lazy-optional-import idiom,
-      which binds the module through a call rather than an ``import`` statement.
+      which binds the module through a call rather than an ``import`` statement;
+    * ``imageio = require_clip_encoder(path, ...)``, the media layer's owner of
+      which encoder modules an output container needs, which by contract returns
+      that same top-level module. It names no module string to read, so the bound
+      name is taken from its documented return value.
 
     Only maximal attribute chains are reported, so ``a.b.c`` yields
     ``("<pkg>.b", "c")`` rather than also ``("<pkg>", "b")``.
@@ -179,17 +188,23 @@ def _imported_imageio_names(source: str) -> set[tuple[str, str]]:
                 continue
             func = call.func
             name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
-            if name != "require_optional" or not call.args:
+            if name == _CLIP_ENCODER_OWNER:
+                # Documented to return the top-level module, so there is no
+                # module string in the call to read.
+                requested_module = _DEP
+            elif name == "require_optional" and call.args:
+                requested = call.args[0]
+                if not isinstance(requested, ast.Constant) or not isinstance(requested.value, str):
+                    continue
+                if not _is_dep(requested.value):
+                    continue
+                requested_module = requested.value
+            else:
                 continue
-            requested = call.args[0]
-            if not isinstance(requested, ast.Constant) or not isinstance(requested.value, str):
-                continue
-            if not _is_dep(requested.value):
-                continue
-            found.add((requested.value, _MODULE))
+            found.add((requested_module, _MODULE))
             for target in node.targets:
                 if isinstance(target, ast.Name):
-                    bound[target.id] = requested.value
+                    bound[target.id] = requested_module
 
     # `a.b.c` is not maximal if it is the receiver of another attribute access.
     receivers = {id(n.value) for n in ast.walk(tree) if isinstance(n, ast.Attribute)}


### PR DESCRIPTION
`imageio` is not one dependency but two: the package, and the plugin that encodes the container. `imageio` declares the MP4 plugin - `imageio_ffmpeg` - as an *optional extra of its own*, so an install can supply the module every writer here imports and still have no MP4 writer behind it. `[vera-sim]` is such an install (it declares `imageio` alone), and its MimicGen example records with an `.mp4` default.

With the plugin absent `imageio` does not refuse the `.mp4` request. It falls through to whatever other plugin claims the container, and the libx264 knobs reach a writer that has never heard of them:

```
TypeError: PyAVPlugin.write() got an unexpected keyword argument 'quality'
TypeError: TiffWriter.write() got an unexpected keyword argument 'fps'   # when PyAV is absent too
```

A `TypeError` naming a writer the caller never asked for - neither what `encode_clip` documents (`ImportError`) nor what its callers handle.

![measured before/after](https://raw.githubusercontent.com/cagataycali/robots/assets-mp4-backend/docs/assets/mp4_backend_required.png)

## What it cost, measured at each of the three writers

| writer | before | after |
|---|---|---|
| `stop_cameras_recording` (MuJoCo), 8 buffered frames | `status="success"`, 0 encoded, a **0-byte** `clip__cam_a.mp4`, recording **deregistered** - 8 frames lost under a success verdict | `status="error"`, recording still registered holding all 8; a second stop with the plugin installed encodes them |
| `stop_cameras_recording` (Isaac) | catches only `ImportError`/`RuntimeError`/`ValueError`, so the `TypeError` **escaped a method documented never to raise** - after the recording state was already cleared | reported through the envelope |
| `run_policy(video=...)` | rollout ran to completion, then `Policy failed: PyAVPlugin.write() got an unexpected keyword argument 'quality'` beside a 0-byte MP4 | `_RolloutVideoWriter.open`'s error envelope, before the loop, writing nothing |

The MuJoCo flush already had an `except ImportError` branch that keeps the recording registered so the caller can install and retry. That branch was simply unreachable for this condition.

## The change

The container decides which modules must be present, and **one function decides it** - `require_clip_encoder` (`strands_robots.rendering`) - which every writer routes its probe through instead of repeating the rule, which is how the rule came to hold for one writer and not the next:

```mermaid
graph LR
  A[encode_clip] --> O[require_clip_encoder]
  B[camera flush<br/>mujoco + isaac] --> O
  C[_RolloutVideoWriter.open] --> O
  O -->|.gif| P[imageio only<br/>Pillow writes GIF]
  O -->|anything else| Q[imageio + imageio_ffmpeg]
```

`.gif` needs no plugin: Pillow writes it, `imageio` hard-requires Pillow, and this package depends on Pillow outright. The refusal comes from `require_optional`, so it names the module actually absent and the extra whose bounds this project owns rather than two bare distributions - and it is raised **before the frames are read**, so a caller keeps its iterable:

```
'imageio_ffmpeg' is required for MP4 video encoding (encode_clip)
Install with:
  pip install 'strands-robots[sim-mujoco]'
  pip install imageio-ffmpeg
```

Both camera flushes now quote that refusal instead of their own fixed `"imageio not installed. pip install imageio imageio-ffmpeg"` line, which named the wrong module whenever it was the plugin that was missing.

## Healthy installs are untouched

The left panel above is frame 12 of a real headless MuJoCo camera recording made on this branch - 25 frames, 81 KB, decoded back with PyAV: [so101__cam_a.mp4](https://raw.githubusercontent.com/cagataycali/robots/assets-mp4-backend/docs/assets/mp4_backend_healthy_recording.mp4).

## Tests

`tests/rendering/test_encode_clip_requires_the_mp4_backend.py` - 12 cells, **9 fail on `main`, 3 pass**; the 3 that pass are the controls (both GIF spellings, and an MP4 on an install that has the plugin), which is the discrimination proof. Absence is produced the way the neighbouring suite already does it (`sys.modules[name] = None` plus dropping `require_optional`'s memo).

- the refusal names the plugin, the distribution and the extra, for `.mp4` / `.MP4` / `.mkv`, leaving no file
- a generator passed as `frames` is **not consumed** before the refusal
- the MuJoCo flush refuses, keeps all 8 frames registered, writes no clip, and a second stop encodes exactly those frames
- the rollout returns the envelope and writes nothing
- structurally: no camera flush substitutes its own diagnosis for the encoder's; no writer in the package probes `imageio` on its own (that cell names `simulation/policy_runner.py:569` on `main`)

Two existing pins moved with the refactor and are updated in the same change: `test_rollout_video_realtime_fps.py` substitutes the shared owner instead of `require_optional`, and the imageio-floor auditor learns the new binding idiom so `imageio.get_writer` is still recorded as a name the package reaches for.

**Gate:** full `tests/` 50576 passed / 64 failed vs `main`'s 50566 / 74 - the 10 fewer are this pin's red cells; failure-name sets identical otherwise, zero regressions. `scripts/check_whole_tree_graders.py` 4721 passed, 13 failures all pre-existing environment drift (absent `awsiot`/`qpsolvers`, lerobot 0.6.2, websockets floor). `ruff check` / `ruff format` clean; `mypy` 20 errors in 6 files, all pre-existing.

LOC: +609 / -33 (390 of the additions are the new pin).