### PR TITLE
fix(simulation): a turn goal outside the measurable heading range is refused, not compiled

### DIFF
--- a/changelog.d/3350-predicate-heading-goal-reachable.md
+++ b/changelog.d/3350-predicate-heading-goal-reachable.md
@@ -1,0 +1,21 @@
+### Bug Fixes
+
+- **simulation**: A `base_yaw_beyond` turn goal outside the range a heading can be measured in
+  is refused rather than compiled. The predicate reads the base heading from `base_quat`
+  through `atan2`, which only ever reports an angle in `(-pi, pi]`, but `yaw` was classified as
+  a signed coordinate and left unbounded - so a goal at or above `+pi` was met by no
+  orientation the base can reach and a goal at or below `-pi` by every one, deciding the
+  success clause before the rollout started either way. Measured with a go2 posed at 61
+  headings spanning `0..pi`: `yaw=1.0` read `True` at 41 of them, `yaw=57.3` (1 rad written as
+  degrees) and `yaw=180` at 0, and `yaw=-4.0` at all 61 including the spawn pose - all four
+  accepted at registration under `status="success"`. A benchmark whose goal was written in
+  degrees therefore burned its whole step budget reporting an honest miss, and one written past
+  `-pi` scored success before the robot moved. Degrees is the route that matters, because the
+  predicate documents its own goal as "~57 deg", so the unit is in the author's hands and the
+  wrong one compiled clean. `make_predicate` now holds a heading kwarg to `(-pi, pi)` at the
+  same choke point that already refuses a non-finite value and a negative tolerance - the
+  domain is read from the param name, so a predicate added later is covered by naming its
+  heading the way this one does - and the refusal names degrees as the likely cause. A negative
+  heading inside the range keeps its signed-coordinate meaning, and a heading *command*
+  (`ros_bridge.navigate_to`, which encodes `yaw` as a quaternion where any angle wraps to a
+  real goal pose) is a different surface and is unaffected.

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -1307,10 +1307,16 @@ def _base_yaw_beyond(yaw: float, robot: str | None = None) -> BoolPredicate:
     half-revolution); the yaw wraps at +-pi, so a goal at or beyond pi is not a
     well-defined single-turn heading (measuring cumulative revolutions would
     need integrated-angle tracking, out of scope here just as ``base_beyond_x``
-    does not track total path length). It is a pure heading test - roll and
-    pitch do NOT affect the yaw, so a base that merely tips (without turning
-    about the vertical) never satisfies a yaw goal; position and height do not
-    affect it either. Because the yaw of a fully toppled base is ill-defined,
+    does not track total path length). That bound is enforced rather than merely
+    documented: :func:`make_predicate` refuses ``|yaw| >= pi``, because such a goal
+    is satisfied by no heading the base can report - or, below ``-pi``, by every
+    one - and so scores the rollout the same way whatever it does. A goal written
+    in degrees, the way that region is usually reached, is named as such in the
+    refusal.
+
+    It is a pure heading test - roll and pitch do NOT affect the yaw, so a base
+    that merely tips (without turning about the vertical) never satisfies a yaw
+    goal; position and height do not affect it either. Because the yaw of a fully toppled base is ill-defined,
     pair it with ``base_tipped`` in a ``failure`` clause so a "turned then fell"
     rollout is rejected on the tilt, not scored as a valid turn.
 
