### PR TITLE
fix(dataset): a read reopens the directory the repo_id recorded to

### DIFF
--- a/changelog.d/3342-dataset-read-back-resolves-the-repo-id.md
+++ b/changelog.d/3342-dataset-read-back-resolves-the-repo-id.md
@@ -1,0 +1,21 @@
+### Fixed: a read reopens the directory the `repo_id` recorded to
+
+Every writing entry point resolves the dataset directory through
+`resolve_dataset_dir` and hands LeRobot the result as an explicit `root`,
+because a `repo_id` that is itself a path (no `owner/name` slash, or
+`./`-prefixed) is a local directory here and is not one to LeRobot, which
+resolves any absent root to `$HF_LEROBOT_HOME/{repo_id}` whatever the id looks
+like. `load_lerobot_episode` -- the shared loader behind
+`Simulation.replay_episode` -- forwarded the caller's `root` unresolved, so a
+read by the recording id looked where the recording had never been and the miss
+fell through to a Hub lookup for a name that only ever meant a directory.
+Measured on lerobot 0.6.2: `start_recording(repo_id="sim_recording", root=None)`
+plus a 45-step rollout wrote 7 files under `./sim_recording` with every call
+`status="success"`, and `replay_episode(repo_id="sim_recording")` then returned
+`status="error"`, "Cannot reach
+https://huggingface.co/api/datasets/sim_recording/refs". The read now applies
+the same rule and replays 45/45 frames from that directory. Only that rule: an
+`owner/name` id keeps its absent root, which is how LeRobot selects the
+revision-safe Hub snapshot cache for a download, and is already the directory a
+local recording under that id wrote to. The rule those surfaces share is now one
+named function, `local_dataset_dir` (#3342).

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -194,6 +194,12 @@ absent `root` there outright, because the directory it would derive for a writer
 is the revision-safe Hub snapshot cache; resolving here is what keeps the append
 reachable on the same arguments the recording was made with.
 
+Reading back applies the same rule, so a path-like `repo_id` replays and
+transforms the directory it recorded to with no `root` restated. Only that rule
+is applied on the read side: an `owner/name` id keeps its absent root so LeRobot
+resolves its own revision-safe snapshot cache for a download - which is already
+the directory a local recording under that id wrote to.
+
 Passing an existing **empty** directory - for example one returned by
 `tempfile.mkdtemp()` - is accepted and recorded into:
 
@@ -929,6 +935,16 @@ plays a recorded episode back through the sim: each recorded frame is one
 control step, applied via `send_action` and integrated for a full control period
 derived from the dataset fps, so a position-servo robot reproduces the recorded
 trajectory. `speed` scales only the wall-clock playback rate.
+
+`root` is resolved from `repo_id` exactly as recording resolves it, so whatever
+id `start_recording` was given replays with nothing restated:
+
+```python
+sim.start_recording(repo_id="sim_recording", task="pick the cube", fps=30)
+...
+sim.stop_recording()
+sim.replay_episode("sim_recording", robot_name="so101")   # same id, same directory
+```
 
 Each recorded action index is bound to an action key. By default those are
 `robot_action_keys(robot_name)` — the robot's **actuator** keys, which is the

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -568,21 +568,56 @@ def _lerobot_home() -> Path:
         return Path.home() / ".cache" / "huggingface" / "lerobot"
 
 
+def local_dataset_dir(repo_id: str) -> Path | None:
+    """The local directory a ``repo_id`` that is itself a path names.
+
+    A ``repo_id`` that is absolute, ``./``-prefixed, or carries no
+    ``owner/name`` slash is read as a local directory. That reading is this
+    repo's, not LeRobot's - ``LeRobotDataset`` resolves any absent root to
+    ``$HF_LEROBOT_HOME/{repo_id}`` whatever the id looks like - so these are
+    exactly the ids whose directory this repo has to state on every surface that
+    opens a dataset by id. Stating it on some of them and not others puts the
+    directory written to and the directory read back in two different places.
+
+    Args:
+        repo_id: HuggingFace dataset id (``owner/name``) or a local path.
+
+    Returns:
+        The directory the id names, or None for an ``owner/name`` Hub id.
+
+        ``None`` is a resolution, not a gap: that id's directory is LeRobot's to
+        derive, and a *reader* must leave it there. An absent root is how
+        LeRobot selects the revision-safe Hub snapshot cache for a download
+        (``snapshot_download(cache_dir=HF_LEROBOT_HUB_CACHE)``); naming the
+        directory instead switches it to a plain ``local_dir=`` materialization
+        and skips the re-download a legacy on-disk layout triggers. A *writer*
+        must never open that shared cache, which is why
+        :func:`resolve_dataset_dir` names ``$HF_LEROBOT_HOME/{repo_id}`` for the
+        same id - the two are the same directory whenever it already exists
+        locally, and they differ only in who owns a download.
+    """
+    if "/" not in repo_id or repo_id.startswith("/") or repo_id.startswith("./"):
+        return Path(repo_id)
+    return None
+
+
 def resolve_dataset_dir(repo_id: str, root: str | None = None) -> Path:
-    """Resolve the on-disk directory a dataset will live in.
+    """Resolve the on-disk directory a dataset will be WRITTEN to.
 
     * explicit ``root`` -> used verbatim;
-    * a ``repo_id`` that is itself a path (absolute, ``./`` prefixed, or with no
-      ``owner/name`` slash) -> treated as a local directory;
+    * a ``repo_id`` that is itself a path -> the directory it names
+      (:func:`local_dataset_dir`);
     * otherwise ``$HF_LEROBOT_HOME/{repo_id}``.
 
-    The middle rule is this repo's reading, not LeRobot's: ``LeRobotDataset``
-    resolves any absent root to ``$HF_LEROBOT_HOME/{repo_id}`` whatever the id
-    looks like. So this is the resolution callers get, and
-    :meth:`DatasetRecorder.create` hands the result down as an explicit ``root``
-    rather than letting the writer resolve a second time - otherwise the
-    directory inspected before the write and the directory written to are two
-    different places for exactly the ids the middle rule covers.
+    Every writing entry point hands the result down as an explicit ``root``
+    rather than letting LeRobot resolve a second time - otherwise the directory
+    inspected before the write and the directory written to are two different
+    places for exactly the ids the middle rule covers.
+
+    This is the writer's resolution: the third rule names a concrete directory
+    for a Hub id because a writer must not be handed LeRobot's shared snapshot
+    cache. A reader resolves the middle rule only and leaves the third to
+    LeRobot; see :func:`local_dataset_dir` on why the two differ.
 
     Args:
         repo_id: HuggingFace dataset id (``owner/name``) or a local path.
@@ -593,8 +628,8 @@ def resolve_dataset_dir(repo_id: str, root: str | None = None) -> Path:
     """
     if root:
         return Path(root)
-    if "/" not in repo_id or repo_id.startswith("/") or repo_id.startswith("./"):
-        return Path(repo_id)
+    if (local := local_dataset_dir(repo_id)) is not None:
+        return local
     return _lerobot_home() / repo_id
 
 
@@ -1937,7 +1972,12 @@ def load_lerobot_episode(repo_id: str, episode: int = 0, root: str | None = None
             once the shared guard has round-tripped it, so an accepted index
             reaches the O(1) episode-row lookup rather than the last-resort
             frame scan a float index falls through to.
-        root: Optional local dataset root override.
+        root: Local dataset directory. When omitted, a ``repo_id`` that is
+            itself a path is read as the directory it names - the same one the
+            recording entry points write to, so the id that recorded a dataset
+            reads it back. An ``owner/name`` id keeps an absent root so LeRobot
+            resolves its own revision-safe cache
+            (:func:`~strands_robots.dataset_recorder.local_dataset_dir`).
 
     Returns:
         Tuple of (dataset, episode_start, episode_length) on success.
@@ -1973,7 +2013,23 @@ def load_lerobot_episode(repo_id: str, episode: int = 0, root: str | None = None
 
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
 
-    ds = LeRobotDataset(repo_id=repo_id, root=root)
+    # The directory to read, resolved by the same rule the recording was written
+    # through. A ``repo_id`` that is itself a path is a local directory here as
+    # it is there (:func:`local_dataset_dir`); forwarding the caller's ``None``
+    # unresolved sent the read somewhere the recording never was, because
+    # LeRobot reads an absent root as ``$HF_LEROBOT_HOME/{repo_id}`` whatever
+    # the id looks like. So the id that recorded a dataset could not read it
+    # back: the miss falls through to a Hub lookup for a dataset name that only
+    # ever named a directory.
+    #
+    # Only that rule is resolved here. An ``owner/name`` id keeps its absent
+    # root, which is how LeRobot selects the revision-safe snapshot cache for a
+    # download - and it already reads back what a local write put at
+    # ``$HF_LEROBOT_HOME/{repo_id}``, since that is the same directory LeRobot
+    # derives. Resolving it here would move Hub downloads out of that cache for
+    # no gain.
+    read_root = Path(root) if root else local_dataset_dir(repo_id)
+    ds = LeRobotDataset(repo_id=repo_id, root=str(read_root) if read_root is not None else None)
 
     num_episodes = ds.meta.total_episodes if hasattr(ds.meta, "total_episodes") else len(ds.meta.episodes)
     if episode >= num_episodes:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -2298,7 +2298,10 @@ class PolicyRunner:
                 non-numeric one is rejected with a structured error before the
                 dataset is downloaded. Refused rather than coerced because the
                 index selects which trajectory reaches the actuators.
-            root: Optional local dataset root override.
+            root: Local dataset directory. When omitted it is resolved from
+                ``repo_id`` by the rule recording writes through, so an id that
+                is itself a path replays the directory it recorded to
+                (:func:`~strands_robots.dataset_recorder.local_dataset_dir`).
             speed: Playback speed multiplier (1.0 = real time). Must be a
                 positive, finite number (any real scalar, including a NumPy
                 scalar such as ``np.float32(2.0)``); a non-positive,

--- a/tests/test_dataset_read_back_reads_what_the_repo_id_recorded.py
+++ b/tests/test_dataset_read_back_reads_what_the_repo_id_recorded.py
@@ -1,0 +1,178 @@
+"""The ``repo_id`` that recorded a dataset reads it back.
+
+Every writing entry point resolves the dataset directory through
+:func:`~strands_robots.dataset_recorder.resolve_dataset_dir` and hands LeRobot
+the result as an explicit ``root``, because a ``repo_id`` that is itself a path
+(absolute, ``./``-prefixed, or with no ``owner/name`` slash) is a local
+directory here and is **not** one to LeRobot, which resolves any absent root to
+``$HF_LEROBOT_HOME/{repo_id}`` whatever the id looks like.
+
+``load_lerobot_episode`` -- the shared loader behind ``Simulation.replay_episode``
+-- forwarded the caller's ``root`` unresolved instead, so a read by the recording
+id looked for the dataset somewhere it had never been. The miss then falls
+through to a Hub lookup for a name that only ever meant a directory. Measured end
+to end against lerobot 0.6.2 on a MuJoCo scene, ``HF_LEROBOT_HOME`` pointed at an
+empty directory and the working directory fresh::
+
+    sim.start_recording(repo_id="sim_recording", task="pick the cube", fps=30,
+                        root=None, overwrite=True)   # status="success"
+    sim.run_policy(policy_provider="mock", n_steps=45, control_frequency=30.0)
+    sim.stop_recording()                             # status="success"
+    # 7 files under ./sim_recording (parquet + 2 per-camera MP4);
+    # $HF_LEROBOT_HOME/sim_recording does not exist.
+
+    sim.replay_episode(repo_id="sim_recording", episode=0)
+    # status="error": "Cannot reach
+    #   https://huggingface.co/api/datasets/sim_recording/refs"
+
+With the read resolving the same rule, the same script replays 45/45 frames under
+``status="success"`` from ``./sim_recording``.
+
+Only that rule is resolved on the read side, and the cells below pin the
+boundary as well as the fix. An ``owner/name`` id keeps its absent root: that is
+how LeRobot selects the revision-safe Hub snapshot cache for a download
+(``snapshot_download(cache_dir=HF_LEROBOT_HUB_CACHE)``), and naming a directory
+instead switches it to a plain ``local_dir=`` materialization. A Hub id needs no
+help anyway -- the directory LeRobot derives for it is already the one a local
+recording under that id wrote to.
+
+The existing dataset doubles all accept any ``root`` silently, so none of them
+could observe this. The reader below reproduces the one property that decides the
+outcome: it finds a dataset only where it is told to look, and falls back to the
+Hub for an absent root exactly as LeRobot does.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import pytest
+
+from strands_robots import dataset_recorder as dr
+
+
+class _OfflineHub(Exception):
+    """Stands in for the hub error a read of a non-existent dataset raises."""
+
+
+class _Meta:
+    total_episodes = 1
+    episodes = [{"dataset_from_index": 0, "dataset_to_index": 45}]
+
+
+class _ReaderThatFindsOnlyWhereItLooks:
+    """A LeRobotDataset double shaped like the reader.
+
+    It records the ``root`` it was handed and resolves an absent one the way
+    LeRobot does -- ``$HF_LEROBOT_HOME/{repo_id}``, then the Hub -- so a read
+    aimed at the wrong directory fails the way a caller actually experiences it
+    rather than merely carrying a different kwarg.
+    """
+
+    home: Path = Path()
+    kwargs: dict[str, Any] = {}
+
+    def __init__(self, repo_id: str, root: str | None = None) -> None:
+        type(self).kwargs = {"repo_id": repo_id, "root": root}
+        looked_in = Path(root) if root else type(self).home / repo_id
+        if not (looked_in / "meta" / "info.json").exists():
+            if root:
+                raise FileNotFoundError(f"No LeRobotDataset at {looked_in}")
+            raise _OfflineHub(f"Cannot reach https://huggingface.co/api/datasets/{repo_id}/refs")
+        self.repo_id = repo_id
+        self.root = looked_in
+        self.meta = _Meta()
+
+
+def plant(directory: Path) -> Path:
+    """Write the minimum on-disk shape a dataset read looks for."""
+    (directory / "meta").mkdir(parents=True, exist_ok=True)
+    (directory / "meta" / "info.json").write_text(json.dumps({"fps": 30}), encoding="utf-8")
+    return directory
+
+
+@pytest.fixture
+def reader(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> type[_ReaderThatFindsOnlyWhereItLooks]:
+    """Inject the double, relocate the dataset home, and anchor the cwd."""
+    module = types.ModuleType("lerobot.datasets.lerobot_dataset")
+    module.LeRobotDataset = _ReaderThatFindsOnlyWhereItLooks  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", module)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(dr, "_lerobot_home", lambda: home)
+    _ReaderThatFindsOnlyWhereItLooks.home = home
+    _ReaderThatFindsOnlyWhereItLooks.kwargs = {}
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    return _ReaderThatFindsOnlyWhereItLooks
+
+
+class _PathLikeId(NamedTuple):
+    repo_id: str
+    # The directory that spelling names, relative to the working directory.
+    name: str
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        _PathLikeId(repo_id="sim_recording", name="sim_recording"),
+        _PathLikeId(repo_id="./dotted", name="dotted"),
+    ],
+    ids=lambda case: case.repo_id,
+)
+def test_a_path_like_repo_id_reads_the_directory_it_recorded_to(
+    reader: type[_ReaderThatFindsOnlyWhereItLooks], case: _PathLikeId
+) -> None:
+    """The read lands where ``resolve_dataset_dir`` put the recording.
+
+    The directory is planted at the *writer's* resolution, so this asserts the
+    two sides agree rather than restating the reader's own arithmetic.
+
+    The relative spellings are the whole exposure. An ABSOLUTE path-like id is
+    not tested here because it cannot be broken: ``$HF_LEROBOT_HOME / "/abs/dir"``
+    is ``/abs/dir`` -- joining an absolute right-hand operand discards the left --
+    so LeRobot's own resolution already lands on it, with or without this fix.
+    """
+    recorded_at = plant(dr.resolve_dataset_dir(case.repo_id, None))
+
+    ds, start, length = dr.load_lerobot_episode(case.repo_id, 0, None)
+
+    assert Path(ds.root).resolve() == (Path.cwd() / case.name).resolve()
+    assert Path(recorded_at).resolve() == Path(ds.root).resolve()
+    assert (start, length) == (0, 45)
+
+
+def test_a_hub_id_is_left_to_lerobots_own_resolution(
+    reader: type[_ReaderThatFindsOnlyWhereItLooks], tmp_path: Path
+) -> None:
+    """An ``owner/name`` id reads with no root, and still finds a local recording.
+
+    The boundary, and the reason the read side does not simply apply
+    ``resolve_dataset_dir``: an absent root is how LeRobot selects the
+    revision-safe Hub snapshot cache for a download, so naming the directory for
+    a Hub id would move every download out of that cache. Nothing is lost by
+    leaving it -- the home LeRobot derives is the one a local recording under
+    that id wrote to, which is why this read succeeds.
+    """
+    plant(tmp_path / "home" / "user" / "data")
+
+    ds, _, _ = dr.load_lerobot_episode("user/data", 0, None)
+
+    assert reader.kwargs["root"] is None
+    assert Path(ds.root) == tmp_path / "home" / "user" / "data"
+
+
+def test_an_explicit_root_is_read_verbatim(reader: type[_ReaderThatFindsOnlyWhereItLooks], tmp_path: Path) -> None:
+    """The control: naming a root replaces the resolution, it is not joined to it."""
+    chosen = plant(tmp_path / "chosen")
+
+    ds, _, _ = dr.load_lerobot_episode("user/data", 0, str(chosen))
+
+    assert Path(reader.kwargs["root"]) == chosen
+    assert Path(ds.root) == chosen


