### PR TITLE
fix(tools/pose_tool): smooth is checked, so a word for "no" cannot change the trajectory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2092,11 +2092,21 @@ which side the enum is on.
   `tests/tools/test_lerobot_camera_posture_flag_domain.py`, which derives the roster
   from the tool's own signature so a fourth flag cannot be added without the domain,
   and whose ordering cell fails when the two guards are swapped.
+  A gate whose flag defaults to `True` inverts in the sharper direction, because a falsy
+  non-boolean then *removes* a behaviour the caller never asked to leave. `pose_tool`'s
+  `smooth` chooses between interpolating towards the joint targets over
+  `steps * step_delay` seconds and writing each goal position once, and it decides whether
+  those two options are read - so `smooth="false", steps=0` was refused for `steps`, and
+  `smooth=0` wrote 2 goal positions where `True` writes 42 over 21 increments, sending the
+  arm to the far end of its travel in one write: the full-travel jump the same module
+  already refuses `steps=True` for. Pinned by
+  `tests/tools/test_pose_tool_smooth_posture_flag_domain.py`.
 - Pinned by `tests/simulation/mujoco/test_actuate_robot_posture_flag_domain.py`,
   `tests/simulation/test_recording_posture_flag_domain.py`,
   `tests/tools/test_lerobot_teleoperate_flag_domain.py`,
   `tests/mesh/test_iot_provisioning_flag_domain.py`,
-  `tests/rendering/test_key_light_posture_flag_domain.py` and
+  `tests/rendering/test_key_light_posture_flag_domain.py`,
+  `tests/tools/test_pose_tool_smooth_posture_flag_domain.py` and
   `tests/test_ros2_command_surface_flag_domain.py`, each of which parametrizes over
   `boolean_flag_error` itself rather than a copied spelling list, so a spelling added to
   the shared domain is covered without an edit.

