### PR TITLE
fix(drivers/crazyflie): a flight command the radio would not carry is refused, not raised

### DIFF
--- a/changelog.d/3326-crazyflie-refused-write-is-an-envelope.md
+++ b/changelog.d/3326-crazyflie-refused-write-is-an-envelope.md
@@ -1,0 +1,21 @@
+### Bug Fixes
+
+- **drivers/crazyflie**: a flight command the radio would not carry is now refused
+  rather than raised. Every caller-facing verb (`send_action`, `set_twist`,
+  `takeoff`, `land`, `emergency_stop`) documents "a success envelope, or an error
+  envelope naming the refusal" and each ends in a CRTP write, which is where a link
+  that opened and then stopped answering shows up - the handle is still live,
+  `is_connected` still reads True, and only the write finds out. The write had no
+  handler, so the SDK's exception left the verb instead of its envelope. The
+  refusal the setpoint repeater already defers to `send_action` - "the next
+  `send_action` reports the refusal through an envelope a caller can read, which a
+  background thread cannot" - now has a receiver, and so do `stop_task`, the agent
+  tool's `land` action and `cleanup`, all three of which were already written for
+  it. `cleanup` is the one that lost state: its documented "every step tolerates a
+  half-built driver" was defeated by its own first statement, so a refused descent
+  skipped the repeater halt, the telemetry block, `close_link` and the state clear,
+  leaving the process holding a radio link and reporting itself connected. The
+  raise set moves to one module constant, `LINK_WRITE_ERRORS`, so the repeater and
+  the verbs cannot drift apart; a refused `emergency_stop` says the motors were
+  **not** cut and points at a hardware cutoff; and a refused setpoint restores what
+  was latched before, because that setpoint is what feeds the firmware supervisor.

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -53,10 +53,20 @@ cf = Robot("crazyflie", mode="real", port="radio://0/80/2M/E7E7E7E7E7")
 if (reason := cf.connect_eagerly()) is not None:
     raise SystemExit(reason)
 
