### PR TITLE
test(simulation): the seeded-replay policy reads the forwarded seed, not the global RNG

### DIFF
--- a/changelog.d/3329-seeded-replay-reads-a-private-fork.md
+++ b/changelog.d/3329-seeded-replay-reads-a-private-fork.md
@@ -1,23 +1,34 @@
-### Tests: the seeded-replay measurement is taken off the process-global RNG
+### Tests: the seeded-replay measurement no longer reads the process-global RNG
 
 `tests/simulation/test_rollout_seed_is_applied_or_refused.py` measures the
 applied half of the rollout seed contract with a policy whose actions depend on
-the RNG state, and the RNG a rollout seed sets is the process-global one. The
-policy drew straight from `random.random()`, so the comparison of two seeded
-evals also assumed the rollout was that object's only reader for the length of
-the rollout. It is not: any other thread in the interpreter that draws from it
-between two of the policy's queries shifts every action after it, and the
-comparison reports that as an unapplied seed. The test failed that way once on a
-branch whose diff touched no RNG code, taking a required check with it.
+the seed, and the RNG `set_eval_seed` sets is the process-global one. The policy
+drew straight from `random.random()`, so the comparison of two seeded evals also
+assumed the rollout was that object's only reader for the length of the rollout.
+It is not: any other thread in the interpreter that draws from it between two of
+the policy's queries shifts every action after it, and the comparison reports
+that as an unapplied seed. The test failed that way once on a branch whose diff
+touched no RNG code, taking a required check with it.
 
-The policy now reads the seeded stream through a private `random.Random` whose
-state is copied from the global one in `reset` - the statement after
-`set_eval_seed` on every rollout surface. The draws are still the ones the global
-RNG would have yielded, so the seed is still what the comparison observes, but a
-later reader of the global object cannot reach them. A new case pins it: one run
-of a seeded pair has a `success_fn` that draws once from the global RNG mid
-rollout, and the two runs must still replay identically while deriving identical
-episode seeds.
+Copying the global state into a private generator after `set_eval_seed` was
+measured and is not enough: `set_eval_seed` continues into NumPy and torch after
+`random.seed`, so the copy is taken hundreds of microseconds later at best, and a
+background reader on a 2 ms period still failed the file 1 run in 3. The policy
+now reads the global object zero times. Every seeded rollout surface forwards the
+seed it applied to `policy.reset(seed=...)` - the contract a service-mode policy
+relies on - and the test policy seeds a private `random.Random` from that value,
+exactly as such a policy would. Under the same 2 ms reader the file is green
+across repeated runs.
+
+Two cases pin it. One run of a seeded pair has a stray draw from the global RNG
+in one of two places - a `success_fn` drawing mid rollout, or a NumPy reseed that
+also draws, which sits inside `set_eval_seed` after `random.seed` - and the two
+runs must still replay identically while deriving identical episode seeds; the
+first placement refuses the direct reader, the second refuses the state copy.
+And because the policy no longer observes the per-episode reseed, that reseed is
+counted as the call it is: every seed `policy.reset` receives was applied with
+`set_eval_seed`, in order, so deleting the per-episode reseed from `evaluate`
+fails that cell and nothing else.
 
 The unseeded case is measured at the appliers instead of at the state they write.
 `assert random.getstate() != expected` could not see the side effect it guarded -

--- a/tests/simulation/test_rollout_seed_is_applied_or_refused.py
+++ b/tests/simulation/test_rollout_seed_is_applied_or_refused.py
@@ -296,17 +296,28 @@ class TestTheSeedIsAppliedOnTheEvalPath:
         service-mode policy and an in-process one are then seeded alike.
         Deleting the per-episode ``set_eval_seed`` from ``evaluate`` leaves the
         forwarded seeds intact and fails only here.
-        """
-        import strands_robots.simulation.policy_runner as runner_mod
 
-        real = runner_mod.set_eval_seed
+        The seam is the namespace ``evaluate`` resolves the name in, not the
+        module a fresh ``import strands_robots.simulation.policy_runner``
+        returns. That statement resolves through the *package attribute*, and a
+        sibling that re-imports the runner to measure its import
+        (``test_policy_runner.py``'s mujoco-leak cell) rebinds that attribute to
+        a fresh module object; ``monkeypatch`` restores the ``sys.modules``
+        entry it deleted, not the attribute the re-import wrote. Patching the
+        fresh object recorded nothing on the ordered run while the same cell
+        passed alone. The ``PolicyRunner`` this file binds at collection is the
+        class ``eval_policy`` instantiates, so its ``evaluate`` globals are the
+        dict the call reads whatever the attribute holds.
+        """
+        seam = PolicyRunner.evaluate.__globals__
+        assert seam["set_eval_seed"] is set_eval_seed, "the seam must be the one this file imported"
         applied: list[int] = []
 
         def recording(seed: int) -> None:
             applied.append(seed)
