### PR TITLE
fix(simulation): a rollout can be stopped on every backend, through one verb

### DIFF
--- a/changelog.d/3349-stop-policy-base-contract.md
+++ b/changelog.d/3349-stop-policy-base-contract.md
@@ -33,6 +33,23 @@ have - `run_policy(n_steps=...)` and `run_policy(stop_when=...)`. The Device
 Connect `stop` RPC now reads that verb and enumerates through the ABC's own
 `list_robots`, so no path reaches into a backend's private registry.
 
+Making the verb universal also changed which branch of `Mesh._dispatch` a
+Newton or Isaac peer takes on the `{"action": "stop"}` fanout `emergency_stop`
+broadcasts: it now passes the `hasattr(r, "stop_policy")` probe and lands in the
+fleet-wide leg, whose population was `_active_policy_robots()` - a registry only
+MuJoCo keeps. On those backends that leg answered `ok=True, "no policies
+running"` for a rollout in flight, where before the promotion the same peer
+failed the probe and answered `ok=False`, so the fleet accounting scored a robot
+still executing as halted with no error and no log. The leg now asks every robot
+`list_robots` names when the engine keeps no registry - `stop_policy` is
+idempotent and reports `was_running` itself, the same population choice the
+Device Connect RPC makes - names as `stopped` only the robots whose answer did
+not say `was_running=False`, carries a backend's refusal through as
+`not_stopped`, and answers `ok=False` for a peer that can enumerate neither its
+rollouts nor its robots. The `was_running` reader both aggregating paths use
+now has one owner, `strands_robots.mesh.core._reported_a_rollout_in_flight`,
+beside the refusal predicate they already share.
+
 The counterpart's own description is corrected in the same change, because it is
 what sent callers looking for a stop that was not there. `start_policy`'s summary
 line read "Start policy execution in a background thread (non-blocking)" while

