### PR TITLE
fix(policies): a CompositePolicy child is never queried with an observation of no keys

### DIFF
--- a/changelog.d/3372-composite-child-observation-not-empty.md
+++ b/changelog.d/3372-composite-child-observation-not-empty.md
@@ -1,0 +1,46 @@
+### Fixed: a `CompositePolicy` child is never queried with an observation of no keys
+
+`lower_obs_keys` / `upper_obs_keys` select the observation each child is
+queried with, and the selection is by name. The names belong to whatever
+produced the observation: a MuJoCo world names them after the robot's own
+joints (`"1"`, `"1.vel"`), while a LeRobot dataset spells the same reading
+`"observation.state"`. A subset written in the wrong namespace shares no
+key at all, and the child was handed `{}` - on every tick, of every
+episode, with the rollout reporting success.
+
+Measured on a 60-tick `run_policy` rollout of `so101` composing a
+state-reading lower child over joints 1-3 with an upper child over 4-6:
+with `lower_obs_keys=["observation.state"]` the lower child was blind on
+60 of 60 ticks and left the joints it owns at `[0.000, 0.030, 0.025]`
+rad, against `[0.418, 0.347, 0.384]` from the same composite with the
+subset spelled in the world's namespace - a 0.418 rad divergence on the
+joints one child was supposed to be closing the loop on. Both rollouts
+returned `status="success"`.
+
+The class already refuses the mirror mistake on the action side: a
+`lower_joints` group sharing no name with what the child emits raises,
+naming the group, the emitted names and the fix, because "a child whose
+whole action dict is dropped reaches no actuator". A child whose whole
+observation is dropped acts on no reading, which is the same failure one
+step earlier. `RobotRLEnv` states the rule for the observation side
+directly - "Validate obs keys up front so a typo fails loudly here, not
+mid-rollout" - and refuses an `actor_obs_keys` the engine does not
+produce, listing the missing keys and the available ones.
+
+`CompositePolicy._filter_obs` now refuses a subset that selects nothing
+from a non-empty observation, naming the seat, the child, the configured
+group and the observation's own keys so the caller can read off the
+namespace the subset should have been written in. The refusal precedes
+both children's inference, so no model runs on a misconfigured composite.
+
+Two boundaries are deliberate, and each is pinned. A *partly* satisfied
+subset is still honored: the child got keys it asked for, and whether it
+can act on those is its own contract (children read by name). An
+observation with no keys at all is left alone, for the reason the action
+side leaves a child that commanded nothing alone - there is nothing for
+the subset to have missed.
+
+`tests/policies/test_composite_child_observation_is_not_empty.py` pins
+both seats, that neither child is queried when the selection is empty,
+the two boundaries, and the `run_policy` envelope - which before this
+change reported `status="success"` for the blind rollout.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -334,6 +334,17 @@ joint) is raised, never silently resolved. The merged chunk length is the
 shorter of the two, so a per-tick controller (WBC, `execution_horizon == 1`) is
 never starved by a slower chunk-emitting manipulation policy.
 
