### PR TITLE
test(simulation): two more seeded-replay cells read the forwarded seed, not the global RNG

### DIFF
--- a/changelog.d/3333-seeded-replay-reads-the-forwarded-seed.md
+++ b/changelog.d/3333-seeded-replay-reads-the-forwarded-seed.md
@@ -1,0 +1,30 @@
+### Tests: two more seeded-replay cells no longer compare the process-global RNG across a rollout
+
+A rollout seed's reproducibility half is only observable through something whose
+output depends on the RNG state the seed sets, and the RNG a rollout seed sets is
+the *process-global* one. Two cells measured it by reading that shared object for
+the length of a rollout, so each also assumed the rollout was its only reader:
+`test_run_policy_seed_reproducibility.py::test_same_seed_same_trajectory` drew
+from `random.random()` / `np.random.random()` inside the policy double, and
+`test_policy_runner_benchmark.py::TestEvalSeeding::test_evaluate_benchmark_reseeds_per_episode`
+drew from the `random` module inside the benchmark spec's `on_episode_start`. One
+stray draw between two of those reads shifts everything after it, and the
+comparison reports it as an unapplied seed - a failure for a draw the rollout
+never made.
+
+Each cell now reads the seeded value the rollout hands it and the shared object
+zero times: the policy double seeds a private `random.Random(seed)` /
+`np.random.default_rng(seed)` in `reset(seed=...)`, and the benchmark spec draws
+from the `episode_rng` the eval loop derives for that episode. What they stop
+observing - that the rollout reseeds the global RNGs at all - is a call, and two
+new cells count it as one, on the single-rollout path and per episode.
+
+`TestEvalSeeding`'s two direct `set_eval_seed` draw-comparisons are removed: a
+cell whose subject is a global reseed has to read the global object, and that
+contract is already pinned, over a wider set of seeds, in
+`test_set_eval_seed_requires_a_seed.py::TestUsableSeedsAreStillApplied`. Pinning
+it in one place with the shortest window, rather than in two, is the whole
+remedy available to that shape.
+
+A tree-wide check keeps the property: a `Policy` subclass in the suite may build
+a private generator, and may not draw from the shared one.

--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -29,7 +29,7 @@ from strands_robots.simulation.benchmark import (
     StepInfo,
     register_benchmark,
 )
-from strands_robots.simulation.policy_runner import CooperativeStop, PolicyRunner
+from strands_robots.simulation.policy_runner import CooperativeStop, PolicyRunner, set_eval_seed
 
 # Fixtures
 
@@ -837,39 +837,17 @@ class TestEvalSeeding:
     ``Isaac-GR00T/scripts/deployment/standalone_inference_script.py:81``,
     minus the global ``CUBLAS_WORKSPACE_CONFIG`` env var and
     ``torch.use_deterministic_algorithms(...)`` flag that would persist