--- a/changelog.d/3349-stop-policy-base-contract.md
+++ b/changelog.d/3349-stop-policy-base-contract.md
@@ -1,0 +1,49 @@
+### Fixed: a rollout can be stopped on every simulation backend, through one verb
+
+`stop_policy` is the counterpart every `start_policy` docstring names, and it
+existed on the MuJoCo engine alone. On Newton, Isaac and any backend written
+against the documented `SimEngine` ABC the attribute was simply absent, so the
+two remote stop paths worked around it instead of reading its answer:
+`Mesh._dispatch` probes `hasattr(r, "stop_policy")` and answered `"peer exposes
+no stop_task"` for a simulation it could have stopped, while the Device Connect
+`stop` RPC re-derived the `was_running` verdict inline from the per-robot flag -
+a second construction of the answer `SimRobot.request_policy_stop` exists to keep
+in one place ("EVERY stop path goes through here ... so they cannot drift to
+different answers about whether a rollout was halted").
+
+That inline fallback also read the robot registry as `sim._world.robots`, which
+is the MuJoCo and Newton spelling. The Isaac engine keeps its robots in
+`_robots` and its `_world` is the Isaac `World`, which has no `.robots` at all,
+so the read raised `AttributeError` and the handler's recovery path reported it
+as `"The simulation changed under the stop loop"` - a race that had not happened
+- before a single robot was asked to stop.
+
+`SimEngine.stop_policy` now owns the question on every backend, the way
+`run_multi_policy` has since #2157: validate the name, then delegate the flag
+write to `_request_policy_stop`, the third member of the
+`_make_run_policy_hook` / `_release_run_policy_hook` seam that already raises and
+lowers the same flag around a rollout the shared facade drives. Newton overrides
+it, so its stop is a real one that reports `was_running` and increments the
+durable `policy_stops` counter. Isaac inherits the base default, which refuses
+and names the class: its per-robot record carries a bare `policy_running` flag
+and not the durable claim, and a bare flag write is exactly what a worker before
+its first frame overwrites (#2833), so it states why it cannot help rather than
+reporting a stop it cannot keep. The refusal names remedies this backend does
+have - `run_policy(n_steps=...)` and `run_policy(stop_when=...)`. The Device
+Connect `stop` RPC now reads that verb and enumerates through the ABC's own
+`list_robots`, so no path reaches into a backend's private registry.
+
+The counterpart's own description is corrected in the same change, because it is
+what sent callers looking for a stop that was not there. `start_policy`'s summary
+line read "Start policy execution in a background thread (non-blocking)" while
+the next line read "Default implementation: synchronous passthrough to
+`run_policy`" - and the summary line is what `help()`, an IDE tooltip and the
+rendered reference show. `docs/api-reference.md` called it an async rollout
+unconditionally and listed `stop_policy` as a `SimEngine` action, and
+`docs/troubleshooting.md` prescribed it as the cure for a hanging agent.
+Measured on the base default with `duration=3.0`, the call returns after 4.6s
+reporting `Policy complete`, against 0.001s and `Policy started (async)` on
+MuJoCo - so the prescribed remedy for a hang was the hang. All three surfaces now
+name the condition, and `describe()["methods"]["start_policy"]` states which of
+the two implementations the engine in hand has, so a caller can tell at runtime
+instead of reading the source.

--- a/changelog.d/3349-stop-policy-base-contract.md
+++ b/changelog.d/3349-stop-policy-base-contract.md
@@ -50,6 +50,16 @@ rollouts nor its robots. The `was_running` reader both aggregating paths use
 now has one owner, `strands_robots.mesh.core._reported_a_rollout_in_flight`,
 beside the refusal predicate they already share.
 
+Widening that population also moved what the branch's own safety log means. It
+read `"stop_policy refused for %d of %d active rollout(s)"`, and the denominator
+is now every robot the engine was asked about - so on a backend running the
+refusing default the message reported how many rollouts were in flight, which is
+the single fact that backend refuses BECAUSE it cannot know. It names the robots
+asked instead. The refusal on the leg for a peer that enumerates neither its
+rollouts nor its robots is logged as well as returned, the way the terminal
+"exposes no `stop_task`" branch beside it already is: the return reaches the
+broadcaster's accounting, while the log is what a console on the robot shows.
+
 The counterpart's own description is corrected in the same change, because it is
 what sent callers looking for a stop that was not there. `start_policy`'s summary
 line read "Start policy execution in a background thread (non-blocking)" while

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -82,8 +82,8 @@ Selected actions:
 | Action | What |
 |--------|------|
 | `run_policy(robot_name, ...)` | Blocking policy rollout. |
-| `start_policy(robot_name, ...)` | Async rollout (background thread). |
-| `stop_policy(robot_name)` | Stop running policy. |
+| `start_policy(robot_name, ...)` | Rollout in a background thread on MuJoCo; a blocking passthrough to `run_policy` on the other backends. `describe()['methods']['start_policy']` states which one the engine you hold implements. |
+| `stop_policy(robot_name)` | Cooperatively stop a rollout; the `json` block reports `was_running`. Refused (naming the class) by a backend with no durable per-robot claim. |
 | `run_multi_policy(policies, ...)` | Synchronized multi-robot rollout, one merged frame per step. |
 | `eval_policy(robot_name, n_episodes, ...)` | Multi-episode evaluation. |
 | `evaluate_benchmark(benchmark_name, ...)` | Run registered benchmark. |

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -49,6 +49,34 @@ results = sim_a.mesh.broadcast({"action": "status"}, timeout=2.0)
 sim_a.mesh.emergency_stop()   # STRANDS_MESH_AUDIT_DIR overrides log location
 ```
 
+## What a fleet e-stop reaches
+
+`emergency_stop()` broadcasts `{"action": "stop"}` with no `robot_name`, so each
+peer decides which of its own robots that reaches. A hardware peer stops its
+task. A simulation peer asks every rollout it could be running: the rollouts its
+backend reports as in flight where it keeps such a registry (MuJoCo prunes
+finished ones), and otherwise every robot the engine lists. `stop_policy` is
+idempotent and reports `was_running` itself, so asking an idle robot costs
+nothing and the verdict is read rather than guessed - `stopped` names only the
+robots whose answer did not say they were idle.
+
+The peer's `ok` is derived from those per-robot answers, never assumed:
+
+```python
+responses = sim_a.mesh.emergency_stop()
+# {"ok": True,  "stopped": ["arm"], "results": {...}}          the rollout halted
+# {"ok": True,  "stopped": [],      "results": {...}}          asked, none was running
+# {"ok": False, "stopped": [], "not_stopped": ["arm"], ...}    a stop was refused
+```
+
+A refusal puts the peer in `peers_not_stopped`, which `emergency_stop()` logs at
+CRITICAL and carries in the safety envelope. A backend that keeps no durable
+per-robot rollout claim refuses, and that refusal is what you want: on the safety
+path an acknowledgement that nothing was running is an affirmative answer given
+on no evidence. Bound such a rollout instead of stopping it -
+`run_policy(n_steps=...)` caps its length and `run_policy(stop_when={...})` ends
+it as soon as the world reaches a state.
+
 ## Recovering from an emergency stop
 
 `emergency_stop()` latches a **lockout** on every peer that receives it. While a

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,7 +85,7 @@ description: Error → fix table for the most common gotchas across install, sim
 |---------|--------------|-----|
 | Agent picks wrong action | Tool spec confusion | Rephrase instruction; check `robot.tool_spec` |
 | `Agent(tools=[robot])` errors | `strands-agents` missing | `uv pip install strands-agents` |
-| Agent hangs | Long-running action | Use `start_policy` instead of `run_policy` |
+| Agent hangs | Long-running action | Bound the rollout: `run_policy(n_steps=...)`, or `stop_when={'predicate': ...}` to end it on a world state. On MuJoCo `start_policy` also returns immediately; on the other backends it is a blocking passthrough, so it is not the fix there |
 | Bedrock/Anthropic auth fails | Provider credentials | See [Strands Agents docs](https://strandsagents.com/) |
 
 Bug reports: [GitHub issues](https://github.com/strands-labs/robots/issues) - include `pip show strands-robots`, Python + OS, minimal repro, full stack trace.

--- a/strands_robots/device_connect/sim_driver.py
+++ b/strands_robots/device_connect/sim_driver.py
@@ -240,29 +240,32 @@ class SimulationDeviceDriver(DeviceDriver):
         only population would leave that rollout untouched. Which of these was
         actually in flight is the answer ``stop_policy`` gives, not a guess made
         here.
+
+        Read through the engine's own :meth:`~strands_robots.simulation.base.SimEngine.list_robots`
+        rather than off ``sim._world.robots``: that attribute is the MuJoCo and
+        Newton spelling of the registry, while the Isaac engine keeps its robots
+        in ``_robots`` and its ``_world`` is the Isaac ``World`` object, which
+        has no ``.robots`` at all. So the private read raised ``AttributeError``
+        on Isaac, and the recovery path below reported it as "the simulation
+        changed under the stop loop" - a race that had not happened - before any
+        robot was asked. ``list_robots`` is the ABC's own accessor and answers
+        ``[]`` on every backend when there is no world.
         """
-        world = getattr(self._sim, "_world", None)
-        if world is None:
-            return []
-        return list(world.robots)
+        return list(self._sim.list_robots())
 
     def _stop_one_rollout(self, robot_name: str) -> dict[str, Any]:
         """Stop one robot's rollout through the verb that owns the question.
 
-        Falls back to the durable flag write for a backend that exposes no
-        ``stop_policy``: :meth:`~strands_robots.simulation.base.SimEngine.start_policy`
-        is a synchronous passthrough there, so no worker outlives the call and
-        the flag is the whole answer. The fallback returns the same envelope
-        shape so the caller above grades one thing.
+        :meth:`~strands_robots.simulation.base.SimEngine.stop_policy` is that
+        verb on every backend, so this reads its answer instead of constructing
+        a second one. It used to fall back to writing the per-robot flag itself
+        whenever the attribute was missing - which was every backend but MuJoCo -
+        and that fallback both reached into ``sim._world.robots`` (absent on
+        Isaac) and re-derived the ``was_running`` verdict that
+        :meth:`~strands_robots.simulation.models.SimRobot.request_policy_stop`
+        exists to keep in one place.
         """
-        stop_policy = getattr(self._sim, "stop_policy", None)
-        if callable(stop_policy):
-            return dict(stop_policy(robot_name=robot_name))
-        robot = self._sim._world.robots[robot_name]
-        return {
-            "status": "success",
-            "content": [{"json": {"robot": robot_name, "was_running": bool(robot.request_policy_stop())}}],
-        }
+        return dict(self._sim.stop_policy(robot_name=robot_name))
 
     @rpc()
     async def getStatus(self) -> dict[str, Any]:

--- a/strands_robots/device_connect/sim_driver.py
+++ b/strands_robots/device_connect/sim_driver.py
@@ -5,7 +5,6 @@ state as structured RPCs and events via Device Connect's DeviceDriver interface.
 """
 
 import logging
-from collections.abc import Mapping
 from typing import Any
 
 from device_connect_edge.drivers import (
@@ -19,7 +18,7 @@ from device_connect_edge.drivers import (
 from device_connect_edge.types import DeviceIdentity, DeviceStatus
 
 from strands_robots.device_connect._authz import attached_runtime, authz_error, is_authorized_caller
-from strands_robots.mesh.core import _reports_failure_to_stop
+from strands_robots.mesh.core import _reported_a_rollout_in_flight, _reports_failure_to_stop
 from strands_robots.mesh.security import is_safe_policy_provider
 from strands_robots.teleop_mixin import _stop_reported_stopped
 
@@ -502,29 +501,3 @@ class SimulationDeviceDriver(DeviceDriver):
             joints: Dict of joint name -> position (radians)
         """
         pass
-
-
-def _reported_a_rollout_in_flight(answer: Mapping[str, Any]) -> bool | None:
-    """Whether a ``stop_policy`` answer says a rollout really was in flight.
-
-    Reads the ``was_running`` key
-    :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.stop_policy`
-    puts in its ``json`` block. Tri-state on purpose, in the same conservative
-    direction as :func:`~strands_robots.mesh.core._reports_failure_to_stop`: an
-    envelope that reports the fact neither way is not read as either one.
-    Counting silence as a halt names a robot the answer never mentioned;
-    counting it as idle lets the caller state "no rollout was in flight" on no
-    evidence. Both are the affirmative lie this verb exists to stop telling.
-
-    Args:
-        answer: One envelope returned by a stop verb.
-
-    Returns:
-        ``True`` or ``False`` as the answer reports it, or ``None`` when the
-        answer carries no verdict at all.
-    """
-    for block in answer.get("content", []):
-        payload = block.get("json")
-        if isinstance(payload, dict) and "was_running" in payload:
-            return bool(payload["was_running"])
-    return None

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -383,6 +383,38 @@ def _reports_failure_to_stop(result: Mapping[str, Any]) -> bool:
     return result.get("ok") is False or result.get("status") == "error"
 
 
+def _reported_a_rollout_in_flight(answer: Mapping[str, Any]) -> bool | None:
+    """Whether a ``stop_policy`` answer says a rollout really was in flight.
+
+    Reads the ``was_running`` key
+    :meth:`~strands_robots.simulation.base.SimEngine.stop_policy` puts in its
+    ``json`` block. Tri-state on purpose, in the same conservative direction as
+    :func:`_reports_failure_to_stop`: an envelope that reports the fact neither
+    way is not read as either one. Counting silence as a halt names a robot the
+    answer never mentioned; counting it as idle lets the caller state "no
+    rollout was in flight" on no evidence. Both are the affirmative lie the
+    stop verb exists to stop telling.
+
+    Lives beside its sibling predicate because it has the same two readers and
+    the same reason for one owner: the fleet-wide branch of
+    :meth:`Mesh._dispatch` and the Device Connect ``stop`` RPC both aggregate
+    per-robot ``stop_policy`` answers, and a second copy of this read is how
+    the two would come to name different robots as halted.
+
+    Args:
+        answer: One envelope returned by a stop verb.
+
+    Returns:
+        ``True`` or ``False`` as the answer reports it, or ``None`` when the
+        answer carries no verdict at all.
+    """
+    for block in answer.get("content", []):
+        payload = block.get("json")
+        if isinstance(payload, dict) and "was_running" in payload:
+            return bool(payload["was_running"])
+    return None
+
+
 def _peers_that_did_not_stop(responses: list[dict[str, Any]]) -> set[str]:
     """Identify responders that explicitly reported they did NOT stop.
 
@@ -2187,11 +2219,41 @@ class Mesh(SensorLoopsMixin):
                 try:
                     if robot_name:
                         return dict(r.stop_policy(robot_name))
-                    # No robot_name: stop every active rollout in the world.
-                    active = list(r._active_policy_robots()) if hasattr(r, "_active_policy_robots") else []
-                    if not active:
-                        return {"ok": True, "stopped": [], "note": "no policies running"}
-                    results = {name: dict(r.stop_policy(name)) for name in active}
+                    # No robot_name: stop every rollout in the world. The
+                    # population is the engine's own choice of registry when
+                    # it keeps one (MuJoCo's ``_active_policy_robots`` prunes
+                    # finished Futures), and otherwise EVERY robot the ABC's
+                    # ``list_robots`` names: ``stop_policy`` is idempotent and
+                    # reports ``was_running`` itself, so asking an idle robot
+                    # costs nothing and the verdict is read rather than
+                    # guessed. Before ``stop_policy`` was on the base this
+                    # branch was unreachable for Newton and Isaac; once it was,
+                    # the registry-only population answered ``ok=True, "no
+                    # policies running"`` for a Newton rollout in flight --
+                    # the same silent false negative the terminal ``ok=False``
+                    # below exists to refuse, reached from the other side.
+                    # An engine that cannot enumerate its robots cannot say
+                    # what it halted, so it answers conservatively.
+                    if hasattr(r, "_active_policy_robots"):
+                        targets = list(r._active_policy_robots())
+                        if not targets:
+                            return {"ok": True, "stopped": [], "note": "no policies running"}
+                    elif hasattr(r, "list_robots"):
+                        targets = list(r.list_robots())
+                        if not targets:
+                            return {"ok": True, "stopped": [], "note": "no robots in this world"}
+                    else:
+                        logger.error(
+                            "[safety] %s: stop requested but %s enumerates neither its rollouts nor its "
+                            "robots; NOTHING was stopped on this peer",
+                            self.peer_id,
+                            type(r).__name__,
+                        )
+                        return {
+                            "ok": False,
+                            "error": f"{type(r).__name__} cannot enumerate rollouts in flight; nothing was stopped",
+                        }
+                    results = {name: dict(r.stop_policy(name)) for name in targets}
                     # ``ok`` is derived from the per-robot answers, never
                     # assumed. Reporting ok=True here counted a refused
                     # stop as a halt: the refusal sat in ``results``, which
@@ -2200,9 +2262,16 @@ class Mesh(SensorLoopsMixin):
                     # the fleet had halted. This is the ONLY stop path that
                     # aggregates -- both sibling branches return the stop
                     # verb's own answer, so a refusal reaches the
-                    # accounting through them unchanged.
+                    # accounting through them unchanged. ``stopped`` names
+                    # only the robots whose answer did not say ``was_running``
+                    # is False: with the whole world as the population, an
+                    # idle robot is asked too, and it was not halted.
                     refused = sorted(n for n, res in results.items() if _reports_failure_to_stop(res))
-                    stopped = [n for n in results if n not in set(refused)]
+                    stopped = [
+                        n
+                        for n, res in results.items()
+                        if n not in set(refused) and _reported_a_rollout_in_flight(res) is not False
+                    ]
                     if refused:
                         logger.error(
                             "[safety] %s: stop_policy refused for %d of %d active rollout(s): %s; "

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -2274,7 +2274,7 @@ class Mesh(SensorLoopsMixin):
                     ]
                     if refused:
                         logger.error(
-                            "[safety] %s: stop_policy refused for %d of %d active rollout(s): %s; "
+                            "[safety] %s: stop_policy refused for %d of %d robot(s) asked: %s; "
                             "those policies may still be executing",
                             self.peer_id,
                             len(refused),

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -4025,7 +4025,7 @@ class SimEngine(ABC):
             Whether a rollout was in flight when the stop arrived, or ``None``
             when this backend keeps no durable claim to move. ``None`` is a stated
             absence of a verdict, not a ``False``: the tri-state matches
-            :func:`~strands_robots.device_connect.sim_driver._reported_a_rollout_in_flight`,
+            :func:`~strands_robots.mesh.core._reported_a_rollout_in_flight`,
             which reads "reported neither way" as neither, so a backend with
             nothing to report cannot be quoted as having reported an idle robot.
             Default: ``None`` - nothing was claimed, so nothing can be released.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -3881,11 +3881,24 @@ class SimEngine(ABC):
         policy_kwargs: dict[str, Any] | None = None,
         seed: int | None = None,
     ) -> dict[str, Any]:
-        """Start policy execution in a background thread (non-blocking).
+        """Run a policy rollout, in the background where the backend has one.
 
-        Default implementation: synchronous passthrough to ``run_policy``.
-        Backends that support true background execution (like MuJoCo via
-        its ``ThreadPoolExecutor``) should override.
+        DEFAULT IMPLEMENTATION IS SYNCHRONOUS: it passes through to
+        :meth:`run_policy` and returns only after the rollout has finished, so
+        its result reports a COMPLETED rollout ("Policy complete on ...") and
+        the call blocks for the whole ``duration``. The summary line used to
+        promise a background thread outright, which is what MuJoCo's override
+        does, not what a caller of this default gets - and the two backends
+        shipped on this default are the ones whose callers most need to know.
+        Backends with true background execution override this (MuJoCo, via the
+        ``ThreadPoolExecutor`` it owns) and return as soon as the rollout is
+        submitted.
+
+        Either way :meth:`stop_policy` is the counterpart, and a caller can tell
+        which of the two it holds without reading the source: this method's
+        entry in :meth:`describe` states which one this engine implements, and a
+        backend that also tracks rollouts in flight advertises
+        ``list_policies_running`` there beside it.
 
         accepts ``n_steps`` (primary) or legacy ``max_steps`` as an
         alternate to ``duration``. See ``run_policy`` for conversion rules.
@@ -3909,6 +3922,115 @@ class SimEngine(ABC):
             policy_kwargs=policy_kwargs,
             seed=seed,
         )
+
+    def stop_policy(self, robot_name: str = "") -> dict[str, Any]:
+        """Stop ``robot_name``'s rollout (cooperative) and report what was in flight.
+
+        The counterpart to :meth:`start_policy`, and the verb that OWNS the
+        question "was a rollout halted" for every backend. It lived only on the
+        MuJoCo engine, so on the other backends the attribute did not exist at
+        all: :meth:`~strands_robots.mesh.Mesh._dispatch` probes for it with
+        ``hasattr`` and answered "peer exposes no stop_task" for a sim it could
+        in fact have stopped, and the Device Connect ``stop`` RPC re-derived the
+        answer inline from the per-robot flag - a second construction of the
+        verdict that
+        :meth:`~strands_robots.simulation.models.SimRobot.request_policy_stop`
+        exists to prevent ("EVERY stop path goes through here ... so they cannot
+        drift to different answers about whether a rollout was halted"). This is
+        the same promotion :meth:`run_multi_policy` had (#2157): a capability
+        every backend is asked for answers in the tool envelope on all of them,
+        never with ``AttributeError`` because there was no contract.
+
+        The flag write itself is backend-owned, because the per-robot rollout
+        claim is: :meth:`_request_policy_stop` is the seam, the mirror of the
+        :meth:`_make_run_policy_hook` / :meth:`_release_run_policy_hook` pair
+        that raises and lowers the same flag around a rollout driven here.
+
+        This is a cooperative stop, not a join: it moves the robot's claim out
+        of date so the rollout's next frame ends it. It cannot interrupt a
+        rollout that is blocked inside a single ``send_action`` or a single
+        policy inference, and on a backend whose :meth:`start_policy` is the
+        synchronous default the caller's own thread is the one inside the
+        rollout - so the callers that reach this verb usefully are the ones on
+        another thread (the Device Connect ``stop`` RPC and the mesh fanout).
+
+        Args:
+            robot_name: The robot whose rollout to stop. Required: an empty name
+                is refused rather than silently matched against the sole robot,
+                because a stop aimed at the wrong robot reads as a stop that
+                worked.
+
+        Returns:
+            The agent-tool envelope. On success the ``json`` block reports
+            ``was_running`` - whether a rollout really was in flight when the
+            stop arrived - so a caller aggregating several answers reads the
+            verdict rather than matching on the sentence. Idempotent: a robot
+            with nothing running is ``status="success"`` with
+            ``was_running=False``, so a caller may stop unconditionally.
+            ``status="error"`` for an empty or unknown ``robot_name``, and for a
+            backend that keeps no durable per-robot claim to move - that refusal
+            names the class, because "nothing was running" would be an
+            affirmative answer given on no evidence. Isaac is on that default
+            today: its per-robot record carries a bare ``policy_running`` flag
+            and not the durable counter, and a bare flag write is the exact
+            thing a worker that has not reached its first frame overwrites
+            (#2833), so it refuses rather than reporting a stop it cannot keep.
+        """
+        if not robot_name:
+            return {"status": "error", "content": [{"text": "stop_policy requires 'robot_name'."}]}
+        if robot_name not in self.list_robots():
+            return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
+        was_running = self._request_policy_stop(robot_name)
+        if was_running is None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"{type(self).__name__} keeps no durable per-robot rollout claim, so a "
+                            f"rollout in flight on '{robot_name}' cannot be stopped cooperatively "
+                            "and this call reports nothing about one. Bound the rollout instead of "
+                            "stopping it: run_policy(n_steps=...) caps its length, and "
+                            "run_policy(stop_when={'predicate': ...}) ends it as soon as the world "
+                            "reaches a state. A backend whose per-robot record carries the durable "
+                            "claim (SimRobot.request_policy_stop) makes this verb work by "
+                            "overriding _request_policy_stop."
+                        )
+                    }
+                ],
+            }
+        msg = f"Stopped on '{robot_name}'" if was_running else f"Was not running on '{robot_name}'"
+        return {
+            "status": "success",
+            "content": [{"text": msg}, {"json": {"robot": robot_name, "was_running": was_running}}],
+        }
+
+    def _request_policy_stop(self, robot_name: str) -> bool | None:
+        """Move ``robot_name``'s rollout claim out of date; report what was in flight.
+
+        The backend half of :meth:`stop_policy`, and the third member of the
+        hook seam that owns the per-robot ``policy_running`` flag:
+        :meth:`_make_run_policy_hook` raises it, :meth:`_release_run_policy_hook`
+        lowers it when the rollout ends, and this lowers it when a caller asks
+        for the rollout to end early. A backend that overrides either of those
+        holds a robot registry and should override this too; the write itself
+        belongs to :meth:`~strands_robots.simulation.models.SimRobot.request_policy_stop`
+        so every stop path reports the same fact.
+
+        Args:
+            robot_name: A robot :meth:`list_robots` names, already validated by
+                :meth:`stop_policy`.
+
+        Returns:
+            Whether a rollout was in flight when the stop arrived, or ``None``
+            when this backend keeps no durable claim to move. ``None`` is a stated
+            absence of a verdict, not a ``False``: the tri-state matches
+            :func:`~strands_robots.device_connect.sim_driver._reported_a_rollout_in_flight`,
+            which reads "reported neither way" as neither, so a backend with
+            nothing to report cannot be quoted as having reported an idle robot.
+            Default: ``None`` - nothing was claimed, so nothing can be released.
+        """
+        return None
 
     def replay_episode(
         self,
@@ -5015,7 +5137,19 @@ class SimEngine(ABC):
                     "'error' on failures) + steps_used so a caller can decide "
                     "whether to retry"
                 ),
