### PR TITLE
fix(tools): lerobot_camera refuses a camera posture it cannot read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2077,6 +2077,21 @@ which side the enum is on.
   supplied it, not where the branch is taken. Pinned by
   `tests/rendering/test_gsplat_background_posture_flag_domain.py`, which measures the
   branch each of the four selects.
+- **A flag that gates whether a numeric row is READ is checked ahead of the numeric
+  guard.** `lerobot_camera` refuses `timeout_ms` only under `async_mode`, because the
+  synchronous read consumes no budget and an option no handler reads must not be
+  refused - so the numeric table's own row is switched on and off by a posture flag
+  from outside the table. Read by truthiness, that gate admitted `timeout_ms=-5` under
+  `async_mode=0` (`status="success"` on an unusable budget) and, under
+  `async_mode="false"`, refused the *budget* by name for a caller whose only mistake was
+  the flag. The order is the point: a posture guard placed after the numeric guard still
+  refuses, but names the value the gate selected rather than the gate, sending the
+  caller to correct the wrong parameter. Scope the roster per action, as
+  `_ACTION_POSTURE_FLAGS` mirrors `_ACTION_NUMERIC_OPTIONS`, so `discover` and `list` -
+  which consume none of the three flags - refuse none of them. Pinned by
+  `tests/tools/test_lerobot_camera_posture_flag_domain.py`, which derives the roster
+  from the tool's own signature so a fourth flag cannot be added without the domain,
+  and whose ordering cell fails when the two guards are swapped.
 - Pinned by `tests/simulation/mujoco/test_actuate_robot_posture_flag_domain.py`,
   `tests/simulation/test_recording_posture_flag_domain.py`,
   `tests/tools/test_lerobot_teleoperate_flag_domain.py`,

--- a/changelog.d/3364-lerobot-camera-posture-flag-domain.md
+++ b/changelog.d/3364-lerobot-camera-posture-flag-domain.md
@@ -1,0 +1,23 @@
+### Fixed: `lerobot_camera` refuses a posture it cannot read, instead of taking the opposite one
+
+`async_mode`, `warmup` and `save_config` select a posture rather than scaling a
+quantity, and were read by truthiness beside the module's tabled numeric options
+and vocabularies. Every non-empty string is truthy, so the words a caller reaches
+for when opting out selected the affirmative posture: `save_config="false"` wrote
+the configuration file under `status="success"`; `warmup="false"` was handed to
+`Camera.connect` as the string, persisted into that file as `"warmup": "false"` -
+the one field of that document declared a boolean - and reported on the line above
+it as `Warmup: on`; `async_mode="false"` selected the asynchronous read path,
+which the plain `False` does not.
+
+The flag also gates a tabled numeric row: `timeout_ms` is only refused under
+`async_mode`, because the synchronous read consumes no budget. Reading that gate
+by truthiness switched the row off from outside its own table, so `async_mode=0`
+with `timeout_ms=-5` was answered `status="success"` - an unusable budget accepted
+because a falsy value that is not a declared spelling of *off* discarded the row.
+
+The three flags now go through `strands_robots.utils.boolean_flag_error`, the
+domain the sibling `lerobot_train` and `lerobot_calibrate` builders already
+consult, keyed by action so `discover` and `list` - which consume none of them -
+still refuse none of them. The check runs ahead of the numeric guard, so the
+refusal names the flag rather than the budget it gates.

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -64,7 +64,11 @@ except ImportError as e:
 from strands import tool
 
 from strands_robots.tools._path_validation import resolve_output_path, validate_save_path
