### PR TITLE
fix(simulation): the rollout facades check their posture flags, so a word for "no" cannot select the other posture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2111,6 +2111,25 @@ which side the enum is on.
   arm to the far end of its travel in one write: the full-travel jump the same module
   already refuses `steps=True` for. Pinned by
   `tests/tools/test_pose_tool_smooth_posture_flag_domain.py`.
+- **A facade that binds its numeric knobs to the tool-error envelope binds its flags the
+  same way, and a surface that submits to a worker checks them before the submit.**
+  `SimEngine.run_policy` validates `control_frequency`, `seed`, `action_horizon` and the
+  rest through `_validate_*` bindings of the shared numeric domains, while the four
+  posture flags in the same signature - `fast_mode`, `reset_between`,
+  `wbc_install_torque_control` and `async_rtc` - were read by truthiness one layer down:
+  `reset_between=0` on a two-episode call started episode two from wherever episode one
+  left the arm, and `async_rtc="false"` reported `rtc_async_enabled=True` beside the
+  background inference thread the caller had declined. `_validate_posture_flags` is the
+  binding, called ahead of robot resolution so a refused call builds no policy. A flag
+  whose `None` is a documented sentinel (`async_rtc` on `run_policy`, "resolve from the
+  policy") is checked only when supplied; the same name declared as a plain `bool` on
+  `eval_policy` refuses `None` with everything else. MuJoCo's `start_policy` repeats the
+  check before `executor.submit`, for the reason its sibling knobs already do: a refusal
+  produced on the worker is discarded with the future and the caller reads "started". The
+  `run_policy` tool checks its own `fast_mode` before `start_recording(overwrite=True)`,
+  so the facade's refusal cannot arrive after the dataset it was asked to record into has
+  been emptied. Pinned by `tests/simulation/test_run_policy_posture_flag_domain.py`,
+  whose roster is read from the facade's signature so a fifth flag cannot skip the domain.
 - Pinned by `tests/simulation/mujoco/test_actuate_robot_posture_flag_domain.py`,
   `tests/simulation/test_recording_posture_flag_domain.py`,
   `tests/tools/test_lerobot_teleoperate_flag_domain.py`,

--- a/changelog.d/3356-rollout-facades-check-their-posture-flags.md
+++ b/changelog.d/3356-rollout-facades-check-their-posture-flags.md
@@ -1,0 +1,28 @@
+### Fixed: the rollout facades check their posture flags, not read them by truthiness
+
+`SimEngine.run_policy` takes four flags that each select one of two postures -
+`fast_mode` (pace the loop at `control_frequency` or run it unpaced),
+`reset_between` (reset the scene between episodes or carry the end state over),
+`wbc_install_torque_control` (install the WBC torque shim for the call or leave
+the actuators alone) and `async_rtc` (overlap inference with actuation, drain
+each chunk first, or `None` to resolve from the policy). `eval_policy` takes
+`async_rtc`, MuJoCo's `start_policy` takes `fast_mode`, and the `run_policy`
+agent tool forwards its own `fast_mode` into the facade. Every one of them was
+read by truthiness, so `"false"`, `"no"`, `"off"` and `"0"` selected the posture
+the word asks to skip, and `0`, `""` and `[]` took the other branch without
+being a declared spelling of it. Measured: `run_policy(fast_mode="false")` ran
+unpaced, `run_policy(n_episodes=2, reset_between=0)` started episode two from
+wherever episode one left the arm, `run_policy(async_rtc="false")` reported
+`rtc_async_enabled=True` beside a background inference thread the caller had
+declined, and each reported `status="success"`.
+
+Every flag is now held to the shared `boolean_flag_error` domain through
+`SimEngine._validate_posture_flags`, the way the numeric knobs beside them
+already are, ahead of robot resolution so a refused call builds no policy and
+touches no scene. `start_policy` checks `fast_mode` before the submit, because
+a refusal on the worker is discarded with the future and the caller reads
+"started". The `run_policy` tool checks it before starting the recording it was
+asked to make, so the refusal cannot arrive after the dataset at `dataset_root`
+has been replaced with an empty one. `async_rtc=None` on `run_policy` is the
+documented "resolve from the policy" spelling and is unchanged; both declared
+postures of every flag are unchanged.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -54,6 +54,7 @@ from strands_robots.simulation.observers import RunPolicyObserver
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
+    boolean_flag_error,
     dds_domain_id_error,
     is_boolean,
     non_negative_count_error,
@@ -1848,6 +1849,39 @@ class SimEngine(ABC):
         return None
 
     @staticmethod
+    def _validate_posture_flags(method: str, **flags: Any) -> dict[str, Any] | None:
+        """Refuse a posture flag that is not a boolean, naming the flag.
+
+        A flag that selects one of two *postures* - pace the loop or run it
+        unpaced, reset the scene between episodes or carry it over, install the
+        WBC torque shim or leave the actuators as they are, overlap inference
+        with actuation or drain each chunk first - is checked rather than read
+        by truthiness. Every non-empty string is truthy, so ``"false"``,
+        ``"no"``, ``"off"`` and ``"0"`` select the posture the word asks to
+        skip, while ``0``, ``""`` and ``[]`` take the other branch without ever
+        being a declared spelling of it. Nothing raises and nothing logs on
+        either half, so the wrong posture is indistinguishable from the right
+        one until the rollout's telemetry is read.
+
+        Thin binding of :func:`~strands_robots.utils.boolean_flag_error` to this
+        class's tool-error envelope, the inverse of the numeric bindings above
+        (which refuse a ``bool`` because it would pass as a silent ``1``). Flags
+        are checked in the order given and the first refusal is returned, so a
+        caller who mistyped two sees the first named.
+
+        Args:
+            method: Public method name the message is prefixed with.
+            **flags: The posture flags to check, keyed by parameter name.
+
+        Returns:
+            A structured error, or ``None`` when every flag is a boolean.
+        """
+        for param, value in flags.items():
+            if message := boolean_flag_error(value, param, method):
+                return {"status": "error", "content": [{"text": message}]}
+        return None
+
+    @staticmethod
     def _validate_seed(seed: Any, method: str) -> dict[str, Any] | None:
         """Reject an unusable RNG seed at the public API.
 
@@ -2522,7 +2556,11 @@ class SimEngine(ABC):
                 and physics allow. When False (default) the loop is paced on a
                 deadline at ``control_frequency``, so the wall clock a step
                 spends working is subtracted from the period rather than added
-                to it and ``duration`` is honored whatever a step costs.
+                to it and ``duration`` is honored whatever a step costs. Must be
+                a boolean: it selects a posture rather than scaling a quantity,
+                so a value of any other type is reported as a structured caller
+                error rather than read by truthiness - a truthy ``"false"``
+                would otherwise run the loop unpaced.
             video: Optional video-recording config dict. Accepted keys:
                 ``path`` (str, output MP4 - required to enable recording),
                 ``fps`` (int, default 30), ``camera`` (str, default backend
@@ -2622,7 +2660,10 @@ class SimEngine(ABC):
             reset_between: When running multiple episodes, reset the sim to its
                 initial state between episodes (default ``True``). The reset
                 never fires after the final episode. Set ``False`` to chain
-                episodes from the end state of the previous one.
+                episodes from the end state of the previous one. Must be a
+                boolean, reported as a structured caller error otherwise - a
+                falsy ``0`` would otherwise chain the episodes without being a
+                declared spelling of that.
             async_rtc: When ``True``, overlap policy inference with action
                 execution so the next action chunk is computed in the
                 background while the current chunk is still draining (latency
@@ -2631,10 +2672,13 @@ class SimEngine(ABC):
                 so chunk-emitting VLA/flow-matching policies (pi0, pi0.5,
                 pi0-FAST, SmolVLA, MolmoAct2) get latency masking automatically
                 while single-step policies stay synchronous; an explicit
-                ``True``/``False`` always wins. Forwarded verbatim to
-                :meth:`PolicyRunner.run`; see its docstring for the full
-                contract (provider-agnostic, RTC-policy seam blending, thread
-                safety).
+                ``True``/``False`` always wins, and a supplied value must be one
+                of those two: any other type is reported as a structured caller
+                error rather than read by truthiness, since a truthy ``"false"``
+                would otherwise start the background inference thread it reads
+                as declining. Forwarded verbatim to :meth:`PolicyRunner.run`;
+                see its docstring for the full contract (provider-agnostic,
+                RTC-policy seam blending, thread safety).
             rtc_inference_timeout_s: Optional hard per-chunk timeout (seconds)
                 for the async-RTC prefetch. When set, a stuck inference surfaces
                 as a structured ``status=error`` result (carrying the RTC
@@ -2650,7 +2694,10 @@ class SimEngine(ABC):
                 PD and the gait diverges, so the documented quickstart silently
                 falls over without it. Set ``False`` to manage the controller
                 yourself or to drive a torque-actuated scene directly. No-op for
-                non-WBC policies and on backends without the hook.
+                non-WBC policies and on backends without the hook. Must be a
+                boolean, reported as a structured caller error otherwise - a
+                falsy ``0`` would otherwise skip the shim without being a
+                declared spelling of that.
             stop_when: Optional semantic early-return condition: end the
                 rollout as soon as the WORLD reaches a state, not only when
                 the step budget runs out - which turns a monolithic rollout
@@ -2824,6 +2871,26 @@ class SimEngine(ABC):
         # policy construction, backend hook creation, clocks, or rollout work.
         if observer_error := optional_callable_error(observer, "observer", "run_policy"):
             return {"status": "error", "content": [{"text": observer_error}]}
+
+        # The posture flags are checked next, for the same reason and ahead of
+        # everything they select: ``fast_mode`` decides whether the runner
+        # acquires a pacer, ``reset_between`` whether ``reset`` runs between
+        # episodes, ``wbc_install_torque_control`` whether the torque shim is
+        # installed on the scene. Read by truthiness, ``"false"`` selected the
+        # posture the word asks to skip and ``0`` took the other branch without
+        # being a declared spelling of it - a two-episode ``reset_between=0``
+        # carried episode one's end state into episode two and reported
+        # success. ``async_rtc`` is the same flag with a ``None`` sentinel that
+        # means "resolve from the policy", so only a supplied value is checked.
+        if err := self._validate_posture_flags(
+            "run_policy",
+            fast_mode=fast_mode,
+            reset_between=reset_between,
+            wbc_install_torque_control=wbc_install_torque_control,
+        ):
+            return err
+        if async_rtc is not None and (err := self._validate_posture_flags("run_policy", async_rtc=async_rtc)):
+            return err
 
         robot_name = self._resolve_single_robot(robot_name)
 
@@ -4153,7 +4220,12 @@ class SimEngine(ABC):
         inference with action-chunk execution, evaluating a chunk-emitting
         policy under the realistic control latency it faces in deployment.
         It is forwarded to :meth:`PolicyRunner.evaluate`; the default keeps
-        the success-rate synchronous and bit-stable. ``rtc_inference_timeout_s``
+        the success-rate synchronous and bit-stable. It must be a boolean -
+        a value of any other type is reported as a structured caller error
+        rather than read by truthiness, since a truthy ``"false"`` would
+        otherwise evaluate under the latency it reads as declining, and a
+        success rate measured that way is not the one the caller asked for.
+        ``rtc_inference_timeout_s``
         bounds each async inference (structured error instead of a hung
         rollout). For benchmark-style latency masking use
         :meth:`run_policy` (``async_rtc=...``).
@@ -4262,6 +4334,13 @@ class SimEngine(ABC):
             ``rtc_prefetch_blocks``, ``rtc_avg_inference_ms`` and
             ``rtc_max_inference_ms``.
         """
+        # Same posture-flag rule as run_policy, ahead of robot resolution: an
+        # evaluation is the one place a misread here would be trusted as a
+        # number, since a success rate carries no field saying which pipeline
+        # produced it.
+        if err := self._validate_posture_flags("eval_policy", async_rtc=async_rtc):
+            return err
+
         robots = self.list_robots()
         if not robots:
             return {"status": "error", "content": [{"text": "No robots in sim. Add one first."}]}

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5348,8 +5348,9 @@ class MuJoCoSimEngine(
         A second ``start_policy`` on the *same* robot is still rejected.
 
         Every request :meth:`run_policy` refuses is refused here too, before the
-        submit: the horizon, the seed, the video config, the provider keyword
-        bags, the recording rate, and the policy configuration itself (provider
+        submit: the pacing posture, the horizon, the seed, the video config, the
+        provider keyword bags, the recording rate, and the policy configuration
+        itself (provider
         resolution plus the provider's own
         :meth:`~strands_robots.policies.base.Policy.preflight` hook, via
         :meth:`~strands_robots.simulation.base.SimEngine._preflight_policy_config`).
@@ -5384,7 +5385,12 @@ class MuJoCoSimEngine(
         # default path, when n_steps is omitted) via _validate_duration. The
         # seed is covered for the same reason and was not: an unusable one
         # reached NumPy on the worker thread, where the raise was swallowed, so
-        # the caller read "started" and the rollout ran unseeded.
+        # the caller read "started" and the rollout ran unseeded. The pacing
+        # posture is covered for the same reason: read by truthiness on the
+        # worker, fast_mode="false" ran the rollout unpaced under a "started"
+        # that named no problem.
+        if err := self._validate_posture_flags("start_policy", fast_mode=fast_mode):
+            return err
         if err := self._validate_positive_frequency(control_frequency, "start_policy"):
             return err
         resolved_duration, resolved_n_steps, horizon_error = self._resolve_horizon(

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -239,7 +239,11 @@ def run_policy(
             Must be a positive integer, reported before the rollout starts
             for the same reason.
         fast_mode: Skip real-time sleep between steps (default True for
-            rollouts - wall-clock pacing slows headless eval).
+            rollouts - wall-clock pacing slows headless eval). Must be a
+            boolean; it selects a posture rather than scaling a quantity, so
+            any other type is reported before the rollout starts rather than
+            read by truthiness - a truthy ``"false"`` would otherwise run the
+            episodes unpaced.
         dataset_root: When set, the tool drives the full recording
             cycle: ``start_recording(root=dataset_root, ...)`` -> N
             rollouts with per-episode save_episode -> ``stop_recording``
@@ -408,6 +412,19 @@ def run_policy(
                 f"above the {MAX_EVAL_SEED} ceiling every rollout surface accepts. Lower the seed or "
                 "the episode count."
             )
+
+    # The pacing posture is checked before step 2 for the same reason as the
+    # options around it: the facade refuses a non-boolean fast_mode itself, but
+    # only once this tool has already created the dataset it was asked to
+    # record into, so every episode would then be reported as refused beside
+    # an empty dataset. Read by truthiness, as it was, ``fast_mode="false"`` ran
+    # every episode unpaced and ``fast_mode=0`` paced them, neither a declared
+    # spelling. The domain is the shared one, so a spelling the facade refuses
+    # is refused here with the same words.
+    from strands_robots.utils import boolean_flag_error
+
+    if flag_error := boolean_flag_error(fast_mode, "fast_mode", "run_policy"):
+        return _err(flag_error)
 
     if video is not None and not isinstance(video, dict):
         return _err(

--- a/tests/simulation/test_run_policy_posture_flag_domain.py
+++ b/tests/simulation/test_run_policy_posture_flag_domain.py
@@ -1,0 +1,408 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The rollout facades check their posture flags instead of reading them by truthiness.
+
+:meth:`SimEngine.run_policy` takes four flags that each select one of two
+postures: ``fast_mode`` (pace the loop at ``control_frequency`` or run it
+unpaced), ``reset_between`` (reset the scene between episodes or carry the end
+state over), ``wbc_install_torque_control`` (install the WBC torque shim for the
+call or leave the actuators alone) and ``async_rtc`` (overlap inference with
+actuation on a background thread, drain each chunk first, or ``None`` to resolve
+from the policy). :meth:`SimEngine.eval_policy` takes ``async_rtc`` as a plain
+``bool``, and MuJoCo's :meth:`start_policy` takes ``fast_mode`` and submits the
+rollout to a worker. Every one of them was read by truthiness, so every
+non-empty string selected the posture the word asks to skip, and every falsy
+non-boolean took the other branch without being a declared spelling of it.
+Measured on ``main`` at ``a03d98d``, driving the real facade over a mock policy,
+three steps at 50 Hz:
+
+| call | selected | asked for |
+|---|---|---|
+| ``run_policy(fast_mode="false")`` | pacer never acquired | a paced loop |
+| ``run_policy(fast_mode=0)`` | pacer acquired | (not a declared spelling) |
+| ``run_policy(n_episodes=2, reset_between=0)`` | no reset between episodes | (not a declared spelling) |
+| ``run_policy(wbc_install_torque_control=0)`` | shim not installed | (not a declared spelling) |
+| ``run_policy(async_rtc="false")`` | ``rtc_async_enabled=True`` | the synchronous loop |
+
+Every row reported ``status="success"``. The ``async_rtc`` row is the sharpest:
+the word for "no" started the background inference thread, and an evaluation's
+success rate carries no field saying which pipeline produced it. The
+``reset_between`` row is the one with a physical consequence - episode two
+started from wherever episode one left the arm, and the dataset those two
+episodes were flushed into does not record that.
+
+The fix binds the shared :func:`~strands_robots.utils.boolean_flag_error`
+domain to the facade's error envelope (``SimEngine._validate_posture_flags``),
+the way the numeric knobs beside these flags are already bound, and checks the
+flags ahead of robot resolution so a refused call builds no policy and touches
+no scene. ``start_policy`` checks ``fast_mode`` before the submit, because a
+refusal on the worker is discarded with the future and the caller reads
+"started". The ``run_policy`` *tool* checks ``fast_mode`` before it starts the
+recording it was asked to make, for the reason its own pre-flight block states:
+the facade's refusal would otherwise arrive after the dataset at ``dataset_root``
+had been replaced with an empty one.
+
+``async_rtc=None`` on ``run_policy`` is the documented "resolve from the policy"
+spelling and is left alone; only a supplied value is held to the domain.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+import threading
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.mesh.pacing as pacing_mod
+import strands_robots.tools.run_policy as rp_mod
+from strands_robots.simulation.base import SimEngine
+from strands_robots.utils import boolean_flag_error
+
+#: Truthy spellings of "off": each selected the posture the word asks to skip.
+TRUTHY_NON_BOOLEANS: tuple[Any, ...] = ("false", "no", "off", "0", 1, 2, math.nan)
+#: Falsy non-booleans: each took the other branch without being a spelling of it.
+FALSY_NON_BOOLEANS: tuple[Any, ...] = (0, 0.0, "", [], {})
+#: ``None`` is a declared sentinel for ``async_rtc`` on ``run_policy`` and for
+#: nothing else here, so it is parametrized separately.
+UNDECLARED: tuple[Any, ...] = (*TRUTHY_NON_BOOLEANS, *FALSY_NON_BOOLEANS)
+
+#: The posture flags ``SimEngine.run_policy`` reads, keyed to the branch each
+#: selects, so the roster below can be checked against the signature.
+RUN_POLICY_FLAGS: tuple[str, ...] = ("fast_mode", "reset_between", "wbc_install_torque_control", "async_rtc")
+
+
+class _Sim(SimEngine):
+    """Minimal ``SimEngine`` that records the branch each flag selects.
+
+    It counts ``reset`` calls (the ``reset_between`` branch), the torque-shim
+    installs (the ``wbc_install_torque_control`` branch) and ``send_action``
+    calls (whether a rollout ran at all). The pacer is observed by replacing the
+    ``Ticker`` class the runner imports lazily, since ``fast_mode`` is read as
+    "acquire one or do not".
+    """
+
+    def __init__(self) -> None:
+        self._robots = {"arm": ["j0", "j1", "j2"]}
+        self._lock = threading.Lock()
+        self.resets = 0
+        self.sends = 0
+        self.shim_installs = 0
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def destroy(self):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def reset(self):  # type: ignore[no-untyped-def]
+        self.resets += 1
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def get_state(self):  # type: ignore[no-untyped-def]
+        return {"sim_time": 0.0, "step_count": self.sends}
+
+    def add_robot(self, name, **kw):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def remove_robot(self, name):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots)
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._robots.get(robot_name, []))
+
+    def add_object(self, name, **kw):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def remove_object(self, name):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):  # type: ignore[no-untyped-def]
+        return {n: 0.0 for n in self._robots["arm"]}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):  # type: ignore[no-untyped-def]
+        self.sends += 1
+
+    def render(self, camera_name="default", width=None, height=None):  # type: ignore[no-untyped-def]
+        return {"image": np.zeros((height or 48, width or 64, 3), dtype=np.uint8)}
+
+    def _maybe_install_wbc_torque_control(self, policy: Any, robot_name: str) -> None:
+        self.shim_installs += 1
+        return None
+
+
+@pytest.fixture
+def pacers(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record the period of every pacer the runner acquires, and acquire none.
+
+    ``PolicyRunner.run`` imports ``Ticker`` from the pacing module inside the
+    call, so replacing the attribute on that module is what the runner sees.
+    """
+    acquired: list[float] = []
+
+    class _Ticker:
+        def __init__(self, period: float) -> None:
+            acquired.append(period)
+
+        def __enter__(self) -> _Ticker:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def wait(self) -> None:
+            return None
+
+        def tick(self) -> None:
+            return None
+
+    monkeypatch.setattr(pacing_mod, "Ticker", _Ticker)
+    return acquired
+
+
+def _run(sim: _Sim, **kwargs: Any) -> dict[str, Any]:
+    """Drive the real facade over the mock policy, three steps at 50 Hz.
+
+    The values under test are deliberately outside the declared ``bool``; one
+    funnel states that once instead of suppressing it per call.
+    """
+    kwargs.setdefault("fast_mode", True)
+    return sim.run_policy("arm", policy_provider="mock", n_steps=3, control_frequency=50.0, **kwargs)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(block.get("text", "") for block in result.get("content") or [] if isinstance(block, dict))
+
+
+def _json(result: dict[str, Any]) -> dict[str, Any]:
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+class TestAnUndeclaredSpellingIsRefusedNamingTheFlag:
+    """Neither half is read as a posture, and the refusal is the shared domain's."""
+
+    @pytest.mark.parametrize("flag", RUN_POLICY_FLAGS)
+    @pytest.mark.parametrize("value", UNDECLARED, ids=repr)
+    def test_run_policy_refuses_it(self, pacers: list[float], flag: str, value: Any) -> None:
+        sim = _Sim()
+        result = _run(sim, **{flag: value})
+        assert result["status"] == "error"
+        assert _text(result) == boolean_flag_error(value, flag, "run_policy")
+
+    @pytest.mark.parametrize("flag", RUN_POLICY_FLAGS)
+    @pytest.mark.parametrize("value", UNDECLARED, ids=repr)
+    def test_the_refusal_precedes_every_side_effect(self, pacers: list[float], flag: str, value: Any) -> None:
+        """No pacer, no shim, no reset, no action: nothing the flag selects ran."""
+        sim = _Sim()
+        _run(sim, n_episodes=2, **{flag: value})
+        assert (pacers, sim.shim_installs, sim.resets, sim.sends) == ([], 0, 0, 0)
+
+    @pytest.mark.parametrize("value", (*UNDECLARED, None), ids=repr)
+    def test_eval_policy_refuses_a_non_boolean_async_rtc(self, value: Any) -> None:
+        """``eval_policy`` declares ``async_rtc: bool``, so ``None`` is refused there too."""
+        sim = _Sim()
+        result = sim.eval_policy("arm", policy_provider="mock", n_episodes=1, max_steps=3, async_rtc=value)
+        assert result["status"] == "error"
+        assert _text(result) == boolean_flag_error(value, "async_rtc", "eval_policy")
+        assert sim.sends == 0
+
+    def test_two_mistyped_flags_report_the_first_in_signature_order(self, pacers: list[float]) -> None:
+        result = _run(_Sim(), fast_mode="false", reset_between="false")
+        assert _text(result) == boolean_flag_error("false", "fast_mode", "run_policy")
+
+
+class TestWhyEachHalfIsRefused:
+    """The branch each undeclared spelling selected, measured on the fixed tree.
+
+    These cells drive the branch through a declared spelling so the behaviour
+    the flag selects is pinned beside the refusal - a future reader can see what
+    ``"false"`` would have done, not only that it is refused.
+    """
+
+    def test_fast_mode_false_acquires_one_pacer_at_the_control_period(self, pacers: list[float]) -> None:
+        result = _run(_Sim(), fast_mode=False)
+        assert result["status"] == "success", _text(result)
+        assert pacers == [pytest.approx(1.0 / 50.0)]
+
+    def test_fast_mode_true_acquires_no_pacer(self, pacers: list[float]) -> None:
+        result = _run(_Sim(), fast_mode=True)
+        assert result["status"] == "success", _text(result)
+        assert pacers == []
+
+    def test_reset_between_false_carries_the_scene_across_episodes(self, pacers: list[float]) -> None:
+        sim = _Sim()
+        result = _run(sim, n_episodes=2, reset_between=False)
+        assert result["status"] == "success", _text(result)
+        assert sim.resets == 0
+
+    def test_reset_between_true_resets_once_between_two_episodes(self, pacers: list[float]) -> None:
+        sim = _Sim()
+        result = _run(sim, n_episodes=2, reset_between=True)
+        assert result["status"] == "success", _text(result)
+        assert sim.resets == 1
+
+    def test_wbc_install_torque_control_false_installs_no_shim(self, pacers: list[float]) -> None:
+        sim = _Sim()
+        result = _run(sim, wbc_install_torque_control=False)
+        assert result["status"] == "success", _text(result)
+        assert sim.shim_installs == 0
+
+    def test_wbc_install_torque_control_true_installs_the_shim(self, pacers: list[float]) -> None:
+        sim = _Sim()
+        result = _run(sim, wbc_install_torque_control=True)
+        assert result["status"] == "success", _text(result)
+        assert sim.shim_installs == 1
+
+    @pytest.mark.parametrize(("value", "enabled"), [(True, True), (False, False), (None, False)], ids=repr)
+    def test_async_rtc_declared_spellings_select_the_pipeline_they_name(
+        self, pacers: list[float], value: Any, enabled: bool
+    ) -> None:
+        """``None`` resolves from the mock policy, which is single-step, so synchronous."""
+        result = _run(_Sim(), async_rtc=value)
+        assert result["status"] == "success", _text(result)
+        assert _json(result)["rtc_async_enabled"] is enabled
+
+
+class TestTheDeclaredSpellingsStillRun:
+    """Over-reach control: a boolean of either type is honoured, whatever the flag."""
+
+    @pytest.mark.parametrize("flag", RUN_POLICY_FLAGS)
+    @pytest.mark.parametrize("value", (True, False, np.True_, np.False_), ids=repr)
+    def test_a_python_or_numpy_boolean_is_accepted(self, pacers: list[float], flag: str, value: Any) -> None:
+        sim = _Sim()
+        result = _run(sim, **{flag: value})
+        assert result["status"] == "success", _text(result)
+        assert sim.sends == 3
+
+    def test_omitting_every_flag_keeps_the_defaults(self, pacers: list[float]) -> None:
+        sim = _Sim()
+        result = sim.run_policy("arm", policy_provider="mock", n_steps=3, control_frequency=50.0)
+        assert result["status"] == "success", _text(result)
+        # The defaults: paced, reset between episodes, shim installed, RTC from the policy.
+        assert pacers == [pytest.approx(1.0 / 50.0)]
+        assert sim.shim_installs == 1
+        assert _json(result)["rtc_async_enabled"] is False
+
+
+class TestTheRosterIsTheSignature:
+    """A posture flag added to ``run_policy`` cannot skip the domain unnoticed."""
+
+    def test_every_boolean_parameter_of_run_policy_is_in_the_roster(self) -> None:
+        declared = {
+            name
+            for name, param in inspect.signature(SimEngine.run_policy).parameters.items()
+            if param.annotation in ("bool", "bool | None", bool, bool | None)
+        }
+        assert declared, "no boolean parameter found - the roster read is broken"
+        assert declared == set(RUN_POLICY_FLAGS), declared
+
+    def test_the_helper_is_the_shared_domain_verbatim(self) -> None:
+        for value in (*UNDECLARED, None, True, False, np.True_):
+            err = SimEngine._validate_posture_flags("run_policy", fast_mode=value)
+            expected = boolean_flag_error(value, "fast_mode", "run_policy")
+            assert (None if err is None else _text(err)) == expected
+
+
+class TestTheToolRefusesBeforeItStartsTheRecording:
+    """The tool starts a recording with ``overwrite=True`` before the episode loop.
+
+    The facade's refusal would therefore arrive after the dataset at
+    ``dataset_root`` had been replaced with an empty one - the same reason the
+    tool already checks the seed, the rates and the keyword bags up front.
+    """
+
+    @pytest.mark.parametrize("value", (*UNDECLARED, None), ids=repr)
+    def test_a_non_boolean_fast_mode_is_refused_with_the_facades_words(self, value: Any, tmp_path: Path) -> None:
+        from tests.tools.test_run_policy import _FakeSim
+
+        sim = _FakeSim()
+        result = dict(
+            rp_mod.run_policy(sim, n_episodes=1, n_steps=4, fast_mode=value, dataset_root=str(tmp_path / "ds"))
+        )
+        assert result["status"] == "error"
+        assert _text(result) == boolean_flag_error(value, "fast_mode", "run_policy")
+        assert sim.start_recording_calls == [], "the refused call reached start_recording(overwrite=True)"
+        assert sim.run_policy_calls == []
+
+    @pytest.mark.parametrize("value", (True, False, np.False_), ids=repr)
+    def test_a_boolean_fast_mode_is_forwarded_verbatim(self, value: Any) -> None:
+        from tests.tools.test_run_policy import _FakeSim
+
+        sim = _FakeSim()
+        result = dict(rp_mod.run_policy(sim, n_episodes=1, n_steps=4, fast_mode=value))
+        assert result["status"] == "success", _text(result)
+        assert [call["fast_mode"] for call in sim.run_policy_calls] == [value]
+
+    def test_every_boolean_parameter_of_the_tool_is_checked(self) -> None:
+        flags = {
+            name
+            for name, param in inspect.signature(rp_mod.run_policy).parameters.items()
+            if param.annotation in (bool, "bool")
+        }
+        assert flags == {"fast_mode"}, flags
+
+
+_ARM_XML = """<mujoco model="arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <geom type="box" size="0.05 0.05 0.1"/>
+      <body name="link1" pos="0 0 0.1">
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-2 2" limited="true" damping="2"/>
+        <geom type="capsule" fromto="0 0 0 0.25 0 0" size="0.03"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="a_shoulder" joint="shoulder" kp="30" ctrlrange="-2 2"/>
+  </actuator>
+</mujoco>
+"""
+
+
+class TestStartPolicyRefusesBeforeTheSubmit:
+    """MuJoCo's ``start_policy`` runs the rollout on a worker.
+
+    A refusal raised there is discarded with the future and the caller reads
+    "started", which is why its sibling knobs are checked synchronously; the
+    pacing posture is now one of them.
+    """
+
+    @pytest.fixture
+    def sim(self, tmp_path: Path) -> Any:
+        pytest.importorskip("mujoco")
+        from strands_robots import Simulation
+
+        arm_xml = tmp_path / "arm.xml"
+        arm_xml.write_text(_ARM_XML, encoding="utf-8")
+        sim = Simulation(backend="mujoco", tool_name="posture_flag_test", mesh=False)
+        sim.create_world()
+        sim.add_robot(name="arm", urdf_path=str(arm_xml))
+        yield sim
+        sim.cleanup()
+
+    @pytest.mark.parametrize("value", (*UNDECLARED, None), ids=repr)
+    def test_a_non_boolean_fast_mode_is_refused_without_reporting_started(self, sim: Any, value: Any) -> None:
+        result = sim.start_policy(
+            robot_name="arm", policy_provider="mock", n_steps=4, control_frequency=30.0, fast_mode=value
+        )
+        assert result["status"] == "error"
+        assert _text(result) == boolean_flag_error(value, "fast_mode", "start_policy")
+        assert "started" not in _text(result).lower()
+        assert "No policies running" in _text(sim.list_policies_running()), "the refused call claimed the robot"
+
+    def test_a_boolean_fast_mode_is_still_submitted(self, sim: Any) -> None:
+        result = sim.start_policy(
+            robot_name="arm", policy_provider="mock", n_steps=4, control_frequency=30.0, fast_mode=True
+        )
+        assert result["status"] == "success", _text(result)
+        sim.stop_policy("arm")


### PR DESCRIPTION
## What

`SimEngine.run_policy` takes four flags that each select one of two postures - `fast_mode`, `reset_between`, `wbc_install_torque_control` and `async_rtc` - and every one was read by truthiness one layer down. `eval_policy` read `async_rtc` the same way, MuJoCo's `start_policy` forwarded `fast_mode` to its worker unread, and the `run_policy` agent tool forwarded its own `fast_mode` into the facade. They are now bound to the shared `boolean_flag_error` domain through one helper, `SimEngine._validate_posture_flags`, the way the numeric knobs in the same signature are already bound (`_validate_positive_frequency`, `_validate_seed`, `_validate_action_horizon`, ...).

The `run_policy.fast_mode` row of #3356 - the last row after #3360, #3364, #3365, #3366 and #3367, with `gr00t_inference` struck as deletion-approved. Measuring the tool row led to the facade, which is where the flag is read and where three siblings share the same shape, so the fix lands there and the tool gets the pre-flight its own comment block says it owes.

Closes #3356

## Measured on `a03d98d`

Driving the real facade over the mock policy, three steps at 50 Hz:

| call | selected | asked for |
|---|---|---|
| `run_policy(fast_mode="false")` | pacer never acquired | a paced loop |
| `run_policy(fast_mode=0)` | pacer acquired | (not a declared spelling) |
| `run_policy(n_episodes=2, reset_between=0)` | no `reset()` between episodes | (not a declared spelling) |
| `run_policy(n_episodes=2, reset_between="false")` | one reset | (default posture, by accident) |
| `run_policy(wbc_install_torque_control=0)` | shim not installed | (not a declared spelling) |
| `run_policy(async_rtc="false")` | `rtc_async_enabled=True` | the synchronous loop |
| `run_policy(async_rtc=0)` | synchronous | (not a declared spelling) |

Every row reported `status="success"`. Two rows are worth singling out. `async_rtc="false"` started the background inference thread the caller had declined, and an evaluation's success rate carries no field saying which pipeline produced it - so on `eval_policy` that misread is trusted as a number. `reset_between=0` on a two-episode call started episode two from wherever episode one left the arm, and the dataset those episodes were flushed into does not record that.

## Shape

- **`SimEngine._validate_posture_flags(method, **flags)`** - one binding of `boolean_flag_error` to the facade's error envelope, beside the numeric bindings. Flags are checked in signature order and the first refusal is returned.
- **`run_policy`** checks `fast_mode`, `reset_between`, `wbc_install_torque_control` right after the observer guard and ahead of `_resolve_single_robot`, so a refused call builds no policy and touches no scene. `async_rtc` has a documented `None` sentinel ("resolve from the policy") and is checked only when supplied.
- **`eval_policy`** declares `async_rtc: bool`, so `None` is refused there with everything else.
- **MuJoCo `start_policy`** checks `fast_mode` before `executor.submit`, for the reason its sibling knobs already do and its docstring already states: a refusal on the worker is discarded with the future and the caller reads "started". On the blocking override nothing extra is needed - `_drive_rollout`'s `finally` releases the claim on the base's early return, same as for every other refusal.
- **The `run_policy` tool** checks `fast_mode` before step 2 (`start_recording(overwrite=True)`), so the facade's refusal cannot arrive after the dataset at `dataset_root` has been replaced with an empty one - the principle the tool's pre-flight block already states for `seed`, `video`, the keyword bags and `stop_when`. Lazy import, matching the module's convention.
- Docstrings on all four `run_policy` flags, `eval_policy`'s `async_rtc`, the tool's `fast_mode` and `start_policy`'s refusal list state the domain, as the numeric knobs' entries already do.
- AGENTS.md: one bullet under "Posture flags are checked" recording the facade shape and the submit-before-check sub-shape.

Out of scope, deliberately: `PolicyRunner.run` / `PolicyRunner.evaluate` themselves. They are the readers, but every public surface reaches them through a facade that now checks, and the runner is documented as the engine-internal loop rather than a caller surface.

## Pinned

`tests/simulation/test_run_policy_posture_flag_domain.py` - 169 cells.

- Refusal cells for every flag x every undeclared spelling, asserting the message is `boolean_flag_error`'s verbatim and that no pacer, shim install, reset or action ran.
- Behaviour cells drive each branch through a declared spelling so what `"false"` *would* have done is pinned beside the refusal (pacer period, reset count, shim count, `rtc_async_enabled`).
- Over-reach controls: `True`, `False`, `np.True_`, `np.False_` accepted on every flag; omitting every flag keeps the defaults.
- Roster read from `SimEngine.run_policy`'s signature and from the tool's, so a fifth flag cannot skip the domain.
- Tool cells assert the refusal precedes `start_recording` and that a boolean is forwarded verbatim.
- `start_policy` cells (MuJoCo, `importorskip`) assert the refusal names `start_policy`, does not read "started", and leaves the robot unclaimed.

Pre-fix (production stashed, test present): **137 failed, 32 passed** - the 32 are the declared-spelling controls, which hold on both trees.

## Verification

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean, 1981 files
- `mypy` on the four touched Python files: `Success: no issues found`
- `tests/simulation/*.py` (top-level): 7884 passed, 16 failed on this branch; the failing set on `main` is byte-identical (no EGL/OSMesa on this host, no `lerobot`)
- Whole-tree graders (roster from `check_whole_tree_graders.py`, 121 graders): 4504 passed, 21 failed, 3 collection errors - every failure names `lerobot`, `awsiot`, `msgpack`, `torch` or an unrenderable camera, and the three I re-ran on pristine `main` fail identically
- `check_changelog_fragment.py`: no `CHANGELOG.md` edit; fragment is `changelog.d/3356-...` since the change claims the issue, so it shipped in the first push
- `check_duplicate_claim.py --issue 3356`: `unique-claim`; `--all-open`: `unique-additions`
- Rebased onto `8377ddc` (#3367's squash) before the push, so the tested tree is the merge result; no path overlaps with what landed since `a03d98d`

## Composition with #3343

`check_merge_base_overlap.py --all-open` pairs this with #3343 on `simulation/base.py` and `mujoco/simulation.py`. Composed as a real 3-way merge of `154f2c7` with `e16b89fd`:

| property | measured |
|---|---|
| `git merge-tree --write-tree` | **0 conflicts** (auto-merged `AGENTS.md`, `base.py`, `mujoco/simulation.py`) |
| hunks, #3343 side of `base.py` | `unknown_model_msg` (module level), a `SimEngine` block near line 1228, and `describe()` |
| hunks, this side of `base.py` | `_validate_posture_flags` beside `_validate_seed`, the `run_policy` and `eval_policy` pre-flight blocks, four `Args:` entries |
| this file + `isaac/test_run_policy_releases_the_robot.py` + `test_rollout_hook_release_leaves_the_robot_idle.py` + `mujoco/test_start_policy_refuses_what_run_policy_refuses.py` + `test_run_policy_multi_episode.py` + `test_run_policy_observer.py` on the composed tree | **262 passed**, 1 skipped, 1 failed - the Newton-absent cell that fails identically on `main` |
| `ruff check` on the two shared files, composed | clean |

Either order lands cleanly.

## Round changelog

- r0 (`154f2c7`): opened, auto-merge (squash) armed. Awaiting the required check and a first review.