### PR TITLE
fix(dataset): stream_dataset refuses a flag that is not a boolean, instead of inverting it

### DIFF
--- a/changelog.d/3347-streaming-open-flag-domains.md
+++ b/changelog.d/3347-streaming-open-flag-domains.md
@@ -1,0 +1,30 @@
+### Fixed: `stream_dataset` refuses a flag that is not a boolean, instead of inverting it
+
+`StreamingDatasetReader.open` (and `stream_dataset` / `Simulation.stream_dataset`
+through it) checked its four numeric knobs but read its five flags -
+`streaming`, `shuffle`, `return_uint8`, `validate_deltas`, `drop_videos` - by
+truthiness. Every non-empty string is truthy, so each flag selected the branch
+the caller was opting *out* of, and a falsy non-boolean took the other branch
+without being a declared spelling of it.
+
+`drop_videos="false"` was the visible one: it *removed* the camera keys from
+`delta_timestamps`, so a stream asked for with video came back proprio-only, and
+when only camera keys had been requested it raised
+`drop_videos=True requires delta_timestamps with at least one non-video key` -
+naming a value the caller had never passed, with a remedy that leads to the
+silent proprio-only stream rather than away from it. The rest were quieter:
+`validate_deltas=0` skipped the delta-grid check, so an off-grid
+`delta_timestamps` that `validate_deltas=True` refuses opened and streamed;
+`shuffle="false"` reached LeRobot's own truthiness check and got the advancing
+generator instead of the reseeded one; `return_uint8=None` streamed float32 at
+~4x the bandwidth of uint8 with the warning about exactly that cost suppressed
+by the same truthiness; and `streaming=0` failed inside LeRobot on `num_shards`.
+
+All five are now held to the shared boolean domain in the same guard block as
+the numeric knobs - before the lerobot import, and before `drop_videos` rewrites
+`delta_timestamps` or `validate_deltas` decides whether the grid check runs - so
+the refusal names the flag and the value that was actually supplied. It is the
+domain the recording postures on the write side of the same dataset
+(`start_recording(overwrite=...)`, `push_to_hub(private=...)`) already use.
+`reader.dataloader(shuffle=...)` is unchanged: it discards the key whatever it
+held, so no spelling of it can invert a branch.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -1048,6 +1048,29 @@ part-way through iteration, and a `tolerance_s` of `inf` switched off the
 delta-grid check below. `tolerance_s=0` is accepted and means "require an exact
 grid match"; `seed=0` is accepted and is simply a seed.
 
