### PR TITLE
fix(simulation): a recorded Isaac or Newton rollout leaves the robot idle when it ends

### DIFF
--- a/changelog.d/3341-rollout-hook-release.md
+++ b/changelog.d/3341-rollout-hook-release.md
@@ -1,0 +1,29 @@
+### Fixed: a recorded Isaac or Newton rollout leaves the robot idle when it ends
+
+Three simulation backends raise the per-robot `policy_running` flag inside
+`_make_run_policy_hook`, the seam that layers dataset recording onto the shared
+run-policy loop. That flag is what a backend's motion primitives and busy
+guards refuse on, so it has to come back down when the rollout ends -- the
+guarantee `MuJoCoSimEngine._drive_rollout` states, and reaches through its own
+`run_policy` override.
+
+Isaac and Newton have no such override. Their hook builders are independent
+copies of the MuJoCo one: both kept the raise and neither had anywhere to put
+the release, so a recorded rollout marked the robot as driven for the rest of
+the session. On Isaac every motion primitive then answered `Cannot 'set_gripper'
+on 'so100' while its policy is running ... Wait for the rollout to finish (Isaac
+policy loops clear the flag on exit)` and `run_multi_policy` answered `policy
+already running on 'so100'. Stop it first` -- two remedies for a rollout that
+had already ended, neither of them reachable, since Isaac exposes no
+`stop_policy`. On Newton the stale flag became `SimRobot.request_policy_stop`'s
+`was_running=True`, which is the entire verdict of the stop paths that reach a
+backend without `stop_policy`, so the Device Connect `stop` RPC reported a
+halted rollout on an idle simulation.
+
+The release now has one owner. `SimEngine._release_run_policy_hook` is the other
+half of the hook seam, called in a `finally` around every rollout the facade
+drives -- the single-episode `run_policy` path and each episode of a
+multi-episode run -- so a rollout that ends for any reason (completion, a
+cooperative stop, or a raise) leaves the robot idle. Isaac and Newton implement
+it beside their hook builders; MuJoCo, which already owned the release, is
+unchanged.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2963,25 +2963,28 @@ class SimEngine(ABC):
                         int(duration * control_frequency),
                     )
                 on_frame = self._make_run_policy_hook(robot_name, instruction)
