### PR TITLE
docs(streaming): the recipe documented as chronological reads shuffled frames

### DIFF
--- a/changelog.d/3344-streaming-capture-order-recipe.md
+++ b/changelog.d/3344-streaming-capture-order-recipe.md
@@ -1,0 +1,28 @@
+### Fixed: the streaming recipe documented as chronological reads shuffled frames
+
+`StreamingDatasetReader`'s "in-process eval / replay" Example and the streaming
+section of `docs/recording.md` both passed `shuffle=False` alone and commented it
+`# chronological for replay/eval`. It is not chronological. `shuffle` reaches
+lerobot's `StreamingLeRobotDataset`, where it decides only WHICH generator drives
+the reordering -- a `default_rng(seed)` reseeded identically on every exhaustion,
+or the dataset's own advancing one -- so it decides reproducibility *across
+epochs*, which is what lerobot documents it as ("whether to shuffle the dataset
+across exhaustions"). The reader reorders either way, at two levels: it samples a
+shard at random per frame, and it yields from a reservoir buffer of
+`buffer_size`.
+
+Reading a 60-frame recorded dataset back through the documented recipe yields
+frame indices `28, 55, 18, 24, 7, ...`, and `shuffle=True` alongside
+`buffer_size=1` reads in capture order anyway -- so the flag is not the order
+knob in either direction. Nothing reports a shuffled read: every frame is
+delivered, only out of order, so an eval or replay loop that followed the
+documented recipe silently consumed its episode scrambled while its own comment
+said otherwise.
+
+Capture order is `buffer_size=1` (a reservoir of one has nothing to reorder)
+together with `max_num_shards=1` (a single shard has nothing to interleave), and
+`examples/06_agent_collect_and_stream.py` already used both. All four documented
+recipes now show that pair, `open()` carries an `Ordering` note stating what
+`shuffle` does decide, and two rules over the package, guide and examples keep a
+surface from claiming capture order -- or offering `shuffle=False` in its place --
+without naming the knob that delivers it.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -979,7 +979,8 @@ reader = sim.stream_dataset(
         "observation.state": [-0.0667, -0.0333, 0.0],
         "action": [0.0, 0.0333, 0.0667],
     },
-    shuffle=False,                     # chronological for replay/eval
+    buffer_size=1,                     # capture order for replay/eval:
+    max_num_shards=1,                  # one reservoir slot, one shard
 )
 print(reader.num_episodes, reader.num_frames, reader.fps)
 for frame in reader:
