### PR TITLE
fix(simulation/isaac): a camera recording is encoded whole, or kept to be encoded

### DIFF
--- a/changelog.d/3330-isaac-camera-flush-keeps-frames.md
+++ b/changelog.d/3330-isaac-camera-flush-keeps-frames.md
@@ -1,0 +1,22 @@
+### Fixed: an Isaac camera recording that cannot be encoded is kept, not discarded
+
+`IsaacSimulation.stop_cameras_recording` deregistered the recording before it
+read a single buffer, so the one failure it reports as an error - no MP4 encoder
+installed, which `encode_clip` raises before opening any writer, having encoded
+nothing and touched nothing - destroyed every camera's frames. The refusal quoted
+the encoder's own remedy ("install it, call again"), and there was nothing left
+to call it on: a second `stop_cameras_recording()` answered `"Was not recording
+cameras."`, and a new `start_cameras_recording` took the slot under
+`status="success"`, silently dropping the buffers.
+
+Now only a flush that encoded deregisters - the rule the MuJoCo recorder already
+applied through `_flush_and_deregister_cameras_recording`, and which
+`docs/recording.md` documented for both. A flush with no encoder returns
+`stopped: False` plus the per-camera buffered counts and leaves the recording
+registered, so installing the encoder and calling the verb again writes the MP4s;
+a start is refused for as long as those frames are unencoded. Capture stops
+either way, so a retained recording cannot grow.
+
+Both recorders now word that one absence from one place,
+`strands_robots.simulation.recording.encoder_absent_flush_refusal`, which is what
+had let the rule hold for one of them and not the other.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -555,6 +555,16 @@ text and as `phase` in its JSON block:
 `[idle]` is therefore a promise that nothing is pending, which is why the
 settled-but-registered state gets its own name instead of borrowing it.
 
+The Isaac backend exposes the same pair. It captures through the `on_frame` hook
+`start_cameras_recording` returns rather than a daemon thread, so it has no join
+to expire and none of the thread-dependent phases above. The encoder-absence rule
+is the same one, and both recorders word it from one place
+(`encoder_absent_flush_refusal`): nothing is encoded and nothing is dropped, the
+refusal carries `stopped: False` with the per-camera buffered counts, the
+recording stays registered, and installing the encoder and calling
+`stop_cameras_recording` again encodes the frames it kept. A start is refused for
+as long as those frames are registered, for the same reason.
+
 `fps`, `width`, `height` and `max_frames_per_camera` on the plain-MP4 recorders
 must be positive whole numbers - the same domain `run_policy(video={...})`,
 `start_recording(fps=...)` and the shared encoder

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -5571,8 +5571,31 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 return {"status": "error", "content": [{"text": "No world created. Call create_world() first."}]}
 
             rec_state = self._cams_rec_state
-            if rec_state and rec_state.get("running"):
+            if rec_state:
                 cur = rec_state["name"]
