### PR TITLE
fix(dataset): an append reopens the dataset its repo_id created

### DIFF
--- a/changelog.d/3339-dataset-append-resolves-its-root.md
+++ b/changelog.d/3339-dataset-append-resolves-its-root.md
@@ -1,0 +1,28 @@
+### Fixed: an append reopens the dataset its `repo_id` created
+
+`DatasetRecorder.create` resolves the dataset directory once, through
+`resolve_dataset_dir`, and forwards the result to LeRobot as an explicit `root`.
+`resume` - the append entry point, and the only writable way into an existing
+dataset - forwarded the caller's `root` unresolved. An absent one stayed absent,
+and `LeRobotDataset.resume` refuses that outright: the directory it would derive
+for a writer is the revision-safe Hub snapshot cache. So the append was
+unreachable on exactly the arguments `create` accepts, and the refusal asked for
+a directory this repo already names - the one the dataset was written to.
+
+Measured against lerobot 0.6.2 on a MuJoCo scene:
+`start_recording(repo_id="probe/append_two_episodes", root=None, overwrite=True)`,
+a 30-step rollout, `stop_recording()`, then the same call again with the default
+`overwrite=False`. The first session wrote one episode with every call
+`status="success"`; the second returned `status="error"` - "Dataset init failed:
+resume() requires an explicit 'root' directory ..." - after resolving that same
+directory to decide an append was wanted and stashing it as
+`last_dataset_root`; `verify_dataset_episodes(expected=2)` then reported 1
+episode / 30 frames. With the resolution in place the script records 2 episodes /
+60 frames and every call reports success. All three backends' `start_recording`
+route their append through this method, so all three were affected.
+
+An explicit `root` is unchanged: it was, and still is, used verbatim. Every
+existing fake dataset class in the suite accepts `root=None` silently, which is
+why none of them observed this; the double in
+`tests/test_dataset_append_reopens_what_the_repo_id_created.py` reproduces the
+one property that decides the outcome - a writer refuses an absent root.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -188,6 +188,12 @@ the directory the dataset is then written into. LeRobot derives an absent root
 as `$HF_LEROBOT_HOME/{repo_id}` for any id, so letting it derive one of its own
 would part company with the rule above for exactly the path-like ids.
 
+`DatasetRecorder.resume` - the append entry point - forwards the same resolved
+directory, so the `repo_id` that created a dataset reopens it. LeRobot refuses an
+absent `root` there outright, because the directory it would derive for a writer
+is the revision-safe Hub snapshot cache; resolving here is what keeps the append
+reachable on the same arguments the recording was made with.
+
 Passing an existing **empty** directory - for example one returned by
 `tempfile.mkdtemp()` - is accepted and recorded into:
 
