### PR TITLE
docs(ci): the apt step's comments and the bound grader's message point at the job bound, not at a number it no longer holds

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -47,17 +47,20 @@ jobs:
 
       - name: Install system dependencies (OpenGL for MuJoCo)
         # The step's own ceiling, so a stall is reaped here rather than at the
-        # job's 45 - only the step-level bound marks the step that stalled, and
-        # a job-level reap renders as a rollup FAILURE with no reason (#2442).
+        # job bound above - only the step-level bound marks the step that
+        # stalled, and a job-level reap renders as a rollup FAILURE with no
+        # reason (#2442).
         # Sized from the observed band: 31 successful runs put this step at
         # p50 33s and max 455s (7m35s). That band was exceeded twice on
         # 2026-08-19 - #2488 (14:27:49Z) and #2489 (15:07:23Z) were both reaped
         # here, 40 minutes apart, by multi-minute mirror stalls rather than by
         # anything in their diffs - so the headroom was restored by cutting what
         # the step downloads (the install below, -30.5%) rather than by raising
-        # this number, because the rest of the job costs up to ~32 min and
-        # anything above ~13 lets a slow apt push the job into the 45-minute
-        # reap it is meant to prevent.
+        # this number, because the rest of the job then cost up to ~32 min and
+        # anything above ~13 let a slow apt push the job into the job-level
+        # reap it is meant to prevent. Those figures were sized against the
+        # 45-minute job bound of the time; #2457 raised it to 60, and #3143
+        # re-measures the band against that.
         timeout-minutes: 12
         run: |
           # The GitHub runner image preconfigures third-party apt repos (e.g.

