### PR TITLE
fix(tools/pose_tool): a pose library is stored whole, or the tool reports that it was not

### DIFF
--- a/changelog.d/3328-pose-library-commit.md
+++ b/changelog.d/3328-pose-library-commit.md
@@ -1,0 +1,24 @@
+### Bug Fixes
+
+- **tools/pose_tool**: a pose-library write now stores the whole library or
+  leaves it exactly as it was, and a write that could not happen is reported
+  instead of being logged. `store_pose` and `delete_pose` are read-modify-writes
+  of the *whole* `<robot_id>_poses.json` document, and the write encoded
+  straight into the destination it had already truncated - so a failure partway
+  through did not lose the pose being changed, it lost every posture the arm
+  had. `_load_poses` reports an unparseable file as *no poses*, so the loss came
+  back as an arm with nothing stored: measured on a full disk, a library holding
+  four postures became 40 unparseable bytes, the next `list_poses` answered "No
+  poses stored for robot hw_arm", and the `store_pose` that destroyed it
+  returned `status=success` with "Stored pose 'inspect'" - one line below the
+  refusal that declines to persist a partially-read arm because "a stored pose
+  is a named posture every later `load_pose` drives towards". A value JSON
+  cannot represent (a NumPy joint angle) did the same thing without any I/O
+  failure at all. The document is now serialized in full before the destination
+  is touched and committed through a temp sibling plus `os.replace` - the
+  sequence `registry.user_registry._save_user_registry` documents - so an
+  unencodable pose raises a `ValueError` naming the library, an I/O error during
+  the commit leaves the previous library intact with no temp file behind, and
+  both surface through `pose_tool` as `status=error` naming the pose that was
+  not stored and the postures that are unchanged. The in-memory library is
+  rolled back with it, so it never holds a pose no reader can find.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -204,6 +204,19 @@ tool, `pose_tool`, and the native `FeetechDriver` bus - reads both from there.
 Addressing an SCS-series servo needs a second word order and a second full scale
 rather than a scale option, so no surface here offers one.
 
+### A stored pose is stored whole, or the tool reports that it was not
+
+`store_pose` and `delete_pose` rewrite the *whole* pose library for a robot -
+`<robot_id>_poses.json` under `.strands_robots/poses/` in the working directory -
+so a write that lands partially loses every posture the arm had, not just the one
+being changed. The document is therefore serialized before the destination is
+touched and committed through a temp sibling plus `os.replace`. A full disk, or a
+joint angle JSON cannot represent (a NumPy scalar), leaves the stored library
+exactly as it was, with no temp file beside it, and the tool answers
+`status="error"` naming the pose it did not store and the postures that are
+unchanged - rather than reporting a named posture that no later `load_pose` can
+find.
+
 ### A mesh wait budget is bounded where the command body cannot carry it
 
 `robot_mesh` takes four numeric options. `duration` and `policy_port` travel

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -13,6 +13,7 @@ This tool provides comprehensive pose management for robotic arms, including:
 
 import json
 import logging
+import os
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -147,14 +148,62 @@ class PoseManager:
                 self.poses = {}
 
     def _save_poses(self) -> None:
-        """Save poses to storage."""
+        """Store the pose library in full, or leave the stored one untouched.
+
+        Every write here rewrites the WHOLE library: :meth:`store_pose` and
+        :meth:`delete_pose` change one entry and store the document back. A
+        write that lands partially therefore does not lose the pose being
+        changed, it loses every pose the file held - and :meth:`_load_poses`
+        reports an unparseable file as *no poses* (an error line, then an empty
+        library), so the loss surfaces as poses that were stored simply not
+        being there.
+
+        So the document is serialized in full *before* the destination is
+        touched, and the text is committed through a temp file in the same
+        directory plus :func:`os.replace` - the sequence
+        :func:`strands_robots.registry.user_registry._save_user_registry`
+        documents for its own whole-document store, for the same two reasons:
+
+        * Serializing first is what keeps a rejected write harmless.
+          ``json.dump`` encodes straight into the stream it is given, so a
+          value it cannot encode - a NumPy scalar read off a joint, say -
+          raises only after a prefix of the new document has replaced the old
+          one on disk.
+        * :func:`os.replace` is atomic within a directory, so a full disk or an
+          I/O error during the commit leaves the previous library intact rather
+          than truncated, and a concurrent reader observes one whole document
+          or the other, never a prefix.
+
+        The temp file is written with :meth:`pathlib.Path.write_text` rather
+        than :func:`tempfile.mkstemp` so the library keeps the ordinary
+        umask-derived mode a plain ``open(path, "w")`` gave it: replacing its
+        contents is not the moment to decide who may read it.
+
+        Raises:
+            ValueError: A pose holds a value JSON cannot represent. Raised
+                before the stored library is touched, so it is still the last
+                one that loaded; the originating ``TypeError`` stays on
+                ``__cause__``, naming the offending type.
+            OSError: The temp file could not be written or renamed. The stored
+                library is likewise unchanged, and no temp file is left behind.
+        """
+        data = {name: pose.to_dict() for name, pose in self.poses.items()}
         try:
-            data = {name: pose.to_dict() for name, pose in self.poses.items()}
-            with open(self.pose_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-            logger.info(f"Saved {len(self.poses)} poses for robot {self.robot_id}")
-        except Exception as e:
-            logger.error(f"Failed to save poses: {e}")
+            payload = json.dumps(data, indent=2) + "\n"
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"a pose is not JSON-serializable, so the library cannot be stored in {self.pose_file}: "
+                f"{exc}. The stored library is unchanged. Pass only JSON types (str, int, float, bool, "
+                "None, list, dict) - a NumPy scalar read off a joint must be converted first."
+            ) from exc
+        tmp = self.pose_file.with_suffix(self.pose_file.suffix + ".tmp")
+        try:
+            tmp.write_text(payload, encoding="utf-8")
+            os.replace(tmp, self.pose_file)
+        except OSError:
+            tmp.unlink(missing_ok=True)
+            raise
+        logger.info(f"Saved {len(self.poses)} poses for robot {self.robot_id}")
 
     def store_pose(
         self,
@@ -163,7 +212,25 @@ class PoseManager:
         description: str | None = None,
         safety_bounds: dict[str, tuple[float, float]] | None = None,
     ) -> RobotPose:
-        """Store a new pose."""
+        """Store a named pose, in the library on disk as well as in memory.
+
+        Args:
+            name: Name the pose is stored under; an existing pose of that name
+                is replaced.
+            positions: Joint angles in degrees.
+            description: Optional free-text note.
+            safety_bounds: Optional per-joint ``(low, high)`` limits.
+
+        Returns:
+            The stored pose.
+
+        Raises:
+            ValueError: The pose holds a value JSON cannot represent.
+            OSError: The library could not be committed to disk.
+
+        Either way the pose is stored nowhere - not on disk, and not in the
+        in-memory library (see :meth:`_save_poses`).
+        """
         pose = RobotPose(
             name=name,
             positions=positions.copy(),
@@ -171,8 +238,20 @@ class PoseManager:
             description=description,
             safety_bounds=safety_bounds,
         )
+        previous = self.poses.get(name)
         self.poses[name] = pose
-        self._save_poses()
+        try:
+            self._save_poses()
+        except (OSError, ValueError):
+            # The library on disk is the one that loaded, so the library in
+            # memory must be too: leaving the pose here would let the next
+            # successful store resurrect a pose this call already reported it
+            # could not keep.
+            if previous is None:
+                del self.poses[name]
+            else:
+                self.poses[name] = previous
+            raise
         return pose
 
     def get_pose(self, name: str) -> RobotPose | None:
@@ -184,10 +263,27 @@ class PoseManager:
         return list(self.poses.keys())
 
     def delete_pose(self, name: str) -> bool:
-        """Delete a pose."""
+        """Delete a pose from the library on disk as well as in memory.
+
+        Args:
+            name: Pose to delete.
+
+        Returns:
+            True when a pose of that name was deleted, False when none existed.
+
+        Raises:
+            ValueError: A pose holds a value JSON cannot represent.
+            OSError: The library could not be committed to disk. The pose is
+                then deleted nowhere - it is still in the stored library and
+                still in the in-memory one (see :meth:`_save_poses`).
+        """
         if name in self.poses:
-            del self.poses[name]
-            self._save_poses()
+            deleted = self.poses.pop(name)
+            try:
+                self._save_poses()
+            except (OSError, ValueError):
+                self.poses[name] = deleted
+                raise
             return True
         return False
 
@@ -1034,7 +1130,24 @@ def pose_tool(
             if not pose_name:
                 return {"status": "error", "content": [{"text": "pose_name required"}]}
 
-            if pose_manager.delete_pose(pose_name):
+            try:
+                deleted = pose_manager.delete_pose(pose_name)
+            except (OSError, ValueError) as exc:
+                # Same reason the partial-arm case below refuses: this one
+                # persists, so a success reported over a library that still
+                # holds the pose would be read as a deletion that happened.
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"Not deleting '{pose_name}': the pose library could not be stored "
+                                f"({exc}). All {len(pose_manager.list_poses())} stored poses are unchanged."
+                            )
+                        }
+                    ],
+                }
+            if deleted:
                 return {"status": "success", "content": [{"text": f"Deleted pose '{pose_name}'"}]}
             else:
                 return {"status": "error", "content": [{"text": f"Pose '{pose_name}' not found"}]}
@@ -1160,7 +1273,26 @@ def pose_tool(
                         ],
                     }
 
