### PR TITLE
fix(drivers/ur): a halt reaches a setpoint already inside send_action

### DIFF
--- a/changelog.d/3338-ur-halt-reaches-a-setpoint-in-flight.md
+++ b/changelog.d/3338-ur-halt-reaches-a-setpoint-in-flight.md
@@ -1,0 +1,30 @@
+### Fixed: a UR halt reaches a setpoint already inside `send_action`
+
+`URDriver`'s rollout loop re-reads its stop event after the policy returns, and
+that re-read is what stops the *next* step. It is not the last thing before the
+write: the loop hands the action to `send_action`, which reads both mode
+registers and the measured pose - three RTDE round trips to the same controller
+the halt is talking to - before it calls `servoJ`. A halt issued while those
+reads were in flight was answered by one more setpoint, on all three halt verbs.
+
+Measured over the RTDE double, with the rollout parked in the mode gate:
+
+| halt verb | order the controller heard | setpoint after the halt |
+| --- | --- | --- |
+| `stop()` | `servoStop`, `servoJ` | yes |
+| `stop_task()` | `servoStop`, `servoJ` | yes |
+| `cleanup()` | `servoStop`, `disconnect`, `servoJ` | yes |
+
+The last row is the one `cleanup`'s own docstring ruled out: clearing the
+interface handles under the lock turns away a thread that has not read them, and
+a thread inside `send_action` is holding them. `stop_task` reported
+`stopped=False` throughout, so the arm moved after a halt the envelope had
+already declined to claim.
+
+Every halt verb now bumps a counter before it issues `servoStop`, and
+`send_action` re-reads it immediately before the write - the position
+`G1Driver` and `Go2Driver` already hold, which they get for free by building and
+publishing the frame inline. A counter rather than a flag, so only a write whose
+gates began before the halt is refused and a setpoint issued after one is still
+written. The dropped setpoint is reported: the loop exits `refused` with a reason
+naming the halt, rather than discarding it silently.

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -143,9 +143,12 @@ waits up to two seconds for its thread and decelerates the arm with `servoStop`;
 policy blocking on a remote inference call outlasts that budget, and the envelope then
 carries `status="error"` with `stopped=False` and a reason naming the timeout, matching
 what `get_task_status()` says about the same loop. The arm is decelerated either way,
-and no further setpoint reaches the controller - the loop re-reads the stop signal after
-the policy returns and before it writes. `stop()` carries no verdict (the driver protocol
-annotates it `-> None`); read `stop_task()` when the outcome matters.
+and no further setpoint reaches the controller. That takes two re-reads rather than one:
+the loop re-reads the stop signal after the policy returns, and `send_action` re-reads the
+driver's halt counter immediately before `servoJ`. Between those two it reads both mode
+registers and the measured pose - three RTDE round trips to the same controller, during
+which a halt was otherwise answered by one more setpoint. `stop()` carries no verdict (the
+driver protocol annotates it `-> None`); read `stop_task()` when the outcome matters.
 
 Joint keys are the arm's own names, in RTDE wire order, and the MuJoCo assets declare
 them identically - so an action dict recorded in simulation streams to the controller

--- a/strands_robots/drivers/ur.py
+++ b/strands_robots/drivers/ur.py
@@ -463,6 +463,13 @@ class URDriver:
         # anchored here rather than on the measured pose.
         self._commanded: list[float] | None = None
 
+        # Bumped by every halt verb, and re-read by ``send_action`` immediately
+        # before its ``servoJ``. Each of that method's gates costs an RTDE round
+        # trip, so a halt issued while a setpoint is being prepared has to be
+        # noticed after those reads rather than only before them. See
+        # :meth:`_begin_halt`.
+        self._halt_epoch = 0
+
         self._rollout: _Rollout | None = None
         self._task_admission = threading.Lock()
 
