### PR TITLE
fix(tools/lerobot_camera): RealSense availability reports the SDK, not the lerobot import

### DIFF
--- a/changelog.d/3327-realsense-availability-reports-the-sdk.md
+++ b/changelog.d/3327-realsense-availability-reports-the-sdk.md
@@ -1,0 +1,23 @@
+### Bug Fixes
+
+- **tools/lerobot_camera**: `REALSENSE_AVAILABLE` now reports whether a
+  RealSense camera can be *opened*, not whether lerobot's camera classes
+  import. lerobot imports `lerobot.cameras.realsense.*` whether or not the
+  Intel SDK is installed - `pyrealsense2` is bound to `None` behind an
+  availability flag and required at the call sites instead - so the flag was
+  `True` on every host with lerobot and no SDK. `camera_details` then answered
+  `SDK Available:  Yes` / `Depth Support:  Yes` with `status="success"` for a
+  host that cannot open one, the branch that reports the SDK absent and names
+  the install became unreachable, and camera discovery called into lerobot only
+  to log `'NoneType' object has no attribute 'context'` as a discovery failure.
+  The same session's `capture` disagreed, because lerobot's own `require_package`
+  raised there naming the install. The flag is now derived from the SDK under
+  its import name - the one both the `pyrealsense2` and `pyrealsense2-macosx`
+  distributions provide - and both surfaces report an absent SDK from one owner,
+  `REALSENSE_SDK_ABSENT`. That message names lerobot's `intelrealsense` extra
+  rather than the `pyrealsense2` distribution, because the extra carries the
+  per-platform split the bare install misses on macOS. A `realsense` request
+  with no SDK is refused as the absent SDK (an `ImportError` carrying
+  `name="pyrealsense2"`) instead of as `Unsupported camera type: realsense`,
+  which sent the caller looking for a spelling that does not exist; an
+  unsupported type keeps that refusal.

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -14,8 +14,15 @@ FPS``, ``Fast``/``Slow``, ``Good``/``Slow``), so a corrected clock is reported
 as a device measurement. The absolute stamps this tool writes - a filename's
 date, a report's ``Timestamp`` line - are the other half of that boundary and
 stay on ``datetime.now()``.
