### PR TITLE
fix(dataset): a failed dataset-stack import reports which install fixes it

### DIFF
--- a/changelog.d/3323-recorder-import-diagnosis-one-owner.md
+++ b/changelog.d/3323-recorder-import-diagnosis-one-owner.md
@@ -1,0 +1,19 @@
+### Fixed: `DatasetRecorder.create` names which install fixes a failed lerobot import
+
+`lerobot.datasets.lerobot_dataset` fails to import for four unrelated reasons,
+and `dataset_recorder` already owns a diagnosis that says which one happened:
+lerobot absent (install `strands-robots[lerobot]`), lerobot present but a
+package its dataset stack needs absent (install `lerobot[dataset]`), lerobot
+present but not providing that module (install the supported range), or a
+binary conflict between installed packages that no install fixes. Every
+backend's `start_recording` reports it.
+
+The documented direct creation API imported the same module for the same
+reasons and composed a second answer -- "lerobot not available. Install with:
+pip install lerobot" -- for all four. Three of them have lerobot installed
+already, so that command named a package that was already there and changed
+nothing; for the conflict case no install is the fix at all.
+
+`DatasetRecorder.create` and `.resume` now raise the diagnosis the probe
+reports, so the two surfaces cannot disagree and the contract pinned on the
+probe holds for the creation API too.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -652,6 +652,20 @@ recorder.save_episode()
 recorder.finalize()
 ```
 
+### A failed import names the install that fixes it
+
+`create()` and `resume()` import `lerobot.datasets.lerobot_dataset`, which fails
+for four unrelated reasons that need four different instructions - so the
+`ImportError` says which one happened, exactly as every backend's
+`start_recording` does:
+
+| Cause | What the error says to do |
+|-------|---------------------------|
+| lerobot itself is absent | `pip install 'strands-robots[lerobot]'` |
+| lerobot is installed, but a package its dataset stack needs (`datasets`, `pandas`, `pyarrow`, `av`, `torchcodec`) is not | `pip install 'lerobot[dataset]'` - installing lerobot alone does not pull those in |
+| lerobot is installed but does not provide that module (an out-of-range or from-source lerobot) | `pip install 'strands-robots[lerobot]'`, which pins the supported range |
+| the import failed with nothing missing (a binary conflict between installed packages) | No install fixes it; reconcile the conflicting packages |
+
 ### Schema column names must be distinct
 
 `camera_keys`, `joint_names` and `action_names` each declare the recorded

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,7 +62,9 @@ description: Error → fix table for the most common gotchas across install, sim
 
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
-| `start_recording` fails: lerobot missing | `[lerobot]` not installed | `uv pip install "strands-robots[lerobot]"` |
+| `start_recording` / `DatasetRecorder.create` fails: `lerobot is not installed` | `[lerobot]` not installed | `uv pip install "strands-robots[lerobot]"` |
+| `lerobot X is installed, but 'pyarrow' (or `datasets`, `pandas`, `av`, `torchcodec`), which its dataset stack needs, is not` | lerobot is installed **without** its `[dataset]` extra. Installing lerobot again does not pull those in | `uv pip install "lerobot[dataset]"` |
+| `...importing its dataset stack failed ... a conflict between installed packages` | Nothing is missing (commonly a `pandas` built against a different `numpy`), so no install of lerobot or its extra fixes it | Reconcile the conflicting packages |
 | Need MP4 without LeRobot | - | Use `start_cameras_recording` / `stop_cameras_recording` |
 | Empty MP4 files | Stopped before any frames | Check `get_recording_status()` frame count |
 | Push fails | Not logged into HF | `hf auth login` (the `huggingface-cli` entry point is not published at the declared `huggingface_hub>=1.5` floor) |

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -521,6 +521,12 @@ def _get_lerobot_dataset_class():
 
     Supports test mocking: if ``strands_robots.dataset_recorder.LeRobotDataset``
     has been set (by a test mock), returns that class directly.
+
+    Raises:
+        ImportError: The dataset stack did not import, carrying the diagnosis
+            :func:`_describe_lerobot_import_failure` composes for that exact
+            failure - which of its four causes applied, and the install that
+            fixes it (or that no install does).
     """
     # Support test mocking: check module-level overrides
     this_module = sys.modules[__name__]
@@ -536,9 +542,14 @@ def _get_lerobot_dataset_class():
 
         return LeRobotDataset
     except (ImportError, ValueError, RuntimeError) as exc:
-        raise ImportError(
-            f"lerobot not available ({exc}). Install with: pip install lerobot\nRequired for LeRobotDataset recording."
-        ) from exc
+        # The same import, the same three exception classes and the same four
+        # causes :func:`lerobot_dataset_import_error` reports, so the diagnosis
+        # has one owner. This raise used to compose its own - "lerobot not
+        # available. Install with: pip install lerobot" - which
+        # :func:`_describe_lerobot_import_failure` records as not a usable
+        # instruction for three of the four: lerobot is installed, so the
+        # command names a package that is already there and changes nothing.
+        raise ImportError(f"{_describe_lerobot_import_failure(exc)}\nRequired for LeRobotDataset recording.") from exc
 
 
 def _lerobot_home() -> Path:

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1582,7 +1582,12 @@ def test_get_lerobot_dataset_class_raises_clean_importerror_when_unavailable(mon
 
     When lerobot's dataset module does not resolve and no test has injected a
     mock class, the resolver must raise an ImportError that names the install
-    remedy rather than leaking the raw import failure to the caller.
+    remedy rather than leaking the raw import failure to the caller. The remedy
+    is the one ``lerobot_dataset_import_error`` reports for that same failure -
+    a module that does not resolve is fixed by the extra that pins the supported
+    range - rather than a second hint composed here; which cause maps to which
+    instruction is pinned in
+    ``tests/test_dataset_recorder_creation_names_the_install_that_fixes_it.py``.
     """
     import sys
 
@@ -1592,7 +1597,7 @@ def test_get_lerobot_dataset_class_raises_clean_importerror_when_unavailable(mon
     monkeypatch.setattr(dr, "LeRobotDataset", None, raising=False)
     monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", None)
 
-    with pytest.raises(ImportError, match="pip install lerobot"):
+    with pytest.raises(ImportError, match=r"pip install 'strands-robots\[lerobot\]'"):
         dr._get_lerobot_dataset_class()
 
 

--- a/tests/test_dataset_recorder_creation_names_the_install_that_fixes_it.py
+++ b/tests/test_dataset_recorder_creation_names_the_install_that_fixes_it.py
@@ -1,0 +1,222 @@
+"""Creating a recorder reports the same import diagnosis the probe reports.
+
+``lerobot.datasets.lerobot_dataset`` fails to import for four unrelated reasons
+and they need four different instructions, so
+:mod:`strands_robots.dataset_recorder` composes one diagnosis
+(:func:`~strands_robots.dataset_recorder.lerobot_dataset_import_error`) naming
+which cause applied and the install that fixes it - or that no install does.
+Every backend's ``start_recording`` reports that diagnosis, and
+``tests/test_lerobot_install_hints_pypi.py`` pins its contract: two causes are
+answered with a lerobot install and the other two deliberately are not, because
+lerobot is already installed for both.
+
+The documented direct creation API - ``DatasetRecorder.create`` and ``.resume`` -
+imported the same module for the same reasons and composed a second,
+contradicting answer: "lerobot not available. Install with: pip install
+lerobot". For an absent dataset dependency that names a package that is already
+there, so following it changes nothing; for a conflict between installed
+packages no install is the fix at all. These cells hold both surfaces to one
+diagnosis, so the contract pinned on the probe covers the creation API too.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import pytest
+
+from strands_robots import dataset_recorder as dr
+
+#: A remedy naming the bare ``lerobot`` distribution, which supplies the package
+#: but not its dataset stack. The lookahead lets ``pip install 'lerobot[dataset]'``
+#: and ``pip install 'strands-robots[lerobot]'`` through.
+_BARE_LEROBOT_INSTALL = re.compile(r"pip install (?:-U )?lerobot(?![\w\[.-])")
+
+
+class _Case(NamedTuple):
+    """One failed import and the answer it must get.
+
+    Attributes:
+        exc: The exception the dataset-stack import raises.
+        installed: Whether lerobot itself is present, the premise the diagnosis
+            branches on (patched, so the case under test is the one named here
+            on every install).
+        version: The lerobot version to report.
+        remedy: The install that fixes this cause, or None when no install does.
+        names: A detail the message must carry, so the caller can act on it.
+    """
+
+    exc: BaseException
+    installed: bool
+    version: str
+    remedy: str | None
+    names: str
+
+
+_CASES = {
+    "lerobot_absent": _Case(
+        ModuleNotFoundError("no lerobot", name="lerobot"),
+        False,
+        "",
+        "pip install 'strands-robots[lerobot]'",
+        "not installed",
+    ),
+    "dataset_dependency_absent": _Case(
+        ModuleNotFoundError("no pyarrow", name="pyarrow"),
+        True,
+        "0.6.1",
+        "pip install 'lerobot[dataset]'",
+        "pyarrow",
+    ),
+    "module_moved": _Case(
+        ImportError("gone", name="lerobot.datasets.lerobot_dataset"),
+        True,
+        "0.6.1",
+        "pip install 'strands-robots[lerobot]'",
+        "lerobot.datasets.lerobot_dataset",
+    ),
+    "packages_conflict": _Case(
+        ValueError("numpy.dtype size changed"),
+        True,
+        "0.6.1",
+        None,
+        "reconcile the conflicting packages",
+    ),
+}
+
+
+def _assert_answers(message: str, case: _Case) -> None:
+    """Check *message* against the one answer *case* may be given."""
+    assert case.names in message, message
+    assert _BARE_LEROBOT_INSTALL.search(message) is None, message
+    if case.remedy is None:
+        # Nothing is absent, so no install is offered rather than one that cannot help.
+        assert "pip install" not in message, message
+    else:
+        assert case.remedy in message, message
+
+
+class _UnusableLerobot:
+    """A ``lerobot`` whose every import raises, recording that it was reached."""
+
+    def __init__(self, case: _Case) -> None:
+        self.case = case
+        self.attempts = 0
+
+    def find_spec(self, name: str, path: Any = None, target: Any = None) -> None:
+        if name == "lerobot" or name.startswith("lerobot."):
+            self.attempts += 1
+            raise self.case.exc
+        return None
+
+
+@pytest.fixture
+def broken(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> _UnusableLerobot:
+    """Make the dataset-stack import fail with the named case's exception."""
+    case = _CASES[request.param]
+    for name in [m for m in list(sys.modules) if m == "lerobot" or m.startswith("lerobot.")]:
+        monkeypatch.delitem(sys.modules, name)
+    breaker = _UnusableLerobot(case)
+    monkeypatch.setattr(sys, "meta_path", [breaker, *sys.meta_path])
+    monkeypatch.setattr(dr, "_lerobot_installed", lambda: case.installed)
+    monkeypatch.setattr(dr, "lerobot_version", lambda: case.version)
+    # A successful probe is cached; the cache has to be empty for the probe to
+    # attempt the import this fixture breaks.
+    monkeypatch.setattr(dr, "_HAS_LEROBOT_DATASET", [])
+    monkeypatch.setattr(dr, "LeRobotDataset", None, raising=False)
+    return breaker
+
+
+def _create(root: Path) -> str:
+    """Return the message ``DatasetRecorder.create`` refuses with."""
+    with pytest.raises(ImportError) as excinfo:
+        dr.DatasetRecorder.create(
+            repo_id="probe/ds",
+            fps=30,
+            robot_type="so100",
+            camera_keys=[],
+            joint_names=["shoulder_pan"],
+            task="pick",
+            root=str(root),
+        )
+    return str(excinfo.value)
+
+
+@pytest.mark.parametrize("broken", list(_CASES), indirect=True)
+def test_the_probe_answers_each_cause_with_its_own_remedy(broken: _UnusableLerobot) -> None:
+    """The reference contract the cells below lean on: four causes, four answers.
+
+    Asserted rather than assumed - a probe that gave one answer to every cause
+    would make "the two surfaces agree" cost nothing.
+    """
+    diagnosis = dr.lerobot_dataset_import_error()
+    assert diagnosis, "premise: the probe did not report the broken import"
+    _assert_answers(diagnosis, broken.case)
+
+
+@pytest.mark.parametrize("broken", list(_CASES), indirect=True)
+def test_create_reports_what_the_probe_reports(broken: _UnusableLerobot, tmp_path: Path) -> None:
+    """One diagnosis, whichever surface the caller reached it through."""
+    diagnosis = dr.lerobot_dataset_import_error()
+    assert diagnosis, "premise: the probe did not report the broken import"
+
+    message = _create(tmp_path / "ds")
+    assert message.startswith(diagnosis), (
+        "DatasetRecorder.create composed its own answer instead of the one the "
+        f"probe reports.\ncreate: {message!r}\nprobe:  {diagnosis!r}"
+    )
+    _assert_answers(message, broken.case)
+    assert broken.attempts, "premise: the dataset stack import was never reached"
+
+
+@pytest.mark.parametrize("broken", ["dataset_dependency_absent"], indirect=True)
+def test_resume_reports_what_the_probe_reports(broken: _UnusableLerobot, tmp_path: Path) -> None:
+    """The append entry point reads the same diagnosis as ``create``."""
+    diagnosis = dr.lerobot_dataset_import_error()
+    assert diagnosis, "premise: the probe did not report the broken import"
+
+    with pytest.raises(ImportError) as excinfo:
+        dr.DatasetRecorder.resume(repo_id="probe/ds", root=str(tmp_path / "ds"), task="pick")
+    assert str(excinfo.value).startswith(diagnosis), str(excinfo.value)
+    _assert_answers(str(excinfo.value), broken.case)
+
+
+def test_the_recorder_writes_one_lerobot_install_remedy() -> None:
+    """No string in the module offers the install its own diagnosis rules out.
+
+    The duplicate was two functions importing the same module, so the pin is on
+    the module's strings rather than on the one call site that had it: the
+    docstring explaining why a bare lerobot install is not the instruction is the
+    only place that spelling belongs.
+    """
+    tree = ast.parse(Path(dr.__file__).read_text(encoding="utf-8"))
+    docstrings = {
+        id(node.body[0].value)
+        for node in [tree, *ast.walk(tree)]
+        if isinstance(node, ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef)
+        and node.body
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Constant)
+        and isinstance(node.body[0].value.value, str)
+    }
+    offenders: list[str] = []
+    explained = 0
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+            continue
+        text = re.sub(r"\s+", " ", node.value)
+        if not _BARE_LEROBOT_INSTALL.search(text):
+            continue
+        if id(node) in docstrings:
+            explained += 1
+            continue
+        offenders.append(f"line {node.lineno}: {text.strip()[:120]}")
+    assert explained, "the matcher found no mention at all, so it is not reading the module"
+    assert not offenders, (
+        "these strings tell a caller to install lerobot, which the module's own "
+        "diagnosis records as not the fix for three of its four causes:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
![DatasetRecorder.create: one import, four causes, and the install it prescribed](https://raw.githubusercontent.com/cagataycali/robots/assets/recorder-import-diagnosis/docs/assets/recorder_import_diagnosis.png)

`lerobot.datasets.lerobot_dataset` fails to import for four unrelated reasons, and `dataset_recorder` already owns the diagnosis that says which one happened (`lerobot_dataset_import_error`). Every backend's `start_recording` reports it, and `tests/test_lerobot_install_hints_pypi.py` pins its contract -- including that two of the four causes deliberately do **not** recommend a lerobot install, because lerobot is already installed for both.

The documented direct creation API (`DatasetRecorder.create` / `.resume`, `docs/recording.md`) imports the same module for the same reasons, 60 lines below that diagnosis, and composed a second answer for all four:

```
lerobot not available (no pyarrow). Install with: pip install lerobot
Required for LeRobotDataset recording.
```

lerobot *is* installed in that case, so the command named a package that was already there and pulled no `pyarrow` in -- which is exactly what the diagnosis it sits beside records in its own docstring: "Plain `pip install lerobot` does not pull those in, so 'install lerobot' is not a usable instruction here: the package it names is already installed." For a binary conflict between installed packages no install is the fix at all, and one was still offered.

## Change

`_get_lerobot_dataset_class` -- the one import both creation entry points go through -- raises `_describe_lerobot_import_failure(exc)` for the same three exception classes it already caught. `strands_robots/dataset_recorder.py` +14/-3.

## Tests

`tests/test_dataset_recorder_creation_names_the_install_that_fixes_it.py`, table-driven over the four causes, each injected with a `sys.meta_path` finder:

| | this branch | on `main` |
|---|---|---|
| the new file | 10 passed | **6 failed**, 4 passed |

The 4 green on `main` are the probe's own four answers -- the reference the equality cells lean on, asserted rather than assumed. The 6 red are the creation surface. `tests/test_dataset_recorder.py::test_get_lerobot_dataset_class_raises_clean_importerror_when_unavailable` matched `pip install lerobot`; it now matches the remedy the probe reports for the cause it constructs.

Healthy path unchanged, measured end to end in MuJoCo (headless): `start_recording` -> 45-step mock rollout -> `stop_recording` wrote 1 episode / 45 frames / a 113 KB h264 `file-000.mp4` + parquet shards, reopened from `meta/info.json`.

Full `tests/` (Python 3.12, `MUJOCO_GL=egl`): **64 failed, 50670 passed, 437 skipped, 37 errors** here vs **74 / 50662 / 437 / 37** on `82be6e684` with this file copied in; the failure-name diff shows zero regressions (the base-only names are this file's expected reds plus two order-flaky `test_zenoh_transport_security` cells). The standing failures are lerobot-version and absent-optional-dependency drift in this environment, identical both ways. `ruff check` / `format` clean, mypy unchanged (20 pre-existing, 6 files).

## LOC

+279 / -6: module +14/-3, regression pin +222, docs +18/-1 (`recording.md` cause table, `troubleshooting.md` rows for the two causes a lerobot install does not fix), changelog fragment +19.