-                result = runner.run(
-                    robot_name,
-                    policy,
-                    instruction=instruction,
-                    duration=duration,
-                    n_steps=n_steps,
-                    control_frequency=control_frequency,
-                    action_horizon=action_horizon,
-                    fast_mode=fast_mode,
-                    video=VideoConfig.from_dict(video),
-                    on_frame=on_frame,
-                    max_onframe_failures=max_onframe_failures,
-                    control_substeps=control_substeps,
-                    policy_kwargs=policy_kwargs,
-                    seed=seed,
-                    async_rtc=async_rtc,
-                    rtc_inference_timeout_s=rtc_inference_timeout_s,
-                    stop_when=stop_when_fn,
-                )
+                try:
+                    result = runner.run(
+                        robot_name,
+                        policy,
+                        instruction=instruction,
+                        duration=duration,
+                        n_steps=n_steps,
+                        control_frequency=control_frequency,
+                        action_horizon=action_horizon,
+                        fast_mode=fast_mode,
+                        video=VideoConfig.from_dict(video),
+                        on_frame=on_frame,
+                        max_onframe_failures=max_onframe_failures,
+                        control_substeps=control_substeps,
+                        policy_kwargs=policy_kwargs,
+                        seed=seed,
+                        async_rtc=async_rtc,
+                        rtc_inference_timeout_s=rtc_inference_timeout_s,
+                        stop_when=stop_when_fn,
+                    )
+                finally:
+                    self._release_run_policy_hook(robot_name)
                 completed = 1 if result.get("status") == "success" else 0
                 contract = self._episode_contract_fields(
                     requested=1, completed=completed, saved=0, flush_deferred=recording
@@ -3344,25 +3347,28 @@ class SimEngine(ABC):
             ep_seed = None if seed is None else seed + ep
             ep_video = self._episode_video_config(video, ep)
             on_frame = self._make_run_policy_hook(robot_name, instruction)
-            result = runner.run(
-                robot_name,
-                policy,
-                instruction=instruction,
-                duration=duration,
-                n_steps=n_steps,
-                control_frequency=control_frequency,
-                action_horizon=action_horizon,
-                fast_mode=fast_mode,
-                video=ep_video,
-                on_frame=on_frame,
-                max_onframe_failures=max_onframe_failures,
-                control_substeps=control_substeps,
-                policy_kwargs=policy_kwargs,
-                seed=ep_seed,
-                async_rtc=async_rtc,
-                rtc_inference_timeout_s=rtc_inference_timeout_s,
-                stop_when=stop_when,
-            )
+            try:
+                result = runner.run(
+                    robot_name,
+                    policy,
+                    instruction=instruction,
+                    duration=duration,
+                    n_steps=n_steps,
+                    control_frequency=control_frequency,
+                    action_horizon=action_horizon,
+                    fast_mode=fast_mode,
+                    video=ep_video,
+                    on_frame=on_frame,
+                    max_onframe_failures=max_onframe_failures,
+                    control_substeps=control_substeps,
+                    policy_kwargs=policy_kwargs,
+                    seed=ep_seed,
+                    async_rtc=async_rtc,
+                    rtc_inference_timeout_s=rtc_inference_timeout_s,
+                    stop_when=stop_when,
+                )
+            finally:
+                self._release_run_policy_hook(robot_name)
             ep_json = self._extract_json_payload(result)
             ep_record: dict[str, Any] = {"episode": ep, **ep_json}
             total_steps += int(ep_json.get("n_steps", 0) or 0)
@@ -4563,6 +4569,34 @@ class SimEngine(ABC):
 
         Returns:
             Callable or ``None``.
+        """
+        return None
+
+    def _release_run_policy_hook(self, robot_name: str) -> None:
+        """Release whatever :meth:`_make_run_policy_hook` claimed for the rollout.
+
+        The other half of the hook seam. A backend whose hook builder marks the
+        robot as driven -- ``policy_running``, the per-robot flag its motion
+        primitives and its busy guards refuse on -- has to lower it when the
+        rollout ends, and only this facade knows when that is: the closure is
+        called per frame and cannot see its own last one.
+
+        Called in a ``finally`` around every rollout driven here (the
+        single-episode :meth:`run_policy` path and each episode of
+        :meth:`_run_episodes`), so a rollout that ends for any reason --
+        completion, a cooperative stop, or a raise -- leaves the robot idle.
+        That is the guarantee
+        :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine._drive_rollout`
+        states for the MuJoCo backend, which reaches it through its own
+        ``run_policy`` override; a backend without such an override reaches it
+        here.
+
+        Args:
+            robot_name: The robot whose rollout has ended.
+
+        Returns:
+            ``None``. Default: nothing was claimed, so nothing is released.
+            Override alongside :meth:`_make_run_policy_hook`.
         """
         return None
 

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -4,7 +4,7 @@ The engine-independent recording lifecycle (``stop_recording`` /
 ``save_episode`` / ``get_recording_status`` / ``stream_dataset`` and the
 ``_is_recording`` / ``_active_recorder`` / ``_active_dataset_root`` overrides)
 lives in :class:`~strands_robots.simulation.recording.DatasetRecordingMixin`,
-which is backend-agnostic. This subclass adds the two Isaac-specific halves:
+which is backend-agnostic. This subclass adds the Isaac-specific parts:
 
 * :meth:`start_recording` declares the dataset schema from the live Isaac
   scene - joint names from every robot (namespaced for multi-robot scenes) and
@@ -20,6 +20,10 @@ which is backend-agnostic. This subclass adds the two Isaac-specific halves:
   so multi-cam recordings never capture a stale secondary product), and
   ``IsaacSimulation.get_observation`` forces images on while a recording is
   active even when the driving policy sets ``requires_images = False``.
+* :meth:`_release_run_policy_hook` lowers the ``policy_running`` flag the hook
+  builder raised, when the rollout that hook served ends. The claim and its
+  release are one contract, and only the shared facade knows where the rollout
+  ends, so it calls this in a ``finally`` around every rollout it drives.
 
 **State seam**: Isaac's ``self._world`` is the Isaac Sim ``World`` handle, not
 the :class:`~strands_robots.simulation.models.SimWorld` the shared mixin's
@@ -51,7 +55,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from strands_robots.simulation.models import registered
+from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     camera_schema_key_collision_error,
@@ -659,3 +663,32 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 )
 
         return _hook
+
+    def _release_run_policy_hook(self, robot_name: str) -> None:
+        """Lower the ``policy_running`` flag :meth:`_make_run_policy_hook` raised.
+
+        The hook builder marks the robot as driven so a motion primitive and
+        the rollout cannot race on the same articulation's PD targets, and
+        :meth:`~strands_robots.simulation.isaac.motion_primitives.IsaacMotionPrimitivesMixin._primitive_resolve_robot`
+        refuses on exactly that flag. Nothing lowered it, so a recorded rollout
+        left the robot marked driven for the rest of the session: every
+        primitive answered ``Cannot 'set_gripper' on 'so100' while its policy
+        is running ... wait for the rollout to finish``, and
+        :meth:`~strands_robots.simulation.isaac.simulation.IsaacSimulation.run_multi_policy`
+        answered ``policy already running ... Stop it first`` - two remedies
+        for a rollout that had already ended, and neither reachable (Isaac
+        exposes no ``stop_policy``).
+
+        ``run_multi_policy`` lowers the flag in its own ``finally`` for the
+        loop it owns; this is the same release for the rollout the shared
+        facade owns, so the flag means "a loop is driving this robot" on both
+        paths. ``policy_instruction`` / ``policy_steps`` stay as the last
+        rollout's record, as they do on the MuJoCo backend.
+
+        Args:
+            robot_name: The robot whose rollout has ended. A robot removed
+                mid-rollout has nothing to release.
+        """
+        robot = registry_entry(self._robots, robot_name)
+        if robot is not None:
+            robot.policy_running = False

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -4,7 +4,7 @@ The engine-independent recording lifecycle (``stop_recording`` /
 ``save_episode`` / ``get_recording_status`` / ``stream_dataset`` and the
 ``_is_recording`` / ``_active_recorder`` / ``_active_dataset_root`` overrides)
 lives in :class:`~strands_robots.simulation.recording.DatasetRecordingMixin`,
-which is backend-agnostic. This subclass adds the two Newton-specific halves:
+which is backend-agnostic. This subclass adds the Newton-specific parts:
 
 * :meth:`start_recording` declares the dataset schema from the live Newton
   scene - joint names from every robot (namespaced for multi-robot scenes) and
@@ -13,6 +13,10 @@ which is backend-agnostic. This subclass adds the two Newton-specific halves:
   :class:`~strands_robots.simulation.base.SimEngine` run-policy loop calls every
   control step. It feeds joint state + action + rendered camera frames to the
   active :class:`~strands_robots.dataset_recorder.DatasetRecorder`.
+* :meth:`_release_run_policy_hook` lowers the ``policy_running`` flag the hook
+  builder raised, when the rollout that hook served ends. The claim and its
+  release are one contract, and only the shared facade knows where the rollout
+  ends, so it calls this in a ``finally`` around every rollout it drives.
 
 The recorder, episode-boundary flushing (``save_episode``), and the canonical
 parquet-correctness contract are identical to the MuJoCo backend - the
@@ -572,3 +576,23 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 )
 
         return _hook
+
+    def _release_run_policy_hook(self, robot_name: str) -> None:
+        """Lower the ``policy_running`` flag :meth:`_make_run_policy_hook` raised.
+
+        Nothing lowered it, so a recorded rollout left the robot marked as
+        driven for the rest of the session. On this backend the flag is what
+        :meth:`~strands_robots.simulation.models.SimRobot.request_policy_stop`
+        reports as ``was_running``, and that answer is the whole verdict of the
+        stop paths that reach a backend exposing no ``stop_policy`` - the
+        Device Connect ``stop`` RPC among them - so an idle simulation reported
+        a halted rollout that had finished on its own.
+
+        Args:
+            robot_name: The robot whose rollout has ended. A robot removed
+                mid-rollout, or a world torn down under it, has nothing to
+                release.
+        """
+        world = self._world
+        if world is not None and registered(world.robots, robot_name):
+            world.robots[robot_name].policy_running = False

--- a/tests/simulation/test_rollout_hook_release_leaves_the_robot_idle.py
+++ b/tests/simulation/test_rollout_hook_release_leaves_the_robot_idle.py
@@ -1,0 +1,305 @@
+"""A rollout the shared facade drives leaves the robot idle when it ends.
+
+``SimEngine._make_run_policy_hook`` is the seam a backend uses to layer
+recording onto the shared run-policy loop, and three backends raise the
+per-robot ``policy_running`` flag inside it: MuJoCo, Isaac and Newton. That
+flag is what a backend's motion primitives and busy guards refuse on, so it
+has to come back down when the rollout ends -- the guarantee
+``MuJoCoSimEngine._drive_rollout`` states ("lowers the flag in a ``finally`` so
+a rollout that ends for any reason - completion, a cooperative stop, or a raise
+- leaves the robot idle").
+
+MuJoCo reaches that guarantee through its own ``run_policy`` override. Isaac and
+Newton have no override, and their hook builders are independent copies of the
+MuJoCo one -- as ``tests/simulation/{isaac,newton}/test_recording_lifecycle_guards``
+put it, "independent copies of one contract, and a guard driven on one backend
+says nothing about the other". Both copies kept the raise and neither had
+anywhere to put the release, so a recorded rollout left the robot marked as
+driven for the rest of the session:
+
+* Isaac: every motion primitive answered ``Cannot 'set_gripper' on 'so100'
+  while its policy is running ... Wait for the rollout to finish (Isaac policy
+  loops clear the flag on exit)`` and ``run_multi_policy`` answered ``policy
+  already running on 'so100'. Stop it first`` -- two remedies for a rollout
+  that had already ended, and neither reachable (Isaac exposes no
+  ``stop_policy``).
+* Newton: ``SimRobot.request_policy_stop`` reported ``was_running=True``, and
+  that is the whole verdict of the stop paths that reach a backend exposing no
+  ``stop_policy`` -- so the Device Connect ``stop`` RPC reported a halted
+  rollout on an idle simulation.
+
+The release now has one owner: ``SimEngine._release_run_policy_hook``, called
+in a ``finally`` around every rollout the facade drives. The cells below pin
+the facade's side of that seam once, each backend's release through the public
+``run_policy`` verb, and MuJoCo as the reference column that was already
+correct.
+
+The rollout itself is stubbed at ``PolicyRunner.run``: what is under test is
+the facade's release, not the loop, and the Isaac / Newton engines are built
+through ``__new__`` (the fixture shape their own recording tests use) so
+neither optional physics stack is needed.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.models import SimRobot, SimWorld
+
+_SO100_JOINTS = ["Rotation", "Pitch", "Elbow", "Wrist_Pitch", "Wrist_Roll", "Jaw"]
+
+_OK = {"status": "success", "content": [{"json": {"n_steps": 3}}]}
+
+
+def _stub_rollout(monkeypatch, run_fn=None) -> None:
+    """Replace the rollout loop on the ``PolicyRunner`` ``run_policy`` instantiates.
+
+    ``SimEngine.run_policy`` builds its runner from the ``PolicyRunner`` symbol
+    bound in its own module namespace, so the patch is applied there rather than
+    on a separately imported name: a test that reloads ``policy_runner`` rebinds
+    that module's class while ``base`` keeps its original import, and a patch on
+    the reloaded object would silently miss the live rollout.
+    """
+    runner_module = sys.modules[SimEngine.run_policy.__module__]
+    monkeypatch.setattr(runner_module.PolicyRunner, "run", run_fn or (lambda self, *a, **k: dict(_OK)))
+
+
+class _HookRaisesTheFlagEngine(SimEngine):
+    """The shape the Isaac and Newton recording mixins share.
+
+    ``_make_run_policy_hook`` marks the robot as driven and returns a closure
+    that is called per frame -- so the closure cannot see its own last frame,
+    and the release cannot live in it. Everything else is a no-op: the rollout
+    loop is stubbed, and only the claim/release bookkeeping is under test.
+    """
+
+    def __init__(self) -> None:
+        self.driven: dict[str, bool] = {"arm": False}
+        self.released: list[str] = []
+
+    def _make_run_policy_hook(self, robot_name: str, instruction: str) -> Any:
+        self.driven[robot_name] = True
+        return lambda step, observation, action: None
+
+    def _release_run_policy_hook(self, robot_name: str) -> None:
+        self.released.append(robot_name)
+        self.driven[robot_name] = False
+
+    # -- abstract surface, as no-ops -------------------------------------
+    def create_world(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def destroy(self) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def reset(self) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def step(self, n_steps: int = 1) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def get_state(self) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def add_robot(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def remove_robot(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def list_robots(self) -> list[str]:
+        return ["arm"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(_SO100_JOINTS)
+
+    def add_object(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def remove_object(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def get_observation(self, robot_name: str | None = None, skip_images: bool = False) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def send_action(
+        self, action: dict[str, Any] | Sequence[float], robot_name: str | None = None, n_substeps: int = 1
+    ) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def physics_timestep(self) -> float:
+        return 0.002
+
+    def render(self, camera_name: str = "default", width: Any = None, height: Any = None) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+
+class TestTheFacadeReleasesEveryRolloutItDrives:
+    """The one owner of the release, exercised through ``run_policy``."""
+
+    def test_a_completed_rollout_leaves_the_robot_idle(self, monkeypatch):
+        _stub_rollout(monkeypatch)
+        engine = _HookRaisesTheFlagEngine()
+
+        result = engine.run_policy("arm", n_steps=3)
+
+        assert result["status"] == "success", result
+        assert engine.released == ["arm"]
+        assert engine.driven["arm"] is False
+
+    def test_a_raising_rollout_leaves_the_robot_idle(self, monkeypatch):
+        # A rollout that dies mid-loop must not leave the robot claimed: the
+        # release is in a ``finally``, not on the success path.
+        def _boom(self, *a: Any, **k: Any) -> dict[str, Any]:
+            raise RuntimeError("the loop died")
+
+        _stub_rollout(monkeypatch, _boom)
+        engine = _HookRaisesTheFlagEngine()
+
+        with pytest.raises(RuntimeError, match="the loop died"):
+            engine.run_policy("arm", n_steps=3)
+
+        assert engine.released == ["arm"]
+        assert engine.driven["arm"] is False
+
+    def test_every_episode_of_a_multi_episode_run_is_released(self, monkeypatch):
+        # ``_run_episodes`` builds a fresh hook per episode, so it owes a
+        # release per episode - not one for the whole call.
+        _stub_rollout(monkeypatch)
+        engine = _HookRaisesTheFlagEngine()
+
+        result = engine.run_policy("arm", n_steps=3, n_episodes=3)
+
+        assert result["status"] == "success", result
+        assert engine.released == ["arm", "arm", "arm"]
+        assert engine.driven["arm"] is False
+
+
+class TestIsaacFreesTheRobotItsRecordingHookClaimed:
+    """Isaac: the flag its primitives and its busy guard refuse on comes down."""
+
+    @staticmethod
+    def _engine() -> Any:
+        from strands_robots.simulation.isaac.config import IsaacConfig
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+
+        class _Articulation:
+            """Enough of an articulation for the primitive preamble to accept."""
+
+            num_dof = len(_SO100_JOINTS)
+            dof_names = list(_SO100_JOINTS)
+
+        engine = IsaacSimulation.__new__(IsaacSimulation)
+        engine._config = IsaacConfig(render_mode="rtx_realtime")
+        engine._lock = threading.RLock()
+        engine._world = object()  # non-None Isaac World stand-in: "world created"
+        engine._world_created = True
+        engine._robots = {
+            "so100": _RobotState(
+                name="so100",
+                prim_path="/World/Robots/so100",
+                joint_names=list(_SO100_JOINTS),
+                data_config="so100",
+                articulation=_Articulation(),
+            )
+        }
+        engine._cameras = {}
+        engine._objects = {}
+        engine._prim_registry = []
+        engine._cams_rec_state = None
+        # A live recording session: what makes the capture hook (and its claim)
+        # exist at all.
+        engine._recording_state_dict = {"recording": True, "dataset_recorder": None}
+        engine._action_controllers = {}
+        engine._sim_time = 0.0
+        engine._step_count = 0
+        engine._replicated = False
+        engine._num_envs_active = 1
+        engine._pump_running = False
+        engine._main_tid = threading.get_ident()
+        return engine
+
+    def test_a_primitive_is_reachable_after_a_recorded_rollout(self, monkeypatch):
+        _stub_rollout(monkeypatch)
+        engine = self._engine()
+
+        assert engine.run_policy("so100", n_steps=3)["status"] == "success"
+
+        with engine._lock:
+            name, robot, error = engine._primitive_resolve_robot("set_gripper", None)
+        assert error is None, error
+        assert name == "so100"
+        assert robot is engine._robots["so100"]
+
+    def test_another_rollout_is_reachable_after_a_recorded_rollout(self, monkeypatch):
+        # ``run_multi_policy``'s busy check reads the same flag, and its remedy
+        # ("Stop it first") names a verb this backend does not expose.
+        _stub_rollout(monkeypatch)
+        engine = self._engine()
+
+        assert engine.run_policy("so100", n_steps=3)["status"] == "success"
+
+        assert engine._robots["so100"].policy_running is False
+        assert not hasattr(engine, "stop_policy")
+
+
+class TestNewtonDoesNotReportAHaltOnAnIdleSimulation:
+    """Newton: an honest ``was_running`` for the stop paths that read the flag."""
+
+    @staticmethod
+    def _engine() -> Any:
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        world = SimWorld()
+        world.robots["so100"] = SimRobot(
+            name="so100", urdf_path="so100.xml", data_config="so100", joint_names=list(_SO100_JOINTS)
+        )
+        world._backend_state["recording"] = True
+        world._backend_state["dataset_recorder"] = None
+        engine = NewtonSimEngine.__new__(NewtonSimEngine)
+        engine._world = world
+        engine._model = object()  # non-None sentinel: "world created"
+        engine.default_width = 64
+        engine.default_height = 48
+        return engine
+
+    def test_a_finished_rollout_is_not_reported_as_halted(self, monkeypatch):
+        from strands_robots.device_connect.sim_driver import SimulationDeviceDriver
+
+        _stub_rollout(monkeypatch)
+        engine = self._engine()
+        assert engine.run_policy("so100", n_steps=3)["status"] == "success"
+
+        driver = SimulationDeviceDriver.__new__(SimulationDeviceDriver)
+        driver._sim = engine
+        # The fallback the driver documents for a backend exposing no
+        # ``stop_policy``: the flag write IS the verdict, so a stale flag is
+        # reported as a rollout this stop halted.
+        answer = driver._stop_one_rollout("so100")
+
+        assert answer["content"][0]["json"] == {"robot": "so100", "was_running": False}
+
+
+class TestMuJoCoWasAlreadyCorrect:
+    """The reference column: the backend whose own override owns the release."""
+
+    def test_a_recorded_rollout_leaves_the_robot_idle(self):
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation(tool_name="rollout_release_probe", mesh=False)
+        try:
+            sim.create_world()
+            sim.add_robot(name="arm", data_config="so100")
+            assert sim.run_policy("arm", n_steps=3, control_frequency=50.0)["status"] == "success"
+            assert sim._world.robots["arm"].policy_running is False
+            # And the flag is not read as a halted rollout afterwards.
+            assert sim._world.robots["arm"].request_policy_stop() is False
+        finally:
+            sim.cleanup()


### PR DESCRIPTION
![policy_running after a recorded rollout ends](https://raw.githubusercontent.com/cagataycali/robots/assets/rollout-hook-release/docs/assets/rollout_hook_release.png)

## The refusal names a remedy the caller has already followed

`_make_run_policy_hook` is the seam a backend uses to layer dataset recording onto the shared run-policy loop, and three backends raise the per-robot `policy_running` flag inside it. That flag is what a backend's motion primitives and busy guards refuse on, so it has to come back down when the rollout ends -- the guarantee `MuJoCoSimEngine._drive_rollout` states verbatim:

> Lowers the flag in a `finally` so a rollout that ends for any reason - completion, a cooperative stop, or a raise - leaves the robot idle.

MuJoCo reaches it through its own `run_policy` override. Isaac and Newton have none, and their hook builders are independent copies of the MuJoCo one -- as their own `test_recording_lifecycle_guards` modules put it, "independent copies of one contract, and a guard driven on one backend says nothing about the other". Both copies kept the raise; neither had anywhere to put the release.

Measured on both trees, two back-to-back `run_policy` calls on one robot:

| measured | before | after |
| --- | --- | --- |
| Isaac `policy_running` after `run_policy` returned | `True` (both rollouts) | `False` (both rollouts) |
| Isaac `set_gripper` after the rollout ended | refused | accepted |
| Isaac exposes `stop_policy` | no | no -- and nothing to stop |
| Newton Device Connect `stop` verdict, idle sim | `was_running=True` | `was_running=False` |

The two Isaac remedies are what makes this more than a stale field:

```
Cannot 'set_gripper' on 'so100' while its policy is running - a primitive and the policy
loop would race on the articulation's PD targets. Wait for the rollout to finish
(Isaac policy loops clear the flag on exit).

run_multi_policy: policy already running on 'so100'. Stop it first.
```

The rollout has finished, no loop is going to clear the flag, and Isaac exposes no `stop_policy` to stop anything with -- so both messages send the caller after something that cannot happen, for the rest of the session. On Newton the stale flag becomes `SimRobot.request_policy_stop`'s `was_running`, which is the *entire* verdict of the stop paths that reach a backend without `stop_policy` (`SimulationDeviceDriver._stop_one_rollout` documents that fallback), so an idle simulation reported a halted rollout.

## The change

`SimEngine._release_run_policy_hook` is the other half of the hook seam, called in a `finally` around every rollout the facade drives -- the single-episode `run_policy` path and each episode of a multi-episode run. Only the facade knows where a rollout ends; the closure is called per frame and cannot see its own last one.

```mermaid
flowchart LR
  A["_make_run_policy_hook\nraises policy_running"] --> B["runner.run\n(the rollout)"]
  B --> C["finally:\n_release_run_policy_hook"]
  C --> D["robot idle"]
  B -.->|"raise / cooperative stop"| C
```

Isaac and Newton implement the release beside their hook builders. MuJoCo, which already owned the release, is a no-op here and unchanged -- its own `finally` also clears `policy_claim_stops`, which is why the release was not hoisted out of it. `policy_instruction` / `policy_steps` stay as the last rollout's record on all three, as they already did on MuJoCo.

## Tests

`tests/simulation/test_rollout_hook_release_leaves_the_robot_idle.py`, 7 cells: the facade's release once (completion, a raising rollout, and one release per episode of a 3-episode run), each backend's release through the public `run_policy` verb, and MuJoCo as the reference column that was already correct.

Each break fires exactly its own cells:

| tree | failing cells |
| --- | --- |
| as shipped | 0 of 7 |
| all three source files reverted | 6 (MuJoCo reference still passes) |
| seam + overrides kept, the two `finally` calls removed | 6 |
| only the Isaac override reverted | 2 (the Isaac cells) |
| only the Newton override reverted | 1 (the Newton cell) |

Full suite, same tree with `strands_robots/` at `main` vs with the fix, 51311 collected both:

| | failed | passed | skipped | errors |
| --- | --- | --- | --- | --- |
| `main` | 73 | 50770 | 437 | 37 |
| this branch | 67 | 50776 | 437 | 37 |

Failures present here but not on `main`: **none**. Failures on `main` but not here: exactly the 6 new cells above. `ruff check` / `ruff format --check` clean, `mypy` at its standing count, `assemble_changelog.py --check` OK.

The figure's timeline is sampled from the real per-step flag, with `PolicyRunner.run` stood in for by a driver that calls the recording hook once per control step; the Isaac and Newton engines are built without their physics stacks, the fixture shape their own recording tests use. LOC: +466 / -41, of which 305 are the test.