+
+RealSense support needs the Intel SDK (``pyrealsense2``) in addition to lerobot,
+which is what ``REALSENSE_AVAILABLE`` reports; importing lerobot's RealSense
+camera classes does not establish it, because lerobot requires the SDK at its
+call sites rather than at import. Every surface that reports the SDK absent
+names the same install, :data:`REALSENSE_SDK_ABSENT`.
 """
 
+import importlib.util
 import json
 import logging
 import os
@@ -38,7 +45,14 @@ try:
         from lerobot.cameras.realsense.camera_realsense import RealSenseCamera
         from lerobot.cameras.realsense.configuration_realsense import RealSenseCameraConfig
 
-        REALSENSE_AVAILABLE = True
+        # These modules import whether or not the Intel SDK is installed: lerobot
+        # binds ``pyrealsense2`` to None behind an availability flag and requires
+        # it at the call sites instead. So the import succeeding says the camera
+        # classes exist, not that a RealSense camera can be opened - that is what
+        # the SDK decides, and it is the question every use of this flag asks. It
+        # is probed under the import name, which is the one both the
+        # ``pyrealsense2`` and the ``pyrealsense2-macosx`` distribution provide.
+        REALSENSE_AVAILABLE = importlib.util.find_spec("pyrealsense2") is not None
     except ImportError:
         REALSENSE_AVAILABLE = False
         RealSenseCamera = None
@@ -51,6 +65,16 @@ from strands import tool
 
 from strands_robots.tools._path_validation import resolve_output_path, validate_save_path
 from strands_robots.utils import positive_finite_number_error, positive_whole_number_error
+
+# The one remedy for an absent RealSense SDK, so every surface that reports it
+# reports the same install. It names lerobot's ``intelrealsense`` extra rather
+# than the ``pyrealsense2`` distribution because the extra is what carries the
+# per-platform split - on macOS the wheel ships as ``pyrealsense2-macosx``, so a
+# bare ``pip install pyrealsense2`` there installs nothing that can be imported.
+REALSENSE_SDK_ABSENT = (
+    "The Intel RealSense SDK (pyrealsense2) is not installed, so RealSense "
+    "cameras cannot be opened. Install with: pip install 'lerobot[intelrealsense]'"
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -414,7 +438,9 @@ def lerobot_camera(
             - "preview": Show live preview from camera
             - "test": Test camera functionality and performance
             - "configure": Configure camera settings and save
-        camera_type: Camera type ("opencv" or "realsense")
+        camera_type: Camera type ("opencv" or "realsense"). "realsense" needs
+            the Intel SDK installed on top of lerobot; without it the action is
+            refused naming that install, rather than reported as unsupported.
         camera_id: Camera device ID (int for index, str for path like "/dev/video0")
         save_path: Directory to save captured images/videos
         filename: Custom filename (without extension). Resolved inside
@@ -711,7 +737,7 @@ def _list_camera_details(camera_type: str, camera_id: int | str | None = None) -
             if not REALSENSE_AVAILABLE and camera_type.lower() == "realsense":
                 details.append(" **RealSense Camera System:**")
                 details.append("   - SDK Available:  Not installed")
-                details.append("   - Install with: `pip install pyrealsense2`")
+                details.append(f"   - {REALSENSE_SDK_ABSENT}")
             else:
                 details.append(f"**Unknown camera type: {camera_type}**")
 
@@ -1330,7 +1356,13 @@ def _create_camera(
         )
         return OpenCVCamera(config)
 
-    elif camera_type.lower() == "realsense" and REALSENSE_AVAILABLE:
+    elif camera_type.lower() == "realsense":
+        # "realsense" is a supported type on every platform this package runs
+        # on, so an absent SDK is reported as the absent SDK. Falling through to
+        # the unsupported-type refusal below would answer a question the caller
+        # did not ask, and send them looking for a spelling that does not exist.
+        if not REALSENSE_AVAILABLE:
+            raise ImportError(REALSENSE_SDK_ABSENT, name="pyrealsense2")
         config = RealSenseCameraConfig(serial_number_or_name=str(camera_id), fps=fps, width=width, height=height)
         return RealSenseCamera(config)
 

--- a/tests/tools/test_lerobot_camera.py
+++ b/tests/tools/test_lerobot_camera.py
@@ -357,13 +357,19 @@ def test_list_probes_specific_camera_failure(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_list_realsense_when_sdk_missing_gives_install_hint(monkeypatch: pytest.MonkeyPatch) -> None:
     """Listing a RealSense camera without the SDK reports the install hint
-    instead of pretending the camera type is unknown."""
+    instead of pretending the camera type is unknown.
+
+    The hint names lerobot's ``intelrealsense`` extra rather than the
+    ``pyrealsense2`` distribution, because the extra carries the per-platform
+    split: on macOS the wheel ships as ``pyrealsense2-macosx``, so a bare
+    ``pip install pyrealsense2`` there installs nothing importable.
+    """
     monkeypatch.setattr(cam_mod, "REALSENSE_AVAILABLE", False)
     result = lerobot_camera(action="list", camera_type="realsense")
     assert result["status"] == "success"
     body = _texts(result)
     assert "Not installed" in body
-    assert "pip install pyrealsense2" in body
+    assert "pip install 'lerobot[intelrealsense]'" in body
     _assert_ascii(body)
 
 
@@ -488,14 +494,6 @@ def test_create_camera_realsense_uses_real_config_dataclass_field() -> None:
 
     assert cam.config.serial_number_or_name == "944622072361"
     assert cam.config.fps == 30
