### PR TITLE
fix(tests): a re-imported module is put back on its parent package, not only in sys.modules

### DIFF
--- a/changelog.d/3336-reimport-restores-the-parent-binding.md
+++ b/changelog.d/3336-reimport-restores-the-parent-binding.md
@@ -1,0 +1,37 @@
+### Tests: a re-imported module is put back on its parent package, not only in `sys.modules`
+
+`importlib.import_module` binds a submodule in two places: the `sys.modules`
+entry, and an attribute of the same name on its parent package.
+`monkeypatch.delitem` restores the first. Two cells removed an entry so a
+module's top level would run again -
+`tests/simulation/test_policy_runner.py::test_policy_runner_import_does_not_pull_in_mujoco`
+and
+`tests/tools/g1/test_motion_switcher_decoder.py::test_module_can_be_imported_without_the_sdk` -
+and put back one of the two. For the rest of the session the parent package
+carried the fresh module while `sys.modules` held the original, and which of the
+two a spelling reaches is not visible where it is written: `import a.b.c as m`,
+`import a.b.c` and `from a.b import c` all resolve through the attribute, while
+`sys.modules[...]`, `from a.b.c import f` and the live code's own globals resolve
+through the entry.
+
+Restoring one of the two is worse than restoring neither. With neither restored
+both halves hold the fresh module and agree; with only the entry restored a cell
+that binds the module inside its body and patches an attribute on it patches the
+copy production does not read, so the stub is inert and the cell grades nothing
+while still passing.
+
+That was live. `tests/tools/test_run_policy.py` binds the runner in-cell to
+install a `PolicyRunner` that raises, and its two cells pin that
+`strands_robots.tools.run_policy._finalize_episode` tolerates a construction
+error and a save error. With both `except Exception` guards deleted from that
+function, the two cells failed on their own and passed after the split was left
+behind - the ordering the full suite collects, `tests/simulation` before
+`tests/tools`.
+
+`tests/_module_reimport.reimport` records both bindings before importing, and
+both cells ask it instead of spelling the pair out. `tests/test_sys_modules_removal_leaves_no_orphan.py`
+grades the rule tree-wide beside the orphan rule it already carried, reading the
+key through a local binding because that is how the graded cells spell it, and
+leaving alone the two remaining remove-and-import cells whose shape cannot split:
+one drives an import that raises, which binds nothing, and one never restores the
+entry.

