### PR TITLE
test(simulation): a seeded eval's replay is measured off the process-global RNG

### DIFF
--- a/changelog.d/3329-seeded-replay-reads-a-private-fork.md
+++ b/changelog.d/3329-seeded-replay-reads-a-private-fork.md
@@ -1,0 +1,27 @@
+### Tests: the seeded-replay measurement is taken off the process-global RNG
+
+`tests/simulation/test_rollout_seed_is_applied_or_refused.py` measures the
+applied half of the rollout seed contract with a policy whose actions depend on
+the RNG state, and the RNG a rollout seed sets is the process-global one. The
+policy drew straight from `random.random()`, so the comparison of two seeded
+evals also assumed the rollout was that object's only reader for the length of
+the rollout. It is not: any other thread in the interpreter that draws from it
+between two of the policy's queries shifts every action after it, and the
+comparison reports that as an unapplied seed. The test failed that way once on a
+branch whose diff touched no RNG code, taking a required check with it.
+
+The policy now reads the seeded stream through a private `random.Random` whose
+state is copied from the global one in `reset` - the statement after
+`set_eval_seed` on every rollout surface. The draws are still the ones the global
+RNG would have yielded, so the seed is still what the comparison observes, but a
+later reader of the global object cannot reach them. A new case pins it: one run
+of a seeded pair has a `success_fn` that draws once from the global RNG mid
+rollout, and the two runs must still replay identically while deriving identical
+episode seeds.
+
+The unseeded case is measured at the appliers instead of at the state they write.
+`assert random.getstate() != expected` could not see the side effect it guarded -
+reseeding from entropy and merely consuming draws both leave a state that differs
+from the one before the call, so it passed either way. A reseed is a call, and
+`set_eval_seed` is the only thing on this path that makes one, so the call is
+what is counted.

--- a/tests/simulation/test_rollout_seed_is_applied_or_refused.py
+++ b/tests/simulation/test_rollout_seed_is_applied_or_refused.py
@@ -38,6 +38,16 @@ while the rollout surfaces that share its destination accepted them.
 
 These tests pin both halves: the seed is applied on the path that dropped it, and
 the one shared domain answers for it at every surface that accepts one.
+
+Measuring the applied half needs a policy whose output depends on the RNG state,
+and the RNG a rollout seed sets is the *process-global* one. Reading it straight
+from ``random.random()`` made the replay comparison depend on being its only
+reader: any other thread in the interpreter that draws from it between two of the
+policy's queries shifts the action sequence, and the comparison reads that as an
+unapplied seed. :func:`_fork_global_rng` takes the measurement off that shared
+object instead - a private generator whose state is copied from the global one at
+the statement after ``set_eval_seed``, so the draws still come from the stream
+the seed selected and nothing later can perturb them.
 """
 
 from __future__ import annotations
@@ -111,18 +121,37 @@ _ARM_XML = """<mujoco model="arm">
 """
 
 
+def _fork_global_rng() -> random.Random:
+    """A private generator continuing the process-global stream from right now.
+
+    ``setstate`` copies the state rather than sharing it, so the fork reads
+    whatever ``set_eval_seed`` last wrote to the global RNG - the reseed under
+    test - and is then immune to every other reader of it.
+    """
+    forked = random.Random()
+    forked.setstate(random.getstate())
+    return forked
+
+
 class _Jitter(Policy):
-    """Draws each action from the global RNG - what a seed exists to pin.
+    """Draws each action from the stream the seed selects - what a seed pins.
 
     A deterministic policy cannot tell a seeded rollout from an unseeded one, so
     the reproducibility half of the contract is unobservable without a policy
     whose output depends on the RNG state the seed is supposed to fix.
+
+    It reads that state once per reset, through :func:`_fork_global_rng`. Every
+    rollout surface applies the seed with ``set_eval_seed`` and then calls
+    ``reset`` on the next statement, so the fork is taken from the state the seed
+    produced; the draws are the ones the global RNG would have yielded, without
+    the whole rollout being exposed to whatever else in the process reads it.
     """
 
     def __init__(self) -> None:
         self.keys: list[str] = []
         self.reset_seeds: list[Any] = []
         self.drawn: list[float] = []
+        self._rng: random.Random | None = None
 
     @property
     def provider_name(self) -> str:
@@ -133,11 +162,16 @@ class _Jitter(Policy):
 
     def reset(self, seed: int | None = None) -> None:
         self.reset_seeds.append(seed)