-                "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
+                "start_policy": (
+                    "(robot_name: str, policy_provider='mock', ...) -> dict  # on "
+                    "THIS engine it runs the rollout to completion and returns "
+                    "its result (synchronous); a backend that runs it in the "
+                    "background instead says so here and advertises "
+                    "list_policies_running beside it, so this entry is how to "
+                    "tell which one you hold"
+                ),
+                "stop_policy": (
+                    "(robot_name: str) -> dict  # cooperatively end a rollout "
+                    "in flight; the json block reports was_running, and "
+                    "robot_name is required (never defaulted to the sole robot)"
+                ),
                 "eval_policy": (
                     "(robot_name: str, policy_provider='mock', n_episodes=1, "
                     "max_steps=300, success_fn=None, ...) -> dict  # multi-episode "

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -676,8 +676,14 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
         is running ... wait for the rollout to finish``, and
         :meth:`~strands_robots.simulation.isaac.simulation.IsaacSimulation.run_multi_policy`
         answered ``policy already running ... Stop it first`` - two remedies
-        for a rollout that had already ended, and neither reachable (Isaac
-        exposes no ``stop_policy``).
+        for a rollout that had already ended, and at the time neither was even
+        reachable, because Isaac exposed no ``stop_policy``. It inherits one now
+        (:meth:`~strands_robots.simulation.base.SimEngine.stop_policy`), which
+        on this backend states why it cannot help - the per-robot record here
+        carries a bare ``policy_running`` flag and not the durable claim
+        ``SimRobot.request_policy_stop`` writes - rather than raising
+        ``AttributeError``. The release below is what makes the remedy
+        unnecessary in the first place.
 
         ``run_multi_policy`` lowers the flag in its own ``finally`` for the
         loop it owns; this is the same release for the rollout the shared

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -3134,6 +3134,16 @@ class MuJoCoSimEngine(
         # spec + action dispatcher; listing them completes the start/stop/list
         # lifecycle on the discovery surface (the resource-management sibling of
         # run_policy's blocking rollout).
+        # start_policy's inherited entry states the base engine's SYNCHRONOUS
+        # reading, which is wrong for this backend -- and it is the entry a
+        # caller reads to tell the two apart, so it is corrected here rather
+        # than left describing another engine.
+        base["methods"]["start_policy"] = (
+            "(robot_name: str, policy_provider='mock', ...) -> dict  # on THIS "
+            "engine it submits the rollout to the ThreadPoolExecutor and returns "
+            "immediately (background, non-blocking); stop_policy ends it and "
+            "list_policies_running reports what is in flight"
+        )
         base["methods"]["stop_policy"] = (
             "(robot_name: str) -> dict  # cooperatively stop the background "
             "policy started by start_policy on robot_name; idempotent (succeeds "

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -583,10 +583,11 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         Nothing lowered it, so a recorded rollout left the robot marked as
         driven for the rest of the session. On this backend the flag is what
         :meth:`~strands_robots.simulation.models.SimRobot.request_policy_stop`
-        reports as ``was_running``, and that answer is the whole verdict of the
-        stop paths that reach a backend exposing no ``stop_policy`` - the
-        Device Connect ``stop`` RPC among them - so an idle simulation reported
-        a halted rollout that had finished on its own.
+        reports as ``was_running``, and that answer is the whole verdict every
+        stop path here reports - :meth:`_request_policy_stop` hands it to
+        :meth:`~strands_robots.simulation.base.SimEngine.stop_policy`, and the
+        Device Connect ``stop`` RPC reads that - so a flag left raised made an
+        idle simulation report a halted rollout that had finished on its own.
 
         Args:
             robot_name: The robot whose rollout has ended. A robot removed

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -2442,6 +2442,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     "(the base contract's synchronous passthrough to run_policy on this backend; "
                     "only MuJoCo runs a policy on a background thread)"
                 ),
+                "stop_policy": (
+                    "(robot_name: str) -> dict  (cooperatively end a rollout in flight; this "
+                    "backend answers from the durable per-robot claim, so the json block reports "
+                    "was_running. robot_name is required, never defaulted to the sole robot)"
+                ),
                 "replay_episode": (
                     "(repo_id: str, robot_name=None, episode=0, root=None, speed=1.0, "
                     "action_key_map=None) -> dict  (replay a recorded LeRobotDataset episode "
@@ -2534,6 +2539,28 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 "With multiple robots, pass robot_name explicitly (from 'robots')."
             ),
         }
+
+    def _request_policy_stop(self, robot_name: str) -> bool | None:
+        """Newton override: move this robot's rollout claim out of date.
+
+        The stop half of the flag this backend already raises and lowers around
+        a rollout (see
+        :meth:`~strands_robots.simulation.newton.recording.NewtonRecordingMixin._make_run_policy_hook`
+        and its ``_release_run_policy_hook``), so
+        :meth:`~strands_robots.simulation.base.SimEngine.stop_policy` reports the
+        same fact those two do instead of refusing for want of a registry.
+
+        Args:
+            robot_name: A robot in this world.
+
+        Returns:
+            Whether a rollout was in flight, or ``None`` when the world (or the
+            robot) is gone - there is no claim to move, and no verdict to give.
+        """
+        world = self._world
+        if world is None or not registered(world.robots, robot_name):
+            return None
+        return world.robots[robot_name].request_policy_stop()
 
     def cleanup(self, policy_stop_timeout: float | None = None) -> None:
         """Release resources (alias for :meth:`destroy`)."""

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -1155,6 +1155,14 @@ class TestPolicyExecution:
         assert "robot_name" in methods["stop_policy"]
         assert "-> dict" in methods["list_policies_running"]
 
+        # start_policy's own entry says WHICH of the two implementations this
+        # engine has. The base surface describes its synchronous passthrough, so
+        # an entry inherited unchanged would advertise the wrong engine here --
+        # the one place a caller looks to tell a 0.001s call from a 3s one.
+        assert "background" in methods["start_policy"]
+        assert "non-blocking" in methods["start_policy"]
+        assert "synchronous" not in methods["start_policy"]
+
         # The advertisement is only useful if the methods it names are real and
         # invocable: list before start reports none, stop is idempotent.
         listed = sim_with_robot.list_policies_running()

--- a/tests/simulation/test_rollout_hook_release_leaves_the_robot_idle.py
+++ b/tests/simulation/test_rollout_hook_release_leaves_the_robot_idle.py
@@ -21,12 +21,14 @@ driven for the rest of the session:
   while its policy is running ... Wait for the rollout to finish (Isaac policy
   loops clear the flag on exit)`` and ``run_multi_policy`` answered ``policy
   already running on 'so100'. Stop it first`` -- two remedies for a rollout
-  that had already ended, and neither reachable (Isaac exposes no
-  ``stop_policy``).
+  that had already ended, and at the time neither was reachable, because Isaac
+  exposed no ``stop_policy`` at all. It inherits ``SimEngine.stop_policy`` now,
+  which on Isaac states why it cannot help instead of raising
+  ``AttributeError``; the release below is what makes the remedy unnecessary.
 * Newton: ``SimRobot.request_policy_stop`` reported ``was_running=True``, and
-  that is the whole verdict of the stop paths that reach a backend exposing no
-  ``stop_policy`` -- so the Device Connect ``stop`` RPC reported a halted
-  rollout on an idle simulation.
+  that is the whole verdict every stop path here reports -- ``stop_policy``
+  reads it through ``_request_policy_stop`` -- so the Device Connect ``stop``
+  RPC reported a halted rollout on an idle simulation.
 
 The release now has one owner: ``SimEngine._release_run_policy_hook``, called
 in a ``finally`` around every rollout the facade drives. The cells below pin
@@ -239,14 +241,18 @@ class TestIsaacFreesTheRobotItsRecordingHookClaimed:
 
     def test_another_rollout_is_reachable_after_a_recorded_rollout(self, monkeypatch):
         # ``run_multi_policy``'s busy check reads the same flag, and its remedy
-        # ("Stop it first") names a verb this backend does not expose.
+        # ("Stop it first") names a verb that on this backend answers with a
+        # stated refusal rather than a halt -- so the release below, not the
+        # remedy, is what makes the next rollout reachable.
         _stub_rollout(monkeypatch)
         engine = self._engine()
 
         assert engine.run_policy("so100", n_steps=3)["status"] == "success"
 
         assert engine._robots["so100"].policy_running is False
-        assert not hasattr(engine, "stop_policy")
+        refusal = engine.stop_policy("so100")
+        assert refusal["status"] == "error"
+        assert "IsaacSimulation keeps no durable per-robot rollout claim" in refusal["content"][0]["text"]
 
 
 class TestNewtonDoesNotReportAHaltOnAnIdleSimulation:
@@ -278,12 +284,14 @@ class TestNewtonDoesNotReportAHaltOnAnIdleSimulation:
 
         driver = SimulationDeviceDriver.__new__(SimulationDeviceDriver)
         driver._sim = engine
-        # The fallback the driver documents for a backend exposing no
-        # ``stop_policy``: the flag write IS the verdict, so a stale flag is
-        # reported as a rollout this stop halted.
+        # The driver reads ``stop_policy``, which on this backend hands the flag
+        # write to ``_request_policy_stop``: the flag IS the verdict, so a stale
+        # flag would be reported as a rollout this stop halted.
         answer = driver._stop_one_rollout("so100")
 
-        assert answer["content"][0]["json"] == {"robot": "so100", "was_running": False}
+        assert answer["status"] == "success"
+        verdicts = [b["json"] for b in answer["content"] if "json" in b]
+        assert verdicts == [{"robot": "so100", "was_running": False}]
 
 
 class TestMuJoCoWasAlreadyCorrect:

--- a/tests/simulation/test_stop_policy_base_contract.py
+++ b/tests/simulation/test_stop_policy_base_contract.py
@@ -1,0 +1,405 @@
+"""A rollout can be stopped on every simulation backend, through one verb.
+
+``stop_policy`` is the counterpart every ``start_policy`` docstring names, and
+it lived on the MuJoCo engine alone. On the other backends the attribute did not
+exist, so the two remote stop paths each worked around its absence rather than
+reading its answer:
+
+* :meth:`~strands_robots.mesh.Mesh._dispatch` probes ``hasattr(r,
+  "stop_policy")`` and, failing it, answered ``"peer exposes no stop_task"`` for
+  a simulation it could in fact have stopped.
+* The Device Connect ``stop`` RPC re-derived the verdict inline from the
+  per-robot flag - a second construction of the ``was_running`` answer that
+  :meth:`~strands_robots.simulation.models.SimRobot.request_policy_stop` exists
+  to keep in one place ("EVERY stop path goes through here ... so they cannot
+  drift to different answers about whether a rollout was halted") - and read the
+  robot registry as ``sim._world.robots``, which is the MuJoCo and Newton
+  spelling. The Isaac engine keeps its robots in ``_robots`` and its ``_world``
+  is the Isaac ``World``, which has no ``.robots``, so that read raised
+  ``AttributeError`` and the handler's recovery path reported it as "the
+  simulation changed under the stop loop" - a race that had not happened.
+
+This is the promotion :meth:`~strands_robots.simulation.base.SimEngine.run_multi_policy`
+already had (#2157), and ``tests/simulation/test_run_multi_policy_base_contract.py``
+states its rule: a capability every backend is asked for answers in the tool
+envelope on all of them, never with ``AttributeError`` because there was no
+contract. The flag write stays backend-owned behind
+:meth:`~strands_robots.simulation.base.SimEngine._request_policy_stop`, the
+third member of the ``_make_run_policy_hook`` / ``_release_run_policy_hook``
+seam that raises and lowers the same flag around a rollout the shared facade
+drives.
+
+The same divergence had a documentation half, pinned at the bottom: the base
+``start_policy`` summary line promised "a background thread (non-blocking)" and
+its next line said "synchronous passthrough to ``run_policy``", while
+``docs/api-reference.md`` called it an async rollout unconditionally and
+``docs/troubleshooting.md`` prescribed it as the fix for a hanging agent. On the
+two backends shipped on that default it blocks for the whole ``duration``, so
+the prescribed remedy was the hang.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.models import SimRobot, SimWorld
+
+_DOCS = Path(__file__).resolve().parents[2] / "docs"
+_JOINTS = ("j1", "j2")
+
+
+class _MinimalEngine(SimEngine):
+    """The smallest backend the ABC admits: no registry, no override.
+
+    A third-party backend written against the documented ABC looks like this,
+    and it is the population the base defaults have to answer for. Only the
+    abstract methods are implemented; ``_request_policy_stop`` is deliberately
+    NOT overridden, so this is also the "no durable claim" column.
+    """
+
+    def __init__(self) -> None:
+        self._q: Any = np.zeros(len(_JOINTS))
+        super().__init__()
+
+    def create_world(
+        self,
+        timestep: float | None = None,
+        gravity: list[float] | None = None,
+        ground_plane: bool = True,
+        terrain: str | None = None,
+        difficulty: float = 1.0,
+    ) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def destroy(self) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def reset(self) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def step(self, n_steps: int = 1) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def get_state(self) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def add_robot(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def remove_robot(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def list_robots(self) -> list[str]:
+        return ["arm"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(_JOINTS)
+
+    def add_object(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def remove_object(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success", "content": []}
+
+    def get_observation(self, robot_name: str | None = None, *, skip_images: bool = False) -> dict[str, Any]:
+        return {"observation.state": self._q.copy()}
+
+    def send_action(
+        self,
+        action: dict[str, Any] | Sequence[float],
+        robot_name: str | None = None,
+        n_substeps: int = 1,
+    ) -> dict[str, Any]:
+        values = [float(action[j]) for j in _JOINTS] if isinstance(action, dict) else [float(v) for v in action]
+        self._q = np.asarray(values, dtype=float)
+        return {"status": "success", "content": []}
+
+    def render(
+        self, camera_name: str = "default", width: int | None = None, height: int | None = None
+    ) -> dict[str, Any]:
+        return {"image": np.zeros((height or 48, width or 64, 3), dtype=np.uint8)}
+
+    def physics_timestep(self) -> float | None:
+        return 0.002
+
+
+def _text(result: dict[str, Any]) -> str:
+    return result["content"][0]["text"]
+
+
+def _verdicts(result: dict[str, Any]) -> list[dict[str, Any]]:
+    return [b["json"] for b in result.get("content", []) if isinstance(b, dict) and isinstance(b.get("json"), dict)]
+
+
+def _newton_engine(policy_running: bool) -> Any:
+    """A Newton engine skeleton whose one robot carries the durable claim.
+
+    ``__new__`` plus the handful of attributes the stop path reads - the fixture
+    shape this backend's own recording tests use, so neither Warp nor a compiled
+    model is needed to grade a flag write.
+    """
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    world = SimWorld()
+    robot = SimRobot(name="arm", urdf_path="arm.xml", data_config="so100", joint_names=list(_JOINTS))
+    robot.policy_running = policy_running
+    world.robots["arm"] = robot
+    engine = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._world = world
+    engine._model = object()
+    return engine
+
+
+# --------------------------------------------------------------------------- #
+# The verb exists on every backend                                            #
+# --------------------------------------------------------------------------- #
+class TestTheVerbIsOnTheBase:
+    """``stop_policy`` answers in the envelope everywhere, never AttributeError."""
+
+    def test_the_base_engine_declares_the_counterpart_start_policy_names(self) -> None:
+        assert hasattr(SimEngine, "stop_policy")
+
+    @pytest.mark.parametrize(
+        "module_path,class_name",
+        [
+            ("strands_robots.simulation.newton.simulation", "NewtonSimEngine"),
+            ("strands_robots.simulation.isaac.simulation", "IsaacSimulation"),
+        ],
+    )
+    def test_a_backend_without_its_own_override_inherits_one(self, module_path: str, class_name: str) -> None:
+        """These two shipped on the base default, so they had no verb at all."""
+        import importlib
+
+        engine_cls = getattr(importlib.import_module(module_path), class_name)
+        assert hasattr(engine_cls, "stop_policy")
+
+
+# --------------------------------------------------------------------------- #
+# The base default: a stated refusal, not a guess                             #
+# --------------------------------------------------------------------------- #
+class TestTheBaseDefaultRefusesWithAReachableRemedy:
+    """No durable claim to move means no verdict, and saying so beats guessing."""
+
+    def test_a_backend_with_no_claim_refuses_and_names_its_class(self) -> None:
+        result = _MinimalEngine().stop_policy("arm")
+        assert result["status"] == "error"
+        assert "_MinimalEngine keeps no durable per-robot rollout claim" in _text(result)
+
+    def test_the_refusal_names_remedies_this_engine_actually_has(self) -> None:
+        """A remedy naming a verb the backend lacks is what this replaces."""
+        engine = _MinimalEngine()
+        text = _text(engine.stop_policy("arm"))
+        assert "n_steps" in text
+        assert "stop_when" in text
+        for named in ("run_policy", "_request_policy_stop"):
+            assert hasattr(engine, named), f"the refusal names {named!r}, which must exist here"
+
+    def test_nothing_running_is_not_reported_as_the_answer(self) -> None:
+        """``was_running=False`` here would be an affirmative claim on no evidence."""
+        assert _verdicts(_MinimalEngine().stop_policy("arm")) == []
+
+    def test_an_empty_robot_name_is_refused_not_matched_to_the_sole_robot(self) -> None:
+        result = _MinimalEngine().stop_policy("")
+        assert result["status"] == "error"
+        assert "requires 'robot_name'" in _text(result)
+
+    def test_an_unknown_robot_is_named_before_any_backend_is_asked(self) -> None:
+        result = _MinimalEngine().stop_policy("ghost")
+        assert result["status"] == "error"
+        assert "Robot 'ghost' not found." in _text(result)
+
+
+# --------------------------------------------------------------------------- #
+# A backend that holds the durable claim answers from it                      #
+# --------------------------------------------------------------------------- #
+class TestNewtonAnswersFromTheDurableClaim:
+    """Newton's robots are ``SimRobot``s, so its stop is a real one."""
+
+    def test_a_rollout_in_flight_is_halted_and_reported(self) -> None:
+        engine = _newton_engine(policy_running=True)
+        result = engine.stop_policy("arm")
+        assert result["status"] == "success"
+        assert _verdicts(result) == [{"robot": "arm", "was_running": True}]
+        assert engine._world.robots["arm"].policy_running is False
+
+    def test_the_stop_is_durable_not_only_a_lowered_flag(self) -> None:
+        """A bare flag write is what a worker before its first frame overwrites (#2833)."""
+        engine = _newton_engine(policy_running=True)
+        before = engine._world.robots["arm"].policy_stops
+        engine.stop_policy("arm")
+        assert engine._world.robots["arm"].policy_stops == before + 1
+
+    def test_stopping_twice_is_idempotent_and_honest_the_second_time(self) -> None:
+        engine = _newton_engine(policy_running=True)
+        assert _verdicts(engine.stop_policy("arm")) == [{"robot": "arm", "was_running": True}]
+        again = engine.stop_policy("arm")
+        assert again["status"] == "success"
+        assert _verdicts(again) == [{"robot": "arm", "was_running": False}]
+
+    def test_a_torn_down_world_has_no_verdict_rather_than_an_idle_one(self) -> None:
+        engine = _newton_engine(policy_running=True)
+        engine._world = None
+        assert engine._request_policy_stop("arm") is None
+
+
+# --------------------------------------------------------------------------- #
+# The Device Connect stop reads the verb instead of working around it          #
+# --------------------------------------------------------------------------- #
+class TestTheStopRpcReadsTheVerb:
+    """One owner for the verdict, and one accessor for the population."""
+
+    @staticmethod
+    def _driver(sim: Any) -> Any:
+        from strands_robots.device_connect.sim_driver import SimulationDeviceDriver
+
+        driver = SimulationDeviceDriver.__new__(SimulationDeviceDriver)
+        driver._sim = sim
+        return driver
+
+    def test_one_rollout_is_stopped_through_the_verb_and_its_answer_returned(self) -> None:
+        engine = _newton_engine(policy_running=True)
+        answer = self._driver(engine)._stop_one_rollout("arm")
+        assert answer["status"] == "success"
+        assert _verdicts(answer) == [{"robot": "arm", "was_running": True}]
+
+    def test_the_population_comes_from_list_robots_not_a_private_registry(self) -> None:
+        """An engine whose ``_world`` has no ``.robots`` is the Isaac shape.
+
+        The private read raised ``AttributeError`` here, which the ``stop``
+        handler's recovery path reported as a scene teardown racing the loop.
+        """
+
+        class _IsaacShapedSim:
+            def __init__(self) -> None:
+                self._world = object()  # the Isaac ``World``: no ``.robots``
+                self._robots = {"arm": object()}
+
+            def list_robots(self) -> list[str]:
+                return list(self._robots)
+
+        assert self._driver(_IsaacShapedSim())._stop_targets() == ["arm"]
+
+    def test_a_backend_that_refuses_is_carried_through_as_a_refusal(self) -> None:
+        """The handler grades one envelope shape whatever the backend answers."""
+        from strands_robots.mesh.core import _reports_failure_to_stop
+
+        answer = self._driver(_MinimalEngine())._stop_one_rollout("arm")
+        assert answer["status"] == "error"
+        assert _reports_failure_to_stop(answer) is True
+
+
+# --------------------------------------------------------------------------- #
+# describe(): which of the two start_policy implementations you hold          #
+# --------------------------------------------------------------------------- #
+class TestDescribeSaysWhichStartPolicyYouHold:
+    """The surface an agent is told to call first, instead of guessing."""
+
+    def test_the_base_entry_states_the_synchronous_reading(self) -> None:
+        entry = _MinimalEngine().describe()["methods"]["start_policy"]
+        assert "synchronous" in entry
+        assert "runs the rollout to completion" in entry
+
+    def test_the_base_surface_advertises_the_counterpart_too(self) -> None:
+        methods = _MinimalEngine().describe()["methods"]
+        assert "robot_name" in methods["stop_policy"]
+        assert "was_running" in methods["stop_policy"]
+
+    def test_the_entry_names_the_signal_that_tells_the_two_apart(self) -> None:
+        """MuJoCo's own describe cell pins the other column of this comparison."""
+        entry = _MinimalEngine().describe()["methods"]["start_policy"]
+        assert "list_policies_running" in entry
+
+
+# --------------------------------------------------------------------------- #
+# The documented surfaces say the same thing the code does                     #
+# --------------------------------------------------------------------------- #
+def _selected_actions() -> list[str]:
+    """Action names from the SimEngine "Selected actions" table in api-reference."""
+    lines = (_DOCS / "api-reference.md").read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.strip() == "Selected actions:")
+    names: list[str] = []
+    for line in lines[start:]:
+        if line.startswith("## "):
+            break
+        if not line.startswith("|"):
+            continue
+        cell = line.split("|")[1]
+        names.extend(re.findall(r"`([A-Za-z_][A-Za-z0-9_]*)\(", cell))
+    return names
+
+
+class TestTheDocumentedActionsResolve:
+    """A row in the SimEngine action table names a method callers really have."""
+
+    def test_the_table_is_still_being_read(self) -> None:
+        """A broken parse would make the rule below vacuously green."""
+        actions = _selected_actions()
+        assert len(actions) >= 8, actions
+        assert "stop_policy" in actions
+
+    @pytest.mark.parametrize("action", _selected_actions())
+    def test_every_documented_action_is_on_the_base_engine(self, action: str) -> None:
+        assert hasattr(SimEngine, action), (
+            f"docs/api-reference.md lists {action!r} as a SimEngine action, but it does not resolve "
+            "there - a caller following the table gets AttributeError on every backend that does "
+            "not happen to override it"
+        )
+
+
+#: A surface makes the claim either by describing start_policy as not blocking,
+#: or by PRESCRIBING it as the cure for something that blocks - which is the
+#: form the troubleshooting table used ("Agent hangs ... Use start_policy
+#: instead of run_policy"), and it carries the same promise without the words.
+_BACKGROUND_CLAIM = re.compile(r"background|non-blocking|\basync\b|\bhang|instead of", re.IGNORECASE)
+_CONDITION = re.compile(r"MuJoCo|backend", re.IGNORECASE)
+
+
+def _start_policy_claims() -> list[tuple[str, str]]:
+    """``(surface, text)`` for each documented place that describes start_policy.
+
+    The base docstring's SUMMARY LINE is graded on its own, because that line is
+    what ``help()``, an IDE tooltip and the rendered API reference show, and it
+    is where the promise and the body disagreed: "Start policy execution in a
+    background thread (non-blocking)." followed by "Default implementation:
+    synchronous passthrough". Grading the whole docstring would have read the
+    qualification three paragraphs down as if the summary carried it. The rest of
+    the body is graded too, plus every markdown line naming ``start_policy``.
+    """
+    doc = SimEngine.start_policy.__doc__ or ""
+    summary, _, body = doc.strip().partition("\n")
+    claims: list[tuple[str, str]] = [
+        ("SimEngine.start_policy docstring summary line", summary),
+        ("SimEngine.start_policy docstring body", body),
+    ]
+    for name in ("api-reference.md", "troubleshooting.md"):
+        for number, line in enumerate((_DOCS / name).read_text(encoding="utf-8").splitlines(), start=1):
+            if "start_policy" in line:
+                claims.append((f"docs/{name}:{number}", line))
+    return claims
+
+
+class TestNoSurfacePromisesABackgroundThreadUnconditionally:
+    """A claim that start_policy does not block must say where that is true."""
+
+    def test_the_surfaces_are_still_being_found(self) -> None:
+        surfaces = [name for name, _ in _start_policy_claims()]
+        assert len(surfaces) >= 4, surfaces
+        assert any("api-reference" in name for name in surfaces)
+        assert any("summary line" in name for name in surfaces)
+
+    @pytest.mark.parametrize("surface,text", _start_policy_claims())
+    def test_a_background_claim_names_the_condition(self, surface: str, text: str) -> None:
+        if not _BACKGROUND_CLAIM.search(text):
+            return
+        assert _CONDITION.search(text), (
+            f"{surface} presents start_policy as a call that does not block, without naming the "
+            "backend condition; it blocks for the whole duration on every engine that ships on "
+            "the base default, so an unconditional claim points a caller at the hang"
+        )