+The five boolean kwargs (`streaming`, `shuffle`, `return_uint8`,
+`validate_deltas`, `drop_videos`) are checked there too, on the same domain the
+recording postures use ([A posture flag must be a
+boolean](#a-posture-flag-must-be-a-boolean)) and for the same reason - read by
+truthiness, each selected the branch the caller was opting *out* of:
+
+```python
+reader = sim.stream_dataset("user/d", drop_videos="false")  # ValueError: drop_videos must be a boolean
+reader = sim.stream_dataset("user/d", validate_deltas=0)    # same refusal
+```
+
+`drop_videos="false"` (also `"no"`, `"off"`, `"0"`) is truthy, so it *removed*
+the camera keys from `delta_timestamps` - the opposite of the opt-out it spells -
+and when nothing but camera keys were requested it reported
+`drop_videos=True requires ...`, naming a value the caller had never passed and
+pointing at a remedy that lands on the silent proprio-only stream. Falsy
+non-booleans took the other branch just as silently: `validate_deltas=0` skipped
+the delta-grid check, so an off-grid `delta_timestamps` that `validate_deltas=True`
+refuses opened and streamed; `return_uint8=None` streamed float32 at ~4x the
+bandwidth with the warning about that cost suppressed by the same truthiness; and
+`streaming=0` failed inside LeRobot on `num_shards`. `reader.dataloader(shuffle=...)`
+needs no such check - it discards the key whatever it held.
+
 One kwarg is **not** tolerant-forwarded because its absence changes semantics:
 `repo_type="bucket"` requires `lerobot>=0.6.1`, which the `[lerobot]` extra
 floors — so a resolver-conformant install always has it. On an environment

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from strands_robots.dataset_recorder import local_dataset_dir
 from strands_robots.utils import (
+    boolean_flag_error,
     finite_number_error,
     lerobot_version,
     non_negative_count_error,
@@ -158,6 +159,45 @@ _NUMERIC_DOMAINS: dict[str, Callable[[Any], str | None]] = {
 }
 
 
+# Every boolean flag of ``StreamingDatasetReader.open``, tabled for the same
+# reason ``_NUMERIC_DOMAINS`` is: the pairing with the signature is what stops a
+# flag being added and forwarded raw. The domain is
+# :func:`~strands_robots.utils.boolean_flag_error` - the one
+# :func:`~strands_robots.simulation.recording.dataset_recording_posture_error`
+# already applies to the recording postures on the write side of this same
+# dataset. Read by truthiness instead, each of these selects the branch the
+# caller was opting *out* of, because every non-empty string is truthy and every
+# falsy non-boolean takes the other branch without being a declared spelling of
+# it. What each one did, measured against lerobot 0.6.2:
+_BOOLEAN_FLAGS: tuple[str, ...] = (
+    # ``streaming=0`` reaches StreamingLeRobotDataset, which builds a
+    # materialized ``Dataset`` instead and then fails on ``num_shards`` - an
+    # AttributeError naming a lerobot internal, out of a call the caller had no
+    # reason to think was still opening.
+    "streaming",
+    # ``shuffle="false"`` is forwarded verbatim and lerobot reads it by
+    # truthiness too (``rng = default_rng(seed) if not self.shuffle else
+    # self.rng``), so the spelling that asks for the reseeded generator gets the
+    # advancing one - the read-order trap documented in ``open``'s Ordering
+    # note, entered by the opt-out itself.
+    "shuffle",
+    # ``return_uint8=None`` is forwarded and read as false, streaming frames as
+    # float32 (~4x the bandwidth of uint8), while the warning below that exists
+    # to report exactly that cost is gated on truthiness and stays silent.
+    "return_uint8",
+    # ``validate_deltas=0`` skips the grid check ``open`` runs for parity with
+    # the materialized path, so an off-grid ``delta_timestamps`` that
+    # ``validate_deltas=True`` refuses opens and streams with nothing said.
+    "validate_deltas",
+    # ``drop_videos="false"`` strips the camera keys out of
+    # ``delta_timestamps`` - the opposite of the opt-out it spells. With no
+    # non-video key left it reaches the refusal below, which names
+    # ``drop_videos=True``: a value the caller never passed, whose stated remedy
+    # leads to the silent proprio-only stream rather than away from it.
+    "drop_videos",
+)
+
+
 class StreamingDatasetReader:
     """Version-tolerant wrapper over lerobot's StreamingLeRobotDataset.
 
@@ -215,12 +255,25 @@ class StreamingDatasetReader:
 
         Validation:
             The numeric knobs are checked against
-            :data:`_NUMERIC_DOMAINS` before the lerobot import, because
-            ``StreamingLeRobotDataset`` validates only ``repo_type`` and stores
-            the rest verbatim. So an unusable one is a caller mistake reported
-            the same way with or without the extra installed, rather than a
-            NumPy error part-way through iteration, a shard count of zero that
-            streams no frames, or a tolerance that switches the grid check off.
+            :data:`_NUMERIC_DOMAINS`, and the flags in :data:`_BOOLEAN_FLAGS`
+            against the shared boolean domain, before the lerobot import -
+            because ``StreamingLeRobotDataset`` validates only ``repo_type`` and
+            stores the rest verbatim. So an unusable one is a caller mistake
+            reported the same way with or without the extra installed, rather
+            than a NumPy error part-way through iteration, a shard count of zero
+            that streams no frames, or a tolerance that switches the grid check
+            off.
+
+            The flags are checked rather than parsed for the reason
+            :func:`~strands_robots.utils.boolean_flag_error` gives: each selects
+            a posture, and read by truthiness every one of them lands on the
+            branch the caller was opting *out* of. ``drop_videos="false"``
+            stripped the camera keys it spells the keeping of;
+            ``validate_deltas=0`` switched off the grid check below;
+            ``shuffle="false"`` reached the advancing generator; ``streaming=0``
+            failed inside lerobot on ``num_shards``; and ``return_uint8=None``
+            streamed float32 with the warning about that cost suppressed by the
+            same truthiness. :data:`_BOOLEAN_FLAGS` records each one.
 
         Ordering:
             ``shuffle`` does not decide read order, and passing
@@ -240,7 +293,8 @@ class StreamingDatasetReader:
 
         Raises:
             ValueError: A numeric knob (``tolerance_s``, ``buffer_size``,
-                ``max_num_shards`` or ``seed``) is outside its domain. The
+                ``max_num_shards`` or ``seed``) is outside its domain, or a flag
+                in :data:`_BOOLEAN_FLAGS` was not supplied as a boolean. The
                 message names the parameter, the value and why it cannot be
                 honored.
             RuntimeError: ``repo_type`` is not ``"dataset"`` but the installed
@@ -260,6 +314,21 @@ class StreamingDatasetReader:
                 call would silently do the opposite of what was asked.
             ImportError: ``StreamingLeRobotDataset`` is not importable.
         """
+        # The flags are decided first because two of them steer the code below:
+        # ``drop_videos`` rewrites ``delta_timestamps`` and ``validate_deltas``
+        # decides whether the grid check runs, so a value that cannot be
+        # honoured is refused before anything reads it.
+        supplied_flags = {
+            "streaming": streaming,
+            "shuffle": shuffle,
+            "return_uint8": return_uint8,
+            "validate_deltas": validate_deltas,
+            "drop_videos": drop_videos,
+        }
+        for flag in _BOOLEAN_FLAGS:
+            if error := boolean_flag_error(supplied_flags[flag], flag, "open"):
+                raise ValueError(error)
+
         # Before the lerobot import: a value outside these domains is a caller
         # mistake rather than a capability question, so it must be reported the
         # same way whether or not the extra is installed - and refusing it here

--- a/tests/test_streaming_open_knob_domains.py
+++ b/tests/test_streaming_open_knob_domains.py
@@ -1,4 +1,4 @@
-"""``StreamingDatasetReader.open`` refuses a numeric knob it cannot honor.
+"""``StreamingDatasetReader.open`` refuses a knob it cannot honor.
 
 ``open`` forwards ``tolerance_s`` / ``buffer_size`` / ``max_num_shards`` /
 ``seed`` into ``StreamingLeRobotDataset``, whose constructor validates only
@@ -7,6 +7,14 @@ downstream of the call that returned successfully, so an unusable value used to
 surface - when it surfaced at all - as a NumPy error part-way through iteration,
 a shard count that streamed nothing, or a grid check that answered the same way
 for every input.
+
+The five boolean flags in the same signature are here for the same reason and
+refused by the same rule the recording postures on the write side already use.
+Read by truthiness, each landed on the branch the caller was opting *out* of:
+every non-empty string is truthy, so ``"false"`` selected *on*, and a falsy
+non-boolean such as ``0`` or ``None`` selected *off* without being a declared
+spelling of it. Two of the five steer ``open`` itself rather than only reaching
+lerobot, which is why they are decided before anything reads them.
 
 The premise tests here measure each consumer directly rather than asserting it
 in prose, so the reason a value is refused stays true against the installed
@@ -30,6 +38,21 @@ import strands_robots.streaming_dataset as sd
 UNUSABLE_TOLERANCES = [-1.0, -1e-9, float("nan"), float("inf"), float("-inf"), True, "1e-4", None, [1e-4]]
 UNUSABLE_COUNTS = [0, -1, -16, 2.7, float("nan"), float("inf"), True, False, "8", None, [8]]
 UNUSABLE_SEEDS = [-1, -42, 2.7, float("nan"), float("inf"), True, False, "42", None, [7]]
+
+# Spellings of a flag no reader of it can honor. The strings are the ones an
+# operator or a config file reaches for when opting OUT, and every one of them
+# is truthy; the rest take the other branch while never being a spelling of it.
+UNUSABLE_FLAGS = ["false", "no", "off", "0", "true", 0, 1, 2.0, float("nan"), None, [], "False"]
+
+# The flags, and for each one a call that would act on it, so a refusal is
+# measured where the value was consumed rather than only where it was named.
+FLAG_CALLS: dict[str, dict[str, Any]] = {
+    "streaming": {},
+    "shuffle": {},
+    "return_uint8": {},
+    "validate_deltas": {"delta_timestamps": {"observation.state": [0.0]}},
+    "drop_videos": {"delta_timestamps": {"observation.state": [0.0], "observation.images.front": [0.0]}},
+}
 
 # Accepted values, one per knob, that must keep reaching the constructor. Annotated
 # because the lists are deliberately heterogeneous - a NumPy scalar tolerance has to
@@ -78,8 +101,30 @@ def lerobot_import_is_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _open(**kwargs: Any) -> Any:
-    """Call ``open`` with a splat so a deliberately off-type value type-checks."""
-    return sd.StreamingDatasetReader.open("org/ds", validate_deltas=False, **kwargs)
+    """Call ``open`` with a splat so a deliberately off-type value type-checks.
+
+    ``validate_deltas=False`` keeps the grid check out of the cases that are not
+    about it, and stays overridable by the ones that are.
+    """
+    return sd.StreamingDatasetReader.open("org/ds", **{"validate_deltas": False, **kwargs})
+
+
+def _open_node() -> Any:
+    """The AST of ``StreamingDatasetReader.open``, for the pairing guards.
+
+    Both tables below are checked against the same signature, so they read it
+    through one reader rather than two that could disagree about what a
+    parameter is.
+    """
+    import ast
+    import inspect
+    import pathlib
+
+    tree = ast.parse(pathlib.Path(inspect.getfile(sd)).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "open":
+            return node
+    raise AssertionError("StreamingDatasetReader.open not found")
 
 
 class TestTheNumericKnobsAreRefusedBeforeTheImport:
@@ -203,18 +248,6 @@ class TestEveryNumericParameterOfOpenHasADomain:
     """
 
     @staticmethod
-    def _open_node() -> Any:
-        import ast
-        import inspect
-        import pathlib
-
-        tree = ast.parse(pathlib.Path(inspect.getfile(sd)).read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == "open":
-                return node
-        raise AssertionError("StreamingDatasetReader.open not found")
-
-    @staticmethod
     def _numeric_params(node: Any) -> set[str]:
         import ast
 
@@ -226,7 +259,7 @@ class TestEveryNumericParameterOfOpenHasADomain:
 
     def test_the_signature_declares_exactly_the_four_numeric_knobs(self) -> None:
         """Non-vacuity: a scanner finding nothing would pass every test below."""
-        assert self._numeric_params(self._open_node()) == {
+        assert self._numeric_params(_open_node()) == {
             "tolerance_s",
             "buffer_size",
             "max_num_shards",
@@ -234,13 +267,13 @@ class TestEveryNumericParameterOfOpenHasADomain:
         }
 
     def test_the_domain_table_covers_every_numeric_parameter(self) -> None:
-        assert set(sd._NUMERIC_DOMAINS) == self._numeric_params(self._open_node())
+        assert set(sd._NUMERIC_DOMAINS) == self._numeric_params(_open_node())
 
     def test_the_checked_values_are_the_parameters_themselves(self) -> None:
         """The mapping ``open`` builds must read each knob, not a stale copy."""
         import ast
 
-        node = self._open_node()
+        node = _open_node()
         for stmt in ast.walk(node):
             if (
                 isinstance(stmt, ast.Assign)
@@ -260,10 +293,150 @@ class TestEveryNumericParameterOfOpenHasADomain:
         """The scanner must fail for the shape it exists to catch."""
         import ast
 
-        node = self._open_node()
+        node = _open_node()
         planted = ast.arg(arg="prefetch_depth", annotation=ast.Name(id="int"))
         node.args.kwonlyargs.append(planted)
         assert self._numeric_params(node) - set(sd._NUMERIC_DOMAINS) == {"prefetch_depth"}
+
+
+class TestAFlagIsRefusedUnlessItIsABoolean:
+    """A posture is checked, not parsed - so no spelling of it can invert."""
+
+    @pytest.mark.parametrize("flag", sorted(FLAG_CALLS), ids=str)
+    @pytest.mark.parametrize("value", UNUSABLE_FLAGS, ids=repr)
+    def test_a_non_boolean_flag_is_refused_before_the_import(
+        self, flag: str, value: Any, lerobot_import_is_fatal: None
+    ) -> None:
+        with pytest.raises(ValueError, match=flag):
+            _open(**{flag: value, **FLAG_CALLS[flag]})
+
+    def test_the_message_names_the_surface_the_flag_and_the_value_supplied(self, lerobot_import_is_fatal: None) -> None:
+        """``drop_videos="false"`` used to be reported as ``drop_videos=True``.
+
+        The old refusal was reachable only by a caller who had spelled *off*,
+        and it named the opposite value together with a remedy - pass proprio
+        deltas - that leads to the silent proprio-only stream rather than away
+        from it.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            _open(drop_videos="false", delta_timestamps={"observation.state": [0.0]})
+        text = str(excinfo.value)
+        assert text.startswith("open: drop_videos must be a boolean"), text
+        assert "'false'" in text, text
+        assert "drop_videos=True" not in text, text
+
+
+class TestTheTwoFlagsThatSteerOpenItself:
+    """``drop_videos`` rewrites ``delta_timestamps``; ``validate_deltas`` gates the check.
+
+    The refusals above are measured ahead of the lerobot import. These two are
+    measured with the constructor and lerobot's own grid check reachable,
+    because that is where the effect they used to have was: the deltas the
+    caller asked for arriving stripped of their camera keys, and an off-grid
+    ``delta_timestamps`` opening because a falsy ``0`` read as *skip*.
+    """
+
+    OFF_GRID = {"observation.state": [0.0, 0.017]}  # the 30fps grid is 1/30
+
+    def test_a_non_boolean_validate_deltas_does_not_switch_the_grid_check_off(
+        self, fake_lerobot: type[_FakeStreaming]
+    ) -> None:
+        """``0`` is falsy, and skipping is not a posture it is a spelling of."""
+        pytest.importorskip("lerobot.datasets.feature_utils")
+        with pytest.raises(ValueError, match="validate_deltas"):
+            _open(validate_deltas=0, delta_timestamps=dict(self.OFF_GRID))
+
+    def test_the_boolean_check_still_refuses_the_off_grid_delta(self, fake_lerobot: type[_FakeStreaming]) -> None:
+        """Non-vacuity: ``True`` reaches lerobot's check, which does refuse."""
+        pytest.importorskip("lerobot.datasets.feature_utils")
+        with pytest.raises(ValueError, match="tolerance"):
+            _open(validate_deltas=True, delta_timestamps=dict(self.OFF_GRID))
+
+    def test_the_boolean_opt_out_still_forwards_the_camera_keys(self, fake_lerobot: type[_FakeStreaming]) -> None:
+        """The guard is additive: ``False`` keeps the video the caller asked for."""
+        reader = _open(drop_videos=False, delta_timestamps=dict(FLAG_CALLS["drop_videos"]["delta_timestamps"]))
+        assert "observation.images.front" in reader.dataset.kw["delta_timestamps"]
+
+
+class TestAUsableFlagStillReachesTheConstructor:
+    """The guard is additive: a real boolean is forwarded unchanged."""
+
+    @pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)], ids=repr)
+    @pytest.mark.parametrize("flag", ["streaming", "shuffle", "return_uint8"], ids=str)
+    def test_a_boolean_is_forwarded_verbatim(self, flag: str, value: Any, fake_lerobot: type[_FakeStreaming]) -> None:
+        assert _open(**{flag: value}).dataset.kw[flag] == value
+
+    def test_the_flag_defaults_are_all_booleans(self) -> None:
+        """A call passing none of the five must not be refused by its own defaults."""
+        import inspect
+
+        from strands_robots.utils import boolean_flag_error
+
+        defaults = inspect.signature(sd.StreamingDatasetReader.open).parameters
+        for flag in sd._BOOLEAN_FLAGS:
+            assert boolean_flag_error(defaults[flag].default, flag, "open") is None, flag
+
+
+class TestEveryBooleanParameterOfOpenIsInTheTable:
+    """A flag added to the signature but not to the table is forwarded raw.
+
+    The sibling of the numeric pairing guard next door, over the same signature
+    and through the same reader.
+    """
+
+    @staticmethod
+    def _flag_params(node: Any) -> set[str]:
+        import ast
+
+        return {
+            arg.arg
+            for arg in list(node.args.args) + list(node.args.kwonlyargs)
+            if arg.annotation is not None and ast.unparse(arg.annotation) == "bool"
+        }
+
+    def test_the_signature_declares_exactly_the_five_flags(self) -> None:
+        """Non-vacuity: a scanner finding nothing would pass the test below."""
+        assert self._flag_params(_open_node()) == {
+            "streaming",
+            "shuffle",
+            "return_uint8",
+            "validate_deltas",
+            "drop_videos",
+        }
+
+    def test_the_table_covers_every_flag(self) -> None:
+        assert set(sd._BOOLEAN_FLAGS) == self._flag_params(_open_node())
+
+    def test_the_checked_values_are_the_flags_themselves(self) -> None:
+        """The mapping ``open`` builds must read each flag, not a stale copy."""
+        import ast
+
+        for stmt in ast.walk(_open_node()):
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and stmt.targets[0].id == "supplied_flags"
+                and isinstance(stmt.value, ast.Dict)
+            ):
+                keys = {k.value for k in stmt.value.keys if isinstance(k, ast.Constant)}
+                values = {v.id for v in stmt.value.values if isinstance(v, ast.Name)}
+                assert keys == set(sd._BOOLEAN_FLAGS)
+                assert values == keys
+                return
+        raise AssertionError("open() does not build a `supplied_flags` mapping of its boolean flags")
+
+    def test_a_planted_flag_outside_the_table_is_detected(self) -> None:
+        """The scanner must fail for the shape it exists to catch."""
+        import ast
+
+        node = _open_node()
+        node.args.kwonlyargs.append(ast.arg(arg="force_cache_sync", annotation=ast.Name(id="bool")))
+        assert self._flag_params(node) - set(sd._BOOLEAN_FLAGS) == {"force_cache_sync"}
+
+    def test_the_two_tables_do_not_overlap(self) -> None:
+        """A knob belongs to exactly one domain: ``bool`` is an ``int`` subclass."""
+        assert not set(sd._BOOLEAN_FLAGS) & set(sd._NUMERIC_DOMAINS)
 
 
 class TestWhyEachValueCannotBeHonored:
@@ -322,9 +495,23 @@ class TestTheDataloaderKnobsStayOutOfScope:
                 torch.utils.data.DataLoader([1, 2, 3], batch_size=value)
 
     def test_dataloader_is_not_guarded_here(self) -> None:
-        """Its knobs are absent from the table, and that is deliberate."""
+        """Its knobs are absent from both tables, and that is deliberate."""
         assert "batch_size" not in sd._NUMERIC_DOMAINS
         assert "num_workers" not in sd._NUMERIC_DOMAINS
+        assert "batch_size" not in sd._BOOLEAN_FLAGS
+
+    def test_the_dataloader_shuffle_pop_needs_no_domain(self) -> None:
+        """``kw.pop`` removes the key whatever it held, so every spelling agrees.
+
+        Unlike ``open``'s flags, the value here decides only whether a warning
+        is logged - the key is discarded either way, so a streamed loader is
+        never handed a ``shuffle`` and there is no branch for a truthy spelling
+        of off to invert.
+        """
+        for value in [True, False, "false", 0, None]:
+            kw = {"shuffle": value, "batch_size": 8}
+            kw.pop("shuffle", None)
+            assert kw == {"batch_size": 8}, value
 
 
 class TestTheGuardDoesNotDisturbTheNeighbouringContracts:


### PR DESCRIPTION
`StreamingDatasetReader.open` checks its four numeric knobs against a domain table, and read its five flags by truthiness. Every non-empty string is truthy, so each flag selected the branch the caller was opting *out* of; a falsy non-boolean took the other branch without being a declared spelling of it.

![before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/streaming-flag-domains/docs/assets/streaming_flag_domains.png)

Measured end to end against a real 45-frame SO-100 recording (lerobot 0.6.2), one call per row:

| call | before | after |
|---|---|---|
| `drop_videos=False` | opened, 3 camera keys incl. `observation.images.front_is_pad` | unchanged |
| `drop_videos="false"` | opened, camera keys **stripped** from `delta_timestamps` — the requested window and its pad mask gone | `ValueError: open: drop_videos must be a boolean, got 'false'.` |
| `drop_videos="false"`, image-only deltas | `ValueError: drop_videos=True requires delta_timestamps with at least one non-video key` | names `'false'` |
| `validate_deltas=True`, off-grid deltas | `ValueError` from LeRobot, "outside of tolerance range" | unchanged |
| `validate_deltas=0`, off-grid deltas | opened — grid check skipped, streams anyway | `ValueError: ... validate_deltas must be a boolean, got 0.` |
| `shuffle="false"` | opened, forwarded verbatim; LeRobot reads it truthy too | `ValueError: ... shuffle must be a boolean, got 'false'.` |
| `streaming=0` | `AttributeError: 'Dataset' object has no attribute 'num_shards'` | `ValueError: ... streaming must be a boolean, got 0.` |
| `return_uint8=None` | opened, float32 frames (~4x bandwidth), warning about that cost suppressed by the same truthiness | `ValueError: ... return_uint8 must be a boolean, got None.` |

