### PR TITLE
fix(drivers/feetech): the read window is graded like baud_rate, and the one a caller sets reaches the bus

### DIFF
--- a/changelog.d/3362-feetech-read-window-is-graded-and-honoured.md
+++ b/changelog.d/3362-feetech-read-window-is-graded-and-honoured.md
@@ -1,0 +1,19 @@
+### Fixed: a Feetech read window that no read can wait for is refused, and the one a caller sets reaches the bus
+
+`FeetechBus` graded `baud_rate` and not `timeout`, though the two are opened on
+the same `serial.Serial` call and the rationale in the class docstring is the
+same for both. pyserial takes `0`, `nan`, `inf` and `None` verbatim as a
+timeout, and each of them makes `_read_one` see an empty buffer that its retry
+loop cannot tell from a servo that never answered, so `sync_read` omits the
+motor and logs "no verified reply": on a fake port that honours its timeout, a
+six-servo arm reported 0 of 6 joints under `timeout=0` and 6 of 6 under the
+default. The two pyserial does refuse - a negative and a string - it refuses
+from inside `connect`, naming neither the bus nor the parameter. `timeout` is
+now held to `positive_finite_number_error` beside `baud_rate`, and the default
+is the named `DEFAULT_TIMEOUT_S`.
+
+`FeetechDriver` popped no `timeout` at all, so a caller who lengthened the
+window for a slow servo had it recorded in `self._extras` while the bus opened
+at the default - the case the driver's own `motor_ids` comment names, a keyword
+that changes nothing while the caller believes the arm is configured. It is now
+forwarded to the bus and graded naming the driver, as `baud_rate` already was.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -146,6 +146,14 @@ successfully at a speed no servo answers, after which every read times out exact
 unplugged arm does. A refusal at the line that states the speed is the only place that
 reads as a caller mistake rather than as broken hardware.
 
+The read window is the same shape. `timeout=` - on `FeetechBus`, and on `FeetechDriver`, which
+forwards a caller's window to it - is how long a read waits for a servo's reply, and it is held
+to a positive finite number at construction. pyserial takes `0`, `nan`, `inf` and `None`
+verbatim, and each of them leaves the read looking at an empty buffer that the retry loop cannot
+tell from a servo that never answered, so a healthy arm reports as motors that did not reply. A
+keyword a driver *records* instead of forwarding fails the same way one layer earlier: the caller
+lengthens the window, the bus opens at its default, and nothing says so.
+
 A driver has **two** ways to halt its robot and they are not the same contract. `stop_task()`
 returns a status envelope and decides an outcome, so that is what a caller reads. `stop()` is
 the lifecycle hook and is annotated `-> None`, so it carries no verdict at all - which makes

--- a/strands_robots/drivers/feetech/bus.py
+++ b/strands_robots/drivers/feetech/bus.py
@@ -45,7 +45,7 @@ from strands_robots.drivers.feetech.protocol import (
     read_packet,
     sync_write_packet,
 )
-from strands_robots.utils import positive_count_error, require_optional
+from strands_robots.utils import positive_count_error, positive_finite_number_error, require_optional
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +137,11 @@ _REGISTER_WIDTH: Final[int] = 2
 #: :func:`~strands_robots.drivers.feetech.protocol.parse_status_packet` skips.
 _READ_BUFFER: Final[int] = 10
 
+#: Seconds a read waits for a servo's reply. Named rather than spelled
+#: twice: :class:`~strands_robots.drivers.feetech.driver.FeetechDriver`
+#: forwards a caller's window to this bus and defaults to the same one.
+DEFAULT_TIMEOUT_S: Final[float] = 1.0
+
 #: Seconds to let a servo answer before reading. The vendor SDK polls; a fixed
 #: settle is enough at 1 Mbaud for a two-byte reply and keeps the read simple.
 _REPLY_SETTLE_S: Final[float] = 0.01
@@ -176,10 +181,19 @@ class FeetechBus:
             only a negative, so an unusable value opens the port at a speed no
             servo answers instead of reporting itself.
         motors: The servos on this bus, defaulting to :data:`SO_ARM_MOTORS`.
-        timeout: Serial read timeout in seconds.
+        timeout: How long a read waits for a servo's reply, in seconds;
+            :data:`DEFAULT_TIMEOUT_S` unless a caller knows the bus answers
+            slower. Held to the same domain as ``baud_rate`` and for the same
+            reason: pyserial accepts ``0``, ``nan``, ``inf`` and ``None`` as a
+            timeout, and every one of them makes :meth:`_read_one` see an empty
+            buffer it cannot tell from a servo that never answered - so a
+            healthy arm reports as motors that did not reply, naming neither
+            this bus nor the value that decided it. The two pyserial does
+            refuse it refuses from inside :meth:`connect`, naming neither.
 
     Raises:
-        ValueError: ``baud_rate`` is not a positive integer.
+        ValueError: ``baud_rate`` is not a positive integer, or ``timeout`` is
+            not a positive finite number.
     """
 
     def __init__(
@@ -187,9 +201,11 @@ class FeetechBus:
         port: str | None,
         baud_rate: int = 1_000_000,
         motors: dict[str, MotorSpec] | None = None,
-        timeout: float = 1.0,
+        timeout: float = DEFAULT_TIMEOUT_S,
     ) -> None:
         if (reason := positive_count_error(baud_rate, "baud_rate", type(self).__name__)) is not None:
+            raise ValueError(reason)
+        if (reason := positive_finite_number_error(timeout, "timeout", type(self).__name__)) is not None:
             raise ValueError(reason)
         self.port = port
         self.baud_rate = baud_rate

--- a/strands_robots/drivers/feetech/driver.py
+++ b/strands_robots/drivers/feetech/driver.py
@@ -48,8 +48,8 @@ if TYPE_CHECKING:
 
 from strands_robots.bus_access import bus_lock
 from strands_robots.drivers.base import undeclared_verb_error
-from strands_robots.drivers.feetech.bus import SO_ARM_MOTORS, FeetechBus
-from strands_robots.utils import boolean_flag_error, positive_count_error
+from strands_robots.drivers.feetech.bus import DEFAULT_TIMEOUT_S, SO_ARM_MOTORS, FeetechBus
+from strands_robots.utils import boolean_flag_error, positive_count_error, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +115,12 @@ class FeetechDriver:
       that is not a count is applied instead of refused.
     * ``motor_ids`` - the servo IDs on the bus, in wire order. Optional at
       construction; the bus discovers them on connect.
+    * ``timeout`` - how long a read waits for a servo's reply, in seconds,
+      defaulting to :data:`~strands_robots.drivers.feetech.bus.DEFAULT_TIMEOUT_S`.
+      Forwarded to the bus rather than recorded, for the reason ``motor_ids`` is:
+      a caller who lengthens the window for a slow servo, and gets the default
+      window and six motors that did not answer, has been told nothing. Held to
+      :func:`~strands_robots.utils.positive_finite_number_error`.
     """
 
     tool_type = _TOOL_TYPE
@@ -154,6 +160,13 @@ class FeetechDriver:
         if (reason := positive_count_error(baud_rate, "baud_rate", f"FeetechDriver({tool_name!r})")) is not None:
             raise ValueError(reason)
         self._baud_rate: int = baud_rate
+        # Forwarded, not recorded. The bus has this knob, so a ``timeout`` left
+        # in ``self._extras`` is not an extension waiting for a downstream
+        # package - it is a window the caller set and the bus never saw.
+        timeout = kwargs.pop("timeout", DEFAULT_TIMEOUT_S)
+        if (reason := positive_finite_number_error(timeout, "timeout", f"FeetechDriver({tool_name!r})")) is not None:
+            raise ValueError(reason)
+        self._timeout: float = float(timeout)
         self._motor_ids: tuple[int, ...] = tuple(kwargs.pop("motor_ids", ()))
         # ``motor_ids`` narrows the arm to a subset of SO_ARM_MOTORS. Honoured
         # rather than recorded: a keyword that changes nothing is worse than one
@@ -169,7 +182,7 @@ class FeetechDriver:
                     f"ids {sorted(known)} map to {[known[i] for i in sorted(known)]}",
                 )
             motors = {known[i]: SO_ARM_MOTORS[known[i]] for i in self._motor_ids}
-        self._bus = FeetechBus(port=self._port, baud_rate=self._baud_rate, motors=motors)
+        self._bus = FeetechBus(port=self._port, baud_rate=self._baud_rate, motors=motors, timeout=self._timeout)
         self._connect_error: str | None = None
         # Extras from the caller are kept for a downstream driver package
         # to consume; refusing them here would refuse a valid future