+        self._rng = _fork_global_rng()
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, float]]:
-        value = random.random()
+        if self._rng is None:
+            # An unseeded rollout applies no seed and so calls no reset; fork on
+            # first use, which reads the global state without advancing it.
+            self._rng = _fork_global_rng()
+        value = self._rng.random()
         self.drawn.append(value)
         return [{key: value - 0.5 for key in self.keys}]
 
@@ -182,6 +216,52 @@ class TestTheSeedIsAppliedOnTheEvalPath:
             runs.append(list(policy.drawn))
         assert runs[0], "the policy must have been queried, or nothing is measured"
         assert runs[0] == runs[1], "a seeded eval must replay identically"
+
+    def test_a_stray_global_draw_mid_rollout_does_not_change_the_replay(self, arm_xml: Path) -> None:
+        """The stream the seed selects is not the rollout's alone to read.
+
+        ``set_eval_seed`` reseeds the *process-global* RNG, and everything else in
+        the interpreter draws from that same object - a thread left by a suite
+        fixture, a library's trace-id generator. One stray ``random()`` between
+        two of the policy's queries shifted every action after it, so the replay
+        assertion above could fail for a draw the rollout never made, on a branch
+        that touched no RNG code, and report it as an unapplied seed.
+
+        The stray reader here is a ``success_fn``, which the eval loop calls after
+        each step: a real consumer of the same global object, in one run of the
+        pair, at a step of this test's choosing. The episode seeds are compared
+        too, so a divergence can only come from the reading, not the seeding.
+        """
+
+        def replay(interfere_at: int | None) -> tuple[list[float], list[Any]]:
+            steps = 0
+
+            def success_fn(observation: dict[str, Any]) -> bool:
+                nonlocal steps
+                steps += 1
+                if steps == interfere_at:
+                    random.random()
+                return False
+
+            sim, policy = _sim_and_policy(arm_xml)
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=policy,
+                n_episodes=2,
+                max_steps=4,
+                control_frequency=30.0,
+                seed=7,
+                success_fn=success_fn,
+            )
+            sim.cleanup()
+            assert result["status"] == "success", _text(result)
+            return list(policy.drawn), list(policy.reset_seeds)
+
+        quiet, quiet_seeds = replay(None)
+        noisy, noisy_seeds = replay(3)
+        assert quiet, "the policy must have been queried, or nothing is measured"
+        assert quiet_seeds == noisy_seeds, "the seed derivation must be identical, or nothing is isolated"
+        assert quiet == noisy, "a draw the rollout did not make changed what a seeded eval replayed"
 
     def test_two_evals_at_different_seeds_draw_different_actions(self, arm_xml: Path) -> None:
         """Non-vacuity: the equality above is the seed's doing, not determinism."""
@@ -232,11 +312,23 @@ class TestTheSeedIsAppliedOnTheEvalPath:
             seeds.append(list(policy.reset_seeds))
         assert seeds[0] == seeds[1]
 