-                pose = pose_manager.store_pose(pose_name, current_positions, description)
+                try:
+                    pose = pose_manager.store_pose(pose_name, current_positions, description)
+                except (OSError, ValueError) as exc:
+                    # A stored pose is a durable named posture, so the same rule
+                    # as the partial-arm refusal above applies to the write
+                    # itself: a library that could not be committed leaves the
+                    # arm's postures as they were, and saying otherwise would
+                    # have the caller believe this posture is recoverable.
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"Not storing '{pose_name}': the pose library could not be stored "
+                                    f"({exc}). All {len(pose_manager.list_poses())} previously stored "
+                                    "poses are unchanged."
+                                )
+                            }
+                        ],
+                    }
 
                 pos_text = "\n".join(
                     [

--- a/tests/tools/test_a_failed_pose_store_keeps_the_library_it_already_held.py
+++ b/tests/tools/test_a_failed_pose_store_keeps_the_library_it_already_held.py
@@ -1,0 +1,229 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A pose library that cannot be written keeps the poses it already held.
+
+``PoseManager`` rewrites the WHOLE library on every change: ``store_pose`` and
+``delete_pose`` alter one entry and store the document back. Encoding that
+document straight into its own destination makes a rejected write destructive -
+the stream is truncated first, so an encoder error or a full disk leaves a
+prefix where the library was, and ``_load_poses`` reports an unparseable file as
+*no poses*. One failed save therefore lost every pose the arm had, and
+``pose_tool``'s ``store_pose`` still reported the new pose as stored - one line
+below the refusal that declines to persist a partially-read arm because "a
+stored pose is a named posture every later load_pose drives towards".
+
+These cells pin the commit instead: the document is serialized before the
+destination is touched, committed through a temp file plus ``os.replace``, and a
+failure is reported to the caller with the stored library - and the in-memory
+one - left as they were.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import errno
+import inspect
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.tools.pose_tool import PoseManager, pose_tool
+
+_REAL_OPEN = io.open
+
+_MOTORS = {"shoulder_pan": 1.0, "shoulder_lift": 2.0, "elbow_flex": 3.0}
+
+
+class _FullDisk:
+    """A text file that accepts ``allowance`` characters, then reports ENOSPC.
+
+    A full disk fails the write that exhausts it *after* the bytes before it
+    landed, which is what makes an in-place rewrite destructive and a
+    temp-file commit harmless. Everything else delegates, so the file the
+    implementation chose to open is the file that fills up.
+    """
+
+    def __init__(self, fh: Any, allowance: int) -> None:
+        self._fh = fh
+        self._left = allowance
+
+    def write(self, data: str) -> int:
+        if len(data) <= self._left:
+            self._left -= len(data)
+            return self._fh.write(data)
+        if self._left:
+            self._fh.write(data[: self._left])
+            self._left = 0
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    def __enter__(self) -> _FullDisk:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._fh.close()
+
+    def close(self) -> None:
+        self._fh.close()
+
+    def flush(self) -> None:
+        self._fh.flush()
+
+
+@pytest.fixture
+def full_disk(monkeypatch: pytest.MonkeyPatch):
+    """Fill the filesystem under any file whose name starts with a prefix.
+
+    Both spellings are covered on purpose - the library itself and any
+    ``.tmp`` sibling a commit writes - so the injection describes the disk
+    rather than the implementation, and hits whichever file is written.
+    """
+
+    def _install(prefix: str, allowance: int = 40) -> None:
+        def _open(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+            fh = _REAL_OPEN(file, mode, *args, **kwargs)
+            if "w" in mode and Path(str(file)).name.startswith(prefix):
+                return _FullDisk(fh, allowance)
+            return fh
+
+        monkeypatch.setattr(io, "open", _open)
+        monkeypatch.setattr(builtins, "open", _open)
+
+    return _install
+
+
+@pytest.fixture
+def write_opens(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record the name of every file opened for writing."""
+    seen: list[str] = []
+
+    def _open(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+        if "w" in mode or "a" in mode:
+            seen.append(Path(str(file)).name)
+        return _REAL_OPEN(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(io, "open", _open)
+    monkeypatch.setattr(builtins, "open", _open)
+    return seen
+
+
+def _stocked(robot_id: str = "arm") -> PoseManager:
+    """A manager holding two stored poses, committed to disk."""
+    mgr = PoseManager(robot_id)
+    mgr.store_pose("home", dict(_MOTORS))
+    mgr.store_pose("ready", dict(_MOTORS), description="staged")
+    return mgr
+
+
+class TestTheStoredLibrarySurvivesAFailedWrite:
+    def test_a_full_disk_leaves_every_pose_it_already_stored(self, cwd_tmp, full_disk) -> None:
+        mgr = _stocked()
+        before = mgr.pose_file.read_bytes()
+        full_disk(mgr.pose_file.name)
+
+        with pytest.raises(OSError) as raised:
+            mgr.store_pose("third", dict(_MOTORS))
+
+        assert raised.value.errno == errno.ENOSPC
+        assert mgr.pose_file.read_bytes() == before
+        assert sorted(json.loads(before)) == ["home", "ready"]
+        # The library that reloads is the library that was stored, and the
+        # in-memory one agrees with it rather than holding a pose no reader can
+        # find.
+        assert sorted(PoseManager("arm").list_poses()) == ["home", "ready"]
+        assert sorted(mgr.list_poses()) == ["home", "ready"]
+
+    def test_no_temp_file_is_left_behind(self, cwd_tmp, full_disk) -> None:
+        mgr = _stocked()
+        full_disk(mgr.pose_file.name)
+        with pytest.raises(OSError):
+            mgr.store_pose("third", dict(_MOTORS))
+        assert [p.name for p in mgr.storage_dir.iterdir()] == [mgr.pose_file.name]
+
+    def test_a_full_disk_leaves_a_deletion_undone(self, cwd_tmp, full_disk) -> None:
+        mgr = _stocked()
+        before = mgr.pose_file.read_bytes()
+        full_disk(mgr.pose_file.name)
+
+        with pytest.raises(OSError):
+            mgr.delete_pose("home")
+
+        assert mgr.pose_file.read_bytes() == before
+        assert sorted(mgr.list_poses()) == ["home", "ready"]
+
+    def test_a_value_json_cannot_encode_is_refused_before_the_library_is_touched(self, cwd_tmp, write_opens) -> None:
+        mgr = _stocked()
+        before = mgr.pose_file.read_bytes()
+        write_opens.clear()
+
+        # A joint angle read through NumPy is the way this arrives: np.float32
+        # is not a JSON type, and json.dump raises on it mid-document.
+        numpy_angle: dict[str, Any] = {"shoulder_pan": np.float32(1.5)}
+        with pytest.raises(ValueError, match="not JSON-serializable"):
+            mgr.store_pose("third", numpy_angle)
+
+        assert write_opens == [], f"the library was opened for writing: {write_opens}"
+        assert mgr.pose_file.read_bytes() == before
+        assert sorted(mgr.list_poses()) == ["home", "ready"]
+
+
+class TestTheToolDoesNotReportAStoreItCouldNotMake:
+    def test_store_pose_reports_the_library_it_could_not_store(self, cwd_tmp, reading_serial, full_disk) -> None:
+        first = pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="home")
+        assert first["status"] == "success"
+        library = Path.cwd() / ".strands_robots" / "poses" / "hw_arm_poses.json"
+        full_disk(library.name)
+
+        result = pose_tool(action="store_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="ready")
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith("Not storing 'ready'"), text
+        assert "1 previously stored poses are unchanged" in text
+        assert sorted(json.loads(library.read_text(encoding="utf-8"))) == ["home"]
+
+    def test_delete_pose_reports_the_library_it_could_not_store(self, cwd_tmp, full_disk) -> None:
+        mgr = _stocked("hw_arm")
+        full_disk(mgr.pose_file.name)
+
+        result = pose_tool(action="delete_pose", robot_id="hw_arm", pose_name="home")
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith("Not deleting 'home'"), text
+        assert sorted(json.loads(mgr.pose_file.read_text(encoding="utf-8"))) == ["home", "ready"]
+
+
+class TestTheCommitItself:
+    def test_a_stored_pose_round_trips_and_leaves_no_temp_file(self, cwd_tmp) -> None:
+        """The control: an ordinary store still lands, whole, with nothing beside it."""
+        mgr = _stocked()
+        mgr.delete_pose("ready")
+        reloaded = PoseManager("arm")
+        assert sorted(reloaded.list_poses()) == ["home"]
+        home = reloaded.get_pose("home")
+        assert home is not None and home.positions == _MOTORS
+        assert [p.name for p in mgr.storage_dir.iterdir()] == [mgr.pose_file.name]
+
+    def test_the_library_is_never_encoded_into_its_own_destination(self) -> None:
+        """No ``json.dump`` in the module: encoding into the destination is the defect."""
+        source = Path(inspect.getsourcefile(PoseManager) or "")
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        streamed = [
+            f"line {node.lineno}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "dump"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "json"
+        ]
+        assert streamed == [], (
+            f"json.dump encodes into the stream it is given, so these writes ({streamed}) truncate the "
+            "pose library before a value they cannot encode can be reported; serialize with json.dumps "
+            "and commit through os.replace instead"
+        )


### PR DESCRIPTION
![a full disk during store_pose, before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/pose-library-commit/docs/assets/pose_library_commit.png)

`store_pose` and `delete_pose` are read-modify-writes of the **whole** `<robot_id>_poses.json` document, and the write encoded straight into the destination it had already truncated. A failure partway through therefore did not lose the pose being changed - it lost every posture the arm had, because `_load_poses` reports an unparseable file as *no poses*.

The tool then reported the store as a success. That sits one line below the refusal that declines to persist a partially-read arm, for a reason that applies to the write itself:

> Refuse rather than report, because this one persists. A stored pose is a named posture every later `load_pose` drives towards [...] with nothing downstream able to notice.

## Measured, both trees, same ENOSPC injected on the write

| | main @ b02a11bd | this change |
|---|---|---|
| `pose_tool(action="store_pose", pose_name="inspect")` | `status=success` "Stored pose 'inspect'" | `status=error` "Not storing 'inspect': the pose library could not be stored ([Errno 28] No space left on device). All 4 previously stored poses are unchanged." |
| `hw_arm_poses.json` | 1616 B -> **40 B**, does not parse (`Unterminated string starting at: line 4 column 5`) | 1617 B -> 1617 B, parses, no `.tmp` beside it |
| next `list_poses` on the same arm | `status=success` "No poses stored for robot hw_arm" | `status=success`, all four postures |
| postures lost | **4 of 4** (`handover`, `home`, `pick_bin`, `ready`) | 0 of 4 |

An I/O failure is not needed to reach it: `positions` is stored verbatim, so a joint angle read through NumPy (`np.float32`) raises inside `json.dump` after a prefix of the new document has already replaced the old one.

## Change

The document is serialized in full **before** the destination is touched, then committed through a temp sibling plus `os.replace` - the sequence `registry.user_registry._save_user_registry` documents, for the same two reasons (an unencodable value cannot truncate anything; an atomic rename leaves the previous document intact and readers never see a prefix). `Path.write_text` rather than `mkstemp`, so the library keeps the umask-derived mode a plain `open(path, "w")` gave it.

The failure is raised instead of logged, so it reaches the caller. `store_pose` / `delete_pose` roll the in-memory library back with it - it never holds a pose no reader can find - and the two `pose_tool` branches answer `status=error` in the module's existing "Not storing 'X': ..." wording, naming the pose that was not stored and the postures that are unchanged.

## Scope

Only this store. The other whole-document JSON stores in the package report their failures already (`lerobot_calibrate.save_calibration` returns `False`; both session registries log the `OSError` and their caller reads the file back), so a caller of those is not told a write happened that did not. This was the one that reported success over a destroyed store.

## Tests

`tests/tools/test_a_failed_pose_store_keeps_the_library_it_already_held.py` - 8 cells, **7 fail / 1 pass** on `main` (the pass is the round-trip control):

- a full disk during `store_pose` / `delete_pose`: raises `OSError`, stored bytes unchanged, a fresh `PoseManager` still lists both poses, in-memory library agrees, no temp file left behind
- a NumPy joint angle: `ValueError` naming the library, and the library is never opened for writing (the recorder is empty)
- both tool surfaces: `status=error` naming the pose, library on disk still holds what it held
- the control: an ordinary store/delete still round-trips whole, leaving no sidecar
- one AST cell: no `json.dump` in the module, so encoding into the destination cannot come back

Full suite on both trees: 64 failed / 50723 passed / 437 skipped / 37 errors here vs 64 / 50711 / 437 / 37 on the base tree - the 101 failing names are identical in both directions (pre-existing environment drift), and the +12 collected is this file's 8 cells plus the per-file / per-fragment roster graders. `ruff check`, `ruff format --check` and `mypy` clean on `strands_robots tests tests_integ`.

Docs: `docs/hardware/tools.md` gains the rule the store now follows.

## Round 2 (no code change)

The required check went red on attempt 1 with one failure, `tests/simulation/test_rollout_seed_is_applied_or_refused.py::...::test_two_evals_at_the_same_seed_draw_the_same_actions` - a `tests/simulation/` cell this diff cannot reach (the branch touches `pose_tool` only, adds no RNG or thread use, and contains the `main` tip). The two runs it compares agreed on draws 1-7 and diverged at the 8th by exactly two global-`random` draws made by something other than the policy; one occurrence across the 40 most recent failed CI runs. Re-run of the failed job requested on the same head (no push, approval intact); tracked as #3329.