-            real(seed)
+            set_eval_seed(seed)
 
-        monkeypatch.setattr(runner_mod, "set_eval_seed", recording)
+        monkeypatch.setitem(seam, "set_eval_seed", recording)
         sim, policy = _sim_and_policy(arm_xml)
         result = sim.eval_policy(
             robot_name="arm",

--- a/tests/simulation/test_rollout_seed_is_applied_or_refused.py
+++ b/tests/simulation/test_rollout_seed_is_applied_or_refused.py
@@ -39,15 +39,26 @@ while the rollout surfaces that share its destination accepted them.
 These tests pin both halves: the seed is applied on the path that dropped it, and
 the one shared domain answers for it at every surface that accepts one.
 
-Measuring the applied half needs a policy whose output depends on the RNG state,
-and the RNG a rollout seed sets is the *process-global* one. Reading it straight
+Measuring the applied half needs a policy whose output depends on the seed, and
+the RNG ``set_eval_seed`` sets is the *process-global* one. Reading it straight
 from ``random.random()`` made the replay comparison depend on being its only
 reader: any other thread in the interpreter that draws from it between two of the
 policy's queries shifts the action sequence, and the comparison reads that as an
-unapplied seed. :func:`_fork_global_rng` takes the measurement off that shared
-object instead - a private generator whose state is copied from the global one at
-the statement after ``set_eval_seed``, so the draws still come from the stream
-the seed selected and nothing later can perturb them.
+unapplied seed. Copying the global state into a private generator after
+``set_eval_seed`` narrows that window without closing it - ``set_eval_seed``
+continues into NumPy and torch after ``random.seed``, so the copy is taken
+hundreds of microseconds later at best, and a reader on a 2 ms period still
+moved the measurement.
+
+So the policy here does not read the global object at all. Every seeded rollout
+surface forwards the seed it applied to ``policy.reset(seed=...)`` - the contract
+a service-mode policy relies on, because its sampler runs in a process
+``set_eval_seed`` cannot reach - and :class:`_Jitter` seeds a private
+``random.Random`` from that value, exactly as such a policy would. What the
+comparison then observes is the forwarded seed; that the loop also applies each
+one with ``set_eval_seed`` is a *call*, and is counted as one, at the same
+seam the unseeded cell counts ``random.seed``. The global reseed itself is
+pinned with no rollout at all in ``test_set_eval_seed_requires_a_seed.py``.
 """
 
 from __future__ import annotations
@@ -121,30 +132,16 @@ _ARM_XML = """<mujoco model="arm">
 """
 
 
-def _fork_global_rng() -> random.Random:
-    """A private generator continuing the process-global stream from right now.
-
-    ``setstate`` copies the state rather than sharing it, so the fork reads
-    whatever ``set_eval_seed`` last wrote to the global RNG - the reseed under
-    test - and is then immune to every other reader of it.
-    """
-    forked = random.Random()
-    forked.setstate(random.getstate())
-    return forked
-
-
 class _Jitter(Policy):
-    """Draws each action from the stream the seed selects - what a seed pins.
+    """Draws each action from a generator seeded by the forwarded seed.
 
     A deterministic policy cannot tell a seeded rollout from an unseeded one, so
     the reproducibility half of the contract is unobservable without a policy
-    whose output depends on the RNG state the seed is supposed to fix.
+    whose output depends on the seed it was handed.
 
-    It reads that state once per reset, through :func:`_fork_global_rng`. Every
-    rollout surface applies the seed with ``set_eval_seed`` and then calls
-    ``reset`` on the next statement, so the fork is taken from the state the seed
-    produced; the draws are the ones the global RNG would have yielded, without
-    the whole rollout being exposed to whatever else in the process reads it.
+    It is the service-mode shape: ``reset(seed=...)`` seeds a private
+    ``random.Random`` and every draw comes from that object, so nothing else in
+    the process can move the measurement - there is no shared reader to race.
     """
 
     def __init__(self) -> None:
@@ -162,15 +159,16 @@ class _Jitter(Policy):
 
     def reset(self, seed: int | None = None) -> None:
         self.reset_seeds.append(seed)
-        self._rng = _fork_global_rng()
+        self._rng = random.Random(seed)
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, float]]:
         if self._rng is None:
-            # An unseeded rollout applies no seed and so calls no reset; fork on
-            # first use, which reads the global state without advancing it.
-            self._rng = _fork_global_rng()
+            # An unseeded rollout forwards no seed and so calls no reset. A
+            # private generator from entropy keeps the global object unread here
+            # too, so the unseeded cell's count of reseed calls is not disturbed.
+            self._rng = random.Random()
         value = self._rng.random()
         self.drawn.append(value)
         return [{key: value - 0.5 for key in self.keys}]
@@ -217,7 +215,14 @@ class TestTheSeedIsAppliedOnTheEvalPath:
         assert runs[0], "the policy must have been queried, or nothing is measured"
         assert runs[0] == runs[1], "a seeded eval must replay identically"
 
-    def test_a_stray_global_draw_mid_rollout_does_not_change_the_replay(self, arm_xml: Path) -> None:
+    @pytest.mark.parametrize(
+        "where",
+        ["between two of the policy's queries", "inside set_eval_seed, after random.seed"],
+        ids=["between-queries", "inside-set_eval_seed"],
+    )
+    def test_a_stray_global_draw_mid_rollout_does_not_change_the_replay(
+        self, arm_xml: Path, monkeypatch: pytest.MonkeyPatch, where: str
+    ) -> None:
         """The stream the seed selects is not the rollout's alone to read.
 
         ``set_eval_seed`` reseeds the *process-global* RNG, and everything else in
@@ -227,41 +232,96 @@ class TestTheSeedIsAppliedOnTheEvalPath:
         assertion above could fail for a draw the rollout never made, on a branch
         that touched no RNG code, and report it as an unapplied seed.
 
-        The stray reader here is a ``success_fn``, which the eval loop calls after
-        each step: a real consumer of the same global object, in one run of the
-        pair, at a step of this test's choosing. The episode seeds are compared
-        too, so a divergence can only come from the reading, not the seeding.
+        The stray reader is a real consumer of the same global object, in one run
+        of the pair, placed by this test - a synchronous stand-in for a thread, so
+        the case is deterministic. Two placements, because two instruments were
+        exposed differently: a ``success_fn`` drawing after step 3 refuses a
+        policy that reads ``random.random()`` directly; a draw made inside
+        ``set_eval_seed`` after ``random.seed`` - here, from a NumPy reseed that
+        also draws - refuses a policy that copies the global state once
+        ``set_eval_seed`` returns, since ``set_eval_seed`` continues into NumPy
+        and torch after ``random.seed`` and the copy is of whatever the shared
+        object holds by then. The episode seeds are compared too, so a divergence
+        can only come from the reading, not the seeding.
         """
+        np = pytest.importorskip("numpy")
+        real_numpy_seed = np.random.seed
 
-        def replay(interfere_at: int | None) -> tuple[list[float], list[Any]]:
+        def replay(noisy: bool) -> tuple[list[float], list[Any]]:
             steps = 0
 
             def success_fn(observation: dict[str, Any]) -> bool:
                 nonlocal steps
                 steps += 1
-                if steps == interfere_at:
+                if noisy and where.startswith("between") and steps == 3:
                     random.random()
                 return False
 
-            sim, policy = _sim_and_policy(arm_xml)
-            result = sim.eval_policy(
-                robot_name="arm",
-                policy_object=policy,
-                n_episodes=2,
-                max_steps=4,
-                control_frequency=30.0,
-                seed=7,
-                success_fn=success_fn,
-            )
-            sim.cleanup()
+            def numpy_seed_that_also_draws(seed: Any) -> None:
+                real_numpy_seed(seed)
+                random.random()
+
+            with pytest.MonkeyPatch.context() as patch:
+                if noisy and where.startswith("inside"):
+                    patch.setattr(np.random, "seed", numpy_seed_that_also_draws)
+                sim, policy = _sim_and_policy(arm_xml)
+                result = sim.eval_policy(
+                    robot_name="arm",
+                    policy_object=policy,
+                    n_episodes=2,
+                    max_steps=4,
+                    control_frequency=30.0,
+                    seed=7,
+                    success_fn=success_fn,
+                )
+                sim.cleanup()
             assert result["status"] == "success", _text(result)
             return list(policy.drawn), list(policy.reset_seeds)
 
-        quiet, quiet_seeds = replay(None)
-        noisy, noisy_seeds = replay(3)
+        quiet, quiet_seeds = replay(noisy=False)
+        noisy, noisy_seeds = replay(noisy=True)
         assert quiet, "the policy must have been queried, or nothing is measured"
         assert quiet_seeds == noisy_seeds, "the seed derivation must be identical, or nothing is isolated"