-from strands_robots.utils import positive_finite_number_error, positive_whole_number_error
+from strands_robots.utils import (
+    boolean_flag_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
 
 # The one remedy for an absent RealSense SDK, so every surface that reports it
 # reports the same install. It names lerobot's ``intelrealsense`` extra rather
@@ -149,6 +153,76 @@ _ACTION_NUMERIC_OPTIONS: dict[str, tuple[str, ...]] = {
 }
 
 
+_ACTION_POSTURE_FLAGS: dict[str, tuple[str, ...]] = {
+    "capture": ("async_mode", "warmup"),
+    "capture_batch": ("async_mode", "warmup"),
+    "record": ("async_mode", "warmup"),
+    "preview": ("async_mode", "warmup"),
+    "test": ("async_mode", "warmup"),
+    "configure": ("save_config", "warmup"),
+}
+
+
+def _posture_flag_error(action: str, *, async_mode: Any, warmup: Any, save_config: Any) -> str | None:
+    """Error text for the first posture flag ``action`` consumes but cannot read.
+
+    These three select a *posture* rather than scaling a quantity, and each was
+    read by truthiness - so every non-empty string, the spellings a caller
+    reaches for when opting out included, selected the affirmative posture.
+    Measured on ``eecaa80`` against a recording camera stand-in:
+
+    * ``save_config="false"`` wrote the configuration file, so a caller who
+      spelled the opt-out got a durable artifact on disk under
+      ``status="success"``;
+    * ``warmup="false"`` was handed to ``Camera.connect`` as the string, was
+      persisted into that file as ``"warmup": "false"`` - a string in the one
+      field of that document declared a boolean, beside the integer geometry and
+      rate that are validated - and was reported on the line above it as
+      ``Warmup: on``, so the file, the report and the caller disagree three ways
+      about one posture;
+    * ``async_mode="false"`` selected the asynchronous read path, which the
+      plain boolean ``False`` does not: one ``async_read`` and no synchronous
+      read, against zero and one.
+
+    It runs ahead of :func:`_numeric_option_error` because that guard's
+    ``timeout_ms`` row is *gated* on this flag - the synchronous read consumes no
+    budget, so an option no handler reads is not refused. Reading the gate by
+    truthiness switched the row off from outside its own table: ``async_mode=0``
+    with ``timeout_ms=-5`` was answered ``status="success"``, an unusable budget
+    accepted because a falsy value that is not a declared spelling of *off*
+    discarded the row. Ordered the other way the refusal also names the wrong
+    parameter - ``async_mode="false", timeout_ms=-5`` reported ``capture:
+    timeout_ms must be > 0``, sending the caller to correct a budget whose only
+    problem was the flag that selected it.
+
+    Keyed by action, and holding only the flags each handler is actually passed,
+    for the reason the numeric table is: ``discover`` and ``list`` take none of
+    the three, so a value neither consults is not refused. The domain itself
+    belongs to neither surface, so it delegates to
+    :func:`~strands_robots.utils.boolean_flag_error` - the one owner the sibling
+    ``lerobot_train`` and ``lerobot_calibrate`` builders already consult - exactly
+    as the numeric rows delegate their spans and counts. What stays here is the
+    roster and the report order, which puts ``save_config`` ahead of ``warmup``
+    so the flag that writes a file is named before the one that only opens a
+    camera.
+
+    Args:
+        action: The requested action; decides which flags are effective.
+        async_mode: Whether the asynchronous read path is selected, as supplied.
+        warmup: Whether the camera is warmed on connection, as supplied.
+        save_config: Whether the configuration is written to a file, as supplied.
+
+    Returns:
+        An error message naming the action and the flag, or ``None`` when every
+        flag this action reads is a boolean.
+    """
+    supplied = {"async_mode": async_mode, "warmup": warmup, "save_config": save_config}
+    for param in _ACTION_POSTURE_FLAGS.get(action, ()):
+        if error := boolean_flag_error(supplied[param], param, action):
+            return error
+    return None
+
+
 def _numeric_option_error(
     action: str,
     *,
@@ -182,7 +256,10 @@ def _numeric_option_error(
     preview's frame period.
 
     ``timeout_ms`` is only effective under ``async_mode``: the synchronous read
-    takes no timeout, so a value it never consumes is not refused.
+    takes no timeout, so a value it never consumes is not refused. That makes the
+    flag a gate on this table, so it is a boolean by the time it is read here -
+    :func:`_posture_flag_error` runs first, and a truthy spelling of *off* can no
+    longer switch the row off from outside the table.
 
     **The frame count is a product, so one factor's sign does not decide whether a
     frame can be captured.** ``positive_finite_number_error`` reads
@@ -464,16 +541,27 @@ def lerobot_camera(
             refused if it names a location outside it.
         capture_duration: Duration for video recording (positive seconds)
         preview_duration: Duration for preview display (positive seconds)
-        async_mode: Use async reading for better performance
+        async_mode: Use async reading for better performance. A boolean; it
+            selects a read path rather than scaling one, so any other value is
+            refused rather than read as its opposite.
         timeout_ms: Timeout for async operations (positive milliseconds; read only when async_mode is on)
-        warmup: Enable camera warmup on connection
-        save_config: Save camera configuration to file
+        warmup: Enable camera warmup on connection. A boolean, refused rather
+            than read by truthiness - it is also recorded in the saved
+            configuration, so a non-boolean would persist there.
+        save_config: Save camera configuration to file. A boolean, refused
+            rather than read by truthiness: it writes a file, so a truthy
+            spelling of off would leave one behind.
 
     Returns:
         Dict containing status and detailed camera operation results
     """
 
     try:
+        # Ahead of the numeric guard: that guard's ``timeout_ms`` row is gated on
+        # ``async_mode``, so the gate is checked before it decides a row.
+        posture_error = _posture_flag_error(action, async_mode=async_mode, warmup=warmup, save_config=save_config)
+        if posture_error:
+            return {"status": "error", "content": [{"text": posture_error}]}
         numeric_error = _numeric_option_error(
             action,
             width=width,

--- a/tests/tools/test_lerobot_camera_async_read_budget.py
+++ b/tests/tools/test_lerobot_camera_async_read_budget.py
@@ -228,13 +228,26 @@ class TestTheBudgetCannotBeDroppedAgain:
     """Structural pins: selecting the asynchronous read implies taking a budget."""
 
     def test_every_handler_that_selects_the_asynchronous_read_takes_a_budget(self) -> None:
-        def params(obj: Any) -> Any:
-            return inspect.signature(obj).parameters
+        """A handler is a function returning the tool's envelope, not a guard.
 
-        handlers = [obj for obj in vars(cam_mod).values() if inspect.isfunction(obj)]
-        selects = {obj.__name__ for obj in handlers if "async_mode" in params(obj)}
-        takes = {obj.__name__ for obj in handlers if "timeout_ms" in params(obj)}
+        The population is taken from the return annotation rather than from
+        every function in the module: the flag is also read by the preflight
+        guards, which answer refusal text and open no camera, so a guard that
+        reads the flag without a budget is correct rather than a violation.
+        """
 
+        def signature(obj: Any) -> Any:
+            return inspect.signature(obj)
+
+        handlers = [
+            obj
+            for obj in vars(cam_mod).values()
+            if inspect.isfunction(obj) and signature(obj).return_annotation == dict[str, Any]
+        ]
+        selects = {obj.__name__ for obj in handlers if "async_mode" in signature(obj).parameters}
+        takes = {obj.__name__ for obj in handlers if "timeout_ms" in signature(obj).parameters}
+
+        assert selects, "no handler selects the asynchronous read; the population is empty"
         assert selects == takes, f"selects the asynchronous read without a budget: {selects - takes}"
 
     def test_every_asynchronous_action_carries_the_guard_row(self) -> None:

--- a/tests/tools/test_lerobot_camera_posture_flag_domain.py
+++ b/tests/tools/test_lerobot_camera_posture_flag_domain.py
@@ -1,0 +1,268 @@
+"""A camera posture flag is checked, never read by truthiness.
+
+``lerobot_camera`` tables its numeric options and its two vocabularies, and read
+its three posture flags - ``async_mode``, ``warmup`` and ``save_config`` - raw.
+Every non-empty string is truthy, so the words a caller reaches for when opting
+out selected the affirmative posture. Measured on ``eecaa80``:
+
+* ``save_config="false"`` wrote the configuration file under
+  ``status="success"``, leaving a durable artifact for a caller who spelled the
+  opt-out;
+* ``warmup="false"`` was passed to ``Camera.connect`` as the string, persisted
+  into that file as ``"warmup": "false"`` - the one field of that document
+  declared a boolean - and reported on the line above it as ``Warmup: on``;
+* ``async_mode="false"`` selected the asynchronous read path, which the plain
+  ``False`` does not.
+
+The flag also *gates* a tabled numeric row: ``timeout_ms`` is only refused under
+``async_mode``, because the synchronous read consumes no budget. Reading that
+gate by truthiness switched the row off from outside its own table -
+``async_mode=0`` with ``timeout_ms=-5`` was answered ``status="success"``.
+
+These tests pin that each flag an action consumes is refused unless it is a
+boolean, that the refusal happens before the effect the truthy value had, that
+the budget row cannot be gated off by a value that is not a declared spelling of
+*off*, that an action consuming none of the three still refuses none of them, and
+that a flag added to the signature cannot skip the roster.
+"""
+
+from __future__ import annotations
+
+import glob
+import inspect
+import json
+import os
+import time
+from typing import Any
+
+import numpy as np
+import pytest
+
+# The module object is needed for the ``cv2``/``os`` handles the tool imports and
+# for the roster's signature scan, so every name is reached through this alias.
+import strands_robots.tools.lerobot_camera as cam_mod
+from strands_robots.utils import boolean_flag_error
+
+# One value per rejection reason of the shared posture domain: the two spellings
+# of *off* that read as *on*, the integers that pass as a silent posture, and the
+# two values that take a branch without being a declared spelling of it.
+BAD_POSTURES = ("false", "no", 0, 1, None, [])
+
+# The flag each action is actually handed, which is what may be refused.
+ACTION_FLAGS = tuple((action, flag) for action, flags in cam_mod._ACTION_POSTURE_FLAGS.items() for flag in flags)
+
+
+class _Camera:
+    """A camera stand-in recording every posture and read path it is driven with."""
+
+    def __init__(self) -> None:
+        self.warmups: list[Any] = []
+        self.sync_reads = 0
+        self.async_reads = 0
+        self.width = 8
+        self.height = 6
+        self.fps = 30
+        self.color_mode = type("_M", (), {"value": "RGB"})()
+        self.rotation: Any = None
+
+    def connect(self, warmup: bool = True) -> None:
+        self.warmups.append(warmup)
+
+    def disconnect(self) -> None:
+        return None
+
+    def _frame(self) -> np.ndarray:
+        # A measurable span keeps the tool's own rate arithmetic off zero.
+        time.sleep(0.0005)
+        return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+    def read(self) -> np.ndarray:
+        self.sync_reads += 1
+        return self._frame()
+
+    def async_read(self, timeout_ms: float = 1000) -> np.ndarray:
+        self.async_reads += 1
+        return self._frame()
+
+
+@pytest.fixture
+def camera(monkeypatch: pytest.MonkeyPatch) -> _Camera:
+    """Substitute the camera factory and neutralise every sink a handler writes to."""
+    cam = _Camera()
+    monkeypatch.setattr(cam_mod, "_create_camera", lambda *a, **k: cam)
+    writer = type("_W", (), {"write": lambda self, f: None, "release": lambda self: None})()
+    monkeypatch.setattr(cam_mod.cv2, "VideoWriter", lambda *a, **k: writer)
+    monkeypatch.setattr(cam_mod.cv2, "VideoWriter_fourcc", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr(cam_mod.cv2, "imwrite", lambda *a, **k: True)
+    monkeypatch.setattr(cam_mod.cv2, "imshow", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(cam_mod.cv2, "waitKey", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr(cam_mod.cv2, "destroyAllWindows", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(cam_mod.os.path, "getsize", lambda p: 1234)
+    return cam
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool with agent-shaped values.
+
+    The three flags are annotated ``bool`` and every value under test here is
+    deliberately outside that annotation, so one ``**kwargs: Any`` helper states
+    that once rather than scattering a suppression over every call site.
+    """
+    return cam_mod.lerobot_camera(**kwargs)
+
+
+def _action_kwargs(action: str, tmp_path: Any) -> dict[str, Any]:
+    """The smallest set of options that drives ``action`` through one read."""
+    common: dict[str, Any] = {
+        "action": action,
+        "camera_type": "opencv",
+        "save_path": str(tmp_path),
+        "width": 8,
+        "height": 6,
+        "fps": 2,
+    }
+    if action == "capture_batch":
+        common["camera_ids"] = [0]
+    else:
+        common["camera_id"] = 0
+    if action == "record":
+        common["capture_duration"] = 0.5
+    if action == "preview":
+        common["preview_duration"] = 0.01
+    return common
+
+
+def _saved_configs(tmp_path: Any) -> list[str]:
+    return glob.glob(os.path.join(str(tmp_path), "camera_config_*.json"))
+
+
+class TestAPostureTheToolCannotReadIsRefused:
+    """Every flag an action consumes is held to the shared boolean domain."""
+
+    @pytest.mark.parametrize(("action", "flag"), ACTION_FLAGS)
+    @pytest.mark.parametrize("value", BAD_POSTURES)
+    def test_a_non_boolean_posture_is_refused_before_the_camera_opens(
+        self, camera: _Camera, tmp_path: Any, action: str, flag: str, value: Any
+    ) -> None:
+        result = _call(**_action_kwargs(action, tmp_path) | {flag: value})
+
+        assert result["status"] == "error"
+        assert _text(result).startswith(f"{action}: {flag} must be a boolean")
+        assert camera.warmups == [], "the camera was opened on a posture the tool cannot read"
+
+    @pytest.mark.parametrize("value", BAD_POSTURES + (True, False, np.True_, np.False_))
+    def test_the_posture_domain_matches_the_shared_helper(self, camera: _Camera, tmp_path: Any, value: Any) -> None:
+        refused = _call(**_action_kwargs("capture", tmp_path) | {"async_mode": value})["status"] == "error"
+
+        assert refused == (boolean_flag_error(value, "async_mode", "capture") is not None)
+
+    def test_an_action_that_consumes_no_posture_refuses_none_of_them(self, camera: _Camera, tmp_path: Any) -> None:
+        """``discover`` reads none of the three, so a value it never consults stands.
+
+        The rule the numeric table already follows: an option no handler consumes
+        must not be refused.
+        """
+        result = _call(action="discover", camera_type="opencv", warmup="false", save_config="false")
+
+        assert "must be a boolean" not in _text(result)
+
+
+class TestTheRefusalPrecedesTheEffectTheTruthyValueHad:
+    """The three postures measured on the pre-fix tree, each now not taken."""
+
+    def test_an_unreadable_save_posture_writes_no_configuration_file(self, camera: _Camera, tmp_path: Any) -> None:
+        result = _call(**_action_kwargs("configure", tmp_path) | {"save_config": "false"})
+
+        assert result["status"] == "error"
+        assert _saved_configs(tmp_path) == [], "the opt-out left a configuration file behind"
+
+    def test_an_unreadable_warmup_posture_reaches_neither_the_driver_nor_the_file(
+        self, camera: _Camera, tmp_path: Any
+    ) -> None:
+        result = _call(**_action_kwargs("configure", tmp_path) | {"save_config": True, "warmup": "false"})
+
+        assert result["status"] == "error"
+        assert camera.warmups == []
+        assert _saved_configs(tmp_path) == []
+
+    def test_an_unreadable_read_path_posture_performs_no_asynchronous_read(
+        self, camera: _Camera, tmp_path: Any
+    ) -> None:
+        result = _call(**_action_kwargs("capture", tmp_path) | {"async_mode": "false"})
+
+        assert result["status"] == "error"
+        assert (camera.async_reads, camera.sync_reads) == (0, 0)
+
+
+class TestAnHonestPostureStillSelectsBothPaths:
+    """The refusal must not cost a caller who supplies the declared domain."""
+
+    @pytest.mark.parametrize(
+        ("async_mode", "expected"),
+        [(True, (1, 0)), (False, (0, 1)), (np.True_, (1, 0)), (np.False_, (0, 1))],
+        ids=["true", "false", "numpy-true", "numpy-false"],
+    )
+    def test_a_boolean_read_path_is_honoured_unchanged(
+        self, camera: _Camera, tmp_path: Any, async_mode: Any, expected: tuple[int, int]
+    ) -> None:
+        result = _call(**_action_kwargs("capture", tmp_path) | {"async_mode": async_mode})
+
+        assert result["status"] == "success"
+        assert (camera.async_reads, camera.sync_reads) == expected
+
+    def test_a_boolean_save_posture_still_persists_the_posture_it_was_given(
+        self, camera: _Camera, tmp_path: Any
+    ) -> None:
+        result = _call(**_action_kwargs("configure", tmp_path) | {"save_config": True, "warmup": False})
+
+        assert result["status"] == "success"
+        saved = _saved_configs(tmp_path)
+        assert len(saved) == 1
+        with open(saved[0], encoding="utf-8") as handle:
+            persisted = json.load(handle)
+        assert persisted["warmup"] is False
+        assert "Warmup: off" in _text(result)
+        assert camera.warmups == [False]
+
+
+class TestTheGateCannotSwitchOffTheBudgetRow:
+    """``timeout_ms`` is refused under ``async_mode``, so the gate is graded first."""
+
+    def test_a_falsy_gate_no_longer_discards_the_budget_row(self, camera: _Camera, tmp_path: Any) -> None:
+        """Pre-fix ``async_mode=0`` reported success with an unusable budget."""
+        result = _call(**_action_kwargs("capture", tmp_path) | {"async_mode": 0, "timeout_ms": -5})
+
+        assert result["status"] == "error"
+        assert camera.sync_reads == 0
+
+    def test_the_refusal_names_the_flag_rather_than_the_budget_it_gates(self, camera: _Camera, tmp_path: Any) -> None:
+        """Placement pin: the numeric guard would blame ``timeout_ms`` instead."""
+        result = _call(**_action_kwargs("capture", tmp_path) | {"async_mode": "false", "timeout_ms": -5})
+
+        assert _text(result).startswith("capture: async_mode must be a boolean")
+
+    def test_a_boolean_gate_still_decides_whether_the_budget_is_read(self, camera: _Camera, tmp_path: Any) -> None:
+        """The row is still gated, so a budget the synchronous read never uses stands."""
+        result = _call(**_action_kwargs("capture", tmp_path) | {"async_mode": False, "timeout_ms": -5})
+
+        assert result["status"] == "success"
+        assert camera.sync_reads == 1
+
+
+class TestThePostureRosterFollowsTheSignature:
+    """Structural pins: a flag cannot be added to the tool and skip the roster."""
+
+    def test_every_boolean_parameter_of_the_tool_is_on_the_roster(self) -> None:
+        annotations = inspect.signature(cam_mod.lerobot_camera).parameters
+        declared = {name for name, param in annotations.items() if param.annotation in (bool, "bool")}
+        rostered = {flag for flags in cam_mod._ACTION_POSTURE_FLAGS.values() for flag in flags}
+
+        assert declared == rostered, f"posture flag read without the domain: {declared - rostered}"
+
+    def test_the_roster_covers_every_action_that_opens_a_camera(self) -> None:
+        """The same six actions the numeric table covers; the other two open none."""
+        assert set(cam_mod._ACTION_POSTURE_FLAGS) == set(cam_mod._ACTION_NUMERIC_OPTIONS)

--- a/tests/tools/test_lerobot_camera_posture_flag_domain.py
+++ b/tests/tools/test_lerobot_camera_posture_flag_domain.py
@@ -46,7 +46,7 @@ from strands_robots.utils import boolean_flag_error
 # One value per rejection reason of the shared posture domain: the two spellings
 # of *off* that read as *on*, the integers that pass as a silent posture, and the
 # two values that take a branch without being a declared spelling of it.
-BAD_POSTURES = ("false", "no", 0, 1, None, [])
+BAD_POSTURES: tuple[Any, ...] = ("false", "no", 0, 1, None, [])
 
 # The flag each action is actually handed, which is what may be refused.
 ACTION_FLAGS = tuple((action, flag) for action, flags in cam_mod._ACTION_POSTURE_FLAGS.items() for flag in flags)


### PR DESCRIPTION
`lerobot_camera` tables its numeric options and its two vocabularies, and read its three posture flags raw. Every non-empty string is truthy, so the words a caller reaches for when opting out selected the affirmative posture.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/camera-posture-34341679915/camera-posture.png)

Measured on `eecaa808` and on this branch with the same camera stand-in ([before](https://raw.githubusercontent.com/cagataycali/robots/assets/camera-posture-34341679915/before-main-eecaa808.json), [after](https://raw.githubusercontent.com/cagataycali/robots/assets/camera-posture-34341679915/after-branch.json)):

| request | before | after |
|---|---|---|
| `save_config="false"` | `status="success"`, **1 config file written** | refused, 0 files |
| `warmup="false"`, saving | persisted as `"warmup": "false"` (**str**), reported `Warmup: on`, `Camera.connect` handed the string | refused |
| `async_mode="false"` | **asynchronous** read path (1 async / 0 sync) | refused |
| `async_mode=False` | 0 async / 1 sync | unchanged |

`warmup` is the one field of the saved document declared a boolean, beside the integer geometry and rate that *are* validated - so the file, the report and the caller disagreed three ways about one posture.

## The flag also gated a tabled numeric row

`timeout_ms` is only refused under `async_mode`, because the synchronous read consumes no budget - an option no handler reads must not be refused. Reading that gate by truthiness switched the row off from **outside its own table**:

| `async_mode` | `timeout_ms=-5` before | after |
|---|---|---|
| `True` | refused, names `timeout_ms` | unchanged |
| `False` | accepted (row correctly not read) | unchanged |
| `0` | **`status="success"`** - unusable budget accepted | refused, names `async_mode` |
| `"false"` | refused, names `timeout_ms` | refused, names `async_mode` |

The `"false"` row is why the check runs *ahead* of the numeric guard rather than beside it: ordered second, the refusal names the budget instead of the flag that selected it, sending the caller to correct a value whose only problem was the gate.

## Change

The three flags delegate to `strands_robots.utils.boolean_flag_error`, the domain the sibling `lerobot_train` and `lerobot_calibrate` builders already consult. `_ACTION_POSTURE_FLAGS` mirrors the neighbouring `_ACTION_NUMERIC_OPTIONS`, so `discover` and `list` - which consume none of the three - refuse none of them.

The roster is derived from the tool's own signature by a test, so a fourth flag cannot be added without the domain.

## Tests

On pre-fix code the new file grades **83 failed / 13 passed**; on this branch **96 passed**. Each mutation fires a distinct group:

| mutation | cells |
|---|---|
| unmutated | 0 |
| guard deleted (the pre-fix read) | 83 |
| coerce with `bool(...)` instead of refusing | 83 |
| guard placed *after* the numeric guard | 1 (the refusal names the flag) |
| roster not action-scoped | 1 (`discover` refuses nothing) |
| roster drops `save_config` | 2 (incl. the signature invariant) |

`tests/tools/test_lerobot_camera_async_read_budget.py` owns a structural pin that every function reading `async_mode` also takes a budget. A preflight guard reads the flag and takes no budget, so the pin's population is now the functions returning the tool envelope - handlers, which is what its name and message already said - plus a floor so it cannot go vacuous. Dropping a budget from `_capture_single_image` still fires it by name.

## Gate

Full `tests/` on both trees, concurrently: this branch **51632 passed / 299 skipped / 0 failed** (29m06s), pristine `main` **51536 passed / 299 skipped / 0 failed** (30m29s) - delta **+96**, exactly the new cells. `ruff check` and `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean over 1974 files.

The new rule is recorded in `AGENTS.md` beside the other posture-flag cases (added in round 1, below - the first push did not carry it). Refs #3356.

## Round changelog

**Round 1** (after approval at `98af19ac`; required check red)

- `ec75ed8c` - `call-test-lint` failed at the mypy step, before pytest ran: `tests/tools/test_lerobot_camera_posture_flag_domain.py:49: Need type annotation for "BAD_POSTURES" [var-annotated]`. The tuple mixes a str, ints, `None` and an empty list, and mypy cannot type `[]` unaided. Annotated `tuple[Any, ...]`; type-only. Reproduced the error on the parent and `Success: no issues found` on the fix, ruff check / format clean. The "mypy clean over 1974 files" line above was measured before the roster was reshaped and did not hold at `98af19ac` - the description overstated it.
- `7e11c9c8` - the description claimed an `AGENTS.md` entry and the branch's `AGENTS.md` was byte-identical to `main`. Added the entry it described, in the *Posture flags are checked* section ahead of the roll-up of pins: a flag that gates whether a numeric row is read is checked ahead of the numeric guard, and the roster is scoped per action. ASCII-only, +15 lines.

Both pushes change the pull request's own diff, so the approval is expected to be dismissed; neither changes tool behaviour.