@@ -991,6 +992,16 @@ for batch in reader.dataloader(batch_size=64, num_workers=4):
 ```
 
 Equivalently, the standalone reader: `from strands_robots import StreamingDatasetReader`.
+
+`shuffle` is **not** the read-order knob, and `shuffle=False` on its own reads
+shuffled frames with nothing reporting it. It selects only which generator
+drives the reordering (a generator reseeded from `seed` on every exhaustion, or
+the dataset's advancing one), so it decides reproducibility *across epochs* —
+lerobot documents it as "whether to shuffle the dataset across exhaustions".
+`StreamingLeRobotDataset` reorders either way: it samples a shard at random per
+frame and yields from a reservoir buffer. Capture order is therefore
+`buffer_size=1` (a reservoir of one cannot reorder) plus `max_num_shards=1`
+(a single shard has nothing to interleave), as above.
 
 Useful kwargs (forwarded to `StreamingLeRobotDataset`, version-tolerant):
 `episodes=[...]` (subset without download), `buffer_size`, `max_num_shards`,

--- a/examples/06_agent_collect_and_stream.py
+++ b/examples/06_agent_collect_and_stream.py
@@ -44,13 +44,13 @@ agent(
 #    same object that recorded it. Camera frames are decoded on the fly from
 #    the MP4 shards (torchcodec, shipped by the [lerobot] extra); state/action
 #    come from the parquet shards. Nothing is re-materialized to disk.
-#    shuffle=False only fixes the seed; the reader re-shards and yields from a
-#    random reservoir, so max_num_shards=1 + buffer_size=1 are what make this
-#    read capture order. Drop all three to train (the shuffle is wanted there).
+#    shuffle only fixes the reservoir seed across exhaustions; the reader
+#    reorders either way, so buffer_size=1 (a reservoir of one) + max_num_shards=1
+#    (one shard to interleave) are what make this read capture order. Drop both
+#    to train (the shuffle is wanted there).
 reader = sim.stream_dataset(
     REPO_ID,
     root=DATASET_ROOT,
-    shuffle=False,
     max_num_shards=1,
     buffer_size=1,
 )

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -1453,8 +1453,11 @@ class DatasetRecordingMixin:
                 a local repo_id paired with ``root=``.
             **kwargs: Forwarded to
                 :meth:`StreamingDatasetReader.open` - e.g. ``root``,
-                ``delta_timestamps``, ``episodes``, ``shuffle``, ``buffer_size``,
-                ``max_num_shards``, ``drop_videos`` (proprio-only,
+                ``delta_timestamps``, ``episodes``, ``shuffle`` (which decides
+                cross-epoch reproducibility, NOT read order - see that method's
+                "Ordering" note), ``buffer_size`` and ``max_num_shards`` (both
+                ``1`` to read in capture order),
+                ``drop_videos`` (proprio-only,
                 torchcodec-free; requires ``delta_timestamps`` with at least one
                 non-video key, else ValueError), ``repo_type`` (``"dataset"`` or
                 ``"bucket"``; ``"bucket"`` requires lerobot>=0.6.1, else
@@ -1468,7 +1471,7 @@ class DatasetRecordingMixin:
                 "local/agent_demo", root="/tmp/strands_agent_dataset",
                 delta_timestamps={"observation.state": [-0.0667, 0.0],
                                   "action": [0.0, 0.0667]},
-                shuffle=False,
+                buffer_size=1, max_num_shards=1,  # capture order for replay
             )
             for frame in reader:
                 ...

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -160,12 +160,16 @@ _NUMERIC_DOMAINS: dict[str, Callable[[Any], str | None]] = {
 class StreamingDatasetReader:
     """Version-tolerant wrapper over lerobot's StreamingLeRobotDataset.
 
+    ``shuffle`` is not the read-order knob - see :meth:`open`'s "Ordering"
+    note. Capture order is ``buffer_size=1`` plus ``max_num_shards=1``.
+
     Example (in-process eval / replay):
         reader = StreamingDatasetReader.open(
             "strands-robots/pick-place",
             delta_timestamps={"observation.images.front": [-0.2, -0.1, 0.0],
                               "action": [0.0, 0.1, 0.2]},
-            shuffle=False,            # chronological for replay/eval
+            buffer_size=1,            # capture order: a reservoir of one
+            max_num_shards=1,         # capture order: one shard to interleave
         )
         for frame in reader:
             ...  # raw tensors; normalize via reader.meta.stats if needed
@@ -205,6 +209,22 @@ class StreamingDatasetReader:
             the same way with or without the extra installed, rather than a
             NumPy error part-way through iteration, a shard count of zero that
             streams no frames, or a tolerance that switches the grid check off.
+
+        Ordering:
+            ``shuffle`` does not decide read order, and passing
+            ``shuffle=False`` alone reads shuffled frames. It selects only
+            which generator drives the reordering -
+            ``np.random.default_rng(seed)``, reseeded identically on every
+            exhaustion, versus the dataset's own advancing one - so it decides
+            reproducibility ACROSS epochs, matching lerobot's own "whether to
+            shuffle the dataset across exhaustions". ``StreamingLeRobotDataset``
+            reorders either way, at two levels: it samples a shard at random per
+            frame, and it yields from a reservoir buffer of ``buffer_size``.
+            Capture order therefore needs ``buffer_size=1`` (a reservoir of one
+            has nothing to reorder) together with ``max_num_shards=1`` (a single
+            shard has nothing to interleave). Nothing reports a shuffled read,
+            so an eval or replay loop that asked for order with ``shuffle``
+            alone silently consumes frames out of order.
 
         Raises:
             ValueError: A numeric knob (``tolerance_s``, ``buffer_size``,
@@ -418,7 +438,8 @@ def stream_dataset(repo_id: str, **kwargs: Any) -> StreamingDatasetReader:
         import strands_robots
 
         reader = strands_robots.stream_dataset(
-            "lerobot/svla_so100_pickplace", shuffle=False
+            "lerobot/svla_so100_pickplace",
+            buffer_size=1, max_num_shards=1,  # capture order, not shuffle=False
         )
         for frame in reader:
             ...

--- a/tests/test_streaming_capture_order_recipe.py
+++ b/tests/test_streaming_capture_order_recipe.py
@@ -1,0 +1,229 @@
+"""Reading a streamed dataset in capture order is ``buffer_size=1``, not ``shuffle=False``.
+
+``StreamingDatasetReader.open`` forwards ``shuffle`` to lerobot's
+``StreamingLeRobotDataset``, where it decides only WHICH generator drives the
+reordering: ``np.random.default_rng(seed)``, reseeded identically on every
+exhaustion, or the dataset's own advancing one. lerobot documents it as
+"whether to shuffle the dataset across exhaustions", and its ``__iter__``
+reorders either way, at two levels - a shard sampled at random per frame, then a
+reservoir buffer of ``buffer_size`` yielded from at a random index.
+
+Two of the recipes a caller reads first - the ``StreamingDatasetReader`` class
+docstring's "in-process eval / replay" Example and the streaming section of
+``docs/recording.md`` - passed ``shuffle=False`` alone and commented it
+"chronological for replay/eval". It is not: on a 60-frame recorded dataset that
+recipe yields frame indices ``28, 55, 18, 24, 7, ...``, and passing
+``shuffle=True`` alongside ``buffer_size=1`` reads in capture order anyway. So
+the flag named for shuffling does not decide order, nothing reports a shuffled
+read, and an eval or replay loop that followed the documented recipe consumed
+its episode out of order while its own comment said otherwise.
+
+The cells below pin both halves: the ordering contract, against a double shaped
+like lerobot's iterator rather than like this module's description of it, and the
+documented recipes, so a surface that claims capture order names the knob that
+delivers it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+import numpy as np
+import pytest
+
+import strands_robots.streaming_dataset as sd
+
+REPO_ID = "local/capture_order"
+FRAMES = 60
+
+
+class _ReservoirShapedStreaming:
+    """Stand-in reproducing the two reorderings lerobot's ``__iter__`` performs.
+
+    Faithful to ``lerobot.datasets.streaming_dataset.StreamingLeRobotDataset``
+    in exactly the respects that decide read order, so these cells measure the
+    dependency's shape rather than this module's account of it:
+
+    * ``shuffle`` selects the generator only - a fresh
+      ``default_rng(seed)`` when False (identical on every exhaustion) versus an
+      advancing one when True. Neither switches the reordering off.
+    * shards are sampled at random per frame from
+      ``min(hf_shards, max_num_shards)`` of them, so more than one shard
+      interleaves.
+    * frames pass through a reservoir of ``buffer_size``, yielded from at a
+      random index, and whatever is left is shuffled once the shards are
+      exhausted.
+
+    ``hf_shards`` is a class attribute because the caller cannot reach it: the
+    reader only forwards the knobs of :meth:`StreamingDatasetReader.open`.
+    """
+
+    hf_shards: ClassVar[int] = 1
+
+    def __init__(self, repo_id: str, **kw: Any) -> None:
+        self.repo_id = repo_id
+        self.kw = kw
+        self.buffer_size = int(kw.get("buffer_size", 1000))
+        self.max_num_shards = int(kw.get("max_num_shards", 16))
+        self.seed = int(kw.get("seed", 42))
+        self.shuffle = bool(kw.get("shuffle", True))
+        self.num_frames = FRAMES
+        self.num_episodes = 1
+        self.fps = 30
+
+    def _shard(self, index: int, count: int) -> list[dict[str, int]]:
+        """Frames of one shard, in capture order (HF shards round-robin)."""
+        return [{"frame_index": i} for i in range(index, FRAMES, count)]
+
+    def __iter__(self) -> Any:
+        rng = np.random.default_rng(self.seed if not self.shuffle else self.seed + 1)
+        count = min(self.hf_shards, self.max_num_shards)
+        shards = {i: iter(self._shard(i, count)) for i in range(count)}
+        buffer: list[dict[str, int]] = []
+        while shards:
+            key = int(rng.choice(list(shards)))
+            frame = next(shards[key], None)
+            if frame is None:
+                del shards[key]
+                continue
+            if len(buffer) == self.buffer_size:
+                slot = int(rng.integers(0, self.buffer_size))
+                yield buffer[slot]
+                buffer[slot] = frame
+            else:
+                buffer.append(frame)
+        rng.shuffle(buffer)  # type: ignore[arg-type]
+        yield from buffer
+
+
+@pytest.fixture
+def reservoir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject the double through the override ``_get_streaming_cls`` honors."""
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _ReservoirShapedStreaming, raising=False)
+    monkeypatch.setattr(_ReservoirShapedStreaming, "hf_shards", 1)
+
+
+def _read_order(**kwargs: Any) -> list[int]:
+    reader = sd.StreamingDatasetReader.open(REPO_ID, root="/tmp/unused", **kwargs)
+    return [int(frame["frame_index"]) for frame in reader]
+
+
+CAPTURE_ORDER = list(range(FRAMES))
+
+
+def test_the_documented_recipe_reads_in_capture_order(reservoir: None) -> None:
+    """``buffer_size=1`` + ``max_num_shards=1`` is what capture order needs."""
+    assert _read_order(buffer_size=1, max_num_shards=1) == CAPTURE_ORDER
+
+
+def test_shuffle_false_alone_does_not_read_in_capture_order(reservoir: None) -> None:
+    """The recipe both docstring and docs used to carry reads reordered frames.
+
+    Every frame is still delivered - the loss is the order, which is the whole
+    point of a replay - so a caller has nothing to notice.
+    """
+    order = _read_order(shuffle=False)
+    assert sorted(order) == CAPTURE_ORDER, "frames were lost, not merely reordered"
+    assert order != CAPTURE_ORDER
+
+
+def test_shuffle_true_with_the_recipe_still_reads_in_capture_order(reservoir: None) -> None:
+    """Order does not depend on ``shuffle`` at all - the direct proof.
+
+    Asking to shuffle and getting capture order anyway is what makes ``shuffle``
+    the wrong knob to document as chronological.
+    """
+    assert _read_order(shuffle=True, buffer_size=1, max_num_shards=1) == CAPTURE_ORDER
+
+
+def test_a_reservoir_of_one_is_not_enough_while_shards_interleave(
+    monkeypatch: pytest.MonkeyPatch, reservoir: None
+) -> None:
+    """``max_num_shards=1`` earns its place in the recipe.
+
+    A reservoir of one cannot reorder within a shard, but the shard sampled per
+    frame is still random, so a multi-shard dataset interleaves without the
+    second knob. A single-shard dataset cannot show this, which is why it is
+    pinned against a double rather than against one recorded dataset.
+    """
+    monkeypatch.setattr(_ReservoirShapedStreaming, "hf_shards", 4)
+    assert _read_order(buffer_size=1, max_num_shards=4) != CAPTURE_ORDER
+    assert _read_order(buffer_size=1, max_num_shards=1) == CAPTURE_ORDER
+
+
+# --- the documented recipes themselves ---------------------------------------
+
+# Surfaces a caller reads to learn how to stream: the package, the guide, the
+# runnable examples. tests_integ is deliberately excluded - its stream_dataset
+# calls verify a schema, not an order, so they make no claim to keep honest.
+_SURFACES = ("strands_robots", "docs", "examples")
+# "def stream_dataset(" is the definition, not a use of the recipe.
+_CALL = re.compile(r"(?<!def )(?:stream_dataset|StreamingDatasetReader\.open)\s*\(")
+_CLAIM = re.compile(r"capture[ -]order|chronological", re.IGNORECASE)
+_LINES_OF_LEAD_IN = 5
+
+
+def _call_windows(text: str) -> list[str]:
+    """Each streaming call's own argument text plus the lines leading into it."""
+    windows = []
+    for match in _CALL.finditer(text):
+        depth, end = 0, match.end()
+        for end in range(match.end() - 1, len(text)):
+            depth += {"(": 1, ")": -1}.get(text[end], 0)
+            if depth == 0:
+                break
+        lead = text[: match.start()].splitlines()[-_LINES_OF_LEAD_IN:]
+        windows.append("\n".join(lead) + text[match.start() : end + 1])
+    return windows
+
+
+def _documented_calls() -> list[tuple[str, str]]:
+    root = Path(__file__).resolve().parent.parent
+    found = []
+    for surface in _SURFACES:
+        for path in sorted((root / surface).rglob("*")):
+            if path.suffix not in (".py", ".md"):
+                continue
+            for window in _call_windows(path.read_text(encoding="utf-8")):
+                found.append((str(path.relative_to(root)), window))
+    return found
+
+
+def test_the_documented_surfaces_still_show_a_streaming_call() -> None:
+    """Guard the rule below against silently scanning nothing."""
+    assert len(_documented_calls()) >= 4
+
+
+def test_every_surface_claiming_capture_order_names_the_knob_that_delivers_it() -> None:
+    """A recipe may not promise capture order while passing only ``shuffle``.
+
+    ``buffer_size=1`` is the knob that stops the reservoir reordering; a surface
+    that claims capture order without it is documenting an order the reader does
+    not deliver, which is exactly what the class docstring and
+    ``docs/recording.md`` did.
+    """
+    offenders = [
+        (where, window)
+        for where, window in _documented_calls()
+        if _CLAIM.search(window) and "buffer_size=1" not in window
+    ]
+    assert not offenders, "\n\n".join(f"{where}:\n{window}" for where, window in offenders)
+
+
+def test_no_documented_surface_opts_out_of_shuffle_as_its_order_knob() -> None:
+    """``shuffle=False`` may not stand in for the recipe, claim or no claim.
+
+    Covers the surfaces the rule above cannot: an Example that passes
+    ``shuffle=False`` and says nothing still teaches it as the way to read a
+    recorded episode back, and that is how four surfaces came to carry a recipe
+    that reorders. ``shuffle=True`` is untouched - a training example wants the
+    shuffle and makes no claim on order.
+    """
+    offenders = [
+        (where, window)
+        for where, window in _documented_calls()
+        if "shuffle=False" in window and "buffer_size=1" not in window
+    ]
+    assert not offenders, "\n\n".join(f"{where}:\n{window}" for where, window in offenders)


### PR DESCRIPTION
`StreamingDatasetReader`'s "in-process eval / replay" Example and the streaming section of `docs/recording.md` both passed `shuffle=False` alone and commented it `# chronological for replay/eval`. It is not chronological.

