### PR TITLE
fix(dataset): streaming a dataset back reopens the directory the repo_id recorded to

### DIFF
--- a/changelog.d/3346-streaming-read-back-resolves-the-repo-id.md
+++ b/changelog.d/3346-streaming-read-back-resolves-the-repo-id.md
@@ -1,0 +1,21 @@
+### Fixed: streaming a dataset back reopens the directory the `repo_id` recorded to
+
+`StreamingDatasetReader.open` -- behind `strands_robots.stream_dataset` and
+`Simulation.stream_dataset`, documented as the in-process counterpart to
+`start_recording` / `stop_recording` -- forwarded the caller's `root`
+unresolved, so the read-back half of that loop looked for the dataset somewhere
+the recording had never been. A `repo_id` that is itself a path (no
+`owner/name` slash, or `./`-prefixed) is a local directory here and is not one
+to LeRobot, which derives any absent root as `$HF_LEROBOT_HOME/{repo_id}`
+whatever the id looks like -- and `StreamingLeRobotDataset` reads a local
+dataset only when it is given a root, so the miss fell through to a Hub lookup
+for a name that only ever meant a directory. Measured on lerobot 0.6.2:
+`start_recording(repo_id="sim_recording", root=None)` plus a 45-step rollout
+wrote 7 files under `./sim_recording` with every call `status="success"`, and
+`stream_dataset("sim_recording")` then raised `RepositoryNotFoundError`, "404
+... https://huggingface.co/api/datasets/sim_recording/refs". The read now
+resolves the same rule recording writes through (`local_dataset_dir`) and
+streams 45 frames from that directory with no `root` restated. Only that rule:
+an `owner/name` id keeps its absent root, which is how LeRobot selects the
+revision-safe Hub metadata cache and is already the directory a local recording
+under that id wrote to (#3346).

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -194,11 +194,11 @@ absent `root` there outright, because the directory it would derive for a writer
 is the revision-safe Hub snapshot cache; resolving here is what keeps the append
 reachable on the same arguments the recording was made with.
 
-Reading back applies the same rule, so a path-like `repo_id` replays and
-transforms the directory it recorded to with no `root` restated. Only that rule
-is applied on the read side: an `owner/name` id keeps its absent root so LeRobot
-resolves its own revision-safe snapshot cache for a download - which is already
-the directory a local recording under that id wrote to.
+Reading back applies the same rule, so a path-like `repo_id` replays, streams
+and transforms the directory it recorded to with no `root` restated. Only that
+rule is applied on the read side: an `owner/name` id keeps its absent root so
+LeRobot resolves its own revision-safe snapshot cache for a download - which is
+already the directory a local recording under that id wrote to.
 
 Passing an existing **empty** directory - for example one returned by
 `tempfile.mkdtemp()` - is accepted and recorded into:
@@ -989,7 +989,7 @@ from strands_robots import Robot
 
 sim = Robot("so100")
 reader = sim.stream_dataset(
-    "user/my_dataset",                 # or a local repo_id + root=
+    "user/my_dataset",                 # a path-like repo_id needs no root=
     root="/tmp/my_dataset",
     delta_timestamps={                 # optional: stacked time windows + *_is_pad masks
         "observation.state": [-0.0667, -0.0333, 0.0],
@@ -1005,6 +1005,17 @@ for frame in reader:
 # torch DataLoader (shuffles INTERNALLY — do not pass shuffle=True):
 for batch in reader.dataloader(batch_size=64, num_workers=4):
     ...
+```
+
+A `repo_id` that is itself a path (no `owner/name` slash, or `./`-prefixed) is
+resolved to the directory recording wrote to, so the record -> read-back loop
+needs no `root` restated:
+
+```python
+sim.start_recording(repo_id="sim_recording", task="pick the cube", fps=30)
+...
+sim.stop_recording()
+reader = sim.stream_dataset("sim_recording")   # ./sim_recording, not the Hub
 ```
 
 Equivalently, the standalone reader: `from strands_robots import StreamingDatasetReader`.

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -1450,7 +1450,9 @@ class DatasetRecordingMixin:
 
         Args:
             repo_id: HF dataset id (e.g. ``"lerobot/svla_so100_pickplace"``) or
-                a local repo_id paired with ``root=``.
+                a ``repo_id`` that is itself a path, which streams the directory
+                it recorded to with no ``root`` restated
+                (:func:`~strands_robots.dataset_recorder.local_dataset_dir`).
             **kwargs: Forwarded to
                 :meth:`StreamingDatasetReader.open` - e.g. ``root``,
                 ``delta_timestamps``, ``episodes``, ``shuffle`` (which decides

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -23,6 +23,7 @@ import sys
 from collections.abc import Callable
 from typing import Any
 
+from strands_robots.dataset_recorder import local_dataset_dir
 from strands_robots.utils import (
     finite_number_error,
     lerobot_version,
@@ -201,6 +202,17 @@ class StreamingDatasetReader:
     ) -> StreamingDatasetReader:
         """Open a version-tolerant streaming reader.
 
+        Local datasets:
+            An absent ``root`` is resolved from ``repo_id`` by the rule
+            recording writes through
+            (:func:`~strands_robots.dataset_recorder.local_dataset_dir`), so a
+            ``repo_id`` that is itself a path streams the directory it recorded
+            to with no ``root`` restated. Only that rule is resolved here: an
+            ``owner/name`` id keeps its absent root, which is how
+            ``StreamingLeRobotDataset`` selects LeRobot's revision-safe Hub
+            metadata cache - already the directory a local recording under that
+            id wrote to.
+
         Validation:
             The numeric knobs are checked against
             :data:`_NUMERIC_DOMAINS` before the lerobot import, because
@@ -262,6 +274,20 @@ class StreamingDatasetReader:
         for param, domain in _NUMERIC_DOMAINS.items():
             if error := domain(supplied[param]):
                 raise ValueError(error)
+
+        # A repo_id that is itself a path names a local directory here and does
+        # not to LeRobot, which derives any absent root as
+        # $HF_LEROBOT_HOME/{repo_id} whatever the id looks like. Recording
+        # resolves that rule and writes to the directory the id names, so this
+        # read has to resolve it too or it streams from somewhere the recording
+        # has never been - and StreamingLeRobotDataset only reads a local
+        # dataset at all when it is given a root (streaming_from_local), so the
+        # miss falls through to a Hub lookup for a name that only ever meant a
+        # directory. An owner/name id is left to LeRobot: an absent root is how
+        # it selects the revision-safe Hub metadata cache, which is already
+        # where a local recording under that id wrote to.
+        if root is None and (local := local_dataset_dir(repo_id)) is not None:
+            root = str(local)
 
         StreamingCls = _get_streaming_cls()
         init_sig = inspect.signature(StreamingCls).parameters
@@ -425,7 +451,8 @@ def stream_dataset(repo_id: str, **kwargs: Any) -> StreamingDatasetReader:
 
     Args:
         repo_id: HF dataset id (e.g. ``"lerobot/svla_so100_pickplace"``) or a
-            local repo_id paired with ``root=``.
+            ``repo_id`` that is itself a path, which streams the directory it
+            recorded to with no ``root`` restated.
         **kwargs: Forwarded to :meth:`StreamingDatasetReader.open` - e.g.
             ``root``, ``delta_timestamps``, ``episodes``, ``shuffle``,
             ``buffer_size``, ``max_num_shards``, ``drop_videos``

--- a/tests/test_dataset_read_back_reads_what_the_repo_id_recorded.py
+++ b/tests/test_dataset_read_back_reads_what_the_repo_id_recorded.py
@@ -7,12 +7,12 @@ the result as an explicit ``root``, because a ``repo_id`` that is itself a path
 directory here and is **not** one to LeRobot, which resolves any absent root to
 ``$HF_LEROBOT_HOME/{repo_id}`` whatever the id looks like.
 
-``load_lerobot_episode`` -- the shared loader behind ``Simulation.replay_episode``
--- forwarded the caller's ``root`` unresolved instead, so a read by the recording
-id looked for the dataset somewhere it had never been. The miss then falls
-through to a Hub lookup for a name that only ever meant a directory. Measured end
-to end against lerobot 0.6.2 on a MuJoCo scene, ``HF_LEROBOT_HOME`` pointed at an
-empty directory and the working directory fresh::
+Both read-back entry points forwarded the caller's ``root`` unresolved instead,
+so a read by the recording id looked for the dataset somewhere it had never
+been. The miss then falls through to a Hub lookup for a name that only ever
+meant a directory. Measured end to end against lerobot 0.6.2 on a MuJoCo scene,
+``HF_LEROBOT_HOME`` pointed at an empty directory and the working directory
+fresh::
 
     sim.start_recording(repo_id="sim_recording", task="pick the cube", fps=30,
                         root=None, overwrite=True)   # status="success"
@@ -24,9 +24,11 @@ empty directory and the working directory fresh::
     sim.replay_episode(repo_id="sim_recording", episode=0)
     # status="error": "Cannot reach
     #   https://huggingface.co/api/datasets/sim_recording/refs"
+    strands_robots.stream_dataset("sim_recording")
+    # RepositoryNotFoundError: 404 ... /api/datasets/sim_recording/refs
 
-With the read resolving the same rule, the same script replays 45/45 frames under
-``status="success"`` from ``./sim_recording``.
+With both reads resolving the same rule, the same script replays 45/45 frames
+under ``status="success"`` and streams 45 frames from ``./sim_recording``.
 
 Only that rule is resolved on the read side, and the cells below pin the
 boundary as well as the fix. An ``owner/name`` id keeps its absent root: that is
@@ -39,7 +41,9 @@ recording under that id wrote to.
 The existing dataset doubles all accept any ``root`` silently, so none of them
 could observe this. The reader below reproduces the one property that decides the
 outcome: it finds a dataset only where it is told to look, and falls back to the
-Hub for an absent root exactly as LeRobot does.
+Hub for an absent root exactly as LeRobot does. It stands in at BOTH read sites,
+so the three properties are asserted of every entry point that opens a dataset
+by id rather than of whichever one was written first.
 """
 
 from __future__ import annotations
@@ -47,12 +51,14 @@ from __future__ import annotations
 import json
 import sys
 import types
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, NamedTuple
 
 import pytest
 
 from strands_robots import dataset_recorder as dr
+from strands_robots import streaming_dataset as sd
 
 
 class _OfflineHub(Exception):
@@ -65,16 +71,22 @@ class _Meta:
 
 
 class _ReaderThatFindsOnlyWhereItLooks:
-    """A LeRobotDataset double shaped like the reader.
+    """A dataset double shaped like the reader.
 
     It records the ``root`` it was handed and resolves an absent one the way
     LeRobot does -- ``$HF_LEROBOT_HOME/{repo_id}``, then the Hub -- so a read
     aimed at the wrong directory fails the way a caller actually experiences it
     rather than merely carrying a different kwarg.
+
+    The two-parameter signature is also what keeps it usable as the streaming
+    double: ``StreamingDatasetReader.open`` forwards a kwarg only when the
+    constructor declares it, so the streaming knobs are skipped and the call
+    reduces to the ``(repo_id, root)`` pair under test.
     """
 
     home: Path = Path()
     kwargs: dict[str, Any] = {}
+    num_frames = 45
 
     def __init__(self, repo_id: str, root: str | None = None) -> None:
         type(self).kwargs = {"repo_id": repo_id, "root": root}
@@ -97,10 +109,11 @@ def plant(directory: Path) -> Path:
 
 @pytest.fixture
 def reader(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> type[_ReaderThatFindsOnlyWhereItLooks]:
-    """Inject the double, relocate the dataset home, and anchor the cwd."""
+    """Inject the double at both read sites, relocate the home, anchor the cwd."""
     module = types.ModuleType("lerobot.datasets.lerobot_dataset")
     module.LeRobotDataset = _ReaderThatFindsOnlyWhereItLooks  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", module)
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _ReaderThatFindsOnlyWhereItLooks, raising=False)
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(dr, "_lerobot_home", lambda: home)
@@ -112,22 +125,48 @@ def reader(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> type[_ReaderThatF
     return _ReaderThatFindsOnlyWhereItLooks
 
 
+def _replay(repo_id: str, root: str | None) -> tuple[Any, Any]:
+    """Read an episode the way ``Simulation.replay_episode`` does."""
+    ds, start, length = dr.load_lerobot_episode(repo_id, 0, root)
+    return ds, (start, length)
+
+
+def _stream(repo_id: str, root: str | None) -> tuple[Any, Any]:
+    """Read frames the way ``Simulation.stream_dataset`` does."""
+    reader = sd.stream_dataset(repo_id, root=root)
+    return reader.dataset, reader.num_frames
+
+
+class _Read(NamedTuple):
+    """A read-back entry point, and what it reports about what it opened."""
+
+    name: str
+    open: Callable[[str, str | None], tuple[Any, Any]]
+    reports: Any
+
+
+READS = [
+    _Read("replay", _replay, (0, 45)),
+    _Read("stream", _stream, 45),
+]
+
+
 class _PathLikeId(NamedTuple):
     repo_id: str
     # The directory that spelling names, relative to the working directory.
     name: str
 
 
-@pytest.mark.parametrize(
-    "case",
-    [
-        _PathLikeId(repo_id="sim_recording", name="sim_recording"),
-        _PathLikeId(repo_id="./dotted", name="dotted"),
-    ],
-    ids=lambda case: case.repo_id,
-)
+PATH_LIKE_IDS = [
+    _PathLikeId(repo_id="sim_recording", name="sim_recording"),
+    _PathLikeId(repo_id="./dotted", name="dotted"),
+]
+
+
+@pytest.mark.parametrize("read", READS, ids=lambda read: read.name)
+@pytest.mark.parametrize("case", PATH_LIKE_IDS, ids=lambda case: case.repo_id)
 def test_a_path_like_repo_id_reads_the_directory_it_recorded_to(
-    reader: type[_ReaderThatFindsOnlyWhereItLooks], case: _PathLikeId
+    reader: type[_ReaderThatFindsOnlyWhereItLooks], read: _Read, case: _PathLikeId
 ) -> None:
     """The read lands where ``resolve_dataset_dir`` put the recording.
 
@@ -141,15 +180,16 @@ def test_a_path_like_repo_id_reads_the_directory_it_recorded_to(
     """
     recorded_at = plant(dr.resolve_dataset_dir(case.repo_id, None))
 
-    ds, start, length = dr.load_lerobot_episode(case.repo_id, 0, None)
+    ds, reported = read.open(case.repo_id, None)
 
     assert Path(ds.root).resolve() == (Path.cwd() / case.name).resolve()
     assert Path(recorded_at).resolve() == Path(ds.root).resolve()
-    assert (start, length) == (0, 45)
+    assert reported == read.reports
 
 
+@pytest.mark.parametrize("read", READS, ids=lambda read: read.name)
 def test_a_hub_id_is_left_to_lerobots_own_resolution(
-    reader: type[_ReaderThatFindsOnlyWhereItLooks], tmp_path: Path
+    reader: type[_ReaderThatFindsOnlyWhereItLooks], read: _Read, tmp_path: Path
 ) -> None:
     """An ``owner/name`` id reads with no root, and still finds a local recording.
 
@@ -162,17 +202,20 @@ def test_a_hub_id_is_left_to_lerobots_own_resolution(
     """
     plant(tmp_path / "home" / "user" / "data")
 
-    ds, _, _ = dr.load_lerobot_episode("user/data", 0, None)
+    ds, _ = read.open("user/data", None)
 
     assert reader.kwargs["root"] is None
     assert Path(ds.root) == tmp_path / "home" / "user" / "data"
 
 
-def test_an_explicit_root_is_read_verbatim(reader: type[_ReaderThatFindsOnlyWhereItLooks], tmp_path: Path) -> None:
+@pytest.mark.parametrize("read", READS, ids=lambda read: read.name)
+def test_an_explicit_root_is_read_verbatim(
+    reader: type[_ReaderThatFindsOnlyWhereItLooks], read: _Read, tmp_path: Path
+) -> None:
     """The control: naming a root replaces the resolution, it is not joined to it."""
     chosen = plant(tmp_path / "chosen")
 
-    ds, _, _ = dr.load_lerobot_episode("user/data", 0, str(chosen))
+    ds, _ = read.open("user/data", str(chosen))
 
     assert Path(reader.kwargs["root"]) == chosen
     assert Path(ds.root) == chosen


### PR DESCRIPTION
`stream_dataset` is documented as the in-process counterpart to `start_recording` / `stop_recording`. Recording resolves a path-like `repo_id` to the directory it names; the streaming read forwarded the caller's `root` unresolved, so the read-back half of that loop looked where the recording had never been.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/streaming-read-back-repo-id/docs/assets/streaming_read_back.png)

One on-disk recording, read by both trees:

| | main | this change |
|---|---|---|
| `start_recording(repo_id="sim_recording", root=None)` + 45-step rollout + `stop_recording()` | `success`, 7 files under `./sim_recording` | same |
| `stream_dataset("sim_recording")` | `RepositoryNotFoundError` 404 `/api/datasets/sim_recording/refs` | `success` |
| `reader.dataset.root` | - | `sim_recording` |
| frames read | 0 | 45 / 45 (6 joints) |

Measured on lerobot 0.6.2, `$HF_LEROBOT_HOME` empty and the working directory fresh. The rollout the read now returns, decoded from the dataset's own MP4:

![streamed rollout](https://raw.githubusercontent.com/cagataycali/robots/assets/streaming-read-back-repo-id/docs/assets/streamed_rollout.gif)

## Why it missed

A `repo_id` that is itself a path (no `owner/name` slash, or `./`-prefixed) is a local directory here and is not one to LeRobot, which derives any absent root as `$HF_LEROBOT_HOME/{repo_id}` whatever the id looks like. `StreamingLeRobotDataset` also reads a local dataset only when it is given a root (`streaming_from_local = root is not None`), so the miss fell through to a Hub lookup for a name that only ever meant a directory.

The fix resolves the rule recording writes through, and only that rule:

```python
if root is None and (local := local_dataset_dir(repo_id)) is not None:
    root = str(local)
```

An `owner/name` id keeps its absent root: that is how LeRobot selects the revision-safe Hub metadata cache, and it is already the directory a local recording under that id wrote to. Naming a directory for a Hub id instead would move every download out of that cache.

## Tests

The read-back cells are now table-driven over both entry points that open a dataset by id (`load_lerobot_episode` behind `replay_episode`, and `stream_dataset`), so each property is asserted of every reader rather than of whichever one was written first. The double stands in at both sites and finds a dataset only where it is told to look, falling back to a Hub-shaped error for an absent root exactly as LeRobot does.

Each mutation fires exactly one cell set (8 cells total):

| mutation | cells that fail |
|---|---|
| shipped | none (8 pass) |
| revert the resolution | `path_like[sim_recording-stream]`, `path_like[./dotted-stream]` |
| resolve with `resolve_dataset_dir` instead (a Hub id gets a directory) | `hub_id_is_left_to_lerobots_own_resolution[stream]` |
| drop the caller's explicit `root` | `an_explicit_root_is_read_verbatim[stream]` |

An absolute path-like id is deliberately not a case: `$HF_LEROBOT_HOME / "/abs/dir"` is `/abs/dir`, so LeRobot's own resolution already lands on it either way.

Full suite, this branch vs `main` with the same test file (lerobot 0.5.1 env, 51325 collected on both): 67 failed / 50790 passed vs 69 failed / 50788 passed. Failing-name sets differ only by the 2 new stream cells, in that direction alone - nothing this branch fails that `main` does not. `ruff check` / `ruff format --check` clean on 1963 files; `mypy` unchanged at the 20 standing errors in 6 files.

LOC: +138 / -34 across 5 files, of which the test file is +61 net for 5 additional asserted cells (3 -> 8) - the parametrisation reuses the existing double and fixtures rather than adding a second file.

Docs: the streaming section of `docs/recording.md` gains the record -> read-back snippet, and the "reading back applies the same rule" paragraph now enumerates streaming with replay and transforms.