+`lower_obs_keys` / `upper_obs_keys` narrow what each child is *queried* with,
+and are optional - left unset, both children receive the whole observation and
+read it by name. The key names belong to whatever produced the observation (a
+simulated world names them after the robot's own joints and cameras, a LeRobot
+dataset spells the joint reading `observation.state`), so a subset that shares
+no key with the observation is refused rather than forwarded as an empty dict:
+a child queried with nothing commands its joints from no reading at all, which
+on a humanoid is the balance controller running open-loop. A subset that
+matches only *some* of its keys is still forwarded - the child got what it
+asked for and reads by name.
+
 Run the composite the same way as a bare policy - the goal payload goes in
 `policy_kwargs`, and the torque shim
 ([In simulation](#in-simulation)) is auto-installed for the

--- a/strands_robots/policies/composite.py
+++ b/strands_robots/policies/composite.py
@@ -76,6 +76,8 @@ class CompositePolicy(Policy):
     Routing that discards a child's ENTIRE action dict raises: the composite
     would otherwise silently be the surviving child alone. Two children that
     drive the same joint set cannot be composed, only cascaded (module docstring).
+    An observation subset that selects NOTHING raises for the mirror reason: a
+    child queried with an empty dict acts on no reading at all.
 
     The merged chunk length is the shorter of the two children's chunks, so the
     more frequently re-querying child sets the re-query cadence
@@ -95,9 +97,14 @@ class CompositePolicy(Policy):
             policy emits on a given tick. ``None`` (default) accepts every upper
             name not already owned by the lower policy.
         lower_obs_keys: Observation keys to forward to the lower policy. ``None``
-            (default) forwards the full observation (children read by name).
+            (default) forwards the full observation (children read by name). A
+            subset that shares no key with the observation is refused rather
+            than forwarded as an empty dict - the names belong to whatever
+            produces the observation, so a subset written in the wrong namespace
+            would otherwise starve the child on every tick.
         upper_obs_keys: Observation keys to forward to the upper policy. ``None``
-            (default) forwards the full observation.
+            (default) forwards the full observation. Held to the same rule as
+            ``lower_obs_keys``.
 
     Raises:
         ValueError: If ``lower`` or ``upper`` is ``None``, or if ``lower_joints``
@@ -215,13 +222,15 @@ class CompositePolicy(Policy):
             child that owns that name.
 
         Raises:
-            ValueError: If either child returns an empty chunk, if routing
-                discards a child's entire action dict (the composite would be
-                the other child alone), or if the lower policy commands a joint
-                ``upper_joints`` assigns to the upper policy.
+            ValueError: If a configured observation subset shares no key with
+                the observation (the child would be queried blind), if either
+                child returns an empty chunk, if routing discards a child's
+                entire action dict (the composite would be the other child
+                alone), or if the lower policy commands a joint ``upper_joints``
+                assigns to the upper policy.
         """
-        lower_obs = self._filter_obs(observation_dict, self._lower_obs_keys)
-        upper_obs = self._filter_obs(observation_dict, self._upper_obs_keys)
+        lower_obs = self._filter_obs(observation_dict, self._lower_obs_keys, "lower", self._lower)
+        upper_obs = self._filter_obs(observation_dict, self._upper_obs_keys, "upper", self._upper)
         lower_chunk, upper_chunk = await asyncio.gather(
             self._lower.get_actions(lower_obs, instruction, **kwargs),
             self._upper.get_actions(upper_obs, instruction, **kwargs),
@@ -366,12 +375,55 @@ class CompositePolicy(Policy):
             return {k: v for k, v in action.items() if k not in exclude}
         return dict(action)
 
-    @staticmethod
-    def _filter_obs(observation_dict: dict[str, Any], keys: set[str] | None) -> dict[str, Any]:
-        """Forward the full observation, or only ``keys`` when a subset is configured."""
+    def _filter_obs(
+        self, observation_dict: dict[str, Any], keys: set[str] | None, role: str, child: Policy
+    ) -> dict[str, Any]:
+        """The observation ``child`` is queried with: all of it, or only ``keys``.
+
+        Refuses a subset that selects nothing from an observation that has keys.
+        A child queried with an empty dict reads none of the state it acts on and
+        commands its joints from no information at all -- the observation-side
+        twin of the discarded action dict :meth:`_reject_discarded_child` already
+        refuses, and it is the mistake a key subset makes most easily, because
+        the names belong to whatever produced the observation: a MuJoCo world
+        names them after the robot's own joints (``"1"``, ``"1.vel"``), while a
+        LeRobot dataset spells the same reading ``"observation.state"``. One
+        subset written in the wrong namespace shares no key at all, so the child
+        is starved on every tick of every episode while the rollout reports
+        success.
+
+        Refused on the total miss rather than on any missing key, for the reason
+        :meth:`_reject_discarded_child` leaves a child that commanded nothing
+        alone: a partly satisfied subset still hands the child keys it asked for,
+        and whether it can act on those is its own contract (children read by
+        name). An observation with no keys at all is likewise left alone -- there
+        is nothing for the subset to have missed.
+
+        Args:
+            observation_dict: The observation the consumer produced this tick.
+            keys: ``child``'s configured key subset, or ``None`` for all of it.
+            role: The seat ``child`` occupies - ``"lower"`` or ``"upper"``.
+            child: The child policy about to be queried.
+
+        Returns:
+            The observation to pass to ``child``.
+
+        Raises:
+            ValueError: If ``keys`` shares no key with a non-empty observation.
+        """
         if keys is None:
             return observation_dict
-        return {k: v for k, v in observation_dict.items() if k in keys}
+        selected = {k: v for k, v in observation_dict.items() if k in keys}
+        if selected or not observation_dict:
+            return selected
+        raise ValueError(
+            f"CompositePolicy: the {role} policy '{child.provider_name}' would be queried with an "
+            f"empty observation - the {role}_obs_keys group {sorted(keys)} shares no key with the "
+            f"observation {sorted(observation_dict)}, so it would command its joints from no "
+            f"reading at all. Set {role}_obs_keys to keys the observation carries (they are named "
+            "by whatever produces it - a simulated world names them after the robot's own joints "
+            f"and cameras), or leave {role}_obs_keys unset to forward the whole observation."
+        )
 
 
 __all__ = ["CompositePolicy"]

--- a/tests/policies/test_composite_child_observation_is_not_empty.py
+++ b/tests/policies/test_composite_child_observation_is_not_empty.py
@@ -1,0 +1,152 @@
+"""A CompositePolicy child is never queried with an observation of no keys.
+
+``lower_obs_keys`` / ``upper_obs_keys`` select the observation each child is
+queried with. The selection is by name, and the names belong to whatever
+produced the observation: a MuJoCo world names them after the robot's own joints
+(``"1"``, ``"1.vel"``), while a LeRobot dataset spells the same reading
+``"observation.state"``. A subset written in the wrong namespace therefore
+shares no key at all, and the child was handed ``{}`` on every tick::
+
+    c = CompositePolicy(locomotion, arms, lower_obs_keys=["observation.state"])
+    # world observation: {"1": ..., "1.vel": ..., "2": ...}
+    # -> locomotion queried with {} on every tick, rollout reports success
+
+Measured on a 60-tick ``run_policy`` rollout of ``so101`` with a state-reading
+lower child: 60 of 60 ticks blind, the joints it owns left 0.418 rad from where
+the same composite put them with the subset spelled correctly, and
+``status="success"`` both times.
+
+The same class already refuses the mirror mistake on the ACTION side - a
+``lower_joints`` group sharing no name with what the child emits raises, naming
+the group and the emitted names - and ``RobotRLEnv`` refuses a configured
+``actor_obs_keys`` the engine does not produce ("Validate obs keys up front so a
+typo fails loudly here, not mid-rollout"). These pin the observation side onto
+the same rule, plus the two boundaries it deliberately keeps: a partly satisfied
+subset is still honored, and an observation with no keys at all is left alone.
+"""
+
+import asyncio
+
+import pytest
+
+from strands_robots.policies import CompositePolicy
+from tests.policies.test_composite import StubPolicy, _run
+
+WORLD_OBS = {"1": 0.0, "1.vel": 0.0, "2": 0.1, "2.vel": 0.0}
+LOWER_TICK = {"1": 1.0, "2": 1.0}
+UPPER_TICK = {"3": 2.0, "4": 2.0}
+
+#: The seat under test, its ``*_obs_keys`` kwarg, and the child it starves.
+SEATS = [("lower", "lower_obs_keys"), ("upper", "upper_obs_keys")]
+
+
+def _composite(**kwargs):
+    """A composite over disjoint groups whose children record their observation."""
+    lower = StubPolicy([dict(LOWER_TICK)], name="locomotion")
+    upper = StubPolicy([dict(UPPER_TICK)], name="manipulation")
+    return CompositePolicy(lower, upper, lower_joints=["1", "2"], upper_joints=["3", "4"], **kwargs), lower, upper
+
+
+class TestASubsetThatSelectsNothingIsRefused:
+    """A key subset sharing no name with the observation refuses the tick."""
+
+    @pytest.mark.parametrize(("role", "kwarg"), SEATS)
+    def test_either_seat_refuses_and_names_what_to_fix(self, role, kwarg):
+        c, lower, upper = _composite(**{kwarg: ["observation.state"]})
+        child = lower if role == "lower" else upper
+
+        with pytest.raises(ValueError) as exc:
+            _run(c, obs=dict(WORLD_OBS))
+
+        message = str(exc.value)
+        assert child.provider_name in message, message
+        assert kwarg in message, message
+        assert "observation.state" in message, message
+        # The observation's own keys, so the caller can read off the namespace
+        # they should have written the subset in.
+        assert "'1.vel'" in message, message
+
+    @pytest.mark.parametrize(("role", "kwarg"), SEATS)
+    def test_neither_child_is_queried(self, role, kwarg):
+        """The refusal precedes the inference, so no child runs on a bad config."""
+        c, lower, upper = _composite(**{kwarg: ["observation.state"]})
+
+        with pytest.raises(ValueError):
+            _run(c, obs=dict(WORLD_OBS))
+
+        assert lower.last_obs is None, "the lower child was queried anyway"
+        assert upper.last_obs is None, "the upper child was queried anyway"
+
+
+class TestTheBoundariesTheRuleKeeps:
+    """What stays honored: a partial subset, and an observation with no keys."""
+
+    def test_a_partly_satisfied_subset_forwards_the_keys_that_are_there(self):
+        """A child that got some of what it asked for still has a reading to act on."""
+        c, lower, _ = _composite(lower_obs_keys=["1", "observation.state"])
+
+        merged = _run(c, obs=dict(WORLD_OBS))
+
+        assert lower.last_obs == {"1": 0.0}
+        assert merged[0] == {"1": 1.0, "2": 1.0, "3": 2.0, "4": 2.0}
+
+    def test_an_observation_with_no_keys_is_left_alone(self):
+        """Nothing was produced, so the subset missed nothing - as on the action side."""
+        c, lower, upper = _composite(lower_obs_keys=["observation.state"])
+
+        merged = _run(c, obs={})
+
+        assert lower.last_obs == {}
+        assert upper.last_obs == {}
+        assert merged[0] == {"1": 1.0, "2": 1.0, "3": 2.0, "4": 2.0}
+
+
+class TestTheRolloutReportsIt:
+    """``run_policy`` surfaces the refusal instead of a successful rollout.
+
+    The composite is built over the robot's own actuator names so the rollout is
+    one a correctly configured caller would get - only the subset's namespace is
+    wrong. Before the rule, this rollout reported ``status="success"`` with the
+    lower child queried blind on every tick.
+    """
+
+    def test_run_policy_returns_an_error_envelope_naming_the_subset(self):
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation(tool_name="composite_blind_child", mesh=False)
+        try:
+            sim.create_world()
+            sim.add_robot(name="so100", data_config="so100")
+            keys = sim.robot_action_keys("so100")
+            half = len(keys) // 2
+            lower = StubPolicy([{k: 0.1 for k in keys[:half]}], name="locomotion")
+            upper = StubPolicy([{k: 0.1 for k in keys[half:]}], name="manipulation")
+            c = CompositePolicy(
+                lower,
+                upper,
+                lower_joints=keys[:half],
+                upper_joints=keys[half:],
+                lower_obs_keys=["observation.state"],
+            )
+
+            result = sim.run_policy(robot_name="so100", policy_object=c, n_steps=3, control_frequency=25.0)
+
+            text = "".join(part.get("text", "") for part in result["content"])
+            assert result["status"] == "error", text
+            assert "lower_obs_keys" in text, text
+            # The engine's own key namespace is what the caller needs to see.
+            assert keys[0] in text, text
+            assert lower.last_obs is None, "the child ran on an empty observation"
+        finally:
+            sim.cleanup()
+
+
+def test_the_full_observation_is_still_forwarded_when_no_subset_is_configured():
+    """The default path is untouched: no subset, no rule to apply."""
+    c, lower, upper = _composite()
+
+    asyncio.run(c.get_actions(dict(WORLD_OBS), ""))
+
+    assert lower.last_obs == WORLD_OBS
+    assert upper.last_obs == WORLD_OBS


### PR DESCRIPTION
## The mistake

`lower_obs_keys` / `upper_obs_keys` select the observation each `CompositePolicy`
child is queried with. The selection is by name, and the names belong to whatever
produced the observation — a MuJoCo world names them after the robot's own joints
(`"1"`, `"1.vel"`), a LeRobot dataset spells the same reading `"observation.state"`.
A subset written in the wrong namespace shares no key at all, so the child was
handed `{}`: on every tick, of every episode, with the rollout reporting success.

![measured](https://raw.githubusercontent.com/cagataycali/robots/assets/composite-blind-child-34384350147/a/composite_blind_child.png)

`so101` in MuJoCo (headless), 60 ticks @ 25 Hz. The lower child owns joints 1-3
and steps each toward +0.6 rad **from the state it reads**; the upper child owns
4-6 and sees the whole observation.

| `lower_obs_keys` | ticks the child had a reading | joints 1-3 after 60 ticks | `run_policy` |
| --- | --- | --- | --- |
| `["observation.state"]` | **0 of 60** | `[0.000, 0.030, 0.025]` | `status="success"` |
| `["1", "2", "3"]` | 60 of 60 | `[0.418, 0.347, 0.384]` | `status="success"` |

0.418 rad of divergence on the joints one child was supposed to be closing the
loop on, and nothing anywhere said so.

## Why this is the class's own rule

The same class already refuses the mirror mistake one step later, on the action
side — measured on the same rollout:

| the configured group shares no name with what is there | before this change |
| --- | --- |
| **action** `lower_joints=['1_typo','2_typo','3_typo']` vs emitted `['1','2','3']` | `status="error"` — *"commanded 3 joint(s) and none of them reached the merged action … Set lower_joints to names this policy emits"* |
| **observation** `lower_obs_keys=['observation.state']` vs observation `['1','1.vel',…]` | `status="success"`, child queried with `{}` |

`_reject_discarded_child` gives the reason in its own docstring: *"A child whose
whole action dict is dropped reaches no actuator, so the composite commands
exactly what the other child alone would."* A child whose whole **observation**
is dropped acts on no reading, which is the same failure one step earlier. And
`RobotRLEnv` already states the rule for the observation side directly —
`training/rl/env.py`: *"Validate obs keys up front so a typo fails loudly here,
not mid-rollout"* — refusing an `actor_obs_keys` the engine does not produce,
listing the missing keys and the available ones.

## The change

`_filter_obs` refuses a subset that selects nothing from a non-empty observation,
naming the seat, the child, the configured group and the observation's own keys
so the caller can read off the namespace the subset should have been written in.
It runs before `asyncio.gather`, so no model is queried on a misconfigured
composite.

```
CompositePolicy: the lower policy 'locomotion' would be queried with an empty
observation - the lower_obs_keys group ['observation.state'] shares no key with
the observation ['1', '1.vel', '2', '2.vel', ...], so it would command its joints
from no reading at all. Set lower_obs_keys to keys the observation carries (they
are named by whatever produces it - a simulated world names them after the
robot's own joints and cameras), or leave lower_obs_keys unset to forward the
whole observation.
```

Two boundaries are deliberate and each is pinned:

- a **partly** satisfied subset is still forwarded — the child got keys it asked
  for, and whether it can act on those is its own contract (children read by name);
- an observation with **no keys at all** is left alone, for the reason the action
  side leaves a child that commanded nothing alone — nothing for the subset to miss.

## Grading

`tests/policies/test_composite_child_observation_is_not_empty.py`, 8 cells.
On pristine `main` with only the test file added: **5 failed / 3 passed**, the
rollout cell failing on `assert 'success' == 'error'` against
`Policy complete on 'so100'`. On this branch: **8 passed**.

| mutant | cells fired |
| --- | --- |
| guard removed (pre-fix body) | 5 — both seats, both "neither child queried", the rollout envelope |
| checked on the lower seat only | 2 — both upper-seat cells |
| refuses **any** missing key (over-refuses) | 1 — the partial-subset boundary |
| refuses an empty observation too | 1 — the empty-observation boundary |
| unmutated | 0 |

Local gate: `ruff check strands_robots tests tests_integ` clean; `mypy
strands_robots tests tests_integ` clean (1979 files); full `MUJOCO_GL=egl pytest
tests/` **51906 passed / 299 skipped / 0 failed** in 29m57s.

LOC: +273 / -12 (fix 15, test 152, changelog 46, docs 11, docstrings the rest).
