### PR TITLE
fix(dataset): a recorded dataset lands in the directory create prepared for it

### DIFF
--- a/changelog.d/3332-dataset-create-writes-where-it-prepared.md
+++ b/changelog.d/3332-dataset-create-writes-where-it-prepared.md
@@ -1,0 +1,29 @@
+### Fixed: a recorded dataset lands in the directory `create` prepared for it
+
+`DatasetRecorder.create` resolved the dataset directory twice. It resolved one
+through `resolve_dataset_dir` and handed it to `_prepare_create_target`, which
+inspects that directory and - under `overwrite=True` - deletes it; then it called
+`LeRobotDataset.create` with the caller's raw `root`, letting the writer resolve a
+directory of its own. The two rules differ: `resolve_dataset_dir` reads a
+`repo_id` that is itself a path (no `owner/name` slash, or `./`-prefixed) as a
+local directory, while LeRobot resolves any absent root to
+`$HF_LEROBOT_HOME/{repo_id}` whatever the id looks like.
+
+Measured end to end against lerobot 0.6.2 -
+`start_recording(repo_id="sim_recording", root=None, overwrite=True)`, a 45-step
+MuJoCo rollout, `stop_recording()`, every call `status="success"`: an unrelated
+`./sim_recording` holding one file was deleted, the dataset was written under
+`$HF_LEROBOT_HOME/sim_recording`, and `verify_dataset_episodes(expected=1)` then
+reported `status="error"`, since the facade records the prepared path as the
+dataset root. With a dataset already at the writer's directory, `overwrite=True`
+could not overwrite at all: the wipe missed it, and LeRobot's own
+`mkdir(exist_ok=False)` raised the bare `FileExistsError` that
+`_prepare_create_target` exists to replace with a message naming `overwrite=True`
+and `resume()`.
+
+`create` now resolves once and forwards the result as an explicit `root`, so the
+directory it inspected and wiped is the directory the dataset is written into -
+which is what `docs/recording.md` already claimed by calling
+`resolve_dataset_dir` the one owner of those rules. An `owner/name` id is
+unchanged (both rules already agreed on `$HF_LEROBOT_HOME/{repo_id}`), and
+`resume`, which resolves and prepares nothing, is untouched.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -181,6 +181,13 @@ recording and where `LeRobotDataset` later reads it back from -
 `resolve_dataset_dir` is the one owner of those rules and every backend's
 `start_recording` applies it.
 