@@ -1969,7 +1975,9 @@ _NUMBER_SEQUENCE_ANNOTATIONS = frozenset({"list[float]", "list[int]", "tuple[flo
 # negative tolerance is not a looser bound, it is an unsatisfiable one. The
 # signed params keep both signs: ``z_offset`` is a signed offset, ``z``/``x``/
 # ``y``/``yaw``/``value``/``target`` are coordinates, ``vx``/``vy``/``wz`` are
-# velocity components and ``weight`` scales a reward term.
+# velocity components and ``weight`` scales a reward term. ``yaw`` keeps both
+# signs too, but is additionally bounded to the range a heading can be measured
+# in - see :data:`_HEADING_PARAM_NAMES`.
 #
 # Read from the param NAME for the same reason the domain above is read from the
 # annotation: a predicate added later is covered by naming its tolerance the way
@@ -1978,6 +1986,40 @@ _NUMBER_SEQUENCE_ANNOTATIONS = frozenset({"list[float]", "list[int]", "tuple[flo
 # as a substring, so a param that merely contains the letters is untouched.
 _TOLERANCE_PARAM_NAMES = frozenset({"tol", "threshold"})
 _TOLERANCE_PARAM_SUFFIX = "_tol"
+
+
+# Numeric params that name a HEADING: an angle read back from the base
+# quaternion through ``atan2``, whose range is ``(-pi, pi]``. A threshold outside
+# that range is not a distant goal, it is a constant - no orientation the base can
+# report satisfies ``heading > yaw`` at or above ``+pi``, and every one satisfies
+# it at or below ``-pi`` - so the clause carries no information about the rollout.
+# That is the same permanently-decided clause :data:`_TOLERANCE_PARAM_NAMES`
+# refuses a negative tolerance for, reached by a different route: a goal written
+# in DEGREES (``yaw: 90``, ``yaw: 180``) or a radian goal past a half-revolution.
+# ``base_yaw_beyond``'s own docstring already states the bound; this holds it.
+#
+# The bound is on the REPRESENTABLE range, not on the author's intent, which is
+# why it does not conflict with the signed-coordinate policy above: a negative
+# heading goal stays accepted (a right-of-spawn heading a base at the identity
+# spawn already reads ``True`` on, exactly as ``base_beyond_x(x=-2.0)`` does),
+# and only the region where no measurable heading exists is refused. A heading
+# COMMAND is unbounded for the same reason - ``ros_bridge.navigate_to`` encodes
+# its ``yaw`` as a quaternion, where any angle wraps to a real goal pose - so the
+# domain belongs to the predicate that compares against ``atan2``, not to the name
+# in general.
+#
+# Read from the param NAME for the same reason the tolerance domain is: a
+# predicate added later is covered by naming its heading the way the shipped one
+# does, with no per-predicate table to drift out of step with the registry.
+_HEADING_PARAM_NAMES = frozenset({"yaw"})
+
+
+def _is_heading_param(param: str) -> bool:
+    """True when ``param`` names a heading and so is bounded to the ``atan2`` range.
+
+    See :data:`_HEADING_PARAM_NAMES` for why the domain is read from the name.
+    """
+    return param in _HEADING_PARAM_NAMES
 
 
 def _is_tolerance_param(param: str) -> bool:
@@ -1991,10 +2033,12 @@ def _is_tolerance_param(param: str) -> bool:
 def _kwarg_domain_error(name: str, factory: PredicateFactory, kwargs: dict[str, Any]) -> str | None:
     """Return an error message if a numeric kwarg for *name* is outside its domain.
 
-    Two domains are enforced: every numeric kwarg must be a finite number, and a
+    Three domains are enforced: every numeric kwarg must be a finite number, a
     kwarg that names a TOLERANCE must additionally be ``>= 0`` (see
-    :func:`_is_tolerance_param`). Both refuse for the same reason - a value that
-    compiles clean and makes the clause unsatisfiable.
+    :func:`_is_tolerance_param`), and a kwarg that names a HEADING must lie
+    strictly inside ``(-pi, pi)`` (see :func:`_is_heading_param`). All three
+    refuse for the same reason - a value that compiles clean and leaves the clause
+    permanently decided.
 
     A spec kwarg is coerced with a bare ``float(...)`` inside the factory and
     then closed over, so a ``nan``/``inf`` threshold or weight compiles clean
@@ -2026,6 +2070,17 @@ def _kwarg_domain_error(name: str, factory: PredicateFactory, kwargs: dict[str, 
     velocity component whose sign is a direction, and ``body_below_z``'s ``z`` is
     a coordinate.
 
+    A heading goal reaches the same permanently-decided clause by a fourth route,
+    and the value that gets there is the one an author is most likely to write:
+    ``yaw`` is compared against a heading read from the base quaternion through
+    ``atan2``, whose range is ``(-pi, pi]``, so a goal in DEGREES (``yaw: 90``,
+    ``yaw: 180``) is satisfied by no orientation the base can report, and a goal at
+    or below ``-pi`` is satisfied by every one - constant either way, and accepted
+    at registration under ``status="success"``. Only the unmeasurable region is
+    refused: a negative heading inside the range keeps its signed-coordinate
+    meaning, and a heading COMMAND (``ros_bridge.navigate_to``, which encodes
+    ``yaw`` as a quaternion) is a different surface with no such bound.
+
     Only params the factory annotates as numeric are constrained, so a ``str``
     body name, a ``bool`` flag and a ``str | None`` robot selector are untouched,
     and a predicate registered via :func:`register_predicate` without
@@ -2056,6 +2111,19 @@ def _kwarg_domain_error(name: str, factory: PredicateFactory, kwargs: dict[str, 
                     "distance, an absolute difference or a squared magnitude, none of which is ever "
                     "negative - so a negative value makes the clause unsatisfiable rather than loose."
                 )
+            # A heading is compared against the base yaw, which ``atan2`` only ever
+            # reports inside ``(-pi, pi]``, so a goal outside that range decides the
+            # clause for every orientation instead of scoring one. ``float(...)`` is
+            # safe here for the same reason it is above.
+            if _is_heading_param(param) and abs(float(value)) >= math.pi:
+                return (
+                    f"{context}: {param} must lie strictly inside (-pi, pi), got {value!r}. It is a "
+                    "heading compared against the base yaw, which is read from the base quaternion "
+                    "through atan2 and so only ever reports an angle in (-pi, pi] - at or above +pi "
+                    "no orientation satisfies the clause and at or below -pi every one does, making "
+                    "it constant rather than a goal. A magnitude this large is usually degrees: "
+                    f"{math.pi / 2.0:.4f} is 90 deg and {math.radians(30.0):.4f} is 30 deg."
+                )
         elif annotation in _NUMBER_SEQUENCE_ANNOTATIONS:
             if (err := finite_vector_error(context, param, value)) is not None:
                 return err
@@ -2070,8 +2138,9 @@ def make_predicate(name: str, **kwargs: Any) -> Callable[[SimEngine], Any]:
     the valid set; bad kwargs surface as whatever ``TypeError`` the factory
     raises.
 
-    Every numeric kwarg is held to a finite domain here - and a tolerance kwarg
-    additionally to a non-negative one - rather than in the
+    Every numeric kwarg is held to a finite domain here - a tolerance kwarg
+    additionally to a non-negative one and a heading kwarg to the measurable
+    ``(-pi, pi)`` range - rather than in the
     spec compiler, because this is the only choke point every predicate call
     passes through: ``staged_reward`` builds its per-stage ``reward`` /
     ``advance_when`` calls by calling back into this function, so a guard in
@@ -2089,8 +2158,9 @@ def make_predicate(name: str, **kwargs: Any) -> Callable[[SimEngine], Any]:
 
     Raises:
         ValueError: If ``name`` is unknown, a kwarg the factory annotates as
-            numeric is not a finite number, or a kwarg that names a tolerance
-            is negative.
+            numeric is not a finite number, a kwarg that names a tolerance is
+            negative, or a kwarg that names a heading lies outside the
+            ``(-pi, pi)`` range a heading can be measured in.
         TypeError: If required factory kwargs are missing.
     """
     factory = PREDICATE_REGISTRY.get(name)

--- a/tests/simulation/test_base_yaw_beyond_predicate.py
+++ b/tests/simulation/test_base_yaw_beyond_predicate.py
@@ -16,10 +16,11 @@ left / counter-clockwise turn from the identity spawn). These tests set a KNOWN
 base pose directly on the sim and assert the threshold, that it reads the YAW
 axis (a pure roll/pitch does NOT trip it, distinguishing it from ``base_tipped``),
 position/height independence, that x-position does NOT trip it (distinct from
-``base_beyond_x``), live tracking, fixed-base degradation, and that a real
-``DeclarativeBenchmark`` whose success is ``base_yaw_beyond`` and failure is
-``base_tipped`` + ``base_below_z`` succeeds once the base turns and is vetoed if
-it falls. They are GL-free (``get_observation`` with ``skip_images``) so they run
+``base_beyond_x``), live tracking, fixed-base degradation, that a goal outside the
+range a heading can be measured in is refused at registration rather than scoring
+every rollout the same way, and that a real ``DeclarativeBenchmark`` whose success
+is ``base_yaw_beyond`` and failure is ``base_tipped`` + ``base_below_z`` succeeds
+once the base turns and is vetoed if it falls. They are GL-free (``get_observation`` with ``skip_images``) so they run
 in CI without a display.
 """
 
@@ -38,6 +39,7 @@ from strands_robots.simulation.predicates import (
     _reset_resolution_warnings,
     make_predicate,
     predicate_kind,
+    register_predicate,
 )
 
 # Floating base with a NAMED free joint (a humanoid's floating_base_joint) plus
@@ -195,9 +197,10 @@ def test_base_yaw_beyond_tracks_the_live_base_heading(sim):
 
 
 def test_base_yaw_beyond_accepts_a_negative_threshold(sim):
-    """yaw is an unvalidated world heading (mirrors base_beyond_x/y): a negative
+    """yaw is a SIGNED world heading (mirrors base_beyond_x/y): a negative
     threshold is a right-of-spawn heading a base at the identity spawn already
-    reads True on."""
+    reads True on. It is bounded to the range a heading can be measured in (see
+    TestAHeadingGoalMustBeReachable) but not to one sign."""
     sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
     pred = make_predicate("base_yaw_beyond", yaw=-0.5)
     _set_base_pose(sim, _axis_quat("z", 0.0))
@@ -280,3 +283,194 @@ def test_declarative_turn_benchmark_succeeds_on_turn_and_is_vetoed_by_a_fall(sim
     # rollout (a toppled base's yaw is ill-defined, so the tilt is the terminal).
     _set_base_pose(sim, _axis_quat("y", 90.0), z=0.8)
     assert bench.is_failure(sim) is True
+
+
+# Headings the base can actually report. ``atan2`` returns a value in (-pi, pi],
+# so this samples that whole interval - it is the set every case below reads its
+# verdict from, which is what makes "no heading satisfies this goal" a measurement
+# rather than an argument about the formula.
+_MEASURABLE_HEADINGS = [
+    -math.pi + 1e-9,  # the open end: a heading arbitrarily close to -pi, never -pi
+    *(-math.pi + i * (2.0 * math.pi) / 240.0 for i in range(1, 240)),
+    math.pi,  # the closed end: atan2(0, -1) really does report +pi
+]
+
+# Goals no measurable heading discriminates, and why each one is reached.
+_UNREACHABLE_GOALS = [
+    pytest.param(180.0, id="180-written-as-degrees"),
+    pytest.param(90.0, id="90-written-as-degrees"),
+    pytest.param(math.degrees(1.0), id="one-radian-converted-to-degrees"),
+    pytest.param(math.pi, id="exactly-plus-pi"),
+    pytest.param(-math.pi, id="exactly-minus-pi"),
+    pytest.param(-4.0, id="past-minus-pi"),
+    pytest.param(2.0 * math.pi, id="a-full-revolution"),
+]
+
+# Goals that do discriminate, including both boundaries.
+_REACHABLE_GOALS = [
+    pytest.param(1.0, id="the-shipped-go2-turn-left-goal"),
+    pytest.param(0.0, id="any-left-turn-at-all"),
+    pytest.param(-1.0, id="a-right-of-spawn-heading"),
+    pytest.param(math.pi - 1e-6, id="just-inside-plus-pi"),
+    pytest.param(-math.pi + 1e-6, id="just-inside-minus-pi"),
+]
+
+
+def _discriminates(goal: float) -> bool:
+    """Whether SOME measurable heading meets ``goal`` and some other does not.
+
+    A goal that fails this decides the clause before the rollout starts: the
+    success verdict is the same for every orientation the base can reach, so the
+    clause reports on the goal rather than on the robot. This is the property the
+    domain exists to protect, stated here in the test rather than as the
+    implementation's ``abs(yaw) >= pi`` - which is why moving that bound in either
+    direction is caught below.
+    """
+    met = [h > goal for h in _MEASURABLE_HEADINGS]
+    return any(met) and not all(met)
+
+
+class TestAHeadingGoalMustBeReachable:
+    """A turn goal outside the measurable heading range is refused, not compiled.
+
+    The heading is read from ``base_quat`` through ``atan2``, which only ever
+    reports an angle in ``(-pi, pi]``. A goal at or above ``+pi`` is therefore met
+    by no orientation the base can reach and a goal at or below ``-pi`` is met by
+    every one - so the success clause is decided before the rollout starts, under
+    ``status="success"`` at registration. Measured on the pre-fix tree with a go2
+    posed at 61 headings spanning 0..pi: ``yaw=1.0`` read True at 41 of them,
+    ``yaw=57.3`` (1 rad written as degrees) and ``yaw=180`` at 0, and ``yaw=-4.0``
+    at all 61 including the spawn pose - all four accepted, none refused. Degrees
+    is the route that matters: the docstring quotes the goal as "~57 deg", so the
+    unit is in the author's hands and the wrong one compiles clean.
+
+    This is the same permanently-decided clause a negative tolerance produces (see
+    ``test_predicate_tolerance_sign_domain``), reached by a different route, and it
+    is refused at the same choke point.
+    """
+
+    def test_the_sweep_reads_the_range_the_predicate_can_report(self, sim):
+        """Non-vacuity: the sampled headings really are what the base reports.
+
+        Every verdict below rests on :data:`_MEASURABLE_HEADINGS` covering the
+        ``atan2`` range, so that is measured against the live predicate instead of
+        assumed - a sample set that missed the interval would make the
+        discrimination cases vacuous.
+        """
+        sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+        pred = make_predicate("base_yaw_beyond", yaw=0.0)
+        _set_base_pose(sim, _axis_quat("z", -90.0))
+        assert pred(sim) is False
+        _set_base_pose(sim, _axis_quat("z", 90.0))
+        assert pred(sim) is True
+        assert min(_MEASURABLE_HEADINGS) > -math.pi, "the range is open at -pi"
+        assert max(_MEASURABLE_HEADINGS) == math.pi, "and closed at +pi"
+        _set_base_pose(sim, _axis_quat("z", 180.0))
+        assert make_predicate("base_yaw_beyond", yaw=math.pi - 1e-6)(sim) is True, (
+            "a half-revolution reports +pi, so the closed end is reachable"
+        )
+
+    @pytest.mark.parametrize("goal", _UNREACHABLE_GOALS)
+    def test_a_goal_no_heading_discriminates_is_refused(self, goal):
+        with pytest.raises(ValueError) as excinfo:
+            make_predicate("base_yaw_beyond", yaw=goal)
+        message = str(excinfo.value)
+        assert "base_yaw_beyond" in message
+        assert "yaw" in message
+        assert "(-pi, pi)" in message
+        assert repr(goal) in message
+
+    @pytest.mark.parametrize("goal", _REACHABLE_GOALS)
+    def test_a_goal_some_heading_discriminates_is_accepted(self, goal):
+        assert callable(make_predicate("base_yaw_beyond", yaw=goal))
+
+    @pytest.mark.parametrize("goal", _UNREACHABLE_GOALS)
+    def test_the_refused_goals_are_exactly_the_ones_no_heading_discriminates(self, goal):
+        """The bound is pinned by the property, not by the number pi.
+
+        Widening it (to ``2 * pi``, say) admits a goal this asserts nothing can
+        discriminate; narrowing it (to ``1.0``) refuses one the sibling case above
+        asserts is usable. Both cases have to hold for the bound to be right.
+        """
+        assert not _discriminates(goal)
+
+    @pytest.mark.parametrize("goal", _REACHABLE_GOALS)
+    def test_the_accepted_goals_are_all_discriminating(self, goal):
+        assert _discriminates(goal)
+
+    def test_a_refused_goal_would_have_scored_every_pose_alike(self, sim):
+        """Why it is refused, in the units of the predicate itself.
+
+        Read through the live predicate rather than the formula: the factory is
+        called past the domain guard so the pre-fix behaviour is exercised on a
+        real posed base, and the verdict is the same at a heading the goal was
+        meant to reject and at one it was meant to accept.
+        """
+        sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+        degrees_goal = PREDICATE_REGISTRY["base_yaw_beyond"](yaw=180.0)
+        reachable_goal = make_predicate("base_yaw_beyond", yaw=1.0)
+        for heading_deg in (0.0, 60.0, 170.0):
+            _set_base_pose(sim, _axis_quat("z", heading_deg))
+            assert degrees_goal(sim) is False, "no reachable heading meets a degrees-spelled goal"
+        _set_base_pose(sim, _axis_quat("z", 0.0))
+        assert reachable_goal(sim) is False
+        _set_base_pose(sim, _axis_quat("z", 60.0))
+        assert reachable_goal(sim) is True
+
+    def test_a_declarative_benchmark_is_refused_at_compile_not_at_rollout(self, sim):
+        """The refusal reaches the surface a benchmark author actually writes.
+
+        ``DeclarativeBenchmark`` compiles its clauses through ``make_predicate``,
+        so the goal is refused while the spec is being read - not by a rollout that
+        burns its whole step budget reporting an honest miss.
+        """
+        sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+        spec = {
+            "name": "turn-left-in-degrees",
+            "default_robot": "humanoid",
+            "max_steps": 1000,
+            "success": {"all": [{"predicate": "base_yaw_beyond", "yaw": 180}]},
+            "failure": {"any": [{"predicate": "base_tipped", "tol": 0.7}]},
+        }
+        with pytest.raises(ValueError, match=r"\(-pi, pi\)"):
+            DeclarativeBenchmark.from_dict(spec)
+        # The same spec in radians compiles and scores the turn it was written for.
+        spec["success"] = {"all": [{"predicate": "base_yaw_beyond", "yaw": math.radians(90.0)}]}
+        bench = DeclarativeBenchmark.from_dict(spec)
+        _set_base_pose(sim, _axis_quat("z", 30.0))
+        assert bench.is_success(sim) is False
+        _set_base_pose(sim, _axis_quat("z", 120.0))
+        assert bench.is_success(sim) is True
+
+    def test_a_heading_on_a_later_registered_predicate_is_covered(self):
+        """The domain is read from the param name, so it needs no registry edit."""
+
+        def _factory(yaw=0.0):
+            def check(_sim):
+                return False
+
+            return check
+
+        # The domain is read from ``__annotations__`` by param name, and this module
+        # does not postpone annotation evaluation, so a literal ``yaw: float`` here
+        # would store the ``float`` CLASS where the guard reads the string form.
+        # Declared the way the module sees a shipped factory instead.
+        _factory.__annotations__["yaw"] = "float"
+        register_predicate("probe_heading_domain", _factory)
+        try:
+            with pytest.raises(ValueError, match="yaw"):
+                make_predicate("probe_heading_domain", yaw=180.0)
+            assert callable(make_predicate("probe_heading_domain", yaw=1.0))
+        finally:
+            PREDICATE_REGISTRY.pop("probe_heading_domain", None)
+
+    def test_a_non_finite_goal_still_reports_finiteness(self):
+        """The pre-existing reason is not displaced by the new one.
+
+        ``nan`` is not comparable to pi, so the heading check must sit behind the
+        finiteness guard whose coercion it depends on.
+        """
+        for value in (math.nan, math.inf, -math.inf):
+            with pytest.raises(ValueError, match="finite") as excinfo:
+                make_predicate("base_yaw_beyond", yaw=value)
+            assert "(-pi, pi)" not in str(excinfo.value)


### PR DESCRIPTION
`base_yaw_beyond` reads the base heading from `base_quat` through `atan2`, which only ever reports an angle in `(-pi, pi]`. `yaw` was classified as a signed coordinate and left unbounded, so a goal at or above `+pi` was met by no orientation the base can reach and a goal at or below `-pi` by every one. Either way the success clause was decided before the rollout started, and accepted at registration under `status="success"`.

![heading goal reachability](https://raw.githubusercontent.com/cagataycali/robots/assets/heading-goal-reachable/docs/assets/heading_goal_reachable.png)

## Measured

A go2 posed at 61 headings spanning `0..pi` in MuJoCo (headless EGL), each goal read through the live predicate:

| goal | before | after |
|---|---|---|
| `yaw=1.0` (a ~57 deg left turn, radians) | accepted, met at **41/61** headings | accepted, met at **41/61** - unchanged |
| `yaw=57.3` (1 rad written as degrees) | accepted, met at **0/61** | **refused at registration** |
| `yaw=180` (half a revolution in degrees) | accepted, met at **0/61** | **refused at registration** |
| `yaw=-4.0` (past `-pi`) | accepted, met at **61/61** incl. the spawn pose | **refused at registration** |
| `yaw=nan` / `yaw=inf` | refused (finiteness) | refused (finiteness), reason unchanged |

So a benchmark whose turn goal was written in degrees burned its whole step budget reporting an honest miss, and one written past `-pi` scored success before the robot moved.

Degrees is the route that matters: the predicate documents its own goal as "~57 deg", so the unit is in the author's hands and the wrong one compiled clean.

## Change

`make_predicate` holds a heading kwarg to `(-pi, pi)` at the same choke point that already refuses a non-finite value and a negative tolerance - `staged_reward` builds its nested calls back through it, so a guard in the spec compiler would leave those unchecked. The domain is read from the param **name**, matching `_TOLERANCE_PARAM_NAMES` beside it, so a predicate added later is covered by naming its heading the way this one does.

The bound is on the representable range, not on intent, which is why it does not conflict with the signed-coordinate policy:

- a negative heading **inside** the range keeps its signed meaning (`yaw=-1.0` is a right-of-spawn heading, exactly as `base_beyond_x(x=-2.0)` is);
- a heading **command** is untouched - `ros_bridge.navigate_to` encodes its `yaw` as a quaternion, where any angle wraps to a real goal pose, so it needs finiteness only.

`base_yaw_beyond`'s docstring already stated this bound ("a goal at or beyond pi is not a well-defined single-turn heading"); it is now enforced rather than only documented. Three docstrings that described `yaw` as unbounded were corrected in the same change.

## Tests

`tests/simulation/test_base_yaw_beyond_predicate.py` gains `TestAHeadingGoalMustBeReachable` (+9 cells), pinning the bound by the **property** rather than by the number `pi`: a goal is refused exactly when no measurable heading discriminates it. Mutation table over that file plus the sibling `test_predicate_tolerance_sign_domain.py` (151 cells, green as shipped):

| mutation | cells that fail |
|---|---|
| revert the guard | 9 - every refusal case, the spec-compile case, the later-registered case |
| widen the bound to `2*pi` | 3 - `exactly-plus-pi`, `exactly-minus-pi`, `past-minus-pi` |
| narrow the bound to `1.0` | 14 - incl. the shipped `go2_turn_left` goal and `TestSignedParamsKeepBothSigns` |
| admit exactly `+-pi` (`>` not `>=`) | 2 - the two boundary cases |
| check the heading before finiteness | 1 - `nan`/`inf` must still report finiteness |

The refusal is also asserted through `DeclarativeBenchmark.from_dict`, so a degrees-spelled goal is refused while the spec is read rather than by a rollout that burns its step budget.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1966 files).
- `mypy` (pinned): 20 standing errors in 6 files, unchanged from `main`.
- Full `tests/` on both trees, **51467 collected on each**: this branch **64 failed / 50935 passed / 437 skipped / 37 errors**; `main` with only the new test file copied in **73 failed / 50926 passed / 437 skipped / 37 errors**. The 9-failure difference is exactly the new discriminating cells - there are **no** failures present on this branch and absent on `main`.

LOC delta: +278 / -15 across 3 files (source +49 net, tests +191, changelog fragment).