-
-
-def test_create_camera_realsense_without_sdk_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Requesting a RealSense camera without the SDK raises a clear
-    unsupported-type error (no silent fallback to OpenCV)."""
-    monkeypatch.setattr(cam_mod, "REALSENSE_AVAILABLE", False)
-    with pytest.raises(ValueError, match="Unsupported camera type: realsense"):
-        cam_mod._create_camera("realsense", "0", 640, 480, 30, "RGB", "NO_ROTATION")
 
 
 # --- frame encoding failure -------------------------------------------------

--- a/tests/tools/test_realsense_availability_tracks_the_sdk.py
+++ b/tests/tools/test_realsense_availability_tracks_the_sdk.py
@@ -1,0 +1,104 @@
+"""``REALSENSE_AVAILABLE`` answers whether a RealSense camera can be opened.
+
+lerobot imports its RealSense camera classes whether or not the Intel SDK is
+installed: ``pyrealsense2`` is bound to ``None`` behind an availability flag and
+required at the call sites instead. So that import succeeding says the classes
+exist, not that the SDK is there - which is the question every use of the flag
+asks. Deriving the flag from the import alone reported ``SDK Available:  Yes``
+and ``Depth Support:  Yes`` for a host with no SDK, left the branch that names
+the install unreachable, and sent the creator to build a camera lerobot then
+refused.
+
+These pin the flag against the SDK itself, and pin that the two surfaces which
+report the SDK absent - the details report and the camera creator - name one
+install between them. A host that does have the SDK still exercises the same
+equality, from the other side.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+import strands_robots.tools.lerobot_camera as cam_mod
+from strands_robots.tools.lerobot_camera import lerobot_camera
+
+# The install that works on every platform this package supports: on macOS the
+# wheel ships as ``pyrealsense2-macosx``, which a bare ``pip install
+# pyrealsense2`` does not reach.
+_EXTRA_INSTALL = "pip install 'lerobot[intelrealsense]'"
+
+
+def _sdk_present() -> bool:
+    """True when the RealSense SDK is importable under its import name."""
+    return importlib.util.find_spec("pyrealsense2") is not None
+
+
+def _texts(result: dict) -> str:
+    """Join every text block of a tool result."""
+    return "\n".join(block.get("text", "") for block in result["content"])
+
+
+def test_the_flag_reports_the_sdk_and_not_the_lerobot_import() -> None:
+    """The flag equals the SDK's presence, whichever way round that is."""
+    assert cam_mod.REALSENSE_AVAILABLE is _sdk_present()
+
+
+def test_lerobot_imports_its_realsense_classes_with_the_sdk_absent() -> None:
+    """The premise: the import cannot decide the SDK, so the flag cannot use it.
+
+    Should lerobot go back to failing that import, the flag stays correct - it
+    reads the SDK - and this cell is what says the premise moved.
+    """
+    if _sdk_present():
+        pytest.skip("the SDK is installed, so the import decides nothing here")
+    assert importlib.util.find_spec("lerobot.cameras.realsense.camera_realsense") is not None
+    assert cam_mod.RealSenseCamera is not None
+
+
+def test_creating_a_realsense_camera_without_the_sdk_reports_the_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent SDK is refused as an absent SDK, not as an unsupported type.
+
+    "realsense" is a supported camera type on every platform, so answering the
+    request with ``Unsupported camera type: realsense`` sends the caller looking
+    for a spelling that does not exist instead of at the install they need. It is
+    still a refusal either way - no camera is returned, and nothing falls back to
+    OpenCV behind the caller's back.
+    """
+    monkeypatch.setattr(cam_mod, "REALSENSE_AVAILABLE", False)
+
+    with pytest.raises(ImportError) as excinfo:
+        cam_mod._create_camera("realsense", "0", 640, 480, 30, "RGB", "NO_ROTATION")
+
+    assert excinfo.value.name == "pyrealsense2"
+    assert _EXTRA_INSTALL in str(excinfo.value)
+    assert "Unsupported camera type" not in str(excinfo.value)
+
+
+def test_an_unsupported_camera_type_is_still_refused_as_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The control: a type this tool really does not support keeps its refusal."""
+    monkeypatch.setattr(cam_mod, "REALSENSE_AVAILABLE", False)
+
+    with pytest.raises(ValueError, match="Unsupported camera type: thermal"):
+        cam_mod._create_camera("thermal", "0", 640, 480, 30, "RGB", "NO_ROTATION")
+
+
+def test_both_surfaces_report_the_absent_sdk_with_one_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The details report and the creator name the same install, from one owner."""
+    monkeypatch.setattr(cam_mod, "REALSENSE_AVAILABLE", False)
+
+    assert _EXTRA_INSTALL in cam_mod.REALSENSE_SDK_ABSENT
+
+    details = _texts(lerobot_camera(action="list", camera_type="realsense"))
+    assert cam_mod.REALSENSE_SDK_ABSENT in details
+
+    with pytest.raises(ImportError) as excinfo:
+        cam_mod._create_camera("realsense", "0", 640, 480, 30, "RGB", "NO_ROTATION")
+    assert str(excinfo.value) == cam_mod.REALSENSE_SDK_ABSENT


### PR DESCRIPTION
`REALSENSE_AVAILABLE` was derived from whether lerobot's RealSense camera modules import. They import whether or not the Intel SDK is installed: lerobot binds `pyrealsense2` to `None` behind an availability flag and requires it at the call sites instead. So the flag was `True` on every host with lerobot and no SDK.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/realsense-availability/docs/assets/realsense-availability.png)

Measured on one host with the SDK absent, lerobot 0.6.2 (the declared floor), both trees:

| surface | before | after |
| --- | --- | --- |
| `find_spec("pyrealsense2")` | `None` | `None` |
| `REALSENSE_AVAILABLE` | `True` | `False` |
| `camera_details(camera_type="realsense")` | `status="success"`, `SDK Available:  Yes`, `Depth Support:  Yes` | `SDK Available:  Not installed` + the install |
| camera discovery | 1 warning: `RealSense camera discovery failed: 'NoneType' object has no attribute 'context'` | no warning |
| `_create_camera("realsense", ...)` | lerobot's `ImportError` naming the install | the same install, from this module's owner |

Three things follow from the flag. The details report describes a depth-camera stack under `status="success"` for a host that cannot open one. The branch right below it, whose whole job is to say the SDK is absent and name the install, is unreachable. And discovery asks lerobot anyway, so `rs` is `None` and the logged "discovery failure" is about `None` rather than about the absent SDK. Meanwhile the same session's `capture` disagrees with `camera_details`, because lerobot's own `require_package` raises there and names the install.

## Change

The flag now reads the SDK, under its import name - the one both the `pyrealsense2` and the `pyrealsense2-macosx` distribution provide, so it is correct on macOS too. That single line makes all three surfaces honest at once.

The two surfaces that report an absent SDK now report it from one owner, `REALSENSE_SDK_ABSENT`. It names lerobot's `intelrealsense` extra rather than the `pyrealsense2` distribution, because the extra carries the per-platform split: on macOS the wheel ships as `pyrealsense2-macosx`, so a bare `pip install pyrealsense2` there installs nothing importable. That string had never reached a user, since the branch printing it was unreachable.

`_create_camera` gains an explicit refusal. With an honest flag a `realsense` request would otherwise fall through to `Unsupported camera type: realsense` - and "realsense" is a supported type on every platform, so that answer sends the caller looking for a spelling that does not exist instead of at the install they need. It is a refusal either way; nothing falls back to OpenCV. An unsupported type keeps its own refusal (pinned).

## Scope

One site. `REALSENSE_AVAILABLE` and `LEROBOT_AVAILABLE` (`tools/lerobot_calibrate.py`) are the only two capability flags in the package, and the second is derived from importing a pure-Python constant with no SDK behind it - it says what it means. The RealSense import is also the only place this package imports a lerobot module whose SDK sits behind lerobot's soft guard.

## Tests

`tests/tools/test_realsense_availability_tracks_the_sdk.py` pins the flag against the SDK, pins that both surfaces name one install, and keeps the unsupported-type refusal as a control. On the pre-fix tree 3 of its 6 cells fail (`assert True is False` for the flag, `ValueError: Unsupported camera type: realsense` for the creator, and no `REALSENSE_SDK_ABSENT` to agree on); the other 3 are the premise and the control, green both ways. A full run of `tests/` on both trees: 50698 passed / 64 failed here vs 50696 / 67 on the pre-fix tree with this file copied in, the failure-name sets differing by exactly those 3 cells in one direction and nothing in the other (the 101 standing rows are environment drift, identical on both).

Two existing cells moved. `test_list_realsense_when_sdk_missing_gives_install_hint` pinned the remedy that the branch could not print; it now pins the extra-based one, with the reason in its docstring. `test_create_camera_realsense_without_sdk_raises` pinned `Unsupported camera type: realsense` - the misdiagnosis - and its stated intent ("no silent fallback to OpenCV") is folded into the new creator cell, so the behaviour keeps one pin instead of two.

## LOC

| | + | - |
| --- | --- | --- |
| `strands_robots/tools/lerobot_camera.py` | 36 | 4 |
| `tests/` | 112 | 10 |
| `changelog.d/` | 23 | 0 |

The code is +32 net, of which 20 lines are the two comments explaining why the flag cannot be the import and why the remedy names the extra - the facts that made this defect survivable. The new pin is 104 lines and it retires 6 that pinned the wrong answer.