### PR TITLE
fix(tools): lerobot_train refuses a posture that is not a boolean, instead of reading it as its opposite

### DIFF
--- a/changelog.d/3355-lerobot-train-flag-domain.md
+++ b/changelog.d/3355-lerobot-train-flag-domain.md
@@ -1,0 +1,28 @@
+### Bug Fixes
+
+- **tools**: `lerobot_train` refuses a training posture that is not a boolean instead of reading
+  it by truthiness. Five flags decide the `lerobot-train` argv - `resume`, `lora`,
+  `train_expert_only`, `gradient_checkpointing` and `push_to_hub` - and each selects a posture
+  rather than scaling a quantity, so every non-empty string a caller reaches for when opting out
+  was truthy and selected the affirmative. Measured on `12dc48d` with `policy_type="act"` unless
+  noted: `resume="false"` built `--config_path=<ckpt> --resume=true` and returned, so the fresh
+  run that was asked for became a resume of a previous config and `--policy.device`, `--steps`,
+  `--batch_size` and `--save_freq` were all dropped from the argv; `lora="false"` emitted
+  `--peft.method_type=LORA`; `gradient_checkpointing="false"` on `pi0` emitted
+  `--policy.gradient_checkpointing=true`; and `push_to_hub="no"` emitted
+  `--policy.push_to_hub=no`, a token only lerobot's own parser inside the detached process can
+  refuse. The remaining three answered with a refusal whose remedy the caller had already
+  followed and so could not act on: `lora="false", train_expert_only="false"` raised "lora and
+  train_expert_only are mutually exclusive ... Pick one fine-tuning strategy" at a caller who
+  picked neither, `train_expert_only="false"` raised "only valid for ['pi0', 'pi05', 'smolvla']
+  policies, not 'act'", and `gradient_checkpointing="false"` on `act` raised "drop
+  gradient_checkpointing=". Nothing reported the silent postures: the argv goes to a detached
+  process, the tool answers `status="success"` with a pid and a log path, and lerobot parses each
+  of those argvs without complaint. The five are now held to the shared `boolean_flag_error`
+  domain the sibling `build_lerobot_command` already applies to its own argv postures, checked
+  before the pair below them is judged so the message names the flag rather than blaming the
+  combination two unusable values happen to spell. The tool refuses them too, ahead of the
+  operator approval gate it consults for `push_to_hub`: an opt-out spelled `"false"` reached that
+  gate as `{"policy.push_to_hub": "false"}` and asked a human to approve a Hub publication nobody
+  requested. Nothing is coerced, and all 33 valid boolean combinations build a byte-identical
+  argv, numpy booleans included.

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -44,6 +44,7 @@ from strands_robots.tools._process_stop import (
     unusable_pid_result,
 )
 from strands_robots.utils import (
+    boolean_flag_error,
     declared_count,
     positive_count_error,
     stale_output_dir_is_clearable,
@@ -622,6 +623,85 @@ def _save_freq_error(value: Any) -> str | None:
     return step_cadence_error(value, "save_freq", "lerobot_train")
 
 
+# Every boolean this argv is built from, in the order each takes effect. The
+# order is the report order: ``resume`` decides whether any of the others reach
+# the argv at all, the mutually-exclusive pair is judged next, and the two
+# per-policy flags last.
+#
+# The invariant: this roster is exactly the set of ``bool`` parameters
+# :func:`build_train_command` declares. A flag added to that signature without a
+# place here is a flag read by truthiness again.
+_ARGV_FLAGS: tuple[str, ...] = (
+    "resume",
+    "lora",
+    "train_expert_only",
+    "gradient_checkpointing",
+    "push_to_hub",
+)
+
+
+def _flag_error(supplied: dict[str, Any], context: str) -> str | None:
+    """Error text for the first flag in :data:`_ARGV_FLAGS` that is not a boolean.
+
+    Each of these selects a *posture*, not a magnitude, and each was read by
+    truthiness - so the words a caller reaches for when opting out selected the
+    affirmative posture, because every non-empty string is truthy. Measured on
+    ``12dc48d`` with ``policy_type="act"`` unless noted:
+
+    * ``resume="false"`` built ``--config_path=<ckpt> --resume=true`` and
+      returned, so the fresh run that was asked for became a resume of a
+      previous config and every other flag - ``--policy.device``, ``--steps``,
+      ``--batch_size``, ``--save_freq`` - was silently dropped from the argv;
+    * ``lora="false"`` emitted ``--peft.method_type=LORA``, training an adapter
+      the caller opted out of;
+    * ``gradient_checkpointing="false"`` on ``pi0`` emitted
+      ``--policy.gradient_checkpointing=true``;
+    * ``push_to_hub="no"`` emitted ``--policy.push_to_hub=no``, a token only
+      lerobot's own parser inside the detached process can refuse.
+
+    The other three answered with a refusal whose remedy the caller had already
+    followed, which is worse than the silent posture because it cannot be acted
+    on: ``lora="false", train_expert_only="false"`` raised "lora and
+    train_expert_only are mutually exclusive ... Pick one fine-tuning strategy"
+    at a caller who picked neither, ``train_expert_only="false"`` raised "only
+    valid for ['pi0', 'pi05', 'smolvla'] policies, not 'act'", and
+    ``gradient_checkpointing="false"`` on ``act`` raised "drop
+    gradient_checkpointing=" at a caller who had spelled exactly that.
+
+    None of the silent postures is reported anywhere. The argv goes to a process
+    launched detached, the tool answers ``status="success"`` with a pid and a log
+    path, and lerobot parses every one of those argvs without complaint - it is
+    simply told the opposite posture. That is the same reason the run-size
+    numerics, ``device`` and ``save_freq`` in this argv are refused up front, and
+    these five are the postures beside them carried through unchecked.
+
+    The domain belongs to neither surface, so this delegates to
+    :func:`~strands_robots.utils.boolean_flag_error` - the one owner the mesh
+    provisioning entry points and the sibling ``lerobot_teleoperate`` builder
+    already consult - exactly as :func:`_save_freq_error` delegates the cadence in
+    this same argv. What stays here is the roster and the report order.
+
+    No coercion follows the check: every reader either gates a ``cmd.append`` or
+    selects a literal, and the numpy booleans ``boolean_flag_error`` also accepts
+    drive both correctly.
+
+    Args:
+        supplied: Every flag named in :data:`_ARGV_FLAGS`, as given by the caller.
+        context: The surface doing the refusing, named in the message. Both
+            surfaces that read these flags refuse them - the builder for the argv
+            it is about to write, and the tool before the approval gate it
+            consults for ``push_to_hub`` - so the message says which one.
+
+    Returns:
+        An error message naming the flag and its domain, or ``None`` when all
+        five are usable.
+    """
+    for param in _ARGV_FLAGS:
+        if error := boolean_flag_error(supplied[param], param, context):
+            return error
+    return None
+
+
 def build_train_command(
     dataset_root: str,
     policy_type: str = "act",
@@ -671,7 +751,9 @@ def build_train_command(
     cadence as "disables periodic saving".
 
     Raises:
-        ValueError: if ``lora`` and ``train_expert_only`` are both set (both
+        ValueError: if any of the five booleans in :data:`_ARGV_FLAGS` is not a
+            boolean (see :func:`_flag_error`), if ``lora`` and
+            ``train_expert_only`` are both set (both
             freeze the VLM and are mutually exclusive), if
             ``train_expert_only`` is requested for a non-expert policy, if
             ``num_gpus`` is not a positive integer, if a supplied ``steps``
@@ -680,6 +762,20 @@ def build_train_command(
             ``device`` is not a device string torch can parse or its
             ``save_freq`` is not a whole number of steps.
     """
+    # Refused before the pair below is judged, so the message names the flag that
+    # is not a boolean rather than blaming the combination two unusable values
+    # happen to spell.
+    if flag_error := _flag_error(
+        {
+            "resume": resume,
+            "lora": lora,
+            "train_expert_only": train_expert_only,
+            "gradient_checkpointing": gradient_checkpointing,
+            "push_to_hub": push_to_hub,
+        },
+        "build_train_command",
+    ):
+        raise ValueError(flag_error)
     if lora and train_expert_only:
         raise ValueError(
             "lora and train_expert_only are mutually exclusive (both freeze the VLM). Pick one fine-tuning strategy."
@@ -923,6 +1019,14 @@ def lerobot_train(
         resumable checkpoint exists, a fresh run starts and a stale empty
         ``output_dir`` is cleared so lerobot's "already exists" guard does not trip.
 
+    Postures:
+        ``resume``, ``lora``, ``train_expert_only``, ``gradient_checkpointing`` and
+        ``push_to_hub`` each select a posture rather than scaling a quantity, so each
+        is checked rather than parsed: a truthy spelling of off - ``"false"``, ``"no"``,
+        ``"0"`` - is refused before the run starts, instead of selecting the affirmative
+        posture it reads as the opposite of. Only ``start`` reads them, so no other
+        action is refused for one.
+
     Actions:
         start: launch a new training run (default).
         status: report a run's PID, uptime, running flag, and recent log tail.
@@ -1001,6 +1105,29 @@ def lerobot_train(
 
     try:
         if action == "start":
+            # The five argv postures, refused by the tool before anything is
+            # launched, prompted or deleted. The builder below refuses them too -
+            # it is public, and owns the argv - but it is reached too late for two
+            # of the readers here: ``push_to_hub`` is consulted by the operator
+            # approval gate further down, so an opt-out spelled ``"false"`` asked
+            # a human to approve a Hub publication nobody requested, and a
+            # refusal placed after the preflight would report the same caller
+            # mistake differently depending on whether lerobot happens to be
+            # installed. Scoped to ``start`` because no other action reads them:
+            # refusing a flag ``status`` never looks at would be a false
+            # rejection, which is the rule the numeric knobs already follow.
+            if flag_error := _flag_error(
+                {
+                    "resume": resume,
+                    "lora": lora,
+                    "train_expert_only": train_expert_only,
+                    "gradient_checkpointing": gradient_checkpointing,
+                    "push_to_hub": push_to_hub,
+                },
+                "lerobot_train",
+            ):
+                return {"status": "error", "content": [{"text": flag_error}]}
+
             # Preflight: lerobot must be importable and the dataset must exist.
             try:
                 import lerobot  # noqa: F401

--- a/tests/tools/test_lerobot_train_flag_domain.py
+++ b/tests/tools/test_lerobot_train_flag_domain.py
@@ -1,0 +1,259 @@
+"""``lerobot_train`` must refuse a training posture it can only misread.
+
+Each of the five booleans this argv is built from selects a *posture*, not a
+magnitude, and each was read by truthiness - so the words a caller reaches for
+when opting out selected the affirmative posture, because every non-empty string
+is truthy. Measured on ``12dc48d`` with ``policy_type="act"`` unless noted:
+
+* ``resume="false"`` built ``--config_path=<ckpt> --resume=true`` and returned,
+  so the fresh run that was asked for became a resume of a previous config and
+  ``--policy.device``, ``--steps``, ``--batch_size`` and ``--save_freq`` were all
+  silently dropped from the argv;
+* ``lora="false"`` emitted ``--peft.method_type=LORA``;
+* ``gradient_checkpointing="false"`` on ``pi0`` emitted
+  ``--policy.gradient_checkpointing=true``;
+* ``push_to_hub="no"`` emitted ``--policy.push_to_hub=no``.
+
+The other three answered with a refusal whose remedy the caller had already
+followed, which cannot be acted on at all: ``lora="false",
+train_expert_only="false"`` raised "Pick one fine-tuning strategy" at a caller
+who picked neither, ``train_expert_only="false"`` raised "only valid for ['pi0',
+'pi05', 'smolvla'] policies", and ``gradient_checkpointing="false"`` on ``act``
+raised "drop gradient_checkpointing=" at a caller who had spelled exactly that.
+
+Nothing reports the silent postures: the argv goes to a detached process, the
+tool answers ``status="success"`` with a pid and a log path, and lerobot parses
+each of those argvs without complaint - it is simply told the opposite posture.
+That is the reason the run-size numerics, ``device`` and ``save_freq`` in the
+same argv are already refused up front
+(``tests/tools/test_lerobot_train_size_knob_domain.py`` and siblings), and these
+five are the postures beside them that were carried through unchecked.
+
+The flags are held to the shared
+:func:`~strands_robots.utils.boolean_flag_error` domain - the one the sibling
+builder ``build_lerobot_command`` already applies to its own argv postures
+(``tests/tools/test_lerobot_teleoperate_flag_domain.py``) - so a posture is
+refused identically wherever it is supplied rather than merely equivalently.
+
+Both surfaces that read the flags refuse them. The builder owns the argv, but is
+reached too late for the tool's own reader: ``push_to_hub`` is consulted by the
+operator approval gate first, so an opt-out asked a human to approve a Hub
+publication nobody requested.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.lerobot_train as train_mod
+from strands_robots.tools.lerobot_train import build_train_command
+
+lerobot_train = train_mod.lerobot_train
+
+# The spellings a caller reaches for when opting out (every one truthy), two
+# truthy numbers, and the falsy values that are not a declared spelling of the
+# negative posture either.
+NOT_A_BOOLEAN = [
+    pytest.param("false", id="str-false"),
+    pytest.param("no", id="str-no"),
+    pytest.param("0", id="str-zero"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(1, id="int-one"),
+    pytest.param(None, id="none"),
+    pytest.param([], id="empty-list"),
+]
+
+# Both python spellings plus the numpy booleans the shared domain also accepts,
+# which arrive from an array-shaped config or a NumPy comparison.
+A_BOOLEAN = [
+    pytest.param(True, id="true"),
+    pytest.param(False, id="false"),
+    pytest.param(np.True_, id="np-true"),
+    pytest.param(np.False_, id="np-false"),
+]
+
+FLAGS = ("resume", "lora", "train_expert_only", "gradient_checkpointing", "push_to_hub")
+
+
+@pytest.fixture
+def checkpoint_tree(tmp_path) -> str:
+    """An ``output_dir`` holding a resumable checkpoint, so ``resume`` is live.
+
+    Without one, ``resume`` decides nothing and the posture it selects cannot be
+    observed in the argv at all.
+    """
+    config = tmp_path / "out" / "checkpoints" / "last" / "pretrained_model" / "train_config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}", encoding="utf-8")
+    return str(tmp_path / "out")
+
+
+def _build(**kwargs: Any) -> list[str]:
+    """Call the builder through one funnel.
+
+    The flag values under test are deliberately outside the declared ``bool``,
+    which is the point; mypy does not narrow a splatted ``dict[str, Any]``, so
+    routing the call through here states that once rather than suppressing it at
+    every call site.
+    """
+    return build_train_command(**{"dataset_root": "/data/ds", **kwargs})
+
+
+def _run_tool(**kwargs: Any) -> dict[str, Any]:
+    """Call the agent tool through one funnel, for the same reason as _build."""
+    return dict(lerobot_train(**{"dataset_root": "/data/ds", **kwargs}))
+
+
+def _text(envelope: dict[str, Any]) -> str:
+    return " ".join(item.get("text", "") for item in envelope.get("content", []))
+
+
+class TestTheBuilderRefusesAPostureItCanOnlyMisread:
+    """Each flag is held to the shared boolean domain, and named when refused."""
+
+    @pytest.mark.parametrize("flag", FLAGS)
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_a_non_boolean_flag_is_refused_by_name(self, flag: str, value: Any, checkpoint_tree: str) -> None:
+        with pytest.raises(ValueError, match=rf"\b{flag} must be a boolean"):
+            _build(output_dir=checkpoint_tree, policy_type="pi0", **{flag: value})
+
+    @pytest.mark.parametrize("value", A_BOOLEAN)
+    @pytest.mark.parametrize("flag", FLAGS)
+    def test_a_usable_boolean_is_not_refused(self, flag: str, value: Any, checkpoint_tree: str) -> None:
+        assert _build(output_dir=checkpoint_tree, policy_type="pi0", **{flag: value})
+
+
+class TestTheRefusalNamesTheFlagRatherThanTheEffectItHad:
+    """The three misdirected refusals name the flag they were given instead."""
+
+    def test_opting_out_of_both_freezing_strategies_is_not_a_choice_of_both(self) -> None:
+        with pytest.raises(ValueError, match=r"\blora must be a boolean") as refusal:
+            _build(lora="false", train_expert_only="false")
+        assert "mutually exclusive" not in str(refusal.value)
+
+    def test_opting_out_on_a_policy_that_cannot_freeze_names_the_flag(self) -> None:
+        with pytest.raises(ValueError, match=r"\btrain_expert_only must be a boolean") as refusal:
+            _build(train_expert_only="false", policy_type="act")
+        assert "only valid for" not in str(refusal.value)
+
+    def test_the_remedy_offered_is_not_the_one_already_followed(self) -> None:
+        with pytest.raises(ValueError, match=r"\bgradient_checkpointing must be a boolean") as refusal:
+            _build(gradient_checkpointing="false", policy_type="act")
+        assert "drop gradient_checkpointing" not in str(refusal.value)
+
+
+class TestTheRefusalReplacesTheOppositePosture:
+    """The argv the misread posture used to produce is never built."""
+
+    def test_a_fresh_run_does_not_become_a_resume(self, checkpoint_tree: str) -> None:
+        with pytest.raises(ValueError, match=r"\bresume must be a boolean"):
+            _build(resume="false", output_dir=checkpoint_tree)
+
+    def test_an_adapter_is_not_trained(self) -> None:
+        with pytest.raises(ValueError, match=r"\blora must be a boolean"):
+            _build(lora="false")
+
+    def test_a_checkpointing_flag_is_not_emitted_as_true(self) -> None:
+        with pytest.raises(ValueError, match=r"\bgradient_checkpointing must be a boolean"):
+            _build(gradient_checkpointing="false", policy_type="pi0")
+
+    def test_the_publication_token_is_not_a_word_only_lerobot_can_refuse(self) -> None:
+        with pytest.raises(ValueError, match=r"\bpush_to_hub must be a boolean"):
+            _build(push_to_hub="no")
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            (dict(resume=True), "--resume=true"),
+            (dict(lora=True), "--peft.method_type=LORA"),
+            (dict(gradient_checkpointing=True, policy_type="pi0"), "--policy.gradient_checkpointing=true"),
+            (dict(push_to_hub=True), "--policy.push_to_hub=true"),
+            (dict(push_to_hub=False), "--policy.push_to_hub=false"),
+        ],
+    )
+    def test_the_posture_a_real_boolean_selects_is_unchanged(
+        self, kwargs: dict[str, Any], expected: str, checkpoint_tree: str
+    ) -> None:
+        assert expected in _build(output_dir=checkpoint_tree, **kwargs)
+
+
+class TestTheToolRefusesBeforeItActs:
+    """The tool refuses ahead of its own readers, and only where they read."""
+
+    @pytest.fixture
+    def gate_calls(self, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+        """Record every approval-gate consultation, and halt if one happens.
+
+        Returning a refusal keeps a reached gate from launching a detached
+        training process, so this fixture cannot start one on the pre-fix code it
+        is written to fail against.
+        """
+        calls: list[dict[str, Any]] = []
+
+        def _spy(extra_flags: dict[str, Any], tool_context: Any) -> dict[str, Any]:
+            calls.append(dict(extra_flags))
+            return {"status": "error", "content": [{"text": "the approval gate was consulted"}]}
+
+        monkeypatch.setattr(train_mod, "_gate_extra_flags", _spy)
+        return calls
+
+    @pytest.fixture
+    def recorded_dataset(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> str:
+        """A dataset the ``start`` preflight accepts, so the gate is reachable.
+
+        Without it the preflight answers "Dataset metadata not found" first and
+        the gate is never consulted - which would make the cell below pass on the
+        pre-fix code for a reason that has nothing to do with the flag.
+        """
+        (tmp_path / "ds" / "meta").mkdir(parents=True)
+        (tmp_path / "ds" / "meta" / "info.json").write_text('{"total_episodes": 3}', encoding="utf-8")
+        monkeypatch.setattr(train_mod, "SESSION_DIR", tmp_path / ".sessions")
+        (tmp_path / ".sessions").mkdir()
+        return str(tmp_path / "ds")
+
+    def test_an_opt_out_does_not_ask_a_human_to_approve_a_publication(
+        self, gate_calls: list[dict[str, Any]], recorded_dataset: str, tmp_path
+    ) -> None:
+        envelope = _run_tool(
+            dataset_root=recorded_dataset,
+            push_to_hub="false",
+            output_dir=str(tmp_path / "out"),
+            session_name="flag_domain",
+        )
+        assert envelope["status"] == "error"
+        assert "push_to_hub must be a boolean" in _text(envelope)
+        # Measured on 12dc48d: [{"policy.push_to_hub": "false"}] - an operator
+        # asked to approve the publication the caller had opted out of.
+        assert gate_calls == []
+
+    @pytest.mark.parametrize("flag", FLAGS)
+    def test_the_refusal_precedes_the_lerobot_and_dataset_preflight(self, flag: str) -> None:
+        envelope = _run_tool(dataset_root="/nonexistent/dataset", **{flag: "false"})
+        assert envelope["status"] == "error"
+        assert f"{flag} must be a boolean" in _text(envelope)
+
+    @pytest.mark.parametrize("action", ["list", "status"])
+    def test_an_action_that_reads_no_flag_is_not_refused_for_one(
+        self, action: str, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        monkeypatch.setattr(train_mod, "SESSION_DIR", tmp_path / ".sessions")
+        (tmp_path / ".sessions").mkdir()
+        envelope = _run_tool(action=action, session_name="absent", resume="false")
+        assert "must be a boolean" not in _text(envelope)
+
+
+class TestEveryBooleanParameterHasADomain:
+    """A flag added to the builder later cannot skip the domain unnoticed."""
+
+    def test_the_roster_is_every_boolean_the_builder_declares(self) -> None:
+        declared = {
+            name
+            for name, param in inspect.signature(build_train_command).parameters.items()
+            if param.annotation in (bool, "bool")
+        }
+        assert declared, "the builder declares no bool parameter; this rule has stopped reading it"
+        assert declared == set(train_mod._ARGV_FLAGS)


### PR DESCRIPTION
![lerobot_train flag domain, before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/lerobot-train-flag-domain/docs/assets/lerobot_train_flag_domain.png)

Five booleans decide the `lerobot-train` argv and each was read by truthiness. Every non-empty string a caller reaches for when opting out is truthy, so it selected the affirmative posture. Measured on `12dc48d`, `policy_type="act"` unless noted:

| supplied | `main` | this PR |
|---|---|---|
| `resume="false"` | `--config_path=<ckpt> --resume=true`, returns — a fresh run became a resume of a previous config and `--policy.device` / `--steps` / `--batch_size` / `--save_freq` were dropped | `ValueError: resume must be a boolean` |
| `lora="false"` | `--peft.method_type=LORA` | `ValueError: lora must be a boolean` |
| `gradient_checkpointing="false"` (pi0) | `--policy.gradient_checkpointing=true` | `ValueError: gradient_checkpointing must be a boolean` |
| `push_to_hub="no"` | `--policy.push_to_hub=no` — a token only lerobot's parser, inside the detached process, can refuse | `ValueError: push_to_hub must be a boolean` |
| `lora="false", train_expert_only="false"` | `ValueError: ... Pick one fine-tuning strategy` | names `lora` |
| `train_expert_only="false"` | `ValueError: only valid for ['pi0','pi05','smolvla'] policies, not 'act'` | names `train_expert_only` |
| `gradient_checkpointing="false"` (act) | `ValueError: ... drop gradient_checkpointing=` | names `gradient_checkpointing` |

The silent rows are reported nowhere — the argv goes to a detached process, the tool answers `status="success"` with a pid and a log path, and lerobot parses every one of those argvs without complaint. The last three are worse than silence: the remedy each offers had already been followed, so the caller cannot act on it.

The run-size numerics, `device` and `save_freq` in this same argv are already refused up front for exactly that reason. These five were the postures beside them carried through unchecked.

## Change

One roster plus one delegating wrapper, in the shape `_save_freq_error` / `_torch_device_error` already use: the domain belongs to `boolean_flag_error` — the owner the sibling `build_lerobot_command` applies to its own argv postures — and what stays local is the roster and the report order.

Placement carries two decisions:

- **In the builder, before the mutually-exclusive pair is judged**, so the message names the flag that is not a boolean rather than blaming the combination two unusable values happen to spell.
- **In the tool too, ahead of its own reader.** `push_to_hub` is consulted by the operator approval gate before the builder is reached, so an opt-out arrived there as `{"policy.push_to_hub": "false"}` and asked a human to approve a Hub publication nobody requested. Measured both ways:

| | `main` | this PR |
|---|---|---|
| `_gate_extra_flags` consulted with | `[{"policy.push_to_hub": "false"}]` | `[]` |

Scoped to `start`, because no other action reads them — refusing a flag `status` never looks at would be a false rejection, the rule the numeric knobs already follow.

Nothing is coerced. All **33** valid boolean combinations build a byte-identical argv, numpy booleans included.

## Tests

`tests/tools/test_lerobot_train_flag_domain.py`, 76 table-driven cells. One row per candidate design:

| mutation | cells failing |
|---|---|
| shipped | 0 |
| revert both guards | 48 |
| revert only the builder guard | 42 (builder cells only) |
| revert only the tool guard | 6 (tool cells only) |
| guard placed after the pair checks | 2 (the misdirected refusals) |
| `push_to_hub` dropped from the roster | 11 (incl. the signature rule) |
| `bool(value)` coercion instead of refusal | 48 |

The last row is why this refuses rather than coerces; the roster row is why a `bool` parameter added to the builder later cannot skip the domain unnoticed.

Full suite, both trees at `12dc48d`, 51543 collected each: **116 failed / 50959 passed / 437 skipped / 37 errors** on `main` + this test file, **68 / 51007 / 437 / 37** with the fix. `main`-only is exactly the 48 discriminating cells; the one remaining difference was `test_no_reference_to_test_files_by_name`, which the roster comment had tripped by citing the test file — rewritten to state the invariant inline, verified green. The 68 standing failures are lerobot-0.5.1 and optional-dependency drift in files this PR does not touch.

ruff clean; mypy unchanged at the repo baseline (20 errors / 6 files).

LOC: **+415 / −1** — 129 in the tool (a 5-entry roster, one wrapper, and the measured rationale the module's siblings carry), 259 in one table-driven test file, 28 changelog.