### PR TITLE
fix(drivers): the servo-bus drivers accept the parameter names the contract declares

### DIFF
--- a/changelog.d/3371-driver-verb-parameter-names.md
+++ b/changelog.d/3371-driver-verb-parameter-names.md
@@ -1,0 +1,20 @@
+### Fixed: the servo-bus drivers accept the parameter names the driver contract declares
+
+`HardwareDriver` declares `run_policy(policy_object, ...)` and
+`start_task(instruction, ...)`. The Feetech and Dynamixel drivers spelled those
+two parameters `policy` and `task`. Both verbs refuse today - neither bus has a
+policy control loop yet - but the refusal was only reachable under the
+undocumented spelling: a caller naming the contract's own parameters as
+keywords got a `TypeError` instead of the status envelope every driver verb
+promises. Because both verbs also take `**kwargs`, the contract's spelling was
+absorbed silently and the error then named a parameter the contract does not
+document, sending the caller to look for an argument that is not in the API.
+
+`missing_driver_members` could not see this: it is `hasattr`, so a renamed
+parameter is still a present member and a drifted driver graded as fully
+conformant. The new `drifted_driver_parameters` closes that gap by making the
+call a conforming caller makes - binding every parameter the Protocol declares,
+by keyword - and it is pinned over every shipped driver, so the next driver is
+held to it the hour it lands. Drivers keep the freedoms they had: extra
+parameters of their own, their own ordering, and absorbing the ones they ignore
+in `**kwargs`.

--- a/strands_robots/drivers/__init__.py
+++ b/strands_robots/drivers/__init__.py
@@ -21,6 +21,7 @@ from strands_robots.drivers.base import (
     DRIVER_CHOICES,
     DRIVER_SURFACE,
     HardwareDriver,
+    drifted_driver_parameters,
     halt_failure_detail,
     missing_driver_members,
 )
