### PR TITLE
feat(simulation): a rollout can be watched without taking the hook that cancels it

### DIFF
--- a/changelog.d/2907-run-policy-observer.md
+++ b/changelog.d/2907-run-policy-observer.md
@@ -1,0 +1,122 @@
+### Added: a rollout can be watched without taking the hook that cancels it
+
+`run_policy` accepts an `observer` callable that receives one `RunPolicyStarted`,
+one `RunPolicyStep` per completed `send_action` call, and one `RunPolicyEnded`.
+A complete backend breakdown says what physically applied; a coarse error keeps
+that state explicitly unknown.
+
+`on_frame` looked like the seam for this and is not one. There is exactly one per
+rollout and `SimEngine.run_policy` fills it from `_make_run_policy_hook`, so on
+MuJoCo it already carries cooperative cancellation, the trajectory mirror,
+rate-limited mesh step telemetry and the LeRobot dataset recorder, and on Isaac
+and Newton the recording half of that. The facade does not accept one from the
+caller at all. A consumer reaching for it through `PolicyRunner.run` directly does
+not *add* observation - it replaces cancellation and recording with a visualiser,
+and `stop_policy` stops working on that rollout.
+
+The new lane sits beside that hook and reports the three things the hook's own
+`(step, obs, action)` signature cannot carry:
+
+- **`action_resolution`** - the backend's per-key `send_action` verdict, normalised
+  to `full` / `partial` / `none` / `unknown`. `partial` and `none` are emitted
+  only from a valid complete per-key breakdown. A coarse atomic refusal is
+  `unknown` with empty explicit key tuples: the input keys are not evidence of
+  what reached physical state. Those refusals still feed the existing dead-rollout
+  probe through the backend error text, so fail-fast is not weakened. Coarse
+  steps are also excluded from aggregate action-rate denominators rather than
+  being counted as confirmed misses; `action_errors` and the result text retain
+  the uncertainty.
+- **`observation_age_steps`** - the authoritative nonnegative count of completed
+  rollout action attempts since the snapshot was sampled. Sync chunks report
+  their chunk index; async prefetch carries the number of remaining old-chunk
+  attempts through the swap and adds the new chunk index; an active recording
+  refreshes every frame and reports zero. On an `unknown` action resolution it
+  does not claim physical advancement.
+- **`observation_is_chunk_reused`** - the narrower chunk-position signal: true
+  only for a later action using the same chunk-start snapshot. It deliberately
+  does not claim freshness; the first action after an async swap can have a
+  positive age without yet reusing that snapshot inside its new chunk.
+- **`legacy_hook_outcome`** - `ok`, `cancelled`, `recording_error`, `error`, or
+  `absent`.
+
+**The step a cancellation aborts on is reported, and that is the point.** The
+legacy hook runs *after* `send_action` and `step_count` is incremented *after* the
+hook, so an action a cancelling or recording-failing hook aborts on has already
+advanced the world while being excluded from `steps_used`, from the video cadence
+and from the resolution denominator. A lane that inherited that boundary would be
+silent about the one step a cancellation is usually debugged from.
+`applied_action_index == legacy_step_index` on every step, including the aborting
+one: both identify the same zero-based action passed to the hook, and
+`legacy_hook_outcome` identifies the abort. Terminal accounting uses a different
+boundary, so `RunPolicyEnded.applied_actions` can exceed `legacy_steps_used` by
+one on that path.
+
+Emission is in a `finally` around the hook, which is also what keeps the hook's
+own behaviour unchanged: each `except` re-raises exactly what it raised before, so
+the exception type, its traceback and its `__cause__` reach the outer handler
+identically - the `finally` merely runs first. Measured against the same suites at
+the same commit, `on_frame` receives an identical argument sequence with and
+without an observer, and the rollout applies an identical action sequence and
+returns identical existing payload fields whether the observer is absent, healthy,
+or raising on every event.
+
+The event shape is observer schema version 2. Once `RunPolicyStarted` dispatch is
+attempted, exactly one `RunPolicyEnded` dispatch is attempted for every Python
+exit from control or result assembly. That includes `KeyboardInterrupt`,
+`SystemExit`, `GeneratorExit`, `asyncio.CancelledError`, and ordinary assembly
+errors; non-cooperative exceptions preserve identity and traceback and still
+propagate. If Step or Ended dispatch raises another non-cooperative exception
+while one is already unwinding from the legacy hook or rollout, the original
+remains primary and the secondary is logged and attached as an exception note. A preflight refusal emits neither
+event. A non-callable `observer` is one such refusal: the facade returns its
+standard `run_policy` error and a direct `PolicyRunner.run` raises `ValueError`,
+both before world/robot discovery, policy, hook, clock, id, inference, or action
+side effects.
+
+Ordinary failures are contained but never hidden. An observer `Exception` or
+`CooperativeStop` cannot change the rollout's outcome and never reaches the
+`max_onframe_failures` watchdog - that
+exists so a recorder losing dataset frames cannot produce a silently empty
+dataset (GH #117), which is not the same event as a visualiser that cannot draw.
+`CooperativeStop` is contained too, and named explicitly: it is a `BaseException`
+precisely so a hook's broad `except Exception` cannot swallow a cancellation, and
+without naming it any observer could cancel a rollout it is only supposed to
+watch. That is the whole reason the guard cannot simply be `except Exception`,
+and it is why the clause is `except (CooperativeStop, Exception)` rather than
+`except BaseException` - the smallest superset that keeps a stop from escaping an
+observer. `KeyboardInterrupt`, `SystemExit`, `GeneratorExit` and
+`asyncio.CancelledError` propagate, none of them being an `Exception` subclass: a
+generator closed underneath a visualiser, or a task cancelled while one was
+drawing, is a teardown rather than a drawing failure, and counting it as an
+observer failure on a rollout that then ran to its full budget said the opposite.
+Every contained failure increments `observer_failures`, reported in the result
+json, so a stream with holes says it has them.
+
+The lane is inert when unused: no clock is read, no id is minted and no sim-time
+lookup is performed unless an observer is installed. When installed, sim time is
+read only from cached `_world.sim_time` or `_sim_time`; telemetry never calls
+`get_state`. `observer_failures` appears in the payload only for a rollout that
+had one, so the documented payload is unchanged for every existing caller.
+
+Payloads are borrowed rather than copied - the same objects the hook received -
+because a per-step deep copy of an image-sized observation is the opposite of what
+an observability lane should cost. Consumers treat them as read-only and snapshot
+synchronously. Dispatch is synchronous on the rollout thread, so this is telemetry
+and not a sandbox: a blocking observer blocks the robot, and that is documented
+rather than defended against.
+
+What that costs the rollout is bounded by the loop's pacing, which is a deadline
+rather than a delay. A consumer therefore has a budget of one control period that
+costs no wall clock at all - its work is absorbed by the period instead of added
+to it - and overrunning the budget costs a dropped deadline rather than a burst of
+catch-up actions at the arm. This lane is the first per-step cost a *caller*
+supplies, so the property is now graded on it as well as on the backend's hook
+(`tests/simulation/test_rollout_loop_paces_on_a_deadline.py`): on a MuJoCo so101
+rollout asking for 2.0 s with an 8 ms observer, absorbing the cost returns in
+2.0092 s where adding it returned in 2.5694 s.
+
+Scoped to `run_policy` (its `n_episodes > 1` path included, one lifecycle and one
+`run_id` per episode) and `PolicyRunner.run`. `eval_policy`,
+`evaluate_benchmark` and `run_multi_policy` are separate loops with different step
+semantics and carry no observer, which the parameter documentation states rather
+than leaving to be discovered.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -275,6 +275,43 @@ At `n_episodes > 1` the same call returns an aggregate, and the aggregate keeps 
 
 What the aggregate adds is `total_steps`, `stopped_reasons` (aligned with `episodes`), `video_paths` and the per-episode `episodes` records; `steps_used` equals `total_steps` and `stopped_reason` is the last episode's. Per-episode action health is *not* summarised, because a per-step rate has no single aggregate an N-episode call can report without choosing one - each record in `episodes` carries its own `action_errors`, `action_resolution_rate` and `partial_action_failure_rate`, so the worst episode is `max(e["partial_action_failure_rate"] for e in report["episodes"])`.
 
+### Watching a rollout: the `observer` lane
+
+`run_policy(observer=...)` takes a read-only callable that receives one `RunPolicyStarted`, one `RunPolicyStep` per completed `send_action` call, and one `RunPolicyEnded`. A complete backend breakdown says what physically applied; a coarse error keeps that state explicitly `unknown`. It is a *second* lane beside the backend's `on_frame` hook, not a use of it - that hook is filled from `_make_run_policy_hook` (cooperative cancellation, the trajectory mirror, mesh step telemetry, dataset recording) and is not available to callers, so supplying one would remove all of that rather than add observation.
+
+```python
+from strands_robots.simulation.observers import RunPolicyStep
+
+def watch(event):
+    if isinstance(event, RunPolicyStep) and event.action_resolution != "full":
+        print(event.applied_action_index, event.unresolved_action_keys)
+
+sim.run_policy(robot_name="alice", policy_provider="mock", observer=watch)
+```
+
+The events use observer schema version **2** and report four things `on_frame`'s `(step, obs, action)` signature cannot carry:
+
+| Field | Why it is not derivable from `on_frame` |
+|-------|------------------------------------------|
+| `action_resolution` | The backend's per-key `send_action` verdict, normalised to `full` / `partial` / `none` / `unknown`. `partial` and `none` require a valid, complete per-key breakdown; a coarse backend error is `unknown` with empty explicit key tuples, because input keys are not proof of what reached physical state. Coarse steps remain in `action_errors` and result text but are excluded from aggregate action-rate denominators rather than counted as physical misses. |
+| `observation_is_chunk_reused` | Narrow chunk-position signal: `true` only for a later action using the same chunk-start snapshot. It is not authoritative freshness, because the first action after an async prefetch swap can already use an old snapshot. |
+| `observation_age_steps` | Authoritative nonnegative age in control-step terms: completed rollout action attempts since the snapshot was sampled. Sync chunks report their chunk index. Async chunks carry the prefetch sample's remaining-old-chunk-attempt count across the swap and add the new chunk index. An active recording refreshes every step and reports `0`. On an `unknown` action resolution this field does not claim physical advancement. |
+| `legacy_hook_outcome` | What the backend's hook did - `ok`, `cancelled`, `recording_error`, `error`, or `absent`. |
+
+`applied_action_index == legacy_step_index` for every `RunPolicyStep`, including a cancelled or recording-failed step: both identify the same zero-based action passed to the hook. The abort is identified by `legacy_hook_outcome`, not by an index offset. Terminal counts have a different boundary: the hook runs *after* `send_action` and `step_count` increments *after* the hook, so `RunPolicyEnded.applied_actions` can exceed `legacy_steps_used` by one when that final hook aborts.
+
+Ordering is explicit: `event_seq` is dense and 0-based within one `run_id`, so a gap is observable; `monotonic_ns` orders the stream (no NTP correction or `date -s` can move it) and `utc_ns` is derived from a single rollout anchor so a wall-clock label can never disagree with it. At `n_episodes > 1` each episode is its own lifecycle with its own `run_id`. Once dispatch of `RunPolicyStarted` is attempted, dispatch of exactly one `RunPolicyEnded` is attempted on every Python exit, including process-control/cancellation exceptions and result-assembly failures. Those non-cooperative exceptions retain their identity and traceback and still propagate. If Step or Ended observer dispatch raises a second non-cooperative exception while one is already unwinding from the legacy hook or rollout, the original remains primary and the secondary failure is logged and attached as an exception note. A preflight refusal opens no lifecycle. `sim_time_s` is read only from a cached `_world.sim_time` or engine `_sim_time`; observation telemetry never calls `get_state`.
+
+Five rules the lane holds to, and one it does not:
+
+- **Additive.** Installing an observer changes no action applied, no existing result-json field, and no observation or render call. It adds one key, `observer_failures`.
+- **Contained, for the classes it is an observer's business to raise.** An `Exception` never alters the rollout outcome and never reaches the `max_onframe_failures` watchdog - that exists for a recorder losing dataset frames, not a visualiser that cannot draw. `CooperativeStop` is contained too, and by name: it is a `BaseException` precisely so a hook's broad `except Exception` cannot swallow a cancellation, so without naming it here any observer could cancel a rollout it is only supposed to watch. Every contained failure is counted and reported as `observer_failures`, so a stream with holes says so.
+- **Not contained: the four signals that are nobody's telemetry.** `KeyboardInterrupt`, `SystemExit`, `GeneratorExit` and `asyncio.CancelledError` propagate. None of the four is an `Exception` subclass, so the guard's `(CooperativeStop, Exception)` clause passes them through by construction. A generator closed underneath a visualiser, or a task cancelled while one was drawing, is a real teardown rather than a drawing failure, and reporting it as `observer_failures` on a rollout that then ran to its full budget said the opposite. If Step or Ended dispatch raises one while another exception is already unwinding from the legacy hook or rollout, the original exception remains primary; the secondary observer failure is logged and attached to it as a note.
+- **Borrowed, not copied.** `observation` and `action` are the same objects the hook received. Treat them as read-only and do not retain them past the call; snapshot what you need synchronously.
+- **Not isolated.** Dispatch is synchronous on the rollout thread, so a blocking observer blocks the robot. This is telemetry, not a sandbox. The rollout loop paces on a *deadline* rather than a delay, so a consumer has a budget of one control period (`1 / control_frequency`) that costs the rollout no wall clock at all - work inside it is absorbed by the period instead of added to it. Overrun that budget and the pace is what gives: the loop drops the missed deadline rather than firing a burst of catch-up actions at the arm, so the arm sees a gap. Keep the callback short and hand anything slower to another thread.
+
+Scope: `run_policy` (including its `n_episodes > 1` path) and `PolicyRunner.run`. `eval_policy`, `evaluate_benchmark` and `run_multi_policy` are separate loops with different step semantics and carry no observer yet.
+
 `eval_policy` accepts the same `video={...}` recording config as `run_policy` (`path` enables it, plus `fps` / `camera` / `width` / `height` - an unknown key or a non-positive size is a caller error, never silently ignored), but writes **one MP4 per episode** with `_ep{i}` inserted into the filename (`eval.mp4` -> `eval_ep0.mp4`, `eval_ep1.mp4`, ...), so a multi-episode evaluation can be *watched* to see why episodes fail rather than only read as an aggregate `success_rate`. The written files are listed in the result json `video_paths`; the output path is validated and the camera probed up-front, so a bad camera fails the eval immediately instead of after N episodes of empty MP4s. `evaluate_benchmark` accepts the same `video={...}` config and records one MP4 per episode too, so a benchmark evaluation can be watched to see why episodes fail. Frames are captured synchronously on the eval thread (render is read-only over `mjData`), so recording does not perturb the bit-stable benchmark rollout.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |
 

--- a/strands_robots/simulation/__init__.py
+++ b/strands_robots/simulation/__init__.py
@@ -86,6 +86,17 @@ from strands_robots.simulation.models import (
     SimWorld,
     TrajectoryStep,
 )
+from strands_robots.simulation.observers import (
+    ActionResolution,
+    LegacyHookOutcome,
+    RunPolicyEnded,
+    RunPolicyEvent,
+    RunPolicyObserver,
+    RunPolicyOutcome,
+    RunPolicyStarted,
+    RunPolicyStep,
+    StoppedReason,
+)
 from strands_robots.simulation.predicates import (
     PREDICATE_REGISTRY,
     make_predicate,
@@ -130,6 +141,16 @@ __all__ = [
     "SimCamera",
     "SimWorld",
     "TrajectoryStep",
+    # Read-only rollout observability (light - stdlib dataclasses only)
+    "ActionResolution",
+    "LegacyHookOutcome",
+    "RunPolicyOutcome",
+    "StoppedReason",
+    "RunPolicyStarted",
+    "RunPolicyStep",
+    "RunPolicyEnded",
+    "RunPolicyEvent",
+    "RunPolicyObserver",
     # MuJoCo scene builder (MjSpec-based, replaces MJCFBuilder)
     "SpecBuilder",
     # Model registry

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -50,12 +50,14 @@ if TYPE_CHECKING:
 # AST). Instead, we reference ``OnFrame`` in the ``evaluate_benchmark``
 # signature as a *string* annotation; ``from __future__ import
 # annotations`` (already in effect) makes that a no-op at runtime.
+from strands_robots.simulation.observers import RunPolicyObserver
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
     dds_domain_id_error,
     is_boolean,
     non_negative_count_error,
+    optional_callable_error,
     positive_count_error,
     positive_finite_number_error,
     process_rss_mb,
@@ -2492,6 +2494,7 @@ class SimEngine(ABC):
         rtc_inference_timeout_s: float | None = None,
         wbc_install_torque_control: bool = True,
         stop_when: dict[str, Any] | Callable[[SimEngine], bool] | None = None,
+        observer: RunPolicyObserver | None = None,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -2704,6 +2707,32 @@ class SimEngine(ABC):
                 dict (the tool surface accepts dicts only). ``None`` (default)
                 keeps the pure step-budget horizon. The result json reports
                 why the rollout ended via ``stopped_reason``.
+            observer: Optional read-only rollout observer, forwarded verbatim to
+                :meth:`PolicyRunner.run`. Receives one
+                :class:`~strands_robots.simulation.observers.RunPolicyStarted`,
+                one :class:`~strands_robots.simulation.observers.RunPolicyStep`
+                per completed ``send_action`` call and one
+                :class:`~strands_robots.simulation.observers.RunPolicyEnded`,
+                carrying the per-key ``send_action`` verdict, authoritative
+                ``observation_age_steps`` (with the narrower
+                ``observation_is_chunk_reused`` chunk-position flag), and what
+                the backend's own ``on_frame`` hook did. Must be ``None`` or
+                callable; another value is refused before policy construction,
+                backend hook creation, or rollout side effects.
+
+                This is a SECOND lane, not the backend's hook: the hook slot is
+                filled from ``_make_run_policy_hook`` (cancellation, trajectory,
+                mesh telemetry, dataset recording) and is not available to
+                callers, which is exactly why a read-only consumer needs this.
+                Installing one changes neither the actions applied nor any
+                existing field of the result json; it adds
+                ``observer_failures``. With ``n_episodes > 1`` each episode is
+                its own lifecycle with its own ``run_id``. Called synchronously,
+                so a blocking observer blocks the rollout, and payloads are
+                borrowed rather than copied - see
+                :mod:`strands_robots.simulation.observers` for the ownership
+                rules. Not yet wired into ``eval_policy``,
+                ``evaluate_benchmark`` or ``run_multi_policy``.
 
         Returns:
             The standard agent-tool envelope
@@ -2728,8 +2757,11 @@ class SimEngine(ABC):
             operational), so ``status`` alone cannot see it: a policy driving 1
             of a Panda's 8 actuators returns ``status="success"`` with
             ``action_errors=0`` and ``partial_action_failure_rate=0.875``. Gate
-            on ``partial_action_failure_rate`` and the binding-degradation
-            flags below to decide whether a rollout is worth anything. A TOTAL
+            on ``action_errors``, ``partial_action_failure_rate`` and the
+            binding-degradation flags below to decide whether a rollout is worth
+            anything. Coarse backend errors remain in ``action_errors`` but are
+            excluded from action-rate denominators rather than fabricated as
+            confirmed misses. A TOTAL
             failure - no emitted key resolving to any actuator - is reported as
             ``status="error"``.
 
@@ -2747,13 +2779,16 @@ class SimEngine(ABC):
             ``stop_policy``; ``"error"`` on error results - so an agent
             deciding whether to retry knows WHY the rollout ended).
 
-            Action health: ``action_errors`` (steps where at least one emitted
-            key did not resolve), ``action_resolution_rate`` (an
-            ``{actuator_name: fraction_of_steps_driven}`` map, so a joint stuck
-            at ``0.0`` names the actuator the policy never drove) and
-            ``partial_action_failure_rate`` (the mean fraction of the robot's
-            DOF never driven; ``0.0`` == every actuator moved every step,
-            ``~0.83`` == only 1 of 6 actuators ever moved).
+            Action health: ``action_errors`` (steps where the backend reported
+            an error), ``action_resolution_rate`` (an
+            ``{actuator_name: fraction_of_resolution-known_steps_driven}`` map,
+            so a joint stuck at ``0.0`` names an actuator not confirmed on any
+            known step) and ``partial_action_failure_rate`` (the mean fraction
+            of the robot's DOF not confirmed driven across those known steps;
+            ``0.0`` == every actuator confirmed every known step, ``~0.83`` ==
+            only 1 of 6). A coarse backend error is excluded from both rate
+            denominators instead of being counted as a physical miss; it remains
+            visible in ``action_errors`` and the human-readable diagnostic.
 
             Video: ``video_path`` (``None`` when no MP4 was written),
             ``video_frames`` and ``video_fps`` (the rate the MP4 plays at -
@@ -2812,6 +2847,11 @@ class SimEngine(ABC):
             surfaced via ``partial_action_failure_rate``.
         """
         from strands_robots.policies import create_policy
+
+        # Refuse a value outside the observer's domain before robot discovery,
+        # policy construction, backend hook creation, clocks, or rollout work.
+        if observer_error := optional_callable_error(observer, "observer", "run_policy"):
+            return {"status": "error", "content": [{"text": observer_error}]}
 
         robot_name = self._resolve_single_robot(robot_name)
 
@@ -2975,6 +3015,7 @@ class SimEngine(ABC):
                         fast_mode=fast_mode,
                         video=VideoConfig.from_dict(video),
                         on_frame=on_frame,
+                        observer=observer,
                         max_onframe_failures=max_onframe_failures,
                         control_substeps=control_substeps,
                         policy_kwargs=policy_kwargs,
@@ -3016,6 +3057,7 @@ class SimEngine(ABC):
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
                 stop_when=stop_when_fn,
+                observer=observer,
             )
         finally:
             if controller_cleanup is not None:
@@ -3322,6 +3364,7 @@ class SimEngine(ABC):
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
         stop_when: Callable[[SimEngine], bool] | None = None,
+        observer: RunPolicyObserver | None = None,
     ) -> dict[str, Any]:
         """Run ``n_episodes`` sequential rollouts; shared multi-episode driver.
 
@@ -3359,6 +3402,7 @@ class SimEngine(ABC):
                     fast_mode=fast_mode,
                     video=ep_video,
                     on_frame=on_frame,
+                    observer=observer,
                     max_onframe_failures=max_onframe_failures,
                     control_substeps=control_substeps,
                     policy_kwargs=policy_kwargs,

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -132,6 +132,7 @@ from strands_robots.simulation.mujoco.spec_builder import (
     _validate_size,
     material_spec_error,
 )
+from strands_robots.simulation.observers import RunPolicyObserver
 from strands_robots.simulation.policy_runner import CooperativeStop
 from strands_robots.simulation.recording import undriven_robot_state
 from strands_robots.simulation.terrain import SUPPORTED_TERRAINS, validate_difficulty, validate_terrain
@@ -143,6 +144,7 @@ from strands_robots.utils import (
     entity_name_error,
     finite_vector_error,
     non_negative_whole_number_error,
+    optional_callable_error,
     positive_count_error,
     positive_finite_number_error,
     positive_whole_number_error,
@@ -5509,6 +5511,7 @@ class MuJoCoSimEngine(
         rtc_inference_timeout_s: float | None = None,
         wbc_install_torque_control: bool = True,
         stop_when: dict[str, Any] | Callable[[SimEngine], bool] | None = None,
+        observer: RunPolicyObserver | None = None,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -5531,6 +5534,13 @@ class MuJoCoSimEngine(
         validates it against the closed predicate registry; see its docstring
         for the schema and the ``stopped_reason`` telemetry contract.
         """
+        # This override claims the robot before delegating to the base facade,
+        # so it must enforce the shared observer domain first. An invalid
+        # callback is configuration, not a rollout, and must not inspect the
+        # world, resolve a robot, or raise ``policy_running``.
+        if observer_error := optional_callable_error(observer, "observer", "run_policy"):
+            return {"status": "error", "content": [{"text": observer_error}]}
+
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
@@ -5565,6 +5575,7 @@ class MuJoCoSimEngine(
             rtc_inference_timeout_s=rtc_inference_timeout_s,
             wbc_install_torque_control=wbc_install_torque_control,
             stop_when=stop_when,
+            observer=observer,
         )
 
     def run_multi_policy(

--- a/strands_robots/simulation/observers.py
+++ b/strands_robots/simulation/observers.py
@@ -1,0 +1,317 @@
+"""Read-only rollout events for :meth:`PolicyRunner.run`.
+
+Why this is a second lane rather than a use of ``on_frame``
+----------------------------------------------------------
+
+``on_frame`` looks like the observation seam and is not one. It is owned by the
+backend for the duration of a rollout: MuJoCo's hook raises
+:class:`~strands_robots.simulation.policy_runner.CooperativeStop` so
+``stop_policy`` can interrupt, appends the trajectory mirror, publishes mesh step
+telemetry and drives the LeRobot dataset recorder; Isaac's and Newton's do the
+recording half of the same job. There is exactly one of them -
+:meth:`~strands_robots.simulation.base.SimEngine.run_policy` obtains it from
+``_make_run_policy_hook`` and does not accept one from the caller - so a consumer
+that supplied its own would not *add* observation, it would silently remove
+cancellation and recording.
+
+These events are therefore emitted beside that hook, and deliberately report the
+three things the hook's own signature cannot carry:
+
+* **what the backend answered** - ``send_action``'s per-key verdict, normalised
+  to :data:`ActionResolution` so a consumer never parses a backend envelope;
+* **how old the observation was** - ``observation_age_steps`` is the
+  authoritative number of completed rollout action attempts since the snapshot
+  was sampled; ``observation_is_chunk_reused`` only says that the same
+  chunk-start snapshot is being used by a later action in that chunk;
+* **what the legacy hook did** - including the step it aborted on, which the
+  legacy step accounting excludes (see :class:`RunPolicyStep`).
+
+The payload-ownership rule
+--------------------------
+
+``RunPolicyStep.observation`` and ``RunPolicyStep.action`` are **borrowed**: the
+same objects the legacy hook received, not copies. Copying them per step would
+put an image-sized deep copy on the control path of every rollout that enables
+the lane, which is the opposite of what an observability lane should cost. So the
+contract is placed on the consumer instead, and it is narrow:
+
+* Treat both as **read-only**. A backend may reuse the same buffers next step,
+  and the dataset recorder reads them after you do.
+* Do not retain them past the call. Snapshot the few fields you need
+  (synchronously, inside the callback) if you intend to hand them to a queue,
+  a thread or a socket.
+
+An event is dispatched **synchronously** on the rollout thread. That makes the
+lane cheap and ordered, and it means a consumer that blocks, blocks the robot.
+Ordinary exceptions and ``CooperativeStop`` are contained - those raises never
+change the rollout's outcome, and never reach the ``on_frame`` consecutive-failure
+watchdog, which exists for a recorder losing dataset frames (GH #117) rather than
+for a visualiser that cannot draw. Process-control and cancellation
+``BaseException`` classes propagate after terminal dispatch is attempted. Containment
+is not isolation: this is telemetry, not a sandbox. Keep the callback short and
+non-blocking.
+
+Ordering guarantees
+-------------------
+
+``event_seq`` is dense and 0-based within one ``run_id``, so a gap is
+observable. ``monotonic_ns`` is the ordering clock (a ``date -s`` or an NTP
+correction cannot move it); ``utc_ns`` is derived from a single rollout anchor so
+a wall-clock label never reorders the stream.
+
+Scope
+-----
+
+Single-policy simulation rollouts through :meth:`PolicyRunner.run` and every
+episode of :meth:`~strands_robots.simulation.base.SimEngine.run_policy` (one
+lifecycle and ``run_id`` per episode). ``eval_policy``, ``evaluate_benchmark``,
+``run_multi_policy`` and hardware carry no observer yet - they are separate
+loops with different step semantics, and claiming them here would promise
+coverage this module does not have.
+
+Example::
+
+    from strands_robots.simulation.observers import RunPolicyStep
+
+    def watch(event):
+        if isinstance(event, RunPolicyStep) and event.action_resolution != "full":
+            print(event.applied_action_index, event.unresolved_action_keys)
+
+    sim.run_policy(robot_name="arm", observer=watch)
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+__all__ = [
+    "ActionResolution",
+    "LegacyHookOutcome",
+    "RunPolicyEnded",
+    "RunPolicyEvent",
+    "RunPolicyObserver",
+    "RunPolicyOutcome",
+    "RunPolicyStarted",
+    "RunPolicyStep",
+    "SCHEMA_VERSION",
+    "StoppedReason",
+]
+
+#: Version of the event shape. Bumped when a field changes meaning or is
+#: removed, so a consumer can refuse a stream it does not understand instead of
+#: reading a renamed field as a missing one.
+SCHEMA_VERSION = 2
+
+#: Normalised backend verdict for one action application.
+#:
+#: ``"full"`` means every emitted key drove an actuator. ``"partial"`` and
+#: ``"none"`` are used only when the backend supplied a complete explicit
+#: per-key breakdown. ``"unknown"`` means the backend rejected the action
+#: without enough structured evidence to say which keys, if any, reached
+#: physical state.
+ActionResolution = Literal["full", "partial", "none", "unknown"]
+
+#: Outcome of the backend-owned legacy hook for one applied action.
+LegacyHookOutcome = Literal["absent", "ok", "cancelled", "recording_error", "error"]
+
+#: Why a rollout terminated, matching the result payload's ``stopped_reason``.
+StoppedReason = Literal["budget", "predicate", "cancelled", "error"]
+
+#: Overall rollout outcome, matching the result envelope's status.
+RunPolicyOutcome = Literal["success", "error"]
+
+
+@dataclass(frozen=True)
+class RunPolicyStarted:
+    """Opens a rollout. Emitted once, after setup, before the first observation.
+
+    Emitted only for a rollout that actually begins: a request refused in
+    pre-flight (a bad horizon, an unusable seed, a video path that cannot be
+    opened) raises or returns before this event, so no lifecycle is opened and
+    none has to be closed.
+
+    Attributes:
+        schema_version: :data:`SCHEMA_VERSION` at emission time.
+        run_id: Identifies this rollout. Every event of one
+            :meth:`PolicyRunner.run` call shares it; a multi-episode
+            ``run_policy`` produces one ``run_id`` per episode, because each
+            episode is its own runner call.
+        event_seq: ``0`` - the first event of the rollout.
+        monotonic_ns: Ordering clock, from :func:`time.monotonic_ns`.
+        utc_ns: Wall-clock label for the same instant, derived from the rollout's
+            single ``(utc, monotonic)`` anchor.
+        robot_name: Robot being driven.
+        policy: Class name of the driving policy (e.g. ``"MockPolicy"``).
+        instruction: Natural-language instruction forwarded to the policy.
+        control_frequency: Target Hz of the control loop.
+        action_horizon: Max actions consumed per policy call, as requested. The
+            effective chunk may be longer when the policy declares a larger
+            ``actions_per_step``.
+        total_steps: Step budget resolved for this rollout.
+        async_rtc: Whether inference is overlapped with action execution. This
+            is the resolved value, so a rollout that auto-detected a
+            chunk-emitting policy reports ``True`` even though the caller passed
+            ``None``.
+    """
+
+    schema_version: int
+    run_id: str
+    event_seq: int
+    monotonic_ns: int
+    utc_ns: int
+    robot_name: str
+    policy: str
+    instruction: str
+    control_frequency: float
+    action_horizon: int
+    total_steps: int
+    async_rtc: bool
+
+
+@dataclass(frozen=True)
+class RunPolicyStep:
+    """One completed ``send_action`` call.
+
+    Emitted after ``send_action`` has returned and after the legacy ``on_frame``
+    hook has run, whatever that hook did. The backend's physical state is known
+    to have advanced only when its result says so; on a coarse atomic refusal the
+    event reports ``action_resolution="unknown"`` rather than inventing applied
+    or unresolved keys.
+
+    The hook runs before the legacy ``step_count`` increments. Consequently
+    :attr:`applied_action_index` and :attr:`legacy_step_index` identify the same
+    zero-based action, including the action whose hook cancels or loses a dataset
+    frame. The abort is identified by :attr:`legacy_hook_outcome`. Terminal
+    accounting is intentionally different: :attr:`RunPolicyEnded.applied_actions`
+    counts calls made to ``send_action``, while
+    :attr:`RunPolicyEnded.legacy_steps_used` excludes a hook-aborted final step.
+
+    Attributes:
+        schema_version: :data:`SCHEMA_VERSION` at emission time.
+        run_id: The rollout this step belongs to.
+        event_seq: Dense, monotonic position in the rollout's event stream.
+        monotonic_ns: Ordering clock, sampled after ``send_action`` completed.
+        utc_ns: Wall-clock label for the same instant.
+        applied_action_index: 0-based count of ``send_action`` calls,
+            including this one. Dense across the whole rollout.
+        legacy_step_index: The index this step's ``on_frame`` call received, or
+            the index it would have received had a hook been installed. Equal to
+            ``applied_action_index``; use ``legacy_hook_outcome`` to identify an
+            aborting step.
+        observation: **Borrowed** pre-action observation - the same object the
+            legacy hook received. Read-only; do not retain past the call. See the
+            module docstring.
+        action: **Borrowed** action sent to the backend. Usually a
+            ``dict[str, float]``; a numeric vector for policies that bind
+            positionally. Same ownership rule as ``observation``.
+        observation_is_chunk_reused: ``True`` only when this is a later action
+            using the same chunk-start snapshot. It is not authoritative
+            freshness: the first action after an async prefetch swap has not
+            reused that snapshot within its new chunk, but the snapshot is
+            already old.
+        observation_age_steps: Authoritative nonnegative count of completed
+            rollout action attempts since ``observation`` was sampled. ``0``
+            means no intervening action attempt; a positive value means the
+            snapshot is older in control-step terms. It does not claim physical
+            advancement when ``action_resolution`` is ``"unknown"``. Dataset
+            recording refreshes the observation per step and therefore reports
+            ``0`` throughout.
+        action_resolution: A :data:`ActionResolution`. ``"partial"`` and
+            ``"none"`` require a complete explicit backend per-key breakdown;
+            a coarse error is ``"unknown"``.
+        applied_action_keys: Keys that drove an actuator this step.
+        unresolved_action_keys: Keys the backend could not absorb. Empty on the
+            success path and on ``"unknown"`` resolutions without a breakdown.
+        elapsed_s: Seconds since the rollout's monotonic start.
+        sim_time_s: Backend simulation clock after the action, when the backend
+            exposes one cheaply; ``None`` otherwise. Never fetched at the cost of
+            an extra backend call.
+        legacy_hook_outcome: A :data:`LegacyHookOutcome`.
+    """
+
+    schema_version: int
+    run_id: str
+    event_seq: int
+    monotonic_ns: int
+    utc_ns: int
+    applied_action_index: int
+    legacy_step_index: int
+    observation: dict[str, Any]
+    action: Any
+    observation_is_chunk_reused: bool
+    observation_age_steps: int
+    action_resolution: ActionResolution
+    applied_action_keys: tuple[str, ...]
+    unresolved_action_keys: tuple[str, ...]
+    elapsed_s: float
+    sim_time_s: float | None
+    legacy_hook_outcome: LegacyHookOutcome
+
+
+@dataclass(frozen=True)
+class RunPolicyEnded:
+    """Closes a rollout. Emitted once, if and only if :class:`RunPolicyStarted` was.
+
+    Attempted on every exit path a started rollout can take - budget exhausted,
+    predicate fired, cooperative stop, or any error - so a consumer can always
+    pair an open with a close. The one thing it cannot survive is the process
+    dying under it (``SIGKILL``, OOM, a consumer that blocks forever), which is
+    why this lane is telemetry rather than a durable record.
+
+    Attributes:
+        schema_version: :data:`SCHEMA_VERSION` at emission time.
+        run_id: The rollout being closed.
+        event_seq: Final position in the rollout's event stream.
+        monotonic_ns: Ordering clock at close.
+        utc_ns: Wall-clock label for the same instant.
+        outcome: ``"success"`` or ``"error"``, matching the rollout result's
+            ``status``.
+        stopped_reason: A :data:`StoppedReason`, matching the result payload's
+            own field.
+        applied_actions: Total ``send_action`` calls made. Equals the number of
+            :class:`RunPolicyStep` events whose dispatch was attempted, and may
+            exceed :attr:`legacy_steps_used` by one when the legacy hook aborted
+            the final step. On ``action_resolution="unknown"`` this count does
+            not claim that physical state changed.
+        legacy_steps_used: The rollout's own ``steps_used`` / ``n_steps``.
+        action_errors: Steps whose ``send_action`` reported an error, partial
+            resolutions included.
+        elapsed_s: Rollout duration, measured on the monotonic clock.
+        error_type: Exception class name when ``outcome == "error"``, else
+            ``None``.
+        error_message: Exception message when ``outcome == "error"``, else
+            ``None``. Truncated; the full traceback stays in the log.
+        observer_failures: Contained failures before this terminal dispatch.
+            The returned result payload is authoritative and also includes a
+            contained failure raised while consuming this Ended event itself.
+    """
+
+    schema_version: int
+    run_id: str
+    event_seq: int
+    monotonic_ns: int
+    utc_ns: int
+    outcome: RunPolicyOutcome
+    stopped_reason: StoppedReason
+    applied_actions: int
+    legacy_steps_used: int
+    action_errors: int
+    elapsed_s: float
+    error_type: str | None
+    error_message: str | None
+    observer_failures: int = field(default=0)
+
+
+#: Union of everything the lane can deliver. Dispatch with ``isinstance``: the
+#: three kinds carry different fields, and a consumer that only wants one should
+#: not have to guess which.
+RunPolicyEvent = RunPolicyStarted | RunPolicyStep | RunPolicyEnded
+
+#: A rollout observer: any callable taking one :data:`RunPolicyEvent`.
+#:
+#: Spelled as a callable alias rather than a protocol class for the same reason
+#: :data:`~strands_robots.simulation.policy_runner.OnFrame` is - a plain function
+#: or a bound method is the common case, and neither should have to satisfy an
+#: interface to watch a rollout. Called synchronously on the rollout thread; see
+#: the module docstring for the ownership and blocking rules.
+RunPolicyObserver = Callable[[RunPolicyEvent], None]

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -33,13 +33,17 @@ from __future__ import annotations
 
 import contextlib
 import difflib
+import functools
 import logging
 import math
 import numbers
 import os
 import random
+import sys
 import time
+import uuid
 from collections.abc import Callable, Iterator
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -49,8 +53,23 @@ from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.dataset_recorder import RecordingFrameError
 from strands_robots.policies.base import collect_required_bodies, resolve_chunk_length
 from strands_robots.rendering.video import require_clip_encoder
+from strands_robots.simulation.observers import (
+    SCHEMA_VERSION as _OBSERVER_SCHEMA_VERSION,
+)
+from strands_robots.simulation.observers import (
+    ActionResolution,
+    LegacyHookOutcome,
+    RunPolicyEnded,
+    RunPolicyEvent,
+    RunPolicyObserver,
+    RunPolicyOutcome,
+    RunPolicyStarted,
+    RunPolicyStep,
+    StoppedReason,
+)
 from strands_robots.utils import (
     non_negative_whole_number_error,
+    optional_callable_error,
     positive_count_error,
     positive_finite_number_error,
     positive_whole_number_error,
@@ -165,6 +184,13 @@ def set_eval_seed(seed: int) -> None:
 
 # Hook signature: called every control step after send_action.
 # on_frame(step_idx, observation, action) -> None
+#
+# NOTE: this is the BACKEND-OWNED hook, not a general observation seam. There is
+# exactly one per rollout and ``SimEngine.run_policy`` fills it from
+# ``_make_run_policy_hook`` (cancellation + trajectory + mesh + dataset
+# recording), so a caller supplying their own does not add observation - it
+# removes all of that. Read-only consumers belong on the ``observer`` lane
+# instead; see :mod:`strands_robots.simulation.observers`.
 OnFrame = Callable[[int, dict[str, Any], dict[str, Any]], None]
 
 # Success function: called after each step during evaluate().
@@ -903,6 +929,85 @@ class _ChunkPipeline:
             idx += 1
 
 
+_LifecycleCloser = Callable[[BaseException], None]
+_run_lifecycle_closer: ContextVar[_LifecycleCloser | None] = ContextVar("policy_runner_lifecycle_closer", default=None)
+
+
+class _PreservePrimaryObserverEscape:
+    """Suppress a secondary observer-dispatch escape without hiding it.
+
+    Used only while another exception is already unwinding ``run``. Returning
+    ``True`` from ``__exit__`` keeps the original exception primary; its note and
+    the log preserve the secondary failure for diagnosis while the surrounding
+    ``finally`` continues propagating the primary exception.
+    """
+
+    def __init__(self, primary: BaseException, event_name: str) -> None:
+        self._primary = primary
+        self._event_name = event_name
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        secondary: BaseException | None,
+        _traceback: object,
+    ) -> bool:
+        if secondary is None:
+            return False
+        BaseException.add_note(
+            self._primary,
+            f"{self._event_name} observer dispatch also raised "
+            f"{type(secondary).__name__}; the original exception was preserved.",
+        )
+        logger.error(
+            "%s observer dispatch raised while propagating %s; preserving the original exception",
+            self._event_name,
+            type(self._primary).__name__,
+            exc_info=(type(secondary), secondary, secondary.__traceback__),
+        )
+        return True
+
+
+def _close_started_lifecycle_on_escape[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+    """Close an opened observer lifecycle when ``run`` escapes by raising.
+
+    The rollout body handles its cooperative and ordinary operational failures,
+    but result assembly intentionally happens afterwards and may itself raise.
+    A per-invocation context variable lets this outermost boundary reach the
+    local idempotent closer without storing mutable run state on ``PolicyRunner``
+    (the same runner may be used concurrently or recursively).
+    """
+
+    @functools.wraps(func)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        token = _run_lifecycle_closer.set(None)
+        try:
+            return func(*args, **kwargs)
+        finally:
+            # ``sys.exception()`` exposes the exception currently propagating
+            # through this finally block without catching it. That preserves its
+            # identity and traceback and avoids turning this lifecycle boundary
+            # into another broad exception handler.
+            error = sys.exception()
+            try:
+                if error is not None:
+                    closer = _run_lifecycle_closer.get()
+                    if closer is not None:
+                        # Keep the propagating exception primary even if terminal
+                        # observer dispatch raises a second one. The context
+                        # manager records that secondary failure and suppresses
+                        # only it.
+                        with _PreservePrimaryObserverEscape(error, "RunPolicyEnded"):
+                            closer(error)
+            finally:
+                _run_lifecycle_closer.reset(token)
+
+    return wrapped
+
+
 class PolicyRunner:
     """Backend-agnostic policy execution against a ``SimEngine``.
 
@@ -1241,6 +1346,7 @@ class PolicyRunner:
         return None
 
     # run(): blocking policy execution
+    @_close_started_lifecycle_on_escape
     def run(
         self,
         robot_name: str,
@@ -1254,6 +1360,7 @@ class PolicyRunner:
         fast_mode: bool = False,
         video: VideoConfig | None = None,
         on_frame: OnFrame | None = None,
+        observer: RunPolicyObserver | None = None,
         max_onframe_failures: int | None = None,
         control_substeps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
@@ -1311,6 +1418,42 @@ class PolicyRunner:
                 after every ``send_action``. Public extension point - backends
                 layer in recording / telemetry / graceful-stop via this hook
                 without subclassing the runner.
+
+                This is the hook the BACKEND owns. There is one per rollout and
+                :meth:`~strands_robots.simulation.base.SimEngine.run_policy`
+                fills it from ``_make_run_policy_hook``, so passing one here
+                replaces cooperative cancellation, the trajectory mirror, mesh
+                step telemetry and dataset recording rather than adding to them.
+                Read-only consumers want ``observer``.
+            observer: Optional read-only rollout observer. Receives one
+                :class:`~strands_robots.simulation.observers.RunPolicyStarted`,
+                one :class:`~strands_robots.simulation.observers.RunPolicyStep`
+                per completed ``send_action`` call, and one
+                :class:`~strands_robots.simulation.observers.RunPolicyEnded` -
+                and reports what ``on_frame``'s signature cannot carry: the
+                backend's complete per-key ``send_action`` verdict (or
+                ``unknown`` on a coarse error), authoritative
+                ``observation_age_steps`` plus the narrower chunk-reuse flag,
+                and what the legacy hook did (including on the step it aborted,
+                which the legacy terminal count excludes). Must be ``None`` or
+                callable; another value raises ``ValueError`` before clocks,
+                ids, policy work, inference, or actions.
+
+                Additive and independent: it does not consume the backend's hook
+                slot, and installing one changes neither the actions applied, the
+                result payload's existing fields, nor the number of observations
+                sampled. Called synchronously on this thread, so a blocking
+                observer blocks the robot; payloads are borrowed rather than
+                copied. Ordinary ``Exception`` values and ``CooperativeStop``
+                are contained, so they never alter the rollout outcome or reach
+                the ``max_onframe_failures`` watchdog, which exists for a
+                recorder losing dataset frames rather than a visualiser that
+                cannot draw. Each contained failure is counted and reported as
+                ``observer_failures`` in the result json. Process-control and
+                cancellation ``BaseException`` classes propagate; if one is
+                already unwinding the rollout, it remains primary if terminal
+                observer dispatch raises another. See
+                :mod:`strands_robots.simulation.observers`.
             policy_kwargs: Optional per-call goal payload forwarded verbatim to
                 every ``policy.get_actions(obs, instruction, **policy_kwargs)``
                 call. This is the local-sim analogue of the mesh ``tell()``
@@ -1445,13 +1588,16 @@ class PolicyRunner:
             ``rtc_prefetch_hits``, ``rtc_prefetch_blocks``, ``rtc_avg_inference_ms``,
             ``rtc_max_inference_ms``) so latency masking is provable from the
             payload instead of from logs. It also carries the per-actuator
-            resolution stats - ``action_resolution_rate`` (a
-            ``{actuator_name: fraction_of_steps_driven}`` map) and
-            ``partial_action_failure_rate`` (the mean fraction of the robot's
-            DOF never driven; ``0.0`` == every actuator moved every step,
-            ``~0.83`` == only 1 of 6 actuators ever moved) - so a rollout that
-            silently drives only a subset of the robot's joints is visible
-            instead of looking like a clean ``success`` with a zero success-rate.
+            resolution stats - ``action_resolution_rate`` (an
+            ``{actuator_name: fraction_of_resolution-known_steps_driven}`` map)
+            and ``partial_action_failure_rate`` (the mean fraction of the robot's
+            DOF not confirmed driven across those known steps; ``0.0`` == every
+            actuator confirmed on every known step, ``~0.83`` == only 1 of 6).
+            Coarse backend errors are excluded from those denominators rather
+            than fabricated as misses and remain visible in ``action_errors``
+            and the result text. This makes a rollout that silently drives only
+            a subset of the robot's joints visible instead of looking like a
+            clean ``success`` with a zero success-rate.
 
             Fail-fast: if EVERY action step in the opening probe window
             (``_FAIL_FAST_PROBE_STEPS``, currently 3) drives zero actuators -
@@ -1464,6 +1610,12 @@ class PolicyRunner:
             is operational and runs to completion, surfaced via
             ``partial_action_failure_rate``.
         """
+        # Validate the observer before every rollout side effect. In particular,
+        # a direct caller must not get a UUID/clock anchor, a Started dispatch,
+        # policy reset/inference or an action from a value that cannot be called.
+        if observer_error := optional_callable_error(observer, "observer", "PolicyRunner.run"):
+            raise ValueError(observer_error)
+
         # A single rollout draws the policy's stochastic ops (VLA action-
         # chunk sampling, diffusion noise) from the unmanaged global RNG, so the
         # same scene + policy grasps on one run and misses on the next. When a
@@ -1615,7 +1767,7 @@ class PolicyRunner:
         # default (the loop ran its full horizon); the CooperativeStop handler
         # re-tags it "cancelled", a fired stop_when re-tags it "predicate",
         # and every error return reports "error".
-        stopped_reason = "budget"
+        stopped_reason: StoppedReason = "budget"
         stop_predicate_fired = False
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
@@ -1651,6 +1803,189 @@ class PolicyRunner:
         # this they fall back to a hardcoded rate and mis-blend the chunk
         # seam at any other frequency.
         policy.set_control_frequency(control_frequency)
+
+        # Read-only observer lane. Everything below is inert when ``observer is
+        # None``: the counters stay at zero, ``_emit_event`` returns immediately,
+        # and no clock, id or sim-time read is performed - so a rollout that did
+        # not ask for the lane pays for nothing but that one identity check.
+        #
+        # ``uuid4`` rather than a counter because a run_id has to be unique
+        # across the sequential rollouts of a multi-episode ``run_policy`` AND
+        # across the concurrent ones of ``start_policy`` on different robots,
+        # and only one of those is visible from here.
+        _obs_run_id = uuid.uuid4().hex if observer is not None else ""
+        _obs_seq = 0
+        _obs_failures = 0
+        _obs_started = False
+        # Completed ``send_action`` calls. Deliberately NOT ``step_count``: that
+        # one is incremented after the legacy hook, so it excludes a call whose
+        # action the hook cancelled or lost a dataset frame on. A coarse backend
+        # error may leave physical application unknown, which is why the event's
+        # resolution is authoritative rather than this count.
+        _applied_actions = 0
+        # One (wall, monotonic) anchor for the whole rollout. Event ORDER comes
+        # from the monotonic clock so an NTP correction or a ``date -s`` mid-
+        # rollout cannot reorder the stream, and the wall-clock label is derived
+        # from the anchor rather than re-read, so it cannot disagree with it.
+        _obs_anchor_utc_ns = time.time_ns() if observer is not None else 0
+        _obs_anchor_mono_ns = time.monotonic_ns() if observer is not None else 0
+
+        def _emit_event(build: Callable[[int, int, int], RunPolicyEvent]) -> None:
+            """Dispatch one observer event with explicit exception boundaries.
+
+            Ordinary exceptions and ``CooperativeStop`` are counted and
+            contained. Process-control and cancellation ``BaseException``
+            classes propagate so observer dispatch can terminate the call.
+
+            ``build`` receives ``(event_seq, monotonic_ns, utc_ns)`` and returns
+            the event, so the sequence and both clocks are assigned in one place
+            and a caller cannot get them out of step.
+
+            The sequence number is consumed BEFORE dispatch, so an event whose
+            observer raised leaves a visible hole rather than silently renumbering
+            the ones after it.
+
+            Naming ``CooperativeStop`` is the reason this helper exists at all:
+            it is a ``BaseException`` precisely so a hook's broad
+            ``except Exception`` cannot swallow a cancellation, so without it
+            here an observer could raise one and cancel a rollout it is only
+            supposed to watch. The tuple is the smallest superset that does
+            that job. ``except BaseException`` would also have done it, and it
+            covered three more signals that are not an observer's to absorb:
+            ``GeneratorExit`` and ``asyncio.CancelledError`` were counted as
+            observer telemetry failures and dropped, on the same reasoning that
+            already re-raises ``KeyboardInterrupt`` / ``SystemExit`` just below.
+            None of those four is an ``Exception`` subclass, so this tuple lets
+            them propagate by construction; the explicit re-raise is kept as a
+            guard against a future widening of the clause under it.
+            """
+            nonlocal _obs_seq, _obs_failures
+            if observer is None:
+                return
+            seq = _obs_seq
+            _obs_seq += 1
+            mono = time.monotonic_ns()
+            utc = _obs_anchor_utc_ns + (mono - _obs_anchor_mono_ns)
+            try:
+                observer(build(seq, mono, utc))
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except (CooperativeStop, Exception) as e:
+                _obs_failures += 1
+                logger.warning(
+                    "run_policy observer raised on event %d (%d failure(s) so far); "
+                    "the rollout is unaffected and the stream now has a hole: %r",
+                    seq,
+                    _obs_failures,
+                    e,
+                )
+
+        def _emit_ended(
+            *,
+            outcome: RunPolicyOutcome,
+            stopped_reason: StoppedReason,
+            error: BaseException | None = None,
+        ) -> None:
+            """Close the observer lifecycle. Idempotent, and a no-op if never opened.
+
+            Clearing ``_obs_started`` is what makes "exactly one Ended per
+            Started" a property of the code rather than of the call sites: the
+            terminal assembly has three exits and the error handler a fourth, and
+            a second call from any of them is dropped here instead of emitting a
+            duplicate close.
+
+            A rollout refused in pre-flight never opened a lifecycle, so there is
+            nothing to close and this returns immediately - which is what lets a
+            consumer treat an unmatched Started as a real anomaly.
+            """
+            nonlocal _obs_started
+            if not _obs_started:
+                return
+            _obs_started = False
+            _emit_event(
+                lambda seq, mono, utc: RunPolicyEnded(
+                    schema_version=_OBSERVER_SCHEMA_VERSION,
+                    run_id=_obs_run_id,
+                    event_seq=seq,
+                    monotonic_ns=mono,
+                    utc_ns=utc,
+                    outcome=outcome,
+                    stopped_reason=stopped_reason,
+                    applied_actions=_applied_actions,
+                    legacy_steps_used=step_count,
+                    action_errors=_action_errors,
+                    elapsed_s=time.monotonic() - start_mono,
+                    error_type=type(error).__name__ if error is not None else None,
+                    # Truncated: the full traceback is already in the log via
+                    # ``logger.exception``, and an event is not the place to ship
+                    # an unbounded string to a socket.
+                    error_message=str(error)[:512] if error is not None else None,
+                    observer_failures=_obs_failures,
+                )
+            )
+
+        def _emit_step(
+            *,
+            observation: dict[str, Any],
+            action: dict[str, Any],
+            observation_is_chunk_reused: bool,
+            observation_age_steps: int,
+            action_resolution: ActionResolution,
+            applied_action_keys: tuple[str, ...],
+            unresolved_action_keys: tuple[str, ...],
+            legacy_hook_outcome: LegacyHookOutcome,
+            primary_error: BaseException | None,
+        ) -> None:
+            """Emit one Step event.
+
+            Named rather than written as a ``lambda`` at the call site because
+            that call site is a ``finally`` block, and ``py/exit-from-finally``
+            reads a lambda body's implicit return as a ``return`` leaving the
+            block it sits in. That block contains no ``return`` / ``break`` /
+            ``continue`` of its own, so the report was about the closure's
+            position rather than about any control flow, and moving the closure
+            out of the block is what answers it. It also leaves the ``finally``
+            holding a single call, which is the shape :func:`_emit_ended`
+            already has.
+
+            The three values read from the enclosing scope - the applied-action
+            index, the elapsed duration and the sim clock - stay inside the
+            closure so they are still sampled when the event is built rather
+            than when this is called; ``_emit_event`` invokes the builder
+            synchronously, so both read the same values either way.
+            """
+
+            def build_step(seq: int, mono: int, utc: int) -> RunPolicyStep:
+                return RunPolicyStep(
+                    schema_version=_OBSERVER_SCHEMA_VERSION,
+                    run_id=_obs_run_id,
+                    event_seq=seq,
+                    monotonic_ns=mono,
+                    utc_ns=utc,
+                    applied_action_index=_applied_actions - 1,
+                    legacy_step_index=step_count,
+                    observation=observation,
+                    action=action,
+                    observation_is_chunk_reused=observation_is_chunk_reused,
+                    observation_age_steps=observation_age_steps,
+                    action_resolution=action_resolution,
+                    applied_action_keys=applied_action_keys,
+                    unresolved_action_keys=unresolved_action_keys,
+                    elapsed_s=time.monotonic() - start_mono,
+                    sim_time_s=self._cached_sim_time(),
+                    legacy_hook_outcome=legacy_hook_outcome,
+                )
+
+            if primary_error is None:
+                _emit_event(build_step)
+            else:
+                # The call site explicitly proves the legacy hook did not
+                # complete. Do not use ambient ``sys.exception()`` here: a run
+                # invoked inside a caller's unrelated ``except`` inherits that
+                # handled exception even though no hook failure is unwinding.
+                with _PreservePrimaryObserverEscape(primary_error, "RunPolicyStep"):
+                    _emit_event(build_step)
+
         # Initialize BEFORE try so CooperativeStop never sees unbound names.
         # ``time.monotonic()``: the only thing derived from this base is how
         # long the rollout ran, and a duration is measured rather than
@@ -1662,6 +1997,10 @@ class PolicyRunner:
         # future reader does not reach for ``time.time()`` again.
         start_mono = time.monotonic()
         step_count = 0
+        # Bound before ``try`` for the same reason ``step_count`` is: the terminal
+        # observer event reports it, and setup inside the try (substep derivation,
+        # actuator discovery) can raise before the loop assigns it.
+        _action_errors = 0  # count send_action failures (unresolved keys)
         # Bound before the rollout so the ``except CooperativeStop`` handler and
         # the ``_apply`` closure never see an unbound name, the same reason
         # ``start_mono`` is bound above.
@@ -1711,6 +2050,33 @@ class PolicyRunner:
 
                     ticker = pacing_resources.enter_context(_Ticker(1.0 / control_frequency))
 
+                # Open the observer lifecycle. Emitted here rather than at the top of
+                # ``run`` so it describes a rollout that will actually begin: every
+                # pre-flight refusal above (horizon, seed, RTC deadline, callback
+                # limit, video path) has already raised or returned, so a caller can
+                # rely on "a Started is always followed by an Ended".
+                _obs_started = observer is not None
+                if _obs_started:
+                    _run_lifecycle_closer.set(
+                        lambda error: _emit_ended(outcome="error", stopped_reason="error", error=error)
+                    )
+                _emit_event(
+                    lambda seq, mono, utc: RunPolicyStarted(
+                        schema_version=_OBSERVER_SCHEMA_VERSION,
+                        run_id=_obs_run_id,
+                        event_seq=seq,
+                        monotonic_ns=mono,
+                        utc_ns=utc,
+                        robot_name=robot_name,
+                        policy=type(policy).__name__,
+                        instruction=instruction,
+                        control_frequency=float(control_frequency),
+                        action_horizon=int(action_horizon),
+                        total_steps=int(total_steps),
+                        async_rtc=bool(async_rtc),
+                    )
+                )
+
                 # Control-rate substepping: a position-servo robot needs the physics
                 # to advance for the FULL control period (1/control_frequency) after
                 # each action so the joints actually track the commanded target
@@ -1728,7 +2094,6 @@ class PolicyRunner:
                     control_frequency,
                     n_substeps,
                 )
-                _action_errors = 0  # count send_action failures (unresolved keys)
                 # Per-actuator resolution tracking (issue #165). Init a counter to 0
                 # for EVERY robot actuator so a never-driven joint surfaces as
                 # resolution_rate 0.0 in the result rather than being absent from the
@@ -1739,8 +2104,11 @@ class PolicyRunner:
                 except Exception:  # noqa: BLE001 - stats are best-effort, never fatal
                     _robot_actuators = []
                 _actuator_resolved: dict[str, int] = dict.fromkeys(_robot_actuators, 0)
+                _known_resolution_steps = 0
                 _total_failure_steps = 0
+                _coarse_failure_steps = 0
                 _last_unresolved: list[str] = []
+                _last_coarse_error = ""
 
                 onframe_failure_limit = (
                     max_onframe_failures if max_onframe_failures is not None else _MAX_CONSECUTIVE_ONFRAME_FAILURES
@@ -1751,97 +2119,188 @@ class PolicyRunner:
                 # the async-RTC pipeline so they send, record, count and pace
                 # identically - only the chunk-ACQUISITION strategy differs between
                 # the two paths.
-                def _apply(observation: dict[str, Any], action_dict: dict[str, Any]) -> None:
+                def _apply(
+                    observation: dict[str, Any],
+                    action_dict: dict[str, Any],
+                    *,
+                    observation_is_chunk_reused: bool = False,
+                    observation_age_steps: int = 0,
+                ) -> None:
                     nonlocal step_count, _action_errors, consecutive_onframe_failures
-                    nonlocal _total_failure_steps, _last_unresolved
+                    nonlocal _total_failure_steps, _coarse_failure_steps, _last_unresolved
+                    nonlocal _last_coarse_error, _applied_actions, _known_resolution_steps
 
                     _send_result = self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                    # ``send_action`` has returned. Count the call here rather than
+                    # beside ``step_count`` below so the tally survives a legacy hook
+                    # that aborts this step; the resolution records whether physical
+                    # application is known.
+                    _applied_actions += 1
                     _is_error = isinstance(_send_result, dict) and _send_result.get("status") == "error"
                     # Resolve which of the robot's actuators this step actually drove
-                    # and which emitted keys no actuator could absorb. On the success
-                    # path send_action returns no json block, so every emitted key
-                    # resolved; on the error path the block enumerates applied /
-                    # unresolved keys.
-                    _unresolved: list[str] = []
+                    # only when the backend gives a COMPLETE per-key breakdown. A
+                    # coarse rejection can still feed the operational fail-fast below,
+                    # but it cannot prove which keys reached physical state.
+                    _applied: list[Any] = []
+                    _unresolved: list[Any] = []
+                    _has_complete_breakdown = False
                     if _is_error:
                         _action_errors += 1
                         _json = _extract_result_json(_send_result)
-                        if _json is not None:
-                            _unresolved = list(_json.get("unresolved_keys", []))
-                            _applied = list(_json.get("applied", []))
-                        else:
-                            # Error without a per-key breakdown (e.g. missing world,
-                            # vector length mismatch): treat the whole step as a
-                            # 100% failure so it counts toward the fail-fast probe.
-                            _applied = []
-                            if isinstance(action_dict, dict):
-                                _unresolved = list(action_dict.keys())
+                        if _json is not None and isinstance(action_dict, dict):
+                            _raw_applied = _json.get("applied")
+                            _raw_unresolved = _json.get("unresolved_keys")
+                            if isinstance(_raw_applied, (list, tuple)) and isinstance(_raw_unresolved, (list, tuple)):
+                                _candidate_applied = list(_raw_applied)
+                                _candidate_unresolved = list(_raw_unresolved)
+                                _emitted_keys = set(action_dict)
+                                try:
+                                    _applied_keys = set(_candidate_applied)
+                                    _unresolved_keys = set(_candidate_unresolved)
+                                except TypeError:
+                                    pass
+                                else:
+                                    _has_complete_breakdown = (
+                                        len(_applied_keys) == len(_candidate_applied)
+                                        and len(_unresolved_keys) == len(_candidate_unresolved)
+                                        and _applied_keys.isdisjoint(_unresolved_keys)
+                                        and _applied_keys | _unresolved_keys == _emitted_keys
+                                    )
+                                    if _has_complete_breakdown:
+                                        _applied = _candidate_applied
+                                        _unresolved = _candidate_unresolved
+                        if not _has_complete_breakdown:
+                            _coarse_failure_steps += 1
+                            if isinstance(_send_result, dict):
+                                _last_coarse_error = "; ".join(
+                                    str(block["text"])
+                                    for block in _send_result.get("content", [])
+                                    if isinstance(block, dict) and "text" in block
+                                )
                     elif isinstance(action_dict, dict):
                         _applied = list(action_dict)
                     else:
                         # A numeric vector binds positionally to every joint.
                         _applied = list(_robot_actuators)
-                    for _name in _applied:
-                        if _name in _actuator_resolved:
-                            _actuator_resolved[_name] += 1
-                    # A step is a 100%-failure when the policy emitted keys but NONE
-                    # resolved to an actuator (the robot did not move at all). A
-                    # PARTIAL failure (some keys resolve) is operational and runs to
-                    # completion -- reported via partial_action_failure_rate.
-                    if _is_error and not _applied:
+                    # Explicit all-unresolved breakdowns and coarse atomic refusals
+                    # both make a rollout operationally dead and feed the existing
+                    # probe. Only the former proves that no key was applied; coarse
+                    # errors remain ``unknown`` in observer telemetry.
+                    if _is_error and (not _has_complete_breakdown or not _applied):
                         _total_failure_steps += 1
                         if _unresolved:
-                            _last_unresolved = _unresolved
+                            _last_unresolved = [str(key) for key in _unresolved]
 
-                    if on_frame is not None:
-                        try:
-                            on_frame(step_count, observation, action_dict)
-                            consecutive_onframe_failures = 0
-                        except CooperativeStop:
-                            # Backend (e.g. MuJoCo) signalled a graceful stop.
-                            raise
-                        except RecordingFrameError:
-                            # A frame the dataset recorder could not write is data
-                            # loss, not telemetry: the episode on disk is already
-                            # shorter than this rollout. Never counted against the
-                            # telemetry tolerance below, which resets on every
-                            # success and so would let an intermittent recorder
-                            # failure truncate the dataset without ever tripping.
-                            raise
-                        except Exception as e:
-                            # on_frame is user-provided telemetry - never fatal
-                            # *per call*. But if it fails on every step, a 500-
-                            # step episode completes "successfully" with zero
-                            # frames recorded and the dataset is silently empty.
-                            # Count consecutive failures and fail the episode
-                            # after ``onframe_failure_limit`` in a row. See GH #117.
-                            consecutive_onframe_failures += 1
-                            logger.warning(
-                                "on_frame hook failed (%d/%d consecutive): %s",
-                                consecutive_onframe_failures,
-                                onframe_failure_limit,
-                                e,
+                    # The legacy hook runs inside a ``try/finally`` whose ONLY purpose
+                    # is the observer emission below. Nothing about the hook's own
+                    # behaviour changes: each ``except`` re-raises exactly what it
+                    # raised before, so the exception type, its traceback and its
+                    # ``__cause__`` reach the outer handler unchanged - the ``finally``
+                    # merely runs first. That is what lets the lane report the step a
+                    # cancellation or a lost dataset frame aborts on, which the legacy
+                    # accounting below (``step_count += 1``) deliberately excludes.
+                    _legacy_outcome: LegacyHookOutcome = "absent"
+                    _legacy_hook_completed = False
+                    try:
+                        if on_frame is not None:
+                            try:
+                                on_frame(step_count, observation, action_dict)
+                                consecutive_onframe_failures = 0
+                                _legacy_outcome = "ok"
+                            except CooperativeStop:
+                                # Backend (e.g. MuJoCo) signalled a graceful stop.
+                                _legacy_outcome = "cancelled"
+                                raise
+                            except RecordingFrameError:
+                                # A frame the dataset recorder could not write is data
+                                # loss, not telemetry: the episode on disk is already
+                                # shorter than this rollout. Never counted against the
+                                # telemetry tolerance below, which resets on every
+                                # success and so would let an intermittent recorder
+                                # failure truncate the dataset without ever tripping.
+                                _legacy_outcome = "recording_error"
+                                raise
+                            except Exception as e:
+                                # on_frame is user-provided telemetry - never fatal
+                                # *per call*. But if it fails on every step, a 500-
+                                # step episode completes "successfully" with zero
+                                # frames recorded and the dataset is silently empty.
+                                # Count consecutive failures and fail the episode
+                                # after ``onframe_failure_limit`` in a row. See GH #117.
+                                _legacy_outcome = "error"
+                                consecutive_onframe_failures += 1
+                                logger.warning(
+                                    "on_frame hook failed (%d/%d consecutive): %s",
+                                    consecutive_onframe_failures,
+                                    onframe_failure_limit,
+                                    e,
+                                )
+                                if consecutive_onframe_failures >= onframe_failure_limit:
+                                    raise RuntimeError(
+                                        f"on_frame hook failed {onframe_failure_limit} times in a row; "
+                                        f"aborting episode to avoid silent dataset corruption. "
+                                        f"Last error: {e!r}"
+                                    ) from e
+                        _legacy_hook_completed = True
+                    finally:
+                        if observer is not None:
+                            # Normalise the backend's answer once, here, so no consumer
+                            # has to parse a ``send_action`` envelope to learn whether
+                            # the robot moved. "partial" is the case a single aggregate
+                            # error count hides: the step IS an error and the robot DID
+                            # move, so a rollout can look healthy while driving one
+                            # joint of six.
+                            if not _is_error:
+                                _resolution: ActionResolution = "full"
+                            elif not _has_complete_breakdown:
+                                _resolution = "unknown"
+                            elif _applied:
+                                _resolution = "partial"
+                            else:
+                                _resolution = "none"
+                            _emit_step(
+                                observation=observation,
+                                action=action_dict,
+                                observation_is_chunk_reused=observation_is_chunk_reused,
+                                observation_age_steps=observation_age_steps,
+                                action_resolution=_resolution,
+                                applied_action_keys=tuple(str(k) for k in _applied),
+                                unresolved_action_keys=tuple(str(k) for k in _unresolved),
+                                legacy_hook_outcome=_legacy_outcome,
+                                primary_error=None if _legacy_hook_completed else sys.exception(),
                             )
-                            if consecutive_onframe_failures >= onframe_failure_limit:
-                                raise RuntimeError(
-                                    f"on_frame hook failed {onframe_failure_limit} times in a row; "
-                                    f"aborting episode to avoid silent dataset corruption. "
-                                    f"Last error: {e!r}"
-                                ) from e
 
                     step_count += 1
+                    # Aggregate action-health rates retain the legacy completed-step
+                    # boundary (a hook-aborted call is excluded). A coarse answer is
+                    # excluded too: empty applied keys mean "unknown" there, not a
+                    # measured miss. Structured partial/none and successful answers
+                    # are resolution-known and form the denominator.
+                    if not _is_error or _has_complete_breakdown:
+                        _known_resolution_steps += 1
+                        for _name in _applied:
+                            if _name in _actuator_resolved:
+                                _actuator_resolved[_name] += 1
 
-                    # Fail fast: if EVERY step of the opening probe window drove zero
-                    # actuators, the policy's output keys cannot match this robot, so
-                    # the rollout is structurally dead -- raise now instead of running
-                    # the remaining steps (and inference / recording I/O). Once any
-                    # step resolves a key, _total_failure_steps < step_count forever
-                    # and this never fires.
+                    # Fail fast when every opening probe step either explicitly
+                    # resolved no keys or was atomically refused without a complete
+                    # breakdown. The coarse case is operationally just as dead, but
+                    # does not justify claiming which physical state changed.
                     if step_count >= _FAIL_FAST_PROBE_STEPS and _total_failure_steps == step_count:
                         try:
                             _valid = self.sim.robot_action_keys(robot_name)
                         except Exception:  # noqa: BLE001
                             _valid = _robot_actuators
+                        if _coarse_failure_steps:
+                            raise RuntimeError(
+                                f"All of the first {step_count} action steps were rejected on "
+                                f"'{robot_name}' without confirming any applied actuator; physical "
+                                f"application is unknown for {_coarse_failure_steps} coarse error(s). "
+                                f"Last backend error: {_last_coarse_error or 'unavailable'}. "
+                                f"Explicit unresolved keys: {_last_unresolved}. Valid actuator/joint "
+                                f"names: {_valid}. Inspect the expected keys via "
+                                f"sim.get_features(robot_name='{robot_name}')."
+                            )
                         raise RuntimeError(
                             f"All of the first {step_count} action steps had 100% "
                             f"unresolved keys on '{robot_name}' -- the robot has not "
@@ -1972,6 +2431,7 @@ class PolicyRunner:
                     executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rtc-prefetch")
                     try:
                         cur_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
+                        cur_obs_base_age = 0
                         cur_chunk = _query_chunk(cur_obs)
                         rtc_chunks_acquired += 1
                         if not cur_chunk:
@@ -1980,6 +2440,7 @@ class PolicyRunner:
                         prefetch_trigger = max(1, len(cur_chunk) // 2)
                         prefetch: Future[list[dict[str, Any]]] | None = None
                         prefetch_obs: dict[str, Any] | None = None
+                        prefetch_obs_base_age = 0
 
                         while step_count < total_steps:
                             if idx >= len(cur_chunk):
@@ -1988,12 +2449,15 @@ class PolicyRunner:
                                     cur_chunk = _swap_in(prefetch)
                                     if prefetch_obs is not None:
                                         cur_obs = prefetch_obs
+                                        cur_obs_base_age = prefetch_obs_base_age
                                     prefetch = None
                                     prefetch_obs = None
+                                    prefetch_obs_base_age = 0
                                 else:
                                     # Chunk was too short to trigger a prefetch;
                                     # fall back to a synchronous re-query.
                                     cur_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
+                                    cur_obs_base_age = 0
                                     cur_chunk = _query_chunk(cur_obs)
                                 rtc_chunks_acquired += 1
                                 if not cur_chunk:
@@ -2007,6 +2471,7 @@ class PolicyRunner:
                                         "synchronous re-query before erroring."
                                     )
                                     cur_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
+                                    cur_obs_base_age = 0
                                     cur_chunk = _query_chunk(cur_obs)
                                     rtc_chunks_acquired += 1
                                     if not cur_chunk:
@@ -2028,7 +2493,8 @@ class PolicyRunner:
                                 # actually takes in wall-clock time (a slow inference
                                 # just stalls the loop; the robot does not advance
                                 # past the chunk end while waiting).
-                                observed_delay = max(0, len(cur_chunk) - prefetch_trigger)
+                                observed_delay = max(0, len(cur_chunk) - idx)
+                                prefetch_obs_base_age = observed_delay
                                 prefetch = executor.submit(_query_chunk, prefetch_obs, observed_delay)
 
                             # When recording, the chunk observation (the initial
@@ -2042,7 +2508,16 @@ class PolicyRunner:
                                 step_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                             else:
                                 step_obs = cur_obs
-                            _apply(step_obs, cur_chunk[idx])
+                            # ``idx > 0`` means this action is replayed from the chunk
+                            # while ``cur_obs`` still holds the snapshot the chunk was
+                            # inferred from, so the observation is stale for it. A
+                            # recording refresh above makes it fresh again.
+                            _apply(
+                                step_obs,
+                                cur_chunk[idx],
+                                observation_is_chunk_reused=idx > 0 and not _record_per_step_obs,
+                                observation_age_steps=0 if _record_per_step_obs else cur_obs_base_age + idx,
+                            )
                             idx += 1
                             # Semantic early return: checked after EVERY applied
                             # action, so the stop lands within one control step of
@@ -2076,7 +2551,12 @@ class PolicyRunner:
                                 step_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                             else:
                                 step_obs = observation
-                            _apply(step_obs, action_dict)
+                            _apply(
+                                step_obs,
+                                action_dict,
+                                observation_is_chunk_reused=chunk_idx > 0 and not _record_per_step_obs,
+                                observation_age_steps=0 if _record_per_step_obs else chunk_idx,
+                            )
                             # Semantic early return: checked after EVERY applied
                             # action (same cadence as the benchmark eval loop), so
                             # the remaining actions of the chunk are dropped as
@@ -2095,11 +2575,19 @@ class PolicyRunner:
                 if vwriter is not None:
                     vwriter.close()
                 logger.exception("PolicyRunner.run failed")
+                _emit_ended(outcome="error", stopped_reason="error", error=e)
+                _error_json: dict[str, Any] = {
+                    **_rtc_telemetry(),
+                    "stopped_reason": "error",
+                    "steps_used": step_count,
+                }
+                if observer is not None:
+                    _error_json["observer_failures"] = _obs_failures
                 return {
                     "status": "error",
                     "content": [
                         {"text": f"Policy failed: {e}"},
-                        {"json": {**_rtc_telemetry(), "stopped_reason": "error", "steps_used": step_count}},
+                        {"json": _error_json},
                     ],
                 }
 
@@ -2208,23 +2696,26 @@ class PolicyRunner:
             payload["video_fps"] = vwriter.write_fps if wrote_video else None
         payload.update(_rtc_telemetry())
 
-        # Per-actuator resolution stats (issue #165): the fraction of steps each
-        # of the robot's actuators was actually driven. A joint stuck at 0.0
-        # means the policy never produced a key that resolved to it (wrong name /
-        # missing DOF), so a caller can see exactly which actuators the policy is
-        # and is not driving -- not just a single aggregate error count.
-        if step_count > 0 and _robot_actuators:
+        # Per-actuator resolution stats (issue #165): fractions over the steps
+        # whose backend answer establishes physical application. Coarse errors
+        # are excluded from this denominator rather than fabricated as misses;
+        # ``action_errors`` and the human diagnostic still expose them.
+        if _known_resolution_steps > 0 and _robot_actuators:
             action_resolution_rate = {
-                name: round(_actuator_resolved.get(name, 0) / step_count, 4) for name in _robot_actuators
+                name: round(_actuator_resolved.get(name, 0) / _known_resolution_steps, 4) for name in _robot_actuators
             }
-            # Aggregate: the mean fraction of the robot's DOF NOT driven across
-            # the rollout. 0.0 == every actuator driven every step; ~0.83 == only
-            # 1 of 6 actuators ever moved. This is per-actuator coverage, distinct
-            # from action_errors (a step-level status count): a policy that drives
-            # 1 of 6 joints every step returns status=success with action_errors=0
-            # yet a partial_action_failure_rate of ~0.83.
+            # Aggregate: the mean fraction of the robot's DOF NOT confirmed
+            # driven across resolution-known steps. 0.0 == every actuator was
+            # confirmed driven on every known step; ~0.83 == only 1 of 6 was.
+            # This is per-actuator coverage, distinct from action_errors (a
+            # step-level backend-error count): a policy that drives 1 of 6 joints
+            # every step returns status=success with action_errors=0 yet a
+            # partial_action_failure_rate of ~0.83.
             _driven = sum(_actuator_resolved.get(n, 0) for n in _robot_actuators)
-            partial_action_failure_rate = round(1.0 - _driven / (len(_robot_actuators) * step_count), 4)
+            partial_action_failure_rate = round(
+                1.0 - _driven / (len(_robot_actuators) * _known_resolution_steps),
+                4,
+            )
             payload["action_resolution_rate"] = action_resolution_rate
             payload["partial_action_failure_rate"] = partial_action_failure_rate
             # Promote a high-but-not-total under-actuation to the human text so a
@@ -2239,28 +2730,45 @@ class PolicyRunner:
             payload["action_resolution_rate"] = {}
             payload["partial_action_failure_rate"] = 0.0
 
-        # If EVERY step was a TOTAL failure (the policy emitted keys but none
-        # resolved to an actuator), the robot never moved -- report this as an
-        # error rather than a false success. This mirrors the fail-fast probe
-        # and must key off ``_total_failure_steps``, NOT ``_action_errors``:
-        # ``_action_errors`` also counts PARTIAL steps (some keys resolve, the
-        # robot moves), so a policy that drives valid keys plus one extra
-        # unresolved key every step (e.g. a 7-DOF-trained policy on a 6-DOF arm)
-        # would otherwise be misreported as "the robot did not move". A partial
-        # rollout is operational -- surfaced via partial_action_failure_rate.
+        # A rollout where every step either explicitly resolved no key or was
+        # coarsely refused is not a usable success. For coarse errors, preserve
+        # the operational no-drive fail-fast without asserting that physical
+        # state is known.
         if _total_failure_steps >= step_count and step_count > 0:
-            text += (
-                f"\n\nALL {step_count} action steps had 100% unresolved keys "
-                f"-- the robot did not move. Check that the policy's output keys "
-                f"match the robot's actuator names."
-            )
+            if _coarse_failure_steps:
+                text += (
+                    f"\n\nALL {step_count} action steps failed to confirm an applied actuator; "
+                    f"physical application is unknown for {_coarse_failure_steps} coarse "
+                    f"backend error(s). Last backend error: "
+                    f"{_last_coarse_error or 'unavailable'}."
+                )
+            else:
+                text += (
+                    f"\n\nALL {step_count} action steps had 100% unresolved keys "
+                    f"-- the robot did not move. Check that the policy's output keys "
+                    f"match the robot's actuator names."
+                )
             # An error result always reports stopped_reason="error": the
             # rollout may have run its full budget, but the outcome is not a
             # retryable "budget" completion.
             payload["stopped_reason"] = "error"
+            _emit_ended(outcome="error", stopped_reason="error")
+            if observer is not None:
+                payload["observer_failures"] = _obs_failures
             return {"status": "error", "content": [{"text": text}, {"json": payload}]}
         if _action_errors > 0:
-            text += f"\n\n{_action_errors}/{step_count} action steps had unresolved keys."
+            if _coarse_failure_steps == 0:
+                text += f"\n\n{_action_errors}/{step_count} action steps had unresolved keys."
+            elif _coarse_failure_steps == _action_errors:
+                text += f"\n\n{_action_errors}/{step_count} action steps reported coarse backend errors."
+            else:
+                text += f"\n\n{_action_errors}/{step_count} action steps had unresolved keys or coarse backend errors."
+        _emit_ended(outcome="success", stopped_reason=stopped_reason)
+        # Read AFTER the terminal event so a failure dispatching that event is
+        # included too - the payload is the number a caller checks, so it must be
+        # the complete one.
+        if observer is not None:
+            payload["observer_failures"] = _obs_failures
         return {"status": "success", "content": [{"text": text}, {"json": payload}]}
 
     # replay(): replay a LeRobotDataset episode
@@ -3652,38 +4160,56 @@ class PolicyRunner:
 
     # Helpers
 
-    def _maybe_sim_time(self) -> float | None:
-        """Best-effort read of sim time from any backend that exposes it.
+    def _cached_sim_time(self) -> float | None:
+        """Read a cached finite simulation clock without backend I/O.
 
-        Tries two paths:
-          1. ``sim._world.sim_time`` - fast path for backends that keep a
-             structured world object (MuJoCo, and any other backend using
-             ``strands_robots.simulation.models.SimWorld``).
-          2. ``sim.get_state()`` fallback for backends that only expose the
-             status-dict shape. If the dict's ``json`` block (or top level)
-             has a ``sim_time`` key, we return it.
+        Prefer ``sim._world.sim_time`` for structured-world backends, then the
+        engine-level ``sim._sim_time`` used by Isaac-like implementations. Step
+        observer telemetry uses this helper because ``get_state`` may synchronize
+        a remote backend or mutate a test double, putting hidden work on every
+        control step.
         """
         world = getattr(self.sim, "_world", None)
-        if world is not None:
-            t = getattr(world, "sim_time", None)
-            if isinstance(t, (int, float)):
-                return float(t)
+        candidates = (getattr(world, "sim_time", None), getattr(self.sim, "_sim_time", None))
+        for value in candidates:
+            if isinstance(value, numbers.Real) and not isinstance(value, bool):
+                numeric = float(value)
+                if math.isfinite(numeric):
+                    return numeric
+        return None
+
+    def _maybe_sim_time(self) -> float | None:
+        """Best-effort terminal sim time, preserving the legacy state fallback.
+
+        The final result is assembled once per rollout, so backends without a
+        cached clock retain the established ``get_state`` lookup. Per-Step
+        observer events use :meth:`_cached_sim_time` and never take this path.
+        """
+        cached = self._cached_sim_time()
+        if cached is not None:
+            return cached
 
         get_state = getattr(self.sim, "get_state", None)
-        if get_state is None:
+        if not callable(get_state):
             return None
         try:
             state = get_state()
         except Exception:
             return None
-        if isinstance(state, dict):
-            if "sim_time" in state:
-                return float(state["sim_time"])
-            for blk in state.get("content", []):
-                if isinstance(blk, dict) and isinstance(blk.get("json"), dict):
-                    t = blk["json"].get("sim_time")
-                    if isinstance(t, (int, float)):
-                        return float(t)
+        if not isinstance(state, dict):
+            return None
+
+        candidates: list[Any] = [state.get("sim_time")]
+        content = state.get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and isinstance(block.get("json"), dict):
+                    candidates.append(block["json"].get("sim_time"))
+        for value in candidates:
+            if isinstance(value, numbers.Real) and not isinstance(value, bool):
+                numeric = float(value)
+                if math.isfinite(numeric):
+                    return numeric
         return None
 
     def _require_default_robot(self) -> str:
@@ -3727,6 +4253,11 @@ class PolicyRunner:
 __all__ = [
     "PolicyRunner",
     "OnFrame",
+    "RunPolicyEnded",
+    "RunPolicyEvent",
+    "RunPolicyObserver",
+    "RunPolicyStarted",
+    "RunPolicyStep",
     "SuccessFn",
     "CooperativeStop",
     "TrajectoryStep",

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -3035,6 +3035,28 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str, *,
     )
 
 
+def optional_callable_error(value: Any, param: str, context: str) -> str | None:
+    """Return an error message unless ``value`` is callable or ``None``.
+
+    Shared by public facades and their directly-drivable implementation layers
+    for optional callback parameters.  ``callable`` is deliberately the whole
+    domain: signatures are not inspected, because builtins, decorated callables
+    and objects with an opaque ``__call__`` cannot be checked reliably before
+    invocation.
+
+    Args:
+        value: The optional callback supplied by the caller.
+        param: Parameter name, used in the refusal text.
+        context: Calling surface, used as the message prefix.
+
+    Returns:
+        ``None`` for ``None`` or a callable, otherwise the refusal text.
+    """
+    if value is None or callable(value):
+        return None
+    return f"{context}: {param} must be callable or None, got {_refusal_repr(value)}."
+
+
 def boolean_flag_error(value: Any, param: str, context: str) -> str | None:
     """Return an error message unless *value* is a python or numpy boolean.
 

--- a/tests/simulation/mujoco/test_action_resolution_fail_fast.py
+++ b/tests/simulation/mujoco/test_action_resolution_fail_fast.py
@@ -220,11 +220,13 @@ class TestFailFastOnDictVectorValuedKey:
 
     The key itself may be a perfectly valid actuator name; it is the value shape
     that is wrong, so nothing on that step drives the robot. The runner must
-    still count the whole step as a 100% failure - crediting the dict's own keys
-    as unresolved from the unstructured error - so the fail-fast probe surfaces a
-    structurally-dead rollout instead of silently running the full episode with
-    an arm that never moves. Pre-pin, this unstructured-error branch (dict form,
-    no json breakdown) was the one action-failure path with no coverage.
+    still count the whole step as an operational probe failure so the fail-fast
+    surfaces a structurally-dead rollout instead of silently running the full
+    episode with an arm that never receives an accepted command. It must not,
+    however, fabricate ``unresolved_keys`` from the input: physical application
+    remains unknown without a complete backend breakdown. Pre-pin, this
+    unstructured-error branch (dict form, no json breakdown) was the one
+    action-failure path with no coverage.
     """
 
     def test_dict_with_vector_valued_key_fails_fast_within_probe_window(self, sim):
@@ -244,8 +246,27 @@ class TestFailFastOnDictVectorValuedKey:
         # Bailed in the probe window; did NOT run the full 50-step episode.
         assert "first 3 action steps" in text
         assert "50 steps" not in text
-        # The unstructured error is attributed to the dict's own key: the
-        # runner records "1" as unresolved for the dead step so the diagnostic
-        # names the offending key rather than reporting an empty key set.
-        assert "'1'" in text
+        # The backend's scalar-shape refusal is preserved as the diagnostic,
+        # while the runner is explicit that physical application is unknown and
+        # does not claim the input key was backend-confirmed unresolved.
+        assert "physical application is unknown" in text
+        assert "scalar number" in text
+        assert "Explicit unresolved keys: []" in text
         assert "get_features" in text
+
+
+class TestObserverPreflight:
+    def test_non_callable_observer_is_refused_before_mujoco_claim(self, sim, monkeypatch):
+        announcements: list[str] = []
+        monkeypatch.setattr(sim, "_announce_rollout", announcements.append)
+
+        result = sim.run_policy(robot_name="so101", observer=42)  # type: ignore[arg-type]
+
+        assert result == {
+            "status": "error",
+            "content": [{"text": "run_policy: observer must be callable or None, got 42."}],
+        }
+        assert announcements == []
+        robot = sim._world.robots["so101"]
+        assert robot.policy_running is False
+        assert robot.policy_claim_stops is None

--- a/tests/simulation/test_blocking_run_policy_claims_and_forwards_the_observer.py
+++ b/tests/simulation/test_blocking_run_policy_claims_and_forwards_the_observer.py
@@ -1,0 +1,306 @@
+"""The MuJoCo blocking entry claims the robot AND forwards the observer.
+
+``MuJoCoSimEngine.run_policy`` is the only surface between a caller and
+:meth:`PolicyRunner.run` on the default backend, and it carries two independent
+obligations that arrived from opposite directions:
+
+* it claims the robot on the launching thread (``_announce_rollout``) and drives
+  the loop through ``_drive_rollout``, so a stop issued before the rollout's
+  first frame lands on a raised flag rather than being answered "was not
+  running" (#2833/#3060);
+* it forwards ``observer`` to the runner, so a read-only consumer of the rollout
+  event lane actually receives events (#2907).
+
+Both are satisfied by *forwarding*, and a forward is exactly what a refactor
+drops silently: the parameter stays in the signature, the call still returns
+``success``, and the rollout applies the same actions. Measured on a real
+12-step SO-101 rollout with the forward removed:
+
+    observer= supplied     events delivered   observer_failures in payload
+    forward present        14 (1+12+1)        0
+    forward removed        0                  ABSENT
+
+Neither obligation was graded here before this file. The observer lane's own
+suite drives :meth:`PolicyRunner.run` through a stand-in engine and never calls
+``MuJoCoSimEngine.run_policy``; the launch-window suite drives ``start_policy``
+exclusively. So each of the two one-sided readings of this method passed every
+test in the tree.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import threading
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation import create_simulation
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.model_registry import resolve_model_path
+from strands_robots.simulation.observers import (
+    SCHEMA_VERSION,
+    RunPolicyEnded,
+    RunPolicyStarted,
+    RunPolicyStep,
+)
+
+N_STEPS = 12
+CONTROL_HZ = 30.0
+
+#: The parameter under test. Named once so the derived scan below and the
+#: behavioural cells above cannot drift apart.
+_PARAM = "observer"
+
+
+@pytest.fixture
+def sim() -> Any:
+    """A real MuJoCo sim holding one arm, torn down after the test."""
+    engine = create_simulation("mujoco")
+    engine.create_world()
+    engine.add_robot(name="arm", urdf_path=str(resolve_model_path("so101")))
+    try:
+        yield engine
+    finally:
+        engine.cleanup()
+
+
+def _rollout(sim: Any, events: list[Any]) -> dict[str, Any]:
+    result = sim.run_policy(
+        robot_name="arm",
+        policy_provider="mock",
+        instruction="wave",
+        n_steps=N_STEPS,
+        control_frequency=CONTROL_HZ,
+        fast_mode=True,
+        observer=events.append,
+    )
+    assert result["status"] == "success", result
+    return result
+
+
+def _payload(result: dict[str, Any]) -> dict[str, Any]:
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+class TestTheObserverReachesTheRunnerThroughTheBackend:
+    """A caller of the backend's own ``run_policy`` receives the event lane."""
+
+    def test_the_lifecycle_is_delivered(self, sim: Any) -> None:
+        events: list[Any] = []
+        _rollout(sim, events)
+
+        assert [type(e) for e in events] == [RunPolicyStarted] + [RunPolicyStep] * N_STEPS + [RunPolicyEnded], (
+            f"the backend delivered {[type(e).__name__ for e in events]}"
+        )
+
+    def test_the_stream_is_dense_and_belongs_to_one_rollout(self, sim: Any) -> None:
+        events: list[Any] = []
+        _rollout(sim, events)
+
+        assert [e.event_seq for e in events] == list(range(len(events)))
+        assert len({e.run_id for e in events}) == 1
+        assert {e.schema_version for e in events} == {SCHEMA_VERSION}
+
+    def test_the_result_payload_reports_the_observers_own_health(self, sim: Any) -> None:
+        """``observer_failures`` is present because the lane ran, and is zero."""
+        events: list[Any] = []
+        result = _rollout(sim, events)
+
+        assert _payload(result)["observer_failures"] == 0
+
+    def test_the_backends_own_hook_still_ran_beside_the_observer(self, sim: Any) -> None:
+        """The whole point of the lane: watching does not take the cancel hook.
+
+        MuJoCo installs its own ``on_frame`` (cooperative stop, trajectory
+        mirror, mesh telemetry, dataset recording). Every step event reporting
+        ``"ok"`` rather than ``"absent"`` is that hook confirming it ran, on the
+        real backend, while an observer was attached.
+        """
+        events: list[Any] = []
+        _rollout(sim, events)
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert [e.legacy_hook_outcome for e in steps] == ["ok"] * N_STEPS
+
+    def test_the_lane_reports_what_the_world_did(self, sim: Any) -> None:
+        """Every applied action resolved against the arm's own actuators."""
+        events: list[Any] = []
+        result = _rollout(sim, events)
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        ended = next(e for e in events if isinstance(e, RunPolicyEnded))
+        joints = set(sim.robot_joint_names("arm"))
+
+        assert [e.applied_action_index for e in steps] == list(range(N_STEPS))
+        assert {e.action_resolution for e in steps} == {"full"}
+        assert all(set(e.applied_action_keys) <= joints for e in steps)
+        assert all(e.unresolved_action_keys == () for e in steps)
+        assert ended.applied_actions == N_STEPS == _payload(result)["steps_used"]
+        assert ended.stopped_reason == _payload(result)["stopped_reason"]
+
+
+class TestTheBlockingEntryClaimsTheRobotBeforeItsFirstFrame:
+    """A stop issued before the first frame is answered as a stop."""
+
+    def test_a_stop_in_the_launch_window_is_honoured(self, sim: Any) -> None:
+        """Park the hook factory, then stop the rollout from another thread.
+
+        ``stop_policy`` reports "Stopped on" or "Was not running on" straight
+        from ``policy_running``, so claiming the robot on the first frame rather
+        than on the calling thread leaves this window answering "was not
+        running" about a rollout that then runs to its full budget (#2833). The
+        launching thread IS the caller for the blocking entry, so only another
+        thread can observe the window - which is exactly where a stop comes
+        from.
+        """
+        at_the_hook = threading.Event()
+        release = threading.Event()
+        real_factory = sim._make_run_policy_hook
+
+        def parked_factory(robot_name: str, instruction: str) -> Any:
+            at_the_hook.set()
+            assert release.wait(30), "test never released the parked rollout"
+            return real_factory(robot_name, instruction)
+
+        sim._make_run_policy_hook = parked_factory
+        done: list[dict[str, Any]] = []
+        worker = threading.Thread(
+            target=lambda: done.append(
+                sim.run_policy(
+                    robot_name="arm",
+                    policy_provider="mock",
+                    n_steps=N_STEPS,
+                    control_frequency=CONTROL_HZ,
+                    fast_mode=True,
+                )
+            ),
+            daemon=True,
+        )
+        worker.start()
+        try:
+            assert at_the_hook.wait(30), "the rollout never reached the hook factory"
+            robot = sim._world.robots["arm"]
+            assert robot.policy_steps == 0, "the window is not open - a frame was already taken"
+            assert robot.policy_running is True, "the rollout was not claimed by the thread that launched it"
+
+            stopped = sim.stop_policy("arm")
+            assert stopped["status"] == "success"
+            assert stopped["content"][0]["text"] == "Stopped on 'arm'"
+        finally:
+            release.set()
+            worker.join(timeout=60)
+
+        assert done, "the rollout never returned"
+        assert sim._world.robots["arm"].policy_steps == 0, "the stop did not land before the first frame"
+        assert sim._world.robots["arm"].policy_running is False, "the rollout ended without releasing the robot"
+
+
+def _scan_root() -> pathlib.Path:
+    # Derived from a symbol rather than a path literal, so a scan rooted
+    # elsewhere fails the non-vacuity assertion below instead of passing.
+    return pathlib.Path(inspect.getfile(SimEngine)).parent
+
+
+def _consumes_the_parameter(fn: ast.AST) -> bool:
+    """The owner reads the lane: it tests it against ``None`` and calls it."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Compare) and isinstance(node.left, ast.Name) and node.left.id == _PARAM:
+            return True
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == _PARAM:
+            return True
+    return False
+
+
+def _forwards_the_parameter(fn: ast.AST) -> bool:
+    """A surface that hands the lane on by keyword delegates to the owner."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == _PARAM and isinstance(kw.value, ast.Name) and kw.value.id == _PARAM:
+                    return True
+    return False
+
+
+def _planted_method(source: str) -> ast.FunctionDef:
+    """The single method of a one-class snippet, narrowed rather than suppressed.
+
+    ``ast.parse(...).body[0].body[0]`` is typed ``stmt``, which carries no
+    ``body``, so reaching through it needs either a suppression or these two
+    assertions. The assertions also make a malformed exemplar fail here, naming
+    the snippet, instead of at the predicate under test.
+    """
+    cls = ast.parse(source).body[0]
+    assert isinstance(cls, ast.ClassDef), source
+    fn = cls.body[0]
+    assert isinstance(fn, ast.FunctionDef), source
+    return fn
+
+
+def _observer_surfaces() -> list[tuple[str, ast.AST]]:
+    found: list[tuple[str, ast.AST]] = []
+    for path in sorted(_scan_root().rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - the package parses
+            continue
+        for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+            if cls.name.startswith("_"):
+                continue
+            for fn in [n for n in cls.body if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)]:
+                if fn.name.startswith("_"):
+                    continue
+                if _PARAM in [a.arg for a in fn.args.args + fn.args.kwonlyargs]:
+                    found.append((f"{path.name}::{cls.name}.{fn.name}", fn))
+    return found
+
+
+class TestNoObserverSurfaceAcceptsTheLaneAndDropsIt:
+    """Every public method taking ``observer`` either consumes it or forwards it.
+
+    Derived from the package rather than listed, so a fourth surface - another
+    backend override, or a second entry point growing the lane - is held to the
+    same rule the moment it lands, which is when the forward is cheapest to add.
+    """
+
+    def test_the_known_surfaces_are_the_ones_found(self) -> None:
+        # Non-vacuity: a scan that resolves nothing would satisfy the negative
+        # assertion below by matching nothing.
+        assert {name for name, _fn in _observer_surfaces()} == {
+            "base.py::SimEngine.run_policy",
+            "policy_runner.py::PolicyRunner.run",
+            "simulation.py::MuJoCoSimEngine.run_policy",
+        }
+
+    def test_every_surface_consumes_or_forwards_the_lane(self) -> None:
+        adrift = [
+            name
+            for name, fn in _observer_surfaces()
+            if not (_consumes_the_parameter(fn) or _forwards_the_parameter(fn))
+        ]
+        assert adrift == [], f"{adrift} accept {_PARAM} and neither consume nor forward it"
+
+    def test_the_scanner_detects_a_planted_surface_that_drops_the_lane(self) -> None:
+        fn = _planted_method(
+            "class Engine:\n    def run_policy(self, observer=None):\n        return super().run_policy()\n"
+        )
+        assert not _consumes_the_parameter(fn)
+        assert not _forwards_the_parameter(fn)
+
+    def test_the_scanner_accepts_a_planted_forwarder_and_a_planted_owner(self) -> None:
+        forwarder = _planted_method(
+            "class Engine:\n"
+            "    def run_policy(self, observer=None):\n"
+            "        return self._drive_rollout('arm', observer=observer)\n"
+        )
+        owner = _planted_method(
+            "class Runner:\n"
+            "    def run(self, observer=None):\n"
+            "        if observer is None:\n            return\n        observer(1)\n"
+        )
+        assert _forwards_the_parameter(forwarder)
+        assert _consumes_the_parameter(owner)

--- a/tests/simulation/test_policy_runner_behaviour.py
+++ b/tests/simulation/test_policy_runner_behaviour.py
@@ -258,22 +258,52 @@ class TestPolicyRunnerEvaluate:
 
 
 class TestHelpers:
-    def test_maybe_sim_time_reads_state(self, sim_with_robot):
+    def test_maybe_sim_time_reads_cached_world_clock(self, sim_with_robot):
         runner = PolicyRunner(sim_with_robot)
         t = runner._maybe_sim_time()
         # Empty sim at t=0 should return 0.0.
         assert t == pytest.approx(0.0, abs=1e-9)
 
-    def test_maybe_sim_time_on_broken_sim_returns_none(self):
+    def test_cached_sim_time_never_calls_get_state(self):
         fake = MagicMock()
-        fake.get_state.side_effect = RuntimeError("boom")
-        runner = PolicyRunner(fake)
-        assert runner._maybe_sim_time() is None
+        fake._world = None
+        fake._sim_time = None
+        fake.get_state.side_effect = AssertionError("must not be called")
 
-    def test_maybe_sim_time_no_get_state_returns_none(self):
+        assert PolicyRunner(fake)._cached_sim_time() is None
+        fake.get_state.assert_not_called()
+
+    def test_cached_sim_time_reads_isaac_like_engine_cache(self):
+        fake = MagicMock()
+        fake._world = None
+        fake._sim_time = 1.25
+        fake.get_state.side_effect = AssertionError("must not be called")
+
+        assert PolicyRunner(fake)._cached_sim_time() == 1.25
+        fake.get_state.assert_not_called()
+
+    @pytest.mark.parametrize("value", [True, False, float("nan"), float("inf"), "1.0"])
+    def test_cached_sim_time_rejects_non_finite_or_non_real_cache(self, value):
+        fake = MagicMock()
+        fake._world = None
+        fake._sim_time = value
+        fake.get_state.side_effect = AssertionError("must not be called")
+
+        assert PolicyRunner(fake)._cached_sim_time() is None
+        fake.get_state.assert_not_called()
+
+    def test_cached_sim_time_without_cached_clock_returns_none(self):
         fake = object()
         runner = PolicyRunner(fake)  # type: ignore[arg-type]
-        assert runner._maybe_sim_time() is None
+        assert runner._cached_sim_time() is None
+
+    def test_maybe_sim_time_on_broken_state_fallback_returns_none(self):
+        fake = MagicMock()
+        fake._world = None
+        fake._sim_time = None
+        fake.get_state.side_effect = RuntimeError("boom")
+
+        assert PolicyRunner(fake)._maybe_sim_time() is None
 
     def test_require_default_robot_empty_raises(self):
         fake = MagicMock()

--- a/tests/simulation/test_policy_runner_paths.py
+++ b/tests/simulation/test_policy_runner_paths.py
@@ -13,7 +13,7 @@ Covers:
   missing-hook, positive (n_contacts / contacts-list) detection, and the
   degradation branches: an unexpected error, a zero-contact negative, and a
   non-dict result all resolve to False without propagating
-* ``_maybe_sim_time`` get_state() fallback (nested ``content[].json.sim_time``)
+* ``_maybe_sim_time`` cached ``_sim_time`` path without backend I/O
 * ``evaluate()`` "never-succeeds" default path (no success_fn)
 """
 
@@ -470,36 +470,67 @@ def test_evaluate_none_success_fn_gives_zero_success_rate():
             break
 
 
-# ── _maybe_sim_time get_state() fallback ─────────────────────────────
+# ── cached per-Step clock / terminal get_state() fallback ─────────────
+
+
+def test_cached_sim_time_reads_engine_clock_without_get_state():
+    """An Isaac-like backend exposes its cheap engine-level ``_sim_time``."""
+
+    class _CachedClockSim(_MinimalSim):
+        _world = None
+        _sim_time = 1.25
+
+        def get_state(self):
+            raise AssertionError("observer telemetry must not call get_state")
+
+    sim = _CachedClockSim(robots=["r0"])
+    sim._world = None
+    sim._sim_time = 1.25
+    assert PolicyRunner(sim)._cached_sim_time() == 1.25
+
+
+def test_cached_sim_time_absent_cache_does_not_probe_get_state():
+    class _NoTimeSim(_MinimalSim):
+        _world = None
+        _sim_time = None
+
+        def get_state(self):
+            raise AssertionError("observer telemetry must not call get_state")
+
+    sim = _NoTimeSim(robots=["r0"])
+    sim._world = None
+    sim._sim_time = None
+    assert PolicyRunner(sim)._cached_sim_time() is None
 
 
 def test_maybe_sim_time_reads_from_get_state_content_json():
-    """Backends with no structured ``_world`` expose sim time via the
-    status-dict ``content[].json.sim_time`` shape. ``_maybe_sim_time`` must
-    dig it out of that nested block.
-    """
+    """Terminal payloads retain the backend status-envelope fallback."""
 
     class _StatusDictSim(_MinimalSim):
-        # No ``_world`` attr → forces the get_state() fallback path.
         _world = None
+        _sim_time = None
 
         def get_state(self):
             return {"content": [{"text": "ok"}, {"json": {"sim_time": 1.25}}]}
 
-    t = PolicyRunner(_StatusDictSim(robots=["r0"]))._maybe_sim_time()
-    assert t == 1.25
+    sim = _StatusDictSim(robots=["r0"])
+    sim._world = None
+    sim._sim_time = None
+    assert PolicyRunner(sim)._maybe_sim_time() == 1.25
 
 
 def test_maybe_sim_time_get_state_without_sim_time_returns_none():
-    """A status dict with no ``sim_time`` anywhere yields None (not a crash)."""
-
     class _NoTimeSim(_MinimalSim):
         _world = None
+        _sim_time = None
 
         def get_state(self):
             return {"content": [{"json": {"step_count": 3}}]}
 
-    assert PolicyRunner(_NoTimeSim(robots=["r0"]))._maybe_sim_time() is None
+    sim = _NoTimeSim(robots=["r0"])
+    sim._world = None
+    sim._sim_time = None
+    assert PolicyRunner(sim)._maybe_sim_time() is None
 
 
 # ── _resolve_success_fn "contact" positive detection ─────────────────

--- a/tests/simulation/test_rollout_loop_paces_on_a_deadline.py
+++ b/tests/simulation/test_rollout_loop_paces_on_a_deadline.py
@@ -50,6 +50,7 @@ import pytest
 os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")
 
 from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.observers import RunPolicyStep
 from strands_robots.simulation.policy_runner import PolicyRunner
 from tests.simulation.test_policy_runner import FakeSim
 
@@ -78,7 +79,14 @@ def _busy_wait(seconds: float) -> None:
         pass
 
 
-def _run(*, n_steps: int, frequency: float, on_frame: Any = None, fast_mode: bool = False) -> float:
+def _run(
+    *,
+    n_steps: int,
+    frequency: float,
+    on_frame: Any = None,
+    observer: Any = None,
+    fast_mode: bool = False,
+) -> float:
     """Drive the real ``PolicyRunner.run`` loop; return the wall clock it took."""
     sim = FakeSim()
     policy = MockPolicy()
@@ -90,6 +98,7 @@ def _run(*, n_steps: int, frequency: float, on_frame: Any = None, fast_mode: boo
         control_frequency=frequency,
         fast_mode=fast_mode,
         on_frame=on_frame,
+        observer=observer,
     )
     elapsed = time.perf_counter() - start
     assert result["status"] == "success", result
@@ -124,6 +133,46 @@ class TestARolloutTakesTheWallClockItWasAskedFor:
             f"median step gap {median_gap * 1000:.1f}ms against a {period * 1000:.0f}ms period with "
             f"{work_s * 1000:.0f}ms of work per step - the work is being added to the period instead "
             "of subtracted from it, so the loop runs at 1 / (period + work). Use mesh.pacing.Ticker."
+        )
+
+    def test_an_observers_own_cost_comes_out_of_the_period_too(self) -> None:
+        """The same for the read-only observer lane, which is the other per-step cost.
+
+        :mod:`strands_robots.simulation.observers` dispatches synchronously on
+        the rollout thread - deliberately, so the stream is cheap and ordered -
+        which makes a consumer's own cost per-step work of exactly the kind the
+        cell above grades. It is also the only per-step cost a CALLER supplies
+        without owning the loop: ``on_frame`` belongs to the backend, so before
+        this lane existed every millisecond in the period was the library's own.
+        Under a delay pacer a visualiser would slow the arm by its full drawing
+        cost while the rollout still reported the duration it was asked for; on
+        a real MuJoCo so101 rollout asking for 2.0 s with a 8 ms observer, the
+        delay pacing returned in 2.5694 s and the deadline in 2.0092 s.
+
+        Graded here rather than beside the observer's own tests because the
+        property is the loop's, not the lane's, and this is the file that owns
+        it.
+        """
+        frequency, n_steps, work_s = 25.0, 20, 0.032
+        period = 1.0 / frequency
+        stamps: list[float] = []
+
+        def observer(event: Any) -> None:
+            # Only the per-step event: the lifecycle pair brackets the loop and
+            # its cost is not paid inside a period.
+            if not isinstance(event, RunPolicyStep):
+                return
+            _busy_wait(work_s)
+            stamps.append(time.perf_counter())
+
+        _run(n_steps=n_steps, frequency=frequency, observer=observer)
+        gaps = sorted(b - a for a, b in zip(stamps, stamps[1:], strict=False))
+        assert gaps, "the observer received no per-step events to measure"
+        median_gap = gaps[len(gaps) // 2]
+        assert median_gap < period * 1.5, (
+            f"median step gap {median_gap * 1000:.1f}ms against a {period * 1000:.0f}ms period with "
+            f"{work_s * 1000:.0f}ms spent in the observer - a read-only consumer is extending the "
+            "control period by its own cost instead of being absorbed by it. Use mesh.pacing.Ticker."
         )
 
     def test_a_free_step_still_takes_the_period(self) -> None:

--- a/tests/simulation/test_run_policy_observer.py
+++ b/tests/simulation/test_run_policy_observer.py
@@ -1,0 +1,889 @@
+"""Contract pins for the ``observer`` lane on :meth:`PolicyRunner.run`.
+
+``on_frame`` is not a general observation seam and cannot be made one. It is
+*owned* by the backend for the duration of a rollout: MuJoCo's hook raises
+:class:`CooperativeStop` for ``stop_policy``, appends the trajectory mirror,
+publishes mesh telemetry and drives the LeRobot dataset recorder, and Isaac's
+and Newton's do the recording half of that. A caller that supplies its own
+``on_frame`` to watch a rollout therefore *replaces* all of it, and
+``SimEngine.run_policy`` does not even accept one - it calls
+``_make_run_policy_hook`` and passes the backend's.
+
+So the observer is a SECOND lane beside that hook rather than a reinterpretation
+of it, and the whole point of these tests is the word "beside": every assertion
+below is about the legacy hook continuing to behave exactly as it did, while the
+new lane reports what it could not.
+
+Three properties are load-bearing and none of them is obvious:
+
+* **Every physically applied action is reported, including the last one.** The
+  legacy hook runs *after* ``send_action``, so an action that a cancelling or
+  recording-failing hook aborts on has already advanced the world - and is
+  excluded from ``steps_used``, from the video cadence and from the resolution
+  denominator, because ``step_count += 1`` sits after the hook. An observability
+  lane that inherited that boundary would be silent about the one step a user
+  debugging a cancellation most needs to see. The emission is therefore in a
+  ``finally``, which is also what keeps the legacy exception byte-for-byte
+  unchanged: same type, same traceback, same ``__cause__``.
+
+* **The observation is BORROWED, and is pre-action.** It is the same object the
+  legacy hook received - not a copy - and under open-loop chunk replay it is the
+  chunk-start observation, so it is stale for every action after the first unless
+  a recording forced a refresh. ``observation_is_chunk_reused`` states which of
+  those it is, per step, rather than leaving a consumer to assume freshness it
+  does not have.
+
+* **An observer failure is not a rollout failure, and is not an ``on_frame``
+  failure either.** It must not reach the consecutive-failure watchdog that
+  exists to catch a silently-empty dataset (GH #117), because a visualiser that
+  cannot draw is not a recorder that cannot write.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.dataset_recorder import RecordingFrameError
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.observers import (
+    SCHEMA_VERSION,
+    RunPolicyEnded,
+    RunPolicyStarted,
+    RunPolicyStep,
+)
+from strands_robots.simulation.policy_runner import CooperativeStop, PolicyRunner
+
+
+class _FakeSim(SimEngine):
+    """Pure-Python engine: no physics, records every public call it receives."""
+
+    def __init__(self, joint_names: tuple[str, ...] = ("j0", "j1", "j2")):
+        self._joint_names = list(joint_names)
+        self.calls: list[tuple] = []
+        self._step_count = 0
+        self._sim_time = 0.0
+        self._robots = {"fake_robot": self._joint_names}
+        self._world: Any = None
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):
+        return {"status": "success"}
+
+    def destroy(self):
+        return {"status": "success"}
+
+    def reset(self):
+        self._step_count = 0
+        self._sim_time = 0.0
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):
+        self._step_count += n_steps
+        self._sim_time += 0.002 * n_steps
+        return {"status": "success"}
+
+    def get_state(self):
+        return {"sim_time": self._sim_time, "step_count": self._step_count}
+
+    def add_robot(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_robot(self, name):
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots.keys())
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._robots.get(robot_name, []))
+
+    def add_object(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_object(self, name):
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):
+        self.calls.append(("get_observation", robot_name))
+        return {n: 0.0 for n in self._joint_names}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        self.calls.append(("send_action", robot_name))
+        self._step_count += 1
+        self._sim_time += 0.002
+
+    def render(self, camera_name="default", width=None, height=None):
+        return {"image": np.zeros((height or 48, width or 64, 3), dtype=np.uint8)}
+
+
+class _PartialResolutionSim(_FakeSim):
+    """``send_action`` that resolves some keys and rejects the rest."""
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        self.calls.append(("send_action", robot_name))
+        self._step_count += 1
+        self._sim_time += 0.002
+        keys = list(action) if isinstance(action, dict) else []
+        return {
+            "status": "error",
+            "content": [
+                {"text": "partial"},
+                {"json": {"applied": keys[:1], "unresolved_keys": keys[1:]}},
+            ],
+        }
+
+
+class _CoarseErrorSim(_FakeSim):
+    """Backend refusal with no complete per-key evidence."""
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        self.calls.append(("send_action", robot_name))
+        return {"status": "error", "content": [{"text": "atomic refusal"}]}
+
+
+class _CoarseThenFullSim(_FakeSim):
+    """One unknown refusal followed by a fully applied action."""
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        self.calls.append(("send_action", robot_name))
+        attempts = sum(name == "send_action" for name, _ in self.calls)
+        if attempts == 1:
+            return {"status": "error", "content": [{"text": "atomic refusal"}]}
+        self._step_count += 1
+        self._sim_time += 0.002
+        return None
+
+
+class _StateOnlyClockSim(_FakeSim):
+    """Backend whose terminal clock is available only through ``get_state``."""
+
+    def __init__(self):
+        super().__init__()
+        del self._sim_time
+        self.state_calls = 0
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        self.calls.append(("send_action", robot_name))
+        self._step_count += 1
+
+    def get_state(self):
+        self.state_calls += 1
+        return {"content": [{"json": {"sim_time": 1.25}}]}
+
+
+class _RecordingSim(_FakeSim):
+    def _is_recording(self) -> bool:
+        return True
+
+
+def _runner_and_policy(sim: _FakeSim | None = None) -> tuple[PolicyRunner, MockPolicy, _FakeSim]:
+    sim = sim if sim is not None else _FakeSim()
+    policy = MockPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+    return PolicyRunner(sim), policy, sim
+
+
+def _run(runner: PolicyRunner, policy: MockPolicy, **kw: Any) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "duration": 0.3,
+        "control_frequency": 10.0,
+        "fast_mode": True,
+    }
+    params.update(kw)
+    return runner.run("fake_robot", policy, **params)
+
+
+class TestSignature:
+    """``observer`` is keyword-only, optional, and defaults to the old behaviour."""
+
+    def test_observer_is_keyword_only_and_optional(self):
+        sig = inspect.signature(PolicyRunner.run)
+        assert "observer" in sig.parameters, (
+            "PolicyRunner.run must accept an ``observer``. Without it the only per-step seam is "
+            "``on_frame``, which the backend owns for cancellation and recording."
+        )
+        param = sig.parameters["observer"]
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+        assert param.default is None, "the default must be the historical no-observer rollout"
+
+    def test_omitting_the_observer_leaves_the_payload_shape_untouched(self):
+        """``observer_failures`` appears only for a rollout that had an observer.
+
+        A key that materialises on every rollout would change the documented
+        payload for callers that never asked for the lane.
+        """
+        runner, policy, _ = _runner_and_policy()
+        payload = _json(_run(runner, policy))
+        assert "observer_failures" not in payload
+
+        runner2, policy2, _ = _runner_and_policy()
+        payload2 = _json(_run(runner2, policy2, observer=lambda _e: None))
+        assert payload2["observer_failures"] == 0
+
+
+def _json(result: dict[str, Any]) -> dict[str, Any]:
+    """Pull the structured block out of a tool-envelope result.
+
+    Scans ``content`` rather than indexing it: an early-refusal envelope carries
+    only a text block, so ``content[1]`` is not a safe assumption.
+    """
+    for block in result.get("content", []):
+        if isinstance(block, dict) and "json" in block:
+            return block["json"]
+    raise AssertionError(f"no json block in result: {result}")
+
+
+class TestEventSequence:
+    """Exactly one ``Started``, one ``Step`` per applied action, one ``Ended``."""
+
+    def test_lifecycle_is_started_then_steps_then_ended(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        result = _run(runner, policy, observer=events.append)
+
+        assert result["status"] == "success"
+        assert isinstance(events[0], RunPolicyStarted), "the first event must open the rollout"
+        assert isinstance(events[-1], RunPolicyEnded), "the last event must close it"
+        assert sum(isinstance(e, RunPolicyStarted) for e in events) == 1
+        assert sum(isinstance(e, RunPolicyEnded) for e in events) == 1
+        assert SCHEMA_VERSION == 2
+        assert {e.schema_version for e in events} == {2}
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert len(steps) == _json(result)["steps_used"] == 3
+
+    def test_event_seq_is_dense_and_monotonic(self):
+        """A consumer must be able to detect a gap, so the sequence is dense."""
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, observer=events.append)
+
+        seqs = [e.event_seq for e in events]
+        assert seqs == list(range(len(events)))
+        assert len({e.run_id for e in events}) == 1, "one rollout is one run_id"
+
+    def test_monotonic_timestamps_never_go_backwards(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, observer=events.append)
+
+        stamps = [e.monotonic_ns for e in events]
+        assert stamps == sorted(stamps)
+
+    def test_started_describes_the_rollout_it_opens(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, instruction="pick the cube", observer=events.append)
+
+        started = events[0]
+        assert started.robot_name == "fake_robot"
+        assert started.policy == "MockPolicy"
+        assert started.instruction == "pick the cube"
+        assert started.control_frequency == 10.0
+        assert started.total_steps == 3
+        assert started.async_rtc is False
+
+    def test_ended_reports_the_terminal_facts(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        result = _run(runner, policy, observer=events.append)
+
+        ended = events[-1]
+        payload = _json(result)
+        assert ended.outcome == "success"
+        assert ended.stopped_reason == "budget" == payload["stopped_reason"]
+        assert ended.legacy_steps_used == payload["steps_used"]
+        assert ended.applied_actions == 3
+        assert ended.error_type is None
+        assert ended.observer_failures == 0
+
+
+class TestLegacyHookIsUnchanged:
+    """The whole contract: adding an observer changes nothing about ``on_frame``."""
+
+    def test_on_frame_receives_identical_arguments_with_and_without_observer(self):
+        seen_without: list[tuple] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, on_frame=lambda s, o, a: seen_without.append((s, dict(o), dict(a))))
+
+        seen_with: list[tuple] = []
+        runner2, policy2, _ = _runner_and_policy()
+        _run(
+            runner2,
+            policy2,
+            on_frame=lambda s, o, a: seen_with.append((s, dict(o), dict(a))),
+            observer=lambda _e: None,
+        )
+
+        assert seen_without == seen_with, (
+            "the observer lane must not change the index, the observation or the action the "
+            "legacy hook is handed - backends decide cancellation and dataset content from these."
+        )
+
+    def test_the_observer_sees_the_same_borrowed_objects_as_on_frame(self):
+        """Borrowed, not copied: identity is the contract a consumer must respect."""
+        hook_payloads: list[tuple[int, Any, Any]] = []
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        _run(
+            runner,
+            policy,
+            on_frame=lambda s, o, a: hook_payloads.append((s, o, a)),
+            observer=events.append,
+        )
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert len(steps) == len(hook_payloads)
+        for step, (idx, obs, action) in zip(steps, hook_payloads, strict=True):
+            assert step.legacy_step_index == idx
+            assert step.observation is obs, "the observation is borrowed, not copied"
+            assert step.action is action, "the action is borrowed, not copied"
+
+    def test_observer_adds_no_observation_or_render_call(self):
+        """The lane reports what the rollout already did; it must not sample more."""
+        runner, policy, sim = _runner_and_policy()
+        _run(runner, policy)
+        without = list(sim.calls)
+
+        runner2, policy2, sim2 = _runner_and_policy()
+        _run(runner2, policy2, observer=lambda _e: None)
+
+        assert sim2.calls == without
+
+    def test_observer_failure_does_not_arm_the_on_frame_watchdog(self):
+        """An observer that fails every step is not a recorder losing frames.
+
+        The consecutive-failure abort exists so a broken recording hook cannot
+        produce a silently empty dataset (GH #117). Routing observer failures
+        into it would abort healthy rollouts because a visualiser is down.
+        """
+        hook_calls: list[int] = []
+        runner, policy, _ = _runner_and_policy()
+
+        def exploding_observer(_event: Any) -> None:
+            raise RuntimeError("observer is down")
+
+        result = _run(
+            runner,
+            policy,
+            duration=1.0,  # 10 steps: well past the 5-failure legacy threshold
+            on_frame=lambda s, o, a: hook_calls.append(s),
+            observer=exploding_observer,
+        )
+
+        assert result["status"] == "success", "a failing observer must not fail the rollout"
+        assert len(hook_calls) == 10, "the legacy hook must still run every step"
+        payload = _json(result)
+        assert payload["steps_used"] == 10
+        assert payload["observer_failures"] >= 10, "every failure must be counted, not swallowed"
+
+
+class TestObserverFailureIsolation:
+    """A failing observer is invisible to the rollout's outcome."""
+
+    def test_result_is_identical_whether_the_observer_throws(self):
+        runner, policy, _ = _runner_and_policy()
+        healthy = _json(_run(runner, policy, observer=lambda _e: None))
+
+        runner2, policy2, _ = _runner_and_policy()
+
+        def boom(_event: Any) -> None:
+            raise ValueError("nope")
+
+        broken = _json(_run(runner2, policy2, observer=boom))
+
+        for key in ("steps_used", "stopped_reason", "action_errors", "partial_action_failure_rate"):
+            assert healthy[key] == broken[key], f"{key} diverged when the observer threw"
+        # Started + one Step per applied action + Ended = 5 dispatches for a
+        # 3-step rollout, and an observer that raises unconditionally fails all
+        # of them. The count is of DISPATCHES, not of steps.
+        assert broken["observer_failures"] == 5
+        assert healthy["observer_failures"] == 0
+
+    def test_an_observer_failure_on_started_still_runs_the_rollout(self):
+        """Failing on the first event must not prevent the rollout or the rest."""
+        seen: list[str] = []
+        runner, policy, _ = _runner_and_policy()
+
+        def fail_started(event: Any) -> None:
+            seen.append(type(event).__name__)
+            if isinstance(event, RunPolicyStarted):
+                raise RuntimeError("cannot open")
+
+        result = _run(runner, policy, observer=fail_started)
+
+        assert result["status"] == "success"
+        assert seen[0] == "RunPolicyStarted"
+        assert "RunPolicyStep" in seen
+        assert seen[-1] == "RunPolicyEnded", "a failed Started must not suppress Ended"
+
+    def test_a_base_exception_from_the_observer_is_also_contained(self):
+        """``CooperativeStop`` is a ``BaseException``; an observer must not fire it.
+
+        The graceful-stop signal belongs to ``on_frame``. If the observer lane
+        let a ``BaseException`` through it would hand every visualiser the
+        ability to cancel a rollout.
+        """
+        runner, policy, _ = _runner_and_policy()
+
+        def rogue(_event: Any) -> None:
+            raise CooperativeStop("observer tried to cancel")
+
+        result = _run(runner, policy, observer=rogue)
+
+        assert result["status"] == "success"
+        payload = _json(result)
+        assert payload["stopped_reason"] == "budget", "the observer must not be able to cancel"
+        assert payload["steps_used"] == 3
+
+
+class TestAppliedActionsIncludesTheAbortingStep:
+    """The step a cancelling hook aborts on physically happened. Report it."""
+
+    def test_cooperative_stop_still_reports_the_applied_action(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        def hook(step: int, _obs: Any, _action: Any) -> None:
+            if step >= 2:
+                raise CooperativeStop("user stopped")
+
+        result = _run(runner, policy, duration=10.0, on_frame=hook, observer=events.append)
+
+        assert result["status"] == "success"
+        payload = _json(result)
+        assert payload["stopped_reason"] == "cancelled"
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        # Steps 0 and 1 completed; step 2 was applied and then cancelled.
+        assert len(steps) == 3
+        assert payload["steps_used"] == 2, "legacy accounting excludes the cancelling step"
+        assert steps[-1].applied_action_index == 2
+        assert steps[-1].legacy_step_index == steps[-1].applied_action_index
+        assert steps[-1].legacy_hook_outcome == "cancelled"
+
+        ended = events[-1]
+        assert ended.stopped_reason == "cancelled"
+        assert ended.applied_actions == 3
+        assert ended.legacy_steps_used == 2
+        assert ended.applied_actions > ended.legacy_steps_used
+
+    def test_recording_frame_loss_still_reports_the_applied_action(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        def hook(step: int, _obs: Any, _action: Any) -> None:
+            if step >= 1:
+                raise RecordingFrameError("dataset write failed")
+
+        result = _run(runner, policy, duration=10.0, on_frame=hook, observer=events.append)
+
+        assert result["status"] == "error", "lost dataset frames stay fatal on the first occurrence"
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert steps[-1].legacy_hook_outcome == "recording_error"
+        assert steps[-1].applied_action_index == 1
+        assert steps[-1].legacy_step_index == steps[-1].applied_action_index
+
+        ended = events[-1]
+        assert isinstance(ended, RunPolicyEnded)
+        assert ended.outcome == "error"
+        assert ended.stopped_reason == "error"
+        assert ended.error_type == "RecordingFrameError"
+
+    def test_legacy_hook_outcome_is_ok_when_nothing_raised(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, on_frame=lambda s, o, a: None, observer=events.append)
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert {s.legacy_hook_outcome for s in steps} == {"ok"}
+
+    def test_legacy_hook_outcome_is_absent_when_no_hook_was_given(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, observer=events.append)
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert {s.legacy_hook_outcome for s in steps} == {"absent"}
+
+
+class TestActionResolution:
+    """Resolution is normalised, so a consumer never parses a backend blob."""
+
+    def test_full_resolution_on_the_success_path(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, observer=events.append)
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert {s.action_resolution for s in steps} == {"full"}
+        for step in steps:
+            assert step.unresolved_action_keys == ()
+            assert set(step.applied_action_keys) == {"j0", "j1", "j2"}
+
+    def test_partial_resolution_is_reported_as_partial(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy(_PartialResolutionSim())
+        result = _run(runner, policy, observer=events.append)
+
+        assert result["status"] == "success", "a partial resolution runs to completion"
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert {s.action_resolution for s in steps} == {"partial"}
+        for step in steps:
+            assert len(step.applied_action_keys) == 1
+            assert len(step.unresolved_action_keys) == 2
+
+    def test_coarse_error_is_unknown_without_fabricated_keys(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy(_CoarseErrorSim())
+
+        result = _run(runner, policy, duration=0.1, observer=events.append)
+
+        assert result["status"] == "error"
+        step = next(e for e in events if isinstance(e, RunPolicyStep))
+        assert step.action_resolution == "unknown"
+        assert step.applied_action_keys == ()
+        assert step.unresolved_action_keys == ()
+        assert "physical application is unknown" in result["content"][0]["text"]
+
+    def test_coarse_step_is_excluded_from_aggregate_resolution_rates(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy(_CoarseThenFullSim())
+
+        result = _run(runner, policy, duration=0.2, observer=events.append)
+
+        assert result["status"] == "success"
+        payload = _json(result)
+        assert payload["action_errors"] == 1
+        assert payload["action_resolution_rate"] == {"j0": 1.0, "j1": 1.0, "j2": 1.0}
+        assert payload["partial_action_failure_rate"] == 0.0
+        assert "coarse backend errors" in result["content"][0]["text"]
+        steps = [event for event in events if isinstance(event, RunPolicyStep)]
+        assert [step.action_resolution for step in steps] == ["unknown", "full"]
+
+    def test_elapsed_is_measured_and_sim_time_is_carried_when_available(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, observer=events.append)
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        elapsed = [s.elapsed_s for s in steps]
+        assert elapsed == sorted(elapsed)
+        assert all(e >= 0.0 for e in elapsed)
+        # ``_FakeSim._sim_time`` is a cheap cached engine clock.
+        sim_times = [s.sim_time_s for s in steps]
+        assert all(t is not None for t in sim_times)
+        assert sim_times == sorted(sim_times)
+
+    @pytest.mark.parametrize("with_observer", [False, True])
+    def test_terminal_result_retains_one_time_get_state_clock_fallback(self, with_observer: bool):
+        events: list[Any] = []
+        sim = _StateOnlyClockSim()
+        runner, policy, _ = _runner_and_policy(sim)
+
+        result = _run(runner, policy, observer=events.append if with_observer else None)
+
+        assert result["status"] == "success"
+        assert _json(result)["sim_time_s"] == 1.25
+        assert sim.state_calls == 1, "Step events must not add get_state calls"
+        if with_observer:
+            steps = [event for event in events if isinstance(event, RunPolicyStep)]
+            assert steps
+            assert {step.sim_time_s for step in steps} == {None}
+
+
+class TestObservationFreshness:
+    """Chunk reuse is stated per step rather than assumed away."""
+
+    def test_chunk_reuse_is_flagged_truthfully(self):
+        """Without a recording, one observation feeds a whole chunk."""
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        _run(runner, policy, duration=0.4, action_horizon=4, observer=events.append)
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert steps, "expected applied actions"
+        assert steps[0].observation_is_chunk_reused is False, "the chunk-start action is fresh"
+        # MockPolicy emits a chunk, so at least one later action reuses it.
+        assert any(s.observation_is_chunk_reused for s in steps[1:]), (
+            "an action replayed from a chunk must not claim a fresh observation"
+        )
+        assert [s.observation_age_steps for s in steps] == [0, 1, 2, 3]
+
+    def test_async_cross_boundary_ages_are_exact(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        _run(
+            runner,
+            policy,
+            duration=0.8,
+            action_horizon=4,
+            async_rtc=True,
+            observer=events.append,
+        )
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert [s.observation_age_steps for s in steps] == [0, 1, 2, 3, 2, 3, 4, 5]
+        assert [s.observation_is_chunk_reused for s in steps] == [
+            False,
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+            True,
+        ]
+
+    @pytest.mark.parametrize("async_rtc", [False, True])
+    def test_recording_refresh_reports_zero_age_throughout(self, async_rtc: bool):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy(_RecordingSim())
+
+        _run(
+            runner,
+            policy,
+            duration=0.8,
+            action_horizon=4,
+            async_rtc=async_rtc,
+            observer=events.append,
+        )
+
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        assert len(steps) == 8
+        assert [s.observation_age_steps for s in steps] == [0] * 8
+        assert not any(s.observation_is_chunk_reused for s in steps)
+
+
+class TestSyncAsyncParity:
+    """Both acquisition strategies report the same number of applied actions."""
+
+    @pytest.mark.parametrize("async_rtc", [False, True])
+    def test_step_event_count_matches_applied_actions(self, async_rtc: bool):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        result = _run(runner, policy, duration=0.6, async_rtc=async_rtc, observer=events.append)
+
+        assert result["status"] == "success"
+        steps = [e for e in events if isinstance(e, RunPolicyStep)]
+        ended = events[-1]
+        assert len(steps) == ended.applied_actions == 6
+        assert events[0].async_rtc is async_rtc
+        indices = [s.applied_action_index for s in steps]
+        assert indices == list(range(len(steps))), "applied indices are dense and 0-based"
+
+
+class TestErrorPaths:
+    """``Ended`` is attempted on every path that emitted ``Started``."""
+
+    def test_a_failing_policy_still_closes_the_lifecycle(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        def explode(*_a: Any, **_k: Any):
+            raise RuntimeError("inference exploded")
+
+        policy.get_actions = explode  # type: ignore[method-assign]
+
+        result = _run(runner, policy, observer=events.append)
+
+        assert result["status"] == "error"
+        assert isinstance(events[0], RunPolicyStarted)
+        ended = events[-1]
+        assert isinstance(ended, RunPolicyEnded)
+        assert ended.outcome == "error"
+        assert ended.stopped_reason == "error"
+        assert ended.error_type == "RuntimeError"
+        assert "inference exploded" in ended.error_message
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(KeyboardInterrupt("stop"), id="keyboard-interrupt"),
+            pytest.param(SystemExit("stop"), id="system-exit"),
+            pytest.param(GeneratorExit("stop"), id="generator-exit"),
+            pytest.param(asyncio.CancelledError("stop"), id="asyncio-cancelled-error"),
+        ],
+    )
+    def test_non_cooperative_base_exception_propagates_and_closes_once(self, error: BaseException):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        def explode(*_a: Any, **_k: Any):
+            raise error
+
+        policy.get_actions = explode  # type: ignore[method-assign]
+
+        with pytest.raises(type(error)) as caught:
+            _run(runner, policy, observer=events.append)
+
+        assert caught.value is error
+        ended = [event for event in events if isinstance(event, RunPolicyEnded)]
+        assert len(ended) == 1
+        assert ended[0].outcome == "error"
+        assert ended[0].error_type == type(error).__name__
+
+    def test_terminal_observer_base_exception_cannot_mask_original(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        original = KeyboardInterrupt("policy interrupted")
+        terminal = SystemExit("observer exit during Ended")
+
+        def explode(*_a: Any, **_k: Any):
+            raise original
+
+        def observer(event: Any) -> None:
+            events.append(event)
+            if isinstance(event, RunPolicyEnded):
+                raise terminal
+
+        policy.get_actions = explode  # type: ignore[method-assign]
+
+        with pytest.raises(KeyboardInterrupt) as caught:
+            _run(runner, policy, observer=observer)
+
+        assert caught.value is original
+        assert sum(isinstance(event, RunPolicyEnded) for event in events) == 1
+        assert any("SystemExit" in note for note in getattr(original, "__notes__", ()))
+        traceback_names: list[str] = []
+        current = caught.value.__traceback__
+        while current is not None:
+            traceback_names.append(current.tb_frame.f_code.co_name)
+            current = current.tb_next
+        assert "explode" in traceback_names
+
+    def test_step_observer_base_exception_cannot_mask_legacy_hook_exception(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        original = KeyboardInterrupt("legacy hook interrupted")
+        secondary = SystemExit("observer exit during Step")
+
+        def on_frame(*_a: Any, **_k: Any) -> None:
+            raise original
+
+        def observer(event: Any) -> None:
+            events.append(event)
+            if isinstance(event, RunPolicyStep):
+                raise secondary
+
+        with pytest.raises(KeyboardInterrupt) as caught:
+            _run(runner, policy, on_frame=on_frame, observer=observer)
+
+        assert caught.value is original
+        assert sum(isinstance(event, RunPolicyStep) for event in events) == 1
+        assert sum(isinstance(event, RunPolicyEnded) for event in events) == 1
+        assert any("SystemExit" in note for note in getattr(original, "__notes__", ()))
+        traceback_names: list[str] = []
+        current = caught.value.__traceback__
+        while current is not None:
+            traceback_names.append(current.tb_frame.f_code.co_name)
+            current = current.tb_next
+        assert "on_frame" in traceback_names
+
+    def test_outer_handled_exception_cannot_suppress_step_observer_escape(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        secondary = SystemExit("observer exit during Step")
+        handled = ValueError("already handled by caller")
+
+        def observer(event: Any) -> None:
+            events.append(event)
+            if isinstance(event, RunPolicyStep):
+                raise secondary
+
+        try:
+            raise handled
+        except ValueError:
+            with pytest.raises(SystemExit) as caught:
+                _run(runner, policy, observer=observer)
+
+        assert caught.value is secondary
+        assert not getattr(handled, "__notes__", ())
+        assert sum(isinstance(event, RunPolicyStep) for event in events) == 1
+        assert sum(isinstance(event, RunPolicyEnded) for event in events) == 1
+
+    def test_post_loop_result_assembly_error_closes_once(self, monkeypatch: pytest.MonkeyPatch):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        error = RuntimeError("result assembly exploded")
+
+        def explode() -> float:
+            raise error
+
+        # Another simulation test deliberately evicts and re-imports the module,
+        # so patch the globals of the exact function object this collected class
+        # will execute rather than whichever module object is currently cached.
+        run_impl = inspect.unwrap(PolicyRunner.run)
+        monkeypatch.setitem(run_impl.__globals__, "process_rss_mb", explode)
+
+        with pytest.raises(RuntimeError) as caught:
+            _run(runner, policy, observer=events.append)
+
+        assert caught.value is error
+        ended = [event for event in events if isinstance(event, RunPolicyEnded)]
+        assert len(ended) == 1
+        assert ended[0].outcome == "error"
+        assert ended[0].error_message == "result assembly exploded"
+
+    def test_non_callable_observer_is_refused_before_direct_runner_side_effects(self):
+        runner, policy, sim = _runner_and_policy()
+
+        with pytest.raises(ValueError, match=r"PolicyRunner\.run: observer must be callable or None"):
+            _run(runner, policy, observer=42)  # type: ignore[arg-type]
+
+        assert sim.calls == []
+
+    def test_non_callable_observer_is_refused_by_facade_before_side_effects(self):
+        runner, policy, sim = _runner_and_policy()
+        del runner
+
+        result = sim.run_policy(
+            robot_name="fake_robot",
+            policy_object=policy,
+            n_steps=1,
+            control_frequency=10.0,
+            fast_mode=True,
+            observer=42,  # type: ignore[arg-type]
+        )
+
+        assert result == {
+            "status": "error",
+            "content": [{"text": "run_policy: observer must be callable or None, got 42."}],
+        }
+        assert sim.calls == []
+
+    def test_a_preflight_refusal_emits_no_events_at_all(self):
+        """No ``Started`` means no ``Ended``: the rollout never began."""
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        with pytest.raises(ValueError):
+            _run(runner, policy, action_horizon=0, observer=events.append)
+
+        assert events == [], "a refused request must not open a rollout lifecycle"
+
+    def test_stop_when_predicate_is_reported_as_the_reason(self):
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+
+        result = _run(
+            runner,
+            policy,
+            duration=10.0,
+            stop_when=lambda _sim: True,
+            observer=events.append,
+        )
+
+        assert result["status"] == "success"
+        ended = events[-1]
+        assert ended.stopped_reason == "predicate"
+        assert ended.applied_actions == 1

--- a/tests/simulation/test_run_policy_observer_containment_is_the_narrowest_superset.py
+++ b/tests/simulation/test_run_policy_observer_containment_is_the_narrowest_superset.py
@@ -1,0 +1,314 @@
+"""What the ``observer`` guard on :meth:`PolicyRunner.run` may absorb, and what it may not.
+
+The guard exists for one class. :class:`CooperativeStop` is a ``BaseException``
+*precisely* so a hook's broad ``except Exception`` cannot swallow a graceful
+stop, so a guard written as ``except Exception`` would let an observer fire one
+and cancel a rollout it is only supposed to watch. That is the defect the guard
+prevents, and the sibling module pins it.
+
+Written as ``except BaseException`` the guard also covered three signals that
+are not an observer's to absorb, and two of them reached a caller as a *counted
+telemetry failure* on a rollout reported ``success``:
+
+======================  =====================  ==========================
+observer raises         ``BaseException``      ``(CooperativeStop, Exception)``
+======================  =====================  ==========================
+``CooperativeStop``     contained              contained
+``ValueError``          contained, counted     contained, counted
+``GeneratorExit``       contained, counted     **propagates**
+``CancelledError``      contained, counted     **propagates**
+``KeyboardInterrupt``   propagates             propagates
+``SystemExit``          propagates             propagates
+======================  =====================  ==========================
+
+The last two propagated only because the clause above the guard re-raises them
+by name. ``GeneratorExit`` and :class:`asyncio.CancelledError` had no such
+clause, so a generator being closed underneath a visualiser, or a task cancelled
+while one was drawing, was reported as "the observer is down, the rollout is
+fine" and the rollout ran to its budget. None of those four is an ``Exception``
+subclass, which is what makes the narrower tuple both sufficient for the one
+class the guard is for and silent about the three it is not.
+
+That tuple is also what ``py/catch-base-exception`` reads, and the rule's
+disposition in ``AGENTS.md`` does not reach this site: it turns on "which thread
+you marshal onto", and this guard marshals onto none - it is a synchronous call
+to a caller's callback on the rollout's own thread. The census in
+``tests/test_codeql_query_filters.py`` says so from the other side, refusing a
+second non-reraising handler that is not the cross-thread marshal box.
+
+The second cell group is about *where* the per-step event is built rather than
+what it contains. The emission sits in a ``finally`` on purpose - that is what
+reports the action a cancelling hook aborted on - and a ``lambda`` written there
+is read by ``py/exit-from-finally`` as a ``return`` leaving the block. The block
+holds no ``return`` / ``break`` / ``continue`` of its own, measured below, so
+naming the builder is what answers the report; the event it produces is
+unchanged, which the field-parity cell holds.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation import policy_runner as policy_runner_module
+from strands_robots.simulation.observers import RunPolicyStep
+from strands_robots.simulation.policy_runner import CooperativeStop
+from tests.simulation.test_run_policy_observer import (
+    _json,
+    _run,
+    _runner_and_policy,
+)
+
+# Bound here rather than reached through the module under test so a rename in
+# production cannot quietly turn a cell below into an assertion about nothing.
+_GUARD_OWNER = "_emit_event"
+_STEP_EMITTER = "_emit_step"
+
+
+def _module_tree() -> ast.Module:
+    """Parse the production module from disk.
+
+    Read as a file rather than through :func:`inspect.getsource` on the nested
+    function: the guard and the step emitter are closures inside ``run``, and a
+    dedented fragment loses the enclosing ``try`` the second group is about.
+    """
+    path = Path(inspect.getfile(policy_runner_module))
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _handlers_in(owner: str) -> list[ast.ExceptHandler]:
+    """Every ``except`` clause owned by the named function."""
+    tree = _module_tree()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == owner:
+            return [h for h in ast.walk(node) if isinstance(h, ast.ExceptHandler)]
+    raise AssertionError(f"no function named {owner!r} in {inspect.getfile(policy_runner_module)}")
+
+
+def _finally_blocks_calling(name: str) -> list[ast.Try]:
+    """Every ``try`` whose ``finally`` calls the named function."""
+    out = []
+    for node in ast.walk(_module_tree()):
+        if not (isinstance(node, ast.Try) and node.finalbody):
+            continue
+        for statement in node.finalbody:
+            for call in ast.walk(statement):
+                if isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id == name:
+                    out.append(node)
+                    break
+            else:
+                continue
+            break
+    return out
+
+
+def _observer_raising(exc: type[BaseException], *, only_step: bool = True):
+    """An observer that raises ``exc`` once, on the first Step event by default."""
+    state = {"fired": False}
+
+    def rogue(event: Any) -> None:
+        if only_step and not isinstance(event, RunPolicyStep):
+            return
+        if not state["fired"]:
+            state["fired"] = True
+            raise exc("observer misbehaved")
+
+    return rogue
+
+
+class TestPremises:
+    """The class facts that make the narrower tuple the right shape. True either way."""
+
+    def test_cooperative_stop_is_a_base_exception_that_is_not_an_exception(self):
+        """Why the guard cannot be ``except Exception``, and why the tuple is not redundant.
+
+        Both halves matter. ``CooperativeStop`` being outside ``Exception`` is
+        what a bare ``except Exception`` would miss, and it is also what makes
+        ``(CooperativeStop, Exception)`` two disjoint members rather than a
+        narrow class beside its own superclass - the shape
+        ``tests/test_except_tuples_state_their_real_scope.py`` refuses.
+        """
+        assert issubclass(CooperativeStop, BaseException)
+        assert not issubclass(CooperativeStop, Exception), (
+            "CooperativeStop must stay outside the Exception tree: that is the whole reason a "
+            "hook's broad `except Exception` cannot swallow a graceful stop, and the reason the "
+            "observer guard has to name it"
+        )
+
+    @pytest.mark.parametrize(
+        "exc",
+        [GeneratorExit, asyncio.CancelledError, KeyboardInterrupt, SystemExit],
+        ids=["GeneratorExit", "CancelledError", "KeyboardInterrupt", "SystemExit"],
+    )
+    def test_the_propagating_classes_are_not_exception_subclasses(self, exc):
+        """Why ``except BaseException`` reached them and the narrower tuple does not."""
+        assert not issubclass(exc, Exception)
+
+    def test_no_finally_in_the_module_carries_a_statement_level_exit(self):
+        """``py/exit-from-finally`` reported a closure's position, not any control flow.
+
+        True on both shapes, and that is the point: it is the reason the answer
+        is to name the builder rather than to restructure the block. Had any
+        ``finally`` here really carried a ``return``, moving a ``lambda`` out of
+        one would have fixed nothing and the report would have been about a real
+        swallowed exception instead.
+        """
+        blocks = [node for node in ast.walk(_module_tree()) if isinstance(node, ast.Try) and node.finalbody]
+        assert blocks, "no `finally` blocks found; the scan stopped reading the module"
+        exits = [
+            f"{type(node).__name__}@{node.lineno}"
+            for block in blocks
+            for statement in block.finalbody
+            for node in ast.walk(statement)
+            if isinstance(node, (ast.Return, ast.Break, ast.Continue))
+        ]
+        assert exits == [], (
+            f"a `finally` now carries statement-level exits {exits}. A `return` there really "
+            "would swallow the in-flight exception the step-emitting block exists to preserve, "
+            "which is a different defect from the one this file is about"
+        )
+
+
+class TestTheGuardAbsorbsOnlyWhatItIsFor:
+    """The behavioural split: two classes stop being absorbed, four are unchanged."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [GeneratorExit, asyncio.CancelledError],
+        ids=["GeneratorExit", "CancelledError"],
+    )
+    def test_a_signal_that_is_not_the_observers_propagates(self, exc):
+        """The regression: neither is an observer's to absorb.
+
+        Absorbed, each one reached the caller as a counted telemetry failure on
+        a rollout reported ``success`` and run to its full budget - a generator
+        closed underneath a visualiser, or a task cancelled while one was
+        drawing, reported as "the observer is down".
+        """
+        runner, policy, _ = _runner_and_policy()
+        with pytest.raises(exc):
+            _run(runner, policy, observer=_observer_raising(exc))
+
+    def test_a_cooperative_stop_from_the_observer_is_still_contained(self):
+        """The guard's whole purpose, and the property the narrowing must not cost.
+
+        Holds either way. It is here because it is the assertion a reader
+        reaches for to argue the guard cannot be narrowed at all, and the tuple
+        is exactly what keeps it true.
+        """
+        runner, policy, _ = _runner_and_policy()
+        result = _run(runner, policy, observer=_observer_raising(CooperativeStop))
+        assert result["status"] == "success"
+        payload = _json(result)
+        assert payload["stopped_reason"] == "budget", "an observer must not be able to cancel"
+        assert payload["observer_failures"] == 1
+
+    def test_an_ordinary_exception_from_the_observer_is_still_contained_and_counted(self):
+        """A visualiser that cannot draw is still not a rollout failure."""
+        runner, policy, _ = _runner_and_policy()
+        result = _run(runner, policy, observer=_observer_raising(ValueError))
+        assert result["status"] == "success"
+        assert _json(result)["observer_failures"] == 1
+
+    @pytest.mark.parametrize("exc", [KeyboardInterrupt, SystemExit], ids=["KeyboardInterrupt", "SystemExit"])
+    def test_the_operators_signals_still_propagate(self, exc):
+        """Unchanged: these were re-raised by name before and are outside the tuple now."""
+        runner, policy, _ = _runner_and_policy()
+        with pytest.raises(exc):
+            _run(runner, policy, observer=_observer_raising(exc))
+
+
+class TestTheShapeThatKeepsBothAlertsClosed:
+    """Structural pins, so neither report returns without a cell naming it."""
+
+    def test_the_guard_names_no_base_exception(self):
+        """``py/catch-base-exception`` and the AGENTS.md census read the same clause."""
+        named: list[str] = []
+        for handler in _handlers_in(_GUARD_OWNER):
+            if handler.type is None:
+                named.append("<bare except>")
+                continue
+            members = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+            named.extend(ast.unparse(member) for member in members)
+        assert named, f"{_GUARD_OWNER}() carries no `except` clause; the guard is the whole point"
+        assert "BaseException" not in named, (
+            f"{_GUARD_OWNER}() names BaseException again (clauses: {named}). That is a "
+            "py/catch-base-exception alert whose review thread gates the merge, and a second "
+            "non-reraising handler in the AGENTS.md census, whose recorded disposition turns on "
+            "marshalling across a thread - which this synchronous callback does not do. The "
+            "smallest superset that keeps a CooperativeStop from escaping an observer is "
+            "(CooperativeStop, Exception)"
+        )
+
+    def test_the_guard_still_names_cooperative_stop(self):
+        """The other half of the clause, and the non-vacuity partner of the cell above.
+
+        ``except Exception`` satisfies the cell above and reintroduces the
+        defect, so "names no BaseException" is only half a contract. Before the
+        narrowing the guard named ``CooperativeStop`` in its prose and not in
+        its clause, which is exactly the gap this closes.
+        """
+        named = [
+            ast.unparse(member)
+            for handler in _handlers_in(_GUARD_OWNER)
+            if handler.type is not None
+            for member in (handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type])
+        ]
+        assert "CooperativeStop" in named, (
+            f"{_GUARD_OWNER}() no longer names CooperativeStop (clauses: {named}). Dropping it "
+            "satisfies the cell above and reintroduces the defect the guard exists for: "
+            "CooperativeStop is outside the Exception tree, so an observer could raise one and "
+            "cancel a rollout it is only supposed to watch"
+        )
+
+    def test_the_step_emit_is_not_a_closure_inside_the_finally(self):
+        """``py/exit-from-finally`` reads a lambda body's implicit return as a block exit."""
+        blocks = _finally_blocks_calling(_STEP_EMITTER)
+        assert len(blocks) == 1, (
+            f"expected exactly one `finally` calling {_STEP_EMITTER}(), found {len(blocks)}. The "
+            "per-step event is emitted from a `finally` on purpose - that is what reports the "
+            "action a cancelling hook aborted on - so the block has to still be there, and the "
+            "builder has to still be named rather than written inline as a closure"
+        )
+        offenders = []
+        for node in ast.walk(_module_tree()):
+            if not (isinstance(node, ast.Try) and node.finalbody):
+                continue
+            offenders += [
+                lam.lineno for statement in node.finalbody for lam in ast.walk(statement) if isinstance(lam, ast.Lambda)
+            ]
+        assert offenders == [], (
+            f"a lambda sits inside a `finally` at line(s) {offenders}. py/exit-from-finally reads "
+            "its implicit return as a `return` leaving the block and opens a review thread that "
+            "gates the merge, even where the block carries no control flow of its own. Name the "
+            f"builder instead, as {_STEP_EMITTER}() does"
+        )
+
+    def test_the_step_event_still_carries_the_same_fields(self):
+        """Over-reach guard: naming the builder moved the closure, not the event.
+
+        The three values the builder reads from the enclosing scope - the
+        applied-action index, the elapsed duration and the sim clock - are the
+        ones that would change if the hoist had turned a lazily-sampled field
+        into an eagerly-passed argument.
+        """
+        events: list[Any] = []
+        runner, policy, _ = _runner_and_policy()
+        result = _run(runner, policy, observer=events.append)
+        assert result["status"] == "success"
+
+        steps = [event for event in events if isinstance(event, RunPolicyStep)]
+        assert steps, "a 3-step rollout must emit Step events for the parity check to mean anything"
+        for index, step in enumerate(steps):
+            assert step.applied_action_index == index, (
+                "applied_action_index is read inside the builder, so it must still count applied "
+                f"actions: step {index} reported {step.applied_action_index}"
+            )
+            assert step.elapsed_s > 0.0, "elapsed_s is sampled when the event is built"
+            assert step.action_resolution in {"full", "partial", "none", "unknown"}
+            assert step.legacy_hook_outcome is None or isinstance(step.legacy_hook_outcome, str)


### PR DESCRIPTION
Rebase of @logesh4v's observer lane onto current `main`. **All of the design and implementation is theirs** ([#2907](https://github.com/strands-labs/robots/pull/2907), approved there); this head exists only because that one was `CONFLICTING` against `main` and the conflict needed resolving. Refs #2907.

![observer lane rebase verification](https://raw.githubusercontent.com/cagataycali/robots/assets/observer-rebase-2907/docs/assets/observer_rebase.png)

## The conflict was 4 keep-both hunks, and only one resolution keeps both merged contracts

`main` gained a `try/finally` that releases the rollout hook (#3341); the observer lane appends `observer=observer` to the same `runner.run(...)` call. The kwarg goes **inside** the wrapper.

| resolution taken | suites that fail | what breaks |
|---|---|---|
| take `main` only (drop `observer=`) | **6 F** | `test_blocking_run_policy_claims_and_forwards_the_observer.py` - the lane is accepted and dropped |
| take the branch only (drop the `finally`) | **6 F** | `test_rollout_hook_release_leaves_the_robot_idle.py` - the robot is never left idle |
| keep both (shipped) | **0 F / 77 P** | - |

The branch's own `test_every_surface_consumes_or_forwards_the_lane` catches the first row; #3341's merged grader catches the second. Nothing was hand-written to prove this - both were already in the tree.

The other three hunks: `mujoco/simulation.py` and `policy_runner.py` sorted-import unions (`optional_callable_error` beside `positive_count_error`; the `observers` block beside `require_clip_encoder`). **No behaviour edit, no file added or removed, no test added or removed relative to #2907.**

## Verified on a real MuJoCo backend (headless EGL, so100, 12 steps @ 30 Hz)

| | `main` 085a4b6c9 | this head |
|---|---|---|
| `run_policy(observer=)` | absent (`No module named ...simulation.observers`) | accepted |
| events delivered | 0 | **14** = 1 `Started` + 12 `Step` + 1 `Ended` |
| rollout status | success | success |
| `n_steps` reported | 12 | 12 |
| `observer_failures` | (key absent) | 0 |

```
applied  legacy  resol  reused  hook   sim_t  keys
      0       0   full   False    ok   0.034     6
      1       1   full    True    ok   0.068     6
      2       2   full    True    ok   0.102     6
      ...
Ended: outcome=success reason=budget applied_actions=12 legacy_steps_used=12
       action_errors=0 observer_failures=0
```

`hook=ok` on every step is the load-bearing line: the backend's own `_make_run_policy_hook` ran **beside** the observer. A second rollout on the same robot then returned `success`, so the `finally` released it. Rollout video (this is the stream above): [observed.mp4](https://raw.githubusercontent.com/cagataycali/robots/assets/observer-rebase-2907/docs/assets/observed.mp4)

![rollout](https://raw.githubusercontent.com/cagataycali/robots/assets/observer-rebase-2907/docs/assets/observed.gif)

## Merge order with #3349 is free

#3349 (`stop_policy` base contract) touches the same two files. Test-merged onto this head: **0 conflicted files**, and the combined tree runs the observer suites + the release grader + `test_stop_policy_base_contract.py` at **116 passed**. Either can land first.

## Gate

| Check | Result |
|---|---|
| full `tests/` on this head | **51269 passed, 299 skipped** (32m06s) |
| full `tests/` on `main` 085a4b6c9, same box, concurrently | **51184 passed, 299 skipped** (32m12s) |
| regressions (`comm -23` of FAILED names) | **none - both runs are 0 F / 0 E** |
| delta | +85 passed = exactly the cells this branch adds |
| `ruff check` + `ruff format --check` (`strands_robots tests tests_integ`) | clean, 1970 files |
| `mypy` 1.20.2 | 20 pre-existing errors in 6 files, all under `examples/isaac_gs/` + `simulation/ik.py`; **none in a changed module** |

LOC delta `+2916 / -171` (net **+2745**): source +1088/-142, tests +1669/-29, docs+changelog +159. Net-positive and justified as a new public surface - `observers.py` (317) is the event schema, and the test half is 60% of the addition because the claim being pinned is "beside, not instead of".

## One correction to the surface as described elsewhere

The observer is a **one-argument** callable receiving frozen event dataclasses (`SCHEMA_VERSION = 2`), not a `(obs, action, info)` triple. `observation` and `action` are two of 14 fields on `RunPolicyStep`, borrowed rather than copied. `docs/simulation/overview.md` in this PR is the authority.

Co-authored-by: LOGESH S <78144264+logesh4v@users.noreply.github.com>