-cf.takeoff(height=0.5, duration=2.0)
-cf.set_twist(vx=0.2, wz=1.0, z=0.5)   # 0.2 m/s forward, 1.0 rad/s yaw, holding 0.5 m
-cf.land()                              # descends under control
-cf.cleanup()
+# Every flight verb answers with an envelope, including for a link that went quiet
+# after connecting - so read `status` rather than assuming the write landed. Each
+# step is checked before the next is issued: after a refused takeoff there is no
+# altitude for the twist to hold.
+try:
+    env = cf.takeoff(height=0.5, duration=2.0)
+    if env["status"] == "success":
+        env = cf.set_twist(vx=0.2, wz=1.0, z=0.5)  # 0.2 m/s fwd, 1.0 rad/s yaw, 0.5 m
+    if env["status"] == "success":
+        env = cf.land()                            # descends under control
+    if env["status"] != "success":
+        print(env["content"][0]["text"])
+finally:
+    cf.cleanup()  # lands if it is still flying, then releases the radio
 ```
 
 Install the client library with the `crazyflie` extra:
@@ -65,7 +75,7 @@ GPLv3 and this project is Apache-2.0, so the copyleft dependency is only install
 caller who names it. Without it the driver still imports and registers; it reports a
 reason naming this extra instead of connecting.
 
-Four things behave differently from a ground robot, and each one is a way to break the
+Five things behave differently from a ground robot, and each one is a way to break the
 aircraft if you assume otherwise:
 
 | | What to know |
@@ -74,6 +84,7 @@ aircraft if you assume otherwise:
 | **Units** | `wz` is **rad/s**, as everywhere else in this package. `cflib` wants deg/s, and the driver is the only place that conversion happens. |
 | **Setpoints are a stream** | The firmware supervisor cuts thrust when the setpoint stream goes quiet, so one `send_action` latches a setpoint and a background repeater keeps it alive at `setpoint_hz` (default 20 Hz). It returns when the setpoint is latched, not when the motion is done. |
 | **`stop` lands** | `stop()` / `stop_task()` / `cleanup()` all perform a controlled descent. Cutting the motors - an airborne aircraft *falls* - is the separately named `emergency_stop()`, and the agent tool schema cannot reach it. |
+| **A link can go quiet in flight** | `is_connected` reads True for a link that opened and then stopped answering - the handle is live and only the write finds out. So every flight verb returns an error envelope for a write the radio would not carry, rather than raising: check `status` on `send_action` / `set_twist` / `takeoff` / `land` / `emergency_stop`, not just on `connect_eagerly()`. Two of those refusals carry a consequence worth acting on - a refused priority handover means the climb or descent was *not* commanded, and a refused `emergency_stop` means the motors are **still turning** with the setpoint stream already stopped, so only a hardware cutoff will stop the aircraft. |
 
 The flight envelope is the driver's, not the SDK's: `cflib` imposes no ceiling and the
 firmware attempts whatever arrives. A setpoint outside it is **refused by name**, never

--- a/strands_robots/drivers/crazyflie.py
+++ b/strands_robots/drivers/crazyflie.py
@@ -217,6 +217,15 @@ ACTION_KEYS: tuple[str, ...] = ("vx", "vy", "vz", "wz", "z")
 HOVER_SETPOINT = "send_hover_setpoint"
 VELOCITY_SETPOINT = "send_velocity_world_setpoint"
 
+#: What a CRTP write raises once the link is no longer usable. Enumerated once
+#: because both halves of the driver need the same set and must not drift: the
+#: setpoint repeater ends its loop on it, and every caller-facing flight verb
+#: turns it into a refusal. ``AttributeError`` is the shape a write takes after
+#: the link handle is gone (``cflib`` reaches through ``Crazyflie.link``, which
+#: is ``None`` once the link closed); ``OSError`` and ``RuntimeError`` are what
+#: the radio and the CRTP stack raise for a link that no longer answers.
+LINK_WRITE_ERRORS: tuple[type[BaseException], ...] = (AttributeError, OSError, RuntimeError)
+
 
 def _refuse(reason: str) -> dict[str, Any]:
     """The driver's error envelope, one shape for every refusal path."""
@@ -706,7 +715,8 @@ class CrazyflieDriver:
                 f"send_action: {self._tool_name} is not armed; the firmware refuses to spin the "
                 "motors until arming succeeds. Reconnect to retry the arming request."
             )
-        self._latch(translated)
+        if (reason := self._latch(translated)) is not None:
+            return _refuse(reason)
         method, args = translated
         return _ok({"commanded": method, "args": list(args), "setpoint_hz": self._setpoint_hz})
 
@@ -769,8 +779,17 @@ class CrazyflieDriver:
         if not self._armed:
             return _refuse(f"takeoff: {self._tool_name} is not armed; reconnect to retry the arming request.")
         self._halt_repeater()
-        self._commander().send_notify_setpoint_stop()
-        self._high_level().takeoff(float(height), float(duration))
+        try:
+            self._commander().send_notify_setpoint_stop()
+        except LINK_WRITE_ERRORS as exc:
+            return _refuse(
+                f"takeoff: the link refused the setpoint-priority handover, so the climb was not "
+                f"commanded - the high-level commander would have ignored it: {exc}"
+            )
+        try:
+            self._high_level().takeoff(float(height), float(duration))
+        except LINK_WRITE_ERRORS as exc:
+            return _refuse(f"takeoff: the link refused the climb: {exc}")
         return _ok({"commanded": "takeoff", "height": float(height), "duration": float(duration)})
 
     def land(self, duration: float = 2.0) -> dict[str, Any]:
@@ -799,9 +818,17 @@ class CrazyflieDriver:
         if not self.is_connected:
             return _refuse(f"land: {self._tool_name} is not connected ({self._connect_error or 'no link'})")
         self._halt_repeater()
-        commander = self._commander()
-        commander.send_notify_setpoint_stop()
-        self._high_level().land(0.0, float(duration))
+        try:
+            self._commander().send_notify_setpoint_stop()
+        except LINK_WRITE_ERRORS as exc:
+            return _refuse(
+                f"land: the link refused the setpoint-priority handover, so the descent was not "
+                f"commanded - the high-level commander would have ignored it: {exc}"
+            )
+        try:
+            self._high_level().land(0.0, float(duration))
+        except LINK_WRITE_ERRORS as exc:
+            return _refuse(f"land: the link refused the descent: {exc}")
         return _ok({"commanded": "land", "duration": float(duration)})
 
     def emergency_stop(self) -> dict[str, Any]:
@@ -819,7 +846,14 @@ class CrazyflieDriver:
         if not self.is_connected:
             return _refuse(f"emergency_stop: {self._tool_name} is not connected")
         self._halt_repeater()
-        self._commander().send_stop_setpoint()
+        try:
+            self._commander().send_stop_setpoint()
+        except LINK_WRITE_ERRORS as exc:
+            return _refuse(
+                f"emergency_stop: the link refused the motor cut, so the motors were NOT cut. The "
+                f"setpoint stream has already been stopped, so the firmware supervisor decides what "
+                f"happens next - use a hardware cutoff: {exc}"
+            )
         return _ok({"commanded": "send_stop_setpoint", "note": "motors cut; an airborne aircraft falls"})
 
     # ------------------------------------------------------------------ #
@@ -1127,11 +1161,30 @@ class CrazyflieDriver:
     # Setpoint stream.                                                   #
     # ------------------------------------------------------------------ #
 
-    def _latch(self, setpoint: tuple[str, tuple[float, float, float, float]]) -> None:
-        """Record the setpoint and make sure the repeater is running."""
+    def _latch(self, setpoint: tuple[str, tuple[float, float, float, float]]) -> str | None:
+        """Record the setpoint and make sure the repeater is running.
+
+        Returns:
+            ``None`` once the setpoint is on the wire and the repeater is
+            running, or the reason the first write did not reach the aircraft.
+            :meth:`send_action` turns that reason into a refusal, which is the
+            report :meth:`_repeat_loop` defers to when it ends its own loop on
+            the same :data:`LINK_WRITE_ERRORS`.
+
+        A refused write leaves the stream holding exactly what it was holding.
+        The previous setpoint is restored rather than left replaced, because on
+        an airframe the latched setpoint is what the repeater feeds the
+        firmware's supervisor: dropping a working hover because a *later*
+        command was refused would turn one refused write into a thrust cut.
+        """
         with self._cache_lock:
-            self._setpoint = setpoint
-        self._send_setpoint(setpoint)
+            previous, self._setpoint = self._setpoint, setpoint
+        try:
+            self._send_setpoint(setpoint)
+        except LINK_WRITE_ERRORS as exc:
+            with self._cache_lock:
+                self._setpoint = previous
+            return f"send_action: the link refused the setpoint, so it never reached the aircraft: {exc}"
         if self._repeater is None or not self._repeater.is_alive():
             self._repeater_stop.clear()
             self._repeater = threading.Thread(
@@ -1140,6 +1193,7 @@ class CrazyflieDriver:
                 daemon=True,
             )
             self._repeater.start()
+        return None
 
     def _repeat_loop(self) -> None:
         """Re-send the latched setpoint until asked to stop.
@@ -1171,7 +1225,7 @@ class CrazyflieDriver:
                     return
                 try:
                     self._send_setpoint(setpoint)
-                except (AttributeError, OSError, RuntimeError) as exc:
+                except LINK_WRITE_ERRORS as exc:
                     logger.warning("Crazyflie setpoint stream stopped: %s", exc)
                     return
 

--- a/tests/drivers/crazyflie/conftest.py
+++ b/tests/drivers/crazyflie/conftest.py
@@ -158,6 +158,12 @@ class FakeCrazyflie:
     * ``"silent"`` - nothing ever fires. A dongle that answered the USB probe and
       then went quiet; only a bounded wait reports it.
 
+    ``commander_raises`` / ``high_level_raises`` choose what a *write* does once
+    the link is up, which ``outcome`` cannot express: a link that opened and then
+    stopped answering still has a live handle, and the CRTP write is where that
+    shows up. Same shape as ``arming``, which already chooses what the
+    ``platform`` request raises.
+
     ``settle_delay`` holds the outcome back for that many seconds, so a test can
     grade *ordering* against the link coming up rather than against a thread
     race: with a delay, a driver that does not wait provably reaches the wire
@@ -169,13 +175,15 @@ class FakeCrazyflie:
         recorder: _Recorder,
         *,
         arming: BaseException | None = None,
+        commander_raises: BaseException | None = None,
+        high_level_raises: BaseException | None = None,
         outcome: str = "connected",
         failure: str = "Cannot find a Crazyradio Dongle",
         settle_delay: float = 0.0,
     ) -> None:
         self.recorder = recorder
-        self.commander = _Stub(recorder, "commander")
-        self.high_level_commander = _Stub(recorder, "high_level")
+        self.commander = _Stub(recorder, "commander", raises=commander_raises)
+        self.high_level_commander = _Stub(recorder, "high_level", raises=high_level_raises)
         self.platform = _Stub(recorder, "platform", raises=arming)
         self.log = _FakeLink(recorder)
         self.uri: str | None = None
@@ -244,20 +252,30 @@ def connected(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder):  # type: ig
     """Build a connected, armed driver over the fake link.
 
     Returns a factory so a test can choose the constructor keywords (a faster
-    ``setpoint_hz``, a failing arming request) and the link ``outcome``, and
-    still get the same fake.
+    ``setpoint_hz``, a failing arming request), the link ``outcome``, and what a
+    CRTP write does once the link is up, and still get the same fake.
     """
     from strands_robots.drivers import crazyflie as module
 
     def build(  # type: ignore[no-untyped-def]
         *,
         arming: BaseException | None = None,
+        commander_raises: BaseException | None = None,
+        high_level_raises: BaseException | None = None,
         outcome: str = "connected",
         failure: str = "Cannot find a Crazyradio Dongle",
         settle_delay: float = 0.0,
         **kwargs: Any,
     ):
-        fake = FakeCrazyflie(recorder, arming=arming, outcome=outcome, failure=failure, settle_delay=settle_delay)
+        fake = FakeCrazyflie(
+            recorder,
+            arming=arming,
+            commander_raises=commander_raises,
+            high_level_raises=high_level_raises,
+            outcome=outcome,
+            failure=failure,
+            settle_delay=settle_delay,
+        )
         pieces = type(
             "_Pieces",
             (),

--- a/tests/drivers/crazyflie/test_crazyflie_a_refused_wire_write_is_an_envelope.py
+++ b/tests/drivers/crazyflie/test_crazyflie_a_refused_wire_write_is_an_envelope.py
@@ -1,0 +1,305 @@
+"""A flight command the radio would not carry is refused, not raised.
+
+Every caller-facing verb on this driver is documented to return "a success
+envelope, or an error envelope naming the refusal", and each one ends in a CRTP
+write. A write is where a link that opened and then stopped answering shows up:
+the handle is still live, ``is_connected`` still reads True, and the write
+raises.
+
+The driver already decided both halves of this. ``_repeat_loop`` ends its own
+loop on :data:`~strands_robots.drivers.crazyflie.LINK_WRITE_ERRORS` and says
+why - "the next ``send_action`` reports the refusal through an envelope a caller
+can read, which a background thread cannot" - so the raise set is settled and so
+is where the report belongs. Three more places are already written for that
+envelope: ``stop_task`` turns a refused descent into its own refusal, the agent
+tool's ``land`` action reaches for ``stop_task``'s verdict *because* "the descent
+itself can be refused - a disconnected link", and ``cleanup`` documents that
+"every step tolerates a half-built driver".
+
+The refusal a caller reads is not the same fact as the exception the SDK raised,
+which is why the messages are pinned rather than only the status. Two of them
+carry a fact no traceback does: a refused priority handover means the high-level
+command was *not* attempted (the firmware would have ignored it underneath the
+low-level stream), and a refused motor cut means the motors are still turning
+while the setpoint stream has already been stopped.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+
+from strands_robots.drivers import crazyflie as module
+
+#: What a link that opened and then stopped answering raises on a write. One
+#: instance reused across the cases so the reason text is checkable.
+LINK_DOWN = OSError("link down: no response from the aircraft")
+
+#: ``(verb, which commander fails, how to call it, what the refusal must name)``.
+#: Both commanders appear because the two-step verbs write to each in turn, and a
+#: guard on one is not a guard on the other.
+CASES: tuple[tuple[str, str, str, str], ...] = (
+    ("send_action", "commander", "send_action", "send_action"),
+    ("set_twist", "commander", "set_twist", "send_action"),
+    ("takeoff, priority handover", "commander", "takeoff", "takeoff"),
+    ("takeoff, the climb", "high_level", "takeoff", "takeoff"),
+    ("land, priority handover", "commander", "land", "land"),
+    ("land, the descent", "high_level", "land", "land"),
+    ("emergency_stop, the motor cut", "commander", "emergency_stop", "emergency_stop"),
+)
+
+
+def _call(driver: object, verb: str) -> dict[str, object]:
+    """Invoke *verb* with arguments the driver accepts, so only the write can fail."""
+    if verb == "send_action":
+        return driver.send_action({"vx": 0.2, "z": 0.5})  # type: ignore[attr-defined,no-any-return]
+    if verb == "set_twist":
+        return driver.set_twist(vx=0.2, z=0.5)  # type: ignore[attr-defined,no-any-return]
+    if verb == "takeoff":
+        return driver.takeoff(height=0.5, duration=2.0)  # type: ignore[attr-defined,no-any-return]
+    if verb == "land":
+        return driver.land(duration=2.0)  # type: ignore[attr-defined,no-any-return]
+    if verb == "emergency_stop":
+        return driver.emergency_stop()  # type: ignore[attr-defined,no-any-return]
+    raise AssertionError(f"unhandled verb {verb}")
+
+
+def _armed(connected, which: str, **kwargs):  # type: ignore[no-untyped-def]
+    """A connected, armed driver whose *which* commander refuses every write."""
+    raises = {f"{which}_raises" if which == "commander" else "high_level_raises": LINK_DOWN}
+    driver, fake, reason = connected(setpoint_hz=100, **raises, **kwargs)
+    assert reason is None, f"the link must come up before a write can be refused: {reason}"
+    return driver, fake
+
+
+class TestARefusedWriteIsReturned:
+    """The verb answers with its envelope instead of raising the SDK's error."""
+
+    @pytest.mark.parametrize(("label", "which", "verb", "named"), CASES, ids=[c[0] for c in CASES])
+    def test_the_verb_refuses_rather_than_raising(  # type: ignore[no-untyped-def]
+        self, connected, label: str, which: str, verb: str, named: str
+    ) -> None:
+        driver, _ = _armed(connected, which)
+
+        envelope = _call(driver, verb)
+
+        assert envelope["status"] == "error", (
+            f"{label}: the write was refused, so the verb owes the caller its error envelope. "
+            "Raising the SDK's exception past the return leaves every consumer written for the "
+            "envelope - stop_task, the agent tool's land action, cleanup - with nothing to read."
+        )
+        text = envelope["content"][0]["text"]  # type: ignore[index]
+        assert named in text, f"{label}: the refusal must name the verb, got {text!r}"
+        assert "link down: no response from the aircraft" in text, (
+            f"{label}: the refusal must carry what the link said, got {text!r}"
+        )
+
+    def test_a_healthy_link_is_untouched(self, connected, recorder) -> None:  # type: ignore[no-untyped-def]
+        """The control: with a link that answers, every verb still reaches the wire.
+
+        Holds on both sides of the fix by construction. It is what separates
+        "a refused write is reported" from "the write is no longer attempted".
+        """
+        driver, _, reason = connected(setpoint_hz=100)
+        assert reason is None
+
+        assert driver.send_action({"vx": 0.2, "z": 0.5})["status"] == "success"
+        assert driver.takeoff(height=0.5, duration=2.0)["status"] == "success"
+        assert driver.land(duration=2.0)["status"] == "success"
+        assert driver.emergency_stop()["status"] == "success"
+        assert recorder.count("high_level.takeoff") == 1
+        assert recorder.count("high_level.land") == 1
+        assert recorder.count("commander.send_stop_setpoint") == 1
+
+
+class TestTheRefusalCarriesWhatTheTracebackDoesNot:
+    """Two refusals state a consequence no SDK exception mentions."""
+
+    @pytest.mark.parametrize("verb", ["takeoff", "land"])
+    def test_a_refused_handover_does_not_command_the_high_level_move(  # type: ignore[no-untyped-def]
+        self, connected, recorder, verb: str
+    ) -> None:
+        """The handover is a precondition, so a refused one ends the verb.
+
+        ``send_notify_setpoint_stop`` is what hands setpoint priority back. Both
+        verbs' docstrings record that a high-level command issued while the
+        low-level stream still owns priority is *ignored* and the aircraft keeps
+        flying the last twist. So a refused handover must not be followed by the
+        move: commanding it anyway would return whatever the second write did
+        about a command the firmware discards.
+        """
+        driver, _ = _armed(connected, "commander")
+
+        envelope = _call(driver, verb)
+
+        assert envelope["status"] == "error"
+        assert recorder.count(f"high_level.{verb}") == 0, (
+            f"a refused priority handover must not be followed by high_level.{verb}; "
+            "the firmware ignores a high-level command underneath the low-level stream"
+        )
+        text = envelope["content"][0]["text"]  # type: ignore[index]
+        assert "handover" in text and "ignored" in text, (
+            f"the refusal must say the move was not commanded and why, got {text!r}"
+        )
+
+    def test_a_refused_motor_cut_says_the_motors_are_still_turning(self, connected) -> None:  # type: ignore[no-untyped-def]
+        """``emergency_stop`` halts the stream first, so a refused cut is the worst state.
+
+        The repeater is stopped before the cut is written, which is correct - it
+        would otherwise re-latch a twist immediately after the stop. It also
+        means a refused cut leaves an aircraft with neither a setpoint stream nor
+        a motor cut, and only the firmware supervisor decides what happens next.
+        A caller reading ``status`` alone cannot act on that; the refusal says it.
+        """
+        driver, _ = _armed(connected, "commander")
+
+        envelope = driver.emergency_stop()
+
+        assert envelope["status"] == "error"
+        text = envelope["content"][0]["text"]  # type: ignore[index]
+        assert "NOT cut" in text, f"the refusal must say the motors were not cut, got {text!r}"
+        assert "hardware cutoff" in text, (
+            f"a refused motor cut leaves no software path to stop the aircraft, got {text!r}"
+        )
+
+
+class TestTheConsumersAlreadyWrittenForIt:
+    """Three callers in the tree read the envelope this fix lets the verbs make."""
+
+    def test_stop_task_composes_the_refused_descent(self, connected) -> None:  # type: ignore[no-untyped-def]
+        """``stop_task`` already branches on ``land()``'s status; it needed one to read."""
+        driver, _ = _armed(connected, "high_level")
+
+        envelope = driver.stop_task()
+
+        assert envelope["status"] == "error"
+        text = envelope["content"][0]["text"]  # type: ignore[index]
+        assert "stop_task: the descent was refused" in text, f"stop_task's own composition must run, got {text!r}"
+        assert "land: the link refused the descent" in text, (
+            f"the composed refusal must carry land()'s reason, got {text!r}"
+        )
+
+    def test_cleanup_releases_the_link_when_the_descent_is_refused(  # type: ignore[no-untyped-def]
+        self, connected, recorder
+    ) -> None:
+        """``cleanup``'s first statement is the descent; a raise there leaked the radio.
+
+        The method documents that "every step tolerates a half-built driver,
+        because cleanup is what runs after a failed connect", and each later step
+        is individually guarded. The descent was not, so a refused one skipped the
+        repeater halt, the telemetry block, ``close_link`` and the state clear -
+        leaving the process holding a radio link and reporting itself connected.
+        """
+        driver, _ = _armed(connected, "high_level")
+
+        driver.cleanup()
+
+        assert recorder.count("close_link") == 1, "the radio link must be released"
+        assert recorder.count("log.stop") == 1, "the telemetry block must be stopped"
+        assert driver.is_connected is False, "a driver that has been cleaned up must not report itself connected"
+
+
+class TestARefusedSetpointLeavesTheStreamAlone:
+    """What the repeater is holding is what keeps the aircraft up."""
+
+    def test_the_previous_setpoint_survives_a_refused_one(self, connected, recorder) -> None:  # type: ignore[no-untyped-def]
+        """A refused *later* command must not drop a hover that is working.
+
+        The firmware supervisor cuts thrust when the setpoint stream goes quiet,
+        so the latched setpoint is load-bearing. Clearing it because a subsequent
+        write was refused would turn one refused command into a thrust cut, which
+        is why the refusal path restores what was latched before.
+        """
+        driver, fake, reason = connected(setpoint_hz=100)
+        assert reason is None
+        assert driver.send_action({"vx": 0.2, "z": 0.5})["status"] == "success"
+        holding = driver._setpoint  # noqa: SLF001 - the state the repeater feeds
+        assert holding is not None
+
+        fake.commander._raises = LINK_DOWN  # noqa: SLF001 - the link stops answering
+        assert driver.send_action({"vx": 0.9, "z": 0.5})["status"] == "error"
+
+        assert driver._setpoint == holding, (  # noqa: SLF001
+            "a refused setpoint must leave the stream holding what it was holding; "
+            "dropping it would stop feeding the supervisor and cut thrust"
+        )
+
+
+class TestOneOwnerForTheRaiseSet:
+    """Every guard around a commander write reads the same set."""
+
+    #: How a write reaches the aircraft: the two commander accessors, and the
+    #: helper the repeater shares with the setpoint path.
+    WRITE_PATHS = ("self._commander()", "self._high_level()", "self._send_setpoint")
+
+    def test_every_guarded_commander_write_reads_the_shared_set(self) -> None:
+        """A write's raise set has one owner, so the two halves cannot drift.
+
+        Keyed on the *operation*, not on the exception names: this driver has
+        four other guards whose sets legitimately differ because they cover
+        different operations (opening the link, closing it, the arming request,
+        the log block). What must not differ is the set around a write through
+        the commander - the repeater and the caller-facing verbs reach the same
+        SDK objects, and a second literal tuple is how one of them came to
+        handle ``AttributeError`` while the other handled nothing at all.
+        """
+        tree = ast.parse(textwrap.dedent(inspect.getsource(module)))
+
+        guarded: list[tuple[int, str]] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            body = "\n".join(ast.unparse(stmt) for stmt in node.body)
+            if not any(path in body for path in self.WRITE_PATHS):
+                continue
+            for handler in node.handlers:
+                guarded.append((handler.lineno, ast.unparse(handler.type) if handler.type else "bare"))
+
+        assert guarded, (
+            "this scan is looking in the wrong place: no guarded commander write found, so it "
+            "would report a driver with none as compliant"
+        )
+        drifted = sorted({spelling for _, spelling in guarded if spelling != "LINK_WRITE_ERRORS"})
+        assert drifted == [], (
+            "a guard around a commander write enumerates its own raise set instead of reading "
+            f"LINK_WRITE_ERRORS: {drifted}"
+        )
+
+    def test_every_write_path_is_guarded(self) -> None:
+        """No commander write is left outside a handler.
+
+        The companion to the rule above: naming the shared set everywhere is
+        only half of it while a write can still sit outside a ``try`` at all,
+        which is exactly the state the caller-facing verbs were in.
+        """
+        tree = ast.parse(textwrap.dedent(inspect.getsource(module)))
+        cls = next(node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "CrazyflieDriver")
+
+        guarded_lines: set[int] = set()
+        for node in ast.walk(cls):
+            if isinstance(node, ast.Try):
+                for stmt in node.body:
+                    guarded_lines.update(range(stmt.lineno, (stmt.end_lineno or stmt.lineno) + 1))
+
+        unguarded: list[tuple[int, str]] = []
+        for fn in ast.walk(cls):
+            # ``_send_setpoint`` is the raw write itself; its two callers own the
+            # handler, which is what lets the repeater end its loop where a verb
+            # returns a refusal.
+            if isinstance(fn, ast.FunctionDef) and fn.name == "_send_setpoint":
+                continue
+            if not isinstance(fn, ast.Call):
+                continue
+            spelling = ast.unparse(fn.func)
+            if not any(spelling.startswith(path) for path in self.WRITE_PATHS):
+                continue
+            if fn.lineno not in guarded_lines:
+                unguarded.append((fn.lineno, spelling))
+
+        assert unguarded == [], (
+            "a commander write is outside every handler, so the link's refusal leaves the verb "
+            f"by raising instead of being returned: {unguarded}"
+        )


### PR DESCRIPTION
## Problem

Every caller-facing verb on the Crazyflie driver documents *"A success envelope, or an error envelope naming the refusal"*, and each one ends in a CRTP write. A write is where a link that **opened and then stopped answering** shows up: the handle is still live, `is_connected` still reads True, and only the write finds out.

None of those writes had a handler. The SDK's exception left the verb instead of its envelope.

The driver had already settled both halves of this. `_repeat_loop` ends its own loop on `(AttributeError, OSError, RuntimeError)` and says why:

> A send that raises stops the loop rather than spinning on a dead link: the next `send_action` reports the refusal **through an envelope a caller can read**, which a background thread cannot.

So the raise set was decided, and so was where the report belongs. The background thread deferred the refusal to the caller-facing verb; the caller-facing verb had nowhere to put it.

**Four consumers in the tree were already written for that envelope:**

| consumer | what it already does |
|---|---|
| `_repeat_loop` | ends its loop and defers the report to `send_action` (quote above) |
| `stop_task` | `if envelope["status"] != "success": return _refuse(f"stop_task: the descent was refused - ...")` |
| agent tool, `land` action | reaches for `stop_task`'s verdict because *"the descent itself can be refused - **a disconnected link**, an unusable duration - and the agent needs that verdict rather than an acknowledgement"* |
| `cleanup` | *"Every step tolerates a half-built driver, because cleanup is what runs after a failed connect"* |

`cleanup` is the one that lost state. Each of its later steps is individually guarded; its **first statement is `self.land()`**, which was not. So a refused descent skipped the repeater halt, the telemetry block, `close_link` and the state clear.

```mermaid
flowchart TD
    subgraph after["after"]
        E["cleanup()"] --> F["land() -> error envelope"]
        F --> G["_halt_repeater()"] --> H["block.stop()"] --> I["close_link()"] --> J["_cf = None<br/>_connected = False"]
    end
    subgraph before["before"]
        A["cleanup()"] --> B["land() raises OSError"]
        B -.->|never reached| C["_halt_repeater()<br/>block.stop()<br/>close_link()"]
        C -.->|never reached| D["_cf = None<br/>_connected = False"]
    end
    style B fill:#c62828,color:#fff
    style D fill:#8d6e63,color:#fff
    style C fill:#8d6e63,color:#fff
    style F fill:#2e7d32,color:#fff
