### PR TITLE
fix(policies): a policy server that accepts the connection and answers nothing is reported, not waited out

### DIFF
--- a/changelog.d/3321-ws-policy-read-deadline.md
+++ b/changelog.d/3321-ws-policy-read-deadline.md
@@ -1,0 +1,23 @@
+### Fixed: a policy server that accepts the connection and answers nothing is reported, not waited out
+
+`VeraWebsocketClient` and `Cosmos3WebsocketClient` read their server's metadata
+handshake and every action chunk with `websockets.sync`'s `recv()`, which has no
+deadline of its own. `open_timeout` covers the TCP connect plus the HTTP upgrade
+only, so a server whose listener accepted the connection and then went quiet - a
+checkpoint still loading onto the GPU, a wedged forward pass - held the calling
+thread indefinitely. Each client's actionable "could not reach the server, start
+it first" hint is raised from `except OSError`, and a listening server never
+produces one, so the one report that says what to do was unreachable; under
+`VeraServerRunner`, whose readiness is a TCP port probe, `start()` returns in
+precisely that state.
+
+Both clients now take a `read_timeout` (positive finite seconds, default 600,
+refused at construction) that bounds every read, and report a read that expires
+as `accepted the connection but sent no ... within read_timeout=Ns` - separately
+from the absent-server hint. A missed read also discards the connection: the
+reply it did not read is still queued on the socket, so the next request would
+otherwise be answered with the previous request's chunk, well-formed and computed
+for an observation the robot has already moved past. The handshake is held to the
+same rule - published before its metadata frame was read, a failed handshake left
+a live connection cached behind the refusal it had just raised, and
+`get_server_metadata()` answered `{}` for a server it had never spoken to.

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -54,6 +54,19 @@ lands in the path. Both are read only when this constructor builds the client; a
 injected `client=` owns its own address. `host="0.0.0.0"` reaches a server bound
 on every interface.
 
+The client's own `read_timeout` - `Cosmos3WebsocketClient(host, port, read_timeout=1800)`,
+injected as `client=` - bounds every read off the live connection - the metadata handshake
+and each action chunk - as a positive finite number of seconds (default 600).
+`websockets`' `recv()` has no deadline of its own, so without it a server that
+accepted the connection and then went quiet, with a checkpoint still loading onto
+the GPU or a wedged forward pass, held the calling thread indefinitely: the
+`ConnectionError` that tells an operator how to start the server is raised from
+`except OSError`, and a listening server never produces one. A read that expires
+reports `accepted the connection but sent no ... within read_timeout=Ns` - kept
+distinct from the "start it first" hint, which is the wrong advice for a server
+that is already running - and discards the connection, so the reply it missed
+cannot be read as the answer to the next observation.
+
 ## Embodiments
 
 | Embodiment | Robot hardware | Strands sim asset |

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -242,6 +242,32 @@ reported as its own cause rather than as the container having exited, which is a
 answer the query never got. `docker run` is not a query and stays unbounded: it
 may pull the image, and it runs before any readiness budget starts.
 
+Readiness is a *port* probe, so it says nothing about whether the server will
+answer. `VeraWebsocketClient` therefore states its own budget: `read_timeout`
+(seconds, the same positive-finite domain, default 600) bounds every read off the
+live connection - the metadata handshake and each endpoint reply. `open_timeout`
+does not cover it, because that budget ends when the HTTP upgrade completes, and
+`websockets`' `recv()` has no deadline of its own: a server whose listener
+accepted the connection while the checkpoint was still loading onto the GPU held
+the first read with no way back to the caller, which is the state `start()`
+returns in. A read that expires reports `accepted the connection but sent no
+metadata handshake within read_timeout=Ns`, separately from the "could not reach
+the VERA policy server ... start it first" hint - that one is written for a server
+that is *absent*, and pointing an operator at a server already running names the
+one thing that is not wrong. Raise the budget for a slower model:
+`VeraPolicy(client=VeraWebsocketClient(host, port, read_timeout=1800))`.
+
+A read that expires also *discards* the connection. The reply it missed is still
+produced and still queued on the socket, so the next request would read the
+previous request's answer - a well-formed `[H, D]` chunk computed for an
+observation the arm has already moved past, with nothing in it to say so. The
+next call opens a fresh connection instead, which is the rule `RemotePolicy`
+states for the same wire. The handshake is discarded on the same terms: published
+before its metadata frame was read, a failed handshake left a live connection
+cached behind the refusal it had just raised, and `get_server_metadata()` then
+answered `{}` - empty action geometry that `_ensure_started` accepts as the
+handshake.
+
 `motion_plan_scale` takes the same domain as the two IK scales below: a positive
 finite number, or `None` to leave the server's own scale alone. `0` is not the
 opt-out — it scales the plan to nothing — so `None` is the off switch and `0` is