-    after the eval. Tests target the seeding helper directly + verify
-    the per-episode RNG path still works via ``episode_rng``.
+    after the eval.
+
+    What is pinned here is the eval loop's use of the helper: that it applies a
+    seed per episode, and that the per-episode ``episode_rng`` it derives is
+    reproducible. That ``set_eval_seed`` itself makes the global Python and NumPy
+    streams reproducible is a property of the helper, pinned without a rollout in
+    ``tests/simulation/test_set_eval_seed_requires_a_seed.py``
+    (``TestUsableSeedsAreStillApplied``) over a wider set of seeds - a cell whose
+    subject is a global reseed has to read the global object, so it is pinned in
+    one place, with the shortest possible window, rather than in two.
     """
-
-    def test_set_eval_seed_seeds_python_random(self):
-        """Round 38 (#168): ``set_eval_seed`` seeds the Python ``random``
-        module so two calls with the same seed produce the same draw.
-
-        Pin the basic contract in case future refactors move the seeding
-        out of the helper."""
-        import random as _stdlib_random
-
-        from strands_robots.simulation.policy_runner import set_eval_seed
-
-        set_eval_seed(42)
-        first = [_stdlib_random.random() for _ in range(5)]
-        set_eval_seed(42)
-        second = [_stdlib_random.random() for _ in range(5)]
-        assert first == second
-
-    def test_set_eval_seed_seeds_numpy(self):
-        """Round 38 (#168): ``set_eval_seed`` seeds NumPy's legacy
-        global RNG (``np.random.seed``). Pin so policies that use
-        ``np.random.rand`` etc. are reproducible across re-runs."""
-        import numpy as np
-
-        from strands_robots.simulation.policy_runner import set_eval_seed
-
-        set_eval_seed(42)
-        first = np.random.rand(5).tolist()
-        set_eval_seed(42)
-        second = np.random.rand(5).tolist()
-        assert first == second
 
     def test_set_eval_seed_tolerates_missing_torch(self, monkeypatch):
         """Round 38 (#168): ``set_eval_seed`` no-ops the torch branch
@@ -1013,21 +991,27 @@ class TestEvalSeeding:
         depends on the cumulative number of draws across all preceding
         episodes.
 
-        Mechanism: capture every ``random.random()`` call inside the
-        spec's ``on_episode_start`` (which fires AFTER the per-episode
-        ``set_eval_seed`` call). On re-run with the same master seed,
-        episode N's draws must match episode N's draws from the first
-        run; AND consecutive episodes must NOT be identical (proves we
-        seed with episode_seed, not master seed).
+        Mechanism: draw from the ``episode_rng`` the loop hands
+        ``on_episode_start`` - the generator it seeds from that episode's
+        derived seed. On re-run with the same master seed, episode N's
+        draws must match episode N's draws from the first run; AND
+        consecutive episodes must NOT be identical (proves we seed with
+        episode_seed, not master seed).
+
+        The draws used to come from the process-global ``random`` module,
+        which every other reader in the interpreter shares: one stray draw
+        between two episodes shifted the sequence and this cell reported it
+        as a lost per-episode reseed. ``episode_rng`` carries the same
+        derivation and nothing else can reach it. That the loop also applies
+        each episode seed globally is a call, counted as one by
+        ``test_set_eval_seed_is_applied_once_per_episode``.
         """
         # Closure-captured list that the spec writes to.
         run_a_draws: list[list[float]] = []
 
         class _RunACapture(_CountingBenchmark):
             def on_episode_start(self, sim, episode_rng):  # noqa: ARG002
-                import random as _r
-
-                run_a_draws.append([_r.random() for _ in range(5)])
+                run_a_draws.append([episode_rng.random() for _ in range(5)])
 
         sim_a = FakeSim()
         spec_a = _RunACapture()
@@ -1046,9 +1030,7 @@ class TestEvalSeeding:
 
         class _RunBCapture(_CountingBenchmark):
             def on_episode_start(self, sim, episode_rng):  # noqa: ARG002
-                import random as _r
-
-                run_b_draws.append([_r.random() for _ in range(5)])
+                run_b_draws.append([episode_rng.random() for _ in range(5)])
 
         sim_b = FakeSim()
         spec_b = _RunBCapture()
@@ -1078,6 +1060,56 @@ class TestEvalSeeding:
             "per-episode seeding may have used a constant instead of "
             "the per-episode-derived seed"
         )
+
+    def test_set_eval_seed_is_applied_once_per_episode(self, monkeypatch):
+        """The loop applies a seed per episode - counted as the call it is.
+
+        The cell above reads ``episode_rng`` rather than the global stream, so it
+        no longer observes that the loop reseeds the process-global RNGs at all.
+        That reseed is a call, and it is pinned as one here: once before the loop
+        with the master seed, then once per episode with that episode's derived
+        seed - the same values the loop forwards to ``policy.reset(seed=...)``,
+        which is what an in-process policy's own sampling is reproducible from.
+
+        The seam is the namespace ``evaluate`` resolves the name in, not the
+        module object a fresh ``import`` returns. That statement resolves through
+        the *package attribute*, and a sibling that re-imports the runner to
+        measure its import (``test_policy_runner.py``'s mujoco-leak cell) rebinds
+        that attribute to a fresh module; ``monkeypatch`` restores the
+        ``sys.modules`` entry it deleted, not the attribute the re-import wrote.
+        Patching the fresh object records nothing once that sibling has run, and
+        it sorts first. The ``PolicyRunner`` bound at collection is the class
+        under test here, so its ``evaluate`` globals are the dict the call reads
+        whatever the attribute holds.
+        """
+        seam = PolicyRunner.evaluate.__globals__
+        assert seam["set_eval_seed"] is set_eval_seed, "the seam must be the one this file imported"
+        applied: list[int] = []
+
+        def spy(seed: int) -> None:
+            applied.append(seed)
+            set_eval_seed(seed)
+
+        monkeypatch.setitem(seam, "set_eval_seed", spy)
+
+        reset_seeds: list[int | None] = []
+        policy = MockPolicy()
+        policy.set_robot_state_keys(FakeSim().robot_joint_names("fake_robot"))
+
+        def _record_reset(seed: int | None = None) -> None:
+            reset_seeds.append(seed)
+
+        policy.reset = _record_reset  # type: ignore[assignment]
+
+        spec = _CountingBenchmark()
+        PolicyRunner(FakeSim()).evaluate("fake_robot", policy, spec=spec, n_episodes=3, seed=42)
+
+        assert applied[0] == 42, f"the master seed was not applied before the episode loop: {applied}"
+        assert applied[1:] == reset_seeds, (
+            "each episode's seed must be applied globally and forwarded to the policy: "
+            f"applied {applied[1:]}, forwarded {reset_seeds}"
+        )
+        assert len(set(applied[1:])) == 3, f"episode seeds must be distinct, got {applied[1:]}"
 
 
 class TestPolicyResetIntegration:

--- a/tests/simulation/test_run_policy_seed_reproducibility.py
+++ b/tests/simulation/test_run_policy_seed_reproducibility.py
@@ -10,34 +10,63 @@ single-rollout path.
 
 Regression for the no-grasp-on-re-run report: identical seed -> identical
 trajectory; the seed is forwarded to ``policy.reset(seed=...)``.
+
+The policy double reads the seed it was *handed*, not the process-global RNG.
+Every seeded rollout surface forwards the seed it applied to
+``policy.reset(seed=...)`` - the contract a service-mode policy relies on, since
+its sampler runs in a process ``set_eval_seed`` cannot reach - so the double
+seeds private generators from that value and reads the shared object zero times.
+Reading the global stream directly made this file's replay comparison depend on
+the rollout being that object's only reader for the whole rollout, and one stray
+draw between two of the policy's queries shifted every action after it, which the
+comparison reported as an unapplied seed. What the comparison then stops
+observing - that the rollout applied the seed globally at all - is a call, and
+``test_the_forwarded_seed_is_the_one_applied_with_set_eval_seed`` counts it as
+one.
 """
 
 from __future__ import annotations
 
+import ast
 import random
+from pathlib import Path
 from typing import Any
 
 import numpy as np
+import pytest
 
 from strands_robots.policies.base import Policy
-from strands_robots.simulation.policy_runner import PolicyRunner
+from strands_robots.simulation.policy_runner import OnFrame, PolicyRunner, set_eval_seed
 
 from .test_policy_runner import FakeSim
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Generators a policy double may build - each one is a private stream seeded from
+# a value the rollout handed it. Reading the module-level generators (``random.``
+# / ``np.random.``) is what these tests exist to keep out of a policy double.
+_PRIVATE_GENERATORS = ("random.Random", "np.random.default_rng", "np.random.RandomState")
+
 
 class StochasticPolicy(Policy):
-    """Policy whose actions are drawn from the global Python/NumPy RNGs.
+    """Policy whose actions come from the seed the rollout forwarded to it.
 
     Stands in for a real VLA whose action-chunk sampling is stochastic. The
     per-step draw is recorded so two rollouts can be compared bit-for-bit.
     Also records the seed passed to :meth:`reset` so the forwarding contract
     can be asserted.
+
+    ``reset`` seeds a private Python and a private NumPy generator from the
+    forwarded seed - what a service-mode policy does with it - so the draws
+    depend on the seed and on nothing else in the process. An unseeded rollout
+    forwards no seed and gets fresh entropy, exactly as it did before.
     """
 
     def __init__(self) -> None:
         self.robot_state_keys: list[str] = []
         self.draws: list[float] = []
         self.reset_seeds: list[int | None] = []
+        self._rngs: tuple[random.Random, np.random.Generator] | None = None
 
     @property
     def provider_name(self) -> str:
@@ -52,18 +81,23 @@ class StochasticPolicy(Policy):
 
     def reset(self, seed: int | None = None) -> None:
         self.reset_seeds.append(seed)
+        self._rngs = (random.Random(seed), np.random.default_rng(seed))
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, Any]]:
-        # Draw from BOTH global RNGs so the test exercises the python+numpy
-        # seeding that set_eval_seed performs.
-        draw = random.random() + float(np.random.random())
+        if self._rngs is None:
+            # No seed was forwarded, so there is nothing to be reproducible
+            # about: draw from fresh entropy, as an unseeded rollout always did.
+            self._rngs = (random.Random(), np.random.default_rng())
+        py_rng, np_rng = self._rngs
+        # Both kinds of generator, because a real policy samples through either.
+        draw = py_rng.random() + float(np_rng.random())
         self.draws.append(draw)
         return [{k: draw for k in self.robot_state_keys}]
 
 
-def _run_once(seed: int | None) -> StochasticPolicy:
+def _run_once(seed: int | None, on_frame: OnFrame | None = None) -> StochasticPolicy:
     sim = FakeSim()
     policy = StochasticPolicy()
     policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
@@ -75,6 +109,7 @@ def _run_once(seed: int | None) -> StochasticPolicy:
         action_horizon=1,
         fast_mode=True,
         seed=seed,
+        on_frame=on_frame,
     )
     assert result["status"] == "success"
     return policy
@@ -111,4 +146,125 @@ def test_no_seed_leaves_reset_untouched():
     policy = _run_once(seed=None)
     assert policy.reset_seeds == [], (
         f"run_policy with no seed should not call policy.reset(seed=...); got {policy.reset_seeds}"
+    )
+
+
+def test_the_forwarded_seed_is_the_one_applied_with_set_eval_seed(monkeypatch):
+    """The rollout also applies the seed to the process-global RNGs.
+
+    A policy that samples in-process is reproducible because ``run`` reseeded
+    those RNGs, and the trajectory comparisons above no longer observe that: the
+    double reads the forwarded seed instead. A reseed is a *call*, so it is
+    counted as one - ``set_eval_seed`` is applied with the same value that
+    reaches ``policy.reset``, before the policy is ever queried.
+
+    The seam is the namespace ``run`` resolves the name in. Patching the module
+    object a fresh ``import`` returns is not the same thing: that resolves
+    through the *package attribute*, which a sibling re-importing the runner
+    rebinds to a fresh module for the rest of the session, and the spy then
+    records nothing while the same cell passes alone.
+    """
+    seam = PolicyRunner.run.__globals__
+    assert seam["set_eval_seed"] is set_eval_seed, "the seam must be the one this file imported"
+    applied: list[int] = []
+
+    def spy(seed: int) -> None:
+        applied.append(seed)
+        set_eval_seed(seed)
+
+    monkeypatch.setitem(seam, "set_eval_seed", spy)
+    policy = _run_once(seed=1234)
+    assert applied == [1234], f"the rollout did not apply the seed globally: {applied}"
+    assert policy.reset_seeds == applied, (
+        f"the seed applied globally and the seed forwarded to the policy differ: {applied} vs {policy.reset_seeds}"
+    )
+
+
+@pytest.mark.parametrize("placement", ["between-queries", "inside-set_eval_seed"])
+def test_a_stray_global_draw_does_not_change_the_replay(placement, monkeypatch):
+    """The global streams are not the rollout's alone to read.
+
+    ``set_eval_seed`` reseeds the *process-global* RNGs and everything else in
+    the interpreter draws from those same objects - a thread left by a fixture, a
+    library's trace-id generator. A double that read them directly turned one
+    stray draw into a different trajectory, so this file could fail for a draw
+    the rollout never made, on a branch that touched no RNG code.
+
+    Two placements, because a stray reader is not confined to one window:
+
+    * ``between-queries`` - an ``on_frame`` hook (user telemetry the runner calls
+      once per applied control step) draws once mid-rollout.
+    * ``inside-set_eval_seed`` - the reseed itself is not atomic: after
+      ``random.seed`` it continues into NumPy, torch and CUDA before returning,
+      so a reader can draw while the seed is only half applied. A patched
+      ``np.random.seed`` that also draws is the deterministic stand-in for that
+      window, and it refuses any instrument that reads the global state after
+      ``set_eval_seed`` returns rather than the seed it was handed.
+
+    Either way both runs of a seeded pair must replay identically.
+    """
+    seed = 1234
+
+    def replay(interfere: bool) -> list[float]:
+        if placement == "between-queries":
+            stray_step = 2
+
+            def on_frame(step_idx: int, observation: dict[str, Any], action: dict[str, Any]) -> None:
+                if step_idx == stray_step:
+                    random.random()
+                    np.random.random()
+
+            return list(_run_once(seed=seed, on_frame=on_frame if interfere else None).draws)
+
+        with monkeypatch.context() as patched:
+            if interfere:
+                real_seed = np.random.seed
+
+                def seed_and_draw(*args: Any, **kwargs: Any) -> None:
+                    real_seed(*args, **kwargs)
+                    random.random()
+                    np.random.random()
+
+                patched.setattr(np.random, "seed", seed_and_draw)
+            return list(_run_once(seed=seed).draws)
+
+    quiet = replay(interfere=False)
+    noisy = replay(interfere=True)
+    assert quiet, "policy produced no action draws"
+    assert quiet == noisy, (
+        "a draw the rollout did not make changed what a seeded rollout replayed"
+        f"\n  no stray draw: {quiet}\n  stray draw:    {noisy}"
+    )
+
+
+def test_no_policy_double_measures_a_seed_off_a_process_global_rng():
+    """Completeness: a policy double reads the seed it is handed, everywhere.
+
+    A policy double is the only way to observe that a rollout seed was applied,
+    and every double that reads ``random`` / ``numpy.random`` is exposed to
+    whatever else in the process reads them. One fixed double proves nothing
+    about the next one, so the property is asserted over the suite: a ``Policy``
+    subclass may build a private generator, and may not draw from the shared one.
+    """
+    offenders: list[str] = []
+    for root in ("tests", "tests_integ"):
+        for path in sorted((_REPO_ROOT / root).rglob("*.py")):
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                if not any("Policy" in ast.unparse(base) for base in node.bases):
+                    continue
+                for inner in ast.walk(node):
+                    if not isinstance(inner, ast.Call):
+                        continue
+                    called = ast.unparse(inner.func)
+                    if called.startswith(("random.", "np.random.", "numpy.random.")) and not called.endswith(
+                        _PRIVATE_GENERATORS
+                    ):
+                        offenders.append(f"{path.relative_to(_REPO_ROOT)}: {node.name} calls {called}()")
+    assert not offenders, (
+        "a policy double draws from a process-global RNG, so a seed measurement "
+        "made with it can be shifted by any other reader in the process; seed a "
+        f"private generator ({', '.join(_PRIVATE_GENERATORS)}) from the seed the "
+        "rollout forwards to reset() instead:\n  " + "\n  ".join(offenders)
     )


### PR DESCRIPTION
Closes #3333. Same remedy as #3331/#3334, applied to the two remaining files that shape lists.

## The instrument assumed the rollout was the only reader of a shared object

A rollout seed's reproducibility half is only observable through something whose output depends on the RNG state the seed sets - and the RNG a rollout seed sets is the *process-global* one. Two cells measured it by reading that shared object for the length of a rollout:

| file | cell | read |
|---|---|---|
| `test_run_policy_seed_reproducibility.py` | `test_same_seed_same_trajectory` | `random.random()` + `np.random.random()` inside the policy double |
| `test_policy_runner_benchmark.py` | `TestEvalSeeding::test_evaluate_benchmark_reseeds_per_episode` | the `random` module inside the spec's `on_episode_start` |

One draw taken by anything else in the interpreter - a fixture's thread, a library's trace-id generator - shifts every value after it, and the comparison reports that as an unapplied seed: a failure for a draw the rollout never made, on a branch that touched no RNG code.

![replay under one stray global draw](https://raw.githubusercontent.com/cagataycali/robots/assets/seeded-replay-stray-draw-3333/docs/assets/seeded_replay_stray_draw.png)

Measured on `upstream/main` with one extra `random.random()` + `np.random.random()` from an `on_frame` hook at step 2 of a `seed=1234` rollout: the replay diverges at step 3 and at every step after, because the stray draw consumed `1.696334` - the value the policy was going to get at step 4. On this head the two runs are identical at all 10 steps.

## Each cell now reads the value it was handed

Every seeded rollout surface forwards the seed it applied to `policy.reset(seed=...)` - the contract a service-mode policy relies on, since its sampler runs in a process `set_eval_seed` cannot reach. The doubles now do what such a policy does:

- the policy double seeds a private `random.Random(seed)` and `np.random.default_rng(seed)` in `reset(seed=...)` and draws from those (both kinds, because a real policy samples through either);
- the benchmark spec draws from the `episode_rng` the eval loop already derives for that episode and hands it.

There is no shared reader left to race, so the exposure is removed rather than narrowed. What the comparisons stop observing - that the rollout reseeds the global RNGs at all - is a **call**, and two new cells count it as one: once per rollout on the single-rollout path, and once with the master seed plus once per episode in the eval loop, each value being the one `policy.reset` receives.

`TestEvalSeeding`'s two direct `set_eval_seed` draw-comparisons are **deleted**. A cell whose subject is a global reseed has to read the global object, and that contract is already pinned - over a wider set of seeds, with the shortest possible window - in `test_set_eval_seed_requires_a_seed.py::TestUsableSeedsAreStillApplied`. Pinning it in one place rather than two is the only remedy that shape admits, and it removed 5 of the observed flakes.

## The seam is the namespace the call resolves the name in

Both new counting cells patch `PolicyRunner.<method>.__globals__` via `monkeypatch.setitem`, not the module object a fresh `import` returns, with a premise assertion that the seam holds the `set_eval_seed` the file imported. The first draft patched the freshly-imported module and failed with `applied []` beside three forwarded seeds - only when `test_policy_runner.py`'s mujoco-leak cell ran first, which it does, since it sorts first:

```
leak cell, then both new cells   ->  1 failed, 2 passed
both new cells alone             ->  2 passed
```

That cell deletes the runner's `sys.modules` entry and re-imports it; the re-import rebinds the **package attribute**, and `monkeypatch` restores the `sys.modules` entry it deleted, not the attribute the re-import wrote. `PolicyRunner` is bound at collection, so its method globals are the dict the call reads whatever the attribute holds. Both cells are green in that order now (3 passed) and the mechanism is recorded in the docstrings.

## A tree-wide check keeps the property

One fixed double proves nothing about the next one, so the property is asserted over `tests/` + `tests_integ/`: a `Policy` subclass may build a private generator (`random.Random`, `np.random.default_rng`, `np.random.RandomState`) and may not draw from the shared one.

## Every instrument fails only the cell that names its cause

| change | stray-draw `[between-queries]` | stray-draw `[inside-set_eval_seed]` | tree-wide check | forwarded-seed count (`run`) | per-episode count (`evaluate`) |
|---|---|---|---|---|---|
| this head | pass | pass | pass | pass | pass |
| double reverted to `random` / `np.random` | **fail** | **fail** | **fail** | pass | pass |
| `set_eval_seed` deleted from `run` (`:1545`) | pass | pass | pass | **fail** | pass |
| per-episode `set_eval_seed` deleted (`:3016`, `:3365`) | pass | pass | pass | pass | **fail** |

And under a background thread reading the global RNG every 2 ms, both files, 5 runs each:

| head | result |
|---|---|
| `upstream/main` | **1-2 failed in every one of 5 runs** (`test_same_seed_same_trajectory` 5/5, `..._reseeds_per_episode` 2/5, `..._seeds_numpy` 3/5, `..._seeds_python_random` 2/5) |
| this head | **69 passed, all 5 runs** |

## Tests

Full `tests/` on `upstream/main` and on this head, same host, same options:

| | collected | passed | failed | errors |
|---|---|---|---|---|
| `upstream/main` | 51290 | 50755 | 67 | 37 |
| this head | 51293 | 50758 | 67 | 37 |

**Zero delta**: the 104 failing/erroring names are identical in both `comm` directions - all pre-existing on a host whose `lerobot` predates the suite. `+3` collected and `+3` passed is exactly 5 new cells minus the 2 deleted ones.

`ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ` (1959 files); `mypy` on the same three unchanged at its standing count; `assemble_changelog.py --check` OK. Changelog fragment added.

LOC: **+269 / -51** across 2 test files and 1 fragment. The instrument change itself is small; the rest is the two counting cells, the two stray-draw placements, the tree-wide check, and docstrings that record why an instrument may not read a shared object.