@@ -736,11 +743,14 @@ class URDriver:
         """Stop motion, leaving both interfaces connected.
 
         Annotated ``-> None`` by the driver protocol, so it carries no verdict:
-        the rollout is signalled and not waited for, and the loop's own step
-        re-reads that signal before its next setpoint, which is what keeps a
-        servoJ from landing after this servoStop. A caller that needs the halt
+        the rollout is signalled and not waited for. Two re-reads keep a servoJ
+        from landing after this servoStop - the loop re-reads the stop signal
+        before its next setpoint, and :meth:`send_action` re-reads the halt
+        counter this sets immediately before the write, which is what covers a
+        setpoint already past the loop's own check. A caller that needs the halt
         outcome reads :meth:`stop_task`, which decides one.
         """
+        self._begin_halt()
         rollout = self._rollout
         if rollout is not None:
             rollout.request_stop()
@@ -758,11 +768,15 @@ class URDriver:
         """Stop the arm and release both interfaces. Idempotent.
 
         The join outcome is not reported - the protocol annotates this ``-> None``
-        - and it does not need to be: the interface handles are cleared under the
-        lock before either is disconnected, so a rollout thread that outlasted
-        the join finds ``None`` and refuses its own write rather than reaching a
-        disconnected interface.
+        - and it does not need to be, because a write that outlives the join is
+        refused rather than reported on. Clearing the interface handles under the
+        lock covers a thread that had not read them yet; a thread already inside
+        :meth:`send_action` holds them, and is turned away by the halt counter
+        :meth:`_begin_halt` bumps here. Both are needed: without the counter, a
+        setpoint prepared before this call reached the interface after it had been
+        disconnected.
         """
+        self._begin_halt()
         rollout = self._rollout
         if rollout is not None:
             rollout.request_stop()
@@ -793,9 +807,11 @@ class URDriver:
         Gates, in order: this driver fronts this robot; both interfaces are
         live; the controller is in a mode that moves; the action names only UR
         joints, every value is finite and within travel, and no joint is asked
-        to move further than its speed ceiling allows in one control period.
-        Only then is the setpoint written - and the controller's own return
-        value decides the verdict, so a rejected write is reported as one.
+        to move further than its speed ceiling allows in one control period; and
+        no halt was issued while those gates were in flight, each of which costs
+        an RTDE round trip (:meth:`_begin_halt`). Only then is the setpoint
+        written - and the controller's own return value decides the verdict, so a
+        rejected write is reported as one.
 
         Args:
             action: Joint targets in radians, keyed by :data:`JOINT_NAMES`
@@ -811,7 +827,7 @@ class URDriver:
         if robot_name is not None and robot_name != self._tool_name:
             return _refuse(f"send_action: this driver fronts {self._tool_name!r} only, not {robot_name!r}")
         with self._lock:
-            control, receive = self._control, self._receive
+            control, receive, halted_at = self._control, self._receive, self._halt_epoch
         if control is None or receive is None:
             return _refuse("send_action: not connected - call connect_eagerly() first")
         if (reason := self._mode_refusal(receive)) is not None:
@@ -833,6 +849,17 @@ class URDriver:
         if reason is not None:
             return _refuse(f"send_action: {reason}")
 
