### PR TITLE
fix(drivers/earthrover): a drive axis past full speed is refused, not sent at full speed

### DIFF
--- a/changelog.d/3353-rover-drive-envelope-refused.md
+++ b/changelog.d/3353-rover-drive-envelope-refused.md
@@ -1,0 +1,25 @@
+### Bug Fixes
+
+- **drivers/earthrover**: A `linear` or `angular` past full speed is refused by name rather than
+  clamped onto full speed, and `lamp` is read as a boolean rather than for truthiness. Both drive
+  axes are a *fraction* of full speed, so clamping mapped every out-of-range magnitude onto the
+  single fastest command the base has: measured across a 61-cell sweep of `linear` from `0.0` to
+  `6.0`, all 50 requests above `1.0` were accepted under `status="success"` and all 50 were sent
+  as `linear=1.0`, collapsing 51 distinct requests onto one wire value. A caller working on a
+  nought-to-a-hundred percent model therefore could not tell its slowest crawl from flat out -
+  `linear=1` and `linear=100` were the same `/control` command - and a rover is
+  velocity-commanded, so the twist it was not asked for keeps being executed until the next
+  command arrives. That is the disposition
+  `strands_robots.drivers.crazyflie.twist_error` already argues for ("a caller who asked for
+  5 m/s never silently flies 1 m/s") and the rule `strands_robots.drivers.feetech.bus` states for
+  a joint target; it is the opposite of
+  `strands_robots.drivers.robotiq.protocol.aperture_mm_to_counts`, which clamps and says why -
+  a bounded *position* really does have an endpoint that "200 mm on an 85 mm gripper" meant,
+  where a velocity has none. `send_action` now holds each axis to `[-1, 1]` through the new
+  `drive_axis_error` at the same point it already refused a non-finite value, and the refusal
+  names a percent or SI scale as the usual cause. `lamp` was read with `1 if action["lamp"] else 0`,
+  so `"off"` and `"false"` - the spellings an operator reaches for when switching the headlamp off -
+  each turned it **on**, while `rover_lamp` one layer above already refused a non-boolean through
+  `boolean_flag_error`; the driver now applies the same domain, so the two layers of one channel
+  agree. Commands inside the envelope are unchanged: `0.0`, `0.25`, `-0.5`, `1.0` and `-1.0` all
+  still put the caller's own value on the wire, and `+/-1.0` remains accepted as full speed.

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -195,6 +195,15 @@ rover.send_action({"linear": 0.4, "angular": -0.2})    # each axis normalised to
 rover.cleanup()                                        # sends a parting zero twist
 ```
 
+Both axes are a fraction of full speed, so `1.0` is already the fastest value there is and
+a magnitude above it is **refused by name**, never clamped - the same disposition as the
+Crazyflie envelope above, for the reason the rover makes sharper: it is velocity-commanded,
+so a twist it was not asked for keeps running until the next command. Clamping sent every
+out-of-range magnitude at full speed, which is exactly what a caller writing the value on a
+percent scale needs to be told about: `linear=1` and `linear=100` are the same command once
+both saturate. `lamp` is read as a boolean rather than for truthiness, so `lamp="off"`
+is refused instead of switching the headlamp on.
+
 Every endpoint - including `POST /control`, which *drives* - is built from that one
 string, so it has to address the host you wrote. A value whose authority names one host
 and resolves to another is refused at construction, because the transport does not refuse

--- a/strands_robots/drivers/earthrover.py
+++ b/strands_robots/drivers/earthrover.py
@@ -42,7 +42,7 @@ import threading
 from typing import TYPE_CHECKING, Any, cast
 
 from strands_robots.drivers.base import halt_failure_detail, undeclared_verb_error
-from strands_robots.utils import finite_number_error, positive_finite_number_error
+from strands_robots.utils import boolean_flag_error, finite_number_error, positive_finite_number_error
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -58,6 +58,11 @@ SUPPORTED_ROBOTS: tuple[str, ...] = ("earthrover",)
 
 #: The whole control surface of a differential-drive base with a headlamp.
 DRIVE_CHANNELS: tuple[str, ...] = ("linear", "angular", "lamp")
+
+#: Magnitude bound on ``linear`` and ``angular``. The SDK's ``/control``
+#: endpoint takes each axis normalised, so this is the whole envelope: ``1.0``
+#: is already full speed and there is no faster value to ask for.
+DRIVE_AXIS_LIMIT: float = 1.0
 
 #: The camera views the SDK serves under ``/v2/<view>``.
 CAMERA_VIEWS: tuple[str, ...] = ("front", "rear")
@@ -89,6 +94,50 @@ def _declared_scheme(value: str) -> str | None:
 def _refuse(reason: str) -> dict[str, Any]:
     """One refusal envelope, so every refusal has the same shape."""
     return {"status": "error", "content": [{"text": reason}]}
+
+
+def drive_axis_error(value: object, param: str, context: str) -> str | None:
+    """Report why ``value`` is not a commandable drive axis, or ``None``.
+
+    Refuses rather than clamping, which is the disposition the module docstring's
+    safety note argues for: a rover is **velocity**-commanded, so a twist it was
+    never asked for keeps being executed until the next command arrives. Clamping
+    maps every out-of-range magnitude onto full speed, so the most common way to
+    get one of these numbers wrong - writing it on the wrong scale - produces the
+    fastest motion the base has, indefinitely, and reports success. A caller on a
+    nought-to-a-hundred percent model then cannot tell its slowest crawl from its
+    top speed: ``1`` and ``100`` are the same wire command once both saturate.
+
+    This is :func:`~strands_robots.drivers.crazyflie.twist_error`'s reasoning at
+    a lower speed, and the same rule
+    :mod:`~strands_robots.drivers.feetech.bus` states for a joint target. It is
+    the opposite disposition to
+    :func:`~strands_robots.drivers.robotiq.protocol.aperture_mm_to_counts`, which
+    clamps and says why: that axis is a bounded *position*, so the endpoint of
+    the stroke really is what "200 mm on an 85 mm gripper" meant. A velocity has
+    no such endpoint to land on.
+
+    Args:
+        value: The axis value as supplied.
+        param: Which axis, to quote in the reason.
+        context: Calling surface to quote in the reason.
+
+    Returns:
+        A reason naming the axis and the bound it broke, or ``None`` when the
+        value is a finite magnitude inside the envelope.
+    """
+    if (reason := finite_number_error(value, param, context)) is not None:
+        return reason
+    magnitude = float(cast("float", value))
+    if abs(magnitude) > DRIVE_AXIS_LIMIT:
+        return (
+            f"{context}: {param}={magnitude} is outside the normalised drive envelope "
+            f"[-{DRIVE_AXIS_LIMIT}, {DRIVE_AXIS_LIMIT}] - the SDK's /control endpoint takes "
+            f"a fraction of full speed, so {DRIVE_AXIS_LIMIT} is already the fastest value "
+            "there is. A value on a percent or SI scale is the usual cause; divide it down "
+            "rather than letting it saturate, because a rover holds the twist it was given."
+        )
+    return None
 
 
 def base_url_error(value: object, param: str, context: str) -> str | None:
@@ -456,15 +505,19 @@ class EarthRoverDriver:
 
         Args:
             action: Values for :data:`DRIVE_CHANNELS` - ``linear`` and
-                ``angular`` in ``[-1, 1]`` (clamped), plus an optional ``lamp``
-                truthy flag. An absent axis is commanded ``0.0``, because a
-                twist is a complete statement of intent: "turn" also means
-                "stop driving forward".
+                ``angular`` inside ``[-1, 1]``, plus an optional ``lamp``
+                boolean. An axis outside the envelope is refused by
+                :func:`drive_axis_error` rather than clamped onto full speed,
+                and ``lamp`` is read as a boolean rather than for truthiness, so
+                ``"off"`` cannot switch the headlamp on. An absent axis is
+                commanded ``0.0``, because a twist is a complete statement of
+                intent: "turn" also means "stop driving forward".
             robot_name: Accepted for parity; this driver fronts one rover.
 
         Returns:
-            A success envelope naming the commanded twist as sent (after
-            clamping and ``turn_sign``), or a refusal naming what was wrong.
+            A success envelope naming the commanded twist as sent (the caller's
+            axes, with ``turn_sign`` applied), or a refusal naming what was
+            wrong. Nothing reaches the SDK on a refusal.
         """
         session = self._session
         if session is None or not self._connected:
@@ -474,12 +527,14 @@ class EarthRoverDriver:
         if bad:
             return _refuse(f"send_action: unknown drive channel(s) {bad}; valid: {list(DRIVE_CHANNELS)}")
         for axis in ("linear", "angular"):
-            if axis in action and (reason := finite_number_error(action[axis], axis, "send_action")):
+            if axis in action and (reason := drive_axis_error(action[axis], axis, "send_action")):
                 return _refuse(reason)
+        if "lamp" in action and (reason := boolean_flag_error(action["lamp"], "lamp", "send_action")):
+            return _refuse(reason)
 
         command: dict[str, float] = {
-            "linear": max(-1.0, min(1.0, float(action.get("linear", 0.0)))),
-            "angular": self._turn_sign * max(-1.0, min(1.0, float(action.get("angular", 0.0)))),
+            "linear": float(action.get("linear", 0.0)),
+            "angular": self._turn_sign * float(action.get("angular", 0.0)),
         }
         if "lamp" in action:
             command["lamp"] = 1 if action["lamp"] else 0
@@ -503,8 +558,9 @@ class EarthRoverDriver:
         """Command a twist by axis - sugar over :meth:`send_action`.
 
         Args:
-            linear: Forward speed, ``[-1, 1]``.
-            angular: Turn rate, ``[-1, 1]``, positive left.
+            linear: Forward speed, inside ``[-1, 1]``; outside it is refused.
+            angular: Turn rate, inside ``[-1, 1]``, positive left; outside it is
+                refused.
 
         Returns:
             :meth:`send_action`'s envelope.

--- a/strands_robots/tools/earthrover.py
+++ b/strands_robots/tools/earthrover.py
@@ -94,10 +94,11 @@ def rover_move(
 
     Args:
         driver: The live EarthRoverDriver handle the orchestrator constructed.
-        linear: Forward speed, ``-1.0`` to ``1.0`` (clamped by the driver);
-            negative is reverse.
-        angular: Turn rate, ``-1.0`` to ``1.0`` (clamped by the driver);
-            positive is left.
+        linear: Forward speed, ``-1.0`` to ``1.0``; negative is reverse. A
+            value outside that envelope is refused by the driver, not clamped
+            onto full speed.
+        angular: Turn rate, ``-1.0`` to ``1.0``; positive is left. Refused
+            outside the envelope, as ``linear`` is.
         duration_s: How long to hold the twist before the forced stop, in
             seconds - at most :data:`MAX_MOVE_DURATION_S`. ``None`` sends the
             twist and returns immediately.

--- a/tests/drivers/test_earthrover_driver.py
+++ b/tests/drivers/test_earthrover_driver.py
@@ -22,10 +22,12 @@ from strands_robots.drivers.base import HardwareDriver, missing_driver_members
 from strands_robots.drivers.earthrover import (
     CAMERA_VIEWS,
     DEFAULT_SDK_URL,
+    DRIVE_AXIS_LIMIT,
     DRIVE_CHANNELS,
     EarthRoverDriver,
     base_url_error,
     detect_image_format,
+    drive_axis_error,
 )
 
 _DATA = {
@@ -254,15 +256,14 @@ class TestSendActionReachesTheWire:
         ("action", "expected"),
         [
             ({"linear": 0.5, "angular": -0.25}, {"linear": 0.5, "angular": -0.25}),
-            ({"linear": 2.0}, {"linear": 1.0, "angular": 0.0}),
-            ({"angular": -3.0}, {"linear": 0.0, "angular": -1.0}),
+            ({"linear": 1.0, "angular": -1.0}, {"linear": 1.0, "angular": -1.0}),
             ({}, {"linear": 0.0, "angular": 0.0}),
             ({"lamp": True}, {"linear": 0.0, "angular": 0.0, "lamp": 1}),
-            ({"lamp": 0}, {"linear": 0.0, "angular": 0.0, "lamp": 0}),
+            ({"lamp": False}, {"linear": 0.0, "angular": 0.0, "lamp": 0}),
         ],
-        ids=["plain", "clamp-linear", "clamp-angular", "empty-is-stop", "lamp-on", "lamp-off"],
+        ids=["plain", "full-speed-both-ways", "empty-is-stop", "lamp-on", "lamp-off"],
     )
-    def test_the_posted_command_is_the_clamped_twist(
+    def test_the_posted_command_is_the_callers_twist(
         self, session: _FakeSession, action: dict[str, Any], expected: dict[str, float]
     ) -> None:
         driver = _live_driver(session)
@@ -294,8 +295,23 @@ class TestSendActionRefusesRatherThanGuesses:
             ({"linear": float("nan")}, "linear"),
             ({"angular": float("inf")}, "angular"),
             ({"linear": "fast"}, "linear"),
+            ({"linear": 2.0}, "outside the normalised drive envelope"),
+            ({"linear": 30.0}, "percent or SI scale"),
+            ({"angular": -3.0}, "outside the normalised drive envelope"),
+            ({"lamp": "off"}, "lamp"),
+            ({"lamp": 1}, "lamp"),
         ],
-        ids=["typo-channel", "nan", "inf", "string"],
+        ids=[
+            "typo-channel",
+            "nan",
+            "inf",
+            "string",
+            "linear-past-full-speed",
+            "linear-on-a-percent-scale",
+            "angular-past-full-speed",
+            "lamp-spelled-off",
+            "lamp-as-an-int",
+        ],
     )
     def test_a_bad_action_is_refused_before_the_wire(
         self, session: _FakeSession, action: dict[str, Any], needle: str
@@ -310,6 +326,57 @@ class TestSendActionRefusesRatherThanGuesses:
     def test_the_channel_refusal_names_the_valid_set(self, session: _FakeSession) -> None:
         refusal = _live_driver(session).send_action({"warp": 9})
         assert str(list(DRIVE_CHANNELS)) in refusal["content"][0]["text"]
+
+    def test_a_twist_past_full_speed_is_not_sent_at_full_speed(self, session: _FakeSession) -> None:
+        """The scale is no longer collapsed onto the fastest command there is.
+
+        Both axes are a fraction of full speed, so clamping mapped every
+        out-of-range magnitude onto the same wire value: on a nought-to-a-hundred
+        percent model a crawl and a top speed were the identical command, and the
+        rover holds a twist until the next one arrives. Neither request is
+        guessed at now, and the grading property is that nothing reached
+        ``/control`` - a refusal that still posted would stop the wheels only by
+        accident.
+        """
+        driver = _live_driver(session)
+        posts_before = len(session.posts)
+        crawl, flat_out = (driver.send_action({"linear": value}) for value in (5.0, 100.0))
+        assert crawl["status"] == "error" and flat_out["status"] == "error"
+        assert len(session.posts) == posts_before
+
+    def test_move_refuses_the_same_envelope_send_action_does(self, session: _FakeSession) -> None:
+        driver = _live_driver(session)
+        posts_before = len(session.posts)
+        assert driver.move(2.0, 0.0)["status"] == "error"
+        assert len(session.posts) == posts_before
+
+
+class TestTheDriveEnvelopeIsTheNormalisedRange:
+    """:func:`drive_axis_error`'s domain, graded as a set rather than a constant.
+
+    The bound is pinned by what it discriminates - every magnitude up to and
+    including :data:`DRIVE_AXIS_LIMIT` is commandable and everything past it is
+    not - so widening the envelope fails the refused cells and narrowing it fails
+    the accepted ones. An ``== 1.0`` assertion would survive both.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [0.0, 0.5, -0.5, DRIVE_AXIS_LIMIT, -DRIVE_AXIS_LIMIT],
+        ids=["stop", "forward", "reverse", "full-speed", "full-reverse"],
+    )
+    def test_a_magnitude_inside_the_envelope_is_commandable(self, value: float) -> None:
+        assert drive_axis_error(value, "linear", "send_action") is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [DRIVE_AXIS_LIMIT + 1e-9, 1.5, -1.5, 30.0, -100.0],
+        ids=["just-past-full-speed", "half-again", "reverse-half-again", "percent-scale", "far-past"],
+    )
+    def test_a_magnitude_outside_the_envelope_names_the_axis_and_the_surface(self, value: float) -> None:
+        reason = drive_axis_error(value, "angular", "send_action")
+        assert reason is not None
+        assert "angular" in reason and "send_action" in reason
 
     @pytest.mark.parametrize(
         ("post_response", "needle"),


### PR DESCRIPTION
Both rover drive axes are a *fraction* of full speed, so clamping mapped every out-of-range magnitude onto the single fastest command the base has. `send_action` already refused a non-finite `linear`/`angular`; it now holds the same two axes to `[-1, 1]` at the same point, and reads `lamp` as a boolean instead of for truthiness.

![measured before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/rover-envelope-final/rover_envelope.png)

## Measured

A 61-cell sweep of `linear` from `0.0` to `6.0` against a recording `requests` double (no rover, no SDK process), run against this branch and against `main`:

| | main | this branch |
|---|---|---|
| requests above `1.0` | **50 of 50 accepted** under `status="success"` | 50 refused |
| distinct requests collapsed onto wire value `1.0` | **51** | 0 |
| distinct wire values sent across the sweep | 2 | 11 |
| POSTs that reached `/control` | 78 | 19 |

On a nought-to-a-hundred percent model the two ends of the scale were the same command:

| `linear=` | main wire | this branch |
|---|---|---|
| `1.0` | `1.0` | sent `1.0` |
| `5.0` | `1.0` | refused |
| `30.0` | `1.0` | refused |
| `60.0` | `1.0` | refused |
| `100.0` | `1.0` | refused |

A 1% crawl and flat-out were indistinguishable on the wire, and a rover is velocity-commanded - `cleanup()`'s parting zero twist exists precisely because it does not hold still when you stop talking to it - so the twist it was not asked for keeps being executed until the next command arrives. Clamping picks the fastest possible reading of a number the caller got wrong.

`lamp` was `1 if action["lamp"] else 0`, so the spellings an operator reaches for when switching it **off** switched it **on**:

| `lamp=` | main | this branch |
|---|---|---|
| `True` / `False` | on / off | unchanged |
| `"off"` | **on** | refused |
| `"false"` | **on** | refused |
| `0` / `1` / `None` | off / on / off | refused |

`rover_lamp`, one layer above, already refused a non-boolean through `boolean_flag_error`; the driver now applies the same domain, so the two layers of one channel agree.

## Why refuse here and not everywhere

This is the disposition `drivers.crazyflie.twist_error` already argues for ("a caller who asked for 5 m/s never silently flies 1 m/s") and the rule `drivers.feetech.bus` states for a joint target. It is deliberately the *opposite* of `drivers.robotiq.protocol.aperture_mm_to_counts`, which clamps and says why: that axis is a bounded **position**, so the end of the stroke really is what "200 mm on an 85 mm gripper" meant. A velocity has no such endpoint to land on.

In-envelope behaviour is unchanged - `0.0`, `0.25`, `-0.5`, `1.0`, `-1.0` all still put the caller's own value on the wire, and `+/-1.0` remains accepted as full speed (measured identical on both trees).

## Tests

`12` cells fail on pre-fix code and pass here. Full suite: **51229 passed, 299 skipped, 0 failed**; the same suite with only this test file applied to `main` gives **12 failed, 51217 passed**, and the failing set is exactly these cells - no other cell in the tree changed verdict either way.

The bound is pinned by what it *discriminates* rather than by its constant, so both directions of over-reach are graded:

| mutation | cells fired |
|---|---|
| revert (clamp + truthy lamp) | 12 |
| widen envelope to `2.0` | 4 |
| narrow envelope to `0.5` | 1 |
| validate only after the POST | 10 |
| drop the `lamp` check | 2 |

The narrow-to-`0.5` row is why the accepted `+/-1.0` cell exists; the validate-late row is why every refusal cell also asserts nothing reached `/control`.

LOC: driver `+68 -12`, tests `+73 -6`, docs `+9`, changelog `+25`.