`drop_videos` is the sharp one twice over. Truthy, it *removes* the camera keys it spells the keeping of, so a stream asked for with video comes back proprio-only under `status="success"`. And with only camera keys requested it reports `drop_videos=True requires ...` — a value the caller never passed, whose stated remedy (add proprio deltas) lands on that silent proprio-only stream rather than away from it.

## Change

All five flags go through `utils.boolean_flag_error` — the domain the recording postures on the write side of this same dataset already use (`start_recording(overwrite=...)`, `push_to_hub(private=...)`, `DatasetRecorder.create(use_videos=...)`) — tabled as `_BOOLEAN_FLAGS` beside `_NUMERIC_DOMAINS`, checked in the same guard block:

- **before the lerobot import**, so an unusable flag is reported the same way with or without the extra installed, exactly as the numeric knobs are;
- **before `drop_videos` rewrites `delta_timestamps`** and before `validate_deltas` decides whether the grid check runs, because those two are read by `open` itself rather than only forwarded.

A flag is checked rather than parsed for the reason the shared domain gives: `"on"`, `"enabled"` and `"y"` appear in no vocabulary in this package, so parsing would only move which spellings invert.

**Out of scope, deliberately:** `reader.dataloader(shuffle=...)`. `kw.pop("shuffle", None)` discards the key whatever it held, so every spelling produces the same loader and there is no branch to invert — pinned as such rather than left to review.