+        # The last gate, and deliberately the last statement before the write:
+        # every gate above costs an RTDE round trip, so a halt issued while they
+        # were in flight is read here rather than only at the interface read this
+        # setpoint started from. See :meth:`_begin_halt`.
+        with self._lock:
+            superseded = self._halt_epoch != halted_at
+        if superseded:
+            return _refuse(
+                "send_action: the stream was halted while this setpoint was being prepared, so the "
+                "setpoint was not written - the arm is under that halt, not under this setpoint"
+            )
         try:
             accepted = control.servoJ(
                 targets,
@@ -950,6 +977,34 @@ class URDriver:
         """
         with self._lock:
             self._commanded = None
+
+    def _begin_halt(self) -> None:
+        """Mark the stream halted, so a setpoint already in flight is not written.
+
+        Every halt verb - :meth:`stop`, :meth:`stop_task`, :meth:`cleanup` - calls
+        this before it issues ``servoStop``, and :meth:`send_action` re-reads the
+        counter immediately before its own write.
+
+        The rollout loop already re-reads its stop event after the policy returns,
+        which is what keeps the *next* step's setpoint in. That re-read is followed
+        by :meth:`send_action`'s three RTDE round trips - both mode registers, then
+        the measured pose - and a halt issued during those was answered by one more
+        ``servoJ``: on a controller that had just been told to decelerate, and on
+        :meth:`cleanup`'s path after the interface it was written to had been
+        disconnected. :class:`~strands_robots.drivers.g1.G1Driver` and
+        :class:`~strands_robots.drivers.go2.Go2Driver` have no equivalent gap because
+        their loops build and publish the frame inline, with only computation between
+        the re-read and the wire; this driver's loop writes through the public
+        :meth:`send_action`, so the gate belongs where the write is.
+
+        A counter rather than a flag, so a halt followed by a fresh setpoint stays an
+        ordinary sequence: only a write whose gates began before the halt is refused,
+        never one a caller issues after it. The counter alone is enough to cover the
+        released interface too: :meth:`connect_eagerly` is idempotent, so the handle
+        is only ever replaced after a :meth:`cleanup` that bumped this.
+        """
+        with self._lock:
+            self._halt_epoch += 1
 
     def _reference_pose(self, receive: Any) -> tuple[list[float], str | None]:
         """Return the pose the next setpoint's step is measured from.
@@ -1165,6 +1220,7 @@ class URDriver:
             way; what the third case refuses to do is claim a halt while
             :meth:`get_task_status` would report ``running=True``.
         """
+        self._begin_halt()
         rollout = self._rollout
         unjoined: _Rollout | None = None
         if rollout is not None and rollout.is_running:
@@ -1183,8 +1239,10 @@ class URDriver:
         self._drop_anchor()
         if unjoined is not None:
             # The thread is still in the loop. It will not write another
-            # setpoint - the step re-reads the stop event before sending - but it
-            # holds the rollout, so reporting success here would hand a caller
+            # setpoint - the step re-reads the stop event before sending, and a
+            # setpoint already past that check is refused by the halt counter
+            # ``_begin_halt`` bumped above - but it holds the rollout, so
+            # reporting success here would hand a caller
             # that reads only ``status`` a halt the payload's own ``running``
             # contradicts.
             snapshot = unjoined.snapshot()
@@ -1362,7 +1420,11 @@ class _Rollout:
                     # a stop signalled during one would otherwise be answered by
                     # one more servoJ - landing after the servoStop the halt
                     # verb just issued, and moving an arm an operator was told
-                    # had stopped.
+                    # had stopped. This check cannot be the only one: the
+                    # ``send_action`` below reads three RTDE registers before it
+                    # writes, and a halt issued during those is caught by the
+                    # halt counter that method re-reads. See
+                    # :meth:`URDriver._begin_halt`.
                     self._finish("stopped")
                     return
 

--- a/tests/drivers/ur/test_ur_stop_task_reports_the_rollout_halt_outcome.py
+++ b/tests/drivers/ur/test_ur_stop_task_reports_the_rollout_halt_outcome.py
@@ -15,6 +15,15 @@ were true of it:
   policy returned, so the setpoint that policy call was computing went out
   *after* the ``servoStop`` - measured landing 0.5 ms later.  An arm an operator
   was told had stopped resumed moving.
+* that re-read is not the last thing before the write: the loop hands the action
+  to :meth:`~strands_robots.drivers.ur.URDriver.send_action`, which reads both
+  mode registers and the measured pose - three RTDE round trips to the same
+  controller - before it calls ``servoJ``.  A halt issued while those were in
+  flight was answered by one more setpoint on every one of the three halt verbs,
+  and on ``cleanup``'s path that setpoint reached the interface *after* it had
+  been disconnected.  ``send_action`` now re-reads the driver's halt counter
+  immediately before the write, which is the position the two drivers below
+  already hold.
 
 :class:`~strands_robots.drivers.g1.G1Driver` and
 :class:`~strands_robots.drivers.go2.Go2Driver` are the fleet's other two drivers
@@ -87,6 +96,54 @@ def blocked_rollout(fake_rtde: FakeRTDE, monkeypatch: pytest.MonkeyPatch) -> Ite
         yield driver, release
     finally:
         release.set()
+        driver.cleanup()
+
+
+@pytest.fixture
+def stalled_write(fake_rtde: FakeRTDE, monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[URDriver, threading.Event]]:
+    """A connected arm whose rollout is parked *inside* ``send_action``.
+
+    The policy has already returned and the loop has already re-read its stop
+    event; the thread is in the mode gate's RTDE round trip, past the interface
+    read this setpoint started from and before its ``servoJ``.  ``blocked_rollout``
+    cannot pose that position - a thread stalled in the policy call is turned back
+    by the loop's own re-read and never enters ``send_action``.
+
+    The stall is armed from inside the policy, which runs on the rollout thread one
+    statement before ``send_action``: ``run_policy`` and ``get_observation`` read no
+    mode register, so nothing else can consume it first.
+    """
+    driver = URDriver(tool_name="ur5e", port=HOST, control_frequency=200.0)
+    assert driver.connect_eagerly() is None
+    _fast_join(monkeypatch)
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def stall() -> None:
+        entered.set()
+        release.wait(10.0)
+
+    def policy(observation: dict[str, Any]) -> dict[str, float]:
+        fake_rtde.receive.on_next_mode_read = stall
+        return _reachable_setpoint()
+
+    assert driver.run_policy(policy, instruction="hold", duration=30.0)["status"] == "success"
+    assert entered.wait(5.0), "the rollout never reached send_action's mode gate"
+    try:
+        yield driver, release
+    finally:
+        release.set()
+        driver.cleanup()
+
+
+def _halt(driver: URDriver, verb: str) -> None:
+    """Issue one of the three halt verbs by name, discarding any verdict."""
+    if verb == "stop":
+        asyncio.run(driver.stop())
+    elif verb == "stop_task":
+        driver.stop_task()
+    else:
         driver.cleanup()
 
 
@@ -171,6 +228,114 @@ class TestNoSetpointOutlivesTheHalt:
         assert json_of(driver.get_task_status())["exit_reason"] == "stopped"
 
 
+class TestAHaltAlsoReachesASetpointPastTheLoopsOwnCheck:
+    """The halt wins over a setpoint already inside ``send_action``.
+
+    Every gate in that method costs an RTDE round trip to the same controller the
+    halt is talking to, so the loop's re-read cannot be the last word: it happens
+    three reads before the write.
+    """
+
+    @pytest.mark.parametrize("verb", ["stop", "stop_task", "cleanup"])
+    def test_the_halt_is_the_last_thing_the_controller_hears(
+        self, stalled_write: tuple[URDriver, threading.Event], verb: str
+    ) -> None:
+        driver, release = stalled_write
+        control = driver._control  # ``cleanup`` clears it, so read it while it is there
+        assert control is not None
+        written = len(control.servoj_calls)
+        _halt(driver, verb)
+        assert control.servo_stops == 1
+        _drain(driver, release)
+        assert len(control.servoj_calls) == written, (
+            f"a setpoint reached the arm after {verb}(): the controller was told to decelerate "
+            "and then handed a fresh position command"
+        )
+
+    def test_cleanup_does_not_release_an_interface_a_setpoint_then_reaches(
+        self, stalled_write: tuple[URDriver, threading.Event]
+    ) -> None:
+        # The claim in ``cleanup``'s own docstring. Clearing the handles under the
+        # lock covers a thread that has not read them; this one is holding them.
+        driver, release = stalled_write
+        control = driver._control
+        assert control is not None
+        written = len(control.servoj_calls)
+        driver.cleanup()
+        assert control.disconnected is True
+        _drain(driver, release)
+        assert len(control.servoj_calls) == written, "a setpoint reached an interface already disconnected"
+
+    def test_the_halt_is_marked_before_the_arm_is_told_to_decelerate(
+        self, stalled_write: tuple[URDriver, threading.Event]
+    ) -> None:
+        """The mark has to precede ``servoStop``, not merely exist somewhere.
+
+        Sequenced rather than timed: the controller double releases the parked
+        rollout from inside ``servoStop`` and does not return until that thread has
+        left the loop, so its write attempt falls strictly inside the deceleration
+        command.  A mark applied *after* ``servoStop`` - by ``_drop_anchor``, which
+        every halt verb already calls - leaves exactly this window open, and every
+        other cell here would still pass.
+        """
+        driver, release = stalled_write
+        control = driver._control
+        assert control is not None
+        rollout = driver._rollout
+        assert rollout is not None
+        written = len(control.servoj_calls)
+
+        def release_the_parked_write() -> None:
+            release.set()
+            deadline = time.monotonic() + 5.0
+            while rollout.is_running and time.monotonic() < deadline:
+                time.sleep(0.005)
+
+        control.on_servo_stop = release_the_parked_write
+        driver.stop_task()
+        assert not rollout.is_running, "the parked write never resumed inside servoStop"
+        assert len(control.servoj_calls) == written, (
+            "a setpoint reached the arm while the deceleration command was still executing"
+        )
+
+    def test_the_dropped_setpoint_is_reported_rather_than_discarded(
+        self, stalled_write: tuple[URDriver, threading.Event]
+    ) -> None:
+        driver, release = stalled_write
+        driver.stop_task()
+        _drain(driver, release)
+        snapshot = json_of(driver.get_task_status())
+        assert snapshot["exit_reason"] == "refused"
+        assert "halted while this setpoint was being prepared" in str(snapshot["refusal"])
+
+
+class TestAHaltDoesNotWedgeTheStream:
+    """Only the setpoint a halt interrupted is refused - never a later one."""
+
+    def test_a_setpoint_issued_after_a_halt_is_still_written(self, fake_rtde: FakeRTDE) -> None:
+        driver = URDriver(tool_name="ur5e", port=HOST, control_frequency=200.0)
+        assert driver.connect_eagerly() is None
+        asyncio.run(driver.stop())
+        written = len(fake_rtde.control.servoj_calls)
+        envelope = driver.send_action(_reachable_setpoint())
+        assert envelope["status"] == "success", text_of(envelope)
+        assert len(fake_rtde.control.servoj_calls) == written + 1
+
+    def test_a_second_rollout_after_a_halt_still_streams(self, fake_rtde: FakeRTDE) -> None:
+        driver = URDriver(tool_name="ur5e", port=HOST, control_frequency=200.0)
+        assert driver.connect_eagerly() is None
+        driver.stop_task()
+        assert (
+            driver.run_policy(lambda observation: _reachable_setpoint(), instruction="hold", n_steps=2)["status"]
+            == "success"
+        )
+        rollout = driver._rollout
+        assert rollout is not None
+        _await_exit(rollout)
+        assert json_of(driver.get_task_status())["exit_reason"] == "n_steps"
+        assert len(fake_rtde.control.servoj_calls) == 2
+
+
 class TestTheJoinReportsWhatItObserved:
     """``_Rollout.join`` is the single source of the halt verdict."""
 
@@ -228,7 +393,14 @@ class TestWhatTheHappyPathStillReports:
 
 
 class TestTeardownDoesNotDisconnectUnderALiveWrite:
-    """``cleanup`` carries no verdict, so the property holds by construction."""
+    """``cleanup`` carries no verdict, so the property holds by construction.
+
+    This cell poses the thread stalled in the *policy call*, which the loop's own
+    re-read turns back before ``send_action`` is entered at all - hence the
+    ``exit_reason`` of ``"stopped"`` rather than a refusal.  The position where
+    the write is already past that re-read is
+    :class:`TestAHaltAlsoReachesASetpointPastTheLoopsOwnCheck`.
+    """
 
     def test_a_late_write_finds_no_interface_rather_than_a_disconnected_one(
         self, blocked_rollout: tuple[URDriver, threading.Event]

--- a/tests/mocks/ur_rtde.py
+++ b/tests/mocks/ur_rtde.py
@@ -14,6 +14,7 @@ motion commands, so a test can assert on the vector that reached the wire.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 #: A plausible measured pose, in the driver's joint order. Not all zeros: a
@@ -42,6 +43,13 @@ class FakeReceive:
         self.robot_mode = 7  # RUNNING
         self.safety_mode = 1  # NORMAL
         self.disconnected = False
+        # Called once at the start of the next ``getRobotMode``, then cleared. A
+        # controller whose RTDE link stalls mid-register-read parks its caller
+        # here, which is how a test puts a driver thread *inside*
+        # ``send_action`` - past the interface read that setpoint started from
+        # and before its ``servoJ``. Nothing else in the driver reads this
+        # register on that path, so arming it targets exactly that window.
+        self.on_next_mode_read: Callable[[], None] | None = None
 
     def getActualQ(self) -> list[float]:  # noqa: N802 - the SDK's own spelling
         return list(self.q)
@@ -59,6 +67,9 @@ class FakeReceive:
         return list(MEASURED_WRENCH)
 
     def getRobotMode(self) -> int:  # noqa: N802
+        hook, self.on_next_mode_read = self.on_next_mode_read, None
+        if hook is not None:
+            hook()
         return self.robot_mode
 
     def getSafetyMode(self) -> int:  # noqa: N802
@@ -78,6 +89,10 @@ class FakeControl:
         self.servo_stops = 0
         self.accepts = True
         self.disconnected = False
+        # Called once at the start of the next ``servoStop``, then cleared. A
+        # test uses it to sequence another thread's write attempt strictly
+        # inside the deceleration command, instead of timing it.
+        self.on_servo_stop: Callable[[], None] | None = None
 
     def servoJ(  # noqa: N802 - the SDK's own spelling
         self,
@@ -92,6 +107,9 @@ class FakeControl:
         return self.accepts
 
     def servoStop(self) -> None:  # noqa: N802
+        hook, self.on_servo_stop = self.on_servo_stop, None
+        if hook is not None:
+            hook()
         self.servo_stops += 1
 
     def disconnect(self) -> None:


### PR DESCRIPTION
## The claim

`URDriver.cleanup`'s docstring, on why it does not report the join outcome:

> the interface handles are cleared under the lock before either is disconnected, so a rollout thread that outlasted the join finds `None` and refuses its own write rather than reaching a disconnected interface.

That holds for a thread which has not read the handles yet. A thread already inside `send_action` is holding them.

## Why the loop's re-read is not the last word

The loop re-reads its stop event after the policy returns - added for exactly this class of bug, and recorded in `test_ur_stop_task_reports_the_rollout_halt_outcome.py`'s own module docstring ("measured landing 0.5 ms later"). But the write is three RTDE round trips further on:

```mermaid
flowchart LR
  P["policy returns"] --> R{"stop event<br/>re-read"}
  R --> S["send_action"]
  S --> M1["getRobotMode"] --> M2["getSafetyMode"] --> Q["getActualQ"] --> G{"halt counter<br/>re-read"} --> W["servoJ"]
  style R fill:#dfd,stroke:#333
  style G fill:#dfd,stroke:#333
  style M1 fill:#fdd
  style M2 fill:#fdd
  style Q fill:#fdd
```

The three red nodes are round trips to the same controller the halt is talking to. `G` is new; before it, a halt landing anywhere in that stretch was answered by one more setpoint.

## Measured

Real `URDriver`, real `_Rollout` loop, real `send_action`, over the repo's own RTDE double with one register read stalled - which is what a wedged controller link does, and what parks the thread in that window. `join()` had already timed out and reported it.

| halt verb | order the controller heard (before) | setpoint after the halt | after this change |
| --- | --- | --- | --- |
| `stop()` | `servoStop`, **`servoJ`** | yes | `servoStop` |
| `stop_task()` | `servoStop`, **`servoJ`** | yes | `servoStop` |
| `cleanup()` | `servoStop`, `disconnect`, **`servoJ`** | yes | `servoStop`, `disconnect` |

`stop_task` returned `status="error"` with `stopped=False` in every case, so the arm moved after a halt whose own envelope had declined to claim it. The `cleanup` row is the docstring claim above: the write reached the interface after `disconnect()`.

## The change

Every halt verb bumps a counter *before* it issues `servoStop`; `send_action` snapshots it with the interface handles and re-reads it immediately before `servoJ`. That is the position `G1Driver` and `Go2Driver` already hold - their loops build and publish the frame inline, with only computation between the re-read and the wire, so they get it for free. This driver's loop writes through the public `send_action`, so the gate belongs where the write is.

A counter rather than a flag: only a write whose gates *began* before the halt is refused, never one a caller issues after it. The counter alone also covers the released interface, since `connect_eagerly` is idempotent and the handle is only replaced after a `cleanup` that bumped it - so no handle-identity check ships.

The dropped setpoint is reported rather than discarded: the loop exits `refused` with a reason naming the halt.

## Tests

The existing suite could not see this. Its `blocked_rollout` fixture stalls the *policy call*, which the loop's own re-read turns back before `send_action` is entered - so `TestTeardownDoesNotDisconnectUnderALiveWrite` passed on the defect. A new `stalled_write` fixture arms the stall from inside the policy, which runs on the rollout thread one statement before `send_action` (`run_policy` and `get_observation` read no mode register, so nothing else consumes it).

Four corners over `tests/drivers/ur/`:

| | base tests | + new cells |
| --- | --- | --- |
| **base `ur.py`** | 93 passed | **6 failed**, 95 passed |
| **this `ur.py`** | 93 passed | 101 passed |

`93 + 8 = 101`; the fix-with-base-tests corner equals the base corner, so no existing cell changed meaning.

Break table (each row against all 101 cells; `collected` stable at 101):

| mutation | fires | which |
| --- | --- | --- |
| control, no mutation | 0 | - |
| `stop()` does not mark the halt | 1 | the `[stop]` row alone |
| `stop_task()` does not mark it | 2 | `[stop_task]` + the refusal report |
| `cleanup()` does not mark it | 2 | `[cleanup]` + the disconnect cell |
| `send_action` drops the late gate | 6 | every regression cell |
| **the gate moves ahead of the RTDE reads** | 6 | every regression cell |
| the counter becomes a one-way latch | 3 | both over-reach controls + a pre-existing gate cell |
| `_drop_anchor` owns the mark instead | 1 | the deceleration-ordering cell alone |

The fifth and sixth rows are the ones worth reading. Moving the gate to just after the interface read - i.e. keeping the counter but asking it before the three round trips - fails every regression cell, so the *placement* is the fix, not the counter's existence.

The last row is why `test_the_halt_is_marked_before_the_arm_is_told_to_decelerate` exists. `_drop_anchor` is called by all three halt verbs already and would have been the cheap place to put the mark, but it runs *after* `servoStop`, leaving that window open; every other cell still passes under it. That cell is sequenced rather than timed: the controller double releases the parked rollout from inside `servoStop` and does not return until the thread has left the loop, so the write attempt falls strictly inside the deceleration call.

The two over-reach controls (`TestAHaltDoesNotWedgeTheStream`) hold on both trees and fire only when the counter is turned into a latch.

## Size

`strands_robots/drivers/ur.py`: **443 -> 454 executable statements** (AST), i.e. +11; the rest of its +76 is docstring and comment, including corrections to the two claims above and to `docs/robots/arms.md`, which stated "the loop re-reads the stop signal after the policy returns and before it writes".

The mock gains two hooks (18 lines): one register read and one `servoStop` that can call back, both cleared after one use.

## Gate

- `ruff check` / `ruff format --check` clean over 1960 files; `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1957 source files`.
- `tests/drivers/ur/`: 101 passed.
- Every census that walks the tree or reads source (498 files) plus all of `tests/drivers/`, `tests/test_docs*.py` and the changelog graders: **27019 passed, 5 failed in 24m21s**. The 5 assert `rclpy` is absent and it resolves from `/opt/ros/jazzy` on this machine; the same 5 node ids fail identically on a pristine `main` worktree.

## Not changed

The residual window is now the two statements between the counter read and `servoJ`, rather than three socket round trips. Closing it entirely means holding the driver lock across the write, which would block `stop()` behind the very setpoint it is trying to prevent - the wrong trade for a halt path, so it is deliberately not taken.