-    def test_an_unseeded_eval_does_not_touch_policy_reset_or_the_global_rng(self, arm_xml: Path) -> None:
-        """``seed=None`` must not acquire a global RNG side effect it never had."""
-        random.seed(1234)
-        expected = random.getstate()
-        random.seed(1234)
+    def test_an_unseeded_eval_does_not_touch_policy_reset_or_the_global_rng(
+        self, arm_xml: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``seed=None`` must not acquire a global RNG side effect it never had.
+
+        Counted at the appliers, not at the state they write. A state comparison
+        cannot tell the defect from a rollout that merely drew: reseeding from
+        entropy and consuming three draws both leave a state that differs from the
+        one before the call, so ``getstate() != expected`` held either way. A
+        reseed is a *call*, and ``set_eval_seed`` - reached only under ``if seed is
+        not None`` - is the only thing on this path that makes one.
+        """
+        np = pytest.importorskip("numpy")
+        reseeded: list[Any] = []
+        monkeypatch.setattr(random, "seed", lambda *a, **k: reseeded.append(("random.seed", a)))
+        monkeypatch.setattr(np.random, "seed", lambda *a, **k: reseeded.append(("numpy.random.seed", a)))
+
         sim, policy = _sim_and_policy(arm_xml)
         result = sim.eval_policy(
             robot_name="arm",
@@ -249,9 +341,7 @@ class TestTheSeedIsAppliedOnTheEvalPath:
         sim.cleanup()
         assert result["status"] == "success", _text(result)
         assert policy.reset_seeds == [], "no seed was supplied, so none is forwarded"
-        # The rollout consumed draws from the un-reseeded stream, so the state
-        # moved on rather than being reset to the start of a new one.
-        assert random.getstate() != expected
+        assert reseeded == [], f"an unseeded eval reseeded a process-global RNG: {reseeded}"
 
     def test_the_seeded_eval_matches_its_sibling_run_policy_contract(self, arm_xml: Path) -> None:
         """``eval_policy``'s docstring promises the two entry points behave alike."""


### PR DESCRIPTION
The applied half of the rollout seed contract is measured with a policy whose actions depend on the RNG state — and the RNG a rollout seed sets is the **process-global** one. The policy drew straight from `random.random()`, so comparing two seeded evals also assumed the rollout was that object's only reader for the length of the rollout. It is not.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/seed-replay-fork/docs/assets/seed_replay_reads_a_private_fork.png)

Closes #3329.

> **Superseded in part by #3334.** This pull request merged at `7901210` by auto-merge at 14:29:02, fifteen minutes before round-1 review feedback was addressed, so the round-1 commit landed on the fork branch of a merged pull request and is re-opened as #3334. The instrument below — copying the global state in `reset()` — was measured under a 2 ms background reader of the global RNG and still failed 1 run in 3: `set_eval_seed` continues into NumPy/torch after `random.seed`, so the copy is not "the statement after" the reseed. #3334 replaces it with a private `random.Random(seed)` seeded from the forwarded seed, which reads the shared object zero times. The unseeded-case change and the stray-draw case below are unchanged by that and stand.

## One draw the rollout never made

Measured in MuJoCo (headless EGL), `eval_policy(seed=7, n_episodes=2, max_steps=4)`, twice — the second run's `success_fn` calls `random()` once after step 3:

| | before | after |
|---|---|---|
| episode seeds, both runs | `[1390851128, 647892279]` | `[1390851128, 647892279]` |
| first divergent draw | **index 3** | none |
| commanded angle at step 4 | **`0.4104` vs `0.0654`** | `0.4104` vs `0.4104` |
| the replay assertion | **fails** | passes |

The seed path is identical in every run, so the divergence was in the *reading*, not the seeding. `set_eval_seed` had done its job: draws 1–3 agree, and the next episode's reseed wipes the drift, which is why the one CI occurrence showed up as a single-episode mismatch on a branch that touched no RNG code and took a required check with it.

## The measurement moves off the shared object, not off the seed (as merged; see #3334)

The policy reads the seeded stream through a private `random.Random` whose state is **copied** from the global one in `reset()` — the statement right after `set_eval_seed` on every rollout surface. `setstate` copies rather than shares, so the draws are still exactly the ones the global RNG would have yielded, and the global reseed is still what the comparison observes. What is gone is the exposure: the window in which another reader can move the measurement shrinks from the whole rollout to the gap between `random.seed` and the copy.

That gap was measured after merge and is not two statements wide (see the note above); #3334 carries the fix and a deterministic case for that window.

## The unseeded case counted a state that could not tell the difference

`assert random.getstate() != expected` guarded against an unseeded eval reseeding from entropy, but reseeding from entropy *and* merely consuming draws both leave a state that differs from the one before the call — measured: the assertion holds in both cases, so it discriminated nothing. A reseed is a **call**, and `set_eval_seed` (reached only under `if seed is not None`) is the only thing on this path that makes one, so the call is now what is counted, on `random.seed` and `numpy.random.seed`. Measured on this path: zero calls to either.

## Tests

New case `test_a_stray_global_draw_mid_rollout_does_not_change_the_replay` in `TestTheSeedIsAppliedOnTheEvalPath`. The stray reader is a real consumer (`success_fn`, which the eval loop calls after each step) in one run of the pair, at a step of the test's choosing — a synchronous stand-in for another thread, so the case is deterministic rather than probabilistic.

Against the previous instrument (same code under test, only the policy's reader reverted): **1 failed, 3 passed** — the new case fails at index 3, and the three controls (same-seed replay, the different-seeds non-vacuity cell, the unseeded cell) pass either way.

Full `tests/` on both trees, run concurrently at `b02a11bd2`: **67 failed / 50729 passed / 437 skipped / 37 errors** on each, identical collection (51264 items), and the failure-name sets are identical in **both** `comm` directions — zero regressions. Since rebased onto `65e107bb9`, whose diff is confined to the Isaac recorder; the file is green there too (125 passed). `ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ` (1958 files); mypy unchanged at the pre-existing 20 errors / 6 files; `assemble_changelog.py --check` OK.

LOC: **+127 / −10**, of which the new case is 46 lines and the fragment 27; the instrument itself is +13 / −3.