--- a/tests/simulation/test_stop_policy_base_contract.py
+++ b/tests/simulation/test_stop_policy_base_contract.py
@@ -52,6 +52,7 @@ from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.models import SimRobot, SimWorld
 
 _DOCS = Path(__file__).resolve().parents[2] / "docs"
+_SRC = Path(__file__).resolve().parents[2] / "strands_robots"
 _JOINTS = ("j1", "j2")
 
 
@@ -374,14 +375,32 @@ class TestTheFleetStopAsksEveryRobotWhenThereIsNoRegistry:
         assert self._flagged(result) is True
 
     def test_the_was_running_reader_has_one_owner(self) -> None:
-        """Both aggregating readers import the reader; neither spells a second copy."""
+        """Both aggregating readers read one definition; neither spells a second copy.
+
+        Ownership is graded through ``__module__`` and the source tree, never
+        through object identity. ``tests/mesh/test_resume_env_validation.py``
+        reloads ``strands_robots.mesh.core``, and :func:`importlib.reload`
+        re-executes a module in its own namespace, so every ``from
+        strands_robots.mesh.core import ...`` binding taken before that reload
+        keeps the pre-reload function object while the module attribute is
+        rebound to a fresh one. An ``is`` comparison therefore grades import
+        order rather than the number of definitions: it holds for this file
+        alone and breaks as soon as a device-connect suite imports the driver
+        before the reload runs. The two facts below are what "one owner"
+        actually means, and neither can be moved by an import generation.
+        """
         import inspect
 
         pytest.importorskip("device_connect_edge")
         from strands_robots.device_connect import sim_driver
         from strands_robots.mesh import core
 
