### PR TITLE
fix(tools): lerobot_calibrate refuses an overwrite that is not a boolean, instead of replacing the calibration it was asked to keep

### DIFF
--- a/changelog.d/3361-lerobot-calibrate-overwrite-flag-domain.md
+++ b/changelog.d/3361-lerobot-calibrate-overwrite-flag-domain.md
@@ -1,0 +1,15 @@
+### Bug Fixes
+
+- **tools**: `lerobot_calibrate` refuses an `overwrite` that is not a boolean instead of reading
+  it by truthiness. On the `restore` action the flag selects a posture - keep a calibration
+  already at the destination, or replace it with the backup's copy - and every non-empty string
+  is truthy, so a caller who spelled the opt-out selected replace. Measured on `f7950da5` with
+  the destination holding `homing_offset=1` and the backup holding `999`: `overwrite="false"`,
+  `"no"` and `"0"` each returned `status="success"`, wrote `999` over `1`, and reported
+  `Overwrite mode: false` beside the file just replaced. Restoring is the path a lost
+  measurement is recovered on, so the file replaced is usually one the operator cannot
+  re-measure. Both surfaces that read the flag now consult the shared `boolean_flag_error`
+  domain: the tool for the `restore` action only, so an action that ignores the flag is never
+  refused for it, and `LeRobotCalibrationManager.restore_calibrations` at the read, ahead of
+  resolving the backup directory, so a refused flag leaves nothing touched. `True` and `False`
+  select exactly what they did before, numpy booleans included. Towards #3356.

--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -33,6 +33,7 @@ from typing import Any
 from strands import tool
 
 from strands_robots.tools._path_validation import validate_save_path
+from strands_robots.utils import boolean_flag_error
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -339,7 +340,29 @@ class LeRobotCalibrationManager:
             return False, str(e), copied_count
 
     def restore_calibrations(self, backup_dir: Path, overwrite: bool = False) -> tuple[bool, str, int]:
-        """Restore calibrations from backup"""
+        """Restore calibrations from backup.
+
+        ``overwrite`` selects a posture - keep or replace a calibration that is
+        already on disk - so it is checked against the shared boolean domain
+        rather than read by truthiness. Read by truthiness, every non-empty
+        string is the affirmative posture: ``overwrite="false"``, ``"no"`` and
+        ``"0"`` each replaced every existing calibration for a caller who had
+        spelled the opt-out, and the tool reported ``Overwrite mode: false``
+        beside the files it had just replaced. Restoring is the path a lost
+        measurement is recovered on, so the file this overwrites is usually the
+        one the operator cannot re-measure; the check therefore runs before the
+        backup directory is even resolved, so a refused flag leaves nothing
+        touched.
+
+        Returns:
+            ``(ok, message, restored_count)``. A refused ``overwrite`` is
+            ``(False, <reason naming the flag>, 0)``, the same shape a missing
+            backup directory reports on.
+        """
+        flag_error = boolean_flag_error(overwrite, "overwrite", "restore_calibrations")
+        if flag_error is not None:
+            return False, flag_error, 0
+
         backup_dir = Path(validate_save_path(str(backup_dir), label="backup_dir"))
 
         if not backup_dir.exists():