@@ -664,6 +670,7 @@ Append to existing dataset (requires `lerobot>=0.5.2`):
 
 ```python
 recorder = DatasetRecorder.resume(repo_id="user/my_dataset", task="pick up the blue cube")
+# root=None -> $HF_LEROBOT_HOME/user/my_dataset, the directory create() wrote to
 recorder.add_frame(observation, action)
 recorder.save_episode()
 recorder.finalize()

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -1267,7 +1267,14 @@ class DatasetRecorder:
 
         Args:
             repo_id: HuggingFace dataset ID (same as the original recording).
-            root: Local dataset directory (same as the original recording).
+            root: Local dataset directory. When omitted, the directory this
+                ``repo_id`` resolves to
+                (:func:`~strands_robots.dataset_recorder.resolve_dataset_dir`) -
+                the same one :meth:`create` writes to, so the id that created a
+                dataset reopens it. It is forwarded to LeRobot as an explicit
+                root either way; LeRobot refuses an absent one, because the
+                directory it derives for a writer would be the revision-safe Hub
+                snapshot cache.
             task: Default task description for appended frames.
             vcodec: Video codec for the per-camera MP4 streams (default
                 "h264"; routed into the version-appropriate encoder
@@ -1314,8 +1321,19 @@ class DatasetRecorder:
                 "Use overwrite=True for a fresh single-session dataset."
             )
 
+        # The directory to append into, resolved once by the same rule
+        # :meth:`create` writes through and forwarded as an explicit ``root`` for
+        # the same reason: an absent root is not LeRobot's to derive here.
+        # ``LeRobotDataset.resume`` refuses one outright - the directory it would
+        # derive is the revision-safe Hub snapshot cache, which a DatasetWriter
+        # must not open - so forwarding the caller's ``None`` unresolved made the
+        # append entry point unreachable on exactly the arguments ``create``
+        # accepts: the ``repo_id`` that created a dataset could not reopen it, and
+        # the refusal asked for the directory this resolver already names.
+        dataset_dir = resolve_dataset_dir(repo_id, root)
+
         resume_sig = inspect.signature(LeRobotDatasetCls.resume).parameters
-        resume_kwargs: dict[str, Any] = dict(repo_id=repo_id, root=root)
+        resume_kwargs: dict[str, Any] = dict(repo_id=repo_id, root=str(dataset_dir))
         # Mirror create()'s version-tolerant codec routing.
         resume_kwargs.update(_codec_create_kwargs(resume_sig, vcodec, context="resume"))
         if "streaming_encoding" in resume_sig:

--- a/tests/test_dataset_append_reopens_what_the_repo_id_created.py
+++ b/tests/test_dataset_append_reopens_what_the_repo_id_created.py
@@ -1,0 +1,174 @@
+"""The ``repo_id`` that created a dataset reopens it for appending.
+
+``DatasetRecorder.create`` resolves the dataset directory once, through
+:func:`~strands_robots.dataset_recorder.resolve_dataset_dir`, and forwards the
+result to LeRobot as an explicit ``root``. ``resume`` -- the multi-episode append
+entry point, and the only writable one for an existing dataset -- forwarded the
+caller's ``root`` unresolved instead. An absent one therefore stayed absent, and
+``LeRobotDataset.resume`` refuses that outright::
+
+    resume() requires an explicit 'root' directory because it creates a
+    DatasetWriter. Writing into the revision-safe Hub snapshot cache (used when
+    root=None) would corrupt the shared cache. Please provide a local directory
+    path.
+
+The refusal is correct about LeRobot's own resolution and asks for a directory
+this repo already names: the one ``create`` wrote the dataset to. So append was
+unreachable on exactly the arguments ``create`` accepts, which is the documented
+default path. Measured end to end against lerobot 0.6.2 on a MuJoCo scene --
+``start_recording(repo_id="probe/append_two_episodes", root=None,
+overwrite=True)``, a 30-step rollout, ``stop_recording()``, then the same
+``start_recording`` call again with the default ``overwrite=False``:
+
+* the first session wrote one episode, every call ``status="success"``;
+* the second returned ``status="error"``, "Dataset init failed: resume()
+  requires an explicit 'root' directory ...", having already resolved that
+  directory to decide an append was wanted and stashed it as
+  ``last_dataset_root``;
+* ``verify_dataset_episodes(expected=2)`` then reported 1 episode / 30 frames.
+
+With ``resume`` resolving once, the same script records 2 episodes / 60 frames
+and every call reports success.
+
+Every existing fake dataset class accepts ``root=None`` silently, so none of them
+could observe this; the double below reproduces the one property that decides the
+outcome -- a writer refuses an absent root -- and is what makes the cells here
+fail on the unresolved forward rather than merely describe it.
+
+An explicit ``root`` is unaffected: it was, and still is, used verbatim.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import pytest
+
+from strands_robots import dataset_recorder as dr
+
+
+class _Meta:
+    total_episodes = 1
+    total_frames = 30
+
+
+class _WriterThatRefusesAnAbsentRoot:
+    """A LeRobotDataset double shaped like the writer, for both entry points.
+
+    ``resume`` and ``create`` record the ``root`` they were handed. ``resume``
+    additionally refuses an absent one with LeRobot's own wording, because that
+    refusal -- not the value of the kwarg -- is what a caller actually hits.
+    """
+
+    resume_kwargs: dict[str, Any] = {}
+    create_kwargs: dict[str, Any] = {}
+
+    def __init__(self, repo_id: str, root: str | None = None) -> None:
+        self.repo_id = repo_id
+        self.root = Path(root) if root else None
+        self.meta = _Meta()
+
+    @classmethod
+    def resume(cls, repo_id: str, root: str | None = None, streaming_encoding: bool = True) -> Any:
+        if not root:
+            raise ValueError(
+                "resume() requires an explicit 'root' directory because it creates a "
+                "DatasetWriter. Writing into the revision-safe Hub snapshot cache "
+                "(used when root=None) would corrupt the shared cache. Please provide "
+                "a local directory path."
+            )
+        cls.resume_kwargs = {"repo_id": repo_id, "root": root}
+        return cls(repo_id, root=root)
+
+    @classmethod
+    def create(
+        cls,
+        repo_id: str,
+        fps: int = 30,
+        root: str | None = None,
+        robot_type: str = "unknown",
+        features: dict[str, Any] | None = None,
+        use_videos: bool = True,
+        image_writer_threads: int = 4,
+    ) -> Any:
+        cls.create_kwargs = {"repo_id": repo_id, "root": root}
+        return cls(repo_id, root=root)
+
+
+@pytest.fixture
+def writer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> type[_WriterThatRefusesAnAbsentRoot]:
+    """Inject the double, relocate the dataset home, and anchor the cwd."""
+    module = types.ModuleType("lerobot.datasets.lerobot_dataset")
+    module.LeRobotDataset = _WriterThatRefusesAnAbsentRoot  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", module)
+    home = tmp_path / "home"
+    monkeypatch.setattr(dr, "_lerobot_home", lambda: home)
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    _WriterThatRefusesAnAbsentRoot.resume_kwargs = {}
+    _WriterThatRefusesAnAbsentRoot.create_kwargs = {}
+    return _WriterThatRefusesAnAbsentRoot
+
+
+class _Case(NamedTuple):
+    repo_id: str
+    # Where resolve_dataset_dir says this id lives, relative to the fixture's
+    # dataset home ("home") or the working directory ("cwd").
+    anchor: str
+    relative: str
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        _Case(repo_id="user/data", anchor="home", relative="user/data"),
+        _Case(repo_id="bare_name", anchor="cwd", relative="bare_name"),
+        _Case(repo_id="./dotted", anchor="cwd", relative="dotted"),
+    ],
+    ids=lambda case: case.repo_id,
+)
+def test_an_absent_root_appends_into_the_directory_the_repo_id_names(
+    writer: type[_WriterThatRefusesAnAbsentRoot], tmp_path: Path, case: _Case
+) -> None:
+    """An append opens the dataset this id resolves to, rather than being refused.
+
+    The path-like ids are the same divergence ``create`` resolves: LeRobot reads
+    any absent root as ``$HF_LEROBOT_HOME/{repo_id}`` whatever the id looks like,
+    while this repo reads an id that is itself a path as the directory. So the
+    resolution has to happen here for the append to land where the recording did.
+    """
+    recorder = dr.DatasetRecorder.resume(repo_id=case.repo_id, root=None)
+
+    anchor = (tmp_path / "home") if case.anchor == "home" else Path.cwd()
+    # Resolved on both sides: a path-like id is forwarded relative, exactly as
+    # ``create`` forwards it, so the effective directory is what has to match.
+    assert Path(writer.resume_kwargs["root"]).resolve() == (anchor / case.relative).resolve()
+    assert recorder.episode_count == 1
+
+
+def test_an_explicit_root_is_still_forwarded_verbatim(
+    writer: type[_WriterThatRefusesAnAbsentRoot], tmp_path: Path
+) -> None:
+    """The control: naming a root replaces the resolution, it is not joined to it."""
+    chosen = tmp_path / "chosen"
+
+    dr.DatasetRecorder.resume(repo_id="user/data", root=str(chosen))
+
+    assert Path(writer.resume_kwargs["root"]) == chosen
+
+
+def test_the_id_that_created_a_dataset_reopens_it(writer: type[_WriterThatRefusesAnAbsentRoot]) -> None:
+    """One id, one directory: the two writable entry points must agree on it.
+
+    They resolve through the same function, so agreement is by construction --
+    which is the point. Before, only ``create`` resolved, and the pair disagreed
+    for every id whose append is worth having.
+    """
+    dr.DatasetRecorder.create(repo_id="bare_name", root=None, joint_names=["j1"], task="pick")
+    dr.DatasetRecorder.resume(repo_id="bare_name", root=None)
+
+    assert Path(writer.resume_kwargs["root"]) == Path(writer.create_kwargs["root"])

--- a/tests/test_dataset_create_writes_where_it_prepared.py
+++ b/tests/test_dataset_create_writes_where_it_prepared.py
@@ -31,10 +31,12 @@ the inspected directory is the written directory by construction. The ordinary
 ``owner/name`` id is unaffected: both resolutions already agreed on
 ``$HF_LEROBOT_HOME/{repo_id}`` there, which the controls below hold.
 
-``DatasetRecorder.resume`` is deliberately untouched. It forwards ``repo_id`` /
-``root`` to ``LeRobotDataset.resume`` without resolving or preparing anything, so
-it has no second resolution to disagree with, and LeRobot refuses an absent root
-there itself with a message that names the fix.
+``DatasetRecorder.resume`` resolves the same way, for a different reason: it
+prepares nothing, so it has no second resolution to disagree with, but LeRobot
+refuses an absent root outright there - a writer must not open the Hub snapshot
+cache - which left the append entry point unreachable on the arguments ``create``
+accepts. See
+``tests/test_dataset_append_reopens_what_the_repo_id_created.py``.
 """
 
 from __future__ import annotations

--- a/tests/test_recording_root_is_not_the_shared_cache.py
+++ b/tests/test_recording_root_is_not_the_shared_cache.py
@@ -54,11 +54,15 @@ test resolving the shared home -- the fallback test named above, which compares
 a path and reads nothing -- and the full unit suite's failure set is unchanged
 with a stray dataset planted at all six ids the offenders used.
 
-``DatasetRecorder.resume`` is deliberately not an entry point here: unlike
-``create`` it forwards ``repo_id`` / ``root`` to ``LeRobotDataset`` without
-resolving the pair itself and without ``_prepare_create_target``, so it neither
-resolves the shared home in this repo nor inspects the target first. The
-instrumentation agrees - no ``resume`` test reached the home.
+``DatasetRecorder.resume`` is deliberately not an entry point here. It resolves
+the pair through the same resolver ``create`` does, so it does reach the shared
+home for an absent root - but it has no ``_prepare_create_target``, so it never
+inspects or writes that directory: the resolved path is handed straight to the
+injected fake dataset class. The exposure this module guards is the *inspection*
+of a shared path before the fake is reached, which is what a planted dataset
+turns into a ``FileExistsError``; computing a path nothing reads is not it. The
+instrumentation agrees - no ``resume`` test reached the home when it was
+recorded, and the ids the ``resume`` tests use are unchanged.
 
 ``tests_integ/`` deliberately records real datasets and may want the shared
 home, so the scan is scoped to ``tests/``.


### PR DESCRIPTION
`DatasetRecorder.create` resolves the dataset directory once, through `resolve_dataset_dir`, and forwards the result to LeRobot as an explicit `root`. `resume` - the append entry point, and the only writable way into an existing dataset - forwarded the caller's `root` unresolved. An absent one stayed absent, and `LeRobotDataset.resume` refuses that outright, because the directory it would derive for a writer is the revision-safe Hub snapshot cache. So the append was unreachable on exactly the arguments `create` accepts, and the refusal asked for a directory this same call had already resolved one step earlier - to decide an append was wanted, and to report as `last_dataset_root`.

![record then append](https://raw.githubusercontent.com/cagataycali/robots/assets/append-root-resolution/docs/assets/append_root_resolution.png)

The appended episode, decoded back out of the dataset it was written into (`videos/observation.images.default/chunk-000/file-001.mp4`, 45 frames):

![appended episode](https://raw.githubusercontent.com/cagataycali/robots/assets/append-root-resolution/docs/assets/appended_episode.gif)

## Measured

MuJoCo `so100` scene, headless EGL, one script per column: `start_recording(repo_id="operator/append_demo", root=None, overwrite=True)`, a 45-step rollout, `stop_recording()`, then the **same call again** with the default `overwrite=False`.

| | before | after |
|---|---|---|
| first session | `success` (1 episode) | `success` (1 episode) |
| second `start_recording` | `error` - "Dataset init failed: resume() requires an explicit 'root' directory ..." | `success` |
| `verify_dataset_episodes(expected=2)` | `error` - MISMATCH, 1 episode / 45 frames | `success` - 2 episodes / 90 frames |
| dataset files | 6 (1 parquet, 1 mp4) | 9 (2 parquet, 2 mp4) |

The refusal is present in both lerobot 0.5.1 and 0.6.2, so it spans the supported range. All three backends' `start_recording` route their append through this method (`mujoco/recording.py:472`, `isaac/recording.py:413`, `newton/recording.py:381`), so all three were affected. An explicit `root` is unchanged: it was, and still is, used verbatim.

## Change

`resume` resolves through `resolve_dataset_dir(repo_id, root)` and forwards the result, exactly as `create` does - so the two writable entry points name one directory per `repo_id` by construction, and the path-like ids (no `owner/name` slash, or `./`-prefixed) that LeRobot would read as `$HF_LEROBOT_HOME/{repo_id}` append where they recorded.

## Tests

`tests/test_dataset_append_reopens_what_the_repo_id_created.py` (5 cells). Every existing fake dataset class in the suite accepts `root=None` silently, which is why none of them could observe this; the double here reproduces the one property that decides the outcome - a writer refuses an absent root, with LeRobot's own wording - so the cells fail on the unresolved forward rather than describe it.

On `024fc7df7` with only this test file added: **4 failed, 1 passed** (the pass is the explicit-root control). After the fix: 5 passed.

Full `tests/` both ways, same host, same interpreter:

| | failed | passed | skipped | errors |
|---|---|---|---|---|
| base + this test file | 71 | 50770 | 437 | 37 |
| this branch | **67** | **50774** | 437 | 37 |

51309 collected on both; the failing-name sets differ by exactly the 4 discriminating cells and nothing else (no regressions in either direction). `ruff check` / `ruff format --check` clean; `mypy` unchanged at its standing count.

Two test-module docstrings stated resume's exclusion as a fact about the old implementation and are corrected in the same change: `test_recording_root_is_not_the_shared_cache.py` (resume now reaches the shared home, but still never inspects or writes it - which is the exposure that module guards, so its roster is unchanged) and `test_dataset_create_writes_where_it_prepared.py`. `docs/recording.md` documents the resolution for the append path and annotates the `resume` example, which had no `root`.