### PR TITLE
fix(training): resume and streaming are checked, so a word for "no" cannot select the other posture

### DIFF
--- a/changelog.d/3367-training-resume-and-streaming-are-checked.md
+++ b/changelog.d/3367-training-resume-and-streaming-are-checked.md
@@ -1,0 +1,29 @@
+### Fixed: a training `resume` or `streaming` that is not a boolean is refused, instead of selecting the other posture
+
+`TrainSpec.resume` and `TrainSpec.streaming` each select a posture rather than
+scaling a quantity, and every backend that read them did so by truthiness.
+Every non-empty string is truthy, so the spellings a caller reaches for when
+opting out selected the affirmative posture. On lerobot, `resume="false"` with
+a checkpoint under `output_dir` emitted `--resume=true --config_path=<ckpt>`,
+and the in-process `build_config` returns the checkpoint's own config in place
+of the spec's - so the fresh run that was asked for became a resume that drops
+the caller's `steps`, `global_batch_size` and `save_freq`. `streaming="false"`
+beside `val_episodes` was refused with "set streaming=False to keep the
+validation split", the remedy the caller had already spelled: the flag gates
+that pair check, so the misread posture was reported as the option it selected
+rather than as itself. GR00T emitted `--resume_from_checkpoint` and SageMaker
+forwarded the raw string as a hyperparameter. The falsy non-booleans (`0`,
+`None`, `""`) took the negative posture without being a declared spelling of it,
+and nothing reported either direction, because nothing raised.
+
+Both fields are now held to the shared `boolean_flag_error` domain through two
+field-scoped gates on `Trainer`, `_resume_problems` and `_streaming_problems`,
+in the same biconditional as the numeric domains beside them: a backend that
+reads the field routes it through the gate (lerobot, GR00T and SageMaker for
+`resume`; lerobot and SageMaker for `streaming`) and a backend that ignores the
+field reports nothing about it. Two gates rather than one because the readers
+differ. lerobot consults the streaming gate ahead of the pair check and reads
+the flag only when it reports nothing, so a misread posture is refused by its
+own name. The provider-agnostic `train_policy` tool reaches both through
+`validate` on every action that builds a spec. The two honoured postures are
+unchanged.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -101,7 +101,8 @@ supports and **ignores the rest** (the same tolerance rule as
 |-------|---------|-------|
 | `dataset_root` | LeRobotDataset v3 root | a data source; has `meta/info.json` (optional when `dataset_repo_id` is set) |
 | `dataset_repo_id` | Hub dataset id `org/name` | alternative data source; train from the Hub (lerobot) |
-| `streaming` | stream frames, no full materialize | lerobot `StreamingLeRobotDataset`; bounded disk (Hub) / RAM (local); mutually exclusive with `val_episodes` |
+| `streaming` | stream frames, no full materialize | lerobot `StreamingLeRobotDataset`; bounded disk (Hub) / RAM (local); mutually exclusive with `val_episodes`. A posture flag, so `validate()` requires a boolean rather than reading it by truthiness: `"false"` is truthy and would stream, and beside `val_episodes` it was refused with "set streaming=False" at a caller who had spelled exactly that |
+| `resume` | continue from the last checkpoint under `output_dir` | lerobot, GR00T, SageMaker. A posture flag, checked like `streaming`: on lerobot a truthy `resume` swaps the spec-built config for the checkpoint's own, so `"false"` would silently drop `steps`, `global_batch_size` and `save_freq` from the run it was meant to start fresh |
 | `base_model` | HF id / local ckpt to tune from | required for GR00T & Cosmos |
 | `steps` / `global_batch_size` | the run size: optimizer steps x batch | each must be a positive integer; `validate()` refuses `0`, a fractional or non-finite value, and a `bool` (`True` would read as a silent one-step run) before anything is loaded |
 | `method` | `full` \| `lora` \| `expert_only` \| `frozen_backbone` | `lora`+`expert_only` are mutually exclusive |

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -167,6 +167,7 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.tools._path_validation import validate_save_path
 from strands_robots.utils import (
+    boolean_flag_error,
     finite_number_error,
     non_negative_count_error,
     positive_count_error,
@@ -762,6 +763,94 @@ def validation_episodes_problems(spec: TrainSpec, *, context: str) -> list[str]:
         return []
     error = positive_count_error(spec.val_episodes, "val_episodes", context)
     return [] if error is None else [error]
+
+
+def _posture_flag_problems(spec: TrainSpec, fields: Sequence[str], *, context: str) -> list[str]:
+    """One problem per field in *fields* that is not a boolean, in that order."""
+    problems: list[str] = []
+    for param in fields:
+        error = boolean_flag_error(getattr(spec, param), param, context)
+        if error is not None:
+            problems.append(error)
+    return problems
+
+
+def resume_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return resume-posture problems for a :class:`TrainSpec`.
+
+    ``resume`` selects one of two postures - continue the run under
+    ``output_dir`` from its last checkpoint, or start a fresh one there - and
+    every backend that reads it does so by truthiness. Every non-empty string is
+    truthy, so ``"false"``, ``"no"`` and ``"0"`` - the spellings a caller reaches
+    for when opting *out* - select the resume, and what that resume does with
+    the rest of the spec is the reason this is a preflight problem rather than a
+    downstream one:
+
+    * LeRobot's ``build_config`` returns the checkpoint's own ``train_config.json``
+      in place of a config built from the spec when ``resume`` is truthy and a
+      checkpoint exists, so the fresh run that was asked for silently becomes a
+      resume of a previous configuration and the spec's ``steps``,
+      ``global_batch_size``, ``save_freq`` and learning rate never reach it.
+      That is the same defect the sibling ``lerobot_train`` tool's argv
+      builder already refuses for its own ``resume``, reached here through the
+      provider-agnostic ``train_policy`` tool one layer up.
+    * LeRobot's ``train`` clears a stale *empty* ``output_dir`` only when
+      ``not spec.resume``, so a truthy opt-out leaves it for lerobot to refuse as
+      already existing - a refusal whose remedy the caller already followed.
+    * GR00T emits ``--resume_from_checkpoint`` and passes the raw value as
+      ``FinetuneConfig.resume_from_checkpoint``, and SageMaker forwards the raw
+      value as a hyperparameter string, so the container is told ``"false"``
+      where the wrapped trainer expects a boolean it can test.
+
+    The falsy non-booleans invert the other way: ``0``, ``None`` and ``""`` take
+    the fresh-start branch without being a declared spelling of it. Nothing
+    reports either direction, because nothing raised.
+
+    The flag is checked against the one shared
+    :func:`~strands_robots.utils.boolean_flag_error` domain rather than parsed:
+    it arrives already typed, and a vocabulary would only move which spellings
+    invert. The check is placed ahead of every read the backend makes of the
+    field, so no reader ever sees a value it can only misread.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single problem when ``resume`` is not a boolean; empty otherwise.
+    """
+    return _posture_flag_problems(spec, ("resume",), context=context)
+
+
+def streaming_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return streaming-posture problems for a :class:`TrainSpec`.
+
+    ``streaming`` selects whether the dataset is materialized or streamed, and
+    the two backends that read it do so by truthiness, so the same inversion
+    :func:`resume_problems` describes applies: ``"false"`` streams. On LeRobot it
+    also *gates* another check - ``validate`` refuses ``streaming`` together with
+    ``val_episodes`` because a held-out split annuls the stream - so a truthy
+    opt-out beside a split was refused with "set streaming=False to keep the
+    validation split", a remedy the caller had already spelled. That is why the
+    backend consults this gate ahead of the pair check rather than beside it: a
+    posture guard placed after the option it gates still refuses, but names the
+    option the misread posture selected rather than the flag.
+
+    Kept separate from :func:`resume_problems` because the two fields have
+    different readers - GR00T reads ``resume`` and ignores ``streaming`` - and a
+    backend that ignores a field MUST NOT report on it (see :class:`TrainSpec`).
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`.
+
+    Returns:
+        A single problem when ``streaming`` is not a boolean; empty otherwise.
+    """
+    return _posture_flag_problems(spec, ("streaming",), context=context)
 
 
 def lora_hyperparameter_problems(spec: TrainSpec, *, context: str) -> list[str]:

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -590,6 +590,45 @@ class Trainer(ABC):
 
         return validation_episodes_problems(spec, context=self.provider_name)
 
+    def _resume_problems(self, spec: TrainSpec) -> list[str]:
+        """Resume-posture preflight shared by every backend that reads it.
+
+        Returns a problem when :attr:`TrainSpec.resume` is not a boolean,
+        against the one shared :func:`~strands_robots.utils.boolean_flag_error`
+        domain. A :meth:`validate` implementation whose backend reads the field
+        - by name or by forwarding it through a table - MUST call this ahead of
+        that read, because the field selects a *posture* and every reader tests
+        it by truthiness: a truthy spelling of off (``"false"``) resumes, and on
+        LeRobot a resume replaces the spec-built config with the checkpoint's,
+        so the run size and cadence the caller set never reach the run.
+
+        A backend that does not read the field MUST NOT call this, for the same
+        reason :meth:`_validation_episodes_problems` gives.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import resume_problems
+
+        return resume_problems(spec, context=self.provider_name)
+
+    def _streaming_problems(self, spec: TrainSpec) -> list[str]:
+        """Streaming-posture preflight shared by every backend that reads it.
+
+        The peer of :meth:`_resume_problems` for :attr:`TrainSpec.streaming`,
+        kept separate because the two fields have different readers. A backend
+        whose ``validate`` branches on the field itself (LeRobot refuses
+        ``streaming`` beside ``val_episodes``) MUST consult this first and read
+        the field only when it reports nothing, so a misread posture is refused
+        by the flag's own name rather than by the option it selected.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import streaming_problems
+
+        return streaming_problems(spec, context=self.provider_name)
+
     def _lora_hyperparameter_problems(self, spec: TrainSpec) -> list[str]:
         """LoRA adapter preflight shared by every backend that reads it.
 

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -156,6 +156,7 @@ class Gr00tTrainer(Trainer):
         problems.extend(self._run_size_problems(spec))
         problems.extend(self._checkpoint_cadence_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
+        problems.extend(self._resume_problems(spec))
         # Captured rather than extended blind: the multi-node refusal below
         # compares num_nodes, which is only a meaningful comparison once this
         # gate has established it IS a count - a string or None would raise out

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -867,7 +867,9 @@ class LerobotTrainer(Trainer):
         ``dataset_repo_id`` (for streaming) - an ``output_dir``, a usable run
         size (``steps`` / ``global_batch_size``), a ``device`` torch can parse,
         single-node only
-        (``num_nodes == 1``), a ``val_episodes``
+        (``num_nodes == 1``), a boolean ``resume`` and ``streaming`` (each
+        selects a posture, so each is checked rather than read by truthiness -
+        ``streaming`` ahead of the pair check it gates), a ``val_episodes``
         split below the dataset total and not asked for alongside ``streaming``
         (lerobot's split path is map-style only), a local dataset format version
         the installed lerobot can read, usable LoRA hyperparameters when
@@ -920,6 +922,13 @@ class LerobotTrainer(Trainer):
         problems.extend(self._checkpoint_cadence_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
         problems.extend(self._seed_problems(spec))
+        problems.extend(self._resume_problems(spec))
+        # Captured rather than extended blind: the streaming / val_episodes pair
+        # check below branches on the flag, and a flag that is not a boolean
+        # would select that branch by truthiness - so the pair was refused with
+        # "set streaming=False" at a caller who had spelled exactly that.
+        streaming_problems = self._streaming_problems(spec)
+        problems.extend(streaming_problems)
         problems.extend(self._device_problems())
         # Captured rather than extended blind: the multi-node refusal below
         # compares num_nodes, which is only a meaningful comparison once this
@@ -943,7 +952,7 @@ class LerobotTrainer(Trainer):
 
         if not val_problems and spec.val_episodes is not None:
             total = self._dataset_total_episodes(spec.dataset_root) if spec.dataset_root else None
-            if spec.streaming:
+            if not streaming_problems and spec.streaming:
                 # Decided from the two fields alone, ahead of every count-derived
                 # check below, because the pair delivers neither field whatever
                 # the episode count is. That count is only readable from a local

--- a/strands_robots/training/sagemaker.py
+++ b/strands_robots/training/sagemaker.py
@@ -340,6 +340,8 @@ class SagemakerTrainer(Trainer):
         problems.extend(self._seed_problems(spec))
         problems.extend(self._validation_episodes_problems(spec))
         problems.extend(self._lora_hyperparameter_problems(spec))
+        problems.extend(self._resume_problems(spec))
+        problems.extend(self._streaming_problems(spec))
 
         # --- the hyperparameter mapping itself ---
         problems.extend(hyperparameter_problems(spec))

--- a/tests/training/test_posture_flag_domain.py
+++ b/tests/training/test_posture_flag_domain.py
@@ -1,0 +1,351 @@
+"""``resume`` and ``streaming`` on a TrainSpec are checked, never read by truthiness.
+
+Each of the two selects a *posture* - continue the run under ``output_dir`` or
+start it fresh; stream the dataset or materialize it - and every backend that
+read either did so by truthiness. Every non-empty string is truthy, so the
+spellings a caller reaches for when opting out (``"false"``, ``"no"``, ``"0"``)
+selected the affirmative posture, and ``0``, ``None`` and ``""`` selected the
+negative one without being a declared spelling of it. Measured on ``d2f23d8``:
+
+* ``TrainSpec(resume="false")`` with a checkpoint under ``output_dir`` made
+  LeRobot's ``build_config`` return the checkpoint's own ``train_config.json``
+  in place of a config built from the spec, so the fresh run that was asked for
+  became a resume of a previous configuration and the spec's ``steps``,
+  ``global_batch_size`` and ``save_freq`` never reached it - the defect
+  ``tests/tools/test_lerobot_train_flag_domain.py`` closed on the sibling tool,
+  still reachable through the provider-agnostic ``train_policy`` one layer up;
+* ``TrainSpec(streaming="false", val_episodes=2)`` was refused by LeRobot's
+  ``validate`` with "set streaming=False to keep the validation split", a remedy
+  the caller had already spelled - the flag *gates* the pair check, so a
+  misread posture was reported as the option it selected rather than as itself;
+* GR00T emitted ``--resume_from_checkpoint`` for ``resume="false"``, and
+  SageMaker forwarded the raw string as a hyperparameter.
+
+The fields are held to the shared :func:`~strands_robots.utils.boolean_flag_error`
+domain through two field-scoped gates on :class:`~strands_robots.training.base.Trainer`,
+in the same biconditional as the numeric domains beside them: a backend that
+reads the field routes it through the gate, and a backend that ignores the field
+reports nothing about it. Two gates rather than one because the readers differ -
+GR00T reads ``resume`` and ignores ``streaming``.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.tools.train_policy import train_policy
+from strands_robots.training._validate import resume_problems, streaming_problems
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.cosmos3 import Cosmos3Trainer
+from strands_robots.training.groot import Gr00tTrainer
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.training.mock import MockTrainer
+from strands_robots.training.sagemaker import SagemakerTrainer
+from tests.training._spec_field_reads import reads_spec_field
+
+# The spellings a caller reaches for when opting out (every one truthy), two
+# truthy numbers, and the falsy values that are not a declared spelling of the
+# negative posture either.
+NOT_A_BOOLEAN = [
+    pytest.param("false", id="str-false"),
+    pytest.param("no", id="str-no"),
+    pytest.param("0", id="str-zero"),
+    pytest.param(1, id="int-one"),
+    pytest.param(0, id="int-zero"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(None, id="none"),
+    pytest.param([], id="empty-list"),
+]
+
+# Both python spellings plus the numpy booleans the shared domain also accepts.
+A_BOOLEAN = [
+    pytest.param(True, id="true"),
+    pytest.param(False, id="false"),
+    pytest.param(np.True_, id="np-true"),
+    pytest.param(np.False_, id="np-false"),
+]
+
+# Which backend reads which field, by name or through a forwarding table. The
+# one-owner scan at the bottom derives the same sets from the tree, so a
+# backend that starts reading a field is graded on arrival.
+READS_RESUME = (LerobotTrainer, Gr00tTrainer, SagemakerTrainer)
+READS_STREAMING = (LerobotTrainer, SagemakerTrainer)
+IGNORES_RESUME = (MockTrainer, Cosmos3Trainer)
+IGNORES_STREAMING = (MockTrainer, Cosmos3Trainer, Gr00tTrainer)
+
+
+@pytest.fixture
+def spec(tmp_path: pathlib.Path) -> TrainSpec:
+    """A spec whose posture flags are the only thing under test.
+
+    ``validate`` may report unrelated problems (Cosmos wants a recipe TOML,
+    SageMaker an S3 URI); every assertion below filters for the field name, so
+    an unrelated problem can neither mask nor fake a verdict.
+    """
+    return TrainSpec(
+        dataset_root=str(tmp_path / "ds"),
+        output_dir=str(tmp_path / "out"),
+        base_model="lerobot/act",
+        embodiment="new_embodiment",
+    )
+
+
+def _problems_about(trainer: Trainer, spec: TrainSpec, field: str) -> list[str]:
+    """``validate`` problems naming *field* in the shared domain's own shape.
+
+    Matched as ``": <field> "`` rather than the bare word: pytest derives
+    ``tmp_path`` from the test name, so an unrelated problem quoting a path can
+    contain the field name too.
+    """
+    return [p for p in trainer.validate(spec) if f": {field} " in p]
+
+
+def _set(spec: TrainSpec, **fields: Any) -> TrainSpec:
+    """Assign posture values through one funnel.
+
+    The values under test are deliberately outside the declared ``bool``, which
+    is the point; routing the assignment through ``setattr`` states that once
+    rather than suppressing it at every site.
+    """
+    for name, value in fields.items():
+        setattr(spec, name, value)
+    return spec
+
+
+def _run_tool(**kwargs: Any) -> dict[str, Any]:
+    """Call the agent tool through one funnel, for the same reason as _set."""
+    return dict(train_policy(**kwargs))
+
+
+def _text(envelope: dict[str, Any]) -> str:
+    return " ".join(item.get("text", "") for item in envelope.get("content", []))
+
+
+class TestEveryReaderRefusesAPostureItCanOnlyMisread:
+    """Each backend that reads a field refuses every non-boolean, by name."""
+
+    @pytest.mark.parametrize("trainer_cls", READS_RESUME)
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_resume_is_refused(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.resume = value
+        problems = _problems_about(trainer_cls(), spec, "resume")
+        assert problems, f"{trainer_cls.__name__} accepted resume={value!r}"
+        assert any("resume must be a boolean" in p for p in problems), problems
+
+    @pytest.mark.parametrize("trainer_cls", READS_STREAMING)
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_streaming_is_refused(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.streaming = value
+        problems = _problems_about(trainer_cls(), spec, "streaming")
+        assert problems, f"{trainer_cls.__name__} accepted streaming={value!r}"
+        assert any("streaming must be a boolean" in p for p in problems), problems
+
+    @pytest.mark.parametrize("trainer_cls", READS_RESUME)
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        trainer = trainer_cls()
+        _set(spec, resume="false")
+        assert any(p.startswith(f"{trainer.provider_name}: resume ") for p in _problems_about(trainer, spec, "resume"))
+
+    @pytest.mark.parametrize("trainer_cls", READS_RESUME)
+    def test_a_refused_flag_is_a_problem_not_an_exception(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        """``validate`` returns problems; a non-boolean must not raise out of it."""
+        _set(spec, resume=[1], streaming={"on": True})
+        problems = trainer_cls().validate(spec)  # must not raise
+        assert any(": resume " in p for p in problems), problems
+
+
+class TestAUsableBooleanIsUntouched:
+    """Both python spellings and the numpy booleans pass every reader."""
+
+    @pytest.mark.parametrize("trainer_cls", READS_RESUME)
+    @pytest.mark.parametrize("value", A_BOOLEAN)
+    def test_resume(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.resume = value
+        assert _problems_about(trainer_cls(), spec, "resume") == []
+
+    @pytest.mark.parametrize("trainer_cls", READS_STREAMING)
+    @pytest.mark.parametrize("value", A_BOOLEAN)
+    def test_streaming(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.streaming = value
+        assert _problems_about(trainer_cls(), spec, "streaming") == []
+
+
+class TestABackendThatIgnoresTheFieldReportsNothing:
+    """A backend must not report on a field it never reads.
+
+    :class:`TrainSpec` documents that a backend "reads the fields it supports
+    and ignores the rest", so each gate is scoped to that field's readers.
+    """
+
+    @pytest.mark.parametrize("trainer_cls", IGNORES_RESUME)
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_resume(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.resume = value
+        assert _problems_about(trainer_cls(), spec, "resume") == []
+
+    @pytest.mark.parametrize("trainer_cls", IGNORES_STREAMING)
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_streaming(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.streaming = value
+        assert _problems_about(trainer_cls(), spec, "streaming") == []
+
+
+class TestTheRefusalPrecedesTheCheckTheFlagGates:
+    """LeRobot's streaming / val_episodes pair check branches on the flag.
+
+    A posture guard placed *after* that check still refuses, but names the
+    option the misread posture selected rather than the flag - "set
+    streaming=False" at a caller who had spelled exactly that. So the gate is
+    consulted first and the pair is read only when it reports nothing.
+    """
+
+    @pytest.fixture
+    def local_dataset(self, spec: TrainSpec) -> TrainSpec:
+        """A readable local ``meta/info.json``, so the pair check is reachable."""
+        meta = pathlib.Path(spec.dataset_root) / "meta"
+        meta.mkdir(parents=True)
+        (meta / "info.json").write_text('{"total_episodes": 10, "total_tasks": 1}', encoding="utf-8")
+        return spec
+
+    def test_an_opt_out_beside_a_split_is_refused_as_the_flag(self, local_dataset: TrainSpec) -> None:
+        _set(local_dataset, streaming="false", val_episodes=2)
+        problems = LerobotTrainer().validate(local_dataset)
+        assert any("streaming must be a boolean" in p for p in problems), problems
+        # Measured on d2f23d8: the pair refusal, whose remedy the caller had
+        # already followed.
+        assert not any("set streaming=False" in p for p in problems), problems
+
+    def test_a_real_opt_in_beside_a_split_is_still_the_pair_refusal(self, local_dataset: TrainSpec) -> None:
+        """Control: the guard narrows nothing the pair check already refused."""
+        local_dataset.streaming = True
+        local_dataset.val_episodes = 2
+        problems = LerobotTrainer().validate(local_dataset)
+        assert any("set streaming=False" in p for p in problems), problems
+        assert not any("must be a boolean" in p for p in problems), problems
+
+
+class TestTheProviderAgnosticToolReportsTheRefusal:
+    """``train_policy`` reaches the gate through ``validate`` on every spec action."""
+
+    @pytest.mark.parametrize("action", ["validate", "train", "export"])
+    @pytest.mark.parametrize("field", ["resume", "streaming"])
+    def test_a_spec_action_is_refused_by_name(self, tmp_path: pathlib.Path, action: str, field: str) -> None:
+        envelope = _run_tool(
+            action=action,
+            provider="lerobot_local",
+            dataset_root=str(tmp_path / "ds"),
+            output_dir=str(tmp_path / "out"),
+            **{field: "false"},
+        )
+        assert envelope["status"] == "error"
+        assert f"{field} must be a boolean" in _text(envelope), _text(envelope)
+
+    def test_an_action_that_builds_no_spec_is_not_refused_for_one(self) -> None:
+        envelope = _run_tool(action="list", resume="false", streaming="no")
+        assert envelope["status"] == "success"
+        assert "must be a boolean" not in _text(envelope)
+
+
+class TestTheGatesAreUsableOnTheirOwn:
+    """Each gate's own contract, independent of any backend."""
+
+    def test_resume_reports_the_context_it_was_given(self, spec: TrainSpec) -> None:
+        _set(spec, resume="false")
+        [problem] = resume_problems(spec, context="acme")
+        assert problem.startswith("acme: resume must be a boolean, got 'false'.")
+
+    def test_streaming_reports_the_context_it_was_given(self, spec: TrainSpec) -> None:
+        _set(spec, streaming=0)
+        [problem] = streaming_problems(spec, context="acme")
+        assert problem.startswith("acme: streaming must be a boolean, got 0.")
+
+    def test_each_gate_reads_only_its_own_field(self, spec: TrainSpec) -> None:
+        _set(spec, resume="false")
+        assert streaming_problems(spec, context="acme") == []
+        _set(spec, resume=False, streaming="false")
+        assert resume_problems(spec, context="acme") == []
+
+    def test_the_defaults_report_nothing(self, spec: TrainSpec) -> None:
+        assert resume_problems(spec, context="acme") == []
+        assert streaming_problems(spec, context="acme") == []
+
+
+def _trainer_modules() -> list[pathlib.Path]:
+    """Every trainer module, minus the one that defines the shared gates.
+
+    Rooted at the module that defines :class:`Trainer` so the scan cannot
+    silently point at the wrong tree. The gates' own module reads the fields as
+    their owner, not as a consumer, and is excluded by derivation rather than by
+    name.
+    """
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(resume_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _calls_the_gate(source: str, gate: str) -> bool:
+    """Does *source* route through ``self.<gate>(...)``?"""
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == gate
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForEachPostureFlag:
+    """No backend may skip a gate for a field it reads, and none may skip a read.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that reads ``spec.resume`` (by name or through a forwarding table)
+    must call ``_resume_problems``, and likewise for ``streaming``, so a backend
+    that starts reading either field fails this test until it does.
+    """
+
+    @pytest.mark.parametrize(
+        ("field", "expected_readers"),
+        [
+            ("resume", {"groot.py", "lerobot.py", "sagemaker.py"}),
+            ("streaming", {"lerobot.py", "sagemaker.py"}),
+        ],
+    )
+    def test_the_scan_finds_the_readers(self, field: str, expected_readers: set[str]) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep of nothing."""
+        readers = {p.name for p in _trainer_modules() if reads_spec_field(p.read_text(), (field,))}
+        assert readers == expected_readers
+
+    @pytest.mark.parametrize(("field", "gate"), [("resume", "_resume_problems"), ("streaming", "_streaming_problems")])
+    def test_every_reader_routes_through_the_gate(self, field: str, gate: str) -> None:
+        adrift = sorted(
+            p.name
+            for p in _trainer_modules()
+            if reads_spec_field(source := p.read_text(), (field,)) and not _calls_the_gate(source, gate)
+        )
+        assert adrift == [], f"modules reading spec.{field} without {gate}: {adrift}"
+
+    @pytest.mark.parametrize(("field", "gate"), [("resume", "_resume_problems"), ("streaming", "_streaming_problems")])
+    def test_no_backend_gates_a_field_it_does_not_read(self, field: str, gate: str) -> None:
+        """The other half of the biconditional: a gate is not a free extra check."""
+        over_reaching = sorted(
+            p.name
+            for p in _trainer_modules()
+            if _calls_the_gate(source := p.read_text(), gate) and not reads_spec_field(source, (field,))
+        )
+        assert over_reaching == [], f"modules calling {gate} without reading spec.{field}: {over_reaching}"
+
+    def test_the_scanner_detects_a_planted_defect(self) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        planted = "def validate(self, spec):\n    return ['--resume'] if spec.resume else []\n"
+        assert reads_spec_field(planted, ("resume",))
+        assert not _calls_the_gate(planted, "_resume_problems")
+
+    def test_the_class_of_readers_reads_the_field_in_the_test_table(self) -> None:
+        """The hand-written reader tuples above agree with the derived ones."""
+        by_module = {"lerobot.py": LerobotTrainer, "groot.py": Gr00tTrainer, "sagemaker.py": SagemakerTrainer}
+        for field, listed in (("resume", READS_RESUME), ("streaming", READS_STREAMING)):
+            readers = {p.name for p in _trainer_modules() if reads_spec_field(p.read_text(), (field,))}
+            assert {by_module[name] for name in readers} == set(listed), field


### PR DESCRIPTION
## What

`TrainSpec.resume` and `TrainSpec.streaming` each select a *posture*, and every backend that read them did so by truthiness. Two field-scoped gates on `Trainer` (`_resume_problems`, `_streaming_problems`, delegating to `strands_robots.utils.boolean_flag_error`) now hold them to the shared boolean domain in the same biconditional as the numeric domains beside them: a backend that reads the field routes it through the gate, and one that ignores the field reports nothing about it.

The `train_policy` row of #3356, one layer down from the tool: the tool forwards both flags into `TrainSpec` unread, so the readers are the backends, and the gate lives where the domain siblings already do.

## Measured on `d2f23d8`

| call | what happened |
|---|---|
| `LerobotTrainer.validate(streaming="false", val_episodes=2)` | refused as `streaming=True cannot be combined with val_episodes=2 ... set streaming=False to keep the validation split` - the remedy the caller had already spelled. The flag *gates* that pair check, so the misread posture was reported as the option it selected rather than as itself |
| `LerobotTrainer.build_command(resume="false")`, checkpoint present | `--resume=true --config_path=<ckpt>/train_config.json` emitted; the in-process `build_config` returns the checkpoint's own config in place of the spec's, so `steps`, `global_batch_size` and `save_freq` never reach the run that was meant to start fresh |
| `Gr00tTrainer.build_command(resume="false")` | `--resume_from_checkpoint` emitted |
| `build_hyperparameters(resume="false", streaming="false")` (SageMaker) | `{'resume': 'false', 'streaming': 'false'}` forwarded to the container |
| `LerobotTrainer.validate(resume=0)` | no problem naming `resume` - the falsy side takes the fresh-start branch without being a declared spelling of it |

Nothing raised in any row.

## Shape

- Two gates rather than one because the readers differ: GR00T reads `resume` and ignores `streaming`, so one gate over both would report on a field GR00T never reads.
- lerobot consults `_streaming_problems` **ahead of** the `streaming`/`val_episodes` pair check (captured, like `_launch_topology_problems` two lines above it) and reads the flag only when the gate reports nothing - the ordering sub-rule #3365 recorded in AGENTS.md.
- Wired into `lerobot` (both), `groot` (`resume`), `sagemaker` (both, it forwards both through `_FORWARDED_FIELDS`). `mock`, `cosmos3` and the RL trainers read neither and call neither.
- `docs/training/overview.md`: the field table gains a `resume` row and the `streaming` row states the domain, as `steps`, `num_gpus` and `seed` already do.

## Pinned

`tests/training/test_posture_flag_domain.py` - 127 cells. Reader sets are derived from the tree with the shared `reads_spec_field` rule (name **or** forwarding table), both halves of the biconditional are graded, the lerobot ordering cell asserts the pair refusal is absent for `"false"` and present for `True`, and the tool reaches the gate on `validate` / `train` / `export` and not on `list`.

Pre-fix: the file fails to collect (the gates do not exist). Gates present but backends unwired: **55 failed, 72 passed**.

## Verification

- `ruff check` / `ruff format --check` clean; `mypy` on the six touched files: `Success: no issues found`
- `tests/training` + `tests/tools/test_train_policy*.py` + `tests/tools/test_lerobot_train_flag_domain.py`: **162 failed, 4782 passed** on `main` and **162 failed, 4909 passed** on this branch - the 162 are the same torch-mock cells on both (no `torch` in this venv), the +127 are this file, and the set difference of failures is empty
- Whole-tree graders (roster from `check_whole_tree_graders.py`): one finding attributable to this diff and fixed before pushing - `test_no_reference_to_test_files_by_name` refused a test filename cited from `_validate.py`'s docstring. The remaining red is `lerobot` / `mujoco` / `qpsolvers` absent in this venv and reproduces on a pristine `main`.
- `check_duplicate_claim.py --all-open`: `unique-additions`; `check_merge_base_overlap.py --all-open`: no shared path with the open set or with what landed on `main` since the merge base.

Refs #3356 (rows remaining after this: `run_policy.fast_mode`; `gr00t_inference` is struck as deletion-approved).

## Round changelog

- r0 (`26d8078` + `0ffdca6`): opened as draft, fragment `changelog.d/3367-training-resume-and-streaming-are-checked.md` pushed, then marked ready. Auto-merge (squash) armed. Awaiting a first review.