### PR TITLE
docs(hardware/tools): the calibration page stopped at the atomic write, not at the flag that arms it

### DIFF
--- a/changelog.d/3363-calibration-restore-docs-flag-half.md
+++ b/changelog.d/3363-calibration-restore-docs-flag-half.md
@@ -1,0 +1,13 @@
+### Documentation
+
+- **hardware/tools**: The calibration section of the tools reference documented the atomic
+  restore write and closed on the report, which reads as "the store is safe now". That is
+  true of a write that *fails*; it says nothing about a write the tool was told to make, and
+  `overwrite` - the confirmation gate in front of the only write in `lerobot_calibrate` that
+  replaces a measurement - was read by truthiness, so `overwrite="false"` selected the
+  overwrite it spells the refusal of and reported `Overwrite mode: false` beside the count of
+  calibrations it had just replaced. The page now carries the flag half beside the write half:
+  which spellings inverted, why neither the atomic commit nor the backup recovers the
+  measurement a successful overwrite replaced, where each of the two surfaces refuses, and
+  that only `action="restore"` consults the flag. The existing write section points forward to
+  it so a reader does not stop where it used to end.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -248,6 +248,36 @@ truncated calibration still `exists()`, `load_calibration` reads it as `None`, a
 `action="view"` renders its path, size and timestamp under `status="success"` with
 no motors in it.
 
+Committing the write covers a write that *fails*. It does not cover a write the tool
+was told to make, which is the next section.
+
+### `overwrite` is checked, so a word for "no" cannot arm the write
+
+`overwrite` is the confirmation gate in front of that same write - the only one in
+this tool that replaces a measurement - and it is checked against the shared boolean
+domain rather than read by truthiness. `not "false"` is `False`, so read by
+truthiness the words a caller reaches for when opting out selected the overwrite they
+spell the refusal of:
+
+```python
+lerobot_calibrate(action="restore", backup_dir=..., overwrite="false")
+```
+
+used to answer `status="success"`, and rendered the posture back as supplied
+(`Overwrite mode: false`) beside a count of the calibrations it had just replaced - the report agreeing with the caller about a
+posture the code had not taken. `"no"`, `"off"`, `"0"` and any non-zero number read
+the same way; `None`, `0` and `""` took the skip branch without being a declared
+spelling of it. Neither the atomic commit above nor the backup helps, because this
+write succeeds and nothing in a backup reconstructs the measurement it replaced.
+
+Both surfaces that read the flag now refuse a non-boolean:
+`LeRobotCalibrationManager.restore_calibrations` raises `ValueError` ahead of reading
+the backup directory, so a refusal cannot arrive after the file it was protecting is
+gone, and the `lerobot_calibrate` facade refuses ahead of that so the message names
+the parameter instead of surfacing as `Tool execution failed`. Only `action="restore"`
+consults the flag, so no other action is refused for it, and the two postures it is
+declared over are unchanged - `True` restores over the existing file, `False` keeps it.
+
 ### A mesh wait budget is bounded where the command body cannot carry it
 
 `robot_mesh` takes four numeric options. `duration` and `policy_port` travel


### PR DESCRIPTION
## Problem

`docs/hardware/tools.md` documents the calibration store at length, and the restore
section (from #3348) ends here:

> This matters more than the report, because nothing downstream flags the loss: a
> truncated calibration still `exists()`, `load_calibration` reads it as `None`, and
> `action="view"` renders its path, size and timestamp under `status="success"` with no
> motors in it.

A reader finishes that and concludes the store is safe. It is safe against a write that
**fails** — which is what the atomic commit buys. It says nothing about a write the tool
was *told* to make, and #3360 measured that the flag deciding that was read by
truthiness.

I reproduced it independently before writing the page, driving the real tool against a
real calibration tree: back up two devices, re-measure the follower afterwards, then
restore while spelling the opt-out.

| `overwrite` | re-measurement | `restored_count` | reported posture |
|---|---|---|---|
| `False` | survived | 0 | `Overwrite mode: False` |
| `True` | replaced | 2 | `Overwrite mode: True` |
| `"false"` / `"no"` / `"off"` | **replaced** | 2 | `Overwrite mode: false` |
| `"0"` | **replaced** | 2 | **`Overwrite mode: 0`** |
| `0` | survived | 0 | **`Overwrite mode: 0`** |

Every replacing row answered `status="success"`. The last two are why the loss could
not be audited either: `overwrite` was echoed back as supplied, so the string and the
integer rendered one identical line while taking opposite branches.

Neither half of what the page already documents helps here. The atomic commit covers a
write that could not finish; this write finishes. And nothing in a backup reconstructs
the measurement it replaced — a calibration is a physical measurement of one arm, so a
lost one costs the procedure, not a re-run, which is the argument the page itself makes
two paragraphs earlier.

## Change

Docs only.

- A new `### overwrite is checked, so a word for "no" cannot arm the write` section
  beside the existing write section: which spellings inverted and why, that `None` / `0`
  / `""` reached the skip branch without being declared spellings of it, where each of
  the two surfaces refuses (the documented API raises `ValueError` ahead of reading the
  backup directory, the facade refuses ahead of that so the message names the parameter
  rather than surfacing as `Tool execution failed`), that only `action="restore"`
  consults the flag, and that both declared postures are unchanged.
- Two sentences at the end of the existing section pointing forward to it, so a reader
  does not stop where it used to end.

`AGENTS.md` already carries the contributor-facing rule (#3360). This is the
user-facing half, which that PR did not touch.

## Verification

`tests/test_docs*.py` + `test_docstring_xref_roles_resolve` + `test_docstrings_no_dangling_doc_refs`
+ `test_markdown_links_resolve`: **245 passed**. Changelog graders: **91 passed**;
the fragment assembles (`assemble_changelog.py --print` finds it once).

Rendering checked against GitHub's own markdown API rather than by eye — 19 code spans,
no literal backtick left in the output, so every span closes. That caught a real defect
in my first draft: `` `Overwrite mode: `false`` `` had nested spans.

## What I did not add

I graded #3360's suite with a nine-mutation table built while reproducing the defect
independently, to see whether anything was owed on the test side. **It catches eight**,
each firing a distinct group — including the two placement properties (`b4` the refusal
precedes the backup read, fires 1 cell alone; `b7` the facade guard hoisted to the tool
entry point, so an action that reads no flag gets refused, fires that cell alone), and
`b5` a local `isinstance` in place of the shared domain, caught by `np.True_` / `np.False_`
already being in its `A_BOOLEAN` set.

The ninth was the report-distinguishability of `"0"` versus `0` — reachable only by
`_refusal_repr` rendering with `str()`. It fires **0** of that file's 37 cells, so I
measured whether it is covered elsewhere before writing a cell for it: it fires **95**
cells across `tests/test_container_refusals_render_elementwise.py`,
`tests/test_refusal_messages_never_raise.py` and `tests/test_utils.py`. Already owned by
a shared pin, so a cell here would have been redundant and is not in this PR.

LOC: **+43 / -0** across 2 files — docs +30, changelog fragment +13. No code, no tests.
