### PR TITLE
fix(tools): a calibration is written whole, or the previous measurement is still there

### DIFF
--- a/changelog.d/3348-a-calibration-is-written-whole.md
+++ b/changelog.d/3348-a-calibration-is-written-whole.md
@@ -1,0 +1,16 @@
+### Bug Fixes
+
+- **tools**: A calibration write that cannot finish leaves the measurement already on
+  disk readable. Both writers of the calibration store encoded straight into the
+  destination - `save_calibration` through `json.dump`, the `"restore"` action through
+  `shutil.copy2` - which truncates the stored file before the first byte of the
+  replacement lands, so a value the encoder rejects or a filesystem that refuses the
+  write left a prefix where the measurement was. Nothing downstream reported it:
+  `calibration_exists` answers `True` for a prefix, `load_calibration` answers `None`,
+  and `action="view"` renders the path, size and timestamp under `status="success"` with
+  no motors in it. `"restore"` was the sharper of the two, being the path a lost
+  calibration is recovered on - with `overwrite=True` a refused write destroyed the
+  calibration being replaced *and* did not install the backup. The calibration is now
+  serialized in full before the stored file is touched and committed through a temp file
+  plus `os.replace`, in one owner both writers ask through, so a failed write leaves the
+  recorded homing offsets and joint travel limits byte-identical and still loadable.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -227,6 +227,27 @@ exactly as it was, with no temp file beside it, and the tool answers
 unchanged - rather than reporting a named posture that no later `load_pose` can
 find.
 
+### A calibration survives a write that could not finish
+
+A calibration is the one file these tools handle that is not derived data: its
+homing offsets and joint travel limits are recorded by disabling torque and moving
+*one physical arm* by hand, so a stored one that is lost costs the procedure, not a
+re-run. Both writers of that store - `save_calibration` and the `"restore"` action -
+therefore commit through a temp sibling plus `os.replace` instead of writing over
+the stored file.
+
+`"restore"` is the sharper of the two, because it is the path a lost calibration is
+recovered on. With `overwrite=True` a write that could not finish used to destroy
+the calibration it was replacing *and* fail to install the backup, so restoring a
+backup over a working arm could leave neither. Now a refused write leaves the
+stored measurement byte-identical and still loadable, and the action reports
+`status="error"` with the count it did restore.
+
+This matters more than the report, because nothing downstream flags the loss: a
+truncated calibration still `exists()`, `load_calibration` reads it as `None`, and
+`action="view"` renders its path, size and timestamp under `status="success"` with
+no motors in it.
+
 ### A mesh wait budget is bounded where the command body cannot carry it
 
 `robot_mesh` takes four numeric options. `duration` and `policy_port` travel

--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -21,9 +21,12 @@ Based on LeRobot's calibration system:
 
 import json
 import logging
+import os
 import re
 import shutil
+from collections.abc import Callable
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +55,61 @@ BACKUP_DIR.mkdir(parents=True, exist_ok=True)
 # Calibration JSON: {motor_name: {id, drive_mode, homing_offset, range_min, range_max}}
 CalibrationMotorData = dict[str, int]
 CalibrationData = dict[str, CalibrationMotorData]