-        assert quiet == noisy, "a draw the rollout did not make changed what a seeded eval replayed"
+        assert quiet == noisy, f"a draw the rollout did not make ({where}) changed what a seeded eval replayed"
+
+    def test_every_seed_forwarded_to_the_policy_was_applied_with_set_eval_seed(
+        self, arm_xml: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The loop reseeds the process RNGs per episode, and the policy is told.
+
+        The policy above measures the forwarded seed, not the global reseed, so
+        the reseed has to be pinned as what it is - a call. ``set_eval_seed`` is
+        applied once with the master seed and once per episode, and each
+        per-episode value is the one ``policy.reset`` receives, in order: a
+        service-mode policy and an in-process one are then seeded alike.
+        Deleting the per-episode ``set_eval_seed`` from ``evaluate`` leaves the
+        forwarded seeds intact and fails only here.
+        """
+        import strands_robots.simulation.policy_runner as runner_mod
+
+        real = runner_mod.set_eval_seed
+        applied: list[int] = []
+
+        def recording(seed: int) -> None:
+            applied.append(seed)
+            real(seed)
+
+        monkeypatch.setattr(runner_mod, "set_eval_seed", recording)
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.eval_policy(
+            robot_name="arm",
+            policy_object=policy,
+            n_episodes=2,
+            max_steps=3,
+            control_frequency=30.0,
+            seed=7,
+        )
+        sim.cleanup()
+        assert result["status"] == "success", _text(result)
+        assert len(policy.reset_seeds) == 2, "one forwarded seed per episode"
+        assert applied == [7, *policy.reset_seeds], (
+            f"set_eval_seed applied {applied}; the policy was handed {policy.reset_seeds}"
+        )
 
     def test_two_evals_at_different_seeds_draw_different_actions(self, arm_xml: Path) -> None:
         """Non-vacuity: the equality above is the seed's doing, not determinism."""


### PR DESCRIPTION
Round 1 of #3331, landed as its own pull request: auto-merge squashed #3331 at `7901210` (14:29:02) while this commit was being verified, so the push at 14:50 landed on the fork branch of a merged pull request and never reached `main` - the #2015 shape from AGENTS.md step 5. This is that commit, cherry-picked onto `f469c13`; `git diff` against the verified commit is 0 lines.

Per #3329 (closed by #3331). Towards #3333, which tracks the two other files with the same shape.

## What #3331 shipped does not hold under the condition it names

#3331 took the measurement off the shared object by copying the global RNG state into a private generator in `reset()`, "the statement after `set_eval_seed`". Review measured that the two statements are not adjacent: `set_eval_seed` continues past `random.seed(seed)` into `np.random.seed`, `torch.manual_seed`, `torch.cuda.is_available()`, `torch.cuda.manual_seed_all` and two cuDNN writes before it returns - 0.3 ms after the reseed in steady state and 1.8 s the first time on a CUDA host - with the global instance readable throughout. Reproduced here: a background thread doing `random.getrandbits(128)` every 2 ms (a library trace-id generator) against `tests/simulation/test_rollout_seed_is_applied_or_refused.py` at `7901210` failed the file **1 run in 3**. The window was narrowed, not closed, and the exposure stayed probabilistic.

## The policy reads the shared object zero times

Every seeded rollout surface forwards the seed it applied to `policy.reset(seed=...)` - the contract a service-mode policy relies on, because its sampler runs in a process `set_eval_seed` cannot reach. The test policy now does what such a policy does: `reset` seeds a private `random.Random(seed)` and every draw comes from that object. There is no shared reader to race, so the exposure is removed rather than narrowed. `_fork_global_rng` is deleted.

What the comparison then observes is the forwarded seed. That the loop also applies each one with `set_eval_seed` is a *call*, and a new cell counts it as one - every seed `policy.reset` receives was applied with `set_eval_seed`, in order (`[7, ep0, ep1]`). Deleting the per-episode `set_eval_seed` at `policy_runner.py:3016` fails that cell and nothing else, so the regression #3331's case caught by accident is now caught by a cell that names its cause. The global reseed itself is already pinned with no rollout at all in `test_set_eval_seed_requires_a_seed.py::TestUsableSeedsAreStillApplied`.

## Two placements of the stray draw, because two instruments were exposed differently

`test_a_stray_global_draw_mid_rollout_does_not_change_the_replay` is parametrized. `between-queries` is #3331's case: a `success_fn` drawing after step 3, which refuses a policy reading `random.random()` directly. `inside-set_eval_seed` is new: a patched `np.random.seed` that also draws from `random`, which sits inside `set_eval_seed` after `random.seed` - a deterministic, synchronous stand-in for the thread in exactly the window the review measured. It refuses the state-copy instrument.

| instrument | `[between-queries]` | `[inside-set_eval_seed]` | `every_seed_forwarded_..._applied` |
|---|---|---|---|
| this head (`Random(seed)`) | pass | pass | pass |
| `random.random()` (before #3331) | **fail** | **fail** | pass |
| copy of global state in `reset` (#3331) | pass | **fail** | pass |
| per-episode `set_eval_seed` deleted at `policy_runner.py:3016` | pass | pass | **fail** |

Under the 2 ms reader, on this host:

| head | runs | result |
|---|---|---|
| `7901210` (#3331, state copy) | 3 | **1 failed** in 1 of 3 |
| this tree | 5 | 127 passed, all 5 - and at 0.2 ms |

## Tests

File: 127 passed. `ruff check` + `ruff format --check` clean; `assemble_changelog.py --check` OK. `scripts/check_whole_tree_graders.py` (118 graders) on `7901210` and on this tree: identical **26 failed / 4422 passed / 3 errors**, every failure pre-existing on a host without `lerobot` / `torch` - zero delta.

The fragment `changelog.d/3329-seeded-replay-reads-a-private-fork.md` is modified rather than duplicated: both changes land in the same release and the release note should describe the instrument that shipped, not the one it replaced. The fragment gate reads fragments the branch adds *or modifies*.

LOC: **+137 / -66**, of which the instrument itself is +5 / -15 (the fork helper and its docstring go; `Random(seed)` arrives); the rest is the new cell, the second parametrization, and prose brought in line with the design.

## Round 2 - `2c7162e0`: the required check was red on the new cell, and only in order

`call-test-lint` on `8b230c81` failed exactly one test, the new `test_every_seed_forwarded_to_the_policy_was_applied_with_set_eval_seed`, with `set_eval_seed applied []` beside two forwarded seeds - i.e. `evaluate` ran, reseeded, forwarded, and the patch saw none of it. The cell passes alone; it fails after `tests/simulation/test_policy_runner.py::test_policy_runner_import_does_not_pull_in_mujoco`, which sorts before it and runs before it in CI.

Mechanism, measured rather than inferred: that sibling deletes the runner's `sys.modules` entry and re-imports it to attribute any `mujoco` import. The re-import rebinds the *package attribute* `strands_robots.simulation.policy_runner` to the fresh module object; `monkeypatch.delitem` restores the `sys.modules` entry and nothing else. `import strands_robots.simulation.policy_runner as runner_mod`, executed at test time, resolves through that attribute (`IMPORT_FROM` reads the attribute before it falls back to `sys.modules`), so the cell patched the fresh module while `PolicyRunner.evaluate.__globals__` is, and stays, the original module's dict:

```
before: pkg attr is sys.modules entry: True  | evaluate globals is orig: True
after : runner_mod is orig: False | runner_mod is pkg attr: True | pkg attr is fresh: True
after : sys.modules[PolicyRunner.__module__] is orig: True | evaluate.__globals__ is vars(orig): True
```

The two sibling tests that patch this module and stay green bind it at *collection* (`from strands_robots.simulation import policy_runner` at module scope), before any test can rebind the attribute; this cell bound it inside the function body, which is the whole difference.

Fix, one concern: patch `PolicyRunner.evaluate.__globals__` via `monkeypatch.setitem`, through the `PolicyRunner` this file already imports at collection - the class `eval_policy` instantiates - with a premise assertion that the seam holds the `set_eval_seed` this file imported. Same shape as `_patch_runner` in `test_run_policy_multi_episode.py`, one level down. The docstring records the mechanism so the next reader does not re-derive it.

| run | `8b230c81` | `2c7162e0` |
|---|---|---|
| leak cell, then this cell (CI order) | **1 failed** | 2 passed |
| this cell alone | 1 passed | 1 passed |
| file + `test_policy_runner.py` + `test_set_eval_seed_requires_a_seed.py` | - | 205 passed, 3 skipped |
| whole-tree roster (118 graders, `--continue-on-collection-errors`) | - | 4463 passed, 26 failed, 2 errors - every failure `lerobot` / `json5` / `awsiot` / `msgpack` / render, none in this file |

`ruff check`, `ruff format --check`, `mypy` on the file: clean. Diff: one test body, +16 / -5.

The sibling's attribute leak is a hazard for any test that binds the runner module at test time; that is a separate concern and is filed rather than folded in here.