--- a/changelog.d/3340-test-lint-comments-name-the-bound-above.md
+++ b/changelog.d/3340-test-lint-comments-name-the-bound-above.md
@@ -1,4 +1,4 @@
-### Documentation: the apt step's comments and the bound grader's message point at the job bound, not at a number it no longer holds
+### Docs: the apt step's comments and the bound grader's message point at the job bound, not at a number it no longer holds
 
 #2457 raised `test-lint.yml`'s job bound 45 -> 60, and three places kept saying
 45 in the present tense: two comments on the apt step ("rather than at the

--- a/changelog.d/3340-test-lint-comments-name-the-bound-above.md
+++ b/changelog.d/3340-test-lint-comments-name-the-bound-above.md
@@ -1,0 +1,12 @@
+### Documentation: the apt step's comments and the bound grader's message point at the job bound, not at a number it no longer holds
+
+#2457 raised `test-lint.yml`'s job bound 45 -> 60, and three places kept saying
+45 in the present tense: two comments on the apt step ("rather than at the
+job's 45", "into the 45-minute reap") and the failure message of
+`test_the_bound_is_tighter_than_the_default`, which read "the widest job in
+this tree is the 45-minute suite" beside a `_CEILING_MINUTES` of 60. The
+comments now point at the `timeout-minutes` line above them, the sizing
+arithmetic that held at 45 is marked as what it was measured against, and the
+message derives its number from the suite job's declared bound through a
+`_suite_job()` helper that also replaces two duplicated lookups. No bound
+changes; the decision #3143 asks for is untouched (#3340).

--- a/tests/test_workflow_jobs_are_bounded.py
+++ b/tests/test_workflow_jobs_are_bounded.py
@@ -133,6 +133,13 @@ def _suite_step_bounds() -> list[int]:
     return [int(match.group(1)) for line in text.splitlines() if (match := _STEP_TIMEOUT_MINUTES.match(line))]
 
 
+def _suite_job() -> Job:
+    """The ``test-lint.yml:test-lint`` job -- the one required check."""
+    suite = [j for j in _ALL_JOBS if j.workflow == "test-lint.yml" and j.job_id == "test-lint"]
+    assert len(suite) == 1, "test-lint.yml:test-lint is the required check and must exist"
+    return suite[0]
+
+
 _JOBS_KEY = re.compile(r"^jobs:\s*$")
 _TOP_LEVEL_KEY = re.compile(r"^\S")
 _JOB_HEADER = re.compile(r"^ {2}([A-Za-z0-9_-]+):\s*$")
@@ -257,7 +264,7 @@ class TestEveryRunnerJobIsBounded:
         minutes = job.timeout_minutes
         assert minutes is not None and 0 < minutes <= _CEILING_MINUTES, (
             f"{job.ref} declares timeout-minutes: {minutes}, outside 1..{_CEILING_MINUTES}; "
-            f"the widest job in this tree is the 45-minute suite"
+            f"the widest job in this tree is the {_suite_job().timeout_minutes}-minute suite"
         )
 
 
@@ -304,10 +311,7 @@ class TestTheSuiteBoundClearsTheMeasuredBand:
     """The one required check is the job the incident actually happened on."""
 
     def test_the_suite_job_is_bounded_above_its_observed_ceiling(self) -> None:
-        suite = [j for j in _ALL_JOBS if j.workflow == "test-lint.yml" and j.job_id == "test-lint"]
-        assert len(suite) == 1, "test-lint.yml:test-lint is the required check and must exist"
-
-        minutes = suite[0].timeout_minutes
+        minutes = _suite_job().timeout_minutes
         assert minutes is not None, "the required check is unbounded (#2239)"
         assert _SUITE_FLOOR_MINUTES <= minutes <= _CEILING_MINUTES, (
             f"the suite bound is {minutes} min; it must clear the measured band "
@@ -327,10 +331,7 @@ class TestTheSuiteBoundClearsTheMeasuredBand:
         against the former 45-minute bound, the step bound had quietly stopped
         being able to fire first.
         """
-        suite = [j for j in _ALL_JOBS if j.workflow == "test-lint.yml" and j.job_id == "test-lint"]
-        assert len(suite) == 1, "test-lint.yml:test-lint is the required check and must exist"
-
-        minutes = suite[0].timeout_minutes
+        minutes = _suite_job().timeout_minutes
         assert minutes is not None, "the required check is unbounded (#2239)"
 
         step_bounds = _suite_step_bounds()


### PR DESCRIPTION
## What

#2457 raised the suite job's `timeout-minutes` 45 -> 60. Three places kept saying 45 in the present tense, and #3143's second comment records them as stale:

| where | read | now |
|---|---|---|
| `test-lint.yml`, apt step comment | "reaped here rather than at the job's 45" | "rather than at the job bound above" |
| `test-lint.yml`, apt step comment | "push the job into the 45-minute reap it is meant to prevent" | "into the job-level reap it is meant to prevent", with the ~32 / ~13 arithmetic marked as what it was sized against (45), and #2457 / #3143 named |
| `tests/test_workflow_jobs_are_bounded.py::test_the_bound_is_tighter_than_the_default` | `"the widest job in this tree is the 45-minute suite"`, 150 lines below `_CEILING_MINUTES = 60` | derived from the suite job's own declared bound |

The second row is the one that could not be a substitution: the sentence's numbers ("the rest of the job costs up to ~32 min", "anything above ~13") were arithmetic against 45 and are not true against 60 - #3143 measures that - so writing 60 there would make the sentence internally inconsistent. It is marked as the historical sizing rationale instead, and the present-tense claim points at the `timeout-minutes` line above it, which cannot drift.

The message derives its number through a `_suite_job()` helper that also replaces the two byte-identical lookups in `TestTheSuiteBoundClearsTheMeasuredBand`, so the required check is named in one place.

## What this does not do

No bound changes. `_SUITE_STEP_CEILING_MINUTES` / `_SUITE_UNBOUNDED_OVERHEAD_MINUTES` are left as they are: #3143 shows that re-deriving them makes the legal-spend cell red on its own arithmetic, so that edit is coupled to the bound decision the issue asks a maintainer for. This PR takes only the drift that is independent of that decision. The docstring citations of the former 45 (`test_workflow_jobs_are_bounded.py:327`, `test_apt_install_declines_recommends.py`, the two `changelog.d` fragments) are history and are left alone.

## Tests

- `tests/test_workflow_jobs_are_bounded.py` plus the five other modules that read `test-lint.yml`: 225 passed.
- The nine modules that grade `changelog.d/`: 402 passed, 1 skipped.
- `ruff check` / `ruff format --check` / `mypy` clean on the changed test module.
- `scripts/check_whole_tree_graders.py` (119 graders): 4820 passed, 52 skipped, 1 failed - `tests/rendering/test_encode_clip_requires_the_mp4_backend.py`, `Rendering unavailable (no OpenGL context)`, the host has no OSMesa; not reached by this diff.

Refs #3143

## Round changelog

- Round 0: opened as draft at `242c669`; fragment `changelog.d/3340-test-lint-comments-name-the-bound-above.md` added at `fd7ad87`, category aligned to the tree's `Docs:` at `23646ff`; marked ready. `check_duplicate_claim.py --all-open` reads `unique-additions` over 6 open PRs.