### PR TITLE
fix(tools): a session store is written whole, or the previous one is still there

### DIFF
--- a/changelog.d/3345-a-failed-session-store-keeps-the-sessions-it-held.md
+++ b/changelog.d/3345-a-failed-session-store-keeps-the-sessions-it-held.md
@@ -1,0 +1,12 @@
+### Bug Fixes
+
+- **tools**: A session store that cannot be written keeps the sessions it already held.
+  `lerobot_teleoperate` and `lerobot_train` write the same whole-document store, so a
+  write that landed partially left a prefix where the store was - and both load paths
+  report an unparseable store as *no sessions*. One failed write therefore dropped every
+  record at once, while the detached processes those records named kept running: `list`
+  answered `status="success"` with no sessions and `stop` answered that the session was
+  not found. The map is now serialized before the destination is touched and committed
+  through a temp file plus `os.replace`, in one shared owner both tools ask through, so a
+  full disk leaves the previous store intact and a record JSON cannot represent is
+  refused naming the store rather than truncating it.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -69,6 +69,16 @@ stores load, modify and write back, so a record a load leaves out is erased from
 disk by the next session started or stopped. What a load counts as "finished"
 therefore decides whether a session stays stoppable.
 
+Loading and writing back is also why the *write* has to land whole. Both tools
+write the same file, so a store that lands partially does not lose the session
+being changed - it loses every session the file held, in both tools at once, and
+both load paths report an unparseable store as *no sessions*. So the map is
+serialized in full before the destination is opened and committed through a temp
+file plus an atomic rename: a full disk during a training run leaves the previous
+store intact rather than truncated, and a record holding a value JSON cannot
+represent is refused naming the store, with everything already recorded still
+listed and still stoppable.
+
 A pid alone cannot answer that, because the kernel hands the number back out once
 the process holding it exits. Each record therefore also carries the identity of
 the process it was written for - how long after boot that process started - and

--- a/strands_robots/tools/_process_stop.py
+++ b/strands_robots/tools/_process_stop.py
@@ -34,15 +34,25 @@ reason: subtracting an ungraded stamp from the clock turns a record that states
 no usable start into a duration - the ``0`` an absent key defaults to renders as
 the whole epoch, a little under fifty-seven years - and reports it beside a
 running flag that is correct.