### PR DESCRIPTION
Recording with a path-like `repo_id` succeeds; reading it back with the same id goes to the Hub.

![record then read back](https://raw.githubusercontent.com/cagataycali/robots/assets/dataset-read-back-resolves-repo-id/docs/assets/dataset_read_back.png)

## The two resolutions

A `repo_id` that is itself a path (no `owner/name` slash, or `./`-prefixed) is a local directory *here* and is not one to LeRobot, which resolves any absent root to `$HF_LEROBOT_HOME/{repo_id}` whatever the id looks like. Every **writing** entry point therefore resolves through `resolve_dataset_dir` and hands LeRobot the result as an explicit `root`. `load_lerobot_episode` -- the shared loader behind `Simulation.replay_episode` -- forwarded the caller's `root` unresolved.

| surface | id `"sim_recording"`, `root=None` | resolved by |
|---|---|---|
| `start_recording` / `DatasetRecorder.create` | `./sim_recording` | this repo |
| `DatasetRecorder.resume` | `./sim_recording` | this repo |
| `load_lerobot_episode` / `replay_episode` | ~~`$HF_LEROBOT_HOME/sim_recording`, then the Hub~~ -> `./sim_recording` | ~~LeRobot~~ -> this repo |

Measured end to end on lerobot 0.6.2, MuJoCo `so100`, `$HF_LEROBOT_HOME` empty and a fresh cwd (the panels above are that script's own output):

| | before | after |
|---|---|---|
| `start_recording` / `stop_recording` | `success` | `success` |
| files under `./sim_recording` | 6 | 6 |
| frames decodable from its MP4 | 45 | 45 |
| `$HF_LEROBOT_HOME/sim_recording` exists | no | no |
| `replay_episode(repo_id="sim_recording")` | **`error`** -- `Cannot reach https://huggingface.co/api/datasets/sim_recording/refs` | **`success`** |
| `frames_applied` | -- (never opened) | **45 / 45** |

The episode replayed after the fix, decoded back out of the dataset's own MP4:

![the replayed episode](https://raw.githubusercontent.com/cagataycali/robots/assets/dataset-read-back-resolves-repo-id/docs/assets/replayed_episode.gif)

## Change

The rule the two sides share is now one named function, `local_dataset_dir(repo_id) -> Path | None`, and the read applies it. Seven executable lines; the rest of the diff is the boundary written down.

**Only that rule is resolved on the read side, deliberately.** An `owner/name` id keeps its absent root, because that is how LeRobot selects the revision-safe Hub snapshot cache for a download (`snapshot_download(cache_dir=HF_LEROBOT_HUB_CACHE)`); naming the directory instead switches it to a plain `local_dir=` materialization and skips the re-download a legacy on-disk layout triggers. Nothing is gained by resolving it -- the home LeRobot derives for a Hub id is already the directory a local recording under that id wrote to. So `local_dataset_dir` returns `None` there, and that `None` is a resolution rather than a gap.

`transforms` is not in this family: it validates `source_root` as required, so it never reaches the loader with an absent one.

## Tests

`tests/test_dataset_read_back_reads_what_the_repo_id_recorded.py`, 4 cells. Every existing dataset double accepts any `root` silently, so none of them could observe this; the reader here reproduces the one property that decides the outcome -- it finds a dataset only where it is told to look, and falls back to the Hub for an absent root exactly as LeRobot does -- so the cells fail on the refusal a caller actually hits rather than on a kwarg value.

Each mutation fires exactly the cells that own it:

| tree | failing cells |
|---|---|
| as shipped | 0 of 4 |
| the read forwards `root` unresolved (pre-fix) | 2 -- both path-like ids, on the Hub refusal |
| the read applies `resolve_dataset_dir` to **every** id | 1 -- the Hub-boundary cell only |
| an explicit `root` is dropped | 1 -- the control |

That middle row is why the boundary cell exists: it is the only thing separating this change from the shorter blanket resolve.

An absolute path-like id is deliberately **not** a case. It cannot be broken -- `$HF_LEROBOT_HOME / "/abs/dir"` is `/abs/dir`, since joining an absolute right-hand operand discards the left -- so a cell for it would pin nothing.

Full unit suite, this branch vs. `main` with the new test file copied in, one clean session each, 51321 collected on both:

| | failed | passed | skipped | errors |
|---|---|---|---|---|
| `main` + the new file | 69 | 50784 | 437 | 37 |
| this branch | **67** | **50786** | 437 | 37 |

The node-id difference is exactly the 2 discriminating cells (failing on `main`, passing here); **nothing fails here that does not also fail on `main`**. The 104 shared failures/errors are the standing environment set (`awsiot`, `rclpy`, lerobot-version drift). `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` at the standing 20 errors / 6 files.

## Docs

`docs/recording.md` gains the read-back half of the `root` rule and a record-then-replay snippet using one id; `load_lerobot_episode` and `replay_episode` document what an omitted `root` resolves to instead of "optional override".

**LOC:** `strands_robots` +74/-15 (of which ~7 executable), `docs` +16, plus a 178-line test and a changelog fragment.