![streaming read-back order](https://raw.githubusercontent.com/cagataycali/robots/assets/streaming-capture-order/docs/assets/streaming_capture_order.png)

## What `shuffle` actually decides

It reaches lerobot's `StreamingLeRobotDataset`, whose `__iter__` picks `np.random.default_rng(seed)` when `shuffle=False` and the dataset's own advancing generator when True — i.e. it decides reproducibility *across exhaustions*, which is exactly what lerobot documents ("whether to shuffle the dataset across exhaustions"). Reordering happens either way, at two levels: a shard is sampled at random per frame, and frames pass through a reservoir buffer of `buffer_size` yielded from at a random index.

```mermaid
flowchart LR
  S["shards<br/>min(hf_shards, max_num_shards)"] -->|"rng.choice per frame"| R["reservoir<br/>buffer_size"]
  R -->|"yield buffer[rng.integers(0, buffer_size)]"| O[frames delivered]
  K["shuffle"] -.->|"picks the generator only"| S
  K -.-> R
```

## Measured, 60-frame recorded dataset read back through `open` (lerobot 0.5.1)

| `open(...)` kwargs | first 10 `frame_index` | capture order |
|---|---|---|
| `shuffle=False` — the old docstring + docs recipe | `28, 55, 18, 24, 7, 17, 27, 50, 59, 39` | no |
| defaults | `28, 55, 18, 24, 7, 17, 27, 50, 59, 39` | no |
| `max_num_shards=1` alone | `28, 55, 18, 24, 7, 17, 27, 50, 59, 39` | no |
| `buffer_size=1` alone | `0 … 9` | yes |
| `shuffle=False, buffer_size=1, max_num_shards=1` | `0 … 9` | yes |
| **`shuffle=True`**`, buffer_size=1, max_num_shards=1` | `0 … 9` | **yes** |

The last row is the direct proof: asking to shuffle still reads capture order, so `shuffle` is not the order knob in either direction. Nothing reports a shuffled read — `sorted(delivered) == range(60)`, every frame arrives, only out of order — so an eval or replay loop that followed the documented recipe consumed its episode scrambled while its own comment said otherwise.

## Change

Capture order is `buffer_size=1` (a reservoir of one has nothing to reorder) plus `max_num_shards=1` (a single shard has nothing to interleave) — the pair `examples/06_agent_collect_and_stream.py` already used. All four documented recipes now show it:

| surface | before | after |
|---|---|---|
| `StreamingDatasetReader` class docstring | `shuffle=False,  # chronological for replay/eval` | `buffer_size=1, max_num_shards=1` |
| `stream_dataset` module alias Example | `shuffle=False` | `buffer_size=1, max_num_shards=1` |
| `Simulation.stream_dataset` Example | `shuffle=False` | `buffer_size=1, max_num_shards=1` |
| `docs/recording.md` streaming section | `shuffle=False,  # chronological for replay/eval` | `buffer_size=1, max_num_shards=1` + a paragraph on what `shuffle` decides |
| `examples/06_...` | already had both knobs | re-attributes which knob does what |

`open()` gains an `Ordering` note beside its existing `Validation` one, stating what `shuffle` decides and that `shuffle=False` alone reads shuffled frames.

## Tests

`tests/test_streaming_capture_order_recipe.py` (7 cells). The ordering contract is pinned against a double shaped like lerobot's `__iter__` — `shuffle` selects the generator only, shards are sampled at random, frames pass a reservoir — rather than like this module's account of it. Two rules then scan `strands_robots/`, `docs/` and `examples/` so the claim cannot drift back. (`tests_integ` is excluded by design: its `stream_dataset` calls verify a schema, not an order.)

One row per edit, in a scratch copy:

| mutation | failing cells |
|---|---|
| shipped | 0 of 7 |
| revert all four surfaces | 2 (both rules) |
| revert only `streaming_dataset.py` | 2 (both rules name it) |
| revert only `docs/recording.md` | 2 (both rules name it) |
| revert only the facade docstring | 1 (`…opts_out_of_shuffle_as_its_order_knob`) |
| revert only `examples/06` | 0 — it already passed both knobs; its edit is attribution only |
| double models "`shuffle=False` disables reordering" | 1 (`…shuffle_false_alone_does_not_read_in_capture_order`) |

`max_num_shards=1` earns its place in a cell driven by a 4-shard double: a reservoir of one cannot reorder within a shard, but the shard sampled per frame is still random. One recorded dataset has a single shard and so cannot show that, which is why it is pinned against the double.

## Gate

`ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ` (1962 files); `mypy` at the repo baseline (20 pre-existing errors in 6 files, unchanged). Full `tests/` run on this branch and on a tree holding `main`'s sources with this test file added, concurrently: **51324 collected on both**, mine `67 failed / 50789 passed / 437 skipped / 37 errors`, base `69 failed / 50787 passed / 437 skipped / 37 errors`. The failing-name sets differ in exactly one direction — the two rule cells — and `comm` finds nothing failing on this branch that does not also fail on `main`.

LOC: +302 / -10. Of that, +45 / -10 is docstrings, guide and example; the remaining 229 is the new test file.