### PR TITLE
fix(registry): a user-registry write stores the whole overlay or leaves it untouched

### DIFF
--- a/changelog.d/3322-user-registry-atomic-write.md
+++ b/changelog.d/3322-user-registry-atomic-write.md
@@ -1,0 +1,20 @@
+### Bug Fixes
+
+- **registry**: a `user_robots.json` write now stores the whole overlay or
+  leaves it exactly as it was. Both `register_robot` and `unregister_robot` are
+  read-modify-writes of the *whole* document, and the write encoded straight
+  into the destination it had already truncated - so a failure partway through
+  did not lose the entry being changed, it lost every robot the overlay held.
+  A value JSON cannot represent reached that point routinely: `hardware` is
+  typed `dict[str, Any]` and stored verbatim, so a `Path` port or a numpy joint
+  count raised `TypeError` after a prefix of the new document had replaced the
+  old one, and `parse_user_robots` reports an unparseable overlay as *no user
+  robots* - a warning, then the package registry alone. A refused registration
+  therefore destroyed the registry it was refused from, and the previously
+  registered robots came back as `Unknown robot` from `get_robot`,
+  `resolve_name` and `sim.add_robot`. The document is now serialized in full
+  before the destination is touched, and the text is committed through a temp
+  sibling plus `os.replace`, so a rejected entry raises a `ValueError` that
+  names the store and states it is unchanged, and an I/O error during the
+  commit leaves the previous document intact with no temp file behind. A
+  successful write produces the same bytes as before.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -47,8 +47,9 @@ from strands_robots.registry import (
 | `list_aliases()` | All 121 aliases, keyed by `normalize_robot_name` (so every key is a spelling a folded query can produce), including every GR00T `data_config` spelling (so `data_config` names resolve as robot names). |
 | `normalize_robot_name(name)` | The fold every registry lookup applies: lowercase, trimmed, dashes as underscores. Canonical names, aliases and the uniqueness constraints over both are all keyed by it, so this is the rule that predicts which robot a name reaches. |
 | `format_robot_table()` | Pretty-printed robot table. |
-| `register_robot(name, entry)` | Add user-defined robot at runtime. `model_xml`/`scene_xml` must name a file inside `asset_dir`. |
+| `register_robot(name, entry)` | Add user-defined robot at runtime. `model_xml`/`scene_xml` must name a file inside `asset_dir`. Values must be JSON types (a `Path` or a numpy scalar in `hardware` is refused, naming the offending type). |
 | `unregister_robot(name)` | Remove a runtime-registered robot. |
+| Both write the whole overlay | `user_robots.json` is read, changed and stored back in one atomic commit, so a refused or failed write leaves every previously registered robot exactly as it was rather than truncating the document they all share. |
 | `list_user_robots()` | Names from `register_robot`. |
 | `user_registry_source()` | Raw bytes of `user_robots.json`, or `None` when absent. What the loader keys its hot-reload cache on, so an edit by another writer is seen even when it lands inside one filesystem timestamp tick. |
 | `parse_user_robots(source)` | Robot definitions held in those bytes; empty when absent or malformed. Parsing the bytes the cache was keyed on is what keeps the cached merge and the key describing the same overlay. |

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -42,6 +42,7 @@ Usage::
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -107,12 +108,71 @@ def _load_user_registry() -> dict[str, Any]:
 
 
 def _save_user_registry(data: dict[str, Any]) -> None:
-    """Save the user-local robot registry file."""
+    """Save the user-local robot registry file, in full or not at all.
+
+    Both halves of that guarantee matter because every write here is a
+    read-modify-write of the WHOLE overlay: :func:`register_robot` and
+    :func:`unregister_robot` load the document, change one entry and store it
+    back. A write that lands partially therefore does not lose the entry being
+    changed, it loses every robot the overlay held - and
+    :func:`parse_user_robots` reports an unparseable overlay as *no user
+    robots* (a warning, then the package registry alone), so the loss surfaces
+    as robots that were registered simply not being there.
+
+    So the document is serialized in full *before* the destination is opened,
+    and the serialized text is committed through a temp file in the same
+    directory plus :func:`os.replace`:
+
+    * Serializing first is what keeps a rejected write harmless. ``json.dump``
+      encodes straight into the stream it is given, so a value it cannot encode
+      - a ``Path`` or a numpy scalar in the caller-supplied ``hardware`` dict,
+      say - raises only after a prefix of the new document has already replaced
+      the old one on disk. The refusal then destroyed the overlay it refused to
+      be added to, which is the opposite of what the
+      :func:`_assert_registry_still_loads` gate one line above its caller is
+      there to guarantee.
+    * ``os.replace`` is atomic within a directory, so a crash or an I/O error
+      during the commit leaves the previous document intact rather than
+      truncated, and a concurrent reader observes one whole document or the
+      other, never a prefix.
+
+    This is the sequence
+    :meth:`strands_robots.tools.harness_memory.HarnessMemory.save_trace` uses
+    for its own JSON store, for the same reasons. The temp file is written with
+    :meth:`pathlib.Path.write_text` rather than :func:`tempfile.mkstemp` so the
+    overlay keeps the ordinary umask-derived mode a plain ``open(path, "w")``
+    gave it: this file is user metadata that a shared ``STRANDS_BASE_DIR``
+    deployment may serve to more than one reader, and replacing its contents is
+    not the moment to decide who may read it.
+
+    Args:
+        data: The whole overlay document to store, as ``{"robots": {...}}``.
+
+    Raises:
+        ValueError: If *data* holds a value JSON cannot represent. Raised
+            before the overlay is touched, so the stored document is still the
+            last one that loaded; the originating ``TypeError`` (or
+            ``ValueError``) stays on ``__cause__``, naming the offending type.
+        OSError: If the temp file cannot be written or renamed. The overlay is
+            likewise unchanged, and no temp file is left behind.
+    """
     path = _get_user_registry_path()
+    try:
+        payload = json.dumps(data, indent=4) + "\n"
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"user registry entry is not JSON-serializable, so it cannot be stored in {path}: {exc}. "
+            "The registry on disk is unchanged. Pass only JSON types (str, int, float, bool, None, "
+            "list, dict) - a filesystem path or a numpy scalar must be converted first."
+        ) from exc
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=4)
-        f.write("\n")
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
     logger.info("Saved user registry: %s (%d robots)", path, len(data.get("robots", {})))
 
 