--- a/tests/_module_reimport.py
+++ b/tests/_module_reimport.py
@@ -1,0 +1,76 @@
+"""A fresh import that puts back every binding the import rebound.
+
+``importlib.import_module`` binds a submodule in **two** places: the
+``sys.modules`` entry, and an attribute of the same name on its parent package.
+A cell that wants a module's top level to run again therefore has two things to
+undo, and ``monkeypatch`` restores whichever ones it was told about. Told about
+only the entry, the fresh module outlives the cell as ``parent.leaf`` while
+``sys.modules`` holds the original, and the two paths stop naming the same
+object for the rest of the session::
+
+    monkeypatch.delitem(sys.modules, "a.b.c", raising=False)
+    importlib.import_module("a.b.c")        # rebinds a.b.c AND a.b's attribute
+    ...                                    # teardown restores only the entry
+
+    import a.b.c as m                      # -> the fresh module (attribute)
+    from a.b.c import f                    # -> the original's f (entry)
+    monkeypatch.setattr(m, "f", double)    # patches the fresh module; the
+                                           # production `from a.b.c import f`
+                                           # still reaches the original
+
+Which side a spelling lands on is not obvious, and both spellings are common in
+this tree, so the split is silent: a stub goes on one module and the code under
+test reads the other, and the cell passes while grading nothing.
+
+Measured, with ``strands_robots.simulation.policy_runner`` split this way and
+both ``except Exception`` guards deleted from
+:func:`strands_robots.tools.run_policy._finalize_episode` - the very tolerance
+those cells exist to pin:
+
+===================================================  ======================
+selection                                            outcome
+===================================================  ======================
+the two ``test_finalize_swallows_*`` cells alone      2 failed
+the same two after the split is left behind          2 passed
+===================================================  ======================
+
+Reaching for this function instead of the two statements keeps the pair
+together. It is the only place in the test trees that removes a ``sys.modules``
+entry in order to import it again;
+:mod:`tests.test_sys_modules_removal_leaves_no_orphan` grades that.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def reimport(monkeypatch: pytest.MonkeyPatch, name: str) -> ModuleType:
+    """Run *name*'s top level again, and put both of its bindings back after.
+
+    Args:
+        monkeypatch: The cell's fixture, which performs the restoration at
+            teardown. Both bindings are recorded on it before the import, so
+            an assertion failure between here and teardown still restores.
+        name: Dotted module path, e.g. ``"strands_robots.simulation.policy_runner"``.
+            A top-level name has no parent package to rebind and only needs the
+            entry.
+
+    Returns:
+        The freshly imported module - the object ``sys.modules`` holds until
+        teardown, so a cell that wants to read the new copy has it without
+        going back through an import spelling.
+    """
+    parent_name, _, leaf = name.rpartition(".")
+    if parent_name:
+        parent = importlib.import_module(parent_name)
+        # ``raising=False`` is what covers a parent that does not carry the
+        # attribute yet: monkeypatch records "absent" and deletes at teardown,
+        # so a module nothing had imported is not left bound either.
+        monkeypatch.setattr(parent, leaf, getattr(parent, leaf, None), raising=False)
+    monkeypatch.delitem(sys.modules, name, raising=False)
+    return importlib.import_module(name)

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -13,7 +13,6 @@ pure-Python ``FakeSim`` stub, plus the real-backend behaviours:
 from __future__ import annotations
 
 import base64
-import importlib
 import inspect
 import io
 import os
@@ -39,6 +38,7 @@ from strands_robots.simulation.policy_runner import (
     _extract_frame_ndarray,
     _RolloutVideoWriter,
 )
+from tests._module_reimport import reimport
 from tests.simulation.mujoco._gl_probe import requires_gl
 
 #
@@ -144,13 +144,18 @@ def test_policy_runner_import_does_not_pull_in_mujoco(monkeypatch):
     asserts only that the entries just deleted are gone, which is true whatever
     the runner's top level does.
 
-    Both removals go through ``monkeypatch`` so the entries are put back.
+    Every removal goes through ``monkeypatch`` so the entries are put back.
     Leaving the runner out of ``sys.modules`` does not undo its import, it
     orphans the references siblings already hold -
     ``test_rollout_video_realtime_fps`` and
     ``test_rollout_durations_survive_a_clock_step`` bind the module and patch
     attributes on it, and ``test_recording_frame_loss_is_not_tolerated`` reads
     its entry directly.
+
+    The re-import goes through :func:`tests._module_reimport.reimport` because
+    the entry is not the only thing it rebinds: it also binds the fresh module
+    as ``policy_runner`` on ``strands_robots.simulation``, and restoring one
+    without the other leaves the two paths naming different objects.
     """
     runner = "strands_robots.simulation.policy_runner"
 
@@ -159,8 +164,7 @@ def test_policy_runner_import_does_not_pull_in_mujoco(monkeypatch):
         monkeypatch.delitem(sys.modules, mod)
 
     # Force a fresh import of the runner module, and perform it.