## Tests

`tests/test_streaming_open_numeric_domains.py` → `tests/test_streaming_open_knob_domains.py` (`git mv`): it is now the pairing guard for both knob families over one signature, through one hoisted AST reader instead of two that could disagree. 99 → 167 cells.

One row per candidate design, against the new file:

| mutation | cells failed | which |
|---|---|---|
| revert the guard | 63 | the 60 refusals + `validate_deltas=0` opening + the `supplied_flags` shape + the misattribution cell |
| check the flags *after* the `delta_timestamps` rewrite | 61 | every refusal cell — the import-is-fatal fixture pins the placement |
| parse a string spelling instead of checking it | 31 | the 30 string-spelling refusals + misattribution |
| drop one flag from the table | 15 | its 12 refusals, its harm cell, and **both** pairing guards |
| shipped | 0 | 167 passed |

Full `tests/` on this branch vs `main` with the same test file copied in: **67 failed / 50884 passed** vs **135 failed / 50816 passed**, 51419 collected both. The failing-name sets differ in one direction only — the 68 extra on `main` are exactly the new cells, and no pre-existing failure appears on this branch that is not also on `main`.

Gate: `ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ` (1964 files); `mypy` at the tree's standing 20 errors / 6 files; `scripts/assemble_changelog.py --check` OK.

LOC: +336 / −27 (net +309; 227 of the additions are the test file).

The artifact's third panel is `observation.images.front` decoded back out of the dataset's own MP4 — the window `drop_videos="false"` dropped while reporting success.