-        assert sim_driver._reported_a_rollout_in_flight is core._reported_a_rollout_in_flight
+        assert sim_driver._reported_a_rollout_in_flight.__module__ == core.__name__
+        assert sorted(
+            path.relative_to(_SRC).as_posix()
+            for path in _SRC.rglob("*.py")
+            if re.search(r"^def _reported_a_rollout_in_flight\b", path.read_text(encoding="utf-8"), re.MULTILINE)
+        ) == ["mesh/core.py"]
         assert "was_running" not in inspect.getsource(sim_driver.SimulationDeviceDriver.stop)
         assert inspect.getsource(sim_driver).count('"was_running"') == 0
 

--- a/tests/simulation/test_stop_policy_base_contract.py
+++ b/tests/simulation/test_stop_policy_base_contract.py
@@ -257,6 +257,7 @@ class TestTheStopRpcReadsTheVerb:
 
     @staticmethod
     def _driver(sim: Any) -> Any:
+        pytest.importorskip("device_connect_edge")
         from strands_robots.device_connect.sim_driver import SimulationDeviceDriver
 
         driver = SimulationDeviceDriver.__new__(SimulationDeviceDriver)
@@ -293,6 +294,96 @@ class TestTheStopRpcReadsTheVerb:
         answer = self._driver(_MinimalEngine())._stop_one_rollout("arm")
         assert answer["status"] == "error"
         assert _reports_failure_to_stop(answer) is True