+
+
+def _commit_calibration(path: Path, fill: Callable[[Path], Any]) -> None:
+    """Replace ``path`` with a whole file, or leave the one already there alone.
+
+    A calibration is a measurement of one physical robot - the homing offsets
+    and joint travel limits recorded by moving that arm by hand - so losing a
+    stored one costs the procedure, not a re-run. Writing into the destination
+    cannot offer that, because the stream is truncated before the first byte of
+    the replacement lands: a value the encoder rejects, or a disk that fills,
+    leaves a prefix where the measurement was. Every reader here then reports
+    that prefix as *no calibration* while
+    :meth:`LeRobotCalibrationManager.calibration_exists` still answers ``True``,
+    so the loss surfaces as a calibration that lists and views but has no
+    motors.
+
+    ``fill`` therefore writes a temp file in the destination's own directory and
+    :func:`os.replace` commits it - the sequence
+    :func:`strands_robots.registry.user_registry._save_user_registry` documents
+    for its own whole-document store, and for the same reason: ``os.replace`` is
+    atomic within a directory, so a failed commit leaves the previous file
+    intact rather than truncated, and a concurrent reader observes one whole
+    calibration or the other, never a prefix.
+
+    The temp name carries a second suffix rather than replacing ``.json``, so
+    the ``*.json`` globs that enumerate this store cannot mistake an
+    uncommitted file for a calibration. Its mode is whatever ``fill`` gives it,
+    which keeps ``shutil.copy2``'s copied permissions and a plain write's
+    umask-derived ones: replacing a file's contents is not the moment to decide
+    who may read it.
+
+    Args:
+        path: The calibration file to replace. Its parent must exist; both
+            callers create it.
+        fill: Writes the whole replacement to the temp path it is given.
+
+    The handler is ``Exception`` rather than ``BaseException`` because the temp
+    name is provably not one this store's enumerations read - so an interrupt that
+    strands one costs nothing a later commit does not clear, and the wider handler
+    would only add a site to the enumerated set in ``AGENTS.md`` without buying a
+    reader anything.
+
+    Raises:
+        Exception: Whatever ``fill`` or the commit raises, after removing the temp
+            file. ``path`` still holds what it last held, and no partial file is
+            left beside it under a name the readers would pick up.
+    """
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        fill(tmp)
+        os.replace(tmp, path)
+    except Exception:
+        # The commit did not happen, so ``path`` is the previous calibration.
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 class LeRobotCalibrationManager:
@@ -120,15 +178,29 @@ class LeRobotCalibrationManager:
             return None
 
     def save_calibration(self, device_type: str, device_model: str, device_id: str, data: CalibrationData) -> bool:
-        """Save calibration data to file"""
+        """Save calibration data to file.
+
+        The calibration is serialized in full before the stored file is touched
+        and committed through :func:`_commit_calibration`, so a value JSON
+        cannot represent is rejected while the previous measurement is still on
+        disk. ``CalibrationData`` is a type alias rather than a runtime check,
+        so such a value reaches here from any caller holding a motor reading
+        that is not a plain ``int``.
+
+        Returns:
+            ``True`` when the stored file is the calibration passed in.
+            ``False`` when it could not be written, in which case the file
+            holds whatever it held before - reported rather than raised, which
+            is the contract callers already had.
+        """
         calib_path = self.get_calibration_path(device_type, device_model, device_id)
 
         # Ensure parent directory exists
         calib_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            with open(calib_path, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
+            payload = json.dumps(data, indent=2)
+            _commit_calibration(calib_path, lambda tmp: tmp.write_text(payload, encoding="utf-8"))
             return True
         except Exception as e:
             logger.error(f"Error saving calibration {calib_path}: {e}")
@@ -292,7 +364,12 @@ class LeRobotCalibrationManager:
                             continue  # Skip existing files unless overwrite is True
 
                         dest_file.parent.mkdir(parents=True, exist_ok=True)
-                        shutil.copy2(calib_file, dest_file)
+                        # Restoring is the path a lost measurement is recovered
+                        # on, so it is the last one that may damage the
+                        # calibration it is writing over: copy into a temp
+                        # sibling and commit, keeping copy2's preserved mode
+                        # and mtime.
+                        _commit_calibration(dest_file, partial(shutil.copy2, calib_file))
                         restored_count += 1
 
             return True, f"Successfully restored {restored_count} calibrations", restored_count

--- a/tests/tools/test_a_failed_calibration_write_keeps_the_measurement_on_disk.py
+++ b/tests/tools/test_a_failed_calibration_write_keeps_the_measurement_on_disk.py
@@ -1,0 +1,293 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A calibration write that fails leaves the measurement already on disk readable.
+
+A calibration is not derived data. Its homing offsets and joint travel limits are
+recorded by disabling torque and moving *one physical arm* by hand, so a stored
+one that is lost costs the procedure, not a re-run.
+
+Both writers of that store used to encode straight into the destination -
+``save_calibration`` through ``json.dump``, ``restore_calibrations`` through
+``shutil.copy2`` - which truncates the stored file before the first byte of the
+replacement lands. A value the encoder rejects, or a filesystem that refuses the
+write, therefore left a prefix where the measurement was. Nothing downstream says
+so: ``calibration_exists`` answers ``True`` for a prefix, ``load_calibration``
+answers ``None``, and the tool's ``view`` renders the path, size and timestamp
+under ``status="success"`` with no motors in it.
+
+``restore_calibrations`` is the sharper of the two, because it is the path a lost
+calibration is recovered on: with ``overwrite=True`` a refused write destroyed the
+calibration being replaced *and* did not install the backup, so an operator who
+restored a backup over a working arm could end up with neither.
+
+These cells pin the commit instead: the calibration is serialized in full before
+the stored file is touched, committed through a temp file plus ``os.replace``, and
+a failed write leaves the stored measurement byte-identical, loadable, and with no
+uncommitted file beside it.
+
+The filesystem refusal is a real one. ``RLIMIT_FSIZE`` is enforced by the kernel on
+the write itself, which is what makes it reach both writers: ``shutil.copy2``
+copies with ``sendfile`` on Linux, so a wrapper around Python's ``open`` never sees
+it, and ``EFBIG`` is not one of the errnos ``shutil`` gives up on and retries.
+
+``backup_calibrations`` also writes JSON, and is deliberately not in this roster:
+its manifest goes into a directory it has just created, so there is no previously
+stored document for a failed write to lose.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import inspect
+import json
+import resource
+import signal
+import textwrap
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.tools.lerobot_calibrate import LeRobotCalibrationManager
+
+#: The motors of an SO-101 follower, in the order lerobot records them.
+_MOTORS = ("shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper")
+
+_DEVICE = ("robots", "so101_follower", "orange_arm")
+
+
+def _measured_calibration() -> dict[str, dict[str, int]]:
+    """A calibration in the shape the procedure produces: per-motor ints."""
+    return {
+        name: {
+            "id": index + 1,
+            "drive_mode": 0,
+            "homing_offset": -1024 + index * 7,
+            "range_min": 800 + index,
+            "range_max": 3200 - index,
+        }
+        for index, name in enumerate(_MOTORS)
+    }
+
+
+def _bus_reading(value: int) -> Any:
+    """A motor reading as the NumPy scalar a bus read produces.
+
+    Annotated ``Any`` because that is the honest static picture: ``CalibrationData``
+    is a type alias, so nothing between a caller holding this and the encoder
+    rejecting it narrows the value to ``int``.
+    """
+    return np.int64(value)
+
+
+@pytest.fixture
+def stored(tmp_path: Path) -> tuple[LeRobotCalibrationManager, Path, bytes]:
+    """A manager with one calibration already measured and stored."""
+    manager = LeRobotCalibrationManager(tmp_path)
+    assert manager.save_calibration(*_DEVICE, _measured_calibration()) is True
+    path = manager.get_calibration_path(*_DEVICE)
+    return manager, path, path.read_bytes()
+
+
+@pytest.fixture
+def refusing_filesystem() -> Iterator[Callable[[int], contextlib.AbstractContextManager[None]]]:
+    """Refuse any write that would take a file past ``ceiling`` bytes.
+
+    A real ``RLIMIT_FSIZE`` ceiling rather than a patched writer, so the refusal
+    reaches whichever call the implementation makes. The default disposition for
+    ``SIGXFSZ`` terminates the process, so it is ignored for the duration and the
+    previous handler and limit are both put back - the window is one call wide on
+    purpose, because the limit applies to every write this process makes.
+    """
+
+    @contextlib.contextmanager
+    def _ceiling(ceiling: int) -> Iterator[None]:
+        soft, hard = resource.getrlimit(resource.RLIMIT_FSIZE)
+        previous = signal.signal(signal.SIGXFSZ, signal.SIG_IGN)
+        resource.setrlimit(resource.RLIMIT_FSIZE, (ceiling, hard))
+        try:
+            yield
+        finally:
+            resource.setrlimit(resource.RLIMIT_FSIZE, (soft, hard))
+            signal.signal(signal.SIGXFSZ, previous)
+
+    yield _ceiling
+
+
+def _assert_measurement_survived(manager: LeRobotCalibrationManager, path: Path, before: bytes, how: str) -> None:
+    """The stored calibration is the one that was measured, and it stands alone."""
+    after = path.read_bytes()
+    assert after == before, f"{how} left the stored measurement changed: {after[:80]!r}"
+    assert json.loads(after), f"{how} left the stored measurement unparseable"
+    loaded = manager.load_calibration(*_DEVICE)
+    assert loaded is not None, f"{how} left a calibration that reads as absent"
+    assert set(loaded) == set(_MOTORS), f"{how} lost motors: {sorted(loaded)}"
+    # An uncommitted file must not be left under a name the ``*.json`` globs that
+    # enumerate this store would pick up as a calibration of its own.
+    strays = sorted(entry.name for entry in path.parent.iterdir() if entry.name != path.name)
+    assert strays == [], f"{how} left an uncommitted file beside the calibration: {strays}"
+
+
+def test_a_value_json_cannot_encode_leaves_the_stored_calibration_intact(
+    stored: tuple[LeRobotCalibrationManager, Path, bytes],
+) -> None:
+    """A NumPy scalar in a re-measured calibration is refused before the stored one is touched.
+
+    ``CalibrationData`` is a type alias, not a runtime check, so a reading that is
+    not a plain ``int`` reaches the writer from any caller. ``json.dump`` encodes
+    into the stream it is given, so such a value used to raise only after a prefix
+    of the new calibration had replaced the stored one.
+    """
+    manager, path, before = stored
+    remeasured = {name: dict(motor) for name, motor in _measured_calibration().items()}
+    remeasured["wrist_roll"]["homing_offset"] = _bus_reading(-1031)
+
+    assert manager.save_calibration(*_DEVICE, remeasured) is False
+    _assert_measurement_survived(manager, path, before, "a rejected value")
+
+
+@pytest.mark.parametrize("writer", ["save", "restore"])
+def test_a_write_the_filesystem_refuses_leaves_the_stored_calibration_intact(
+    stored: tuple[LeRobotCalibrationManager, Path, bytes],
+    refusing_filesystem: Callable[[int], contextlib.AbstractContextManager[None]],
+    writer: str,
+) -> None:
+    """Both writers of the store keep the measurement when the write cannot complete.
+
+    Parametrized over which one performs it because both replace the same file and
+    both used to truncate it first. ``restore`` is driven with ``overwrite=True``,
+    which is the recovery case: the calibration it destroyed was the one it was
+    asked to write over, and the backup did not land either.
+    """
+    manager, path, before = stored
+    ceiling = len(before) // 2
+
+    if writer == "save":
+        with refusing_filesystem(ceiling):
+            reported: object = manager.save_calibration(*_DEVICE, _measured_calibration())
+        assert reported is False
+    else:
+        ok, _where, count = manager.backup_calibrations(output_dir=path.parent.parent.parent / "bk")
+        assert (ok, count) == (True, 1), "the backup this restore reads was not written"
+        with refusing_filesystem(ceiling):
+            ok, message, restored = manager.restore_calibrations(path.parent.parent.parent / "bk", overwrite=True)
+        assert ok is False and restored == 0, message
+
+    _assert_measurement_survived(manager, path, before, f"a refused {writer}")
+
+
+def test_an_uncommitted_calibration_is_not_named_like_one(
+    stored: tuple[LeRobotCalibrationManager, Path, bytes],
+) -> None:
+    """A temp file that outlives its process is not enumerated as a calibration.
+
+    The commit removes its own temp file, but a kill between the write and the
+    rename cannot. The name is taken from the commit rather than restated here, so
+    the choice of suffix is what is graded: were it to keep ``.json``, the
+    ``*.json`` globs that enumerate this store would read a partial write as a
+    measurement, and ``backup_calibrations`` - which reads that enumeration -
+    would preserve it as one.
+    """
+    from strands_robots.tools.lerobot_calibrate import _commit_calibration
+
+    manager, path, _before = stored
+    written: list[Path] = []
+
+    def _record_then_die(tmp: Path) -> None:
+        written.append(tmp)
+        tmp.write_bytes(b'{"partial":')
+        raise RuntimeError("killed before the rename")
+
+    with pytest.raises(RuntimeError):
+        _commit_calibration(path, _record_then_die)
+    assert written, "the commit handed its fill no path to write"
+    # The commit cleaned its own up; a kill at the same point could not, so put
+    # one back under exactly the name the commit chose.
+    written[0].write_bytes(b'{"partial":')
+
+    structure = manager.get_calibration_structure()
+    assert structure["robots"]["so101_follower"] == ["orange_arm"], (
+        f"an uncommitted write was enumerated as a calibration: {structure}"
+    )
+    ok, where, count = manager.backup_calibrations(output_dir=path.parent.parent.parent / "bk2")
+    assert (ok, count) == (True, 1), f"an uncommitted write was backed up as a calibration: {where}"
+
+
+def test_a_blocked_write_target_is_reported_rather_than_raised(tmp_path: Path) -> None:
+    """CONTROL: a write that cannot start at all still reports failure.
+
+    Holds either way. It is the fail-soft contract callers already had, kept so
+    this change is about what survives a failure and not about how one is
+    reported.
+    """
+    manager = LeRobotCalibrationManager(tmp_path)
+    manager.get_calibration_path(*_DEVICE).mkdir(parents=True)
+    assert manager.save_calibration(*_DEVICE, _measured_calibration()) is False
+
+
+def test_an_ordinary_save_and_restore_still_round_trip(tmp_path: Path) -> None:
+    """CONTROL: the working paths still store and recover a calibration.
+
+    Holds either way, so a commit that refused every write - or one that never
+    renamed its temp file into place - would not satisfy it.
+    """
+    manager = LeRobotCalibrationManager(tmp_path)
+    measured = _measured_calibration()
+    assert manager.save_calibration(*_DEVICE, measured) is True
+    assert manager.load_calibration(*_DEVICE) == measured
+
+    ok, where, count = manager.backup_calibrations(output_dir=tmp_path / "bk")
+    assert (ok, count) == (True, 1)
+
+    changed = {name: dict(motor) for name, motor in measured.items()}
+    changed["gripper"]["range_max"] = 1
+    assert manager.save_calibration(*_DEVICE, changed) is True
+    assert manager.load_calibration(*_DEVICE) == changed
+
+    ok, message, restored = manager.restore_calibrations(Path(where), overwrite=True)
+    assert (ok, restored) == (True, 1), message
+    assert manager.load_calibration(*_DEVICE) == measured, "the restored calibration is not the backed-up one"
+
+
+def test_both_calibration_writers_commit_through_the_one_owner() -> None:
+    """Neither writer spells the commit itself, so the sequence lives in one place.
+
+    Graded on the calls each writer makes rather than on the text: the rule is
+    which function performs the replacement, and a second copy of ``tmp`` plus
+    ``os.replace`` is exactly the drift that leaves one of the two destructive.
+    """
+    for method, forbidden in (
+        (LeRobotCalibrationManager.save_calibration, "json.dump"),
+        (LeRobotCalibrationManager.restore_calibrations, "shutil.copy2"),
+    ):
+        source = textwrap.dedent(inspect.getsource(method))
+        called: set[str] = {
+            ast.unparse(node.func) for node in ast.walk(ast.parse(source)) if isinstance(node, ast.Call)
+        }
+        assert "_commit_calibration" in called, (
+            f"{method.__qualname__} does not commit through the shared owner: {sorted(called)}"
+        )
+        assert forbidden not in called, (
+            f"{method.__qualname__} still writes {forbidden} straight into the stored calibration"
+        )
+
+
+def test_the_commit_owner_removes_its_temp_file_when_the_commit_does_not_happen(tmp_path: Path) -> None:
+    """A failure inside the owner leaves neither a changed destination nor a temp file."""
+    from strands_robots.tools.lerobot_calibrate import _commit_calibration
+
+    destination = tmp_path / "arm.json"
+    destination.write_text('{"kept": true}', encoding="utf-8")
+
+    def _fill(tmp: Path) -> Any:
+        tmp.write_text("partial", encoding="utf-8")
+        raise RuntimeError("the write could not finish")
+
+    with pytest.raises(RuntimeError):
+        _commit_calibration(destination, _fill)
+
+    assert json.loads(destination.read_text()) == {"kept": True}
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["arm.json"]


### PR DESCRIPTION
## The defect

A calibration is the one file this tool handles that is not derived data. Its homing
offsets and joint travel limits are recorded by disabling torque and moving **one
physical arm** by hand, so a stored one that is lost costs the procedure, not a re-run.

Both writers of that store encoded straight into the destination, which truncates the
stored file before the first byte of the replacement lands:

| writer | reachable via | wrote |
|---|---|---|
| `save_calibration` | public method on `LeRobotCalibrationManager` | `open(path, "w")` + `json.dump` |
| `restore_calibrations` | `lerobot_calibrate(action="restore")` | `shutil.copy2(src, dest)` |

`json.dump` encodes into the stream it is given, and `CalibrationData` is a type alias
rather than a runtime check, so a motor reading that is not a plain `int` raises only
after a prefix of the new calibration has replaced the stored one. `copy2` fails the
same way when the filesystem refuses the write.

## Measured

`06b5d3bb9` vs this branch, one 6-motor SO-101 follower calibration (776 B). The
filesystem refusal is a real `RLIMIT_FSIZE` ceiling — enforced by the kernel on the
write itself, which is what makes it reach `copy2`, since that copies with `sendfile`.

| | on `main` | on this branch |
|---|---|---|
| `save_calibration`, one `numpy.int64` homing offset | 776 → **596 B**, unparseable | 776 → **776 B** |
| … `load_calibration()` | **`None`** | 6 motors |
| `restore_calibrations(overwrite=True)`, refused write | 776 → **388 B**, unparseable | 776 → **776 B**, byte-identical |
| … `load_calibration()` | **`None`** | 6 motors |
| … backup installed? | no | no (and nothing lost) |
| `calibration_exists()` afterwards | `True` | `True` |
| reported outcome | `False` / `(False, msg, 0)` | unchanged |

`restore` is the sharper of the two, because it is the path a lost calibration is
recovered on: a refused write destroyed the calibration it was replacing *and* did not
install the backup, so restoring a backup over a working arm could leave neither.

### Nothing downstream reports the loss

```
tool view    -> status='success'
**Calibration Details: `robots/so101_follower/orange_arm`**
**Path:** .../robots/so101_follower/orange_arm.json
**Modified:** 2026-09-09 01:17:44
**Size:** 596 bytes (0.6 KB)
```

A path, a timestamp, a size — and no motors. `list` and `analyze` likewise answer
`status="success"`.

## The change

```mermaid
flowchart LR
  subgraph before
    A1[encode / copy] -->|truncates first| A2[(stored calibration)]
    A1 -.->|fails partway| A3[prefix where the measurement was]
  end
  subgraph after
    B1[serialize in full] --> B2[fill temp sibling] --> B3[os.replace]
    B3 --> B4[(stored calibration)]
    B2 -.->|fails| B5[temp removed, stored file untouched]
  end
```

One owner, `_commit_calibration`, that both writers ask through — the sequence
`_save_user_registry` documents and `_process_stop` already uses for the session store.
Serializing first is load-bearing rather than belt-and-braces: encoding into the temp
file instead makes `save_calibration` report **`True`** for a write that never landed,
because the encoder writes into a buffered handle the commit never closes, so the
ceiling is hit at flush — after `os.replace` has already run.

**+11 executable statements** (307 → 318 by AST) for +81/−4 raw in the tool; the rest is
docstring.

## Tests

`tests/tools/test_a_failed_calibration_write_keeps_the_measurement_on_disk.py`, 8 cells.

| corner | selection | result |
|---|---|---|
| A | `main`, existing calibration suite | 72 passed |
| B | `main` sources + the new file | **6 failed** / 74 passed |
| C | this branch, both | 80 passed |
| D | `main`, existing suite (= A) | 72 passed |

`72 + 8 = 80`; `74 = 72 + 2` controls. Each corner-B failure names the defect, e.g.
`a refused restore left the stored measurement changed: b'{\n "shoulder_pan"...`.
The 2 cells that pass on `main` are the controls: a write that cannot start is still
reported rather than raised, and the working save/restore paths still round-trip.

One mutation per decision, run against the new file (control 0, each a distinct set):

| mutation | fires |
|---|---|
| both writers write in place again | 4 |
| only `save` writes in place again | 3 |
| only `restore` writes in place again | 2 |
| encode into the temp file instead of serializing first | 2 |
| temp name ends in `.json` | 1 |
| a failed commit keeps its temp file | 3 |
| the temp file is never committed (over-reach) | 2 — both controls |

The last row is what shows the commit still installs the file rather than refusing
every write; the `.json` row is what earns the cell that reads the temp name **from the
commit** rather than restating it.

## Gate

- `ruff` 0.15.20 clean on `strands_robots tests tests_integ`
- `mypy` 1.20.2 — `Success: no issues found in 1963 source files`, no suppressions added
- 500-file tree-walking grader population + `tests/tools/`: **5 failed / 27,934 passed /
  72 skipped** in 24m27s. All 5 assert `rclpy` is absent where it resolves, and the
  failing node-id set is identical on a pristine `06b5d3bb9` worktree (`comm` empty both
  ways) — none attributable.

## Deliberately unchanged

- **How a failure is reported.** Both writers keep their fail-soft contracts (`False`,
  `(False, message, count)`); this is about what survives one, not how one is reported.
- **`backup_calibrations`' manifest.** It is written into a directory the call has just
  created, so there is no previously stored document for a failed write to lose.
- **The handler width.** `Exception`, not `BaseException`: the temp name is provably not
  one this store's enumerations read, so an interrupt that strands one costs nothing a
  later commit does not clear, and the wider handler would only add a site to the
  enumerated set in `AGENTS.md`.