@@ -127,6 +128,7 @@ __all__ = [
     "DRIVER_CHOICES",
     "DRIVER_SURFACE",
     "HardwareDriver",
+    "drifted_driver_parameters",
     "driver_choice_error",
     "get_native_driver_class",
     "halt_failure_detail",

--- a/strands_robots/drivers/base.py
+++ b/strands_robots/drivers/base.py
@@ -53,6 +53,7 @@ interpreted by the driver that receives it.
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -219,6 +220,13 @@ DRIVER_CHOICES = ("auto", DEFAULT_DRIVER, "strands")
 DRIVER_SURFACE: tuple[str, ...] = tuple(sorted(name for name in dir(HardwareDriver) if not name.startswith("_")))
 
 
+#: Stand-in receiver for binding an *unbound* verb in
+#: :func:`drifted_driver_parameters`. Binding a signature that still declares
+#: ``self`` needs something in that slot, and it is never called or read - a
+#: driver class is graded before any instance of it exists.
+_UNBOUND_SELF = object()
+
+
 def missing_driver_members(candidate: object) -> tuple[str, ...]:
     """Report which :data:`DRIVER_SURFACE` members ``candidate`` does not have.
 
@@ -236,6 +244,55 @@ def missing_driver_members(candidate: object) -> tuple[str, ...]:
         satisfies the whole surface.
     """
     return tuple(name for name in DRIVER_SURFACE if not hasattr(candidate, name))
+
+
+def drifted_driver_parameters(candidate: object) -> tuple[tuple[str, str], ...]:
+    """Report verbs whose parameters ``candidate`` spells differently from the Protocol.
+
+    :func:`missing_driver_members` answers whether the *names on the class* are
+    all there, and that is all it can answer: it is ``hasattr``, so a driver
+    that renames a documented parameter satisfies it completely. A driver is
+    invoked as an agent tool, and a dispatcher that spells the contract's own
+    parameter names as keywords is the ordinary caller - so a renamed parameter
+    is not a style difference, it is a ``TypeError`` raised past dispatch in
+    place of the status envelope every verb here promises to return.
+
+    The check is the call a conforming caller makes: bind every parameter
+    :class:`HardwareDriver` declares for the verb, by keyword. That admits the
+    freedoms a driver legitimately has - extra parameters of its own, its own
+    ordering, absorbing the ones it ignores in ``**kwargs`` - and refuses only
+    the one thing no caller can work around, a required parameter reachable
+    solely under a name the contract does not document.
+
+    Args:
+        candidate: A driver class or a built driver instance.
+
+    Returns:
+        ``(verb, reason)`` pairs in sorted order, ``reason`` being the binding
+        failure; empty when every verb accepts the contract's own spelling.
+    """
+    drifted: list[tuple[str, str]] = []
+    for verb in DRIVER_SURFACE:
+        declared = getattr(HardwareDriver, verb, None)
+        implemented = getattr(candidate, verb, None)
+        if not callable(declared) or not callable(implemented):
+            continue
+        try:
+            contract = inspect.signature(declared)
+            actual = inspect.signature(implemented)
+        except (TypeError, ValueError):  # pragma: no cover - builtins/C callables
+            continue
+        keywords = {
+            name: None
+            for name, parameter in contract.parameters.items()
+            if name != "self" and parameter.kind in (parameter.POSITIONAL_OR_KEYWORD, parameter.KEYWORD_ONLY)
+        }
+        bound = actual.parameters.get("self") is not None
+        try:
+            actual.bind(*((_UNBOUND_SELF,) if bound else ()), **keywords)
+        except TypeError as e:
+            drifted.append((verb, str(e)))
+    return tuple(sorted(drifted))
 
 
 def halt_failure_detail(envelope: dict[str, Any]) -> str | None:

--- a/strands_robots/drivers/dynamixel/driver.py
+++ b/strands_robots/drivers/dynamixel/driver.py
@@ -229,23 +229,34 @@ class DynamixelDriver:
 
     def start_task(
         self,
-        task: str,
+        instruction: str,
         robot_name: str | None = None,
-        policy: Policy | None = None,
+        policy_object: Policy | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Refuse: no policy execution path exists on the servo bus yet."""
-        del task, robot_name, policy, kwargs
+        """Refuse: no policy execution path exists on the servo bus yet.
+
+        The parameters are spelled the way
+        :meth:`~strands_robots.drivers.base.HardwareDriver.start_task` declares
+        them, so a caller that names them as keywords reaches this refusal
+        instead of a :class:`TypeError`.
+        """
+        del instruction, robot_name, policy_object, kwargs
         return _refuse(f"start_task: {_NOT_WIRED}")
 
     def run_policy(
         self,
-        policy: Policy,
+        policy_object: Policy,
         robot_name: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Refuse: no policy execution path exists on the servo bus yet."""
-        del policy, robot_name, kwargs
+        """Refuse: no policy execution path exists on the servo bus yet.
+
+        ``policy_object`` is the name
+        :meth:`~strands_robots.drivers.base.HardwareDriver.run_policy` declares;
+        see :meth:`start_task` for why the refusal honours it.
+        """
+        del policy_object, robot_name, kwargs
         return _refuse(f"run_policy: {_NOT_WIRED}")
 
     def get_task_status(self) -> dict[str, Any]:

--- a/strands_robots/drivers/feetech/driver.py
+++ b/strands_robots/drivers/feetech/driver.py
@@ -334,23 +334,35 @@ class FeetechDriver:
 
     def start_task(
         self,
-        task: str,
+        instruction: str,
         robot_name: str | None = None,
-        policy: Policy | None = None,
+        policy_object: Policy | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Refuse: the bus is live, but no policy control loop drives it yet."""
-        del task, robot_name, policy, kwargs
+        """Refuse: the bus is live, but no policy control loop drives it yet.
+
+        The parameters are spelled the way
+        :meth:`~strands_robots.drivers.base.HardwareDriver.start_task` declares
+        them, so a caller that names them as keywords reaches this refusal
+        instead of a :class:`TypeError`. A refusal is a contract too: the day
+        the loop lands, no caller changes.
+        """
+        del instruction, robot_name, policy_object, kwargs
         return _refuse(f"start_task: {_NO_POLICY_LOOP}")
 
     def run_policy(
         self,
-        policy: Policy,
+        policy_object: Policy,
         robot_name: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Refuse: the bus is live, but no policy control loop drives it yet."""
-        del policy, robot_name, kwargs
+        """Refuse: the bus is live, but no policy control loop drives it yet.
+
+        ``policy_object`` is the name
+        :meth:`~strands_robots.drivers.base.HardwareDriver.run_policy` declares;
+        see :meth:`start_task` for why the refusal honours it.
+        """
+        del policy_object, robot_name, kwargs
         return _refuse(f"run_policy: {_NO_POLICY_LOOP}")
 
     def get_task_status(self) -> dict[str, Any]:

--- a/tests/drivers/test_driver_verbs_accept_the_contract_parameter_names.py
+++ b/tests/drivers/test_driver_verbs_accept_the_contract_parameter_names.py
@@ -1,0 +1,149 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Every shipped driver accepts the parameter names its Protocol declares.
+
+:data:`~strands_robots.drivers.base.DRIVER_SURFACE` is derived from
+:class:`~strands_robots.drivers.base.HardwareDriver` so the member *names* can
+never disagree, and :func:`~strands_robots.drivers.base.missing_driver_members`
+grades a candidate against it. That grader is ``hasattr``, which is the whole
+gap this module closes: a driver may rename a documented parameter and satisfy
+it completely, because a renamed parameter is still a present member.
+
+The renamed parameter is not cosmetic. A driver is invoked as an agent tool and
+every verb promises a status envelope - "never raise past dispatch", because an
+exception there is not something the caller can handle. A caller that spells the
+contract's own parameter names as keywords, which is what a dispatcher built
+against :class:`HardwareDriver` does, gets a :class:`TypeError` instead. Worse
+for diagnosis, a verb with ``**kwargs`` absorbs the contract's spelling
+silently and then reports a *different* name missing - one the contract never
+documents - so the message sends the caller looking for a parameter that is not
+in the API.
+
+The population is derived from
+:data:`~strands_robots.drivers._SHIPPED_DRIVERS`, so the thirteenth driver is
+held to this the hour it lands rather than inheriting an exemption by being
+absent from a list.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers as drivers_mod
+from strands_robots.drivers import (
+    DRIVER_SURFACE,
+    drifted_driver_parameters,
+    missing_driver_members,
+)
+from strands_robots.drivers.dynamixel.driver import DynamixelDriver
+from strands_robots.drivers.feetech import FeetechDriver
+
+
+def _shipped_driver_classes() -> list[type]:
+    """Every driver class the shipped table registers, deduplicated by name."""
+    classes: dict[str, type] = {}
+    for module_path, class_name, _names in drivers_mod._SHIPPED_DRIVERS:
+        module = importlib.import_module(module_path)
+        classes.setdefault(class_name, getattr(module, class_name))
+    return [classes[name] for name in sorted(classes)]
+
+
+SHIPPED = _shipped_driver_classes()
+
+
+class TestTheWholeFleetHonoursTheContractSpelling:
+    """The invariant, over every driver the package ships."""
+
+    def test_the_population_is_not_empty(self) -> None:
+        """Non-vacuity: an empty population would make every cell below pass."""
+        assert len(SHIPPED) >= 10, SHIPPED
+
+    @pytest.mark.parametrize("driver_cls", SHIPPED, ids=lambda c: c.__name__)
+    def test_no_verb_renames_a_declared_parameter(self, driver_cls: type) -> None:
+        assert drifted_driver_parameters(driver_cls) == ()
+
+
+class TestTheTwoServoDriversThatHadDrifted:
+    """The regression: these four calls raised :class:`TypeError` before the fix.
+
+    ``run_policy`` and ``start_task`` on both servo-bus drivers spelled the
+    contract's ``policy_object`` as ``policy`` and its ``instruction`` as
+    ``task``. Both verbs refuse today - the control loop is a separate slice -
+    and a refusal is a contract too: it has to be *reachable* under the
+    documented names, so the day the loop lands no caller changes.
+    """
+
+    @pytest.mark.parametrize("driver_cls", [FeetechDriver, DynamixelDriver], ids=["feetech", "dynamixel"])
+    def test_run_policy_refuses_under_the_declared_name(self, driver_cls: type) -> None:
+        driver: Any = driver_cls(tool_name="arm")
+        result = driver.run_policy(policy_object=None)
+        assert result["status"] == "error"
+        assert "run_policy" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("driver_cls", [FeetechDriver, DynamixelDriver], ids=["feetech", "dynamixel"])
+    def test_start_task_refuses_under_the_declared_name(self, driver_cls: type) -> None:
+        driver: Any = driver_cls(tool_name="arm")
+        result = driver.start_task(instruction="pick up the cube")
+        assert result["status"] == "error"
+        assert "start_task" in result["content"][0]["text"]
+
+
+class TestTheGraderItself:
+    """A guard that cannot fail grades nothing, so grade the guard."""
+
+    def test_a_renamed_parameter_is_caught(self) -> None:
+        """The exact drift the two servo drivers carried."""
+
+        class Renamed:
+            def run_policy(self, policy: Any, **kwargs: Any) -> dict[str, Any]:
+                return {}
+
+        drifted = dict(drifted_driver_parameters(Renamed))
+        assert "run_policy" in drifted, drifted
+        assert "policy" in drifted["run_policy"]
+
+    def test_the_member_name_grader_is_blind_to_it(self) -> None:
+        """Why this module exists: ``hasattr`` cannot see a renamed parameter."""
+
+        class Renamed:
+            def run_policy(self, policy: Any, **kwargs: Any) -> dict[str, Any]:
+                return {}
+
+        assert "run_policy" not in missing_driver_members(Renamed)
+        assert drifted_driver_parameters(Renamed) != ()
+
+    def test_an_instance_is_graded_like_its_class(self) -> None:
+        """A caller holding a built driver gets the same answer."""
+        assert drifted_driver_parameters(FeetechDriver(tool_name="arm")) == ()
+
+    def test_extra_parameters_of_the_driver_s_own_are_allowed(self) -> None:
+        """A driver may take more than the contract; only renames are refused."""
+
+        class Extra:
+            def send_action(
+                self, action: dict[str, Any], robot_name: str | None = None, retries: int = 3
+            ) -> dict[str, Any]:
+                return {}
+
+        assert [verb for verb, _ in drifted_driver_parameters(Extra)] == []
+
+    def test_kwargs_may_absorb_the_parameters_a_driver_ignores(self) -> None:
+        """``start_task`` declares five; absorbing four in ``**kwargs`` conforms."""
+
+        class Absorbing:
+            def start_task(self, instruction: str, **kwargs: Any) -> dict[str, Any]:
+                return {}
+
+        assert [verb for verb, _ in drifted_driver_parameters(Absorbing)] == []
+
+    def test_a_verb_the_candidate_does_not_have_is_not_reported_here(self) -> None:
+        """Absence is :func:`missing_driver_members`' verdict, not this one."""
+
+        class Nothing:
+            pass
+
+        assert drifted_driver_parameters(Nothing) == ()
+        assert set(missing_driver_members(Nothing)) == set(DRIVER_SURFACE)

--- a/tests/drivers/test_dynamixel_driver.py
+++ b/tests/drivers/test_dynamixel_driver.py
@@ -375,7 +375,7 @@ class TestDriver:
 
     def test_run_policy_refuses(self) -> None:
         driver = DynamixelDriver(tool_name="koch")
-        result = driver.run_policy(policy=None)  # type: ignore[arg-type]
+        result = driver.run_policy(policy_object=None)  # type: ignore[arg-type]
         assert result["status"] == "error"
         assert _NOT_WIRED in result["content"][0]["text"]
 

--- a/tests/drivers/test_feetech_driver.py
+++ b/tests/drivers/test_feetech_driver.py
@@ -271,9 +271,9 @@ class TestPolicyRefusals:
         }
 
     def test_run_policy_refuses_naming_the_policy_loop(self) -> None:
-        # ``policy=None`` because the refusal fires before the argument is
-        # inspected.
-        result = FeetechDriver(tool_name="so101").run_policy(policy=None)  # type: ignore[arg-type]
+        # ``policy_object=None`` because the refusal fires before the argument
+        # is inspected.
+        result = FeetechDriver(tool_name="so101").run_policy(policy_object=None)  # type: ignore[arg-type]
         assert result == {
             "status": "error",
             "content": [{"text": f"run_policy: {_NO_POLICY_LOOP}"}],


### PR DESCRIPTION
`HardwareDriver` declares `run_policy(policy_object, ...)` and `start_task(instruction, ...)`. `FeetechDriver` and `DynamixelDriver` spelled those two parameters `policy` and `task`.

Both verbs refuse today - neither servo bus has a policy control loop yet - but the refusal was reachable **only under the undocumented spelling**. A driver is invoked as an agent tool, and every verb promises a status envelope precisely because an exception past dispatch is not something the caller can handle:

```python
FeetechDriver(tool_name="so101").run_policy(policy_object=None)
# before: TypeError: FeetechDriver.run_policy() missing 1 required positional argument: 'policy'
# after:  {'status': 'error', 'content': [{'text': 'run_policy: not wired yet (the policy control loop)'}]}
```

Because both verbs also take `**kwargs`, the contract's spelling was absorbed silently and the error then named a parameter **the contract does not document** - so the message sends the caller looking for an argument that is not in the API.

![driver verb parameter-name conformance](https://raw.githubusercontent.com/cagataycali/robots/assets/driver-param-parity-34383651571/driver_param_parity.png)

## Why no existing guard caught it

`DRIVER_SURFACE` is derived from the Protocol so the member *names* can never disagree, and `missing_driver_members` grades a candidate against it. That grader is `hasattr` - a renamed parameter is still a present member, so a drifted driver graded as fully conformant:

```python
missing_driver_members(FeetechDriver)   # () on upstream/main - conformant
```

`drifted_driver_parameters` closes the gap by making the call a conforming caller makes: bind every parameter the Protocol declares, by keyword. That admits the freedoms a driver legitimately has - extra parameters of its own, its own ordering, absorbing the ones it ignores in `**kwargs` - and refuses only a required parameter reachable solely under a name the contract does not document.

## Measured

Every shipped driver x every Protocol verb, on `upstream/main` 8377ddc3 vs this branch:

| | drivers | (driver, verb) cells raising TypeError |
|---|---|---|
| before | 12 | **4** - `run_policy` + `start_task` on Feetech and Dynamixel |
| after | 12 | **0** |

The other 10 shipped drivers were already clean, so this is a two-driver correction rather than a new convention.

## Tests

`tests/drivers/test_driver_verbs_accept_the_contract_parameter_names.py`, 23 cells. Against pristine `upstream/main` with only the *instrument* added (helper + export, drivers untouched): **7 failed / 16 passed** - the 2 fleet-parity cells, the 4 refusal cells (each on the real `TypeError`), and the instance cell. With the renames: 23 pass.

The parametrized population is derived from `_SHIPPED_DRIVERS`, so the thirteenth driver is held to this the hour it lands rather than inheriting an exemption by being absent from a list; a non-vacuity cell pins the population non-empty. `TestTheGraderItself` grades the guard - a renamed parameter is caught, `missing_driver_members` is pinned *blind* to it, and the three legitimate freedoms are pinned as conforming.

## Gate

- `ruff check strands_robots tests tests_integ` clean
- `mypy strands_robots tests tests_integ` - Success, 1979 source files
- full `pytest tests/` - **51921 passed, 299 skipped, 0 failed** (30m15s); collected 52220 vs 52197 on base, delta +23 = exactly the new file's cells

## Scope

The Feetech policy control loop is deliberately **not** here - that needs a real STS3215 chain to verify and is its own slice. This makes the refusal honest under the documented spelling, so the day the loop lands no caller changes. LOC: +100 / -18 in `strands_robots/`, plus the test file.