--- a/strands_robots/policies/_ws_wire.py
+++ b/strands_robots/policies/_ws_wire.py
@@ -1,0 +1,73 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""One report for a policy server that answered the connect and nothing else.
+
+The two WebSocket policy clients in this package -
+:class:`~strands_robots.policies.vera.client.VeraWebsocketClient` and
+:class:`~strands_robots.policies.cosmos3.client.Cosmos3WebsocketClient` - each
+carry an actionable "could not reach the server" hint, raised from
+``except OSError`` around the connect. That report is written for a server that
+is *absent*, and it is the wrong report for a server that is *present and
+silent*: one whose listener accepted the connection while the checkpoint is
+still loading onto the GPU, or whose forward pass is wedged.
+
+The two cases are told apart by which side the wait is on, so they get separate
+words. Telling an operator to start a server that is already running points them
+at the one thing that is not wrong, and the remedy for a slow load ("wait, or
+raise the budget") is not the remedy for an absent process.
+
+``recv`` states the budget it waited out, because that budget is the knob: a WAN
+world model can take minutes to answer, so a read that expired is as likely to
+be a budget set too low as a server in trouble, and the operator cannot tell
+which without the number.
+
+Which case a caller is in is decided by ``except TimeoutError`` *before*
+``except OSError``, at the entry point that made the call - never by re-raising
+``ConnectionError`` to protect an already-specific report, because
+``ConnectionRefusedError`` is a ``ConnectionError`` too and that clause would
+hand a bare ``[Errno 111] Connection refused`` straight to the caller, which is
+the one report the start-the-server hint exists to replace.
+"""
+
+from typing import Any
+
+
+def silent_server_error(*, server: str, uri: str, what: str, timeout: float, budget_param: str) -> str:
+    """Return the report for a peer that accepted the connection and went quiet.
+
+    Args:
+        server: Human name of the service being dialled (e.g. ``"VERA policy
+            server"``), used to name what is silent rather than what is absent.
+        uri: The WebSocket URI the client dialled, so the message names the
+            endpoint actually in use rather than the one the caller meant.
+        what: The reply that did not arrive (e.g. ``"metadata handshake"``,
+            ``"'infer' reply"``).
+        timeout: The budget, in seconds, that expired waiting for it.
+        budget_param: Name of the constructor parameter that carries *timeout*,
+            so the remedy names the knob a caller can actually reach.
+
+    Returns:
+        A message stating that the connection was accepted, what did not arrive,
+        the budget that expired, and both remedies (read the server's log, or
+        raise the budget).
+    """
+    return (
+        f"{server} at {uri} accepted the connection but sent no {what} within "
+        f"{budget_param}={timeout:g}s. The server is listening, so it is still loading "
+        f"(a large checkpoint takes minutes) or it is wedged: read its log to tell those "
+        f"apart, and raise {budget_param} if the model is simply slower than the budget."
+    )
+
+
+def close_quietly(ws: Any) -> None:
+    """Close a websocket connection, ignoring any failure.
+
+    Shared by the discard paths and each client's ``close``. A connection being
+    discarded is already being abandoned over an error, and letting the close
+    raise would replace the report the caller needs with the failure of the
+    cleanup.
+    """
+    try:
+        ws.close()
+    except Exception:  # noqa: BLE001 - a discarded connection is already lost
+        pass

--- a/strands_robots/policies/cosmos3/client.py
+++ b/strands_robots/policies/cosmos3/client.py
@@ -22,9 +22,25 @@ Wire contract (verified against the server source):
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
+from strands_robots.policies._ws_wire import close_quietly, silent_server_error
+from strands_robots.utils import positive_finite_number_error
+
 logger = logging.getLogger(__name__)
+
+#: Seconds any single read off the live connection may wait, by default. A
+#: Cosmos 3 forward pass on a video world model is slow, so this is generous -
+#: but it is a deadline, and ``websockets`` gives ``recv()`` none of its own:
+#: without it a server that accepted the connection and then went quiet (a
+#: checkpoint still loading onto the GPU, a wedged forward pass) left every read
+#: blocked with no way back to the caller. The connect side is already bounded
+#: by ``websockets``' own ``open_timeout`` default.
+_READ_TIMEOUT_SECS = 600.0
+
+#: What the reports call the service, so "absent" and "silent" name one server.
+_SERVER_NAME = "Cosmos 3 policy server"
 
 
 class _RawWebsocketTransport:
@@ -39,9 +55,10 @@ class _RawWebsocketTransport:
     Requires only ``websockets`` and ``msgpack``.
     """
 
-    def __init__(self, host: str, port: int, api_key: str | None = None):
+    def __init__(self, host: str, port: int, api_key: str | None = None, read_timeout: float = _READ_TIMEOUT_SECS):
         self.uri = f"ws://{host}:{port}"
         self.api_key = api_key
+        self.read_timeout = float(read_timeout)
         self._ws: Any = None
         from . import _msgpack_numpy as _mnp  # vendored, numpy-agnostic
 
@@ -49,22 +66,64 @@ class _RawWebsocketTransport:
         self._packer = _mnp.Packer()
 
     def _ensure(self) -> Any:
-        if self._ws is None:
-            import websockets.sync.client as _wsc
+        if self._ws is not None:
+            return self._ws
+        import websockets.sync.client as _wsc
 
-            headers = {"Authorization": f"Api-Key {self.api_key}"} if self.api_key else None
-            self._ws = _wsc.connect(self.uri, compression=None, max_size=None, additional_headers=headers)
-            self._mnp.unpackb(self._ws.recv())  # server metadata handshake
-        return self._ws
+        headers = {"Authorization": f"Api-Key {self.api_key}"} if self.api_key else None
+        # ``Any`` for the same reason ``self._ws`` is declared ``Any``: the frames
+        # go straight to the vendored packer, which treats them as opaque.
+        ws: Any = _wsc.connect(self.uri, compression=None, max_size=None, additional_headers=headers)
+        # ``self._ws`` is published only once the handshake has been consumed.
+        # Assigned before the read, a failed handshake left a live connection
+        # cached behind the error it had just raised, with the metadata frame
+        # still unread - so the next ``infer`` would have read that blob as its
+        # action chunk. Same rule as ``RemotePolicy._connect`` (MODULE
+        # strands_robots.inference.client).
+        established = False
+        try:
+            self._mnp.unpackb(ws.recv(timeout=self.read_timeout))  # server metadata handshake
+            established = True
+        finally:
+            if not established:
+                close_quietly(ws)
+        self._ws = ws
+        return ws
 
     def get_server_metadata(self) -> dict[str, Any]:
         self._ensure()
         return {}
 
-    def infer(self, observation: dict[str, Any]) -> dict[str, Any]:
+    def _exchange(self, message: Mapping[str, Any]) -> Any:
+        """Send one request and read its reply, or discard the connection.
+
+        A reply that was not read is still produced and still queued on the
+        socket, so a connection whose exchange did not complete is in an unknown
+        position: the next request would read the previous request's answer, and
+        a stale ``[T, D]`` chunk is well-formed - it drives the robot from an
+        observation it has already moved past, with nothing to distinguish it.
+        Discarding it is the rule ``RemotePolicy._request`` states for the same
+        wire (MODULE strands_robots.inference.client).
+        """
         ws = self._ensure()
-        ws.send(self._packer.pack(observation))
-        resp = ws.recv()
+        exchanged = False
+        try:
+            ws.send(self._packer.pack(dict(message)))
+            resp = ws.recv(timeout=self.read_timeout)
+            exchanged = True
+            return resp
+        finally:
+            if not exchanged:
+                self.close()
+
+    def close(self) -> None:
+        """Drop the connection if one is open (best-effort and idempotent)."""
+        if self._ws is not None:
+            close_quietly(self._ws)
+            self._ws = None
+
+    def infer(self, observation: dict[str, Any]) -> dict[str, Any]:
+        resp = self._exchange(observation)
         if isinstance(resp, str):
             raise RuntimeError(f"Error in inference server:\n{resp}")
         return self._mnp.unpackb(resp)
@@ -80,6 +139,15 @@ class Cosmos3WebsocketClient:
         host: Server hostname or IP.
         port: Server WebSocket port.
         api_key: Optional bearer token forwarded to the server, when set.
+        read_timeout: Seconds any single read off the connection may wait - the
+            metadata handshake and every action chunk. Only a positive finite
+            number names a budget: ``0``, a negative and ``True`` expire against
+            a server that is answering normally, and ``inf`` cannot express "no
+            deadline" here at all, because ``websockets`` raises
+            ``OverflowError`` computing a deadline from it. Refused in the
+            constructor, while the caller still holds the value, since the
+            connection is opened lazily and an unusable budget would otherwise
+            surface mid-rollout naming no parameter.
         transport: Accepted for backwards compatibility. The only supported
             transport is the vendored raw msgpack+websockets packer; any
             value is treated as ``"raw"`` and a deprecation warning is
@@ -88,6 +156,9 @@ class Cosmos3WebsocketClient:
     The connection is established lazily on the first :meth:`infer` (or
     :meth:`get_server_metadata`) call so constructing a policy does not
     require the server to already be up - matching ``Gr00tInferenceClient``.
+
+    Raises:
+        ValueError: If *read_timeout* is not a positive finite number.
     """
 
     def __init__(
@@ -96,10 +167,14 @@ class Cosmos3WebsocketClient:
         port: int = 8000,
         api_key: str | None = None,
         transport: str = "raw",
+        read_timeout: float = _READ_TIMEOUT_SECS,
     ):
+        if err := positive_finite_number_error(read_timeout, "read_timeout", type(self).__name__):
+            raise ValueError(err)
         self.host = host
         self.port = port
         self.api_key = api_key
+        self.read_timeout = float(read_timeout)
         if transport not in (None, "", "raw"):
             logger.warning(
                 "Cosmos3WebsocketClient(transport=%r) is deprecated - the "
@@ -110,6 +185,16 @@ class Cosmos3WebsocketClient:
             )
         self.transport = "raw"
         self._client: Any = None
+
+    def _silent_server_error(self, what: str) -> str:
+        """Report for a server that accepted the connection and then went quiet."""
+        return silent_server_error(
+            server=_SERVER_NAME,
+            uri=f"ws://{self.host}:{self.port}",
+            what=what,
+            timeout=self.read_timeout,
+            budget_param="read_timeout",
+        )
 
     def _server_hint(self) -> str:
         """Actionable hint for starting the Cosmos 3 RoboLab policy server."""
@@ -128,7 +213,7 @@ class Cosmos3WebsocketClient:
         if self._client is not None:
             return self._client
         try:
-            self._client = _RawWebsocketTransport(self.host, self.port, self.api_key)
+            self._client = _RawWebsocketTransport(self.host, self.port, self.api_key, self.read_timeout)
         except OSError as e:
             raise ConnectionError(self._server_hint()) from e
         logger.info(
@@ -143,6 +228,12 @@ class Cosmos3WebsocketClient:
         client = self._ensure_client()
         try:
             return client.get_server_metadata()
+        except TimeoutError as e:
+            # Before ``OSError`` (a ``TimeoutError`` is one), because the two
+            # cases have separate remedies: this server is listening and did not
+            # answer, so telling the operator to start it names the one thing
+            # that is not wrong.
+            raise ConnectionError(self._silent_server_error("metadata handshake")) from e
         except OSError as e:
             raise ConnectionError(self._server_hint()) from e
 
@@ -161,6 +252,14 @@ class Cosmos3WebsocketClient:
         client = self._ensure_client()
         try:
             return client.infer(observation)
+        except TimeoutError as e:
+            # Before ``OSError`` (a ``TimeoutError`` is one), because the two
+            # cases have separate remedies: this server is listening and did not
+            # answer, so telling the operator to start it names the one thing
+            # that is not wrong. "reply" rather than "action chunk" because the
+            # first call also performs the handshake, and this clause cannot see
+            # which of the two reads expired.
+            raise ConnectionError(self._silent_server_error("reply")) from e
         except OSError as e:
             raise ConnectionError(self._server_hint()) from e
 

--- a/strands_robots/policies/vera/client.py
+++ b/strands_robots/policies/vera/client.py
@@ -21,12 +21,27 @@ and ``vera.controller.run_mimicgen_eval.RemotePolicy``):
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
+
+from strands_robots.policies._ws_wire import close_quietly, silent_server_error
+from strands_robots.utils import positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
 # WAN forward passes are slow; keep the connection generous on open.
 _OPEN_TIMEOUT_SECS = 600
+
+#: Seconds any single read off the live connection may wait, by default. Held at
+#: the open budget because both wait on the same thing - a WAN world model - and
+#: ``open_timeout`` covers only the TCP connect plus the HTTP upgrade, so it
+#: says nothing about a read. ``websockets`` gives ``recv()`` no deadline of its
+#: own, so without this a server that accepted the connection and then went
+#: quiet left every read blocked with no way back to the caller.
+_READ_TIMEOUT_SECS = 600.0
+
+#: What the reports call the service, so "absent" and "silent" name one server.
+_SERVER_NAME = "VERA policy server"
 
 
 class VeraWebsocketClient:
@@ -39,11 +54,26 @@ class VeraWebsocketClient:
     Args:
         host: Server hostname or IP.
         port: Server websocket port.
+        read_timeout: Seconds any single read off the connection may wait - the
+            metadata handshake and every endpoint reply. Only a positive finite
+            number names a budget: ``0``, a negative and ``True`` expire against
+            a server that is answering normally, and ``inf`` cannot express "no
+            deadline" here at all, because ``websockets`` raises
+            ``OverflowError`` computing a deadline from it. Refused in the
+            constructor, while the caller still holds the value, since the
+            connection is opened lazily and an unusable budget would otherwise
+            surface mid-rollout naming no parameter.
+
+    Raises:
+        ValueError: If *read_timeout* is not a positive finite number.
     """
 
-    def __init__(self, host: str = "127.0.0.1", port: int = 8800) -> None:
+    def __init__(self, host: str = "127.0.0.1", port: int = 8800, *, read_timeout: float = _READ_TIMEOUT_SECS) -> None:
+        if err := positive_finite_number_error(read_timeout, "read_timeout", type(self).__name__):
+            raise ValueError(err)
         self.host = host
         self.port = port
+        self.read_timeout = float(read_timeout)
         self.uri = f"ws://{host}:{port}"
         self._ws: Any = None
         self._server_metadata: dict[str, Any] | None = None
@@ -66,24 +96,96 @@ class VeraWebsocketClient:
             "Then set VERA_CKPT_ROOT to that directory."
         )
 
+    def _silent_server_error(self, what: str) -> str:
+        """Report for a server that accepted the connection and then went quiet."""
+        return silent_server_error(
+            server=_SERVER_NAME,
+            uri=self.uri,
+            what=what,
+            timeout=self.read_timeout,
+            budget_param="read_timeout",
+        )
+
     def _ensure(self) -> Any:
         if self._ws is not None:
             return self._ws
         try:
             import websockets.sync.client as _wsc
 
-            self._ws = _wsc.connect(
+            # ``Any`` for the same reason ``self._ws`` is declared ``Any``: the
+            # connection object is handed straight to the vendored packer, whose
+            # frames this module treats as opaque.
+            ws: Any = _wsc.connect(
                 self.uri,
                 compression=None,
                 max_size=None,
                 open_timeout=_OPEN_TIMEOUT_SECS,
             )
-            # Server sends its VeraServerConfig as the first message.
-            self._server_metadata = self._mnp.unpackb(self._ws.recv())
         except OSError as e:
             raise ConnectionError(self._server_hint()) from e
+        # ``self._ws`` is published only once the handshake has been consumed.
+        # Assigned before the read, a failed handshake left a live connection
+        # cached behind the refusal it had just raised, with the metadata frame
+        # still unread: the short-circuit above then handed that connection back,
+        # ``get_server_metadata`` answered ``{}`` for a server it never spoke to,
+        # and the next ``infer`` would have read the metadata blob as its action
+        # chunk. Same rule as ``RemotePolicy._connect`` (MODULE
+        # strands_robots.inference.client) - a connection whose exchange did not
+        # complete is in an unknown position, so it is discarded, and the next
+        # call opens a fresh one.
+        established = False
+        try:
+            # Server sends its VeraServerConfig as the first message.
+            self._server_metadata = self._mnp.unpackb(ws.recv(timeout=self.read_timeout))
+            established = True
+        except TimeoutError as e:
+            raise ConnectionError(self._silent_server_error("metadata handshake")) from e
+        except OSError as e:
+            raise ConnectionError(self._server_hint()) from e
+        finally:
+            if not established:
+                close_quietly(ws)
+        self._ws = ws
         logger.info("VeraWebsocketClient connected to %s", self.uri)
-        return self._ws
+        return ws
+
+    def _exchange(self, message: Mapping[str, Any], endpoint: str) -> Any:
+        """Send one request and read its reply, or discard the connection.
+
+        Args:
+            message: Wire dict to pack and send; *endpoint* is added to it.
+            endpoint: The server endpoint being called, named in the report if
+                the reply does not arrive.
+
+        Returns:
+            The raw reply frame - ``bytes`` to unpack, or a ``str`` error
+            sentinel for the caller to raise.
+
+        Raises:
+            ConnectionError: If the server accepted the connection but did not
+                answer within ``read_timeout``.
+
+        A reply that was not read is still produced and still queued on the
+        socket, so a connection whose exchange did not complete is in an unknown
+        position: the next request would read the previous request's answer, and
+        a stale ``[H, D]`` chunk is well-formed - it drives the arm from an
+        observation it has already moved past, with nothing to distinguish it.
+        Discarding the connection is what keeps a missed read from becoming a
+        wrong one, and is the rule ``RemotePolicy._request`` states for the same
+        wire (MODULE strands_robots.inference.client).
+        """
+        ws = self._ensure()
+        exchanged = False
+        try:
+            ws.send(self._packer.pack({**message, "endpoint": endpoint}))
+            resp = ws.recv(timeout=self.read_timeout)
+            exchanged = True
+            return resp
+        except TimeoutError as e:
+            raise ConnectionError(self._silent_server_error(f"{endpoint!r} reply")) from e
+        finally:
+            if not exchanged:
+                self.close()
 
     def get_server_metadata(self) -> dict[str, Any]:
         """Return the ``VeraServerConfig`` dict the server sends on connect."""
@@ -105,10 +207,7 @@ class VeraWebsocketClient:
             Response dict containing at least ``"action"`` - an ``[H, D]``
             NumPy array - the chunk the controller plays before refilling.
         """
-        ws = self._ensure()
-        msg = {**observation, "endpoint": "infer"}
-        ws.send(self._packer.pack(msg))
-        resp = ws.recv()
+        resp = self._exchange(observation, "infer")
         if isinstance(resp, str):
             raise RuntimeError(f"VERA inference server error:\n{resp}")
         return self._mnp.unpackb(resp)
@@ -116,24 +215,21 @@ class VeraWebsocketClient:
     def reset(self, reset_info: dict[str, Any] | None = None) -> None:
         """Clear the server's per-episode state (history + KV caches)."""
         try:
-            ws = self._ensure()
+            resp = self._exchange(reset_info or {}, "reset")
         except ConnectionError:
             # Reset is best-effort - never a correctness requirement (mirrors
-            # Cosmos3WebsocketClient.reset / Gr00tPolicy.reset).
+            # Cosmos3WebsocketClient.reset / Gr00tPolicy.reset). Covers the
+            # server that is absent and the one that accepted the connection
+            # without answering: both report ConnectionError, and neither is a
+            # reason to fail the episode.
             return
-        msg = {**(reset_info or {}), "endpoint": "reset"}
-        ws.send(self._packer.pack(msg))
-        resp = ws.recv()
         if isinstance(resp, str) and resp != "reset successful":
             raise RuntimeError(f"VERA reset server error:\n{resp}")
 
     def configure(self, params: dict[str, Any]) -> dict[str, Any]:
         """Live-tune runtime knobs (motion_plan_scale, sample_steps, guidance)
         without a model rebuild. Returns the server's ``{"applied": {...}}``."""
-        ws = self._ensure()
-        msg = {**params, "endpoint": "configure"}
-        ws.send(self._packer.pack(msg))
-        resp = ws.recv()
+        resp = self._exchange(params, "configure")
         if isinstance(resp, str):
             raise RuntimeError(f"VERA configure server error:\n{resp}")
         return self._mnp.unpackb(resp)
@@ -141,8 +237,5 @@ class VeraWebsocketClient:
     def close(self) -> None:
         """Close the underlying websocket if open (best-effort and idempotent)."""
         if self._ws is not None:
-            try:
-                self._ws.close()
-            except Exception:  # noqa: BLE001 - close is best-effort
-                pass
+            close_quietly(self._ws)
             self._ws = None

--- a/tests/policies/cosmos3/test_websocket_client_transport.py
+++ b/tests/policies/cosmos3/test_websocket_client_transport.py
@@ -35,7 +35,13 @@ class _FakeWebsocket:
         self.sent = []
         self.closed = False
 
-    def recv(self):
+    def recv(self, timeout=None):
+        """Hand back the next queued payload.
+
+        ``timeout`` is accepted and ignored: the client states a deadline on
+        every read, and a double that refused the keyword would be pinning its
+        own signature rather than the wire.
+        """
         return self._recv_queue.pop(0)
 
     def send(self, data):

--- a/tests/policies/test_policy_client_wire_reads_state_a_deadline.py
+++ b/tests/policies/test_policy_client_wire_reads_state_a_deadline.py
@@ -1,0 +1,274 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A policy client's wire read is bounded, and a missed read is not a wrong one.
+
+The two WebSocket policy clients in this package -
+:class:`~strands_robots.policies.vera.client.VeraWebsocketClient` and
+:class:`~strands_robots.policies.cosmos3.client.Cosmos3WebsocketClient` - read
+their server's metadata handshake and every action chunk with
+``websockets.sync``'s ``recv()``, which has no deadline of its own. ``VERA``
+passed ``open_timeout=600`` to ``connect``, and that covers the TCP connect plus
+the HTTP upgrade only: a server whose listener accepted the connection and then
+went quiet - a checkpoint still loading onto the GPU, a wedged forward pass -
+held the calling thread with no way back to the caller.
+
+Two documented contracts fail on that. Each client converts ``OSError`` around
+its connect into an actionable ``ConnectionError`` ("could not reach the server -
+start it first"), and that report is unreachable for a listening server, because
+no ``TimeoutError`` (an ``OSError``) is ever raised. And ``VeraServerRunner``
+judges readiness with a TCP port probe, so ``start()`` returns as soon as the
+listener is up - which is exactly the state that hangs the first read.
+
+Bounding the read alone would trade the hang for a *wrong* answer, so both
+halves are pinned here. A reply that was not read is still produced and still
+queued on the socket, so the next request reads the previous request's chunk -
+well-formed, and computed for an observation the robot has already moved past.
+``RemotePolicy`` states that rule for the same wire (see
+``tests/inference/test_a_failed_exchange_does_not_leave_the_connection_cached.py``);
+these two clients now state it too, and the handshake gets it as well - assigned
+before the metadata frame was read, a failed handshake left a live connection
+cached behind the refusal it had just raised, and ``get_server_metadata``
+answered ``{}`` for a server it had never spoken to.
+
+No network access and no GPU: every server here is a loopback listener, and the
+one read that has to miss its reply is parked by the server rather than raced.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("websockets", reason="the raw websocket transports need websockets")
+
+from websockets.sync.server import serve  # noqa: E402
+
+from strands_robots.policies.cosmos3.client import Cosmos3WebsocketClient  # noqa: E402
+from strands_robots.policies.vera import _msgpack_numpy as mnp  # noqa: E402
+from strands_robots.policies.vera.client import VeraWebsocketClient  # noqa: E402
+
+#: Budget handed to the client for a read that must miss its reply. Waited out in
+#: full on every run, so it is the one value here worth keeping small.
+READ_TIMEOUT_S = 0.3
+
+#: How long the server withholds the one parked reply. Well above
+#: ``READ_TIMEOUT_S`` so the miss is deterministic rather than a race, and the
+#: reply provably still exists when the client's budget expires.
+PARK_S = 2.0
+
+#: How long to wait for a worker thread that must finish. Generous - a bounded
+#: read returns as soon as its budget fires, so this is never waited out on a
+#: passing run - but bounded, so an unbounded read renders as a failure instead
+#: of hanging the suite.
+JOIN_S = 8.0
+
+
+def _serve(handler: Any) -> int:
+    """Run *handler* on a loopback WebSocket listener; return its port."""
+    server = serve(handler, "127.0.0.1", 0)
+    port = int(server.socket.getsockname()[1])
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return port
+
+
+@pytest.fixture
+def silent_server() -> int:
+    """A server that accepts the connection and then sends nothing at all.
+
+    The listening-but-silent state: the port probe that ``VeraServerRunner``
+    calls readiness answers yes, and the metadata frame never comes.
+    """
+    return _serve(lambda conn: time.sleep(JOIN_S * 4))
+
+
+def _call_on_a_thread(call: Any) -> tuple[threading.Thread, list[BaseException]]:
+    """Run *call* on a daemon thread, capturing whatever it raises."""
+    raised: list[BaseException] = []
+
+    def attempt() -> None:
+        try:
+            call()
+        except Exception as exc:  # noqa: BLE001 - the outcome is the measurement
+            raised.append(exc)
+
+    thread = threading.Thread(target=attempt, daemon=True)
+    thread.start()
+    thread.join(JOIN_S)
+    return thread, raised
+
+
+#: The two clients, each with the call that performs its metadata handshake and
+#: the wording its own "the server is absent" hint uses - which is the report a
+#: silent server must NOT receive.
+CLIENTS = [
+    pytest.param(VeraWebsocketClient, "get_server_metadata", "Could not reach the VERA policy server", id="vera"),
+    pytest.param(Cosmos3WebsocketClient, "get_server_metadata", "Start it first", id="cosmos3"),
+]
+
+
+@pytest.mark.parametrize(("client_cls", "call_name", "absent_hint"), CLIENTS)
+class TestASilentServerIsReportedRatherThanWaitedOut:
+    """The read that a listening-but-silent server never answers has a deadline."""
+
+    def test_the_read_returns_inside_the_stated_budget(
+        self, client_cls: Any, call_name: str, absent_hint: str, silent_server: int
+    ) -> None:
+        client = client_cls(host="127.0.0.1", port=silent_server, read_timeout=READ_TIMEOUT_S)
+        thread, raised = _call_on_a_thread(getattr(client, call_name))
+        assert not thread.is_alive(), (
+            f"{client_cls.__name__} is still blocked {JOIN_S}s into a read the server will never "
+            f"answer: recv() has no deadline of its own, and open_timeout covers the connect only"
+        )
+        assert raised and isinstance(raised[0], ConnectionError), f"expected a ConnectionError, got {raised}"
+
+    def test_the_report_names_the_silent_server_and_the_budget_that_expired(
+        self, client_cls: Any, call_name: str, absent_hint: str, silent_server: int
+    ) -> None:
+        client = client_cls(host="127.0.0.1", port=silent_server, read_timeout=READ_TIMEOUT_S)
+        _thread, raised = _call_on_a_thread(getattr(client, call_name))
+        message = str(raised[0])
+        assert f"ws://127.0.0.1:{silent_server}" in message, message
+        assert "accepted the connection" in message, message
+        assert f"read_timeout={READ_TIMEOUT_S:g}s" in message, message
+
+    def test_the_absent_server_hint_is_not_the_report_a_listening_server_gets(
+        self, client_cls: Any, call_name: str, absent_hint: str, silent_server: int
+    ) -> None:
+        """Telling an operator to start a running server names the one thing that is right."""
+        client = client_cls(host="127.0.0.1", port=silent_server, read_timeout=READ_TIMEOUT_S)
+        _thread, raised = _call_on_a_thread(getattr(client, call_name))
+        assert absent_hint not in str(raised[0]), (
+            f"a server that accepted the connection is running, so the 'start it first' hint misreports it: {raised[0]}"
+        )
+
+
+class TestAFailedExchangeDoesNotLeaveTheConnectionCached:
+    """A connection whose exchange did not complete is discarded, not reused."""
+
+    @staticmethod
+    def _parking_server() -> int:
+        """Serve tagged chunks, withholding the first reply past the read budget.
+
+        The marker each request carries comes back in its own reply, which is
+        what makes a stale answer visible at all: a desynchronised stream returns
+        a well-formed ``[H, D]`` chunk, so only its content distinguishes it.
+        ``served`` is shared across connections so a *fresh* connection is
+        answered promptly - the discard is then measurable rather than masked by
+        a server that parks every first request.
+        """
+        packer = mnp.Packer()
+        served = {"n": 0}
+
+        def handler(conn: Any) -> None:
+            try:
+                conn.send(packer.pack({"action_dim": 2, "action_horizon": 1}))
+                while True:
+                    request = mnp.unpackb(conn.recv())
+                    served["n"] += 1
+                    if served["n"] == 1:
+                        time.sleep(PARK_S)  # the reply is produced late, not never
+                    conn.send(packer.pack({"action": np.zeros((1, 2), np.float32), "marker": request["marker"]}))
+            except Exception:  # noqa: BLE001 - a discarded connection ends the handler
+                return
+
+        return _serve(handler)
+
+    def test_the_next_request_gets_its_own_chunk_not_the_previous_one(self) -> None:
+        client = VeraWebsocketClient(host="127.0.0.1", port=self._parking_server(), read_timeout=READ_TIMEOUT_S)
+        with pytest.raises(ConnectionError):
+            client.infer({"marker": 1})
+        time.sleep(PARK_S + 0.5)  # the parked reply has now landed on the socket
+        assert client.infer({"marker": 2})["marker"] == 2, (
+            "the second request was answered with the first request's chunk - a well-formed "
+            "action chunk computed for an observation the robot has already moved past"
+        )
+
+    def test_a_handshake_that_did_not_complete_is_not_answered_with_empty_metadata(self) -> None:
+        """A dead connection must not report a server contract nobody sent.
+
+        The refusal's own *type* is the transport's to choose - a server that
+        closes mid-handshake raises ``ConnectionClosed``, which is not what this
+        rule is about. What it is about is that both attempts refuse: the second
+        one answering at all means the connection was cached behind the first
+        refusal, and ``{}`` then stood in for a server contract nobody sent -
+        empty geometry that ``VeraPolicy._ensure_started`` would have accepted as
+        the handshake, marking itself started.
+        """
+        port = _serve(lambda conn: conn.close())
+        client = VeraWebsocketClient(host="127.0.0.1", port=port, read_timeout=READ_TIMEOUT_S)
+        for attempt in (1, 2):
+            try:
+                metadata = client.get_server_metadata()
+            except Exception:  # noqa: BLE001 - any refusal is a refusal
+                continue
+            pytest.fail(f"call {attempt} to a server that closed mid-handshake answered with {metadata!r}")
+
+    def test_a_completed_exchange_keeps_its_connection(self) -> None:
+        """The discard is not a reconnect-per-request: a good connection is reused."""
+        connections: list[int] = []
+        packer = mnp.Packer()
+
+        def handler(conn: Any) -> None:
+            connections.append(1)
+            try:
+                conn.send(packer.pack({"action_dim": 2}))
+                while True:
+                    request = mnp.unpackb(conn.recv())
+                    conn.send(packer.pack({"action": np.zeros((1, 2), np.float32), "marker": request["marker"]}))
+            except Exception:  # noqa: BLE001
+                return
+
+        client = VeraWebsocketClient(host="127.0.0.1", port=_serve(handler), read_timeout=JOIN_S)
+        assert client.infer({"marker": 1})["marker"] == 1
+        assert client.infer({"marker": 2})["marker"] == 2
+        assert len(connections) == 1, f"one connection served both requests, got {len(connections)}"
+
+
+@pytest.mark.parametrize(("client_cls", "call_name", "absent_hint"), CLIENTS)
+class TestTheReadBudgetIsGraded:
+    """The budget is refused while the caller still holds it, not mid-rollout."""
+
+    @pytest.mark.parametrize("unusable", [0, -1.0, True, math.nan, math.inf, "600", None])
+    def test_a_budget_that_bounds_nothing_is_refused(
+        self, client_cls: Any, call_name: str, absent_hint: str, unusable: Any
+    ) -> None:
+        with pytest.raises(ValueError, match="read_timeout"):
+            client_cls(host="127.0.0.1", port=8800, read_timeout=unusable)
+
+    def test_the_default_budget_is_positive_and_finite(self, client_cls: Any, call_name: str, absent_hint: str) -> None:
+        default = client_cls(host="127.0.0.1", port=8800).read_timeout
+        assert math.isfinite(default) and default > 0, default
+
+
+class TestEveryReadOffTheseWiresStatesADeadline:
+    """No read in either client module is left on ``recv()``'s absent default."""
+
+    #: The client modules this rule covers, relative to the package root.
+    MODULES = ("policies/vera/client.py", "policies/cosmos3/client.py")
+
+    def test_no_recv_call_omits_its_timeout(self) -> None:
+        package = Path(__file__).resolve().parents[2] / "strands_robots"
+        found = 0
+        unbounded: list[str] = []
+        for relative in self.MODULES:
+            path = package / relative
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                    continue
+                if node.func.attr != "recv":
+                    continue
+                found += 1
+                if not any(keyword.arg == "timeout" for keyword in node.keywords):
+                    unbounded.append(f"{relative}:{node.lineno} {ast.unparse(node)}")
+        assert found >= 4, f"the scan found only {found} recv() calls; the client modules have moved"
+        assert not unbounded, (
+            "websockets' recv() has no default deadline, so each of these blocks indefinitely on a "
+            "server that accepted the connection and then went quiet:\n" + "\n".join(unbounded)
+        )

--- a/tests/policies/vera/test_vera_client_transport.py
+++ b/tests/policies/vera/test_vera_client_transport.py
@@ -35,7 +35,13 @@ class _FakeWebsocket:
         self.sent = []
         self.closed = False
 
-    def recv(self):
+    def recv(self, timeout=None):
+        """Hand back the next queued payload.
+
+        ``timeout`` is accepted and ignored: the client states a deadline on
+        every read, and a double that refused the keyword would be pinning its
+        own signature rather than the wire.
+        """
         return self._recv_queue.pop(0)
 
     def send(self, data):


### PR DESCRIPTION
`VeraWebsocketClient` and `Cosmos3WebsocketClient` read their server's metadata handshake and every action chunk with `websockets.sync`'s `recv()`, which has **no deadline of its own**. VERA passes `open_timeout=600` to `connect`, and that budget ends when the HTTP upgrade completes - so a server whose listener accepted the connection and then went quiet (a checkpoint still loading onto the GPU, a wedged forward pass) held the calling thread with no way back to the caller.

That also makes each client's one actionable report unreachable. Both convert an `OSError` around the connect into "could not reach the server - start it first", and a **listening** server never raises one, because no read ever expires. Under `VeraServerRunner` that is the state `start()` returns in: readiness is a TCP port probe, so the first read is where a silent server shows up.

![measured](https://raw.githubusercontent.com/cagataycali/robots/assets/ws-read-deadline/docs/assets/ws-read-deadline.png)

Measured against a loopback server that accepts the connection and sends nothing (top panel), and one that parks exactly one reply (bottom). Every number in the figure comes from those two runs; nothing is hand-typed.

## Why the discard is in the same change

Bounding the read alone trades a hang for a **wrong answer**. The reply that was not read is still produced and still queued on the socket, so the next request is answered with the previous request's chunk - well-formed `[H, D]`, computed for an observation the robot has already moved past. With the deadline alone, the second request measurably comes back with the first request's marker. `RemotePolicy` states that rule for the same wire (`tests/inference/test_a_failed_exchange_does_not_leave_the_connection_cached.py`); these two clients now state it too.

The handshake is held to the same rule. Published before its metadata frame was read, a failed handshake left a live connection cached behind the refusal it had just raised, so `get_server_metadata()` answered `{}` for a server it had never spoken to - empty action geometry that `VeraPolicy._ensure_started` accepts as the handshake and marks itself started on. Measured pre-fix against a server that closes mid-handshake: first call raises, second call returns `{}`.

## Change

| | |
|---|---|
| `read_timeout` | new on both clients: positive finite seconds, default 600, refused in the constructor (`positive_finite_number_error`) while the caller still holds the value. `inf` is refused because `websockets` raises `OverflowError` computing a deadline from it, so it cannot express "no deadline" here. |
| every `recv` | takes that budget - handshake and each endpoint reply |
| a read that expires | reports `accepted the connection but sent no ... within read_timeout=Ns`, naming the endpoint, the budget and both remedies - separate words from the absent-server hint, which points an operator at the one thing that is not wrong |
| a missed read | discards the connection; the next call opens a fresh one |
| `policies/_ws_wire.py` | one owner for that report and for the best-effort close, so the two clients cannot drift and a third does not add a copy |
| `TimeoutError` before `OSError` | the clause order that separates the two cases. Matching `ConnectionError` instead would have handed a bare `[Errno 111] Connection refused` straight to the caller - `ConnectionRefusedError` is a `ConnectionError` - which is exactly the report the start-the-server hint exists to replace. |

## Tests

`tests/policies/test_policy_client_wire_reads_state_a_deadline.py`, 26 cells, no network and no GPU (loopback listeners; the one read that must miss its reply is parked by the server rather than raced). Pre-fix on `upstream/main`: **26 failed, 0 passed** - including the completeness cell, which names all six unbounded `recv()` sites.

The read that must return is asserted on a worker thread with a bounded join, so an unbounded read renders as a failure instead of hanging the suite.

Two existing `_FakeWebsocket.recv(self)` doubles were widened to accept and ignore `timeout`: a double that pins its own signature is not pinning the wire.

## LOC

+666 / -34. Library `+273` net (`_ws_wire.py` 73, cosmos3 +110/-11, vera +114/-21 - comment-heavy, and the shared module is what keeps the two clients from each carrying a copy), tests +281, docs + changelog +62.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1951 files)
- `mypy`: 20 errors / 6 files, identical to `upstream/main`
- full `tests/`, this branch vs `upstream/main` measured side by side: **64 failed / 50675 passed** vs **64 failed / 50648 passed**, 37 errors both, failure-name sets identical in both directions (+27 = the new cells). The standing failures are environment drift on this box (`awsiot` and `qpsolvers` absent, lerobot import surface, websockets 16.0 under the declared 17.0 floor).
- `scripts/check_whole_tree_graders.py`: 4710 passed, the same 13 standing drift failures.