@@ -466,7 +489,10 @@ def lerobot_calibrate(
         query: Search query for search action
         output_dir: Output directory for backup action
         backup_dir: Backup directory for restore action
-        overwrite: Whether to overwrite existing files during restore
+        overwrite: Whether to replace a calibration that already exists at the
+            destination during restore. A boolean only: a string such as
+            "false" is refused rather than read as the posture it spells the
+            opposite of, since every non-empty string is truthy
         base_path: Custom base path for calibrations (default: ~/.cache/huggingface/lerobot/calibration)
 
     Returns:
@@ -652,6 +678,14 @@ def lerobot_calibrate(
         elif action == "restore":
             if not backup_dir:
                 return {"status": "error", "content": [{"text": "**restore** action requires: backup_dir"}]}
+
+            # Only this action reads ``overwrite``, so only this action refuses
+            # an unusable one; a caller listing calibrations is never refused
+            # for a flag the request ignores. The manager checks it again at
+            # the read, for a caller driving that method directly.
+            flag_error = boolean_flag_error(overwrite, "overwrite", "lerobot_calibrate")
+            if flag_error is not None:
+                return {"status": "error", "content": [{"text": f"**Restore failed:** {flag_error}"}]}
 
             success, message, count = manager.restore_calibrations(Path(backup_dir), overwrite)
 

--- a/tests/tools/test_lerobot_calibrate_overwrite_flag_domain.py
+++ b/tests/tools/test_lerobot_calibrate_overwrite_flag_domain.py
@@ -1,0 +1,224 @@
+"""``lerobot_calibrate``'s ``overwrite`` is checked, never read by truthiness.
+
+``overwrite`` selects a posture on the ``restore`` action: keep a calibration
+that is already at the destination, or replace it with the backup's copy. Read
+by truthiness, every non-empty string is the affirmative posture, so a caller
+who spelled the opt-out - ``overwrite="false"``, ``"no"``, ``"0"`` - replaced
+every existing calibration, and the tool reported ``Overwrite mode: `false```
+beside the files it had just replaced. Measured on ``main`` at ``f7950da5``
+with a destination holding ``homing_offset=1`` and a backup holding ``999``:
+
+======================  ==========  ==================================
+``overwrite=``          status      ``homing_offset`` after the restore
+======================  ==========  ==================================
+``"false"``             success     999 - replaced
+``"no"``                success     999 - replaced
+``"0"``                 success     999 - replaced
+``None`` / ``[]``       success     1 - kept, without being a spelling of keep
+``False``               success     1 - kept
+``True``                success     999 - replaced
+======================  ==========  ==================================
+
+Restoring is the path a lost measurement is recovered on, so the file this
+replaces is usually one the operator cannot re-measure - which is why this row
+of #3356 is the destructive one, and why the check has to run before anything
+is touched rather than merely before the report is written.
+
+Both surfaces that read the flag refuse it: the tool for the ``restore``
+action, and ``LeRobotCalibrationManager.restore_calibrations`` for a caller
+driving that method directly (the facade rule - a guard on the convenience
+surface alone leaves the documented method disagreeing about which values are
+usable). Both delegate to :func:`strands_robots.utils.boolean_flag_error`, the
+one owner of the domain, and the cells here parametrize over that owner's own
+verdict rather than a copied spelling list, so a spelling the shared domain
+learns to refuse is covered without an edit here.
+
+Refs #3356.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.tools.lerobot_calibrate import (
+    LeRobotCalibrationManager,
+    lerobot_calibrate,
+)
+from strands_robots.utils import boolean_flag_error
+
+# The spellings a caller reaches for when opting out (every one truthy), a
+# truthy number, nan, and the falsy values that are not a declared spelling of
+# the keep posture either.
+NOT_A_BOOLEAN = [
+    pytest.param("false", id="str-false"),
+    pytest.param("no", id="str-no"),
+    pytest.param("0", id="str-zero"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(1, id="int-one"),
+    pytest.param(None, id="none"),
+    pytest.param([], id="empty-list"),
+]
+
+# Both python spellings plus the numpy booleans the shared domain also accepts.
+A_BOOLEAN = [
+    pytest.param(True, id="true"),
+    pytest.param(False, id="false"),
+    pytest.param(np.True_, id="np-true"),
+    pytest.param(np.False_, id="np-false"),
+]
+
+KEPT = {"m": {"id": 1, "drive_mode": 0, "homing_offset": 1, "range_min": 0, "range_max": 4095}}
+BACKED_UP = {"m": {"id": 1, "drive_mode": 0, "homing_offset": 999, "range_min": 0, "range_max": 4095}}
+
+
+@pytest.fixture
+def backup(tmp_path: Path) -> str:
+    """A backup directory holding one robot calibration with ``homing_offset=999``."""
+    src = LeRobotCalibrationManager(tmp_path / "src")
+    src.save_calibration("robots", "so101_follower", "orange_arm", BACKED_UP)
+    ok, location, count = src.backup_calibrations(output_dir=tmp_path / "bk")
+    assert ok and count == 1
+    return location
+
+
+@pytest.fixture
+def destination(tmp_path: Path) -> LeRobotCalibrationManager:
+    """A destination already holding that calibration with ``homing_offset=1``."""
+    dest = LeRobotCalibrationManager(tmp_path / "dest")
+    dest.save_calibration("robots", "so101_follower", "orange_arm", KEPT)
+    return dest
+
+
+def _restore(destination: LeRobotCalibrationManager, backup: str, **kwargs: Any) -> dict[str, Any]:
+    """Call the tool through one funnel.
+
+    The flag values under test are deliberately outside the declared ``bool``;
+    mypy does not narrow a splatted ``dict[str, Any]``, so the call is routed
+    through here rather than suppressed at every site.
+    """
+    return dict(
+        lerobot_calibrate(
+            **{"action": "restore", "backup_dir": backup, "base_path": str(destination.base_path), **kwargs}
+        )
+    )
+
+
+def _text(envelope: dict[str, Any]) -> str:
+    return " ".join(item.get("text", "") for item in envelope.get("content", []))
+
+
+def _on_disk(destination: LeRobotCalibrationManager) -> dict[str, Any]:
+    return json.loads(destination.get_calibration_path("robots", "so101_follower", "orange_arm").read_text("utf-8"))
+
+
+class TestTheToolRefusesAPostureItCanOnlyMisread:
+    """The ``restore`` action refuses a non-boolean ``overwrite`` by name, and touches nothing."""
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_the_refusal_is_the_shared_domain_verdict(
+        self, value: Any, destination: LeRobotCalibrationManager, backup: str
+    ) -> None:
+        result = _restore(destination, backup, overwrite=value)
+        assert result["status"] == "error"
+        expected = boolean_flag_error(value, "overwrite", "lerobot_calibrate")
+        assert expected is not None
+        assert expected in _text(result)
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_a_refused_flag_leaves_the_existing_calibration_untouched(
+        self, value: Any, destination: LeRobotCalibrationManager, backup: str
+    ) -> None:
+        before = _on_disk(destination)
+        _restore(destination, backup, overwrite=value)
+        assert _on_disk(destination) == before == KEPT
+
+    @pytest.mark.parametrize("value", A_BOOLEAN)
+    def test_a_usable_boolean_is_not_refused(
+        self, value: Any, destination: LeRobotCalibrationManager, backup: str
+    ) -> None:
+        result = _restore(destination, backup, overwrite=value)
+        assert result["status"] == "success", _text(result)
+
+
+class TestTheRefusalReplacesTheOppositePosture:
+    """What each real boolean selects is unchanged; the opt-out spellings no longer select replace."""
+
+    def test_false_keeps_the_existing_calibration(self, destination: LeRobotCalibrationManager, backup: str) -> None:
+        result = _restore(destination, backup, overwrite=False)
+        assert result["status"] == "success"
+        assert _on_disk(destination) == KEPT
+
+    def test_true_replaces_it_with_the_backup(self, destination: LeRobotCalibrationManager, backup: str) -> None:
+        result = _restore(destination, backup, overwrite=True)
+        assert result["status"] == "success"
+        assert _on_disk(destination) == BACKED_UP
+
+    @pytest.mark.parametrize("spelling", ["false", "no", "0"])
+    def test_an_opt_out_spelling_no_longer_replaces_the_calibration(
+        self, spelling: str, destination: LeRobotCalibrationManager, backup: str
+    ) -> None:
+        """The destructive row: pre-fix each of these reported success and wrote 999 over 1."""
+        result = _restore(destination, backup, overwrite=spelling)
+        assert result["status"] == "error"
+        assert _on_disk(destination) == KEPT
+
+
+class TestTheRefusalIsScopedToTheActionThatReadsTheFlag:
+    """A caller whose action ignores ``overwrite`` is never refused for it."""
+
+    @pytest.mark.parametrize("action", ["list", "search", "path"])
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_an_action_that_reads_no_flag_is_not_refused_for_one(
+        self, action: str, value: Any, destination: LeRobotCalibrationManager
+    ) -> None:
+        result = dict(
+            lerobot_calibrate(
+                **{
+                    "action": action,
+                    "overwrite": value,
+                    "base_path": str(destination.base_path),
+                    "device_type": "robots",
+                    "device_model": "so101_follower",
+                    "device_id": "orange_arm",
+                }
+            )
+        )
+        assert result["status"] == "success", _text(result)
+
+    def test_a_missing_backup_dir_is_still_the_first_refusal(self, destination: LeRobotCalibrationManager) -> None:
+        """The pre-existing precedence is kept: the required argument is reported ahead of the flag."""
+        result = dict(
+            lerobot_calibrate(**{"action": "restore", "overwrite": "false", "base_path": str(destination.base_path)})
+        )
+        assert result["status"] == "error"
+        assert "requires: backup_dir" in _text(result)
+
+
+class TestTheManagerRefusesItAtTheRead:
+    """The documented method refuses the same values, in its own ``(ok, message, count)`` shape."""
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_a_non_boolean_is_refused_before_the_backup_dir_is_resolved(
+        self, value: Any, destination: LeRobotCalibrationManager, tmp_path: Path
+    ) -> None:
+        # The backup dir does not exist: a refusal naming the flag rather than
+        # the directory is what shows the flag was judged first.
+        ok, message, count = destination.restore_calibrations(tmp_path / "absent", overwrite=value)
+        assert ok is False
+        assert count == 0
+        assert message == boolean_flag_error(value, "overwrite", "restore_calibrations")
+        assert _on_disk(destination) == KEPT
+
+    @pytest.mark.parametrize("value", A_BOOLEAN)
+    def test_a_usable_boolean_reaches_the_restore(
+        self, value: Any, destination: LeRobotCalibrationManager, backup: str
+    ) -> None:
+        ok, message, count = destination.restore_calibrations(Path(backup), overwrite=value)
+        assert ok is True, message
+        assert count == (1 if bool(value) else 0)
+        assert _on_disk(destination) == (BACKED_UP if bool(value) else KEPT)


### PR DESCRIPTION
`lerobot_calibrate(action="restore", ...)`'s `overwrite` selects a posture - keep a calibration that is already at the destination, or replace it with the backup's copy - and was read by truthiness at the one site that decides it, `restore_calibrations`: `if dest_file.exists() and not overwrite`. Every non-empty string is truthy, so a caller who spelled the opt-out selected *replace*.

This is the destructive row of #3356. Restoring is the path a lost measurement is recovered on, so the file it replaces is usually the one the operator cannot re-measure.

## Measured

On `main` at `f7950da5`, destination holding `homing_offset=1`, backup holding `999`:

| `overwrite=` | status | report | `homing_offset` after |
|---|---|---|---|
| `"false"` | success | `Overwrite mode: false` | **999 - replaced** |
| `"no"` | success | `Overwrite mode: no` | **999 - replaced** |
| `"0"` | success | `Overwrite mode: 0` | **999 - replaced** |
| `None` / `[]` | success | `Overwrite mode: None` | 1 - kept, without being a spelling of keep |
| `False` | success | `Overwrite mode: False` | 1 - kept |
| `True` | success | `Overwrite mode: True` | 999 - replaced |

The tool's own report agreed with the caller about a posture the code did not take.

## Change

Both surfaces that read the flag consult the shared `boolean_flag_error` domain (the one owner; the mesh provisioning entry points, `lerobot_teleoperate` and #3355's `lerobot_train` already delegate to it):

- **the tool**, for the `restore` action only - keyed on the action so a caller listing calibrations is never refused for a flag the request ignores; the pre-existing `requires: backup_dir` refusal keeps precedence.
- **`LeRobotCalibrationManager.restore_calibrations`**, at the read, *ahead of* resolving the backup directory - so a refused flag leaves nothing touched. This is the facade rule from AGENTS.md ("a facade that checks a flag does not check it for the method it forwards to"): the method is documented and driven directly by an existing test, so a guard on the tool alone would leave it disagreeing about which values are usable. Its refusal takes the `(False, message, 0)` shape a missing backup directory already reports on.

Nothing is coerced. `True` / `False` / `np.True_` / `np.False_` select exactly what they did before. The `Args:` entry for `overwrite` now states the domain (verified to reach the tool schema as a real description rather than the `Parameter overwrite` placeholder).

After, same six rows: the four non-booleans return `status="error"` naming `overwrite` with the file untouched at `1`; `False` keeps `1`; `True` writes `999`.

## Tests

`tests/tools/test_lerobot_calibrate_overwrite_flag_domain.py`, 56 cells parametrized over `boolean_flag_error`'s own verdict rather than a copied spelling list, so a spelling the shared domain learns to refuse is covered here without an edit.

| grading run | result |
|---|---|
| new file on pre-fix source | **22 of 56 fail** (every refusal cell + the three opt-out-spelling cells) |
| this branch | 56 of 56 pass |

The 34 that pass both ways are the over-correction guards: real booleans still select their posture, `list` / `search` / `path` are never refused for the flag, and `requires: backup_dir` still comes first.

`tests/tools/test_lerobot_calibrate.py` + `test_a_failed_calibration_write_keeps_the_measurement_on_disk.py` + `test_lerobot_train_flag_domain.py`: 212 passed. `ruff check` + `ruff format --check` clean; `mypy strands_robots/tools/lerobot_calibrate.py` clean.

Whole-tree graders: 210 passed locally. Two of the roster (`test_agent_tool_parameter_descriptions.py`, `test_agent_tool_parameters_reach_the_body.py`) import every tool and need the `lerobot` extra, which this host does not have; the property the first one grades was checked directly against `lerobot_calibrate.tool_spec` (no placeholder description on any parameter), and CI collects both.

## Scope

One tool, one flag - the destructive row. #3356 stays open for the remaining six tools and for the roster-vs-tree-wide-grader decision it raises; this does not pre-empt that decision, it removes the row where the misread deletes an operator's data. Towards #3356.

LOC: source +36 / -2; tests +230.