@@ -217,7 +277,11 @@ def register_robot(
             Also raised when ``model_xml`` or ``scene_xml`` escapes the asset
             directory they are declared relative to (see
             :func:`_asset_relative`), since the readers refuse such a path and
-            the registration would persist a robot that cannot be loaded.
+            the registration would persist a robot that cannot be loaded, and
+            when a value in *hardware* (or any other field) is not
+            JSON-serializable, since the overlay is a JSON document - see
+            :func:`_save_user_registry`, which refuses such an entry before the
+            stored overlay is touched.
         FileNotFoundError: If ``model_xml`` doesn't exist at the resolved path.
 
     Example::

--- a/tests/registry/test_user_registry_write_is_all_or_nothing.py
+++ b/tests/registry/test_user_registry_write_is_all_or_nothing.py
@@ -1,0 +1,198 @@
+"""A user-registry write stores the whole overlay or leaves it untouched.
+
+Every write to ``user_robots.json`` is a read-modify-write of the WHOLE
+document: :func:`~strands_robots.registry.user_registry.register_robot` and
+:func:`~strands_robots.registry.user_registry.unregister_robot` both load the
+overlay, change one entry and store it back. So a write that lands only
+partially does not lose the entry being changed - it loses every robot the
+overlay held.
+
+Nothing reports that loss. :func:`parse_user_robots` treats an unparseable
+overlay as *no user robots*: it logs a warning and the merged registry falls
+back to the package ``robots.json`` alone, so previously registered robots are
+simply absent and ``get_robot`` calls them unknown.
+
+Two ways the write could land partially, both closed here:
+
+1. ``json.dump`` encodes straight into the stream it is handed, so a value it
+   cannot encode raises only *after* a prefix of the new document has already
+   replaced the old one. A ``Path`` or a numpy scalar in the caller-supplied
+   ``hardware`` dict is such a value, which made a *rejected* registration
+   destroy the overlay it was rejected from - the exact outcome the
+   ``_assert_registry_still_loads`` gate one line above the write exists to
+   prevent (see ``test_registry_lookup_hardening``, which owns the read-time
+   half of that guarantee).
+2. Writing into the destination itself truncates it first, so any error partway
+   through the commit - a full disk, a crash - leaves a prefix on disk rather
+   than the previous good document.
+
+The fix serializes the document in full before the destination is opened and
+commits the text through a temp sibling plus ``os.replace``. These pins measure
+the property, not the mechanism: after a refused or failed write, the overlay
+still reads back exactly the robots it held.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from strands_robots.registry import get_robot
+from strands_robots.registry.user_registry import (
+    _get_user_registry_path,
+    _invalidate_cache,
+    get_user_robots,
+    register_robot,
+    unregister_robot,
+)
+
+_MINIMAL_MJCF = '<mujoco><worldbody><body><geom size="0.1"/></body></worldbody></mujoco>'
+
+
+def _register(assets: Path, name: str, **kwargs: object) -> None:
+    """Register *name* against a real one-geom MJCF under *assets*."""
+    robot_dir = assets / name
+    robot_dir.mkdir(parents=True, exist_ok=True)
+    (robot_dir / "bot.xml").write_text(_MINIMAL_MJCF)
+    kwargs.setdefault("joints", 6)
+    register_robot(name=name, model_xml="bot.xml", asset_dir=name, **kwargs)  # type: ignore[arg-type]
+
+
+def _populate(assets: Path, count: int = 3) -> list[str]:
+    """Register *count* robots and return their names."""
+    names = [f"fleet_arm_{i}" for i in range(count)]
+    for name in names:
+        _register(assets, name)
+    return names
+
+
+# A value JSON cannot encode, reaching the overlay through a documented,
+# caller-supplied field. ``hardware`` is typed ``dict[str, Any]`` and stored
+# verbatim; ``joints`` is stored verbatim too, and a joint count read off an
+# array is a numpy integer.
+_UNSERIALIZABLE = [
+    pytest.param({"hardware": {"port": Path("/dev/ttyACM0")}}, id="a-path-in-hardware"),
+    pytest.param({"hardware": {"motor_ids": {1, 2, 3}}}, id="a-set-in-hardware"),
+    pytest.param({"joints": np.int64(6)}, id="a-numpy-joint-count"),
+]
+
+
+@pytest.mark.parametrize("bad_kwargs", _UNSERIALIZABLE)
+def test_a_refused_registration_changes_nothing_on_disk(tmp_path, bad_kwargs):
+    """The overlay a refused registration was refused from still holds its robots."""
+    assets = tmp_path / "assets"
+    existing = _populate(assets)
+    overlay = _get_user_registry_path()
+    before = overlay.read_bytes()
+
+    with pytest.raises(ValueError) as excinfo:
+        _register(assets, "rejected_arm", **bad_kwargs)
+
+    # The refusal names the store and says the store is intact, so a caller is
+    # not left guessing whether the registration half-landed.
+    assert str(overlay) in str(excinfo.value)
+    assert "unchanged" in str(excinfo.value)
+    # The originating encoder error is kept, so the offending type stays visible.
+    assert isinstance(excinfo.value.__cause__, TypeError | ValueError)
+
+    assert overlay.read_bytes() == before
+    _invalidate_cache()
+    assert sorted(get_user_robots()) == existing
+    for name in existing:
+        assert get_robot(name) is not None, f"{name} was registered and must still resolve"
+    # No debris beside the store: a temp sibling holding a rejected document is
+    # itself a document a later reader could pick up.
+    assert sorted(p.name for p in overlay.parent.glob("user_robots.json*")) == ["user_robots.json"]
+
+
+def test_a_commit_that_fails_leaves_the_previous_document(tmp_path, monkeypatch):
+    """An I/O error during the commit leaves the stored overlay readable.
+
+    The commit being a rename is what makes that possible, so this also pins
+    that a rename is where the new document lands: a write aimed at the
+    destination itself has already truncated it by the time any error can be
+    raised, and there is no commit step left to interrupt.
+    """
+    assets = tmp_path / "assets"
+    existing = _populate(assets)
+    overlay = _get_user_registry_path()
+    before = overlay.read_bytes()
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(os, "replace", refuse)
+    with pytest.raises(OSError, match="no space left"):
+        _register(assets, "fourth_arm")
+
+    assert overlay.read_bytes() == before
+    _invalidate_cache()
+    assert sorted(get_user_robots()) == existing
+    assert sorted(p.name for p in overlay.parent.glob("user_robots.json*")) == ["user_robots.json"]
+
+
+def test_an_unregister_whose_commit_fails_keeps_every_robot(tmp_path, monkeypatch):
+    """The delete path rewrites the whole overlay too, so it gets the same guarantee.
+
+    Removing one robot re-serializes every other one, which is the case where a
+    torn write costs the most: the caller asked to lose a single entry.
+    """
+    assets = tmp_path / "assets"
+    existing = _populate(assets)
+    overlay = _get_user_registry_path()
+    before = overlay.read_bytes()
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(os, "replace", refuse)
+    with pytest.raises(OSError, match="read-only"):
+        unregister_robot(existing[0])
+
+    assert overlay.read_bytes() == before
+    _invalidate_cache()
+    assert sorted(get_user_robots()) == existing
+
+
+def test_the_stored_document_is_what_a_reader_parses_back(tmp_path):
+    """A successful write is unaffected: same JSON text, four-space indent, one trailing newline."""
+    assets = tmp_path / "assets"
+    names = _populate(assets, count=2)
+    overlay = _get_user_registry_path()
+
+    text = overlay.read_text(encoding="utf-8")
+    document = json.loads(text)
+    assert sorted(document["robots"]) == names
+    assert text == json.dumps(document, indent=4) + "\n"
+
+
+def test_the_overlay_is_never_encoded_into_the_destination():
+    """No writer in the module encodes JSON into an open file.
+
+    The property above holds only because serialization completes before the
+    destination is touched. ``json.dump`` writes as it encodes, so a single call
+    to it anywhere in this module reintroduces the torn write for whichever
+    field is added next; ``json.dumps`` returns text a caller commits by itself.
+    """
+    import strands_robots.registry.user_registry as module
+
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    streaming = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "dump"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "json"
+    ]
+    assert streaming == [], "json.dump encodes into the destination; serialize with json.dumps and commit the text"
+    # Population check: the module really is the overlay's writer, so an empty
+    # result above means "no streaming encoder", not "nothing found here".
+    assert "json.dumps(" in source
+    assert "os.replace(" in source


### PR DESCRIPTION
Three custom arms are registered. A fourth registration is refused. On `main` the three arms are gone.

![measured](https://raw.githubusercontent.com/cagataycali/robots/assets/user-registry-atomic-write/docs/assets/user_registry_atomic_write.png)

| | overlay on disk | `get_user_robots()` | `get_robot()` resolves | `Robot("fleet_arm_0", mode="sim")` |
|---|---|---|---|---|
| before | 1402 -> **1762 bytes** (a prefix of the new document) | 3 -> **0** | **0 of 3** | `ValueError: Unknown robot 'fleet_arm_0'` |
| after | 1402 -> **1402 bytes** | 3 -> **3** | **3 of 3** | renders (800x600, 104 KB) |

Both columns run the same script against the two trees; the figure asserts every cell before drawing it, and the right-hand frame is the real MuJoCo render (headless, EGL) the left-hand column never reaches.

## Why a refusal could do that

Every write to `user_robots.json` is a read-modify-write of the **whole** document - `register_robot` and `unregister_robot` both load the overlay, change one entry and store it back. The write encoded straight into the destination it had already truncated:

```python
with open(path, "w", encoding="utf-8") as f:
    json.dump(data, f, indent=4)   # encodes INTO the stream
```

`json.dump` writes as it encodes, so a value it cannot encode raises only after a prefix of the new document has replaced the old one. Such a value arrives through a documented parameter: `hardware` is typed `dict[str, Any]` and stored verbatim, so a `Path` port or a numpy joint count is enough.

Nothing then reports the loss. `parse_user_robots` treats an unparseable overlay as *no user robots* - a `logger.warning`, then the package registry alone - so robots that were registered are simply absent, and `get_robot` calls them unknown. A **refused** registration destroyed the registry it was refused from, which is the outcome the `_assert_registry_still_loads` gate one line above the write exists to prevent (`Without this the registration "succeeds" but every subsequent get_robot/resolve_name raises ... until user_robots.json is hand-edited`). The gate runs the loader's uniqueness validator on the in-memory dict; it never considered whether the dict can be written down.

## Change

Serialize in full before the destination is touched, then commit the text through a temp sibling plus `os.replace` - the sequence `HarnessMemory.save_trace` already uses for its own JSON store, and for the same two reasons:

```python
try:
    payload = json.dumps(data, indent=4) + "\n"
except (TypeError, ValueError) as exc:
    raise ValueError(f"... cannot be stored in {path}: {exc}. The registry on disk is unchanged. ...") from exc
tmp = path.with_suffix(path.suffix + ".tmp")
try:
    tmp.write_text(payload, encoding="utf-8")
    os.replace(tmp, path)
except OSError:
    tmp.unlink(missing_ok=True)
    raise
```

The refusal names the store and states that it is unchanged, keeping the encoder's `TypeError` on `__cause__` so the offending type stays visible. `Path.write_text` rather than `mkstemp` keeps the umask-derived mode a plain `open(path, "w")` gave the overlay - this is user metadata a shared `STRANDS_BASE_DIR` may serve to more than one reader, and replacing its contents is not the moment to decide who may read it. A successful write produces the same bytes as before (pinned).

## Pins

`tests/registry/test_user_registry_write_is_all_or_nothing.py` - 7 cells, **6 fail on `main`, 1 passes**:

| cell | on `main` |
|---|---|
| a refused registration changes nothing on disk x 3 (`Path` / `set` in `hardware`, numpy `joints`) | `TypeError: Object of type PosixPath / set / int64 is not JSON serializable`, overlay truncated, 0 of 3 robots resolve |
| a commit that fails leaves the previous document | no commit step exists to interrupt |
| an unregister whose commit fails keeps every robot | as above |
| the overlay is never encoded into the destination (AST, with a population check) | one `json.dump` call found |
| the stored document is what a reader parses back | **passes** - the control that shows the bytes are unchanged |

## Gate

Full `tests/` on both trees: `64 failed, 50648 passed, 437 skipped, 37 errors` on `main` -> `64 failed, 50655 passed, ...` here. `+7` is exactly the new cells, and the 101 failing/erroring test names are identical in both directions (pre-existing environment drift: lerobot 0.6.2, absent `awsiot`/`qpsolvers`). `scripts/check_whole_tree_graders.py`: 4709 passed, same 13 standing failures. `ruff check` + `ruff format --check` clean over 1951 files; `mypy` unchanged at its 20 pre-existing errors in 6 files.

**LOC**: `+289 / -6`. The module is `+74/-6`, of which 9 lines are code - the rest is the docstring stating the two guarantees and why the mode is preserved. The remaining growth is the 198-line pin and the changelog fragment; no production surface was added.