-    monkeypatch.delitem(sys.modules, runner, raising=False)
-    importlib.import_module(runner)
+    reimport(monkeypatch, runner)
 
     leaked = [m for m in sys.modules if m.startswith("mujoco")]
     assert not leaked, (

--- a/tests/test_sys_modules_removal_leaves_no_orphan.py
+++ b/tests/test_sys_modules_removal_leaves_no_orphan.py
@@ -67,6 +67,41 @@ It is deliberately one-directional and under-reports rather than over-reports:
 ``monkeypatch.setitem(sys.modules, name, None)`` is the idiom for "make
 ``import name`` raise ``ImportError``": it has the same effect and it restores.
 ``tests/mesh/test_iot_camera_offload.py`` uses it for ``cv2`` in the same file.
+
+A second rule lives here, for the cells that remove an entry in order to
+**import the module again**. ``importlib.import_module`` binds a submodule in
+two places - the ``sys.modules`` entry, and an attribute of the same name on its
+parent package - and ``monkeypatch.delitem`` restores only the first. Restoring
+one of the two is worse than restoring neither: with neither restored both halves
+hold the fresh module and agree, while with only the entry restored the two
+disagree for the rest of the session, and which one a spelling reaches is not
+visible at the call site. Measured after
+``test_policy_runner_import_does_not_pull_in_mujoco``, with the entry restored::
+
+    import a.b.c as m                 -> the fresh module
+    import a.b.c ; a.b.c              -> the fresh module
+    from a.b import c as m            -> the fresh module
+    sys.modules["a.b.c"]              -> the original
+    from a.b.c import f               -> the original's f
+    <the live code's own globals>     -> the original
+
+So a cell that binds the module *inside* its body and patches an attribute on it
+patches the fresh copy, while production's ``from a.b.c import f`` reads the
+original: the stub is silently inert and the cell grades nothing. That is not
+hypothetical. With ``strands_robots.simulation.policy_runner`` split this way,
+``tests/tools/test_run_policy.py`` binds it in-cell to install a ``PolicyRunner``
+that raises, and the two cells pinning that
+``strands_robots.tools.run_policy._finalize_episode`` tolerates a construction
+error and a save error keep passing with both ``except Exception`` guards deleted
+from production - they alone report the deletion.
+
+:func:`tests._module_reimport.reimport` records both bindings, and
+:class:`TestAReimportPutsTheParentBindingBack` grades that every re-importing
+cell goes through it or an equivalent ``setattr``. Two cells are in scope. The
+two others that remove-and-import are not, for reasons the scan reads rather
+than lists: ``tests/test_dashboard_extra_is_declared.py`` drives an import that
+*raises*, which binds nothing, and ``tests/test_device_connect_drivers.py``
+never restores the entry, so both halves agree on the fresh module.
 """
 
 from __future__ import annotations
@@ -469,3 +504,310 @@ class TestTheOrphaningMechanism:
 
         assert held.value == "double", "premise: the patch reached the object it was applied to"
         assert fresh.value == 1, "the fresh module does not carry the patch - the double is orphaned"
+
+
+#: A re-importing population smaller than this means the second scan stopped
+#: reaching the tree. Two cells re-import a module they removed; both are
+#: named in :meth:`TestAReimportPutsTheParentBindingBack.test_the_reimporting_cells_are_found`.
+_MINIMUM_REIMPORTS = 2
+
+#: The shared owner of "remove, import again, put both bindings back".
+_REIMPORT_HELPER = "reimport"
+
+
+def _literal_str(node: ast.AST, names: dict[str, str]) -> str | None:
+    """The string *node* evaluates to, following simple local bindings."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return names.get(node.id)
+    return None
+
+
+def _string_names(*scopes: ast.AST) -> dict[str, str]:
+    """``name -> value`` for each ``name = "literal"`` assignment in *scopes*.
+
+    The key a cell removes is as often bound to a local as written inline
+    (``runner = "strands_robots.simulation.policy_runner"``), so a scan that
+    reads only ``ast.Constant`` cannot see the cells this rule exists for.
+    Anything more involved than a plain string assignment is out of reach of a
+    static read and is not claimed.
+    """
+    bound: dict[str, str] = {}
+    for scope in scopes:
+        for node in ast.walk(scope):
+            if (
+                isinstance(node, ast.Assign)
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
+            ):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        bound[target.id] = node.value.value
+    return bound
+
+
+def _lines_under_raises(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[int]:
+    """Line numbers inside a ``with pytest.raises(...)`` block in *fn*.
+
+    An import that raises binds nothing - not the entry and not the attribute -
+    so a cell driving a *failing* import has nothing to put back.
+    ``tests/test_dashboard_extra_is_declared.py`` is that shape.
+    """
+    lines: set[int] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.With | ast.AsyncWith) and any(
+            "raises" in ast.unparse(item.context_expr) for item in node.items
+        ):
+            lines.update(getattr(child, "lineno", -1) for child in ast.walk(node))
+    return lines
+
+
+def _restored_removal_keys(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef, registries: set[str], names: dict[str, str]
+) -> set[str]:
+    """Keys *fn* removes from ``sys.modules`` through the restoring idiom.
+
+    Only ``monkeypatch.delitem`` is read. A removal that is *not* restored is
+    the other rule's business, and it cannot produce the asymmetry this one
+    grades: with the entry left holding the fresh module, the parent attribute
+    holds the same fresh module and the two paths still agree.
+    """
+    keys: set[str] = set()
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "delitem"
+            and len(node.args) >= 2
+            and ast.unparse(node.args[0]) in registries
+        ):
+            if key := _literal_str(node.args[1], names):
+                keys.add(key)
+    return keys
+
+
+def _reimported_keys(fn: ast.FunctionDef | ast.AsyncFunctionDef, names: dict[str, str]) -> dict[str, int]:
+    """``key -> lineno`` for every module *fn* imports, outside a ``raises`` block."""
+    exempt = _lines_under_raises(fn)
+    found: dict[str, int] = {}
+    for node in ast.walk(fn):
+        if getattr(node, "lineno", -1) in exempt:
+            continue
+        if isinstance(node, ast.Call) and ast.unparse(node.func).endswith("import_module") and node.args:
+            if key := _literal_str(node.args[0], names):
+                found.setdefault(key, node.lineno)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                found.setdefault(alias.name, node.lineno)
+        elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
+            found.setdefault(node.module, node.lineno)
+    return found
+
+
+def _delegated_keys(fn: ast.FunctionDef | ast.AsyncFunctionDef, names: dict[str, str]) -> dict[str, int]:
+    """``key -> lineno`` for each module *fn* re-imports through the shared owner.
+
+    A delegating cell is *in scope and satisfied*, rather than invisible. That
+    is what keeps the population the same size before and after a cell is
+    moved onto the owner, so the floor in
+    :meth:`TestAReimportPutsTheParentBindingBack.test_the_reimporting_cells_are_found`
+    means "the scan is still reaching the tree" rather than "nobody re-imports
+    anything today".
+    """
+    found: dict[str, int] = {}
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Call)
+            and (ast.unparse(node.func) == _REIMPORT_HELPER or ast.unparse(node.func).endswith(f".{_REIMPORT_HELPER}"))
+            and len(node.args) >= 2
+        ):
+            if key := _literal_str(node.args[1], names):
+                found.setdefault(key, node.lineno)
+    return found
+
+
+def _restores_the_leaf(fn: ast.FunctionDef | ast.AsyncFunctionDef, leaf: str) -> bool:
+    """Whether *fn* records an attribute named *leaf* for restoration itself.
+
+    Permissive in the same way :func:`_restores` is: the point is that the pair
+    is kept together, not which spelling keeps it.
+    """
+    return any(
+        isinstance(node, ast.Call)
+        and ast.unparse(node.func).endswith("setattr")
+        and len(node.args) >= 2
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value == leaf
+        for node in ast.walk(fn)
+    )
+
+
+def reimporting_cells(tree: ast.Module) -> list[tuple[int, str, str, bool]]:
+    """``(lineno, function, key, puts_it_back)`` per cell that re-imports what it removed.
+
+    In scope either way it is spelled: the cell removes the entry through
+    ``monkeypatch.delitem`` and imports the module again itself, or it asks the
+    shared owner to do both.
+    """
+    registries = {f"{alias}.modules" for alias in _sys_aliases(tree)}
+    module_names = _string_names(*tree.body)
+    reported: list[tuple[int, str, str, bool]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        names = module_names | _string_names(node)
+        delegated = _delegated_keys(node, names)
+        reimported = _reimported_keys(node, names)
+        hand_rolled = _restored_removal_keys(node, registries, names) & set(reimported)
+        for key in sorted(set(delegated) | hand_rolled):
+            if "." not in key:
+                continue  # a top-level module has no parent package to rebind
+            lineno = delegated.get(key) or reimported[key]
+            puts_it_back = key in delegated or _restores_the_leaf(node, key.rpartition(".")[2])
+            reported.append((lineno, node.name, key, puts_it_back))
+    return reported
+
+
+def splitting_reimports() -> list[str]:
+    """Every cell that re-imports a module and leaves the parent binding split."""
+    offenders: list[str] = []
+    for path in _graded_files():
+        tree = _parse(path)
+        if tree is None:
+            continue
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        for lineno, function, key, restored in reimporting_cells(tree):
+            if not restored:
+                parent, _, leaf = key.rpartition(".")
+                offenders.append(
+                    f"{rel}:{lineno} in {function}() re-imports {key!r} without restoring {leaf!r} on {parent}"
+                )
+    return offenders
+
+
+class TestAReimportPutsTheParentBindingBack:
+    """The second rule: an import rebinds two things, so two go back."""
+
+    def test_no_reimport_leaves_the_parent_binding_split(self) -> None:
+        offenders = splitting_reimports()
+        assert offenders == [], (
+            "a test removes a sys.modules entry, imports the module again, and restores "
+            "only the entry - so the fresh module stays bound as an attribute of its "
+            "parent package while sys.modules holds the original, and for the rest of "
+            "the session `import a.b.c as m` and `from a.b.c import f` name different "
+            "objects. A stub then goes on one and the code under test reads the other. "
+            "Import through tests._module_reimport.reimport, which records both:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_the_reimporting_cells_are_found(self) -> None:
+        """So a clean result means the scan looked, rather than found nothing to look at."""
+        found = {
+            (path.relative_to(_REPO_ROOT).as_posix(), key)
+            for path in _graded_files()
+            if (tree := _parse(path)) is not None
+            for _, _, key, _ in reimporting_cells(tree)
+        }
+        assert len(found) >= _MINIMUM_REIMPORTS, (
+            f"only {len(found)} re-importing cells read as in scope; the scan is no "
+            f"longer reaching {_TEST_TREES} under {_REPO_ROOT}: {sorted(found)}"
+        )
+        expected = {
+            ("tests/simulation/test_policy_runner.py", "strands_robots.simulation.policy_runner"),
+            ("tests/tools/g1/test_motion_switcher_decoder.py", "strands_robots.tools.g1._motion_switcher"),
+        }
+        assert expected <= found, (
+            "these cells remove an entry and import the module again, so the rule has "
+            f"to reach them; missing {sorted(expected - found)}"
+        )
+
+
+class TestTheReimportScanIsSpecific:
+    """Planted sources, so a clean tree means the rule works rather than accepts anything."""
+
+    _REMOVE_AND_IMPORT = (
+        "import importlib",
+        "import sys",
+        "def test_x(monkeypatch):",
+        "    monkeypatch.delitem(sys.modules, 'a.b.c', raising=False)",
+        "    importlib.import_module('a.b.c')",
+    )
+
+    def test_restoring_only_the_entry_is_reported(self) -> None:
+        source = "\n".join(self._REMOVE_AND_IMPORT)
+        assert reimporting_cells(ast.parse(source)) == [(5, "test_x", "a.b.c", False)]
+
+    def test_the_shared_owner_is_accepted(self) -> None:
+        source = "\n".join(
+            [
+                "from tests._module_reimport import reimport",
+                "def test_x(monkeypatch):",
+                "    reimport(monkeypatch, 'a.b.c')",
+            ]
+        )
+        assert reimporting_cells(ast.parse(source)) == [(3, "test_x", "a.b.c", True)]
+
+    def test_an_explicit_setattr_on_the_parent_is_accepted(self) -> None:
+        source = "\n".join(
+            [
+                *self._REMOVE_AND_IMPORT[:4],
+                "    monkeypatch.setattr(a.b, 'c', a.b.c)",
+                "    importlib.import_module('a.b.c')",
+            ]
+        )
+        assert reimporting_cells(ast.parse(source)) == [(6, "test_x", "a.b.c", True)]
+
+    def test_a_key_bound_to_a_local_is_read(self) -> None:
+        """The spelling the graded cells use, and the one a literal-only scan misses."""
+        source = "\n".join(
+            [
+                "import importlib",
+                "import sys",
+                "def test_x(monkeypatch):",
+                "    name = 'a.b.c'",
+                "    monkeypatch.delitem(sys.modules, name, raising=False)",
+                "    importlib.import_module(name)",
+            ]
+        )
+        assert reimporting_cells(ast.parse(source)) == [(6, "test_x", "a.b.c", False)]
+
+    def test_an_import_that_raises_is_not_claimed(self) -> None:
+        """A failing import binds nothing, so it leaves nothing to put back."""
+        source = "\n".join(
+            [
+                "import importlib",
+                "import sys",
+                "import pytest",
+                "def test_x(monkeypatch):",
+                "    monkeypatch.delitem(sys.modules, 'a.b.c', raising=False)",
+                "    with pytest.raises(ImportError):",
+                "        importlib.import_module('a.b.c')",
+            ]
+        )
+        assert reimporting_cells(ast.parse(source)) == []
+
+    def test_an_unrestored_removal_is_the_other_rule(self) -> None:
+        """Both halves then hold the fresh module, so this rule has nothing to say."""
+        source = "\n".join(
+            [
+                "import importlib",
+                "import sys",
+                "def test_x():",
+                "    del sys.modules['a.b.c']",
+                "    importlib.import_module('a.b.c')",
+            ]
+        )
+        assert reimporting_cells(ast.parse(source)) == []
+
+    def test_a_top_level_module_is_not_claimed(self) -> None:
+        """There is no parent package to rebind."""
+        source = "\n".join(
+            [
+                "import importlib",
+                "import sys",
+                "def test_x(monkeypatch):",
+                "    monkeypatch.delitem(sys.modules, 'boto3', raising=False)",
+                "    importlib.import_module('boto3')",
+            ]
+        )
+        assert reimporting_cells(ast.parse(source)) == []

--- a/tests/tools/g1/test_motion_switcher_decoder.py
+++ b/tests/tools/g1/test_motion_switcher_decoder.py
@@ -35,6 +35,7 @@ from strands_robots.tools.g1._motion_switcher import (
     decode_fsm_id,
     read_fsm_id,
 )
+from tests._module_reimport import reimport
 
 
 class _FakeSwitcherClient:
@@ -373,16 +374,20 @@ class TestModuleImportsWithoutTheSDK:
         binds it at module level and patches
         :func:`_load_motion_switcher_client` on it, and against an orphan that
         patch is invisible to the driver's own lazy import.
+
+        Putting the entry back is not enough on its own, which is why the
+        re-import goes through :func:`tests._module_reimport.reimport`: the
+        import also binds the fresh module as ``_motion_switcher`` on
+        ``strands_robots.tools.g1``, and a sibling that binds the module inside
+        a cell reads that attribute rather than the restored entry.
         """
-        import importlib
         import sys
 
         # Snapshot the SDK modules present before the re-import.
         before = {k for k in sys.modules if k.startswith("unitree_sdk2py")}
 
         # Force a fresh import so the module's top-level runs again.
-        monkeypatch.delitem(sys.modules, "strands_robots.tools.g1._motion_switcher", raising=False)
-        importlib.import_module("strands_robots.tools.g1._motion_switcher")
+        reimport(monkeypatch, "strands_robots.tools.g1._motion_switcher")
 
         after = {k for k in sys.modules if k.startswith("unitree_sdk2py")}
         # The re-import must not have added any new ``unitree_sdk2py`` entries.


### PR DESCRIPTION
## Problem

`importlib.import_module` binds a submodule in **two** places: the `sys.modules` entry, and an attribute of the same name on its parent package. `monkeypatch.delitem` restores the first.

Two cells remove an entry so a module's top level runs again, and put back one of the two:

| cell | module |
| --- | --- |
| `tests/simulation/test_policy_runner.py::test_policy_runner_import_does_not_pull_in_mujoco` | `strands_robots.simulation.policy_runner` |
| `tests/tools/g1/test_motion_switcher_decoder.py::test_module_can_be_imported_without_the_sdk` | `strands_robots.tools.g1._motion_switcher` |

For the rest of the session the parent package then carries the fresh module while `sys.modules` holds the original, and **which of the two a spelling reaches is not visible where it is written.** Measured immediately after the first cell:

| spelling | resolves to |
| --- | --- |
| `import a.b.c as m` | the fresh module |
| `import a.b.c` then `a.b.c` | the fresh module |
| `from a.b import c as m` | the fresh module |
| `sys.modules["a.b.c"]` | the original |
| `from a.b.c import f` | the original's `f` |
| the live code's own globals | the original |

Restoring one of the two is worse than restoring neither: with neither restored both halves hold the fresh module and agree. With only the entry restored, a cell that binds the module *inside its body* and patches an attribute on it patches the copy production does not read — the stub is inert and the cell grades nothing, while still passing.

## That was live on `main`

`tests/tools/test_run_policy.py` binds the runner in-cell to install a `PolicyRunner` that raises, and its two `test_finalize_swallows_*` cells pin that `strands_robots.tools.run_policy._finalize_episode` tolerates a construction error and a save error. Deleting **both** `except Exception` guards from that function:

| tree | the two cells alone | the same two after `test_policy_runner_import_does_not_pull_in_mujoco` |
| --- | --- | --- |
| `main` (`6407ec4`) | 2 failed | **2 passed** |
| this branch | 2 failed | 2 failed |

The right-hand column is the ordering the full suite collects — `tests/simulation` sorts before `tests/tools`. So on `main` those two cells report a production deletion only when they are run on their own.

## Change

`tests/_module_reimport.reimport(monkeypatch, name)` records both bindings before importing, and both cells ask it instead of spelling the pair out. `raising=False` on the attribute covers a parent that does not carry it yet: monkeypatch records "absent" and deletes at teardown, so a module nothing had imported is not left bound either.

`tests/test_sys_modules_removal_leaves_no_orphan.py` — whose existing rule is "a removal leaves no orphan", and which reads only the `sys.modules` half of what an import binds — now grades this half too, beside it. The key is read through a local binding (`runner = "strands_robots.simulation.policy_runner"`) because that is how the graded cells spell it; a literal-only scan cannot see either of them.

Two further cells remove-and-import and are **not** in scope, for reasons the scan reads rather than lists: `tests/test_dashboard_extra_is_declared.py` drives an import that *raises*, which binds nothing, and `tests/test_device_connect_drivers.py` never restores the entry, so both halves agree on the fresh module. Both were confirmed by instrumenting a run: neither leaves the two paths disagreeing.

## Tests

The new rule reverted to the two cells' previous shape, guard present:

```
tests/simulation/test_policy_runner.py:163 in test_policy_runner_import_does_not_pull_in_mujoco()
    re-imports 'strands_robots.simulation.policy_runner' without restoring 'policy_runner' on strands_robots.simulation
tests/tools/g1/test_motion_switcher_decoder.py:385 in test_module_can_be_imported_without_the_sdk()
    re-imports 'strands_robots.tools.g1._motion_switcher' without restoring '_motion_switcher' on strands_robots.tools.g1
1 failed, 24 passed
```

With the cells fixed: 25 passed. The 24 that hold both ways are the controls and the planted sources — including one for each accepted shape (the shared owner, an explicit `setattr`, an import under `pytest.raises`, an unrestored removal, a top-level module with no parent package to rebind) and one for the local-binding spelling a literal-only scan misses.

An instrumented run confirms no module is left with its attribute and its entry disagreeing, and the seeded-replay suite's ordering-dependent failure goes away (41 passed after the polluting cell, where it previously reported `set_eval_seed applied []` for a rollout that applied three seeds).

## Gate

- `ruff check` / `ruff format --check strands_robots tests tests_integ` clean (0.15.20, 1960 files)
- `mypy strands_robots tests tests_integ` — `Success: no issues found in 1957 source files` (1.20.2)
- Every tree-walking guard (497 files) plus `tests/simulation tests/tools tests/drivers`: **37338 passed, 108 skipped**, 38m34s. 7 failed, all pre-existing on this host and unrelated: 6 assert `rclpy` is absent where `/opt/ros/jazzy` supplies it, 1 is `newton/test_multi_camera.py` asserting older wording of a camera-shape refusal.
- All doc/xref/changelog graders: 237 + 91 passed. The xref grader caught a wrong symbol name in a draft docstring here, which is why it cites `_finalize_episode`.

## Size

Test-only. Both call sites get **smaller** (−1 executable statement each by AST); the additions are the shared owner (+12) and the rule (+116).

| file | added | removed |
| --- | --- | --- |
| `tests/_module_reimport.py` | 76 | 0 |
| `tests/test_sys_modules_removal_leaves_no_orphan.py` | 342 | 0 |
| `tests/simulation/test_policy_runner.py` | 8 | 4 |
| `tests/tools/g1/test_motion_switcher_decoder.py` | 8 | 3 |
| `changelog.d/3336-*.md` | 37 | 0 |