### PR TITLE
fix(assets): a symlink inside a downloaded robot tree is never followed into the cache

### DIFF
--- a/changelog.d/3325-asset-cache-external-tree-symlinks.md
+++ b/changelog.d/3325-asset-cache-external-tree-symlinks.md
@@ -1,0 +1,31 @@
+### Bug Fixes
+
+Every copy of a downloaded robot tree now refuses to follow a symlink inside it.
+`strands_robots.assets.download` reaches the same upstream description
+repositories by three routes. The two clone routes each passed
+`reject_symlinks=True` and carried a comment naming the escape: `shutil.copytree`
+defaults to `symlinks=False`, which *follows* a nested symlink, so a description
+carrying `robot_dir/assets -> $HOME/.ssh` copies host files into the asset cache.
+The `robot_descriptions` route reaches those same clones through the installed
+package and called a bare `shutil.copytree`, so a package holding that link
+copied the private key into `$STRANDS_ASSETS_DIR` and reported `downloaded`. That
+copy is not an edge path: it is taken whenever the cache cannot hold a symlink -
+a FAT/exFAT card on an edge robot, or Windows without the privilege - which is
+exactly the host the guard was missing on.
+
+The two copy helpers are now one owner, `_copy_external_tree`, and the symlink
+skip is unconditional: no tree reaching it is trusted, so a caller can no longer
+ask for the following behaviour. Each skipped entry is logged by name, so a model
+left incomplete by an intra-tree link is diagnosable rather than merely wrong.
+The `robot_descriptions` route passes `drop_docs=False`, keeping the docs and
+preview images its preferred path exposes by symlinking the package directory
+whole - a cache that cannot hold a symlink must not silently hold fewer files
+than one that can. A package-wide test pins the rule instead of the two sites:
+the only `shutil.copytree` call in `strands_robots` is the one inside that owner.
+
+`docs/security.md` gains a **Robot asset cache (`STRANDS_ASSETS_DIR`)** section
+stating the posture an operator can rely on: what is treated as externally
+sourced, that symlinks are never followed into the cache, that `safe_join`
+closes the `../` and symlinked-root routes, and that the cache itself is
+integrity-sensitive because it holds the MJCF a `mode="real"` robot is built
+from.