+
+
+# --------------------------------------------------------------------------- #
+# The mesh fleet stop is the verb's other remote reader                        #
+# --------------------------------------------------------------------------- #
+class TestTheFleetStopAsksEveryRobotWhenThereIsNoRegistry:
+    """Putting ``stop_policy`` on the base flips a probe this diff does not touch.
+
+    :meth:`~strands_robots.mesh.Mesh._dispatch` gates its sim stop branch on
+    ``hasattr(r, "stop_policy")``, and the no-``robot_name`` leg - the shape
+    :meth:`~strands_robots.mesh.Mesh.emergency_stop` broadcasts - enumerated
+    ``_active_policy_robots``, which only MuJoCo defines. So the moment the verb
+    became universal, a Newton peer entered that leg with an empty population
+    and answered ``ok=True, "no policies running"`` while a rollout was in
+    flight, where pre-promotion it failed the probe and answered ``ok=False``.
+    A semantic conflict the diff cannot show, graded here so the mutation table
+    has a mesh row.
+    """
+
+    @staticmethod
+    def _fleet_stop(engine: Any) -> dict[str, Any]:
+        from strands_robots.mesh import Mesh
+
+        return Mesh(engine, peer_id="sim-1", peer_type="simulation")._dispatch({"action": "stop"})
+
+    @staticmethod
+    def _flagged(result: dict[str, Any]) -> bool:
+        from strands_robots.mesh.core import _peers_that_did_not_stop
+
+        return bool(_peers_that_did_not_stop([{"responder_id": "sim-1", "result": result}]))
+
+    def test_a_newton_rollout_in_flight_is_halted_by_the_fleet_stop(self) -> None:
+        engine = _newton_engine(policy_running=True)
+        result = self._fleet_stop(engine)
+        assert result["ok"] is True
+        assert result["stopped"] == ["arm"]
+        assert engine._world.robots["arm"].policy_running is False
+        assert self._flagged(result) is False
+
+    def test_an_idle_robot_is_asked_but_not_named_as_halted(self) -> None:
+        engine = _newton_engine(policy_running=False)
+        result = self._fleet_stop(engine)
+        assert result["ok"] is True
+        assert result["stopped"] == []
+        assert _verdicts(result["results"]["arm"]) == [{"robot": "arm", "was_running": False}]
+
+    def test_a_backend_with_no_claim_is_scored_as_not_stopped(self) -> None:
+        """The base refusal reaches the fleet accounting as a refusal, not a halt."""
+        result = self._fleet_stop(_MinimalEngine())
+        assert result["ok"] is False
+        assert result["not_stopped"] == ["arm"]
+        assert self._flagged(result) is True
+
+    def test_the_fleet_and_the_named_stop_agree_about_one_rollout(self) -> None:
+        """Both remote readers derive the verdict from the same answer."""
+        from strands_robots.mesh import Mesh
+
+        fleet = _newton_engine(policy_running=True)
+        named = _newton_engine(policy_running=True)
+        fleet_result = self._fleet_stop(fleet)
+        named_result = Mesh(named, peer_id="sim-1", peer_type="simulation")._dispatch(
+            {"action": "stop", "robot_name": "arm"}
+        )
+        assert fleet_result["stopped"] == ["arm"]
+        assert _verdicts(named_result) == [{"robot": "arm", "was_running": True}]
+        assert self._flagged(fleet_result) is self._flagged(named_result) is False
+
+    def test_a_peer_that_cannot_enumerate_answers_conservatively(self) -> None:
+        """Neither a registry nor ``list_robots``: nothing can be named as halted."""
+
+        class _Opaque:
+            def stop_policy(self, robot_name: str = "") -> dict[str, Any]:
+                return {"status": "success", "content": []}
+
+        result = self._fleet_stop(_Opaque())
+        assert result["ok"] is False
+        assert "_Opaque" in result["error"]
+        assert self._flagged(result) is True
+
+    def test_the_was_running_reader_has_one_owner(self) -> None:
+        """Both aggregating readers import the reader; neither spells a second copy."""
+        import inspect
+
+        pytest.importorskip("device_connect_edge")
+        from strands_robots.device_connect import sim_driver
+        from strands_robots.mesh import core
+
+        assert sim_driver._reported_a_rollout_in_flight is core._reported_a_rollout_in_flight
+        assert "was_running" not in inspect.getsource(sim_driver.SimulationDeviceDriver.stop)
+        assert inspect.getsource(sim_driver).count('"was_running"') == 0
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/simulation/test_stop_policy_base_contract.py
+++ b/tests/simulation/test_stop_policy_base_contract.py
@@ -40,8 +40,9 @@ the prescribed remedy was the hang.
 
 from __future__ import annotations
 