+
+Reading a record presupposes that the file still holds one, which is what
+:func:`store_sessions` is for. Every session store here is a whole document: a
+verb that starts or stops one session loads every record, changes that one, and
+writes them all back. A write that lands partially therefore does not lose the
+session being changed, it loses every session the file held - and the load path
+reports an unparseable store as *no sessions*, so the loss surfaces as an arm
+that is still being driven by a process no verb can name.
 """
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import sys
 import time
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 import psutil
@@ -315,6 +325,74 @@ def unusable_pid_result(session_name: str, recorded: Any) -> dict[str, Any]:
             {"json": {"session_name": session_name, "pid_usable": False, "stopped": False}},
         ],
     }
+
+
+def store_sessions(sessions_file: Path, sessions: Mapping[str, Any]) -> None:
+    """Replace a session store whole, or leave the stored one untouched.
+
+    Both session verbs persist a whole document: :meth:`add_session` and
+    :meth:`remove_session` load every record, change one entry, and store the
+    map back. So a write that lands partially does not lose the session being
+    changed - it loses every session the file held, and the load path reports an
+    unparseable store as *no sessions*. Both stores go to the same file, and the
+    records in it are the only place a detached process's pid is written down, so
+    the loss is not cosmetic: the processes keep running, ``list`` reports none,
+    and ``stop`` answers that the session was not found.
+
+    The document is therefore serialized in full *before* the destination is
+    touched, and the text is committed through a temp file in the same directory
+    plus :func:`os.replace` - the sequence
+    :func:`strands_robots.registry.user_registry._save_user_registry` documents
+    for its own whole-document store, for the same two reasons:
+
+    * Serializing first is what keeps a rejected write harmless. ``json.dump``
+      encodes straight into the stream it is given, so a value it cannot encode
+      raises only after a prefix of the new document has replaced the stored one.
+    * :func:`os.replace` is atomic within a directory, so a full disk or an I/O
+      error during the commit leaves the previous store intact rather than
+      truncated, and a concurrent reader observes one whole document or the
+      other, never a prefix.
+
+    The temp file is written with :meth:`pathlib.Path.write_text` rather than
+    :func:`tempfile.mkstemp` so the store keeps the ordinary umask-derived mode a
+    plain ``open(path, "w")`` gave it: replacing its contents is not the moment
+    to decide who may read it.
+
+    Args:
+        sessions_file: The store to replace. Its parent directory must exist -
+            both callers create it when their module loads.
+        sessions: The whole session map to store.
+
+    Raises:
+        ValueError: A record holds a value JSON cannot represent. Raised before
+            the stored store is touched, so it still holds what it last held;
+            the originating ``TypeError`` stays on ``__cause__``, naming the
+            offending type.
+        OSError: The temp file could not be written or renamed. The stored store
+            is likewise unchanged, and no temp file is left behind.
+    """
+    try:
+        # Name the encoding the reader names, so the store's spelling is a
+        # property of the file rather than of the locale that wrote it.
+        payload = json.dumps(dict(sessions), indent=2)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"a session record is not JSON-serializable, so the store cannot be written to "
+            f"{sessions_file}: {exc}. The stored sessions are unchanged, so every session "
+            f"already recorded stays stoppable. Pass only JSON types (str, int, float, bool, "
+            f"None, list, dict)."
+        ) from exc
+
+    tmp = sessions_file.with_suffix(sessions_file.suffix + ".tmp")
+    try:
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, sessions_file)
+    except OSError:
+        # The commit did not happen, so the stored document is the previous one.
+        # Leaving the temp file behind would put a second, partial store next to
+        # it under a name the load path does not read.
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 def session_is_running(info: Mapping[str, Any]) -> bool:

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -33,6 +33,7 @@ from strands_robots.tools._process_stop import (
     reused_pid_result,
     session_is_running,
     session_uptime,
+    store_sessions,
     unstopped_result,
     unusable_pid_result,
 )
@@ -369,10 +370,14 @@ class SessionManager:
             return {}
 
     def _save_sessions(self, sessions: dict[str, Any]):
-        """Save sessions to disk, in the encoding the load path reads."""
+        """Store the session map in full, or leave the stored one untouched.
+
+        :func:`~strands_robots.tools._process_stop.store_sessions` owns the
+        sequence, because losing this store is what makes a live session
+        unstoppable and both session tools write the same file.
+        """
         try:
-            with open(self.sessions_file, "w", encoding="utf-8") as f:
-                json.dump(sessions, f, indent=2)
+            store_sessions(self.sessions_file, sessions)
         except OSError as e:
             logger.error(f"Error saving sessions: {e}")
 

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -39,6 +39,7 @@ from strands_robots.tools._process_stop import (
     reused_pid_result,
     session_is_running,
     session_uptime,
+    store_sessions,
     unstopped_result,
     unusable_pid_result,
 )
@@ -439,11 +440,14 @@ class SessionManager:
                 )
 
     def _save_sessions(self, sessions: dict[str, Any]) -> None:
+        """Store the session map in full, or leave the stored one untouched.
+
+        :func:`~strands_robots.tools._process_stop.store_sessions` owns the
+        sequence, because losing this store is what makes a live session
+        unstoppable and both session tools write the same file.
+        """
         try:
-            # Name the encoding the reader names, so the store's spelling is a
-            # property of the file rather than of the locale that wrote it.
-            with open(self.sessions_file, "w", encoding="utf-8") as f:
-                json.dump(sessions, f, indent=2)
+            store_sessions(self.sessions_file, sessions)
         except OSError as e:
             logger.error(f"Error saving sessions: {e}")
 

--- a/tests/tools/test_a_failed_session_store_keeps_the_sessions_it_already_held.py
+++ b/tests/tools/test_a_failed_session_store_keeps_the_sessions_it_already_held.py
@@ -1,0 +1,302 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A session store that cannot be written keeps the sessions it already held.
+
+Both session tools persist a whole document to the same file: ``add_session``
+and ``remove_session`` load every record, change one entry, and store the map
+back. Encoding that document straight into its own destination made a rejected
+write destructive - the stream is truncated first, so a full disk left a prefix
+where the store was, and both load paths report an unparseable store as *no
+sessions*.
+
+The records in that file are the only place a detached process's pid is written
+down, which ``SessionManager`` says out loud: it "never deletes one" because of
+it, and its load path keeps a record it could not inspect "so the session stays
+stoppable". One failed write dropped all of them at once, so three live
+processes - one of them a teleoperation loop driving a follower arm - kept
+running while ``list`` answered ``status="success"`` with no sessions and
+``stop`` answered that the session was not found.
+
+These cells pin the commit instead: the document is serialized before the
+destination is touched, committed through a temp file plus ``os.replace``, and a
+failed write leaves every session already recorded stored, listed and stoppable.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import errno
+import importlib
+import inspect
+import io
+import json
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.tools._process_stop import (
+    PID_STARTED_SINCE_BOOT,
+    process_started_since_boot,
+)
+
+tele_mod = importlib.import_module("strands_robots.tools.lerobot_teleoperate")
+train_mod = importlib.import_module("strands_robots.tools.lerobot_train")
+
+_REAL_OPEN = io.open
+
+#: The store both tools write. Its ``.tmp`` commit sibling shares the prefix.
+_STORE_PREFIX = "active_sessions"
+
+
+class _FullDisk:
+    """A text file that accepts ``allowance`` characters, then reports ENOSPC.
+
+    A full disk fails the write that exhausts it *after* the bytes before it
+    landed, which is what makes an in-place rewrite destructive and a temp-file
+    commit harmless. Everything else delegates, so the file the implementation
+    chose to open is the file that fills up.
+    """
+
+    def __init__(self, fh: Any, allowance: int) -> None:
+        self._fh = fh
+        self._left = allowance
+
+    def write(self, data: str) -> int:
+        if len(data) <= self._left:
+            self._left -= len(data)
+            return self._fh.write(data)
+        if self._left:
+            self._fh.write(data[: self._left])
+            self._left = 0
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    def __enter__(self) -> _FullDisk:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._fh.close()
+
+    def close(self) -> None:
+        self._fh.close()
+
+    def flush(self) -> None:
+        self._fh.flush()
+
+
+@pytest.fixture
+def full_disk(monkeypatch: pytest.MonkeyPatch):
+    """Fill the filesystem under any file whose name starts with a prefix.
+
+    Both spellings are covered on purpose - the store itself and any ``.tmp``
+    sibling a commit writes - so the injection describes the disk rather than
+    the implementation, and hits whichever file is written.
+    """
+
+    def _install(prefix: str = _STORE_PREFIX, allowance: int = 120) -> None:
+        def _open(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+            fh = _REAL_OPEN(file, mode, *args, **kwargs)
+            if "w" in mode and Path(str(file)).name.startswith(prefix):
+                return _FullDisk(fh, allowance)
+            return fh
+
+        # ``Path.write_text`` reaches ``io.open``; a plain ``open(...)`` call
+        # reaches ``builtins.open``. Both are the disk.
+        monkeypatch.setattr(io, "open", _open)
+        monkeypatch.setattr(builtins, "open", _open)
+
+    return _install
+
+
+@pytest.fixture
+def managers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Both session managers, pointed at one throwaway store.
+
+    Both modules compute ``SESSION_DIR`` at import time from ``cwd``; rebind it
+    so the tools share a temporary store, which is what they do in production -
+    ``lerobot_train`` reuses the teleoperate directory on purpose.
+    """
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(tele_mod, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(train_mod, "SESSION_DIR", session_dir)
+    return {"teleop": tele_mod.SessionManager(), "train": train_mod.SessionManager()}
+
+
+@pytest.fixture
+def live_pids() -> Any:
+    """Hand out real, live process ids and reap them however the test ends."""
+    procs: list[subprocess.Popen[bytes]] = []
+
+    def _spawn() -> subprocess.Popen[bytes]:
+        proc = subprocess.Popen(["sleep", "60"])
+        procs.append(proc)
+        return proc
+
+    yield _spawn
+    for proc in procs:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()
+
+
+def _record(pid: int, action: str) -> dict[str, Any]:
+    """A session record carrying the identity the load path checks."""
+    return {
+        "pid": pid,
+        PID_STARTED_SINCE_BOOT: process_started_since_boot(pid),
+        "action": action,
+        "start_time": time.time(),
+    }
+
+
+def _seed(managers: dict[str, Any], live_pids: Any) -> dict[str, int]:
+    """Record one live teleoperation session and one live training session."""
+    teleop_proc, train_proc = live_pids(), live_pids()
+    managers["teleop"].add_session("teleop_arm", _record(teleop_proc.pid, "teleoperate"))
+    managers["train"].add_session("train_act", _record(train_proc.pid, "train"))
+    return {"teleop_arm": teleop_proc.pid, "train_act": train_proc.pid}
+
+
+@pytest.mark.parametrize("writer", ["teleop", "train"])
+def test_a_failed_store_keeps_every_session_already_recorded(
+    managers: dict[str, Any], live_pids: Any, full_disk: Any, writer: str
+) -> None:
+    """A write that runs out of disk leaves the stored sessions readable.
+
+    Parametrized over which tool performs the failing write because both write
+    the same file: a training run that fills the disk must not drop the record
+    of a teleoperation loop, and the reverse.
+    """
+    seeded = _seed(managers, live_pids)
+    store = managers["teleop"].sessions_file
+    before = store.read_bytes()
+
+    full_disk()
+    managers[writer].add_session("late_session", _record(live_pids().pid, "train"))
+
+    after = store.read_bytes()
+    assert json.loads(after), f"the store no longer parses, so every session in it is lost: {after!r}"
+    # Both managers read the same file, so both must still see both records.
+    for manager in managers.values():
+        listed = manager.list_sessions()
+        for name, pid in seeded.items():
+            assert name in listed, f"{name} was dropped by a write that failed for another session"
+            assert manager.get_session(name)["pid"] == pid
+    assert json.loads(before).keys() == json.loads(after).keys()
+
+
+def test_the_stop_verb_still_finds_the_session_after_a_failed_store(
+    managers: dict[str, Any], live_pids: Any, full_disk: Any
+) -> None:
+    """The tool can still stop a live session whose store write was not the one that failed.
+
+    The store is the only route by which ``stop`` can name the process, so this
+    drives the real verb rather than the manager: a session that cannot be found
+    is a process that keeps driving the follower arm.
+    """
+    seeded = _seed(managers, live_pids)
+
+    full_disk()
+    managers["train"].add_session("late_session", _record(live_pids().pid, "train"))
+
+    result = tele_mod.lerobot_teleoperate(action="stop", session_name="teleop_arm")
+    assert result["status"] == "success", result["content"][0]["text"]
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not process_started_since_boot(seeded["teleop_arm"]):
+            break
+        time.sleep(0.05)
+    assert process_started_since_boot(seeded["teleop_arm"]) is None, "the stopped process is still running"
+
+
+def test_a_record_json_cannot_encode_is_refused_before_the_store_is_touched(
+    managers: dict[str, Any], live_pids: Any
+) -> None:
+    """A NumPy scalar in a record leaves the stored sessions byte-identical.
+
+    ``json.dump`` encodes into the stream it is given, so a value it cannot
+    encode used to raise only after a prefix of the new document had replaced
+    the stored one - and past the ``OSError`` handler, which does not cover it.
+    """
+    _seed(managers, live_pids)
+    store = managers["teleop"].sessions_file
+    before = store.read_bytes()
+
+    poisoned = _record(live_pids().pid, "train")
+    poisoned["steps"] = np.int32(20000)
+    with pytest.raises(ValueError) as excinfo:
+        managers["train"].add_session("late_session", poisoned)
+
+    assert "int32" in str(excinfo.value.__cause__), "the refusal must name the offending type"
+    assert store.read_bytes() == before, "the stored sessions were touched by a rejected write"
+    # Serializing first is what makes the refusal leave nothing at all. Encoding
+    # into the temp file would keep the store intact but strand a partial one
+    # beside it, and raise the encoder's own ``TypeError`` rather than a refusal
+    # naming the store.
+    strays = [q.name for q in store.parent.iterdir() if q.name != store.name]
+    assert strays == [], f"a rejected record left a partial store behind: {strays}"
+
+
+def test_a_failed_store_leaves_no_partial_sibling_behind(
+    managers: dict[str, Any], live_pids: Any, full_disk: Any
+) -> None:
+    """A commit that did not happen leaves no second, partial store next to the real one."""
+    _seed(managers, live_pids)
+    store = managers["teleop"].sessions_file
+
+    full_disk()
+    managers["teleop"].add_session("late_session", _record(live_pids().pid, "teleoperate"))
+
+    strays = [p.name for p in store.parent.iterdir() if p.name != store.name]
+    assert strays == [], f"a partial store was left beside the real one: {strays}"
+
+
+def test_an_unwritable_store_is_reported_and_not_raised(
+    managers: dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    """CONTROL: an I/O failure still logs and returns rather than raising.
+
+    Holds either way - it is the contract the tools already had, kept so the
+    commit change is about durability and not about how a failure is reported.
+    """
+    manager = managers["teleop"]
+    manager.sessions_file = manager.sessions_file.parent / "missing_dir" / "active_sessions.json"
+    with caplog.at_level("ERROR"):
+        manager._save_sessions({"s": {"pid": 1}})
+    assert any("Error saving sessions" in r.message for r in caplog.records)
+
+
+def test_a_store_that_succeeds_is_readable_by_both_managers(managers: dict[str, Any], live_pids: Any) -> None:
+    """CONTROL: the ordinary path still writes a store both tools read.
+
+    Holds either way, so a commit that refused every write would not satisfy it.
+    """
+    seeded = _seed(managers, live_pids)
+    assert set(managers["teleop"].list_sessions()) == set(seeded)
+    assert set(managers["train"].list_sessions()) == set(seeded)
+    managers["teleop"].remove_session("teleop_arm")
+    assert set(managers["train"].list_sessions()) == {"train_act"}
+
+
+def test_both_session_stores_commit_through_the_one_owner() -> None:
+    """Neither tool spells the commit itself, so the sequence lives in one place.
+
+    Graded on the call rather than the text: the rule is which function performs
+    the write, and a second copy of ``tmp`` plus ``os.replace`` is exactly the
+    drift that leaves one of the two stores destructive.
+    """
+    for module in (tele_mod, train_mod):
+        source = inspect.getsource(module.SessionManager._save_sessions)
+        called = {
+            ast.unparse(node.func)
+            for node in ast.walk(ast.parse(textwrap.dedent(source)))
+            if isinstance(node, ast.Call)
+        }
+        assert "store_sessions" in called, f"{module.__name__} does not commit through the shared owner: {called}"
+        assert "json.dump" not in called, f"{module.__name__} still encodes into its own destination"


### PR DESCRIPTION
`lerobot_teleoperate` and `lerobot_train` persist a **whole document** to the same file: `add_session` and `remove_session` load every record, change one entry, and store the map back. That document was encoded straight into its own destination, so a rejected write was destructive - `open(path, "w")` truncates first and `json.dump` streams into it. A write that landed partially therefore did not lose the session being changed, it lost **every session the file held**, and both load paths report an unparseable store as *no sessions*.

The records in that file are the only place a detached process's pid is written down, which `SessionManager` states as its own reason for never dropping one:

> The load step classifies a record as running or finished but never deletes one: `remove_session` is the only thing that drops a record, because this store is the only place a detached training process's pid is written down.

and its load path keeps a record it could not inspect "so the session stays stoppable". The care taken in the read path is exactly what one failed write undid.

## Measured

Two live detached sessions recorded, then a third `add_session` from `lerobot_train` meets a full disk part-way through. Both tools share `.strands_robots/.sessions/active_sessions.json` - deliberately, `# Reuse the teleoperate session store so all robot sessions live together` - so this is a training run destroying a teleoperation record.

| after the failed write | before | after |
|---|---|---|
| the store | 120 B, `JSONDecodeError: Unterminated string` | 386 B, parses |
| records readable | **none** | `teleop_arm`, `train_act` |
| `lerobot_teleoperate(action="list")` | `status="success"`, `(0) No active sessions` | `status="success"`, `(1)` |
| `lerobot_teleoperate(action="stop", session_name="teleop_arm")` | `status="error"`, `Session 'teleop_arm' not found` | `status="success"`, `Session Stopped, PID: 1264` |
| the teleoperation process | **still running** | stopped |

The failure was logged either way. Nothing else reported it, and the arm kept being driven by a process no verb could name.

A full disk is not the only trigger. `json.dump` encodes into the stream it is given, so a value it cannot encode - a NumPy scalar off a servo read - wrote a valid prefix and *then* raised, and raised `TypeError`, which the `except OSError` handler does not cover. A 724-byte, six-motor document became 435 unparseable bytes ending mid-value.

## Change

```mermaid
flowchart LR
  subgraph before
    A1[load every record] --> A2["open(store, 'w')<br/>truncates"] --> A3[json.dump streams] -.->|raises part-way| A4([prefix where<br/>the store was])
  end
  subgraph after
    B1[load every record] --> B2["json.dumps to text"] -.->|refuses here| B5([store untouched])
    B2 --> B3[write store.tmp] -.->|refuses here| B5
    B3 --> B4["os.replace"] --> B6([one whole<br/>document or the other])
  end
```

The sequence lives in one new `store_sessions` in `strands_robots/tools/_process_stop.py` - the module that already owns every other question about a session record (`recorded_pid`, `session_uptime`, `session_is_running`) and is already imported by both tools. It is the same sequence `registry.user_registry._save_user_registry` and `tools.pose_tool._save_poses` document for their own whole-document stores. Both call sites shrink or stay flat; the whole cost is the one owner:

| | AST statements |
|---|---|
| `_process_stop.py` | 88 -> 101 (+13) |
| `lerobot_teleoperate.py` | 349 -> 348 (**-1**) |
| `lerobot_train.py` | 357 -> 357 (0) |

**Deliberately unchanged:** how a failure is *reported*. `_save_sessions` still logs an `OSError` and returns, which is the contract both tools had and which `test_save_sessions_swallows_oserror` pins - this change is about whether the previous store survives, not about the report. `restore_calibrations` uses `shutil.copy2`, a different write, and is untouched.

## Tests

`tests/tools/test_a_failed_session_store_keeps_the_sessions_it_already_held.py` - a real `_FullDisk` file object matched on the store's name *prefix*, so it fills up whichever file the implementation opens (the store, or a `.tmp` sibling) and stays valid either side of the fix. Real detached processes, and the real `stop` verb rather than the manager.

Four corners, over `tests/tools/test_lerobot_teleoperate.py` + `tests/tools/test_lerobot_train.py` (106 cells) and the new file (8):

| | existing | new |
|---|---|---|
| main | 106 passed | **5 failed / 3 passed** |
| this branch | 106 passed | 8 passed |

On `main` the failures name the defect: `JSONDecodeError: Unterminated string` in both directions (a teleop write and a train write), `Session 'teleop_arm' not found` through the real verb, `TypeError: Object of type int32 is not JSON serializable`, and `{'json.dump', 'logger.error', 'open'}` from the one-owner cell. The 3 that pass are the two declared controls plus the no-stray-`.tmp` cell, which holds vacuously on `main` because an in-place write leaves nothing beside itself - it pins a property of the commit, and mutation b3 is what earns it.

Mutations, `collected` stable at 8:

| mutation | fires | cells |
|---|---|---|
| b0 control | 0 | - |
| b1 encode straight into the destination | 3 | both store cells + the `stop` verb |
| b2 stream the encoder into the temp file | 1 | the refusal, alone |
| b3 leave the partial temp file behind | 1 | no-stray-`.tmp`, alone |
| b4 refuse every write (over-reach) | 5 | incl. the success control |
| b5 one tool keeps its own in-place write | 2 | incl. the one-owner cell |
| b6 swallow the non-serializable record | 1 | the refusal, alone |

Gate: `ruff check` / `ruff format --check` clean over 1962 files; `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1959 source files`; `tests/tools/` 4069 passed; the 499 tree-walking graders + `tests/tools/` -> 27843 passed, 5 failed, all five asserting `rclpy` is absent where the environment supplies it and reproduced byte-identically on a pristine `upstream/main` worktree.

Docs: `docs/hardware/tools.md` already explains that the store is the only place a pid is recorded and reasons about which records a *load* leaves out; it now also covers the write that has to land whole.