--- a/tests/drivers/test_feetech_read_window_is_graded_and_honoured.py
+++ b/tests/drivers/test_feetech_read_window_is_graded_and_honoured.py
@@ -1,0 +1,129 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The read window a Feetech caller sets is graded, and reaches the port.
+
+``timeout`` is how long :meth:`FeetechBus._read_one` waits for a servo's reply.
+An unusable one does not surface as an error: pyserial accepts ``0``, ``nan``,
+``inf`` and ``None`` as a timeout, and each of them makes the read see an empty
+buffer that the retry loop cannot tell from a servo that never answered - so
+``sync_read`` omits the motor and logs "no verified reply", and a healthy arm
+reports as dead servos. That is the same failure ``baud_rate`` is graded to
+prevent, in the same constructor, so the window is held to the domain every
+other driver holds its timeout to.
+
+The second half is the driver: a window it recorded in ``_extras`` instead of
+forwarding is the case its own ``motor_ids`` comment names - a keyword that
+changes nothing, leaving the caller believing the bus is configured.
+
+No serial port is opened. The one cell that grades ``connect`` replaces the
+bus's ``require_optional`` with a recorder, which is what makes the number the
+port was opened with readable at all.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers.feetech.bus as bus_module
+from strands_robots.drivers.feetech.bus import DEFAULT_TIMEOUT_S, FeetechBus
+from strands_robots.drivers.feetech.driver import FeetechDriver
+from tests.drivers.conftest import MIDPOINT_COUNTS, FakeServoPort
+
+#: Windows no read can wait for. ``0`` returns immediately, a negative and a
+#: string are what pyserial itself refuses - but from inside ``connect``, naming
+#: neither the bus nor the parameter - and ``nan``/``inf``/``None``/``True``
+#: pyserial takes verbatim, so nothing downstream reports them either.
+UNUSABLE = [
+    pytest.param(0, id="zero"),
+    pytest.param(0.0, id="zero-float"),
+    pytest.param(-1.0, id="negative"),
+    pytest.param("1.0", id="string"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(None, id="none"),
+    pytest.param(True, id="bool-reads-as-one-second"),
+]
+
+#: Windows a read can wait for: fractional, whole, and short-but-real.
+USABLE = [1.0, 0.5, 2, 0.001]
+
+
+class TestTheBusGradesTheReadWindow:
+    """The window is refused at construction, where ``baud_rate`` is refused."""
+
+    @pytest.mark.parametrize("timeout", UNUSABLE)
+    def test_an_unusable_read_window_is_refused(self, timeout: Any) -> None:
+        """The refusal names the bus, the parameter and the value handed in.
+
+        All three, because the caller has to be able to act on it: a bare
+        "invalid timeout" from inside pyserial names none of them.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            FeetechBus(port="/dev/fake", timeout=timeout)
+        message = str(excinfo.value)
+        assert "FeetechBus" in message
+        assert "timeout" in message
+        assert repr(timeout) in message or str(timeout) in message
+
+    @pytest.mark.parametrize("timeout", USABLE)
+    def test_a_usable_read_window_is_kept_as_given(self, timeout: float) -> None:
+        """A positive finite window is the caller's to choose, unrounded."""
+        assert FeetechBus(port="/dev/fake", timeout=timeout).timeout == timeout
+
+    def test_the_two_layers_default_to_one_shared_window(self) -> None:
+        """One number, so the driver cannot drift from the bus it builds."""
+        assert FeetechBus(port="/dev/fake").timeout == DEFAULT_TIMEOUT_S
+        assert FeetechDriver(tool_name="so101", port="/dev/fake").bus.timeout == DEFAULT_TIMEOUT_S
+
+
+class TestTheDriverForwardsTheReadWindow:
+    """A window the caller passes is honoured, not recorded."""
+
+    def test_the_window_the_caller_asked_for_reaches_the_bus(self) -> None:
+        """Forwarded to the bus, and gone from the extras bucket.
+
+        Both halves matter: the bucket exists for keywords a downstream driver
+        package may consume, and a knob this bus already has is not one of
+        them.
+        """
+        driver = FeetechDriver(tool_name="so101", port="/dev/fake", timeout=0.25)
+        assert driver.bus.timeout == 0.25
+        assert "timeout" not in driver._extras
+
+    @pytest.mark.parametrize("timeout", UNUSABLE)
+    def test_an_unusable_window_is_refused_naming_the_driver(self, timeout: Any) -> None:
+        """The driver names itself, as it does for ``baud_rate``.
+
+        A refusal that named the bus would send the caller to a layer they did
+        not construct.
+        """
+        with pytest.raises(ValueError, match=r"FeetechDriver\('so101'\): timeout"):
+            FeetechDriver(tool_name="so101", port="/dev/fake", timeout=timeout)
+
+
+class TestTheWindowReachesThePort:
+    """The graded number is the one pyserial is opened with."""
+
+    def test_connect_opens_the_port_with_the_window_the_caller_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Grading a value the port never sees would pin nothing.
+
+        The recorder stands in for the ``serial`` module the bus imports on
+        connect, so the keyword arguments the port was opened with become
+        readable without a serial stack.
+        """
+        opened: list[dict[str, Any]] = []
+
+        def _serial(port: str, baud_rate: int, **kwargs: Any) -> FakeServoPort:
+            opened.append({"port": port, "baud_rate": baud_rate, **kwargs})
+            return FakeServoPort(MIDPOINT_COUNTS)
+
+        fake = types.ModuleType("serial")
+        fake.Serial = _serial  # type: ignore[attr-defined]
+        monkeypatch.setattr(bus_module, "require_optional", lambda *_a, **_k: fake)
+
+        driver = FeetechDriver(tool_name="so101", port="/dev/fake", timeout=0.25)
+        assert driver.connect_eagerly() is None
+        assert opened == [{"port": "/dev/fake", "baud_rate": 1_000_000, "timeout": 0.25}]


### PR DESCRIPTION
![the read window is graded like baud_rate, and forwarded](https://raw.githubusercontent.com/cagataycali/robots/assets/feetech-read-window-34336316452/feetech-read-window.png)

## Problem

`FeetechBus.__init__` grades `baud_rate` and not `timeout`, though both are handed to the same `serial.Serial(...)` call, and the class docstring states one rationale that covers both: pyserial "coerces the speed through its own `int()` and refuses only a negative, so an unusable value opens the port at a speed no servo answers instead of reporting itself".

That is exactly what an unusable read window does. pyserial takes `0`, `nan`, `inf` and `None` verbatim as a timeout, and each of them leaves `_read_one` looking at an empty buffer that its retry loop cannot tell from a servo that never answered - so `sync_read` omits the motor and logs `no verified Present_Position reply from <motor>`. Panel B: on a fake port that honours its own timeout, a healthy six-servo arm reported **0 of 6** joints under `timeout=0` and 6 of 6 under the default, with six warnings blaming the servos. The read `sync_read` performs is the one `bus_access.read_joints` publishes, so that is also what the arm looks like to the fleet.

The two values pyserial *does* refuse - a negative and a string - it refuses from inside `connect()`, naming neither the bus nor the parameter (panel A, amber). Every other driver in the tree already holds its timeout to `positive_finite_number_error`: `MicroduckDriver`, `RobotiqDriver` (both `timeout` and `activation_timeout`) and `EarthRoverDriver`, each with the same reason written beside it.

The second half is `FeetechDriver`. It pops `port`, `baud_rate` and `motor_ids`, and `timeout` was not among them - so it landed in `self._extras` while the bus opened at its default (panel C). That is the case the driver's own `motor_ids` comment names:

> `motor_ids` narrows the arm to a subset of `SO_ARM_MOTORS`. Honoured rather than recorded: **a keyword that changes nothing is worse than one that is refused, because the caller believes the arm is configured.**

A caller who lengthens the window for a slow servo, gets the default window and six motors that did not answer, has been told nothing.

## Change

| | before | after |
|---|---|---|
| `FeetechBus(timeout=...)` | 8 of 8 unusable values accepted | held to `positive_finite_number_error`, beside `baud_rate` |
| default | `1.0` literal in two places | one named `DEFAULT_TIMEOUT_S` |
| `FeetechDriver(timeout=...)` | kept in `_extras`, bus opened at `1.0` | graded naming the driver, forwarded to the bus |

Geometry, units, framing and the retry loop are untouched; a caller who passes no `timeout` gets the same `1.0` s window as before.

## Tests

`tests/drivers/test_feetech_read_window_is_graded_and_honoured.py`, 23 cells over 6 behaviours. **18 fail pre-fix** (the pre-fix tree needs only the `DEFAULT_TIMEOUT_S` name to import, so the failures are behavioural rather than collection errors), including the one that reads what the port was actually opened with:

```
AssertionError: assert [{... 'timeout': 1.0}] == [{... 'timeout': 0.25}]
```

Every cell discriminates - each mutation of the fix fires a distinct group:

| mutation | cells failing |
|---|---|
| unmutated | 0 of 23 |
| bus guard deleted | 8 |
| driver guard deleted (bus still grades) | 8 - the refusal then names `FeetechBus`, a layer the caller did not construct |
| graded but not forwarded | 2 |
| bus coerces to the default instead of refusing | 8 - the refuse-not-coerce pin |

`tests/drivers/`: 2467 passed, 17 skipped. Full `tests/` on both trees, run concurrently: this branch **51520 passed, 299 skipped, 0 failed** (51819 collected, 31m34s) against pristine `main` at `f7950da5` **51497 passed, 299 skipped, 0 failed** (51796 collected, 30m22s) - delta `+23` collected and `+23` passed, exactly the new cells, and no failure on either side.

## Docs

`docs/getting-started/robot-factory.md` already argues this for `baud_rate=` ("an ungraded value is *applied* ... after which every read times out exactly as an unplugged arm does"). The read window is added to that section as the same shape, including the one-layer-earlier case of a keyword a driver records instead of forwarding.

LOC: +192 / -7 across 5 files - `bus.py` +20/-4, `driver.py` +16/-3 (most of it the two docstrings that state the domain), tests +129, docs +8, changelog fragment +19.