--- a/docs/security.md
+++ b/docs/security.md
@@ -216,6 +216,16 @@ Reference: `strands_robots.tools.gr00t_inference`.
 - **Calibration files** under `~/.cache/huggingface/lerobot/calibration/` define how joint commands map to the physical device. Protect them as integrity-sensitive configuration - corrupted or swapped calibration can produce unexpected motion.
 - **The `serial_tool` is broad.** It can enumerate and write to any serial port the process can see, not just the intended robot. Scope it out of agents that do not need raw device access (see [Tool scoping](#prompt-injection)).
 
+## Robot asset cache (`STRANDS_ASSETS_DIR`)
+
+`download_assets` / `auto_download_robot` populate the asset cache from trees this process did not author: a shallow `git clone` of MuJoCo Menagerie, a custom GitHub source named by a registry entry, or a `robot_descriptions` package that clones the same upstream repositories on first import. All three are treated identically:
+
+- **A symlink inside a downloaded tree is never followed into the cache.** `shutil.copytree` follows nested symlinks by default, so a description carrying `robot_dir/assets -> /home/<user>/.ssh` would copy host files into the cache and the download would still report `downloaded`. Every copy goes through one owner that skips symlinked entries and logs each one it skipped, so a model left incomplete by an intra-tree link is diagnosable rather than merely wrong. The `robot_descriptions` route is included: it prefers to symlink the installed package directory whole, and the copy it falls back to when the cache cannot hold a symlink (a FAT/exFAT card, or Windows without the privilege) is guarded the same way.
+- **A path component from a registry entry cannot escape the cache.** `asset.dir` and `asset.source.subdir` are joined with `safe_join`, which rejects a `../` component lexically and - for the clone trees, whose own symlinks may escape - re-checks containment after full symlink resolution. That second check is what covers a *root* that is itself a symlink out of the clone, which the nested-entry filter above cannot see.
+- **The cache is ordinary filesystem state.** Point `STRANDS_ASSETS_DIR` at a directory only the account running the agent can write; a writable cache is a way to swap the MJCF a `mode="real"` robot is built from.
+
+Reference: `strands_robots.assets.download`, `strands_robots.utils.safe_join`.
+
 ## ROS 2 / DDS bridge command surface
 
 `Robot(ros2_bridge=True)` can expose an inbound `/<robot>/joint_command` topic that drives the physical arm. Because **any participant on the DDS domain can publish to it**, the command surface is hardened:

--- a/strands_robots/assets/download.py
+++ b/strands_robots/assets/download.py
@@ -317,35 +317,61 @@ _COPY_CLEAN_SKIP = frozenset({"README.md", "LICENSE", "CHANGELOG.md"})
 _COPY_CLEAN_SUFFIX = (".png", ".jpg", ".jpeg")
 
 
-def _copy_and_clean(src: Path, dst: Path, *, reject_symlinks: bool = False) -> None:
-    """Copy *src* tree to *dst*, skipping non-essential files at copy time.
+def _copy_external_tree(src: Path, dst: Path, *, drop_docs: bool = True) -> None:
+    """Copy the externally sourced tree *src* into *dst* without following its symlinks.
 
-    Previous implementation deleted matching files from *dst* after copytree,
-    which meant a user's own ``README.md`` in the destination could be wiped.
-    This version filters on read so only files from *src* are dropped.
+    Every tree this module copies into the asset cache comes from outside the
+    process - a shallow clone, or a ``robot_descriptions`` package that clones
+    the same upstream repositories on first import - so a symlinked entry inside
+    *src* is always skipped.  ``shutil.copytree`` defaults to ``symlinks=False``,
+    which *follows* a nested symlink, so a description carrying
+    ``robot_dir/assets -> /home/<user>/.ssh`` would copy host files into the
+    cache and the download would still report success.  The skip is
+    unconditional because no tree reaching here is trusted; a caller cannot ask
+    for the following behaviour.
+
+    Note this covers entries *inside* *src* only: ``shutil.copytree`` follows a
+    symlinked *src* root before the ignore callback runs, so callers must
+    validate the root separately (see :func:`safe_join` with
+    ``resolve_symlinks``).
+
+    Files are filtered on read rather than deleted from *dst* afterwards, so a
+    user's own ``README.md`` kept beside the assets is never wiped.
 
     Args:
-        src: Source tree to copy.
-        dst: Destination directory.
-        reject_symlinks: When ``True``, any symlinked entry inside *src* is
-            skipped at copy time.  Enable this when *src* is an untrusted or
-            externally sourced tree (e.g. a freshly cloned repository) whose
-            symlinks may point outside the tree.  The default ``symlinks=False``
-            behaviour of ``shutil.copytree`` *follows* nested symlinks, so a
-            malicious clone with ``robot_dir/cfg -> /etc`` would copy host files
-            into the asset cache without this guard.  Note this covers entries
-            *inside* *src* only: ``shutil.copytree`` follows a symlinked *src*
-            root before the ignore callback runs, so callers must validate the
-            root separately (see :func:`safe_join` with ``resolve_symlinks``).
+        src: Externally sourced tree to copy.
+        dst: Destination directory inside the asset cache.
+        drop_docs: When ``True`` (the clone routes), also skip the docs, preview
+            images and ``.git`` bookkeeping a description repository ships around
+            the model.  The ``robot_descriptions`` route passes ``False``: its
+            preferred path symlinks the installed package directory whole, and
+            the copy fallback taken when the cache cannot hold a symlink must
+            expose the same files that symlink would have.
     """
 
     def _ignore(dir_path: str, names: list[str]) -> list[str]:
-        skip = [
-            n for n in names if n in _COPY_CLEAN_SKIP or n.lower().endswith(_COPY_CLEAN_SUFFIX) or n.startswith(".git")
-        ]
-        if reject_symlinks:
-            parent = Path(dir_path)
-            skip.extend(n for n in names if (parent / n).is_symlink() and n not in skip)
+        skip = (
+            [
+                n
+                for n in names
+                if n in _COPY_CLEAN_SKIP or n.lower().endswith(_COPY_CLEAN_SUFFIX) or n.startswith(".git")
+            ]
+            if drop_docs
+            else []
+        )
+        parent = Path(dir_path)
+        links = [n for n in names if n not in skip and (parent / n).is_symlink()]
+        if links:
+            # Named rather than dropped quietly: an intra-tree link is skipped by
+            # the same rule as an escaping one, so a model that loses a file this
+            # way is diagnosable from the log instead of just being incomplete.
+            logger.warning(
+                "Skipping symlinked entries %s under %s: a symlink in an externally "
+                "sourced tree is not followed into the asset cache",
+                links,
+                dir_path,
+            )
+            skip.extend(links)
         return skip
 
     shutil.copytree(str(src), str(dst), dirs_exist_ok=True, ignore=_ignore)
@@ -403,7 +429,12 @@ def _download_via_robot_descriptions(robots: dict[str, dict], dest_dir: Path) ->
             try:
                 dst.symlink_to(package_path)
             except OSError:
-                shutil.copytree(str(package_path), str(dst), dirs_exist_ok=True)
+                # A cache that cannot hold a symlink (a FAT/exFAT card, or
+                # Windows without the privilege) takes the copy instead, and the
+                # installed package is an externally sourced tree exactly like a
+                # fresh clone - so it goes through the same owner, not a bare
+                # copytree that would follow a symlink out of the description.
+                _copy_external_tree(package_path, dst, drop_docs=False)
 
             # Validate: expected XML must exist in the linked/copied dir
             expected_xml = safe_join(dst, str(info["asset"]["model_xml"]))
@@ -455,7 +486,7 @@ def _download_via_git(robots: dict[str, dict], dest_dir: Path) -> dict[str, str]
                 if not src.exists():
                     results[name] = f"failed: {asset_dir} not in menagerie"
                     continue
-                _copy_and_clean(src, safe_join(dest_dir, asset_dir), reject_symlinks=True)
+                _copy_external_tree(src, safe_join(dest_dir, asset_dir))
                 results[name] = "downloaded"
             except Exception as exc:
                 results[name] = f"failed: {exc}"
@@ -487,7 +518,7 @@ def _download_from_github(name: str, info: dict, dest_dir: Path) -> str:
             # from the registry entry, so both escape routes must be closed before
             # the copy: a lexical '../' component, and a subdir that is itself a
             # symlink out of the clone.  The nested-symlink filter in
-            # _copy_and_clean cannot cover the latter - copytree follows a
+            # _copy_external_tree cannot cover the latter - copytree follows a
             # symlinked *root* before the ignore callback runs.
             src = safe_join(Path(clone_dir), subdir, resolve_symlinks=True) if subdir else Path(clone_dir)
         except ValueError as exc:
@@ -497,7 +528,7 @@ def _download_from_github(name: str, info: dict, dest_dir: Path) -> str:
 
         dst = safe_join(dest_dir, asset_dir)
         try:
-            _copy_and_clean(src, dst, reject_symlinks=True)
+            _copy_external_tree(src, dst)
             return "downloaded"
         except Exception as exc:
             return f"failed: {exc}"

--- a/tests/test_asset_download.py
+++ b/tests/test_asset_download.py
@@ -156,10 +156,10 @@ def test_shallow_clone_invokes_git_for_valid_url() -> None:
     assert args[-2:] == ["https://github.com/o/r.git", "/tmp/dest"]
 
 
-# _copy_and_clean
+# _copy_external_tree
 
 
-def test_copy_and_clean_skips_docs_and_images(tmp_path: Path) -> None:
+def test_copy_external_tree_skips_docs_and_images(tmp_path: Path) -> None:
     src = tmp_path / "src"
     src.mkdir()
     (src / "model.xml").write_text("x")
@@ -167,7 +167,7 @@ def test_copy_and_clean_skips_docs_and_images(tmp_path: Path) -> None:
     (src / "preview.png").write_text("img")
     (src / "mesh.stl").write_text("m")
     dst = tmp_path / "dst"
-    dl._copy_and_clean(src, dst)
+    dl._copy_external_tree(src, dst)
     assert (dst / "model.xml").exists()
     assert (dst / "mesh.stl").exists()
     assert not (dst / "README.md").exists()
@@ -585,7 +585,7 @@ def test_git_download_reports_copy_failure(tmp_path: Path) -> None:
 
     with (
         patch(f"{_MOD}._shallow_clone", side_effect=_fake_clone),
-        patch(f"{_MOD}._copy_and_clean", side_effect=OSError("disk full")),
+        patch(f"{_MOD}._copy_external_tree", side_effect=OSError("disk full")),
     ):
         results = dl._download_via_git({"panda": info}, tmp_path)
     assert results["panda"].startswith("failed:")
@@ -610,7 +610,7 @@ def test_github_download_reports_copy_failure(tmp_path: Path) -> None:
 
     with (
         patch(f"{_MOD}._shallow_clone", side_effect=_fake_clone),
-        patch(f"{_MOD}._copy_and_clean", side_effect=OSError("permission denied")),
+        patch(f"{_MOD}._copy_external_tree", side_effect=OSError("permission denied")),
     ):
         result = dl._download_from_github("myrobot", info, tmp_path)
     assert result.startswith("failed:")
@@ -686,3 +686,98 @@ def test_git_download_rejects_nested_symlink_inside_asset_dir(tmp_path: Path, mo
     # The nested symlink target must not have been copied.
     assert not (dest / "panda" / "cfg").exists()
     assert not (dest / "panda" / "cfg" / "passwd").exists()
+
+
+def test_rd_copy_fallback_rejects_nested_symlink_inside_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ``robot_descriptions`` copy fallback must not follow a symlink out of the package.
+
+    Sibling of :func:`test_git_download_rejects_nested_symlink_inside_asset_dir`
+    for the other route into the same upstream trees: ``robot_descriptions``
+    clones the very repositories the git fallback treats as untrusted, so its
+    copy is subject to the same escape.  The copy is taken whenever the cache
+    cannot hold a symlink - a FAT/exFAT card on an edge robot, or Windows
+    without the privilege - which is exactly the host that must be guarded.
+    """
+    pkg = tmp_path / "rd_cache" / "panda_mj_description"
+    pkg.mkdir(parents=True)
+    (pkg / "model.xml").write_text("<mujoco/>")
+    outside = tmp_path / "outside_secrets"
+    outside.mkdir()
+    (outside / "id_rsa").write_text("PRIVATE KEY MATERIAL")
+    (pkg / "assets").symlink_to(outside, target_is_directory=True)
+
+    def _no_symlinks(self: Path, target: object, target_is_directory: bool = False) -> None:
+        raise OSError(1, "Operation not permitted")
+
+    monkeypatch.setattr(Path, "symlink_to", _no_symlinks)
+    dest = tmp_path / "cache"
+    dest.mkdir()
+    info = _entry("panda", robot_descriptions_module="panda_mj_description")
+    with patch(f"{_MOD}.importlib.import_module", return_value=SimpleNamespace(PACKAGE_PATH=str(pkg))):
+        results = dl._download_via_robot_descriptions({"panda": info}, dest)
+
+    # The model itself still lands, so the guard costs the caller nothing...
+    assert results["panda"] == "downloaded"
+    assert (dest / "panda" / "model.xml").exists()
+    # ...but the symlink target from outside the package must not be in the cache.
+    assert not (dest / "panda" / "assets").exists()
+    assert not (dest / "panda" / "assets" / "id_rsa").exists()
+
+
+def test_rd_copy_fallback_keeps_what_the_symlink_would_have_exposed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The copy fallback lands the same files the preferred symlink would expose.
+
+    The clone routes strip docs and preview images from a description
+    repository; the ``robot_descriptions`` route must not, or a cache that
+    cannot hold a symlink would silently hold fewer files than one that can.
+    """
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "model.xml").write_text("<mujoco/>")
+    (pkg / "README.md").write_text("doc")
+    (pkg / "texture.png").write_text("img")
+
+    def _no_symlinks(self: Path, target: object, target_is_directory: bool = False) -> None:
+        raise OSError(1, "Operation not permitted")
+
+    monkeypatch.setattr(Path, "symlink_to", _no_symlinks)
+    dest = tmp_path / "cache"
+    dest.mkdir()
+    info = _entry("panda", robot_descriptions_module="panda_mj_description")
+    with patch(f"{_MOD}.importlib.import_module", return_value=SimpleNamespace(PACKAGE_PATH=str(pkg))):
+        results = dl._download_via_robot_descriptions({"panda": info}, dest)
+
+    assert results["panda"] == "downloaded"
+    assert (dest / "panda" / "README.md").exists()
+    assert (dest / "panda" / "texture.png").exists()
+
+
+def test_every_asset_tree_copy_goes_through_the_one_owner() -> None:
+    """No module copies an external tree with a bare ``shutil.copytree``.
+
+    The escape above existed because one of two copies in the same module
+    carried the symlink guard.  Pin the rule rather than the two sites: the only
+    ``shutil.copytree`` call in the package is the one inside
+    :func:`~strands_robots.assets.download._copy_external_tree`, so a new copy
+    route cannot reintroduce a following copy without moving this line.
+    """
+    import ast
+
+    import strands_robots
+
+    root = Path(strands_robots.__file__).parent
+    callers: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for func in ast.walk(tree):
+            if not isinstance(func, ast.FunctionDef):
+                continue
+            for node in ast.walk(func):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "copytree":
+                    callers.append(f"{path.relative_to(root)} in {func.name}()")
+
+    assert callers == ["assets/download.py in _copy_external_tree()"], callers


### PR DESCRIPTION
![asset cache symlink guard](https://raw.githubusercontent.com/cagataycali/robots/assets/asset-cache-symlink-guard/docs/assets/asset_cache_symlink_guard.png)

`strands_robots.assets.download` reaches the same upstream description repositories by three routes. Two of them clone; the third imports a `robot_descriptions` package that clones them for us. Only two carried the symlink guard.

| route | copies via | symlink inside the tree |
|---|---|---|
| `_download_via_git` (Menagerie clone) | `_copy_and_clean(..., reject_symlinks=True)` | skipped |
| `_download_from_github` (custom source) | `_copy_and_clean(..., reject_symlinks=True)` | skipped |
| `_download_via_robot_descriptions` | bare `shutil.copytree` | **followed** |

The two guarded call sites already carried the reason in a comment: `shutil.copytree` defaults to `symlinks=False`, which *follows* a nested symlink, so a description carrying `robot_dir/assets -> $HOME/.ssh` copies host files into the asset cache. The third route reaches the very same clones through the installed package, and it copied that link's target in and returned `"downloaded"`.

That copy is not an edge path. It is the `except OSError` fallback for `dst.symlink_to(package_path)`, taken whenever the cache cannot hold a symlink - a FAT/exFAT card on an edge robot, or Windows without the privilege - which is exactly the host on which the guard was missing.

Measured on the figure's fixture (a package holding `scene.xml`, `LICENSE` and `assets -> <a dir with an ssh key>`, with `symlink_to` failing):

| | files in `$STRANDS_ASSETS_DIR` | escaped host files | reported status |
|---|---|---|---|
| before | `panda/LICENSE`, `panda/assets/id_ed25519`, `panda/assets/known_hosts`, `panda/scene.xml` | **2** | `"downloaded"` |
| after | `panda/LICENSE`, `panda/scene.xml` | **0** | `"downloaded"` |

## Change

The two copy helpers become one owner, `_copy_external_tree`, and the symlink skip is **unconditional** - no tree reaching it is trusted, so a caller can no longer ask for the following behaviour. Each skipped entry is logged by name, so a model left incomplete by a legitimate intra-tree link is diagnosable from the log rather than merely wrong.

The `robot_descriptions` route passes `drop_docs=False`. Its preferred path symlinks the installed package directory *whole*, so the copy fallback must land the same files that symlink would have exposed; routing it through the clone routes' doc/image stripping would have traded this defect for a cache that silently holds fewer files on the hosts that cannot symlink. The right panel is the model that did land, loaded straight out of the fixed cache and rendered in MuJoCo (headless EGL, 800x600) - the guard costs the caller nothing.

## Tests

- `test_rd_copy_fallback_rejects_nested_symlink_inside_package` - sibling of the existing `test_git_download_rejects_nested_symlink_inside_asset_dir`, for the other route into the same trees.
- `test_rd_copy_fallback_keeps_what_the_symlink_would_have_exposed` - passes on both trees; it is the control proving the fix did not smuggle in the clone routes' stripping.
- `test_every_asset_tree_copy_goes_through_the_one_owner` - pins the rule rather than the two sites: the only `shutil.copytree` call in `strands_robots` is the one inside that owner, so a new copy route cannot reintroduce a following copy.

Against pre-fix code the three discriminating cells fail (the leaked key is present; the AST pin names both `_copy_and_clean()` and `_download_via_robot_descriptions()`) and the control passes.

Full `tests/` on this branch and on `main` back to back: **64 failed / 50697 passed / 437 skipped / 37 errors** vs **70 / 50691 / 437 / 37**; the failing-name sets differ only by the new and renamed cells, with nothing failing here that passes on `main`. `ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` unchanged at the pre-existing 20 errors in 6 files.

## Docs

`docs/security.md` gains a **Robot asset cache (`STRANDS_ASSETS_DIR`)** section: what is treated as externally sourced, that a symlink inside a downloaded tree is never followed, that `safe_join` closes the `../` and symlinked-root routes the nested-entry filter cannot see, and that the cache is integrity-sensitive because it holds the MJCF a `mode="real"` robot is built from.

LOC: +200 / -33 (code +54 net, tests +105, docs +10, changelog +31).