+import contextlib
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -321,6 +322,33 @@ class TestTheFleetStopAsksEveryRobotWhenThereIsNoRegistry:
         return Mesh(engine, peer_id="sim-1", peer_type="simulation")._dispatch({"action": "stop"})
 
     @staticmethod
+    @contextlib.contextmanager
+    def _at_error() -> Iterator[list[str]]:
+        """Collect ``mesh.core`` ERROR records emitted inside the block.
+
+        Reads the module's own logger rather than ``caplog``, whose handler sits
+        on the root logger for the whole test: an assertion over every record in
+        the process would be graded by any other logger that happened to speak.
+        """
+        import logging
+
+        records: list[str] = []
+
+        class _Collect(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record.getMessage())
+
+        logger = logging.getLogger("strands_robots.mesh.core")
+        handler = _Collect(level=logging.ERROR)
+        logger.addHandler(handler)
+        previous, logger.level = logger.level, min(logger.level or logging.ERROR, logging.ERROR)
+        try:
+            yield records
+        finally:
+            logger.removeHandler(handler)
+            logger.level = previous
+
+    @staticmethod
     def _flagged(result: dict[str, Any]) -> bool:
         from strands_robots.mesh.core import _peers_that_did_not_stop
 
@@ -373,6 +401,48 @@ class TestTheFleetStopAsksEveryRobotWhenThereIsNoRegistry:
         assert result["ok"] is False
         assert "_Opaque" in result["error"]
         assert self._flagged(result) is True