--- a/changelog.d/3365-pose-tool-smooth-posture-flag-domain.md
+++ b/changelog.d/3365-pose-tool-smooth-posture-flag-domain.md
@@ -1,0 +1,20 @@
+### Fixed: `pose_tool`'s `smooth` is checked, not read by truthiness
+
+`smooth` selects one of two trajectories towards the same joint targets -
+interpolate over `steps * step_delay` seconds, or write each `Goal_Position`
+once - and it was read by truthiness, so both undeclared halves silently
+inverted. `smooth=0` (also `""`, `None`, `[]`) wrote 2 goal positions where
+`smooth=True` writes 42 over 21 increments; since the flag defaults to `True`,
+that *removes* an interpolation the caller never asked to leave and sends the
+arm to the far end of its travel in one write - the full-travel jump the tool
+already refuses `steps=True` for. `smooth="false"` (also `"no"`, `"off"`,
+`"0"`) is truthy, so it kept the interpolation the word asks to skip. Because
+the flag decides whether `steps` / `step_delay` are read at all,
+`smooth="false", steps=0` was refused for `steps`, an option the caller's
+posture said nobody would read.
+
+The flag is now held to the shared `boolean_flag_error` domain, ahead of the
+`steps` / `step_delay` check so a bad flag is named as the flag, and only for
+`"load_pose"` and `"move_multiple"` - `"reset_to_home"` supplies its own
+`smooth=True` and every other action moves in one shot, so none of them is
+refused for it. Both declared postures are unchanged.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -278,6 +278,33 @@ the parameter instead of surfacing as `Tool execution failed`. Only `action="res
 consults the flag, so no other action is refused for it, and the two postures it is
 declared over are unchanged - `True` restores over the existing file, `False` keeps it.
 
+### `smooth` is checked, so a word for "no" cannot change the trajectory
+
+`pose_tool`'s `smooth` selects one of two ways to reach the same joint targets,
+not a magnitude: interpolate over `steps * step_delay` seconds, or write each
+`Goal_Position` once and let the servo travel at its own speed. It was read by
+truthiness, and the two undeclared halves invert in opposite directions:
+
+| `smooth=` | Trajectory written | Trajectory asked for |
+|-----------|--------------------|----------------------|
+| `True` (default) | 21 increments, paced | same |
+| `False` | one write per motor | same |
+| `0`, `""`, `None`, `[]` | one write per motor | the default, interpolated |
+| `"false"`, `"no"`, `"off"`, `"0"` | 21 increments, paced | one write per motor |
+
+The falsy half is the sharper one, because this flag defaults to `True`: it
+*removes* an interpolation the caller never asked to leave, and what reaches the
+bus is a single write to the far end of the travel - the full-travel jump this
+tool already refuses `steps=True` for. The flag also decides whether `steps` and
+`step_delay` are read at all, so `smooth="false", steps=0` was refused for
+`steps` - an option the caller's own posture said nobody would read.
+
+Both halves are now refused against the shared boolean domain, ahead of the
+`steps` / `step_delay` check so a bad flag is named as the flag. Only
+`"load_pose"` and `"move_multiple"` consult it: `"reset_to_home"` interpolates
+unconditionally and supplies its own, and every other action moves in one shot,
+so none of them is refused for it. The two declared postures are unchanged.
+
 ### A mesh wait budget is bounded where the command body cannot carry it
 
 `robot_mesh` takes four numeric options. `duration` and `policy_port` travel

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -25,7 +25,12 @@ from strands import tool
 
 from strands_robots.drivers.feetech.protocol import MAX_GOAL_POSITION, decode_word, encode_word
 from strands_robots.tools._path_validation import resolve_output_path, validate_save_path
-from strands_robots.utils import finite_number_error, positive_count_error, positive_finite_number_error
+from strands_robots.utils import (
+    boolean_flag_error,
+    finite_number_error,
+    positive_count_error,
+    positive_finite_number_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +40,9 @@ logger = logging.getLogger(__name__)
 # ``steps`` and ``step_delay`` are only consumed on the interpolated path, so an
 # action that moves in one shot never reads them and must never be refused for
 # them. ``reset_to_home`` interpolates unconditionally; ``load_pose`` and
-# ``move_multiple`` interpolate only when the caller leaves ``smooth`` truthy.
+# ``move_multiple`` interpolate only when the caller leaves ``smooth`` true, so
+# they are also the actions that read ``smooth`` at all and the ones it is
+# checked for.
 _INTERPOLATING_ACTIONS = frozenset({"load_pose", "move_multiple"})
 _ALWAYS_INTERPOLATING_ACTIONS = frozenset({"reset_to_home"})
 
@@ -52,7 +59,51 @@ def _interpolates(action: str, smooth: bool) -> bool:
     """
     if action in _ALWAYS_INTERPOLATING_ACTIONS:
         return True
-    return action in _INTERPOLATING_ACTIONS and bool(smooth)
+    return action in _INTERPOLATING_ACTIONS and smooth
+
+
+def _smooth_posture_error(action: str, smooth: Any) -> str | None:
+    """Error text when ``smooth`` is not a spelling of a posture this action reads.
+
+    ``smooth`` selects between two trajectories towards the same targets, not a
+    quantity: interpolate over ``steps * step_delay`` seconds, or write each
+    goal position once. Read by truthiness, the two undeclared halves fail in
+    opposite directions and neither reports itself.
+
+    A falsy non-boolean - ``0``, ``""``, ``None``, ``[]`` - takes the one-shot
+    branch, and the flag defaults to ``True``, so it silently *removes* the
+    interpolation a caller never asked to leave. What arrives at the servo is a
+    single write to the far end of the travel: the full-travel jump this module
+    already refuses ``steps=True`` for, on the grounds that it is "exactly the
+    path a caller asking to interpolate wanted to avoid". Every non-empty string
+    is truthy, so the opt-out spellings ``"false"``, ``"no"``, ``"off"`` and
+    ``"0"`` select the *interpolating* branch instead - and, because this flag
+    also decides whether ``steps`` and ``step_delay`` are read at all, the
+    caller is then refused for one of those options while believing they had
+    spelled nobody reading them.
+
+    It is checked only for the actions that consult it, matching
+    :func:`_smooth_move_option_error`: ``reset_to_home`` interpolates
+    unconditionally and passes its own ``smooth=True``, and every other action
+    moves in one shot, so neither reads the caller's flag and neither may be
+    refused for it.
+
+    The check is ordered ahead of :func:`_smooth_move_option_error` so a bad
+    flag is named as the flag. Behind it, the refusal names ``steps`` or
+    ``step_delay`` - sending the caller to correct a value whose only problem
+    was the posture that decided it would be read.
+
+    Args:
+        action: The requested action; decides whether the flag is read.
+        smooth: The interpolation posture, as supplied.
+
+    Returns:
+        An error message naming the action and the flag, or ``None`` when the
+        action ignores it or the value is a boolean.
+    """
+    if action not in _INTERPOLATING_ACTIONS:
+        return None
+    return boolean_flag_error(smooth, "smooth", action)
 
 
 def _smooth_move_option_error(action: str, *, smooth: bool, steps: Any, step_delay: Any) -> str | None:
@@ -96,7 +147,7 @@ def _smooth_move_option_error(action: str, *, smooth: bool, steps: Any, step_del
         An error message naming the action and the option, or ``None`` when the
         action reads neither option or both values are usable.
     """
-    if not _interpolates(action, bool(smooth)):
+    if not _interpolates(action, smooth):
         return None
     if error := positive_count_error(steps, "steps", action):
         return error
@@ -1016,7 +1067,13 @@ def pose_tool(
             value is held to the same domain as ``position``, and the first that
             is not names the motor it came from.
         description: Description for stored poses
-        smooth: Use smooth interpolated movement
+        smooth: Interpolate towards the targets over ``steps * step_delay``
+            seconds instead of writing each goal position once. A boolean:
+            it selects one of two trajectories, so a value that is only
+            truthy or only falsy is refused rather than read as one of
+            them - ``smooth=0`` would drop the interpolation this defaults
+            to, and ``smooth="false"`` would keep it. Read only by
+            ``load_pose`` and ``move_multiple``.
         steps: Number of increments for an interpolated move. A positive
             integer - it divides the travel and bounds the write loop.
         step_delay: Seconds between increments of an interpolated move. A
@@ -1026,15 +1083,23 @@ def pose_tool(
             (the default 20 x 0.05s = ~1s).
 
     Both interpolation options are read only by ``load_pose`` and
-    ``move_multiple`` (when ``smooth`` is left truthy) and by
-    ``reset_to_home``, which always interpolates; any other action ignores them
-    and is never refused for them.
+    ``move_multiple`` (when ``smooth`` is left true) and by ``reset_to_home``,
+    which always interpolates; any other action ignores them and is never
+    refused for them. ``smooth`` itself is read only by the first two -
+    ``reset_to_home`` supplies its own - so only those two are refused for it.
 
     Returns:
         Dict containing status and response content, or an error dict when an
         interpolation option or a joint target the requested action reads cannot
         be honored.
     """
+
+    # ``smooth`` decides which of two trajectories reaches the servos, and it
+    # also decides whether the two options below are read at all - so it is
+    # checked first, and a bad flag is named as the flag rather than surfacing
+    # as a refusal for an option the caller's posture says nobody reads.
+    if posture_error := _smooth_posture_error(action, smooth):
+        return {"status": "error", "content": [{"text": posture_error}]}
 
     # Both interpolation options are consumed on a live servo bus - one as a
     # divisor and loop bound, one as the pause between goal positions - so an

--- a/tests/tools/test_pose_tool_smooth_posture_flag_domain.py
+++ b/tests/tools/test_pose_tool_smooth_posture_flag_domain.py
@@ -1,0 +1,272 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``pose_tool`` must refuse a ``smooth`` posture it can only misread.
+
+``smooth`` selects between two trajectories towards the same joint targets, not
+a magnitude: interpolate over ``steps * step_delay`` seconds, or write each goal
+position once. It was read by truthiness, and the two undeclared halves invert
+in opposite directions - measured on ``b882372``, ``move_multiple`` with two
+motors and the default ``steps=20``:
+
+* ``smooth=0`` (also ``""``, ``None``, ``[]``) wrote **2** goal positions with no
+  pause, against **42** over 21 increments for ``smooth=True``. The flag defaults
+  to ``True``, so a falsy non-boolean silently *removes* the interpolation the
+  caller never asked to leave, and what reaches the servo is a single write to
+  the far end of the travel - the full-travel jump this module already refuses
+  ``steps=True`` for, on the grounds that it is "exactly the path a caller asking
+  to interpolate wanted to avoid".
+* ``smooth="false"`` (also ``"no"``, ``"off"``, ``"0"``) is truthy, so it selected
+  the interpolating branch the word asks to skip.
+* Because the flag also decides whether ``steps`` / ``step_delay`` are read at
+  all, ``smooth="false", steps=0`` was refused with ``move_multiple: steps must
+  be a positive integer, got 0.`` - sending the caller to correct an option their
+  posture said nobody would read.
+
+All four rows reported ``status="success"`` (or, in the last, an error about the
+wrong parameter), so the wrong trajectory was indistinguishable from the right
+one.
+
+The flag is now held to the shared
+:func:`~strands_robots.utils.boolean_flag_error` domain, ahead of the
+``steps`` / ``step_delay`` check so a bad flag is named as the flag, and only for
+the two actions that read it - the scoping rule those numeric options already
+follow (``tests/tools/test_pose_tool_interpolation_options.py``).
+
+Every test that reaches the motor path takes a serial double and passes an
+explicit fake ``port``: ``pose_tool``'s ``port`` defaults to ``/dev/ttyACM0``, so
+a test that omits it drives whatever arm is plugged into the machine running the
+suite.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.pose_tool as pose_mod
+from strands_robots.tools.pose_tool import (
+    MotorController,
+    PoseManager,
+    _smooth_posture_error,
+    pose_tool,
+)
+from strands_robots.utils import boolean_flag_error
+
+from .conftest import FakeSerial, ReadingSerial
+
+# The two actions that consult the caller's flag. ``reset_to_home`` interpolates
+# unconditionally and passes its own ``smooth=True``; every other action moves in
+# one shot. Neither reads this flag, so neither may be refused for it.
+_READS_THE_FLAG = ("load_pose", "move_multiple")
+_IGNORES_THE_FLAG = ("reset_to_home", "read_all", "connect", "list_poses")
+
+# Truthy: these select the interpolating branch the word asks to skip.
+_TRUTHY_NON_BOOLEANS: tuple[Any, ...] = ("false", "no", "off", "0", 1, 2, math.nan)
+# Falsy: these drop the interpolation, and none is a declared spelling of that.
+_FALSY_NON_BOOLEANS: tuple[Any, ...] = (0, 0.0, "", None, [], {})
+
+_MOTORS = {"shoulder_pan": 5.0, "elbow_flex": -5.0}
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool through one funnel.
+
+    The values under test are deliberately outside the declared ``bool``, which
+    is the point; mypy does not narrow a splatted ``dict[str, Any]``, so routing
+    every call through here states that once instead of suppressing it per call.
+    """
+    return pose_tool(**kwargs)
+
+
+def _texts(result: dict[str, Any]) -> str:
+    """Concatenate every ``text`` field of a tool result."""
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+@pytest.fixture
+def pacing(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
+    """Record every motor write and the delay each ``time.sleep`` is asked for.
+
+    The recorder replaces the sleep rather than shortening it, so the assertion
+    is on the pacing the loop *requested*, which no host load can change.
+    """
+    seen: dict[str, list[Any]] = {"sleeps": [], "moves": []}
+    real_move = MotorController.move_motor
+
+    def _sleep(seconds: Any) -> None:
+        seen["sleeps"].append(seconds)
+
+    def _move(self: MotorController, motor_name: str, position_degrees: float) -> bool:
+        seen["moves"].append((motor_name, position_degrees))
+        return bool(real_move(self, motor_name, position_degrees))
+
+    monkeypatch.setattr(pose_mod.time, "sleep", _sleep)
+    monkeypatch.setattr(MotorController, "move_motor", _move)
+    return seen
+
+
+def _drive(action: str, **extra: Any) -> dict[str, Any]:
+    """Invoke one action with the arguments it requires and a fake port."""
+    kwargs: dict[str, Any] = {"action": action, "robot_id": "hw_arm", "port": "/dev/ttyTEST"}
+    if action == "load_pose":
+        kwargs["pose_name"] = "target"
+    if action == "move_multiple":
+        kwargs["positions"] = dict(_MOTORS)
+    kwargs.update(extra)
+    return _call(**kwargs)
+
+
+@pytest.fixture
+def stored_pose(cwd_tmp: Any) -> None:
+    """Persist a pose named ``target`` for the ``load_pose`` action to load."""
+    PoseManager("hw_arm").store_pose("target", dict(_MOTORS))
+
+
+class TestAPostureThatIsNotABooleanIsRefused:
+    """Neither half is read as a trajectory, and the port stays closed."""
+
+    @pytest.mark.parametrize("action", _READS_THE_FLAG)
+    @pytest.mark.parametrize("smooth", (*_TRUTHY_NON_BOOLEANS, *_FALSY_NON_BOOLEANS))
+    def test_an_undeclared_spelling_is_refused_naming_the_flag(
+        self, action: str, smooth: Any, stored_pose: None, fake_serial: list[FakeSerial]
+    ) -> None:
+        result = _drive(action, smooth=smooth)
+        text = _texts(result)
+        assert result["status"] == "error", text
+        assert "smooth" in text and action in text, text
+        assert text.isascii(), text
+        assert fake_serial == [], "the refused call opened the serial port"
+
+    def test_the_refusal_precedes_reading_the_pose_file(self, cwd_tmp: Any, fake_serial: list[FakeSerial]) -> None:
+        """The flag is checked before the action's own arguments are resolved."""
+        result = _drive("load_pose", pose_name="no_such_pose", smooth="false")
+        text = _texts(result)
+        assert result["status"] == "error"
+        assert "smooth" in text and "not found" not in text, text
+
+    def test_the_flag_is_named_before_the_options_it_gates(self) -> None:
+        """A bad flag is reported as the flag, not as the option it switches on.
+
+        ``smooth`` decides whether ``steps`` / ``step_delay`` are read at all, so
+        checked second it produced a refusal naming an option the caller's
+        posture said nobody would read.
+        """
+        result = _drive("move_multiple", smooth="false", steps=0, step_delay=-1)
+        text = _texts(result)
+        assert result["status"] == "error"
+        assert "smooth" in text, text
+        assert "steps" not in text and "step_delay" not in text, text
+
+
+class TestWhyEachHalfIsRefused:
+    """Each half measured against the branch it would have selected.
+
+    ``MotorController.move_multiple_motors`` is the branch point, and it is left
+    reading the flag it is handed - the domain is enforced once, at the tool,
+    where the caller supplies it, exactly as ``steps`` and ``step_delay`` are.
+    Driving it directly is what shows what the refused values did.
+    """
+
+    @staticmethod
+    def _connected(reading_serial: list[ReadingSerial]) -> MotorController:
+        controller = MotorController("/dev/ttyTEST")
+        connected, error = controller.connect()
+        assert connected, error
+        return controller
+
+    @pytest.mark.parametrize("smooth", _FALSY_NON_BOOLEANS)
+    def test_a_falsy_spelling_is_a_single_full_travel_write(
+        self, smooth: Any, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        """One goal position per motor, straight to the target, and no pause."""
+        controller = self._connected(reading_serial)
+        assert controller.move_multiple_motors(dict(_MOTORS), smooth, steps=20, step_delay=0.05) is True
+        assert len(pacing["moves"]) == len(_MOTORS), pacing["moves"]
+        assert pacing["sleeps"] == []
+
+    @pytest.mark.parametrize("smooth", _TRUTHY_NON_BOOLEANS)
+    def test_a_truthy_opt_out_spelling_interpolates_anyway(
+        self, smooth: Any, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        """The word asks to go straight to the target; 21 increments are written."""
+        controller = self._connected(reading_serial)
+        assert controller.move_multiple_motors(dict(_MOTORS), smooth, steps=20, step_delay=0.05) is True
+        assert len(pacing["moves"]) == 21 * len(_MOTORS), len(pacing["moves"])
+        assert pacing["sleeps"].count(0.05) == 21
+
+
+class TestTheDeclaredSpellingsStillSelectBothBranches:
+    """The fix refuses the undeclared halves and nothing else."""
+
+    def test_true_interpolates(
+        self, stored_pose: None, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        assert _drive("move_multiple", smooth=True, steps=4, step_delay=0.02)["status"] == "success"
+        assert len(pacing["moves"]) == 5 * len(_MOTORS)
+
+    def test_false_goes_straight_to_the_targets(
+        self, stored_pose: None, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        assert _drive("move_multiple", smooth=False)["status"] == "success"
+        assert len(pacing["moves"]) == len(_MOTORS)
+        assert pacing["sleeps"] == []
+
+    def test_a_numpy_boolean_is_a_boolean(
+        self, stored_pose: None, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        """The shared domain accepts ``np.bool_``, and so does this surface."""
+        assert _drive("move_multiple", smooth=np.False_)["status"] == "success"
+        assert len(pacing["moves"]) == len(_MOTORS)
+
+    def test_omitting_the_flag_keeps_the_default_interpolated_move(
+        self, stored_pose: None, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        assert _drive("move_multiple")["status"] == "success"
+        assert pacing["sleeps"].count(0.05) == 21
+
+
+class TestOnlyTheActionsThatReadTheFlagAreRefused:
+    """A caller is never refused for a value the requested action ignores."""
+
+    @pytest.mark.parametrize("action", _IGNORES_THE_FLAG)
+    @pytest.mark.parametrize("smooth", ("false", 0))
+    def test_an_action_that_ignores_the_flag_is_not_refused_for_it(
+        self, action: str, smooth: Any, stored_pose: None, reading_serial: list[ReadingSerial]
+    ) -> None:
+        assert "smooth" not in _texts(_drive(action, smooth=smooth)), action
+
+    def test_reset_to_home_still_interpolates_whatever_the_flag_says(
+        self, stored_pose: None, reading_serial: list[ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        """It supplies its own ``smooth=True``, so the caller's flag is unread."""
+        assert _drive("reset_to_home", smooth="false", steps=3, step_delay=0.02)["status"] == "success"
+        # One pause per increment: range(steps + 1). The read of the current pose
+        # pauses 0.01s per motor, so the asserted delay is deliberately not that.
+        assert pacing["sleeps"].count(0.02) == 4, pacing["sleeps"]
+
+
+class TestTheDomainIsTheSharedOne:
+    """The accepted spellings cannot drift from the library-wide flag domain."""
+
+    @pytest.mark.parametrize("value", (*_TRUTHY_NON_BOOLEANS, *_FALSY_NON_BOOLEANS, True, False, np.True_))
+    def test_the_message_is_the_shared_flag_domain_verbatim(self, value: Any) -> None:
+        assert _smooth_posture_error("move_multiple", value) == boolean_flag_error(value, "smooth", "move_multiple")
+
+    @pytest.mark.parametrize("action", _IGNORES_THE_FLAG)
+    def test_an_action_that_ignores_the_flag_yields_no_error(self, action: str) -> None:
+        assert _smooth_posture_error(action, "false") is None
+
+    def test_every_boolean_parameter_of_the_tool_is_checked(self) -> None:
+        """A flag added to the signature cannot skip the domain unnoticed."""
+        flags = {
+            name
+            for name, param in inspect.signature(pose_tool).parameters.items()
+            if param.annotation in (bool, "bool")
+        }
+        assert flags, "no boolean parameter found - the roster read is broken"
+        assert flags == {"smooth"}, flags
+        assert all(_smooth_posture_error("move_multiple", None) is not None for _ in flags)


### PR DESCRIPTION
`pose_tool`'s `smooth` selects one of two trajectories towards the same joint
targets - interpolate over `steps * step_delay` seconds, or write each
`Goal_Position` once - and it was read by truthiness. Both undeclared halves
inverted, in opposite directions, under `status="success"`.

![smooth posture](https://raw.githubusercontent.com/cagataycali/robots/assets/pose-smooth-34346902367/pose-tool-smooth-posture.png)

## What each spelling did

Measured on `b882372`, `move_multiple`, `steps=20` (default), at the branch point
`MotorController.move_multiple_motors`:

| `smooth=` | writes | paced increments | trajectory asked for |
|---|---|---|---|
| `True` (default) | 21 | 21 | same |
| `False` | 1 | 0 | same |
| `0`, `0.0`, `""`, `None`, `[]`, `{}` | 1 | 0 | **the default, interpolated** |
| `"false"`, `"no"`, `"off"`, `"0"`, `1`, `nan` | 21 | 21 | **one write per motor** |

The falsy half is the sharper one, because this flag defaults to `True`: it
*removes* an interpolation the caller never asked to leave, and what reaches the
bus is a single write to the far end of the travel. That is the full-travel jump
this module already refuses `steps=True` for, in its own words - "a silent single
increment - a full-travel jump on exactly the path a caller asking to interpolate
wanted to avoid".

`smooth` also decides whether `steps` and `step_delay` are read at all, so it
inverts a second time:

```
pose_tool(action="move_multiple", positions=..., smooth="false", steps=0)
before -> error: move_multiple: steps must be a positive integer, got 0.
after  -> error: move_multiple: smooth must be a boolean, got 'false'. ...
```

Before, the caller was sent to correct an option their own posture said nobody
would read.

## Change

`smooth` is held to the shared `boolean_flag_error` domain, **ordered ahead of**
the `steps` / `step_delay` check so a bad flag is named as the flag, and only for
the two actions that read it - `"load_pose"` and `"move_multiple"`.
`"reset_to_home"` interpolates unconditionally and supplies its own `smooth=True`,
and every other action moves in one shot, so none of them is refused for it: the
same scoping rule those two numeric options already follow. Both declared
postures are unchanged.

The `bool(smooth)` coercions in `_interpolates` and `_smooth_move_option_error`
are removed rather than left as a second reader of a domain now enforced once,
where the caller supplies it. `MotorController.move_multiple_motors` keeps reading
the flag it is handed, matching `steps` / `step_delay`, which are also validated
at the tool and trusted below it.

## Tests

`tests/tools/test_pose_tool_smooth_posture_flag_domain.py`, 75 cells, parametrized
over `boolean_flag_error` itself rather than a copied spelling list. It measures
each refused half against the branch it would have selected, so the domain is
justified by what the loop does with the value.

| Mutation | Cells that fire |
|---|---|
| unmutated | 0 |
| guard removed (pre-fix truthiness) | 42 |
| guard ordered *after* `steps` / `step_delay` | 1 |
| guard not action-scoped | 13 |
| scope widened to `reset_to_home` | 4 |
| local message instead of the shared domain | 15 |

Pre-fix evidence: the file on `b882372` (with `_smooth_posture_error` shimmed to
return `None`, the pre-fix semantics) is **42 failed / 33 passed**; on this branch
**75 passed**.

## Gate

| | this branch | pristine `b882372` |
|---|---|---|
| `pytest tests/` | **51634 passed, 299 skipped, 0 failed** (30m10s) | 51559 passed, 299 skipped, 0 failed (31m22s) |

Delta +75 = exactly this file's cells. `ruff check` / `ruff format --check` clean
over `strands_robots tests tests_integ`; `mypy strands_robots tests tests_integ`
clean (1975 files); `scripts/check_whole_tree_graders.py` 4880 passed, 51 skipped.

## LOC

`+408 / -9` across 5 files, of which `+272` is the pin file and `+27` docs. The
guard itself is 5 lines of logic; the rest of its 45 is the rationale docstring,
matching `_smooth_move_option_error` beside it. `docs/hardware/tools.md` gains the
posture section next to the existing `overwrite` one, and `AGENTS.md` records the
sub-shape this is the first instance of: a posture flag that also gates another
parameter's validation inverts twice, so it is checked ahead of the options it
gates.

The figure is produced by driving the real module against a recording serial
double; the two traces per pair coincide exactly, which is the finding rather
than a plotting artifact.