+                if not rec_state.get("running"):
+                    # Registered but no longer capturing: the only way to reach
+                    # this is a flush that refused because the encoder is absent
+                    # and therefore kept the frames (see
+                    # :meth:`stop_cameras_recording`). A start replaces the
+                    # attribute, so proceeding would discard exactly the frames
+                    # that refusal promised were still recoverable - quietly, and
+                    # under ``status="success"``.
+                    buffered = {cam: len(rec_state["buffers"][cam]) for cam in rec_state["cameras"]}
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"Camera recording {cur!r} is still registered with frames no flush "
+                                    f"has read: {buffered}. Install the encoder and call "
+                                    f"stop_cameras_recording() first to encode them. Starting a new "
+                                    f"recording here would discard them."
+                                )
+                            },
+                            {"json": {"recording": cur, "buffered_frames": buffered}},
+                        ],
+                    }
                 return {
                     "status": "error",
                     "content": [{"text": f"Already recording '{cur}'. Call stop_cameras_recording() first."}],
@@ -5672,31 +5695,49 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         ``{name}__{camera}.mp4`` under the ``output_dir`` passed to
         :meth:`start_cameras_recording`, using ``imageio`` (the same
         encoder the MuJoCo recorder uses). Idempotent: a no-op success
-        when nothing is recording.
+        when nothing is registered.
 
         Best-effort: per-camera flush failures are reported in the result
         (``frames`` / ``errors`` / ``size_kb``) but never raise, so a
-        partial encode still yields a structured success response.
+        partial encode still yields a structured success response - and the
+        recording is deregistered, because every camera was offered to the
+        encoder and there is nothing left to flush.
+
+        The absent encoder is the one exception, and it is why this verb can
+        be called twice: the probe raises before any writer is opened, so no
+        frame was written and none was dropped. The recording stays
+        registered holding its buffers, and a later call - once the encoder
+        is installed - encodes them (see
+        :func:`~strands_robots.simulation.recording.encoder_absent_flush_refusal`,
+        which the MuJoCo recorder returns for the same absence). Capture has
+        already stopped either way, so a retained recording cannot grow.
 
         Returns
         -------
         dict
             Standard ``{"status", "content": [{"text"}, {"json"}]}``
-            envelope. ``json`` carries ``recording`` (the tag) and an
-            ``artifacts`` list of ``{camera, path, frames, errors,
-            size_kb}`` per camera.
+            envelope. On success ``json`` carries ``recording`` (the tag) and
+            an ``artifacts`` list of ``{camera, path, frames, errors,
+            size_kb}`` per camera. When no encoder is installed it is instead
+            an error envelope carrying ``stopped=False`` and
+            ``buffered_frames``, and the frames are still there to flush.
         """
         import os as _os
         import time as _time
 
         with self._lock:
             state = getattr(self, "_cams_rec_state", None)
-            if not state or not state.get("running"):
+            if not state:
                 return {"status": "success", "content": [{"text": "Was not recording cameras."}]}
+            # Stops the ``on_frame`` capture (it gates on this flag), so the
+            # buffers are settled and this thread is their only reader. The
+            # registration itself is NOT dropped here: a flush that cannot
+            # encode leaves the frames to be flushed by a later call, and only a
+            # flush that encoded deregisters (below).
             state["running"] = False
-            self._cams_rec_state = None
 
         from strands_robots.rendering.video import encode_clip
+        from strands_robots.simulation.recording import encoder_absent_flush_refusal
 
         elapsed = _time.monotonic() - state["started_mono"]
         lines = [
@@ -5718,19 +5759,13 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                     encode_clip(frames_buffer, path, fps=state["fps"])
                     frames_written = len(frames_buffer)
                 except ImportError as exc:
-                    # Quote the encoder's own refusal rather than asserting
-                    # which module is missing: ``encode_clip`` needs both
-                    # ``imageio`` and the MP4 plugin ``imageio`` itself leaves
-                    # optional, and it raises through ``require_optional``,
-                    # which names the one actually absent plus the extra of
-                    # this package that supplies it. A fixed
-                    # "imageio not installed" line claims the wrong module
-                    # whenever it is the plugin that is missing, and sends the
-                    # caller to an install that changes nothing.
-                    return {
-                        "status": "error",
-                        "content": [{"text": f"{exc}"}],
-                    }
+                    # Fires on the first camera holding frames, before any writer
+                    # is opened, so nothing is encoded and no buffer is touched.
+                    # Returning here leaves ``_cams_rec_state`` registered, which
+                    # is what makes the remedy the message names followable - the
+                    # shared owner words both recorders' answer to this absence.
+                    buffered = {_c: len(state["buffers"][_c]) for _c in state["cameras"]}
+                    return encoder_absent_flush_refusal(exc, state["name"], buffered)
                 except (RuntimeError, ValueError) as e:
                     # ``encode_clip`` refused the clip: ``RuntimeError`` when it
                     # wrote no file, ``ValueError`` when it will not encode at
@@ -5763,11 +5798,18 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 artifact["flush_error"] = flush_error
             artifacts.append(artifact)
 
+        # Every camera was offered to the encoder, so there is nothing left to
+        # flush: drop the registration that kept the frames reachable.
+        tag = state["name"]
+        with self._lock:
+            if self._cams_rec_state is state:
+                self._cams_rec_state = None
+
         return {
             "status": "success",
             "content": [
                 {"text": "\n".join(lines)},
-                {"json": {"recording": state["name"], "artifacts": artifacts}},
+                {"json": {"recording": tag, "artifacts": artifacts}},
             ],
         }
 

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -2575,6 +2575,7 @@ class RenderingMixin:
         import time as _time
 
         from strands_robots.rendering.video import encode_clip
+        from strands_robots.simulation.recording import encoder_absent_flush_refusal
 
         elapsed = _time.monotonic() - state["started_mono"]
         lines = [
@@ -2613,45 +2614,14 @@ class RenderingMixin:
                     encode_clip(to_encode, path, fps=state["fps"])
                     frames_written = len(to_encode)
                 except ImportError as exc:
-                    # Fires on the first camera holding frames, before any
-                    # writer is opened, so nothing is encoded and no buffer is
-                    # touched. Report it the way the expired-join refusal
-                    # reports its own recoverable state - counts included, and
-                    # naming the verb that encodes them - because the caller
-                    # here can follow that advice for the same reason: the
-                    # recording is left registered. See
-                    # :meth:`_flush_and_deregister_cameras_recording`.
-                    #
-                    # The encoder's own text is quoted rather than a fixed
-                    # "imageio not installed" diagnosis: two different modules
-                    # can be the one missing (``imageio``, or the MP4 plugin it
-                    # leaves optional), so a fixed line names the wrong one half
-                    # the time and prescribes a remedy that leaves the encode
-                    # exactly as impossible. ``encode_clip`` raises through
-                    # ``require_optional``, which names the module actually
-                    # absent and the extra of this package that supplies it at
-                    # the version it is tested against.
+                    # Fires on the first camera holding frames, before any writer
+                    # is opened, so nothing is encoded and no buffer is touched.
+                    # The retention that makes its remedy followable is
+                    # :meth:`_flush_and_deregister_cameras_recording`'s, and the
+                    # wording is the shared owner's - see
+                    # :func:`~strands_robots.simulation.recording.encoder_absent_flush_refusal`.
                     buffered = {_c: len(state["buffers"][_c]) for _c in state["cameras"]}
-                    return {
-                        "status": "error",
-                        "content": [
-                            {
-                                "text": (
-                                    f"{exc}\n"
-                                    f"Nothing was encoded and nothing was dropped: camera recording "
-                                    f"{state['name']!r} is left registered holding {buffered}. Install "
-                                    f"the encoder and call stop_cameras_recording() again to flush it."
-                                )
-                            },
-                            {
-                                "json": {
-                                    "stopped": False,
-                                    "recording": state["name"],
-                                    "buffered_frames": buffered,
-                                }
-                            },
-                        ],
-                    }
+                    return encoder_absent_flush_refusal(exc, state["name"], buffered)
                 except Exception as e:  # noqa: BLE001 - best-effort flush must never raise
                     flush_error = f"{type(e).__name__}: {e}"
                     logger.warning("camera recorder flush failed for %r -> %s: %s", cam, path, flush_error)

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -199,6 +199,63 @@ def camera_schema_key_collision_error(method: str, camera_names: Iterable[str]) 
     }
 
 
+def encoder_absent_flush_refusal(reason: object, name: str, buffered: Mapping[str, int]) -> dict[str, Any]:
+    """The refusal a raw-camera flush owes buffers whose encoder is not installed.
+
+    A ``stop_cameras_recording`` flush is best-effort and never-raises, so every
+    other way an encode can fail is folded into its success envelope and the
+    recording is deregistered. The absent encoder is the one exception, and it is
+    the reason this refusal exists rather than being one more artifact line:
+    :func:`~strands_robots.rendering.require_clip_encoder` raises before any
+    writer is opened, so NO camera was written and NO buffer was touched. The
+    frames are all still in memory, and the remedy - install the encoder, call
+    the verb again - is only followable while the recording is still registered.
+
+    Deregistering there discarded exactly the frames the message promised were
+    recoverable. So the envelope and the retention are one decision, and this is
+    the one place that words it: both raw-camera recorders (MuJoCo's daemon-
+    thread capture and Isaac's ``on_frame`` capture) return it, which is what
+    keeps the two from drifting into different answers about the same absence.
+
+    Args:
+        reason: The encoder's own refusal - an ``ImportError`` raised through
+            :func:`~strands_robots.utils.require_optional`. It is quoted rather
+            than re-diagnosed: ``imageio`` and the MP4 plugin it leaves optional
+            are two different absences, so a fixed line names the wrong module
+            half the time and prescribes an install that changes nothing.
+        name: The registered recording's tag, echoed so a caller holding several
+            knows which one is still resident.
+        buffered: Frames held per camera, which is what the caller loses by not
+            following the remedy.
+
+    Returns:
+        A tool-style error envelope whose ``json`` carries ``stopped=False``,
+        ``recording`` and ``buffered_frames`` - the state a caller needs to
+        decide, without parsing the message.
+    """
+    held = dict(buffered)
+    return {
+        "status": "error",
+        "content": [
+            {
+                "text": (
+                    f"{reason}\n"
+                    f"Nothing was encoded and nothing was dropped: camera recording "
+                    f"{name!r} is left registered holding {held}. Install "
+                    f"the encoder and call stop_cameras_recording() again to flush it."
+                )
+            },
+            {
+                "json": {
+                    "stopped": False,
+                    "recording": name,
+                    "buffered_frames": held,
+                }
+            },
+        ],
+    }
+
+
 def recorder_dataset_fps(recorder: Any) -> int | None:
     """Read the frame rate of a live recorder's dataset, or None if unavailable.
 

--- a/tests/simulation/isaac/test_cameras_recording_flush_keeps_unencodable_frames.py
+++ b/tests/simulation/isaac/test_cameras_recording_flush_keeps_unencodable_frames.py
@@ -1,0 +1,240 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""An Isaac camera recording is encoded whole, or it stays there to be encoded.
+
+``IsaacSimulation.stop_cameras_recording`` hands each camera's buffer to
+:func:`strands_robots.rendering.encode_clip`, whose encoder is two dependencies -
+``imageio`` and the MP4 plugin ``imageio`` itself leaves optional - so the probe
+can refuse before any writer is opened. Nothing is encoded and nothing is
+touched, and the refusal quotes the encoder's own remedy: install it and call the
+verb again.
+
+That remedy is only followable while the frames are still reachable, and the
+flush had already dropped ``_cams_rec_state`` before reading a single buffer. So
+the refusal destroyed exactly what it said was recoverable: every camera's frames
+went with the registration, a second call answered "Was not recording cameras."
+about them, and a new ``start`` replaced the attribute under ``status="success"``.
+
+The MuJoCo recorder decided this already - only a flush that encoded deregisters
+(``_flush_and_deregister_cameras_recording``) - and words it in the shared
+:func:`~strands_robots.simulation.recording.encoder_absent_flush_refusal`. These
+cells pin the same three answers for Isaac: what the refusal reports, that a
+later call encodes the frames it kept, and that a start cannot discard them.
+
+The engine is a skeleton ``IsaacSimulation`` built with ``__new__`` (the fixture
+shape ``test_cameras_recording_preflight_guards.py`` uses) so the recording
+lifecycle runs without the Isaac Sim Kit runtime.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import threading
+
+import numpy as np
+import pytest
+
+from strands_robots import utils
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _CameraState
+
+_CAMERAS = ["front", "wrist"]
+_FRAMES = 4
+
+
+@contextlib.contextmanager
+def _blocked_encoder():
+    """An install with no ``imageio``, for one block.
+
+    Two steps, because :func:`~strands_robots.utils.require_optional` memoises a
+    module it has already imported: the ``sys.modules`` entry is what makes the
+    import fail, and dropping the cache entry is what stops an earlier import in
+    the same session from answering instead.
+    """
+    cached = utils._lazy_modules.pop("imageio", None)
+    sys.modules["imageio"] = None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        del sys.modules["imageio"]
+        if cached is not None:
+            utils._lazy_modules["imageio"] = cached
+
+
+@pytest.fixture
+def no_encoder():
+    """:func:`_blocked_encoder` for a whole cell."""
+    with _blocked_encoder():
+        yield
+
+
+def _json_block(envelope: dict) -> dict:
+    """The ``json`` payload of a tool envelope."""
+    for block in envelope["content"]:
+        if "json" in block:
+            return block["json"]
+    raise AssertionError(f"no json block in {envelope}")
+
+
+class _FakeCameraHandle:
+    """Stub RTX camera handle returning a fixed RGBA buffer."""
+
+    def __init__(self, rgba: np.ndarray) -> None:
+        self.rgba = rgba
+
+    def get_rgba(self) -> np.ndarray:
+        return self.rgba
+
+
+class _Recorder:
+    """A skeleton Isaac engine with a live camera recording and a frame source."""
+
+    def __init__(self, output_dir, *, width: int = 32, height: int = 24) -> None:
+        engine = IsaacSimulation.__new__(IsaacSimulation)
+        engine._config = IsaacConfig()
+        engine._lock = threading.RLock()
+        engine._world = None
+        engine._world_created = True
+        engine._robots = {}
+        engine._objects = {}
+        engine._prim_registry = []
+        engine._cams_rec_state = None
+        engine._sim_time = 0.0
+        engine._step_count = 0
+        engine._main_tid = threading.get_ident()
+        engine._cameras = {}
+        for name in _CAMERAS:
+            cam = _CameraState(name=name, prim_path=f"/World/Cameras/{name}", width=width, height=height)
+            cam.handle = _FakeCameraHandle(np.zeros((height, width, 4), dtype=np.uint8))
+            engine._cameras[name] = cam
+        # A gradient rather than a flat fill: an encoder that silently wrote
+        # nothing would still produce a plausible file from constant frames.
+        self._rgb = np.tile(
+            np.linspace(0, 255, width, dtype=np.uint8)[None, :, None],
+            (height, 1, 3),
+        )
+        engine._render_frame = lambda camera_name, **_kw: (self._rgb, None, {})  # type: ignore[method-assign]
+        self.sim = engine
+        self.output_dir = output_dir
+
+    def start(self, name: str = "wedge") -> dict:
+        return self.sim.start_cameras_recording(
+            cameras=list(_CAMERAS), output_dir=str(self.output_dir), fps=30, name=name
+        )
+
+    def buffer_a_few(self, frames: int = _FRAMES) -> int:
+        """Arm a recording and capture ``frames`` frames on every camera."""
+        started = self.start()
+        assert started["status"] == "success", started
+        on_frame = _json_block(started)["on_frame"]
+        for step in range(frames):
+            on_frame(step, {}, {})
+        assert self.buffered() == {cam: frames for cam in _CAMERAS}, "premise: frames were buffered"
+        return frames
+
+    def buffered(self) -> dict[str, int]:
+        state = self.sim._cams_rec_state
+        if not state:
+            return {}
+        return {cam: len(state["buffers"][cam]) for cam in state["cameras"]}
+
+
+@pytest.fixture
+def recorder(tmp_path):
+    return _Recorder(tmp_path)
+
+
+class TestAFlushWithNoEncoder:
+    """Nothing was written, so nothing may be dropped."""
+
+    def test_the_refusal_reports_what_it_kept(self, recorder, no_encoder) -> None:
+        """The verdict, and the counts that make the advice followable."""
+        buffered = recorder.buffer_a_few()
+
+        result = recorder.sim.stop_cameras_recording()
+
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "pip install imageio" in text, text
+        assert "stop_cameras_recording()" in text, text
+        payload = _json_block(result)
+        assert payload["stopped"] is False
+        assert payload["recording"] == "wedge"
+        assert payload["buffered_frames"] == {cam: buffered for cam in _CAMERAS}
+
+    def test_the_frames_are_still_there(self, recorder, no_encoder, tmp_path) -> None:
+        """The registration is the only route back to them, so it survives."""
+        buffered = recorder.buffer_a_few()
+
+        recorder.sim.stop_cameras_recording()
+
+        assert recorder.sim._cams_rec_state is not None, "the registration is the only route back"
+        assert recorder.buffered() == {cam: buffered for cam in _CAMERAS}
+        assert list(tmp_path.glob("*.mp4")) == [], "nothing is encoded without an encoder"
+
+    def test_a_later_call_encodes_them(self, recorder, tmp_path) -> None:
+        """Following the message's own advice recovers every frame."""
+        imageio = pytest.importorskip("imageio.v2")
+        with _blocked_encoder():
+            buffered = recorder.buffer_a_few()
+            first = recorder.sim.stop_cameras_recording()
+            assert first["status"] == "error", first
+
+        second = recorder.sim.stop_cameras_recording()
+
+        assert second["status"] == "success", second
+        artifacts = _json_block(second)["artifacts"]
+        assert [a["frames"] for a in artifacts] == [buffered] * len(_CAMERAS), artifacts
+        for artifact in artifacts:
+            with imageio.get_reader(artifact["path"]) as reader:
+                assert sum(1 for _ in reader) == buffered
+        assert recorder.sim._cams_rec_state is None, "the encoded recording is deregistered"
+
+    def test_a_start_cannot_discard_them(self, recorder, no_encoder) -> None:
+        """A start reads the registration, so it refuses instead of replacing."""
+        buffered = recorder.buffer_a_few()
+        recorder.sim.stop_cameras_recording()
+
+        again = recorder.start(name="second")
+
+        assert again["status"] == "error", again
+        assert "stop_cameras_recording() first" in again["content"][0]["text"]
+        assert recorder.sim._cams_rec_state["name"] == "wedge"
+        assert recorder.buffered() == {cam: buffered for cam in _CAMERAS}
+
+
+class TestAFlushThatEncoded:
+    """The ordinary path is unchanged: encode, then deregister."""
+
+    def test_it_deregisters_and_the_next_call_is_the_no_op(self, recorder, tmp_path) -> None:
+        """Only a flush that encoded may report the recording gone."""
+        pytest.importorskip("imageio.v2")
+        buffered = recorder.buffer_a_few()
+
+        result = recorder.sim.stop_cameras_recording()
+
+        assert result["status"] == "success", result
+        assert [a["frames"] for a in _json_block(result)["artifacts"]] == [buffered] * len(_CAMERAS)
+        assert len(list(tmp_path.glob("*.mp4"))) == len(_CAMERAS)
+        assert recorder.sim._cams_rec_state is None
+        assert "Was not recording" in recorder.sim.stop_cameras_recording()["content"][0]["text"]
+
+    def test_nothing_registered_is_still_the_no_op(self, recorder) -> None:
+        """The idempotent success is about an absent registration, not an idle one."""
+        result = recorder.sim.stop_cameras_recording()
+
+        assert result["status"] == "success", result
+        assert "Was not recording" in result["content"][0]["text"]
+
+
+def test_both_recorders_word_one_absence_the_same_way() -> None:
+    """One owner for the refusal, so the two recorders cannot drift apart."""
+    from strands_robots.simulation.recording import encoder_absent_flush_refusal
+
+    refusal = encoder_absent_flush_refusal(ImportError("no imageio"), "tag", {"front": 3})
+
+    assert refusal["status"] == "error"
+    assert "no imageio" in refusal["content"][0]["text"]
+    assert "left registered holding {'front': 3}" in refusal["content"][0]["text"]
+    assert _json_block(refusal) == {"stopped": False, "recording": "tag", "buffered_frames": {"front": 3}}


### PR DESCRIPTION
`IsaacSimulation.stop_cameras_recording` dropped `_cams_rec_state` **before** it read a single buffer. So the one failure it reports as an error — no MP4 encoder installed, which `encode_clip` raises before opening any writer, having encoded nothing and touched nothing — destroyed every camera's frames, then told the caller to install the encoder and call again.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/isaac-camera-flush/docs/assets/isaac_camera_flush_keeps_frames.png)

## The refusal destroyed what it said was recoverable

Measured on both trees, 24 buffered frames (2 cameras x 12), encoder absent:

| | before | after |
|---|---|---|
| refusal `status` | `error` | `error` |
| recording still registered | **`False`** | `True` |
| frames still held | **`{}`** | `{'front': 12, 'wrist': 12}` |
| `json` payload | **`None`** | `stopped=False`, `buffered_frames` |
| follow its advice: install, call again | **`"Was not recording cameras."`** | `success` — 12 + 12 frames |
| or start a new recording instead | **`success`** (slot taken silently) | `error` — refuses to discard |
| MP4s written / frames decodable | **`[]` / 0** | 2 files, 19.7 + 20.0 KB / **12** |

The third column of the figure is frame 6 decoded back out of the recovered `rollout__front.mp4`.

## Why this branch, and why only this one

MuJoCo decided this already: `_flush_and_deregister_cameras_recording` is, in its own words, "the one place the 'only a successful flush deregisters' rule lives", because *both* of its flush paths had the same hole. Isaac was never routed through it. `docs/recording.md` documents the contract (`stopped: False`, buffered counts, "a later call can still encode it") without scoping it to one backend.

The absent encoder is the **only** cause in scope, and deliberately so: it is the one that raises before any writer is opened, so nothing was written and nothing was dropped. Every other encode failure is folded into the success envelope and still deregisters on both backends — that is the documented best-effort contract, unchanged here.

Three coupled edits, because retention is worth nothing on its own:

- the flush no longer deregisters up front; it deregisters after every camera was offered to the encoder;
- the idempotent no-op now keys on *nothing registered* rather than *not running*, so a retained recording is flushable by a later call (this is what made the advertised remedy reachable);
- `start_cameras_recording` refuses while unencoded frames are registered — otherwise the next start would quietly discard exactly what the refusal promised.

`on_frame` already gates on `running`, so a retained recording cannot grow.

## One owner for one absence

Both recorders now build that envelope from `simulation.recording.encoder_absent_flush_refusal`. The duplication is what let the rule hold for one recorder and not the other — the same reasoning `require_clip_encoder` records for the probe it centralises. MuJoCo's text is byte-identical (its 20-line inline comment became a pointer, hence the −46 there).

## Tests

`tests/simulation/isaac/test_cameras_recording_flush_keeps_unencodable_frames.py` — what the refusal reports, that the frames survive, that a later call encodes and decodes them, that a start cannot discard them, plus the shared-owner pin. Skeleton engine via `__new__`, so no Kit runtime.

Against unmodified `main` (b02a11bd2): **5 failed, 2 passed** — the 2 passes are the encode-path controls, unchanged by this PR.

Full suite both trees, concurrently: **67F / 50735P** (this branch) vs **73F / 50729P** (main with the new file copied in). `comm` on the failure names: **zero in mine that are not in main**; the 6 extras on main are the 5 cells above plus `test_docstring_xref_roles_resolve` (its `:func:` xref names the symbol main lacks). 97 standing failures identical on both. `ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ` (1957 files); mypy at the pre-existing 20 errors / 6 files; `assemble_changelog.py --check` OK.

LOC: +401 / −60, of which +240 is the test and +57 the shared owner; the two engines net +86 / −46.

The capture source in the figure is a MuJoCo EGL render standing in for Isaac's RTX camera — the flush path under test needs no Kit runtime.