+
+    def test_the_unenumerable_refusal_is_loud_in_the_log(self) -> None:
+        """An unstoppable peer must be loud in the log, not only in the return.
+
+        The property ``tests/mesh/test_estop_stop_honesty.py`` already pins for
+        the terminal "no ``stop_task``" branch, which this leg now sits beside:
+        the return reaches the BROADCASTER's accounting, while the log is what a
+        console on the robot itself shows. Removing the ``logger.error`` leaves
+        the return intact, so nothing but this grades it.
+        """
+
+        class _Opaque:
+            def stop_policy(self, robot_name: str = "") -> dict[str, Any]:
+                return {"status": "success", "content": []}
+
+        with self._at_error() as records:
+            self._fleet_stop(_Opaque())
+
+        assert any("NOTHING was stopped" in m and "_Opaque" in m for m in records), records
+
+    def test_the_refusal_log_does_not_call_the_robots_it_asked_active_rollouts(self) -> None:
+        """The denominator is the population asked, which is not the in-flight count.
+
+        Widening the population is what makes the distinction matter: on a
+        backend that keeps no rollout registry every robot is asked, so a
+        message reading "N of M active rollout(s)" reports how many rollouts
+        were in flight - the one thing a backend on the refusing default cannot
+        know, and the reason it refuses.
+        """
+
+        class _ThreeRobots(_MinimalEngine):
+            def list_robots(self) -> list[str]:
+                return ["arm", "gripper", "base"]
+
+        with self._at_error() as records:
+            result = self._fleet_stop(_ThreeRobots())
+
+        assert result["not_stopped"] == ["arm", "base", "gripper"], result
+        refusals = [m for m in records if "stop_policy refused" in m]
+        assert refusals, records
+        assert "3 of 3 robot(s) asked" in refusals[0], refusals
+        assert "active rollout" not in refusals[0], refusals
 
     def test_the_was_running_reader_has_one_owner(self) -> None:
         """Both aggregating readers read one definition; neither spells a second copy.

--- a/tests/test_device_connect_all_robots.py
+++ b/tests/test_device_connect_all_robots.py
@@ -253,6 +253,11 @@ def _make_mock_sim(name, info, robots_in_world=None):
     # See ``tests._sim_stop_policy_stand_in``: the driver's ``stop`` reads the
     # verdict this returns, which a bare ``MagicMock`` does not carry.
     sim.stop_policy.side_effect = stop_policy_stand_in(world)
+    # ``list_robots`` is an ABSTRACT method of the SimEngine ABC, so a stand-in
+    # for a simulation has to answer it: the driver's stop enumerates through it
+    # rather than off ``sim._world.robots``, which is only the MuJoCo/Newton
+    # spelling of the registry. A bare ``MagicMock`` returns a mock, not a list.
+    sim.list_robots.return_value = list(world.robots)
     sim.start_policy.return_value = {"status": "success", "content": [{"text": "Policy started"}]}
     sim.get_state.return_value = {"status": "success", "content": [{"text": "State info"}]}
     sim.get_features.return_value = {"status": "success", "content": [{"json": {"features": {}}}]}

--- a/tests/test_device_connect_drivers.py
+++ b/tests/test_device_connect_drivers.py
@@ -219,6 +219,11 @@ def _make_mock_sim(tool_name="so100_sim"):
     # reads the verdict out of the answer, so a bare ``MagicMock`` here observes
     # neither half of what the verb does. See ``tests._sim_stop_policy_stand_in``.
     sim.stop_policy.side_effect = stop_policy_stand_in(world)
+    # ``list_robots`` is an ABSTRACT method of the SimEngine ABC, so a stand-in
+    # for a simulation has to answer it: the driver's stop enumerates through it
+    # rather than off ``sim._world.robots``, which is only the MuJoCo/Newton
+    # spelling of the registry. A bare ``MagicMock`` returns a mock, not a list.
+    sim.list_robots.return_value = list(world.robots)
     sim.start_policy.return_value = {"status": "success", "content": [{"text": "Policy started"}]}
     sim.get_state.return_value = {"status": "success", "content": [{"text": "State info"}]}
     sim.get_features.return_value = {"status": "success", "content": [{"json": {"features": {}}}]}

--- a/tests/test_device_connect_sim_stop_reports_the_rollouts_it_halted.py
+++ b/tests/test_device_connect_sim_stop_reports_the_rollouts_it_halted.py
@@ -101,7 +101,7 @@ class _World:
 
 
 class _SimPeer:
-    """A simulation exposing the two attributes both stop routers look for.
+    """A simulation exposing the three surfaces both stop routers look for.
 
     Deliberately not a ``Mock``: ``hasattr`` is what the routers test, and a
     mock answers every ``hasattr`` truthfully-by-fabrication. ``stop_policy``
@@ -134,6 +134,15 @@ class _SimPeer:
         if self._world is not None:
             for name in self._active:
                 self._world.robots[name].policy_running = True
+
+    def list_robots(self) -> list[str]:
+        """The ABC's own accessor, which the driver's stop enumerates through.
+
+        Abstract on ``SimEngine``, so a stand-in for a simulation has to answer
+        it; ``_world.robots`` is only the MuJoCo/Newton spelling of the same
+        registry and the Isaac engine has no such attribute.
+        """
+        return [] if self._world is None else list(self._world.robots)
 
     def _active_policy_robots(self) -> list[str]:
         return list(self._active)


### PR DESCRIPTION
`stop_policy` is the counterpart every `start_policy` docstring names. It existed on the MuJoCo engine alone, so on Newton, Isaac and any backend written against the documented `SimEngine` ABC the attribute was simply absent — and the two remote stop paths worked around that instead of reading its answer.

![measured before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/stop-policy-base-contract/docs/assets/stop_policy_base_contract.png)

## Measured, this branch vs `upstream/main`

| | upstream/main | this branch |
|---|---|---|
| `hasattr(SimEngine, "stop_policy")` | `False` | `True` |
| `hasattr(NewtonSimEngine, ...)` / `IsaacSimulation` | `False` / `False` | `True` / `True` |
| a third-party backend's `stop_policy("arm")` | `AttributeError: 'Tiny' object has no attribute 'stop_policy'` | `status="error"`, refusal naming the class + `n_steps` / `stop_when` |
| `_stop_targets()` on an Isaac-shaped engine | `AttributeError: 'object' object has no attribute 'robots'` | `['arm']` |
| Newton `_stop_one_rollout('arm')`, rollout in flight | `success`, text `[]`, `was_running=True` | `success`, `"Stopped on 'arm'"`, `was_running=True`, `policy_stops=1` |
| `describe()["methods"]` has `stop_policy` | `False` | `True` |

## The two workarounds

`Mesh._dispatch` probes `hasattr(r, "stop_policy")` and, failing it, answered `"peer exposes no stop_task"` for a simulation it could have stopped. The Device Connect `stop` RPC re-derived the `was_running` verdict inline from the per-robot flag — the second construction `SimRobot.request_policy_stop` exists to prevent: *"EVERY stop path goes through here ... so they cannot drift to different answers about whether a rollout was halted."*

That fallback also read the registry as `sim._world.robots`, which is the MuJoCo and Newton spelling. The Isaac engine keeps its robots in `_robots` and its `_world` is the Isaac `World`, which has no `.robots` at all (`grep -c '_world.robots' isaac/simulation.py` → 0). So the read raised `AttributeError`, and the handler's recovery path reported it as `"The simulation changed under the stop loop"` — a race that had not happened — before a single robot was asked.

## Change

The promotion `run_multi_policy` already had (#2157): a capability every backend is asked for answers in the tool envelope on **all** of them, never with `AttributeError` because there was no contract.

```
SimEngine.stop_policy(robot_name)        validate -> _request_policy_stop -> envelope
     |                                   (base default: None -> stated refusal)
     +-- Newton      overrides _request_policy_stop -> SimRobot.request_policy_stop
     +-- Isaac       inherits the refusal (see below)
     +-- MuJoCo      keeps its own stop_policy override (Future registry)
```

`_request_policy_stop` is the third member of the `_make_run_policy_hook` / `_release_run_policy_hook` seam that already raises and lowers the same flag around a rollout the shared facade drives, so the flag write stays backend-owned.

**Isaac deliberately inherits the refusal.** Its per-robot record carries a bare `policy_running` flag and not the durable claim, and a bare flag write is exactly what a worker before its first frame overwrites (#2833) — so it states why it cannot help rather than reporting a stop it cannot keep. The refusal names two remedies this backend really has: `run_policy(n_steps=...)` and `run_policy(stop_when=...)`. Giving Isaac's record the durable counter is a separate change.

The Device Connect `stop` RPC now reads the verb and enumerates through the ABC's own `list_robots`, so no path reaches into a backend's private registry — its docstring already claimed to be *"its third reader rather than a surface that produced no answer to grade"*.

## `start_policy`'s own description, same change

It is what sent callers looking for a stop that was not there. The summary line — what `help()`, a tooltip and the rendered reference show — read *"Start policy execution in a background thread (non-blocking)"* while the next line read *"Default implementation: synchronous passthrough to `run_policy`"*. `docs/api-reference.md` called it an async rollout unconditionally and listed `stop_policy` as a `SimEngine` action; `docs/troubleshooting.md` prescribed it as the cure for a hanging agent.

Measured with `duration=3.0`: MuJoCo returns in **0.001 s** with `"Policy started on 'so100' (async)"`; the base default returns after **3.0 s** with `"Policy complete on 'arm'"`. The prescribed remedy for a hang was the hang. Newton's own `describe()` already said so (*"only MuJoCo runs a policy on a background thread"*), and so did `tests/simulation/mujoco/test_simulation.py` — the base surface and the docs were the ones that did not.

Behaviour is unchanged; `describe()["methods"]["start_policy"]` now states which of the two the engine in hand implements, and the presence of `list_policies_running` beside it is the documented signal.

## Tests

`tests/simulation/test_stop_policy_base_contract.py` (33 cells), sibling to `test_run_multi_policy_base_contract.py`. One row per candidate design:

| mutation | cells fired |
|---|---|
| remove the base `stop_policy` | 16 |
| base answers `was_running=False` instead of refusing | 5 |
| remove Newton's override | 5 |
| Newton writes the bare flag (no durable counter) | 1 — `test_the_stop_is_durable_not_only_a_lowered_flag` |
| driver keeps the private `_world.robots` read | 1 — `test_the_population_comes_from_list_robots...` |
| driver re-derives the verdict itself | 1 — `test_a_backend_that_refuses_is_carried_through...` |
| revert `describe()` | 3 |
| MuJoCo `describe()` not corrected | 1 (its own cell) |
| revert the two doc rows | 2 |
| revert the docstring summary line | 1 |
| driver keeps the now-dead `getattr` fallback | 0 — unreachable once the verb is universal, which is why deleting it is safe |

Two executable rules generalise it: every action named in the `SimEngine` "Selected actions" table resolves on `SimEngine` (`stop_policy` failed pre-fix), and no surface may present `start_policy` as non-blocking without naming the condition — graded on the docstring's **summary line** separately, since that is where the promise and the body disagreed. Both carry non-vacuity guards.

Collateral, corrected honestly rather than deleted: three source docstrings and two cells asserted *"Isaac exposes no `stop_policy`"*. The Device Connect doubles gained `list_robots` — abstract on the ABC, so a stand-in for a simulation has to answer it. Newton's from-scratch `describe()` now advertises the verb it delivers, which the repo's own `test_sim_engine_describe_discovery` rule required.

## Gate

Full `tests/` on this branch vs `upstream/main` carrying **the identical test files**, so the source change is the only variable:

| | this branch | base |
|---|---|---|
| result | **67 failed, 50933 passed, 437 skipped, 37 errors** (32m35s) | 91 failed, 50904 passed, 437 skipped, 37 errors (31m44s) |
| failing names only on this branch | **none** | — |
| failing names only on base | — | **24** = exactly the discriminating cells |

The 67/437/37 are this environment's standing set (`awsiot`, `rclpy`, lerobot 0.5.1 drift), identical in both directions. Collected 51468 vs 51463: the docstring/Args graders parametrise over the new public method (19 vs 13 cells naming `stop_policy` / `_request_policy_stop`), all passing.

`ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` unchanged at this environment's 20 standing errors in 6 files.

## LOC

`+235 / -43` across 10 files, plus 2 new files. Code is net-negative — the driver loses 13 lines (two workarounds collapse to one call each); the additions are the new base method and docstrings that replace claims which were wrong.

## Composition with the open set

`scripts/check_merge_base_overlap.py --all-open` pairs this branch with #2907 on `strands_robots/simulation/base.py` and `strands_robots/simulation/mujoco/simulation.py`. Measured on `7f48728`:

| | result |
|---|---|
| `compare/main...cagataycali:robots:fix/stop-policy-base-contract` | `behind_by=0` - the tree CI graded is the merge result |
| `git merge-tree upstream/main <#2907 head e561d2d7>` | conflicts on `base.py`, `mujoco/simulation.py`, `policy_runner.py` |
| `git merge-tree <this head> <#2907 head>` | the same three files, no new one - `policy_runner.py` is not in this diff |

So #2907's conflict with `main` predates this branch and is unchanged by it; the composition cannot be run until #2907 absorbs `main`, which is its author's push to make (the button is the same push - #2907 has spent its approval on it twice). Whichever lands second re-runs the `run_policy` / `stop_policy` cells on the composed tree.

## Review rounds

**Round 1 - `a7c8204c`.** Review feedback, one MUST FIX: promoting `stop_policy` to the base flips the `hasattr` probe on `Mesh._dispatch`'s sim stop branch, so a Newton/Isaac peer reached the fleet-wide leg `emergency_stop` broadcasts, whose population was the MuJoCo-only `_active_policy_robots()` - it answered `ok=True, "no policies running"` over a rollout in flight. Reproduced on `7f48728`. The leg now takes `list_robots()` as its population when the engine keeps no registry, names as `stopped` only robots whose answer did not report `was_running=False`, carries a refusal through as `not_stopped`, and answers `ok=False` for a peer that can enumerate neither. The `was_running` reader moves to `mesh.core` beside `_reports_failure_to_stop` (one owner for both aggregating paths; `sim_driver` imports it). Mutation table gains a mesh row: 6 cells, 5 fire on the previous head. Whole-tree graders: identical 21-id standing set on both heads (delta 0). LOC now `+275 / -47`; `mesh/core.py` is the one production file added to the diff.

**Round 1, CI repair - `2089d0ca` (test-only).** `call-test-lint` failed the round-1 head on one cell: the "one owner" pin compared `sim_driver._reported_a_rollout_in_flight` with `mesh.core`'s by identity, and `tests/mesh/test_resume_env_validation.py` reloads `strands_robots.mesh.core`. `importlib.reload` rebinds the module attribute to a fresh function while every `from ... import` binding taken earlier keeps the pre-reload object, so the cell graded import order rather than the number of definitions - green on the file alone, red under the whole-suite alphabetical walk (device_connect, then mesh, then simulation). Reproduced locally with that three-file order. The cell now asserts the two facts "one owner" means and neither moves with an import generation: the function the driver reads has `__module__ == "strands_robots.mesh.core"`, and `def _reported_a_rollout_in_flight` appears in exactly one source file. Still discriminating - reverting the round-1 source flips it on `__module__` where it previously flipped on `AttributeError`; mutation table unchanged (6 / 5 / 1). No source behaviour touched; LOC unchanged on `strands_robots/`.