```

## Measured

Driven against the real `CrazyflieDriver` over the hardware-shaped `cflib` stand-in already in `tests/drivers/crazyflie/conftest.py`, with the link answering `open_link` and then refusing every write (`OSError("link down: no response from the aircraft")`).

| verb | before | after |
|---|---|---|
| `send_action` | **raises** `OSError` | `error` — "send_action: the link refused the setpoint, so it never reached the aircraft: …" |
| `set_twist` | **raises** `OSError` | `error` — same, via `send_action` |
| `takeoff`, priority handover | **raises** `OSError` | `error` — "…refused the setpoint-priority handover, so the climb was not commanded - the high-level commander would have ignored it" |
| `takeoff`, the climb | **raises** `OSError` | `error` — "takeoff: the link refused the climb: …" |
| `land`, priority handover | **raises** `OSError` | `error` — "…so the descent was not commanded…" |
| `land`, the descent | **raises** `OSError` | `error` — "land: the link refused the descent: …" |
| `emergency_stop` | **raises** `OSError` | `error` — "the motors were **NOT** cut … use a hardware cutoff" |
| `stop_task` | **raises** `OSError` | `error` — "stop_task: the descent was refused - land: the link refused the descent: …" (its own composition, unchanged) |

And the state `cleanup` was leaking:

| after a refused descent | before | after |
|---|---|---|
| `close_link` calls | **0** | 1 |
| `log.stop` calls | **0** | 1 |
| `is_connected` | **True** | False |

A driver reporting itself connected while holding a radio link it will not release is the part that outlives the failed call.

## Why the whole driver and not one verb

`booster.py` and `ur.py` guard every vendor write in an envelope-returning verb. This driver guarded none of them, so the gap is the file, not a site:

| driver | vendor writes in envelope-returning verbs | unguarded |
|---|---|---|
| `booster.py` | 5 | 0 |
| `ur.py` | 8 | 0 |
| `crazyflie.py` (before) | 5 | **5** |

## Change

House style throughout — inline `try` per site returning `_refuse(...)`, the same shape `booster.py` and `ur.py` use at all 13 of their sites. Three things beyond adding handlers:

- **One owner for the raise set.** `LINK_WRITE_ERRORS` replaces the literal tuple inside `_repeat_loop`, so the background loop and the verbs cannot drift apart — which is how one of them came to handle `AttributeError` while the other handled nothing.
- **A refused handover ends the verb.** Both `takeoff` and `land` document that a high-level command issued while the low-level stream still owns setpoint priority is *ignored*. Commanding the move after a refused handover would report on a command the firmware discards, so the two writes are guarded separately.
- **A refused setpoint leaves the stream alone.** `_latch` restores what was latched before. The latched setpoint is what the repeater feeds the firmware supervisor, so dropping a working hover because a *later* command was refused would turn one refused write into a thrust cut.

`emergency_stop` keeps halting the repeater first — otherwise the stream re-latches a twist immediately after the stop — which is also why its refusal is the bluntest: an aircraft with neither a setpoint stream nor a motor cut has no software path left.

## Tests

`tests/drivers/crazyflie/test_crazyflie_a_refused_wire_write_is_an_envelope.py`, 16 cells. The fixture gains `commander_raises` / `high_level_raises`, mirroring the `arming` knob it already had; `outcome` cannot express this state because a link that went quiet after connecting still has a live handle.

**Four corners**, over `tests/drivers/crazyflie/`:

| | tests | production | result |
|---|---|---|---|
| A | base | base | 109 passed, 1 skipped |
| B | **new** | base | **15 failed / 1 passed** |
| C | new | new | 125 passed, 1 skipped |
| D | base | **new** | 109 passed, 1 skipped |

`109 + 16 = 125`. **D is identical to A** — no existing cell pinned the old behaviour. Corner B's single pass is `test_a_healthy_link_is_untouched`, the control that holds both ways by construction.

**Break table** — 10 mutations, all detected, 10 distinct firing sets, `collected` stable at 16:

| mutation | fires |
|---|---|
| control | 0 |
| `_latch` write unguarded | 4 |
| `takeoff`/`land` handover unguarded | 5 |
| `land` descent unguarded | 4 (incl. `stop_task` and `cleanup`) |
| `takeoff` climb unguarded | 2 |
| `emergency_stop` cut unguarded | 3 |
| refused setpoint clears the latch | **1** |
| refused handover still commands the move | 4 |
| e-stop refusal drops the consequence | **1** |
| repeater keeps its own literal tuple | **1** |
| over-reach: refuse *every* setpoint | 4 (incl. the healthy-link control) |

The three rows firing exactly one cell are what earn those cells their lines. The over-reach row firing the healthy-link control is what shows the fix reports a refused write rather than stopping the write.

## Gate

- `ruff check` / `ruff format --check` clean over 1954 files.
- `mypy strands_robots tests tests_integ` — `Success: no issues found in 1951 source files`. No new suppressions.
- Every tree-walking guard in `tests/` (495 modules) plus all of `tests/drivers/` — **26876 passed, 7 failed**, all 7 pre-existing and environmental on this machine: 5 assert `rclpy` is absent where a ROS install supplies it, 2 read `websockets` 16.0 against the declared `>=17.0` floor (`Server.shutdown` is absent at that version).
- Changelog graders: 91 passed.

## Size

`+431 / -22` across 5 files. `crazyflie.py` is **+16 executable statements** (371 → 387 by AST); of its `+66 / -12`, the rest is the refusal wording and the docstrings recording why the handover and the latch behave as they do. 305 of the additions are the new test file, 21 the changelog fragment.

Docs: `docs/robots/mobile.md` gains a fifth row to its "things that behave differently from a ground robot" table, and its example now reads the verdict it is now guaranteed to get.