+Being the one owner is what makes `overwrite` mean something: the resolved
+directory is forwarded to `LeRobotDataset.create` as an explicit `root`, so the
+directory inspected (and, under `overwrite=True`, deleted) before the write is
+the directory the dataset is then written into. LeRobot derives an absent root
+as `$HF_LEROBOT_HOME/{repo_id}` for any id, so letting it derive one of its own
+would part company with the rule above for exactly the path-like ids.
+
 Passing an existing **empty** directory - for example one returned by
 `tempfile.mkdtemp()` - is accepted and recorded into:
 

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -571,13 +571,18 @@ def _lerobot_home() -> Path:
 def resolve_dataset_dir(repo_id: str, root: str | None = None) -> Path:
     """Resolve the on-disk directory a dataset will live in.
 
-    Mirrors ``LeRobotDataset`` root resolution so callers can inspect the
-    target before ``create``/``resume``:
-
     * explicit ``root`` -> used verbatim;
     * a ``repo_id`` that is itself a path (absolute, ``./`` prefixed, or with no
       ``owner/name`` slash) -> treated as a local directory;
     * otherwise ``$HF_LEROBOT_HOME/{repo_id}``.
+
+    The middle rule is this repo's reading, not LeRobot's: ``LeRobotDataset``
+    resolves any absent root to ``$HF_LEROBOT_HOME/{repo_id}`` whatever the id
+    looks like. So this is the resolution callers get, and
+    :meth:`DatasetRecorder.create` hands the result down as an explicit ``root``
+    rather than letting the writer resolve a second time - otherwise the
+    directory inspected before the write and the directory written to are two
+    different places for exactly the ids the middle rule covers.
 
     Args:
         repo_id: HuggingFace dataset id (``owner/name``) or a local path.
@@ -986,7 +991,12 @@ class DatasetRecorder:
                 ``base_quat.*`` columns). Scalar joint/action fallbacks ignore
                 these; add_frame reads the source keys, not the expanded names.
             task: Default task description
-            root: Local directory for dataset storage
+            root: Local directory for dataset storage. When omitted, the
+                directory is resolved by
+                :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`
+                and forwarded to ``LeRobotDataset.create`` explicitly, so the
+                target ``overwrite`` inspects is the target the dataset is
+                written to.
             use_videos: Encode camera frames as video (True) or keep as images.
                 Selects a posture rather than scaling a quantity, so it must be a
                 boolean (:func:`~strands_robots.utils.boolean_flag_error`) - the
@@ -1164,11 +1174,22 @@ class DatasetRecorder:
 
         logger.info(f"Creating LeRobotDataset: {repo_id} @ {fps}fps, {len(features)} features, robot_type={robot_type}")
 
+        # The directory this dataset will live in, resolved once. It is passed to
+        # ``LeRobotDataset.create`` as an explicit ``root`` rather than letting
+        # the writer re-derive it from ``repo_id``, because the two derivations
+        # are not the same one: ``resolve_dataset_dir`` reads a ``repo_id`` that
+        # is itself a path (no ``owner/name`` slash, or ``./``-prefixed) as a
+        # local directory, while LeRobot resolves any absent root to
+        # ``$HF_LEROBOT_HOME/{repo_id}``. Resolving twice put the directory
+        # ``_prepare_create_target`` inspects and wipes somewhere other than the
+        # directory the dataset is written to - see the call below.
+        dataset_dir = resolve_dataset_dir(repo_id, root)
+
         # Build kwargs, skip unsupported params for this LeRobot version.
         create_kwargs = dict(
             repo_id=repo_id,
             fps=fps,
-            root=root,
+            root=str(dataset_dir),
             robot_type=robot_type,
             features=features,
             use_videos=use_videos,
@@ -1197,7 +1218,11 @@ class DatasetRecorder:
         # otherwise dead-end on a bare FileExistsError. This also keeps the
         # resume() docstring and its no-resume RuntimeError message honest: both
         # point callers at an ``overwrite=`` parameter that now exists here.
-        _prepare_create_target(resolve_dataset_dir(repo_id, root), overwrite=overwrite)
+        # ``dataset_dir`` is the same path ``create_kwargs["root"]`` carries, so
+        # what is inspected here is what gets written; a second, independent
+        # resolution here would leave this guard reading a directory the writer
+        # never touches, and ``overwrite=True`` deleting it.
+        _prepare_create_target(dataset_dir, overwrite=overwrite)
 
         dataset = LeRobotDatasetCls.create(**create_kwargs)
 

--- a/tests/test_dataset_create_writes_where_it_prepared.py
+++ b/tests/test_dataset_create_writes_where_it_prepared.py
@@ -1,0 +1,200 @@
+"""A dataset is written into the directory ``create`` prepared for it.
+
+``DatasetRecorder.create`` does two things with a dataset directory. It resolves
+one through :func:`~strands_robots.dataset_recorder.resolve_dataset_dir` and
+hands it to ``_prepare_create_target``, which inspects it and - under
+``overwrite=True`` - deletes it; then it calls ``LeRobotDataset.create``, which
+resolves a directory of its own from ``repo_id`` whenever ``root`` is absent.
+Those two resolutions are not the same one. ``resolve_dataset_dir`` reads a
+``repo_id`` that is itself a path - no ``owner/name`` slash, or ``./``-prefixed -
+as a local directory, while LeRobot resolves any absent root to
+``$HF_LEROBOT_HOME/{repo_id}`` whatever the id looks like. For those ids the
+guard therefore inspected one directory and the writer wrote another.
+
+Measured against lerobot 0.6.2 with the dataset home and the working directory
+both redirected into a scratch tree, ``repo_id="sim_recording"``, ``root=None``:
+
+* ``overwrite=True`` with an unrelated ``./sim_recording`` holding one file:
+  the file's directory was **deleted** and the dataset was created under
+  ``$HF_LEROBOT_HOME/sim_recording``. The delete and the write named different
+  places, so what ``overwrite`` consumed was not what it replaced.
+* ``overwrite=True`` with a dataset already at ``$HF_LEROBOT_HOME/sim_recording``
+  raised ``FileExistsError: [Errno 17] File exists`` and the stale dataset
+  survived: the flag could not overwrite, because the wipe was aimed elsewhere.
+* ``overwrite=False`` in the same arrangement raised the same bare ``[Errno 17]``
+  rather than the message naming ``overwrite=True`` and :meth:`resume` -
+  ``_prepare_create_target`` exists to replace that error and was reading a
+  directory the write never touched.
+
+``create`` now resolves once and forwards the result as an explicit ``root``, so
+the inspected directory is the written directory by construction. The ordinary
+``owner/name`` id is unaffected: both resolutions already agreed on
+``$HF_LEROBOT_HOME/{repo_id}`` there, which the controls below hold.
+
+``DatasetRecorder.resume`` is deliberately untouched. It forwards ``repo_id`` /
+``root`` to ``LeRobotDataset.resume`` without resolving or preparing anything, so
+it has no second resolution to disagree with, and LeRobot refuses an absent root
+there itself with a message that names the fix.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any, ClassVar, NamedTuple
+
+import pytest
+
+from strands_robots import dataset_recorder as dr
+from strands_robots.dataset_recorder import DatasetRecorder, resolve_dataset_dir
+
+
+class _Writer:
+    """A ``create`` shaped like ``LeRobotDataset.create``.
+
+    Two properties matter and both decide where a dataset ends up: an absent
+    ``root`` resolves to ``$HF_LEROBOT_HOME/{repo_id}``, and the directory is
+    made with ``exist_ok=False`` so an existing one raises the bare
+    ``FileExistsError`` that ``_prepare_create_target`` exists to pre-empt. A
+    double that ignored ``root`` could not see this defect at all.
+    """
+
+    #: Stands in for ``$HF_LEROBOT_HOME``; the fixture points it at a scratch dir.
+    home: ClassVar[Path] = Path()
+
+    def __init__(self, repo_id: str, root: Path) -> None:
+        self.repo_id = repo_id
+        self.root = root
+
+    @classmethod
+    def create(
+        cls,
+        repo_id: str,
+        fps: int = 30,
+        root: str | None = None,
+        robot_type: str | None = None,
+        features: dict[str, Any] | None = None,
+        use_videos: bool = True,
+        image_writer_threads: int = 0,
+    ) -> _Writer:
+        resolved = Path(root) if root is not None else cls.home / repo_id
+        resolved.mkdir(parents=True, exist_ok=False)
+        (resolved / "meta").mkdir()
+        return cls(repo_id, resolved)
+
+
+class _Bench(NamedTuple):
+    """A private dataset home and working directory, plus the writer."""
+
+    home: Path
+    work: Path
+
+
+@pytest.fixture
+def bench(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _Bench:
+    """Redirect both halves of the resolution into a scratch tree.
+
+    ``_lerobot_home`` is patched rather than ``$HF_LEROBOT_HOME`` because
+    lerobot reads that variable once at import; the working directory is
+    redirected too, since a bare ``repo_id`` resolves relative to it.
+    """
+    home = tmp_path / "lerobot_home"
+    home.mkdir()
+    work = tmp_path / "workdir"
+    work.mkdir()
+    monkeypatch.setattr(dr, "_lerobot_home", lambda: home)
+    monkeypatch.setattr(_Writer, "home", home)
+    monkeypatch.chdir(work)
+    module = types.ModuleType("lerobot.datasets.lerobot_dataset")
+    module.LeRobotDataset = _Writer  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", module)
+    return _Bench(home=home, work=work)
+
+
+def _create(**kwargs: Any) -> _Writer:
+    """Record through ``create``, with the schema every case shares.
+
+    ``repo_id`` rides in ``kwargs`` rather than being named here so each case
+    states its own id beside its own ``root`` - which is also what the
+    shared-cache rule in ``test_recording_root_is_not_the_shared_cache`` reads.
+    """
+    recorder = DatasetRecorder.create(joint_names=["shoulder_pan"], **kwargs)
+    dataset = recorder.dataset
+    assert isinstance(dataset, _Writer)
+    return dataset
+
+
+def _plant_dataset(directory: Path) -> Path:
+    """An existing LeRobotDataset: a ``meta/`` dir with an ``info.json`` in it."""
+    (directory / "meta").mkdir(parents=True)
+    info = directory / "meta" / "info.json"
+    info.write_text('{"fps": 30}', encoding="utf-8")
+    return info
+
+
+# A repo_id that is itself a path, in both forms resolve_dataset_dir names.
+PATH_LIKE = ("bare_name", "./dot_slash_name")
+
+
+@pytest.mark.parametrize("repo_id", PATH_LIKE)
+def test_the_dataset_is_written_into_the_directory_that_was_resolved(bench: _Bench, repo_id: str) -> None:
+    """The writer's directory is the one ``resolve_dataset_dir`` named."""
+    dataset = _create(repo_id=repo_id, root=None)
+
+    assert dataset.root.resolve() == resolve_dataset_dir(repo_id, None).resolve()
+    assert dataset.root.resolve() == (bench.work / Path(repo_id).name).resolve()
+
+
+def test_an_overwrite_replaces_the_directory_it_deleted(bench: _Bench) -> None:
+    """What ``overwrite=True`` deletes is what the dataset is then written into."""
+    target = bench.work / "bare_name"
+    target.mkdir()
+    (target / "unrelated_notes.txt").write_text("a file the caller cares about", encoding="utf-8")
+
+    dataset = _create(repo_id="bare_name", root=None, overwrite=True)
+
+    assert dataset.root.resolve() == target.resolve(), (
+        "overwrite deleted one directory and the dataset was written to another"
+    )
+    assert (target / "meta").is_dir()
+    assert not (bench.home / "bare_name").exists()
+
+
+def test_a_dataset_outside_the_resolved_directory_does_not_refuse_the_create(bench: _Bench) -> None:
+    """An unrelated dataset under the dataset home neither blocks nor is touched.
+
+    Pre-fix this create reached the writer's ``exist_ok=False`` mkdir on that
+    very directory, so it died on the bare ``FileExistsError`` the guard exists
+    to replace - for a dataset the caller had not addressed.
+    """
+    unrelated = _plant_dataset(bench.home / "bare_name")
+
+    dataset = _create(repo_id="bare_name", root=None)
+
+    assert dataset.root.resolve() == (bench.work / "bare_name").resolve()
+    assert unrelated.read_text(encoding="utf-8") == '{"fps": 30}'
+
+
+def test_an_owner_name_repo_id_still_resolves_under_the_dataset_home(bench: _Bench) -> None:
+    """The ordinary id: both resolutions agreed already, and still do."""
+    dataset = _create(repo_id="user/data", root=None)
+
+    assert dataset.root.resolve() == (bench.home / "user" / "data").resolve()
+
+
+def test_an_explicit_root_is_still_used_verbatim(bench: _Bench) -> None:
+    """A caller-named root is the target for both halves, as before."""
+    chosen = bench.work / "chosen_dir"
+
+    dataset = _create(repo_id="user/data", root=str(chosen))
+
+    assert dataset.root.resolve() == chosen.resolve()
+
+
+def test_an_existing_dataset_at_the_target_still_names_overwrite_and_resume(bench: _Bench) -> None:
+    """The actionable refusal survives: it is now aimed at the written directory."""
+    _plant_dataset(bench.work / "bare_name")
+
+    with pytest.raises(FileExistsError, match="overwrite=True.*resume|resume.*overwrite=True"):
+        _create(repo_id="bare_name", root=None)


### PR DESCRIPTION
![before/after: the prepared directory vs the written directory, plus the rollout that produced the dataset](https://github.com/cagataycali/robots/releases/download/artifact-dataset-target-34233699345/dataset_target.png)

## The two resolutions

`DatasetRecorder.create` resolves a dataset directory twice, and the two rules are not the same rule.

```mermaid
flowchart LR
  A["create(repo_id, root=None)"] --> B["resolve_dataset_dir\nrepo_id that is a path -> local dir"]
  B --> C["_prepare_create_target\ninspects it; overwrite=True deletes it"]
  A --> D["LeRobotDataset.create(root=None)\nabsent root -> $HF_LEROBOT_HOME/{repo_id}"]
  D --> E["the dataset is written here"]
  C -. "same directory?\nnot for a path-like repo_id" .-> E
```

`resolve_dataset_dir` reads a `repo_id` that is itself a path - no `owner/name` slash, or `./`-prefixed - as a local directory. LeRobot resolves any absent root to `$HF_LEROBOT_HOME/{repo_id}` whatever the id looks like. So for exactly those ids, the directory the guard inspected and wiped was not the directory the dataset was written to.

## Measured, end to end

`start_recording(repo_id="sim_recording", root=None, overwrite=True)` -> 45-step MuJoCo rollout (headless, EGL) -> `stop_recording()`, against lerobot 0.6.2, with `$HF_LEROBOT_HOME` and the working directory both redirected into a scratch tree. Every call returned `status="success"` in both columns.

| | before | after |
|---|---|---|
| `./sim_recording/unrelated_notes.txt` | directory deleted | directory is the dataset (7 files: parquet + 2 MP4) |
| `$HF_LEROBOT_HOME/sim_recording/` | the dataset (7 files) | absent |
| `verify_dataset_episodes(expected=1)` | `status="error"` | `status="success"` |

Two further arrangements, same id, through `DatasetRecorder.create` directly:

- a dataset already at the writer's directory, `overwrite=True`: `FileExistsError: [Errno 17] File exists` and the stale dataset survived. The flag could not overwrite, because the wipe was aimed elsewhere.
- the same, `overwrite=False`: the same bare `[Errno 17]` rather than the message naming `overwrite=True` and `resume()`. `_prepare_create_target` exists to replace that error and was reading a directory the write never touched.

## Change

`create` resolves once and forwards the result to `LeRobotDataset.create` as an explicit `root`, so the inspected directory is the written directory by construction. This is what `docs/recording.md` already claimed by calling `resolve_dataset_dir` the one owner of those rules; the doc now says the resolved directory is forwarded, and `resolve_dataset_dir`'s docstring no longer claims to mirror LeRobot's resolution, which it deliberately does not.

An `owner/name` id is unchanged: both rules already agreed on `$HF_LEROBOT_HOME/{repo_id}`. `resume` is untouched - it resolves and prepares nothing, so it has no second resolution to disagree with, and LeRobot refuses an absent root there itself with a message naming the fix.

## Tests

`tests/test_dataset_create_writes_where_it_prepared.py`, 7 cells, through a `create` double shaped like `LeRobotDataset.create` (absent root -> `$HF_LEROBOT_HOME/{repo_id}`, `mkdir(exist_ok=False)`) - a double that ignored `root` could not see this defect.

On the unmodified tree: **4 failed, 3 passed**. The three that pass are the controls (the `owner/name` id, an explicit `root`, and the actionable `overwrite=`/`resume()` refusal). After: **7 passed**.

Full unit suite on both trees, same host: base 50742 passed / 72 failed / 437 skipped / 37 errors; this branch 50749 passed (+7, exactly the new cells) / 72 failed / 437 skipped / 37 errors. The failing-name sets differ only in `tests/mesh/test_zenoh_transport_security.py`, which passes 9/9 in isolation on this branch and is order-dependent. `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` unchanged at its pre-existing 20 errors in 6 files.

LOC: +267 / -6, of which +200 is the regression module and +29 the changelog fragment; the fix itself is +26/-2 (24 of those lines comment).